### PR TITLE
op-wheel: Support for Engine API V3 calls & version selection

### DIFF
--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -94,14 +94,7 @@ func (o *OracleEngine) PayloadByHash(ctx context.Context, hash common.Hash) (*et
 	if block == nil {
 		return nil, ErrNotFound
 	}
-	payload, err := eth.BlockAsPayload(block, o.rollupCfg.CanyonTime)
-	if err != nil {
-		return nil, err
-	}
-	return &eth.ExecutionPayloadEnvelope{
-		ParentBeaconBlockRoot: block.BeaconRoot(),
-		ExecutionPayload:      payload,
-	}, nil
+	return eth.BlockAsPayloadEnv(block, o.rollupCfg.CanyonTime)
 }
 
 func (o *OracleEngine) PayloadByNumber(ctx context.Context, n uint64) (*eth.ExecutionPayloadEnvelope, error) {

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -316,12 +316,7 @@ func (ea *L2EngineAPI) getPayload(ctx context.Context, payloadId eth.PayloadID) 
 		return nil, engine.UnknownPayload
 	}
 
-	payload, err := eth.BlockAsPayload(bl, ea.config().CanyonTime)
-	if err != nil {
-		return nil, err
-	}
-
-	return &eth.ExecutionPayloadEnvelope{ExecutionPayload: payload, ParentBeaconBlockRoot: bl.BeaconRoot()}, nil
+	return eth.BlockAsPayloadEnv(bl, ea.config().CanyonTime)
 }
 
 func (ea *L2EngineAPI) forkchoiceUpdated(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -152,11 +152,13 @@ type Uint256Quantity = hexutil.U256
 
 type Data = hexutil.Bytes
 
-type PayloadID = engine.PayloadID
-type PayloadInfo struct {
-	ID        PayloadID
-	Timestamp uint64
-}
+type (
+	PayloadID   = engine.PayloadID
+	PayloadInfo struct {
+		ID        PayloadID
+		Timestamp uint64
+	}
+)
 
 type ExecutionPayloadEnvelope struct {
 	ParentBeaconBlockRoot *common.Hash      `json:"parentBeaconBlockRoot,omitempty"`
@@ -296,14 +298,17 @@ type PayloadAttributes struct {
 	SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient"`
 	// Withdrawals to include into the block -- should be nil or empty depending on Shanghai enablement
 	Withdrawals *types.Withdrawals `json:"withdrawals,omitempty"`
+	// parentBeaconBlockRoot optional extension in Dencun
+	ParentBeaconBlockRoot *common.Hash `json:"parentBeaconBlockRoot,omitempty"`
+
+	// Optimism additions
+
 	// Transactions to force into the block (always at the start of the transactions list).
 	Transactions []Data `json:"transactions,omitempty"`
 	// NoTxPool to disable adding any transactions from the transaction-pool.
 	NoTxPool bool `json:"noTxPool,omitempty"`
 	// GasLimit override
 	GasLimit *Uint64Quantity `json:"gasLimit,omitempty"`
-	// parentBeaconBlockRoot optional extension in Dencun
-	ParentBeaconBlockRoot *common.Hash `json:"parentBeaconBlockRoot,omitempty"`
 }
 
 type ExecutePayloadStatus string

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -289,6 +289,17 @@ func BlockAsPayload(bl *types.Block, canyonForkTime *uint64) (*ExecutionPayload,
 	return payload, nil
 }
 
+func BlockAsPayloadEnv(bl *types.Block, canyonForkTime *uint64) (*ExecutionPayloadEnvelope, error) {
+	payload, err := BlockAsPayload(bl, canyonForkTime)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecutionPayloadEnvelope{
+		ExecutionPayload:      payload,
+		ParentBeaconBlockRoot: bl.BeaconRoot(),
+	}, nil
+}
+
 type PayloadAttributes struct {
 	// value for the timestamp field of the new payload
 	Timestamp Uint64Quantity `json:"timestamp"`

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -31,6 +31,7 @@ func EngineClientDefaultConfig(config *rollup.Config) *EngineClientConfig {
 // EngineClient extends L2Client with engine API bindings.
 type EngineClient struct {
 	*L2Client
+	*EngineAPIClient
 }
 
 func NewEngineClient(client client.RPC, log log.Logger, metrics caching.Metrics, config *EngineClientConfig) (*EngineClient, error) {
@@ -39,10 +40,38 @@ func NewEngineClient(client client.RPC, log log.Logger, metrics caching.Metrics,
 		return nil, err
 	}
 
+	engineAPIClient := NewEngineAPIClient(client, log, config.RollupCfg)
+
 	return &EngineClient{
-		L2Client: l2Client,
+		L2Client:        l2Client,
+		EngineAPIClient: engineAPIClient,
 	}, nil
 }
+
+// EngineAPIClient is an RPC client for the Engine API functions.
+type EngineAPIClient struct {
+	RPC client.RPC
+	log log.Logger
+	evp EngineVersionProvider
+}
+
+type EngineVersionProvider interface {
+	ForkchoiceUpdatedVersion(attr *eth.PayloadAttributes) eth.EngineAPIMethod
+	NewPayloadVersion(timestamp uint64) eth.EngineAPIMethod
+	GetPayloadVersion(timestamp uint64) eth.EngineAPIMethod
+}
+
+func NewEngineAPIClient(rpc client.RPC, l log.Logger, evp EngineVersionProvider) *EngineAPIClient {
+	return &EngineAPIClient{
+		RPC: rpc,
+		log: l,
+		evp: evp,
+	}
+}
+
+// EngineVersionProvider returns the underlying engine version provider used for
+// resolving the correct Engine API versions.
+func (s *EngineAPIClient) EngineVersionProvider() EngineVersionProvider { return s.evp }
 
 // ForkchoiceUpdate updates the forkchoice on the execution client. If attributes is not nil, the engine client will also begin building a block
 // based on attributes after the new head block and return the payload ID.
@@ -51,15 +80,15 @@ func NewEngineClient(client client.RPC, log log.Logger, metrics caching.Metrics,
 // 1. Processing error: ForkchoiceUpdatedResult.PayloadStatusV1.ValidationError or other non-success PayloadStatusV1,
 // 2. `error` as eth.InputError: the forkchoice state or attributes are not valid.
 // 3. Other types of `error`: temporary RPC errors, like timeouts.
-func (s *EngineClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceState, attributes *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+func (s *EngineAPIClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceState, attributes *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	llog := s.log.New("state", fc)       // local logger
 	tlog := llog.New("attr", attributes) // trace logger
 	tlog.Trace("Sharing forkchoice-updated signal")
 	fcCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	var result eth.ForkchoiceUpdatedResult
-	method := s.rollupCfg.ForkchoiceUpdatedVersion(attributes)
-	err := s.client.CallContext(fcCtx, &result, string(method), fc, attributes)
+	method := s.evp.ForkchoiceUpdatedVersion(attributes)
+	err := s.RPC.CallContext(fcCtx, &result, string(method), fc, attributes)
 	if err == nil {
 		tlog.Trace("Shared forkchoice-updated signal")
 		if attributes != nil { // block building is optional, we only get a payload ID if we are building a block
@@ -87,7 +116,7 @@ func (s *EngineClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceS
 // NewPayload executes a full block on the execution engine.
 // This returns a PayloadStatusV1 which encodes any validation/processing error,
 // and this type of error is kept separate from the returned `error` used for RPC errors, like timeouts.
-func (s *EngineClient) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
+func (s *EngineAPIClient) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
 	e := s.log.New("block_hash", payload.BlockHash)
 	e.Trace("sending payload for execution")
 
@@ -96,11 +125,11 @@ func (s *EngineClient) NewPayload(ctx context.Context, payload *eth.ExecutionPay
 	var result eth.PayloadStatusV1
 
 	var err error
-	switch method := s.rollupCfg.NewPayloadVersion(uint64(payload.Timestamp)); method {
+	switch method := s.evp.NewPayloadVersion(uint64(payload.Timestamp)); method {
 	case eth.NewPayloadV3:
-		err = s.client.CallContext(execCtx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot)
+		err = s.RPC.CallContext(execCtx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot)
 	case eth.NewPayloadV2:
-		err = s.client.CallContext(execCtx, &result, string(method), payload)
+		err = s.RPC.CallContext(execCtx, &result, string(method), payload)
 	default:
 		return nil, fmt.Errorf("unsupported NewPayload version: %s", method)
 	}
@@ -117,12 +146,12 @@ func (s *EngineClient) NewPayload(ctx context.Context, payload *eth.ExecutionPay
 // There may be two types of error:
 // 1. `error` as eth.InputError: the payload ID may be unknown
 // 2. Other types of `error`: temporary RPC errors, like timeouts.
-func (s *EngineClient) GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+func (s *EngineAPIClient) GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
 	e := s.log.New("payload_id", payloadInfo.ID)
 	e.Trace("getting payload")
 	var result eth.ExecutionPayloadEnvelope
-	method := s.rollupCfg.GetPayloadVersion(payloadInfo.Timestamp)
-	err := s.client.CallContext(ctx, &result, string(method), payloadInfo.ID)
+	method := s.evp.GetPayloadVersion(payloadInfo.Timestamp)
+	err := s.RPC.CallContext(ctx, &result, string(method), payloadInfo.ID)
 	if err != nil {
 		e.Warn("Failed to get payload", "payload_id", payloadInfo.ID, "err", err)
 		if rpcErr, ok := err.(rpc.Error); ok {
@@ -143,9 +172,9 @@ func (s *EngineClient) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 	return &result, nil
 }
 
-func (s *EngineClient) SignalSuperchainV1(ctx context.Context, recommended, required params.ProtocolVersion) (params.ProtocolVersion, error) {
+func (s *EngineAPIClient) SignalSuperchainV1(ctx context.Context, recommended, required params.ProtocolVersion) (params.ProtocolVersion, error) {
 	var result params.ProtocolVersion
-	err := s.client.CallContext(ctx, &result, "engine_signalSuperchainV1", &catalyst.SuperchainSignal{
+	err := s.RPC.CallContext(ctx, &result, "engine_signalSuperchainV1", &catalyst.SuperchainSignal{
 		Recommended: recommended,
 		Required:    required,
 	})

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -76,6 +76,12 @@ var (
 		Name:    "engine.version",
 		Usage:   "Engine API version to use for Engine calls (1, 2, or 3)",
 		EnvVars: prefixEnvVars("ENGINE_VERSION"),
+		Action: func(ctx *cli.Context, ev int) error {
+			if ev < 1 || ev > 3 {
+				return fmt.Errorf("invalid Engine API version: %d", ev)
+			}
+			return nil
+		},
 	}
 	FeeRecipientFlag = &cli.GenericFlag{
 		Name:    "fee-recipient",
@@ -185,9 +191,6 @@ func initVersionProvider(ctx *cli.Context, lgr log.Logger) (sources.EngineVersio
 	// static configuration takes precedent, if set
 	if ctx.IsSet(EngineVersion.Name) {
 		ev := ctx.Int(EngineVersion.Name)
-		if ev < 1 || ev > 3 {
-			return nil, fmt.Errorf("invalid Engine API version: %d", ev)
-		}
 		return engine.StaticVersionProvider(ev), nil
 	}
 

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -649,13 +649,18 @@ var (
 				Required: true,
 				EnvVars:  prefixEnvVars("REWIND_TO"),
 			},
+			&cli.BoolFlag{
+				Name:    "set-head",
+				Usage:   "Whether to also call debug_setHead when rewinding",
+				EnvVars: prefixEnvVars("REWIND_SET_HEAD"),
+			},
 		),
 		Action: EngineAction(func(ctx *cli.Context, client *sources.EngineAPIClient, lgr log.Logger) error {
 			open, err := initOpenEngineRPC(ctx, lgr)
 			if err != nil {
 				return fmt.Errorf("failed to dial open RPC endpoint: %w", err)
 			}
-			return engine.Rewind(ctx.Context, lgr, client, open, ctx.Uint64("to"))
+			return engine.Rewind(ctx.Context, lgr, client, open, ctx.Uint64("to"), ctx.Bool("set-head"))
 		}),
 	}
 

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -10,41 +10,26 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
-type PayloadAttributesV2 struct {
-	Timestamp             uint64              `json:"timestamp"`
-	Random                common.Hash         `json:"prevRandao"`
-	SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient"`
-	Withdrawals           []*types.Withdrawal `json:"withdrawals"`
-}
+const (
+	methodEthGetBlockByNumber = "eth_getBlockByNumber"
+	methodDebugChainConfig    = "debug_chainConfig"
+)
 
-func (p PayloadAttributesV2) MarshalJSON() ([]byte, error) {
-	type PayloadAttributes struct {
-		Timestamp             hexutil.Uint64      `json:"timestamp"             gencodec:"required"`
-		Random                common.Hash         `json:"prevRandao"            gencodec:"required"`
-		SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient" gencodec:"required"`
-		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
-	}
-	var enc PayloadAttributes
-	enc.Timestamp = hexutil.Uint64(p.Timestamp)
-	enc.Random = p.Random
-	enc.SuggestedFeeRecipient = p.SuggestedFeeRecipient
-	enc.Withdrawals = make([]*types.Withdrawal, 0)
-	return json.Marshal(&enc)
-}
-
-func DialClient(ctx context.Context, endpoint string, jwtSecret [32]byte) (client.RPC, error) {
+func DialRPC(ctx context.Context, endpoint string, jwtSecret [32]byte) (client.RPC, error) {
 	auth := node.NewJWTAuth(jwtSecret)
 
 	rpcClient, err := rpc.DialOptions(ctx, endpoint, rpc.WithHTTPAuth(auth))
@@ -52,6 +37,11 @@ func DialClient(ctx context.Context, endpoint string, jwtSecret [32]byte) (clien
 		return nil, fmt.Errorf("failed to dial engine endpoint: %w", err)
 	}
 	return client.NewBaseRPCClient(rpcClient), nil
+}
+
+func GetChainConfig(ctx context.Context, cl client.RPC) (cfg *params.ChainConfig, err error) {
+	err = cl.CallContext(ctx, &cfg, methodDebugChainConfig)
+	return
 }
 
 type RPCBlock struct {
@@ -78,44 +68,44 @@ func getHeader(ctx context.Context, client client.RPC, method string, tag string
 }
 
 func headSafeFinalized(ctx context.Context, client client.RPC) (head *types.Block, safe, finalized *types.Header, err error) {
-	head, err = getBlock(ctx, client, "eth_getBlockByNumber", "latest")
+	head, err = getBlock(ctx, client, methodEthGetBlockByNumber, "latest")
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get block: %w", err)
 	}
-	safe, err = getHeader(ctx, client, "eth_getBlockByNumber", "safe")
+	safe, err = getHeader(ctx, client, methodEthGetBlockByNumber, "safe")
 	if err != nil {
 		return head, nil, nil, fmt.Errorf("failed to get safe block: %w", err)
 	}
-	finalized, err = getHeader(ctx, client, "eth_getBlockByNumber", "finalized")
+	finalized, err = getHeader(ctx, client, methodEthGetBlockByNumber, "finalized")
 	if err != nil {
 		return head, safe, nil, fmt.Errorf("failed to get finalized block: %w", err)
 	}
 	return head, safe, finalized, nil
 }
 
-func insertBlock(ctx context.Context, client client.RPC, payload *engine.ExecutableData) error {
-	var payloadResult *engine.PayloadStatusV1
-	if err := client.CallContext(ctx, &payloadResult, "engine_newPayloadV2", payload); err != nil {
-		return fmt.Errorf("failed to insert block %d: %w", payload.Number, err)
+func insertBlock(ctx context.Context, client *sources.EngineAPIClient, payloadEnv *eth.ExecutionPayloadEnvelope) error {
+	payload := payloadEnv.ExecutionPayload
+	payloadResult, err := client.NewPayload(ctx, payload, payloadEnv.ParentBeaconBlockRoot)
+	if err != nil {
+		return fmt.Errorf("failed to insert block %d: %w", payload.BlockNumber, err)
 	}
-	if payloadResult.Status != string(eth.ExecutionValid) {
+	if payloadResult.Status != eth.ExecutionValid {
 		return fmt.Errorf("block insertion was not valid: %v", payloadResult.ValidationError)
 	}
 	return nil
 }
 
-func updateForkchoice(ctx context.Context, client client.RPC, head, safe, finalized common.Hash) error {
-	var post engine.ForkChoiceResponse
-	if err := client.CallContext(ctx, &post, "engine_forkchoiceUpdatedV2",
-		engine.ForkchoiceStateV1{
-			HeadBlockHash:      head,
-			SafeBlockHash:      safe,
-			FinalizedBlockHash: finalized,
-		}, nil); err != nil {
-		return fmt.Errorf("failed to set forkchoice with new block %s: %w", head, err)
+func updateForkchoice(ctx context.Context, client *sources.EngineAPIClient, head, safe, finalized common.Hash) error {
+	res, err := client.ForkchoiceUpdate(ctx, &eth.ForkchoiceState{
+		HeadBlockHash:      head,
+		SafeBlockHash:      safe,
+		FinalizedBlockHash: finalized,
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to udpate forkchoice with new head %s: %w", head, err)
 	}
-	if post.PayloadStatus.Status != string(eth.ExecutionValid) {
-		return fmt.Errorf("post-block forkchoice update was not valid: %v", post.PayloadStatus.ValidationError)
+	if res.PayloadStatus.Status != eth.ExecutionValid {
+		return fmt.Errorf("forkchoice update was not valid: %v", res.PayloadStatus.ValidationError)
 	}
 	return nil
 }
@@ -129,7 +119,7 @@ type BlockBuildingSettings struct {
 	BuildTime    time.Duration
 }
 
-func BuildBlock(ctx context.Context, client client.RPC, status *StatusData, settings *BlockBuildingSettings) (*engine.ExecutableData, error) {
+func BuildBlock(ctx context.Context, client *sources.EngineAPIClient, status *StatusData, settings *BlockBuildingSettings) (*eth.ExecutionPayloadEnvelope, error) {
 	timestamp := status.Head.Time + settings.BlockTime
 	if settings.AllowGaps {
 		now := uint64(time.Now().Unix())
@@ -137,20 +127,17 @@ func BuildBlock(ctx context.Context, client client.RPC, status *StatusData, sett
 			timestamp = now - ((now - timestamp) % settings.BlockTime)
 		}
 	}
-	var pre engine.ForkChoiceResponse
-	if err := client.CallContext(ctx, &pre, "engine_forkchoiceUpdatedV2",
-		engine.ForkchoiceStateV1{
+	attrs := newPayloadAttributes(client.EngineVersionProvider(), timestamp, settings.Random, settings.FeeRecipient)
+	pre, err := client.ForkchoiceUpdate(ctx,
+		&eth.ForkchoiceState{
 			HeadBlockHash:      status.Head.Hash,
 			SafeBlockHash:      status.Safe.Hash,
 			FinalizedBlockHash: status.Finalized.Hash,
-		}, PayloadAttributesV2{
-			Timestamp:             timestamp,
-			Random:                settings.Random,
-			SuggestedFeeRecipient: settings.FeeRecipient,
-		}); err != nil {
+		}, attrs)
+	if err != nil {
 		return nil, fmt.Errorf("failed to set forkchoice when building new block: %w", err)
 	}
-	if pre.PayloadStatus.Status != string(eth.ExecutionValid) {
+	if pre.PayloadStatus.Status != eth.ExecutionValid {
 		return nil, fmt.Errorf("pre-block forkchoice update was not valid: %v", pre.PayloadStatus.ValidationError)
 	}
 
@@ -161,26 +148,45 @@ func BuildBlock(ctx context.Context, client client.RPC, status *StatusData, sett
 	case <-time.After(settings.BuildTime):
 	}
 
-	var payload *engine.ExecutionPayloadEnvelope
-	if err := client.CallContext(ctx, &payload, "engine_getPayloadV2", pre.PayloadID); err != nil {
+	payload, err := client.GetPayload(ctx, eth.PayloadInfo{ID: *pre.PayloadID, Timestamp: timestamp})
+	if err != nil {
 		return nil, fmt.Errorf("failed to get payload %v, %d time after instructing engine to build it: %w", pre.PayloadID, settings.BuildTime, err)
 	}
 
-	if err := insertBlock(ctx, client, payload.ExecutionPayload); err != nil {
+	if err := insertBlock(ctx, client, payload); err != nil {
 		return nil, err
 	}
 	if err := updateForkchoice(ctx, client, payload.ExecutionPayload.BlockHash, status.Safe.Hash, status.Finalized.Hash); err != nil {
 		return nil, err
 	}
 
-	return payload.ExecutionPayload, nil
+	return payload, nil
 }
 
-func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logger, shutdown <-chan struct{}, settings *BlockBuildingSettings) error {
+func newPayloadAttributes(evp sources.EngineVersionProvider, timestamp uint64, prevRandao common.Hash, feeRecipient common.Address) *eth.PayloadAttributes {
+	pa := &eth.PayloadAttributes{
+		Timestamp:             hexutil.Uint64(timestamp),
+		PrevRandao:            eth.Bytes32(prevRandao),
+		SuggestedFeeRecipient: feeRecipient,
+	}
+
+	ver := evp.ForkchoiceUpdatedVersion(pa)
+	if ver == eth.FCUV2 || ver == eth.FCUV3 {
+		withdrawals := make(types.Withdrawals, 0)
+		pa.Withdrawals = &withdrawals
+	}
+	if ver == eth.FCUV3 {
+		pa.ParentBeaconBlockRoot = new(common.Hash)
+	}
+
+	return pa
+}
+
+func Auto(ctx context.Context, metrics Metricer, client *sources.EngineAPIClient, log log.Logger, shutdown <-chan struct{}, settings *BlockBuildingSettings) error {
 	ticker := time.NewTicker(time.Millisecond * 100)
 	defer ticker.Stop()
 
-	var lastPayload *engine.ExecutableData
+	var lastPayload *eth.ExecutionPayload
 	var buildErr error
 	for {
 		select {
@@ -194,7 +200,7 @@ func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logg
 			blockTime := time.Duration(settings.BlockTime) * time.Second
 			lastTime := uint64(0)
 			if lastPayload != nil {
-				lastTime = lastPayload.Timestamp
+				lastTime = uint64(lastPayload.Timestamp)
 			}
 			buildTriggerTime := time.Unix(int64(lastTime), 0).Add(blockTime - settings.BuildTime)
 
@@ -206,7 +212,7 @@ func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logg
 					buildTime = 10 * time.Millisecond
 				}
 				buildErr = nil
-				status, err := Status(ctx, client)
+				status, err := Status(ctx, client.RPC)
 				if err != nil {
 					log.Error("failed to get pre-block engine status", "err", err)
 					metrics.RecordBlockFail()
@@ -220,7 +226,7 @@ func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logg
 				// There are no gap slots, so we just go back 32 blocks.
 				if status.Head.Number%32 == 0 {
 					if status.Safe.Number+32 <= status.Head.Number {
-						safe, err := getHeader(ctx, client, "eth_getBlockByNumber", hexutil.Uint64(status.Head.Number-32).String())
+						safe, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, hexutil.Uint64(status.Head.Number-32).String())
 						if err != nil {
 							buildErr = err
 							log.Error("failed to find block for new safe block progress", "err", err)
@@ -229,7 +235,7 @@ func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logg
 						status.Safe = eth.L1BlockRef{Hash: safe.Hash(), Number: safe.Number.Uint64(), Time: safe.Time, ParentHash: safe.ParentHash}
 					}
 					if status.Finalized.Number+32 <= status.Safe.Number {
-						finalized, err := getHeader(ctx, client, "eth_getBlockByNumber", hexutil.Uint64(status.Safe.Number-32).String())
+						finalized, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, hexutil.Uint64(status.Safe.Number-32).String())
 						if err != nil {
 							buildErr = err
 							log.Error("failed to find block for new finalized block progress", "err", err)
@@ -239,7 +245,7 @@ func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logg
 					}
 				}
 
-				payload, err := BuildBlock(ctx, client, status, &BlockBuildingSettings{
+				payloadEnv, err := BuildBlock(ctx, client, status, &BlockBuildingSettings{
 					BlockTime:    settings.BlockTime,
 					AllowGaps:    settings.AllowGaps,
 					Random:       settings.Random,
@@ -251,12 +257,16 @@ func Auto(ctx context.Context, metrics Metricer, client client.RPC, log log.Logg
 					log.Error("failed to produce block", "err", err)
 					metrics.RecordBlockFail()
 				} else {
+					payload := payloadEnv.ExecutionPayload
 					lastPayload = payload
-					log.Info("created block", "hash", payload.BlockHash, "number", payload.Number,
+					log.Info("created block", "hash", payload.BlockHash, "number", payload.BlockNumber,
 						"timestamp", payload.Timestamp, "txs", len(payload.Transactions),
 						"gas", payload.GasUsed, "basefee", payload.BaseFeePerGas)
-					basefee, _ := new(big.Float).SetInt(payload.BaseFeePerGas).Float64()
-					metrics.RecordBlockStats(payload.BlockHash, payload.Number, payload.Timestamp, uint64(len(payload.Transactions)), payload.GasUsed, basefee)
+					basefee := (*uint256.Int)(&payload.BaseFeePerGas).Float64()
+					metrics.RecordBlockStats(
+						payload.BlockHash, uint64(payload.BlockNumber), uint64(payload.Timestamp),
+						uint64(len(payload.Transactions)),
+						uint64(payload.GasUsed), basefee)
 				}
 			}
 		}
@@ -291,58 +301,73 @@ func Status(ctx context.Context, client client.RPC) (*StatusData, error) {
 
 // Copy takes the forkchoice state of copyFrom, and applies it to copyTo, and inserts the head-block.
 // The destination engine should then start syncing to this new chain if it has peers to do so.
-func Copy(ctx context.Context, copyFrom client.RPC, copyTo client.RPC) error {
+func Copy(ctx context.Context, copyFrom client.RPC, copyTo *sources.EngineAPIClient) error {
 	copyHead, copySafe, copyFinalized, err := headSafeFinalized(ctx, copyFrom)
 	if err != nil {
 		return err
 	}
-	payloadEnv := engine.BlockToExecutableData(copyHead, nil, nil)
+	payloadEnv, err := blockAsPayloadEnv(copyHead, copyTo.EngineVersionProvider())
+	if err != nil {
+		return err
+	}
+
 	if err := updateForkchoice(ctx, copyTo, copyHead.ParentHash(), copySafe.Hash(), copyFinalized.Hash()); err != nil {
 		return err
 	}
-	payload := payloadEnv.ExecutionPayload
-	if err := insertBlock(ctx, copyTo, payload); err != nil {
+	if err := insertBlock(ctx, copyTo, payloadEnv); err != nil {
 		return err
 	}
-	if err := updateForkchoice(ctx, copyTo, payload.BlockHash, copySafe.Hash(), copyFinalized.Hash()); err != nil {
+	if err := updateForkchoice(ctx, copyTo,
+		payloadEnv.ExecutionPayload.BlockHash, copySafe.Hash(), copyFinalized.Hash()); err != nil {
 		return err
 	}
 	return nil
 }
 
 // CopyPaylod takes the execution payload at number & applies it via NewPayload to copyTo
-func CopyPayload(ctx context.Context, number uint64, copyFrom client.RPC, copyTo client.RPC) error {
-	copyHead, err := getBlock(ctx, copyFrom, "eth_getBlockByNumber", hexutil.EncodeUint64(number))
+func CopyPayload(ctx context.Context, number uint64, copyFrom client.RPC, copyTo *sources.EngineAPIClient) error {
+	copyHead, err := getBlock(ctx, copyFrom, methodEthGetBlockByNumber, hexutil.EncodeUint64(number))
 	if err != nil {
 		return err
 	}
-	payloadEnv := engine.BlockToExecutableData(copyHead, nil, nil)
-	payload := payloadEnv.ExecutionPayload
-	if err := insertBlock(ctx, copyTo, payload); err != nil {
+	payloadEnv, err := blockAsPayloadEnv(copyHead, copyTo.EngineVersionProvider())
+	if err != nil {
+		return err
+	}
+	if err := insertBlock(ctx, copyTo, payloadEnv); err != nil {
 		return err
 	}
 	return nil
 }
 
-func SetForkchoice(ctx context.Context, client client.RPC, finalizedNum, safeNum, unsafeNum uint64) error {
+func blockAsPayloadEnv(block *types.Block, evp sources.EngineVersionProvider) (*eth.ExecutionPayloadEnvelope, error) {
+	var canyon *uint64
+	// hack: if we're calling at least FCUV2, get empty withdrawals by setting Canyon before the block time
+	if v := evp.ForkchoiceUpdatedVersion(&eth.PayloadAttributes{Timestamp: hexutil.Uint64(block.Time())}); v != eth.FCUV1 {
+		canyon = new(uint64)
+	}
+	return eth.BlockAsPayloadEnv(block, canyon)
+}
+
+func SetForkchoice(ctx context.Context, client *sources.EngineAPIClient, finalizedNum, safeNum, unsafeNum uint64) error {
 	if unsafeNum < safeNum {
 		return fmt.Errorf("cannot set unsafe (%d) < safe (%d)", unsafeNum, safeNum)
 	}
 	if safeNum < finalizedNum {
 		return fmt.Errorf("cannot set safe (%d) < finalized (%d)", safeNum, finalizedNum)
 	}
-	head, err := getHeader(ctx, client, "eth_getBlockByNumber", "latest")
+	head, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, "latest")
 	if err != nil {
 		return fmt.Errorf("failed to get latest block: %w", err)
 	}
 	if unsafeNum > head.Number.Uint64() {
 		return fmt.Errorf("cannot set unsafe (%d) > latest (%d)", unsafeNum, head.Number.Uint64())
 	}
-	finalizedHeader, err := getHeader(ctx, client, "eth_getBlockByNumber", hexutil.Uint64(finalizedNum).String())
+	finalizedHeader, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, hexutil.Uint64(finalizedNum).String())
 	if err != nil {
 		return fmt.Errorf("failed to get block %d to mark finalized: %w", finalizedNum, err)
 	}
-	safeHeader, err := getHeader(ctx, client, "eth_getBlockByNumber", hexutil.Uint64(safeNum).String())
+	safeHeader, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, hexutil.Uint64(safeNum).String())
 	if err != nil {
 		return fmt.Errorf("failed to get block %d to mark safe: %w", safeNum, err)
 	}
@@ -352,7 +377,7 @@ func SetForkchoice(ctx context.Context, client client.RPC, finalizedNum, safeNum
 	return nil
 }
 
-func SetForkchoiceByHash(ctx context.Context, client client.RPC, finalized, safe, unsafe common.Hash) error {
+func SetForkchoiceByHash(ctx context.Context, client *sources.EngineAPIClient, finalized, safe, unsafe common.Hash) error {
 	if err := updateForkchoice(ctx, client, unsafe, safe, finalized); err != nil {
 		return fmt.Errorf("failed to update forkchoice: %w", err)
 	}

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -91,7 +91,7 @@ func updateForkchoice(ctx context.Context, client *sources.EngineAPIClient, head
 		FinalizedBlockHash: finalized,
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("failed to udpate forkchoice with new head %s: %w", head, err)
+		return fmt.Errorf("failed to update forkchoice with new head %s: %w", head, err)
 	}
 	if res.PayloadStatus.Status != eth.ExecutionValid {
 		return fmt.Errorf("forkchoice update was not valid: %v", res.PayloadStatus.ValidationError)

--- a/op-wheel/engine/version_provider.go
+++ b/op-wheel/engine/version_provider.go
@@ -1,0 +1,44 @@
+package engine
+
+import (
+	"strconv"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type StaticVersionProvider int
+
+func (v StaticVersionProvider) ForkchoiceUpdatedVersion(*eth.PayloadAttributes) eth.EngineAPIMethod {
+	switch int(v) {
+	case 1:
+		return eth.FCUV1
+	case 2:
+		return eth.FCUV2
+	case 3:
+		return eth.FCUV3
+	default:
+		panic("invalid Engine API version: " + strconv.Itoa(int(v)))
+	}
+}
+
+func (v StaticVersionProvider) NewPayloadVersion(uint64) eth.EngineAPIMethod {
+	switch int(v) {
+	case 1, 2:
+		return eth.NewPayloadV2
+	case 3:
+		return eth.NewPayloadV3
+	default:
+		panic("invalid Engine API version: " + strconv.Itoa(int(v)))
+	}
+}
+
+func (v StaticVersionProvider) GetPayloadVersion(uint64) eth.EngineAPIMethod {
+	switch int(v) {
+	case 1, 2:
+		return eth.GetPayloadV2
+	case 3:
+		return eth.GetPayloadV3
+	default:
+		panic("invalid Engine API version: " + strconv.Itoa(int(v)))
+	}
+}


### PR DESCRIPTION
**Description**

* Support for new V3 Engine API calls.
* Supports selecting the Engine API version to use for FCU, NewPayload and GetPayload calls.
* Replaces local types with equivalents from package `eth`
* Uses `EngineAPIClient` from package `sources`
* Fixes _source_ env var for `engine copy` commands
* Adds new `engine rewind` command to rewind an EL client using `debug_setHead` (optional) followed by a FCU call
  * guarantees that safe & finalized are only rewound backwards, not forward

**Tests**

* Tested new `engine rewind` command on internal devnet
   * Implicitly tested chain config loading & use of FCUv3
* Tested setting static Engine API version with `--engine.version`

**Additional context**

Necessary to use op-wheel post Ecotone.

Makes chain rewinding easier & faster in emergency situations.

**Metadata**

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/153
