### PR TITLE
chore(contracts-bedrock): refine error message of config.sh

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -20,7 +20,12 @@ reqenv "GS_SEQUENCER_ADDRESS"
 reqenv "L1_RPC_URL"
 
 # Get the finalized block timestamp and hash
-block=$(cast block finalized --rpc-url "$L1_RPC_URL")
+if ! block=$(cast block finalized --rpc-url "$L1_RPC_URL" 2>&1); then
+    echo "Execute cast block failed, $block"
+    echo "Please check if your L1_RPC_URL ('$L1_RPC_URL') is valid and accessible."
+    exit 1
+fi
+
 timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
 blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
When executing packages/contracts-bedrock/scripts/getting-started/config.sh with an invalid L1_RPC_URL, the error message is confusing and not user-friendly, making it difficult to identify the real problem. Therefore, I've refined the script to print a clearer error message and exit without continuing execution.

**Additional context**
Error message before fixed:
```
Error:
No such file or directory (os error 2)
```

Error message after fixed:
```
Execute cast block failed, Error:
URL scheme is not supported: hxxxttps://ethereum-mainnet.s.com/
Please check if your L1_RPC_URL ('hxxxttps://ethereum-mainnet.s.com/') is valid and accessible.
```
