### PR TITLE
compute `SingularChannelOut.rlpLength` correctly

### DIFF
--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -157,6 +157,9 @@ func (co *SingularChannelOut) AddSingularBatch(batch *SingularBatch, _ uint64) (
 
 	// avoid using io.Copy here, because we need all or nothing
 	written, err := co.compress.Write(buf.Bytes())
+	if err != nil {
+		co.rlpLength -= buf.Len()
+	}
 	return uint64(written), err
 }
 


### PR DESCRIPTION
When compressor returns an error(e.g. `CompressorFullErr`), should not include the corresponding rlp bytes into `rlpLength` .