### PR TITLE
Making necessary changes to deploy periphery to include L1 sepolia

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployPeriphery.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployPeriphery.s.sol
@@ -338,7 +338,7 @@ contract DeployPeriphery is Script, Artifacts {
                 _adminWalletDripName(l1BridgeAddress, cfg.dripVersion())
             );
         }
-        _installTrasnferEthToDrip(
+        _installTransferEthToDrip(
             adminWallet,
             cfg.opChainAdminWalletDripValue(),
             cfg.opChainAdminWalletDripInterval(),
@@ -360,7 +360,7 @@ contract DeployPeriphery is Script, Artifacts {
                 _faucetDripName(l1BridgeAddress, cfg.dripVersion())
             );
         }
-        _installTrasnferEthToDrip(
+        _installTransferEthToDrip(
             faucetProxy,
             cfg.largeOpChainFaucetDripValue(),
             cfg.largeOpChainFaucetDripInterval(),
@@ -730,7 +730,7 @@ contract DeployPeriphery is Script, Artifacts {
         _activateIfPausedDrip(drippie, dripName);
     }
 
-    function _installTrasnferEthToDrip(
+    function _installTransferEthToDrip(
         address _depositTo,
         uint256 _dripValue,
         uint256 _dripInterval,


### PR DESCRIPTION
Adding changes so that we can configure Drippie to deposit to the L1 Sepolia faucet contract

Introduces 1 new function
- `_installTrasnferEthToDrip` : it makes a transfer call to send eth to the faucet contract address

This function is used twice 
- in `installLargeOpChainFaucetsDrips` 
- in `installLargeOpChainAdminWalletDrips`

This PR also modifies the way we get deploymentContext
`string memory deploymentContext = Config.deploymentContext();`
