### PR TITLE
op-ufm: pin monorepo dependency, remove replace

### DIFF
--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.6
 require (
 	cloud.google.com/go/kms v1.12.1
 	github.com/BurntSushi/toml v1.3.2
-	github.com/ethereum-optimism/optimism v1.5.0-rc.3.0.20240131131533-152d1e0a458d
+	github.com/ethereum-optimism/optimism v1.6.2-0.20240222202618-f707883038d5
 	github.com/ethereum/go-ethereum v1.13.8
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
@@ -99,6 +99,4 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.8 => github.com/ethereum-optimism/op-geth v1.101308.0-rc.1
-
-replace github.com/ethereum-optimism/optimism => ../.
+replace github.com/ethereum/go-ethereum v1.13.8 => github.com/ethereum-optimism/op-geth v1.101308.2-rc.2

--- a/op-ufm/go.sum
+++ b/op-ufm/go.sum
@@ -84,8 +84,10 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum-optimism/op-geth v1.101308.0-rc.1 h1:cRlgrl7EQ2eh5IyKXgb4QglTJC5iphi/JC9MuWQzNTo=
-github.com/ethereum-optimism/op-geth v1.101308.0-rc.1/go.mod h1:ztegoX+28Fc+7JbR3AEukmpWYyg5psoxF3Ax+BTkYi0=
+github.com/ethereum-optimism/op-geth v1.101308.2-rc.2 h1:Tjm2n7/actyINbRIbqeDS+SyWAcIl+pRfOHODwW7lpQ=
+github.com/ethereum-optimism/op-geth v1.101308.2-rc.2/go.mod h1:RPqVhnX00rJNys/YRDK4Wl4PvS6dgFrLqhsopIZOhEw=
+github.com/ethereum-optimism/optimism v1.6.2-0.20240222202618-f707883038d5 h1:Znxv0SuujGbgZocNLXdUAyTJ6/nPNGSo2PvKWEBtrvM=
+github.com/ethereum-optimism/optimism v1.6.2-0.20240222202618-f707883038d5/go.mod h1:CT8RgUDaJuySsnQ/6XTiBYmwVuIys587cE8zMPwflZ8=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240222155908-ab073f6aa74f h1:L2ub0d0iW2Nqwh1r9WxMqebgZf7rU+wHuVCv21uAGx8=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240222155908-ab073f6aa74f/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=


### PR DESCRIPTION

**Description**

This might help with local `go mod tidy` diffs.

Also udpates op-geth dependency while we're at it.
