### PR TITLE
remove preinstall only-allow command from packages

### DIFF
--- a/.changeset/calm-boxes-do.md
+++ b/.changeset/calm-boxes-do.md
@@ -2,4 +2,4 @@
 '@eth-optimism/sdk': patch
 ---
 
-fixed issue with vercel builds failing on preinstall command
+Fixed an issue where Vercel builds were failing due to the `preinstall` command.

--- a/.changeset/calm-boxes-do.md
+++ b/.changeset/calm-boxes-do.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+fixed issue with vercel builds failing on preinstall command

--- a/packages/chain-mon/package.json
+++ b/packages/chain-mon/package.json
@@ -29,7 +29,6 @@
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json",
     "build": "tsc -p ./tsconfig.json",
     "clean": "rimraf  dist/ ./tsconfig.tsbuildinfo",
-    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm lint:fix && pnpm lint:check",
     "pre-commit": "lint-staged",
     "lint:fix": "pnpm lint:check --fix",

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -12,7 +12,6 @@
     "all": "pnpm clean && pnpm build && pnpm test && pnpm lint:fix && pnpm lint",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
-    "preinstall": "npx only-allow pnpm",
     "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "pnpm lint:check --fix",
     "lint": "pnpm lint:fix && pnpm lint:check",

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -34,7 +34,6 @@
     "validate-spacers:no-build": "npx tsx scripts/checks/check-spacers.ts",
     "validate-spacers": "pnpm build && pnpm validate-spacers:no-build",
     "clean": "rm -rf ./artifacts ./forge-artifacts ./cache ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo ./scripts/go-ffi/go-ffi ./.testdata ./deployments/hardhat/*",
-    "preinstall": "npx only-allow pnpm",
     "pre-pr:no-build": "pnpm gas-snapshot:no-build && pnpm snapshots && pnpm semver-lock && pnpm autogen:invariant-docs && pnpm lint && pnpm bindings:go:no-build",
     "pre-pr": "pnpm clean && pnpm build:go-ffi && pnpm build && pnpm pre-pr:no-build",
     "pre-pr:full": "pnpm test && pnpm validate-deploy-configs && pnpm validate-spacers && pnpm pre-pr",

--- a/packages/contracts-ts/package.json
+++ b/packages/contracts-ts/package.json
@@ -37,7 +37,6 @@
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf ./dist",
-    "preinstall": "npx only-allow pnpm",
     "generate": "wagmi generate && pnpm build && pnpm lint:fix",
     "generate:check": "pnpm generate && git diff --exit-code ./addresses.json && git diff --exit-code ./abis.json",
     "lint": "prettier --check .",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -11,7 +11,6 @@
     "all": "pnpm clean && pnpm build && pnpm test && pnpm lint:fix && pnpm lint",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
-    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm lint:fix && pnpm lint:check",
     "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "pnpm lint:check --fix",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,7 +12,6 @@
     "all": "pnpm clean && pnpm build && pnpm test && pnpm lint:fix && pnpm lint",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
-    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm lint:fix && pnpm lint:check",
     "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "pnpm lint:check --fix",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Removes the `preinstall` scripts from package folders so that consumers of these packages are not forced into using `pnpm`
- Leaves the `preinstall` script in the root `package.json` file so that contributors to this repository continue to be prompted to install with `pnpm`

**Tests**

No code changes

**Metadata**

- Fixes #9078 9078
