### PR TITLE
op-challenger: Adjust honest actor behaviour to counter freeloaders.

### DIFF
--- a/op-challenger/game/fault/solver/game_solver.go
+++ b/op-challenger/game/fault/solver/game_solver.go
@@ -30,13 +30,17 @@ func (s *GameSolver) CalculateNextActions(ctx context.Context, game types.Game) 
 	}
 	var errs []error
 	var actions []types.Action
+	agreedClaims := newHonestClaimTracker()
+	if agreeWithRootClaim {
+		agreedClaims.AddHonestClaim(types.Claim{}, game.Claims()[0])
+	}
 	for _, claim := range game.Claims() {
 		var action *types.Action
 		var err error
 		if claim.Depth() == game.MaxDepth() {
-			action, err = s.calculateStep(ctx, game, agreeWithRootClaim, claim)
+			action, err = s.calculateStep(ctx, game, claim, agreedClaims)
 		} else {
-			action, err = s.calculateMove(ctx, game, agreeWithRootClaim, claim)
+			action, err = s.calculateMove(ctx, game, claim, agreedClaims)
 		}
 		if err != nil {
 			errs = append(errs, err)
@@ -50,19 +54,16 @@ func (s *GameSolver) CalculateNextActions(ctx context.Context, game types.Game) 
 	return actions, errors.Join(errs...)
 }
 
-func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, agreeWithRootClaim bool, claim types.Claim) (*types.Action, error) {
+func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, claim types.Claim, agreedClaims *honestClaimTracker) (*types.Action, error) {
 	if claim.CounteredBy != (common.Address{}) {
 		return nil, nil
 	}
-	if game.AgreeWithClaimLevel(claim, agreeWithRootClaim) {
-		return nil, nil
-	}
-	step, err := s.claimSolver.AttemptStep(ctx, game, claim)
-	if errors.Is(err, ErrStepIgnoreInvalidPath) {
-		return nil, nil
-	}
+	step, err := s.claimSolver.AttemptStep(ctx, game, claim, agreedClaims)
 	if err != nil {
 		return nil, err
+	}
+	if step == nil {
+		return nil, nil
 	}
 	return &types.Action{
 		Type:           types.ActionTypeStep,
@@ -75,15 +76,16 @@ func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, agreeWi
 	}, nil
 }
 
-func (s *GameSolver) calculateMove(ctx context.Context, game types.Game, agreeWithRootClaim bool, claim types.Claim) (*types.Action, error) {
-	if game.AgreeWithClaimLevel(claim, agreeWithRootClaim) {
-		return nil, nil
-	}
-	move, err := s.claimSolver.NextMove(ctx, claim, game)
+func (s *GameSolver) calculateMove(ctx context.Context, game types.Game, claim types.Claim, honestClaims *honestClaimTracker) (*types.Action, error) {
+	move, err := s.claimSolver.NextMove(ctx, claim, game, honestClaims)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate next move for claim index %v: %w", claim.ContractIndex, err)
 	}
-	if move == nil || game.IsDuplicate(*move) {
+	if move == nil {
+		return nil, nil
+	}
+	honestClaims.AddHonestClaim(claim, *move)
+	if game.IsDuplicate(*move) {
 		return nil, nil
 	}
 	return &types.Action{

--- a/op-challenger/game/fault/solver/honest_claims.go
+++ b/op-challenger/game/fault/solver/honest_claims.go
@@ -1,0 +1,36 @@
+package solver
+
+import "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+
+type honestClaimTracker struct {
+	// agreed tracks the existing claims in the game that the honest actor would make
+	// The claims may not yet have been made so are tracked by ClaimID not ContractIndex
+	agreed map[types.ClaimID]bool
+
+	// counters tracks the counter claim for a claim by contract index.
+	// The counter claim may not yet be part of the game state (ie it may be a move the honest actor is planning to make)
+	counters map[types.ClaimID]types.Claim
+}
+
+func newHonestClaimTracker() *honestClaimTracker {
+	return &honestClaimTracker{
+		agreed:   make(map[types.ClaimID]bool),
+		counters: make(map[types.ClaimID]types.Claim),
+	}
+}
+
+func (a *honestClaimTracker) AddHonestClaim(parent types.Claim, claim types.Claim) {
+	a.agreed[claim.ID()] = true
+	if parent != (types.Claim{}) {
+		a.counters[parent.ID()] = claim
+	}
+}
+
+func (a *honestClaimTracker) IsHonest(claim types.Claim) bool {
+	return a.agreed[claim.ID()]
+}
+
+func (a *honestClaimTracker) HonestCounter(parent types.Claim) (types.Claim, bool) {
+	counter, ok := a.counters[parent.ID()]
+	return counter, ok
+}

--- a/op-challenger/game/fault/solver/honest_claims_test.go
+++ b/op-challenger/game/fault/solver/honest_claims_test.go
@@ -1,0 +1,38 @@
+package solver
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHonestClaimTracker_RootClaim(t *testing.T) {
+	tracker := newHonestClaimTracker()
+	builder := test.NewAlphabetClaimBuilder(t, big.NewInt(3), 4)
+
+	claim := builder.Seq().Get()
+	require.False(t, tracker.IsHonest(claim))
+
+	tracker.AddHonestClaim(types.Claim{}, claim)
+	require.True(t, tracker.IsHonest(claim))
+}
+
+func TestHonestClaimTracker_ChildClaim(t *testing.T) {
+	tracker := newHonestClaimTracker()
+	builder := test.NewAlphabetClaimBuilder(t, big.NewInt(3), 4)
+
+	seq := builder.Seq().Attack().Defend()
+	parent := seq.Get()
+	child := seq.Attack().Get()
+	require.Zero(t, child.ContractIndex, "should work for claims that are not in the game state yet")
+
+	tracker.AddHonestClaim(parent, child)
+	require.False(t, tracker.IsHonest(parent))
+	require.True(t, tracker.IsHonest(child))
+	counter, ok := tracker.HonestCounter(parent)
+	require.True(t, ok)
+	require.Equal(t, child, counter)
+}

--- a/op-challenger/game/fault/types/game.go
+++ b/op-challenger/game/fault/types/game.go
@@ -3,9 +3,6 @@ package types
 import (
 	"errors"
 	"math/big"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var (
@@ -39,31 +36,21 @@ type Game interface {
 	AncestorWithTraceIndex(claim Claim, idx *big.Int) (Claim, bool)
 }
 
-type claimID common.Hash
-
-func computeClaimID(claim Claim) claimID {
-	return claimID(crypto.Keccak256Hash(
-		claim.Position.ToGIndex().Bytes(),
-		claim.Value.Bytes(),
-		big.NewInt(int64(claim.ParentContractIndex)).Bytes(),
-	))
-}
-
 // gameState is a struct that represents the state of a dispute game.
 // The game state implements the [Game] interface.
 type gameState struct {
 	// claims is the list of claims in the same order as the contract
 	claims   []Claim
-	claimIDs map[claimID]bool
+	claimIDs map[ClaimID]bool
 	depth    Depth
 }
 
 // NewGameState returns a new game state.
 // The provided [Claim] is used as the root node.
 func NewGameState(claims []Claim, depth Depth) *gameState {
-	claimIDs := make(map[claimID]bool)
+	claimIDs := make(map[ClaimID]bool)
 	for _, claim := range claims {
-		claimIDs[computeClaimID(claim)] = true
+		claimIDs[claim.ID()] = true
 	}
 	return &gameState{
 		claims:   claims,
@@ -85,7 +72,7 @@ func (g *gameState) AgreeWithClaimLevel(claim Claim, agreeWithRootClaim bool) bo
 }
 
 func (g *gameState) IsDuplicate(claim Claim) bool {
-	return g.claimIDs[computeClaimID(claim)]
+	return g.claimIDs[claim.ID()]
 }
 
 func (g *gameState) Claims() []Claim {

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -8,14 +8,11 @@ import (
 
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var (
 	ErrGameDepthReached = errors.New("game depth reached")
-
-	// NoLocalContext is the LocalContext value used when the cannon trace provider is used alone instead of as part
-	// of a split game.
-	NoLocalContext = common.Hash{}
 )
 
 const (
@@ -134,6 +131,8 @@ func (c *ClaimData) ValueBytes() [32]byte {
 	return responseArr
 }
 
+type ClaimID common.Hash
+
 // Claim extends ClaimData with information about the relationship between two claims.
 // It uses ClaimData to break cyclicity without using pointers.
 // If the position of the game is Depth 0, IndexAtDepth 0 it is the root claim
@@ -151,6 +150,14 @@ type Claim struct {
 	// for claims that have not made it to the contract.
 	ContractIndex       int
 	ParentContractIndex int
+}
+
+func (c Claim) ID() ClaimID {
+	return ClaimID(crypto.Keccak256Hash(
+		c.Position.ToGIndex().Bytes(),
+		c.Value.Bytes(),
+		big.NewInt(int64(c.ParentContractIndex)).Bytes(),
+	))
 }
 
 // IsRoot returns true if this claim is the root claim.

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -103,6 +103,8 @@ func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 }
 
 func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
+	// TODO(client-pod#103): Update ExhaustDishonestClaims to not fail if claim it tried to post exists
+	t.Skip("Challenger performs many more moves now creating conflicts")
 	op_e2e.InitParallel(t)
 
 	testCase := func(t *testing.T, isRootCorrect bool) {
@@ -170,8 +172,6 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 }
 
 func TestOutputAlphabetGame_FreeloaderEarnsNothing(t *testing.T) {
-	t.Skip("CLI-103")
-
 	op_e2e.InitParallel(t)
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -218,7 +218,11 @@ func TestOutputAlphabetGame_FreeloaderEarnsNothing(t *testing.T) {
 	freeloaders = append(freeloaders, dishonest.DefendWithTransactOpts(ctx, common.Hash{0x05}, freeloaderOpts))
 
 	for _, freeloader := range freeloaders {
-		freeloader.WaitForCounterClaim(ctx)
+		if freeloader.IsMaxDepth(ctx) {
+			freeloader.WaitForCountered(ctx)
+		} else {
+			freeloader.WaitForCounterClaim(ctx)
+		}
 	}
 
 	game.LogGameData(ctx)


### PR DESCRIPTION
**Description**

Built on https://github.com/ethereum-optimism/optimism/pull/9637 this adjusts the honest actor behaviour to get all tests passing.

The rules are now simple, claims in the game are only countered if:
1. They are the child of a claim the honest actor would make (ie directly countering an honest claim)
2. They are at the same depth as a claim the honest actor would make _and_ have a trace index <= the honest actor's move

Being a self-referential definition, this requires processing claims in contract order, starting from the root and tracking each move that the honest challenger would make in response to that claim. The root claim is considered a move the honest actor would make iff it has a correct value. When responding, the honest actor attacks if the claim has an incorrect value and defend if it is correct.

The exhaustive e2e test has been disabled as the challenger now posts some of the same claims the test posts which creates a race condition. The new exhaustive unit tests from #9637 verify the challenger behaviour is correct. It would be useful to keep the e2e test to ensure the contracts and unit test rules are in sync - will update it in a follow up PR.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/103
- fixes https://github.com/ethereum-optimism/client-pod/issues/614
