### PR TITLE
op-dispute-mon: Include the output root block number in unexpected game result logs

### DIFF
--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -76,7 +76,10 @@ func (d *detector) checkAgreement(ctx context.Context, addr common.Address, bloc
 			expectedResult = types.GameStatusChallengerWon
 		}
 		if status != expectedResult {
-			d.logger.Error("Unexpected game result", "gameAddr", addr, "expectedResult", expectedResult, "actualResult", status, "rootClaim", rootClaim, "correctClaim", expectedClaim)
+			d.logger.Error("Unexpected game result",
+				"gameAddr", addr, "blockNum", blockNum,
+				"expectedResult", expectedResult, "actualResult", status,
+				"rootClaim", rootClaim, "correctClaim", expectedClaim)
 		}
 	}
 	return batch, nil

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -76,19 +76,27 @@ func (f *forecast) forecastGame(ctx context.Context, game monTypes.EnrichedGameD
 		// If we agree with the output root proposal, the Defender should win, defending that claim.
 		if status == types.GameStatusChallengerWon {
 			metrics.AgreeChallengerAhead++
-			f.logger.Warn("Forecasting unexpected game result", "status", status, "game", game.Proxy, "rootClaim", game.RootClaim, "expected", expected)
+			f.logger.Warn("Forecasting unexpected game result", "status", status,
+				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"rootClaim", game.RootClaim, "expected", expected)
 		} else {
 			metrics.AgreeDefenderAhead++
-			f.logger.Debug("Forecasting expected game result", "status", status, "game", game.Proxy, "rootClaim", game.RootClaim, "expected", expected)
+			f.logger.Debug("Forecasting expected game result", "status", status,
+				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"rootClaim", game.RootClaim, "expected", expected)
 		}
 	} else {
 		// If we disagree with the output root proposal, the Challenger should win, challenging that claim.
 		if status == types.GameStatusDefenderWon {
 			metrics.DisagreeDefenderAhead++
-			f.logger.Warn("Forecasting unexpected game result", "status", status, "game", game.Proxy, "rootClaim", game.RootClaim, "expected", expected)
+			f.logger.Warn("Forecasting unexpected game result", "status", status,
+				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"rootClaim", game.RootClaim, "expected", expected)
 		} else {
 			metrics.DisagreeChallengerAhead++
-			f.logger.Debug("Forecasting expected game result", "status", status, "game", game.Proxy, "rootClaim", game.RootClaim, "expected", expected)
+			f.logger.Debug("Forecasting expected game result", "status", status,
+				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"rootClaim", game.RootClaim, "expected", expected)
 		}
 	}
 


### PR DESCRIPTION
**Description**

Add the L2 block number to error and warning logs about unexpected game results. Makes it easy for people to verify that the expected claim is correct by querying a node.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/540
