### PR TITLE
Rename derive.CompressorFullErr to conventional ErrCompressorFull

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -154,7 +154,7 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 		return l1info, fmt.Errorf("converting block to batch: %w", err)
 	}
 
-	if _, err = c.co.AddSingularBatch(batch, l1info.SequenceNumber); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.CompressorFullErr) {
+	if _, err = c.co.AddSingularBatch(batch, l1info.SequenceNumber); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.ErrCompressorFull) {
 		c.setFullErr(err)
 		return l1info, c.FullErr()
 	} else if err != nil {
@@ -253,7 +253,7 @@ func (c *ChannelBuilder) IsFull() bool {
 //
 // It returns a ChannelFullError wrapping one of the following possible reasons
 // for the channel being full:
-//   - derive.CompressorFullErr if the compressor target has been reached,
+//   - derive.ErrCompressorFull if the compressor target has been reached,
 //   - derive.MaxRLPBytesPerChannel if the general maximum amount of input data
 //     would have been exceeded by the latest AddBlock call,
 //   - ErrMaxFrameIndex if the maximum number of frames has been generated

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -452,7 +452,7 @@ func TestChannelBuilder_OutputFrames_SpanBatch(t *testing.T) {
 			// There should be no ready bytes until the channel is full
 			require.Equal(t, cb.co.ReadyBytes(), 0)
 		} else {
-			require.ErrorIs(t, err, derive.CompressorFullErr)
+			require.ErrorIs(t, err, derive.ErrCompressorFull)
 			break
 		}
 	}
@@ -516,7 +516,7 @@ func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 		_, err = cb.AddBlock(a)
 		if cb.IsFull() {
 			fullErr := cb.FullErr()
-			require.ErrorIs(t, fullErr, derive.CompressorFullErr)
+			require.ErrorIs(t, fullErr, derive.ErrCompressorFull)
 			break
 		}
 		require.NoError(t, err)
@@ -550,7 +550,7 @@ func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
 	_, err = cb.AddBlock(a)
 	require.NoError(err)
 	_, err = cb.AddBlock(a)
-	require.ErrorIs(err, derive.CompressorFullErr)
+	require.ErrorIs(err, derive.ErrCompressorFull)
 	// without fix, adding the second block would succeed and then adding a
 	// third block would fail with full error and the compressor would be full.
 
@@ -593,7 +593,7 @@ func ChannelBuilder_AddBlock(t *testing.T, batchType uint) {
 
 	// Since the channel output is full, the next call to AddBlock
 	// should return the channel out full error
-	require.ErrorIs(t, addMiniBlock(cb), derive.CompressorFullErr)
+	require.ErrorIs(t, addMiniBlock(cb), derive.ErrCompressorFull)
 }
 
 func TestChannelBuilder_CheckTimeout(t *testing.T) {
@@ -782,7 +782,7 @@ func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 	for {
 		block := dtest.RandomL2BlockWithChainId(rng, rng.Intn(32), defaultTestRollupConfig.L2ChainID)
 		_, err := cb.AddBlock(block)
-		if errors.Is(err, derive.CompressorFullErr) {
+		if errors.Is(err, derive.ErrCompressorFull) {
 			break
 		}
 		require.NoError(err)

--- a/op-batcher/compressor/non_compressor.go
+++ b/op-batcher/compressor/non_compressor.go
@@ -45,7 +45,7 @@ func (t *NonCompressor) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	if uint64(t.buf.Len()) > t.config.TargetOutputSize {
-		t.fullErr = derive.CompressorFullErr
+		t.fullErr = derive.ErrCompressorFull
 	}
 	return n, nil
 }

--- a/op-batcher/compressor/ratio_compressor.go
+++ b/op-batcher/compressor/ratio_compressor.go
@@ -66,7 +66,7 @@ func (t *RatioCompressor) Flush() error {
 
 func (t *RatioCompressor) FullErr() error {
 	if t.inputTargetReached() {
-		return derive.CompressorFullErr
+		return derive.ErrCompressorFull
 	}
 	return nil
 }

--- a/op-batcher/compressor/shadow_compressor.go
+++ b/op-batcher/compressor/shadow_compressor.go
@@ -76,7 +76,7 @@ func (t *ShadowCompressor) Write(p []byte) (int, error) {
 		}
 		newBound = uint64(t.shadowBuf.Len()) + CloseOverheadZlib
 		if newBound > t.config.TargetOutputSize {
-			t.fullErr = derive.CompressorFullErr
+			t.fullErr = derive.ErrCompressorFull
 			if t.Len() > 0 {
 				// only return an error if we've already written data to this compressor before
 				// (otherwise single blocks over the target would never be written)

--- a/op-batcher/compressor/shadow_compressor_test.go
+++ b/op-batcher/compressor/shadow_compressor_test.go
@@ -41,19 +41,19 @@ func TestShadowCompressor(t *testing.T) {
 		targetOutputSize: 1 + derive.FrameV0OverHeadSize,
 		data:             [][]byte{bytes.Repeat([]byte{0}, 1024)},
 		errs:             []error{nil},
-		fullErr:          derive.CompressorFullErr,
+		fullErr:          derive.ErrCompressorFull,
 	}, {
 		name:             "large second block",
 		targetOutputSize: 1 + derive.FrameV0OverHeadSize,
 		data:             [][]byte{bytes.Repeat([]byte{0}, 512), bytes.Repeat([]byte{0}, 1024)},
-		errs:             []error{nil, derive.CompressorFullErr},
-		fullErr:          derive.CompressorFullErr,
+		errs:             []error{nil, derive.ErrCompressorFull},
+		fullErr:          derive.ErrCompressorFull,
 	}, {
 		name:             "random data",
 		targetOutputSize: 1 << 17,
 		data:             [][]byte{randomBytes((1 << 17) - 1000), randomBytes(512), randomBytes(512)},
-		errs:             []error{nil, nil, derive.CompressorFullErr},
-		fullErr:          derive.CompressorFullErr,
+		errs:             []error{nil, nil, derive.ErrCompressorFull},
+		fullErr:          derive.ErrCompressorFull,
 	}}
 	for _, test := range tests {
 		test := test

--- a/op-e2e/actions/l2_batcher_test.go
+++ b/op-e2e/actions/l2_batcher_test.go
@@ -515,7 +515,7 @@ func BigL2Txs(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 		sequencer.ActL2EndBlock(t)
 		for batcher.l2BufferedBlock.Number < sequencer.SyncStatus().UnsafeL2.Number {
 			// if we run out of space, close the channel and submit all the txs
-			if err := batcher.Buffer(t); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.CompressorFullErr) {
+			if err := batcher.Buffer(t); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.ErrCompressorFull) {
 				log.Info("flushing filled channel to batch txs", "id", batcher.l2ChannelOut.ID())
 				batcher.ActL2ChannelClose(t)
 				for batcher.l2ChannelOut != nil {

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -13,10 +13,13 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-var ErrMaxFrameSizeTooSmall = errors.New("maxSize is too small to fit the fixed frame overhead")
-var ErrNotDepositTx = errors.New("first transaction in block is not a deposit tx")
-var ErrTooManyRLPBytes = errors.New("batch would cause RLP bytes to go over limit")
-var ErrChannelOutAlreadyClosed = errors.New("channel-out already closed")
+var (
+	ErrMaxFrameSizeTooSmall    = errors.New("maxSize is too small to fit the fixed frame overhead")
+	ErrNotDepositTx            = errors.New("first transaction in block is not a deposit tx")
+	ErrTooManyRLPBytes         = errors.New("batch would cause RLP bytes to go over limit")
+	ErrChannelOutAlreadyClosed = errors.New("channel-out already closed")
+	ErrCompressorFull          = errors.New("compressor is full")
+)
 
 // FrameV0OverHeadSize is the absolute minimum size of a frame.
 // This is the fixed overhead frame size, calculated as specified
@@ -25,11 +28,9 @@ var ErrChannelOutAlreadyClosed = errors.New("channel-out already closed")
 // [Frame Format]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/derivation.md#frame-format
 const FrameV0OverHeadSize = 23
 
-var CompressorFullErr = errors.New("compressor is full")
-
 type Compressor interface {
 	// Writer is used to write uncompressed data which will be compressed. Should return
-	// CompressorFullErr if the compressor is full and no more data should be written.
+	// ErrCompressorFull if the compressor is full and no more data should be written.
 	io.Writer
 	// Closer Close function should be called before reading any data.
 	io.Closer
@@ -43,9 +44,9 @@ type Compressor interface {
 	// Flush flushes any uncompressed data to the compression buffer. This will result in a
 	// non-optimal compression ratio.
 	Flush() error
-	// FullErr returns CompressorFullErr if the compressor is known to be full. Note that
+	// FullErr returns ErrCompressorFull if the compressor is known to be full. Note that
 	// calls to Write will fail if an error is returned from this method, but calls to Write
-	// can still return CompressorFullErr even if this does not.
+	// can still return ErrCompressorFull even if this does not.
 	FullErr() error
 }
 

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -138,7 +138,7 @@ func (co *SpanChannelOut) AddSingularBatch(batch *SingularBatch, seqNum uint64) 
 	if co.compress.FullErr() != nil {
 		err = co.compress.FullErr()
 		if co.spanBatchBuilder.GetBlockCount() == 1 {
-			// Do not return CompressorFullErr for the first block in the batch
+			// Do not return ErrCompressorFull for the first block in the batch
 			// In this case, reader must be empty. then the contents of compressor will be copied to reader when the channel is closed.
 			err = nil
 		}


### PR DESCRIPTION
**Description**

Renames `derive.CompressorFullErr` to error naming convention `ErrCompressorFull`. All other errors in that package also follow that convention and this has been bugging me for a while...