### PR TITLE
ci: use latest ci-builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.42.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.43.0
   base_image:
     type: string
     default: default


### PR DESCRIPTION
**Description**

Includes foundry version that compiles faster

https://github.com/ethereum-optimism/optimism/pull/9579

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
