### PR TITLE
Asterisc integration

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -141,7 +141,7 @@ def devnet_l1_genesis(paths):
 
     fqn = 'scripts/Deploy.s.sol:Deploy'
     run_command([
-        'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()"
+        'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     ], env={}, cwd=paths.contracts_bedrock_dir)
 
     forge_dump = read_json(paths.forge_dump_path)

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -140,6 +140,7 @@ def devnet_l1_genesis(paths):
     init_devnet_l1_deploy_config(paths)
 
     fqn = 'scripts/Deploy.s.sol:Deploy'
+    # Use foundry pre-funded account #1 for the deployer
     run_command([
         'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     ], env={}, cwd=paths.contracts_bedrock_dir)

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -26,6 +26,9 @@ op-program-client-mips:
 	# verify output with: readelf -h bin/op-program-client.elf
 	# result is mips32, big endian, R3000
 
+op-program-client-riscv:
+	env GO111MODULE=on GOOS=linux GOARCH=riscv64 go build -v -gcflags="all=-d=softfloat" $(LDFLAGS) -o ./bin/op-program-client-riscv.elf ./client/cmd/main.go
+
 reproducible-prestate:
 	@docker build --output ./bin/ --progress plain -f Dockerfile.repro ../
 	@echo "Absolute prestate hash:"
@@ -74,6 +77,7 @@ verify-compat: verify-sepolia-delta verify-sepolia-ecotone verify-mainnet-genesi
 	op-program-host \
 	op-program-client \
 	op-program-client-mips \
+	op-program-client-riscv \
 	clean \
 	test \
 	capture-goerli-verify \

--- a/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
+++ b/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
@@ -106,6 +106,9 @@ library GameTypes {
     /// @dev A permissioned dispute game type the uses the cannon vm.
     GameType internal constant PERMISSIONED_CANNON = GameType.wrap(1);
 
+    /// @notice A dispute game type the uses the asterisc VM
+    GameType internal constant ASTERISC = GameType.wrap(2);
+
     /// @notice A dispute game type that uses an alphabet vm.
     ///         Not intended for production use.
     GameType internal constant ALPHABET = GameType.wrap(255);


### PR DESCRIPTION
**Description**

This PR contains small changes to integrate Asterisc into OP stack fault proof system.
1. Add `ASTERISC` dispute game type
2. Add a make command in op-program to build op-program-client into the RISC-V binary.
3. Deploy contracts with the foundry pre-funded account for the local devnet. We need this change to use the same account in the Asterisc deploy script.

Corresponding Asterisc PR is open: https://github.com/ethereum-optimism/asterisc/pull/26