### PR TITLE
op-dispute-mon: Fix resolution to respect step actions

### DIFF
--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -3,18 +3,32 @@ package solver
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"testing"
 
 	faulttest "github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/resolution"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/transform"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
+const expectFreeloaderCounters = false
+
+type RunCondition uint8
+
+const (
+	RunAlways RunCondition = iota
+	RunFreeloadersCountered
+	RunFreeloadersNotCountered
+)
+
 func TestCalculateNextActions(t *testing.T) {
-	maxDepth := types.Depth(4)
+	maxDepth := types.Depth(6)
 	startingL2BlockNumber := big.NewInt(0)
 	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, startingL2BlockNumber, maxDepth)
 
@@ -22,6 +36,7 @@ func TestCalculateNextActions(t *testing.T) {
 		name             string
 		rootClaimCorrect bool
 		setupGame        func(builder *faulttest.GameBuilder)
+		runCondition     RunCondition
 	}{
 		{
 			name: "AttackRootClaim",
@@ -61,6 +76,8 @@ func TestCalculateNextActions(t *testing.T) {
 				lastHonestClaim := builder.Seq().
 					AttackCorrect().
 					AttackCorrect().
+					DefendCorrect().
+					DefendCorrect().
 					DefendCorrect()
 				lastHonestClaim.AttackCorrect().ExpectStepDefend()
 				lastHonestClaim.Attack(common.Hash{0xdd}).ExpectStepAttack()
@@ -84,18 +101,109 @@ func TestCalculateNextActions(t *testing.T) {
 					Attack(maliciousStateHash)
 			},
 		},
+		{
+			name: "Freeloader-ValidClaimAtInvalidAttackPosition",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                // Honest response to invalid root
+					DefendCorrect().ExpectDefend(). // Defender agrees at this point, we should defend
+					AttackCorrect().ExpectDefend()  // Freeloader attacks instead of defends
+			},
+			runCondition: RunFreeloadersCountered,
+		},
+		{
+			name: "Freeloader-InvalidClaimAtInvalidAttackPosition",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                         // Honest response to invalid root
+					DefendCorrect().ExpectDefend().          // Defender agrees at this point, we should defend
+					Attack(common.Hash{0xbb}).ExpectAttack() // Freeloader attacks with wrong claim instead of defends
+			},
+			runCondition: RunFreeloadersCountered,
+		},
+		{
+			name: "Freeloader-InvalidClaimAtValidDefensePosition",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                         // Honest response to invalid root
+					DefendCorrect().ExpectDefend().          // Defender agrees at this point, we should defend
+					Defend(common.Hash{0xbb}).ExpectAttack() // Freeloader defends with wrong claim, we should attack
+			},
+			runCondition: RunFreeloadersCountered,
+		},
+		{
+			name: "Freeloader-InvalidClaimAtValidAttackPosition",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                          // Honest response to invalid root
+					Defend(common.Hash{0xaa}).ExpectAttack(). // Defender disagrees at this point, we should attack
+					Attack(common.Hash{0xbb}).ExpectAttack()  // Freeloader attacks with wrong claim instead of defends
+			},
+			runCondition: RunFreeloadersCountered,
+		},
+		{
+			name: "Freeloader-InvalidClaimAtInvalidDefensePosition",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                          // Honest response to invalid root
+					Defend(common.Hash{0xaa}).ExpectAttack(). // Defender disagrees at this point, we should attack
+					Defend(common.Hash{0xbb})                 // Freeloader defends with wrong claim but we must not respond to avoid poisoning
+			},
+		},
+		{
+			name: "Freeloader-ValidClaimAtInvalidAttackPosition-RespondingToDishonestButCorrectAttack",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                // Honest response to invalid root
+					AttackCorrect().ExpectDefend(). // Defender attacks with correct value, we should defend
+					AttackCorrect().ExpectDefend()  // Freeloader attacks with wrong claim, we should defend
+			},
+			runCondition: RunFreeloadersCountered,
+		},
+		{
+			name: "Freeloader-DoNotCounterOwnClaim",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().                // Honest response to invalid root
+					AttackCorrect().ExpectDefend(). // Defender attacks with correct value, we should defend
+					AttackCorrect().                // Freeloader attacks instead, we should defend
+					DefendCorrect()                 // We do defend and we shouldn't counter our own claim
+			},
+			runCondition: RunFreeloadersCountered,
+		},
+		{
+			name: "Freeloader-ContinueDefendingAgainstFreeloader",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq(). // invalid root
+						AttackCorrect().                // Honest response to invalid root
+						AttackCorrect().ExpectDefend(). // Defender attacks with correct value, we should defend
+						AttackCorrect().                // Freeloader attacks instead, we should defend
+						DefendCorrect().                // We do defend
+						Attack(common.Hash{0xaa}).      // freeloader attacks our defense, we should attack
+						ExpectAttack()
+			},
+			runCondition: RunFreeloadersCountered,
+		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			switch test.runCondition {
+			case RunAlways:
+			case RunFreeloadersCountered:
+				if !expectFreeloaderCounters {
+					t.Skip("Freeloader countering not enabled")
+				}
+			case RunFreeloadersNotCountered:
+				if expectFreeloaderCounters {
+					t.Skip("Freeloader countering enabled")
+				}
+			}
 			builder := claimBuilder.GameBuilder(test.rootClaimCorrect)
 			test.setupGame(builder)
 			game := builder.Game
-			for i, claim := range game.Claims() {
-				t.Logf("Claim %v: Pos: %v TraceIdx: %v ParentIdx: %v, CounteredBy: %v, Value: %v",
-					i, claim.Position.ToGIndex(), claim.Position.TraceIndex(maxDepth), claim.ParentContractIndex, claim.CounteredBy, claim.Value)
-			}
+			logClaims(t, game)
 
 			solver := NewGameSolver(maxDepth, trace.NewSimpleTraceAccessor(claimBuilder.CorrectTraceProvider()))
 			actions, err := solver.CalculateNextActions(context.Background(), game)
@@ -112,6 +220,61 @@ func TestCalculateNextActions(t *testing.T) {
 				require.Containsf(t, actions, action, "Expected claim %v missing", i)
 			}
 			require.Len(t, actions, len(builder.ExpectedActions), "Incorrect number of actions")
+
+			challengerAddr := common.Address{0xaa, 0xbb, 0xcc, 0xdd}
+			postState := applyActions(game, challengerAddr, actions)
+			t.Log("Post game state:")
+			logClaims(t, postState)
+			actualResult := gameResult(postState)
+			expectedResult := gameTypes.GameStatusChallengerWon
+			if test.rootClaimCorrect {
+				expectedResult = gameTypes.GameStatusDefenderWon
+			}
+			require.Equalf(t, expectedResult, actualResult, "Game should resolve correctly expected %v but was %v", expectedResult, actualResult)
 		})
 	}
+}
+
+func logClaims(t *testing.T, game types.Game) {
+	for i, claim := range game.Claims() {
+		t.Logf("Claim %v: Pos: %v TraceIdx: %v Depth: %v IndexAtDepth: %v ParentIdx: %v Value: %v Claimant: %v CounteredBy: %v",
+			i, claim.Position.ToGIndex(), claim.Position.TraceIndex(game.MaxDepth()), claim.Position.Depth(), claim.Position.IndexAtDepth(), claim.ParentContractIndex, claim.Value, claim.Claimant, claim.CounteredBy)
+	}
+}
+
+func applyActions(game types.Game, claimant common.Address, actions []types.Action) types.Game {
+	claims := game.Claims()
+	for _, action := range actions {
+		switch action.Type {
+		case types.ActionTypeMove:
+			newPosition := action.ParentPosition.Attack()
+			if !action.IsAttack {
+				newPosition = action.ParentPosition.Defend()
+			}
+			claim := types.Claim{
+				ClaimData: types.ClaimData{
+					Value:    action.Value,
+					Bond:     big.NewInt(0),
+					Position: newPosition,
+				},
+				Claimant:            claimant,
+				Clock:               nil,
+				ContractIndex:       len(claims),
+				ParentContractIndex: action.ParentIdx,
+			}
+			claims = append(claims, claim)
+		case types.ActionTypeStep:
+			counteredClaim := claims[action.ParentIdx]
+			counteredClaim.CounteredBy = claimant
+			claims[action.ParentIdx] = counteredClaim
+		default:
+			panic(fmt.Errorf("unknown move type: %v", action.Type))
+		}
+	}
+	return types.NewGameState(claims, game.MaxDepth())
+}
+
+func gameResult(game types.Game) gameTypes.GameStatus {
+	tree := transform.CreateBidirectionalTree(game.Claims())
+	return resolution.Resolve(tree)
 }

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -184,6 +184,16 @@ func TestCalculateNextActions(t *testing.T) {
 			},
 			runCondition: RunFreeloadersCountered,
 		},
+		{
+			name: "Freeloader-FreeloaderCountersRootClaim",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					ExpectAttack().            // Honest response to invalid root
+					Attack(common.Hash{0xaa}). // freeloader
+					ExpectAttack()             // Honest response to freeloader
+			},
+			runCondition: RunFreeloadersCountered,
+		},
 	}
 
 	for _, test := range tests {

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var DefaultClaimant = common.Address{0x09, 0x23, 0x34, 0x45, 0x13, 0xb3}
+
 // ClaimBuilder is a test utility to enable creating claims in a wide range of situations
 type ClaimBuilder struct {
 	require  *require.Assertions
@@ -80,6 +82,7 @@ func (c *ClaimBuilder) CreateRootClaim(correct bool) types.Claim {
 			Value:    value,
 			Position: types.NewPosition(0, common.Big0),
 		},
+		Claimant: DefaultClaimant,
 	}
 	return claim
 }
@@ -91,6 +94,7 @@ func (c *ClaimBuilder) CreateLeafClaim(traceIndex *big.Int, correct bool) types.
 			Value:    c.claim(pos, correct),
 			Position: pos,
 		},
+		Claimant: DefaultClaimant,
 	}
 }
 
@@ -102,6 +106,7 @@ func (c *ClaimBuilder) AttackClaim(claim types.Claim, correct bool) types.Claim 
 			Position: pos,
 		},
 		ParentContractIndex: claim.ContractIndex,
+		Claimant:            DefaultClaimant,
 	}
 }
 
@@ -113,6 +118,7 @@ func (c *ClaimBuilder) AttackClaimWithValue(claim types.Claim, value common.Hash
 			Position: pos,
 		},
 		ParentContractIndex: claim.ContractIndex,
+		Claimant:            DefaultClaimant,
 	}
 }
 
@@ -124,6 +130,7 @@ func (c *ClaimBuilder) DefendClaim(claim types.Claim, correct bool) types.Claim 
 			Position: pos,
 		},
 		ParentContractIndex: claim.ContractIndex,
+		Claimant:            DefaultClaimant,
 	}
 }
 
@@ -135,5 +142,6 @@ func (c *ClaimBuilder) DefendClaimWithValue(claim types.Claim, value common.Hash
 			Position: pos,
 		},
 		ParentContractIndex: claim.ContractIndex,
+		Claimant:            DefaultClaimant,
 	}
 }

--- a/op-challenger/game/fault/test/game_builder.go
+++ b/op-challenger/game/fault/test/game_builder.go
@@ -86,6 +86,12 @@ func (s *GameBuilderSeq) Defend(value common.Hash) *GameBuilderSeq {
 	}
 }
 
+func (s *GameBuilderSeq) Step() {
+	claims := s.gameBuilder.Game.Claims()
+	claims[len(claims)-1].CounteredBy = DefaultClaimant
+	s.gameBuilder.Game = types.NewGameState(claims, s.builder.maxDepth)
+}
+
 func (s *GameBuilderSeq) ExpectAttack() *GameBuilderSeq {
 	newPos := s.lastClaim.Position.Attack()
 	value := s.builder.CorrectClaimAtPosition(newPos)

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -296,7 +296,6 @@ func createDeepClaimList() []faultTypes.Claim {
 				Position: faultTypes.NewPosition(0, big.NewInt(0)),
 			},
 			ContractIndex:       0,
-			CounteredBy:         common.HexToAddress("0x222222"),
 			ParentContractIndex: math.MaxInt64,
 			Claimant:            common.HexToAddress("0x111111"),
 		},
@@ -304,7 +303,6 @@ func createDeepClaimList() []faultTypes.Claim {
 			ClaimData: faultTypes.ClaimData{
 				Position: faultTypes.NewPosition(1, big.NewInt(0)),
 			},
-			CounteredBy:         common.HexToAddress("0x111111"),
 			ContractIndex:       1,
 			ParentContractIndex: 0,
 			Claimant:            common.HexToAddress("0x222222"),

--- a/op-dispute-mon/mon/resolution/resolver.go
+++ b/op-dispute-mon/mon/resolution/resolver.go
@@ -13,7 +13,7 @@ import (
 func Resolve(tree *monTypes.BidirectionalTree) gameTypes.GameStatus {
 	for i := len(tree.Claims) - 1; i >= 0; i-- {
 		claim := tree.Claims[i]
-		counterClaimant := common.Address{}
+		counterClaimant := claim.Claim.CounteredBy
 		for _, child := range claim.Children {
 			if child.Claim.CounteredBy == (common.Address{}) {
 				counterClaimant = child.Claim.Claimant

--- a/op-dispute-mon/mon/resolution/resolver_test.go
+++ b/op-dispute-mon/mon/resolution/resolver_test.go
@@ -1,91 +1,129 @@
 package resolution
 
 import (
-	"math"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/transform"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 )
 
 func TestResolver_Resolve(t *testing.T) {
 	t.Run("NoClaims", func(t *testing.T) {
-		tree := &monTypes.BidirectionalTree{Claims: []*monTypes.BidirectionalClaim{}}
+		tree := transform.CreateBidirectionalTree([]faultTypes.Claim{})
 		status := Resolve(tree)
 		require.Equal(t, gameTypes.GameStatusDefenderWon, status)
 	})
 
 	t.Run("SingleRootClaim", func(t *testing.T) {
-		tree := createBidirectionalTree(1)
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 4).GameBuilder(true)
+		tree := transform.CreateBidirectionalTree(builder.Game.Claims())
 		tree.Claims[0].Claim.CounteredBy = common.Address{}
 		status := Resolve(tree)
 		require.Equal(t, gameTypes.GameStatusDefenderWon, status)
 	})
 
 	t.Run("ManyClaims_ChallengerWon", func(t *testing.T) {
-		tree := createBidirectionalTree(2)
-		tree.Claims[1].Claim.CounteredBy = common.Address{}
-		tree.Claims[1].Children = make([]*monTypes.BidirectionalClaim, 0)
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 5).GameBuilder(true)
+		builder.Seq(). // Defender winning
+				AttackCorrect(). // Challenger winning
+				AttackCorrect(). // Defender winning
+				DefendCorrect(). // Challenger winning
+				DefendCorrect(). // Defender winning
+				AttackCorrect()  // Challenger winning
+		tree := transform.CreateBidirectionalTree(builder.Game.Claims())
 		status := Resolve(tree)
 		require.Equal(t, gameTypes.GameStatusChallengerWon, status)
 	})
 
 	t.Run("ManyClaims_DefenderWon", func(t *testing.T) {
-		status := Resolve(createBidirectionalTree(3))
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 5).GameBuilder(true)
+		builder.Seq(). // Defender winning
+				AttackCorrect(). // Challenger winning
+				AttackCorrect(). // Defender winning
+				DefendCorrect(). // Challenger winning
+				DefendCorrect()  // Defender winning
+		tree := transform.CreateBidirectionalTree(builder.Game.Claims())
+		status := Resolve(tree)
 		require.Equal(t, gameTypes.GameStatusDefenderWon, status)
 	})
-}
 
-func createBidirectionalTree(claimCount uint64) *monTypes.BidirectionalTree {
-	claimList := createDeepClaimList()
-	bidirectionalClaimList := make([]*monTypes.BidirectionalClaim, len(claimList))
-	bidirectionalClaimList[2] = &monTypes.BidirectionalClaim{
-		Claim:    &claimList[2],
-		Children: make([]*monTypes.BidirectionalClaim, 0),
-	}
-	bidirectionalClaimList[1] = &monTypes.BidirectionalClaim{
-		Claim:    &claimList[1],
-		Children: []*monTypes.BidirectionalClaim{bidirectionalClaimList[2]},
-	}
-	bidirectionalClaimList[0] = &monTypes.BidirectionalClaim{
-		Claim:    &claimList[0],
-		Children: []*monTypes.BidirectionalClaim{bidirectionalClaimList[1]},
-	}
-	return &monTypes.BidirectionalTree{Claims: bidirectionalClaimList[:claimCount]}
-}
+	t.Run("MultipleBranches_ChallengerWon", func(t *testing.T) {
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 5).GameBuilder(true)
+		forkPoint := builder.Seq(). // Defender winning
+						AttackCorrect(). // Challenger winning
+						AttackCorrect()  // Defender winning
+		forkPoint.
+			DefendCorrect(). // Challenger winning
+			DefendCorrect(). // Defender winning
+			AttackCorrect()  // Challenger winning
+		forkPoint.Defend(common.Hash{0xbb}). // Challenger winning
+							DefendCorrect(). // Defender winning
+							AttackCorrect(). // Challenger winning
+							Step()           // Defender winning
+		forkPoint.Defend(common.Hash{0xcc}). // Challenger winning
+							DefendCorrect() // Defender winning
+		tree := transform.CreateBidirectionalTree(builder.Game.Claims())
+		status := Resolve(tree)
+		// First fork has an uncountered claim with challenger winning so that invalidates the parent and wins the game
+		require.Equal(t, gameTypes.GameStatusChallengerWon, status)
+	})
 
-func createDeepClaimList() []faultTypes.Claim {
-	return []faultTypes.Claim{
-		{
-			ClaimData: faultTypes.ClaimData{
-				Position: faultTypes.NewPosition(0, big.NewInt(0)),
-			},
-			ContractIndex:       0,
-			CounteredBy:         common.HexToAddress("0x222222"),
-			ParentContractIndex: math.MaxInt64,
-			Claimant:            common.HexToAddress("0x111111"),
-		},
-		{
-			ClaimData: faultTypes.ClaimData{
-				Position: faultTypes.NewPosition(1, big.NewInt(0)),
-			},
-			CounteredBy:         common.HexToAddress("0x111111"),
-			ContractIndex:       1,
-			ParentContractIndex: 0,
-			Claimant:            common.HexToAddress("0x222222"),
-		},
-		{
-			ClaimData: faultTypes.ClaimData{
-				Position: faultTypes.NewPosition(2, big.NewInt(0)),
-			},
-			ContractIndex:       2,
-			ParentContractIndex: 1,
-			Claimant:            common.HexToAddress("0x111111"),
-		},
-	}
+	t.Run("MultipleBranches_DefenderWon", func(t *testing.T) {
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 5).GameBuilder(true)
+		forkPoint := builder.Seq(). // Defender winning
+						AttackCorrect(). // Challenger winning
+						AttackCorrect()  // Defender winning
+		forkPoint.
+			DefendCorrect(). // Challenger winning
+			DefendCorrect()  // Defender winning
+		forkPoint.Defend(common.Hash{0xbb}). // Challenger winning
+							DefendCorrect(). // Defender winning
+							AttackCorrect(). // Challenger winning
+							Step()           // Defender winning
+		forkPoint.Defend(common.Hash{0xcc}). // Challenger winning
+							DefendCorrect() // Defender winning
+		tree := transform.CreateBidirectionalTree(builder.Game.Claims())
+		status := Resolve(tree)
+		// Defender won all forks
+		require.Equal(t, gameTypes.GameStatusDefenderWon, status)
+	})
+
+	t.Run("SteppedClaimed_ChallengerWon", func(t *testing.T) {
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 4).GameBuilder(true)
+		builder.Seq(). // Defender winning
+				AttackCorrect(). // Challenger winning
+				AttackCorrect(). // Defender winning
+				DefendCorrect(). // Challenger winning
+				DefendCorrect(). // Defender winning
+				Step()           // Challenger winning
+		claims := builder.Game.Claims()
+		// Successful step so mark as countered
+		claims[len(claims)-1].CounteredBy = common.Address{0xaa}
+		tree := transform.CreateBidirectionalTree(claims)
+		status := Resolve(tree)
+		require.Equal(t, gameTypes.GameStatusChallengerWon, status)
+	})
+
+	t.Run("SteppedClaimed_DefenderWon", func(t *testing.T) {
+		builder := test.NewAlphabetClaimBuilder(t, big.NewInt(10), 5).GameBuilder(true)
+		builder.Seq(). // Defender winning
+				AttackCorrect(). // Challenger winning
+				AttackCorrect(). // Defender winning
+				DefendCorrect(). // Challenger winning
+				DefendCorrect(). // Defender winning
+				AttackCorrect(). // Challenger winning
+				Step()           // Defender winning
+		claims := builder.Game.Claims()
+		// Successful step so mark as countered
+		claims[len(claims)-1].CounteredBy = common.Address{0xaa}
+		tree := transform.CreateBidirectionalTree(claims)
+		status := Resolve(tree)
+		require.Equal(t, gameTypes.GameStatusDefenderWon, status)
+	})
 }


### PR DESCRIPTION
**Description**

op-dispute-mon: Fix resolution to respect step actions. A successful step call sets the `CounteredBy` field on the claim but the resolution code was not starting with this and only considered the claim countered if it had a child countering it (which is impossible at max depth level).  Also updated the tests to cover more cases and use the game builder.

op-challenger: Add skipped game_solver tests for freeloader claims. Also checks that the game resolves correctly if the challenger's moves are applied.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/103
