### PR TITLE
contracts-bedrock: delete dead comments

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -25,15 +25,15 @@
   },
   "src/L1/L2OutputOracle.sol": {
     "initCodeHash": "0x14c3a582ca46ef2a6abad5590323f4de26ff4de54415c927c62e131ccbf8d9ba",
-    "sourceCodeHash": "0xad40d88dad5e371af8cd52673c1bec59c02012cc5627cfd60db32a05b3dcb029"
+    "sourceCodeHash": "0xf5fcf570721e25459fadbb37e02f9efe349e1c8afcbf1e3b5fdb09c9f612cdc0"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0x54658799b54481f56acb6481db4f37ad830a8238a8fd592c96e8b1a2b60e0627",
-    "sourceCodeHash": "0xdc27421279afb6c3b26fc8c589c5d213695f666c74d2c2c41cb7df719d172f37"
+    "sourceCodeHash": "0xf549ae16033b63e7cb3e032898a6495e1a13090dc8dd1422f7f650076ae973f8"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x718b2bc2925ca1551a98908b26237fc7dd6634f7ca35c766a42b3d7e20eecd5e",
-    "sourceCodeHash": "0x686871310ca57017c027aa414888b0d576e29d8b08691ae8eeee19ee1655d717"
+    "sourceCodeHash": "0x5941d020f7ce1f6eeab2be25bb492cd955b77c379eaed2d66880a5caaaeaf0de"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x72cd467e8bcf019c02675d72ab762e088bcc9cc0f1a4e9f587fa4589f7fdd1b8",
@@ -45,7 +45,7 @@
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0xa14bfe090e923acbacb361d9aa60e0d56fc1dff158ddbd1dc221a5380679f37f",
-    "sourceCodeHash": "0x1ad56af089f740b63d7a21f2d98b2844860f40b06b692eafb6d0f65aa61ef398"
+    "sourceCodeHash": "0x58d078f2f352ccb9001afe8245f4655b47ed0227189ede9ef56523b2193059bd"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0x2744d34573be83206d1b75d049d18a7bb37f9058e68c0803e5008c46b0dc2474",
@@ -105,7 +105,7 @@
   },
   "src/legacy/L1BlockNumber.sol": {
     "initCodeHash": "0xd586c4f93caf1753e53fcdc05eb547c1f3a69afda2904ae9f9d851b73e1c9c1d",
-    "sourceCodeHash": "0x2a42b124a918a987da60934d9059a72d4fe13dba2609b9f80146f9c8a3fc8293"
+    "sourceCodeHash": "0xed7d0d1695f28bf967626ee58debcf235204ecc5e814f53da369c94a9ed7cf0d"
   },
   "src/legacy/LegacyMessagePasser.sol": {
     "initCodeHash": "0x024ff54be1762f8946c6dc1796517bd5e622349a26a908f78a31872969f10369",

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -154,7 +154,6 @@ contract L2OutputOracle is Initializable, ISemver {
     ///         the given output index. Only the challenger address can delete outputs.
     /// @param _l2OutputIndex Index of the first L2 output to be deleted.
     ///                       All outputs after this output will also be deleted.
-    // solhint-disable-next-line ordering
     function deleteL2Outputs(uint256 _l2OutputIndex) external {
         require(msg.sender == challenger, "L2OutputOracle: only the challenger address can delete outputs");
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -177,7 +177,6 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     ///         funds be deposited to their address on L2. This is intended as a convenience
     ///         function for EOAs. Contracts should call the depositTransaction() function directly
     ///         otherwise any deposited funds will be lost due to address aliasing.
-    // solhint-disable-next-line ordering
     receive() external payable {
         depositTransaction(msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, false, bytes(""));
     }

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -212,7 +212,6 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     ///         funds be deposited to their address on L2. This is intended as a convenience
     ///         function for EOAs. Contracts should call the depositTransaction() function directly
     ///         otherwise any deposited funds will be lost due to address aliasing.
-    // solhint-disable-next-line ordering
     receive() external payable {
         depositTransaction(msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, false, bytes(""));
     }

--- a/packages/contracts-bedrock/src/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/src/L1/ResourceMetering.sol
@@ -153,7 +153,6 @@ abstract contract ResourceMetering is Initializable {
     /// @notice Sets initial resource parameter values.
     ///         This function must either be called by the initializer function of an upgradeable
     ///         child contract.
-    // solhint-disable-next-line func-name-mixedcase
     function __ResourceMetering_init() internal onlyInitializing {
         if (params.prevBlockNum == 0) {
             params = ResourceParams({ prevBaseFee: 1 gwei, prevBoughtGas: 0, prevBlockNum: uint64(block.number) });

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -201,7 +201,6 @@ contract SystemConfig is OwnableUpgradeable, ISemver {
     ///         Unsafe blocks can be propagated across the p2p network if they are signed by the
     ///         key corresponding to this address.
     /// @return addr_ Address of the unsafe block signer.
-    // solhint-disable-next-line ordering
     function unsafeBlockSigner() public view returns (address addr_) {
         addr_ = Storage.getAddress(UNSAFE_BLOCK_SIGNER_SLOT);
     }

--- a/packages/contracts-bedrock/src/Safe/SafeSigners.sol
+++ b/packages/contracts-bedrock/src/Safe/SafeSigners.sol
@@ -22,7 +22,6 @@ library SafeSigners {
         pure
         returns (uint8 v, bytes32 r, bytes32 s)
     {
-        // solhint-disable-next-line no-inline-assembly
         assembly {
             let signaturePos := mul(0x41, pos)
             r := mload(add(signatures, add(signaturePos, 0x20)))

--- a/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
+++ b/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
@@ -28,7 +28,6 @@ contract L1BlockNumber is ISemver {
     }
 
     /// @notice Returns the L1 block number.
-    // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
         uint256 l1BlockNumber = getL1BlockNumber();
         assembly {

--- a/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
@@ -30,7 +30,6 @@ contract ResolvedDelegateProxy {
     }
 
     /// @notice Fallback, performs a delegatecall to the resolved implementation address.
-    // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
         address target = addressManager[address(this)].getAddress((implementationName[address(this)]));
 

--- a/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
+++ b/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
@@ -248,7 +248,6 @@ library RLPReader {
         }
 
         // Mostly based on Solidity's copy_memory_to_memory:
-        // solhint-disable max-line-length
         // https://github.com/ethereum/solidity/blob/34dd30d71b4da730488be72ff6af7083cf2a91f6/libsolidity/codegen/YulUtilFunctions.cpp#L102-L114
         uint256 src = MemoryPointer.unwrap(_src) + _offset;
         assembly {

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -360,7 +360,6 @@ abstract contract CrossDomainMessenger is
 
     /// @notice Initializer.
     /// @param _otherMessenger CrossDomainMessenger contract on the other chain.
-    // solhint-disable-next-line func-name-mixedcase
     function __CrossDomainMessenger_init(CrossDomainMessenger _otherMessenger) internal onlyInitializing {
         // We only want to set the xDomainMsgSender to the default value if it hasn't been initialized yet,
         // meaning that this is a fresh contract deployment.

--- a/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
@@ -69,7 +69,6 @@ abstract contract ERC721Bridge is Initializable {
     /// @notice Initializer.
     /// @param _messenger   Contract of the CrossDomainMessenger on this network.
     /// @param _otherBridge Contract of the ERC721 bridge on the other network.
-    // solhint-disable-next-line func-name-mixedcase
     function __ERC721Bridge_init(
         CrossDomainMessenger _messenger,
         StandardBridge _otherBridge

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -114,7 +114,6 @@ abstract contract StandardBridge is Initializable {
     /// @notice Initializer.
     /// @param _messenger   Contract for CrossDomainMessenger on this network.
     /// @param _otherBridge Contract for the other StandardBridge contract.
-    // solhint-disable-next-line func-name-mixedcase
     function __StandardBridge_init(
         CrossDomainMessenger _messenger,
         StandardBridge _otherBridge

--- a/packages/contracts-bedrock/test/safe-tools/CompatibilityFallbackHandler_1_3_0.sol
+++ b/packages/contracts-bedrock/test/safe-tools/CompatibilityFallbackHandler_1_3_0.sol
@@ -162,7 +162,6 @@ contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValid
         targetContract;
         calldataPayload;
 
-        // solhint-disable-next-line no-inline-assembly
         assembly {
             let internalCalldata := mload(0x40)
             // Store `simulateAndRevert.selector`.


### PR DESCRIPTION
**Description**

This commit removes all of the solhint-ignore comments.
solhint has not been used by this repository for quite
some time so there is no reason to keep these comments
around.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

