### PR TITLE
fix log line to use the txlogger instead of default logger

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -490,7 +490,7 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 
 		if err == nil {
 			m.metr.TxPublished("")
-			log.Info("Transaction successfully published")
+			l.Info("Transaction successfully published")
 			return tx, true
 		}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The "Transaction successfully published" log message wasn't using the txLogger so it is missing important fields like the tx hash.

**Tests**

none, change is logging only.

**Additional context**

**Metadata**

- Fixes #[Link to Issue]
