### PR TITLE
ci: Only run develop-fault-proofs on commits to develop, not scheduled triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2010,7 +2010,10 @@ workflows:
 
   develop-fault-proofs:
     when:
-      equal: [ "develop", <<pipeline.git.branch>> ]
+      and:
+        - equal: [ "develop", <<pipeline.git.branch>> ]
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - go-mod-download
       - cannon-prestate:


### PR DESCRIPTION
**Description**

Run the `develop-fault-proofs` job on each commit to develop as we currently do, but stop running it on every scheduled run.  Currently it runs about every hour in addition to on every commit to develop.
