### PR TITLE
feat(interop): superchain backend

### DIFF
--- a/op-service/rpc/service.go
+++ b/op-service/rpc/service.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Service struct {
+	log     log.Logger
+	srv     *Server
+	stopped atomic.Bool
+}
+
+func NewService(log log.Logger, srv *Server) *Service {
+	return &Service{log: log, srv: srv, stopped: atomic.Bool{}}
+}
+
+func (s *Service) Start(_ context.Context) error {
+	log.Info("starting rpc server")
+	return s.srv.Start()
+}
+
+func (s *Service) Stop(_ context.Context) error {
+	if s.stopped.Load() {
+		return nil
+	}
+
+	log.Info("stopping rpc server")
+	err := s.srv.Stop()
+	if err == nil {
+		s.stopped.Store(true)
+	}
+
+	return err
+}
+
+func (s *Service) Stopped() bool {
+	return s.stopped.Load()
+}

--- a/op-service/rpc/service.go
+++ b/op-service/rpc/service.go
@@ -18,7 +18,7 @@ func NewService(log log.Logger, srv *Server) *Service {
 }
 
 func (s *Service) Start(_ context.Context) error {
-	log.Info("starting rpc server")
+	s.log.Info("starting rpc server")
 	return s.srv.Start()
 }
 
@@ -27,7 +27,7 @@ func (s *Service) Stop(_ context.Context) error {
 		return nil
 	}
 
-	log.Info("stopping rpc server")
+	s.log.Info("stopping rpc server")
 	err := s.srv.Stop()
 	if err == nil {
 		s.stopped.Store(true)

--- a/op-service/solabi/util.go
+++ b/op-service/solabi/util.go
@@ -82,6 +82,21 @@ func ReadUint256(r io.Reader) (*big.Int, error) {
 	return new(big.Int).SetBytes(n[:]), nil
 }
 
+func ReadBytes(r io.Reader) ([]byte, error) {
+	byteLen, err := ReadUint64(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read byte length")
+	}
+
+	paddedByteLength := byteLen + (32 - (byteLen % 32))
+	n := make([]byte, paddedByteLength)
+	if _, err := io.ReadFull(r, n[:]); err != nil {
+		return nil, err
+	}
+
+	return n[:byteLen], nil
+}
+
 func EmptyReader(r io.Reader) bool {
 	var t [1]byte
 	n, err := r.Read(t[:])

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -96,7 +96,8 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	// ChainID Invariant.
 	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
 	//   When the predeploy is added, this needs to be tied to the dependency set registered on-chain
-	l2Node, ok := b.l2PeerNodes[id.ChainId]
+	//   TODO: Either assume chain id never exceeds uint64 or handle this appropriately
+	l2Node, ok := b.l2PeerNodes[id.ChainId.Uint64()]
 	if !ok {
 		return Invalid, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
 	}
@@ -107,7 +108,7 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	// Since eth_getLogs doesn't support specifying the log index, we fetch
 	// all the outbox reciepts for this block (TODO: add address filter). The
 	// timestamp is grabbed via the block header as getLogs omits this
-	blockNumber := hexutil.EncodeUint64(id.BlockNumber)
+	blockNumber := hexutil.EncodeBig(id.BlockNumber)
 	filterArgs := map[string]interface{}{"fromBlock": blockNumber, "toBlock": blockNumber}
 	batchElems := make([]rpc.BatchElem, 2)
 	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockNumber, false}, Result: &header}

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type SuperchainBackend interface {
+type Backend interface {
 	MessageSafety(context.Context, MessageIdentifier, hexutil.Bytes) (MessageSafetyLabel, error)
 }
 
@@ -32,7 +31,7 @@ type backend struct {
 	l2PeerNodes map[uint64]client.RPC
 }
 
-func NewSuperchainBackend(ctx context.Context, log log.Logger, m metrics.Factory, cfg *SuperchainConfig) (SuperchainBackend, error) {
+func NewBackend(ctx context.Context, log log.Logger, m metrics.Factory, cfg *Config) (Backend, error) {
 	log = log.New("module", "superchain")
 	backend := backend{log: log, l2PeerNodes: map[uint64]client.RPC{}}
 
@@ -50,48 +49,31 @@ func NewSuperchainBackend(ctx context.Context, log log.Logger, m metrics.Factory
 		backend.l2PeerNodes[chainId] = l2Node
 	}
 
-	/** eth.PollBlockChanges expects an L1BlocksRefSources so we'll use this tooling for now **/
-	cacheMetrics := metrics.NewCacheMetrics(m, "superchain", "l2_source_cache", "L2 Source Cache")
-	l2ClientConfig := sources.L1ClientConfig{
-		L1BlockRefsCacheSize: 10,
-		EthClientConfig: sources.EthClientConfig{
-			TrustRPC:              true,
-			MaxConcurrentRequests: 10,
-			MaxRequestsPerBatch:   10,
-			TransactionsCacheSize: 10,
-			HeadersCacheSize:      10,
-			PayloadsCacheSize:     10,
-			RPCProviderKind:       sources.RPCKindAny,
-			MethodResetDuration:   time.Minute,
-		},
-	}
-
-	l2Client, err := sources.NewL1Client(l2Node, log, cacheMetrics, &l2ClientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct l2 client: %w", err)
-	}
-
 	// retrieve the current references before setting up the poll
-	finalizedHeadRef, err := l2Client.L1BlockRefByLabel(ctx, eth.Finalized)
+	l2BlockRefsClient := &blockRefsClient{l2Node}
+	finalizedHeadRef, err := l2BlockRefsClient.L1BlockRefByLabel(ctx, eth.Finalized)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query finalized block ref: %w", err)
 	}
 
 	backend.l2FinalizedBlockRef = &finalizedHeadRef
+	log.Info("detected finalized head", "number", finalizedHeadRef.Number, "hash", finalizedHeadRef.Hash)
+
 	l2FinalizedHeadSignal := func(ctx context.Context, sig eth.L1BlockRef) {
+		log.Info("new finalized head", "number", sig.Number, "hash", sig.Hash)
 		backend.mu.Lock()
 		backend.l2FinalizedBlockRef = &sig
 		backend.mu.Unlock()
 	}
 
-	pollInterval, timeout := time.Second*12*32, time.Second*10
-	backend.l2FinalizedHeadSub = eth.PollBlockChanges(log, l2Client, l2FinalizedHeadSignal, eth.Finalized, pollInterval, timeout)
+	pollInterval, timeout := time.Second, time.Second*10
+	backend.l2FinalizedHeadSub = eth.PollBlockChanges(log, l2BlockRefsClient, l2FinalizedHeadSignal, eth.Finalized, pollInterval, timeout)
 
 	return &backend, nil
 }
 
 func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, payloadBytes hexutil.Bytes) (MessageSafetyLabel, error) {
-	b.log.Info("message safety check", "chain_id", id.ChainId, "block_num", id.BlockNumber, "log_index", id.LogIndex)
+	b.log.Info("message safety check", "chain_id", id.ChainId, "block_number", id.BlockNumber, "log_index", id.LogIndex)
 
 	// ChainID Invariant.
 	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
@@ -99,7 +81,7 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	//   TODO: Either assume chain id never exceeds uint64 or handle this appropriately
 	l2Node, ok := b.l2PeerNodes[id.ChainId.Uint64()]
 	if !ok {
-		return Invalid, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
+		return MessageUnknown, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
 	}
 
 	var logs []types.Log
@@ -114,13 +96,13 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockNumber, false}, Result: &header}
 	batchElems[1] = rpc.BatchElem{Method: "eth_getLogs", Args: []interface{}{filterArgs}, Result: &logs}
 	if err := l2Node.BatchCallContext(ctx, batchElems); err != nil {
-		return Invalid, fmt.Errorf("unable to request logs: %w", err)
+		return MessageUnknown, fmt.Errorf("unable to request logs: %w", err)
 	}
 	if batchElems[0].Error != nil || batchElems[1].Error != nil {
-		return Invalid, fmt.Errorf("caught batch rpc failures: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
+		return MessageUnknown, fmt.Errorf("caught batch rpc failures: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
 	}
 	if header == nil {
-		return Invalid, fmt.Errorf("block %d does not exist", id.BlockNumber)
+		return MessageUnknown, fmt.Errorf("block %d does not exist", id.BlockNumber)
 	}
 
 	// Message Log Integrity
@@ -128,21 +110,21 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 
 	// TODO: If we filter by address, then this needs to change
 	if id.LogIndex >= uint64(len(logs)) {
-		return Invalid, fmt.Errorf("invalid log index")
+		return MessageInvalid, fmt.Errorf("invalid log index")
 	}
 
 	log := logs[id.LogIndex]
 	if id.LogIndex != uint64(log.Index) {
-		return Invalid, fmt.Errorf("message log index mismatch")
+		return MessageInvalid, fmt.Errorf("message log index mismatch")
 	}
 	if !bytes.Equal(payloadBytes, MessagePayloadBytes(&log)) {
-		return Invalid, fmt.Errorf("message payload bytes mismatch")
+		return MessageInvalid, fmt.Errorf("message payload bytes mismatch")
 	}
 	if id.Origin != log.Address {
-		return Invalid, fmt.Errorf("message origin mismatch")
+		return MessageInvalid, fmt.Errorf("message origin mismatch")
 	}
 	if id.Timestamp != header.Time {
-		return Invalid, fmt.Errorf("message timestamp mismatch")
+		return MessageInvalid, fmt.Errorf("message timestamp mismatch")
 	}
 
 	// Message Safety
@@ -155,10 +137,11 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	b.mu.RUnlock()
 
 	if id.Timestamp <= finalizedL2Timestamp {
-		return Finalized, nil
+		return MessageFinalized, nil
 	}
 
 	// TODO: support for the other safety labels
 
-	return Invalid, nil
+	// Cant determine validity
+	return MessageUnknown, nil
 }

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -78,7 +78,7 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	// ChainID Invariant.
 	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
 	//   When the predeploy is added, this needs to be tied to the dependency set registered on-chain
-	//   TODO: Either assume chain id never exceeds uint64 or handle this appropriately
+	//   TODO: handle *big.Int chain ids this appropriately
 	l2Node, ok := b.l2PeerNodes[id.ChainId.Uint64()]
 	if !ok {
 		return MessageUnknown, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -1,0 +1,163 @@
+package superchain
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type SuperchainBackend interface {
+	MessageSafety(context.Context, MessageIdentifier, hexutil.Bytes) (MessageSafetyLabel, error)
+}
+
+type backend struct {
+	log log.Logger
+	mu  sync.RWMutex
+
+	l2FinalizedHeadSub  ethereum.Subscription
+	l2FinalizedBlockRef *eth.L1BlockRef
+
+	l2PeerNodes map[uint64]client.RPC
+}
+
+func NewSuperchainBackend(ctx context.Context, log log.Logger, m metrics.Factory, cfg *SuperchainConfig) (SuperchainBackend, error) {
+	log = log.New("module", "superchain")
+	backend := backend{log: log, l2PeerNodes: map[uint64]client.RPC{}}
+
+	rpcOpts := []client.RPCOption{client.WithDialBackoff(10)}
+	l2Node, err := client.NewRPC(ctx, log, cfg.L2NodeAddr, rpcOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to L2 node: %w", err)
+	}
+
+	for chainId, l2NodeAddr := range cfg.PeerL2NodeAddrs {
+		l2Node, err := client.NewRPC(ctx, log, l2NodeAddr, rpcOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Peer L2 node, %d: %w", chainId, err)
+		}
+		backend.l2PeerNodes[chainId] = l2Node
+	}
+
+	/** eth.PollBlockChanges expects an L1BlocksRefSources so we'll use this tooling for now **/
+	cacheMetrics := metrics.NewCacheMetrics(m, "superchain", "l2_source_cache", "L2 Source Cache")
+	l2ClientConfig := sources.L1ClientConfig{
+		L1BlockRefsCacheSize: 10,
+		EthClientConfig: sources.EthClientConfig{
+			TrustRPC:              true,
+			MaxConcurrentRequests: 10,
+			MaxRequestsPerBatch:   10,
+			TransactionsCacheSize: 10,
+			HeadersCacheSize:      10,
+			PayloadsCacheSize:     10,
+			RPCProviderKind:       sources.RPCKindAny,
+			MethodResetDuration:   time.Minute,
+		},
+	}
+
+	l2Client, err := sources.NewL1Client(l2Node, log, cacheMetrics, &l2ClientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct l2 client: %w", err)
+	}
+
+	// retrieve the current references before setting up the poll
+	finalizedHeadRef, err := l2Client.L1BlockRefByLabel(ctx, eth.Finalized)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query finalized block ref: %w", err)
+	}
+
+	backend.l2FinalizedBlockRef = &finalizedHeadRef
+	l2FinalizedHeadSignal := func(ctx context.Context, sig eth.L1BlockRef) {
+		backend.mu.Lock()
+		backend.l2FinalizedBlockRef = &sig
+		backend.mu.Unlock()
+	}
+
+	pollInterval, timeout := time.Second*12*32, time.Second*10
+	backend.l2FinalizedHeadSub = eth.PollBlockChanges(log, l2Client, l2FinalizedHeadSignal, eth.Finalized, pollInterval, timeout)
+
+	return &backend, nil
+}
+
+func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, payloadBytes hexutil.Bytes) (MessageSafetyLabel, error) {
+	b.log.Info("message safety check", "chain_id", id.ChainId, "block_num", id.BlockNumber, "log_index", id.LogIndex)
+
+	// ChainID Invariant.
+	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
+	//   When the predeploy is added, this needs to be tied to the dependency set registered on-chain
+	l2Node, ok := b.l2PeerNodes[id.ChainId]
+	if !ok {
+		return Invalid, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
+	}
+
+	var logs []types.Log
+	var header *types.Header
+
+	// Since eth_getLogs doesn't support specifying the log index, we fetch
+	// all the outbox reciepts for this block (TODO: add address filter). The
+	// timestamp is grabbed via the block header as getLogs omits this
+	blockNumber := hexutil.EncodeUint64(id.BlockNumber)
+	filterArgs := map[string]interface{}{"fromBlock": blockNumber, "toBlock": blockNumber}
+	batchElems := make([]rpc.BatchElem, 2)
+	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockNumber, false}, Result: &header}
+	batchElems[1] = rpc.BatchElem{Method: "eth_getLogs", Args: []interface{}{filterArgs}, Result: &logs}
+	if err := l2Node.BatchCallContext(ctx, batchElems); err != nil {
+		return Invalid, fmt.Errorf("unable to request logs: %w", err)
+	}
+	if batchElems[0].Error != nil || batchElems[1].Error != nil {
+		return Invalid, fmt.Errorf("caught batch rpc failures: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
+	}
+	if header == nil {
+		return Invalid, fmt.Errorf("block %d does not exist", id.BlockNumber)
+	}
+
+	// Message Log Integrity
+	// 	 -- BlockNumber & ChainID are handled via the RPC connection & inputs
+
+	// TODO: If we filter by address, then this needs to change
+	if id.LogIndex >= uint64(len(logs)) {
+		return Invalid, fmt.Errorf("invalid log index")
+	}
+
+	log := logs[id.LogIndex]
+	if id.LogIndex != uint64(log.Index) {
+		return Invalid, fmt.Errorf("message log index mismatch")
+	}
+	if !bytes.Equal(payloadBytes, MessagePayloadBytes(&log)) {
+		return Invalid, fmt.Errorf("message payload bytes mismatch")
+	}
+	if id.Origin != log.Address {
+		return Invalid, fmt.Errorf("message origin mismatch")
+	}
+	if id.Timestamp != header.Time {
+		return Invalid, fmt.Errorf("message timestamp mismatch")
+	}
+
+	// Message Safety
+	//   The block builder & verifier must locally enforce the timestamp invariant. This only
+	//   provides fidelity into the safety label of this message relative to its dependencies.
+
+	var finalizedL2Timestamp uint64
+	b.mu.RLock()
+	finalizedL2Timestamp = b.l2FinalizedBlockRef.Time
+	b.mu.RUnlock()
+
+	if id.Timestamp <= finalizedL2Timestamp {
+		return Finalized, nil
+	}
+
+	// TODO: support for the other safety labels
+
+	return Invalid, nil
+}

--- a/op-superchain/cli.go
+++ b/op-superchain/cli.go
@@ -1,0 +1,102 @@
+package superchain
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	L2FlagName      = "l2"
+	L2PeersFlagName = "l2-peers"
+)
+
+func superchainEnv(envprefix, v string) []string {
+	return []string{envprefix + "_SUPERCHAIN_" + v}
+}
+
+func parseMapFlag(input string) (map[string]string, error) {
+	result := map[string]string{}
+	pairs := strings.Split(input, ",")
+	for _, pair := range pairs {
+		keyValue := strings.Split(pair, "=")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("Invalid key-value pair: %s\n", pair)
+		}
+		result[strings.TrimSpace(keyValue[0])] = strings.TrimSpace(keyValue[1])
+	}
+	return result, nil
+}
+
+func L2PeersFlag(envPrefix string) cli.Flag {
+	return &cli.StringFlag{
+		Name:    L2PeersFlagName,
+		Usage:   "List of L2 Peers JSON-rpc endpoints. 'chain1=url1,chain2=url2...'",
+		Value:   "",
+		EnvVars: superchainEnv(envPrefix, "L2_PEERS_ETH_RPCS"),
+	}
+}
+
+func CLIFlags(envPrefix string) []cli.Flag {
+	return []cli.Flag{
+		L2PeersFlag(envPrefix),
+		&cli.StringFlag{
+			Name:    L2FlagName,
+			Usage:   "Address of L2 JSON-RPC endpoint to use (eth namespace required)",
+			Value:   "http://127.0.0.1:9545",
+			EnvVars: superchainEnv(envPrefix, "L2_ETH_RPC"),
+		},
+	}
+}
+
+type CLIConfig struct {
+	L2RPCUrl      string
+	L2PeersRPCUrl string
+}
+
+func (c CLIConfig) Check() error {
+	if c.L2RPCUrl == "" {
+		return errors.New("missing l2 rpc")
+	}
+
+	l2PeersMap, err := parseMapFlag(c.L2PeersRPCUrl)
+	if err != nil {
+		return fmt.Errorf("l2 peer rpcs encoded incorrectly: %w", err)
+	}
+	for id, _ := range l2PeersMap {
+		_, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse chain id (%s): %w", id, err)
+		}
+	}
+
+	return nil
+}
+
+func (c CLIConfig) Config() (*Config, error) {
+	cfg := &Config{L2NodeAddr: c.L2PeersRPCUrl, PeerL2NodeAddrs: map[uint64]string{}}
+
+	l2PeersMap, err := parseMapFlag(c.L2PeersRPCUrl)
+	if err != nil {
+		return nil, fmt.Errorf("l2 peer rpcs encoded incorrectly: %w", err)
+	}
+	for id, url := range l2PeersMap {
+		chainId, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse chain id: %w", err)
+		}
+		cfg.PeerL2NodeAddrs[chainId] = url
+	}
+
+	return cfg, nil
+}
+
+func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+	return CLIConfig{
+		L2RPCUrl:      ctx.String(L2FlagName),
+		L2PeersRPCUrl: ctx.String(L2PeersFlagName),
+	}
+}

--- a/op-superchain/cli.go
+++ b/op-superchain/cli.go
@@ -66,7 +66,7 @@ func (c CLIConfig) Check() error {
 	if err != nil {
 		return fmt.Errorf("l2 peer rpcs encoded incorrectly: %w", err)
 	}
-	for id, _ := range l2PeersMap {
+	for id := range l2PeersMap {
 		_, err := strconv.ParseUint(id, 10, 64)
 		if err != nil {
 			return fmt.Errorf("unable to parse chain id (%s): %w", id, err)

--- a/op-superchain/client.go
+++ b/op-superchain/client.go
@@ -1,0 +1,35 @@
+package superchain
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// In order to allow op-node/rollup/derive to depend on this, we cannot have a dependency
+// on op-service/sources as it has a dependency on op-node. Until we fix this, we create
+// an alternative head source here.
+
+type L1BlockRefsSource interface {
+	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
+}
+
+type blockRefsClient struct {
+	clnt client.RPC
+}
+
+func (b *blockRefsClient) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
+	var head *types.Header
+	err := b.clnt.CallContext(ctx, &head, "eth_getBlockByNumber", label.Arg(), false)
+	if err != nil {
+		return eth.L1BlockRef{}, err
+	}
+	if head == nil {
+		return eth.L1BlockRef{}, ethereum.NotFound
+	}
+
+	return eth.L1BlockRef{Hash: head.Hash(), Number: head.Number.Uint64(), ParentHash: head.ParentHash, Time: head.Time}, nil
+}

--- a/op-superchain/client.go
+++ b/op-superchain/client.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// In order to allow op-node/rollup/derive to depend on this, we cannot have a dependency
-// on op-service/sources as it has a dependency on op-node. Until we fix this, we create
-// an alternative head source here.
+// In order to allow `op-node/rollup/derive` to depend on this, we cannot have a dependency
+// on op-service/sources as that creates a circular dependency on op-node. Until we fix this,
+// we create an alternative head source here.
 
 type L1BlockRefsSource interface {
 	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)

--- a/op-superchain/cmd/main.go
+++ b/op-superchain/cmd/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	gethRPC "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	GitCommit    = ""
+	GitDate      = ""
+	EnvVarPrefix = "OP_SUPERCHAIN"
+)
+
+func prefixEnvVars(name string) []string {
+	return []string{EnvVarPrefix + "_" + name}
+}
+
+func parseMapFlag(input string) (map[string]string, error) {
+	result := map[string]string{}
+	pairs := strings.Split(input, ",")
+	for _, pair := range pairs {
+		keyValue := strings.Split(pair, "=")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("Invalid key-value pair: %s\n", pair)
+		}
+		result[strings.TrimSpace(keyValue[0])] = strings.TrimSpace(keyValue[1])
+	}
+	return result, nil
+}
+
+// Flags
+var (
+	/** Required SuperchainBackend Flags **/
+	L2NodeAddr = &cli.StringFlag{
+		Name:    "l2",
+		Usage:   "Address of L2 User JSON-RPC endpoint to use (eth namespace required)",
+		Value:   "http://127.0.0.1:9545",
+		EnvVars: prefixEnvVars("L2_ETH_RPC"),
+	}
+	L2PeersNodeAddrs = &cli.StringFlag{
+		Name:    "l2-peers",
+		Usage:   "List of L2 Peers JSON-rpc endpoints. 'chain1=url1,chain2=url2...'",
+		Value:   "",
+		EnvVars: prefixEnvVars("L2_PEERS_ETH_RPCS"),
+	}
+)
+
+func main() {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Version = params.VersionWithCommit(GitCommit, GitDate)
+	app.Name = "op-superchain"
+	app.Usage = "Optimism Superchain Messaging Backend"
+	app.Description = "Runs the superchain messaging backend"
+	app.Action = cliapp.LifecycleCmd(SuperchainBackendMain)
+
+	logFlags := oplog.CLIFlags(EnvVarPrefix)
+	rpcFlags := rpc.CLIFlags(EnvVarPrefix)
+	backendFlags := []cli.Flag{L2NodeAddr, L2PeersNodeAddrs}
+	app.Flags = append(append(backendFlags, rpcFlags...), logFlags...)
+
+	ctx := opio.WithInterruptBlocker(context.Background())
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		log.Crit("Application Failed", "err", err)
+	}
+}
+
+func SuperchainBackendMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx))
+	m := metrics.With(metrics.NewRegistry())
+
+	cfg := superchain.SuperchainConfig{
+		L2NodeAddr:      ctx.String(L2NodeAddr.Name),
+		PeerL2NodeAddrs: map[uint64]string{},
+	}
+
+	l2PeersMap, err := parseMapFlag(ctx.String(L2PeersNodeAddrs.Name))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse list of peers: %w", err)
+	}
+	for id, url := range l2PeersMap {
+		chainId, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse chain id: %w", err)
+		}
+		cfg.PeerL2NodeAddrs[chainId] = url
+	}
+
+	s, err := superchain.NewSuperchainBackend(ctx.Context, log, m, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to start superchain backend: %w", err)
+	}
+
+	rpcConfig := rpc.ReadCLIConfig(ctx)
+	rpcApis := []gethRPC.API{{Namespace: "superchain", Service: s}}
+	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpc.WithAPIs(rpcApis))
+	return rpc.NewService(log, rpcServer), nil
+}

--- a/op-superchain/cmd/main.go
+++ b/op-superchain/cmd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -44,36 +43,19 @@ func parseMapFlag(input string) (map[string]string, error) {
 	return result, nil
 }
 
-// Flags
-var (
-	/** Required SuperchainBackend Flags **/
-	L2NodeAddr = &cli.StringFlag{
-		Name:    "l2",
-		Usage:   "Address of L2 User JSON-RPC endpoint to use (eth namespace required)",
-		Value:   "http://127.0.0.1:9545",
-		EnvVars: prefixEnvVars("L2_ETH_RPC"),
-	}
-	L2PeersNodeAddrs = &cli.StringFlag{
-		Name:    "l2-peers",
-		Usage:   "List of L2 Peers JSON-rpc endpoints. 'chain1=url1,chain2=url2...'",
-		Value:   "",
-		EnvVars: prefixEnvVars("L2_PEERS_ETH_RPCS"),
-	}
-)
-
 func main() {
 	oplog.SetupDefaults()
 
 	app := cli.NewApp()
 	app.Version = params.VersionWithCommit(GitCommit, GitDate)
 	app.Name = "op-superchain"
-	app.Usage = "Optimism Superchain Messaging Backend"
-	app.Description = "Runs the superchain messaging backend"
+	app.Usage = "Optimism Superchain Backend"
+	app.Description = "Runs the superchain backend"
 	app.Action = cliapp.LifecycleCmd(SuperchainBackendMain)
 
 	logFlags := oplog.CLIFlags(EnvVarPrefix)
 	rpcFlags := rpc.CLIFlags(EnvVarPrefix)
-	backendFlags := []cli.Flag{L2NodeAddr, L2PeersNodeAddrs}
+	backendFlags := superchain.CLIFlags(EnvVarPrefix)
 	app.Flags = append(append(backendFlags, rpcFlags...), logFlags...)
 
 	ctx := opio.WithInterruptBlocker(context.Background())
@@ -86,30 +68,20 @@ func SuperchainBackendMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (
 	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx))
 	m := metrics.With(metrics.NewRegistry())
 
-	cfg := superchain.SuperchainConfig{
-		L2NodeAddr:      ctx.String(L2NodeAddr.Name),
-		PeerL2NodeAddrs: map[uint64]string{},
-	}
-
-	l2PeersMap, err := parseMapFlag(ctx.String(L2PeersNodeAddrs.Name))
+	cfg, err := superchain.ReadCLIConfig(ctx).Config()
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse list of peers: %w", err)
-	}
-	for id, url := range l2PeersMap {
-		chainId, err := strconv.ParseUint(id, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse chain id: %w", err)
-		}
-		cfg.PeerL2NodeAddrs[chainId] = url
+		return nil, fmt.Errorf("unable to parse superchain flags: %w", err)
 	}
 
-	s, err := superchain.NewSuperchainBackend(ctx.Context, log, m, &cfg)
+	backend, err := superchain.NewBackend(ctx.Context, log, m, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start superchain backend: %w", err)
 	}
 
 	rpcConfig := rpc.ReadCLIConfig(ctx)
-	rpcApis := []gethRPC.API{{Namespace: "superchain", Service: s}}
-	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpc.WithAPIs(rpcApis))
+	rpcApis := []gethRPC.API{{Namespace: "superchain", Service: backend}}
+	rpcOpts := []rpc.ServerOption{rpc.WithAPIs(rpcApis), rpc.WithLogger(log)}
+
+	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpcOpts...)
 	return rpc.NewService(log, rpcServer), nil
 }

--- a/op-superchain/cmd/main.go
+++ b/op-superchain/cmd/main.go
@@ -26,10 +26,6 @@ var (
 	EnvVarPrefix = "OP_SUPERCHAIN"
 )
 
-func prefixEnvVars(name string) []string {
-	return []string{EnvVarPrefix + "_" + name}
-}
-
 func parseMapFlag(input string) (map[string]string, error) {
 	result := map[string]string{}
 	pairs := strings.Split(input, ",")

--- a/op-superchain/cmd/main.go
+++ b/op-superchain/cmd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -25,19 +24,6 @@ var (
 	GitDate      = ""
 	EnvVarPrefix = "OP_SUPERCHAIN"
 )
-
-func parseMapFlag(input string) (map[string]string, error) {
-	result := map[string]string{}
-	pairs := strings.Split(input, ",")
-	for _, pair := range pairs {
-		keyValue := strings.Split(pair, "=")
-		if len(keyValue) != 2 {
-			return nil, fmt.Errorf("Invalid key-value pair: %s\n", pair)
-		}
-		result[strings.TrimSpace(keyValue[0])] = strings.TrimSpace(keyValue[1])
-	}
-	return result, nil
-}
 
 func main() {
 	oplog.SetupDefaults()

--- a/op-superchain/config.go
+++ b/op-superchain/config.go
@@ -1,0 +1,13 @@
+package superchain
+
+type SuperchainConfig struct {
+	// Simply take in the node addresses directly for now. We
+	// may want to expand and accept more general endpoint
+	// configuration like RateLimits, MaxConcurrency, etc
+
+	// If we want op-node to use this as a library rather than an
+	// external service, configuration should be extensible to support
+	// plugging in configured client tooling that's ready to use.
+	L2NodeAddr      string
+	PeerL2NodeAddrs map[uint64]string
+}

--- a/op-superchain/config.go
+++ b/op-superchain/config.go
@@ -1,6 +1,6 @@
 package superchain
 
-type SuperchainConfig struct {
+type Config struct {
 	// Simply take in the node addresses directly for now. We
 	// may want to expand and accept more general endpoint
 	// configuration like RateLimits, MaxConcurrency, etc

--- a/op-superchain/logs.go
+++ b/op-superchain/logs.go
@@ -1,0 +1,48 @@
+package superchain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type LogsProvider interface {
+	// FetchLog returns a block's info and logs
+	FetchLogs(context.Context, rpc.BlockNumberOrHash) (eth.BlockInfo, []types.Log, error)
+}
+
+type logsProvider struct {
+	clnt client.RPC
+}
+
+func NewLogProvider(clnt client.RPC) LogsProvider {
+	return &logsProvider{clnt}
+}
+
+func (p *logsProvider) FetchLogs(ctx context.Context, id rpc.BlockNumberOrHash) (eth.BlockInfo, []types.Log, error) {
+	var logs []types.Log
+	var header *types.Header
+
+	blockId := id.String()
+	filterArgs := map[string]interface{}{"fromBlock": blockId, "toBlock": blockId}
+	batchElems := make([]rpc.BatchElem, 2)
+	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockId, false}, Result: &header}
+	batchElems[1] = rpc.BatchElem{Method: "eth_getLogs", Args: []interface{}{filterArgs}, Result: &logs}
+	if err := p.clnt.BatchCallContext(ctx, batchElems); err != nil {
+		return nil, nil, fmt.Errorf("unable to request logs: %w", err)
+	}
+	if batchElems[0].Error != nil || batchElems[1].Error != nil {
+		return nil, nil, fmt.Errorf("batch rpc failure: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
+	}
+
+	if header == nil {
+		return nil, nil, ethereum.NotFound
+	}
+
+	return eth.HeaderBlockInfo(header), logs, nil
+}

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -21,11 +21,6 @@ type MessageIdentifier struct {
 	ChainId     uint64
 }
 
-type MessagePayload struct {
-	// changes: not the entire log
-	Log *types.Log
-}
-
 func MessagePayloadBytes(log *types.Log) []byte {
 	msg := []byte{}
 	for _, topic := range log.Topics {

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -22,6 +22,8 @@ type MessageSafetyLabel int
 const (
 	MessageUnknown MessageSafetyLabel = iota - 1
 	MessageInvalid
+	MessageUnsafe
+	MessageCrossUnsafe
 	MessageSafe
 	MessageFinalized
 )

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -1,18 +1,30 @@
 package superchain
 
 import (
+	"bytes"
+	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/solabi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	crossL2InboxAddr                  = common.Address{}
+	inboxExecuteMessageSignature      = "executeMessage((address,uint256,uint256,uint256,uint256),address,bytes)"
+	inboxExecuteMessageBytes4         = crypto.Keccak256([]byte(inboxExecuteMessageSignature))[:4]
+	inboxExecuteMessagePayloadDataLoc = common.HexToHash("0xe0")
 )
 
 type MessageSafetyLabel int
 
 const (
-	Invalid MessageSafetyLabel = iota
-	Safe
-	Finalized
+	MessageUnknown MessageSafetyLabel = iota - 1
+	MessageInvalid
+	MessageSafe
+	MessageFinalized
 )
 
 type MessageIdentifier struct {
@@ -29,4 +41,61 @@ func MessagePayloadBytes(log *types.Log) []byte {
 		msg = append(msg, topic.Bytes()...)
 	}
 	return append(msg, log.Data...)
+}
+
+// Parse the transaction data posted to the inbox `executeMessage` function, extracing it's parameters
+func ParseInboxExecuteMessageTxData(txData []byte) (common.Address, MessageIdentifier, []byte, error) {
+	var target common.Address
+	var id MessageIdentifier
+
+	r := bytes.NewReader(txData)
+
+	// Validate Function Signature
+	_, err := solabi.ReadAndValidateSignature(r, inboxExecuteMessageBytes4)
+	if err != nil {
+		return target, id, nil, err
+	}
+
+	// Read Identifier
+	id.Origin, err = solabi.ReadAddress(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier origin: %w", err)
+	}
+	id.BlockNumber, err = solabi.ReadUint256(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier block number: %w", err)
+	}
+	id.LogIndex, err = solabi.ReadUint64(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier log index: %w", err)
+	}
+	id.Timestamp, err = solabi.ReadUint64(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier timestamp: %w", err)
+	}
+	id.ChainId, err = solabi.ReadUint256(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier chain id: %w", err)
+	}
+
+	// Read target
+	target, err = solabi.ReadAddress(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read target: %w", err)
+	}
+
+	// Read Message Bytes
+	dataLoc, err := solabi.ReadHash(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read message data loc: %w", err)
+	}
+	if dataLoc != inboxExecuteMessagePayloadDataLoc {
+		return target, id, nil, fmt.Errorf("mismatched message data loc. Got %s, Expected: %s", dataLoc, inboxExecuteMessagePayloadDataLoc)
+	}
+	message, err := solabi.ReadBytes(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read message: %w", err)
+	}
+
+	return target, id, message, nil
 }

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -1,6 +1,8 @@
 package superchain
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -15,10 +17,10 @@ const (
 
 type MessageIdentifier struct {
 	Origin      common.Address
-	BlockNumber uint64
+	BlockNumber *big.Int
 	LogIndex    uint64
 	Timestamp   uint64
-	ChainId     uint64
+	ChainId     *big.Int
 }
 
 func MessagePayloadBytes(log *types.Log) []byte {

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	crossL2InboxAddr                  = common.Address{}
 	inboxExecuteMessageSignature      = "executeMessage((address,uint256,uint256,uint256,uint256),address,bytes)"
 	inboxExecuteMessageBytes4         = crypto.Keccak256([]byte(inboxExecuteMessageSignature))[:4]
 	inboxExecuteMessagePayloadDataLoc = common.HexToHash("0xe0")

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -1,0 +1,35 @@
+package superchain
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type MessageSafetyLabel int
+
+const (
+	Invalid MessageSafetyLabel = iota
+	Safe
+	Finalized
+)
+
+type MessageIdentifier struct {
+	Origin      common.Address
+	BlockNumber uint64
+	LogIndex    uint64
+	Timestamp   uint64
+	ChainId     uint64
+}
+
+type MessagePayload struct {
+	// changes: not the entire log
+	Log *types.Log
+}
+
+func MessagePayloadBytes(log *types.Log) []byte {
+	msg := []byte{}
+	for _, topic := range log.Topics {
+		msg = append(msg, topic.Bytes()...)
+	}
+	return append(msg, log.Data...)
+}

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -13,6 +13,9 @@ import (
 )
 
 var (
+	// TODO: use predeploy constant when available
+	crossL2InboxAddr = common.Address{}
+
 	inboxExecuteMessageSignature      = "executeMessage((address,uint256,uint256,uint256,uint256),address,bytes)"
 	inboxExecuteMessageBytes4         = crypto.Keccak256([]byte(inboxExecuteMessageSignature))[:4]
 	inboxExecuteMessagePayloadDataLoc = common.HexToHash("0xe0")
@@ -47,7 +50,7 @@ func MessagePayloadBytes(log *types.Log) []byte {
 
 // Check if a transaction is an executing message to the CrossL2Inbox
 func IsInboxExecutingMessageTx(tx *types.Transaction) bool {
-	if tx.To() == nil || *tx.To() == common.HexToAddress("0xa") {
+	if tx.To() == nil || *tx.To() == crossL2InboxAddr {
 		return false
 	}
 
@@ -56,7 +59,7 @@ func IsInboxExecutingMessageTx(tx *types.Transaction) bool {
 }
 
 // Check the message id and payload against the fields of the log.
-func MessageLogCheck(id MessageIdentifier, payload hexutil.Bytes, log *types.Log) error {
+func CheckMessageLog(id MessageIdentifier, payload hexutil.Bytes, log *types.Log) error {
 	if id.LogIndex != uint64(log.Index) {
 		return fmt.Errorf("log index mismatch")
 	}

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -2,6 +2,7 @@ package superchain
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -61,16 +62,16 @@ func IsInboxExecutingMessageTx(tx *types.Transaction) bool {
 // Check the message id and payload against the fields of the log.
 func CheckMessageLog(id MessageIdentifier, payload hexutil.Bytes, log *types.Log) error {
 	if id.LogIndex != uint64(log.Index) {
-		return fmt.Errorf("log index mismatch")
+		return errors.New("log index mismatch")
 	}
 	if !bytes.Equal(payload, MessagePayloadBytes(log)) {
-		return fmt.Errorf("payload mismatch")
+		return errors.New("payload mismatch")
 	}
 	if id.Origin != log.Address {
-		return fmt.Errorf("origin mismatch")
+		return errors.New("origin mismatch")
 	}
 	if id.BlockNumber.Uint64() != log.BlockNumber {
-		return fmt.Errorf("block number mismatch")
+		return errors.New("block number mismatch")
 	}
 	return nil
 }

--- a/op-superchain/message_test.go
+++ b/op-superchain/message_test.go
@@ -1,0 +1,62 @@
+package superchain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	BytesType, _   = abi.NewType("bytes", "", nil)
+	AddressType, _ = abi.NewType("address", "", nil)
+	MsgIdType, _   = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "origin", Type: "address"},
+		{Name: "blockNumber", Type: "uint256"},
+
+		// for simplicity use uint64 since these go fields as parameterized
+		// this way. makes no difference to the abi encoding of the tuple
+		{Name: "logIndex", Type: "uint64"},
+		{Name: "timestamp", Type: "uint64"},
+
+		{Name: "chainId", Type: "uint256"},
+	})
+
+	ExecuteMessageMethod = abi.NewMethod(
+		"executeMessage", // name
+		"executeMessage", // raw name
+		abi.Function,     // fn type
+		"",               // mutability
+		false,            // isConst
+		false,            // isPayable
+		abi.Arguments{{Type: MsgIdType}, {Type: AddressType}, {Type: BytesType}}, // inputs
+		abi.Arguments{}, // ouputs
+	)
+)
+
+func TestParseInboxExecuteMessageUnpacking(t *testing.T) {
+	msgId := MessageIdentifier{common.HexToAddress("0xa"), big.NewInt(10), 1, 1, big.NewInt(10)}
+	msgTarget := common.HexToAddress("0xb")
+
+	calldata, err := ExecuteMessageMethod.Inputs.Pack(msgId, msgTarget, []byte{byte(1)})
+	require.NoError(t, err)
+
+	target, id, msg, err := ParseInboxExecuteMessageTxData(append(inboxExecuteMessageBytes4, calldata...))
+	require.NoError(t, err)
+
+	// target
+	require.Equal(t, target, msgTarget)
+
+	// id
+	require.Equal(t, msgId.Origin, id.Origin)
+	require.Equal(t, msgId.BlockNumber.Uint64(), id.BlockNumber.Uint64())
+	require.Equal(t, msgId.LogIndex, id.LogIndex)
+	require.Equal(t, msgId.Timestamp, id.Timestamp)
+	require.Equal(t, msgId.ChainId.Uint64(), id.ChainId.Uint64())
+
+	// msg
+	require.Len(t, msg, 1)
+	require.Equal(t, msg[0], byte(1))
+}

--- a/op-superchain/message_test.go
+++ b/op-superchain/message_test.go
@@ -37,12 +37,12 @@ var (
 	)
 )
 
-func TestMessageLogCheck(t *testing.T) {
+func TestCheckMessageLog(t *testing.T) {
 	origin := common.HexToAddress("0xA")
 	blockNum := big.NewInt(1)
 	logIndex := uint64(1)
 
-	// Specifiy the fields set in the log
+	// Specify the fields set in the log
 	id := MessageIdentifier{Origin: origin, BlockNumber: blockNum, LogIndex: logIndex}
 
 	log := &types.Log{
@@ -54,29 +54,29 @@ func TestMessageLogCheck(t *testing.T) {
 	}
 
 	payload := MessagePayloadBytes(log)
-	require.NoError(t, MessageLogCheck(id, payload, log))
+	require.NoError(t, CheckMessageLog(id, payload, log))
 
 	// origin mismatch
 	id.Origin = common.HexToAddress("0xB")
-	require.Error(t, MessageLogCheck(id, payload, log))
+	require.Error(t, CheckMessageLog(id, payload, log))
 	id.Origin = origin
-	require.NoError(t, MessageLogCheck(id, payload, log))
+	require.NoError(t, CheckMessageLog(id, payload, log))
 
 	// block number mismatch
 	id.BlockNumber = big.NewInt(2)
-	require.Error(t, MessageLogCheck(id, payload, log))
+	require.Error(t, CheckMessageLog(id, payload, log))
 	id.BlockNumber = blockNum
-	require.NoError(t, MessageLogCheck(id, payload, log))
+	require.NoError(t, CheckMessageLog(id, payload, log))
 
 	// log index mismatch
 	id.LogIndex = 2
-	require.Error(t, MessageLogCheck(id, payload, log))
+	require.Error(t, CheckMessageLog(id, payload, log))
 	id.LogIndex = logIndex
-	require.NoError(t, MessageLogCheck(id, payload, log))
+	require.NoError(t, CheckMessageLog(id, payload, log))
 
 	// payload mismatch
-	require.Error(t, MessageLogCheck(id, payload[:1], log))
-	require.NoError(t, MessageLogCheck(id, payload, log))
+	require.Error(t, CheckMessageLog(id, payload[:1], log))
+	require.NoError(t, CheckMessageLog(id, payload, log))
 }
 
 func TestParseInboxExecuteMessageUnpacking(t *testing.T) {

--- a/op-superchain/message_test.go
+++ b/op-superchain/message_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,6 +36,48 @@ var (
 		abi.Arguments{}, // ouputs
 	)
 )
+
+func TestMessageLogCheck(t *testing.T) {
+	origin := common.HexToAddress("0xA")
+	blockNum := big.NewInt(1)
+	logIndex := uint64(1)
+
+	// Specifiy the fields set in the log
+	id := MessageIdentifier{Origin: origin, BlockNumber: blockNum, LogIndex: logIndex}
+
+	log := &types.Log{
+		Topics:      []common.Hash{common.HexToHash("0xA"), common.HexToHash("0xB")},
+		Data:        []byte{byte(1), byte(2), byte(3)},
+		BlockNumber: blockNum.Uint64(),
+		Address:     origin,
+		Index:       uint(logIndex),
+	}
+
+	payload := MessagePayloadBytes(log)
+	require.NoError(t, MessageLogCheck(id, payload, log))
+
+	// origin mismatch
+	id.Origin = common.HexToAddress("0xB")
+	require.Error(t, MessageLogCheck(id, payload, log))
+	id.Origin = origin
+	require.NoError(t, MessageLogCheck(id, payload, log))
+
+	// block number mismatch
+	id.BlockNumber = big.NewInt(2)
+	require.Error(t, MessageLogCheck(id, payload, log))
+	id.BlockNumber = blockNum
+	require.NoError(t, MessageLogCheck(id, payload, log))
+
+	// log index mismatch
+	id.LogIndex = 2
+	require.Error(t, MessageLogCheck(id, payload, log))
+	id.LogIndex = logIndex
+	require.NoError(t, MessageLogCheck(id, payload, log))
+
+	// payload mismatch
+	require.Error(t, MessageLogCheck(id, payload[:1], log))
+	require.NoError(t, MessageLogCheck(id, payload, log))
+}
 
 func TestParseInboxExecuteMessageUnpacking(t *testing.T) {
 	msgId := MessageIdentifier{common.HexToAddress("0xa"), big.NewInt(10), 1, 1, big.NewInt(10)}


### PR DESCRIPTION
This contains the start of the backend for superchain interopability. Implementation of the spec described in ethereum-optimism/specs#58

This backend exposes a single endpoint `superchain_messageSafety` that
will verify that the message identifier matches the supplied payload and
returns the safety label relative to it's dependencies. As a start,
we only support the `Finalized` label to enable tx mempool validation
and block building in op-geth

Closes ethereum-optimism/protocol-quest#158
