### PR TITLE
fix(op-dispute-mon): Update Credit Enrichment Logic

### DIFF
--- a/op-dispute-mon/mon/extract/bond_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_enricher.go
@@ -29,9 +29,10 @@ func NewBondEnricher() *BondEnricher {
 func (b *BondEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
 	recipients := make(map[common.Address]bool)
 	for _, claim := range game.Claims {
-		recipients[claim.Claimant] = true
 		if claim.CounteredBy != (common.Address{}) {
 			recipients[claim.CounteredBy] = true
+		} else {
+			recipients[claim.Claimant] = true
 		}
 	}
 

--- a/op-dispute-mon/mon/extract/bond_enricher_test.go
+++ b/op-dispute-mon/mon/extract/bond_enricher_test.go
@@ -61,7 +61,6 @@ func TestBondEnricher(t *testing.T) {
 	t.Run("GetCreditsSuccess", func(t *testing.T) {
 		game := makeGame()
 		expectedRecipients := []common.Address{
-			game.Claims[0].Claimant,
 			game.Claims[0].CounteredBy,
 			game.Claims[1].Claimant,
 			// Claim 1 CounteredBy is unset
@@ -70,9 +69,8 @@ func TestBondEnricher(t *testing.T) {
 		}
 		enricher := NewBondEnricher()
 		expectedCredits := map[common.Address]*big.Int{
-			expectedRecipients[0]: big.NewInt(10),
-			expectedRecipients[1]: big.NewInt(20),
-			expectedRecipients[2]: big.NewInt(30),
+			expectedRecipients[0]: big.NewInt(20),
+			expectedRecipients[1]: big.NewInt(30),
 		}
 		caller := &mockGameCaller{credits: expectedCredits}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)


### PR DESCRIPTION
**Description**

Previously, the `BondEnricher` would add the `claim.Claimant` as a recipient address to the recipients map even if the claim had been countered.

This PR updates the `BondEnricher` to construct the recipients list as a mutually exclusive map over the counter or the claimant.