### PR TITLE
op-batcher: fix "handle receipt" log message to properly log id

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -253,8 +253,8 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(ctx context.Context) (eth.
 func (l *BatchSubmitter) loop() {
 	defer l.wg.Done()
 
-	receiptsCh := make(chan txmgr.TxReceipt[txData])
-	queue := txmgr.NewQueue[txData](l.killCtx, l.Txmgr, l.Config.MaxPendingTransactions)
+	receiptsCh := make(chan txmgr.TxReceipt[txID])
+	queue := txmgr.NewQueue[txID](l.killCtx, l.Txmgr, l.Config.MaxPendingTransactions)
 
 	// start the receipt/result processing loop
 	receiptLoopDone := make(chan struct{})
@@ -326,7 +326,7 @@ func (l *BatchSubmitter) loop() {
 
 // publishStateToL1 queues up all pending TxData to be published to the L1, returning when there is
 // no more data to queue for publishing or if there was an error queing the data.
-func (l *BatchSubmitter) publishStateToL1(queue *txmgr.Queue[txData], receiptsCh chan txmgr.TxReceipt[txData]) {
+func (l *BatchSubmitter) publishStateToL1(queue *txmgr.Queue[txID], receiptsCh chan txmgr.TxReceipt[txID]) {
 	for {
 		// if the txmgr is closed, we stop the transaction sending
 		if l.Txmgr.IsClosed() {
@@ -383,7 +383,7 @@ func (l *BatchSubmitter) clearState(ctx context.Context) {
 }
 
 // publishTxToL1 submits a single state tx to the L1
-func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[txData], receiptsCh chan txmgr.TxReceipt[txData]) error {
+func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[txID], receiptsCh chan txmgr.TxReceipt[txID]) error {
 	// send all available transactions
 	l1tip, err := l.l1Tip(ctx)
 	if err != nil {
@@ -435,7 +435,7 @@ func (l *BatchSubmitter) safeL1Origin(ctx context.Context) (eth.BlockID, error) 
 
 // sendTransaction creates & queues for sending a transaction to the batch inbox address with the given `txData`.
 // The method will block if the queue's MaxPendingTransactions is exceeded.
-func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, queue *txmgr.Queue[txData], receiptsCh chan txmgr.TxReceipt[txData]) error {
+func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, queue *txmgr.Queue[txID], receiptsCh chan txmgr.TxReceipt[txID]) error {
 	var err error
 	// Do the gas estimation offline. A value of 0 will cause the [txmgr] to estimate the gas limit.
 
@@ -460,7 +460,7 @@ func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, que
 			if err != nil {
 				l.Log.Error("Failed to post input to Plasma DA", "error", err)
 				// requeue frame if we fail to post to the DA Provider so it can be retried
-				l.recordFailedTx(txdata, err)
+				l.recordFailedTx(txdata.ID(), err)
 				return nil
 			}
 			// signal plasma commitment tx with TxDataVersion1
@@ -477,7 +477,7 @@ func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, que
 		candidate.GasLimit = intrinsicGas
 	}
 
-	queue.Send(txdata, *candidate, receiptsCh)
+	queue.Send(txdata.ID(), *candidate, receiptsCh)
 	return nil
 }
 
@@ -505,7 +505,7 @@ func (l *BatchSubmitter) calldataTxCandidate(data []byte) *txmgr.TxCandidate {
 	}
 }
 
-func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txData]) {
+func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txID]) {
 	// Record TX Status
 	if r.Err != nil {
 		l.recordFailedTx(r.ID, r.Err)
@@ -522,15 +522,15 @@ func (l *BatchSubmitter) recordL1Tip(l1tip eth.L1BlockRef) {
 	l.Metr.RecordLatestL1Block(l1tip)
 }
 
-func (l *BatchSubmitter) recordFailedTx(txd txData, err error) {
-	l.Log.Warn("Transaction failed to send", logFields(txd, err)...)
-	l.state.TxFailed(txd.ID())
+func (l *BatchSubmitter) recordFailedTx(id txID, err error) {
+	l.Log.Warn("Transaction failed to send", logFields(id, err)...)
+	l.state.TxFailed(id)
 }
 
-func (l *BatchSubmitter) recordConfirmedTx(txd txData, receipt *types.Receipt) {
-	l.Log.Info("Transaction confirmed", logFields(txd, receipt)...)
+func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) {
+	l.Log.Info("Transaction confirmed", logFields(id, receipt)...)
 	l1block := eth.ReceiptBlockID(receipt)
-	l.state.TxConfirmed(txd.ID(), l1block)
+	l.state.TxConfirmed(id, l1block)
 }
 
 // l1Tip gets the current L1 tip as a L1BlockRef. The passed context is assumed
@@ -548,8 +548,8 @@ func (l *BatchSubmitter) l1Tip(ctx context.Context) (eth.L1BlockRef, error) {
 func logFields(xs ...any) (fs []any) {
 	for _, x := range xs {
 		switch v := x.(type) {
-		case txData:
-			fs = append(fs, "tx_id", v.ID(), "data_len", v.Len())
+		case txID:
+			fs = append(fs, "tx_id", v.String())
 		case *types.Receipt:
 			fs = append(fs, "tx", v.TxHash, "block", eth.ReceiptBlockID(v))
 		case error:


### PR DESCRIPTION
**Description**

Fixes "handle receipt" log message to properly log id. It used to log the full transaction frames.

While fixing this, decided to attach only the `txID` to the transaction candidate, instead of the full `txData`. We only need the attached id as an identifier, not the full data. This made me remove the `data_len` field from one log, but that's fine because we already log the channel and tx length in multiple places before. We don't need to log it when confirming a receipt.

Note that the bug was in [line 266](https://github.com/ethereum-optimism/optimism/pull/9918/files#diff-c734d1296b2fd691221b92df3edf09c7533c507a74c2316117745c75c3ad5776R266) and is now implicitly solved by changing the type of the `ID` field of the receipt.

**Tests**

n/a

