### PR TITLE
improve currentheads function

### DIFF
--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -74,10 +74,11 @@ func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain) (*FindHea
 	}
 
 	safe, err := l2.L2BlockRefByLabel(ctx, eth.Safe)
-	if errors.Is(err, ethereum.NotFound) {
+	if err!=nil{
+		if !errors.Is(err, ethereum.NotFound){
+			return nil, fmt.Errorf("failed to find the safe L2 block: %w", err)
+		}
 		safe = finalized
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to find the safe L2 block: %w", err)
 	}
 
 	unsafe, err := l2.L2BlockRefByLabel(ctx, eth.Unsafe)

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -74,7 +74,7 @@ func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain) (*FindHea
 	}
 
 	safe, err := l2.L2BlockRefByLabel(ctx, eth.Safe)
-	if err!=nil{
+	if err != nil{
 		if !errors.Is(err, ethereum.NotFound){
 			return nil, fmt.Errorf("failed to find the safe L2 block: %w", err)
 		}


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

errors.Is() function is a time-consuming operation.this depends on the assertion and reflection mechanism he uses. In the most situations, the error is not nil,so this improvement can avoid the too much use errors.Is() function.

**Tests**

This is a very small transfer without modifying the logic.

