### PR TITLE
all: use errors.New() which has no param instead of fmt.Errorf()

### DIFF
--- a/cannon/mipsevm/evm_test.go
+++ b/cannon/mipsevm/evm_test.go
@@ -138,7 +138,7 @@ func encodePreimageOracleInput(t *testing.T, wit *StepWitness, localContext Loca
 		return input, nil
 	case preimage.KZGPointEvaluationKeyType:
 		if localOracle == nil {
-			return nil, fmt.Errorf("local oracle is required for point evaluation preimages")
+			return nil, errors.New("local oracle is required for point evaluation preimages")
 		}
 		preimage := localOracle.GetPreimage(preimage.Keccak256Key(wit.PreimageKey).PreimageKey())
 		input, err := preimageAbi.Pack(

--- a/cannon/mipsevm/patch.go
+++ b/cannon/mipsevm/patch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -100,7 +101,7 @@ func PatchStack(st *State) error {
 	sp := uint32(0x7f_ff_d0_00)
 	// allocate 1 page for the initial stack data, and 16KB = 4 pages for the stack to grow
 	if err := st.Memory.SetMemoryRange(sp-4*PageSize, bytes.NewReader(make([]byte, 5*PageSize))); err != nil {
-		return fmt.Errorf("failed to allocate page for stack content")
+		return errors.New("failed to allocate page for stack content")
 	}
 	st.Registers[29] = sp
 

--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -120,7 +121,7 @@ func runReorgDeletion(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to query L1 header at height: %w", err)
 	} else if l1Header == nil {
-		return fmt.Errorf("no header found at height")
+		return errors.New("no header found at height")
 	}
 
 	db, err := database.NewDB(ctx.Context, log, cfg.DB)

--- a/indexer/config/devnet.go
+++ b/indexer/config/devnet.go
@@ -31,7 +31,7 @@ func DevnetPreset() (*Preset, error) {
 
 	content, err := os.ReadFile(devnetFilepath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read .devnet/addressees.json")
+		return nil, errors.New("unable to read .devnet/addressees.json")
 	}
 
 	var l1Contracts L1Contracts

--- a/indexer/database/bridge_transfers.go
+++ b/indexer/database/bridge_transfers.go
@@ -154,7 +154,7 @@ func (db *bridgeTransfersDB) L1TxDepositSum() (float64, error) {
 // coupled with the L1/L2 transaction hashes that complete the bridge transaction.
 func (db *bridgeTransfersDB) L1BridgeDepositsByAddress(address common.Address, cursor string, limit int) (*L1BridgeDepositsResponse, error) {
 	if limit <= 0 {
-		return nil, fmt.Errorf("limit must be greater than 0")
+		return nil, errors.New("limit must be greater than 0")
 	}
 
 	cursorClause := ""
@@ -311,7 +311,7 @@ type L2BridgeWithdrawalsResponse struct {
 // that complete the bridge transaction. The hashes that correspond with the Bedrock multi-step withdrawal process are also surfaced
 func (db *bridgeTransfersDB) L2BridgeWithdrawalsByAddress(address common.Address, cursor string, limit int) (*L2BridgeWithdrawalsResponse, error) {
 	if limit <= 0 {
-		return nil, fmt.Errorf("limit must be greater than 0")
+		return nil, errors.New("limit must be greater than 0")
 	}
 
 	// (1) Generate cursor clause provided a cursor tx hash

--- a/indexer/database/serializers/bytes.go
+++ b/indexer/database/serializers/bytes.go
@@ -2,6 +2,7 @@ package serializers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -67,7 +68,7 @@ func (BytesSerializer) Value(ctx context.Context, field *schema.Field, dst refle
 
 	fieldBytes, ok := fieldValue.(BytesInterface)
 	if !ok {
-		return nil, fmt.Errorf("field does not satisfy the `Bytes() []byte` interface")
+		return nil, errors.New("field does not satisfy the `Bytes() []byte` interface")
 	}
 
 	hexStr := hexutil.Encode(fieldBytes.Bytes())

--- a/indexer/etl/etl.go
+++ b/indexer/etl/etl.go
@@ -3,7 +3,6 @@ package etl
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -129,10 +128,10 @@ func (etl *ETL) processBatch(headers []types.Header) error {
 	if logs.ToBlockHeader.Number.Cmp(lastHeader.Number) != 0 {
 		// Warn and simply wait for the provider to synchronize state
 		batchLog.Warn("mismatch in FilterLog#ToBlock number", "queried_to_block_number", lastHeader.Number, "reported_to_block_number", logs.ToBlockHeader.Number)
-		return fmt.Errorf("mismatch in FilterLog#ToBlock number")
+		return errors.New("mismatch in FilterLog#ToBlock number")
 	} else if logs.ToBlockHeader.Hash() != lastHeader.Hash() {
 		batchLog.Error("mismatch in FilterLog#ToBlock block hash!!!", "queried_to_block_hash", lastHeader.Hash().String(), "reported_to_block_hash", logs.ToBlockHeader.Hash().String())
-		return fmt.Errorf("mismatch in FilterLog#ToBlock block hash!!!")
+		return errors.New("mismatch in FilterLog#ToBlock block hash!!!")
 	}
 
 	if len(logs.Logs) > 0 {

--- a/indexer/node/header_traversal.go
+++ b/indexer/node/header_traversal.go
@@ -54,7 +54,7 @@ func (f *HeaderTraversal) NextHeaders(maxSize uint64) ([]types.Header, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to query latest block: %w", err)
 	} else if latestHeader == nil {
-		return nil, fmt.Errorf("latest header unreported")
+		return nil, errors.New("latest header unreported")
 	} else {
 		f.latestHeader = latestHeader
 	}

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -273,7 +273,7 @@ func (b *BridgeProcessor) processInitiatedL2Events(latestL2Header *types.Header)
 	if err != nil {
 		return fmt.Errorf("failed to query new L2 state: %w", err)
 	} else if toL2Header == nil {
-		return fmt.Errorf("no new L2 state found")
+		return errors.New("no new L2 state found")
 	}
 
 	fromL2Height, toL2Height := new(big.Int).Add(lastL2BlockNumber, bigint.One), toL2Header.Number

--- a/op-bindings/bindgen/remote_handlers.go
+++ b/op-bindings/bindgen/remote_handlers.go
@@ -3,6 +3,7 @@ package bindgen
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -261,7 +262,7 @@ func (generator *BindGenGeneratorRemote) CompareInitBytecodeWithOp(contractMetad
 
 func (generator *BindGenGeneratorRemote) CompareDeployedBytecodeWithOp(contractMetadataEth *RemoteContractMetadata, deployedCodeShouldMatch bool) error {
 	if contractMetadataEth.DeployedBin == "" {
-		return fmt.Errorf("no deployed bytecode provided for ETH deployment for comparison")
+		return errors.New("no deployed bytecode provided for ETH deployment for comparison")
 	}
 
 	var zeroAddress common.Address

--- a/op-bindings/bindgen/remote_handlers.go
+++ b/op-bindings/bindgen/remote_handlers.go
@@ -222,7 +222,7 @@ func (generator *BindGenGeneratorRemote) removeDeploymentSalt(deploymentData, de
 
 func (generator *BindGenGeneratorRemote) CompareInitBytecodeWithOp(contractMetadataEth *RemoteContractMetadata, initCodeShouldMatch bool) error {
 	if contractMetadataEth.InitBin == "" {
-		return fmt.Errorf("no initialization bytecode provided for ETH deployment for comparison")
+		return errors.New("no initialization bytecode provided for ETH deployment for comparison")
 	}
 
 	var zeroAddress common.Address

--- a/op-bindings/etherscan/client.go
+++ b/op-bindings/etherscan/client.go
@@ -183,7 +183,7 @@ func (c *client) FetchDeploymentTxHash(ctx context.Context, address string) (str
 	}
 
 	if len(results) == 0 {
-		return "", fmt.Errorf("API response result is an empty array")
+		return "", errors.New("API response result is an empty array")
 	}
 
 	return results[0].Hash, nil

--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -90,7 +90,7 @@ func Main(cliCtx *cli.Context) error {
 		Authenticated: false,
 	})
 	if err := rpcServer.Start(); err != nil {
-		return fmt.Errorf("failed to start the RPC server")
+		return errors.New("failed to start the RPC server")
 	}
 	defer func() {
 		if err := rpcServer.Stop(); err != nil {

--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -72,12 +72,12 @@ func Main(cliCtx *cli.Context) error {
 		return err
 	}
 	if p2pNode.Dv5Udp() == nil {
-		return fmt.Errorf("uninitialized discovery service")
+		return errors.New("uninitialized discovery service")
 	}
 
 	rpcCfg := oprpc.ReadCLIConfig(cliCtx)
 	if err := rpcCfg.Check(); err != nil {
-		return fmt.Errorf("failed to validate RPC config")
+		return errors.New("failed to validate RPC config")
 	}
 	rpcServer := oprpc.NewServer(rpcCfg.ListenAddr, rpcCfg.ListenPort, "", oprpc.WithLogger(logger))
 	if rpcCfg.EnableAdmin {

--- a/op-chain-ops/cmd/check-derivation/main.go
+++ b/op-chain-ops/cmd/check-derivation/main.go
@@ -202,7 +202,7 @@ func getSenderAddress(privateKey *ecdsa.PrivateKey) (common.Address, error) {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return common.Address{}, fmt.Errorf("error casting public key to ECDSA")
+		return common.Address{}, errors.New("error casting public key to ECDSA")
 	}
 	from := crypto.PubkeyToAddress(*publicKeyECDSA)
 	return from, nil

--- a/op-chain-ops/cmd/check-ecotone/main.go
+++ b/op-chain-ops/cmd/check-ecotone/main.go
@@ -572,11 +572,11 @@ func checkBeaconBlockRoot(ctx context.Context, env *actionEnv) error {
 	l2EthCl, err := sources.NewL2Client(l2RPC, env.log, nil,
 		sources.L2ClientDefaultConfig(rollupCfg, false))
 	if err != nil {
-		return fmt.Errorf("failed to create eth client")
+		return errors.New("failed to create eth client")
 	}
 	result, err := l2EthCl.GetProof(ctx, predeploys.EIP4788ContractAddr, nil, eth.Unsafe)
 	if err != nil {
-		return fmt.Errorf("failed to get account proof to inspect storage-root")
+		return errors.New("failed to get account proof to inspect storage-root")
 	}
 	if result.StorageHash == types.EmptyRootHash {
 		return fmt.Errorf("expected contract storage to be set, but got none (%s)",
@@ -655,7 +655,7 @@ func checkUpgradeTxs(ctx context.Context, env *actionEnv) error {
 	l2EthCl, err := sources.NewL2Client(l2RPC, env.log, nil,
 		sources.L2ClientDefaultConfig(rollupCfg, false))
 	if err != nil {
-		return fmt.Errorf("failed to create eth client")
+		return errors.New("failed to create eth client")
 	}
 	activBlock, txs, err := l2EthCl.InfoAndTxsByNumber(ctx, activationBlockNum)
 	if err != nil {
@@ -680,11 +680,11 @@ func checkUpgradeTxs(ctx context.Context, env *actionEnv) error {
 		switch i {
 		case 1, 2, 6: // 2 implementations + 4788 contract deployment
 			if rec.ContractAddress == (common.Address{}) {
-				return fmt.Errorf("expected contract deployment, but got none")
+				return errors.New("expected contract deployment, but got none")
 			}
 		case 3, 4, 5: // proxy upgrades and setEcotone call
 			if rec.ContractAddress != (common.Address{}) {
-				return fmt.Errorf("unexpected contract deployment")
+				return errors.New("unexpected contract deployment")
 			}
 		}
 	}

--- a/op-chain-ops/cmd/protocol-version/main.go
+++ b/op-chain-ops/cmd/protocol-version/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 
@@ -110,7 +111,7 @@ func encodeProtocolVersion(ctx *cli.Context) error {
 	}
 	buildVal := ctx.String(BuildFlag.Name)
 	if len(buildVal) != 16 {
-		return fmt.Errorf("build flag value must be 16 characters")
+		return errors.New("build flag value must be 16 characters")
 	}
 	var build [8]byte
 	if _, err := hex.Decode(build[:], []byte(buildVal)); err != nil {
@@ -130,7 +131,7 @@ func encodeProtocolVersion(ctx *cli.Context) error {
 
 func decodeProtocolVersion(ctx *cli.Context) error {
 	if ctx.NArg() != 1 {
-		return fmt.Errorf("expected 1 argument: protocol version")
+		return errors.New("expected 1 argument: protocol version")
 	}
 	hexVersion := ctx.Args().Get(0)
 	var v params.ProtocolVersion

--- a/op-chain-ops/immutables/immutables.go
+++ b/op-chain-ops/immutables/immutables.go
@@ -1,6 +1,7 @@
 package immutables
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -221,11 +222,11 @@ func l2ImmutableDeployer(backend *backends.SimulatedBackend, opts *bind.Transact
 	case "OptimismMintableERC721Factory":
 		bridge, ok := deployment.Args[0].(common.Address)
 		if !ok {
-			return nil, fmt.Errorf("invalid type for bridge")
+			return nil, errors.New("invalid type for bridge")
 		}
 		remoteChainId, ok := deployment.Args[1].(*big.Int)
 		if !ok {
-			return nil, fmt.Errorf("invalid type for remoteChainId")
+			return nil, errors.New("invalid type for remoteChainId")
 		}
 		_, tx, _, err = bindings.DeployOptimismMintableERC721Factory(opts, backend, bridge, remoteChainId)
 	case "EAS":
@@ -241,15 +242,15 @@ func l2ImmutableDeployer(backend *backends.SimulatedBackend, opts *bind.Transact
 func prepareFeeVaultArguments(deployment deployer.Constructor) (common.Address, *big.Int, uint8, error) {
 	recipient, ok := deployment.Args[0].(common.Address)
 	if !ok {
-		return common.Address{}, nil, 0, fmt.Errorf("invalid type for recipient")
+		return common.Address{}, nil, 0, errors.New("invalid type for recipient")
 	}
 	minimumWithdrawalAmountHex, ok := deployment.Args[1].(*big.Int)
 	if !ok {
-		return common.Address{}, nil, 0, fmt.Errorf("invalid type for minimumWithdrawalAmount")
+		return common.Address{}, nil, 0, errors.New("invalid type for minimumWithdrawalAmount")
 	}
 	withdrawalNetwork, ok := deployment.Args[2].(uint8)
 	if !ok {
-		return common.Address{}, nil, 0, fmt.Errorf("invalid type for withdrawalNetwork")
+		return common.Address{}, nil, 0, errors.New("invalid type for withdrawalNetwork")
 	}
 	return recipient, minimumWithdrawalAmountHex, withdrawalNetwork, nil
 }

--- a/op-chain-ops/safe/batch.go
+++ b/op-chain-ops/safe/batch.go
@@ -197,7 +197,7 @@ func (bt *BatchTransaction) Check() error {
 		sig := bt.Signature()
 		selector := crypto.Keccak256([]byte(sig))[0:4]
 		if !bytes.Equal(bt.Data[0:4], selector) {
-			return fmt.Errorf("data does not match signature")
+			return errors.New("data does not match signature")
 		}
 
 		// Check the calldata

--- a/op-chain-ops/state/encoding.go
+++ b/op-chain-ops/state/encoding.go
@@ -87,7 +87,7 @@ func EncodeStorageKeyValue(value any, entry solc.StorageLayoutEntry, storageType
 
 		values, ok := value.(map[any]any)
 		if !ok {
-			return nil, fmt.Errorf("mapping must be map[any]any")
+			return nil, errors.New("mapping must be map[any]any")
 		}
 
 		keyEncoder, err := getElementEncoder(storageType, "key")

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -1,6 +1,7 @@
 package upgrades
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -115,11 +116,11 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 	}
 
 	if optimismPortal != common.Address(list.OptimismPortalProxy) {
-		return fmt.Errorf("Portal address doesn't match config")
+		return errors.New("Portal address doesn't match config")
 	}
 
 	if otherMessenger != predeploys.L2CrossDomainMessengerAddr {
-		return fmt.Errorf("OtherMessenger address doesn't match config")
+		return errors.New("OtherMessenger address doesn't match config")
 	}
 
 	calldata, err := l1CrossDomainMessengerABI.Pack("initialize", superchainConfigProxy, optimismPortal)
@@ -391,35 +392,35 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 
 	if config != nil {
 		if l2OutputOracleSubmissionInterval.Uint64() != config.L2OutputOracleSubmissionInterval {
-			return fmt.Errorf("L2OutputOracleSubmissionInterval address doesn't match config")
+			return errors.New("L2OutputOracleSubmissionInterval address doesn't match config")
 		}
 
 		if l2BlockTime.Uint64() != config.L2BlockTime {
-			return fmt.Errorf("L2BlockTime address doesn't match config")
+			return errors.New("L2BlockTime address doesn't match config")
 		}
 
 		if l2OutputOracleStartingBlockNumber.Uint64() != config.L2OutputOracleStartingBlockNumber {
-			return fmt.Errorf("L2OutputOracleStartingBlockNumber address doesn't match config")
+			return errors.New("L2OutputOracleStartingBlockNumber address doesn't match config")
 		}
 
 		if config.L2OutputOracleStartingTimestamp < 0 {
-			return fmt.Errorf("L2OutputOracleStartingTimestamp must be concrete")
+			return errors.New("L2OutputOracleStartingTimestamp must be concrete")
 		}
 
 		if int(l2OutputOracleStartingTimestamp.Int64()) != config.L2OutputOracleStartingTimestamp {
-			return fmt.Errorf("L2OutputOracleStartingTimestamp address doesn't match config")
+			return errors.New("L2OutputOracleStartingTimestamp address doesn't match config")
 		}
 
 		if l2OutputOracleProposer != config.L2OutputOracleProposer {
-			return fmt.Errorf("L2OutputOracleProposer address doesn't match config")
+			return errors.New("L2OutputOracleProposer address doesn't match config")
 		}
 
 		if l2OutputOracleChallenger != config.L2OutputOracleChallenger {
-			return fmt.Errorf("L2OutputOracleChallenger address doesn't match config")
+			return errors.New("L2OutputOracleChallenger address doesn't match config")
 		}
 
 		if finalizationPeriodSeconds.Uint64() != config.FinalizationPeriodSeconds {
-			return fmt.Errorf("FinalizationPeriodSeconds address doesn't match config")
+			return errors.New("FinalizationPeriodSeconds address doesn't match config")
 		}
 	}
 
@@ -697,22 +698,22 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 	}
 
 	if gasPriceOracleOverhead.Uint64() != config.GasPriceOracleOverhead {
-		return fmt.Errorf("GasPriceOracleOverhead address doesn't match config")
+		return errors.New("GasPriceOracleOverhead address doesn't match config")
 	}
 	if gasPriceOracleScalar.Uint64() != config.GasPriceOracleScalar {
-		return fmt.Errorf("GasPriceOracleScalar address doesn't match config")
+		return errors.New("GasPriceOracleScalar address doesn't match config")
 	}
 	if batcherHash != common.BytesToHash(config.BatchSenderAddress.Bytes()) {
-		return fmt.Errorf("BatchSenderAddress address doesn't match config")
+		return errors.New("BatchSenderAddress address doesn't match config")
 	}
 	if l2GenesisBlockGasLimit != uint64(config.L2GenesisBlockGasLimit) {
-		return fmt.Errorf("L2GenesisBlockGasLimit address doesn't match config")
+		return errors.New("L2GenesisBlockGasLimit address doesn't match config")
 	}
 	if p2pSequencerAddress != config.P2PSequencerAddress {
-		return fmt.Errorf("P2PSequencerAddress address doesn't match config")
+		return errors.New("P2PSequencerAddress address doesn't match config")
 	}
 	if finalSystemOwner != config.FinalSystemOwner {
-		return fmt.Errorf("FinalSystemOwner address doesn't match config")
+		return errors.New("FinalSystemOwner address doesn't match config")
 	}
 
 	resourceConfig, err := systemConfig.ResourceConfig(&bind.CallOpts{})
@@ -721,22 +722,22 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 	}
 
 	if resourceConfig.MaxResourceLimit != genesis.DefaultResourceConfig.MaxResourceLimit {
-		return fmt.Errorf("DefaultResourceConfig MaxResourceLimit doesn't match contract MaxResourceLimit")
+		return errors.New("DefaultResourceConfig MaxResourceLimit doesn't match contract MaxResourceLimit")
 	}
 	if resourceConfig.ElasticityMultiplier != genesis.DefaultResourceConfig.ElasticityMultiplier {
-		return fmt.Errorf("DefaultResourceConfig ElasticityMultiplier doesn't match contract ElasticityMultiplier")
+		return errors.New("DefaultResourceConfig ElasticityMultiplier doesn't match contract ElasticityMultiplier")
 	}
 	if resourceConfig.BaseFeeMaxChangeDenominator != genesis.DefaultResourceConfig.BaseFeeMaxChangeDenominator {
-		return fmt.Errorf("DefaultResourceConfig BaseFeeMaxChangeDenominator doesn't match contract BaseFeeMaxChangeDenominator")
+		return errors.New("DefaultResourceConfig BaseFeeMaxChangeDenominator doesn't match contract BaseFeeMaxChangeDenominator")
 	}
 	if resourceConfig.MinimumBaseFee != genesis.DefaultResourceConfig.MinimumBaseFee {
-		return fmt.Errorf("DefaultResourceConfig MinimumBaseFee doesn't match contract MinimumBaseFee")
+		return errors.New("DefaultResourceConfig MinimumBaseFee doesn't match contract MinimumBaseFee")
 	}
 	if resourceConfig.SystemTxMaxGas != genesis.DefaultResourceConfig.SystemTxMaxGas {
-		return fmt.Errorf("DefaultResourceConfig SystemTxMaxGas doesn't match contract SystemTxMaxGas")
+		return errors.New("DefaultResourceConfig SystemTxMaxGas doesn't match contract SystemTxMaxGas")
 	}
 	if resourceConfig.MaximumBaseFee.Cmp(genesis.DefaultResourceConfig.MaximumBaseFee) != 0 {
-		return fmt.Errorf("DefaultResourceConfig MaximumBaseFee doesn't match contract MaximumBaseFee")
+		return errors.New("DefaultResourceConfig MaximumBaseFee doesn't match contract MaximumBaseFee")
 	}
 
 	calldata, err := systemConfigABI.Pack(

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -198,11 +198,11 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 	}
 
 	if messenger != common.Address(list.L1CrossDomainMessengerProxy) {
-		return fmt.Errorf("Messenger address doesn't match config")
+		return errors.New("Messenger address doesn't match config")
 	}
 
 	if otherBridge != predeploys.L2ERC721BridgeAddr {
-		return fmt.Errorf("OtherBridge address doesn't match config")
+		return errors.New("OtherBridge address doesn't match config")
 	}
 
 	calldata, err := l1ERC721BridgeABI.Pack("initialize", messenger, superchainConfigProxy)
@@ -282,11 +282,11 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 	}
 
 	if messenger != common.Address(list.L1CrossDomainMessengerProxy) {
-		return fmt.Errorf("Messenger address doesn't match config")
+		return errors.New("Messenger address doesn't match config")
 	}
 
 	if otherBridge != predeploys.L2StandardBridgeAddr {
-		return fmt.Errorf("OtherBridge address doesn't match config")
+		return errors.New("OtherBridge address doesn't match config")
 	}
 
 	calldata, err := l1StandardBridgeABI.Pack("initialize", messenger, superchainConfigProxy)
@@ -505,7 +505,7 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 	}
 
 	if bridge != common.Address(list.L1StandardBridgeProxy) {
-		return fmt.Errorf("Bridge address doesn't match config")
+		return errors.New("Bridge address doesn't match config")
 	}
 
 	calldata, err := optimismMintableERC20FactoryABI.Pack("initialize", bridge)
@@ -583,11 +583,11 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 	}
 
 	if l2OutputOracle != common.Address(list.L2OutputOracleProxy) {
-		return fmt.Errorf("L2OutputOracle address doesn't match config")
+		return errors.New("L2OutputOracle address doesn't match config")
 	}
 
 	if systemConfig != common.Address(list.SystemConfigProxy) {
-		return fmt.Errorf("SystemConfig address doesn't match config")
+		return errors.New("SystemConfig address doesn't match config")
 	}
 
 	calldata, err := optimismPortalABI.Pack("initialize", l2OutputOracle, systemConfig, superchainConfigProxy)

--- a/op-challenger/cmd/move.go
+++ b/op-challenger/cmd/move.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
@@ -43,7 +44,7 @@ func Move(ctx *cli.Context) error {
 	claim := common.HexToHash(ctx.String(ClaimFlag.Name))
 
 	if attack && defend {
-		return fmt.Errorf("both attack and defense flags cannot be set")
+		return errors.New("both attack and defense flags cannot be set")
 	}
 
 	contract, txMgr, err := NewContractWithTxMgr[*contracts.FaultDisputeGameContract](ctx, GameAddressFlag.Name, contracts.NewFaultDisputeGameContract)
@@ -63,7 +64,7 @@ func Move(ctx *cli.Context) error {
 			return fmt.Errorf("failed to create defense tx: %w", err)
 		}
 	} else {
-		return fmt.Errorf("either attack or defense flag must be set")
+		return errors.New("either attack or defense flag must be set")
 	}
 
 	rct, err := txMgr.Send(context.Background(), tx)

--- a/op-challenger/game/fault/player_test.go
+++ b/op-challenger/game/fault/player_test.go
@@ -3,7 +3,6 @@ package fault
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
@@ -14,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var mockValidatorError = fmt.Errorf("mock validator error")
+var mockValidatorError = errors.New("mock validator error")
 
 func TestProgressGame_LogErrorFromAct(t *testing.T) {
 	handler, game, actor, _ := setupProgressGameTest(t)

--- a/op-challenger/game/fault/preimages/types.go
+++ b/op-challenger/game/fault/preimages/types.go
@@ -2,7 +2,7 @@ package preimages
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var ErrNilPreimageData = fmt.Errorf("cannot upload nil preimage data")
+var ErrNilPreimageData = errors.New("cannot upload nil preimage data")
 
 // PreimageUploader is responsible for posting preimages.
 type PreimageUploader interface {

--- a/op-challenger/game/fault/validator_test.go
+++ b/op-challenger/game/fault/validator_test.go
@@ -2,7 +2,7 @@ package fault
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -15,8 +15,8 @@ import (
 
 var (
 	prestate          = []byte{0x00, 0x01, 0x02, 0x03}
-	mockProviderError = fmt.Errorf("mock provider error")
-	mockLoaderError   = fmt.Errorf("mock loader error")
+	mockProviderError = errors.New("mock provider error")
+	mockLoaderError   = errors.New("mock loader error")
 )
 
 func TestValidate(t *testing.T) {

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -3,7 +3,6 @@ package game
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"sync"
 	"testing"
@@ -112,7 +111,7 @@ func TestMonitorGames(t *testing.T) {
 				return mockHeadSource.Sub() != nil, nil
 			})
 			require.NoError(t, waitErr)
-			mockHeadSource.Sub().errChan <- fmt.Errorf("test error")
+			mockHeadSource.Sub().errChan <- errors.New("test error")
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -84,7 +85,7 @@ func TestMonitorGames(t *testing.T) {
 				// Just to avoid a tight loop
 				time.Sleep(100 * time.Millisecond)
 			}
-			mockHeadSource.SetErr(fmt.Errorf("eth subscribe test error"))
+			mockHeadSource.SetErr(errors.New("eth subscribe test error"))
 			cancel()
 		}()
 
@@ -132,7 +133,7 @@ func TestMonitorGames(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 			require.NoError(t, waitErr)
-			mockHeadSource.SetErr(fmt.Errorf("eth subscribe test error"))
+			mockHeadSource.SetErr(errors.New("eth subscribe test error"))
 			cancel()
 		}()
 

--- a/op-challenger/game/scheduler/coordinator_test.go
+++ b/op-challenger/game/scheduler/coordinator_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -90,7 +91,7 @@ func TestSchedule_SkipPrestateValidationErrors(t *testing.T) {
 func TestSchedule_PrestateValidationFailure(t *testing.T) {
 	c, _, _, games, _, _ := setupCoordinatorTest(t, 10)
 	c.allowInvalidPrestate = true
-	games.PrestateErr = fmt.Errorf("failed to fetch prestate")
+	games.PrestateErr = errors.New("failed to fetch prestate")
 	gameAddr1 := common.Address{0xaa}
 	ctx := context.Background()
 

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -1,7 +1,6 @@
 package conductor
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -60,22 +59,22 @@ type Config struct {
 // Check validates the CLIConfig.
 func (c *Config) Check() error {
 	if c.ConsensusAddr == "" {
-		return fmt.Errorf("missing consensus address")
+		return errors.New("missing consensus address")
 	}
 	if c.ConsensusPort < 0 || c.ConsensusPort > math.MaxUint16 {
-		return fmt.Errorf("invalid RPC port")
+		return errors.New("invalid RPC port")
 	}
 	if c.RaftServerID == "" {
-		return fmt.Errorf("missing raft server ID")
+		return errors.New("missing raft server ID")
 	}
 	if c.RaftStorageDir == "" {
-		return fmt.Errorf("missing raft storage directory")
+		return errors.New("missing raft storage directory")
 	}
 	if c.NodeRPC == "" {
-		return fmt.Errorf("missing node RPC")
+		return errors.New("missing node RPC")
 	}
 	if c.ExecutionRPC == "" {
-		return fmt.Errorf("missing geth RPC")
+		return errors.New("missing geth RPC")
 	}
 	if err := c.HealthCheck.Check(); err != nil {
 		return errors.Wrap(err, "invalid health check config")
@@ -147,13 +146,13 @@ type HealthCheckConfig struct {
 
 func (c *HealthCheckConfig) Check() error {
 	if c.Interval == 0 {
-		return fmt.Errorf("missing health check interval")
+		return errors.New("missing health check interval")
 	}
 	if c.SafeInterval == 0 {
-		return fmt.Errorf("missing safe interval")
+		return errors.New("missing safe interval")
 	}
 	if c.MinPeerCount == 0 {
-		return fmt.Errorf("missing minimum peer count")
+		return errors.New("missing minimum peer count")
 	}
 	return nil
 }

--- a/op-conductor/consensus/raft_fsm.go
+++ b/op-conductor/consensus/raft_fsm.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -23,7 +24,7 @@ type unsafeHeadTracker struct {
 // Apply implements raft.FSM, it applies the latest change (latest unsafe head payload) to FSM.
 func (t *unsafeHeadTracker) Apply(l *raft.Log) interface{} {
 	if l.Data == nil || len(l.Data) == 0 {
-		return fmt.Errorf("log data is nil or empty")
+		return errors.New("log data is nil or empty")
 	}
 
 	data := &eth.ExecutionPayloadEnvelope{}

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -1,7 +1,7 @@
 package extract
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -35,7 +35,7 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 		{
 			name:        "InvalidGameType",
 			game:        types.GameMetadata{GameType: 2, Proxy: fdgAddr},
-			expectedErr: fmt.Errorf("unsupported game type: 2"),
+			expectedErr: errors.New("unsupported game type: 2"),
 		},
 	}
 

--- a/op-e2e/external_geth/main.go
+++ b/op-e2e/external_geth/main.go
@@ -46,10 +46,10 @@ func run(configPath string) error {
 
 	binPath, err := filepath.Abs("op-geth")
 	if err != nil {
-		return fmt.Errorf("could not get absolute path of op-geth")
+		return errors.New("could not get absolute path of op-geth")
 	}
 	if _, err := os.Stat(binPath); err != nil {
-		return fmt.Errorf("could not locate op-geth in working directory, did you forget to run '--init'?")
+		return errors.New("could not locate op-geth in working directory, did you forget to run '--init'?")
 	}
 
 	fmt.Printf("================== op-geth shim initializing chain config ==========================\n")
@@ -66,7 +66,7 @@ func run(configPath string) error {
 
 	fmt.Printf("==================    op-geth shim encoding ready-file   ==========================\n")
 	if err := external.AtomicEncode(config.EndpointsReadyPath, sess.endpoints); err != nil {
-		return fmt.Errorf("could not encode endpoints")
+		return errors.New("could not encode endpoints")
 	}
 
 	fmt.Printf("==================    op-geth shim awaiting termination  ==========================\n")
@@ -101,7 +101,7 @@ func awaitExit(sess *gexec.Session) error {
 		case <-sess.Exited:
 			return nil
 		case <-time.After(30 * time.Second):
-			return fmt.Errorf("exiting after 30 second timeout")
+			return errors.New("exiting after 30 second timeout")
 		}
 	}
 }
@@ -131,7 +131,7 @@ func (es *gethSession) Close() {
 
 func execute(binPath string, config external.Config) (*gethSession, error) {
 	if config.Verbosity < 2 {
-		return nil, fmt.Errorf("a minimum configured verbosity of 2 is required")
+		return nil, errors.New("a minimum configured verbosity of 2 is required")
 	}
 	cmd := exec.Command(
 		binPath,
@@ -164,11 +164,11 @@ func execute(binPath string, config external.Config) (*gethSession, error) {
 	for enginePort == 0 || httpPort == 0 {
 		match, err := matcher.Match(sess.Err)
 		if err != nil {
-			return nil, fmt.Errorf("could not execute matcher")
+			return nil, errors.New("could not execute matcher")
 		}
 		if !match {
 			if sess.Err.Closed() {
-				return nil, fmt.Errorf("op-geth exited before announcing http ports")
+				return nil, errors.New("op-geth exited before announcing http ports")
 			}
 			// Wait for a bit more output, then try again
 			time.Sleep(10 * time.Millisecond)

--- a/op-e2e/external_geth/main.go
+++ b/op-e2e/external_geth/main.go
@@ -31,7 +31,7 @@ func main() {
 
 func run(configPath string) error {
 	if configPath == "" {
-		return fmt.Errorf("must supply a '--config <path>' flag")
+		return errors.New("must supply a '--config <path>' flag")
 	}
 
 	configFile, err := os.Open(configPath)

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -269,7 +269,7 @@ func readBlockJSON(path string) (*types.Block, error) {
 	}
 
 	if len(body.UncleHashes) > 0 {
-		return nil, fmt.Errorf("cannot unmarshal block with uncles")
+		return nil, errors.New("cannot unmarshal block with uncles")
 	}
 
 	txs := make([]*types.Transaction, len(body.Transactions))

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -129,7 +129,7 @@ func (cfg *L1EndpointConfig) Check() error {
 		return fmt.Errorf("batch size is invalid or unreasonable: %d", cfg.BatchSize)
 	}
 	if cfg.RateLimit < 0 {
-		return fmt.Errorf("rate limit cannot be negative")
+		return errors.New("rate limit cannot be negative")
 	}
 	if cfg.MaxConcurrency < 1 {
 		return fmt.Errorf("max concurrent requests cannot be less than 1, was %d", cfg.MaxConcurrency)

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -140,7 +140,7 @@ func (cfg *Config) Check() error {
 	}
 	if cfg.Rollup.EcotoneTime != nil {
 		if cfg.Beacon == nil {
-			return fmt.Errorf("the Ecotone upgrade is scheduled but no L1 Beacon API endpoint is configured")
+			return errors.New("the Ecotone upgrade is scheduled but no L1 Beacon API endpoint is configured")
 		}
 		if err := cfg.Beacon.Check(); err != nil {
 			return fmt.Errorf("misconfigured L1 Beacon API endpoint: %w", err)
@@ -165,10 +165,10 @@ func (cfg *Config) Check() error {
 	}
 	if cfg.ConductorEnabled {
 		if state, _ := cfg.ConfigPersistence.SequencerState(); state != StateUnset {
-			return fmt.Errorf("config persistence must be disabled when conductor is enabled")
+			return errors.New("config persistence must be disabled when conductor is enabled")
 		}
 		if !cfg.Driver.SequencerEnabled {
-			return fmt.Errorf("sequencer must be enabled when conductor is enabled")
+			return errors.New("sequencer must be enabled when conductor is enabled")
 		}
 	}
 	if err := cfg.Plasma.Check(); err != nil {

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	secureRand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -74,7 +75,7 @@ func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort 
 	} else if conf.ListenTCPPort != 0 { // otherwise default to the port we configured it to listen on
 		localNode.Set(enr.TCP(conf.ListenTCPPort))
 	} else {
-		return nil, nil, fmt.Errorf("no TCP port to put in discovery record")
+		return nil, nil, errors.New("no TCP port to put in discovery record")
 	}
 	dat := OpStackENRData{
 		chainID: rollupCfg.L2ChainID.Uint64(),
@@ -155,7 +156,7 @@ func enrToAddrInfo(r *enode.Node) (*peer.AddrInfo, *crypto.Secp256k1PublicKey, e
 	}
 	var enrPub Secp256k1
 	if err := r.Load(&enrPub); err != nil {
-		return nil, nil, fmt.Errorf("failed to load pubkey as libp2p pubkey type from ENR")
+		return nil, nil, errors.New("failed to load pubkey as libp2p pubkey type from ENR")
 	}
 	pub := (*crypto.Secp256k1PublicKey)(&enrPub)
 	peerID, err := peer.IDFromPublicKey(pub)

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -640,7 +640,7 @@ func (s *SyncClient) doRequest(ctx context.Context, id peer.ID, expectedBlockNum
 	}
 
 	if err := str.CloseRead(); err != nil {
-		return fmt.Errorf("failed to close reading side")
+		return errors.New("failed to close reading side")
 	}
 	if err := verifyBlock(envelope, expectedBlockNum); err != nil {
 		return fmt.Errorf("received execution payload is invalid: %w", err)

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -158,16 +158,16 @@ func fillBlobPointers(data []blobOrCalldata, blobs []*eth.Blob) error {
 			continue
 		}
 		if blobIndex >= len(blobs) {
-			return fmt.Errorf("didn't get enough blobs")
+			return errors.New("didn't get enough blobs")
 		}
 		if blobs[blobIndex] == nil {
-			return fmt.Errorf("found a nil blob")
+			return errors.New("found a nil blob")
 		}
 		data[i].blob = blobs[blobIndex]
 		blobIndex++
 	}
 	if blobIndex != len(blobs) {
-		return fmt.Errorf("got too many blobs")
+		return errors.New("got too many blobs")
 	}
 	return nil
 }

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -2,7 +2,7 @@ package derive
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -66,7 +66,7 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	var src DataIter
 	if ds.ecotoneTime != nil && ref.Time >= *ds.ecotoneTime {
 		if ds.blobsFetcher == nil {
-			return nil, fmt.Errorf("ecotone upgrade active but beacon endpoint not configured")
+			return nil, errors.New("ecotone upgrade active but beacon endpoint not configured")
 		}
 		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr)
 	} else {

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -144,7 +144,7 @@ func (e *EngineController) SetUnsafeHead(r eth.L2BlockRef) {
 
 func (e *EngineController) StartPayload(ctx context.Context, parent eth.L2BlockRef, attrs *AttributesWithParent, updateSafe bool) (errType BlockInsertionErrType, err error) {
 	if e.IsEngineSyncing() {
-		return BlockInsertTemporaryErr, fmt.Errorf("engine is in progess of p2p sync")
+		return BlockInsertTemporaryErr, errors.New("engine is in progess of p2p sync")
 	}
 	if e.buildingInfo != (eth.PayloadInfo{}) {
 		e.log.Warn("did not finish previous block building, starting new building now", "prev_onto", e.buildingOnto, "prev_payload_id", e.buildingInfo.ID, "new_onto", parent)
@@ -174,7 +174,7 @@ func (e *EngineController) StartPayload(ctx context.Context, parent eth.L2BlockR
 func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
 	// don't create a BlockInsertPrestateErr if we have a cached gossip payload
 	if e.buildingInfo == (eth.PayloadInfo{}) && agossip.Get() == nil {
-		return nil, BlockInsertPrestateErr, fmt.Errorf("cannot complete payload building: not currently building a payload")
+		return nil, BlockInsertPrestateErr, errors.New("cannot complete payload building: not currently building a payload")
 	}
 	if p := agossip.Get(); p != nil && e.buildingOnto == (eth.L2BlockRef{}) {
 		e.log.Warn("Found reusable payload from async gossiper, and no block was being built. Reusing payload.",

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -941,7 +942,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	// Expect initial building update, to process the attributes we queued up
 	eng.ExpectForkchoiceUpdate(preFc, attrs, preFcRes, nil)
 	// Don't let the payload be confirmed straight away
-	mockErr := fmt.Errorf("mock error")
+	mockErr := errors.New("mock error")
 	eng.ExpectGetPayload(id, nil, mockErr)
 	// The job will be not be cancelled, the untyped error is a temporary error
 

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -210,19 +210,19 @@ func (info *L1BlockInfo) unmarshalBinaryEcotone(data []byte) error {
 		return err
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if info.BaseFee, err = solabi.ReadUint256(r); err != nil {
 		return err

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -1,6 +1,7 @@
 package rollup
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -57,7 +58,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 
 	addrs, ok := superchain.Addresses[chainID]
 	if !ok {
-		return nil, fmt.Errorf("unable to retrieve deposit contract address")
+		return nil, errors.New("unable to retrieve deposit contract address")
 	}
 
 	regolithTime := uint64(0)

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -3,6 +3,7 @@ package rollup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -420,7 +421,7 @@ func TestConfig_Check(t *testing.T) {
 				ecotoneTime := uint64(1)
 				cfg.EcotoneTime = &ecotoneTime
 			},
-			expectedErr: fmt.Errorf("fork ecotone set (to 1), but prior fork delta missing"),
+			expectedErr: errors.New("fork ecotone set (to 1), but prior fork delta missing"),
 		},
 		{
 			name: "PriorForkHasHigherOffset",
@@ -430,7 +431,7 @@ func TestConfig_Check(t *testing.T) {
 				cfg.RegolithTime = &regolithTime
 				cfg.CanyonTime = &canyonTime
 			},
-			expectedErr: fmt.Errorf("fork canyon set to 1, but prior fork regolith has higher offset 2"),
+			expectedErr: errors.New("fork canyon set to 1, but prior fork regolith has higher offset 2"),
 		},
 		{
 			name: "PriorForkOK",

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -156,7 +156,7 @@ func NewL2EndpointConfig(ctx *cli.Context, log log.Logger) (*node.L2EndpointConf
 	var secret [32]byte
 	fileName = strings.TrimSpace(fileName)
 	if fileName == "" {
-		return nil, fmt.Errorf("file-name of jwt secret is empty")
+		return nil, errors.New("file-name of jwt secret is empty")
 	}
 	if data, err := os.ReadFile(fileName); err == nil {
 		jwtSecret := common.FromHex(strings.TrimSpace(string(data)))

--- a/op-plasma/cli.go
+++ b/op-plasma/cli.go
@@ -1,6 +1,7 @@
 package plasma
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -51,7 +52,7 @@ type CLIConfig struct {
 func (c CLIConfig) Check() error {
 	if c.Enabled {
 		if c.DAServerURL == "" {
-			return fmt.Errorf("DA server URL is required when plasma da is enabled")
+			return errors.New("DA server URL is required when plasma da is enabled")
 		}
 		if _, err := url.Parse(c.DAServerURL); err != nil {
 			return fmt.Errorf("DA server URL is invalid: %w", err)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -212,7 +212,7 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 // It returns: the next block number, if the proposal should be made, error
 func (l *L2OutputSubmitter) FetchNextOutputInfo(ctx context.Context) (*eth.OutputResponse, bool, error) {
 	if l.l2ooContract == nil {
-		return nil, false, fmt.Errorf("L2OutputOracle contract not set, cannot fetch next output info")
+		return nil, false, errors.New("L2OutputOracle contract not set, cannot fetch next output info")
 	}
 
 	cCtx, cancel := context.WithTimeout(ctx, l.Cfg.NetworkTimeout)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -356,7 +356,7 @@ func (l *L2OutputSubmitter) waitForL1Head(ctx context.Context, blockNum uint64) 
 				return err
 			}
 		case <-l.done:
-			return fmt.Errorf("L2OutputSubmitter is done()")
+			return errors.New("L2OutputSubmitter is done()")
 		}
 	}
 	return nil

--- a/op-service/dial/active_l2_provider_test.go
+++ b/op-service/dial/active_l2_provider_test.go
@@ -2,6 +2,7 @@ package dial
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -204,7 +205,7 @@ func TestRollupProvider_FailoverOnErroredSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, primarySequencer, firstSequencerUsed)
 
-	primarySequencer.ExpectSequencerActive(true, fmt.Errorf("a test error")) // error-out after that
+	primarySequencer.ExpectSequencerActive(true, errors.New("a test error")) // error-out after that
 	primarySequencer.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 	secondSequencerUsed, err := rollupProvider.RollupClient(context.Background())
@@ -231,7 +232,7 @@ func TestEndpointProvider_FailoverOnErroredSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, primaryEthClient, firstSequencerUsed)
 
-	primarySequencer.ExpectSequencerActive(true, fmt.Errorf("a test error")) // error out after that
+	primarySequencer.ExpectSequencerActive(true, errors.New("a test error")) // error out after that
 	primarySequencer.MaybeClose()
 	primaryEthClient.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
@@ -465,7 +466,7 @@ func TestRollupProvider_ConstructorErrorOnFirstSequencerOffline(t *testing.T) {
 	ept := setupEndpointProviderTest(t, 2)
 
 	// First sequencer is dead, second sequencer is active
-	ept.rollupClients[0].ExpectSequencerActive(false, fmt.Errorf("I am offline"))
+	ept.rollupClients[0].ExpectSequencerActive(false, errors.New("I am offline"))
 	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 
@@ -482,7 +483,7 @@ func TestEndpointProvider_ConstructorErrorOnFirstSequencerOffline(t *testing.T) 
 	ept := setupEndpointProviderTest(t, 2)
 
 	// First sequencer is dead, second sequencer is active
-	ept.rollupClients[0].ExpectSequencerActive(false, fmt.Errorf("I am offline"))
+	ept.rollupClients[0].ExpectSequencerActive(false, errors.New("I am offline"))
 	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 	ept.rollupClients[1].ExpectSequencerActive(true, nil) // see comment in other tests about why we expect this twice
@@ -533,7 +534,7 @@ func TestRollupProvider_FailOnAllErroredSequencers(t *testing.T) {
 
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
-		sequencer.ExpectSequencerActive(true, fmt.Errorf("a test error"))
+		sequencer.ExpectSequencerActive(true, errors.New("a test error"))
 		sequencer.MaybeClose()
 	}
 
@@ -549,7 +550,7 @@ func TestEndpointProvider_FailOnAllErroredSequencers(t *testing.T) {
 
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
-		sequencer.ExpectSequencerActive(true, fmt.Errorf("a test error"))
+		sequencer.ExpectSequencerActive(true, errors.New("a test error"))
 		sequencer.MaybeClose()
 	}
 
@@ -711,7 +712,7 @@ func TestRollupProvider_HandlesManyIndexClientMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// primarySequencer goes down
-	seq0.ExpectSequencerActive(false, fmt.Errorf("I'm offline now"))
+	seq0.ExpectSequencerActive(false, errors.New("I'm offline now"))
 	seq0.MaybeClose()
 	ept.setRollupDialOutcome(0, false) // primarySequencer fails to dial
 	// secondarySequencer is inactive, but online

--- a/op-service/eth/status.go
+++ b/op-service/eth/status.go
@@ -1,18 +1,19 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
 )
 
 func ForkchoiceUpdateErr(payloadStatus PayloadStatusV1) error {
 	switch payloadStatus.Status {
 	case ExecutionSyncing:
-		return fmt.Errorf("updated forkchoice, but node is syncing")
+		return errors.New("updated forkchoice, but node is syncing")
 	case ExecutionAccepted, ExecutionInvalidTerminalBlock, ExecutionInvalidBlockHash:
 		// ACCEPTED, INVALID_TERMINAL_BLOCK, INVALID_BLOCK_HASH are only for execution
 		return fmt.Errorf("unexpected %s status, could not update forkchoice", payloadStatus.Status)
 	case ExecutionInvalid:
-		return fmt.Errorf("cannot update forkchoice, block is invalid")
+		return errors.New("cannot update forkchoice, block is invalid")
 	case ExecutionValid:
 		return nil
 	default:

--- a/op-service/solabi/util.go
+++ b/op-service/solabi/util.go
@@ -69,7 +69,7 @@ func ReadUint64(r io.Reader) (uint64, error) {
 		return n, fmt.Errorf("number padding was not empty: %x", readPadding[:])
 	}
 	if err := binary.Read(r, binary.BigEndian, &n); err != nil {
-		return 0, fmt.Errorf("expected number length to be 8 bytes")
+		return 0, errors.New("expected number length to be 8 bytes")
 	}
 	return n, nil
 }

--- a/op-service/sources/batching/batching.go
+++ b/op-service/sources/batching/batching.go
@@ -2,6 +2,7 @@ package batching
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -176,7 +177,7 @@ func (ibc *IterativeBatchCall[K, V]) Result() ([]V, error) {
 	ibc.resetLock.RLock()
 	if atomic.LoadUint32(&ibc.completed) < uint32(len(ibc.requestsKeys)) {
 		ibc.resetLock.RUnlock()
-		return nil, fmt.Errorf("results not available yet, Fetch more first")
+		return nil, errors.New("results not available yet, Fetch more first")
 	}
 	ibc.resetLock.RUnlock()
 	return ibc.requestsValues, nil

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -11,6 +11,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -88,7 +89,7 @@ func (c *EthClientConfig) Check() error {
 			// an RCP receipts fetcher, so below rpc config parameters don't need to be checked.
 			return nil
 		} else {
-			return fmt.Errorf("rethdb path specified, but built without rethdb support")
+			return errors.New("rethdb path specified, but built without rethdb support")
 		}
 	}
 	if c.MaxConcurrentRequests < 1 {

--- a/op-service/sources/limit_test.go
+++ b/op-service/sources/limit_test.go
@@ -2,7 +2,7 @@ package sources
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -97,10 +97,10 @@ func TestLimitClient(t *testing.T) {
 		// None of the clients should return yet
 	}
 
-	m.errC <- fmt.Errorf("fake-error")
-	m.errC <- fmt.Errorf("fake-error")
+	m.errC <- errors.New("fake-error")
+	m.errC <- errors.New("fake-error")
 	require.Eventually(t, func() bool { return m.blockedCallers.Load() == 1 }, time.Second, 10*time.Millisecond)
-	m.errC <- fmt.Errorf("fake-error")
+	m.errC <- errors.New("fake-error")
 
 	require.ErrorContains(t, <-errC1, "fake-error")
 	require.ErrorContains(t, <-errC2, "fake-error")

--- a/op-service/sources/reth_db.go
+++ b/op-service/sources/reth_db.go
@@ -5,6 +5,7 @@ package sources
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -37,7 +38,7 @@ import "C"
 // and populates the given results slice pointer with the receipts that were found.
 func FetchRethReceipts(dbPath string, blockHash *common.Hash) (types.Receipts, error) {
 	if blockHash == nil {
-		return nil, fmt.Errorf("Must provide a block hash to fetch receipts for.")
+		return nil, errors.New("Must provide a block hash to fetch receipts for.")
 	}
 
 	// Convert the block hash to a C byte array and defer its deallocation

--- a/op-service/sources/reth_db.go
+++ b/op-service/sources/reth_db.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"unsafe"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -53,7 +52,7 @@ func FetchRethReceipts(dbPath string, blockHash *common.Hash) (types.Receipts, e
 	receiptsResult := C.rdb_read_receipts((*C.uint8_t)(cBlockHash), C.size_t(len(blockHash)), cDbPath)
 
 	if receiptsResult.error {
-		return nil, fmt.Errorf("Error fetching receipts from Reth Database.")
+		return nil, errors.New("Error fetching receipts from Reth Database.")
 	}
 
 	// Free the memory allocated by the C code

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -229,7 +230,7 @@ func (block *RPCBlock) verify() error {
 	}
 	if block.WithdrawalsRoot != nil {
 		if block.Withdrawals == nil {
-			return fmt.Errorf("expected withdrawals")
+			return errors.New("expected withdrawals")
 		}
 		for i, w := range *block.Withdrawals {
 			if w == nil {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -286,7 +286,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 	var txMessage types.TxData
 	if sidecar != nil {
 		if blobBaseFee == nil {
-			return nil, fmt.Errorf("expected non-nil blobBaseFee")
+			return nil, errors.New("expected non-nil blobBaseFee")
 		}
 		blobFeeCap := calcBlobFeeCap(blobBaseFee)
 		message := &types.BlobTx{
@@ -869,19 +869,19 @@ func errStringMatch(err, target error) bool {
 func finishBlobTx(message *types.BlobTx, chainID, tip, fee, blobFee, value *big.Int) error {
 	var o bool
 	if message.ChainID, o = uint256.FromBig(chainID); o {
-		return fmt.Errorf("ChainID overflow")
+		return errors.New("ChainID overflow")
 	}
 	if message.GasTipCap, o = uint256.FromBig(tip); o {
-		return fmt.Errorf("GasTipCap overflow")
+		return errors.New("GasTipCap overflow")
 	}
 	if message.GasFeeCap, o = uint256.FromBig(fee); o {
-		return fmt.Errorf("GasFeeCap overflow")
+		return errors.New("GasFeeCap overflow")
 	}
 	if message.BlobFeeCap, o = uint256.FromBig(blobFee); o {
-		return fmt.Errorf("BlobFeeCap overflow")
+		return errors.New("BlobFeeCap overflow")
 	}
 	if message.Value, o = uint256.FromBig(value); o {
-		return fmt.Errorf("Value overflow")
+		return errors.New("Value overflow")
 	}
 	return nil
 }

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -595,7 +595,7 @@ func TestTxMgr_EstimateGasFails(t *testing.T) {
 	lastNonce := tx.Nonce()
 
 	// Mock gas estimation failure.
-	h.gasPricer.err = fmt.Errorf("execution error")
+	h.gasPricer.err = errors.New("execution error")
 	_, err = h.mgr.craftTx(context.Background(), candidate)
 	require.ErrorContains(t, err, "failed to estimate gas")
 
@@ -612,7 +612,7 @@ func TestTxMgr_SigningFails(t *testing.T) {
 	cfg := configWithNumConfs(1)
 	cfg.Signer = func(ctx context.Context, from common.Address, tx *types.Transaction) (*types.Transaction, error) {
 		if errorSigning {
-			return nil, fmt.Errorf("signer error")
+			return nil, errors.New("signer error")
 		} else {
 			return tx, nil
 		}

--- a/op-service/util.go
+++ b/op-service/util.go
@@ -140,5 +140,5 @@ func FindMonorepoRoot(startDir string) (string, error) {
 		}
 		dir = parentDir
 	}
-	return "", fmt.Errorf("monorepo root not found")
+	return "", errors.New("monorepo root not found")
 }

--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -148,10 +149,10 @@ func (ch *Cheater) RunAndClose(fn HeadFn) error {
 	oldBody := rawdb.ReadBodyRLP(ch.DB, preID.Hash, preID.Number)
 	newKey := blockBodyKey(preID.Number, blockHash)
 	if err := batch.Delete(oldKey); err != nil {
-		return fmt.Errorf("error deleting old block body key")
+		return errors.New("error deleting old block body key")
 	}
 	if err := batch.Put(newKey, oldBody); err != nil {
-		return fmt.Errorf("error setting new block body key")
+		return errors.New("error setting new block body key")
 	}
 
 	// Flush the whole batch into the disk, exit the node if failed
@@ -320,7 +321,7 @@ func StoragePatch(patch io.Reader, address common.Address) HeadFn {
 			case '-':
 				headState.SetState(address, key, common.Hash{})
 			default:
-				return fmt.Errorf("unrecognized line diff token")
+				return errors.New("unrecognized line diff token")
 			}
 			i += 1
 			if i%1000 == 0 { // for every 1000 values, commit to disk

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -571,7 +572,7 @@ var (
 		ArgsUsage: "<rpc-method-name> [params...]",
 		Action: EngineAction(func(ctx *cli.Context, client client.RPC) error {
 			if ctx.NArg() == 0 {
-				return fmt.Errorf("expected at least 1 argument: RPC method name")
+				return errors.New("expected at least 1 argument: RPC method name")
 			}
 			var r io.Reader
 			var args []string

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -154,7 +154,7 @@ type TextFlag[T Text] struct {
 func (a *TextFlag[T]) Set(value string) error {
 	var defaultValue T
 	if a.Value == defaultValue {
-		return fmt.Errorf("cannot unmarshal into nil value")
+		return errors.New("cannot unmarshal into nil value")
 	}
 	return a.Value.UnmarshalText([]byte(value))
 }

--- a/packages/contracts-bedrock/scripts/go-ffi/utils.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/utils.go
@@ -19,7 +19,7 @@ var UnknownNonceVersion = errors.New("Unknown nonce version")
 // Shorthand to ease go's god awful error handling
 func checkOk(ok bool) {
 	if !ok {
-		panic(fmt.Errorf("checkOk failed"))
+		panic(errors.New("checkOk failed"))
 	}
 }
 

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -453,7 +453,7 @@ func (b *Backend) ForwardRPC(ctx context.Context, res *RPCRes, id string, method
 	}
 
 	if len(slicedRes) != 1 {
-		return fmt.Errorf("unexpected response len for non-batched request (len != 1)")
+		return errors.New("unexpected response len for non-batched request (len != 1)")
 	}
 	if slicedRes[0].IsError() {
 		return fmt.Errorf(slicedRes[0].Error.Error())

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -204,7 +204,7 @@ func Start(config *Config) (*Server, func(), error) {
 	}
 
 	if wsBackendGroup == nil && config.Server.WSPort != 0 {
-		return nil, nil, fmt.Errorf("a ws port was defined, but no ws group was defined")
+		return nil, nil, errors.New("a ws port was defined, but no ws group was defined")
 	}
 
 	for _, bg := range config.RPCMethodMappings {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

fmt.Errorf() with no param should be replace by errors.New()

**Tests**

N/A

**Additional context**

N/A

**Metadata**

- use errors.New which has no param instead of fmt.Errorf
