### PR TITLE
fix: OwnableUpgradeable does not have a constructor

### DIFF
--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -41,7 +41,7 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, ISemver 
     GameId[] internal _disputeGameList;
 
     /// @notice Constructs a new DisputeGameFactory contract.
-    constructor() OwnableUpgradeable() {
+    constructor() {
         initialize(address(0));
     }
 


### PR DESCRIPTION
OwnableUpgradeable does not have a constructor, therefore the call will be made to the default empty constructor but will not make any changes on OwnableUpgradeable. It was removed to avoid confusion.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

OwnableUpgradeable does not have a constructor, therefore the call will be made to the default empty constructor but will not make any changes on OwnableUpgradeable. It was removed to avoid confusion.

**Tests**

By looking at  `OwnableUpgradeable` and the call traces in the deployment of `DisputeGameFactory`, it was determined that a constructor was not defined in  `OwnableUpgradeable` and although the `DisputeGameFactory` contract was deployed successfully, the call for empty OwnableUpgradeable constructor is redundant. Testing was not needed because it was obvious.

**Additional context**

Removing unnecessary calls is important to prevent confusion, potential attack vectors and improves efficiency.
