### PR TITLE
feat(op-dispute-mon): Output Fetch Timestamp Metric

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -38,6 +38,8 @@ type Metricer interface {
 
 	RecordClaimResolutionDelayMax(delay float64)
 
+	RecordOutputFetchTime(timestamp float64)
+
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 	RecordGameAgreement(status GameAgreementStatus, count int)
 
@@ -56,6 +58,8 @@ type Metrics struct {
 
 	info prometheus.GaugeVec
 	up   prometheus.Gauge
+
+	lastOutputFetch prometheus.Gauge
 
 	claimResolutionDelayMax prometheus.Gauge
 
@@ -91,6 +95,11 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "up",
 			Help:      "1 if the op-challenger has finished starting up",
+		}),
+		lastOutputFetch: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "last_output_fetch",
+			Help:      "Timestamp of the last output fetch",
 		}),
 		claimResolutionDelayMax: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -153,6 +162,10 @@ func (m *Metrics) RecordGamesStatus(inProgress, defenderWon, challengerWon int) 
 	m.trackedGames.WithLabelValues("in_progress").Set(float64(inProgress))
 	m.trackedGames.WithLabelValues("defender_won").Set(float64(defenderWon))
 	m.trackedGames.WithLabelValues("challenger_won").Set(float64(challengerWon))
+}
+
+func (m *Metrics) RecordOutputFetchTime(timestamp float64) {
+	m.lastOutputFetch.Set(timestamp)
 }
 
 func (m *Metrics) RecordGameAgreement(status GameAgreementStatus, count int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -12,5 +12,7 @@ func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
 func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64) {}
 
+func (*NoopMetricsImpl) RecordOutputFetchTime(timestamp float64) {}
+
 func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}
 func (*NoopMetricsImpl) RecordGameAgreement(status GameAgreementStatus, count int)    {}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -100,7 +100,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 }
 
 func (s *Service) initOutputValidator() {
-	s.validator = newOutputValidator(s.rollupClient)
+	s.validator = newOutputValidator(s.metrics, s.rollupClient)
 }
 
 func (s *Service) initGameCallerCreator() {

--- a/op-dispute-mon/mon/validator_test.go
+++ b/op-dispute-mon/mon/validator_test.go
@@ -18,45 +18,58 @@ func TestDetector_CheckRootAgreement(t *testing.T) {
 	t.Parallel()
 
 	t.Run("OutputFetchFails", func(t *testing.T) {
-		validator, rollup := setupOutputValidatorTest(t)
+		validator, rollup, metrics := setupOutputValidatorTest(t)
 		rollup.err = errors.New("boom")
 		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 0, mockRootClaim)
 		require.ErrorIs(t, err, rollup.err)
 		require.Equal(t, common.Hash{}, fetched)
 		require.False(t, agree)
+		require.Zero(t, metrics.fetchTime)
 	})
 
 	t.Run("OutputMismatch", func(t *testing.T) {
-		validator, _ := setupOutputValidatorTest(t)
+		validator, _, metrics := setupOutputValidatorTest(t)
 		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 0, common.Hash{})
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, fetched)
 		require.False(t, agree)
+		require.NotZero(t, metrics.fetchTime)
 	})
 
 	t.Run("OutputMatches", func(t *testing.T) {
-		validator, _ := setupOutputValidatorTest(t)
+		validator, _, metrics := setupOutputValidatorTest(t)
 		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 0, mockRootClaim)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, fetched)
 		require.True(t, agree)
+		require.NotZero(t, metrics.fetchTime)
 	})
 
 	t.Run("OutputNotFound", func(t *testing.T) {
-		validator, rollup := setupOutputValidatorTest(t)
+		validator, rollup, metrics := setupOutputValidatorTest(t)
 		// This crazy error is what we actually get back from the API
 		rollup.err = errors.New("failed to get L2 block ref with sync status: failed to determine L2BlockRef of height 42984924, could not get payload: not found")
 		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 42984924, mockRootClaim)
 		require.NoError(t, err)
 		require.Equal(t, common.Hash{}, fetched)
 		require.False(t, agree)
+		require.Zero(t, metrics.fetchTime)
 	})
 }
 
-func setupOutputValidatorTest(t *testing.T) (*outputValidator, *stubRollupClient) {
+func setupOutputValidatorTest(t *testing.T) (*outputValidator, *stubRollupClient, *stubOutputMetrics) {
 	client := &stubRollupClient{}
-	validator := newOutputValidator(client)
-	return validator, client
+	metrics := &stubOutputMetrics{}
+	validator := newOutputValidator(metrics, client)
+	return validator, client, metrics
+}
+
+type stubOutputMetrics struct {
+	fetchTime float64
+}
+
+func (s *stubOutputMetrics) RecordOutputFetchTime(fetchTime float64) {
+	s.fetchTime = fetchTime
 }
 
 type stubRollupClient struct {


### PR DESCRIPTION
**Description**

Adds a metric to record when the last successful output was fetched.

This provides a simple way for a consumer to raise an alert if there hasn't been an update for a while.

To keep this metric simple, no error tracking is done since the dispute monitor logs can be checked for output fetch errors to see why the associated alert is raised.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/565
