### PR TITLE
Use NewConfig to ensure defaults are set correctly

### DIFF
--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -128,17 +128,10 @@ func Run(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string,
 	if err != nil {
 		return fmt.Errorf("failed to load rollup config: %w", err)
 	}
-	offlineCfg := config.Config{
-		Rollup:             rollupCfg,
-		DataDir:            dataDir,
-		L2ChainConfig:      chainCfg,
-		L2Head:             l2Head,
-		L2OutputRoot:       agreedOutput.OutputRoot,
-		L2Claim:            l2Claim,
-		L2ClaimBlockNumber: l2BlockNumber.Uint64(),
-		L1Head:             l1Head,
-	}
-	onlineCfg := offlineCfg
+	offlineCfg := config.NewConfig(
+		rollupCfg, chainCfg, l1Head, l2Head, agreedOutput.OutputRoot, l2Claim, l2BlockNumber.Uint64())
+	offlineCfg.DataDir = dataDir
+	onlineCfg := *offlineCfg
 	onlineCfg.L1URL = l1RpcUrl
 	onlineCfg.L1BeaconURL = l1BeaconUrl
 	onlineCfg.L2URL = l2RpcUrl
@@ -153,7 +146,7 @@ func Run(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string,
 	}
 
 	fmt.Println("Running in offline mode")
-	err = host.Main(oplog.NewLogger(os.Stderr, logger), &offlineCfg)
+	err = host.Main(oplog.NewLogger(os.Stderr, logger), offlineCfg)
 	if err != nil {
 		return fmt.Errorf("offline mode failed: %w", err)
 	}


### PR DESCRIPTION
**Description**

fpp-verify is failing because the L1Kind wound up unset instead of using the default.  Use the `NewConfig` constructor to ensure defaults are used.
