### PR TITLE
op-dispute-mon: Collateral is only required for claims that are NOT resolved

### DIFF
--- a/op-dispute-mon/mon/bonds/collateral.go
+++ b/op-dispute-mon/mon/bonds/collateral.go
@@ -38,7 +38,7 @@ func CalculateRequiredCollateral(games []*monTypes.EnrichedGameData) map[common.
 func requiredCollateralForGame(game *monTypes.EnrichedGameData) *big.Int {
 	required := big.NewInt(0)
 	for _, claim := range game.Claims {
-		if claim.Resolved {
+		if !claim.Resolved {
 			required = new(big.Int).Add(required, claim.Bond)
 		}
 	}

--- a/op-dispute-mon/mon/bonds/collateral_test.go
+++ b/op-dispute-mon/mon/bonds/collateral_test.go
@@ -101,7 +101,6 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 					Claimant:    common.Address{0x03},
 					CounteredBy: common.Address{},
 				},
-				Resolved: true,
 			},
 		},
 		Credits: map[common.Address]*big.Int{


### PR DESCRIPTION
**Description**

Dispute-mon was expecting to have enough collateral to cover the resolved bond sentinel value because it was only counting resolved claims instead of only unresolved ones.

**Tests**

Fixed the tests which had the same mistake.
