### PR TITLE
ci-builder: add yq

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -58,13 +58,15 @@ RUN go install github.com/ethereum/go-ethereum/cmd/geth@$(jq -r .geth < versions
 RUN go install gotest.tools/gotestsum@latest
 RUN go install github.com/vektra/mockery/v2@v2.28.1
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+RUN go install github.com/mikefarah/yq/v4@latest
 
 # Strip binaries to reduce size
 RUN strip /go/bin/gotestsum && \
   strip /go/bin/mockery && \
   strip /go/bin/golangci-lint && \
   strip /go/bin/abigen && \
-  strip /go/bin/geth
+  strip /go/bin/geth && \
+  strip /go/bin/yq
 
 FROM --platform=linux/amd64 debian:bullseye-slim as base-builder
 

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -58,7 +58,7 @@ RUN go install github.com/ethereum/go-ethereum/cmd/geth@$(jq -r .geth < versions
 RUN go install gotest.tools/gotestsum@latest
 RUN go install github.com/vektra/mockery/v2@v2.28.1
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
-RUN go install github.com/mikefarah/yq/v4@latest
+RUN go install github.com/mikefarah/yq/v4@v4.43.1
 
 # Strip binaries to reduce size
 RUN strip /go/bin/gotestsum && \

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -55,7 +55,7 @@ COPY ./versions.json ./versions.json
 RUN go install github.com/ethereum/go-ethereum/cmd/abigen@$(jq -r .abigen < versions.json)
 RUN go install github.com/ethereum/go-ethereum/cmd/geth@$(jq -r .geth < versions.json)
 
-RUN go install gotest.tools/gotestsum@latest
+RUN go install gotest.tools/gotestsum@v1.11.0
 RUN go install github.com/vektra/mockery/v2@v2.28.1
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 RUN go install github.com/mikefarah/yq/v4@v4.43.1


### PR DESCRIPTION
**Description**

Adds `yq` to `ci-builder` so that we can read the yaml information
inside of the superchain registry.

`yq` is `jq` but for yaml, see https://github.com/mikefarah/yq

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

