### PR TITLE
Use a nightly version of foundry

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -25,6 +25,7 @@ remappings = [
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 build_info_path = 'artifacts/build-info'
+ast = true
 
 # Test / Script Runner Settings
 ffi = true

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "617dfc28cb8206a0003edcf73a6f1058adaef740",
+  "foundry": "dbc48ead1044066a3e12c796fca9dc077f5913fe",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
   "slither": "0.10.0",

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "dbc48ead1044066a3e12c796fca9dc077f5913fe",
+  "foundry": "d94e3c631e2da7756af46c70f8f58b75563b7013",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
The current commit of foundry is not tagged as nightly, so needs to be built instead of downloading.

Update: per the conversation below, we'll merge this if the tag is persisted.