### PR TITLE
op-challenger: Add function to run op-program and determine safe head limit

### DIFF
--- a/op-challenger/game/fault/trace/outputs/source/opprogram.go
+++ b/op-challenger/game/fault/trace/outputs/source/opprogram.go
@@ -1,0 +1,74 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	opnode "github.com/ethereum-optimism/optimism/op-node"
+	"github.com/ethereum-optimism/optimism/op-program/client/driver"
+	"github.com/ethereum-optimism/optimism/op-program/host"
+	fpp_config "github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const subdirName = "output_preimages"
+
+type fppRunner struct {
+	logger log.Logger
+	cfg    *config.Config
+	runFPP func(context.Context, log.Logger, *fpp_config.Config) error
+}
+
+func newFPPRunner(logger log.Logger, cfg *config.Config) *fppRunner {
+	return &fppRunner{
+		logger: logger,
+		cfg:    cfg,
+		runFPP: host.FaultProofProgram,
+	}
+}
+
+// RunProgram runs op-program natively to determine if the output root is valid or not.
+// Returns the maximum L2 block number that is supported by data on L1 and whether the output root is valid.
+func (r *fppRunner) RunProgram(ctx context.Context, l1Head common.Hash, l2Start eth.BlockID, l2StartOutputRoot common.Hash, l2Claim common.Hash, l2ClaimBlockNum uint64) (uint64, bool, error) {
+	logger := r.logger.New("claim", l2Claim, "claimBlock", l2ClaimBlockNum, "l1Head", l1Head, "startBlock", l2Start)
+	logger.Info("Checking output root validity")
+	fppConfig, err := createFPPConfig(logger, r.cfg, l1Head, l2Start.Hash, l2StartOutputRoot, l2Claim, l2ClaimBlockNum)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid op-program config: %w", err)
+	}
+	err = r.runFPP(ctx, logger, fppConfig)
+	if errors.Is(err, driver.ErrClaimNotValid) {
+		// Output root is invalid
+		// TODO(client-pod#416): Determine the safe head derivation stopped at and return it
+		return math.MaxUint64, false, nil
+	} else if err != nil {
+		// Failed to determine validity
+		return 0, false, fmt.Errorf("failed to check claim validity: %w", err)
+	}
+	// Output root is valid, no need to restrict our output root range
+	return math.MaxUint64, true, nil
+}
+
+func createFPPConfig(logger log.Logger, cfg *config.Config, l1Head common.Hash, l2Head common.Hash, l2OutputRoot common.Hash, l2Claim common.Hash, l2ClaimBlockNumber uint64) (*fpp_config.Config, error) {
+	rollupCfg, err := opnode.NewRollupConfig(logger, cfg.CannonNetwork, cfg.CannonRollupConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load rollup config: %w", err)
+	}
+	l2Genesis, isCustomChainConfig, err := fpp_config.LoadL2Genesis(cfg.CannonNetwork, cfg.CannonL2GenesisPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load l2 genesis: %w", err)
+	}
+	fppCfg := fpp_config.NewConfig(rollupCfg, l2Genesis, l1Head, l2Head, l2OutputRoot, l2Claim, l2ClaimBlockNumber)
+	fppCfg.DataDir = filepath.Join(cfg.Datadir, subdirName)
+	fppCfg.IsCustomChainConfig = isCustomChainConfig
+	fppCfg.L1URL = cfg.L1EthRpc
+	fppCfg.L2URL = cfg.CannonL2
+	fppCfg.L1BeaconURL = cfg.L1Beacon
+	return fppCfg, nil
+}

--- a/op-challenger/game/fault/trace/outputs/source/opprogram.go
+++ b/op-challenger/game/fault/trace/outputs/source/opprogram.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -43,7 +42,7 @@ func (r *fppRunner) RunProgram(ctx context.Context, l1Head common.Hash, l2Start 
 		return 0, false, fmt.Errorf("invalid op-program config: %w", err)
 	}
 	err = r.runFPP(ctx, logger, fppConfig)
-	if errors.Is(err, driver.ErrClaimNotValid) {
+	if driver.IsClaimNotValidError(err) {
 		// Output root is invalid
 		// TODO(client-pod#416): Determine the safe head derivation stopped at and return it
 		return math.MaxUint64, false, nil

--- a/op-challenger/game/fault/trace/outputs/source/opprogram_test.go
+++ b/op-challenger/game/fault/trace/outputs/source/opprogram_test.go
@@ -1,0 +1,99 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-program/client/driver"
+	fpp_config "github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunOPProgram(t *testing.T) {
+	rollupCfg := chaincfg.Sepolia
+	l2ChainConfig, err := params.LoadOPStackChainConfig(rollupCfg.L2ChainID.Uint64())
+	require.NoError(t, err)
+	logger := testlog.Logger(t, log.LvlInfo)
+	l1Rpc := "http://l1:8544"
+	l1BeaconApi := "http://beacon:9545"
+	dataDir := t.TempDir()
+	l1Head := common.Hash{0xab}
+	l2Head := eth.BlockID{
+		Hash:   common.Hash{0x2a},
+		Number: 4892,
+	}
+	l2OutputRoot := common.Hash{0x2b}
+	l2Claim := common.Hash{0x2c}
+	l2ClaimBlockNumber := uint64(15886)
+
+	cfg := config.NewConfig(common.Address{}, l1Rpc, l1BeaconApi, dataDir, config.TraceTypeCannon)
+	cfg.CannonNetwork = "sepolia"
+	cfg.RollupRpc = "http://rollup:1234"
+	cfg.CannonL2 = "http://l2:4888"
+
+	runProgram := func(t *testing.T, programErr error) (uint64, bool, *fpp_config.Config, error) {
+		var actualCfg *fpp_config.Config
+		runner := &fppRunner{
+			logger: logger,
+			cfg:    &cfg,
+			runFPP: func(_ context.Context, _ log.Logger, fppConfig *fpp_config.Config) error {
+				actualCfg = fppConfig
+				return programErr
+			},
+		}
+		maxSafeHead, valid, err := runner.RunProgram(context.Background(), l1Head, l2Head, l2OutputRoot, l2Claim, l2ClaimBlockNumber)
+		return maxSafeHead, valid, actualCfg, err
+	}
+
+	t.Run("Config", func(t *testing.T) {
+		_, _, actual, err := runProgram(t, nil)
+		require.NoError(t, err)
+		require.NoError(t, actual.Check())
+		require.Equal(t, rollupCfg, actual.Rollup)
+		require.Equal(t, filepath.Join(dataDir, subdirName), actual.DataDir)
+		require.Equal(t, l1Head, actual.L1Head)
+		require.Equal(t, l1Rpc, actual.L1URL)
+		require.Equal(t, l1BeaconApi, actual.L1BeaconURL)
+		require.Equal(t, false, actual.L1TrustRPC)
+		// TODO(client-pod#590): Support setting trust rpc
+		// TODO(client-pod#590): Support setting rpc kind
+		require.Equal(t, l2Head.Hash, actual.L2Head)
+		require.Equal(t, l2OutputRoot, actual.L2OutputRoot)
+		require.Equal(t, cfg.CannonL2, actual.L2URL)
+		require.Equal(t, l2Claim, actual.L2Claim)
+		require.Equal(t, l2ClaimBlockNumber, actual.L2ClaimBlockNumber)
+		require.Equal(t, l2ChainConfig, actual.L2ChainConfig)
+		require.Equal(t, false, actual.IsCustomChainConfig)
+	})
+
+	t.Run("ValidOutputRoot", func(t *testing.T) {
+		maxSafeHead, valid, _, err := runProgram(t, nil)
+		require.NoError(t, err)
+		require.Equal(t, uint64(math.MaxUint64), maxSafeHead, "No need to restrict with valid output root")
+		require.True(t, valid)
+	})
+
+	t.Run("InvalidOutputRoot", func(t *testing.T) {
+		maxSafeHead, valid, _, err := runProgram(t, driver.ErrClaimNotValid)
+		require.NoError(t, err)
+		// TODO(client-pod#416): Verify the final safe head was returned
+		require.Equal(t, uint64(math.MaxUint64), maxSafeHead, "No need to restrict with valid output root")
+		require.False(t, valid)
+	})
+
+	t.Run("DerivationError", func(t *testing.T) {
+		expectedErr := errors.New("boom")
+		_, _, _, err := runProgram(t, expectedErr)
+		require.ErrorIs(t, err, expectedErr)
+	})
+}

--- a/op-challenger/game/fault/trace/outputs/source/opprogram_test.go
+++ b/op-challenger/game/fault/trace/outputs/source/opprogram_test.go
@@ -84,10 +84,11 @@ func TestRunOPProgram(t *testing.T) {
 	})
 
 	t.Run("InvalidOutputRoot", func(t *testing.T) {
-		maxSafeHead, valid, _, err := runProgram(t, driver.ErrClaimNotValid)
+		expectedMaxSafeHead := uint64(4444)
+		maxSafeHead, valid, _, err := runProgram(t, driver.ClaimNotValidError{SafeHead: eth.L2BlockRef{Number: expectedMaxSafeHead}})
 		require.NoError(t, err)
 		// TODO(client-pod#416): Verify the final safe head was returned
-		require.Equal(t, uint64(math.MaxUint64), maxSafeHead, "No need to restrict with valid output root")
+		require.Equal(t, expectedMaxSafeHead, maxSafeHead)
 		require.False(t, valid)
 	})
 

--- a/op-challenger/game/fault/trace/outputs/source/opprogram_test.go
+++ b/op-challenger/game/fault/trace/outputs/source/opprogram_test.go
@@ -87,7 +87,6 @@ func TestRunOPProgram(t *testing.T) {
 		expectedMaxSafeHead := uint64(4444)
 		maxSafeHead, valid, _, err := runProgram(t, driver.ClaimNotValidError{SafeHead: eth.L2BlockRef{Number: expectedMaxSafeHead}})
 		require.NoError(t, err)
-		// TODO(client-pod#416): Verify the final safe head was returned
 		require.Equal(t, expectedMaxSafeHead, maxSafeHead)
 		require.False(t, valid)
 	})

--- a/op-e2e/system_fpp_test.go
+++ b/op-e2e/system_fpp_test.go
@@ -320,7 +320,7 @@ func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *Syste
 	if s.Detached {
 		require.Error(t, err, "exit status 1")
 	} else {
-		require.ErrorIs(t, err, driver.ErrClaimNotValid)
+		require.True(t, driver.IsClaimNotValidError(err))
 	}
 }
 

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -26,7 +26,7 @@ func Main(logger log.Logger) {
 	log.Info("Starting fault proof program client")
 	preimageOracle := CreatePreimageChannel()
 	preimageHinter := CreateHinterChannel()
-	if err := RunProgram(logger, preimageOracle, preimageHinter); errors.Is(err, cldr.ErrClaimNotValid) {
+	if err := RunProgram(logger, preimageOracle, preimageHinter); cldr.IsClaimNotValidError(err) {
 		log.Error("Claim is invalid", "err", err)
 		os.Exit(1)
 	} else if err != nil {


### PR DESCRIPTION
**Description**

Adds a function to run op-program natively (and in process) to validate a claimed output root. If the output root is invalid, it returns the last safe head supported by the data on L1 up to the specified L1 head. Valid output roots don't need additional restrictions because the output roots used by the game are already limited to the claimed output root.

**Tests**

Added unit tests.


**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/416
