### PR TITLE
feat(op-dispute-mon): Extractor Claim Fetching

### DIFF
--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -27,15 +27,13 @@ type DetectorMetrics interface {
 type detector struct {
 	logger    log.Logger
 	metrics   DetectorMetrics
-	creator   GameCallerCreator
 	validator OutputValidator
 }
 
-func newDetector(logger log.Logger, metrics DetectorMetrics, creator GameCallerCreator, validator OutputValidator) *detector {
+func newDetector(logger log.Logger, metrics DetectorMetrics, validator OutputValidator) *detector {
 	return &detector{
 		logger:    logger,
 		metrics:   metrics,
-		creator:   creator,
 		validator: validator,
 	}
 }

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -33,10 +33,10 @@ func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimes
 	if err != nil {
 		return nil, fmt.Errorf("failed to load games: %w", err)
 	}
-	return e.enrichGameMetadata(ctx, games), nil
+	return e.enrichGames(ctx, games), nil
 }
 
-func (e *Extractor) enrichGameMetadata(ctx context.Context, games []gameTypes.GameMetadata) []monTypes.EnrichedGameData {
+func (e *Extractor) enrichGames(ctx context.Context, games []gameTypes.GameMetadata) []monTypes.EnrichedGameData {
 	var enrichedGames []monTypes.EnrichedGameData
 	for _, game := range games {
 		caller, err := e.createContract(game)
@@ -49,11 +49,17 @@ func (e *Extractor) enrichGameMetadata(ctx context.Context, games []gameTypes.Ga
 			e.logger.Error("failed to fetch game metadata", "err", err)
 			continue
 		}
+		claims, err := caller.GetAllClaims(ctx)
+		if err != nil {
+			e.logger.Error("failed to fetch game claims", "err", err)
+			continue
+		}
 		enrichedGames = append(enrichedGames, monTypes.EnrichedGameData{
 			GameMetadata:  game,
 			L2BlockNumber: l2BlockNum,
 			RootClaim:     rootClaim,
 			Status:        status,
+			Claims:        claims,
 		})
 	}
 	return enrichedGames

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -35,20 +35,37 @@ func TestExtractor_Extract(t *testing.T) {
 		require.Len(t, enriched, 0)
 		require.Equal(t, 1, games.calls)
 		require.Equal(t, 1, creator.calls)
-		verifyLogs(t, logs, 1, 0)
+		require.Equal(t, 0, creator.caller.metadataCalls)
+		require.Equal(t, 0, creator.caller.claimsCalls)
+		verifyLogs(t, logs, 1, 0, 0)
 	})
 
 	t.Run("MetadataFetchErrorLog", func(t *testing.T) {
 		extractor, creator, games, logs := setupExtractorTest(t)
 		games.games = []gameTypes.GameMetadata{{}}
-		creator.caller.err = errors.New("boom")
+		creator.caller.metadataErr = errors.New("boom")
 		enriched, err := extractor.Extract(context.Background(), common.Hash{}, 0)
 		require.NoError(t, err)
 		require.Len(t, enriched, 0)
 		require.Equal(t, 1, games.calls)
 		require.Equal(t, 1, creator.calls)
-		require.Equal(t, 1, creator.caller.calls)
-		verifyLogs(t, logs, 0, 1)
+		require.Equal(t, 1, creator.caller.metadataCalls)
+		require.Equal(t, 0, creator.caller.claimsCalls)
+		verifyLogs(t, logs, 0, 1, 0)
+	})
+
+	t.Run("ClaimsFetchErrorLog", func(t *testing.T) {
+		extractor, creator, games, logs := setupExtractorTest(t)
+		games.games = []gameTypes.GameMetadata{{}}
+		creator.caller.claimsErr = errors.New("boom")
+		enriched, err := extractor.Extract(context.Background(), common.Hash{}, 0)
+		require.NoError(t, err)
+		require.Len(t, enriched, 0)
+		require.Equal(t, 1, games.calls)
+		require.Equal(t, 1, creator.calls)
+		require.Equal(t, 1, creator.caller.metadataCalls)
+		require.Equal(t, 1, creator.caller.claimsCalls)
+		verifyLogs(t, logs, 0, 0, 1)
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -59,11 +76,12 @@ func TestExtractor_Extract(t *testing.T) {
 		require.Len(t, enriched, 1)
 		require.Equal(t, 1, games.calls)
 		require.Equal(t, 1, creator.calls)
-		require.Equal(t, 1, creator.caller.calls)
+		require.Equal(t, 1, creator.caller.metadataCalls)
+		require.Equal(t, 1, creator.caller.claimsCalls)
 	})
 }
 
-func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr int, metadataErr int) {
+func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr int, metadataErr int, claimsErr int) {
 	errorLevelFilter := testlog.NewLevelFilter(log.LevelError)
 	createMessageFilter := testlog.NewMessageFilter("failed to create game caller")
 	l := logs.FindLogs(errorLevelFilter, createMessageFilter)
@@ -71,6 +89,9 @@ func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr int, met
 	fetchMessageFilter := testlog.NewMessageFilter("failed to fetch game metadata")
 	l = logs.FindLogs(errorLevelFilter, fetchMessageFilter)
 	require.Len(t, l, metadataErr)
+	claimsMessageFilter := testlog.NewMessageFilter("failed to fetch game claims")
+	l = logs.FindLogs(errorLevelFilter, claimsMessageFilter)
+	require.Len(t, l, claimsErr)
 }
 
 func setupExtractorTest(t *testing.T) (*Extractor, *mockGameCallerCreator, *mockGameFetcher, *testlog.CapturingHandler) {
@@ -117,23 +138,26 @@ func (m *mockGameCallerCreator) CreateGameCaller(_ gameTypes.GameMetadata) (Game
 }
 
 type mockGameCaller struct {
-	calls     int
-	err       error
-	rootClaim common.Hash
+	metadataCalls int
+	metadataErr   error
+	claimsCalls   int
+	claimsErr     error
+	rootClaim     common.Hash
+	claims        []faultTypes.Claim
 }
 
 func (m *mockGameCaller) GetGameMetadata(_ context.Context) (uint64, common.Hash, types.GameStatus, error) {
-	m.calls++
-	if m.err != nil {
-		return 0, common.Hash{}, 0, m.err
+	m.metadataCalls++
+	if m.metadataErr != nil {
+		return 0, common.Hash{}, 0, m.metadataErr
 	}
 	return 0, mockRootClaim, 0, nil
 }
 
 func (m *mockGameCaller) GetAllClaims(ctx context.Context) ([]faultTypes.Claim, error) {
-	m.calls++
-	if m.err != nil {
-		return nil, m.err
+	m.claimsCalls++
+	if m.claimsErr != nil {
+		return nil, m.claimsErr
 	}
-	return []faultTypes.Claim{{}}, nil
+	return m.claims, nil
 }

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -26,15 +26,13 @@ type ForecastMetrics interface {
 type forecast struct {
 	logger    log.Logger
 	metrics   ForecastMetrics
-	creator   GameCallerCreator
 	validator OutputValidator
 }
 
-func newForecast(logger log.Logger, metrics ForecastMetrics, creator GameCallerCreator, validator OutputValidator) *forecast {
+func newForecast(logger log.Logger, metrics ForecastMetrics, validator OutputValidator) *forecast {
 	return &forecast{
 		logger:    logger,
 		metrics:   metrics,
-		creator:   creator,
 		validator: validator,
 	}
 }
@@ -62,19 +60,8 @@ func (f *forecast) forecastGame(ctx context.Context, game monTypes.EnrichedGameD
 		return nil
 	}
 
-	loader, err := f.creator.CreateContract(game.GameMetadata)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrContractCreation, err)
-	}
-
-	// Load all claims for the game.
-	claims, err := loader.GetAllClaims(ctx)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrClaimFetch, err)
-	}
-
 	// Create the bidirectional tree of claims.
-	tree := transform.CreateBidirectionalTree(claims)
+	tree := transform.CreateBidirectionalTree(game.Claims)
 
 	// Compute the resolution status of the game.
 	status := Resolve(tree)

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -111,11 +111,11 @@ func (s *Service) initExtractor() {
 }
 
 func (s *Service) initForecast(cfg *config.Config) {
-	s.forecast = newForecast(s.logger, s.metrics, s.game, s.validator)
+	s.forecast = newForecast(s.logger, s.metrics, s.validator)
 }
 
 func (s *Service) initDetector() {
-	s.detector = newDetector(s.logger, s.metrics, s.game, s.validator)
+	s.detector = newDetector(s.logger, s.metrics, s.validator)
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -11,6 +11,7 @@ type EnrichedGameData struct {
 	L2BlockNumber uint64
 	RootClaim     common.Hash
 	Status        types.GameStatus
+	Claims        []faultTypes.Claim
 }
 
 // BidirectionalTree is a tree of claims represented as a flat list of claims.


### PR DESCRIPTION
**Description**

Moves game claim fetching into the `extractor` component so it isn't performed in multiple downstream ETL processing components.

**Tests**

Cleaned up unit tests around modifications.

Unit tests added for the `extractor` component for when claim fetching fails.

**Metadata**

Precusor for https://github.com/ethereum-optimism/client-pod/issues/537.
