### PR TITLE
test(ctb): downgrade foundry to an old commit to fix kontrol tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.46.1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.46.2-rc.1
   ci_builder_rust_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:latest

--- a/ops/check-changed/main.py
+++ b/ops/check-changed/main.py
@@ -57,6 +57,10 @@ log = logging.getLogger(__name__)
 
 
 def main():
+    # Temporarily always build
+    if True:
+      exit_build()
+
     patterns = sys.argv[1].split(',') + REBUILD_ALL_PATTERNS
     no_go_deps = os.getenv('CHECK_CHANGED_NO_GO_DEPS')
     if no_go_deps is None:

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "a170021b0e058925047a2c9697ba61f10fc0b2ce",
+  "foundry": "de33b6af53005037b463318d2628b5cfcaf39916",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
   "slither": "0.10.0",

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "617dfc28cb8206a0003edcf73a6f1058adaef740",
+  "foundry": "a170021b0e058925047a2c9697ba61f10fc0b2ce",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
Since https://github.com/ethereum-optimism/optimism/pull/9950 kontrol tests have been consistently failing. There are a few theories as to why, but to fix tests in the meantime we will downgrade the version. 

It's possible this causes "llegal instruction" panics in some devnet tests, so let's try this, and incrementally increase the foundry version until we find a version that works for both until we properly debug the issues.

I've manually triggered the pipeline with `kontrol_dispatch=true` so we can run tests before merge, status can be found here: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism?branch=mds1-patch-1

Edit: Manual dispatch did not work as check-change exited early. So if CI passes we can merge, update ci-builder, and iterate from there?
