### PR TITLE
fix: Revert foundry version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "9f6bb3bb47de9d5a1f2a6c38cbc57e0f4f5508c2",
+  "foundry": "a170021b0e058925047a2c9697ba61f10fc0b2ce",
   "geth": "v1.13.4",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
## Overview

We are not yet ready to update foundry due to stack too deep errors that arise with the new version. Reverts back to `a170021b0e058925047a2c9697ba61f10fc0b2ce`, which is what `ci-builder/v0.43.0` is using.
