### PR TITLE
feat(op-dispute-mon): Claim Monitor

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -13,17 +13,20 @@ type NoopMetricsImpl struct {
 
 var NoopMetrics Metricer = new(NoopMetricsImpl)
 
-func (*NoopMetricsImpl) RecordInfo(version string) {}
-func (*NoopMetricsImpl) RecordUp()                 {}
+func (*NoopMetricsImpl) RecordInfo(_ string) {}
+func (*NoopMetricsImpl) RecordUp()           {}
 
 func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
+func (*NoopMetricsImpl) RecordClaims(_ ClaimStatus, _ int) {}
+
 func (*NoopMetricsImpl) RecordWithdrawalRequests(_ common.Address, _ bool, _ int) {}
-func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64)              {}
 
-func (*NoopMetricsImpl) RecordOutputFetchTime(timestamp float64) {}
+func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(_ float64) {}
 
-func (*NoopMetricsImpl) RecordGameAgreement(status GameAgreementStatus, count int) {}
+func (*NoopMetricsImpl) RecordOutputFetchTime(_ float64) {}
+
+func (*NoopMetricsImpl) RecordGameAgreement(_ GameAgreementStatus, _ int) {}
 
 func (i *NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -1,0 +1,86 @@
+package mon
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type RClock interface {
+	Now() time.Time
+}
+
+type ClaimMetrics interface {
+	RecordClaims(status metrics.ClaimStatus, count int)
+}
+
+type ClaimMonitor struct {
+	logger  log.Logger
+	clock   RClock
+	metrics ClaimMetrics
+}
+
+func NewClaimMonitor(logger log.Logger, clock RClock, metrics ClaimMetrics) *ClaimMonitor {
+	return &ClaimMonitor{logger, clock, metrics}
+}
+
+func (c *ClaimMonitor) CheckClaims(games []*types.EnrichedGameData) {
+	claimStatus := make(map[metrics.ClaimStatus]int)
+	for _, game := range games {
+		c.checkGameClaims(game, claimStatus)
+	}
+	for status, count := range claimStatus {
+		c.metrics.RecordClaims(status, count)
+	}
+}
+
+func (c *ClaimMonitor) checkGameClaims(game *types.EnrichedGameData, claimStatus map[metrics.ClaimStatus]int) {
+	// Check if the game is in the first half
+	duration := uint64(c.clock.Now().Unix()) - game.Timestamp
+	firstHalf := duration <= (game.Duration / 2)
+
+	// Iterate over the game's claims
+	for _, claim := range game.Claims {
+		// Check if the clock has expired
+		if firstHalf && claim.Resolved {
+			c.logger.Error("Claim resolved in the first half of the game duration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+		}
+
+		maxChessTime := time.Duration(game.Duration/2) * time.Second
+		accumulatedTime := claim.ChessTime(c.clock.Now())
+		clockExpired := accumulatedTime >= maxChessTime
+
+		if claim.Resolved {
+			if clockExpired {
+				if firstHalf {
+					claimStatus[metrics.FirstHalfExpiredResolved]++
+				} else {
+					claimStatus[metrics.SecondHalfExpiredResolved]++
+				}
+			} else {
+				if firstHalf {
+					claimStatus[metrics.FirstHalfNotExpiredResolved]++
+				} else {
+					claimStatus[metrics.SecondHalfNotExpiredResolved]++
+				}
+			}
+		} else {
+			if clockExpired {
+				c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+				if firstHalf {
+					claimStatus[metrics.FirstHalfExpiredUnresolved]++
+				} else {
+					claimStatus[metrics.SecondHalfExpiredUnresolved]++
+				}
+			} else {
+				if firstHalf {
+					claimStatus[metrics.FirstHalfNotExpiredUnresolved]++
+				} else {
+					claimStatus[metrics.SecondHalfNotExpiredUnresolved]++
+				}
+			}
+		}
+	}
+}

--- a/op-dispute-mon/mon/claims_test.go
+++ b/op-dispute-mon/mon/claims_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,7 +52,7 @@ func (s *stubClaimMetrics) RecordClaims(status metrics.ClaimStatus, count int) {
 
 func makeMultipleTestGames(duration uint64) []*types.EnrichedGameData {
 	return []*types.EnrichedGameData{
-		makeTestGame(duration), // first half
+		makeTestGame(duration),      // first half
 		makeTestGame(duration * 10), // second half
 	}
 }
@@ -73,7 +73,7 @@ func makeTestGame(duration uint64) *types.EnrichedGameData {
 				Resolved: true,
 			},
 			{
-				Claim: faultTypes.Claim{},
+				Claim:    faultTypes.Claim{},
 				Resolved: true,
 			},
 			{

--- a/op-dispute-mon/mon/claims_test.go
+++ b/op-dispute-mon/mon/claims_test.go
@@ -1,0 +1,89 @@
+package mon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var frozen = time.Unix(int64(time.Hour.Seconds()), 0)
+
+func TestClaimMonitor_CheckClaims(t *testing.T) {
+	cm, cl, cMetrics := newTestClaimMonitor(t)
+	games := makeMultipleTestGames(uint64(cl.Now().Unix()))
+	cm.CheckClaims(games)
+
+	require.Equal(t, 1, cMetrics.calls[metrics.FirstHalfExpiredResolved])
+	require.Equal(t, 1, cMetrics.calls[metrics.FirstHalfExpiredUnresolved])
+	require.Equal(t, 1, cMetrics.calls[metrics.FirstHalfNotExpiredResolved])
+	require.Equal(t, 1, cMetrics.calls[metrics.FirstHalfNotExpiredUnresolved])
+
+	require.Equal(t, 1, cMetrics.calls[metrics.SecondHalfExpiredResolved])
+	require.Equal(t, 1, cMetrics.calls[metrics.SecondHalfExpiredUnresolved])
+	require.Equal(t, 1, cMetrics.calls[metrics.SecondHalfNotExpiredResolved])
+	require.Equal(t, 1, cMetrics.calls[metrics.SecondHalfNotExpiredUnresolved])
+}
+
+func newTestClaimMonitor(t *testing.T) (*ClaimMonitor, *clock.DeterministicClock, *stubClaimMetrics) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	cl := clock.NewDeterministicClock(frozen)
+	metrics := &stubClaimMetrics{}
+	return NewClaimMonitor(logger, cl, metrics), cl, metrics
+}
+
+type stubClaimMetrics struct {
+	calls map[metrics.ClaimStatus]int
+}
+
+func (s *stubClaimMetrics) RecordClaims(status metrics.ClaimStatus, count int) {
+	if s.calls == nil {
+		s.calls = make(map[metrics.ClaimStatus]int)
+	}
+	s.calls[status] += count
+}
+
+func makeMultipleTestGames(duration uint64) []*types.EnrichedGameData {
+	return []*types.EnrichedGameData{
+		makeTestGame(duration), // first half
+		makeTestGame(duration * 10), // second half
+	}
+}
+
+func makeTestGame(duration uint64) *types.EnrichedGameData {
+	return &types.EnrichedGameData{
+		Duration: duration,
+		Recipients: map[common.Address]bool{
+			common.Address{0x02}: true,
+			common.Address{0x03}: true,
+			common.Address{0x04}: true,
+		},
+		Claims: []types.EnrichedClaim{
+			{
+				Claim: faultTypes.Claim{
+					Clock: faultTypes.NewClock(time.Duration(0), frozen),
+				},
+				Resolved: true,
+			},
+			{
+				Claim: faultTypes.Claim{},
+				Resolved: true,
+			},
+			{
+				Claim: faultTypes.Claim{
+					Clock: faultTypes.NewClock(time.Duration(0), frozen),
+				},
+			},
+			{
+				Claim: faultTypes.Claim{},
+			},
+		},
+	}
+}

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -15,6 +15,7 @@ import (
 
 type Forecast func(ctx context.Context, games []*types.EnrichedGameData)
 type Bonds func(games []*types.EnrichedGameData)
+type MonitorClaims func(games []*types.EnrichedGameData)
 type MonitorWithdrawals func(games []*types.EnrichedGameData)
 type BlockHashFetcher func(ctx context.Context, number *big.Int) (common.Hash, error)
 type BlockNumberFetcher func(ctx context.Context) (uint64, error)
@@ -35,6 +36,7 @@ type gameMonitor struct {
 	delays           RecordClaimResolutionDelayMax
 	forecast         Forecast
 	bonds            Bonds
+	claims           MonitorClaims
 	withdrawals      MonitorWithdrawals
 	extract          Extract
 	fetchBlockHash   BlockHashFetcher
@@ -50,6 +52,7 @@ func newGameMonitor(
 	delays RecordClaimResolutionDelayMax,
 	forecast Forecast,
 	bonds Bonds,
+	claims MonitorClaims,
 	withdrawals MonitorWithdrawals,
 	extract Extract,
 	fetchBlockNumber BlockNumberFetcher,
@@ -65,6 +68,7 @@ func newGameMonitor(
 		delays:           delays,
 		forecast:         forecast,
 		bonds:            bonds,
+		claims:           claims,
 		withdrawals:      withdrawals,
 		extract:          extract,
 		fetchBlockNumber: fetchBlockNumber,
@@ -90,6 +94,7 @@ func (m *gameMonitor) monitorGames() error {
 	m.delays(enrichedGames)
 	m.forecast(m.ctx, enrichedGames)
 	m.bonds(enrichedGames)
+	m.claims(enrichedGames)
 	m.withdrawals(enrichedGames)
 	return nil
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -42,6 +42,7 @@ type Service struct {
 	forecast     *forecast
 	bonds        *bonds.Bonds
 	game         *extract.GameCallerCreator
+	claims       *ClaimMonitor
 	withdrawals  *WithdrawalMonitor
 	rollupClient *sources.RollupClient
 	validator    *outputValidator
@@ -86,6 +87,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
 
+	s.initClaimMonitor()
 	s.initWithdrawalMonitor()
 
 	s.initOutputValidator()   // Must be called before initForecast
@@ -103,6 +105,10 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.metrics.RecordUp()
 
 	return nil
+}
+
+func (s *Service) initClaimMonitor() {
+	s.claims = NewClaimMonitor(s.logger, s.cl, s.metrics)
 }
 
 func (s *Service) initWithdrawalMonitor() {
@@ -223,6 +229,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.delays.RecordClaimResolutionDelayMax,
 		s.forecast.Forecast,
 		s.bonds.CheckBonds,
+		s.claims.CheckClaims,
 		s.withdrawals.CheckWithdrawals,
 		s.extractor.Extract,
 		s.l1Client.BlockNumber,


### PR DESCRIPTION
**Description**

Introduces a claim monitor to track claims resolved too early, claims that could have been resolved, and a large amount of unresolved claims.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/680