### PR TITLE
chore: fix invalid env variable in docker-compose.yml

### DIFF
--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       OP_CHALLENGER_GAME_FACTORY_ADDRESS: ${DGF_ADDRESS}
       # The devnet can't set the absolute prestate output root because the contracts are deployed in L1 genesis
       # before the L2 genesis is known.
-      OP_CHALLENGER_UNSAFE_ALLOW_INVALID_PRESTATE: true
+      OP_CHALLENGER_UNSAFE_ALLOW_INVALID_PRESTATE: "true"
       OP_CHALLENGER_DATADIR: temp/challenger-data
       OP_CHALLENGER_CANNON_ROLLUP_CONFIG: ./.devnet/rollup.json
       OP_CHALLENGER_CANNON_L2_GENESIS: ./.devnet/genesis-l2.json


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change env variable's value of `OP_CHALLENGER_UNSAFE_ALLOW_INVALID_PRESTATE` to a string type to avoid docker compose build failure which will cause `make devnet-up` to fail.

**Additional context**

Error message before fixed:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.op-challenger.environment.OP_CHALLENGER_UNSAFE_ALLOW_INVALID_PRESTATE contains true, which is an invalid type, it should be a string, number, or a null
```
