### PR TITLE
op-program: Readd missing var to makefile to fix capturing data.

### DIFF
--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -8,6 +8,7 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Vers
 LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+COMPAT_DIR := temp/compat
 
 op-program: \
 	op-program-host \


### PR DESCRIPTION
**Description**

Re-add COMPAT_DIR var which is actually still required to capture the compat data.