### PR TITLE
op-challenger: Include bond with create game transactions

### DIFF
--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -43,7 +43,7 @@ func CreateGame(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create dispute game factory bindings: %w", err)
 	}
 
-	txCandidate, err := contract.CreateTx(uint32(traceType), outputRoot, l2BlockNum)
+	txCandidate, err := contract.CreateTx(ctx.Context, uint32(traceType), outputRoot, l2BlockNum)
 	if err != nil {
 		return fmt.Errorf("failed to create tx: %w", err)
 	}

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -212,10 +212,14 @@ func TestCreateTx(t *testing.T) {
 	traceType := uint32(123)
 	outputRoot := common.Hash{0x01}
 	l2BlockNum := common.BigToHash(big.NewInt(456)).Bytes()
+	bond := big.NewInt(49284294829)
+	stubRpc.SetResponse(factoryAddr, methodInitBonds, rpcblock.Latest, []interface{}{traceType}, []interface{}{bond})
 	stubRpc.SetResponse(factoryAddr, methodCreateGame, rpcblock.Latest, []interface{}{traceType, outputRoot, l2BlockNum}, nil)
-	tx, err := factory.CreateTx(traceType, outputRoot, uint64(456))
+	tx, err := factory.CreateTx(context.Background(), traceType, outputRoot, uint64(456))
 	require.NoError(t, err)
 	stubRpc.VerifyTxCandidate(tx)
+	require.NotNil(t, tx.Value)
+	require.Truef(t, bond.Cmp(tx.Value) == 0, "Expected bond %v but was %v", bond, tx.Value)
 }
 
 func setupDisputeGameFactoryTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameFactoryContract) {


### PR DESCRIPTION
**Description**

Fixes the `create-game` subcommand of `op-challenger` so that it includes the init bond payable when creating a game.

**Tests**

Updated contract bindings test.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/675
