### PR TITLE
fix(op-dispute-mon): Pointer Argument Optimization

### DIFF
--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -3,9 +3,66 @@ package types
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestClaim_RemainingDuration(t *testing.T) {
+	tests := []struct {
+		name      string
+		duration  uint64
+		timestamp uint64
+		now       int64
+		expected  uint64
+	}{
+		{
+			name:      "AllZeros",
+			duration:  0,
+			timestamp: 0,
+			now:       0,
+			expected:  0,
+		},
+		{
+			name:      "ZeroTimestamp",
+			duration:  5,
+			timestamp: 0,
+			now:       0,
+			expected:  5,
+		},
+		{
+			name:      "ZeroTimestampWithNow",
+			duration:  5,
+			timestamp: 0,
+			now:       10,
+			expected:  15,
+		},
+		{
+			name:      "ZeroNow",
+			duration:  5,
+			timestamp: 10,
+			now:       0,
+			expected:  5,
+		},
+		{
+			name:      "ValidTimeSinze",
+			duration:  20,
+			timestamp: 10,
+			now:       15,
+			expected:  25,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			claim := &Claim{
+				Clock: NewClock(test.duration, test.timestamp),
+			}
+			require.Equal(t, time.Duration(test.expected), claim.ChessTime(time.Unix(test.now, 0)))
+		})
+	}
+}
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {

--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -39,7 +39,7 @@ func newDetector(logger log.Logger, metrics DetectorMetrics, validator OutputVal
 	}
 }
 
-func (d *detector) Detect(ctx context.Context, games []monTypes.EnrichedGameData) {
+func (d *detector) Detect(ctx context.Context, games []*monTypes.EnrichedGameData) {
 	statBatch := monTypes.StatusBatch{}
 	detectBatch := monTypes.DetectionBatch{}
 	for _, game := range games {

--- a/op-dispute-mon/mon/detector_test.go
+++ b/op-dispute-mon/mon/detector_test.go
@@ -19,7 +19,7 @@ func TestDetector_Detect(t *testing.T) {
 
 	t.Run("NoGames", func(t *testing.T) {
 		detector, m, _, _ := setupDetectorTest(t)
-		detector.Detect(context.Background(), []monTypes.EnrichedGameData{})
+		detector.Detect(context.Background(), []*monTypes.EnrichedGameData{})
 		m.Equals(t, 0, 0, 0)
 		m.Mapped(t, map[metrics.GameAgreementStatus]int{})
 	})
@@ -27,21 +27,21 @@ func TestDetector_Detect(t *testing.T) {
 	t.Run("CheckAgreementFails", func(t *testing.T) {
 		detector, m, rollup, _ := setupDetectorTest(t)
 		rollup.err = errors.New("boom")
-		detector.Detect(context.Background(), []monTypes.EnrichedGameData{{}})
+		detector.Detect(context.Background(), []*monTypes.EnrichedGameData{{}})
 		m.Equals(t, 1, 0, 0) // Status should still be metriced here!
 		m.Mapped(t, map[metrics.GameAgreementStatus]int{})
 	})
 
 	t.Run("SingleGame", func(t *testing.T) {
 		detector, m, _, _ := setupDetectorTest(t)
-		detector.Detect(context.Background(), []monTypes.EnrichedGameData{{Status: types.GameStatusChallengerWon}})
+		detector.Detect(context.Background(), []*monTypes.EnrichedGameData{{Status: types.GameStatusChallengerWon}})
 		m.Equals(t, 0, 0, 1)
 		m.Mapped(t, map[metrics.GameAgreementStatus]int{metrics.DisagreeChallengerWins: 1})
 	})
 
 	t.Run("MultipleGames", func(t *testing.T) {
 		detector, m, _, _ := setupDetectorTest(t)
-		detector.Detect(context.Background(), []monTypes.EnrichedGameData{
+		detector.Detect(context.Background(), []*monTypes.EnrichedGameData{
 			{Status: types.GameStatusChallengerWon},
 			{Status: types.GameStatusChallengerWon},
 			{Status: types.GameStatusChallengerWon},

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -28,7 +28,7 @@ func NewExtractor(logger log.Logger, creator CreateGameCaller, fetchGames Factor
 	}
 }
 
-func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]monTypes.EnrichedGameData, error) {
+func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*monTypes.EnrichedGameData, error) {
 	games, err := e.fetchGames(ctx, blockHash, minTimestamp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load games: %w", err)
@@ -36,8 +36,8 @@ func (e *Extractor) Extract(ctx context.Context, blockHash common.Hash, minTimes
 	return e.enrichGames(ctx, games), nil
 }
 
-func (e *Extractor) enrichGames(ctx context.Context, games []gameTypes.GameMetadata) []monTypes.EnrichedGameData {
-	var enrichedGames []monTypes.EnrichedGameData
+func (e *Extractor) enrichGames(ctx context.Context, games []gameTypes.GameMetadata) []*monTypes.EnrichedGameData {
+	var enrichedGames []*monTypes.EnrichedGameData
 	for _, game := range games {
 		caller, err := e.createContract(game)
 		if err != nil {
@@ -54,7 +54,7 @@ func (e *Extractor) enrichGames(ctx context.Context, games []gameTypes.GameMetad
 			e.logger.Error("failed to fetch game claims", "err", err)
 			continue
 		}
-		enrichedGames = append(enrichedGames, monTypes.EnrichedGameData{
+		enrichedGames = append(enrichedGames, &monTypes.EnrichedGameData{
 			GameMetadata:  game,
 			L2BlockNumber: l2BlockNum,
 			RootClaim:     rootClaim,

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -38,7 +38,7 @@ func newForecast(logger log.Logger, metrics ForecastMetrics, validator OutputVal
 	}
 }
 
-func (f *forecast) Forecast(ctx context.Context, games []monTypes.EnrichedGameData) {
+func (f *forecast) Forecast(ctx context.Context, games []*monTypes.EnrichedGameData) {
 	batch := monTypes.ForecastBatch{}
 	for _, game := range games {
 		if err := f.forecastGame(ctx, game, &batch); err != nil {
@@ -55,7 +55,7 @@ func (f *forecast) recordBatch(batch monTypes.ForecastBatch) {
 	f.metrics.RecordGameAgreement(metrics.DisagreeDefenderAhead, batch.DisagreeDefenderAhead)
 }
 
-func (f *forecast) forecastGame(ctx context.Context, game monTypes.EnrichedGameData, metrics *monTypes.ForecastBatch) error {
+func (f *forecast) forecastGame(ctx context.Context, game *monTypes.EnrichedGameData, metrics *monTypes.ForecastBatch) error {
 	if game.Status != types.GameStatusInProgress {
 		f.logger.Debug("Game is not in progress, skipping forecast", "game", game.Proxy, "status", game.Status)
 		return nil

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -28,7 +28,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("NoGames", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{})
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -38,7 +38,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("RollupFetchFails", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
 		rollup.err = errors.New("boom")
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{{}})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}})
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -52,7 +52,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("ChallengerWonGameSkipped", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon}
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{expectedGame})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame})
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -68,7 +68,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("DefenderWonGameSkipped", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon}
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{expectedGame})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame})
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -83,7 +83,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("SingleGame", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{{}})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}})
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -95,7 +95,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("MultipleGames", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{{}, {}, {}})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}, {}, {}})
 		require.Equal(t, 3, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -111,7 +111,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("AgreeDefenderWins", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		games := []monTypes.EnrichedGameData{{
+		games := []*monTypes.EnrichedGameData{{
 			Status:    types.GameStatusInProgress,
 			RootClaim: mockRootClaim,
 			Claims:    createDeepClaimList()[:1],
@@ -135,7 +135,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("AgreeChallengerWins", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		games := []monTypes.EnrichedGameData{{
+		games := []*monTypes.EnrichedGameData{{
 			Status:    types.GameStatusInProgress,
 			RootClaim: mockRootClaim,
 			Claims:    createDeepClaimList()[:2],
@@ -159,7 +159,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("DisagreeChallengerWins", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{{
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{
 			Status: types.GameStatusInProgress,
 			Claims: createDeepClaimList()[:2],
 		}})
@@ -181,7 +181,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 
 	t.Run("DisagreeDefenderWins", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []monTypes.EnrichedGameData{{
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{
 			Status: types.GameStatusInProgress,
 			Claims: createDeepClaimList()[:1],
 		}})
@@ -237,11 +237,13 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 		{},
 		{},
 	}
-	games := make([]monTypes.EnrichedGameData, 9)
+	games := make([]*monTypes.EnrichedGameData, 9)
 	for i := range games {
-		games[i].Status = gameStatus[i]
-		games[i].Claims = claims[i]
-		games[i].RootClaim = rootClaims[i]
+		games[i] = &monTypes.EnrichedGameData{
+			Status:    gameStatus[i],
+			Claims:    claims[i],
+			RootClaim: rootClaims[i],
+		}
 	}
 	forecast.Forecast(context.Background(), games)
 	require.Equal(t, 4, rollup.calls)

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -13,11 +13,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type Detect func(ctx context.Context, games []types.EnrichedGameData)
-type Forecast func(ctx context.Context, games []types.EnrichedGameData)
+type Detect func(ctx context.Context, games []*types.EnrichedGameData)
+type Forecast func(ctx context.Context, games []*types.EnrichedGameData)
 type BlockHashFetcher func(ctx context.Context, number *big.Int) (common.Hash, error)
 type BlockNumberFetcher func(ctx context.Context) (uint64, error)
-type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]types.EnrichedGameData, error)
+type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*types.EnrichedGameData, error)
 
 type gameMonitor struct {
 	logger log.Logger

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -71,7 +71,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 
 	t.Run("DetectsWithNoGames", func(t *testing.T) {
 		monitor, factory, detector, _ := setupMonitorTest(t)
-		factory.games = []monTypes.EnrichedGameData{}
+		factory.games = []*monTypes.EnrichedGameData{}
 		err := monitor.monitorGames()
 		require.NoError(t, err)
 		require.Equal(t, 1, detector.calls)
@@ -79,7 +79,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 
 	t.Run("DetectsMultipleGames", func(t *testing.T) {
 		monitor, factory, detector, _ := setupMonitorTest(t)
-		factory.games = []monTypes.EnrichedGameData{{}, {}, {}}
+		factory.games = []*monTypes.EnrichedGameData{{}, {}, {}}
 		err := monitor.monitorGames()
 		require.NoError(t, err)
 		require.Equal(t, 1, detector.calls)
@@ -91,7 +91,7 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 		addr1 := common.Address{0xaa}
 		addr2 := common.Address{0xbb}
 		monitor, factory, detector, _ := setupMonitorTest(t)
-		factory.games = []monTypes.EnrichedGameData{newFDG(addr1, 9999), newFDG(addr2, 9999)}
+		factory.games = []*monTypes.EnrichedGameData{newEnrichedGameData(addr1, 9999), newEnrichedGameData(addr2, 9999)}
 		factory.maxSuccess = len(factory.games) // Only allow two successful fetches
 
 		monitor.StartMonitoring()
@@ -115,8 +115,8 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 	})
 }
 
-func newFDG(proxy common.Address, timestamp uint64) monTypes.EnrichedGameData {
-	return monTypes.EnrichedGameData{
+func newEnrichedGameData(proxy common.Address, timestamp uint64) *monTypes.EnrichedGameData {
+	return &monTypes.EnrichedGameData{
 		GameMetadata: types.GameMetadata{
 			Proxy:     proxy,
 			Timestamp: timestamp,
@@ -158,7 +158,7 @@ type mockForecast struct {
 	calls int
 }
 
-func (m *mockForecast) Forecast(ctx context.Context, games []monTypes.EnrichedGameData) {
+func (m *mockForecast) Forecast(ctx context.Context, games []*monTypes.EnrichedGameData) {
 	m.calls++
 }
 
@@ -166,7 +166,7 @@ type mockDetector struct {
 	calls int
 }
 
-func (m *mockDetector) Detect(ctx context.Context, games []monTypes.EnrichedGameData) {
+func (m *mockDetector) Detect(ctx context.Context, games []*monTypes.EnrichedGameData) {
 	m.calls++
 }
 
@@ -174,14 +174,14 @@ type mockExtractor struct {
 	fetchErr   error
 	calls      int
 	maxSuccess int
-	games      []monTypes.EnrichedGameData
+	games      []*monTypes.EnrichedGameData
 }
 
 func (m *mockExtractor) Extract(
 	_ context.Context,
 	_ common.Hash,
 	_ uint64,
-) ([]monTypes.EnrichedGameData, error) {
+) ([]*monTypes.EnrichedGameData, error) {
 	m.calls++
 	if m.fetchErr != nil {
 		return nil, m.fetchErr


### PR DESCRIPTION
**Description**

Updates the `op-dispute-mon` components to receive and return game data pointers.

All values are read and not written to so it's safe to use pointers and less intensive than copying large game data lists into each dispute monitor component invocation.

**Metadata**

Refactored out of https://github.com/ethereum-optimism/optimism/pull/9567.

Precursor to https://github.com/ethereum-optimism/client-pod/issues/537
