### PR TITLE
op-chain-ops: allow ecotone at genesis

### DIFF
--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -97,7 +97,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		return nil, fmt.Errorf("transition block extradata too long: %d", size)
 	}
 
-	return &core.Genesis{
+	genesis := &core.Genesis{
 		Config:     &optimismChainConfig,
 		Nonce:      uint64(config.L2GenesisBlockNonce),
 		Timestamp:  block.Time(),
@@ -111,7 +111,14 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		ParentHash: config.L2GenesisBlockParentHash,
 		BaseFee:    baseFee.ToInt(),
 		Alloc:      map[common.Address]core.GenesisAccount{},
-	}, nil
+	}
+
+	if optimismChainConfig.IsEcotone(genesis.Timestamp) {
+		genesis.BlobGasUsed = u64ptr(0)
+		genesis.ExcessBlobGas = u64ptr(0)
+	}
+
+	return genesis, nil
 }
 
 // NewL1Genesis will create a new L1 genesis config


### PR DESCRIPTION
**Description**

Adds the cancun specific changes to the genesis block.
Cancun is coupled to ecotone so using `IsEcotone` to
see if the fields should be added to the genesis.
Is it a bad assumption to assume that cancun execution
is coupled to ecotone optimism network upgrade?

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

