### PR TITLE
fix(ci): Fix `ci-builder-rust` release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1779,7 +1779,7 @@ workflows:
           name: op-stack-go-docker-build-release
           filters:
             tags:
-              only: /^(proxyd|chain-mon|indexer|ci-builder|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
+              only: /^(proxyd|chain-mon|indexer|ci-builder(-rust)?|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
             branches:
               ignore: /.*/
           docker_name: op-stack-go


### PR DESCRIPTION
## Overview

> [!WARNING]
> Blocked by #9693 

Fixes the `ci-builder-rust` release to unblock https://github.com/ethereum-optimism/optimism/pull/9692. Currently, the release job fails due to the regex in `op-stack-go-docker-build-release` not matching `ci-builder-rust`.
