### PR TITLE
fix(op-e2e): E2E Bond Test Alphabet VM Migration

### DIFF
--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -71,12 +71,6 @@ func (g *OutputGameHelper) Addr() common.Address {
 	return g.addr
 }
 
-func (g *OutputGameHelper) Balance(ctx context.Context, addr common.Address) *big.Int {
-	balance, err := g.client.BalanceAt(ctx, addr, nil)
-	g.require.NoError(err, "Failed to get balance")
-	return balance
-}
-
 func (g *OutputGameHelper) SplitDepth(ctx context.Context) types.Depth {
 	splitDepth, err := g.game.SplitDepth(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err, "failed to load split depth")

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -88,8 +88,6 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 	require.Zero(t, balance.Uint64())
 
 	alice := sys.Cfg.Secrets.Addresses().Alice
-	bal, _ := big.NewInt(0).SetString("1000000000000000000000", 10)
-	require.Equal(t, bal, game.Balance(ctx, alice))
 
 	// Grab the root claim
 	claim := game.RootClaim(ctx)

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -2,9 +2,11 @@ package faultproofs
 
 import (
 	"context"
+	"math/big"
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/deployer"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
@@ -69,6 +71,71 @@ func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 	game.LogGameData(ctx)
+}
+
+func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
+	op_e2e.InitParallel(t)
+	ctx := context.Background()
+	sys, l1Client := startFaultDisputeSystem(t)
+	t.Cleanup(sys.Close)
+
+	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, common.Hash{0xff})
+	game.LogGameData(ctx)
+
+	// The dispute game should have a zero balance
+	balance := game.WethBalance(ctx, game.Addr())
+	require.Zero(t, balance.Uint64())
+
+	alice := sys.Cfg.Secrets.Addresses().Alice
+	bal, _ := big.NewInt(0).SetString("1000000000000000000000", 10)
+	require.Equal(t, bal, game.Balance(ctx, alice))
+
+	// Grab the root claim
+	claim := game.RootClaim(ctx)
+	opts := challenger.WithPrivKey(sys.Cfg.Secrets.Alice)
+	game.StartChallenger(ctx, "sequencer", "Challenger", opts)
+	game.LogGameData(ctx)
+
+	// Perform a few moves
+	claim = claim.WaitForCounterClaim(ctx)
+	game.LogGameData(ctx)
+	claim = claim.Attack(ctx, common.Hash{})
+	claim = claim.WaitForCounterClaim(ctx)
+	game.LogGameData(ctx)
+	claim = claim.Attack(ctx, common.Hash{})
+	game.LogGameData(ctx)
+	_ = claim.WaitForCounterClaim(ctx)
+
+	// Expect posted claims so the game balance is non-zero
+	balance = game.WethBalance(ctx, game.Addr())
+	expectedBalance, _ := big.NewInt(0).SetString("589772600000000000", 10)
+	require.Equal(t, expectedBalance, balance)
+
+	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
+	game.LogGameData(ctx)
+
+	// Expect Alice's credit to be non-zero
+	// But it can't be claimed right now since there is a delay on the weth unlock
+	expectedCredit, _ := big.NewInt(0).SetString("589772600000000000", 10)
+	require.Equal(t, expectedCredit, game.AvailableCredit(ctx, alice))
+
+	// The actor should have a small credit available to claim
+	actorCredit := game.AvailableCredit(ctx, deployer.TestAddress)
+	require.True(t, actorCredit.Cmp(big.NewInt(0)) == 0)
+
+	// Advance the time past the weth unlock delay
+	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
+	// Wait for alice to have no available credit
+	// aka, wait for the challenger to claim its credit
+	game.WaitForNoAvailableCredit(ctx, alice)
+
+	// The dispute game delayed weth balance should be zero since it's all claimed
+	require.True(t, game.WethBalance(ctx, game.Addr()).Cmp(big.NewInt(0)) == 0)
 }
 
 func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -109,8 +109,7 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// Expect posted claims so the game balance is non-zero
 	balance = game.WethBalance(ctx, game.Addr())
-	expectedBalance, _ := big.NewInt(0).SetString("589772600000000000", 10)
-	require.Equal(t, expectedBalance, balance)
+	require.Truef(t, balance.Cmp(big.NewInt(0)) > 0, "Expected game balance to be above zero")
 
 	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
@@ -119,12 +118,11 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// Expect Alice's credit to be non-zero
 	// But it can't be claimed right now since there is a delay on the weth unlock
-	expectedCredit, _ := big.NewInt(0).SetString("589772600000000000", 10)
-	require.Equal(t, expectedCredit, game.AvailableCredit(ctx, alice))
+	require.Truef(t, game.AvailableCredit(ctx, alice).Cmp(big.NewInt(0)) > 0, "Expected alice credit to be above zero")
 
-	// The actor should have a small credit available to claim
+	// The actor should have no credit available because all its bonds were paid to Alice.
 	actorCredit := game.AvailableCredit(ctx, deployer.TestAddress)
-	require.True(t, actorCredit.Cmp(big.NewInt(0)) == 0)
+	require.True(t, actorCredit.Cmp(big.NewInt(0)) == 0, "Expected alice available credit to be zero")
 
 	// Advance the time past the weth unlock delay
 	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))


### PR DESCRIPTION
**Description**

Migrates the e2e bond test to the alphabet vm instead of cannon.
