### PR TITLE
chore: Release new versions of all js packages

### DIFF
--- a/.changeset/modern-geese-hammer.md
+++ b/.changeset/modern-geese-hammer.md
@@ -1,0 +1,14 @@
+---
+'@eth-optimism/endpoint-monitor': patch
+'@eth-optimism/indexer-api': patch
+'@eth-optimism/chain-mon': patch
+'@eth-optimism/common-ts': patch
+'@eth-optimism/contracts-bedrock': patch
+'@eth-optimism/contracts-ts': patch
+'@eth-optimism/core-utils': patch
+'@eth-optimism/fee-estimation': patch
+'@eth-optimism/sdk': patch
+'@eth-optimism/web3.js-plugin': patch
+---
+
+Removed only-allow command from package.json


### PR DESCRIPTION
We recently removed only-allow as a workaround for users whose vercel accounts were falsely running preinstall scripts. We did not add a changeset to every package however
