### PR TITLE
op-wheel: delete dead code

### DIFF
--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -23,11 +23,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-var HundredETH = big.NewInt(0).Mul(big.NewInt(100), big.NewInt(1000000000000000000))
+var HundredETH = big.NewInt(0).Mul(big.NewInt(100), big.NewInt(params.Ether))
 
 type Cheater struct {
 	// The database of the chain with the head block that we patch the state-root of, once the state is updated.
@@ -329,58 +330,6 @@ func StoragePatch(patch io.Reader, address common.Address) HeadFn {
 				}
 			}
 		}
-		return nil
-	}
-}
-
-type OvmOwnersConfig struct {
-	Network   string         `json:"network"`
-	Owner     common.Address `json:"owner"`
-	Sequencer common.Address `json:"sequencer"`
-	Proposer  common.Address `json:"proposer"`
-}
-
-func OvmOwners(conf *OvmOwnersConfig) HeadFn {
-	return func(_ *types.Header, headState *state.StateDB) error {
-		var addressManager common.Address // Lib_AddressManager
-		var l1SBProxy common.Address      // Proxy__OVM_L1StandardBridge
-		var l1XDMProxy common.Address     // Proxy__OVM_L1CrossDomainMessenger
-		var l1ERC721BridgeProxy common.Address
-		switch conf.Network {
-		case "mainnet":
-			addressManager = common.HexToAddress("0xdE1FCfB0851916CA5101820A69b13a4E276bd81F")
-			l1SBProxy = common.HexToAddress("0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1")
-			l1XDMProxy = common.HexToAddress("0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1")
-			l1ERC721BridgeProxy = common.HexToAddress("0x5a7749f83b81B301cAb5f48EB8516B986DAef23D")
-		case "goerli":
-			addressManager = common.HexToAddress("0xa6f73589243a6A7a9023b1Fa0651b1d89c177111")
-			l1SBProxy = common.HexToAddress("0x636Af16bf2f682dD3109e60102b8E1A089FedAa8")
-			l1XDMProxy = common.HexToAddress("0x5086d1eEF304eb5284A0f6720f79403b4e9bE294")
-			l1ERC721BridgeProxy = common.HexToAddress("0x8DD330DdE8D9898d43b4dc840Da27A07dF91b3c9")
-		default:
-			return fmt.Errorf("unknown network: %q", conf.Network)
-		}
-		// See Proxy.sol OWNER_KEY: https://eips.ethereum.org/EIPS/eip-1967#admin-address
-		ownerSlot := common.HexToHash("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")
-
-		// Address manager owner
-		// Ownable, first storage slot
-		headState.SetState(addressManager, common.Hash{}, eth.AddressAsLeftPaddedHash(conf.Owner))
-		// L1SB proxy owner
-		headState.SetState(l1SBProxy, ownerSlot, eth.AddressAsLeftPaddedHash(conf.Owner))
-		// L1XDM owner
-		// 0x33 = 51. L1CrossDomainMessenger is L1CrossDomainMessenger (0) Lib_AddressResolver (1) OwnableUpgradeable (1, but covered by gap) + ContextUpgradeable (special gap of 50) and then _owner
-		headState.SetState(l1XDMProxy, common.Hash{31: 0x33}, eth.AddressAsLeftPaddedHash(conf.Owner))
-		// L1 ERC721 bridge owner
-		headState.SetState(l1ERC721BridgeProxy, ownerSlot, eth.AddressAsLeftPaddedHash(conf.Owner))
-		// Legacy sequencer/proposer addresses
-		// See AddressManager.sol "addresses" mapping(bytes32 => address), at slot position 1
-		addressesSlot := common.BigToHash(big.NewInt(1))
-		headState.SetState(addressManager, crypto.Keccak256Hash(crypto.Keccak256([]byte("OVM_Sequencer")), addressesSlot.Bytes()), eth.AddressAsLeftPaddedHash(conf.Sequencer))
-		headState.SetState(addressManager, crypto.Keccak256Hash(crypto.Keccak256([]byte("OVM_Proposer")), addressesSlot.Bytes()), eth.AddressAsLeftPaddedHash(conf.Proposer))
-		// Fund sequencer and proposer with 100 ETH
-		headState.SetBalance(conf.Sequencer, HundredETH)
-		headState.SetBalance(conf.Proposer, HundredETH)
 		return nil
 	}
 }

--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -409,30 +409,6 @@ var (
 			return ch.RunAndClose(cheat.SetNonce(addrFlagValue("address", ctx), bigFlagValue("balance", ctx).Uint64()))
 		}),
 	}
-	CheatOvmOwnersCmd = &cli.Command{
-		Name: "ovm-owners",
-		Flags: []cli.Flag{
-			DataDirFlag,
-			&cli.StringFlag{
-				Name:     "config",
-				Usage:    "Path to JSON config of OVM address replacements to apply.",
-				Required: true,
-				EnvVars:  prefixEnvVars("OVM_OWNERS"),
-				Value:    "ovm-owners.json",
-			},
-		},
-		Action: CheatAction(false, func(ctx *cli.Context, ch *cheat.Cheater) error {
-			confData, err := os.ReadFile(ctx.String("config"))
-			if err != nil {
-				return fmt.Errorf("failed to read OVM owners JSON config file: %w", err)
-			}
-			var conf cheat.OvmOwnersConfig
-			if err := json.Unmarshal(confData, &conf); err != nil {
-				return err
-			}
-			return ch.RunAndClose(cheat.OvmOwners(&conf))
-		}),
-	}
 	CheatPrintHeadBlock = &cli.Command{
 		Name:  "head-block",
 		Usage: "dump head block as JSON",
@@ -702,7 +678,6 @@ var CheatCmd = &cli.Command{
 		CheatSetBalanceCmd,
 		CheatSetCodeCmd,
 		CheatSetNonceCmd,
-		CheatOvmOwnersCmd,
 		CheatPrintHeadBlock,
 		CheatPrintHeadHeader,
 	},


### PR DESCRIPTION
**Description**

The `ovm-owners` command was only relevant for the migration from legacy
op mainnet to bedrock. Now that bedrock is running in production, we can
delete this code. It reduces code in the codebase that is no longer
necessary to make maintaining easier.

The ability to perform the upgrade is preserved in the legacy codebase,
snapshotted at a point where the migration is reproducible.

See https://github.com/ethereum-optimism/optimism-legacy

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

