### PR TITLE
txmgr: fix racy access to nonces slice in TestQueue_Send with mutex

### DIFF
--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -181,10 +182,15 @@ func TestQueue_Send(t *testing.T) {
 			}
 
 			// track the nonces, and return any expected errors from tx sending
-			var nonces []uint64
+			var (
+				nonces  []uint64
+				nonceMu sync.Mutex
+			)
 			sendTx := func(ctx context.Context, tx *types.Transaction) error {
 				index := int(tx.Data()[0])
+				nonceMu.Lock()
 				nonces = append(nonces, tx.Nonce())
+				nonceMu.Unlock()
 				var testTx *testTx
 				if index < len(test.txs) {
 					testTx = &test.txs[index]


### PR DESCRIPTION

**Description**

Fixes a racy access to `nonces` slice in `TestQueue_Send`. The `sendTx` function is potentially called concurrently by the Queue.

Failed e.g. in [this CI run](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/49684/workflows/88f73970-d8f1-4a90-95e3-9c8a931cdfe3/jobs/2168234/tests) where it would explain why nonce `3` was missing.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/716
