### PR TITLE
op-dispute-mon: Add additional labels to dispute game agreement metrics

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -11,4 +11,4 @@ func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
 func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}
-func (*NoopMetricsImpl) RecordGameAgreement(status string, count int)                 {}
+func (*NoopMetricsImpl) RecordGameAgreement(status GameAgreementStatus, count int)    {}

--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/extract"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 
@@ -20,7 +21,7 @@ type GameCallerCreator interface {
 }
 
 type DetectorMetrics interface {
-	RecordGameAgreement(status string, count int)
+	RecordGameAgreement(status metrics.GameAgreementStatus, count int)
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 }
 
@@ -56,11 +57,10 @@ func (d *detector) Detect(ctx context.Context, games []monTypes.EnrichedGameData
 }
 
 func (d *detector) recordBatch(batch monTypes.DetectionBatch) {
-	d.metrics.RecordGameAgreement("in_progress", batch.InProgress)
-	d.metrics.RecordGameAgreement("agree_defender_wins", batch.AgreeDefenderWins)
-	d.metrics.RecordGameAgreement("disagree_defender_wins", batch.DisagreeDefenderWins)
-	d.metrics.RecordGameAgreement("agree_challenger_wins", batch.AgreeChallengerWins)
-	d.metrics.RecordGameAgreement("disagree_challenger_wins", batch.DisagreeChallengerWins)
+	d.metrics.RecordGameAgreement(metrics.AgreeDefenderWins, batch.AgreeDefenderWins)
+	d.metrics.RecordGameAgreement(metrics.DisagreeDefenderWins, batch.DisagreeDefenderWins)
+	d.metrics.RecordGameAgreement(metrics.AgreeChallengerWins, batch.AgreeChallengerWins)
+	d.metrics.RecordGameAgreement(metrics.DisagreeChallengerWins, batch.DisagreeChallengerWins)
 }
 
 func (d *detector) checkAgreement(ctx context.Context, addr common.Address, blockNum uint64, rootClaim common.Hash, status types.GameStatus) (monTypes.DetectionBatch, error) {

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/transform"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 
@@ -20,7 +21,7 @@ var (
 )
 
 type ForecastMetrics interface {
-	RecordGameAgreement(status string, count int)
+	RecordGameAgreement(status metrics.GameAgreementStatus, count int)
 }
 
 type forecast struct {
@@ -48,10 +49,10 @@ func (f *forecast) Forecast(ctx context.Context, games []monTypes.EnrichedGameDa
 }
 
 func (f *forecast) recordBatch(batch monTypes.ForecastBatch) {
-	f.metrics.RecordGameAgreement("agree_challenger_ahead", batch.AgreeChallengerAhead)
-	f.metrics.RecordGameAgreement("disagree_challenger_ahead", batch.DisagreeChallengerAhead)
-	f.metrics.RecordGameAgreement("agree_defender_ahead", batch.AgreeDefenderAhead)
-	f.metrics.RecordGameAgreement("disagree_defender_ahead", batch.DisagreeDefenderAhead)
+	f.metrics.RecordGameAgreement(metrics.AgreeChallengerAhead, batch.AgreeChallengerAhead)
+	f.metrics.RecordGameAgreement(metrics.DisagreeChallengerAhead, batch.DisagreeChallengerAhead)
+	f.metrics.RecordGameAgreement(metrics.AgreeDefenderAhead, batch.AgreeDefenderAhead)
+	f.metrics.RecordGameAgreement(metrics.DisagreeDefenderAhead, batch.DisagreeDefenderAhead)
 }
 
 func (f *forecast) forecastGame(ctx context.Context, game monTypes.EnrichedGameData, metrics *monTypes.ForecastBatch) error {

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -8,6 +8,7 @@ import (
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -266,15 +267,15 @@ type mockForecastMetrics struct {
 	disagreeChallengerAhead int
 }
 
-func (m *mockForecastMetrics) RecordGameAgreement(status string, count int) {
+func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementStatus, count int) {
 	switch status {
-	case "agree_defender_ahead":
+	case metrics.AgreeDefenderAhead:
 		m.agreeDefenderAhead = count
-	case "disagree_defender_ahead":
+	case metrics.DisagreeDefenderAhead:
 		m.disagreeDefenderAhead = count
-	case "agree_challenger_ahead":
+	case metrics.AgreeChallengerAhead:
 		m.agreeChallengerAhead = count
-	case "disagree_challenger_ahead":
+	case metrics.DisagreeChallengerAhead:
 		m.disagreeChallengerAhead = count
 	}
 }


### PR DESCRIPTION
**Description**

Modifies the `op_dispute_mon_games_agreement` metric to add additional labels:
* `completion` - either `in_progress` or `complete`
* `result_correctness` - is the actual or forecasted result what we'd expect? either `correct` or `incorrect`
* `root_agreement` - is the proposed output root correct - either `agree` or `disagree`

The existing `status` metric is still present with all the same values, except that `in_progress` has been removed. The in progress games were being double counted because they were also included in the `*Ahead` statuses. The number of in progress games can still be found with `sum by (completion) (op_dispute_mon_games_agreement)` or just `op_dispute_mon_games_agreement{completion="in_progress"}` to get what would have been `status="in_progress"`.

Since the values for the new labels are always the same based on the `status` label we don't actually introduce any new time-series (ie there are no new combinations of labels), there's just a breakdown of the information already encapsulated by `status` available as additional labels.

Makes it easy to query things like the number of games with valid output roots, or the number of games that resolved incorrectly.  Some examples:

* Break down of games that have or are forecast to resolve correctly or not: `sum by (result_correctness) (op_dispute_mon_games_agreement)` 
* Completed vs in progress games: `sum by (completeness) (op_dispute_mon_games_agreement)`
* Completed games that have resolved incorrectly: `op_dispute_mon_games_agreement{completeness="complete", result_correctness="incorrect"}`


Note: As a follow up we should combine `detector` and `forecaster` - they're both updating the same metric so makes sense to just have them in one place.

**Tests**

Updated unit tests.

