### PR TITLE
op-challenger: Fix list-claims command

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -103,7 +103,7 @@ func listClaims(ctx context.Context, game *contracts.FaultDisputeGameContract) e
 		if claim.Depth() <= splitDepth {
 			traceIdx = claim.TraceIndex(splitDepth)
 		} else {
-			relativePos, err := claim.Position.RelativeToAncestorAtDepth(splitDepth)
+			relativePos, err := claim.Position.RelativeToAncestorAtDepth(splitDepth + 1)
 			if err != nil {
 				fmt.Printf("Error calculating relative position for claim %v: %v", claim.ContractIndex, err)
 				traceIdx = big.NewInt(-1)


### PR DESCRIPTION
This fixes a crash when computing the trace index of large depths. The top game ends at exactly `splitDepth`. Thus, bottom game positions should be oriented one level below that.