### PR TITLE
simplify bigMSB

### DIFF
--- a/op-challenger/game/fault/types/position.go
+++ b/op-challenger/game/fault/types/position.go
@@ -146,9 +146,5 @@ func bigMSB(x *big.Int) Depth {
 	if x.Cmp(big.NewInt(0)) == 0 {
 		return 0
 	}
-	out := Depth(0)
-	for ; x.Cmp(big.NewInt(0)) != 0; out++ {
-		x = new(big.Int).Rsh(x, 1)
-	}
-	return out - 1
+	return Depth(x.BitLen() - 1)
 }


### PR DESCRIPTION
No need to add extra tests since there already [exists](https://github.com/ethereum-optimism/optimism/blob/c9677e4133c12ab1cfbd910035b3a69b60bcba61/op-challenger/game/fault/types/position_test.go#L16)