### PR TITLE
op-chain-ops: detangle addresses from deploy config

### DIFF
--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -20,7 +20,7 @@ import (
 )
 
 // BuildL2Genesis will build the L2 genesis block.
-func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Genesis, error) {
+func BuildL2Genesis(config *DeployConfig, deployments *L1Deployments, l1StartBlock *types.Block) (*core.Genesis, error) {
 	genspec, err := NewL2Genesis(config, l1StartBlock)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Gene
 
 	SetPrecompileBalances(db)
 
-	storage, err := NewL2StorageConfig(config, l1StartBlock)
+	storage, err := NewL2StorageConfig(config, deployments, l1StartBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/op-chain-ops/genesis/layer_two_test.go
+++ b/op-chain-ops/genesis/layer_two_test.go
@@ -40,7 +40,9 @@ func testBuildL2Genesis(t *testing.T, config *genesis.DeployConfig) *core.Genesi
 	block, err := backend.BlockByNumber(context.Background(), common.Big0)
 	require.NoError(t, err)
 
-	gen, err := genesis.BuildL2Genesis(config, block)
+	deployments := genesis.L1Deployments{}
+
+	gen, err := genesis.BuildL2Genesis(config, &deployments, block)
 	require.Nil(t, err)
 	require.NotNil(t, gen)
 


### PR DESCRIPTION
**Description**

Remove the addresses from the deploy config and instead
use the struct made specifically for reading `superchain-ops`
style deploy artifacts. The problem with having the addresses
in the deploy config is that the addresses are the output of
a process that takes the deploy config as input (contract deployments).
So it makes no sense to use deploy config to deploy contracts then
mutate the deploy config to pass to the L2 genesis generation. Instead
the deployment step should output its own artifact which is then input
to the L2 genesis gen along with the original deploy config.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

