### PR TITLE
feat(proxyd): ha redis namespace should be both backend group name and the namespace itself

### DIFF
--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -355,7 +355,8 @@ func Start(config *Config) (*Server, func(), error) {
 				if err != nil {
 					return nil, nil, err
 				}
-				tracker = NewRedisConsensusTracker(context.Background(), consensusHARedisClient, bg, bg.Name, topts...)
+				ns := fmt.Sprintf("%s:%s", bgcfg.ConsensusHARedis.Namespace, bg.Name)
+				tracker = NewRedisConsensusTracker(context.Background(), consensusHARedisClient, bg, ns, topts...)
 				copts = append(copts, WithTracker(tracker))
 			}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When two proxyd instances use the same HA redis instance, they need to scope to their own namespace otherwise it may cause cache key collision.

Part of https://github.com/ethereum-optimism/devinfra-pod/issues/110

