### PR TITLE
op-program: Enable sepolia-econtone compat test

### DIFF
--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -67,7 +67,7 @@ verify-mainnet-genesis: op-program-host op-program-client
 verify-sepolia-ecotone: op-program-host op-program-client
 	./scripts/run-compat.sh "sepolia-ecotone"
 
-verify-compat: verify-sepolia-delta verify-mainnet-genesis
+verify-compat: verify-sepolia-delta verify-sepolia-ecotone verify-mainnet-genesis
 
 .PHONY: \
 	op-program \

--- a/op-program/scripts/run-compat.sh
+++ b/op-program/scripts/run-compat.sh
@@ -5,7 +5,7 @@ SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 COMPAT_DIR="${SCRIPTS_DIR}/../temp/compat"
 
 TESTNAME="${1?Must specify compat file to run}"
-BASEURL="${2:-https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-03-14}"
+BASEURL="${2:-https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-03-14.3}"
 
 URL="${BASEURL}/${TESTNAME}.tar.bz"
 


### PR DESCRIPTION
**Description**

Enable running the sepolia-econte compat test now the preimage data has been captured.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/649
