### PR TITLE
indexer: update format string for uuid.UUID

### DIFF
--- a/indexer/bigint/bigint.go
+++ b/indexer/bigint/bigint.go
@@ -8,7 +8,7 @@ var (
 )
 
 // Clamp returns a new big.Int for `end` to which `end - start` <= size.
-// @note (start, end) is an inclusive range
+// @note (start, end) is an inclusive range. This function assumes that `start` is not greater than `end`.
 func Clamp(start, end *big.Int, size uint64) *big.Int {
 	temp := new(big.Int)
 	count := temp.Sub(end, start).Uint64() + 1

--- a/indexer/database/bridge_messages.go
+++ b/indexer/database/bridge_messages.go
@@ -119,7 +119,7 @@ func (db bridgeMessagesDB) MarkRelayedL1BridgeMessage(messageHash common.Hash, r
 	if message.RelayedMessageEventGUID != nil && message.RelayedMessageEventGUID.ID() == relayEvent.ID() {
 		return nil
 	} else if message.RelayedMessageEventGUID != nil {
-		return fmt.Errorf("relayed message %s re-relayed with a different event %d", messageHash, relayEvent)
+		return fmt.Errorf("relayed message %s re-relayed with a different event %s", messageHash, relayEvent)
 	}
 
 	message.RelayedMessageEventGUID = &relayEvent

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS l2_block_headers (
     hash        VARCHAR PRIMARY KEY,
     parent_hash VARCHAR NOT NULL UNIQUE,
     number      UINT256 NOT NULL UNIQUE,
-    timestamp   INTEGER NOT NULL,
+    timestamp   INTEGER NOT NULL CHECK (timestamp > 0),
 
     -- Raw Data
     rlp_bytes VARCHAR NOT NULL


### PR DESCRIPTION
**Description**

This PR introduces several minor changes for `indexer`:
- 302cc940b30f6586195c06f679ccddf878e651a0    indexer: doc bigint.Clamp assumption
- 7f177fbb686b4a76ee0be1872eed5b2e6a828666    indexer: constraint l2_block_headers.timestamp > 0
- 19c5beca5f1988f255e07c6c2012a76af8e9b746    indexer: update format string for uuid.UUID
    The relayEvent variable is of type uuid.UUID, but it's being formatted as an
    integer (%d). This will cause a runtime error. Use %s to format the UUID as a
    string.