### PR TITLE
op-program: Avoid requesting L1 genesis block when starting from L2 genesis

### DIFF
--- a/op-node/node/safedb/disabled.go
+++ b/op-node/node/safedb/disabled.go
@@ -14,6 +14,10 @@ var (
 	ErrNotEnabled = errors.New("safe head database not enabled")
 )
 
+func (d *DisabledDB) Enabled() bool {
+	return false
+}
+
 func (d *DisabledDB) SafeHeadUpdated(_ eth.L2BlockRef, _ eth.BlockID) error {
 	return nil
 }

--- a/op-node/node/safedb/safedb.go
+++ b/op-node/node/safedb/safedb.go
@@ -93,6 +93,10 @@ func NewSafeDB(logger log.Logger, path string) (*SafeDB, error) {
 	}, nil
 }
 
+func (d *SafeDB) Enabled() bool {
+	return true
+}
+
 func (d *SafeDB) SafeHeadUpdated(safeHead eth.L2BlockRef, l1Head eth.BlockID) error {
 	d.m.Lock()
 	defer d.m.Unlock()

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -898,7 +898,6 @@ func TestBlockBuildingRace(t *testing.T) {
 	l1F.ExpectL1BlockRefByNumber(refA.Number, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)
-	l1F.ExpectL1BlockRefByNumber(0, refA, nil)
 
 	eng.ExpectSystemConfigByL2Hash(refA0.Hash, cfg.Genesis.SystemConfig, nil)
 
@@ -1024,7 +1023,6 @@ func TestResetLoop(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(1234))
 
-	l1Genesis := eth.L1BlockRef{Number: 0}
 	refA := testutils.RandomBlockRef(rng)
 	refA0 := eth.L2BlockRef{
 		Hash:           testutils.RandomHash(rng),
@@ -1082,7 +1080,6 @@ func TestResetLoop(t *testing.T) {
 	eng.ExpectL2BlockRefByHash(refA1.Hash, refA1, nil)
 	eng.ExpectL2BlockRefByHash(refA0.Hash, refA0, nil)
 	eng.ExpectSystemConfigByL2Hash(refA0.Hash, cfg.Genesis.SystemConfig, nil)
-	l1F.ExpectL1BlockRefByNumber(0, l1Genesis, nil)
 	l1F.ExpectL1BlockRefByNumber(refA.Number, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)
 	l1F.ExpectL1BlockRefByHash(refA.Hash, refA, nil)


### PR DESCRIPTION
**Description**

Avoids requesting the L1 genesis block to populate the safe head db when the derivation starts from L2 genesis.  In op-program there is no safe head db recording and walking back to L1 genesis is a very expensive operation.

**Tests**

None yet - will follow up by adding precaptured network data to validate the first L2 block on a chain as part of the `op-program-compat` job which runs purely offline so will fail if we try to request additional block data.

