### PR TITLE
feat(proxyd): add smoke test

### DIFF
--- a/proxyd/cmd/proxyd/main.go
+++ b/proxyd/cmd/proxyd/main.go
@@ -28,8 +28,7 @@ var (
 func main() {
 	// Set up logger with a default INFO level in case we fail to parse flags.
 	// Otherwise the final critical log won't show what the parsing error was.
-	log.SetDefault(log.NewLogger(slog.NewJSONHandler(
-		os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	proxyd.SetLogLevel(slog.LevelInfo)
 
 	log.Info("starting proxyd", "version", GitVersion, "commit", GitCommit, "date", GitDate)
 
@@ -50,8 +49,7 @@ func main() {
 			log.Warn("invalid server.log_level set: " + config.Server.LogLevel)
 		}
 	}
-	log.SetDefault(log.NewLogger(slog.NewJSONHandler(
-		os.Stdout, &slog.HandlerOptions{Level: logLevel})))
+	proxyd.SetLogLevel(logLevel)
 
 	if config.Server.EnablePprof {
 		log.Info("starting pprof", "addr", "0.0.0.0", "port", "6060")

--- a/proxyd/integration_tests/smoke_test.go
+++ b/proxyd/integration_tests/smoke_test.go
@@ -1,0 +1,51 @@
+package integration_tests
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/proxyd"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitProxyd(t *testing.T) {
+	goodBackend := NewMockBackend(BatchedResponseHandler(200, goodResponse))
+	defer goodBackend.Close()
+
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	config := ReadConfig("smoke")
+
+	sysStdOut := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	proxyd.SetLogLevel(log.LevelInfo)
+
+	defer func() {
+		w.Close()
+		out, _ := io.ReadAll(r)
+		require.True(t, strings.Contains(string(out), "started proxyd"))
+		require.True(t, strings.Contains(string(out), "shutting down proxyd"))
+		fmt.Println(string(out))
+		os.Stdout = sysStdOut
+	}()
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	t.Run("initialization", func(t *testing.T) {
+		client := NewProxydClient("http://127.0.0.1:8545")
+		res, code, err := client.SendRPC(ethChainID, nil)
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.NotNil(t, res)
+	})
+
+}

--- a/proxyd/integration_tests/testdata/smoke.toml
+++ b/proxyd/integration_tests/testdata/smoke.toml
@@ -1,0 +1,18 @@
+[server]
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"
+

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -13,8 +13,14 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
+	"golang.org/x/exp/slog"
 	"golang.org/x/sync/semaphore"
 )
+
+func SetLogLevel(logLevel slog.Leveler) {
+	log.SetDefault(log.NewLogger(slog.NewJSONHandler(
+		os.Stdout, &slog.HandlerOptions{Level: logLevel})))
+}
 
 func Start(config *Config) (*Server, func(), error) {
 	if len(config.Backends) == 0 {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a simple smoke test case to check proxyd has initialized and shutdown correctly, with proper log output.

**Tests**

```
go test ./...
```

**Additional context**

- Regression introduced by https://github.com/ethereum-optimism/optimism/pull/8917
- Fix https://github.com/ethereum-optimism/optimism/pull/9785

**Metadata**

Fixes https://github.com/ethereum-optimism/devinfra-pod/issues/109
