### PR TITLE
ci: Fix testsplits causing incorrectly skipped tests

### DIFF
--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -391,10 +391,11 @@ func TestMixedDepositValidity(t *testing.T) {
 // TestMixedWithdrawalValidity makes a number of withdrawal transactions and ensures ones with modified parameters are
 // rejected while unmodified ones are accepted. This runs test cases in different systems.
 func TestMixedWithdrawalValidity(t *testing.T) {
-	InitParallel(t)
-
 	// There are 7 different fields we try modifying to cause a failure, plus one "good" test result we test.
 	for i := 0; i <= 8; i++ {
+		if i == 8 {
+			t.Skip("TODO, this test is currently broken, see issue #9586")
+		}
 		i := i // avoid loop var capture
 		t.Run(fmt.Sprintf("withdrawal test#%d", i+1), func(t *testing.T) {
 			ctx, bgCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
**Description**

Adds code to identify unintentionally skipped tests

Since test splitting was introduced it's now possible to accidentally initialize test parallelization in such a way that tests will be unconditionally skipped in CI.  In general, if `InitParallel` is called in an outer test, then again in a subtest, then the test has a high probability of being skipped.  This is because for 6 runners, if the outer test is skipped on 5 of 6 runners, then each inner test has only a 1 in 6 chance of being assigned to the same runner, otherwise it ends up being skipped.

In the TestMixedWithdrawalValidity test, only 1 of 9 test cases was actually executing in CI.

This PR also re-enables those skipped TestMixedWithdrawalValidity tests.
 
Since these tests were being skipped in CI.  And, one of these (the final green path test) is actually broken, this PR adds an explicit Skip for that test with a TODO to remove.

**Additional context**

Relates to #9586 