### PR TITLE
make `TargetFrameSize` no less than `MaxFrameSize`

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -206,6 +206,9 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("unknown data availability type: %v", cfg.DataAvailabilityType)
 	}
 	bs.ChannelConfig.MaxFrameSize-- // subtract 1 byte for version
+	if bs.ChannelConfig.CompressorConfig.TargetNumFrames == 1 && bs.ChannelConfig.CompressorConfig.TargetFrameSize < bs.ChannelConfig.MaxFrameSize {
+		bs.ChannelConfig.CompressorConfig.TargetFrameSize = bs.ChannelConfig.MaxFrameSize
+	}
 
 	if bs.UseBlobs && !bs.RollupConfig.IsEcotone(uint64(time.Now().Unix())) {
 		bs.Log.Error("Cannot use Blob data before Ecotone!") // log only, the batcher may not be actively running.


### PR DESCRIPTION
Here's the default compressor configuration according to [this code](https://github.com/ethereum-optimism/optimism/blob/c87a469d7d679e8a4efbace56c3646b925bcc009/op-batcher/compressor/cli.go#L71):

`compressor.CLIConfig{Kind: compressor.ShadowKind, TargetL1TxSizeBytes: 100_000, TargetNumFrames: 1, ApproxComprRatio: 0.4}`

For da type `blobs`, `MaxFrameSize` is `130044` according to [this code](https://github.com/ethereum-optimism/optimism/blob/34779f7dd720bcf70a67da0f9e8525780b9cdfa8/op-batcher/batcher/service.go#L200).

So in this case it holds that `TargetFrameSize<MaxFrameSize`, and the channel will never fill the `MaxFrameSize`, because when `CompressorFullErr` is returned, the channel will be [handled](https://github.com/ethereum-optimism/optimism/blob/34779f7dd720bcf70a67da0f9e8525780b9cdfa8/op-batcher/batcher/channel_builder.go#L216-L217) as full..

I think when `TargetNumFrames` is `1`, `TargetFrameSize` should be no less than `MaxFrameSize`, but this is just a starting point... 