### PR TITLE
feat(op-node): clean peer state when disconnectPeer is called and log intercept blocks

### DIFF
--- a/op-node/p2p/gating/scoring.go
+++ b/op-node/p2p/gating/scoring.go
@@ -1,6 +1,7 @@
 package gating
 
 import (
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -22,22 +23,43 @@ func AddScoring(gater BlockingConnectionGater, scores Scores, minScore float64) 
 	return &ScoringConnectionGater{BlockingConnectionGater: gater, scores: scores, minScore: minScore}
 }
 
-func (g *ScoringConnectionGater) checkScore(p peer.ID) (allow bool) {
+func (g *ScoringConnectionGater) checkScore(p peer.ID) (allow bool, score float64) {
 	score, err := g.scores.GetPeerScore(p)
 	if err != nil {
-		return false
+		return false, score
 	}
-	return score >= g.minScore
+	return score >= g.minScore, score
 }
 
 func (g *ScoringConnectionGater) InterceptPeerDial(p peer.ID) (allow bool) {
-	return g.BlockingConnectionGater.InterceptPeerDial(p) && g.checkScore(p)
+	if !g.BlockingConnectionGater.InterceptPeerDial(p) {
+		return false
+	}
+	check, score := g.checkScore(p)
+	if !check {
+		log.Warn("peer has failed checkScore", "peer_id", p, "score", score, "min_score", g.minScore)
+	}
+	return check
 }
 
 func (g *ScoringConnectionGater) InterceptAddrDial(id peer.ID, ma multiaddr.Multiaddr) (allow bool) {
-	return g.BlockingConnectionGater.InterceptAddrDial(id, ma) && g.checkScore(id)
+	if !g.BlockingConnectionGater.InterceptAddrDial(id, ma) {
+		return false
+	}
+	check, score := g.checkScore(id)
+	if !check {
+		log.Warn("peer has failed checkScore", "peer_id", id, "score", score, "min_score", g.minScore)
+	}
+	return check
 }
 
 func (g *ScoringConnectionGater) InterceptSecured(dir network.Direction, id peer.ID, mas network.ConnMultiaddrs) (allow bool) {
-	return g.BlockingConnectionGater.InterceptSecured(dir, id, mas) && g.checkScore(id)
+	if !g.BlockingConnectionGater.InterceptSecured(dir, id, mas) {
+		return false
+	}
+	check, score := g.checkScore(id)
+	if !check {
+		log.Warn("peer has failed checkScore", "peer_id", id, "score", score, "min_score", g.minScore)
+	}
+	return check
 }

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -208,11 +208,15 @@ func TestP2PFull(t *testing.T) {
 	require.Equal(t, uint(1), stats.Connected)
 
 	// disconnect
+	hostBId := hostB.ID().String()
+	peerDump, err = p2pClientA.Peers(ctx, false)
+	data = peerDump.Peers[hostBId]
+	require.NotNil(t, data)
 	require.NoError(t, p2pClientA.DisconnectPeer(ctx, hostB.ID()))
 	peerDump, err = p2pClientA.Peers(ctx, false)
 	require.Nil(t, err)
-	data = peerDump.Peers[hostB.ID().String()]
-	require.Equal(t, data.Connectedness, network.NotConnected)
+	data = peerDump.Peers[hostBId]
+	require.Nil(t, data)
 
 	// reconnect
 	addrsB, err := peer.AddrInfoToP2pAddrs(&peer.AddrInfo{ID: hostB.ID(), Addrs: hostB.Addrs()})

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -378,5 +378,9 @@ func (s *APIBackend) ConnectPeer(ctx context.Context, addr string) error {
 func (s *APIBackend) DisconnectPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_disconnectPeer")
 	defer recordDur()
-	return s.node.Host().Network().ClosePeer(id)
+	err := s.node.Host().Network().ClosePeer(id)
+	ps := s.node.Host().Peerstore()
+	ps.RemovePeer(id)
+	ps.ClearAddrs(id)
+	return err
 }

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -2,6 +2,8 @@ package proxyd
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -262,6 +264,14 @@ var (
 		"backend_group_name",
 	})
 
+	consensusHAError = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "group_consensus_ha_error",
+		Help:      "Consensus HA error count",
+	}, []string{
+		"error",
+	})
+
 	consensusHALatestBlock = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "group_consensus_ha_latest_block",
@@ -463,6 +473,16 @@ func RecordCacheError(method string) {
 
 func RecordBatchSize(size int) {
 	batchSizeHistogram.Observe(float64(size))
+}
+
+var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z ]+`)
+
+func RecordGroupConsensusError(group *BackendGroup, label string, err error) {
+	errClean := nonAlphanumericRegex.ReplaceAllString(err.Error(), "")
+	errClean = strings.ReplaceAll(errClean, " ", "_")
+	errClean = strings.ReplaceAll(errClean, "__", "_")
+	label = fmt.Sprintf("%s.%s", label, errClean)
+	consensusHAError.WithLabelValues(label).Inc()
 }
 
 func RecordGroupConsensusHALatestBlock(group *BackendGroup, leader string, blockNumber hexutil.Uint64) {

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -264,7 +264,7 @@ var (
 		"backend_group_name",
 	})
 
-	consensusHAError = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	consensusHAError = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "group_consensus_ha_error",
 		Help:      "Consensus HA error count",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change adds a cleanup on P2P RPC opp2p_disconnectPeer and add some logs around P2P connection blocking.

**Tests**

Added behavior to P2P Full Test Case.
