### PR TITLE
op-node: Add flag category and improve testing

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -292,10 +292,11 @@ var (
 		Category: RollupCategory,
 	}
 	SafeDBPath = &cli.StringFlag{
-		Name:    "safedb.path",
-		Usage:   "File path used to persist safe head update data. Disabled if not set.",
-		EnvVars: prefixEnvVars("SAFEDB_PATH"),
-		Hidden:  true,
+		Name:     "safedb.path",
+		Usage:    "File path used to persist safe head update data. Disabled if not set.",
+		EnvVars:  prefixEnvVars("SAFEDB_PATH"),
+		Hidden:   true,
+		Category: OperationsCategory,
 	}
 	/* Deprecated Flags */
 	L2EngineSyncEnabled = &cli.BoolFlag{

--- a/op-node/node/safedb/safedb_test.go
+++ b/op-node/node/safedb/safedb_test.go
@@ -214,11 +214,156 @@ func TestTruncateOnSafeHeadReset_BeforeFirstEntry(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestTruncateOnSafeHeadReset_AfterLastEntry(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	dir := t.TempDir()
+	db, err := NewSafeDB(logger, dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	l2a := eth.L2BlockRef{
+		Hash:   common.Hash{0x02, 0xaa},
+		Number: 20,
+		L1Origin: eth.BlockID{
+			Number: 60,
+		},
+	}
+	l2b := eth.L2BlockRef{
+		Hash:   common.Hash{0x02, 0xbb},
+		Number: 22,
+		L1Origin: eth.BlockID{
+			Number: 90,
+		},
+	}
+	l2c := eth.L2BlockRef{
+		Hash:   common.Hash{0x02, 0xcc},
+		Number: 25,
+		L1Origin: eth.BlockID{
+			Number: 110,
+		},
+	}
+	l1a := eth.BlockID{
+		Hash:   common.Hash{0x01, 0xaa},
+		Number: 100,
+	}
+	l1b := eth.BlockID{
+		Hash:   common.Hash{0x01, 0xbb},
+		Number: 150,
+	}
+	l1c := eth.BlockID{
+		Hash:   common.Hash{0x01, 0xcc},
+		Number: 160,
+	}
+
+	// Add some entries
+	require.NoError(t, db.SafeHeadUpdated(l2a, l1a))
+	require.NoError(t, db.SafeHeadUpdated(l2b, l1b))
+	require.NoError(t, db.SafeHeadUpdated(l2c, l1c))
+
+	verifySafeHeads := func() {
+		// Everything is still safe
+		actualL1, actualL2, err := db.SafeHeadAtL1(context.Background(), l1a.Number)
+		require.NoError(t, err)
+		require.Equal(t, l1a, actualL1)
+		require.Equal(t, l2a.ID(), actualL2)
+
+		// Everything is still safe
+		actualL1, actualL2, err = db.SafeHeadAtL1(context.Background(), l1b.Number)
+		require.NoError(t, err)
+		require.Equal(t, l1b, actualL1)
+		require.Equal(t, l2b.ID(), actualL2)
+
+		// Everything is still safe
+		actualL1, actualL2, err = db.SafeHeadAtL1(context.Background(), l1c.Number)
+		require.NoError(t, err)
+		require.Equal(t, l1c, actualL1)
+		require.Equal(t, l2c.ID(), actualL2)
+	}
+	verifySafeHeads()
+
+	// Then reset to an L2 block after all entries with an origin after all L1 entries
+	require.NoError(t, db.SafeHeadReset(eth.L2BlockRef{
+		Hash:   common.Hash{0x02, 0xdd},
+		Number: 30,
+		L1Origin: eth.BlockID{
+			Number: l1c.Number + 1,
+		},
+	}))
+	verifySafeHeads()
+
+	// Then reset to an L2 block after all entries with an origin before some L1 entries
+	require.NoError(t, db.SafeHeadReset(eth.L2BlockRef{
+		Hash:   common.Hash{0x02, 0xdd},
+		Number: 30,
+		L1Origin: eth.BlockID{
+			Number: l1b.Number - 1,
+		},
+	}))
+	verifySafeHeads()
+}
+
 func TestKeysFollowNaturalByteOrdering(t *testing.T) {
 	vals := []uint64{0, 1, math.MaxUint32 - 1, math.MaxUint32, math.MaxUint32 + 1, math.MaxUint64 - 1, math.MaxUint64}
 	for i := 1; i < len(vals); i++ {
-		prev := SafeByL1BlockNumKey.Of(vals[i-1])
-		cur := SafeByL1BlockNumKey.Of(vals[i])
+		prev := safeByL1BlockNumKey.Of(vals[i-1])
+		cur := safeByL1BlockNumKey.Of(vals[i])
 		require.True(t, slices.Compare(prev, cur) < 0, "Expected %v key %x to be less than %v key %x", vals[i-1], prev, vals[i], cur)
 	}
+}
+
+func TestDecodeSafeByL1BlockNum(t *testing.T) {
+	l1 := eth.BlockID{
+		Hash:   common.Hash{0x01},
+		Number: 84298,
+	}
+	l2 := eth.BlockID{
+		Hash:   common.Hash{0x02},
+		Number: 3224,
+	}
+	validKey := safeByL1BlockNumKey.Of(l1.Number)
+	validValue := safeByL1BlockNumValue(l1, l2)
+
+	t.Run("Roundtrip", func(t *testing.T) {
+		actualL1, actualL2, err := decodeSafeByL1BlockNum(validKey, validValue)
+		require.NoError(t, err)
+		require.Equal(t, l1, actualL1)
+		require.Equal(t, l2, actualL2)
+	})
+
+	t.Run("ErrorOnEmptyKey", func(t *testing.T) {
+		_, _, err := decodeSafeByL1BlockNum([]byte{}, validValue)
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
+
+	t.Run("ErrorOnTooShortKey", func(t *testing.T) {
+		_, _, err := decodeSafeByL1BlockNum([]byte{1, 2, 3, 4}, validValue)
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
+
+	t.Run("ErrorOnTooLongKey", func(t *testing.T) {
+		_, _, err := decodeSafeByL1BlockNum(append(validKey, 2), validValue)
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
+
+	t.Run("ErrorOnWrongKeyPrefix", func(t *testing.T) {
+		invalidKey := slices.Clone(validKey)
+		invalidKey[0] = 49
+		_, _, err := decodeSafeByL1BlockNum(invalidKey, validValue)
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
+
+	t.Run("ErrorOnEmptyValue", func(t *testing.T) {
+		_, _, err := decodeSafeByL1BlockNum(validKey, []byte{})
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
+
+	t.Run("ErrorOnTooShortValue", func(t *testing.T) {
+		_, _, err := decodeSafeByL1BlockNum(validKey, []byte{1, 2, 3, 4})
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
+
+	t.Run("ErrorOnTooLongValue", func(t *testing.T) {
+		_, _, err := decodeSafeByL1BlockNum(validKey, append(validKey, 2))
+		require.ErrorIs(t, err, ErrInvalidEntry)
+	})
 }


### PR DESCRIPTION
**Description**

Adds a category to the safedb.path flag. Put in operations since it's storage related and affects what's available on the API.

Improved test coverage of safe db code and made a few variables/functions not exported to keep things neat.