### PR TITLE
fix(op-challenger): Remove Verbose Claim Logging

### DIFF
--- a/op-challenger/game/fault/solver/game_rules_test.go
+++ b/op-challenger/game/fault/solver/game_rules_test.go
@@ -14,8 +14,6 @@ import (
 
 func verifyGameRules(t *testing.T, game types.Game, rootClaimCorrect bool) {
 	actualResult, claimTree, resolvedGame := gameResult(game)
-	t.Log("Resolved game:")
-	logClaims(t, resolvedGame)
 
 	verifyExpectedGameResult(t, rootClaimCorrect, actualResult)
 
@@ -90,10 +88,4 @@ func gameResult(game types.Game) (gameTypes.GameStatus, *disputeTypes.Bidirectio
 		resolvedClaims = append(resolvedClaims, *claim.Claim)
 	}
 	return result, tree, types.NewGameState(resolvedClaims, game.MaxDepth())
-}
-
-func logClaims(t *testing.T, game types.Game) {
-	for _, claim := range game.Claims() {
-		t.Log(printClaim(claim, game))
-	}
 }

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -180,7 +180,6 @@ func TestCalculateNextActions(t *testing.T) {
 			builder := claimBuilder.GameBuilder(faulttest.WithInvalidValue(!test.rootClaimCorrect))
 			test.setupGame(builder)
 			game := builder.Game
-			logClaims(t, game)
 
 			solver := NewGameSolver(maxDepth, trace.NewSimpleTraceAccessor(claimBuilder.CorrectTraceProvider()))
 			postState, actions := runStep(t, solver, game, claimBuilder.CorrectTraceProvider())
@@ -201,8 +200,6 @@ func runStep(t *testing.T, solver *GameSolver, game types.Game, correctTraceProv
 	require.NoError(t, err)
 
 	postState := applyActions(game, challengerAddr, actions)
-	t.Log("Post state:")
-	logClaims(t, postState)
 
 	for i, action := range actions {
 		t.Logf("Move %v: Type: %v, ParentIdx: %v, Attack: %v, Value: %v, PreState: %v, ProofData: %v",
@@ -288,7 +285,6 @@ func TestMultipleRounds(t *testing.T) {
 				claimBuilder := faulttest.NewAlphabetClaimBuilder(t, startingL2BlockNumber, maxDepth)
 				builder := claimBuilder.GameBuilder(faulttest.WithInvalidValue(!rootClaimCorrect))
 				game := builder.Game
-				logClaims(t, game)
 
 				correctTrace := claimBuilder.CorrectTraceProvider()
 				solver := NewGameSolver(maxDepth, trace.NewSimpleTraceAccessor(correctTrace))


### PR DESCRIPTION
**Description**

Removes the `logClaims` method in the `op-challenger` solver tests.
This logging was very verbose by default and cluttered testing.
