### PR TITLE
op-dispute-mon: Track left most claim when resolving games.

### DIFF
--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -61,7 +61,7 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 	claimBuilder := test.NewClaimBuilder(t, depth, alphabet.NewTraceProvider(big.NewInt(0), depth))
 
 	claimLoader.claims = []types.Claim{
-		claimBuilder.CreateRootClaim(true),
+		claimBuilder.CreateRootClaim(),
 	}
 
 	require.NoError(t, agent.Act(context.Background()))

--- a/op-challenger/game/fault/solver/solver_test.go
+++ b/op-challenger/game/fault/solver/solver_test.go
@@ -41,9 +41,9 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(common.Big0),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					Attack(common.Hash{0xaa}).
-					AttackCorrect().
-					Attack(common.Hash{0xbb})
+					Attack(faulttest.WithValue(common.Hash{0xaa})).
+					Attack().
+					Attack(faulttest.WithValue(common.Hash{0xbb}))
 			},
 		},
 		{
@@ -54,9 +54,9 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(big.NewInt(1)),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					Attack(common.Hash{0xaa}).
-					AttackCorrect().
-					AttackCorrect()
+					Attack(faulttest.WithValue(common.Hash{0xaa})).
+					Attack().
+					Attack()
 			},
 		},
 		{
@@ -67,9 +67,9 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(big.NewInt(4)),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					AttackCorrect().
-					DefendCorrect().
-					Attack(common.Hash{0xaa})
+					Attack().
+					Defend().
+					Attack(faulttest.WithValue(common.Hash{0xaa}))
 			},
 		},
 		{
@@ -80,9 +80,9 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(big.NewInt(5)),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					AttackCorrect().
-					DefendCorrect().
-					AttackCorrect()
+					Attack().
+					Defend().
+					Attack()
 			},
 		},
 		{
@@ -93,9 +93,9 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(lastLeafTraceIndex),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					AttackCorrect().
-					DefendCorrect().
-					Defend(common.Hash{0xaa})
+					Attack().
+					Defend().
+					Defend(faulttest.WithValue(common.Hash{0xaa}))
 			},
 		},
 		{
@@ -106,15 +106,15 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(lastLeafTraceIndexPlusOne),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					AttackCorrect().
-					DefendCorrect().
-					DefendCorrect()
+					Attack().
+					Defend().
+					Defend()
 			},
 		},
 		{
 			name: "CannotStepNonLeaf",
 			setupGame: func(builder *faulttest.GameBuilder) {
-				builder.Seq().AttackCorrect().AttackCorrect()
+				builder.Seq().Attack().Attack()
 			},
 			expectedErr:         ErrStepNonLeafNode,
 			agreeWithOutputRoot: true,
@@ -123,9 +123,9 @@ func TestAttemptStep(t *testing.T) {
 			name: "CannotStepAgreedNode",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					AttackCorrect().
-					Attack(common.Hash{0xaa}).
-					AttackCorrect()
+					Attack().
+					Attack(faulttest.WithValue(common.Hash{0xaa})).
+					Attack()
 			},
 			expectedErr:         ErrStepIgnoreInvalidPath,
 			agreeWithOutputRoot: true,
@@ -134,9 +134,9 @@ func TestAttemptStep(t *testing.T) {
 			name: "CannotStepInvalidPath",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					Attack(common.Hash{0xaa}).
-					Attack(common.Hash{0xbb}).
-					Attack(common.Hash{0xcc})
+					Attack(faulttest.WithValue(common.Hash{0xaa})).
+					Attack(faulttest.WithValue(common.Hash{0xbb})).
+					Attack(faulttest.WithValue(common.Hash{0xcc}))
 			},
 			expectedErr:         ErrStepIgnoreInvalidPath,
 			agreeWithOutputRoot: true,
@@ -149,9 +149,9 @@ func TestAttemptStep(t *testing.T) {
 			expectedOracleData: claimBuilder.CorrectOracleData(big.NewInt(4)),
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().
-					AttackCorrect().
-					DefendCorrect().
-					DefendCorrect()
+					Attack().
+					Defend().
+					Defend()
 			},
 			expectedErr:         ErrStepIgnoreInvalidPath,
 			agreeWithOutputRoot: true,
@@ -161,7 +161,7 @@ func TestAttemptStep(t *testing.T) {
 	for _, tableTest := range tests {
 		tableTest := tableTest
 		t.Run(tableTest.name, func(t *testing.T) {
-			builder := claimBuilder.GameBuilder(!tableTest.agreeWithOutputRoot)
+			builder := claimBuilder.GameBuilder(faulttest.WithInvalidValue(tableTest.agreeWithOutputRoot))
 			tableTest.setupGame(builder)
 			alphabetSolver := newClaimSolver(maxDepth, trace.NewSimpleTraceAccessor(claimBuilder.CorrectTraceProvider()))
 			game := builder.Game

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -12,6 +12,55 @@ import (
 
 var DefaultClaimant = common.Address{0x09, 0x23, 0x34, 0x45, 0x13, 0xb3}
 
+type claimCfg struct {
+	value        common.Hash
+	invalidValue bool
+	claimant     common.Address
+	parentIdx    int
+}
+
+func newClaimCfg(opts ...ClaimOpt) *claimCfg {
+	cfg := &claimCfg{}
+	for _, opt := range opts {
+		opt.Apply(cfg)
+	}
+	return cfg
+}
+
+type ClaimOpt interface {
+	Apply(cfg *claimCfg)
+}
+
+type claimOptFn func(cfg *claimCfg)
+
+func (c claimOptFn) Apply(cfg *claimCfg) {
+	c(cfg)
+}
+
+func WithValue(value common.Hash) ClaimOpt {
+	return claimOptFn(func(cfg *claimCfg) {
+		cfg.value = value
+	})
+}
+
+func WithInvalidValue(invalid bool) ClaimOpt {
+	return claimOptFn(func(cfg *claimCfg) {
+		cfg.invalidValue = invalid
+	})
+}
+
+func WithClaimant(claimant common.Address) ClaimOpt {
+	return claimOptFn(func(cfg *claimCfg) {
+		cfg.claimant = claimant
+	})
+}
+
+func WithParent(claim types.Claim) ClaimOpt {
+	return claimOptFn(func(cfg *claimCfg) {
+		cfg.parentIdx = claim.ContractIndex
+	})
+}
+
 // ClaimBuilder is a test utility to enable creating claims in a wide range of situations
 type ClaimBuilder struct {
 	require  *require.Assertions
@@ -67,81 +116,44 @@ func (c *ClaimBuilder) incorrectClaim(pos types.Position) common.Hash {
 	return common.BigToHash(pos.TraceIndex(c.maxDepth))
 }
 
-func (c *ClaimBuilder) claim(pos types.Position, correct bool) common.Hash {
-	if correct {
-		return c.CorrectClaimAtPosition(pos)
-	} else {
-		return c.incorrectClaim(pos)
-	}
-}
-
-func (c *ClaimBuilder) CreateRootClaim(correct bool) types.Claim {
-	value := c.claim(types.NewPositionFromGIndex(big.NewInt(1)), correct)
+func (c *ClaimBuilder) claim(pos types.Position, opts ...ClaimOpt) types.Claim {
+	cfg := newClaimCfg(opts...)
 	claim := types.Claim{
 		ClaimData: types.ClaimData{
-			Value:    value,
-			Position: types.NewPosition(0, common.Big0),
+			Position: pos,
 		},
 		Claimant: DefaultClaimant,
 	}
+	if cfg.claimant != (common.Address{}) {
+		claim.Claimant = cfg.claimant
+	}
+	if cfg.value != (common.Hash{}) {
+		claim.Value = cfg.value
+	} else if cfg.invalidValue {
+		claim.Value = c.incorrectClaim(pos)
+	} else {
+		claim.Value = c.CorrectClaimAtPosition(pos)
+	}
+	claim.ParentContractIndex = cfg.parentIdx
 	return claim
 }
 
-func (c *ClaimBuilder) CreateLeafClaim(traceIndex *big.Int, correct bool) types.Claim {
+func (c *ClaimBuilder) CreateRootClaim(opts ...ClaimOpt) types.Claim {
+	pos := types.NewPositionFromGIndex(big.NewInt(1))
+	return c.claim(pos, opts...)
+}
+
+func (c *ClaimBuilder) CreateLeafClaim(traceIndex *big.Int, opts ...ClaimOpt) types.Claim {
 	pos := types.NewPosition(c.maxDepth, traceIndex)
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    c.claim(pos, correct),
-			Position: pos,
-		},
-		Claimant: DefaultClaimant,
-	}
+	return c.claim(pos, opts...)
 }
 
-func (c *ClaimBuilder) AttackClaim(claim types.Claim, correct bool) types.Claim {
+func (c *ClaimBuilder) AttackClaim(claim types.Claim, opts ...ClaimOpt) types.Claim {
 	pos := claim.Position.Attack()
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    c.claim(pos, correct),
-			Position: pos,
-		},
-		ParentContractIndex: claim.ContractIndex,
-		Claimant:            DefaultClaimant,
-	}
+	return c.claim(pos, append([]ClaimOpt{WithParent(claim)}, opts...)...)
 }
 
-func (c *ClaimBuilder) AttackClaimWithValue(claim types.Claim, value common.Hash) types.Claim {
-	pos := claim.Position.Attack()
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    value,
-			Position: pos,
-		},
-		ParentContractIndex: claim.ContractIndex,
-		Claimant:            DefaultClaimant,
-	}
-}
-
-func (c *ClaimBuilder) DefendClaim(claim types.Claim, correct bool) types.Claim {
+func (c *ClaimBuilder) DefendClaim(claim types.Claim, opts ...ClaimOpt) types.Claim {
 	pos := claim.Position.Defend()
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    c.claim(pos, correct),
-			Position: pos,
-		},
-		ParentContractIndex: claim.ContractIndex,
-		Claimant:            DefaultClaimant,
-	}
-}
-
-func (c *ClaimBuilder) DefendClaimWithValue(claim types.Claim, value common.Hash) types.Claim {
-	pos := claim.Position.Defend()
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    value,
-			Position: pos,
-		},
-		ParentContractIndex: claim.ContractIndex,
-		Claimant:            DefaultClaimant,
-	}
+	return c.claim(pos, append([]ClaimOpt{WithParent(claim)}, opts...)...)
 }

--- a/op-challenger/game/fault/test/seq_builder.go
+++ b/op-challenger/game/fault/test/seq_builder.go
@@ -12,24 +12,24 @@ type SequenceBuilder struct {
 // Seq starts building a claim by following a sequence of attack and defend moves from the root
 // The returned SequenceBuilder can be used to add additional moves. e.g:
 // claim := Seq(true).Attack(false).Attack(true).Defend(true).Get()
-func (c *ClaimBuilder) Seq(rootCorrect bool) *SequenceBuilder {
-	claim := c.CreateRootClaim(rootCorrect)
+func (c *ClaimBuilder) Seq(rootOpts ...ClaimOpt) *SequenceBuilder {
+	claim := c.CreateRootClaim(rootOpts...)
 	return &SequenceBuilder{
 		builder:   c,
 		lastClaim: claim,
 	}
 }
 
-func (s *SequenceBuilder) Attack(correct bool) *SequenceBuilder {
-	claim := s.builder.AttackClaim(s.lastClaim, correct)
+func (s *SequenceBuilder) Attack(opts ...ClaimOpt) *SequenceBuilder {
+	claim := s.builder.AttackClaim(s.lastClaim, opts...)
 	return &SequenceBuilder{
 		builder:   s.builder,
 		lastClaim: claim,
 	}
 }
 
-func (s *SequenceBuilder) Defend(correct bool) *SequenceBuilder {
-	claim := s.builder.DefendClaim(s.lastClaim, correct)
+func (s *SequenceBuilder) Defend(opts ...ClaimOpt) *SequenceBuilder {
+	claim := s.builder.DefendClaim(s.lastClaim, opts...)
 	return &SequenceBuilder{
 		builder:   s.builder,
 		lastClaim: claim,

--- a/op-challenger/game/fault/trace/split/split_test.go
+++ b/op-challenger/game/fault/trace/split/split_test.go
@@ -147,12 +147,12 @@ func TestBottomProviderAttackingTopLeaf(t *testing.T) {
 				// If the ref is the leaf of the top claim, ensure we respect whether the test is setup
 				// to attack or defend the top leaf claim.
 				if ref.Depth() != splitDepth || !pos.RightOf(ref.Position) {
-					gameBuilder.SeqFrom(ref).AttackCorrect()
+					gameBuilder.SeqFrom(ref).Attack()
 					attackRef := latestClaim(gameBuilder)
 					testDescendantClaims(attackRef, attackRef.Position)
 				}
 				if ref.Depth() != splitDepth || pos.RightOf(ref.Position) {
-					gameBuilder.SeqFrom(ref).DefendCorrect()
+					gameBuilder.SeqFrom(ref).Defend()
 					defendRef := latestClaim(gameBuilder)
 					testDescendantClaims(defendRef, defendRef.Position)
 				}
@@ -164,10 +164,10 @@ func TestBottomProviderAttackingTopLeaf(t *testing.T) {
 
 func attackTopLeafGIndex8(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
 	// Generate claims down to the top provider's leaf
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
-	seq = seq.AttackCorrect() // gindex 4, trace 1
-	seq.AttackCorrect()       // gindex 8, trace 0
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
+	seq = seq.Attack()       // gindex 4, trace 1
+	seq.Attack()             // gindex 8, trace 0
 	expectPost = latestClaim(gameBuilder)
 
 	// No pre-claim as the first output root is being challenged.
@@ -180,11 +180,11 @@ func attackTopLeafGIndex8(_ *testing.T, gameBuilder *test.GameBuilder) (ref type
 
 func defendTopLeafGIndex8(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
 	// Generate claims down to the top provider's leaf
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
-	seq = seq.AttackCorrect() // gindex 4, trace 1
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
+	seq = seq.Attack()       // gindex 4, trace 1
 	expectPost = latestClaim(gameBuilder)
-	seq.AttackCorrect() // gindex 8, trace 0
+	seq.Attack() // gindex 8, trace 0
 	expectPre = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -193,11 +193,11 @@ func defendTopLeafGIndex8(_ *testing.T, gameBuilder *test.GameBuilder) (ref type
 }
 
 func attackTopLeafGIndex10(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
-	seq = seq.AttackCorrect() // gindex 4, trace 1
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
+	seq = seq.Attack()       // gindex 4, trace 1
 	expectPre = latestClaim(gameBuilder)
-	seq.DefendCorrect() // gindex 10, trace 2
+	seq.Defend() // gindex 10, trace 2
 	expectPost = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -206,11 +206,11 @@ func attackTopLeafGIndex10(_ *testing.T, gameBuilder *test.GameBuilder) (ref typ
 }
 
 func defendTopLeafGIndex10(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
 	expectPost = latestClaim(gameBuilder)
-	seq = seq.AttackCorrect() // gindex 4, trace 1
-	seq.DefendCorrect()       // gindex 10, trace 2
+	seq = seq.Attack() // gindex 4, trace 1
+	seq.Defend()       // gindex 10, trace 2
 	expectPre = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -219,11 +219,11 @@ func defendTopLeafGIndex10(_ *testing.T, gameBuilder *test.GameBuilder) (ref typ
 }
 
 func attackTopLeafGIndex12(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
 	expectPre = latestClaim(gameBuilder)
-	seq = seq.DefendCorrect() // gindex 6, trace 5
-	seq.AttackCorrect()       // gindex 12, trace 4
+	seq = seq.Defend() // gindex 6, trace 5
+	seq.Attack()       // gindex 12, trace 4
 	expectPost = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -232,11 +232,11 @@ func attackTopLeafGIndex12(_ *testing.T, gameBuilder *test.GameBuilder) (ref typ
 }
 
 func defendTopLeafGIndex12(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
-	seq = seq.DefendCorrect() // gindex 6, trace 5
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
+	seq = seq.Defend()       // gindex 6, trace 5
 	expectPost = latestClaim(gameBuilder)
-	seq.AttackCorrect() // gindex 12, trace 4
+	seq.Attack() // gindex 12, trace 4
 	expectPre = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -245,11 +245,11 @@ func defendTopLeafGIndex12(_ *testing.T, gameBuilder *test.GameBuilder) (ref typ
 }
 
 func attackTopLeafGIndex14(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
-	seq := gameBuilder.Seq()  // gindex 1, trace 7
-	seq = seq.AttackCorrect() // gindex 2, trace 3
-	seq = seq.DefendCorrect() // gindex 6, trace 5
+	seq := gameBuilder.Seq() // gindex 1, trace 7
+	seq = seq.Attack()       // gindex 2, trace 3
+	seq = seq.Defend()       // gindex 6, trace 5
 	expectPre = latestClaim(gameBuilder)
-	seq.DefendCorrect() // gindex 14, trace 6
+	seq.Defend() // gindex 14, trace 6
 	expectPost = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -260,9 +260,9 @@ func attackTopLeafGIndex14(_ *testing.T, gameBuilder *test.GameBuilder) (ref typ
 func defendTopLeafGIndex14(_ *testing.T, gameBuilder *test.GameBuilder) (ref types.Claim, pos types.Position, expectPre types.Claim, expectPost types.Claim) {
 	seq := gameBuilder.Seq() // gindex 1, trace 7
 	expectPost = latestClaim(gameBuilder)
-	seq = seq.AttackCorrect() // gindex 2, trace 3
-	seq = seq.DefendCorrect() // gindex 6, trace 5
-	seq.DefendCorrect()       // gindex 14, trace 6
+	seq = seq.Attack() // gindex 2, trace 3
+	seq = seq.Defend() // gindex 6, trace 5
+	seq.Defend()       // gindex 14, trace 6
 	expectPre = latestClaim(gameBuilder)
 
 	ref = latestClaim(gameBuilder)
@@ -277,7 +277,7 @@ func latestClaim(gameBuilder *test.GameBuilder) types.Claim {
 func createClaimsToDepth(gameBuilder *test.GameBuilder, depth int) {
 	seq := gameBuilder.Seq()
 	for i := 0; i < depth; i++ {
-		seq = seq.AttackCorrect()
+		seq = seq.Attack()
 	}
 }
 
@@ -314,7 +314,7 @@ func setupAlphabetSplitSelector(t *testing.T) (*alphabet.AlphabetTraceProvider, 
 	selector := NewSplitProviderSelector(top, splitDepth, bottomCreator)
 
 	claimBuilder := test.NewAlphabetClaimBuilder(t, big.NewInt(0), gameDepth)
-	gameBuilder := claimBuilder.GameBuilder(true)
+	gameBuilder := claimBuilder.GameBuilder()
 	return top, selector, gameBuilder
 }
 

--- a/op-dispute-mon/mon/resolution/resolver.go
+++ b/op-dispute-mon/mon/resolution/resolver.go
@@ -1,6 +1,8 @@
 package resolution
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
@@ -14,9 +16,14 @@ func Resolve(tree *monTypes.BidirectionalTree) gameTypes.GameStatus {
 	for i := len(tree.Claims) - 1; i >= 0; i-- {
 		claim := tree.Claims[i]
 		counterClaimant := claim.Claim.CounteredBy
+		var leftmostCounter *big.Int
 		for _, child := range claim.Children {
-			if child.Claim.CounteredBy == (common.Address{}) {
+			if child.Claim.CounteredBy != (common.Address{}) {
+				continue // Ignore countered claims
+			}
+			if leftmostCounter == nil || child.Claim.Position.IndexAtDepth().Cmp(leftmostCounter) < 0 {
 				counterClaimant = child.Claim.Claimant
+				leftmostCounter = child.Claim.Position.IndexAtDepth()
 			}
 		}
 		claim.Claim.CounteredBy = counterClaimant


### PR DESCRIPTION
**Description**

When forecasting the game resolution, respect the left most claim rule when setting the `CounteredBy`. Doesn't affect dispute-mon currently, but is useful for testing honest actor algorithms.

**Tests**

Added unit tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/9650

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/103
