### PR TITLE
op-node: Cleanup unsafe payload handling

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -180,7 +180,7 @@ func NewEngineQueue(log log.Logger, cfg *rollup.Config, l2Source L2Source, engin
 		engine:         l2Source,
 		metrics:        metrics,
 		finalityData:   make([]FinalityData, 0, finalityLookback),
-		unsafePayloads: NewPayloadsQueue(maxUnsafePayloadsMemory, payloadMemSize),
+		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
 		prev:           prev,
 		l1Fetcher:      l1Fetcher,
 		syncCfg:        syncCfg,
@@ -472,7 +472,7 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 	}
 
 	// Ensure that the unsafe payload builds upon the current unsafe head
-	if eq.syncCfg.SyncMode != sync.ELSync && first.ParentHash != eq.ec.UnsafeL2Head().Hash {
+	if first.ParentHash != eq.ec.UnsafeL2Head().Hash {
 		if uint64(first.BlockNumber) == eq.ec.UnsafeL2Head().Number+1 {
 			eq.log.Info("skipping unsafe payload, since it does not build onto the existing unsafe chain", "safe", eq.ec.SafeL2Head().ID(), "unsafe", first.ID(), "payload", first.ID())
 			eq.unsafePayloads.Pop()

--- a/op-node/rollup/derive/payloads_queue_test.go
+++ b/op-node/rollup/derive/payloads_queue_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 func TestPayloadsByNumber(t *testing.T) {
@@ -81,7 +83,7 @@ func envelope(payload *eth.ExecutionPayload) *eth.ExecutionPayloadEnvelope {
 }
 
 func TestPayloadsQueue(t *testing.T) {
-	pq := NewPayloadsQueue(payloadMemFixedCost*3, payloadMemSize)
+	pq := NewPayloadsQueue(testlog.Logger(t, log.LvlInfo), payloadMemFixedCost*3, payloadMemSize)
 	require.Equal(t, 0, pq.Len())
 	require.Nil(t, pq.Peek())
 	require.Nil(t, pq.Pop())

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -348,7 +348,7 @@ func (s *Driver) eventLoop() {
 				if err := s.engineController.InsertUnsafePayload(s.driverCtx, envelope, ref); err != nil {
 					s.log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
 				}
-				s.logSyncProgress("unsafe payload from sequencer")
+				s.logSyncProgress("unsafe payload from sequencer while in EL sync")
 			}
 		case newL1Head := <-s.l1HeadSig:
 			s.l1State.HandleNewL1HeadBlock(newL1Head)

--- a/op-service/testlog/capturing.go
+++ b/op-service/testlog/capturing.go
@@ -62,6 +62,34 @@ func NewLevelFilter(level slog.Level) LogFilter {
 	}
 }
 
+func NewAttributesFilter(key, value string) LogFilter {
+	return func(r *slog.Record) bool {
+		found := false
+		r.Attrs(func(a slog.Attr) bool {
+			if a.Key == key && a.Value.String() == value {
+				found = true
+				return false
+			}
+			return true // try next
+		})
+		return found
+	}
+}
+
+func NewAttributesContainsFilter(key, value string) LogFilter {
+	return func(r *slog.Record) bool {
+		found := false
+		r.Attrs(func(a slog.Attr) bool {
+			if a.Key == key && strings.Contains(a.Value.String(), value) {
+				found = true
+				return false
+			}
+			return true // try next
+		})
+		return found
+	}
+}
+
 func NewMessageFilter(message string) LogFilter {
 	return func(r *slog.Record) bool {
 		return r.Message == message

--- a/op-service/testlog/capturing_test.go
+++ b/op-service/testlog/capturing_test.go
@@ -41,3 +41,20 @@ func TestCaptureLogger(t *testing.T) {
 	require.EqualValues(t, 3, recOp.AttrValue("c"))
 	// Note: "b" attributes won't be visible on captured record
 }
+
+func TestCaptureLoggerAttributesFilter(t *testing.T) {
+	lgr, logs := testlog.CaptureLogger(t, log.LevelInfo)
+	msg := "foo bar"
+	lgr.Info(msg, "a", "test")
+	lgr.Info(msg, "a", "test 2")
+	lgr.Info(msg, "a", "random")
+	msgFilter := testlog.NewMessageFilter(msg)
+	attrFilter := testlog.NewAttributesFilter("a", "random")
+
+	rec := logs.FindLog(msgFilter, attrFilter)
+	require.Equal(t, msg, rec.Message)
+	require.EqualValues(t, "random", rec.AttrValue("a"))
+
+	recs := logs.FindLogs(msgFilter, attrFilter)
+	require.Len(t, recs, 1)
+}


### PR DESCRIPTION
**Description**

This PR does a couple small things:
1. Add a logger to the payload queue to log when payloads are dropped from the UPQ.
2. Differentiate the sync progress log between the EL sync insert and the CL sync insert.
3. Fix a bug in execution layer sync where it could accidentally be triggered by the op-node after the op-node had transitioned to block by block sync.

Specifically, the old implementation of EL sync would always insert payloads from inside the engine queue's unsafe payload queue when configured to use EL sync; however, the new implementation would assume that once it had finished EL sync, it would switch to CL sync and process blocks in order and one by one.
