### PR TITLE
txmgr: add blob base fee metrics

### DIFF
--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -188,8 +188,8 @@ func NewMetrics(procName string) *Metrics {
 		blobUsedBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: ns,
 			Name:      "blob_used_bytes",
-			Help:      "Blob size in bytes being submitted.",
-			Buckets:   prometheus.LinearBuckets(0.0, eth.MaxBlobDataSize/13, 13),
+			Help:      "Blob size in bytes (of last blob only for multi-blob txs).",
+			Buckets:   prometheus.LinearBuckets(0.0, eth.MaxBlobDataSize/13, 14),
 		}),
 
 		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),

--- a/op-service/txmgr/metrics/noop.go
+++ b/op-service/txmgr/metrics/noop.go
@@ -15,5 +15,6 @@ func (*NoopTxMetrics) RecordTxConfirmationLatency(int64) {}
 func (*NoopTxMetrics) TxConfirmed(*types.Receipt)        {}
 func (*NoopTxMetrics) TxPublished(string)                {}
 func (*NoopTxMetrics) RecordBaseFee(*big.Int)            {}
+func (*NoopTxMetrics) RecordBlobBaseFee(*big.Int)        {}
 func (*NoopTxMetrics) RecordTipCap(*big.Int)             {}
 func (*NoopTxMetrics) RPCError()                         {}

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -18,6 +18,7 @@ type TxMetricer interface {
 	TxConfirmed(*types.Receipt)
 	TxPublished(string)
 	RecordBaseFee(*big.Int)
+	RecordBlobBaseFee(*big.Int)
 	RecordTipCap(*big.Int)
 	RPCError()
 }
@@ -34,6 +35,7 @@ type TxMetrics struct {
 	publishEvent       *metrics.Event
 	confirmEvent       metrics.EventVec
 	baseFee            prometheus.Gauge
+	blobBaseFee        prometheus.Gauge
 	tipCap             prometheus.Gauge
 	rpcError           prometheus.Counter
 }
@@ -107,7 +109,13 @@ func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
 		baseFee: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "basefee_wei",
-			Help:      "Latest L1 baseFee (in Wei)",
+			Help:      "Latest L1 base fee (in Wei)",
+			Subsystem: "txmgr",
+		}),
+		blobBaseFee: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "blob_basefee_wei",
+			Help:      "Latest Blob base fee (in Wei)",
 			Subsystem: "txmgr",
 		}),
 		tipCap: factory.NewGauge(prometheus.GaugeOpts{
@@ -161,6 +169,11 @@ func (t *TxMetrics) TxPublished(errString string) {
 func (t *TxMetrics) RecordBaseFee(baseFee *big.Int) {
 	bff, _ := baseFee.Float64()
 	t.baseFee.Set(bff)
+}
+
+func (t *TxMetrics) RecordBlobBaseFee(blobBaseFee *big.Int) {
+	bff, _ := blobBaseFee.Float64()
+	t.blobBaseFee.Set(bff)
 }
 
 func (t *TxMetrics) RecordTipCap(tipcap *big.Int) {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -317,7 +317,6 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		}
 	}
 	return m.signWithNextNonce(ctx, txMessage) // signer sets the nonce field of the tx
-
 }
 
 // MakeSidecar builds & returns the BlobTxSidecar and corresponding blob hashes from the raw blob
@@ -599,6 +598,11 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 	}
 
 	m.metr.RecordBaseFee(tip.BaseFee)
+	if tip.ExcessBlobGas != nil {
+		blobFee := eip4844.CalcBlobFee(*tip.ExcessBlobGas)
+		m.metr.RecordBlobBaseFee(blobFee)
+	}
+
 	m.l.Debug("Transaction mined, checking confirmations", "tx", txHash,
 		"block", eth.ReceiptBlockID(receipt), "tip", eth.HeaderBlockID(tip),
 		"numConfirmations", m.cfg.NumConfirmations)
@@ -752,6 +756,7 @@ func (m *SimpleTxManager) suggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 	var blobFee *big.Int
 	if head.ExcessBlobGas != nil {
 		blobFee = eip4844.CalcBlobFee(*head.ExcessBlobGas)
+		m.metr.RecordBlobBaseFee(blobFee)
 	}
 	return tip, baseFee, blobFee, nil
 }


### PR DESCRIPTION

**Description**

Adds blob base fee metrics to the txmgr.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/659
