### PR TITLE
op-challenger: Skip attempting to resolve claims when the chess clock hasn't expired

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -167,7 +167,7 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 
 	var resolvableClaims []uint64
 	for _, claim := range claims {
-		if claim.ChessTime(a.l1Clock.Now()) < maxChessTime {
+		if claim.ChessTime(a.l1Clock.Now()) <= maxChessTime {
 			continue
 		}
 		if a.selective {

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/solver"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -32,22 +33,26 @@ type ClaimLoader interface {
 }
 
 type Agent struct {
-	metrics   metrics.Metricer
-	cl        clock.Clock
-	solver    *solver.GameSolver
-	loader    ClaimLoader
-	responder Responder
-	selective bool
-	claimants []common.Address
-	maxDepth  types.Depth
-	log       log.Logger
+	metrics      metrics.Metricer
+	systemClock  clock.Clock
+	l1Clock      types.ClockReader
+	solver       *solver.GameSolver
+	loader       ClaimLoader
+	responder    Responder
+	selective    bool
+	claimants    []common.Address
+	maxDepth     types.Depth
+	gameDuration time.Duration
+	log          log.Logger
 }
 
 func NewAgent(
 	m metrics.Metricer,
-	cl clock.Clock,
+	systemClock clock.Clock,
+	l1Clock types.ClockReader,
 	loader ClaimLoader,
 	maxDepth types.Depth,
+	gameDuration time.Duration,
 	trace types.TraceAccessor,
 	responder Responder,
 	log log.Logger,
@@ -55,15 +60,17 @@ func NewAgent(
 	claimants []common.Address,
 ) *Agent {
 	return &Agent{
-		metrics:   m,
-		cl:        cl,
-		solver:    solver.NewGameSolver(maxDepth, trace),
-		loader:    loader,
-		responder: responder,
-		selective: selective,
-		claimants: claimants,
-		maxDepth:  maxDepth,
-		log:       log,
+		metrics:      m,
+		systemClock:  systemClock,
+		l1Clock:      l1Clock,
+		solver:       solver.NewGameSolver(maxDepth, trace),
+		loader:       loader,
+		responder:    responder,
+		selective:    selective,
+		claimants:    claimants,
+		maxDepth:     maxDepth,
+		gameDuration: gameDuration,
+		log:          log,
 	}
 }
 
@@ -73,9 +80,9 @@ func (a *Agent) Act(ctx context.Context) error {
 		return nil
 	}
 
-	start := a.cl.Now()
+	start := a.systemClock.Now()
 	defer func() {
-		a.metrics.RecordGameActTime(a.cl.Since(start).Seconds())
+		a.metrics.RecordGameActTime(a.systemClock.Since(start).Seconds())
 	}()
 	game, err := a.newGameFromContracts(ctx)
 	if err != nil {
@@ -156,9 +163,13 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 	if len(claims) == 0 {
 		return errNoResolvableClaims
 	}
+	maxChessTime := a.gameDuration / 2
 
 	var resolvableClaims []uint64
 	for _, claim := range claims {
+		if claim.ChessTime(a.l1Clock.Now()) < maxChessTime {
+			continue
+		}
 		if a.selective {
 			a.log.Trace("Selective claim resolution, checking if claim is incentivized", "claimIdx", claim.ContractIndex)
 			isUncounteredClaim := slices.Contains(a.claimants, claim.Claimant) && claim.CounteredBy == common.Address{}
@@ -186,9 +197,9 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 }
 
 func (a *Agent) resolveClaims(ctx context.Context) error {
-	start := a.cl.Now()
+	start := a.systemClock.Now()
 	defer func() {
-		a.metrics.RecordClaimResolutionTime(a.cl.Since(start).Seconds())
+		a.metrics.RecordClaimResolutionTime(a.systemClock.Since(start).Seconds())
 	}()
 	for {
 		err := a.tryResolveClaims(ctx)

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
@@ -239,13 +240,13 @@ func (f *FaultDisputeGameContract) GetOracle(ctx context.Context) (*PreimageOrac
 	return vm.Oracle(ctx)
 }
 
-func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {
+func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (time.Duration, error) {
 	defer f.metrics.StartContractRequest("GetGameDuration")()
 	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodGameDuration))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
 	}
-	return result.GetUint64(0), nil
+	return time.Duration(result.GetUint64(0)) * time.Second, nil
 }
 
 func (f *FaultDisputeGameContract) GetMaxGameDepth(ctx context.Context) (types.Depth, error) {
@@ -381,18 +382,18 @@ func (f *FaultDisputeGameContract) resolveCall() *batching.ContractCall {
 }
 
 // decodeClock decodes a uint128 into a Clock duration and timestamp.
-func decodeClock(clock *big.Int) *types.Clock {
+func decodeClock(clock *big.Int) types.Clock {
 	maxUint64 := new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1))
 	remainder := new(big.Int)
 	quotient, _ := new(big.Int).QuoRem(clock, maxUint64, remainder)
-	return types.NewClock(quotient.Uint64(), remainder.Uint64())
+	return types.NewClock(time.Duration(quotient.Int64())*time.Second, time.Unix(remainder.Int64(), 0))
 }
 
 // packClock packs the Clock duration and timestamp into a uint128.
-func packClock(c *types.Clock) *big.Int {
-	duration := new(big.Int).SetUint64(c.Duration)
+func packClock(c types.Clock) *big.Int {
+	duration := big.NewInt(int64(c.Duration.Seconds()))
 	encoded := new(big.Int).Lsh(duration, 64)
-	return new(big.Int).Or(encoded, new(big.Int).SetUint64(c.Timestamp))
+	return new(big.Int).Or(encoded, big.NewInt(c.Timestamp.Unix()))
 }
 
 func (f *FaultDisputeGameContract) decodeClaim(result *batching.CallResult, contractIndex int) types.Claim {

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
@@ -46,6 +47,7 @@ func TestSimpleGetters(t *testing.T) {
 			methodAlias: "gameDuration",
 			method:      methodGameDuration,
 			result:      uint64(5566),
+			expected:    5566 * time.Second,
 			call: func(game *FaultDisputeGameContract) (any, error) {
 				return game.GetGameDuration(context.Background())
 			},
@@ -114,8 +116,8 @@ func TestClock_EncodingDecoding(t *testing.T) {
 		by := common.Hex2Bytes("00000000000000050000000000000002")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
-		require.Equal(t, uint64(5), clock.Duration)
-		require.Equal(t, uint64(2), clock.Timestamp)
+		require.Equal(t, 5*time.Second, clock.Duration)
+		require.Equal(t, time.Unix(2, 0), clock.Timestamp)
 		require.Equal(t, encoded, packClock(clock))
 	})
 
@@ -123,8 +125,8 @@ func TestClock_EncodingDecoding(t *testing.T) {
 		by := common.Hex2Bytes("00000000000000000000000000000002")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
-		require.Equal(t, uint64(0), clock.Duration)
-		require.Equal(t, uint64(2), clock.Timestamp)
+		require.Equal(t, 0*time.Second, clock.Duration)
+		require.Equal(t, time.Unix(2, 0), clock.Timestamp)
 		require.Equal(t, encoded, packClock(clock))
 	})
 
@@ -132,8 +134,8 @@ func TestClock_EncodingDecoding(t *testing.T) {
 		by := common.Hex2Bytes("00000000000000050000000000000000")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
-		require.Equal(t, uint64(5), clock.Duration)
-		require.Equal(t, uint64(0), clock.Timestamp)
+		require.Equal(t, 5*time.Second, clock.Duration)
+		require.Equal(t, time.Unix(0, 0), clock.Timestamp)
 		require.Equal(t, encoded, packClock(clock))
 	})
 
@@ -141,8 +143,8 @@ func TestClock_EncodingDecoding(t *testing.T) {
 		by := common.Hex2Bytes("00000000000000000000000000000000")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
-		require.Equal(t, uint64(0), clock.Duration)
-		require.Equal(t, uint64(0), clock.Timestamp)
+		require.Equal(t, 0*time.Second, clock.Duration)
+		require.Equal(t, time.Unix(0, 0), clock.Timestamp)
 		require.Equal(t, encoded.Uint64(), packClock(clock).Uint64())
 	})
 }

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -320,7 +320,6 @@ func applyActions(game types.Game, claimant common.Address, actions []types.Acti
 					Position: newPosition,
 				},
 				Claimant:            claimant,
-				Clock:               nil,
 				ContractIndex:       len(claims),
 				ParentContractIndex: action.ParentIdx,
 			}

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -2,8 +2,10 @@ package test
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,10 +15,11 @@ import (
 var DefaultClaimant = common.Address{0xba, 0xdb, 0xad, 0xba, 0xdb, 0xad}
 
 type claimCfg struct {
-	value        common.Hash
-	invalidValue bool
-	claimant     common.Address
-	parentIdx    int
+	value         common.Hash
+	invalidValue  bool
+	claimant      common.Address
+	parentIdx     int
+	clockDuration time.Duration
 }
 
 func newClaimCfg(opts ...ClaimOpt) *claimCfg {
@@ -58,6 +61,11 @@ func WithClaimant(claimant common.Address) ClaimOpt {
 func WithParent(claim types.Claim) ClaimOpt {
 	return claimOptFn(func(cfg *claimCfg) {
 		cfg.parentIdx = claim.ContractIndex
+	})
+}
+func WithExpiredClock(gameDuration time.Duration) ClaimOpt {
+	return claimOptFn(func(cfg *claimCfg) {
+		cfg.clockDuration = gameDuration / 2
 	})
 }
 
@@ -123,6 +131,10 @@ func (c *ClaimBuilder) claim(pos types.Position, opts ...ClaimOpt) types.Claim {
 			Position: pos,
 		},
 		Claimant: DefaultClaimant,
+		Clock: types.Clock{
+			Duration:  cfg.clockDuration,
+			Timestamp: time.Unix(math.MaxInt64-1, 0),
+		},
 	}
 	if cfg.claimant != (common.Address{}) {
 		claim.Claimant = cfg.claimant

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -11,8 +11,8 @@ import (
 func TestClaim_RemainingDuration(t *testing.T) {
 	tests := []struct {
 		name      string
-		duration  uint64
-		timestamp uint64
+		duration  time.Duration
+		timestamp int64
 		now       int64
 		expected  uint64
 	}{
@@ -25,28 +25,28 @@ func TestClaim_RemainingDuration(t *testing.T) {
 		},
 		{
 			name:      "ZeroTimestamp",
-			duration:  5,
+			duration:  5 * time.Second,
 			timestamp: 0,
 			now:       0,
 			expected:  5,
 		},
 		{
 			name:      "ZeroTimestampWithNow",
-			duration:  5,
+			duration:  5 * time.Second,
 			timestamp: 0,
 			now:       10,
 			expected:  15,
 		},
 		{
 			name:      "ZeroNow",
-			duration:  5,
+			duration:  5 * time.Second,
 			timestamp: 10,
 			now:       0,
 			expected:  5,
 		},
 		{
 			name:      "ValidTimeSinze",
-			duration:  20,
+			duration:  20 * time.Second,
 			timestamp: 10,
 			now:       15,
 			expected:  25,
@@ -57,9 +57,9 @@ func TestClaim_RemainingDuration(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			claim := &Claim{
-				Clock: NewClock(test.duration, test.timestamp),
+				Clock: NewClock(test.duration, time.Unix(test.timestamp, 0)),
 			}
-			require.Equal(t, time.Duration(test.expected), claim.ChessTime(time.Unix(test.now, 0)))
+			require.Equal(t, time.Duration(test.expected)*time.Second, claim.ChessTime(time.Unix(test.now, 0)))
 		})
 	}
 }

--- a/op-dispute-mon/mon/resolution/delay.go
+++ b/op-dispute-mon/mon/resolution/delay.go
@@ -1,6 +1,8 @@
 package resolution
 
 import (
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 )
@@ -41,10 +43,10 @@ func (d *DelayCalculator) getOverflowTime(maxGameDuration uint64, claim *types.E
 	if claim.Resolved {
 		return 0
 	}
-	maxChessTime := maxGameDuration / 2
-	accumulatedTime := uint64(claim.ChessTime(d.clock.Now()))
+	maxChessTime := time.Duration(maxGameDuration/2) * time.Second
+	accumulatedTime := claim.ChessTime(d.clock.Now())
 	if accumulatedTime < maxChessTime {
 		return 0
 	}
-	return accumulatedTime - maxChessTime
+	return uint64((accumulatedTime - maxChessTime).Seconds())
 }

--- a/op-dispute-mon/mon/resolution/delay_test.go
+++ b/op-dispute-mon/mon/resolution/delay_test.go
@@ -29,8 +29,8 @@ func TestDelayCalculator_getOverflowTime(t *testing.T) {
 
 	t.Run("RemainingTime", func(t *testing.T) {
 		d, metrics, cl := setupDelayCalculatorTest(t)
-		duration := uint64(3 * 60)
-		timestamp := uint64(cl.Now().Add(-time.Minute).Unix())
+		duration := 3 * time.Minute
+		timestamp := cl.Now().Add(-time.Minute)
 		claim := &monTypes.EnrichedClaim{
 			Claim: types.Claim{
 				ClaimData: types.ClaimData{
@@ -46,8 +46,8 @@ func TestDelayCalculator_getOverflowTime(t *testing.T) {
 
 	t.Run("OverflowTime", func(t *testing.T) {
 		d, metrics, cl := setupDelayCalculatorTest(t)
-		duration := maxGameDuration / 2
-		timestamp := uint64(cl.Now().Add(4 * -time.Minute).Unix())
+		duration := time.Duration(maxGameDuration/2) * time.Second
+		timestamp := cl.Now().Add(4 * -time.Minute)
 		claim := &monTypes.EnrichedClaim{
 			Claim: types.Claim{
 				ClaimData: types.ClaimData{
@@ -136,10 +136,10 @@ func createGameWithClaimsList() []*monTypes.EnrichedGameData {
 }
 
 func createClaimList() []monTypes.EnrichedClaim {
-	newClock := func(multiplier int) *types.Clock {
+	newClock := func(multiplier int) types.Clock {
 		duration := maxGameDuration / 2
-		timestamp := uint64(frozen.Add(-time.Minute * time.Duration(multiplier)).Unix())
-		return types.NewClock(duration, timestamp)
+		timestamp := frozen.Add(-time.Minute * time.Duration(multiplier))
+		return types.NewClock(time.Duration(duration)*time.Second, timestamp)
 	}
 	return []monTypes.EnrichedClaim{
 		{


### PR DESCRIPTION
**Description**

Don't waste time trying to resolve claims if the chess clock hasn't expired yet.

Fixes weirdness in the Clock handling where it treated `time.Duration` as being in seconds when it's actually nanoseconds. Switched to using the go `time.Duration` and `time.Time` types directly to make it easier to understand what the values actually are.

**Tests**

Updated unit tests.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/687
