### PR TITLE
op-program: Update verify scripts to supply a beacon endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1397,9 +1397,9 @@ jobs:
       - restore_cache:
           key: golang-build-cache
       - run:
-          name: compat-goerli
+          name: compat-sepolia
           command: |
-            make run-goerli-verify
+            make run-sepolia-verify
           working_directory: op-program
 
   check-generated-mocks-op-node:

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -48,18 +48,18 @@ run-goerli-verify: op-program-host op-program-client
 	./bin/op-program `cat "$(COMPAT_DIR)/goerli/args.txt"`
 
 verify-sepolia: op-program-host op-program-client
-	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l2 $$SEPOLIA_L2URL
+	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l1.beacon $$SEPOLIA_BEACON_URL --l2 $$SEPOLIA_L2URL
 
 capture-sepolia-verify: op-program-host op-program-client
 	rm -rf "$(COMPAT_DIR)/sepolia" "$(COMPAT_DIR)/sepolia.tar.bz"
-	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l2 $$SEPOLIA_L2URL --datadir "$(COMPAT_DIR)/sepolia"
+	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l1.beacon $$SEPOLIA_BEACON_URL --l2 $$SEPOLIA_L2URL --datadir "$(COMPAT_DIR)/sepolia"
 	tar jcf "$(COMPAT_DIR)/sepolia.tar.bz" -C "$(COMPAT_DIR)" sepolia
 
 capture-chain-test-data: capture-sepolia-verify
 
 run-sepolia-verify: op-program-host op-program-client
 	mkdir -p "$(COMPAT_DIR)"
-	curl -L -o "$(COMPAT_DIR)/sepolia.tar.bz" https://github.com/ethereum-optimism/chain-test-data/releases/download/2023-10-11/sepolia.tar.bz
+	curl -L -o "$(COMPAT_DIR)/sepolia.tar.bz" https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-03-01.2-branch/sepolia.tar.bz
 	tar jxf "$(COMPAT_DIR)/sepolia.tar.bz" -C "$(COMPAT_DIR)"
 	./bin/op-program `cat "$(COMPAT_DIR)/sepolia/args.txt"`
 

--- a/op-program/verify/goerli/cmd/goerli.go
+++ b/op-program/verify/goerli/cmd/goerli.go
@@ -13,22 +13,32 @@ import (
 func main() {
 	var l1RpcUrl string
 	var l1RpcKind string
+	var l1BeaconUrl string
 	var l2RpcUrl string
 	var dataDir string
 	flag.StringVar(&l1RpcUrl, "l1", "", "L1 RPC URL to use")
-	flag.StringVar(&l1RpcKind, "l1-rpckind", "debug_geth", "L1 RPC kind")
+	flag.StringVar(&l1BeaconUrl, "l1.beacon", "", "L1 Beacon URL to use")
+	flag.StringVar(&l1RpcKind, "l1-rpckind", "", "L1 RPC kind")
 	flag.StringVar(&l2RpcUrl, "l2", "", "L2 RPC URL to use")
 	flag.StringVar(&dataDir, "datadir", "",
 		"Directory to use for storing pre-images. If not set a temporary directory will be used.")
 	flag.Parse()
 
-	if l1RpcUrl == "" || l2RpcUrl == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l1 and --l2 RPC URLs")
+	if l1RpcUrl == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l1 RPC URL")
+		os.Exit(2)
+	}
+	if l1BeaconUrl == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l1.beacon URL")
+		os.Exit(2)
+	}
+	if l2RpcUrl == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l2 RPC URL")
 		os.Exit(2)
 	}
 
 	goerliOutputAddress := common.HexToAddress("0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0")
-	err := verify.Run(l1RpcUrl, l1RpcKind, l2RpcUrl, goerliOutputAddress, dataDir, "goerli", chainconfig.OPGoerliChainConfig)
+	err := verify.Run(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, goerliOutputAddress, dataDir, "goerli", chainconfig.OPGoerliChainConfig)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed: %v\n", err.Error())
 		os.Exit(1)

--- a/op-program/verify/sepolia/cmd/sepolia.go
+++ b/op-program/verify/sepolia/cmd/sepolia.go
@@ -13,22 +13,32 @@ import (
 func main() {
 	var l1RpcUrl string
 	var l1RpcKind string
+	var l1BeaconUrl string
 	var l2RpcUrl string
 	var dataDir string
 	flag.StringVar(&l1RpcUrl, "l1", "", "L1 RPC URL to use")
-	flag.StringVar(&l1RpcKind, "l1-rpckind", "debug_geth", "L1 RPC kind")
+	flag.StringVar(&l1BeaconUrl, "l1.beacon", "", "L1 Beacon URL to use")
+	flag.StringVar(&l1RpcKind, "l1-rpckind", "", "L1 RPC kind")
 	flag.StringVar(&l2RpcUrl, "l2", "", "L2 RPC URL to use")
 	flag.StringVar(&dataDir, "datadir", "",
 		"Directory to use for storing pre-images. If not set a temporary directory will be used.")
 	flag.Parse()
 
-	if l1RpcUrl == "" || l2RpcUrl == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l1 and --l2 RPC URLs")
+	if l1RpcUrl == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l1 RPC URL")
+		os.Exit(2)
+	}
+	if l1BeaconUrl == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l1.beacon URL")
+		os.Exit(2)
+	}
+	if l2RpcUrl == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Must specify --l2 RPC URL")
 		os.Exit(2)
 	}
 
 	sepoliaOutputAddress := common.HexToAddress("0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F")
-	err := verify.Run(l1RpcUrl, l1RpcKind, l2RpcUrl, sepoliaOutputAddress, dataDir, "sepolia", chainconfig.OPSepoliaChainConfig)
+	err := verify.Run(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, sepoliaOutputAddress, dataDir, "sepolia", chainconfig.OPSepoliaChainConfig)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed: %v\n", err.Error())
 		os.Exit(1)

--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func Run(l1RpcUrl string, l1RpcKind string, l2RpcUrl string, l2OracleAddr common.Address, dataDir string, network string, chainCfg *params.ChainConfig) error {
+func Run(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string, l2OracleAddr common.Address, dataDir string, network string, chainCfg *params.ChainConfig) error {
 	ctx := context.Background()
 	logger := oplog.DefaultCLIConfig()
 	logger.Level = log.LevelDebug
@@ -140,8 +140,11 @@ func Run(l1RpcUrl string, l1RpcKind string, l2RpcUrl string, l2OracleAddr common
 	}
 	onlineCfg := offlineCfg
 	onlineCfg.L1URL = l1RpcUrl
+	onlineCfg.L1BeaconURL = l1BeaconUrl
 	onlineCfg.L2URL = l2RpcUrl
-	onlineCfg.L1RPCKind = sources.RPCProviderKind(l1RpcKind)
+	if l1RpcKind != "" {
+		onlineCfg.L1RPCKind = sources.RPCProviderKind(l1RpcKind)
+	}
 
 	fmt.Println("Running in online mode")
 	err = host.Main(oplog.NewLogger(os.Stderr, logger), &onlineCfg)


### PR DESCRIPTION
**Description**

Should fix `fpp-verify`, fixes the ability to capture compat data and updates to compat data that includes precompile preimages in preparation for using them.
