### PR TITLE
op-challenger: Fix a race condition in challenger tests

### DIFF
--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace"
@@ -172,6 +173,7 @@ func (s *stubClaimLoader) GetAllClaims(_ context.Context, _ rpcblock.Block) ([]t
 }
 
 type stubResponder struct {
+	l                 sync.Mutex
 	callResolveCount  int
 	callResolveStatus gameTypes.GameStatus
 	callResolveErr    error
@@ -185,21 +187,29 @@ type stubResponder struct {
 }
 
 func (s *stubResponder) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
+	s.l.Lock()
+	defer s.l.Unlock()
 	s.callResolveCount++
 	return s.callResolveStatus, s.callResolveErr
 }
 
 func (s *stubResponder) Resolve() error {
+	s.l.Lock()
+	defer s.l.Unlock()
 	s.resolveCount++
 	return s.resolveErr
 }
 
 func (s *stubResponder) CallResolveClaim(ctx context.Context, clainIdx uint64) error {
+	s.l.Lock()
+	defer s.l.Unlock()
 	s.callResolveClaimCount++
 	return s.callResolveClaimErr
 }
 
 func (s *stubResponder) ResolveClaim(clainIdx uint64) error {
+	s.l.Lock()
+	defer s.l.Unlock()
 	s.resolveClaimCount++
 	return nil
 }

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -184,7 +184,8 @@ type mockGameCaller struct {
 	claims           []faultTypes.Claim
 	requestedCredits []common.Address
 	creditsErr       error
-	credits          []*big.Int
+	credits          map[common.Address]*big.Int
+	extraCredit      []*big.Int
 	balanceErr       error
 	balance          *big.Int
 	balanceAddr      common.Address
@@ -211,7 +212,16 @@ func (m *mockGameCaller) GetCredits(_ context.Context, _ rpcblock.Block, recipie
 	if m.creditsErr != nil {
 		return nil, m.creditsErr
 	}
-	return m.credits, nil
+	response := make([]*big.Int, 0, len(recipients))
+	for _, recipient := range recipients {
+		credit, ok := m.credits[recipient]
+		if !ok {
+			credit = big.NewInt(0)
+		}
+		response = append(response, credit)
+	}
+	response = append(response, m.extraCredit...)
+	return response, nil
 }
 
 func (m *mockGameCaller) GetBalance(_ context.Context, _ rpcblock.Block) (*big.Int, common.Address, error) {


### PR DESCRIPTION
**Description**

The responder stub needs to be thread safe now that actions are performed parallel.  The real responder doesn't share anything between different actions but the stub keeps a counter that needs protection.

Also fixes a flaky dispute-mon test which was expecting consistent ordering from maps.