### PR TITLE
feat(proxyd): use a specific redis instance for consensus_ha

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -123,6 +123,7 @@ type BackendGroupConfig struct {
 	ConsensusHA                  bool         `toml:"consensus_ha"`
 	ConsensusHAHeartbeatInterval TOMLDuration `toml:"consensus_ha_heartbeat_interval"`
 	ConsensusHALockPeriod        TOMLDuration `toml:"consensus_ha_lock_period"`
+	ConsensusHARedis             RedisConfig  `toml:"consensus_ha_redis"`
 }
 
 type BackendGroupsConfig map[string]*BackendGroupConfig


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change allows proxyd to use a specific redis instance for Consensus HA, making the consensus_ha cache keys protected from cache flood.

**Tests**

```
go test ./...
```

**Metadata**

Part of:
- https://github.com/ethereum-optimism/devinfra-pod/issues/86
- https://github.com/ethereum-optimism/devinfra-pod/issues/110
