### PR TITLE
Fix kontrol script to avoid workspace bind-mount

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/scripts/common.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/common.sh
@@ -154,7 +154,6 @@ start_docker () {
     --detach \
     --env FOUNDRY_PROFILE="$FOUNDRY_PROFILE" \
     --workdir /home/user/workspace \
-    -v "$WORKSPACE_DIR":/home/user/workspace \
     runtimeverificationinc/kontrol:ubuntu-jammy-"$KONTROL_RELEASE"
 
   copy_to_docker


### PR DESCRIPTION
The workspace bind-mount borks the local workspace as the files are chown'd to the docker user after they're copied to the remote container.
Docker isn't used in non-local mode so there's no point bind-mounting the workspace. 