### PR TITLE
op-e2e: Add failing e2e test for proposals not supported by L1 data

### DIFF
--- a/op-e2e/e2eutils/disputegame/output_honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_honest_helper.go
@@ -18,13 +18,24 @@ type OutputHonestHelper struct {
 	correctTrace types.TraceAccessor
 }
 
+func (h *OutputHonestHelper) CounterClaim(ctx context.Context, claim *ClaimHelper, opts ...MoveOpt) *ClaimHelper {
+	game, target := h.loadState(ctx, claim.index)
+	value, err := h.correctTrace.Get(ctx, game, target, target.Position)
+	h.require.NoErrorf(err, "Failed to determine correct claim at position %v with g index %v", target.Position, target.Position.ToGIndex())
+	if value == claim.claim {
+		return h.DefendClaim(ctx, claim, opts...)
+	} else {
+		return h.AttackClaim(ctx, claim, opts...)
+	}
+}
+
 func (h *OutputHonestHelper) AttackClaim(ctx context.Context, claim *ClaimHelper, opts ...MoveOpt) *ClaimHelper {
 	h.Attack(ctx, claim.index, opts...)
 	return claim.WaitForCounterClaim(ctx)
 }
 
-func (h *OutputHonestHelper) DefendClaim(ctx context.Context, claim *ClaimHelper) *ClaimHelper {
-	h.Defend(ctx, claim.index)
+func (h *OutputHonestHelper) DefendClaim(ctx context.Context, claim *ClaimHelper, opts ...MoveOpt) *ClaimHelper {
+	h.Defend(ctx, claim.index, opts...)
 	return claim.WaitForCounterClaim(ctx)
 }
 

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -660,3 +660,77 @@ func TestDisputeOutputRoot_ChangeClaimedOutputRoot(t *testing.T) {
 	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 	game.LogGameData(ctx)
 }
+
+func TestInvalidateUnsafeProposal(t *testing.T) {
+	// TODO(client-pod#540) Fix and enable TestInvalidateUnsafeProposal
+	t.Skip("Agreed head not correctly restricted yet")
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		strategy func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper
+	}{
+		{
+			name: "Attack",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.AttackClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Defend",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.DefendClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Counter",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.CounterClaim(ctx, parent)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+			sys, l1Client := startFaultDisputeSystem(t, withSequencerWindowSize(1000))
+			t.Cleanup(sys.Close)
+
+			// Wait for the safe head to advance at least one block to init the safe head database
+			require.NoError(t, wait.ForSafeBlock(ctx, sys.RollupClient("sequencer"), 1))
+
+			// Now stop the batcher so the safe head doesn't advance any further
+			require.NoError(t, sys.BatchSubmitter.Stop(ctx))
+
+			// Wait for the unsafe head to advance to be sure it is beyond the safe head
+			require.NoError(t, wait.ForNextBlock(ctx, sys.NodeClient("sequencer")))
+			blockNum, err := sys.NodeClient("sequencer").BlockNumber(ctx)
+			require.NoError(t, err)
+
+			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
+			// Root claim is _dishonest_ because the required data is not available on L1
+			game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", blockNum, disputegame.WithUnsafeProposal())
+
+			correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+
+			// Start the honest challenger
+			game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+
+			game.DefendClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				if parent.IsBottomGameRoot(ctx) {
+					return correctTrace.AttackClaim(ctx, parent)
+				}
+				return test.strategy(correctTrace, parent)
+			})
+
+			// Time travel past when the game will be resolvable.
+			sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
+			game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
+			game.LogGameData(ctx)
+		})
+	}
+}

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -41,6 +41,12 @@ func withEcotone() faultDisputeConfigOpts {
 	}
 }
 
+func withSequencerWindowSize(size uint64) faultDisputeConfigOpts {
+	return func(cfg *op_e2e.SystemConfig) {
+		cfg.DeployConfig.SequencerWindowSize = size
+	}
+}
+
 func startFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts) (*op_e2e.System, *ethclient.Client) {
 	cfg := op_e2e.DefaultSystemConfig(t)
 	delete(cfg.Nodes, "verifier")


### PR DESCRIPTION
**Description**

Adds a failing e2e test to cover the case where an output root is published from an unsafe node. While this matches the reference node's view of the chain, the batch data required to support it is not present on L1 before the L1 head block used for the game so the game is invalid.

The challenger doesn't yet correctly respond to this hence the test being skipped. Will follow up with a fix for the production code.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/540
