### PR TITLE
op-node: Record genesis as being safe from L1 genesis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1312,18 +1312,6 @@ jobs:
           paths:
             - "/go/pkg/mod"
 
-  go-mod-tidy:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - restore_cache:
-          name: Restore Go modules cache
-          key: gomod-{{ checksum "go.sum" }}
-      - run:
-          name: "Go mod tidy"
-          command: make mod-tidy && git diff --exit-code
-
   op-service-rethdb-tests:
     docker:
       - image: <<pipeline.parameters.ci_builder_rust_image>>

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -898,6 +898,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	l1F.ExpectL1BlockRefByNumber(refA.Number, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)
+	l1F.ExpectL1BlockRefByNumber(0, refA, nil)
 
 	eng.ExpectSystemConfigByL2Hash(refA0.Hash, cfg.Genesis.SystemConfig, nil)
 
@@ -1023,6 +1024,7 @@ func TestResetLoop(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(1234))
 
+	l1Genesis := eth.L1BlockRef{Number: 0}
 	refA := testutils.RandomBlockRef(rng)
 	refA0 := eth.L2BlockRef{
 		Hash:           testutils.RandomHash(rng),
@@ -1080,6 +1082,7 @@ func TestResetLoop(t *testing.T) {
 	eng.ExpectL2BlockRefByHash(refA1.Hash, refA1, nil)
 	eng.ExpectL2BlockRefByHash(refA0.Hash, refA0, nil)
 	eng.ExpectSystemConfigByL2Hash(refA0.Hash, cfg.Genesis.SystemConfig, nil)
+	l1F.ExpectL1BlockRefByNumber(0, l1Genesis, nil)
 	l1F.ExpectL1BlockRefByNumber(refA.Number, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)


### PR DESCRIPTION
**Description**

When the derivation pipeline resets and the safe head is genesis, record that in the safe head database. This allows a node that syncs from genesis (or bedrock activation block) to have a complete safe head database instead of it starting only at the first safe head update.

The L2 genesis is considered to have always been safe since no batch data needs to be read to construct it.  Importantly the safe head database entry records the actual L1 genesis block, not the rollup config `Genesis.L1` value since the contracts will have been deployed to the L1 before the `Genesis.L1` value, potentially allowing dispute games to be created before then and the challenger needs to be able to respond to them. The challenger can only respond if it knows the L2 block that is safe at the game's L1 head. Using the real L1 genesis block as the entry key ensures the L2 genesis is safe for every L1 block and thus every possible dispute game.

**Tests**

Updated action test.

Updated e2e tests to confirm the challenger can dispute games even for chains where the safe head has never advanced.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/615
