### PR TITLE
op-challenger: Add actor based tests for game solver

### DIFF
--- a/op-challenger/game/fault/solver/actors.go
+++ b/op-challenger/game/fault/solver/actors.go
@@ -1,0 +1,136 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type actor interface {
+	Apply(t *testing.T, game types.Game, correctTrace types.TraceProvider) (types.Game, bool)
+}
+
+type actorFn func(t *testing.T, game types.Game, correctTrace types.TraceProvider) (types.Game, bool)
+
+func (a actorFn) Apply(t *testing.T, game types.Game, correctTrace types.TraceProvider) (types.Game, bool) {
+	return a(t, game, correctTrace)
+}
+
+type builderFn func(builder *test.GameBuilder) bool
+
+func (a builderFn) Apply(t *testing.T, game types.Game, correctTrace types.TraceProvider) (types.Game, bool) {
+	builder := test.NewGameBuilderFromGame(t, correctTrace, game)
+	done := a(builder)
+	return builder.Game, done
+}
+
+func combineActors(actors ...actor) actor {
+	return actorFn(func(t *testing.T, game types.Game, correctTrace types.TraceProvider) (types.Game, bool) {
+		done := true
+		for _, actor := range actors {
+			newGame, actorDone := actor.Apply(t, game, correctTrace)
+			game = newGame
+			done = done && actorDone
+		}
+		return game, done
+	})
+}
+
+var doNothingActor builderFn = func(builder *test.GameBuilder) bool {
+	return true
+}
+
+var correctAttackLastClaim = respondLastClaim(func(seq *test.GameBuilderSeq) {
+	seq.Attack()
+})
+
+var correctDefendLastClaim = respondLastClaim(func(seq *test.GameBuilderSeq) {
+	if seq.IsRoot() {
+		// Must attack the root
+		seq.Attack()
+	} else {
+		seq.Defend()
+	}
+})
+
+var incorrectAttackLastClaim = respondLastClaim(func(seq *test.GameBuilderSeq) {
+	seq.Attack(test.WithValue(common.Hash{0xaa}))
+})
+
+var incorrectDefendLastClaim = respondLastClaim(func(seq *test.GameBuilderSeq) {
+	if seq.IsRoot() {
+		// Must attack the root
+		seq.Attack(test.WithValue(common.Hash{0xdd}))
+	} else {
+		seq.Defend(test.WithValue(common.Hash{0xdd}))
+	}
+})
+
+var attackEverythingCorrect = respondAllClaims(func(seq *test.GameBuilderSeq) {
+	seq.Attack()
+})
+
+var defendEverythingCorrect = respondAllClaims(func(seq *test.GameBuilderSeq) {
+	if seq.IsRoot() {
+		// Must attack root
+		seq.Attack()
+	} else {
+		seq.Defend()
+	}
+})
+
+var attackEverythingIncorrect = respondAllClaims(func(seq *test.GameBuilderSeq) {
+	seq.Attack(test.WithValue(common.Hash{0xaa}))
+})
+
+var defendEverythingIncorrect = respondAllClaims(func(seq *test.GameBuilderSeq) {
+	if seq.IsRoot() {
+		// Must attack root
+		seq.Attack(test.WithValue(common.Hash{0xbb}))
+	} else {
+		seq.Defend(test.WithValue(common.Hash{0xbb}))
+	}
+})
+
+var exhaustive = respondAllClaims(func(seq *test.GameBuilderSeq) {
+	seq.Attack()
+	seq.Attack(test.WithValue(common.Hash{0xaa}))
+	if !seq.IsRoot() {
+		seq.Defend()
+		seq.Defend(test.WithValue(common.Hash{0xdd}))
+	}
+})
+
+func respondLastClaim(respond func(seq *test.GameBuilderSeq)) builderFn {
+	return func(builder *test.GameBuilder) bool {
+		seq := seqFromLastClaim(builder)
+		if seq.IsMaxDepth() {
+			// Can't counter the leaf claim
+			return true
+		}
+		respond(seq)
+		return false
+	}
+}
+
+func respondAllClaims(respond func(seq *test.GameBuilderSeq)) builderFn {
+	return func(builder *test.GameBuilder) bool {
+		startingCount := len(builder.Game.Claims())
+		for _, claim := range builder.Game.Claims() {
+			if claim.Depth() == builder.Game.MaxDepth() {
+				continue
+			}
+			respond(builder.SeqFrom(claim))
+		}
+		finalCount := len(builder.Game.Claims())
+		return finalCount == startingCount
+	}
+}
+
+func seqFromLastClaim(builder *test.GameBuilder) *test.GameBuilderSeq {
+	claims := builder.Game.Claims()
+	claim := claims[len(claims)-1]
+	return builder.SeqFrom(claim)
+}

--- a/op-challenger/game/fault/solver/game_rules_test.go
+++ b/op-challenger/game/fault/solver/game_rules_test.go
@@ -1,0 +1,99 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/resolution"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/transform"
+	disputeTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func verifyGameRules(t *testing.T, game types.Game, rootClaimCorrect bool) {
+	actualResult, claimTree, resolvedGame := gameResult(game)
+	t.Log("Resolved game:")
+	logClaims(t, resolvedGame)
+
+	verifyExpectedGameResult(t, rootClaimCorrect, actualResult)
+
+	verifyNoChallengerClaimsWereSuccessfullyCountered(t, resolvedGame)
+	verifyChallengerAlwaysWinsParentBond(t, resolvedGame)
+	verifyChallengerNeverCountersAClaimTwice(t, claimTree)
+}
+
+// verifyExpectedGameResult verifies that valid output roots are successfully defended and invalid roots are challenged
+// Rationale: Ensures the game always and only allows valid output roots to be finalized.
+func verifyExpectedGameResult(t *testing.T, rootClaimCorrect bool, actualResult gameTypes.GameStatus) {
+	expectedResult := gameTypes.GameStatusChallengerWon
+	if rootClaimCorrect {
+		expectedResult = gameTypes.GameStatusDefenderWon
+	}
+	require.Equalf(t, expectedResult, actualResult, "Game should resolve correctly expected %v but was %v", expectedResult, actualResult)
+}
+
+// verifyNoChallengerClaimsWereSuccessfullyCountered verifies the challenger didn't lose any of its bonds
+// Note that this also forbids the challenger losing a bond to itself since it shouldn't challenge its own claims
+// Rationale: If honest actors lose their bond, it indicates that incentive compatibility is broken because honest actors
+// lose money.
+func verifyNoChallengerClaimsWereSuccessfullyCountered(t *testing.T, resolvedGame types.Game) {
+	for _, claim := range resolvedGame.Claims() {
+		if claim.Claimant != challengerAddr {
+			continue
+		}
+		if claim.CounteredBy != (common.Address{}) {
+			t.Fatalf("Challenger posted claim %v but it was countered by someone else:\n%v", claim.ContractIndex, printClaim(claim, resolvedGame))
+		}
+	}
+}
+
+// verifyChallengerAlwaysWinsParentBond verifies that the challenger is always allocated the bond of any parent claim it
+// counters.
+// Rationale: If an honest action does not win the bond for countering a claim, incentive compatibility is broken because
+// honest actors are not being paid to perform their job (or the challenger is posting unnecessary claims)
+func verifyChallengerAlwaysWinsParentBond(t *testing.T, resolvedGame types.Game) {
+	for _, claim := range resolvedGame.Claims() {
+		if claim.Claimant != challengerAddr {
+			continue
+		}
+		parent, err := resolvedGame.GetParent(claim)
+		require.NoErrorf(t, err, "Failed to get parent of claim %v", claim.ContractIndex)
+		require.Equal(t, challengerAddr, parent.CounteredBy,
+			"Expected claim %v to have challenger as its claimant because of counter claim %v", parent.ContractIndex, claim.ContractIndex)
+	}
+}
+
+// verifyChallengerNeverCountersAClaimTwice verifies that the challenger never posts more than one counter to a claim
+// Rationale: The parent claim bond is only intended to cover costs of a single counter claim so incentive compatibility
+// is broken if the challenger needs to post multiple claims. Or if the claim wasn't required, the challenger is just
+// wasting money posting unnecessary claims.
+func verifyChallengerNeverCountersAClaimTwice(t *testing.T, tree *disputeTypes.BidirectionalTree) {
+	for _, claim := range tree.Claims {
+		challengerCounterCount := 0
+		for _, child := range claim.Children {
+			if child.Claim.Claimant != challengerAddr {
+				continue
+			}
+			challengerCounterCount++
+		}
+		require.LessOrEqualf(t, challengerCounterCount, 1, "Found multiple honest counters to claim %v", claim.Claim.ContractIndex)
+	}
+}
+
+func gameResult(game types.Game) (gameTypes.GameStatus, *disputeTypes.BidirectionalTree, types.Game) {
+	tree := transform.CreateBidirectionalTree(game.Claims())
+	result := resolution.Resolve(tree)
+	resolvedClaims := make([]types.Claim, 0, len(tree.Claims))
+	for _, claim := range tree.Claims {
+		resolvedClaims = append(resolvedClaims, *claim.Claim)
+	}
+	return result, tree, types.NewGameState(resolvedClaims, game.MaxDepth())
+}
+
+func logClaims(t *testing.T, game types.Game) {
+	for _, claim := range game.Claims() {
+		t.Log(printClaim(claim, game))
+	}
+}

--- a/op-challenger/game/fault/solver/rules.go
+++ b/op-challenger/game/fault/solver/rules.go
@@ -1,38 +1,60 @@
 package solver
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"math/big"
+	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
-type actionRule func(game types.Game, action types.Action) error
+var challengerAddr = common.Address(bytes.Repeat([]byte{0xaa}, 20))
+
+type actionRule func(game types.Game, action types.Action, correctTrace types.TraceProvider) error
 
 var rules = []actionRule{
 	parentMustExist,
 	onlyStepAtMaxDepth,
 	onlyMoveBeforeMaxDepth,
 	doNotDuplicateExistingMoves,
+	doNotStepAlreadyCounteredClaims,
 	doNotDefendRootClaim,
+	avoidPoisonedPrestate,
+	detectPoisonedStepPrestate,
+	detectFailedStep,
+	doNotCounterSelf,
 }
 
-func checkRules(game types.Game, action types.Action) error {
+func printClaim(claim types.Claim, game types.Game) string {
+	return fmt.Sprintf("Claim %v: Pos: %v TraceIdx: %v Depth: %v IndexAtDepth: %v ParentIdx: %v Value: %v Claimant: %v CounteredBy: %v",
+		claim.ContractIndex, claim.Position.ToGIndex(), claim.Position.TraceIndex(game.MaxDepth()), claim.Position.Depth(), claim.Position.IndexAtDepth(), claim.ParentContractIndex, claim.Value, claim.Claimant, claim.CounteredBy)
+}
+
+func checkRules(game types.Game, action types.Action, correctTrace types.TraceProvider) error {
 	var errs []error
 	for _, rule := range rules {
-		errs = append(errs, rule(game, action))
+		errs = append(errs, rule(game, action, correctTrace))
 	}
 	return errors.Join(errs...)
 }
 
-func parentMustExist(game types.Game, action types.Action) error {
+// parentMustExist checks that every action performed has a valid parent claim
+// Rationale: The action would be rejected by the contracts
+func parentMustExist(game types.Game, action types.Action, _ types.TraceProvider) error {
 	if len(game.Claims()) <= action.ParentIdx || action.ParentIdx < 0 {
 		return fmt.Errorf("parent claim %v does not exist in game with %v claims", action.ParentIdx, len(game.Claims()))
 	}
 	return nil
 }
 
-func onlyStepAtMaxDepth(game types.Game, action types.Action) error {
+// onlyStepAtMaxDepth verifies that step actions are only performed against leaf claims
+// Rationale: The action would be rejected by the contracts
+func onlyStepAtMaxDepth(game types.Game, action types.Action, _ types.TraceProvider) error {
 	if action.Type == types.ActionTypeStep {
 		return nil
 	}
@@ -44,7 +66,9 @@ func onlyStepAtMaxDepth(game types.Game, action types.Action) error {
 	return nil
 }
 
-func onlyMoveBeforeMaxDepth(game types.Game, action types.Action) error {
+// onlyMoveBeforeMaxDepth verifies that move actions are not performed against leaf claims
+// Rationale: The action would be rejected by the contracts
+func onlyMoveBeforeMaxDepth(game types.Game, action types.Action, _ types.TraceProvider) error {
 	if action.Type == types.ActionTypeMove {
 		return nil
 	}
@@ -56,7 +80,9 @@ func onlyMoveBeforeMaxDepth(game types.Game, action types.Action) error {
 	return nil
 }
 
-func doNotDuplicateExistingMoves(game types.Game, action types.Action) error {
+// doNotDuplicateExistingMoves verifies that the challenger doesn't attempt to post a duplicate claim
+// Rationale: The action would be rejected by the contracts
+func doNotDuplicateExistingMoves(game types.Game, action types.Action, _ types.TraceProvider) error {
 	newClaimData := types.ClaimData{
 		Value:    action.Value,
 		Position: resultingPosition(game, action),
@@ -67,9 +93,176 @@ func doNotDuplicateExistingMoves(game types.Game, action types.Action) error {
 	return nil
 }
 
-func doNotDefendRootClaim(game types.Game, action types.Action) error {
+// doNotStepAlreadyCounteredClaims checks the challenger does not attempt to call step on already countered claims
+// Rationale: The step call is redundant and a waste of gas
+func doNotStepAlreadyCounteredClaims(game types.Game, action types.Action, _ types.TraceProvider) error {
+	claim := game.Claims()[action.ParentIdx]
+	if claim.CounteredBy != (common.Address{}) {
+		return fmt.Errorf("attempting to step already countered claim: %v", claim.ContractIndex)
+	}
+	return nil
+}
+
+// doNotDefendRootClaim checks the challenger doesn't attempt to defend the root claim
+// Rationale: The action would be rejected by the contracts
+func doNotDefendRootClaim(game types.Game, action types.Action, _ types.TraceProvider) error {
 	if game.Claims()[action.ParentIdx].IsRootPosition() && !action.IsAttack {
 		return fmt.Errorf("defending the root claim at idx %v", action.ParentIdx)
+	}
+	return nil
+}
+
+// doNotCounterSelf checks the challenger doesn't counter its own claims
+// Rationale: The challenger should not disagree with itself
+func doNotCounterSelf(game types.Game, action types.Action, _ types.TraceProvider) error {
+	claim := game.Claims()[action.ParentIdx]
+	if claim.Claimant == challengerAddr {
+		return fmt.Errorf("countering own claim at idx %v", action.ParentIdx)
+	}
+	return nil
+}
+
+// avoidPoisonedPrestate checks the challenger does not perform a move that results in a claim where the ancestor
+// with the largest trace index less than the new claim's trace index is invalid.
+// Rationale: If such a claim were posted, an attacker could attack with invalid values down to max depth and setup a
+// step call which uses the invalid claim as the pre-state. The challenger could not call step because it does not have
+// the preimage of the invalid state. If the attacker should call step, they could provide a carefully crafted state
+// that allows it to successfully step against the challenger's claim.
+func avoidPoisonedPrestate(game types.Game, action types.Action, correctTrace types.TraceProvider) error {
+	if action.Type == types.ActionTypeStep {
+		return nil
+	}
+	ancestors := ""
+	movePosition := resultingPosition(game, action)
+	honestTraceIndex := movePosition.TraceIndex(game.MaxDepth())
+	// Walk back up the claims and find the claim with highest trace index < honestTraceIndex
+	claim := game.Claims()[action.ParentIdx]
+	var preStateClaim types.Claim
+	for {
+		ancestors += printClaim(claim, game) + "\n"
+		claimTraceIdx := claim.TraceIndex(game.MaxDepth())
+		if claimTraceIdx.Cmp(honestTraceIndex) < 0 { // Check it's left of the honest claim
+			if preStateClaim == (types.Claim{}) || claimTraceIdx.Cmp(preStateClaim.TraceIndex(game.MaxDepth())) > 0 {
+				preStateClaim = claim
+			}
+		}
+		if claim.IsRoot() {
+			break
+		}
+		parent, err := game.GetParent(claim)
+		if err != nil {
+			return fmt.Errorf("no parent of claim %v: %w", claim.ContractIndex, err)
+		}
+		claim = parent
+	}
+	if preStateClaim == (types.Claim{}) {
+		// No claim to the left of the honest claim, so can't have been poisoned
+		return nil
+	}
+	correctValue, err := correctTrace.Get(context.Background(), preStateClaim.Position)
+	if err != nil {
+		return fmt.Errorf("failed to get correct trace at position %v: %w", preStateClaim.Position, err)
+	}
+	if correctValue != preStateClaim.Value {
+		err = fmt.Errorf("prestate poisoned claim %v has invalid prestate and is left of honest claim countering %v at trace index %v", preStateClaim.ContractIndex, action.ParentIdx, honestTraceIndex)
+		return err
+	}
+	return nil
+}
+
+// detectFailedStep checks that step actions will succeed.
+// Rationale: The action would be rejected by the contracts
+//
+// INVARIANT: If a step is an attack, the poststate is valid if the step produces
+//
+//	the same poststate hash as the parent claim's value.
+//	If a step is a defense:
+//	  1. If the parent claim and the found post state agree with each other
+//	     (depth diff % 2 == 0), the step is valid if it produces the same
+//	     state hash as the post state's claim.
+//	  2. If the parent claim and the found post state disagree with each other
+//	     (depth diff % 2 != 0), the parent cannot be countered unless the step
+//	     produces the same state hash as `postState.claim`.
+func detectFailedStep(game types.Game, action types.Action, correctTrace types.TraceProvider) error {
+	if action.Type != types.ActionTypeStep {
+		// An invalid post state is not an issue if we are moving, only if the honest challenger has to call step.
+		return nil
+	}
+	position := resultingPosition(game, action)
+	if position.Depth() != game.MaxDepth() {
+		// Not at max depth yet
+		return nil
+	}
+	honestTraceIndex := position.TraceIndex(game.MaxDepth())
+	poststateIndex := honestTraceIndex
+	if !action.IsAttack {
+		poststateIndex = new(big.Int).Add(honestTraceIndex, big.NewInt(1))
+	}
+	// Walk back up the claims and find the claim required post state index
+	claim := game.Claims()[action.ParentIdx]
+	poststateClaim, ok := game.AncestorWithTraceIndex(claim, poststateIndex)
+	if !ok {
+		return fmt.Errorf("did not find required poststate at %v to counter claim %v", poststateIndex, action.ParentIdx)
+	}
+	correctValue, err := correctTrace.Get(context.Background(), poststateClaim.Position)
+	if err != nil {
+		return fmt.Errorf("failed to get correct trace at position %v: %w", poststateClaim.Position, err)
+	}
+	validStep := correctValue == poststateClaim.Value
+	parentPostAgree := (claim.Depth()-poststateClaim.Depth())%2 == 0
+	if parentPostAgree == validStep {
+		return fmt.Errorf("failed step against claim at %v using poststate from claim %v post state is correct? %v parentPostAgree? %v",
+			action.ParentIdx, poststateClaim.ContractIndex, validStep, parentPostAgree)
+	}
+	return nil
+}
+
+// detectPoisonedStepPrestate checks that:
+// 1. step actions performed by the challenger always have a valid prestate
+// 2. move actions that create a claim a max depth would have a valid prestate if they are attacked
+// 3. the actual prestate provided matches the prestate claim's commitment
+// Rationale: A step against an invalid prestate will fail because the preimage of the prestate claim is unknown
+// and claims at max depth with an invalid prestate could be stepped against because the prestate is invalid so a VM
+// step will not result in the correct post-state.
+func detectPoisonedStepPrestate(game types.Game, action types.Action, correctTrace types.TraceProvider) error {
+	position := resultingPosition(game, action)
+	if position.Depth() != game.MaxDepth() {
+		// Not at max depth yet
+		return nil
+	}
+	honestTraceIndex := position.TraceIndex(game.MaxDepth())
+	prestateIndex := honestTraceIndex
+	// If we're performing a move to post a leaf claim, assume the attacker will try to attack it from their
+	// poisoned prestate
+	if action.IsAttack || action.Type == types.ActionTypeMove {
+		prestateIndex = new(big.Int).Sub(prestateIndex, big.NewInt(1))
+	}
+	if prestateIndex.Cmp(big.NewInt(0)) < 0 {
+		// Absolute prestate is not poisoned
+		return nil
+	}
+	// Walk back up the claims and find the claim with highest trace index < honestTraceIndex
+	claim := game.Claims()[action.ParentIdx]
+	preStateClaim, ok := game.AncestorWithTraceIndex(claim, prestateIndex)
+	if !ok {
+		return fmt.Errorf("performing step against claim %v with no prestate available at %v", claim.ContractIndex, prestateIndex)
+	}
+	correctValue, err := correctTrace.Get(context.Background(), preStateClaim.Position)
+	if err != nil {
+		return fmt.Errorf("failed to get correct trace at position %v: %w", preStateClaim.Position, err)
+	}
+	if correctValue != preStateClaim.Value {
+		if action.Type == types.ActionTypeStep {
+			return fmt.Errorf("stepping from poisoned prestate at claim %v when countering %v", preStateClaim.ContractIndex, action.ParentIdx)
+		} else {
+			return fmt.Errorf("posting leaf claim with poisoned prestate from claim %v when countering %v", preStateClaim.ContractIndex, action.ParentIdx)
+		}
+	}
+	if action.Type == types.ActionTypeStep {
+		prestateHash := crypto.Keccak256Hash(action.PreState)
+		if !slices.Equal(prestateHash[1:], preStateClaim.Value[1:]) {
+			return fmt.Errorf("prestate hash %v does not match expected prestate claim %v from claim %v", prestateHash, preStateClaim.Value, preStateClaim.ContractIndex)
+		}
 	}
 	return nil
 }

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var DefaultClaimant = common.Address{0x09, 0x23, 0x34, 0x45, 0x13, 0xb3}
+var DefaultClaimant = common.Address{0xba, 0xdb, 0xad, 0xba, 0xdb, 0xad}
 
 type claimCfg struct {
 	value        common.Hash


### PR DESCRIPTION
**Description**

Add tests for game solver where the attacker is a variety of malicious actors.  The game is played all the way through until there are no further moves to be made and then the final resolution is checked.

Also added rules to detect when the challenger posts a move that leaves it susceptible to a poisoned prestate.  One rule which tries to detect the first problematic rule currently just logs and a second rule detects when the challenger is calling step against a claim where the prestate is invalid (this call will fail logged https://github.com/ethereum-optimism/client-pod/issues/611 for the case where we try to do this) and for the case where the challenger posts a leaf claim that can be attacked using a poisoned prestate.

It also checks that none of the challenger's claims never resolved to being countered (ie the challenger always gets all its bond back).

**Tests**

So so many.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/103
