### PR TITLE
op-dispute-mon: Remove tracked games metric

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -42,7 +42,6 @@ type Metricer interface {
 
 	RecordOutputFetchTime(timestamp float64)
 
-	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 	RecordGameAgreement(status GameAgreementStatus, count int)
 
 	RecordBondCollateral(addr common.Address, required *big.Int, available *big.Int)
@@ -67,7 +66,6 @@ type Metrics struct {
 
 	claimResolutionDelayMax prometheus.Gauge
 
-	trackedGames   prometheus.GaugeVec
 	gamesAgreement prometheus.GaugeVec
 
 	requiredCollateral  prometheus.GaugeVec
@@ -112,13 +110,6 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "claim_resolution_delay_max",
 			Help:      "Maximum claim resolution delay in seconds",
-		}),
-		trackedGames: *factory.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Name:      "tracked_games",
-			Help:      "Number of games being tracked by the challenger",
-		}, []string{
-			"status",
 		}),
 		gamesAgreement: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -183,12 +174,6 @@ func (m *Metrics) RecordClaimResolutionDelayMax(delay float64) {
 
 func (m *Metrics) Document() []opmetrics.DocumentedMetric {
 	return m.factory.Document()
-}
-
-func (m *Metrics) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {
-	m.trackedGames.WithLabelValues("in_progress").Set(float64(inProgress))
-	m.trackedGames.WithLabelValues("defender_won").Set(float64(defenderWon))
-	m.trackedGames.WithLabelValues("challenger_won").Set(float64(challengerWon))
 }
 
 func (m *Metrics) RecordOutputFetchTime(timestamp float64) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -20,7 +20,6 @@ func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64) {}
 
 func (*NoopMetricsImpl) RecordOutputFetchTime(timestamp float64) {}
 
-func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}
-func (*NoopMetricsImpl) RecordGameAgreement(status GameAgreementStatus, count int)    {}
+func (*NoopMetricsImpl) RecordGameAgreement(status GameAgreementStatus, count int) {}
 
 func (i *NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -42,23 +42,6 @@ type BidirectionalClaim struct {
 	Children []*BidirectionalClaim
 }
 
-type StatusBatch struct {
-	InProgress    int
-	DefenderWon   int
-	ChallengerWon int
-}
-
-func (s *StatusBatch) Add(status types.GameStatus) {
-	switch status {
-	case types.GameStatusInProgress:
-		s.InProgress++
-	case types.GameStatusDefenderWon:
-		s.DefenderWon++
-	case types.GameStatusChallengerWon:
-		s.ChallengerWon++
-	}
-}
-
 type ForecastBatch struct {
 	AgreeDefenderAhead      int
 	DisagreeDefenderAhead   int

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -1,69 +1,11 @@
 package types
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMaxValue(t *testing.T) {
 	require.Equal(t, ResolvedBondAmount.String(), "340282366920938463463374607431768211455")
-}
-
-func TestStatusBatch_Add(t *testing.T) {
-	statusExpectations := []struct {
-		status types.GameStatus
-		create func(int) StatusBatch
-	}{
-		{
-			status: types.GameStatusInProgress,
-			create: func(inProgress int) StatusBatch {
-				return StatusBatch{inProgress, 0, 0}
-			},
-		},
-		{
-			status: types.GameStatusDefenderWon,
-			create: func(defenderWon int) StatusBatch {
-				return StatusBatch{0, defenderWon, 0}
-			},
-		},
-		{
-			status: types.GameStatusChallengerWon,
-			create: func(challengerWon int) StatusBatch {
-				return StatusBatch{0, 0, challengerWon}
-			},
-		},
-	}
-
-	type test struct {
-		name        string
-		status      types.GameStatus
-		invocations int
-		expected    StatusBatch
-	}
-
-	var tests []test
-	for i := 0; i < 100; i++ {
-		for _, exp := range statusExpectations {
-			tests = append(tests, test{
-				name:        fmt.Sprintf("Invocation-%d", i),
-				status:      exp.status,
-				invocations: i,
-				expected:    exp.create(i),
-			})
-		}
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			s := StatusBatch{}
-			for i := 0; i < test.invocations; i++ {
-				s.Add(test.status)
-			}
-			require.Equal(t, test.expected, s)
-		})
-	}
 }


### PR DESCRIPTION
**Description**

Somewhere along the line this metric stopped being populated. Since the data can be easily derived from the game_agreement anyway, just remove the metric entirely.
