### PR TITLE
contracts-bedrock: cancun evm version

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -26,7 +26,7 @@ bytecode_hash = 'none'
 build_info_path = 'artifacts/build-info'
 ast = true
 evm_version = "cancun"
-ignored_error_codes = [2394, 5574, 3860]
+ignored_error_codes = ["transient-storage", "code-size", "init-code-size"]
 
 # Test / Script Runner Settings
 ffi = true

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -25,6 +25,8 @@ extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 build_info_path = 'artifacts/build-info'
 ast = true
+evm_version = "cancun"
+ignored_error_codes = [2394, 5574, 3860]
 
 # Test / Script Runner Settings
 ffi = true


### PR DESCRIPTION
**Description**

Turns on the cancun evm version for the evm now that
decun is on mainnet. Also ignores some compiler warnings
related to tstore, code too large and initcode too large.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying EVM version "Cancun" and ignoring specific error codes in contract configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->