### PR TITLE
ci: Add param to allow manually running develop-fault-proof task against other branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   # Add a new `*_dispatch` parameter for any pipeline you want manual dispatch for.
   main_dispatch:
     type: boolean
-    default: false # main workflow will still trigger in response to changes being pushed
+    default: true # default to running main in case the manual run cancelled an automatic run
   fault_proofs_dispatch:
     type: boolean
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,16 @@ parameters:
   base_image:
     type: string
     default: default
+  # The dispatch parameters are used to manually dispatch pipelines that normally only run post-merge on develop
+  # from the CircleCI UI. Example configuration:
+  #   when:
+  #     or:
+  #       - equal: [ "develop", <<pipeline.git.branch>> ]
+  #       - equal: [ true, <<pipeline.parameters.cannon_dispatch>> ]
+  # Add a new `*_dispatch` parameter for any pipeline you want manual dispatch for.
+  cannon_dispatch:
+    type: boolean
+    default: false
 
 orbs:
   go: circleci/go@1.8.0
@@ -851,11 +861,6 @@ jobs:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
     resource_class: xlarge
-    # Note: Tests are split between runs manually.
-    # Tests default to run on the first executor but can be moved to the second with:
-    # InitParallel(t, UseExecutor(1))
-    # Any tests assigned to an executor greater than the number available automatically use the last executor.
-    # Executor indexes start from 0
     parallelism: <<parameters.parallelism>>
     steps:
       - checkout
@@ -2011,7 +2016,9 @@ workflows:
   develop-fault-proofs:
     when:
       and:
-        - equal: [ "develop", <<pipeline.git.branch>> ]
+        - or:
+          - equal: [ "develop", <<pipeline.git.branch>> ]
+          - equal: [ true, <<pipeline.parameters.cannon_dispatch>> ]
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,12 @@ parameters:
   #   when:
   #     or:
   #       - equal: [ "develop", <<pipeline.git.branch>> ]
-  #       - equal: [ true, <<pipeline.parameters.cannon_dispatch>> ]
+  #       - equal: [ true, <<pipeline.parameters.main_dispatch>> ]
   # Add a new `*_dispatch` parameter for any pipeline you want manual dispatch for.
-  cannon_dispatch:
+  main_dispatch:
+    type: boolean
+    default: false # main workflow will still trigger in response to changes being pushed
+  fault_proofs_dispatch:
     type: boolean
     default: false
 
@@ -1466,8 +1469,11 @@ jobs:
 workflows:
   main:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      or:
+          # Trigger on new commits
+        - equal: [ webhook, << pipeline.trigger_source >> ]
+          # Trigger on manual triggers if explicitly requested
+        - equal: [ true, << pipeline.parameters.main_dispatch >> ]
     jobs:
       - pnpm-monorepo:
           name: pnpm-monorepo
@@ -2018,7 +2024,7 @@ workflows:
       and:
         - or:
           - equal: [ "develop", <<pipeline.git.branch>> ]
-          - equal: [ true, <<pipeline.parameters.cannon_dispatch>> ]
+          - equal: [ true, <<pipeline.parameters.fault_proofs_dispatch>> ]
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:


### PR DESCRIPTION
**Description**

Add a param to the CircleCI config to allow manually running the `develop-fault-proofs` job which normally only runs post-commit against a specific branch. Very useful for confirming the tests aren't broken prior to merge when changing things that are specifically related to cannon tests.

The catch with manual runs is that for anything except the develop branch, CircleCI will automatically cancel any existing pipeline runs when a new one starts. So if you trigger a run of the cannon jobs while the main workflow is still running for pushing a commit, the main workflow will be cancelled as redundant. Then you need to trigger the main workflow again (which cancels the cannon job). :facepalm:  So you wind up needing to wait for one job to finish before doing anything that would trigger the other - not the end of the world but an annoying foot gun.

So this includes a `main_dispatch` param to control whether to run the `main` workflow which defaults to true. The `main` workflow is also configured to always run on web hook calls (e.g GitHub push notifications) just to be ultra defensive and ensure it does keep running when it should.  With this setup, manually triggering a run might cancel an existing `main` run from the previous commit but at least it starts a new one which will likely finish before the job that normally runs only on develop does anyway.  You can save some CI time by manually disabling the rerun of main if you know the previous instance has already completed.

There's still a foot-gun where your manual pipeline gets cancelled if you push another commit to the branch but we can't do much about that.

**Additional context**

Hat tip to https://github.com/ethereum-optimism/optimism/pull/9530/ and apologies for the conflicts. :) 

