### PR TITLE
op-challenger: Delay claiming credit until games are complete

### DIFF
--- a/op-challenger/game/fault/claims/claimer.go
+++ b/op-challenger/game/fault/claims/claimer.go
@@ -17,7 +17,7 @@ type BondClaimMetrics interface {
 }
 
 type BondContract interface {
-	GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error)
+	GetCredit(ctx context.Context, receipient common.Address) (*big.Int, types.GameStatus, error)
 	ClaimCredit(receipient common.Address) (txmgr.TxCandidate, error)
 }
 
@@ -55,11 +55,15 @@ func (c *Claimer) claimBond(ctx context.Context, game types.GameMetadata) error 
 	if err != nil {
 		return fmt.Errorf("failed to create bond contract bindings: %w", err)
 	}
-	credit, err := contract.GetCredit(ctx, c.txSender.From())
+	credit, status, err := contract.GetCredit(ctx, c.txSender.From())
 	if err != nil {
 		return fmt.Errorf("failed to get credit: %w", err)
 	}
 
+	if status == types.GameStatusInProgress {
+		c.logger.Debug("Not claiming credit from in progress game", "game", game.Proxy, "status", status)
+		return nil
+	}
 	if credit.Cmp(big.NewInt(0)) == 0 {
 		c.logger.Debug("No credit to claim", "game", game.Proxy)
 		return nil

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -377,12 +377,15 @@ func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 func TestFaultDisputeGame_GetCredit(t *testing.T) {
 	stubRpc, game := setupFaultDisputeGameTest(t)
 	addr := common.Address{0x01}
-	expected := big.NewInt(4284)
-	stubRpc.SetResponse(fdgAddr, methodCredit, batching.BlockLatest, []interface{}{addr}, []interface{}{expected})
+	expectedCredit := big.NewInt(4284)
+	expectedStatus := types.GameStatusChallengerWon
+	stubRpc.SetResponse(fdgAddr, methodCredit, batching.BlockLatest, []interface{}{addr}, []interface{}{expectedCredit})
+	stubRpc.SetResponse(fdgAddr, methodStatus, batching.BlockLatest, nil, []interface{}{expectedStatus})
 
-	actual, err := game.GetCredit(context.Background(), addr)
+	actualCredit, actualStatus, err := game.GetCredit(context.Background(), addr)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Equal(t, expectedCredit, actualCredit)
+	require.Equal(t, expectedStatus, actualStatus)
 }
 
 func TestFaultDisputeGame_GetCredits(t *testing.T) {

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/preimages"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/responder"
@@ -44,6 +45,7 @@ type GamePlayer struct {
 type GameContract interface {
 	preimages.PreimageGameContract
 	responder.GameContract
+	claims.BondContract
 	GameInfo
 	ClaimLoader
 	GetStatus(ctx context.Context) (gameTypes.GameStatus, error)

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -24,8 +24,6 @@ type GameContract interface {
 	DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error)
 	StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error)
 	GetRequiredBond(ctx context.Context, position types.Position) (*big.Int, error)
-	GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error)
-	ClaimCredit(receipient common.Address) (txmgr.TxCandidate, error)
 }
 
 type Oracle interface {

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -123,7 +123,7 @@ func (s stubPreimageOracle) GetActivePreimages(_ context.Context, _ common.Hash)
 
 type stubBondContract struct{}
 
-func (s *stubBondContract) GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error) {
+func (s *stubBondContract) GetCredit(ctx context.Context, receipient common.Address) (*big.Int, types.GameStatus, error) {
 	panic("not supported")
 }
 


### PR DESCRIPTION
**Description**

Avoids paying additional transaction costs while a game's claims are being resolved and works better with bond locking.

**Tests**

Updated unit tests

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/445
