### PR TITLE
fix(op-challenger): Packed Claim Clock

### DIFF
--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -3,9 +3,66 @@ package types
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestClaim_RemainingDuration(t *testing.T) {
+	tests := []struct {
+		name      string
+		duration  uint64
+		timestamp uint64
+		now       int64
+		expected  uint64
+	}{
+		{
+			name:      "AllZeros",
+			duration:  0,
+			timestamp: 0,
+			now:       0,
+			expected:  0,
+		},
+		{
+			name:      "ZeroTimestamp",
+			duration:  5,
+			timestamp: 0,
+			now:       0,
+			expected:  5,
+		},
+		{
+			name:      "ZeroTimestampWithNow",
+			duration:  5,
+			timestamp: 0,
+			now:       10,
+			expected:  15,
+		},
+		{
+			name:      "ZeroNow",
+			duration:  5,
+			timestamp: 10,
+			now:       0,
+			expected:  5,
+		},
+		{
+			name:      "ValidTimeSinze",
+			duration:  20,
+			timestamp: 10,
+			now:       15,
+			expected:  25,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			claim := &Claim{
+				Clock: NewClock(test.duration, test.timestamp),
+			}
+			require.Equal(t, time.Duration(test.expected), claim.ChessTime(time.Unix(test.now, 0)))
+		})
+	}
+}
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {


### PR DESCRIPTION
**Description**

In the `FaultDisputeGame` contracts, a claim's chess clock duration and timestamp since posted are tracked using the packed `uint128` clock value composed of the packed 64 bit duration and timestamp elements.

This looks like the following, as documented in the [`DisputeTypes`](https://github.com/ethereum-optimism/optimism/blob/e4e02eb1c0741a692a0c226abf8a30414bd7d99b/packages/contracts-bedrock/src/libraries/DisputeTypes.sol#L59-L67)

```
 /// ┌────────────┬────────────────┐ 
 /// │    Bits    │     Value      │ 
 /// ├────────────┼────────────────┤ 
 /// │ [0, 64)    │ Duration       │ 
 /// │ [64, 128)  │ Timestamp      │ 
 /// └────────────┴────────────────┘
```

Natively, the `FaultDisputeGame` contract performs duration and timestamp packing and unwrapping through the [`LibClock.sol`](https://github.com/ethereum-optimism/optimism/blob/1e62a0b7adccfc3b9d937f13c4671c8febc07ba5/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol) library.

The Challenger however does not properly unpack the clock and has since only set a claims golang clock value to the raw `uint128`, as a big integer.

This PR updates the challenger's `Claim.Clock` field to use a newly introduced typed `Clock` that properly parses the packed 64 bit duration and timestamp elements from the raw `uint128` clock value.

Adding this functionality is a pre-requisite to properly calculating the resolution delay that will be tracked by the `op-dispute-mon`.

> **Note**
>
> The addition of the `ChessTime` method updates the suggestion [here](https://github.com/ethereum-optimism/optimism/pull/9567#discussion_r1491754873) and isolates the clock logic alongside its associated type.

**Tests**

Unit tests are performed around the new `Clock` type and it's methods, as well as the added `Claim` type's `ChessTime` method.

**Metadata**

Required for https://github.com/ethereum-optimism/client-pod/issues/537
