### PR TITLE
Some improvements to the code

### DIFF
--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -10,7 +10,8 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum-optimism/optimism/op-node"
+
+	opnode "github.com/ethereum-optimism/optimism/op-node"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
 	"github.com/ethereum-optimism/optimism/op-node/cmd/networks"
@@ -19,8 +20,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/version"
-	"github.com/ethereum-optimism/optimism/op-service"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/metrics/doc"
 	"github.com/ethereum-optimism/optimism/op-service/opio"
 )


### PR DESCRIPTION
Group related imports together for better readability. Use log.Fatal instead of log.Crit to terminate the program immediately after logging the error message. Use errors.Wrap to provide more context to the error messages. Use logrus for logging instead of oplog for better performance and flexibility.
