### PR TITLE
op-challenger: Support claiming bonds for multiple addresses

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -472,6 +472,44 @@ func TestUnsafeAllowInvalidPrestate(t *testing.T) {
 	})
 }
 
+func TestAdditionalBondClaimants(t *testing.T) {
+	t.Run("DefaultsToEmpty", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--additional-bond-claimants"))
+		require.Empty(t, cfg.AdditionalBondClaimants)
+	})
+
+	t.Run("Valid-Single", func(t *testing.T) {
+		claimant := common.Address{0xaa}
+		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--additional-bond-claimants", claimant.Hex()))
+		require.Contains(t, cfg.AdditionalBondClaimants, claimant)
+		require.Len(t, cfg.AdditionalBondClaimants, 1)
+	})
+
+	t.Run("Valid-Multiple", func(t *testing.T) {
+		claimant1 := common.Address{0xaa}
+		claimant2 := common.Address{0xbb}
+		claimant3 := common.Address{0xcc}
+		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet,
+			"--additional-bond-claimants", fmt.Sprintf("%v,%v,%v", claimant1.Hex(), claimant2.Hex(), claimant3.Hex())))
+		require.Contains(t, cfg.AdditionalBondClaimants, claimant1)
+		require.Contains(t, cfg.AdditionalBondClaimants, claimant2)
+		require.Contains(t, cfg.AdditionalBondClaimants, claimant3)
+		require.Len(t, cfg.AdditionalBondClaimants, 3)
+	})
+
+	t.Run("Invalid-Single", func(t *testing.T) {
+		verifyArgsInvalid(t, "invalid additional claimant",
+			addRequiredArgs(config.TraceTypeAlphabet, "--additional-bond-claimants", "nope"))
+	})
+
+	t.Run("Invalid-Multiple", func(t *testing.T) {
+		claimant1 := common.Address{0xaa}
+		claimant2 := common.Address{0xbb}
+		verifyArgsInvalid(t, "invalid additional claimant",
+			addRequiredArgs(config.TraceTypeAlphabet, "--additional-bond-claimants", fmt.Sprintf("%v,nope,%v", claimant1.Hex(), claimant2.Hex())))
+	})
+}
+
 func verifyArgsInvalid(t *testing.T, messageContains string, cliArgs []string) {
 	_, _, err := dryRunWithArgs(cliArgs)
 	require.ErrorContains(t, err, messageContains)

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -99,6 +99,8 @@ type Config struct {
 	PollInterval         time.Duration    // Polling interval for latest-block subscription when using an HTTP RPC provider
 	AllowInvalidPrestate bool             // Whether to allow responding to games where the prestate does not match
 
+	AdditionalBondClaimants []common.Address // List of addresses to claim bonds for in addition to the tx manager sender
+
 	TraceTypes []TraceType // Type of traces supported
 
 	// Specific to the output cannon trace type

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -83,6 +83,11 @@ var (
 		EnvVars: prefixEnvVars("HTTP_POLL_INTERVAL"),
 		Value:   config.DefaultPollInterval,
 	}
+	AdditionalBondClaimants = &cli.StringSliceFlag{
+		Name:    "additional-bond-claimants",
+		Usage:   "List of addresses to claim bonds for, in addition to the configured transaction sender",
+		EnvVars: prefixEnvVars("ADDITIONAL_BOND_CLAIMANTS"),
+	}
 	CannonNetworkFlag = &cli.StringFlag{
 		Name: "cannon-network",
 		Usage: fmt.Sprintf(
@@ -163,6 +168,7 @@ var optionalFlags = []cli.Flag{
 	MaxConcurrencyFlag,
 	MaxPendingTransactionsFlag,
 	HTTPPollInterval,
+	AdditionalBondClaimants,
 	GameAllowlistFlag,
 	CannonNetworkFlag,
 	CannonRollupConfigFlag,
@@ -281,31 +287,42 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 	if maxConcurrency == 0 {
 		return nil, fmt.Errorf("%v must not be 0", MaxConcurrencyFlag.Name)
 	}
+	var claimants []common.Address
+	if ctx.IsSet(AdditionalBondClaimants.Name) {
+		for _, addrStr := range ctx.StringSlice(AdditionalBondClaimants.Name) {
+			claimant, err := opservice.ParseAddress(addrStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid additional claimant: %w", err)
+			}
+			claimants = append(claimants, claimant)
+		}
+	}
 	return &config.Config{
 		// Required Flags
-		L1EthRpc:               ctx.String(L1EthRpcFlag.Name),
-		L1Beacon:               ctx.String(L1BeaconFlag.Name),
-		TraceTypes:             traceTypes,
-		GameFactoryAddress:     gameFactoryAddress,
-		GameAllowlist:          allowedGames,
-		GameWindow:             ctx.Duration(GameWindowFlag.Name),
-		MaxConcurrency:         maxConcurrency,
-		MaxPendingTx:           ctx.Uint64(MaxPendingTransactionsFlag.Name),
-		PollInterval:           ctx.Duration(HTTPPollInterval.Name),
-		RollupRpc:              ctx.String(RollupRpcFlag.Name),
-		CannonNetwork:          ctx.String(CannonNetworkFlag.Name),
-		CannonRollupConfigPath: ctx.String(CannonRollupConfigFlag.Name),
-		CannonL2GenesisPath:    ctx.String(CannonL2GenesisFlag.Name),
-		CannonBin:              ctx.String(CannonBinFlag.Name),
-		CannonServer:           ctx.String(CannonServerFlag.Name),
-		CannonAbsolutePreState: ctx.String(CannonPreStateFlag.Name),
-		Datadir:                ctx.String(DatadirFlag.Name),
-		CannonL2:               ctx.String(CannonL2Flag.Name),
-		CannonSnapshotFreq:     ctx.Uint(CannonSnapshotFreqFlag.Name),
-		CannonInfoFreq:         ctx.Uint(CannonInfoFreqFlag.Name),
-		TxMgrConfig:            txMgrConfig,
-		MetricsConfig:          metricsConfig,
-		PprofConfig:            pprofConfig,
-		AllowInvalidPrestate:   ctx.Bool(UnsafeAllowInvalidPrestate.Name),
+		L1EthRpc:                ctx.String(L1EthRpcFlag.Name),
+		L1Beacon:                ctx.String(L1BeaconFlag.Name),
+		TraceTypes:              traceTypes,
+		GameFactoryAddress:      gameFactoryAddress,
+		GameAllowlist:           allowedGames,
+		GameWindow:              ctx.Duration(GameWindowFlag.Name),
+		MaxConcurrency:          maxConcurrency,
+		MaxPendingTx:            ctx.Uint64(MaxPendingTransactionsFlag.Name),
+		PollInterval:            ctx.Duration(HTTPPollInterval.Name),
+		AdditionalBondClaimants: claimants,
+		RollupRpc:               ctx.String(RollupRpcFlag.Name),
+		CannonNetwork:           ctx.String(CannonNetworkFlag.Name),
+		CannonRollupConfigPath:  ctx.String(CannonRollupConfigFlag.Name),
+		CannonL2GenesisPath:     ctx.String(CannonL2GenesisFlag.Name),
+		CannonBin:               ctx.String(CannonBinFlag.Name),
+		CannonServer:            ctx.String(CannonServerFlag.Name),
+		CannonAbsolutePreState:  ctx.String(CannonPreStateFlag.Name),
+		Datadir:                 ctx.String(DatadirFlag.Name),
+		CannonL2:                ctx.String(CannonL2Flag.Name),
+		CannonSnapshotFreq:      ctx.Uint(CannonSnapshotFreqFlag.Name),
+		CannonInfoFreq:          ctx.Uint(CannonInfoFreqFlag.Name),
+		TxMgrConfig:             txMgrConfig,
+		MetricsConfig:           metricsConfig,
+		PprofConfig:             pprofConfig,
+		AllowInvalidPrestate:    ctx.Bool(UnsafeAllowInvalidPrestate.Name),
 	}, nil
 }


### PR DESCRIPTION
**Description**

Allows the challenger to be configured to claim bonds for the proposer. Longer term, the proposer probably should be able to stand alone, but it already depends on the challenger to resolve the games it creates so having it also leave claiming bonds to the challenger isn't a big leap and doesn't make things any worse.

**Tests**

Unit tests added.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/641
- Will log a separate issue as a nice to have to make the proposer fully independent of the challenger.
