### PR TITLE
fix: getting-started.json trailing comma causing json parse error

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -97,7 +97,7 @@ config=$(cat << EOL
   "faultGameSplitDepth": 14,
 
   "preimageOracleMinProposalSize": 1800000,
-  "preimageOracleChallengePeriod": 86400,
+  "preimageOracleChallengePeriod": 86400
 }
 EOL
 )


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

getting-started.json generation script generated with an extra trailing comma causing JSON parse error. (See diff for more info)

The effect is that we can't deploy a new OP stack chain following the [docs](https://docs.optimism.io/builders/chain-operators/tutorials/create-l2-rollup#configure-your-network)
