### PR TITLE
ci: use ci-builder image for slither

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   slither-analyze:
-    runs-on: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.43.0
+    runs-on: ubuntu-latest
+    container:
+      image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.43.0
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   slither-analyze:
-    runs-on: ubuntu-latest
+    runs-on: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.43.0
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Updates the slither github action to use CI builder, so our pinned version of foundry is used, instead of the latest version.

@ethereum-optimism/contract-reviewers Please note that now when updating the CI builder image in `.circleci/config.yml` we'll also need to update it here