### PR TITLE
op-challenger: Use TxSender to batch send resolve claim transactions.

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -22,7 +22,7 @@ type Responder interface {
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	Resolve() error
 	CallResolveClaim(ctx context.Context, claimIdx uint64) error
-	ResolveClaim(claimIdx uint64) error
+	ResolveClaims(claimIdx ...uint64) error
 	PerformAction(ctx context.Context, action types.Action) error
 }
 
@@ -149,7 +149,7 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 		return errNoResolvableClaims
 	}
 
-	var resolvableClaims []int64
+	var resolvableClaims []uint64
 	for _, claim := range claims {
 		if a.selective {
 			a.log.Trace("Selective claim resolution, checking if claim is incentivized", "claimIdx", claim.ContractIndex)
@@ -163,7 +163,7 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 		a.log.Trace("Checking if claim is resolvable", "claimIdx", claim.ContractIndex)
 		if err := a.responder.CallResolveClaim(ctx, uint64(claim.ContractIndex)); err == nil {
 			a.log.Info("Resolving claim", "claimIdx", claim.ContractIndex)
-			resolvableClaims = append(resolvableClaims, int64(claim.ContractIndex))
+			resolvableClaims = append(resolvableClaims, uint64(claim.ContractIndex))
 		}
 	}
 	if len(resolvableClaims) == 0 {
@@ -171,19 +171,9 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 	}
 	a.log.Info("Resolving claims", "numClaims", len(resolvableClaims))
 
-	var wg sync.WaitGroup
-	wg.Add(len(resolvableClaims))
-	for _, claimIdx := range resolvableClaims {
-		claimIdx := claimIdx
-		go func() {
-			defer wg.Done()
-			err := a.responder.ResolveClaim(uint64(claimIdx))
-			if err != nil {
-				a.log.Error("Failed to resolve claim", "err", err)
-			}
-		}()
+	if err := a.responder.ResolveClaims(resolvableClaims...); err != nil {
+		a.log.Error("Failed to resolve claims", "err", err)
 	}
-	wg.Wait()
 	return nil
 }
 

--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -186,7 +186,7 @@ type stubResponder struct {
 	resolveClaimCount     int
 }
 
-func (s *stubResponder) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
+func (s *stubResponder) CallResolve(_ context.Context) (gameTypes.GameStatus, error) {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.callResolveCount++
@@ -200,20 +200,20 @@ func (s *stubResponder) Resolve() error {
 	return s.resolveErr
 }
 
-func (s *stubResponder) CallResolveClaim(ctx context.Context, clainIdx uint64) error {
+func (s *stubResponder) CallResolveClaim(_ context.Context, _ uint64) error {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.callResolveClaimCount++
 	return s.callResolveClaimErr
 }
 
-func (s *stubResponder) ResolveClaim(clainIdx uint64) error {
+func (s *stubResponder) ResolveClaims(claims ...uint64) error {
 	s.l.Lock()
 	defer s.l.Unlock()
-	s.resolveClaimCount++
+	s.resolveClaimCount += len(claims)
 	return nil
 }
 
-func (s *stubResponder) PerformAction(ctx context.Context, response types.Action) error {
+func (s *stubResponder) PerformAction(_ context.Context, _ types.Action) error {
 	return nil
 }

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -72,13 +72,19 @@ func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx uint64) 
 	return r.contract.CallResolveClaim(ctx, claimIdx)
 }
 
-// ResolveClaim executes a resolveClaim transaction to resolve a fault dispute game.
-func (r *FaultResponder) ResolveClaim(claimIdx uint64) error {
-	candidate, err := r.contract.ResolveClaimTx(claimIdx)
-	if err != nil {
-		return err
+// ResolveClaims executes resolveClaim transactions to resolve claims in a dispute game.
+func (r *FaultResponder) ResolveClaims(claimIdxs ...uint64) error {
+	txs := make([]txmgr.TxCandidate, 0, len(claimIdxs))
+	for _, claimIdx := range claimIdxs {
+		candidate, err := r.contract.ResolveClaimTx(claimIdx)
+		if err != nil {
+			return err
+		}
+		txs = append(txs, candidate)
 	}
-	return r.sendTxAndWait("resolve claim", candidate)
+
+	_, err := r.sender.SendAndWait("resolve claim", txs...)
+	return err
 }
 
 func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action) error {

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -84,16 +84,23 @@ func TestResolveClaim(t *testing.T) {
 	t.Run("SendFails", func(t *testing.T) {
 		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		mockTxMgr.sendFails = true
-		err := responder.ResolveClaim(0)
+		err := responder.ResolveClaims(0)
 		require.ErrorIs(t, err, mockSendError)
 		require.Equal(t, 0, mockTxMgr.sends)
 	})
 
 	t.Run("Success", func(t *testing.T) {
 		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
-		err := responder.ResolveClaim(0)
+		err := responder.ResolveClaims(0)
 		require.NoError(t, err)
 		require.Equal(t, 1, mockTxMgr.sends)
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
+		err := responder.ResolveClaims(0, 1, 2, 3)
+		require.NoError(t, err)
+		require.Equal(t, 4, mockTxMgr.sends)
 	})
 }
 


### PR DESCRIPTION
**Description**

Simplifies the claim resolution code by using the `TxSender` to send resolution transactions in parallel rather than manually doing multithreading.

**Tests**

No change in resulting behaviour - existing tests cover it.
