### PR TITLE
feat(op-dispute-mon): Resolution Status Monitor Component

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -19,8 +19,11 @@ func (*NoopMetricsImpl) RecordUp()                 {}
 func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
+func (*NoopMetricsImpl) RecordGameResolutionStatus(_ bool, _ bool, _ int) {}
+
 func (*NoopMetricsImpl) RecordWithdrawalRequests(_ common.Address, _ bool, _ int) {}
-func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64)              {}
+
+func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64) {}
 
 func (*NoopMetricsImpl) RecordOutputFetchTime(timestamp float64) {}
 

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -15,6 +15,7 @@ import (
 
 type Forecast func(ctx context.Context, games []*types.EnrichedGameData)
 type Bonds func(games []*types.EnrichedGameData)
+type Resolutions func(games []*types.EnrichedGameData)
 type MonitorWithdrawals func(games []*types.EnrichedGameData)
 type BlockHashFetcher func(ctx context.Context, number *big.Int) (common.Hash, error)
 type BlockNumberFetcher func(ctx context.Context) (uint64, error)
@@ -35,6 +36,7 @@ type gameMonitor struct {
 	delays           RecordClaimResolutionDelayMax
 	forecast         Forecast
 	bonds            Bonds
+	resolutions      Resolutions
 	withdrawals      MonitorWithdrawals
 	extract          Extract
 	fetchBlockHash   BlockHashFetcher
@@ -50,6 +52,7 @@ func newGameMonitor(
 	delays RecordClaimResolutionDelayMax,
 	forecast Forecast,
 	bonds Bonds,
+	resolutions Resolutions,
 	withdrawals MonitorWithdrawals,
 	extract Extract,
 	fetchBlockNumber BlockNumberFetcher,
@@ -65,6 +68,7 @@ func newGameMonitor(
 		delays:           delays,
 		forecast:         forecast,
 		bonds:            bonds,
+		resolutions:      resolutions,
 		withdrawals:      withdrawals,
 		extract:          extract,
 		fetchBlockNumber: fetchBlockNumber,
@@ -87,6 +91,7 @@ func (m *gameMonitor) monitorGames() error {
 	if err != nil {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
+	m.resolutions(enrichedGames)
 	m.delays(enrichedGames)
 	m.forecast(m.ctx, enrichedGames)
 	m.bonds(enrichedGames)

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -24,7 +24,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 	t.Parallel()
 
 	t.Run("FailedFetchBlocknumber", func(t *testing.T) {
-		monitor, _, _, _, _, _, _ := setupMonitorTest(t)
+		monitor, _, _, _, _, _, _, _ := setupMonitorTest(t)
 		boom := errors.New("boom")
 		monitor.fetchBlockNumber = func(ctx context.Context) (uint64, error) {
 			return 0, boom
@@ -34,7 +34,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 	})
 
 	t.Run("FailedFetchBlockHash", func(t *testing.T) {
-		monitor, _, _, _, _, _, _ := setupMonitorTest(t)
+		monitor, _, _, _, _, _, _, _ := setupMonitorTest(t)
 		boom := errors.New("boom")
 		monitor.fetchBlockHash = func(ctx context.Context, number *big.Int) (common.Hash, error) {
 			return common.Hash{}, boom
@@ -74,7 +74,7 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 	t.Run("MonitorsGames", func(t *testing.T) {
 		addr1 := common.Address{0xaa}
 		addr2 := common.Address{0xbb}
-		monitor, factory, forecaster, _, _, _, _ := setupMonitorTest(t)
+		monitor, factory, forecaster, _, _, _, _, _ := setupMonitorTest(t)
 		factory.games = []*monTypes.EnrichedGameData{newEnrichedGameData(addr1, 9999), newEnrichedGameData(addr2, 9999)}
 		factory.maxSuccess = len(factory.games) // Only allow two successful fetches
 
@@ -87,7 +87,7 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 	})
 
 	t.Run("FailsToFetchGames", func(t *testing.T) {
-		monitor, factory, forecaster, _, _, _, _ := setupMonitorTest(t)
+		monitor, factory, forecaster, _, _, _, _, _ := setupMonitorTest(t)
 		factory.fetchErr = errors.New("boom")
 
 		monitor.StartMonitoring()
@@ -151,7 +151,7 @@ type mockResolutionMonitor struct {
 }
 
 func (m *mockResolutionMonitor) CheckResolutions(games []*monTypes.EnrichedGameData) {
-  	m.calls++
+	m.calls++
 }
 
 type mockClaimMonitor struct {

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -24,7 +24,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 	t.Parallel()
 
 	t.Run("FailedFetchBlocknumber", func(t *testing.T) {
-		monitor, _, _, _, _, _ := setupMonitorTest(t)
+		monitor, _, _, _, _, _, _ := setupMonitorTest(t)
 		boom := errors.New("boom")
 		monitor.fetchBlockNumber = func(ctx context.Context) (uint64, error) {
 			return 0, boom
@@ -34,7 +34,7 @@ func TestMonitor_MonitorGames(t *testing.T) {
 	})
 
 	t.Run("FailedFetchBlockHash", func(t *testing.T) {
-		monitor, _, _, _, _, _ := setupMonitorTest(t)
+		monitor, _, _, _, _, _, _ := setupMonitorTest(t)
 		boom := errors.New("boom")
 		monitor.fetchBlockHash = func(ctx context.Context, number *big.Int) (common.Hash, error) {
 			return common.Hash{}, boom
@@ -44,24 +44,26 @@ func TestMonitor_MonitorGames(t *testing.T) {
 	})
 
 	t.Run("MonitorsWithNoGames", func(t *testing.T) {
-		monitor, factory, forecast, delays, bonds, withdrawals := setupMonitorTest(t)
+		monitor, factory, forecast, delays, bonds, withdrawals, resolutions := setupMonitorTest(t)
 		factory.games = []*monTypes.EnrichedGameData{}
 		err := monitor.monitorGames()
 		require.NoError(t, err)
 		require.Equal(t, 1, forecast.calls)
 		require.Equal(t, 1, delays.calls)
 		require.Equal(t, 1, bonds.calls)
+		require.Equal(t, 1, resolutions.calls)
 		require.Equal(t, 1, withdrawals.calls)
 	})
 
 	t.Run("MonitorsMultipleGames", func(t *testing.T) {
-		monitor, factory, forecast, delays, bonds, withdrawals := setupMonitorTest(t)
+		monitor, factory, forecast, delays, bonds, withdrawals, resolutions := setupMonitorTest(t)
 		factory.games = []*monTypes.EnrichedGameData{{}, {}, {}}
 		err := monitor.monitorGames()
 		require.NoError(t, err)
 		require.Equal(t, 1, forecast.calls)
 		require.Equal(t, 1, delays.calls)
 		require.Equal(t, 1, bonds.calls)
+		require.Equal(t, 1, resolutions.calls)
 		require.Equal(t, 1, withdrawals.calls)
 	})
 }
@@ -70,7 +72,7 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 	t.Run("MonitorsGames", func(t *testing.T) {
 		addr1 := common.Address{0xaa}
 		addr2 := common.Address{0xbb}
-		monitor, factory, forecaster, _, _, _ := setupMonitorTest(t)
+		monitor, factory, forecaster, _, _, _, _ := setupMonitorTest(t)
 		factory.games = []*monTypes.EnrichedGameData{newEnrichedGameData(addr1, 9999), newEnrichedGameData(addr2, 9999)}
 		factory.maxSuccess = len(factory.games) // Only allow two successful fetches
 
@@ -83,7 +85,7 @@ func TestMonitor_StartMonitoring(t *testing.T) {
 	})
 
 	t.Run("FailsToFetchGames", func(t *testing.T) {
-		monitor, factory, forecaster, _, _, _ := setupMonitorTest(t)
+		monitor, factory, forecaster, _, _, _, _ := setupMonitorTest(t)
 		factory.fetchErr = errors.New("boom")
 
 		monitor.StartMonitoring()
@@ -105,7 +107,7 @@ func newEnrichedGameData(proxy common.Address, timestamp uint64) *monTypes.Enric
 	}
 }
 
-func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast, *mockDelayCalculator, *mockBonds, *mockWithdrawalMonitor) {
+func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast, *mockDelayCalculator, *mockBonds, *mockWithdrawalMonitor, *mockResolutionMonitor) {
 	logger := testlog.Logger(t, log.LvlDebug)
 	fetchBlockNum := func(ctx context.Context) (uint64, error) {
 		return 1, nil
@@ -119,6 +121,7 @@ func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast
 	extractor := &mockExtractor{}
 	forecast := &mockForecast{}
 	bonds := &mockBonds{}
+	resolutions := &mockResolutionMonitor{}
 	withdrawals := &mockWithdrawalMonitor{}
 	delays := &mockDelayCalculator{}
 	monitor := newGameMonitor(
@@ -130,12 +133,21 @@ func setupMonitorTest(t *testing.T) (*gameMonitor, *mockExtractor, *mockForecast
 		delays.RecordClaimResolutionDelayMax,
 		forecast.Forecast,
 		bonds.CheckBonds,
+		resolutions.CheckResolutions,
 		withdrawals.CheckWithdrawals,
 		extractor.Extract,
 		fetchBlockNum,
 		fetchBlockHash,
 	)
-	return monitor, extractor, forecast, delays, bonds, withdrawals
+	return monitor, extractor, forecast, delays, bonds, withdrawals, resolutions
+}
+
+type mockResolutionMonitor struct {
+	calls int
+}
+
+func (m *mockResolutionMonitor) CheckResolutions(games []*monTypes.EnrichedGameData) {
+	m.calls++
 }
 
 type mockWithdrawalMonitor struct {

--- a/op-dispute-mon/mon/resolutions.go
+++ b/op-dispute-mon/mon/resolutions.go
@@ -1,16 +1,10 @@
 package mon
 
 import (
-	"time"
-
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum/go-ethereum/log"
 )
-
-type RClock interface {
-	Now() time.Time
-}
 
 type ResolutionMetrics interface {
 	RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int)

--- a/op-dispute-mon/mon/resolutions.go
+++ b/op-dispute-mon/mon/resolutions.go
@@ -1,0 +1,68 @@
+package mon
+
+import (
+	"time"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type RClock interface {
+	Now() time.Time
+}
+
+type ResolutionMetrics interface {
+	RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int)
+}
+
+type ResolutionMonitor struct {
+	logger  log.Logger
+	clock   RClock
+	metrics ResolutionMetrics
+}
+
+func NewResolutionMonitor(logger log.Logger, metrics ResolutionMetrics, clock RClock) *ResolutionMonitor {
+	return &ResolutionMonitor{
+		logger:  logger,
+		clock:   clock,
+		metrics: metrics,
+	}
+}
+
+type resolutionStatus struct {
+	completeMaxDuration         int
+	completeBeforeMaxDuration   int
+	inProgressMaxDuration       int
+	inProgressBeforeMaxDuration int
+}
+
+func (r *resolutionStatus) Inc(complete, maxDuration bool) {
+	if complete {
+		if maxDuration {
+			r.completeMaxDuration++
+		} else {
+			r.completeBeforeMaxDuration++
+		}
+	} else {
+		if maxDuration {
+			r.inProgressMaxDuration++
+		} else {
+			r.inProgressBeforeMaxDuration++
+		}
+	}
+}
+
+func (r *ResolutionMonitor) CheckResolutions(games []*types.EnrichedGameData) {
+	status := &resolutionStatus{}
+	for _, game := range games {
+		complete := game.Status != gameTypes.GameStatusInProgress
+		duration := uint64(r.clock.Now().Unix()) - game.Timestamp
+		maxDurationReached := duration >= game.Duration
+		status.Inc(complete, maxDurationReached)
+	}
+	r.metrics.RecordGameResolutionStatus(true, true, status.completeMaxDuration)
+	r.metrics.RecordGameResolutionStatus(true, false, status.completeBeforeMaxDuration)
+	r.metrics.RecordGameResolutionStatus(false, true, status.inProgressMaxDuration)
+	r.metrics.RecordGameResolutionStatus(false, false, status.inProgressBeforeMaxDuration)
+}

--- a/op-dispute-mon/mon/resolutions_test.go
+++ b/op-dispute-mon/mon/resolutions_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var frozen = time.Unix(int64(time.Hour.Seconds()), 0)
-
 func TestResolutionMonitor_CheckResolutions(t *testing.T) {
 	r, cl, m := newTestResolutionMonitor(t)
 	games := newTestGames(uint64(cl.Now().Unix()))
@@ -27,7 +25,7 @@ func TestResolutionMonitor_CheckResolutions(t *testing.T) {
 
 func newTestResolutionMonitor(t *testing.T) (*ResolutionMonitor, *clock.DeterministicClock, *stubResolutionMetrics) {
 	logger := testlog.Logger(t, log.LvlInfo)
-	cl := clock.NewDeterministicClock(frozen)
+	cl := clock.NewDeterministicClock(time.Unix(int64(time.Hour.Seconds()), 0))
 	metrics := &stubResolutionMetrics{}
 	return NewResolutionMonitor(logger, metrics, cl), cl, metrics
 }

--- a/op-dispute-mon/mon/resolutions_test.go
+++ b/op-dispute-mon/mon/resolutions_test.go
@@ -1,0 +1,58 @@
+package mon
+
+import (
+	"testing"
+	"time"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var frozen = time.Unix(int64(time.Hour.Seconds()), 0)
+
+func TestResolutionMonitor_CheckResolutions(t *testing.T) {
+	r, cl, m := newTestResolutionMonitor(t)
+	games := newTestGames(uint64(cl.Now().Unix()))
+	r.CheckResolutions(games)
+
+	require.Equal(t, 1, m.calls[true][true])
+	require.Equal(t, 1, m.calls[true][false])
+	require.Equal(t, 1, m.calls[false][true])
+	require.Equal(t, 1, m.calls[false][false])
+}
+
+func newTestResolutionMonitor(t *testing.T) (*ResolutionMonitor, *clock.DeterministicClock, *stubResolutionMetrics) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	cl := clock.NewDeterministicClock(frozen)
+	metrics := &stubResolutionMetrics{}
+	return NewResolutionMonitor(logger, metrics, cl), cl, metrics
+}
+
+type stubResolutionMetrics struct {
+	calls map[bool]map[bool]int // completed -> max duration reached -> call count
+}
+
+func (s *stubResolutionMetrics) RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int) {
+	if s.calls == nil {
+		s.calls = make(map[bool]map[bool]int)
+		s.calls[true] = make(map[bool]int)
+		s.calls[false] = make(map[bool]int)
+	}
+	s.calls[complete][maxDurationReached] += count
+}
+
+func newTestGames(duration uint64) []*types.EnrichedGameData {
+	newTestGame := func(duration uint64, status gameTypes.GameStatus) *types.EnrichedGameData {
+		return &types.EnrichedGameData{Duration: duration, Status: status}
+	}
+	return []*types.EnrichedGameData{
+		newTestGame(duration, gameTypes.GameStatusInProgress),
+		newTestGame(duration*10, gameTypes.GameStatusInProgress),
+		newTestGame(duration, gameTypes.GameStatusDefenderWon),
+		newTestGame(duration*10, gameTypes.GameStatusChallengerWon),
+	}
+}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -42,6 +42,7 @@ type Service struct {
 	forecast     *forecast
 	bonds        *bonds.Bonds
 	game         *extract.GameCallerCreator
+	resolutions  *ResolutionMonitor
 	withdrawals  *WithdrawalMonitor
 	rollupClient *sources.RollupClient
 	validator    *outputValidator
@@ -86,6 +87,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
 
+	s.initResolutionMonitor()
 	s.initWithdrawalMonitor()
 
 	s.initOutputValidator()   // Must be called before initForecast
@@ -103,6 +105,10 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.metrics.RecordUp()
 
 	return nil
+}
+
+func (s *Service) initResolutionMonitor() {
+	s.resolutions = NewResolutionMonitor(s.logger, s.metrics, s.cl)
 }
 
 func (s *Service) initWithdrawalMonitor() {
@@ -223,6 +229,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.delays.RecordClaimResolutionDelayMax,
 		s.forecast.Forecast,
 		s.bonds.CheckBonds,
+		s.resolutions.CheckResolutions,
 		s.withdrawals.CheckWithdrawals,
 		s.extractor.Extract,
 		s.l1Client.BlockNumber,


### PR DESCRIPTION
**Description**

Adds a minimal resolution status component to the dispute monitor to metrice the number of games grouped by status and max duration reached.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/679