### PR TITLE
op-challenger: Reduce log level to warn when local not node in sync

### DIFF
--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -2,6 +2,7 @@ package fault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
@@ -159,8 +160,11 @@ func (g *GamePlayer) ProgressGame(ctx context.Context) gameTypes.GameStatus {
 		g.logger.Trace("Skipping completed game")
 		return g.status
 	}
-	if err := g.syncValidator.ValidateNodeSynced(ctx, g.gameL1Head); err != nil {
-		g.logger.Error("Local node not sufficiently up to date", "err", err)
+	if err := g.syncValidator.ValidateNodeSynced(ctx, g.gameL1Head); errors.Is(err, ErrNotInSync) {
+		g.logger.Warn("Local node not sufficiently up to date", "err", err)
+		return g.status
+	} else if err != nil {
+		g.logger.Error("Could not check local node was in sync", "err", err)
 		return g.status
 	}
 	g.logger.Trace("Checking if actions are required")


### PR DESCRIPTION
**Description**

This often happens for new games because op-node is configured with a follow distance so shouldn't be an error level log.
