### PR TITLE
feat(proxyd): change default cache ttl to 1 hour and make it configurable

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -29,7 +29,8 @@ type ServerConfig struct {
 }
 
 type CacheConfig struct {
-	Enabled bool `toml:"enabled"`
+	Enabled bool         `toml:"enabled"`
+	TTL     TOMLDuration `toml:"ttl"`
 }
 
 type RedisConfig struct {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -235,7 +235,11 @@ func Start(config *Config) (*Server, func(), error) {
 			log.Warn("redis is not configured, using in-memory cache")
 			cache = newMemoryCache()
 		} else {
-			cache = newRedisCache(redisClient, config.Redis.Namespace)
+			ttl := defaultCacheTtl
+			if config.Cache.TTL != 0 {
+				ttl = time.Duration(config.Cache.TTL)
+			}
+			cache = newRedisCache(redisClient, config.Redis.Namespace, ttl)
 		}
 		rpcCache = newRPCCache(newCacheWithCompression(cache))
 	}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -42,6 +42,7 @@ const (
 	defaultWSHandshakeTimeout    = 10 * time.Second
 	defaultWSReadTimeout         = 2 * time.Minute
 	defaultWSWriteTimeout        = 10 * time.Second
+	defaultCacheTtl              = 1 * time.Hour
 	maxRequestBodyLogLen         = 2000
 	defaultMaxUpstreamBatchSize  = 10
 	defaultRateLimitHeader       = "X-Forwarded-For"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change introduces a new cache config allowing customization of `ttl` (key expiration) in certain cases.

It also changes the hard coded default to `1 hour` (previously `30 x 7 x 24 horus` ~ 7 months).

**Tests**

Tested manually.

**Additional context**

Improve cache reliability, surfaced on https://github.com/ethereum-optimism/devinfra-pod/issues/86