### PR TITLE
feat(op-challenger): Unexpected Claim Resolution

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	methodClaimedBondFlag     = "claimedBondFlag"
 	methodGameDuration        = "gameDuration"
 	methodMaxGameDepth        = "maxGameDepth"
 	methodAbsolutePrestate    = "absolutePrestate"
@@ -225,6 +226,14 @@ func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (uint64,
 		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
 	}
 	return result.GetUint64(0), nil
+}
+
+func (f *FaultDisputeGameContract) GetClaimedBondFlag(ctx context.Context) (*big.Int, error) {
+	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodClaimedBondFlag))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch claimed bond flag: %w", err)
+	}
+	return result.GetBigInt(0), nil
 }
 
 func (f *FaultDisputeGameContract) GetMaxGameDepth(ctx context.Context) (types.Depth, error) {

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/resolved"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/cannon"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
@@ -27,6 +28,7 @@ type CloseFunc func()
 type Registry interface {
 	RegisterGameType(gameType uint32, creator scheduler.PlayerCreator)
 	RegisterBondContract(gameType uint32, creator claims.BondContractCreator)
+	RegisterGameContract(gameType uint32, creator resolved.GameContractCreator)
 }
 
 type OracleRegistry interface {
@@ -140,10 +142,14 @@ func registerAlphabet(
 	}
 	registry.RegisterGameType(faultTypes.AlphabetGameType, playerCreator)
 
-	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
+	bondContractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
 		return contracts.NewFaultDisputeGameContract(game.Proxy, caller)
 	}
-	registry.RegisterBondContract(faultTypes.AlphabetGameType, contractCreator)
+	gameContractCreator := func(game types.GameMetadata) (resolved.GameContract, error) {
+		return contracts.NewFaultDisputeGameContract(game.Proxy, caller)
+	}
+	registry.RegisterBondContract(faultTypes.AlphabetGameType, bondContractCreator)
+	registry.RegisterGameContract(faultTypes.AlphabetGameType, gameContractCreator)
 	return nil
 }
 
@@ -224,10 +230,14 @@ func registerCannon(
 	}
 	registry.RegisterGameType(gameType, playerCreator)
 
-	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
+	bondContractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
 		return contracts.NewFaultDisputeGameContract(game.Proxy, caller)
 	}
-	registry.RegisterBondContract(gameType, contractCreator)
+	gameContractCreator := func(game types.GameMetadata) (resolved.GameContract, error) {
+		return contracts.NewFaultDisputeGameContract(game.Proxy, caller)
+	}
+	registry.RegisterBondContract(gameType, bondContractCreator)
+	registry.RegisterGameContract(gameType, gameContractCreator)
 	return nil
 }
 

--- a/op-challenger/game/fault/resolved/claims.go
+++ b/op-challenger/game/fault/resolved/claims.go
@@ -1,0 +1,83 @@
+package resolved
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type GameContract interface {
+	GetAllClaims(ctx context.Context, block rpcblock.Block) ([]faultTypes.Claim, error)
+	GetClaimedBondFlag(ctx context.Context) (*big.Int, error)
+}
+
+type GameContractCreator func(game types.GameMetadata) (GameContract, error)
+
+type ClaimValidatorMetrics interface {
+	RecordUnexpectedClaimResolution()
+}
+
+type claimValidator struct {
+	logger    log.Logger
+	metrics   ClaimValidatorMetrics
+	creator   GameContractCreator
+	claimants []common.Address
+}
+
+func NewClaimValidator(l log.Logger, m ClaimValidatorMetrics, creator GameContractCreator, claimants ...common.Address) *claimValidator {
+	return &claimValidator{
+		logger:    l,
+		metrics:   m,
+		creator:   creator,
+		claimants: claimants,
+	}
+}
+
+func (v *claimValidator) Validate(ctx context.Context, block uint64, games []types.GameMetadata) (err error) {
+	for _, game := range games {
+		err = errors.Join(err, v.validateGame(ctx, rpcblock.ByNumber(block), game))
+	}
+	return err
+}
+
+func (v *claimValidator) validateGame(ctx context.Context, block rpcblock.Block, game types.GameMetadata) error {
+	contract, err := v.creator(game)
+	if err != nil {
+		return err
+	}
+
+	claims, err := contract.GetAllClaims(ctx, block)
+	if err != nil {
+		return err
+	}
+
+	claimedBondFlag, err := contract.GetClaimedBondFlag(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, claim := range claims {
+		countered := claim.CounteredBy != (common.Address{})
+		maxBond := claim.Bond.Cmp(claimedBondFlag) == 0
+		if v.isClaimant(claim.Claimant) && countered && maxBond {
+			v.metrics.RecordUnexpectedClaimResolution()
+			v.logger.Warn("Encountered unexpected claim resolution", "game", game.Proxy, "counter", claim.CounteredBy)
+		}
+	}
+	return nil
+}
+
+func (v *claimValidator) isClaimant(claimant common.Address) bool {
+	for _, c := range v.claimants {
+		if c == claimant {
+			return true
+		}
+	}
+	return false
+}

--- a/op-challenger/game/fault/resolved/claims_test.go
+++ b/op-challenger/game/fault/resolved/claims_test.go
@@ -1,0 +1,117 @@
+package resolved
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testClaimants = []common.Address{
+	common.Address{0xaa},
+}
+
+func TestClaimer_Validate(t *testing.T) {
+	t.Run("GameValidationSucceeds", func(t *testing.T) {
+		gameAddr := common.HexToAddress("0x1234")
+		validator, metrics, contract := newTestClaimValidator(t)
+		ctx := context.Background()
+		games := []types.GameMetadata{{Proxy: gameAddr}, {Proxy: gameAddr}, {Proxy: gameAddr}}
+		err := validator.Validate(ctx, uint64(0), games)
+		require.NoError(t, err)
+		require.Equal(t, 3, contract.getAllClaimsCalls)
+		require.Equal(t, 3, contract.getClaimedBondFlagCalls)
+		require.Equal(t, 6, metrics.calls)
+	})
+
+	t.Run("ContractCreationFails", func(t *testing.T) {
+		validator, _, _ := newTestClaimValidator(t)
+		validator.creator = func(game types.GameMetadata) (GameContract, error) {
+			return nil, assert.AnError
+		}
+		err := validator.Validate(context.Background(), uint64(0), []types.GameMetadata{{}})
+		require.Error(t, err)
+	})
+
+	t.Run("GetAllClaimsFails", func(t *testing.T) {
+		validator, _, contract := newTestClaimValidator(t)
+		contract.getAllClaimsErr = assert.AnError
+		err := validator.Validate(context.Background(), uint64(0), []types.GameMetadata{{}})
+		require.Error(t, err)
+	})
+
+	t.Run("GetClaimedBondFlagFails", func(t *testing.T) {
+		validator, _, contract := newTestClaimValidator(t)
+		contract.getClaimedBondFlagErr = assert.AnError
+		err := validator.Validate(context.Background(), uint64(0), []types.GameMetadata{{}})
+		require.Error(t, err)
+	})
+}
+
+func newTestClaimValidator(t *testing.T) (*claimValidator, *stubValidatorMetrics, *stubGameContract) {
+	logger := testlog.Logger(t, log.LvlDebug)
+	m := &stubValidatorMetrics{}
+	c := &stubGameContract{}
+	creator := func(game types.GameMetadata) (GameContract, error) {
+		return c, nil
+	}
+	return NewClaimValidator(logger, m, creator, testClaimants...), m, c
+}
+
+type stubValidatorMetrics struct {
+	calls int
+}
+
+func (s *stubValidatorMetrics) RecordUnexpectedClaimResolution() {
+	s.calls++
+}
+
+type stubGameContract struct {
+	getAllClaimsCalls       int
+	getAllClaimsErr         error
+	getClaimedBondFlagCalls int
+	getClaimedBondFlagErr   error
+}
+
+func newClaim(claimant common.Address, counter common.Address, bond *big.Int) faultTypes.Claim {
+	return faultTypes.Claim{
+		ClaimData: faultTypes.ClaimData{
+			Bond: bond,
+		},
+		Claimant:    claimant,
+		CounteredBy: counter,
+	}
+}
+
+func (s *stubGameContract) GetAllClaims(ctx context.Context, block rpcblock.Block) ([]faultTypes.Claim, error) {
+	s.getAllClaimsCalls++
+	if s.getAllClaimsErr != nil {
+		return nil, s.getAllClaimsErr
+	}
+	return []faultTypes.Claim{
+		newClaim(testClaimants[0], common.Address{0xbb}, big.NewInt(100)),
+		newClaim(testClaimants[0], common.Address{0xbb}, big.NewInt(10)),
+		newClaim(testClaimants[0], common.Address{}, big.NewInt(10)),
+		newClaim(common.Address{}, common.Address{}, big.NewInt(10)),
+		newClaim(testClaimants[0], common.Address{0xbb}, big.NewInt(100)),
+		newClaim(testClaimants[0], common.Address{0xbb}, big.NewInt(10)),
+		newClaim(testClaimants[0], common.Address{}, big.NewInt(10)),
+		newClaim(common.Address{}, common.Address{}, big.NewInt(10)),
+	}, nil
+}
+
+func (s *stubGameContract) GetClaimedBondFlag(ctx context.Context) (*big.Int, error) {
+	s.getClaimedBondFlagCalls++
+	if s.getClaimedBondFlagErr != nil {
+		return nil, s.getClaimedBondFlagErr
+	}
+	return big.NewInt(100), nil
+}

--- a/op-challenger/game/fault/resolved/scheduler.go
+++ b/op-challenger/game/fault/resolved/scheduler.go
@@ -1,0 +1,74 @@
+package resolved
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Validator func(ctx context.Context, block uint64, games []types.GameMetadata) error
+
+type ValidatorScheduler struct {
+	log        log.Logger
+	ch         chan schedulerMessage
+	validators []Validator
+	cancel     func()
+	wg         sync.WaitGroup
+}
+
+type schedulerMessage struct {
+	blockNumber uint64
+	games       []types.GameMetadata
+}
+
+func NewValidatorScheduler(logger log.Logger, validators ...Validator) *ValidatorScheduler {
+	return &ValidatorScheduler{
+		log:        logger,
+		ch:         make(chan schedulerMessage, 1),
+		validators: validators,
+	}
+}
+
+func (v *ValidatorScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	v.cancel = cancel
+	v.wg.Add(1)
+	go v.run(ctx)
+}
+
+func (v *ValidatorScheduler) Close() error {
+	v.cancel()
+	v.wg.Wait()
+	return nil
+}
+
+func (v *ValidatorScheduler) run(ctx context.Context) {
+	defer v.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-v.ch:
+			v.validate(ctx, msg)
+		}
+	}
+}
+
+func (v *ValidatorScheduler) validate(ctx context.Context, msg schedulerMessage) {
+	for _, validator := range v.validators {
+		if err := validator(ctx, msg.blockNumber, msg.games); err != nil {
+			v.log.Error("Failed to validate game", "blockNumber", msg.blockNumber, "err", err)
+		}
+	}
+}
+
+func (v *ValidatorScheduler) Schedule(blockNumber uint64, games []types.GameMetadata) error {
+	select {
+	case v.ch <- schedulerMessage{blockNumber, games}:
+	default:
+		v.log.Trace("Skipping validation while validators in progress")
+	}
+	return nil
+}

--- a/op-challenger/game/fault/resolved/scheduler_test.go
+++ b/op-challenger/game/fault/resolved/scheduler_test.go
@@ -1,0 +1,82 @@
+package resolved
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var mockClaimResolutionError = errors.New("mock claim resolution error")
+
+func TestValidatorScheduler_Schedule(t *testing.T) {
+	tests := []struct {
+		name                  string
+		validateErr           error
+		games                 []types.GameMetadata
+		expectedValidateCalls int
+	}{
+		{
+			name:                  "SingleGame_Succeeds",
+			games:                 []types.GameMetadata{{}},
+			expectedValidateCalls: 1,
+		},
+		{
+			name:                  "SingleGame_Fails",
+			validateErr:           mockClaimResolutionError,
+			games:                 []types.GameMetadata{{}},
+			expectedValidateCalls: 1,
+		},
+		{
+			name:                  "MultipleGames_Succeed",
+			games:                 []types.GameMetadata{{}, {}, {}},
+			expectedValidateCalls: 1,
+		},
+		{
+			name:                  "MultipleGames_Fails",
+			validateErr:           mockClaimResolutionError,
+			games:                 []types.GameMetadata{{}, {}, {}},
+			expectedValidateCalls: 1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheduler, validator := setupTestValidatorScheduler(t)
+			validator.err = test.validateErr
+			scheduler.Start(ctx)
+			defer scheduler.Close()
+
+			err := scheduler.Schedule(1, test.games)
+			require.NoError(t, err)
+			require.Eventually(t, func() bool {
+				return int(validator.calls.Load()) == test.expectedValidateCalls
+			}, 10*time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
+func setupTestValidatorScheduler(t *testing.T) (*ValidatorScheduler, *stubValidator) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	validator := &stubValidator{}
+	scheduler := NewValidatorScheduler(logger, validator.Validate)
+	return scheduler, validator
+}
+
+type stubValidator struct {
+	calls atomic.Int64
+	err   error
+}
+
+func (s *stubValidator) Validate(_ context.Context, _ uint64, _ []types.GameMetadata) error {
+	s.calls.Add(1)
+	return s.err
+}

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -165,6 +165,7 @@ func setupMonitorTest(
 	preimages := &stubPreimageScheduler{}
 	mockHeadSource := &mockNewHeadSource{}
 	stubClaimer := &mockScheduler{}
+	stubValidator := &mockScheduler{}
 	monitor := newGameMonitor(
 		logger,
 		clock.NewSimpleClock(),
@@ -173,6 +174,7 @@ func setupMonitorTest(
 		preimages,
 		time.Duration(0),
 		stubClaimer,
+		stubValidator,
 		fetchBlockNum,
 		allowedGames,
 		mockHeadSource,

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -40,6 +40,8 @@ type Metricer interface {
 	RecordBondClaimFailed()
 	RecordBondClaimed(amount uint64)
 
+	RecordUnexpectedClaimResolution()
+
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 
 	RecordGameUpdateScheduled()
@@ -70,6 +72,8 @@ type Metrics struct {
 
 	bondClaimFailures prometheus.Counter
 	bondsClaimed      prometheus.Counter
+
+	unexpectedClaimResolutions prometheus.Counter
 
 	preimageChallenged      prometheus.Counter
 	preimageChallengeFailed prometheus.Counter
@@ -151,6 +155,11 @@ func NewMetrics() *Metrics {
 			Name:      "bonds",
 			Help:      "Number of bonds claimed by the challenge agent",
 		}),
+		unexpectedClaimResolutions: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "unexpected_claim_resolutions",
+			Help:      "Number of unexpected claim resolutions",
+		}),
 		preimageChallenged: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: Namespace,
 			Name:      "preimage_challenged",
@@ -231,6 +240,10 @@ func (m *Metrics) RecordBondClaimFailed() {
 
 func (m *Metrics) RecordBondClaimed(amount uint64) {
 	m.bondsClaimed.Add(float64(amount))
+}
+
+func (m *Metrics) RecordUnexpectedClaimResolution() {
+	m.unexpectedClaimResolutions.Add(1)
 }
 
 func (m *Metrics) RecordCannonExecutionTime(t float64) {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -34,6 +34,8 @@ func (*NoopMetricsImpl) RecordPreimageChallengeFailed() {}
 func (*NoopMetricsImpl) RecordBondClaimFailed()   {}
 func (*NoopMetricsImpl) RecordBondClaimed(uint64) {}
 
+func (*NoopMetricsImpl) RecordUnexpectedClaimResolution() {}
+
 func (*NoopMetricsImpl) RecordCannonExecutionTime(t float64) {}
 
 func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}


### PR DESCRIPTION
**Description**

Adds a component to the `op-challenger` to log and track via a simple counter metric unexpected claim resolution against the challenger or any of its claimants.

This component follows the bond claimer pattern of having its own scheduler since it doesn't exactly tie in nicely into the core game player since games that are not in progress are "skipped", and I don't think it's a good idea to deviate from this behavior now.

**Tests**

Added unit tests around the `resolved` fault package scheduler and claim validator components.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/524