### PR TITLE
chore: remove an impossible case

### DIFF
--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -142,9 +142,6 @@ func ParseFrames(data []byte) ([]Frame, error) {
 		}
 		frames = append(frames, f)
 	}
-	if buf.Len() != 0 {
-		return nil, fmt.Errorf("did not fully consume data: have %d frames and %d bytes left", len(frames), buf.Len())
-	}
 	if len(frames) == 0 {
 		return nil, errors.New("was not able to find any frames")
 	}


### PR DESCRIPTION
The for loop [above](https://github.com/ethereum-optimism/optimism/blob/1e62a0b7adccfc3b9d937f13c4671c8febc07ba5/op-node/rollup/derive/frame.go#L138) won't quit if`buf.Len() != 0`