### PR TITLE
op-node: Add flag categories

### DIFF
--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -130,7 +130,7 @@ func init() {
 	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, txmgr.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, compressor.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, plasma.CLIFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, plasma.CLIFlags(EnvVarPrefix, "")...)
 
 	Flags = append(requiredFlags, optionalFlags...)
 }

--- a/op-bootnode/flags/flags.go
+++ b/op-bootnode/flags/flags.go
@@ -13,8 +13,8 @@ import (
 const envVarPrefix = "OP_BOOTNODE"
 
 var Flags = []cli.Flag{
-	opflags.CLINetworkFlag(envVarPrefix),
-	opflags.CLIRollupConfigFlag(envVarPrefix),
+	opflags.CLINetworkFlag(envVarPrefix, ""),
+	opflags.CLIRollupConfigFlag(envVarPrefix, ""),
 }
 
 func init() {

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -112,7 +112,7 @@ func init() {
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, "")...)
 
 	Flags = append(requiredFlags, optionalFlags...)
 }

--- a/op-node/cmd/networks/cmd.go
+++ b/op-node/cmd/networks/cmd.go
@@ -18,7 +18,7 @@ var Subcommands = []*cli.Command{
 		Name:  "dump-rollup-config",
 		Usage: "Dumps network configs",
 		Flags: []cli.Flag{
-			opflags.CLINetworkFlag(flags.EnvVarPrefix),
+			opflags.CLINetworkFlag(flags.EnvVarPrefix, ""),
 		},
 		Action: func(ctx *cli.Context) error {
 			logCfg := oplog.ReadCLIConfig(ctx)

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -20,13 +20,19 @@ import (
 const EnvVarPrefix = "OP_NODE"
 
 const (
-	RollupCategory     = "ROLLUP"
-	L1RPCCategory      = "L1 RPC"
-	SequencerCategory  = "SEQUENCER"
-	P2PCategory        = "NETWORKING"
-	OperationsCategory = "LOGGING, METRICS, DEBUGGING, AND API"
-	PlasmaCategory     = "PLASMA (EXPERIMENTAL)"
+	RollupCategory     = "1. ROLLUP"
+	L1RPCCategory      = "2. L1 RPC"
+	SequencerCategory  = "3. SEQUENCER"
+	OperationsCategory = "4. LOGGING, METRICS, DEBUGGING, AND API"
+	P2PCategory        = "5. PEER-TO-PEER"
+	PlasmaCategory     = "6. PLASMA (EXPERIMENTAL)"
+	MiscCategory       = "7. MISC"
 )
+
+func init() {
+	cli.HelpFlag.(*cli.BoolFlag).Category = MiscCategory
+	cli.VersionFlag.(*cli.BoolFlag).Category = MiscCategory
+}
 
 func prefixEnvVars(name string) []string {
 	return []string{EnvVarPrefix + "_" + name}
@@ -55,7 +61,6 @@ var (
 		Destination: new(string),
 		Category:    RollupCategory,
 	}
-	/* Optional Flags */
 	BeaconAddr = &cli.StringFlag{
 		Name:     "l1.beacon",
 		Usage:    "Address of L1 Beacon-node HTTP endpoint to use.",
@@ -63,19 +68,20 @@ var (
 		EnvVars:  prefixEnvVars("L1_BEACON"),
 		Category: RollupCategory,
 	}
+	/* Optional Flags */
 	BeaconHeader = &cli.StringFlag{
 		Name:     "l1.beacon-header",
 		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
 		Required: false,
 		EnvVars:  prefixEnvVars("L1_BEACON_HEADER"),
-		Category: RollupCategory,
+		Category: L1RPCCategory,
 	}
 	BeaconArchiverAddr = &cli.StringFlag{
 		Name:     "l1.beacon-archiver",
 		Usage:    "Address of L1 Beacon-node compatible HTTP endpoint to use. This is used to fetch blobs that the --l1.beacon does not have (i.e expired blobs).",
 		Required: false,
 		EnvVars:  prefixEnvVars("L1_BEACON_ARCHIVER"),
-		Category: RollupCategory,
+		Category: L1RPCCategory,
 	}
 	BeaconCheckIgnore = &cli.BoolFlag{
 		Name:     "l1.beacon.ignore",
@@ -83,7 +89,7 @@ var (
 		Required: false,
 		Value:    false,
 		EnvVars:  prefixEnvVars("L1_BEACON_IGNORE"),
-		Category: RollupCategory,
+		Category: L1RPCCategory,
 	}
 	BeaconFetchAllSidecars = &cli.BoolFlag{
 		Name:     "l1.beacon.fetch-all-sidecars",
@@ -91,7 +97,7 @@ var (
 		Required: false,
 		Value:    false,
 		EnvVars:  prefixEnvVars("L1_BEACON_FETCH_ALL_SIDECARS"),
-		Category: RollupCategory,
+		Category: L1RPCCategory,
 	}
 	SyncModeFlag = &cli.GenericFlag{
 		Name:    "syncmode",

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -19,6 +19,15 @@ import (
 
 const EnvVarPrefix = "OP_NODE"
 
+const (
+	RollupCategory     = "ROLLUP"
+	L1RPCCategory      = "L1 RPC"
+	SequencerCategory  = "SEQUENCER"
+	P2PCategory        = "NETWORKING"
+	OperationsCategory = "LOGGING, METRICS, DEBUGGING, AND API"
+	PlasmaCategory     = "PLASMA (EXPERIMENTAL)"
+)
+
 func prefixEnvVars(name string) []string {
 	return []string{EnvVarPrefix + "_" + name}
 }
@@ -26,15 +35,17 @@ func prefixEnvVars(name string) []string {
 var (
 	/* Required Flags */
 	L1NodeAddr = &cli.StringFlag{
-		Name:    "l1",
-		Usage:   "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
-		Value:   "http://127.0.0.1:8545",
-		EnvVars: prefixEnvVars("L1_ETH_RPC"),
+		Name:     "l1",
+		Usage:    "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
+		Value:    "http://127.0.0.1:8545",
+		EnvVars:  prefixEnvVars("L1_ETH_RPC"),
+		Category: RollupCategory,
 	}
 	L2EngineAddr = &cli.StringFlag{
-		Name:    "l2",
-		Usage:   "Address of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)",
-		EnvVars: prefixEnvVars("L2_ENGINE_RPC"),
+		Name:     "l2",
+		Usage:    "Address of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)",
+		EnvVars:  prefixEnvVars("L2_ENGINE_RPC"),
+		Category: RollupCategory,
 	}
 	L2EngineJWTSecret = &cli.StringFlag{
 		Name:        "l2.jwt-secret",
@@ -42,6 +53,7 @@ var (
 		EnvVars:     prefixEnvVars("L2_ENGINE_AUTH"),
 		Value:       "",
 		Destination: new(string),
+		Category:    RollupCategory,
 	}
 	/* Optional Flags */
 	BeaconAddr = &cli.StringFlag{
@@ -49,18 +61,21 @@ var (
 		Usage:    "Address of L1 Beacon-node HTTP endpoint to use.",
 		Required: false,
 		EnvVars:  prefixEnvVars("L1_BEACON"),
+		Category: RollupCategory,
 	}
 	BeaconHeader = &cli.StringFlag{
 		Name:     "l1.beacon-header",
 		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
 		Required: false,
 		EnvVars:  prefixEnvVars("L1_BEACON_HEADER"),
+		Category: RollupCategory,
 	}
 	BeaconArchiverAddr = &cli.StringFlag{
 		Name:     "l1.beacon-archiver",
 		Usage:    "Address of L1 Beacon-node compatible HTTP endpoint to use. This is used to fetch blobs that the --l1.beacon does not have (i.e expired blobs).",
 		Required: false,
 		EnvVars:  prefixEnvVars("L1_BEACON_ARCHIVER"),
+		Category: RollupCategory,
 	}
 	BeaconCheckIgnore = &cli.BoolFlag{
 		Name:     "l1.beacon.ignore",
@@ -68,6 +83,7 @@ var (
 		Required: false,
 		Value:    false,
 		EnvVars:  prefixEnvVars("L1_BEACON_IGNORE"),
+		Category: RollupCategory,
 	}
 	BeaconFetchAllSidecars = &cli.BoolFlag{
 		Name:     "l1.beacon.fetch-all-sidecars",
@@ -75,6 +91,7 @@ var (
 		Required: false,
 		Value:    false,
 		EnvVars:  prefixEnvVars("L1_BEACON_FETCH_ALL_SIDECARS"),
+		Category: RollupCategory,
 	}
 	SyncModeFlag = &cli.GenericFlag{
 		Name:    "syncmode",
@@ -84,33 +101,39 @@ var (
 			out := sync.CLSync
 			return &out
 		}(),
+		Category: RollupCategory,
 	}
 	RPCListenAddr = &cli.StringFlag{
-		Name:    "rpc.addr",
-		Usage:   "RPC listening address",
-		EnvVars: prefixEnvVars("RPC_ADDR"),
-		Value:   "127.0.0.1",
+		Name:     "rpc.addr",
+		Usage:    "RPC listening address",
+		EnvVars:  prefixEnvVars("RPC_ADDR"),
+		Value:    "127.0.0.1",
+		Category: OperationsCategory,
 	}
 	RPCListenPort = &cli.IntFlag{
-		Name:    "rpc.port",
-		Usage:   "RPC listening port",
-		EnvVars: prefixEnvVars("RPC_PORT"),
-		Value:   9545, // Note: op-service/rpc/cli.go uses 8545 as the default.
+		Name:     "rpc.port",
+		Usage:    "RPC listening port",
+		EnvVars:  prefixEnvVars("RPC_PORT"),
+		Value:    9545, // Note: op-service/rpc/cli.go uses 8545 as the default.
+		Category: OperationsCategory,
 	}
 	RPCEnableAdmin = &cli.BoolFlag{
-		Name:    "rpc.enable-admin",
-		Usage:   "Enable the admin API (experimental)",
-		EnvVars: prefixEnvVars("RPC_ENABLE_ADMIN"),
+		Name:     "rpc.enable-admin",
+		Usage:    "Enable the admin API (experimental)",
+		EnvVars:  prefixEnvVars("RPC_ENABLE_ADMIN"),
+		Category: OperationsCategory,
 	}
 	RPCAdminPersistence = &cli.StringFlag{
-		Name:    "rpc.admin-state",
-		Usage:   "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
-		EnvVars: prefixEnvVars("RPC_ADMIN_STATE"),
+		Name:     "rpc.admin-state",
+		Usage:    "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
+		EnvVars:  prefixEnvVars("RPC_ADMIN_STATE"),
+		Category: OperationsCategory,
 	}
 	L1TrustRPC = &cli.BoolFlag{
-		Name:    "l1.trustrpc",
-		Usage:   "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",
-		EnvVars: prefixEnvVars("L1_TRUST_RPC"),
+		Name:     "l1.trustrpc",
+		Usage:    "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",
+		EnvVars:  prefixEnvVars("L1_TRUST_RPC"),
+		Category: L1RPCCategory,
 	}
 	L1RPCProviderKind = &cli.GenericFlag{
 		Name: "l1.rpckind",
@@ -121,124 +144,146 @@ var (
 			out := sources.RPCKindStandard
 			return &out
 		}(),
+		Category: L1RPCCategory,
 	}
 	L1RethDBPath = &cli.StringFlag{
-		Name:    "l1.rethdb",
-		Usage:   "The L1 RethDB path, used to fetch receipts for L1 blocks. Only applicable when using the `reth_db` RPC kind with `l1.rpckind`.",
-		EnvVars: prefixEnvVars("L1_RETHDB"),
-		Hidden:  true,
+		Name:     "l1.rethdb",
+		Usage:    "The L1 RethDB path, used to fetch receipts for L1 blocks. Only applicable when using the `reth_db` RPC kind with `l1.rpckind`.",
+		EnvVars:  prefixEnvVars("L1_RETHDB"),
+		Hidden:   true,
+		Category: L1RPCCategory,
 	}
 	L1RPCMaxConcurrency = &cli.IntFlag{
-		Name:    "l1.max-concurrency",
-		Usage:   "Maximum number of concurrent RPC requests to make to the L1 RPC provider.",
-		EnvVars: prefixEnvVars("L1_MAX_CONCURRENCY"),
-		Value:   10,
+		Name:     "l1.max-concurrency",
+		Usage:    "Maximum number of concurrent RPC requests to make to the L1 RPC provider.",
+		EnvVars:  prefixEnvVars("L1_MAX_CONCURRENCY"),
+		Value:    10,
+		Category: L1RPCCategory,
 	}
 	L1RPCRateLimit = &cli.Float64Flag{
-		Name:    "l1.rpc-rate-limit",
-		Usage:   "Optional self-imposed global rate-limit on L1 RPC requests, specified in requests / second. Disabled if set to 0.",
-		EnvVars: prefixEnvVars("L1_RPC_RATE_LIMIT"),
-		Value:   0,
+		Name:     "l1.rpc-rate-limit",
+		Usage:    "Optional self-imposed global rate-limit on L1 RPC requests, specified in requests / second. Disabled if set to 0.",
+		EnvVars:  prefixEnvVars("L1_RPC_RATE_LIMIT"),
+		Value:    0,
+		Category: L1RPCCategory,
 	}
 	L1RPCMaxBatchSize = &cli.IntFlag{
-		Name:    "l1.rpc-max-batch-size",
-		Usage:   "Maximum number of RPC requests to bundle, e.g. during L1 blocks receipt fetching. The L1 RPC rate limit counts this as N items, but allows it to burst at once.",
-		EnvVars: prefixEnvVars("L1_RPC_MAX_BATCH_SIZE"),
-		Value:   20,
+		Name:     "l1.rpc-max-batch-size",
+		Usage:    "Maximum number of RPC requests to bundle, e.g. during L1 blocks receipt fetching. The L1 RPC rate limit counts this as N items, but allows it to burst at once.",
+		EnvVars:  prefixEnvVars("L1_RPC_MAX_BATCH_SIZE"),
+		Value:    20,
+		Category: L1RPCCategory,
 	}
 	L1HTTPPollInterval = &cli.DurationFlag{
-		Name:    "l1.http-poll-interval",
-		Usage:   "Polling interval for latest-block subscription when using an HTTP RPC provider. Ignored for other types of RPC endpoints.",
-		EnvVars: prefixEnvVars("L1_HTTP_POLL_INTERVAL"),
-		Value:   time.Second * 12,
+		Name:     "l1.http-poll-interval",
+		Usage:    "Polling interval for latest-block subscription when using an HTTP RPC provider. Ignored for other types of RPC endpoints.",
+		EnvVars:  prefixEnvVars("L1_HTTP_POLL_INTERVAL"),
+		Value:    time.Second * 12,
+		Category: L1RPCCategory,
 	}
 	VerifierL1Confs = &cli.Uint64Flag{
-		Name:    "verifier.l1-confs",
-		Usage:   "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
-		EnvVars: prefixEnvVars("VERIFIER_L1_CONFS"),
-		Value:   0,
+		Name:     "verifier.l1-confs",
+		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
+		EnvVars:  prefixEnvVars("VERIFIER_L1_CONFS"),
+		Value:    0,
+		Category: L1RPCCategory,
 	}
 	SequencerEnabledFlag = &cli.BoolFlag{
-		Name:    "sequencer.enabled",
-		Usage:   "Enable sequencing of new L2 blocks. A separate batch submitter has to be deployed to publish the data for verifiers.",
-		EnvVars: prefixEnvVars("SEQUENCER_ENABLED"),
+		Name:     "sequencer.enabled",
+		Usage:    "Enable sequencing of new L2 blocks. A separate batch submitter has to be deployed to publish the data for verifiers.",
+		EnvVars:  prefixEnvVars("SEQUENCER_ENABLED"),
+		Category: SequencerCategory,
 	}
 	SequencerStoppedFlag = &cli.BoolFlag{
-		Name:    "sequencer.stopped",
-		Usage:   "Initialize the sequencer in a stopped state. The sequencer can be started using the admin_startSequencer RPC",
-		EnvVars: prefixEnvVars("SEQUENCER_STOPPED"),
+		Name:     "sequencer.stopped",
+		Usage:    "Initialize the sequencer in a stopped state. The sequencer can be started using the admin_startSequencer RPC",
+		EnvVars:  prefixEnvVars("SEQUENCER_STOPPED"),
+		Category: SequencerCategory,
 	}
 	SequencerMaxSafeLagFlag = &cli.Uint64Flag{
-		Name:    "sequencer.max-safe-lag",
-		Usage:   "Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe. Disabled if 0.",
-		EnvVars: prefixEnvVars("SEQUENCER_MAX_SAFE_LAG"),
-		Value:   0,
+		Name:     "sequencer.max-safe-lag",
+		Usage:    "Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe. Disabled if 0.",
+		EnvVars:  prefixEnvVars("SEQUENCER_MAX_SAFE_LAG"),
+		Value:    0,
+		Category: SequencerCategory,
 	}
 	SequencerL1Confs = &cli.Uint64Flag{
-		Name:    "sequencer.l1-confs",
-		Usage:   "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
-		EnvVars: prefixEnvVars("SEQUENCER_L1_CONFS"),
-		Value:   4,
+		Name:     "sequencer.l1-confs",
+		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
+		EnvVars:  prefixEnvVars("SEQUENCER_L1_CONFS"),
+		Value:    4,
+		Category: SequencerCategory,
 	}
 	L1EpochPollIntervalFlag = &cli.DurationFlag{
-		Name:    "l1.epoch-poll-interval",
-		Usage:   "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
-		EnvVars: prefixEnvVars("L1_EPOCH_POLL_INTERVAL"),
-		Value:   time.Second * 12 * 32,
+		Name:     "l1.epoch-poll-interval",
+		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
+		EnvVars:  prefixEnvVars("L1_EPOCH_POLL_INTERVAL"),
+		Value:    time.Second * 12 * 32,
+		Category: L1RPCCategory,
 	}
 	RuntimeConfigReloadIntervalFlag = &cli.DurationFlag{
-		Name:    "l1.runtime-config-reload-interval",
-		Usage:   "Poll interval for reloading the runtime config, useful when config events are not being picked up. Disabled if 0 or negative.",
-		EnvVars: prefixEnvVars("L1_RUNTIME_CONFIG_RELOAD_INTERVAL"),
-		Value:   time.Minute * 10,
+		Name:     "l1.runtime-config-reload-interval",
+		Usage:    "Poll interval for reloading the runtime config, useful when config events are not being picked up. Disabled if 0 or negative.",
+		EnvVars:  prefixEnvVars("L1_RUNTIME_CONFIG_RELOAD_INTERVAL"),
+		Value:    time.Minute * 10,
+		Category: L1RPCCategory,
 	}
 	MetricsEnabledFlag = &cli.BoolFlag{
-		Name:    "metrics.enabled",
-		Usage:   "Enable the metrics server",
-		EnvVars: prefixEnvVars("METRICS_ENABLED"),
+		Name:     "metrics.enabled",
+		Usage:    "Enable the metrics server",
+		EnvVars:  prefixEnvVars("METRICS_ENABLED"),
+		Category: OperationsCategory,
 	}
 	MetricsAddrFlag = &cli.StringFlag{
-		Name:    "metrics.addr",
-		Usage:   "Metrics listening address",
-		Value:   "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
-		EnvVars: prefixEnvVars("METRICS_ADDR"),
+		Name:     "metrics.addr",
+		Usage:    "Metrics listening address",
+		Value:    "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
+		EnvVars:  prefixEnvVars("METRICS_ADDR"),
+		Category: OperationsCategory,
 	}
 	MetricsPortFlag = &cli.IntFlag{
-		Name:    "metrics.port",
-		Usage:   "Metrics listening port",
-		Value:   7300,
-		EnvVars: prefixEnvVars("METRICS_PORT"),
+		Name:     "metrics.port",
+		Usage:    "Metrics listening port",
+		Value:    7300,
+		EnvVars:  prefixEnvVars("METRICS_PORT"),
+		Category: OperationsCategory,
 	}
 	SnapshotLog = &cli.StringFlag{
-		Name:    "snapshotlog.file",
-		Usage:   "Path to the snapshot log file",
-		EnvVars: prefixEnvVars("SNAPSHOT_LOG"),
+		Name:     "snapshotlog.file",
+		Usage:    "Path to the snapshot log file",
+		EnvVars:  prefixEnvVars("SNAPSHOT_LOG"),
+		Category: OperationsCategory,
 	}
 	HeartbeatEnabledFlag = &cli.BoolFlag{
-		Name:    "heartbeat.enabled",
-		Usage:   "Enables or disables heartbeating",
-		EnvVars: prefixEnvVars("HEARTBEAT_ENABLED"),
+		Name:     "heartbeat.enabled",
+		Usage:    "Enables or disables heartbeating",
+		EnvVars:  prefixEnvVars("HEARTBEAT_ENABLED"),
+		Category: OperationsCategory,
 	}
 	HeartbeatMonikerFlag = &cli.StringFlag{
-		Name:    "heartbeat.moniker",
-		Usage:   "Sets a moniker for this node",
-		EnvVars: prefixEnvVars("HEARTBEAT_MONIKER"),
+		Name:     "heartbeat.moniker",
+		Usage:    "Sets a moniker for this node",
+		EnvVars:  prefixEnvVars("HEARTBEAT_MONIKER"),
+		Category: OperationsCategory,
 	}
 	HeartbeatURLFlag = &cli.StringFlag{
-		Name:    "heartbeat.url",
-		Usage:   "Sets the URL to heartbeat to",
-		EnvVars: prefixEnvVars("HEARTBEAT_URL"),
-		Value:   "https://heartbeat.optimism.io",
+		Name:     "heartbeat.url",
+		Usage:    "Sets the URL to heartbeat to",
+		EnvVars:  prefixEnvVars("HEARTBEAT_URL"),
+		Value:    "https://heartbeat.optimism.io",
+		Category: OperationsCategory,
 	}
 	RollupHalt = &cli.StringFlag{
-		Name:    "rollup.halt",
-		Usage:   "Opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled onchain in L1",
-		EnvVars: prefixEnvVars("ROLLUP_HALT"),
+		Name:     "rollup.halt",
+		Usage:    "Opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled onchain in L1",
+		EnvVars:  prefixEnvVars("ROLLUP_HALT"),
+		Category: RollupCategory,
 	}
 	RollupLoadProtocolVersions = &cli.BoolFlag{
-		Name:    "rollup.load-protocol-versions",
-		Usage:   "Load protocol versions from the superchain L1 ProtocolVersions contract (if available), and report in logs and metrics",
-		EnvVars: prefixEnvVars("ROLLUP_LOAD_PROTOCOL_VERSIONS"),
+		Name:     "rollup.load-protocol-versions",
+		Usage:    "Load protocol versions from the superchain L1 ProtocolVersions contract (if available), and report in logs and metrics",
+		EnvVars:  prefixEnvVars("ROLLUP_LOAD_PROTOCOL_VERSIONS"),
+		Category: RollupCategory,
 	}
 	/* Deprecated Flags */
 	L2EngineSyncEnabled = &cli.BoolFlag{
@@ -276,22 +321,25 @@ var (
 		Hidden:  true,
 	}
 	ConductorEnabledFlag = &cli.BoolFlag{
-		Name:    "conductor.enabled",
-		Usage:   "Enable the conductor service",
-		EnvVars: prefixEnvVars("CONDUCTOR_ENABLED"),
-		Value:   false,
+		Name:     "conductor.enabled",
+		Usage:    "Enable the conductor service",
+		EnvVars:  prefixEnvVars("CONDUCTOR_ENABLED"),
+		Value:    false,
+		Category: SequencerCategory,
 	}
 	ConductorRpcFlag = &cli.StringFlag{
-		Name:    "conductor.rpc",
-		Usage:   "Conductor service rpc endpoint",
-		EnvVars: prefixEnvVars("CONDUCTOR_RPC"),
-		Value:   "http://127.0.0.1:8547",
+		Name:     "conductor.rpc",
+		Usage:    "Conductor service rpc endpoint",
+		EnvVars:  prefixEnvVars("CONDUCTOR_RPC"),
+		Value:    "http://127.0.0.1:8547",
+		Category: SequencerCategory,
 	}
 	ConductorRpcTimeoutFlag = &cli.DurationFlag{
-		Name:    "conductor.rpc-timeout",
-		Usage:   "Conductor service rpc timeout",
-		EnvVars: prefixEnvVars("CONDUCTOR_RPC_TIMEOUT"),
-		Value:   time.Second * 1,
+		Name:     "conductor.rpc-timeout",
+		Usage:    "Conductor service rpc timeout",
+		EnvVars:  prefixEnvVars("CONDUCTOR_RPC_TIMEOUT"),
+		Value:    time.Second * 1,
+		Category: SequencerCategory,
 	}
 )
 
@@ -355,11 +403,11 @@ var Flags []cli.Flag
 func init() {
 	DeprecatedFlags = append(DeprecatedFlags, deprecatedP2PFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, P2PFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, oplog.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
+	optionalFlags = append(optionalFlags, oppprof.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
 	optionalFlags = append(optionalFlags, DeprecatedFlags...)
-	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, plasma.CLIFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, RollupCategory)...)
+	optionalFlags = append(optionalFlags, plasma.CLIFlags(EnvVarPrefix, PlasmaCategory)...)
 	Flags = append(requiredFlags, optionalFlags...)
 }
 

--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -62,6 +62,7 @@ func deprecatedP2PFlags(envPrefix string) []cli.Flag {
 			Usage:    fmt.Sprintf("Deprecated: Use %v instead", ScoringName),
 			Required: false,
 			Hidden:   true,
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     PeerScoreBandsName,
@@ -69,12 +70,14 @@ func deprecatedP2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "",
 			Hidden:   true,
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     TopicScoringName,
 			Usage:    fmt.Sprintf("Deprecated: Use %v instead", ScoringName),
 			Required: false,
 			Hidden:   true,
+			Category: P2PCategory,
 		},
 	}
 }
@@ -88,12 +91,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Usage:    "Completely disable the P2P stack",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "DISABLE"),
+			Category: P2PCategory,
 		},
 		&cli.BoolFlag{
 			Name:     NoDiscoveryName,
 			Usage:    "Disable Discv5 (node discovery)",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "NO_DISCOVERY"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     ScoringName,
@@ -101,6 +106,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "light",
 			EnvVars:  p2pEnv(envPrefix, "PEER_SCORING"),
+			Category: P2PCategory,
 		},
 		&cli.BoolFlag{
 			// Banning Flag - whether or not we want to act on the scoring
@@ -109,6 +115,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Value:    true,
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING"),
+			Category: P2PCategory,
 		},
 		&cli.Float64Flag{
 			Name:     BanningThresholdName,
@@ -116,6 +123,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    -100,
 			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING_THRESHOLD"),
+			Category: P2PCategory,
 		},
 		&cli.DurationFlag{
 			Name:     BanningDurationName,
@@ -123,6 +131,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    1 * time.Hour,
 			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING_DURATION"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name: P2PPrivPathName,
@@ -132,6 +141,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Value:     "opnode_p2p_priv.txt",
 			EnvVars:   p2pEnv(envPrefix, "PRIV_PATH"),
 			TakesFile: true,
+			Category:  P2PCategory,
 		},
 		&cli.StringFlag{
 			// sometimes it may be ok to not persist the peer priv key as file, and instead pass it directly.
@@ -141,6 +151,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Hidden:   true,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "PRIV_RAW"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     ListenIPName,
@@ -148,6 +159,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "0.0.0.0",
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_IP"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     ListenTCPPortName,
@@ -155,6 +167,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    9222,
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_TCP_PORT"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     ListenUDPPortName,
@@ -162,6 +175,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    0, // can simply match the TCP libp2p port
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_UDP_PORT"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     AdvertiseIPName,
@@ -169,8 +183,9 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			// Ignored by default, nodes can discover their own external IP in the happy case,
 			// by communicating with bootnodes. Fixed IP is recommended for faster bootstrap though.
-			Value:   "",
-			EnvVars: p2pEnv(envPrefix, "ADVERTISE_IP"),
+			Value:    "",
+			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_IP"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     AdvertiseTCPPortName,
@@ -178,6 +193,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    0,
 			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_TCP"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     AdvertiseUDPPortName,
@@ -185,6 +201,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    0,
 			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_UDP"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     BootnodesName,
@@ -192,6 +209,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "BOOTNODES"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name: StaticPeersName,
@@ -200,12 +218,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "STATIC"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     NetRestrictName,
 			Usage:    "Comma-separated list of CIDR masks. P2P will only try to connect on these networks",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "NETRESTRICT"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     HostMuxName,
@@ -214,6 +234,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "yamux,mplex",
 			EnvVars:  p2pEnv(envPrefix, "MUX"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     HostSecurityName,
@@ -222,6 +243,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "noise",
 			EnvVars:  p2pEnv(envPrefix, "SECURITY"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     PeersLoName,
@@ -229,6 +251,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    20,
 			EnvVars:  p2pEnv(envPrefix, "PEERS_LO"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     PeersHiName,
@@ -236,6 +259,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    30,
 			EnvVars:  p2pEnv(envPrefix, "PEERS_HI"),
+			Category: P2PCategory,
 		},
 		&cli.DurationFlag{
 			Name:     PeersGraceName,
@@ -243,12 +267,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    30 * time.Second,
 			EnvVars:  p2pEnv(envPrefix, "PEERS_GRACE"),
+			Category: P2PCategory,
 		},
 		&cli.BoolFlag{
 			Name:     NATName,
 			Usage:    "Enable NAT traversal with PMP/UPNP devices to learn external IP.",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "NAT"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     UserAgentName,
@@ -257,6 +283,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "optimism",
 			EnvVars:  p2pEnv(envPrefix, "AGENT"),
+			Category: P2PCategory,
 		},
 		&cli.DurationFlag{
 			Name:     TimeoutNegotiationName,
@@ -265,6 +292,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    10 * time.Second,
 			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_NEGOTIATION"),
+			Category: P2PCategory,
 		},
 		&cli.DurationFlag{
 			Name:     TimeoutAcceptName,
@@ -273,6 +301,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    10 * time.Second,
 			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_ACCEPT"),
+			Category: P2PCategory,
 		},
 		&cli.DurationFlag{
 			Name:     TimeoutDialName,
@@ -281,6 +310,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    10 * time.Second,
 			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_DIAL"),
+			Category: P2PCategory,
 		},
 		&cli.StringFlag{
 			Name: PeerstorePathName,
@@ -291,6 +321,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			TakesFile: true,
 			Value:     "opnode_peerstore_db",
 			EnvVars:   p2pEnv(envPrefix, "PEERSTORE_PATH"),
+			Category:  P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:      DiscoveryPathName,
@@ -299,6 +330,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			TakesFile: true,
 			Value:     "opnode_discovery_db",
 			EnvVars:   p2pEnv(envPrefix, "DISCOVERY_PATH"),
+			Category:  P2PCategory,
 		},
 		&cli.StringFlag{
 			Name:     SequencerP2PKeyName,
@@ -306,6 +338,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "SEQUENCER_KEY"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     GossipMeshDName,
@@ -314,6 +347,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Hidden:   true,
 			Value:    p2p.DefaultMeshD,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_D"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     GossipMeshDloName,
@@ -322,6 +356,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Hidden:   true,
 			Value:    p2p.DefaultMeshDlo,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DLO"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     GossipMeshDhiName,
@@ -330,6 +365,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Hidden:   true,
 			Value:    p2p.DefaultMeshDhi,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DHI"),
+			Category: P2PCategory,
 		},
 		&cli.UintFlag{
 			Name:     GossipMeshDlazyName,
@@ -338,6 +374,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Hidden:   true,
 			Value:    p2p.DefaultMeshDlazy,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DLAZY"),
+			Category: P2PCategory,
 		},
 		&cli.BoolFlag{
 			Name:     GossipFloodPublishName,
@@ -345,6 +382,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Hidden:   true,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_FLOOD_PUBLISH"),
+			Category: P2PCategory,
 		},
 		&cli.BoolFlag{
 			Name:     SyncReqRespName,
@@ -352,6 +390,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Value:    true,
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "SYNC_REQ_RESP"),
+			Category: P2PCategory,
 		},
 	}
 }

--- a/op-plasma/cli.go
+++ b/op-plasma/cli.go
@@ -17,24 +17,27 @@ func plasmaEnv(envprefix, v string) []string {
 	return []string{envprefix + "_PLASMA_" + v}
 }
 
-func CLIFlags(envPrefix string) []cli.Flag {
+func CLIFlags(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
-			Name:    EnabledFlagName,
-			Usage:   "Enable plasma mode",
-			Value:   false,
-			EnvVars: plasmaEnv(envPrefix, "ENABLED"),
+			Name:     EnabledFlagName,
+			Usage:    "Enable plasma mode",
+			Value:    false,
+			EnvVars:  plasmaEnv(envPrefix, "ENABLED"),
+			Category: category,
 		},
 		&cli.StringFlag{
-			Name:    DaServerAddressFlagName,
-			Usage:   "HTTP address of a DA Server",
-			EnvVars: plasmaEnv(envPrefix, "DA_SERVER"),
+			Name:     DaServerAddressFlagName,
+			Usage:    "HTTP address of a DA Server",
+			EnvVars:  plasmaEnv(envPrefix, "DA_SERVER"),
+			Category: category,
 		},
 		&cli.BoolFlag{
-			Name:    VerifyOnReadFlagName,
-			Usage:   "Verify input data matches the commitments from the DA storage service",
-			Value:   true,
-			EnvVars: plasmaEnv(envPrefix, "VERIFY_ON_READ"),
+			Name:     VerifyOnReadFlagName,
+			Usage:    "Verify input data matches the commitments from the DA storage service",
+			Value:    true,
+			EnvVars:  plasmaEnv(envPrefix, "VERIFY_ON_READ"),
+			Category: category,
 		},
 	}
 }

--- a/op-service/flags/flags.go
+++ b/op-service/flags/flags.go
@@ -18,44 +18,49 @@ const (
 	EcotoneOverrideFlagName = "override.ecotone"
 )
 
-func CLIFlags(envPrefix string) []cli.Flag {
+func CLIFlags(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.Uint64Flag{
-			Name:    CanyonOverrideFlagName,
-			Usage:   "Manually specify the Canyon fork timestamp, overriding the bundled setting",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "OVERRIDE_CANYON"),
-			Hidden:  false,
+			Name:     CanyonOverrideFlagName,
+			Usage:    "Manually specify the Canyon fork timestamp, overriding the bundled setting",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_CANYON"),
+			Hidden:   false,
+			Category: category,
 		},
 		&cli.Uint64Flag{
-			Name:    DeltaOverrideFlagName,
-			Usage:   "Manually specify the Delta fork timestamp, overriding the bundled setting",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "OVERRIDE_DELTA"),
-			Hidden:  false,
+			Name:     DeltaOverrideFlagName,
+			Usage:    "Manually specify the Delta fork timestamp, overriding the bundled setting",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_DELTA"),
+			Hidden:   false,
+			Category: category,
 		},
 		&cli.Uint64Flag{
-			Name:    EcotoneOverrideFlagName,
-			Usage:   "Manually specify the Ecotone fork timestamp, overriding the bundled setting",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "OVERRIDE_ECOTONE"),
-			Hidden:  false,
+			Name:     EcotoneOverrideFlagName,
+			Usage:    "Manually specify the Ecotone fork timestamp, overriding the bundled setting",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_ECOTONE"),
+			Hidden:   false,
+			Category: category,
 		},
-		CLINetworkFlag(envPrefix),
-		CLIRollupConfigFlag(envPrefix),
+		CLINetworkFlag(envPrefix, category),
+		CLIRollupConfigFlag(envPrefix, category),
 	}
 }
 
-func CLINetworkFlag(envPrefix string) cli.Flag {
+func CLINetworkFlag(envPrefix string, category string) cli.Flag {
 	return &cli.StringFlag{
-		Name:    NetworkFlagName,
-		Usage:   fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
-		EnvVars: opservice.PrefixEnvVar(envPrefix, "NETWORK"),
+		Name:     NetworkFlagName,
+		Usage:    fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
+		EnvVars:  opservice.PrefixEnvVar(envPrefix, "NETWORK"),
+		Category: category,
 	}
 }
 
-func CLIRollupConfigFlag(envPrefix string) cli.Flag {
+func CLIRollupConfigFlag(envPrefix string, category string) cli.Flag {
 	return &cli.StringFlag{
-		Name:    RollupConfigFlagName,
-		Usage:   "Rollup chain parameters",
-		EnvVars: opservice.PrefixEnvVar(envPrefix, "ROLLUP_CONFIG"),
+		Name:     RollupConfigFlagName,
+		Usage:    "Rollup chain parameters",
+		EnvVars:  opservice.PrefixEnvVar(envPrefix, "ROLLUP_CONFIG"),
+		Category: category,
 	}
 }
 

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -22,27 +22,34 @@ const (
 	ColorFlagName  = "log.color"
 )
 
-// CLIFlags creates flag definitions for the logging utils.
+func CLIFlags(envPrefix string) []cli.Flag {
+	return CLIFlagsWithCategory(envPrefix, "")
+}
+
+// CLIFlagsWithCategory creates flag definitions for the logging utils.
 // Warning: flags are not safe to reuse due to an upstream urfave default-value mutation bug in GenericFlag.
 // Use cliapp.ProtectFlags(flags) to create a copy before passing it into an App if the app runs more than once.
-func CLIFlags(envPrefix string) []cli.Flag {
+func CLIFlagsWithCategory(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.GenericFlag{
-			Name:    LevelFlagName,
-			Usage:   "The lowest log level that will be output",
-			Value:   NewLevelFlagValue(log.LevelInfo),
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "LOG_LEVEL"),
+			Name:     LevelFlagName,
+			Usage:    "The lowest log level that will be output",
+			Value:    NewLevelFlagValue(log.LevelInfo),
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "LOG_LEVEL"),
+			Category: category,
 		},
 		&cli.GenericFlag{
-			Name:    FormatFlagName,
-			Usage:   "Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty',",
-			Value:   NewFormatFlagValue(FormatText),
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "LOG_FORMAT"),
+			Name:     FormatFlagName,
+			Usage:    "Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty',",
+			Value:    NewFormatFlagValue(FormatText),
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "LOG_FORMAT"),
+			Category: category,
 		},
 		&cli.BoolFlag{
-			Name:    ColorFlagName,
-			Usage:   "Color the log output if in terminal mode",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "LOG_COLOR"),
+			Name:     ColorFlagName,
+			Usage:    "Color the log output if in terminal mode",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "LOG_COLOR"),
+			Category: category,
 		},
 	}
 }

--- a/op-service/oppprof/cli.go
+++ b/op-service/oppprof/cli.go
@@ -61,29 +61,37 @@ func DefaultCLIConfig() CLIConfig {
 }
 
 func CLIFlags(envPrefix string) []cli.Flag {
+	return CLIFlagsWithCategory(envPrefix, "")
+}
+
+func CLIFlagsWithCategory(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
-			Name:    EnabledFlagName,
-			Usage:   "Enable the pprof server",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "PPROF_ENABLED"),
+			Name:     EnabledFlagName,
+			Usage:    "Enable the pprof server",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "PPROF_ENABLED"),
+			Category: category,
 		},
 		&cli.StringFlag{
-			Name:    ListenAddrFlagName,
-			Usage:   "pprof listening address",
-			Value:   defaultListenAddr, // TODO(CLI-4159): Switch to 127.0.0.1
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "PPROF_ADDR"),
+			Name:     ListenAddrFlagName,
+			Usage:    "pprof listening address",
+			Value:    defaultListenAddr, // TODO(CLI-4159): Switch to 127.0.0.1
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "PPROF_ADDR"),
+			Category: category,
 		},
 		&cli.IntFlag{
-			Name:    PortFlagName,
-			Usage:   "pprof listening port",
-			Value:   defaultListenPort,
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "PPROF_PORT"),
+			Name:     PortFlagName,
+			Usage:    "pprof listening port",
+			Value:    defaultListenPort,
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "PPROF_PORT"),
+			Category: category,
 		},
 		&cli.GenericFlag{
-			Name:    ProfilePathFlagName,
-			Usage:   "pprof file path. If it is a directory, the path is {dir}/{profileType}.prof",
-			Value:   new(flags.PathFlag),
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "PPROF_PATH"),
+			Name:     ProfilePathFlagName,
+			Usage:    "pprof file path. If it is a directory, the path is {dir}/{profileType}.prof",
+			Value:    new(flags.PathFlag),
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "PPROF_PATH"),
+			Category: category,
 		},
 		&cli.GenericFlag{
 			Name:  ProfileTypeFlagName,
@@ -92,7 +100,8 @@ func CLIFlags(envPrefix string) []cli.Flag {
 				defaultProfType := profileType("")
 				return &defaultProfType
 			}(),
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "PPROF_TYPE"),
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "PPROF_TYPE"),
+			Category: category,
 		},
 	}
 }


### PR DESCRIPTION
**Description**

Added categories to organize the op-node flags. Tested that an empty category puts it into the global category for non op-node binaries.
