### PR TITLE
contracts-bedrock: Add L1_RPC_URL validation before create configuration

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -12,12 +12,19 @@ reqenv() {
     fi
 }
 
+validate_url () {
+  url="${!1}"
+  if [[ `curl -s --head url | head -n 1 | grep "HTTP/[1-3].[0-9] [23].."` ]]; then echo "true"; fi
+}
+
 # Check required environment variables
 reqenv "GS_ADMIN_ADDRESS"
 reqenv "GS_BATCHER_ADDRESS"
 reqenv "GS_PROPOSER_ADDRESS"
 reqenv "GS_SEQUENCER_ADDRESS"
 reqenv "L1_RPC_URL"
+
+validate_url "L1_RPC_URL"
 
 # Get the finalized block timestamp and hash
 block=$(cast block finalized --rpc-url "$L1_RPC_URL")


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add validation of `L1_RPC_URL` before create configuration.

**Tests**

- Result on invalid URL, this will prompt error on curl
<img width="1170" alt="Screenshot 2567-03-08 at 08 57 06" src="https://github.com/ethereum-optimism/optimism/assets/14361087/343d034d-b3ab-46dc-b920-ea0857e1e998">

- Result on valid URL
<img width="1170" alt="Screenshot 2567-03-08 at 08 57 23" src="https://github.com/ethereum-optimism/optimism/assets/14361087/be638d8c-724e-4c7c-a6df-dfb609adecfe">


**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/9656
