### PR TITLE
op-challenger: Implement expanded honest challenger behaviour

### DIFF
--- a/op-challenger/game/fault/solver/agreed.go
+++ b/op-challenger/game/fault/solver/agreed.go
@@ -1,0 +1,21 @@
+package solver
+
+import "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+
+type agreedClaimTracker struct {
+	agreed map[int]bool
+}
+
+func newAgreedClaimTracker() *agreedClaimTracker {
+	return &agreedClaimTracker{
+		agreed: make(map[int]bool),
+	}
+}
+
+func (a *agreedClaimTracker) MarkAgreed(claim types.Claim) {
+	a.agreed[claim.ContractIndex] = true
+}
+
+func (a *agreedClaimTracker) IsAgreed(claim types.Claim) bool {
+	return a.agreed[claim.ContractIndex]
+}

--- a/op-challenger/game/fault/solver/game_solver.go
+++ b/op-challenger/game/fault/solver/game_solver.go
@@ -76,10 +76,7 @@ func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, agreeWi
 }
 
 func (s *GameSolver) calculateMove(ctx context.Context, game types.Game, agreeWithRootClaim bool, claim types.Claim) (*types.Action, error) {
-	if game.AgreeWithClaimLevel(claim, agreeWithRootClaim) {
-		return nil, nil
-	}
-	move, err := s.claimSolver.NextMove(ctx, claim, game)
+	move, err := s.claimSolver.NextMove(ctx, claim, game, agreeWithRootClaim)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate next move for claim index %v: %w", claim.ContractIndex, err)
 	}

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -150,6 +150,18 @@ func TestCalculateNextActions(t *testing.T) {
 					DefendCorrect()                 // We do defend and we shouldn't counter our own claim
 			},
 		},
+		{
+			name: "Freeloader-ContinueDefendingAgainstFreeloader",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq(). // invalid root
+						AttackCorrect().                // Honest response to invalid root
+						AttackCorrect().ExpectDefend(). // Defender attacks with correct value, we should defend
+						AttackCorrect().                // Freeloader attacks instead, we should defend
+						DefendCorrect().                // We do defend
+						Attack(common.Hash{0xaa}).      // freeloader attacks our defense, we should attack
+						ExpectAttack()
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/op-challenger/game/fault/solver/rules.go
+++ b/op-challenger/game/fault/solver/rules.go
@@ -61,7 +61,7 @@ func doNotDuplicateExistingMoves(game types.Game, action types.Action) error {
 		Value:    action.Value,
 		Position: resultingPosition(game, action),
 	}
-	if game.IsDuplicate(types.Claim{ClaimData: newClaimData, ParentContractIndex: action.ParentIdx}) {
+	if _, dupe := game.IsDuplicate(types.Claim{ClaimData: newClaimData, ParentContractIndex: action.ParentIdx}); dupe {
 		return fmt.Errorf("creating duplicate claim at %v with value %v", newClaimData.Position.ToGIndex(), newClaimData.Value)
 	}
 	return nil

--- a/op-challenger/game/fault/solver/solver.go
+++ b/op-challenger/game/fault/solver/solver.go
@@ -112,18 +112,6 @@ func (s *claimSolver) respond(ctx context.Context, claim types.Claim, game types
 	}
 }
 
-func (s *claimSolver) respondToClaim(ctx context.Context, claim types.Claim, game types.Game) (*types.Claim, error) {
-	agree, err := s.agreeWithClaim(ctx, game, claim)
-	if err != nil {
-		return nil, err
-	}
-	if agree {
-		return s.defend(ctx, game, claim)
-	} else {
-		return s.attack(ctx, game, claim)
-	}
-}
-
 // NextMove returns the next move to make given the current state of the game.
 func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, game types.Game, agreedClaims *agreedClaimTracker) (*types.Claim, error) {
 	if claim.Depth() == s.gameDepth {

--- a/op-challenger/game/fault/solver/solver_test.go
+++ b/op-challenger/game/fault/solver/solver_test.go
@@ -167,7 +167,11 @@ func TestAttemptStep(t *testing.T) {
 			game := builder.Game
 			claims := game.Claims()
 			lastClaim := claims[len(claims)-1]
-			step, err := alphabetSolver.AttemptStep(ctx, game, lastClaim)
+			agreedClaims := newAgreedClaimTracker()
+			if tableTest.agreeWithOutputRoot {
+				agreedClaims.MarkAgreed(claims[0])
+			}
+			step, err := alphabetSolver.AttemptStep(ctx, game, lastClaim, agreedClaims)
 			if tableTest.expectedErr == nil {
 				require.NoError(t, err)
 				require.Equal(t, lastClaim, step.LeafClaim)

--- a/op-challenger/game/fault/types/game_test.go
+++ b/op-challenger/game/fault/types/game_test.go
@@ -54,12 +54,22 @@ func TestIsDuplicate(t *testing.T) {
 	g := NewGameState([]Claim{root, top}, testMaxDepth)
 
 	// Root + Top should be duplicates
-	require.True(t, g.IsDuplicate(root))
-	require.True(t, g.IsDuplicate(top))
+	dupeClaim, isDupe := g.IsDuplicate(root)
+	require.True(t, isDupe)
+	require.Equal(t, root, dupeClaim)
+
+	dupeClaim, isDupe = g.IsDuplicate(top)
+	require.True(t, isDupe)
+	require.Equal(t, top, dupeClaim)
 
 	// Middle + Bottom should not be a duplicate
-	require.False(t, g.IsDuplicate(middle))
-	require.False(t, g.IsDuplicate(bottom))
+
+	dupeClaim, isDupe = g.IsDuplicate(middle)
+	require.False(t, isDupe)
+	require.Equal(t, Claim{}, dupeClaim)
+	dupeClaim, isDupe = g.IsDuplicate(bottom)
+	require.False(t, isDupe)
+	require.Equal(t, Claim{}, dupeClaim)
 }
 
 func TestGame_Claims(t *testing.T) {

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -179,13 +179,13 @@ func (g *OutputGameHelper) waitForClaim(ctx context.Context, timeout time.Durati
 	var matchedClaim ContractClaim
 	var matchClaimIdx int64
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
-		count, err := g.game.ClaimDataLen(&bind.CallOpts{Context: timedCtx})
+		count, err := g.game.ClaimDataLen(&bind.CallOpts{Context: ctx})
 		if err != nil {
 			return false, fmt.Errorf("retrieve number of claims: %w", err)
 		}
 		// Search backwards because the new claims are at the end and more likely the ones we want.
 		for i := count.Int64() - 1; i >= 0; i-- {
-			claimData, err := g.game.ClaimData(&bind.CallOpts{Context: timedCtx}, big.NewInt(i))
+			claimData, err := g.game.ClaimData(&bind.CallOpts{Context: ctx}, big.NewInt(i))
 			if err != nil {
 				return false, fmt.Errorf("retrieve claim %v: %w", i, err)
 			}


### PR DESCRIPTION
**Description**

Implements the expanded honest actor behaviour to counter freeloaders as per https://github.com/ethereum-optimism/specs/pull/21/ The code has deliberately been adjusted to be much closer to the python in the spec implementation.

This identifies two problems with the spec:

1. The honest challenger is incorrectly countering correct attacks (correct hash and in correct position)
2. The honest challenger counters its own claims against freeloaders because in the sub-game created to invalidate the freeloader claim, the honest challenger is on the opposite team to when considering the root claim. ie if they were defending, they're now challenging.

TODO: This same logic needs to be applied for checking if we should step and add unit and e2e test for that case. Specifically we should not try to step against our own claims that are countering a freeloader and should step against a freeloader at max depth.

**Tests**

Added game solver unit tests to cover the key cases and demonstrate the self-countering issue.
Updated the e2e test to operate in the top half of the game - previously the freeloader claims were at the game max depth and had to be counted by calling step rather than performing moves.


**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/103
