### PR TITLE
WIP: deactivate Ecotone for OPMainnet

### DIFF
--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -64,7 +64,7 @@ var mainnetCfg = rollup.Config{
 	RegolithTime:            u64Ptr(0),
 	CanyonTime:              u64Ptr(1704992401),
 	DeltaTime:               u64Ptr(1708560000),
-	EcotoneTime:             u64Ptr(1710374401),
+	EcotoneTime:             nil,
 	ProtocolVersionsAddress: common.HexToAddress("0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"),
 }
 

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -82,6 +82,12 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		deltaTime = new(uint64)
 	}
 
+	ecotoneTime := superChain.Config.EcotoneTime
+
+	if chainID == opMainnet {
+		ecotoneTime = nil // The Ecotone upgrade was vetoed
+	}
+
 	cfg := &Config{
 		Genesis: Genesis{
 			L1: eth.BlockID{
@@ -108,7 +114,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		RegolithTime:           &regolithTime,
 		CanyonTime:             superChain.Config.CanyonTime,
 		DeltaTime:              deltaTime,
-		EcotoneTime:            superChain.Config.EcotoneTime,
+		EcotoneTime:            ecotoneTime,
 		FjordTime:              superChain.Config.FjordTime,
 		BatchInboxAddress:      common.Address(chConfig.BatchInboxAddr),
 		DepositContractAddress: common.Address(addrs.OptimismPortalProxy),


### PR DESCRIPTION
This is in preparation in case there is a veto of the Ecotone network upgrade.