### PR TITLE
cannon: Go runtime panic example

### DIFF
--- a/cannon/example/highmem/go.mod
+++ b/cannon/example/highmem/go.mod
@@ -1,0 +1,3 @@
+module highmem
+
+go 1.21.1

--- a/cannon/example/highmem/main.go
+++ b/cannon/example/highmem/main.go
@@ -1,0 +1,14 @@
+package main
+
+var mem [2][]byte
+var memsiz int32 = 512 * 1024 * 1024
+
+func main() {
+	for i := range mem {
+		mem[i] = make([]byte, memsiz)
+		// dirty memory to ensure allocated memory is flushed
+		for j := range mem[i] {
+			mem[i][j] = 0x12
+		}
+	}
+}


### PR DESCRIPTION
## Description

Demonstrate Cannon bug causing panics in the Go runtime. To reproduce:

```
cd cannon

make cannon && make -C example elf
./bin/cannon load-elf --path ./example/bin/highmem.elf  --out /tmp/highmem-prestate.json --meta /tmp/highmem-meta.json
./bin/cannon run --proof-at '=0' --stop-at '=1' --input /tmp/highmem-prestate.json --meta /tmp/highmem-meta.json --proof-fmt '/tmp/highmem-%d.json' --output ""
./bin/cannon run --input /tmp/highmem-prestate.json --output /tmp/final.json.gz --meta /tmp/highmem-meta.json  --info-at '%10000000'