### PR TITLE
make txmgr aware of the txpool.ErrAlreadyReserved condition

### DIFF
--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -158,7 +158,7 @@ func TestQueue_Send(t *testing.T) {
 				{},
 			},
 			nonces: []uint64{0, 1},
-			total:  3 * time.Second,
+			total:  1 * time.Second,
 		},
 	}
 	for _, test := range testCases {

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -392,6 +392,23 @@ func TestTxMgrNeverConfirmCancel(t *testing.T) {
 	require.Nil(t, receipt)
 }
 
+// TestAlreadyReserved tests that AlreadyReserved error results in immediate abort of transaction
+// sending.
+func TestAlreadyReserved(t *testing.T) {
+	conf := configWithNumConfs(1)
+	h := newTestHarnessWithConfig(t, conf)
+
+	sendTx := func(ctx context.Context, tx *types.Transaction) error {
+		return ErrAlreadyReserved
+	}
+	h.backend.setTxSender(sendTx)
+
+	_, err := h.mgr.Send(context.Background(), TxCandidate{
+		To: &common.Address{},
+	})
+	require.ErrorIs(t, err, ErrAlreadyReserved)
+}
+
 // TestTxMgrConfirmsAtMaxGasPrice asserts that Send properly returns the max gas
 // price receipt if none of the lower gas price txs were mined.
 func TestTxMgrConfirmsAtHigherGasPrice(t *testing.T) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

With the introduction of blob transactions, the geth transaction pool will allow either a blob tx or a regular tx in the pool from a single account at any given time, but not both.   This PR extends the txmgr so that it knows when it's trying to submit a transaction of incompatible type with some other pending transaction.   Under this situation, it will immediately return ErrAlreadyReserved to the caller of Send(), making it the responsibility of the caller to determine how to best handle the stuck transaction.

**Tests**

Added unit test to confirm the AlreadyReserved error gets passed to the caller.

**Additional context**

**Metadata**

- pertains to https://github.com/ethereum-optimism/protocol-quest/issues/102
