### PR TITLE
feat: add service for creating and relaying withdrawals

### DIFF
--- a/.changeset/funny-ravens-matter.md
+++ b/.changeset/funny-ravens-matter.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Updates getMessageStatus to throw when a proposal has been invalidated.

--- a/.changeset/light-pumas-taste.md
+++ b/.changeset/light-pumas-taste.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Fixes a bug that would result in some variables including "L1" to have the wrong corresponding environment variable.

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -151,7 +151,7 @@ export abstract class BaseServiceV2<
      */
     const opSnakeCase = (str: string) => {
       const reg = /l_1|l_2/g
-      const repl = str.includes('l1') ? 'l1' : 'l2'
+      const repl = str.toLowerCase().includes('l1') ? 'l1' : 'l2'
       return snakeCase(str).replace(reg, repl)
     }
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "devDependencies": {
+    "@eth-optimism/common-ts": "workspace:^",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",

--- a/packages/sdk/scripts/fpac-auto-withdrawals.ts
+++ b/packages/sdk/scripts/fpac-auto-withdrawals.ts
@@ -1,0 +1,295 @@
+import {
+  BaseServiceV2,
+  StandardOptions,
+  Counter,
+  validators,
+  Gauge,
+} from '@eth-optimism/common-ts'
+import { ethers } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+import { getChainId } from '@eth-optimism/core-utils'
+
+import { CrossChainMessenger, MessageStatus, TokenBridgeMessage } from '../src'
+
+type WithdrawerOptions = {
+  startingBlockNumber: number
+  addrOptimismPortal: string
+  addrDisputeGameFactory: string
+  addrL1CrossDomainMessenger: string
+  addrL1StandardBridge: string
+  l1RpcProvider: Provider
+  l2RpcProvider: Provider
+  key: string
+}
+
+type WithdrawerMetrics = {
+  withdrawalsActive: Gauge
+  withdrawalsCreated: Counter
+  withdrawalsProven: Counter
+  withdrawalsFinalized: Counter
+  withdrawalsReproven: Counter
+  highestSyncedBlock: Gauge
+  highestKnownBlock: Gauge
+}
+
+type WithdrawerState = {
+  messenger: CrossChainMessenger
+  withdrawals: TokenBridgeMessage[]
+  finalized: TokenBridgeMessage[]
+  highestSyncedBlock: number
+}
+
+export class WithdrawerService extends BaseServiceV2<
+  WithdrawerOptions,
+  WithdrawerMetrics,
+  WithdrawerState
+> {
+  constructor(options?: Partial<WithdrawerOptions & StandardOptions>) {
+    super({
+      version: '0.0.1',
+      name: 'fpac-auto-withdrawals',
+      loop: true,
+      options: {
+        loopIntervalMs: 60_000,
+        ...options,
+      },
+      optionsSpec: {
+        startingBlockNumber: {
+          validator: validators.num,
+          desc: 'Block number to start syncing from',
+          default: 0,
+          public: true,
+        },
+        addrOptimismPortal: {
+          validator: validators.str,
+          desc: 'Address of the OptimismPortal proxy contract',
+          public: true,
+        },
+        addrDisputeGameFactory: {
+          validator: validators.str,
+          desc: 'Address of the DisputeGameFactory proxy contract',
+          public: true,
+        },
+        addrL1CrossDomainMessenger: {
+          validator: validators.str,
+          desc: 'Address of the L1CrossDomainMessenger proxy contract',
+          public: true,
+        },
+        addrL1StandardBridge: {
+          validator: validators.str,
+          desc: 'Address of the L1StandardBridge proxy contract',
+          public: true,
+        },
+        l1RpcProvider: {
+          validator: validators.provider,
+          desc: 'Provider for L1 network to connect to',
+        },
+        l2RpcProvider: {
+          validator: validators.provider,
+          desc: 'Provider for L2 network to connect to',
+        },
+        key: {
+          validator: validators.str,
+          desc: 'Private key to use for signing transactions',
+        },
+      },
+      metricsSpec: {
+        withdrawalsActive: {
+          type: Gauge,
+          desc: 'Number of active withdrawals',
+        },
+        withdrawalsCreated: {
+          type: Counter,
+          desc: 'Number of withdrawals created',
+        },
+        withdrawalsProven: {
+          type: Counter,
+          desc: 'Number of withdrawals proven',
+        },
+        withdrawalsFinalized: {
+          type: Counter,
+          desc: 'Number of withdrawals finalized',
+        },
+        withdrawalsReproven: {
+          type: Counter,
+          desc: 'Number of withdrawals reproven',
+        },
+        highestSyncedBlock: {
+          type: Gauge,
+          desc: 'Highest block number synced',
+        },
+        highestKnownBlock: {
+          type: Gauge,
+          desc: 'Highest block number known',
+        },
+      },
+    })
+  }
+
+  protected async init(): Promise<void> {
+    this.state.highestSyncedBlock = this.options.startingBlockNumber
+    this.state.withdrawals = []
+    this.state.finalized = []
+    this.state.messenger = new CrossChainMessenger({
+      l1SignerOrProvider: new ethers.Wallet(
+        this.options.key,
+        this.options.l1RpcProvider
+      ),
+      l2SignerOrProvider: new ethers.Wallet(
+        this.options.key,
+        this.options.l2RpcProvider
+      ),
+      l1ChainId: await getChainId(this.options.l1RpcProvider),
+      l2ChainId: await getChainId(this.options.l2RpcProvider),
+      contracts: {
+        l1: {
+          OptimismPortal: this.options.addrOptimismPortal,
+          OptimismPortal2: this.options.addrOptimismPortal,
+          DisputeGameFactory: this.options.addrDisputeGameFactory,
+          L1CrossDomainMessenger: this.options.addrL1CrossDomainMessenger,
+          L1StandardBridge: this.options.addrL1StandardBridge,
+
+          // Rest need to be filled out but can be empty.
+          AddressManager: ethers.constants.AddressZero,
+          StateCommitmentChain: ethers.constants.AddressZero,
+          CanonicalTransactionChain: ethers.constants.AddressZero,
+          BondManager: ethers.constants.AddressZero,
+          L2OutputOracle: ethers.constants.AddressZero,
+        },
+      },
+    })
+  }
+
+  protected async main(): Promise<void> {
+    // Update highest known block.
+    const latestBlockNumber = await this.options.l2RpcProvider.getBlockNumber()
+    this.metrics.highestKnownBlock.set(latestBlockNumber)
+
+    // Sync withdrawals to tip.
+    while (this.state.highestSyncedBlock < latestBlockNumber) {
+      // Sync withdrawals in chunks of 2000 blocks.
+      const targetBlock = Math.min(
+        this.state.highestSyncedBlock + 2000,
+        latestBlockNumber
+      )
+      this.logger.info('Syncing block range', {
+        fromBlock: this.state.highestSyncedBlock,
+        toBlock: targetBlock,
+        target: latestBlockNumber,
+      })
+
+      // Grab all withdrawals for the block range.
+      let withdrawals = await this.state.messenger.getWithdrawalsByAddress(
+        await this.state.messenger.l2Signer.getAddress(),
+        {
+          fromBlock: this.state.highestSyncedBlock,
+          toBlock: targetBlock,
+        }
+      )
+
+      // Remove any duplicates for overlapping block ranges.
+      withdrawals = withdrawals.filter((withdrawal) => {
+        return !this.state.withdrawals.some((other) => {
+          return other.transactionHash === withdrawal.transactionHash
+        })
+      })
+
+      // Insert the withdrawals.
+      this.state.withdrawals.push(...withdrawals)
+      this.logger.info('Block range synced', { count: withdrawals.length })
+
+      // Update the highest synced block.
+      this.state.highestSyncedBlock = targetBlock
+      this.metrics.highestSyncedBlock.set(this.state.highestSyncedBlock)
+    }
+
+    // Create a withdrawal.
+    this.logger.info('Creating a new withdrawal')
+    const wd = await this.state.messenger.withdrawETH(1)
+    this.logger.info('Withdrawal created', { hash: wd.hash })
+    this.metrics.withdrawalsCreated.inc()
+
+    // Check if any withdrawals are ready for relay.
+    for (const withdrawal of this.state.withdrawals) {
+      // Don't process finalized withdrawals.
+      if (this.state.finalized.includes(withdrawal)) {
+        continue
+      }
+
+      try {
+        // Grab the status of the withdrawal.
+        const status = await this.state.messenger.getMessageStatus(withdrawal)
+
+        // If the withdrawal is ready to prove, prove it.
+        if (status === MessageStatus.READY_TO_PROVE) {
+          this.logger.info('Proving a withdrawal', {
+            hash: withdrawal.transactionHash,
+          })
+
+          const receipt = await this.state.messenger.proveMessage(withdrawal)
+          await this.state.messenger.waitForMessageStatus(
+            withdrawal,
+            MessageStatus.IN_CHALLENGE_PERIOD,
+            { timeoutMs: 120_000 }
+          )
+
+          this.logger.info('Withdrawal proven', { hash: receipt.hash })
+          this.metrics.withdrawalsProven.inc()
+        }
+
+        // If the withdrawal is ready for relay, finalize it.
+        if (status === MessageStatus.READY_FOR_RELAY) {
+          this.logger.info('Finalizing a withdrawal', {
+            hash: withdrawal.transactionHash,
+          })
+
+          const receipt = await this.state.messenger.finalizeMessage(withdrawal)
+          await this.state.messenger.waitForMessageStatus(
+            withdrawal,
+            MessageStatus.RELAYED,
+            { timeoutMs: 120_000 }
+          )
+
+          this.logger.info('Withdrawal finalized', { hash: receipt.hash })
+          this.state.finalized.push(withdrawal)
+          this.metrics.withdrawalsFinalized.inc()
+        }
+
+        // If the withdrawal was already relayed, remove it from the list.
+        if (status === MessageStatus.RELAYED) {
+          this.logger.info('Withdrawal already relayed', {
+            hash: withdrawal.transactionHash,
+          })
+
+          this.state.finalized.push(withdrawal)
+          this.metrics.withdrawalsFinalized.inc()
+        }
+      } catch (err) {
+        // If the withdrawal was invalidated, reprove it.
+        if (
+          err.message.includes(
+            'withdrawal proposal was invalidated, must reprove'
+          )
+        ) {
+          this.logger.info('Reproving a withdrawal', {
+            hash: withdrawal.transactionHash,
+          })
+
+          const receipt = await this.state.messenger.proveMessage(withdrawal)
+          this.logger.info('Withdrawal reproven', { hash: receipt.hash })
+          this.metrics.withdrawalsReproven.inc()
+        } else {
+          throw err
+        }
+      }
+    }
+
+    // Update active withdrawal count.
+    this.metrics.withdrawalsActive.set(this.state.withdrawals.length)
+  }
+}
+
+if (require.main === module) {
+  const service = new WithdrawerService()
+  service.run()
+}

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -73,6 +73,7 @@ import {
   DEPOSIT_CONFIRMATION_BLOCKS,
   CHAIN_BLOCK_TIMES,
   hashMessageHash,
+  getContractInterfaceBedrock,
 } from './utils'
 
 export class CrossChainMessenger {
@@ -120,6 +121,11 @@ export class CrossChainMessenger {
    * Whether or not Bedrock compatibility is enabled.
    */
   public bedrock: boolean
+
+  /**
+   * Cache for output root validation. Output roots are expensive to verify, so we cache them.
+   */
+  private _outputCache: Array<{ root: string; valid: boolean }> = []
 
   /**
    * Creates a new CrossChainProvider instance.
@@ -721,22 +727,23 @@ export class CrossChainMessenger {
       (await messenger.successfulMessages(messageHashV0)) ||
       (await messenger.successfulMessages(messageHashV1))
 
+    // Avoid the extra query if we already know the message was successful.
+    if (success) {
+      return MessageStatus.RELAYED
+    }
+
     const failure =
       (await messenger.failedMessages(messageHashV0)) ||
       (await messenger.failedMessages(messageHashV1))
 
     if (resolved.direction === MessageDirection.L1_TO_L2) {
-      if (success) {
-        return MessageStatus.RELAYED
-      } else if (failure) {
+      if (failure) {
         return MessageStatus.FAILED_L1_TO_L2_MESSAGE
       } else {
         return MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE
       }
     } else {
-      if (success) {
-        return MessageStatus.RELAYED
-      } else if (failure) {
+      if (failure) {
         return MessageStatus.READY_FOR_RELAY
       } else {
         let timestamp: number
@@ -793,6 +800,31 @@ export class CrossChainMessenger {
             resolved,
             messageIndex
           )
+
+          // Get the withdrawal hash.
+          const withdrawalHash = hashLowLevelMessage(withdrawal)
+
+          // Grab the proven withdrawal data.
+          const provenWithdrawal =
+            await this.contracts.l1.OptimismPortal2.provenWithdrawals(
+              withdrawalHash
+            )
+
+          // Attach to the FaultDisputeGame.
+          const game = new ethers.Contract(
+            provenWithdrawal.disputeGameProxy,
+            getContractInterfaceBedrock('FaultDisputeGame'),
+            this.l1SignerOrProvider
+          )
+
+          // Check if the game resolved to status 1 = "CHALLENGER_WINS". If so, the withdrawal was
+          // proven against a proposal that was invalidated and will need to be reproven. We throw
+          // an error here instead of creating a new status mostly because it's easier to integrate
+          // into the SDK.
+          const status = await game.status()
+          if (status === 1) {
+            throw new Error(`withdrawal proposal was invalidated, must reprove`)
+          }
 
           try {
             // If this doesn't revert then we should be fine to relay.
@@ -1279,29 +1311,100 @@ export class CrossChainMessenger {
           Math.min(100, gameCount.toNumber())
         )
 
-      // Find a game with a block number that is greater than or equal to the block number that the
-      // message was included in. We can use this proposal to prove the message to the portal.
-      let match: any
+      // Find all games that are for proposals about blocks newer than the message block.
+      const matches: any[] = []
       for (const game of latestGames) {
-        const [blockNumber] = ethers.utils.defaultAbiCoder.decode(
-          ['uint256'],
-          game.extraData
-        )
-        if (blockNumber.gte(resolved.blockNumber)) {
-          match = {
-            ...game,
-            l2BlockNumber: blockNumber,
+        try {
+          const [blockNumber] = ethers.utils.defaultAbiCoder.decode(
+            ['uint256'],
+            game.extraData
+          )
+          if (blockNumber.gte(resolved.blockNumber)) {
+            matches.push({
+              ...game,
+              l2BlockNumber: blockNumber,
+            })
           }
-          break
+        } catch (err) {
+          // If we can't decode the extra data then we just skip this game.
+          continue
         }
       }
 
-      // TODO: It would be more correct here to actually verify the proposal since proposals are
-      // not guaranteed to be correct. proveMessage will actually do this verification for us but
-      // there's a devex edge case where this message appears to give back a valid proposal that
-      // ends up reverting inside of proveMessage. At least this is safe for users but not ideal
-      // for developers and we should work out the simplest way to fix it. Main blocker is that
-      // verifying the proposal may require access to an archive node.
+      // Shuffle the list of matches. We shuffle here to avoid potential DoS vectors where the
+      // latest games are all invalid and the SDK would be forced to make a bunch of archive calls.
+      for (let i = matches.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[matches[i], matches[j]] = [matches[j], matches[i]]
+      }
+
+      // Now we verify the proposals in the matches array.
+      let match: any
+      for (const option of matches) {
+        // Use the cache if we can.
+        const cached = this._outputCache.find((other) => {
+          return other.root === option.rootClaim
+        })
+
+        // Skip if we can use the cached.
+        if (cached) {
+          if (cached.valid) {
+            match = option
+            break
+          } else {
+            continue
+          }
+        }
+
+        // If the cache ever gets to 10k elements, clear out the first half. Works well enough
+        // since the cache will generally tend to be used in a FIFO manner.
+        if (this._outputCache.length > 10000) {
+          this._outputCache = this._outputCache.slice(5000)
+        }
+
+        // We didn't hit the cache so we're going to have to do the work.
+        try {
+          // Grab the raw block JSON (need state root).
+          const block = await (
+            this.l2Provider as ethers.providers.JsonRpcProvider
+          ).send('eth_getBlockByNumber', [
+            toRpcHexString(option.l2BlockNumber),
+            false,
+          ])
+
+          // Grab the storage proof.
+          const proof = await makeStateTrieProof(
+            this.l2Provider as ethers.providers.JsonRpcProvider,
+            option.l2BlockNumber,
+            this.contracts.l2.OVM_L2ToL1MessagePasser.address,
+            ethers.constants.HashZero
+          )
+
+          // Compute the output.
+          const output = ethers.utils.solidityKeccak256(
+            ['bytes32', 'bytes32', 'bytes32', 'bytes32'],
+            [
+              ethers.constants.HashZero,
+              block.stateRoot,
+              proof.storageRoot,
+              block.hash,
+            ]
+          )
+
+          // If the output matches the proposal then we're good.
+          if (output === option.rootClaim) {
+            this._outputCache.push({ root: option.rootClaim, valid: true })
+            match = option
+            break
+          } else {
+            this._outputCache.push({ root: option.rootClaim, valid: false })
+          }
+        } catch (err) {
+          // Just skip this option, whatever. If it was a transient error then we'll try again in
+          // the next loop iteration. If it was a permanent error then we'll get the same thing.
+          continue
+        }
+      }
 
       // If there's no match then we can't prove the message to the portal.
       if (!match) {

--- a/packages/sdk/src/utils/contracts.ts
+++ b/packages/sdk/src/utils/contracts.ts
@@ -16,6 +16,7 @@ import l2ToL1MessagePasser from '@eth-optimism/contracts-bedrock/forge-artifacts
 import gasPriceOracle from '@eth-optimism/contracts-bedrock/forge-artifacts/GasPriceOracle.sol/GasPriceOracle.json'
 import disputeGameFactory from '@eth-optimism/contracts-bedrock/forge-artifacts/DisputeGameFactory.sol/DisputeGameFactory.json'
 import optimismPortal2 from '@eth-optimism/contracts-bedrock/forge-artifacts/OptimismPortal2.sol/OptimismPortal2.json'
+import faultDisputeGame from '@eth-optimism/contracts-bedrock/forge-artifacts/FaultDisputeGame.sol/FaultDisputeGame.json'
 
 import { toAddress } from './coercion'
 import { DeepPartial } from './type-utils'
@@ -48,7 +49,9 @@ const NAME_REMAPPING = {
   BedrockMessagePasser: 'L2ToL1MessagePasser' as const,
 }
 
-const getContractInterfaceBedrock = (name: string): ethers.utils.Interface => {
+export const getContractInterfaceBedrock = (
+  name: string
+): ethers.utils.Interface => {
   let artifact: any = ''
   switch (name) {
     case 'Lib_AddressManager':
@@ -102,6 +105,9 @@ const getContractInterfaceBedrock = (name: string): ethers.utils.Interface => {
       break
     case 'OptimismPortal2':
       artifact = optimismPortal2
+      break
+    case 'FaultDisputeGame':
+      artifact = faultDisputeGame
       break
   }
   return new ethers.utils.Interface(artifact.abi)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 8.0.1(@swc/core@1.4.1)(typescript@5.3.3)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.17)
+        version: 1.2.2(@types/node@20.11.17)(jsdom@24.0.0)
 
   packages/chain-mon:
     dependencies:
@@ -454,6 +454,9 @@ importers:
         specifier: ^7.6.0
         version: 7.6.0
     devDependencies:
+      '@eth-optimism/common-ts':
+        specifier: workspace:^
+        version: link:../common-ts
       '@ethersproject/abstract-provider':
         specifier: ^5.7.0
         version: 5.7.0
@@ -522,7 +525,7 @@ importers:
         version: 2.7.19(typescript@5.3.3)(zod@3.22.4)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.17)
+        version: 1.2.2(@types/node@20.11.17)(jsdom@24.0.0)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -565,7 +568,7 @@ importers:
         version: 5.1.5(@types/node@20.11.17)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.17)
+        version: 1.2.2(@types/node@20.11.17)(jsdom@24.0.0)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -17233,63 +17236,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.2(@types/node@20.11.17):
-    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.17
-      '@vitest/expect': 1.2.2
-      '@vitest/runner': 1.2.2
-      '@vitest/snapshot': 1.2.2
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.3.10
-      debug: 4.3.4(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      std-env: 3.6.0
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.17)
-      vite-node: 1.2.2(@types/node@20.11.17)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vitest@1.2.2(@types/node@20.11.17)(jsdom@24.0.0):
     resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -17335,7 +17281,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.2
-      vite: 5.1.5(@types/node@20.11.17)
+      vite: 5.0.12(@types/node@20.11.17)
       vite-node: 1.2.2(@types/node@20.11.17)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds a service for automatically creating and relaying withdrawals. Service is designed to be used during the FPAC testing process.

Also includes a number of important improvements to the SDK. 

- SDK has been updated to throw an error if a message was proven against a root claim that turned out to be invalid.
- SDK has been updated to properly validate root claims and, importantly, cache the results of that validation to avoid making lots of expensive `eth_getProof` calls.
