### PR TITLE
feat(op-node): p2p rpc input validation

### DIFF
--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -181,6 +181,17 @@ func TestP2PFull(t *testing.T) {
 	require.Equal(t, []peer.ID{hostB.ID()}, blockedPeers)
 	require.NoError(t, p2pClientA.UnblockPeer(ctx, hostB.ID()))
 
+	require.Error(t, p2pClientA.BlockAddr(ctx, nil))
+	require.Error(t, p2pClientA.UnblockAddr(ctx, nil))
+	require.Error(t, p2pClientA.BlockSubnet(ctx, nil))
+	require.Error(t, p2pClientA.UnblockSubnet(ctx, nil))
+	require.Error(t, p2pClientA.BlockPeer(ctx, ""))
+	require.Error(t, p2pClientA.UnblockPeer(ctx, ""))
+	require.Error(t, p2pClientA.ProtectPeer(ctx, ""))
+	require.Error(t, p2pClientA.UnprotectPeer(ctx, ""))
+	require.Error(t, p2pClientA.ConnectPeer(ctx, ""))
+	require.Error(t, p2pClientA.DisconnectPeer(ctx, ""))
+
 	require.NoError(t, p2pClientA.BlockAddr(ctx, net.IP{123, 123, 123, 123}))
 	blockedIPs, err := p2pClientA.ListBlockedAddrs(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change hardness the input validation on authoritative P2P RPC methods for op-node.

**Tests**

Added new invalid input cases.

**Additional context**

Part of PMS: https://github.com/ethereum-optimism/devinfra-pod/issues/38

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/666
