### PR TITLE
op-node: Add optional Beacon header flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -50,6 +50,12 @@ var (
 		Required: false,
 		EnvVars:  prefixEnvVars("L1_BEACON"),
 	}
+	BeaconHeader = &cli.StringFlag{
+		Name:     "l1.beacon-header",
+		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
+		Required: false,
+		EnvVars:  prefixEnvVars("L1_BEACON_HEADER"),
+	}
 	BeaconArchiverAddr = &cli.StringFlag{
 		Name:     "l1.beacon-archiver",
 		Usage:    "Address of L1 Beacon-node compatible HTTP endpoint to use. This is used to fetch blobs that the --l1.beacon does not have (i.e expired blobs).",
@@ -298,6 +304,7 @@ var requiredFlags = []cli.Flag{
 
 var optionalFlags = []cli.Flag{
 	BeaconAddr,
+	BeaconHeader,
 	BeaconArchiverAddr,
 	BeaconCheckIgnore,
 	BeaconFetchAllSidecars,

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -177,6 +179,7 @@ func (cfg *PreparedL1Endpoint) Check() error {
 
 type L1BeaconEndpointConfig struct {
 	BeaconAddr             string // Address of L1 User Beacon-API endpoint to use (beacon namespace required)
+	BeaconHeader           string // Optional HTTP header for all requests to L1 Beacon
 	BeaconArchiverAddr     string // Address of L1 User Beacon-API Archive endpoint to use for expired blobs (beacon namespace required)
 	BeaconCheckIgnore      bool   // When false, halt startup if the beacon version endpoint fails
 	BeaconFetchAllSidecars bool   // Whether to fetch all blob sidecars and filter locally
@@ -185,7 +188,16 @@ type L1BeaconEndpointConfig struct {
 var _ L1BeaconEndpointSetup = (*L1BeaconEndpointConfig)(nil)
 
 func (cfg *L1BeaconEndpointConfig) Setup(ctx context.Context, log log.Logger) (cl sources.BeaconClient, fb []sources.BlobSideCarsFetcher, err error) {
-	a := client.NewBasicHTTPClient(cfg.BeaconAddr, log)
+	var opts []client.BasicHTTPClientOption
+	if cfg.BeaconHeader != "" {
+		hdr, err := parseHTTPHeader(cfg.BeaconHeader)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing beacon header: %w", err)
+		}
+		opts = append(opts, client.WithHeader(hdr))
+	}
+
+	a := client.NewBasicHTTPClient(cfg.BeaconAddr, log, opts...)
 	if cfg.BeaconArchiverAddr != "" {
 		b := client.NewBasicHTTPClient(cfg.BeaconArchiverAddr, log)
 		fb = append(fb, sources.NewBeaconHTTPClient(b))
@@ -206,4 +218,14 @@ func (cfg *L1BeaconEndpointConfig) ShouldIgnoreBeaconCheck() bool {
 
 func (cfg *L1BeaconEndpointConfig) ShouldFetchAllSidecars() bool {
 	return cfg.BeaconFetchAllSidecars
+}
+
+func parseHTTPHeader(headerStr string) (http.Header, error) {
+	h := make(http.Header, 1)
+	s := strings.SplitN(headerStr, ": ", 2)
+	if len(s) != 2 {
+		return nil, errors.New("invalid header format")
+	}
+	h.Add(s[0], s[1])
+	return h, nil
 }

--- a/op-node/node/client_test.go
+++ b/op-node/node/client_test.go
@@ -1,0 +1,62 @@
+package node
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHTTPHeader(t *testing.T) {
+	for _, test := range []struct {
+		desc   string
+		str    string
+		expHdr http.Header
+		expErr bool
+	}{
+		{
+			desc:   "err-empty",
+			expErr: true,
+		},
+		{
+			desc:   "err-no-colon",
+			str:    "Key",
+			expErr: true,
+		},
+		{
+			desc:   "err-only-key",
+			str:    "Key:",
+			expErr: true,
+		},
+		{
+			desc:   "err-no-space",
+			str:    "Key:value",
+			expErr: true,
+		},
+		{
+			desc:   "valid",
+			str:    "Key: value",
+			expHdr: http.Header{"Key": []string{"value"}},
+		},
+		{
+			desc:   "valid-small",
+			str:    "key: value",
+			expHdr: http.Header{"Key": []string{"value"}},
+		},
+		{
+			desc:   "valid-spaces-colons",
+			str:    "X-Key: a long value with spaces: and: colons",
+			expHdr: http.Header{"X-Key": []string{"a long value with spaces: and: colons"}},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			h, err := parseHTTPHeader(test.str)
+			if test.expErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expHdr, h)
+			}
+		})
+	}
+}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -130,6 +130,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 func NewBeaconEndpointConfig(ctx *cli.Context) node.L1BeaconEndpointSetup {
 	return &node.L1BeaconEndpointConfig{
 		BeaconAddr:             ctx.String(flags.BeaconAddr.Name),
+		BeaconHeader:           ctx.String(flags.BeaconHeader.Name),
 		BeaconArchiverAddr:     ctx.String(flags.BeaconArchiverAddr.Name),
 		BeaconCheckIgnore:      ctx.Bool(flags.BeaconCheckIgnore.Name),
 		BeaconFetchAllSidecars: ctx.Bool(flags.BeaconFetchAllSidecars.Name),

--- a/op-service/client/http_test.go
+++ b/op-service/client/http_test.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"golang.org/x/exp/slog"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicHTTPClient(t *testing.T) {
+	called := make(chan *http.Request, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		called <- r
+	}))
+	defer ts.Close()
+
+	// generate deep clones
+	mkhdr := func() http.Header {
+		return http.Header{
+			"Foo":        []string{"bar", "baz"},
+			"Superchain": []string{"op"},
+		}
+	}
+	opt := WithHeader(mkhdr())
+	c := NewBasicHTTPClient(ts.URL, testlog.Logger(t, slog.LevelInfo), opt)
+
+	const ep = "/api/version"
+	query := url.Values{
+		"key": []string{"123"},
+	}
+	getheader := http.Header{
+		"Fruits":     []string{"apple"},
+		"Superchain": []string{"base"},
+	}
+	resp, err := c.Get(context.Background(), ep, query, getheader)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	req := <-called
+	require.Equal(t, ep, req.URL.Path)
+	require.Equal(t, query, req.URL.Query())
+	require.ElementsMatch(t, req.Header.Values("Foo"), mkhdr()["Foo"])
+	require.ElementsMatch(t, req.Header.Values("Fruits"), getheader["Fruits"])
+	require.ElementsMatch(t, req.Header.Values("Superchain"), []string{"op", "base"})
+}
+
+func TestAddHTTPHeaders(t *testing.T) {
+	for _, test := range []struct {
+		desc      string
+		expheader http.Header
+		headers   []http.Header
+	}{
+		{
+			desc:      "all-empty",
+			expheader: http.Header{},
+			headers:   nil,
+		},
+		{
+			desc:      "1-header-and-nils",
+			expheader: http.Header{"Foo": []string{"bar"}},
+			headers: []http.Header{
+				nil,
+				{"Foo": []string{"bar"}},
+				nil,
+			},
+		},
+		{
+			desc: "2-headers",
+			expheader: http.Header{
+				"Foo":   []string{"bar", "baz"},
+				"Super": []string{"chain"},
+				"Fruit": []string{"apple"},
+			},
+			headers: []http.Header{
+				{
+					"Foo":   []string{"bar"},
+					"Super": []string{"chain"},
+				},
+				{
+					"Foo":   []string{"baz"},
+					"Fruit": []string{"apple"},
+				},
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			h := make(http.Header)
+			addHTTPHeaders(h, test.headers...)
+			require.Equal(t, test.expheader, h)
+		})
+	}
+}


### PR DESCRIPTION

**Description**

Adds optional Beacon header flag. Useful for authentication with Beacon endpoint.

**Tests**

Added test of http header parsing.

**Additional context**

Follow-up to #9601.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/600
