### PR TITLE
Tests: Batching Benchmarks

### DIFF
--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -1,0 +1,128 @@
+package benchmarks
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func RandomSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int) *derive.SingularBatch {
+	signer := types.NewLondonSigner(chainID)
+	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
+	txsEncoded := make([]hexutil.Bytes, 0, txCount)
+	// force each tx to have equal chainID
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, baseFee, signer)
+		txEncoded, err := tx.MarshalBinary()
+		if err != nil {
+			panic("tx Marshal binary" + err.Error())
+		}
+		txsEncoded = append(txsEncoded, hexutil.Bytes(txEncoded))
+	}
+	return &derive.SingularBatch{
+		ParentHash:   testutils.RandomHash(rng),
+		EpochNum:     rollup.Epoch(1 + rng.Int63n(100_000_000)),
+		EpochHash:    testutils.RandomHash(rng),
+		Timestamp:    uint64(rng.Int63n(2_000_000_000)),
+		Transactions: txsEncoded,
+	}
+}
+
+type BatchingBenchmarkTC struct {
+	BatchType  uint
+	BatchCount int
+	txPerBatch int
+}
+
+func (t BatchingBenchmarkTC) String(cName string) string {
+	var btype string
+	if t.BatchType == derive.SingularBatchType {
+		btype = "Singular"
+	}
+	if t.BatchType == derive.SpanBatchType {
+		btype = "Span"
+	}
+	return fmt.Sprintf("BatchType=%s, txPerBatch=%d, BatchCount=%d, Compressor=%s", btype, t.txPerBatch, t.BatchCount, cName)
+}
+
+// BenchmarkChannelOut benchmarks the performance of adding singular batches to a channel out
+// this exercises the compression and batching logic, as well as any batch-building logic
+// Every Compressor in the compressor map is benchmarked for each test case
+func BenchmarkChannelOut(b *testing.B) {
+	rc, _ := compressor.NewRatioCompressor(compressor.Config{
+		TargetFrameSize:  100000,
+		TargetNumFrames:  1,
+		ApproxComprRatio: 0.4,
+	})
+	sc, _ := compressor.NewShadowCompressor(compressor.Config{
+		TargetFrameSize:  100000,
+		TargetNumFrames:  1,
+		ApproxComprRatio: 0.4,
+	})
+	nc, _ := compressor.NewNonCompressor(compressor.Config{
+		TargetFrameSize:  100000,
+		TargetNumFrames:  1,
+		ApproxComprRatio: 0.4,
+	})
+
+	compressors := map[string]derive.Compressor{
+		"RatioCompressor":  rc,
+		"ShadowCompressor": sc,
+		"NonCompressor":    nc,
+	}
+
+	tests := []BatchingBenchmarkTC{
+		// Singular Batch Tests
+		// low-throughput chains
+		{derive.SingularBatchType, 10, 1},
+		{derive.SingularBatchType, 50, 1},
+		{derive.SingularBatchType, 100, 1},
+		{derive.SingularBatchType, 200, 1},
+		{derive.SingularBatchType, 1000, 1},
+
+		// higher-throughput chains
+		{derive.SingularBatchType, 10, 10},
+		{derive.SingularBatchType, 100, 10},
+
+		// Span Batch Tests
+		// low-throughput chains
+		{derive.SpanBatchType, 10, 1},
+		{derive.SpanBatchType, 50, 1},
+		{derive.SpanBatchType, 100, 1},
+		{derive.SpanBatchType, 200, 1},
+		{derive.SpanBatchType, 1000, 1},
+
+		// higher-throughput chains
+		{derive.SpanBatchType, 10, 10},
+		{derive.SpanBatchType, 100, 10},
+	}
+
+	// for each compressor, run each the tests
+	for cName, c := range compressors {
+		for _, tc := range tests {
+			chainID := big.NewInt(333)
+			spanBatchBuilder := derive.NewSpanBatchBuilder(0, chainID)
+			rng := rand.New(rand.NewSource(0x543331))
+			c.Reset()
+			// pre-generate batches to keep the benchmark from including the random generation
+			batches := make([]*derive.SingularBatch, tc.BatchCount)
+			for i := 0; i < tc.BatchCount; i++ {
+				batches[i] = RandomSingularBatch(rng, tc.txPerBatch, chainID)
+			}
+			b.Run(tc.String(cName), func(b *testing.B) {
+				cout, _ := derive.NewChannelOut(tc.BatchType, c, spanBatchBuilder)
+				for i := 0; i < tc.BatchCount; i++ {
+					cout.AddSingularBatch(batches[i], 0)
+				}
+			})
+		}
+	}
+}

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -109,7 +109,7 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 				compressors[tc.compKey].Reset()
 				spanBatchBuilder := derive.NewSpanBatchBuilder(0, chainID)
 				cout, _ := derive.NewChannelOut(tc.BatchType, compressors[tc.compKey], spanBatchBuilder)
-				// add all but the final batche to the channel out
+				// add all but the final batch to the channel out
 				for i := 0; i < tc.BatchCount-1; i++ {
 					_, err := cout.AddSingularBatch(batches[i], 0)
 					require.NoError(b, err)
@@ -174,10 +174,8 @@ func BenchmarkAllBatchesChannelOut(b *testing.B) {
 				compressors[tc.compKey].Reset()
 				spanBatchBuilder := derive.NewSpanBatchBuilder(0, chainID)
 				cout, _ := derive.NewChannelOut(tc.BatchType, compressors[tc.compKey], spanBatchBuilder)
-				// add all but the final batche to the channel out
-				// measure the time to add the final batch
 				b.StartTimer()
-				// add the final batch to the channel out
+				// add all batches to the channel out
 				for i := 0; i < tc.BatchCount; i++ {
 					_, err := cout.AddSingularBatch(batches[i], 0)
 					require.NoError(b, err)

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -36,6 +36,7 @@ var (
 	batchTypes = []uint{
 		derive.SpanBatchType,
 		// uncomment to include singular batches in the benchmark
+		// singular batches are not included by default because they are not the target of the benchmark
 		//derive.SingularBatchType,
 	}
 )
@@ -65,7 +66,7 @@ func (t BatchingBenchmarkTC) String() string {
 // Every Compressor in the compressor map is benchmarked for each test case
 // The results of the Benchmark measure *only* the time to add the final batch to the channel out,
 // not the time to send all the batches through the channel out
-// Hint: Raise the derive.MaxRLPBytesPerChannel to 10_000_000_000 to avoid hitting limits
+// Hint: Raise the derive.MaxRLPBytesPerChannel to 10_000_000_000 to avoid hitting limits if adding larger test cases
 func BenchmarkFinalBatchChannelOut(b *testing.B) {
 	// Targets define the number of batches and transactions per batch to test
 	type target struct{ bs, tpb int }
@@ -73,7 +74,6 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 		{10, 1},
 		{100, 1},
 		{1000, 1},
-		//{10000, 1},
 
 		{10, 100},
 		{100, 100},
@@ -137,7 +137,6 @@ func BenchmarkAllBatchesChannelOut(b *testing.B) {
 		{10, 1},
 		{100, 1},
 		{1000, 1},
-		//{10000, 1},
 
 		{10, 100},
 		{100, 100},

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -39,7 +39,7 @@ var (
 	}
 )
 
-// a test case for the benchmark controlls the number of batches and transactions per batch,
+// a test case for the benchmark controls the number of batches and transactions per batch,
 // as well as the batch type and compressor used
 type BatchingBenchmarkTC struct {
 	BatchType  uint
@@ -162,7 +162,8 @@ func BenchmarkGetRawSpanBatch(b *testing.B) {
 					spanBatchBuilder.AppendSingularBatch(batches[i], 0)
 				}
 				b.StartTimer()
-				spanBatchBuilder.GetRawSpanBatch()
+				_, err := spanBatchBuilder.GetRawSpanBatch()
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -11,13 +11,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+
+	// compressors used in the benchmark
+	rc, _ = compressor.NewRatioCompressor(compressor.Config{
+		TargetOutputSize: 100_000_000_000,
+		ApproxComprRatio: 0.4,
+	})
+	sc, _ = compressor.NewShadowCompressor(compressor.Config{
+		TargetOutputSize: 100_000_000_000,
+	})
+	nc, _ = compressor.NewNonCompressor(compressor.Config{
+		TargetOutputSize: 100_000_000_000,
+	})
+
+	compressors = map[string]derive.Compressor{
+		"NonCompressor":    nc,
+		"RatioCompressor":  rc,
+		"ShadowCompressor": sc,
+	}
+
+	// batch types used in the benchmark
+	batchTypes = []uint{
+		derive.SingularBatchType,
+		derive.SpanBatchType,
+	}
+)
+
+// a test case for the benchmark controlls the number of batches and transactions per batch,
+// as well as the batch type and compressor used
 type BatchingBenchmarkTC struct {
 	BatchType  uint
 	BatchCount int
 	txPerBatch int
+	compKey    string
 }
 
-func (t BatchingBenchmarkTC) String(cName string) string {
+func (t BatchingBenchmarkTC) String() string {
 	var btype string
 	if t.BatchType == derive.SingularBatchType {
 		btype = "Singular"
@@ -25,77 +55,68 @@ func (t BatchingBenchmarkTC) String(cName string) string {
 	if t.BatchType == derive.SpanBatchType {
 		btype = "Span"
 	}
-	return fmt.Sprintf("BatchType=%s, txPerBatch=%d, BatchCount=%d, Compressor=%s", btype, t.txPerBatch, t.BatchCount, cName)
+	return fmt.Sprintf("BatchType=%s, txPerBatch=%d, BatchCount=%d, Compressor=%s", btype, t.txPerBatch, t.BatchCount, t.compKey)
 }
 
 // BenchmarkChannelOut benchmarks the performance of adding singular batches to a channel out
 // this exercises the compression and batching logic, as well as any batch-building logic
 // Every Compressor in the compressor map is benchmarked for each test case
+// The results of the Benchmark measure *only* the time to add the final batch to the channel out,
+// not the time to send all the batches through the channel out
+// Hint: Remove the Start/Stop timers to measure the time to send all the batches through the channel out
+// Hint: Raise the derive.MaxRLPBytesPerChannel to 10_000_000_000 to avoid hitting limits
 func BenchmarkChannelOut(b *testing.B) {
-	rc, _ := compressor.NewRatioCompressor(compressor.Config{
-		TargetOutputSize: 100_000_000_000,
-		ApproxComprRatio: 0.4,
-	})
-	sc, _ := compressor.NewShadowCompressor(compressor.Config{
-		TargetOutputSize: 100_000_000_000,
-	})
-	nc, _ := compressor.NewNonCompressor(compressor.Config{
-		TargetOutputSize: 100_000_000_000,
-	})
 
-	compressors := map[string]derive.Compressor{
-		"NonCompressor":    nc,
-		"RatioCompressor":  rc,
-		"ShadowCompressor": sc,
+	// Targets define the number of batches and transactions per batch to test
+	type target struct{ bs, tpb int }
+	targets := []target{
+		{10, 1},
+		{100, 1},
+		{1000, 1},
+		{10000, 1},
+
+		{10, 100},
+		{100, 100},
+		{1000, 100},
 	}
 
-	tests := []BatchingBenchmarkTC{
-		// Singular Batch Tests
-		// low-throughput chains
-		{derive.SingularBatchType, 10, 1},
-		{derive.SingularBatchType, 100, 1},
-		{derive.SingularBatchType, 1000, 1},
-		{derive.SingularBatchType, 10000, 1},
-
-		// higher-throughput chains
-		{derive.SingularBatchType, 10, 100},
-		{derive.SingularBatchType, 100, 100},
-		{derive.SingularBatchType, 1000, 100},
-
-		// Span Batch Tests
-		// low-throughput chains
-		{derive.SpanBatchType, 10, 1},
-		{derive.SpanBatchType, 100, 1},
-		{derive.SpanBatchType, 1000, 1},
-		{derive.SpanBatchType, 10000, 1},
-
-		// higher-throughput chains
-		{derive.SpanBatchType, 10, 100},
-		{derive.SpanBatchType, 100, 100},
-		{derive.SpanBatchType, 1000, 100},
-	}
-
-	// for each compressor, run each the tests
-	for cName, c := range compressors {
-		for _, tc := range tests {
-			chainID := big.NewInt(333)
-			spanBatchBuilder := derive.NewSpanBatchBuilder(0, chainID)
-			rng := rand.New(rand.NewSource(0x543331))
-			c.Reset()
-			// pre-generate batches to keep the benchmark from including the random generation
-			batches := make([]*derive.SingularBatch, tc.BatchCount)
-			for i := 0; i < tc.BatchCount; i++ {
-				batches[i] = derive.RandomSingularBatch(rng, tc.txPerBatch, chainID)
+	// build a set of test cases for each batch type, compressor, and target-pair
+	tests := []BatchingBenchmarkTC{}
+	for _, bt := range batchTypes {
+		for compkey := range compressors {
+			for _, t := range targets {
+				tests = append(tests, BatchingBenchmarkTC{bt, t.bs, t.tpb, compkey})
 			}
-			b.Run(tc.String(cName), func(b *testing.B) {
-				for bn := 0; bn < b.N; bn++ {
-					cout, _ := derive.NewChannelOut(tc.BatchType, c, spanBatchBuilder)
-					for i := 0; i < tc.BatchCount; i++ {
-						_, err := cout.AddSingularBatch(batches[i], 0)
-						require.NoError(b, err)
-					}
-				}
-			})
 		}
+	}
+
+	for _, tc := range tests {
+		chainID := big.NewInt(333)
+		spanBatchBuilder := derive.NewSpanBatchBuilder(0, chainID)
+		rng := rand.New(rand.NewSource(0x543331))
+		// pre-generate batches to keep the benchmark from including the random generation
+		batches := make([]*derive.SingularBatch, tc.BatchCount)
+		for i := 0; i < tc.BatchCount; i++ {
+			batches[i] = derive.RandomSingularBatch(rng, tc.txPerBatch, chainID)
+		}
+		b.Run(tc.String(), func(b *testing.B) {
+			// reset the compressor used in the test case
+			compressors[tc.compKey].Reset()
+			for bn := 0; bn < b.N; bn++ {
+				// don't measure the setup time
+				b.StopTimer()
+				cout, _ := derive.NewChannelOut(tc.BatchType, compressors[tc.compKey], spanBatchBuilder)
+				// add all but the final batche to the channel out
+				for i := 0; i < tc.BatchCount-1; i++ {
+					_, err := cout.AddSingularBatch(batches[i], 0)
+					require.NoError(b, err)
+				}
+				// measure the time to add the final batch
+				b.StartTimer()
+				// add the final batch to the channel out
+				_, err := cout.AddSingularBatch(batches[tc.BatchCount-1], 0)
+				require.NoError(b, err)
+			}
+		})
 	}
 }

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -34,8 +34,9 @@ var (
 
 	// batch types used in the benchmark
 	batchTypes = []uint{
-		derive.SingularBatchType,
 		derive.SpanBatchType,
+		// uncomment to include singular batches in the benchmark
+		//derive.SingularBatchType,
 	}
 )
 
@@ -72,11 +73,10 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 		{10, 1},
 		{100, 1},
 		{1000, 1},
-		{10000, 1},
+		//{10000, 1},
 
 		{10, 100},
 		{100, 100},
-		{1000, 100},
 	}
 
 	// build a set of test cases for each batch type, compressor, and target-pair
@@ -137,11 +137,10 @@ func BenchmarkAllBatchesChannelOut(b *testing.B) {
 		{10, 1},
 		{100, 1},
 		{1000, 1},
-		{10000, 1},
+		//{10000, 1},
 
 		{10, 100},
 		{100, 100},
-		{1000, 100},
 	}
 
 	// build a set of test cases for each batch type, compressor, and target-pair

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -76,28 +76,6 @@ func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 	return &rawSpanBatch
 }
 
-func RandomSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int) *SingularBatch {
-	signer := types.NewLondonSigner(chainID)
-	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
-	txsEncoded := make([]hexutil.Bytes, 0, txCount)
-	// force each tx to have equal chainID
-	for i := 0; i < txCount; i++ {
-		tx := testutils.RandomTx(rng, baseFee, signer)
-		txEncoded, err := tx.MarshalBinary()
-		if err != nil {
-			panic("tx Marshal binary" + err.Error())
-		}
-		txsEncoded = append(txsEncoded, hexutil.Bytes(txEncoded))
-	}
-	return &SingularBatch{
-		ParentHash:   testutils.RandomHash(rng),
-		EpochNum:     rollup.Epoch(1 + rng.Int63n(100_000_000)),
-		EpochHash:    testutils.RandomHash(rng),
-		Timestamp:    uint64(rng.Int63n(2_000_000_000)),
-		Transactions: txsEncoded,
-	}
-}
-
 func RandomValidConsecutiveSingularBatches(rng *rand.Rand, chainID *big.Int) []*SingularBatch {
 	blockCount := 2 + rng.Intn(128)
 	l2BlockTime := uint64(2)

--- a/op-node/rollup/derive/batch_test_utils.go
+++ b/op-node/rollup/derive/batch_test_utils.go
@@ -1,0 +1,33 @@
+package derive
+
+import (
+	"math/big"
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func RandomSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int) *SingularBatch {
+	signer := types.NewLondonSigner(chainID)
+	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
+	txsEncoded := make([]hexutil.Bytes, 0, txCount)
+	// force each tx to have equal chainID
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, baseFee, signer)
+		txEncoded, err := tx.MarshalBinary()
+		if err != nil {
+			panic("tx Marshal binary" + err.Error())
+		}
+		txsEncoded = append(txsEncoded, hexutil.Bytes(txEncoded))
+	}
+	return &SingularBatch{
+		ParentHash:   testutils.RandomHash(rng),
+		EpochNum:     rollup.Epoch(1 + rng.Int63n(100_000_000)),
+		EpochHash:    testutils.RandomHash(rng),
+		Timestamp:    uint64(rng.Int63n(2_000_000_000)),
+		Transactions: txsEncoded,
+	}
+}


### PR DESCRIPTION
This Benchmark measures the time it takes to add a singular batch to either a Singular Batch, or a Span Batch. In its present configuration it measures only the *FINAL* batch added, in order to show that as a batch grows, its performance changes over time.

It has a collection of test targets for number-of-batches and tx-per-batch, which it then multiplies by the two Batch Types, and then multiplies again by each Compressor type.

We are investigating the root cause of Quadratic Batcher Performance when using span batches, so this helps to demonstrate the loss in performance, and will help us to confirm the improvement as we fix it.


# Sample Output
Span Batches are low performance to the extent that I am still waiting for results from this latest version of the test, but here is an example of Singular vs Span with the NonCompressor:
```
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=10,_Compressor=NonCompressor-12            	       1	      2791 ns/op	     408 B/op	       4 allocs/op
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=100,_Compressor=NonCompressor-12           	       1	      2875 ns/op	     984 B/op	       4 allocs/op
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=1000,_Compressor=NonCompressor-12          	       1	      2375 ns/op	     440 B/op	       4 allocs/op
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=10000,_Compressor=NonCompressor-12         	       1	      9167 ns/op	     328 B/op	       4 allocs/op
-vs-
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=10,_Compressor=NonCompressor-12                	       1	     30667 ns/op	   35912 B/op	     392 allocs/op
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=100,_Compressor=NonCompressor-12               	       1	    175542 ns/op	  456648 B/op	    3277 allocs/op
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=1000,_Compressor=NonCompressor-12              	       1	   1614501 ns/op	 3107656 B/op	   31859 allocs/op
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=10000,_Compressor=NonCompressor-12             	       1	  18388584 ns/op	51128768 B/op	  316991 allocs/op
```

And the same for Ratio Compressor:
```
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=10,_Compressor=RatioCompressor-12          	       1	      8167 ns/op	     408 B/op	       4 allocs/op
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=100,_Compressor=RatioCompressor-12         	       1	     27251 ns/op	     984 B/op	       4 allocs/op
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=1000,_Compressor=RatioCompressor-12        	       1	     26459 ns/op	     440 B/op	       4 allocs/op
BenchmarkChannelOut/BatchType=Singular,_txPerBatch=1,_BatchCount=10000,_Compressor=RatioCompressor-12       	       1	     22124 ns/op	     328 B/op	       4 allocs/op
-vs-
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=10,_Compressor=RatioCompressor-12              	       1	    136708 ns/op	   35912 B/op	     392 allocs/op
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=100,_Compressor=RatioCompressor-12             	       1	   1700959 ns/op	  325576 B/op	    3276 allocs/op
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=1000,_Compressor=RatioCompressor-12            	       1	   9804126 ns/op	 3107656 B/op	   31859 allocs/op
BenchmarkChannelOut/BatchType=Span,_txPerBatch=1,_BatchCount=10000,_Compressor=RatioCompressor-12           	       1	  96453916 ns/op	32441608 B/op	  316943 allocs/op
```