### PR TITLE
feat(interop): verifier safe head progression

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -13,6 +13,7 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
 )
 
 // Flags
@@ -422,6 +423,7 @@ func init() {
 	optionalFlags = append(optionalFlags, DeprecatedFlags...)
 	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, RollupCategory)...)
 	optionalFlags = append(optionalFlags, plasma.CLIFlags(EnvVarPrefix, PlasmaCategory)...)
+	optionalFlags = append(optionalFlags, superchain.L2PeersFlag(EnvVarPrefix))
 	Flags = append(requiredFlags, optionalFlags...)
 }
 

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -389,6 +389,10 @@ func NewMetrics(procName string) *Metrics {
 	}
 }
 
+func (m *Metrics) Factory() metrics.Factory {
+	return m.factory
+}
+
 // SetPeerScores updates the peer score metrics.
 // Accepts a slice of peer scores in any order.
 func (m *Metrics) SetPeerScores(allScores []store.PeerScores) {

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	plasma "github.com/ethereum-optimism/optimism/op-plasma"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -76,6 +77,9 @@ type Config struct {
 
 	// Plasma DA config
 	Plasma plasma.CLIConfig
+
+	// Superchain config
+	Superchain superchain.CLIConfig
 }
 
 type RPCConfig struct {
@@ -173,6 +177,9 @@ func (cfg *Config) Check() error {
 	}
 	if err := cfg.Plasma.Check(); err != nil {
 		return fmt.Errorf("plasma config error: %w", err)
+	}
+	if err := cfg.Superchain.Check(); err != nil {
+		return fmt.Errorf("superchain config error: %w", err)
 	}
 	return nil
 }

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -72,15 +72,14 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 		return nil, err
 	}
 
-	// Pass attributes through the filterer. Original attributes may be
-	// mutated so any prior state is unreliable after the filter is applied.
-	attrs, forceProgressSafe, err := aq.filterer.FilterAttributes(ctx, attrs)
+	// Pass attributes through the filterer
+	attrs, resetPendingSafe, err := aq.filterer.FilterAttributes(ctx, attrs)
 	if err != nil {
 		return nil, err
 	}
 
 	// Clear out the local state once we will succeed
-	attr := AttributesWithParent{attrs, parent, aq.isLastInSpan, forceProgressSafe}
+	attr := AttributesWithParent{attrs, parent, aq.isLastInSpan, resetPendingSafe}
 	aq.batch = nil
 	aq.isLastInSpan = false
 	return &attr, nil

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -154,7 +154,7 @@ func TestAttributesFilterer(t *testing.T) {
 		GasLimit:              (*eth.Uint64Quantity)(&expectedL1Cfg.GasLimit),
 	}
 
-	// Filter out txs with "drop" as the data
+	// Filter out non-deposit txs
 	depositsOnlyFilterer := testAttributesFilterer{
 		filter: func(attrs *eth.PayloadAttributes) *eth.PayloadAttributes {
 			var deposits []eth.Data
@@ -175,7 +175,7 @@ func TestAttributesFilterer(t *testing.T) {
 	actual, err := aq.NextAttributes(context.Background(), safeHead)
 	require.NoError(t, err)
 
-	// drop the deposits in the pre-image attributes
+	// keep only deposits
 	attrs.Transactions = attrs.Transactions[:1]
 	require.Equal(t, attrs, *actual.attributes)
 }

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
@@ -17,6 +18,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
+
+type testAttributesFilterer struct {
+	filter func(*eth.PayloadAttributes) *eth.PayloadAttributes
+}
+
+func (f testAttributesFilterer) FilterAttributes(ctx context.Context, attrs *eth.PayloadAttributes) (*eth.PayloadAttributes, bool, error) {
+	return f.filter(attrs), false, nil
+}
 
 // TestAttributesQueue checks that it properly uses the PreparePayloadAttributes function
 // (which is well tested) and that it properly sets NoTxPool and adds in the candidate
@@ -77,12 +86,96 @@ func TestAttributesQueue(t *testing.T) {
 		NoTxPool:              true,
 		GasLimit:              (*eth.Uint64Quantity)(&expectedL1Cfg.GasLimit),
 	}
-	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l2Fetcher)
 
-	aq := NewAttributesQueue(testlog.Logger(t, log.LevelError), cfg, attrBuilder, nil)
+	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l2Fetcher)
+	attrFilterer := testAttributesFilterer{filter: func(attrs *eth.PayloadAttributes) *eth.PayloadAttributes { return attrs }}
+	aq := NewAttributesQueue(testlog.Logger(t, log.LevelError), cfg, attrBuilder, attrFilterer, nil)
 
 	actual, err := aq.createNextAttributes(context.Background(), &batch, safeHead)
 
 	require.NoError(t, err)
 	require.Equal(t, attrs, *actual)
+}
+
+func TestAttributesFilterer(t *testing.T) {
+	// test config, only init the necessary fields
+	cfg := &rollup.Config{
+		BlockTime:              2,
+		L1ChainID:              big.NewInt(101),
+		L2ChainID:              big.NewInt(102),
+		DepositContractAddress: common.Address{0xbb},
+		L1SystemConfigAddress:  common.Address{0xcc},
+	}
+	rng := rand.New(rand.NewSource(1234))
+	l1Info := testutils.RandomBlockInfo(rng)
+
+	l1Fetcher := &testutils.MockL1Source{}
+	defer l1Fetcher.AssertExpectations(t)
+
+	l1Fetcher.ExpectInfoByHash(l1Info.InfoHash, l1Info, nil)
+
+	safeHead := testutils.RandomL2BlockRef(rng)
+	safeHead.L1Origin = l1Info.ID()
+	safeHead.Time = l1Info.InfoTime
+
+	batch := SingularBatch{
+		ParentHash:   safeHead.Hash,
+		EpochNum:     rollup.Epoch(l1Info.InfoNum),
+		EpochHash:    l1Info.InfoHash,
+		Timestamp:    safeHead.Time + cfg.BlockTime,
+		Transactions: []eth.Data{eth.Data("foobar"), eth.Data("example")},
+	}
+
+	parentL1Cfg := eth.SystemConfig{
+		BatcherAddr: common.Address{42},
+		Overhead:    [32]byte{},
+		Scalar:      [32]byte{},
+		GasLimit:    1234,
+	}
+	expectedL1Cfg := eth.SystemConfig{
+		BatcherAddr: common.Address{42},
+		Overhead:    [32]byte{},
+		Scalar:      [32]byte{},
+		GasLimit:    1234,
+	}
+
+	l2Fetcher := &testutils.MockL2Client{}
+	l2Fetcher.ExpectSystemConfigByL2Hash(safeHead.Hash, parentL1Cfg, nil)
+
+	rollupCfg := rollup.Config{}
+	l1InfoTx, err := L1InfoDepositBytes(&rollupCfg, expectedL1Cfg, safeHead.SequenceNumber+1, l1Info, 0)
+	require.NoError(t, err)
+	attrs := eth.PayloadAttributes{
+		Timestamp:             eth.Uint64Quantity(safeHead.Time + cfg.BlockTime),
+		PrevRandao:            eth.Bytes32(l1Info.InfoMixDigest),
+		SuggestedFeeRecipient: predeploys.SequencerFeeVaultAddr,
+		Transactions:          []eth.Data{l1InfoTx, eth.Data("foobar"), eth.Data("example")},
+		NoTxPool:              true,
+		GasLimit:              (*eth.Uint64Quantity)(&expectedL1Cfg.GasLimit),
+	}
+
+	// Filter out txs with "drop" as the data
+	depositsOnlyFilterer := testAttributesFilterer{
+		filter: func(attrs *eth.PayloadAttributes) *eth.PayloadAttributes {
+			var deposits []eth.Data
+			for i, data := range attrs.Transactions {
+				if data[0] == types.DepositTxType {
+					deposits = attrs.Transactions[:i+1]
+				}
+			}
+			attrs.Transactions = deposits
+			return attrs
+		},
+	}
+
+	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l2Fetcher)
+	aq := NewAttributesQueue(testlog.Logger(t, log.LevelError), cfg, attrBuilder, depositsOnlyFilterer, nil)
+
+	aq.batch = &batch
+	actual, err := aq.NextAttributes(context.Background(), safeHead)
+	require.NoError(t, err)
+
+	// drop the deposits in the pre-image attributes
+	attrs.Transactions = attrs.Transactions[:1]
+	require.Equal(t, attrs, *actual.attributes)
 }

--- a/op-node/rollup/derive/cross_l2.go
+++ b/op-node/rollup/derive/cross_l2.go
@@ -1,0 +1,111 @@
+package derive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
+)
+
+var (
+	crossL2InboxAddr = common.Address{}
+)
+
+type CrossL2TxValidity uint8
+
+const (
+	CrossL2TxDrop = iota
+	CrossL2TxAccept
+	CrossL2TxUndecided
+)
+
+type CrossL2 struct {
+	log       log.Logger
+	rollupCfg *rollup.Config
+	backend   superchain.Backend
+}
+
+func NewCrossL2(log log.Logger, cfg *rollup.Config, backend superchain.Backend) *CrossL2 {
+	return &CrossL2{log, cfg, backend}
+}
+
+func (inbox *CrossL2) FilterAttributes(ctx context.Context, attrs *eth.PayloadAttributes) (*eth.PayloadAttributes, bool, error) {
+	if !inbox.rollupCfg.IsInterop(uint64(attrs.Timestamp)) {
+		return attrs, false, nil
+	}
+
+	var deposits []eth.Data
+	for i, data := range attrs.Transactions {
+		if data[0] == types.DepositTxType {
+			// skip over deposits and track them in-case these attributes are spoiled:w
+			deposits = attrs.Transactions[:i+1]
+			continue
+		}
+
+		validity := inbox.checkTxBytes(ctx, data)
+		if validity == CrossL2TxDrop {
+			inbox.log.Info("converting payload to deposits-only due to an invalid cross-l2 tx")
+			attrs.Transactions = deposits
+			return attrs, true, nil
+		}
+
+		// The only way a tx can be undecided with security derived from L1 is if:
+		//  - Transient RPC failures with the backend
+		//  - L2 Peer information wasn't added in configuration setup
+		//  - Initiating message hasn't been deemed finalized or safe relative to L2
+		//
+		// In these scenarios, we can choose to let the attributes pass through and progress the
+		// pending safe head, relying on the engine_queue to re-org when progressing the safe head
+		// but instead we'll raise a temporary error and wait since this failure mode is transient
+		if validity == CrossL2TxUndecided {
+			return nil, false, NewTemporaryError(fmt.Errorf(""))
+		}
+
+		// CrossL2TxAccepted
+	}
+
+	return attrs, false, nil
+}
+
+// Check for basic validity of cross-l2 executing messages. Intended only batch validation
+func (inbox *CrossL2) checkTxBytes(ctx context.Context, txBytes hexutil.Bytes) CrossL2TxValidity {
+	var tx types.Transaction
+	if err := rlp.DecodeBytes(txBytes, &tx); err != nil {
+		inbox.log.Warn("unable to decode tx bytes")
+		return CrossL2TxDrop
+	}
+
+	// Skip over non-inbox transactions
+	if tx.To() == nil || *tx.To() != crossL2InboxAddr {
+		return CrossL2TxAccept
+	}
+
+	_, id, payload, err := superchain.ParseInboxExecuteMessageTxData(tx.Data())
+	if err != nil {
+		inbox.log.Warn("unable to decode inbox tx data", "tx_hash", tx.Hash())
+		return CrossL2TxDrop
+	}
+
+	// Check validity with the backend
+	safetyLabel, err := inbox.backend.MessageSafety(ctx, id, payload)
+	if err != nil {
+		inbox.log.Warn("failed to check inbox tx against message backend", "err", err)
+		return CrossL2TxUndecided
+	}
+
+	if safetyLabel == superchain.MessageInvalid {
+		return CrossL2TxDrop
+	} else if safetyLabel == superchain.MessageUnknown {
+		return CrossL2TxUndecided
+	}
+
+	return CrossL2TxAccept
+}

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -21,10 +21,6 @@ type L1TransactionFetcher interface {
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
 }
 
-type L2TransactionFetcher interface {
-	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
-}
-
 type L1BlobsFetcher interface {
 	// GetBlobs fetches blobs that were confirmed in the given L1 block with the given indexed hashes.
 	GetBlobs(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.Blob, error)

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -21,6 +21,10 @@ type L1TransactionFetcher interface {
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
 }
 
+type L2TransactionFetcher interface {
+	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
+}
+
 type L1BlobsFetcher interface {
 	// GetBlobs fetches blobs that were confirmed in the given L1 block with the given indexed hashes.
 	GetBlobs(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.Blob, error)

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -23,18 +23,12 @@ type AttributesWithParent struct {
 	attributes *eth.PayloadAttributes
 	parent     eth.L2BlockRef
 
-	// When attributes are pushed through to the queue, `pendingSafe` is only
-	// progressed when all blocks to a specific batch has been progressed. This
-	// is indicated with the `isLastInSpan` bool. With interop, we also want to
-	// commit deposit-only blocks that may occur on inclusion of an invalid
-	// cross-l2 message. This will indicated with the `progressSafe` bool. Although
-	// these two can be combined, we'll keep them seperate for clarity.
-	//
-	// We need to progress the safe head on a deposits-only conversion as future the
-	// blocks derived after within the same span may fail due to invalidated tx
-	// nonces.
-	isLastInSpan      bool
-	forceProgressSafe bool
+	isLastInSpan bool
+
+	// Available to be set by a filterer in the attributes pipeline. As named,
+	// this will reset the pending safe marker to the known safe head will cause
+	// the batch queue to progress with a different batch on the safe head, if available.
+	resetPendingSafe bool
 }
 
 func NewAttributesWithParent(attributes *eth.PayloadAttributes, parent eth.L2BlockRef, isLastInSpan bool) *AttributesWithParent {
@@ -534,6 +528,13 @@ func (eq *EngineQueue) tryNextSafeAttributes(ctx context.Context) error {
 			eq.ec.PendingSafeL2Head(), eq.ec.PendingSafeL2Head().ParentID(), eq.safeAttributes.parent))
 
 	}
+	// validate that the next attributes does not signal pending safe reset before processing it.
+	if eq.safeAttributes.resetPendingSafe {
+		eq.safeAttributes = nil
+		eq.ec.SetPendingSafeL2Head(eq.ec.SafeL2Head())
+		return nil
+	}
+
 	if eq.ec.PendingSafeL2Head().Number < eq.ec.UnsafeL2Head().Number {
 		return eq.consolidateNextSafeAttributes(ctx)
 	} else if eq.ec.PendingSafeL2Head().Number == eq.ec.UnsafeL2Head().Number {
@@ -571,7 +572,7 @@ func (eq *EngineQueue) consolidateNextSafeAttributes(ctx context.Context) error 
 		return NewResetError(fmt.Errorf("failed to decode L2 block ref from payload: %w", err))
 	}
 	eq.ec.SetPendingSafeL2Head(ref)
-	if eq.safeAttributes.isLastInSpan || eq.safeAttributes.forceProgressSafe {
+	if eq.safeAttributes.isLastInSpan {
 		eq.ec.SetSafeHead(ref)
 		if err := eq.postProcessSafeL2(); err != nil {
 			return err
@@ -591,7 +592,6 @@ func (eq *EngineQueue) forceNextSafeAttributes(ctx context.Context) error {
 	}
 	attrs := eq.safeAttributes.attributes
 	lastInSpan := eq.safeAttributes.isLastInSpan
-	forceSafeProgression := eq.safeAttributes.forceProgressSafe
 	errType, err := eq.StartPayload(ctx, eq.ec.PendingSafeL2Head(), eq.safeAttributes, true)
 	if err == nil {
 		_, errType, err = eq.ec.ConfirmPayload(ctx, async.NoOpGossiper{}, &conductor.NoOpConductor{})
@@ -636,7 +636,7 @@ func (eq *EngineQueue) forceNextSafeAttributes(ctx context.Context) error {
 	}
 	eq.safeAttributes = nil
 	eq.logSyncProgress("processed safe block derived from L1")
-	if lastInSpan || forceSafeProgression {
+	if lastInSpan {
 		if err := eq.postProcessSafeL2(); err != nil {
 			return err
 		}

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -39,7 +39,7 @@ func (f *fakeAttributesQueue) NextAttributes(_ context.Context, safeHead eth.L2B
 	if f.attrs == nil {
 		return nil, io.EOF
 	}
-	return &AttributesWithParent{f.attrs, safeHead, f.islastInSpan}, nil
+	return &AttributesWithParent{f.attrs, safeHead, f.islastInSpan, false}, nil
 }
 
 var _ NextAttributesProvider = (*fakeAttributesQueue)(nil)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
 )
 
 type Metrics interface {
@@ -119,6 +120,7 @@ func NewDriver(
 	cfg *rollup.Config,
 	l2 L2Chain,
 	l1 L1Chain,
+	superchain superchain.Backend,
 	l1Blobs derive.L1BlobsFetcher,
 	altSync AltSync,
 	network Network,
@@ -137,7 +139,7 @@ func NewDriver(
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	engine := derive.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode)
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, engine, metrics, syncCfg, safeHeadListener)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, superchain, engine, metrics, syncCfg, safeHeadListener)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log) // Only use the metered engine in the sequencer b/c it records sequencing metrics.
 	sequencer := NewSequencer(log, cfg, meteredEngine, attrBuilder, findL1Origin, metrics)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -13,6 +13,7 @@ import (
 	plasma "github.com/ethereum-optimism/optimism/op-plasma"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
@@ -74,6 +75,10 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		haltOption = ""
 	}
 
+	// L2PCUrl hydrated from the L2EndpointConfig, not from flags
+	superchainCfg := superchain.ReadCLIConfig(ctx)
+	superchainCfg.L2RPCUrl = l2Endpoint.L2EngineAddr
+
 	cfg := &node.Config{
 		L1:     l1Endpoint,
 		L2:     l2Endpoint,
@@ -111,6 +116,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		ConductorRpcTimeout: ctx.Duration(flags.ConductorRpcTimeoutFlag.Name),
 
 		Plasma: plasma.ReadCLIConfig(ctx),
+
+		Superchain: superchainCfg,
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {

--- a/op-service/rpc/service.go
+++ b/op-service/rpc/service.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Service struct {
+	log     log.Logger
+	srv     *Server
+	stopped atomic.Bool
+}
+
+func NewService(log log.Logger, srv *Server) *Service {
+	return &Service{log: log, srv: srv, stopped: atomic.Bool{}}
+}
+
+func (s *Service) Start(_ context.Context) error {
+	log.Info("starting rpc server")
+	return s.srv.Start()
+}
+
+func (s *Service) Stop(_ context.Context) error {
+	if s.stopped.Load() {
+		return nil
+	}
+
+	log.Info("stopping rpc server")
+	err := s.srv.Stop()
+	if err == nil {
+		s.stopped.Store(true)
+	}
+
+	return err
+}
+
+func (s *Service) Stopped() bool {
+	return s.stopped.Load()
+}

--- a/op-service/rpc/service.go
+++ b/op-service/rpc/service.go
@@ -18,7 +18,7 @@ func NewService(log log.Logger, srv *Server) *Service {
 }
 
 func (s *Service) Start(_ context.Context) error {
-	log.Info("starting rpc server")
+	s.log.Info("starting rpc server")
 	return s.srv.Start()
 }
 
@@ -27,7 +27,7 @@ func (s *Service) Stop(_ context.Context) error {
 		return nil
 	}
 
-	log.Info("stopping rpc server")
+	s.log.Info("stopping rpc server")
 	err := s.srv.Stop()
 	if err == nil {
 		s.stopped.Store(true)

--- a/op-service/solabi/util.go
+++ b/op-service/solabi/util.go
@@ -82,6 +82,21 @@ func ReadUint256(r io.Reader) (*big.Int, error) {
 	return new(big.Int).SetBytes(n[:]), nil
 }
 
+func ReadBytes(r io.Reader) ([]byte, error) {
+	byteLen, err := ReadUint64(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read byte length")
+	}
+
+	paddedByteLength := byteLen + (32 - (byteLen % 32))
+	n := make([]byte, paddedByteLength)
+	if _, err := io.ReadFull(r, n[:]); err != nil {
+		return nil, err
+	}
+
+	return n[:byteLen], nil
+}
+
 func EmptyReader(r io.Reader) bool {
 	var t [1]byte
 	n, err := r.Read(t[:])

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -96,7 +96,8 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	// ChainID Invariant.
 	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
 	//   When the predeploy is added, this needs to be tied to the dependency set registered on-chain
-	l2Node, ok := b.l2PeerNodes[id.ChainId]
+	//   TODO: Either assume chain id never exceeds uint64 or handle this appropriately
+	l2Node, ok := b.l2PeerNodes[id.ChainId.Uint64()]
 	if !ok {
 		return Invalid, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
 	}
@@ -107,7 +108,7 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	// Since eth_getLogs doesn't support specifying the log index, we fetch
 	// all the outbox reciepts for this block (TODO: add address filter). The
 	// timestamp is grabbed via the block header as getLogs omits this
-	blockNumber := hexutil.EncodeUint64(id.BlockNumber)
+	blockNumber := hexutil.EncodeBig(id.BlockNumber)
 	filterArgs := map[string]interface{}{"fromBlock": blockNumber, "toBlock": blockNumber}
 	batchElems := make([]rpc.BatchElem, 2)
 	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockNumber, false}, Result: &header}

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type SuperchainBackend interface {
+type Backend interface {
 	MessageSafety(context.Context, MessageIdentifier, hexutil.Bytes) (MessageSafetyLabel, error)
 }
 
@@ -32,7 +31,7 @@ type backend struct {
 	l2PeerNodes map[uint64]client.RPC
 }
 
-func NewSuperchainBackend(ctx context.Context, log log.Logger, m metrics.Factory, cfg *SuperchainConfig) (SuperchainBackend, error) {
+func NewBackend(ctx context.Context, log log.Logger, m metrics.Factory, cfg *Config) (Backend, error) {
 	log = log.New("module", "superchain")
 	backend := backend{log: log, l2PeerNodes: map[uint64]client.RPC{}}
 
@@ -50,48 +49,31 @@ func NewSuperchainBackend(ctx context.Context, log log.Logger, m metrics.Factory
 		backend.l2PeerNodes[chainId] = l2Node
 	}
 
-	/** eth.PollBlockChanges expects an L1BlocksRefSources so we'll use this tooling for now **/
-	cacheMetrics := metrics.NewCacheMetrics(m, "superchain", "l2_source_cache", "L2 Source Cache")
-	l2ClientConfig := sources.L1ClientConfig{
-		L1BlockRefsCacheSize: 10,
-		EthClientConfig: sources.EthClientConfig{
-			TrustRPC:              true,
-			MaxConcurrentRequests: 10,
-			MaxRequestsPerBatch:   10,
-			TransactionsCacheSize: 10,
-			HeadersCacheSize:      10,
-			PayloadsCacheSize:     10,
-			RPCProviderKind:       sources.RPCKindAny,
-			MethodResetDuration:   time.Minute,
-		},
-	}
-
-	l2Client, err := sources.NewL1Client(l2Node, log, cacheMetrics, &l2ClientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct l2 client: %w", err)
-	}
-
 	// retrieve the current references before setting up the poll
-	finalizedHeadRef, err := l2Client.L1BlockRefByLabel(ctx, eth.Finalized)
+	l2BlockRefsClient := &blockRefsClient{l2Node}
+	finalizedHeadRef, err := l2BlockRefsClient.L1BlockRefByLabel(ctx, eth.Finalized)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query finalized block ref: %w", err)
 	}
 
 	backend.l2FinalizedBlockRef = &finalizedHeadRef
+	log.Info("detected finalized head", "number", finalizedHeadRef.Number, "hash", finalizedHeadRef.Hash)
+
 	l2FinalizedHeadSignal := func(ctx context.Context, sig eth.L1BlockRef) {
+		log.Info("new finalized head", "number", sig.Number, "hash", sig.Hash)
 		backend.mu.Lock()
 		backend.l2FinalizedBlockRef = &sig
 		backend.mu.Unlock()
 	}
 
-	pollInterval, timeout := time.Second*12*32, time.Second*10
-	backend.l2FinalizedHeadSub = eth.PollBlockChanges(log, l2Client, l2FinalizedHeadSignal, eth.Finalized, pollInterval, timeout)
+	pollInterval, timeout := time.Second, time.Second*10
+	backend.l2FinalizedHeadSub = eth.PollBlockChanges(log, l2BlockRefsClient, l2FinalizedHeadSignal, eth.Finalized, pollInterval, timeout)
 
 	return &backend, nil
 }
 
 func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, payloadBytes hexutil.Bytes) (MessageSafetyLabel, error) {
-	b.log.Info("message safety check", "chain_id", id.ChainId, "block_num", id.BlockNumber, "log_index", id.LogIndex)
+	b.log.Info("message safety check", "chain_id", id.ChainId, "block_number", id.BlockNumber, "log_index", id.LogIndex)
 
 	// ChainID Invariant.
 	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
@@ -99,7 +81,7 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	//   TODO: Either assume chain id never exceeds uint64 or handle this appropriately
 	l2Node, ok := b.l2PeerNodes[id.ChainId.Uint64()]
 	if !ok {
-		return Invalid, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
+		return MessageUnknown, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
 	}
 
 	var logs []types.Log
@@ -114,13 +96,13 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockNumber, false}, Result: &header}
 	batchElems[1] = rpc.BatchElem{Method: "eth_getLogs", Args: []interface{}{filterArgs}, Result: &logs}
 	if err := l2Node.BatchCallContext(ctx, batchElems); err != nil {
-		return Invalid, fmt.Errorf("unable to request logs: %w", err)
+		return MessageUnknown, fmt.Errorf("unable to request logs: %w", err)
 	}
 	if batchElems[0].Error != nil || batchElems[1].Error != nil {
-		return Invalid, fmt.Errorf("caught batch rpc failures: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
+		return MessageUnknown, fmt.Errorf("caught batch rpc failures: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
 	}
 	if header == nil {
-		return Invalid, fmt.Errorf("block %d does not exist", id.BlockNumber)
+		return MessageUnknown, fmt.Errorf("block %d does not exist", id.BlockNumber)
 	}
 
 	// Message Log Integrity
@@ -128,21 +110,21 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 
 	// TODO: If we filter by address, then this needs to change
 	if id.LogIndex >= uint64(len(logs)) {
-		return Invalid, fmt.Errorf("invalid log index")
+		return MessageInvalid, fmt.Errorf("invalid log index")
 	}
 
 	log := logs[id.LogIndex]
 	if id.LogIndex != uint64(log.Index) {
-		return Invalid, fmt.Errorf("message log index mismatch")
+		return MessageInvalid, fmt.Errorf("message log index mismatch")
 	}
 	if !bytes.Equal(payloadBytes, MessagePayloadBytes(&log)) {
-		return Invalid, fmt.Errorf("message payload bytes mismatch")
+		return MessageInvalid, fmt.Errorf("message payload bytes mismatch")
 	}
 	if id.Origin != log.Address {
-		return Invalid, fmt.Errorf("message origin mismatch")
+		return MessageInvalid, fmt.Errorf("message origin mismatch")
 	}
 	if id.Timestamp != header.Time {
-		return Invalid, fmt.Errorf("message timestamp mismatch")
+		return MessageInvalid, fmt.Errorf("message timestamp mismatch")
 	}
 
 	// Message Safety
@@ -155,10 +137,11 @@ func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, paylo
 	b.mu.RUnlock()
 
 	if id.Timestamp <= finalizedL2Timestamp {
-		return Finalized, nil
+		return MessageFinalized, nil
 	}
 
 	// TODO: support for the other safety labels
 
-	return Invalid, nil
+	// Cant determine validity
+	return MessageUnknown, nil
 }

--- a/op-superchain/backend.go
+++ b/op-superchain/backend.go
@@ -1,0 +1,163 @@
+package superchain
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type SuperchainBackend interface {
+	MessageSafety(context.Context, MessageIdentifier, hexutil.Bytes) (MessageSafetyLabel, error)
+}
+
+type backend struct {
+	log log.Logger
+	mu  sync.RWMutex
+
+	l2FinalizedHeadSub  ethereum.Subscription
+	l2FinalizedBlockRef *eth.L1BlockRef
+
+	l2PeerNodes map[uint64]client.RPC
+}
+
+func NewSuperchainBackend(ctx context.Context, log log.Logger, m metrics.Factory, cfg *SuperchainConfig) (SuperchainBackend, error) {
+	log = log.New("module", "superchain")
+	backend := backend{log: log, l2PeerNodes: map[uint64]client.RPC{}}
+
+	rpcOpts := []client.RPCOption{client.WithDialBackoff(10)}
+	l2Node, err := client.NewRPC(ctx, log, cfg.L2NodeAddr, rpcOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to L2 node: %w", err)
+	}
+
+	for chainId, l2NodeAddr := range cfg.PeerL2NodeAddrs {
+		l2Node, err := client.NewRPC(ctx, log, l2NodeAddr, rpcOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Peer L2 node, %d: %w", chainId, err)
+		}
+		backend.l2PeerNodes[chainId] = l2Node
+	}
+
+	/** eth.PollBlockChanges expects an L1BlocksRefSources so we'll use this tooling for now **/
+	cacheMetrics := metrics.NewCacheMetrics(m, "superchain", "l2_source_cache", "L2 Source Cache")
+	l2ClientConfig := sources.L1ClientConfig{
+		L1BlockRefsCacheSize: 10,
+		EthClientConfig: sources.EthClientConfig{
+			TrustRPC:              true,
+			MaxConcurrentRequests: 10,
+			MaxRequestsPerBatch:   10,
+			TransactionsCacheSize: 10,
+			HeadersCacheSize:      10,
+			PayloadsCacheSize:     10,
+			RPCProviderKind:       sources.RPCKindAny,
+			MethodResetDuration:   time.Minute,
+		},
+	}
+
+	l2Client, err := sources.NewL1Client(l2Node, log, cacheMetrics, &l2ClientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct l2 client: %w", err)
+	}
+
+	// retrieve the current references before setting up the poll
+	finalizedHeadRef, err := l2Client.L1BlockRefByLabel(ctx, eth.Finalized)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query finalized block ref: %w", err)
+	}
+
+	backend.l2FinalizedBlockRef = &finalizedHeadRef
+	l2FinalizedHeadSignal := func(ctx context.Context, sig eth.L1BlockRef) {
+		backend.mu.Lock()
+		backend.l2FinalizedBlockRef = &sig
+		backend.mu.Unlock()
+	}
+
+	pollInterval, timeout := time.Second*12*32, time.Second*10
+	backend.l2FinalizedHeadSub = eth.PollBlockChanges(log, l2Client, l2FinalizedHeadSignal, eth.Finalized, pollInterval, timeout)
+
+	return &backend, nil
+}
+
+func (b *backend) MessageSafety(ctx context.Context, id MessageIdentifier, payloadBytes hexutil.Bytes) (MessageSafetyLabel, error) {
+	b.log.Info("message safety check", "chain_id", id.ChainId, "block_num", id.BlockNumber, "log_index", id.LogIndex)
+
+	// ChainID Invariant.
+	//   TODO: Assumption here that the configured peers exactly maps to the registered dependency set.
+	//   When the predeploy is added, this needs to be tied to the dependency set registered on-chain
+	l2Node, ok := b.l2PeerNodes[id.ChainId]
+	if !ok {
+		return Invalid, fmt.Errorf("peer with chain id %d is not configured", id.ChainId)
+	}
+
+	var logs []types.Log
+	var header *types.Header
+
+	// Since eth_getLogs doesn't support specifying the log index, we fetch
+	// all the outbox reciepts for this block (TODO: add address filter). The
+	// timestamp is grabbed via the block header as getLogs omits this
+	blockNumber := hexutil.EncodeUint64(id.BlockNumber)
+	filterArgs := map[string]interface{}{"fromBlock": blockNumber, "toBlock": blockNumber}
+	batchElems := make([]rpc.BatchElem, 2)
+	batchElems[0] = rpc.BatchElem{Method: "eth_getBlockByNumber", Args: []interface{}{blockNumber, false}, Result: &header}
+	batchElems[1] = rpc.BatchElem{Method: "eth_getLogs", Args: []interface{}{filterArgs}, Result: &logs}
+	if err := l2Node.BatchCallContext(ctx, batchElems); err != nil {
+		return Invalid, fmt.Errorf("unable to request logs: %w", err)
+	}
+	if batchElems[0].Error != nil || batchElems[1].Error != nil {
+		return Invalid, fmt.Errorf("caught batch rpc failures: getBlockByNumber: %w, getLogs: %w", batchElems[0].Error, batchElems[1].Error)
+	}
+	if header == nil {
+		return Invalid, fmt.Errorf("block %d does not exist", id.BlockNumber)
+	}
+
+	// Message Log Integrity
+	// 	 -- BlockNumber & ChainID are handled via the RPC connection & inputs
+
+	// TODO: If we filter by address, then this needs to change
+	if id.LogIndex >= uint64(len(logs)) {
+		return Invalid, fmt.Errorf("invalid log index")
+	}
+
+	log := logs[id.LogIndex]
+	if id.LogIndex != uint64(log.Index) {
+		return Invalid, fmt.Errorf("message log index mismatch")
+	}
+	if !bytes.Equal(payloadBytes, MessagePayloadBytes(&log)) {
+		return Invalid, fmt.Errorf("message payload bytes mismatch")
+	}
+	if id.Origin != log.Address {
+		return Invalid, fmt.Errorf("message origin mismatch")
+	}
+	if id.Timestamp != header.Time {
+		return Invalid, fmt.Errorf("message timestamp mismatch")
+	}
+
+	// Message Safety
+	//   The block builder & verifier must locally enforce the timestamp invariant. This only
+	//   provides fidelity into the safety label of this message relative to its dependencies.
+
+	var finalizedL2Timestamp uint64
+	b.mu.RLock()
+	finalizedL2Timestamp = b.l2FinalizedBlockRef.Time
+	b.mu.RUnlock()
+
+	if id.Timestamp <= finalizedL2Timestamp {
+		return Finalized, nil
+	}
+
+	// TODO: support for the other safety labels
+
+	return Invalid, nil
+}

--- a/op-superchain/cli.go
+++ b/op-superchain/cli.go
@@ -1,0 +1,102 @@
+package superchain
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	L2FlagName      = "l2"
+	L2PeersFlagName = "l2-peers"
+)
+
+func superchainEnv(envprefix, v string) []string {
+	return []string{envprefix + "_SUPERCHAIN_" + v}
+}
+
+func parseMapFlag(input string) (map[string]string, error) {
+	result := map[string]string{}
+	pairs := strings.Split(input, ",")
+	for _, pair := range pairs {
+		keyValue := strings.Split(pair, "=")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("Invalid key-value pair: %s\n", pair)
+		}
+		result[strings.TrimSpace(keyValue[0])] = strings.TrimSpace(keyValue[1])
+	}
+	return result, nil
+}
+
+func L2PeersFlag(envPrefix string) cli.Flag {
+	return &cli.StringFlag{
+		Name:    L2PeersFlagName,
+		Usage:   "List of L2 Peers JSON-rpc endpoints. 'chain1=url1,chain2=url2...'",
+		Value:   "",
+		EnvVars: superchainEnv(envPrefix, "L2_PEERS_ETH_RPCS"),
+	}
+}
+
+func CLIFlags(envPrefix string) []cli.Flag {
+	return []cli.Flag{
+		L2PeersFlag(envPrefix),
+		&cli.StringFlag{
+			Name:    L2FlagName,
+			Usage:   "Address of L2 JSON-RPC endpoint to use (eth namespace required)",
+			Value:   "http://127.0.0.1:9545",
+			EnvVars: superchainEnv(envPrefix, "L2_ETH_RPC"),
+		},
+	}
+}
+
+type CLIConfig struct {
+	L2RPCUrl      string
+	L2PeersRPCUrl string
+}
+
+func (c CLIConfig) Check() error {
+	if c.L2RPCUrl == "" {
+		return errors.New("missing l2 rpc")
+	}
+
+	l2PeersMap, err := parseMapFlag(c.L2PeersRPCUrl)
+	if err != nil {
+		return fmt.Errorf("l2 peer rpcs encoded incorrectly: %w", err)
+	}
+	for id, _ := range l2PeersMap {
+		_, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return fmt.Errorf("unable to parse chain id (%s): %w", id, err)
+		}
+	}
+
+	return nil
+}
+
+func (c CLIConfig) Config() (*Config, error) {
+	cfg := &Config{L2NodeAddr: c.L2PeersRPCUrl, PeerL2NodeAddrs: map[uint64]string{}}
+
+	l2PeersMap, err := parseMapFlag(c.L2PeersRPCUrl)
+	if err != nil {
+		return nil, fmt.Errorf("l2 peer rpcs encoded incorrectly: %w", err)
+	}
+	for id, url := range l2PeersMap {
+		chainId, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse chain id: %w", err)
+		}
+		cfg.PeerL2NodeAddrs[chainId] = url
+	}
+
+	return cfg, nil
+}
+
+func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+	return CLIConfig{
+		L2RPCUrl:      ctx.String(L2FlagName),
+		L2PeersRPCUrl: ctx.String(L2PeersFlagName),
+	}
+}

--- a/op-superchain/client.go
+++ b/op-superchain/client.go
@@ -1,0 +1,35 @@
+package superchain
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// In order to allow op-node/rollup/derive to depend on this, we cannot have a dependency
+// on op-service/sources as it has a dependency on op-node. Until we fix this, we create
+// an alternative head source here.
+
+type L1BlockRefsSource interface {
+	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
+}
+
+type blockRefsClient struct {
+	clnt client.RPC
+}
+
+func (b *blockRefsClient) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
+	var head *types.Header
+	err := b.clnt.CallContext(ctx, &head, "eth_getBlockByNumber", label.Arg(), false)
+	if err != nil {
+		return eth.L1BlockRef{}, err
+	}
+	if head == nil {
+		return eth.L1BlockRef{}, ethereum.NotFound
+	}
+
+	return eth.L1BlockRef{Hash: head.Hash(), Number: head.Number.Uint64(), ParentHash: head.ParentHash, Time: head.Time}, nil
+}

--- a/op-superchain/cmd/main.go
+++ b/op-superchain/cmd/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	gethRPC "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	superchain "github.com/ethereum-optimism/optimism/op-superchain"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	GitCommit    = ""
+	GitDate      = ""
+	EnvVarPrefix = "OP_SUPERCHAIN"
+)
+
+func prefixEnvVars(name string) []string {
+	return []string{EnvVarPrefix + "_" + name}
+}
+
+func parseMapFlag(input string) (map[string]string, error) {
+	result := map[string]string{}
+	pairs := strings.Split(input, ",")
+	for _, pair := range pairs {
+		keyValue := strings.Split(pair, "=")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("Invalid key-value pair: %s\n", pair)
+		}
+		result[strings.TrimSpace(keyValue[0])] = strings.TrimSpace(keyValue[1])
+	}
+	return result, nil
+}
+
+// Flags
+var (
+	/** Required SuperchainBackend Flags **/
+	L2NodeAddr = &cli.StringFlag{
+		Name:    "l2",
+		Usage:   "Address of L2 User JSON-RPC endpoint to use (eth namespace required)",
+		Value:   "http://127.0.0.1:9545",
+		EnvVars: prefixEnvVars("L2_ETH_RPC"),
+	}
+	L2PeersNodeAddrs = &cli.StringFlag{
+		Name:    "l2-peers",
+		Usage:   "List of L2 Peers JSON-rpc endpoints. 'chain1=url1,chain2=url2...'",
+		Value:   "",
+		EnvVars: prefixEnvVars("L2_PEERS_ETH_RPCS"),
+	}
+)
+
+func main() {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Version = params.VersionWithCommit(GitCommit, GitDate)
+	app.Name = "op-superchain"
+	app.Usage = "Optimism Superchain Messaging Backend"
+	app.Description = "Runs the superchain messaging backend"
+	app.Action = cliapp.LifecycleCmd(SuperchainBackendMain)
+
+	logFlags := oplog.CLIFlags(EnvVarPrefix)
+	rpcFlags := rpc.CLIFlags(EnvVarPrefix)
+	backendFlags := []cli.Flag{L2NodeAddr, L2PeersNodeAddrs}
+	app.Flags = append(append(backendFlags, rpcFlags...), logFlags...)
+
+	ctx := opio.WithInterruptBlocker(context.Background())
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		log.Crit("Application Failed", "err", err)
+	}
+}
+
+func SuperchainBackendMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx))
+	m := metrics.With(metrics.NewRegistry())
+
+	cfg := superchain.SuperchainConfig{
+		L2NodeAddr:      ctx.String(L2NodeAddr.Name),
+		PeerL2NodeAddrs: map[uint64]string{},
+	}
+
+	l2PeersMap, err := parseMapFlag(ctx.String(L2PeersNodeAddrs.Name))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse list of peers: %w", err)
+	}
+	for id, url := range l2PeersMap {
+		chainId, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse chain id: %w", err)
+		}
+		cfg.PeerL2NodeAddrs[chainId] = url
+	}
+
+	s, err := superchain.NewSuperchainBackend(ctx.Context, log, m, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to start superchain backend: %w", err)
+	}
+
+	rpcConfig := rpc.ReadCLIConfig(ctx)
+	rpcApis := []gethRPC.API{{Namespace: "superchain", Service: s}}
+	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpc.WithAPIs(rpcApis))
+	return rpc.NewService(log, rpcServer), nil
+}

--- a/op-superchain/cmd/main.go
+++ b/op-superchain/cmd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -44,36 +43,19 @@ func parseMapFlag(input string) (map[string]string, error) {
 	return result, nil
 }
 
-// Flags
-var (
-	/** Required SuperchainBackend Flags **/
-	L2NodeAddr = &cli.StringFlag{
-		Name:    "l2",
-		Usage:   "Address of L2 User JSON-RPC endpoint to use (eth namespace required)",
-		Value:   "http://127.0.0.1:9545",
-		EnvVars: prefixEnvVars("L2_ETH_RPC"),
-	}
-	L2PeersNodeAddrs = &cli.StringFlag{
-		Name:    "l2-peers",
-		Usage:   "List of L2 Peers JSON-rpc endpoints. 'chain1=url1,chain2=url2...'",
-		Value:   "",
-		EnvVars: prefixEnvVars("L2_PEERS_ETH_RPCS"),
-	}
-)
-
 func main() {
 	oplog.SetupDefaults()
 
 	app := cli.NewApp()
 	app.Version = params.VersionWithCommit(GitCommit, GitDate)
 	app.Name = "op-superchain"
-	app.Usage = "Optimism Superchain Messaging Backend"
-	app.Description = "Runs the superchain messaging backend"
+	app.Usage = "Optimism Superchain Backend"
+	app.Description = "Runs the superchain backend"
 	app.Action = cliapp.LifecycleCmd(SuperchainBackendMain)
 
 	logFlags := oplog.CLIFlags(EnvVarPrefix)
 	rpcFlags := rpc.CLIFlags(EnvVarPrefix)
-	backendFlags := []cli.Flag{L2NodeAddr, L2PeersNodeAddrs}
+	backendFlags := superchain.CLIFlags(EnvVarPrefix)
 	app.Flags = append(append(backendFlags, rpcFlags...), logFlags...)
 
 	ctx := opio.WithInterruptBlocker(context.Background())
@@ -86,30 +68,20 @@ func SuperchainBackendMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (
 	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx))
 	m := metrics.With(metrics.NewRegistry())
 
-	cfg := superchain.SuperchainConfig{
-		L2NodeAddr:      ctx.String(L2NodeAddr.Name),
-		PeerL2NodeAddrs: map[uint64]string{},
-	}
-
-	l2PeersMap, err := parseMapFlag(ctx.String(L2PeersNodeAddrs.Name))
+	cfg, err := superchain.ReadCLIConfig(ctx).Config()
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse list of peers: %w", err)
-	}
-	for id, url := range l2PeersMap {
-		chainId, err := strconv.ParseUint(id, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse chain id: %w", err)
-		}
-		cfg.PeerL2NodeAddrs[chainId] = url
+		return nil, fmt.Errorf("unable to parse superchain flags: %w", err)
 	}
 
-	s, err := superchain.NewSuperchainBackend(ctx.Context, log, m, &cfg)
+	backend, err := superchain.NewBackend(ctx.Context, log, m, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start superchain backend: %w", err)
 	}
 
 	rpcConfig := rpc.ReadCLIConfig(ctx)
-	rpcApis := []gethRPC.API{{Namespace: "superchain", Service: s}}
-	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpc.WithAPIs(rpcApis))
+	rpcApis := []gethRPC.API{{Namespace: "superchain", Service: backend}}
+	rpcOpts := []rpc.ServerOption{rpc.WithAPIs(rpcApis), rpc.WithLogger(log)}
+
+	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpcOpts...)
 	return rpc.NewService(log, rpcServer), nil
 }

--- a/op-superchain/config.go
+++ b/op-superchain/config.go
@@ -1,0 +1,13 @@
+package superchain
+
+type SuperchainConfig struct {
+	// Simply take in the node addresses directly for now. We
+	// may want to expand and accept more general endpoint
+	// configuration like RateLimits, MaxConcurrency, etc
+
+	// If we want op-node to use this as a library rather than an
+	// external service, configuration should be extensible to support
+	// plugging in configured client tooling that's ready to use.
+	L2NodeAddr      string
+	PeerL2NodeAddrs map[uint64]string
+}

--- a/op-superchain/config.go
+++ b/op-superchain/config.go
@@ -1,6 +1,6 @@
 package superchain
 
-type SuperchainConfig struct {
+type Config struct {
 	// Simply take in the node addresses directly for now. We
 	// may want to expand and accept more general endpoint
 	// configuration like RateLimits, MaxConcurrency, etc

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -21,11 +21,6 @@ type MessageIdentifier struct {
 	ChainId     uint64
 }
 
-type MessagePayload struct {
-	// changes: not the entire log
-	Log *types.Log
-}
-
 func MessagePayloadBytes(log *types.Log) []byte {
 	msg := []byte{}
 	for _, topic := range log.Topics {

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -1,18 +1,30 @@
 package superchain
 
 import (
+	"bytes"
+	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/solabi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	crossL2InboxAddr                  = common.Address{}
+	inboxExecuteMessageSignature      = "executeMessage((address,uint256,uint256,uint256,uint256),address,bytes)"
+	inboxExecuteMessageBytes4         = crypto.Keccak256([]byte(inboxExecuteMessageSignature))[:4]
+	inboxExecuteMessagePayloadDataLoc = common.HexToHash("0xe0")
 )
 
 type MessageSafetyLabel int
 
 const (
-	Invalid MessageSafetyLabel = iota
-	Safe
-	Finalized
+	MessageUnknown MessageSafetyLabel = iota - 1
+	MessageInvalid
+	MessageSafe
+	MessageFinalized
 )
 
 type MessageIdentifier struct {
@@ -29,4 +41,61 @@ func MessagePayloadBytes(log *types.Log) []byte {
 		msg = append(msg, topic.Bytes()...)
 	}
 	return append(msg, log.Data...)
+}
+
+// Parse the transaction data posted to the inbox `executeMessage` function, extracing it's parameters
+func ParseInboxExecuteMessageTxData(txData []byte) (common.Address, MessageIdentifier, []byte, error) {
+	var target common.Address
+	var id MessageIdentifier
+
+	r := bytes.NewReader(txData)
+
+	// Validate Function Signature
+	_, err := solabi.ReadAndValidateSignature(r, inboxExecuteMessageBytes4)
+	if err != nil {
+		return target, id, nil, err
+	}
+
+	// Read Identifier
+	id.Origin, err = solabi.ReadAddress(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier origin: %w", err)
+	}
+	id.BlockNumber, err = solabi.ReadUint256(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier block number: %w", err)
+	}
+	id.LogIndex, err = solabi.ReadUint64(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier log index: %w", err)
+	}
+	id.Timestamp, err = solabi.ReadUint64(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier timestamp: %w", err)
+	}
+	id.ChainId, err = solabi.ReadUint256(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read identifier chain id: %w", err)
+	}
+
+	// Read target
+	target, err = solabi.ReadAddress(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read target: %w", err)
+	}
+
+	// Read Message Bytes
+	dataLoc, err := solabi.ReadHash(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read message data loc: %w", err)
+	}
+	if dataLoc != inboxExecuteMessagePayloadDataLoc {
+		return target, id, nil, fmt.Errorf("mismatched message data loc. Got %s, Expected: %s", dataLoc, inboxExecuteMessagePayloadDataLoc)
+	}
+	message, err := solabi.ReadBytes(r)
+	if err != nil {
+		return target, id, nil, fmt.Errorf("failed to read message: %w", err)
+	}
+
+	return target, id, message, nil
 }

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -1,6 +1,8 @@
 package superchain
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -15,10 +17,10 @@ const (
 
 type MessageIdentifier struct {
 	Origin      common.Address
-	BlockNumber uint64
+	BlockNumber *big.Int
 	LogIndex    uint64
 	Timestamp   uint64
-	ChainId     uint64
+	ChainId     *big.Int
 }
 
 func MessagePayloadBytes(log *types.Log) []byte {

--- a/op-superchain/message.go
+++ b/op-superchain/message.go
@@ -1,0 +1,35 @@
+package superchain
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type MessageSafetyLabel int
+
+const (
+	Invalid MessageSafetyLabel = iota
+	Safe
+	Finalized
+)
+
+type MessageIdentifier struct {
+	Origin      common.Address
+	BlockNumber uint64
+	LogIndex    uint64
+	Timestamp   uint64
+	ChainId     uint64
+}
+
+type MessagePayload struct {
+	// changes: not the entire log
+	Log *types.Log
+}
+
+func MessagePayloadBytes(log *types.Log) []byte {
+	msg := []byte{}
+	for _, topic := range log.Topics {
+		msg = append(msg, topic.Bytes()...)
+	}
+	return append(msg, log.Data...)
+}

--- a/op-superchain/message_test.go
+++ b/op-superchain/message_test.go
@@ -1,0 +1,62 @@
+package superchain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	BytesType, _   = abi.NewType("bytes", "", nil)
+	AddressType, _ = abi.NewType("address", "", nil)
+	MsgIdType, _   = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "origin", Type: "address"},
+		{Name: "blockNumber", Type: "uint256"},
+
+		// for simplicity use uint64 since these go fields as parameterized
+		// this way. makes no difference to the abi encoding of the tuple
+		{Name: "logIndex", Type: "uint64"},
+		{Name: "timestamp", Type: "uint64"},
+
+		{Name: "chainId", Type: "uint256"},
+	})
+
+	ExecuteMessageMethod = abi.NewMethod(
+		"executeMessage", // name
+		"executeMessage", // raw name
+		abi.Function,     // fn type
+		"",               // mutability
+		false,            // isConst
+		false,            // isPayable
+		abi.Arguments{{Type: MsgIdType}, {Type: AddressType}, {Type: BytesType}}, // inputs
+		abi.Arguments{}, // ouputs
+	)
+)
+
+func TestParseInboxExecuteMessageUnpacking(t *testing.T) {
+	msgId := MessageIdentifier{common.HexToAddress("0xa"), big.NewInt(10), 1, 1, big.NewInt(10)}
+	msgTarget := common.HexToAddress("0xb")
+
+	calldata, err := ExecuteMessageMethod.Inputs.Pack(msgId, msgTarget, []byte{byte(1)})
+	require.NoError(t, err)
+
+	target, id, msg, err := ParseInboxExecuteMessageTxData(append(inboxExecuteMessageBytes4, calldata...))
+	require.NoError(t, err)
+
+	// target
+	require.Equal(t, target, msgTarget)
+
+	// id
+	require.Equal(t, msgId.Origin, id.Origin)
+	require.Equal(t, msgId.BlockNumber.Uint64(), id.BlockNumber.Uint64())
+	require.Equal(t, msgId.LogIndex, id.LogIndex)
+	require.Equal(t, msgId.Timestamp, id.Timestamp)
+	require.Equal(t, msgId.ChainId.Uint64(), id.ChainId.Uint64())
+
+	// msg
+	require.Len(t, msg, 1)
+	require.Equal(t, msg[0], byte(1))
+}


### PR DESCRIPTION
Allow op-node to hook into the superchain backend in configuration.

Cross-L2 Block invalidation :
- CrossL2 implements the `AttributesFilterer` interface. If an invalid
cross-l2 transaction is observed, the `resetPendingSafe` flag is set
- When trying the next safe attributes, this flag is checked on the attributes
and the pending safe head is reset back to the known safe head while dropping
the attributes. The batch_queue will progress and look for the next batch


_Note:_ This implementation keeps the derivation pipeline consistent with the existing
rules (batches are dropped with invalid txs). We'll be following with a proposal to change
this such that invalidated batches are not dropped and instead converted into deposits-only empty
blocks