### PR TITLE
close Backend resources during testing

### DIFF
--- a/op-chain-ops/deployer/deployer.go
+++ b/op-chain-ops/deployer/deployer.go
@@ -49,6 +49,7 @@ type Deployer func(*backends.SimulatedBackend, *bind.TransactOpts, Constructor) 
 
 // NewL1Backend returns a SimulatedBackend suitable for L1. It has
 // the latest L1 hardforks enabled.
+// The returned backend should be closed after use.
 func NewL1Backend() (*backends.SimulatedBackend, error) {
 	backend, err := NewBackendWithGenesisTimestamp(ChainID, 0, true, nil)
 	return backend, err
@@ -56,6 +57,7 @@ func NewL1Backend() (*backends.SimulatedBackend, error) {
 
 // NewL2Backend returns a SimulatedBackend suitable for L2.
 // It has the latest L2 hardforks enabled.
+// The returned backend should be closed after use.
 func NewL2Backend() (*backends.SimulatedBackend, error) {
 	backend, err := NewBackendWithGenesisTimestamp(ChainID, 0, false, nil)
 	return backend, err
@@ -63,6 +65,7 @@ func NewL2Backend() (*backends.SimulatedBackend, error) {
 
 // NewL2BackendWithChainIDAndPredeploys returns a SimulatedBackend suitable for L2.
 // It has the latest L2 hardforks enabled, and allows for the configuration of the network's chain ID and predeploys.
+// The returned backend should be closed after use.
 func NewL2BackendWithChainIDAndPredeploys(chainID *big.Int, predeploys map[string]*common.Address) (*backends.SimulatedBackend, error) {
 	backend, err := NewBackendWithGenesisTimestamp(chainID, 0, false, predeploys)
 	return backend, err

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -83,6 +83,7 @@ func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Gene
 			if err != nil {
 				return nil, err
 			}
+			backend.Close()
 			deployResults[name] = deployedBin
 			fallthrough
 		case "MultiCall3", "Create2Deployer", "Safe_v130",

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -81,6 +81,7 @@ func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Gene
 			}
 			deployedBin, err := deployer.DeployWithDeterministicDeployer(backend, name)
 			if err != nil {
+				backend.Close()
 				return nil, err
 			}
 			backend.Close()

--- a/op-chain-ops/immutables/immutables.go
+++ b/op-chain-ops/immutables/immutables.go
@@ -166,6 +166,7 @@ func deployContractsWithImmutables(constructors []deployer.Constructor) (Deploym
 	if err != nil {
 		return nil, err
 	}
+	defer backend.Close()
 	deployments, err := deployer.Deploy(backend, constructors, l2ImmutableDeployer)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Close backend resources after use to avoid these resources from leaking during e2e testing.  This was leading to a proliferation of stagnant goroutines.

**Tests**

**Additional context**

**Metadata**
