### PR TITLE
feat(sdk): add DGF address to the SDK for OP Sepolia

### DIFF
--- a/.changeset/wicked-points-grin.md
+++ b/.changeset/wicked-points-grin.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Sets the address of the DisputeGameFactory contract for OP Sepolia.

--- a/packages/sdk/src/utils/chain-constants.ts
+++ b/packages/sdk/src/utils/chain-constants.ts
@@ -33,6 +33,12 @@ const l1CrossDomainMessengerAddresses = {
   sepolia: '0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef',
 }
 
+const disputeGameFactoryAddresses = {
+  mainnet: ethers.constants.AddressZero,
+  goerli: ethers.constants.AddressZero,
+  sepolia: '0x05F9613aDB30026FFd634f38e5C4dFd30a197Fa1',
+}
+
 // legacy
 const stateCommitmentChainAddresses = {
   mainnet: '0xBe5dAb4A2e9cd0F27300dB4aB94BeE3A233AEB19',
@@ -121,7 +127,7 @@ const getL1ContractsByNetworkName = (network: string): OEL1ContractsLike => {
     OptimismPortal: portalAddresses[network],
     L2OutputOracle: l2OutputOracleAddresses[network],
     OptimismPortal2: portalAddresses[network],
-    DisputeGameFactory: ethers.constants.AddressZero,
+    DisputeGameFactory: disputeGameFactoryAddresses[network],
   }
 }
 


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds the DGF address to the SDK now that OP Sepolia has been updated.