### PR TITLE
op-challenger: Verify large preimages in all oracles

### DIFF
--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -105,6 +105,11 @@ func registerAlphabet(
 		if err != nil {
 			return nil, err
 		}
+		oracle, err := contract.GetOracle(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)
+		}
+		oracles.RegisterOracle(oracle)
 		prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
 		if err != nil {
 			return nil, err
@@ -184,6 +189,11 @@ func registerCannon(
 		if err != nil {
 			return nil, err
 		}
+		oracle, err := contract.GetOracle(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)
+		}
+		oracles.RegisterOracle(oracle)
 		prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
 		if err != nil {
 			return nil, err

--- a/op-challenger/game/keccak/scheduler_test.go
+++ b/op-challenger/game/keccak/scheduler_test.go
@@ -50,7 +50,7 @@ func TestScheduleNextCheck(t *testing.T) {
 	}
 	cl := clock.NewDeterministicClock(time.Unix(int64(currentTimestamp), 0))
 	challenger := &stubChallenger{}
-	scheduler := NewLargePreimageScheduler(logger, cl, []keccakTypes.LargePreimageOracle{oracle}, challenger)
+	scheduler := NewLargePreimageScheduler(logger, cl, OracleSourceArray{oracle}, challenger)
 	scheduler.Start(ctx)
 	defer scheduler.Close()
 	err := scheduler.Schedule(common.Hash{0xaa}, 3)
@@ -132,4 +132,10 @@ func (s *stubChallenger) Checked() []keccakTypes.LargePreimageMetaData {
 	v := make([]keccakTypes.LargePreimageMetaData, len(s.checked))
 	copy(v, s.checked)
 	return v
+}
+
+type OracleSourceArray []keccakTypes.LargePreimageOracle
+
+func (o OracleSourceArray) Oracles() []keccakTypes.LargePreimageOracle {
+	return o
 }

--- a/op-challenger/game/registry/oracles.go
+++ b/op-challenger/game/registry/oracles.go
@@ -1,0 +1,32 @@
+package registry
+
+import (
+	"sync"
+
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/exp/maps"
+)
+
+type OracleRegistry struct {
+	l       sync.Mutex
+	oracles map[common.Address]keccakTypes.LargePreimageOracle
+}
+
+func NewOracleRegistry() *OracleRegistry {
+	return &OracleRegistry{
+		oracles: make(map[common.Address]keccakTypes.LargePreimageOracle),
+	}
+}
+
+func (r *OracleRegistry) RegisterOracle(oracle keccakTypes.LargePreimageOracle) {
+	r.l.Lock()
+	defer r.l.Unlock()
+	r.oracles[oracle.Addr()] = oracle
+}
+
+func (r *OracleRegistry) Oracles() []keccakTypes.LargePreimageOracle {
+	r.l.Lock()
+	defer r.l.Unlock()
+	return maps.Values(r.oracles)
+}

--- a/op-challenger/game/registry/oracles_test.go
+++ b/op-challenger/game/registry/oracles_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeduplicateOracles(t *testing.T) {
+	registry := NewOracleRegistry()
+	oracleA := stubPreimageOracle{0xaa}
+	oracleB := stubPreimageOracle{0xbb}
+	registry.RegisterOracle(oracleA)
+	registry.RegisterOracle(oracleB)
+	registry.RegisterOracle(oracleB)
+	oracles := registry.Oracles()
+	require.Len(t, oracles, 2)
+	require.Contains(t, oracles, oracleA)
+	require.Contains(t, oracles, oracleB)
+}
+
+type stubPreimageOracle common.Address
+
+func (s stubPreimageOracle) ChallengePeriod(_ context.Context) (uint64, error) {
+	panic("not supported")
+}
+
+func (s stubPreimageOracle) GetProposalTreeRoot(_ context.Context, _ rpcblock.Block, _ keccakTypes.LargePreimageIdent) (common.Hash, error) {
+	panic("not supported")
+}
+
+func (s stubPreimageOracle) ChallengeTx(_ keccakTypes.LargePreimageIdent, _ keccakTypes.Challenge) (txmgr.TxCandidate, error) {
+	panic("not supported")
+}
+
+func (s stubPreimageOracle) GetInputDataBlocks(_ context.Context, _ rpcblock.Block, _ keccakTypes.LargePreimageIdent) ([]uint64, error) {
+	panic("not supported")
+}
+
+func (s stubPreimageOracle) DecodeInputData(_ []byte) (*big.Int, keccakTypes.InputData, error) {
+	panic("not supported")
+}
+
+func (s stubPreimageOracle) Addr() common.Address {
+	return common.Address(s)
+}
+
+func (s stubPreimageOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]keccakTypes.LargePreimageMetaData, error) {
+	return nil, nil
+}

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
-	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -29,7 +27,7 @@ func TestKnownGameType(t *testing.T) {
 	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		return expectedPlayer, nil
 	}
-	registry.RegisterGameType(0, creator, nil)
+	registry.RegisterGameType(0, creator)
 	player, err := registry.CreatePlayer(types.GameMetadata{GameType: 0}, "")
 	require.NoError(t, err)
 	require.Same(t, expectedPlayer, player)
@@ -40,26 +38,10 @@ func TestPanicsOnDuplicateGameType(t *testing.T) {
 	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		return nil, nil
 	}
-	registry.RegisterGameType(0, creator, nil)
+	registry.RegisterGameType(0, creator)
 	require.Panics(t, func() {
-		registry.RegisterGameType(0, creator, nil)
+		registry.RegisterGameType(0, creator)
 	})
-}
-
-func TestDeduplicateOracles(t *testing.T) {
-	registry := NewGameTypeRegistry()
-	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return nil, nil
-	}
-	oracleA := stubPreimageOracle{0xaa}
-	oracleB := stubPreimageOracle{0xbb}
-	registry.RegisterGameType(0, creator, oracleA)
-	registry.RegisterGameType(1, creator, oracleB)
-	registry.RegisterGameType(2, creator, oracleB)
-	oracles := registry.Oracles()
-	require.Len(t, oracles, 2)
-	require.Contains(t, oracles, oracleA)
-	require.Contains(t, oracles, oracleB)
 }
 
 func TestBondContracts(t *testing.T) {
@@ -89,36 +71,6 @@ func TestBondContracts(t *testing.T) {
 			registry.RegisterBondContract(0, creator)
 		})
 	})
-}
-
-type stubPreimageOracle common.Address
-
-func (s stubPreimageOracle) ChallengePeriod(_ context.Context) (uint64, error) {
-	panic("not supported")
-}
-
-func (s stubPreimageOracle) GetProposalTreeRoot(_ context.Context, _ rpcblock.Block, _ keccakTypes.LargePreimageIdent) (common.Hash, error) {
-	panic("not supported")
-}
-
-func (s stubPreimageOracle) ChallengeTx(_ keccakTypes.LargePreimageIdent, _ keccakTypes.Challenge) (txmgr.TxCandidate, error) {
-	panic("not supported")
-}
-
-func (s stubPreimageOracle) GetInputDataBlocks(_ context.Context, _ rpcblock.Block, _ keccakTypes.LargePreimageIdent) ([]uint64, error) {
-	panic("not supported")
-}
-
-func (s stubPreimageOracle) DecodeInputData(_ []byte) (*big.Int, keccakTypes.InputData, error) {
-	panic("not supported")
-}
-
-func (s stubPreimageOracle) Addr() common.Address {
-	return common.Address(s)
-}
-
-func (s stubPreimageOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]keccakTypes.LargePreimageMetaData, error) {
-	return nil, nil
 }
 
 type stubBondContract struct{}


### PR DESCRIPTION
**Description**

Since game types can be updated, the oracle used by game types might be changed, even while some games are still in progress.  To ensure the challenger verifies all large preimages, it now checks all the oracles from the currently registered game types (that will be used for new games) as well as all oracles from existing games.

**Tests**

Updated unit tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/645
