### PR TITLE
feat(op-e2e): Bond Claiming Tests

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -445,7 +445,7 @@ func TestGameWindow(t *testing.T) {
 	})
 
 	t.Run("ParsesDefault", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--game-window=264h"))
+		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--game-window=360h"))
 		require.Equal(t, config.DefaultGameWindow, cfg.GameWindow)
 	})
 }

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -79,9 +79,9 @@ const (
 	DefaultCannonInfoFreq     = uint(10_000_000)
 	// DefaultGameWindow is the default maximum time duration in the past
 	// that the challenger will look for games to progress.
-	// The default value is 11 days, which is a 4 day resolution buffer
+	// The default value is 15 days, which is an 8 day resolution buffer
 	// and bond claiming buffer plus the 7 day game finalization window.
-	DefaultGameWindow   = time.Duration(11 * 24 * time.Hour)
+	DefaultGameWindow   = time.Duration(15 * 24 * time.Hour)
 	DefaultMaxPendingTx = 10
 )
 

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -250,6 +250,7 @@ func (s *Service) initMonitor(cfg *config.Config) {
 func (s *Service) Start(ctx context.Context) error {
 	s.logger.Info("starting scheduler")
 	s.sched.Start(ctx)
+	s.claimer.Start(ctx)
 	s.preimages.Start(ctx)
 	s.logger.Info("starting monitoring")
 	s.monitor.StartMonitoring()

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -42,12 +42,6 @@ type Helper struct {
 
 type Option func(config2 *config.Config)
 
-func WithClaimants(claimants ...common.Address) Option {
-	return func(c *config.Config) {
-		c.AdditionalBondClaimants = append(c.AdditionalBondClaimants, claimants...)
-	}
-}
-
 func WithFactoryAddress(addr common.Address) Option {
 	return func(c *config.Config) {
 		c.GameFactoryAddress = addr

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -42,6 +42,12 @@ type Helper struct {
 
 type Option func(config2 *config.Config)
 
+func WithClaimants(claimants ...common.Address) Option {
+	return func(c *config.Config) {
+		c.AdditionalBondClaimants = append(c.AdditionalBondClaimants, claimants...)
+	}
+}
+
 func WithFactoryAddress(addr common.Address) Option {
 	return func(c *config.Config) {
 		c.GameFactoryAddress = addr

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -70,6 +70,12 @@ func (g *OutputGameHelper) Addr() common.Address {
 	return g.addr
 }
 
+func (g *OutputGameHelper) Balance(ctx context.Context, addr common.Address) *big.Int {
+	balance, err := g.client.BalanceAt(ctx, addr, nil)
+	g.require.NoError(err, "Failed to get balance")
+	return balance
+}
+
 func (g *OutputGameHelper) SplitDepth(ctx context.Context) types.Depth {
 	splitDepth, err := g.game.SplitDepth(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err, "failed to load split depth")
@@ -163,6 +169,50 @@ func (g *OutputGameHelper) GameDuration(ctx context.Context) time.Duration {
 	duration, err := g.game.GameDuration(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err, "failed to get game duration")
 	return time.Duration(duration) * time.Second
+}
+
+func (g *OutputGameHelper) WaitForNoAvailableCredit(ctx context.Context, addr common.Address) {
+	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		bal, err := g.game.Credit(&bind.CallOpts{Context: timedCtx}, addr)
+		if err != nil {
+			return false, err
+		}
+		g.t.Log("Waiting for zero available credit", "current", bal, "addr", addr)
+		return bal.Cmp(big.NewInt(0)) == 0, nil
+	})
+	if err != nil {
+		g.LogGameData(ctx)
+		g.require.NoError(err, "Failed to wait for zero available credit")
+	}
+}
+
+func (g *OutputGameHelper) AvailableCredit(ctx context.Context, addr common.Address) *big.Int {
+	credit, err := g.game.Credit(&bind.CallOpts{Context: ctx}, addr)
+	g.require.NoErrorf(err, "Failed to fetch available credit for %v", addr)
+	return credit
+}
+
+func (g *OutputGameHelper) CreditUnlockDuration(ctx context.Context) time.Duration {
+	weth, err := g.game.Weth(&bind.CallOpts{Context: ctx})
+	g.require.NoError(err, "Failed to get WETH contract")
+	contract, err := bindings.NewDelayedWETH(weth, g.client)
+	g.require.NoError(err)
+	period, err := contract.Delay(&bind.CallOpts{Context: ctx})
+	g.require.NoError(err, "Failed to get WETH unlock period")
+	float, _ := period.Float64()
+	return time.Duration(float) * time.Second
+}
+
+func (g *OutputGameHelper) WethBalance(ctx context.Context, addr common.Address) *big.Int {
+	weth, err := g.game.Weth(&bind.CallOpts{Context: ctx})
+	g.require.NoError(err, "Failed to get WETH contract")
+	contract, err := bindings.NewDelayedWETH(weth, g.client)
+	g.require.NoError(err)
+	balance, err := contract.BalanceOf(&bind.CallOpts{Context: ctx}, addr)
+	g.require.NoError(err, "Failed to get WETH balance")
+	return balance
 }
 
 // WaitForClaimCount waits until there are at least count claims in the game.

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -95,13 +95,7 @@ func TestOutputCannon_ReclaimBond(t *testing.T) {
 
 	// Grab the root claim
 	claim := game.RootClaim(ctx)
-	game.StartChallenger(
-		ctx,
-		"sequencer",
-		"Challenger",
-		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
-		challenger.WithClaimants(alice),
-	)
+	game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	// Perform a few moves
 	claim = claim.WaitForCounterClaim(ctx)
@@ -139,9 +133,6 @@ func TestOutputCannon_ReclaimBond(t *testing.T) {
 	// Wait for alice to have no available credit
 	// aka, wait for the challenger to claim its credit
 	game.WaitForNoAvailableCredit(ctx, alice)
-
-	// Alice should have no available credit since it's been claimed
-	require.True(t, game.AvailableCredit(ctx, alice).Cmp(big.NewInt(0)) == 0)
 
 	// The dispute game delayed weth balance should be zero since it's all claimed
 	require.True(t, game.WethBalance(ctx, game.Addr()).Cmp(big.NewInt(0)) == 0)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/deployer"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/cannon"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
@@ -71,6 +72,79 @@ func TestOutputCannonGame(t *testing.T) {
 	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
+}
+
+func TestOutputCannon_ReclaimBond(t *testing.T) {
+	// The dishonest actor always posts claims with all zeros.
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, l1Client := startFaultDisputeSystem(t)
+	t.Cleanup(sys.Close)
+
+	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, common.Hash{})
+	game.LogGameData(ctx)
+
+	// The dispute game should have a zero balance
+	balance := game.WethBalance(ctx, game.Addr())
+	require.Zero(t, balance.Uint64())
+
+	alice := sys.Cfg.Secrets.Addresses().Alice
+	bal, _ := big.NewInt(0).SetString("1000000000000000000000", 10)
+	require.Equal(t, bal, game.Balance(ctx, alice))
+
+	// Grab the root claim
+	claim := game.RootClaim(ctx)
+	game.StartChallenger(
+		ctx,
+		"sequencer",
+		"Challenger",
+		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
+		challenger.WithClaimants(alice),
+	)
+
+	// Perform a few moves
+	claim = claim.WaitForCounterClaim(ctx)
+	game.LogGameData(ctx)
+	claim = claim.Attack(ctx, common.Hash{})
+	claim = claim.WaitForCounterClaim(ctx)
+	game.LogGameData(ctx)
+	claim = claim.Attack(ctx, common.Hash{})
+	game.LogGameData(ctx)
+	_ = claim.WaitForCounterClaim(ctx)
+
+	// Expect posted claims so the game balance is non-zero
+	balance = game.WethBalance(ctx, game.Addr())
+	expectedBalance, _ := big.NewInt(0).SetString("589772600000000000", 10)
+	require.Equal(t, expectedBalance, balance)
+
+	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
+	game.LogGameData(ctx)
+
+	// Expect Alice's credit to be non-zero
+	// But it can't be claimed right now since there is a delay on the weth unlock
+	expectedCredit, _ := big.NewInt(0).SetString("589772600000000000", 10)
+	require.Equal(t, expectedCredit, game.AvailableCredit(ctx, alice))
+
+	// The actor should have a small credit available to claim
+	actorCredit := game.AvailableCredit(ctx, deployer.TestAddress)
+	require.True(t, actorCredit.Cmp(big.NewInt(0)) == 0)
+
+	// Advance the time past the weth unlock delay
+	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
+	// Wait for alice to have no available credit
+	// aka, wait for the challenger to claim its credit
+	game.WaitForNoAvailableCredit(ctx, alice)
+
+	// Alice should have no available credit since it's been claimed
+	require.True(t, game.AvailableCredit(ctx, alice).Cmp(big.NewInt(0)) == 0)
+
+	// The dispute game delayed weth balance should be zero since it's all claimed
+	require.True(t, game.WethBalance(ctx, game.Addr()).Cmp(big.NewInt(0)) == 0)
 }
 
 func TestOutputCannon_ChallengeAllZeroClaim(t *testing.T) {


### PR DESCRIPTION
**Description**

Tests bond claiming by waiting for the challenger to claim all bonds and then checking actor balances.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/445
