### PR TITLE
fix: `versions.json` foundry sha

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "9f6bb3bb47de9d5a1f2a6c38cbc57e0f4f5508c2 ",
+  "foundry": "9f6bb3bb47de9d5a1f2a6c38cbc57e0f4f5508c2",
   "geth": "v1.13.4",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
## Overview

Fixes the `versions.json` foundry sha - a typo in #9810 left a space at the end, breaking `install-foundry.sh`.
