### PR TITLE
fix(sdk) depositETH gas estimation bug

### DIFF
--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -1137,7 +1137,7 @@ export class CrossChainMessenger {
       throw new Error(`cannot estimate gas limit for L2 => L1 message`)
     }
 
-    const estimate = await this.l2Provider.estimateGas({
+    const estimate = await this.l2SignerOrProvider.estimateGas({
       from,
       to: resolved.target,
       data: resolved.message,
@@ -2426,9 +2426,9 @@ export class CrossChainMessenger {
     ): Promise<BigNumber> => {
       const tx = await this.populateTransaction.sendMessage(message, opts)
       if (message.direction === MessageDirection.L1_TO_L2) {
-        return this.l1Provider.estimateGas(tx)
+        return this.l1SignerOrProvider.estimateGas(tx)
       } else {
-        return this.l2Provider.estimateGas(tx)
+        return this.l2SignerOrProvider.estimateGas(tx)
       }
     },
 
@@ -2448,7 +2448,7 @@ export class CrossChainMessenger {
         overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
-      return this.l1Provider.estimateGas(
+      return this.l1SignerOrProvider.estimateGas(
         await this.populateTransaction.resendMessage(
           message,
           messageGasLimit,
@@ -2473,7 +2473,7 @@ export class CrossChainMessenger {
       },
       messageIndex = 0
     ): Promise<BigNumber> => {
-      return this.l1Provider.estimateGas(
+      return this.l1SignerOrProvider.estimateGas(
         await this.populateTransaction.proveMessage(message, opts, messageIndex)
       )
     },
@@ -2494,7 +2494,7 @@ export class CrossChainMessenger {
       },
       messageIndex = 0
     ): Promise<BigNumber> => {
-      return this.l1Provider.estimateGas(
+      return this.l1SignerOrProvider.estimateGas(
         await this.populateTransaction.finalizeMessage(
           message,
           opts,
@@ -2542,7 +2542,7 @@ export class CrossChainMessenger {
         overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
-      return this.l2Provider.estimateGas(
+      return this.l2SignerOrProvider.estimateGas(
         await this.populateTransaction.withdrawETH(amount, opts)
       )
     },
@@ -2565,7 +2565,7 @@ export class CrossChainMessenger {
         overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
-      return this.l1Provider.estimateGas(
+      return this.l1SignerOrProvider.estimateGas(
         await this.populateTransaction.approveERC20(
           l1Token,
           l2Token,
@@ -2628,7 +2628,7 @@ export class CrossChainMessenger {
         overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
-      return this.l2Provider.estimateGas(
+      return this.l2SignerOrProvider.estimateGas(
         await this.populateTransaction.withdrawERC20(
           l1Token,
           l2Token,

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -2360,7 +2360,7 @@ export class CrossChainMessenger {
           l1Token,
           l2Token,
           amount,
-          opts,
+          opts
         )
         return {
           ...opts,

--- a/packages/sdk/test/cross-chain-messenger.spec.ts
+++ b/packages/sdk/test/cross-chain-messenger.spec.ts
@@ -33,7 +33,7 @@ describe('CrossChainMessenger', () => {
         const from = tx.from ?? ethers.constants.AddressZero
         const value = tx.value ?? ethers.constants.Zero
         const balance = await this.getBalance(from)
-        if (balance <= value) {
+        if (balance < value) {
           throw Error(
             `gas estimation failed: insufficient balance from=${from} value=${value} balance=${balance}`
           )
@@ -1120,7 +1120,7 @@ describe('CrossChainMessenger', () => {
         const message = {
           direction: MessageDirection.L1_TO_L2,
           target: '0x' + '11'.repeat(20),
-          sender: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec', // account 13
+          sender: '0x' + '22'.repeat(20),
           message: '0x' + '33'.repeat(64),
           messageNonce: 1234,
           logIndex: 0,
@@ -1149,7 +1149,7 @@ describe('CrossChainMessenger', () => {
         const message = {
           direction: MessageDirection.L1_TO_L2,
           target: '0x' + '11'.repeat(20),
-          sender: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec', // account 13
+          sender: '0x' + '22'.repeat(20),
           message: '0x' + '33'.repeat(64),
           messageNonce: 1234,
           logIndex: 0,


### PR DESCRIPTION
**Description**

Fix a bug in the sdk where gas estimation uses the zero address as the source instead of propagating the source address for the transaction.

**Tests**

Depositing eth via the CrossChainMessenger now works properly and estimateGas no longer reverts due to a lack of funds available at the zero address.

**Metadata**

- Fixes #6723 #7896