### PR TITLE
contracts-bedrock: adds spdx header to weth98

### DIFF
--- a/packages/contracts-bedrock/src/dispute/weth/WETH98.sol
+++ b/packages/contracts-bedrock/src/dispute/weth/WETH98.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
 // Copyright (C) 2015, 2016, 2017 Dapphub
 
 // This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
**Description**

Without the header, it results in a warning message.
This prevents CI from passing.
We also want to ensure that its free software.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

