### PR TITLE
feat(op-node): gater unblock

### DIFF
--- a/op-node/p2p/gating/expiry.go
+++ b/op-node/p2p/gating/expiry.go
@@ -46,7 +46,12 @@ func AddBanExpiry(gater BlockingConnectionGater, store ExpiryStore, log log.Logg
 }
 
 func (g *ExpiryConnectionGater) UnblockPeer(p peer.ID) error {
+	if err := g.BlockingConnectionGater.UnblockPeer(p); err != nil {
+		log.Warn("failed to unblock peer from underlying gater", "method", "UnblockPeer", "peer_id", p, "err", err)
+		return err
+	}
 	if err := g.store.SetPeerBanExpiration(p, time.Time{}); err != nil {
+		log.Warn("failed to unblock peer from expiry gater", "method", "UnblockPeer", "peer_id", p, "err", err)
 		return err
 	}
 	g.m.RecordPeerUnban()

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -159,7 +159,7 @@ func TestP2PFull(t *testing.T) {
 	require.False(t, nodeB.IsStatic(hostB.ID()), "node B must not be static peer of node B itself")
 
 	select {
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("failed to connect new host")
 	case c := <-conns:
 		require.Equal(t, hostB.ID(), c.RemotePeer())

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -379,8 +379,15 @@ func (s *APIBackend) DisconnectPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_disconnectPeer")
 	defer recordDur()
 	err := s.node.Host().Network().ClosePeer(id)
+	if err != nil {
+		return err
+	}
 	ps := s.node.Host().Peerstore()
 	ps.RemovePeer(id)
 	ps.ClearAddrs(id)
-	return err
+	err = s.node.ConnectionGater().UnblockPeer(id)
+	if err != nil {
+		return fmt.Errorf("closed peer but failed to unblock: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change implements the UnblockPeer in `ExpiryConnectionGater` so we can externally clear the node from being banned. It also automatically clears the state on authoritative disconnects.

**Tests**

`go test ./...`

**Meta**

Part of https://github.com/ethereum-optimism/devinfra-pod/issues/38
