### PR TITLE
feat(indexer): index block after specified period of inactivity

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -54,7 +54,7 @@ The indexer service is responsible for polling and processing real-time batches 
 
 #### L1 Poller
 L1 blocks are only indexed if they contain L1 contract events. This is done to reduce the amount of unnecessary data that is indexed. Because of this, the `l1_block_headers` table will not contain every L1 block header unlike L2 blocks.
-An **exception** to this is if no log activity has been observed over the specified `ETLAllowedInactivityWindowSeconds` value in the chain config -- disabled by default with a zero value. Past this duration, the L1 ETL will index the latest
+An **exception** to this is if no log activity has been observed over the specified `ETLAllowedInactivityWindowSeconds` value in the [chain config](https://github.com/ethereum-optimism/optimism/blob/develop/indexer/config/config.go) -- disabled by default with a zero value. Past this duration, the L1 ETL will index the latest
 observed L1 header.
 
 #### Database

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -54,7 +54,8 @@ The indexer service is responsible for polling and processing real-time batches 
 
 #### L1 Poller
 L1 blocks are only indexed if they contain L1 contract events. This is done to reduce the amount of unnecessary data that is indexed. Because of this, the `l1_block_headers` table will not contain every L1 block header unlike L2 blocks.
-
+An **exception** to this is if no log activity has been observed over the specified `ETLAllowedInactivityWindowSeconds` value in the chain config -- disabled by default with a zero value. Past this duration, the L1 ETL will index the latest
+observed L1 header.
 
 #### Database
 The indexer service currently supports a Postgres database for storing L1/L2 OP Stack chain data. The most up-to-date database schemas can be found in the `./migrations` directory. **Run the idempotent migrations prior to starting the indexer**

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -114,6 +114,9 @@ type ChainConfig struct {
 
 	L1HeaderBufferSize uint `toml:"l1-header-buffer-size"`
 	L2HeaderBufferSize uint `toml:"l2-header-buffer-size"`
+
+	// Inactivity allowed before a block is indexed by the ETL. Default 0 value disables this feature
+	ETLAllowedInactivityWindowSeconds uint `toml:"etl-allowed-inactivity-window-seconds"`
 }
 
 // RPCsConfig configures the RPC urls

--- a/indexer/e2e_tests/etl_e2e_test.go
+++ b/indexer/e2e_tests/etl_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/indexer/config"
 	"github.com/ethereum-optimism/optimism/indexer/database"
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-bindings/bindingspreview"
@@ -20,6 +21,33 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestE2EL1ETLInactivityWindow(t *testing.T) {
+	withInactivityWindow := func(cfg *config.Config) *config.Config {
+		cfg.Chain.ETLAllowedInactivityWindowSeconds = 1
+
+		// Passing the inactivity window will index the latest header
+		// in the batch. Make the batch size 1 so all blocks are indexed
+		cfg.Chain.L1HeaderBufferSize = 1
+		return cfg
+	}
+
+	testSuite := createE2ETestSuite(t, withInactivityWindow)
+
+	// wait for 10 L1 blocks to be posted
+	require.NoError(t, wait.For(context.Background(), time.Second, func() (bool, error) {
+		l1Header := testSuite.Indexer.BridgeProcessor.LastL1Header
+		return l1Header != nil && l1Header.Number.Uint64() >= 10, nil
+	}))
+
+	// each block is indexed
+	for height := int64(0); height < int64(10); height++ {
+		header, err := testSuite.DB.Blocks.L1BlockHeaderWithFilter(database.BlockHeader{Number: big.NewInt(height)})
+		require.NoError(t, err)
+		require.NotNil(t, header)
+		require.Equal(t, header.Number.Uint64(), uint64(height))
+	}
+}
 
 func TestE2EETL(t *testing.T) {
 	testSuite := createE2ETestSuite(t)

--- a/indexer/etl/etl.go
+++ b/indexer/etl/etl.go
@@ -20,6 +20,9 @@ type Config struct {
 	LoopIntervalMsec uint
 	HeaderBufferSize uint
 
+	// Applicable only to the L1 ETL (all L2 block are indexed)
+	AllowedInactivityWindowSeconds uint
+
 	StartHeight       *big.Int
 	ConfirmationDepth *big.Int
 }

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -20,7 +20,7 @@ import (
 
 type L2ETL struct {
 	ETL
-	LatestHeader *types.Header
+	latestHeader *types.Header
 
 	// the batch handler may do work that we can interrupt on shutdown
 	resourceCtx    context.Context
@@ -31,7 +31,7 @@ type L2ETL struct {
 	db *database.DB
 
 	mu        sync.Mutex
-	listeners []chan interface{}
+	listeners []chan *types.Header
 }
 
 func NewL2ETL(cfg Config, log log.Logger, db *database.DB, metrics Metricer, client node.EthClient,
@@ -86,7 +86,7 @@ func NewL2ETL(cfg Config, log log.Logger, db *database.DB, metrics Metricer, cli
 	resCtx, resCancel := context.WithCancel(context.Background())
 	return &L2ETL{
 		ETL:          etl,
-		LatestHeader: fromHeader,
+		latestHeader: fromHeader,
 
 		resourceCtx:    resCtx,
 		resourceCancel: resCancel,
@@ -150,6 +150,8 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 		l2Etl.ETL.metrics.RecordIndexedLog(batch.Logs[i].Address)
 	}
 
+	/** Every L2 block is indexed so the inactivity window does not apply here **/
+
 	// Continually try to persist this batch. If it fails after 10 attempts, we simply error out
 	retryStrategy := &retry.ExponentialStrategy{Min: 1000, Max: 20_000, MaxJitter: 250}
 	if _, err := retry.Do[interface{}](l2Etl.resourceCtx, 10, retryStrategy, func() (interface{}, error) {
@@ -177,16 +179,16 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 	batch.Logger.Info("indexed batch")
 
 	// All L2 blocks are indexed so len(batch.Headers) == len(l2BlockHeaders)
-	l2Etl.LatestHeader = &batch.Headers[len(batch.Headers)-1]
+	l2Etl.latestHeader = &batch.Headers[len(batch.Headers)-1]
 	l2Etl.ETL.metrics.RecordIndexedHeaders(len(l2BlockHeaders))
-	l2Etl.ETL.metrics.RecordEtlLatestHeight(l2Etl.LatestHeader.Number)
+	l2Etl.ETL.metrics.RecordEtlLatestHeight(l2Etl.latestHeader.Number)
 
 	// Notify Listeners
 	l2Etl.mu.Lock()
 	defer l2Etl.mu.Unlock()
 	for i := range l2Etl.listeners {
 		select {
-		case l2Etl.listeners[i] <- struct{}{}:
+		case l2Etl.listeners[i] <- l2Etl.latestHeader:
 		default:
 			// do nothing if the listener hasn't picked
 			// up the previous notif
@@ -196,10 +198,9 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 	return nil
 }
 
-// Notify returns a channel that'll receive a value every time new data has
-// been persisted by the L2ETL
-func (l2Etl *L2ETL) Notify() <-chan interface{} {
-	receiver := make(chan interface{})
+// Notify returns a channel that'll receive the latest header when new data has been persisted
+func (l2Etl *L2ETL) Notify() <-chan *types.Header {
+	receiver := make(chan *types.Header)
 	l2Etl.mu.Lock()
 	defer l2Etl.mu.Unlock()
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -191,10 +191,11 @@ func (ix *Indexer) initDB(ctx context.Context, cfg config.DBConfig) error {
 
 func (ix *Indexer) initL1ETL(chainConfig config.ChainConfig) error {
 	l1Cfg := etl.Config{
-		LoopIntervalMsec:  chainConfig.L1PollingInterval,
-		HeaderBufferSize:  chainConfig.L1HeaderBufferSize,
-		ConfirmationDepth: big.NewInt(int64(chainConfig.L1ConfirmationDepth)),
-		StartHeight:       big.NewInt(int64(chainConfig.L1StartingHeight)),
+		LoopIntervalMsec:               chainConfig.L1PollingInterval,
+		HeaderBufferSize:               chainConfig.L1HeaderBufferSize,
+		AllowedInactivityWindowSeconds: chainConfig.ETLAllowedInactivityWindowSeconds,
+		ConfirmationDepth:              big.NewInt(int64(chainConfig.L1ConfirmationDepth)),
+		StartHeight:                    big.NewInt(int64(chainConfig.L1StartingHeight)),
 	}
 	l1Etl, err := etl.NewL1ETL(l1Cfg, ix.log, ix.DB, etl.NewMetrics(ix.metricsRegistry, "l1"),
 		ix.l1Client, chainConfig.L1Contracts, ix.shutdown)

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -92,9 +92,9 @@ func (b *BridgeProcessor) Start() error {
 	// start L1 worker
 	b.tasks.Go(func() error {
 		l1EtlUpdates := b.l1Etl.Notify()
-		for range l1EtlUpdates {
-			b.log.Info("notified of traversed L1 state", "l1_etl_block_number", b.l1Etl.LatestHeader.Number)
-			if err := b.onL1Data(b.l1Etl.LatestHeader); err != nil {
+		for latestHeader := range l1EtlUpdates {
+			b.log.Info("notified of traversed L1 state", "l1_etl_block_number", latestHeader.Number)
+			if err := b.onL1Data(latestHeader); err != nil {
 				b.log.Error("failed l1 bridge processing interval", "err", err)
 			}
 		}
@@ -104,9 +104,9 @@ func (b *BridgeProcessor) Start() error {
 	// start L2 worker
 	b.tasks.Go(func() error {
 		l2EtlUpdates := b.l2Etl.Notify()
-		for range l2EtlUpdates {
-			b.log.Info("notified of traversed L2 state", "l2_etl_block_number", b.l2Etl.LatestHeader.Number)
-			if err := b.onL2Data(b.l2Etl.LatestHeader); err != nil {
+		for latestHeader := range l2EtlUpdates {
+			b.log.Info("notified of traversed L2 state", "l2_etl_block_number", latestHeader.Number)
+			if err := b.onL2Data(latestHeader); err != nil {
 				b.log.Error("failed l2 bridge processing interval", "err", err)
 			}
 		}


### PR DESCRIPTION
For low activity chains, the L1 ETL may not index any new blocks for prolonged periods
of time. Downstream processors that transform indexed state may look like they are stalled
due to the lack of progression.

To address this, provide a `ETLAllowedInactivityWindowSeconds` chain config parameter that
will force the ETL to index latest seen block if the time elapsed since the last indexed
block exceeds the inactivity window. This way downstream works can progress their L1 markers
for latest processed L1 HEAD.

## Aside
Update the ETL notification channel to supply the latest header in the receiver channel,
rather than refer to reference directly
