### PR TITLE
op-e2e: Add test that proposals for future blocks are invalidated

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -59,6 +59,7 @@ func (s Status) String() string {
 }
 
 type gameCfg struct {
+	allowFuture bool
 	allowUnsafe bool
 }
 type GameOpt interface {
@@ -73,6 +74,12 @@ func (g gameOptFn) Apply(cfg *gameCfg) {
 func WithUnsafeProposal() GameOpt {
 	return gameOptFn(func(c *gameCfg) {
 		c.allowUnsafe = true
+	})
+}
+
+func WithFutureProposal() GameOpt {
+	return gameOptFn(func(c *gameCfg) {
+		c.allowFuture = true
 	})
 }
 
@@ -279,6 +286,11 @@ func (h *FactoryHelper) createBisectionGameExtraData(l2Node string, l2BlockNumbe
 }
 
 func (h *FactoryHelper) waitForBlock(l2Node string, l2BlockNumber uint64, cfg *gameCfg) {
+	if cfg.allowFuture {
+		// Proposing a block that doesn't exist yet, so don't perform any checks
+		return
+	}
+
 	l2Client := h.system.NodeClient(l2Node)
 	if cfg.allowUnsafe {
 		_, err := geth.WaitForBlock(new(big.Int).SetUint64(l2BlockNumber), l2Client, 1*time.Minute)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -732,3 +732,68 @@ func TestInvalidateUnsafeProposal(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidateProposalForFutureBlock(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		strategy func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper
+	}{
+		{
+			name: "Attack",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.AttackClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Defend",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.DefendClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Counter",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.CounterClaim(ctx, parent)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+			sys, l1Client := startFaultDisputeSystem(t, withSequencerWindowSize(1000))
+			t.Cleanup(sys.Close)
+
+			// Wait for the safe head to advance at least one block to init the safe head database
+			require.NoError(t, wait.ForSafeBlock(ctx, sys.RollupClient("sequencer"), 1))
+
+			farFutureBlockNum := uint64(10_000_000)
+			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
+			// Root claim is _dishonest_ because the required data is not available on L1
+			game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", farFutureBlockNum, common.Hash{0xaa}, disputegame.WithFutureProposal())
+
+			correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+
+			// Start the honest challenger
+			game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+
+			game.DefendClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				if parent.IsBottomGameRoot(ctx) {
+					return correctTrace.AttackClaim(ctx, parent)
+				}
+				return test.strategy(correctTrace, parent)
+			})
+
+			// Time travel past when the game will be resolvable.
+			sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
+			game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
+			game.LogGameData(ctx)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Adds an e2e test to confirm that proposals for blocks that don't exist yet are successfully countered.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/556
