### PR TITLE
`l2ImmutableDeployer` : remove contracts with no immutable

### DIFF
--- a/op-chain-ops/immutables/immutables.go
+++ b/op-chain-ops/immutables/immutables.go
@@ -192,10 +192,6 @@ func l2ImmutableDeployer(backend *backends.SimulatedBackend, opts *bind.Transact
 	}
 
 	switch deployment.Name {
-	case "L2CrossDomainMessenger":
-		_, tx, _, err = bindings.DeployL2CrossDomainMessenger(opts, backend)
-	case "L2StandardBridge":
-		_, tx, _, err = bindings.DeployL2StandardBridge(opts, backend)
 	case "SequencerFeeVault":
 		recipient, minimumWithdrawalAmount, withdrawalNetwork, err = prepareFeeVaultArguments(deployment)
 		if err != nil {
@@ -214,10 +210,6 @@ func l2ImmutableDeployer(backend *backends.SimulatedBackend, opts *bind.Transact
 			return nil, err
 		}
 		_, tx, _, err = bindings.DeployL1FeeVault(opts, backend, recipient, minimumWithdrawalAmount, withdrawalNetwork)
-	case "OptimismMintableERC20Factory":
-		_, tx, _, err = bindings.DeployOptimismMintableERC20Factory(opts, backend)
-	case "L2ERC721Bridge":
-		_, tx, _, err = bindings.DeployL2ERC721Bridge(opts, backend)
 	case "OptimismMintableERC721Factory":
 		bridge, ok := deployment.Args[0].(common.Address)
 		if !ok {

--- a/op-chain-ops/state/state.go
+++ b/op-chain-ops/state/state.go
@@ -73,6 +73,7 @@ func ComputeStorageSlots(layout *solc.StorageLayout, values StorageValues) ([]*E
 		for _, entry := range layout.Storage {
 			if label == entry.Label {
 				target = entry
+				break
 			}
 		}
 		if target.Label == "" {

--- a/op-node/rollup/derive/ecotone_upgrade_transactions.go
+++ b/op-node/rollup/derive/ecotone_upgrade_transactions.go
@@ -42,7 +42,7 @@ var (
 )
 
 func EcotoneNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
-	upgradeTxns := make([]hexutil.Bytes, 0, 5)
+	upgradeTxns := make([]hexutil.Bytes, 0, 6)
 
 	deployL1BlockTransaction, err := types.NewTx(&types.DepositTx{
 		SourceHash:          deployL1BlockSource.SourceHash(),


### PR DESCRIPTION
`l2ImmutableDeployer` is used to deploy contracts with immutables and [this line](https://github.com/ethereum-optimism/optimism/blob/b36eb5515cc2a34a15383b2eee488dbac83d6caf/op-chain-ops/immutables/immutables.go#L190) will stop contracts without immutables from being deployed.

This PR removes the contracts which `HasImmutableReferences` returns false.
