### PR TITLE
feat(op-dispute-mon): Min Resolution Delay Gauge

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -20,6 +20,7 @@ type Metricer interface {
 	RecordUp()
 
 	RecordClaimResolutionDelayMax(delay float64)
+	RecordClaimResolutionDelayMin(delay float64)
 
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 	RecordGameAgreement(status string, count int)
@@ -41,6 +42,7 @@ type Metrics struct {
 	up   prometheus.Gauge
 
 	claimResolutionDelayMax prometheus.Gauge
+	claimResolutionDelayMin prometheus.Gauge
 
 	trackedGames   prometheus.GaugeVec
 	gamesAgreement prometheus.GaugeVec
@@ -79,6 +81,11 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "claim_resolution_delay_max",
 			Help:      "Maximum claim resolution delay in seconds",
+		}),
+		claimResolutionDelayMin: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "claim_resolution_delay_min",
+			Help:      "Minimum claim resolution delay in seconds",
 		}),
 		trackedGames: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -123,6 +130,10 @@ func (m *Metrics) RecordUp() {
 
 func (m *Metrics) RecordClaimResolutionDelayMax(delay float64) {
 	m.claimResolutionDelayMax.Set(delay)
+}
+
+func (m *Metrics) RecordClaimResolutionDelayMin(delay float64) {
+	m.claimResolutionDelayMin.Set(delay)
 }
 
 func (m *Metrics) Document() []opmetrics.DocumentedMetric {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -11,6 +11,7 @@ func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
 func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64) {}
+func (*NoopMetricsImpl) RecordClaimResolutionDelayMin(delay float64) {}
 
 func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}
 func (*NoopMetricsImpl) RecordGameAgreement(status string, count int)                 {}

--- a/op-dispute-mon/mon/resolution/delay.go
+++ b/op-dispute-mon/mon/resolution/delay.go
@@ -1,6 +1,8 @@
 package resolution
 
 import (
+	"math"
+
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -8,6 +10,7 @@ import (
 
 type DelayMetrics interface {
 	RecordClaimResolutionDelayMax(delay float64)
+	RecordClaimResolutionDelayMin(delay float64)
 }
 
 type DelayCalculator struct {
@@ -22,25 +25,36 @@ func NewDelayCalculator(metrics DelayMetrics, clock clock.Clock) *DelayCalculato
 	}
 }
 
-func (d *DelayCalculator) RecordClaimResolutionDelayMax(games []*monTypes.EnrichedGameData) {
+func (d *DelayCalculator) RecordResolutionDelays(games []*monTypes.EnrichedGameData) {
 	var maxDelay uint64 = 0
+	var minDelay uint64 = math.MaxUint64
 	for _, game := range games {
-		maxDelay = max(d.getMaxResolutionDelay(game), maxDelay)
+		gameMin, gameMax := d.getResolutionDelays(game)
+		maxDelay = max(gameMax, maxDelay)
+		minDelay = min(gameMin, minDelay)
 	}
 	d.metrics.RecordClaimResolutionDelayMax(float64(maxDelay))
+	d.metrics.RecordClaimResolutionDelayMin(float64(minDelay))
 }
 
-func (d *DelayCalculator) getMaxResolutionDelay(game *monTypes.EnrichedGameData) uint64 {
+func (d *DelayCalculator) getResolutionDelays(game *monTypes.EnrichedGameData) (uint64, uint64) {
 	var maxDelay uint64 = 0
+	var minDelay uint64 = math.MaxUint64
 	for _, claim := range game.Claims {
-		maxDelay = max(d.getRemainingTime(game.Duration, &claim), maxDelay)
+		// If the bond amount is the max uint128 value, the claim is resolved.
+		// Don't include it in the delay calculation.
+		if monTypes.ResolvedBondAmount.Cmp(claim.ClaimData.Bond) == 0 {
+			continue
+		}
+		remainingTime := d.getRemainingTime(game.Duration, &claim)
+		maxDelay = max(remainingTime, maxDelay)
+		minDelay = min(remainingTime, minDelay)
 	}
-	return maxDelay
+	return minDelay, maxDelay
 }
 
 func (d *DelayCalculator) getRemainingTime(maxGameDuration uint64, claim *types.Claim) uint64 {
-	// If the bond amount is the max uint128 value, the claim is resolved.
-	if monTypes.ResolvedBondAmount.Cmp(claim.ClaimData.Bond) == 0 {
+	if claim.Clock == nil {
 		return 0
 	}
 	maxChessTime := maxGameDuration / 2

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -202,7 +202,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.cl,
 		cfg.MonitorInterval,
 		cfg.GameWindow,
-		s.delays.RecordClaimResolutionDelayMax,
+		s.delays.RecordResolutionDelays,
 		s.detector.Detect,
 		s.forecast.Forecast,
 		s.extractor.Extract,


### PR DESCRIPTION
**Description**

As noted [here](https://github.com/ethereum-optimism/optimism/pull/9567#discussion_r1492857100) this pr adds the complimentary _minimum_ resolution delay gauge metric to the `op-dispute-mon` service.

If this is not desired, can be closed out.

**Tests**

Updated unit tests surrounding `DelayCalculator` methods with min delay assertions.

**Metadata**

Adds an additional metric for https://github.com/ethereum-optimism/client-pod/issues/537.
