### PR TITLE
ci: fix juint path specificer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1490,7 +1490,7 @@ jobs:
       - store_artifacts:
           path: ./packages/contracts-bedrock/test/kontrol/logs/kontrol-results_latest.tar.gz
       - store_test_results:
-          path: ./packages/contracts-bedrock/kontrol_prove_report.xml
+          path: ./packages/contracts-bedrock
       - notify-failures-on-develop
 
 workflows:


### PR DESCRIPTION
Per the CircleCI [docs](https://circleci.com/docs/collect-test-data/), this should point to a path, not a file. This is why individual test data is now showing up for kontrol tests in https://app.circleci.com/insights/github/ethereum-optimism/optimism/workflows/develop-kontrol-tests/tests