### PR TITLE
op-e2e: Always run subtests on the parent executor.

### DIFF
--- a/op-e2e/e2eutils/wait/withdrawals.go
+++ b/op-e2e/e2eutils/wait/withdrawals.go
@@ -20,6 +20,8 @@ import (
 // This function polls and can block for a very long time if used on mainnet.
 // This returns the block number to use for proof generation.
 func ForOutputRootPublished(ctx context.Context, client *ethclient.Client, l2OutputOracleAddr common.Address, l2BlockNumber *big.Int) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
 	l2BlockNumber = new(big.Int).Set(l2BlockNumber) // Don't clobber caller owned l2BlockNumber
 	opts := &bind.CallOpts{Context: ctx}
 
@@ -76,6 +78,8 @@ func ForFinalizationPeriod(ctx context.Context, client *ethclient.Client, l1Prov
 
 // ForGamePublished waits until a game is published on L1 for the given l2BlockNumber.
 func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPortalAddr common.Address, disputeGameFactoryAddr common.Address, l2BlockNumber *big.Int) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
 	l2BlockNumber = new(big.Int).Set(l2BlockNumber) // Don't clobber caller owned l2BlockNumber
 
 	optimismPortal2Contract, err := bindingspreview.NewOptimismPortal2Caller(optimismPortalAddr, client)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -101,6 +101,7 @@ func TestOutputCannon_ChallengeAllZeroClaim(t *testing.T) {
 }
 
 func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	tests := []struct {
 		disputeL2BlockNumber uint64
 	}{
@@ -129,6 +130,7 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 }
 
 func TestOutputCannonDisputeGame(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	tests := []struct {
 		name             string
 		defendClaimDepth types.Depth
@@ -254,6 +256,7 @@ func TestOutputCannonStepWithLargePreimage(t *testing.T) {
 }
 
 func TestOutputCannonStepWithPreimage(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	testPreimageStep := func(t *testing.T, preimageType cannon.PreimageOpt, preloadPreimage bool) {
 		op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
@@ -296,6 +299,7 @@ func TestOutputCannonStepWithPreimage(t *testing.T) {
 
 func TestOutputCannonStepWithKZGPointEvaluation(t *testing.T) {
 	t.Skip("TODO: Fix flaky test")
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	testPreimageStep := func(t *testing.T, preloadPreimage bool) {
 		op_e2e.InitParallel(t, op_e2e.UsesCannon)
@@ -337,6 +341,7 @@ func TestOutputCannonStepWithKZGPointEvaluation(t *testing.T) {
 }
 
 func TestOutputCannonProposedOutputRootValid(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
 	honestStepsFail := func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
 		// Attack step should fail

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestPrecompiles(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	// precompile test vectors copied from go-ethereum
 	tests := []struct {
 		name    string

--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 )
@@ -20,6 +21,21 @@ func InitParallel(t e2eutils.TestingBase, args ...func(t e2eutils.TestingBase, o
 		t.Parallel()
 	}
 
+	autoAllocateExecutor(t, args)
+}
+
+// isSubTest determines if the test is a sub-test or top level test.
+// It does this by checking if the test name contains /
+// This is not a particularly great way check, but appears to be the only option currently.
+func isSubTest(t e2eutils.TestingBase) bool {
+	return strings.Contains(t.Name(), "/")
+}
+
+func autoAllocateExecutor(t e2eutils.TestingBase, args []func(t e2eutils.TestingBase, opts *testopts)) {
+	if isSubTest(t) {
+		// Always run subtests, they only start on the same executor as their parent.
+		return
+	}
 	info := getExecutorInfo(t)
 	tName := t.Name()
 	tHash := md5.Sum([]byte(tName))

--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -546,7 +546,6 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 			transactor.ExpectedL2Nonce = transactor.ExpectedL2Nonce + 1
 
 			// Wait for the finalization period, then we can finalize this withdrawal.
-			ctx, withdrawalCancel := context.WithTimeout(context.Background(), 60*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 			require.NotEqual(t, cfg.L1Deployments.L2OutputOracleProxy, common.Address{})
 			var blockNumber uint64
 			if e2eutils.UseFPAC() {
@@ -554,12 +553,9 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 			} else {
 				blockNumber, err = wait.ForOutputRootPublished(ctx, l1Client, cfg.L1Deployments.L2OutputOracleProxy, receipt.BlockNumber)
 			}
-			withdrawalCancel()
 			require.Nil(t, err)
 
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			header, err = l2Verif.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
-			txCancel()
 			require.Nil(t, err)
 
 			rpcClient, err := rpc.Dial(sys.EthInstances["verifier"].WSEndpoint())
@@ -662,9 +658,7 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 				require.Nil(t, err, "finalize withdrawal")
 
 				// Verify balance after withdrawal
-				ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 				header, err = l1Client.HeaderByNumber(ctx, receipt.BlockNumber)
-				txCancel()
 				require.Nil(t, err)
 
 				// Ensure that withdrawal - gas fees are added to the L1 balance
@@ -700,39 +694,27 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 			// At the end, assert our account balance/nonce states.
 
 			// Obtain the L2 sequencer account balance
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			endL1Balance, err := l1Client.BalanceAt(ctx, transactor.Account.L1Opts.From, nil)
-			txCancel()
 			require.NoError(t, err)
 
 			// Obtain the L1 account nonce
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			endL1Nonce, err := l1Client.NonceAt(ctx, transactor.Account.L1Opts.From, nil)
-			txCancel()
 			require.NoError(t, err)
 
 			// Obtain the L2 sequencer account balance
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			endL2SeqBalance, err := l2Seq.BalanceAt(ctx, transactor.Account.L1Opts.From, nil)
-			txCancel()
 			require.NoError(t, err)
 
 			// Obtain the L2 sequencer account nonce
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			endL2SeqNonce, err := l2Seq.NonceAt(ctx, transactor.Account.L1Opts.From, nil)
-			txCancel()
 			require.NoError(t, err)
 
 			// Obtain the L2 verifier account balance
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			endL2VerifBalance, err := l2Verif.BalanceAt(ctx, transactor.Account.L1Opts.From, nil)
-			txCancel()
 			require.NoError(t, err)
 
 			// Obtain the L2 verifier account nonce
-			ctx, txCancel = context.WithTimeout(context.Background(), txTimeoutDuration)
 			endL2VerifNonce, err := l2Verif.NonceAt(ctx, transactor.Account.L1Opts.From, nil)
-			txCancel()
 			require.NoError(t, err)
 
 			// TODO: Check L1 balance as well here. We avoided this due to time constraints as it seems L1 fees


### PR DESCRIPTION
**Description**

Only spread top level tests across executors. If subtests are invoked, it's because their parent has been allocated to this executor. They must run now as they won't even get invoked on other executors.

Also fixes TestMixedWithdrawalValidity which wasn't running all cases in CI but not using an already cancelled context and starting a challenger to ensure dispute games are resolved so withdrawals can be completed.

**Metadata**

- fixes https://github.com/ethereum-optimism/optimism/issues/9586
