### PR TITLE
feat(ct): add autogen task to contracts-bedrock

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -17,6 +17,7 @@
     "prebuild": "./scripts/checks/check-foundry-install.sh",
     "build": "forge build",
     "build:go-ffi": "(cd scripts/go-ffi && go build)",
+    "autogen": "pnpm bindings:go && pnpm autogen:invariant-docs && pnpm semver-lock && pnpm gas-snapshot && pnpm snapshots",
     "autogen:invariant-docs": "npx tsx scripts/autogen/generate-invariant-docs.ts",
     "test": "pnpm build:go-ffi && forge test",
     "test:kontrol": "./test/kontrol/scripts/run-kontrol.sh",


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds a new autogen task to contracts-bedrock that does all of the autogen tasks all at once. It's somewhat annoying to do each of these individually, this does them all at once.
