### PR TITLE
op-program: Run new compat tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1421,7 +1421,7 @@ jobs:
       - run:
           name: compat-sepolia
           command: |
-            make run-sepolia-verify
+            make verify-compat
           working_directory: op-program
 
   check-generated-mocks-op-node:

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -8,7 +8,6 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Vers
 LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-COMPAT_DIR := temp/compat
 
 op-program: \
 	op-program-host \
@@ -56,13 +55,18 @@ capture-sepolia-ecotone: op-program-host op-program-client
 	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l1.beacon $$SEPOLIA_BEACON_URL --l2 $$SEPOLIA_L2URL --datadir "$(COMPAT_DIR)/sepolia-ecotone" --l1.head "0x5d491a8c1e728a4e70720c09fefdaa083681a9421cd365af85220cf8bd4448a3" --l2.start "9205715" --l2.end "9205815"
 	tar jcf "$(COMPAT_DIR)/sepolia-ecotone.tar.bz" -C "$(COMPAT_DIR)" sepolia-ecotone
 
-capture-chain-test-data: capture-mainnet-genesis capture-sepolia-delta
+capture-chain-test-data: capture-mainnet-genesis capture-sepolia-delta capture-sepolia-ecotone
 
-run-sepolia-verify: op-program-host op-program-client
-	mkdir -p "$(COMPAT_DIR)"
-	curl -L -o "$(COMPAT_DIR)/sepolia.tar.bz" https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-03-01.2-branch/sepolia.tar.bz
-	tar jxf "$(COMPAT_DIR)/sepolia.tar.bz" -C "$(COMPAT_DIR)"
-	./bin/op-program `cat "$(COMPAT_DIR)/sepolia/args.txt"`
+verify-sepolia-delta: op-program-host op-program-client
+	./scripts/run-compat.sh "sepolia-delta"
+
+verify-mainnet-genesis: op-program-host op-program-client
+	./scripts/run-compat.sh "mainnet-genesis"
+
+verify-sepolia-ecotone: op-program-host op-program-client
+	./scripts/run-compat.sh "sepolia-ecotone"
+
+verify-compat: verify-sepolia-delta verify-mainnet-genesis
 
 .PHONY: \
 	op-program \
@@ -78,4 +82,5 @@ run-sepolia-verify: op-program-host op-program-client
 	capture-sepolia-ecotone \
 	capture-chain-test-data \
 	run-goerli-verify \
-	run-sepolia-verify
+	run-sepolia-verify \
+	run-compat

--- a/op-program/scripts/run-compat.sh
+++ b/op-program/scripts/run-compat.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+COMPAT_DIR="${SCRIPTS_DIR}/../temp/compat"
+
+TESTNAME="${1?Must specify compat file to run}"
+BASEURL="${2:-https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-03-14}"
+
+URL="${BASEURL}/${TESTNAME}.tar.bz"
+
+mkdir -p "${COMPAT_DIR}"
+curl --etag-save "${COMPAT_DIR}/${TESTNAME}-etag.txt" --etag-compare "${COMPAT_DIR}/${TESTNAME}-etag.txt" -L --fail -o "${COMPAT_DIR}/${TESTNAME}.tar.bz" "${URL}"
+tar jxf "${COMPAT_DIR}/${TESTNAME}.tar.bz" -C "${COMPAT_DIR}"
+# shellcheck disable=SC2046
+"${SCRIPTS_DIR}/../bin/op-program" $(cat "${COMPAT_DIR}/${TESTNAME}/args.txt")


### PR DESCRIPTION
**Description**

Runs the sepolia-delta and mainnet-genesis  compatibility tests.

Adds capture-sepolia-ecotone to list of data sets to capture. The verify for it isn't run yet because the data wasn't captured. Will need to merge this, tag a new release of chain-test-data then update to run sepolia-ecotone.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/649
