### PR TITLE
chore: Publish new version of contracts-bedrock

### DIFF
--- a/.changeset/four-crabs-cover.md
+++ b/.changeset/four-crabs-cover.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts-bedrock': minor
+'@eth-optimism/contracts-ts': minor
+---
+
+Added new fault-proof alpha contracts such as OptimismPortal2.sol


### PR DESCRIPTION
To unblock op-viem we need to publish a version of contracts-bedrock and contract-ts that includes the fault proof alpha contracts like OptimismPortal2.sol

