### PR TITLE
op-wheel: Add set-fcu-by-hash and copy-payload

### DIFF
--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -496,6 +496,38 @@ var (
 		}),
 	}
 
+	EngineSetForkchoiceHashCmd = &cli.Command{
+		Name:        "set-forkchoice-by-hash",
+		Description: "Set forkchoice, specify unsafe, safe and finalized blocks by hash",
+		Flags: []cli.Flag{
+			EngineEndpoint, EngineJWTPath,
+			&cli.StringFlag{
+				Name:     "unsafe",
+				Usage:    "Block hash of block to set as latest block",
+				Required: true,
+				EnvVars:  prefixEnvVars("UNSAFE"),
+			},
+			&cli.StringFlag{
+				Name:     "safe",
+				Usage:    "Block hash of block to set as safe block",
+				Required: true,
+				EnvVars:  prefixEnvVars("SAFE"),
+			},
+			&cli.StringFlag{
+				Name:     "finalized",
+				Usage:    "Block hash of block to set as finalized block",
+				Required: true,
+				EnvVars:  prefixEnvVars("FINALIZED"),
+			},
+		},
+		Action: EngineAction(func(ctx *cli.Context, client client.RPC) error {
+			finalized := common.HexToHash(ctx.String("finalized"))
+			safe := common.HexToHash(ctx.String("safe"))
+			unsafe := common.HexToHash(ctx.String("unsafe"))
+			return engine.SetForkchoiceByHash(ctx.Context, client, finalized, safe, unsafe)
+		}),
+	}
+
 	EngineJSONCmd = &cli.Command{
 		Name:        "json",
 		Description: "read json values from remaining args, or STDIN, and use them as RPC params to call the engine RPC method (first arg)",
@@ -551,6 +583,7 @@ var EngineCmd = &cli.Command{
 		EngineStatusCmd,
 		EngineCopyCmd,
 		EngineSetForkchoiceCmd,
+		EngineSetForkchoiceHashCmd,
 		EngineJSONCmd,
 	},
 }

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -482,7 +482,7 @@ var (
 				Name:     "number",
 				Usage:    "Block number to copy from the source",
 				Required: true,
-				EnvVars:  prefixEnvVars("ENGINE"),
+				EnvVars:  prefixEnvVars("NUMBER"),
 			},
 		},
 		Action: EngineAction(func(ctx *cli.Context, dest client.RPC) error {

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -468,7 +468,8 @@ var (
 	}
 
 	EngineCopyPayloadCmd = &cli.Command{
-		Name: "copy-payload",
+		Name:        "copy-payload",
+		Description: "Take the block by number from source and insert it to the engine with NewPayload. No other calls are made.",
 		Flags: []cli.Flag{
 			EngineEndpoint, EngineJWTPath,
 			&cli.StringFlag{

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -467,6 +467,33 @@ var (
 		}),
 	}
 
+	EngineCopyPayloadCmd = &cli.Command{
+		Name: "copy-payload",
+		Flags: []cli.Flag{
+			EngineEndpoint, EngineJWTPath,
+			&cli.StringFlag{
+				Name:     "source",
+				Usage:    "Unauthenticated regular eth JSON RPC to pull block data from, can be HTTP/WS/IPC.",
+				Required: true,
+				EnvVars:  prefixEnvVars("ENGINE"),
+			},
+			&cli.Uint64Flag{
+				Name:     "number",
+				Usage:    "Block number to copy from the source",
+				Required: true,
+				EnvVars:  prefixEnvVars("ENGINE"),
+			},
+		},
+		Action: EngineAction(func(ctx *cli.Context, dest client.RPC) error {
+			rpcClient, err := rpc.DialOptions(context.Background(), ctx.String("source"))
+			if err != nil {
+				return fmt.Errorf("failed to dial engine source endpoint: %w", err)
+			}
+			source := client.NewBaseRPCClient(rpcClient)
+			return engine.CopyPayload(context.Background(), ctx.Uint64("number"), source, dest)
+		}),
+	}
+
 	EngineSetForkchoiceCmd = &cli.Command{
 		Name:        "set-forkchoice",
 		Description: "Set forkchoice, specify unsafe, safe and finalized blocks by number",
@@ -582,6 +609,7 @@ var EngineCmd = &cli.Command{
 		EngineAutoCmd,
 		EngineStatusCmd,
 		EngineCopyCmd,
+		EngineCopyPayloadCmd,
 		EngineSetForkchoiceCmd,
 		EngineSetForkchoiceHashCmd,
 		EngineJSONCmd,

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -310,6 +310,20 @@ func Copy(ctx context.Context, copyFrom client.RPC, copyTo client.RPC) error {
 	return nil
 }
 
+// CopyPaylod takes the execution payload at number & applies it via NewPayload to copyTo
+func CopyPayload(ctx context.Context, number uint64, copyFrom client.RPC, copyTo client.RPC) error {
+	copyHead, err := getBlock(ctx, copyFrom, "eth_getBlockByNumber", fmt.Sprintf("%#.6x", number))
+	if err != nil {
+		return err
+	}
+	payloadEnv := engine.BlockToExecutableData(copyHead, nil, nil)
+	payload := payloadEnv.ExecutionPayload
+	if err := insertBlock(ctx, copyTo, payload); err != nil {
+		return err
+	}
+	return nil
+}
+
 func SetForkchoice(ctx context.Context, client client.RPC, finalizedNum, safeNum, unsafeNum uint64) error {
 	if unsafeNum < safeNum {
 		return fmt.Errorf("cannot set unsafe (%d) < safe (%d)", unsafeNum, safeNum)

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -338,6 +338,13 @@ func SetForkchoice(ctx context.Context, client client.RPC, finalizedNum, safeNum
 	return nil
 }
 
+func SetForkchoiceByHash(ctx context.Context, client client.RPC, finalized, safe, unsafe common.Hash) error {
+	if err := updateForkchoice(ctx, client, unsafe, safe, finalized); err != nil {
+		return fmt.Errorf("failed to update forkchoice: %w", err)
+	}
+	return nil
+}
+
 func RawJSONInteraction(ctx context.Context, client client.RPC, method string, args []string, input io.Reader, output io.Writer) error {
 	var params []any
 	if input != nil {

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -312,7 +312,7 @@ func Copy(ctx context.Context, copyFrom client.RPC, copyTo client.RPC) error {
 
 // CopyPaylod takes the execution payload at number & applies it via NewPayload to copyTo
 func CopyPayload(ctx context.Context, number uint64, copyFrom client.RPC, copyTo client.RPC) error {
-	copyHead, err := getBlock(ctx, copyFrom, "eth_getBlockByNumber", fmt.Sprintf("%#.6x", number))
+	copyHead, err := getBlock(ctx, copyFrom, "eth_getBlockByNumber", hexutil.EncodeUint64(number))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description**

Add `set-fcu-by-hash` and `copy-payload` commands to `op-wheel`


**Additional context**

Note: `copy` and `copy-payload` do not work if there is a deposit in the block. I'm unsure why it is not serializing properly.