### PR TITLE
ctb: Add DeputyGuardianModule

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -92,8 +92,8 @@
     "sourceCodeHash": "0x9633cea9b66077e222f470439fe3e9a31f3e33b4f7a5618374c44310fd234b24"
   },
   "src/Safe/LivenessModule.sol": {
-    "initCodeHash": "0xcd8b76f70634330e242d4ff497bba1f8e0aaa11d7aecf9845090029c43027a7f",
-    "sourceCodeHash": "0x3b358b51fce4f1516191104d2e1f782c8ec3edecee63c502cc301671aa632b93"
+    "initCodeHash": "0x391b039087c3638a346c416e1731bcb14ba330be36c8d60412e4413ea79b7aae",
+    "sourceCodeHash": "0xbd062bb0edd3a84b669d52cca4c8c6ba9694816c8c8a9d32400a5920ef34d736"
   },
   "src/cannon/MIPS.sol": {
     "initCodeHash": "0xaf2ac814f64ccf12e9c6738db7cef865f51f9e39f39105adef9fba11465f6ee1",
@@ -167,4 +167,3 @@
     "initCodeHash": "0xb656d2aa6aff3e6435e747a0c23236d1b66f1f5c0b45e4b1a10d290a90223c5a",
     "sourceCodeHash": "0xebfc968e6b78d7ea355547d427300739f14d000a11ff35f29d9ded3ddb7882da"
   }
-}

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -92,8 +92,8 @@
     "sourceCodeHash": "0x9633cea9b66077e222f470439fe3e9a31f3e33b4f7a5618374c44310fd234b24"
   },
   "src/Safe/LivenessModule.sol": {
-    "initCodeHash": "0x391b039087c3638a346c416e1731bcb14ba330be36c8d60412e4413ea79b7aae",
-    "sourceCodeHash": "0xbd062bb0edd3a84b669d52cca4c8c6ba9694816c8c8a9d32400a5920ef34d736"
+    "initCodeHash": "0xa8b233f0f26f8a73b997b12ba06d64cefa8ee98d523f68cd63320e9787468fae",
+    "sourceCodeHash": "0x73aa5934e56ba2a45f368806c5db1d442bf5713d51b2184749f4638eaceb832e"
   },
   "src/cannon/MIPS.sol": {
     "initCodeHash": "0xaf2ac814f64ccf12e9c6738db7cef865f51f9e39f39105adef9fba11465f6ee1",
@@ -167,3 +167,4 @@
     "initCodeHash": "0xb656d2aa6aff3e6435e747a0c23236d1b66f1f5c0b45e4b1a10d290a90223c5a",
     "sourceCodeHash": "0xebfc968e6b78d7ea355547d427300739f14d000a11ff35f29d9ded3ddb7882da"
   }
+}

--- a/packages/contracts-bedrock/snapshots/abi/LivenessModule.json
+++ b/packages/contracts-bedrock/snapshots/abi/LivenessModule.json
@@ -22,6 +22,11 @@
         "type": "uint256"
       },
       {
+        "internalType": "uint256",
+        "name": "_thresholdPercentage",
+        "type": "uint256"
+      },
+      {
         "internalType": "address",
         "name": "_fallbackOwner",
         "type": "address"
@@ -68,9 +73,14 @@
         "internalType": "uint256",
         "name": "_numOwners",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_percentage",
+        "type": "uint256"
       }
     ],
-    "name": "get75PercentThreshold",
+    "name": "getRequiredThreshold",
     "outputs": [
       {
         "internalType": "uint256",
@@ -146,6 +156,19 @@
         "internalType": "contract Safe",
         "name": "safe_",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "thresholdPercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "thresholdPercentage_",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/abi/LivenessModule.json
+++ b/packages/contracts-bedrock/snapshots/abi/LivenessModule.json
@@ -73,11 +73,6 @@
         "internalType": "uint256",
         "name": "_numOwners",
         "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_percentage",
-        "type": "uint256"
       }
     ],
     "name": "getRequiredThreshold",
@@ -88,7 +83,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/src/Safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/Safe/LivenessModule.sol
@@ -35,6 +35,9 @@ contract LivenessModule is ISemver {
     ///         This can be updated by replacing with a new module.
     uint256 internal immutable MIN_OWNERS;
 
+    /// @notice The percentage used to calculate the threshold for the Safe.
+    uint256 internal immutable THRESHOLD_PERCENTAGE;
+
     /// @notice The fallback owner of the Safe
     ///         This can be updated by replacing with a new module.
     address internal immutable FALLBACK_OWNER;
@@ -53,25 +56,27 @@ contract LivenessModule is ISemver {
         LivenessGuard _livenessGuard,
         uint256 _livenessInterval,
         uint256 _minOwners,
+        uint256 _thresholdPercentage,
         address _fallbackOwner
     ) {
         SAFE = _safe;
         LIVENESS_GUARD = _livenessGuard;
         LIVENESS_INTERVAL = _livenessInterval;
+        THRESHOLD_PERCENTAGE = _thresholdPercentage;
         FALLBACK_OWNER = _fallbackOwner;
         MIN_OWNERS = _minOwners;
         address[] memory owners = _safe.getOwners();
         require(_minOwners <= owners.length, "LivenessModule: minOwners must be less than the number of owners");
         require(
-            _safe.getThreshold() >= get75PercentThreshold(owners.length),
-            "LivenessModule: Safe must have a threshold of at least 75% of the number of owners"
+            _safe.getThreshold() >= getRequiredThreshold(owners.length, THRESHOLD_PERCENTAGE),
+            "LivenessModule: Insufficient threshold for the number of owners"
         );
     }
 
-    /// @notice For a given number of owners, return the lowest threshold which is greater than 75.
+    /// @notice For a given number of owners, return the lowest threshold which is greater than the required percentage.
     ///         Note: this function returns 1 for numOwners == 1.
-    function get75PercentThreshold(uint256 _numOwners) public pure returns (uint256 threshold_) {
-        threshold_ = (_numOwners * 75 + 99) / 100;
+    function getRequiredThreshold(uint256 _numOwners, uint256 _percentage) public pure returns (uint256 threshold_) {
+        threshold_ = (_numOwners * _percentage + 99) / 100;
     }
 
     /// @notice Getter function for the Safe contract instance
@@ -98,7 +103,13 @@ contract LivenessModule is ISemver {
         minOwners_ = MIN_OWNERS;
     }
 
-    /// @notice Getter function for the fallback owner
+    /// @notice Getter function for the required threshold percentage
+    /// @return thresholdPercentage_ The minimum number of owners
+    function thresholdPercentage() public view returns (uint256 thresholdPercentage_) {
+        thresholdPercentage_ = THRESHOLD_PERCENTAGE;
+    }
+
+    /// @notice Getter function for the fallback
     /// @return fallbackOwner_ The fallback owner of the Safe
     function fallbackOwner() public view returns (address fallbackOwner_) {
         fallbackOwner_ = FALLBACK_OWNER;
@@ -161,7 +172,7 @@ contract LivenessModule is ISemver {
     /// @param _newOwnersCount New number of owners after removal.
     function _removeOwner(address _prevOwner, address _ownerToRemove, uint256 _newOwnersCount) internal {
         if (_newOwnersCount > 0) {
-            uint256 newThreshold = get75PercentThreshold(_newOwnersCount);
+            uint256 newThreshold = getRequiredThreshold(_newOwnersCount, THRESHOLD_PERCENTAGE);
             // Remove the owner and update the threshold
             _removeOwnerSafeCall({ _prevOwner: _prevOwner, _owner: _ownerToRemove, _threshold: newThreshold });
         } else {
@@ -223,11 +234,11 @@ contract LivenessModule is ISemver {
 
         // Check that"LivenessModule: must remove all owners and transfer to fallback owner if numOwners < minOwners"
         // the threshold is correct. This check is also correct when there is a single
-        // owner, because get75PercentThreshold(1) returns 1.
+        // owner, because getRequiredThreshold(1) returns 1.
         uint256 threshold = SAFE.getThreshold();
         require(
-            threshold == get75PercentThreshold(numOwners),
-            "LivenessModule: Safe must have a threshold of 75% of the number of owners"
+            threshold == getRequiredThreshold(numOwners, THRESHOLD_PERCENTAGE),
+            "LivenessModule: Insufficient threshold for the number of owners"
         );
 
         // Check that the guard has not been changed

--- a/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
@@ -184,6 +184,63 @@ contract LivenessModule_GetRequiredThreshold_Test is LivenessModule_TestInit {
             _getRequiredThreshold(numOwners, percentage), _getLeastIntegerValueAbovePercentage(numOwners, percentage)
         );
     }
+
+    /// @dev check the return values of the getRequiredThreshold function against the boundary conditions of 1 and 100
+    ///      percent.
+    function testFuzz_getRequiredThreshold_atBoundaries_works(uint256 _numOwners) external {
+        // Enforce a sane number of owners to keep runtime in check
+        uint256 numOwners = bound(_numOwners, 1, 100);
+        assertEq(_getRequiredThreshold(numOwners, 100), numOwners);
+        assertEq(_getRequiredThreshold(numOwners, 1), 1);
+    }
+
+    /// @dev check the return values of the getRequiredThreshold function against manually
+    ///      calculated values.
+    function test_getRequiredThreshold_hardcoded_works() external {
+        // 75% threshold
+        assertEq(_getRequiredThreshold(20, 75), 15);
+        assertEq(_getRequiredThreshold(19, 75), 15);
+        assertEq(_getRequiredThreshold(18, 75), 14);
+        assertEq(_getRequiredThreshold(17, 75), 13);
+        assertEq(_getRequiredThreshold(16, 75), 12);
+        assertEq(_getRequiredThreshold(15, 75), 12);
+        assertEq(_getRequiredThreshold(14, 75), 11);
+        assertEq(_getRequiredThreshold(13, 75), 10);
+        assertEq(_getRequiredThreshold(12, 75), 9);
+        assertEq(_getRequiredThreshold(11, 75), 9);
+        assertEq(_getRequiredThreshold(10, 75), 8);
+        assertEq(_getRequiredThreshold(9, 75), 7);
+        assertEq(_getRequiredThreshold(8, 75), 6);
+        assertEq(_getRequiredThreshold(7, 75), 6);
+        assertEq(_getRequiredThreshold(6, 75), 5);
+        assertEq(_getRequiredThreshold(5, 75), 4);
+        assertEq(_getRequiredThreshold(4, 75), 3);
+        assertEq(_getRequiredThreshold(3, 75), 3);
+        assertEq(_getRequiredThreshold(2, 75), 2);
+        assertEq(_getRequiredThreshold(1, 75), 1);
+
+        // 33% threshold
+        assertEq(_getRequiredThreshold(20, 33), 7);
+        assertEq(_getRequiredThreshold(19, 33), 7);
+        assertEq(_getRequiredThreshold(18, 33), 6);
+        assertEq(_getRequiredThreshold(17, 33), 6);
+        assertEq(_getRequiredThreshold(16, 33), 6);
+        assertEq(_getRequiredThreshold(15, 33), 5);
+        assertEq(_getRequiredThreshold(14, 33), 5);
+        assertEq(_getRequiredThreshold(13, 33), 5);
+        assertEq(_getRequiredThreshold(12, 33), 4);
+        assertEq(_getRequiredThreshold(11, 33), 4);
+        assertEq(_getRequiredThreshold(10, 33), 4);
+        assertEq(_getRequiredThreshold(9, 33), 3);
+        assertEq(_getRequiredThreshold(8, 33), 3);
+        assertEq(_getRequiredThreshold(7, 33), 3);
+        assertEq(_getRequiredThreshold(6, 33), 2);
+        assertEq(_getRequiredThreshold(5, 33), 2);
+        assertEq(_getRequiredThreshold(4, 33), 2);
+        assertEq(_getRequiredThreshold(3, 33), 1);
+        assertEq(_getRequiredThreshold(2, 33), 1);
+        assertEq(_getRequiredThreshold(1, 33), 1);
+    }
 }
 
 contract LivenessModule_RemoveOwners_TestFail is LivenessModule_TestInit {


### PR DESCRIPTION
**Description**

Adds the `DeputyGuardianModule` as described in the [related specs PR](https://github.com/ethereum-optimism/specs/pull/102).

**Tests**

Tests have been written ensuring that each external state changing function on the module are:
1. callable only by the Deputy Guardian
2. result in the expected state changes in the SuperchainConfig or Portal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the Deputy Guardian Module to enhance security and management capabilities. This module allows for blacklisting dispute games, setting game types, and pausing/unpausing operations.

- **Documentation**
	- Updated contract documentation to include the functionalities and events associated with the Deputy Guardian Module.

- **Tests**
	- Added comprehensive tests for the Deputy Guardian Module to ensure its functionality meets security and operational standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->