### PR TITLE
op-node: Unhide the safedb.path option

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -295,7 +295,6 @@ var (
 		Name:     "safedb.path",
 		Usage:    "File path used to persist safe head update data. Disabled if not set.",
 		EnvVars:  prefixEnvVars("SAFEDB_PATH"),
-		Hidden:   true,
 		Category: OperationsCategory,
 	}
 	/* Deprecated Flags */


### PR DESCRIPTION
**Description**

Unhide the `--safedb.path` option for op-node.  This is working well and will be needed for people wanting to run `op-challenger`.
