### PR TITLE
feat(op-dispute-mon): Unsafe Output Validation Metrics

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -16,6 +16,8 @@ func (*NoopMetricsImpl) RecordUp()                 {}
 func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
+func (*NoopMetricsImpl) RecordUnsafeOutput() {}
+
 func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64) {}
 
 func (*NoopMetricsImpl) RecordOutputFetchTime(timestamp float64) {}

--- a/op-dispute-mon/mon/validator_test.go
+++ b/op-dispute-mon/mon/validator_test.go
@@ -85,6 +85,7 @@ func TestDetector_CheckRootAgreement(t *testing.T) {
 		require.Equal(t, mockRootClaim, fetched)
 		require.False(t, agree)
 		require.NotZero(t, metrics.fetchTime)
+		require.Equal(t, 1, metrics.unsafeOutputs)
 	})
 
 	t.Run("OutputNotFound", func(t *testing.T) {
@@ -108,7 +109,12 @@ func setupOutputValidatorTest(t *testing.T) (*outputValidator, *stubRollupClient
 }
 
 type stubOutputMetrics struct {
-	fetchTime float64
+	fetchTime     float64
+	unsafeOutputs int
+}
+
+func (s *stubOutputMetrics) RecordUnsafeOutput() {
+	s.unsafeOutputs++
 }
 
 func (s *stubOutputMetrics) RecordOutputFetchTime(fetchTime float64) {


### PR DESCRIPTION
**Description**

Adds a simple gauge to count the number of unsafe output comparisons using the safe head db.

Also cleans up some small grammar and styling from recent op-dm changes.