### PR TITLE
refactor: cast type instead of doing two runtime conversions

### DIFF
--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -42,7 +42,7 @@ func CheckL1(ctx context.Context, list *superchain.ImplementationList, backend b
 // CheckVersionedContract will check that the version of the deployed contract matches
 // the artifact in the superchain registry.
 func CheckVersionedContract(ctx context.Context, contract superchain.VersionedContract, backend bind.ContractBackend) error {
-	addr := common.HexToAddress(contract.Address.String())
+	addr := common.Address(contract.Address)
 	code, err := backend.CodeAt(ctx, addr, nil)
 	if err != nil {
 		return err
@@ -65,31 +65,31 @@ func GetContractVersions(ctx context.Context, addresses *superchain.AddressList,
 	var versions superchain.ContractVersions
 	var err error
 
-	versions.L1CrossDomainMessenger, err = getVersion(ctx, common.HexToAddress(addresses.L1CrossDomainMessengerProxy.String()), backend)
+	versions.L1CrossDomainMessenger, err = getVersion(ctx, common.Address(addresses.L1CrossDomainMessengerProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("L1CrossDomainMessenger: %w", err)
 	}
-	versions.L1ERC721Bridge, err = getVersion(ctx, common.HexToAddress(addresses.L1ERC721BridgeProxy.String()), backend)
+	versions.L1ERC721Bridge, err = getVersion(ctx, common.Address(addresses.L1ERC721BridgeProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("L1ERC721Bridge: %w", err)
 	}
-	versions.L1StandardBridge, err = getVersion(ctx, common.HexToAddress(addresses.L1StandardBridgeProxy.String()), backend)
+	versions.L1StandardBridge, err = getVersion(ctx, common.Address(addresses.L1StandardBridgeProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("L1StandardBridge: %w", err)
 	}
-	versions.L2OutputOracle, err = getVersion(ctx, common.HexToAddress(addresses.L2OutputOracleProxy.String()), backend)
+	versions.L2OutputOracle, err = getVersion(ctx, common.Address(addresses.L2OutputOracleProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("L2OutputOracle: %w", err)
 	}
-	versions.OptimismMintableERC20Factory, err = getVersion(ctx, common.HexToAddress(addresses.OptimismMintableERC20FactoryProxy.String()), backend)
+	versions.OptimismMintableERC20Factory, err = getVersion(ctx, common.Address(addresses.OptimismMintableERC20FactoryProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("OptimismMintableERC20Factory: %w", err)
 	}
-	versions.OptimismPortal, err = getVersion(ctx, common.HexToAddress(addresses.OptimismPortalProxy.String()), backend)
+	versions.OptimismPortal, err = getVersion(ctx, common.Address(addresses.OptimismPortalProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("OptimismPortal: %w", err)
 	}
-	versions.SystemConfig, err = getVersion(ctx, common.HexToAddress(chainConfig.SystemConfigAddr.String()), backend)
+	versions.SystemConfig, err = getVersion(ctx, common.Address(chainConfig.SystemConfigAddr), backend)
 	if err != nil {
 		return versions, fmt.Errorf("SystemConfig: %w", err)
 	}

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -86,11 +86,11 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 			return err
 		}
 		args := []any{
-			common.HexToAddress(list.L1CrossDomainMessengerProxy.String()),
+			common.Address(list.L1CrossDomainMessengerProxy),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 		return err
 	}
 
-	l1CrossDomainMessenger, err := bindings.NewL1CrossDomainMessengerCaller(common.HexToAddress(list.L1CrossDomainMessengerProxy.String()), backend)
+	l1CrossDomainMessenger, err := bindings.NewL1CrossDomainMessengerCaller(common.Address(list.L1CrossDomainMessengerProxy), backend)
 	if err != nil {
 		return err
 	}
@@ -128,12 +128,12 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 	}
 
 	args := []any{
-		common.HexToAddress(list.L1CrossDomainMessengerProxy.String()),
-		common.HexToAddress(implementations.L1CrossDomainMessenger.Address.String()),
+		common.Address(list.L1CrossDomainMessengerProxy),
+		common.Address(implementations.L1CrossDomainMessenger.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}
@@ -168,11 +168,11 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 			return fmt.Errorf("setBytes32: %w", err)
 		}
 		args := []any{
-			common.HexToAddress(list.L1ERC721BridgeProxy.String()),
+			common.Address(list.L1ERC721BridgeProxy),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	l1ERC721Bridge, err := bindings.NewL1ERC721BridgeCaller(common.HexToAddress(list.L1ERC721BridgeProxy.String()), backend)
+	l1ERC721Bridge, err := bindings.NewL1ERC721BridgeCaller(common.Address(list.L1ERC721BridgeProxy), backend)
 	if err != nil {
 		return err
 	}
@@ -210,12 +210,12 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 	}
 
 	args := []any{
-		common.HexToAddress(list.L1ERC721BridgeProxy.String()),
-		common.HexToAddress(implementations.L1ERC721Bridge.Address.String()),
+		common.Address(list.L1ERC721BridgeProxy),
+		common.Address(implementations.L1ERC721Bridge.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}
@@ -250,11 +250,11 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 			return err
 		}
 		args := []any{
-			common.HexToAddress(list.L1StandardBridgeProxy.String()),
+			common.Address(list.L1StandardBridgeProxy),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 		return err
 	}
 
-	l1StandardBridge, err := bindings.NewL1StandardBridgeCaller(common.HexToAddress(list.L1StandardBridgeProxy.String()), backend)
+	l1StandardBridge, err := bindings.NewL1StandardBridgeCaller(common.Address(list.L1StandardBridgeProxy), backend)
 	if err != nil {
 		return err
 	}
@@ -294,12 +294,12 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 	}
 
 	args := []any{
-		common.HexToAddress(list.L1StandardBridgeProxy.String()),
-		common.HexToAddress(implementations.L1StandardBridge.Address.String()),
+		common.Address(list.L1StandardBridgeProxy),
+		common.Address(implementations.L1StandardBridge.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}
@@ -334,11 +334,11 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 			return err
 		}
 		args := []any{
-			common.HexToAddress(list.L2OutputOracleProxy.String()),
+			common.Address(list.L2OutputOracleProxy),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -349,7 +349,7 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	l2OutputOracle, err := bindings.NewL2OutputOracleCaller(common.HexToAddress(list.L2OutputOracleProxy.String()), backend)
+	l2OutputOracle, err := bindings.NewL2OutputOracleCaller(common.Address(list.L2OutputOracleProxy), backend)
 	if err != nil {
 		return err
 	}
@@ -438,12 +438,12 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 	}
 
 	args := []any{
-		common.HexToAddress(list.L2OutputOracleProxy.String()),
-		common.HexToAddress(implementations.L2OutputOracle.Address.String()),
+		common.Address(list.L2OutputOracleProxy),
+		common.Address(implementations.L2OutputOracle.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}
@@ -478,11 +478,11 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 			return err
 		}
 		args := []any{
-			common.HexToAddress(list.OptimismMintableERC20FactoryProxy.String()),
+			common.Address(list.OptimismMintableERC20FactoryProxy),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -493,7 +493,7 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 		return err
 	}
 
-	optimismMintableERC20Factory, err := bindings.NewOptimismMintableERC20FactoryCaller(common.HexToAddress(list.OptimismMintableERC20FactoryProxy.String()), backend)
+	optimismMintableERC20Factory, err := bindings.NewOptimismMintableERC20FactoryCaller(common.Address(list.OptimismMintableERC20FactoryProxy), backend)
 	if err != nil {
 		return err
 	}
@@ -513,12 +513,12 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 	}
 
 	args := []any{
-		common.HexToAddress(list.OptimismMintableERC20FactoryProxy.String()),
-		common.HexToAddress(implementations.OptimismMintableERC20Factory.Address.String()),
+		common.Address(list.OptimismMintableERC20FactoryProxy),
+		common.Address(implementations.OptimismMintableERC20Factory.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}
@@ -553,11 +553,11 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 			return err
 		}
 		args := []any{
-			common.HexToAddress(list.OptimismPortalProxy.String()),
+			common.Address(list.OptimismPortalProxy),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -568,7 +568,7 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	optimismPortal, err := bindings.NewOptimismPortalCaller(common.HexToAddress(list.OptimismPortalProxy.String()), backend)
+	optimismPortal, err := bindings.NewOptimismPortalCaller(common.Address(list.OptimismPortalProxy), backend)
 	if err != nil {
 		return err
 	}
@@ -581,11 +581,11 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	if l2OutputOracle != common.HexToAddress(list.L2OutputOracleProxy.String()) {
+	if l2OutputOracle != common.Address(list.L2OutputOracleProxy) {
 		return fmt.Errorf("L2OutputOracle address doesn't match config")
 	}
 
-	if systemConfig != common.HexToAddress(chainConfig.SystemConfigAddr.String()) {
+	if systemConfig != common.Address(chainConfig.SystemConfigAddr) {
 		return fmt.Errorf("SystemConfig address doesn't match config")
 	}
 
@@ -595,12 +595,12 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 	}
 
 	args := []any{
-		common.HexToAddress(list.OptimismPortalProxy.String()),
-		common.HexToAddress(implementations.OptimismPortal.Address.String()),
+		common.Address(list.OptimismPortalProxy),
+		common.Address(implementations.OptimismPortal.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}
@@ -646,11 +646,11 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 			return err
 		}
 		args := []any{
-			common.HexToAddress(chainConfig.SystemConfigAddr.String()),
+			common.Address(chainConfig.SystemConfigAddr),
 			storageSetterAddr,
 			calldata,
 		}
-		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		proxyAdmin := common.Address(list.ProxyAdmin)
 		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
@@ -661,7 +661,7 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		return err
 	}
 
-	systemConfig, err := bindings.NewSystemConfigCaller(common.HexToAddress(chainConfig.SystemConfigAddr.String()), backend)
+	systemConfig, err := bindings.NewSystemConfigCaller(common.Address(chainConfig.SystemConfigAddr), backend)
 	if err != nil {
 		return err
 	}
@@ -763,12 +763,12 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 	}
 
 	args := []any{
-		common.HexToAddress(chainConfig.SystemConfigAddr.String()),
-		common.HexToAddress(implementations.SystemConfig.Address.String()),
+		common.Address(chainConfig.SystemConfigAddr),
+		common.Address(implementations.SystemConfig.Address),
 		calldata,
 	}
 
-	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+	proxyAdmin := common.Address(list.ProxyAdmin)
 	if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Find: `common.HexToAddress\((.*)\.String\(\)\)`
Replace: `common.Address($1)`

This:
* improves readability
* cuts some runtime code (which copies bytes around, and does some encoding) in favour of type casting

Excluding some cases where `common.HexToAddress("0xhexliteral").String()` is used to get a checksum formatted string. 

**Tests**

Existing suite. 
