### PR TITLE
op-node: driver v2 illustrative draft of condition/effect pattern

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -52,7 +52,7 @@ type OpNode struct {
 	l1FinalizedSub ethereum.Subscription // Subscription to get L1 safe blocks, a.k.a. justified data (polling)
 
 	l1Source  *sources.L1Client     // L1 Client to fetch data from
-	l2Driver  *driver.Driver        // L2 Engine to Sync
+	l2Driver  driver.Driver         // L2 Engine to Sync
 	l2Source  *sources.EngineClient // L2 Execution Engine RPC bindings
 	server    *rpcServer            // RPC server hosting the rollup-node API
 	p2pNode   *p2p.NodeP2P          // P2P node functionality

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -115,7 +115,7 @@ type SafeHeadListener interface {
 }
 
 // Max memory used for buffering unsafe payloads
-const maxUnsafePayloadsMemory = 500 * 1024 * 1024
+const MaxUnsafePayloadsMemory = 500 * 1024 * 1024
 
 // finalityLookback defines the amount of L1<>L2 relations to track for finalization purposes, one per L1 block.
 //
@@ -204,7 +204,7 @@ func NewEngineQueue(log log.Logger, cfg *rollup.Config, l2Source L2Source, engin
 		engine:         l2Source,
 		metrics:        metrics,
 		finalityData:   make([]FinalityData, 0, calcFinalityLookback(cfg)),
-		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
+		unsafePayloads: NewPayloadsQueue(log, MaxUnsafePayloadsMemory, PayloadMemSize),
 		prev:           prev,
 		l1Fetcher:      l1Fetcher,
 		syncCfg:        syncCfg,

--- a/op-node/rollup/derive/payloads_queue.go
+++ b/op-node/rollup/derive/payloads_queue.go
@@ -57,7 +57,7 @@ const (
 	payloadTxMemOverhead uint64 = 24
 )
 
-func payloadMemSize(p *eth.ExecutionPayloadEnvelope) uint64 {
+func PayloadMemSize(p *eth.ExecutionPayloadEnvelope) uint64 {
 	out := payloadMemFixedCost
 	if p == nil {
 		return out
@@ -156,4 +156,19 @@ func (upq *PayloadsQueue) Pop() *eth.ExecutionPayloadEnvelope {
 	// remove the key from the block hashes map
 	delete(upq.blockHashes, ps.envelope.ExecutionPayload.BlockHash)
 	return ps.envelope
+}
+
+// Max returns the payload with the highest block number from the queue in O(N).
+// TODO: this is not a double-sided data-structure, can't fetch the maximum entry efficiently.
+func (upq *PayloadsQueue) Max() (out *eth.ExecutionPayloadEnvelope) {
+	if len(upq.pq) == 0 {
+		return nil
+	}
+	out = upq.pq[0].envelope
+	for _, v := range upq.pq {
+		if v.envelope.ExecutionPayload.BlockNumber > out.ExecutionPayload.BlockNumber {
+			out = v.envelope
+		}
+	}
+	return out
 }

--- a/op-node/rollup/derive/payloads_queue_test.go
+++ b/op-node/rollup/derive/payloads_queue_test.go
@@ -65,12 +65,12 @@ func TestPayloadsByNumber(t *testing.T) {
 }
 
 func TestPayloadMemSize(t *testing.T) {
-	require.Equal(t, payloadMemFixedCost, payloadMemSize(nil), "nil is same fixed cost")
-	require.Equal(t, payloadMemFixedCost, payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{}}), "empty payload fixed cost")
-	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{nil}}}), "nil tx counts")
-	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{make([]byte, 0)}}}), "empty tx counts")
+	require.Equal(t, payloadMemFixedCost, PayloadMemSize(nil), "nil is same fixed cost")
+	require.Equal(t, payloadMemFixedCost, PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{}}), "empty payload fixed cost")
+	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{nil}}}), "nil tx counts")
+	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{make([]byte, 0)}}}), "empty tx counts")
 	require.Equal(t, payloadMemFixedCost+4*payloadTxMemOverhead+42+1337+0+1,
-		payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{
+		PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{
 			make([]byte, 42),
 			make([]byte, 1337),
 			make([]byte, 0),
@@ -83,7 +83,7 @@ func envelope(payload *eth.ExecutionPayload) *eth.ExecutionPayloadEnvelope {
 }
 
 func TestPayloadsQueue(t *testing.T) {
-	pq := NewPayloadsQueue(testlog.Logger(t, log.LvlInfo), payloadMemFixedCost*3, payloadMemSize)
+	pq := NewPayloadsQueue(testlog.Logger(t, log.LvlInfo), payloadMemFixedCost*3, PayloadMemSize)
 	require.Equal(t, 0, pq.Len())
 	require.Nil(t, pq.Peek())
 	require.Nil(t, pq.Pop())

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,7 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// EnableV2 enables v2 driver functionality, built for interop.
+	EnableV2 bool `json:"enable_v2"`
 }

--- a/op-node/rollup/driver/driverv2.go
+++ b/op-node/rollup/driver/driverv2.go
@@ -1,0 +1,343 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	async2 "github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/async"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TODO: it would be nice if we can enhance this to RLock with ctx timeout.
+type LockedL2Ref struct {
+	eth.L2BlockRef
+	sync.RWMutex
+}
+
+type LockedL1Ref struct {
+	eth.L1BlockRef
+	sync.RWMutex
+}
+
+type DriverCondition struct {
+	name string
+	*async.RepeatCond
+}
+
+type EnginelessPipeline interface {
+	Reset()
+}
+
+type DriverV2 struct {
+	log log.Logger
+
+	cfg *Config
+
+	unsafeHead    LockedL2Ref
+	safeHead      LockedL2Ref
+	finalizedHead LockedL2Ref
+	pendingHead   LockedL2Ref
+
+	currentL1   LockedL1Ref
+	finalizedL1 LockedL1Ref
+	headL1      LockedL1Ref
+	safeL1      LockedL1Ref
+
+	// See specs draft in https://github.com/ethereum-optimism/specs/blob/664e92361ab7a1b1021660a1f67db8cdd50ba887/specs/interop/driver.md
+	// This section enumerates all condition/effect pairs.
+	attributesGeneration      *DriverCondition
+	unsafeBlockSyncTrigger    *DriverCondition
+	unsafeBlockProcessor      *DriverCondition
+	sequencerAction           *DriverCondition
+	attributesForceProcessing *DriverCondition
+	safetyProgression         *DriverCondition
+	safetyReversal            *DriverCondition
+	finalityProgression       *DriverCondition
+	engineConsistency         *DriverCondition
+
+	conditions []*DriverCondition
+
+	pipeline     EnginelessPipeline
+	pipelineLock sync.Mutex // unfortunately we need a lock, since both attributes-generation and manual RPC may reset.
+
+	sequencer SequencerIface
+
+	// async gossiper for payloads to be gossiped without
+	// blocking the event loop or waiting for insertion
+	asyncGossiper      async2.AsyncGossiper
+	sequencerConductor conductor.SequencerConductor
+
+	engineController *derive.EngineController
+
+	l2 L2Chain
+
+	// TODO interop repeat-conditions: (also modify some of the above effects)
+	// TODO interop safety progression
+	// TODO interop safety reversal
+
+	payloads     *derive.PayloadsQueue
+	payloadsLock sync.RWMutex
+
+	lifetimeCtx    context.Context
+	lifetimeCancel context.CancelCauseFunc
+
+	starter sync.Once
+
+	closeWg sync.WaitGroup
+}
+
+var _ Driver = (*DriverV2)(nil)
+
+func NewDriverV2(log log.Logger,
+	sequencer SequencerIface,
+	asyncGossiper async2.AsyncGossiper,
+	sequencerConductor conductor.SequencerConductor,
+	engineController *derive.EngineController,
+	l2 L2Chain,
+) *DriverV2 {
+	lifetimeCtx, lifetimeCancel := context.WithCancelCause(context.Background())
+	d := &DriverV2{
+		log:                log,
+		lifetimeCtx:        lifetimeCtx,
+		lifetimeCancel:     lifetimeCancel,
+		payloads:           derive.NewPayloadsQueue(log, derive.MaxUnsafePayloadsMemory, derive.PayloadMemSize),
+		pipeline:           nil, // TODO
+		sequencer:          sequencer,
+		asyncGossiper:      asyncGossiper,
+		sequencerConductor: sequencerConductor,
+		engineController:   engineController,
+		l2:                 l2,
+	}
+
+	todoCondition := func() bool {
+		// TODO
+		return false
+	}
+	todoEffect := func() {
+		// TODO
+	}
+	d.attributesGeneration = d.registerCondition("attributes generation", &d.currentL1, d.checkGenerateAttributes, d.doGenerateAttributes)
+	d.unsafeBlockSyncTrigger = d.registerCondition("unsafe block sync trigger", &d.unsafeHead, d.checkUnsafeBlockSyncTrigger, d.doUnsafeBlockSyncTrigger)
+	d.unsafeBlockProcessor = d.registerCondition("unsafe block processor", &d.unsafeHead, d.checkUnsafeBlockProcessing, d.doUnsafeBlockProcessing)
+	d.sequencerAction = d.registerCondition("sequencer action", &d.unsafeHead, d.checkSequencerAction, d.doSequencerAction)
+	d.attributesForceProcessing = d.registerCondition("attributes force processing", &d.unsafeHead, todoCondition, todoEffect)
+	d.safetyProgression = d.registerCondition("safety progression", &d.safeHead, todoCondition, todoEffect)
+	d.safetyReversal = d.registerCondition("safety reversal", &d.safeHead, todoCondition, todoEffect)
+	d.finalityProgression = d.registerCondition("finality progression", &d.finalizedHead, todoCondition, todoEffect)
+	d.engineConsistency = d.registerCondition("engine consistency", &d.unsafeHead, todoCondition, todoEffect)
+	// Design note: more conditions / effects can be registered.
+	// And optionally based on hardforks, feature-flags, OP-Stack forks, etc.
+	return d
+}
+
+func (d *DriverV2) registerCondition(name string, locker sync.Locker, conditional func() bool, effect func()) *DriverCondition {
+	c := async.NewRepeatCond(d.lifetimeCtx, locker, func() bool {
+		d.log.Debug("driver condition start", "name", name)
+		startTime := time.Now()
+		v := conditional()
+		d.log.Debug("driver condition end", "name", name, "value", v, "elapsed", time.Since(startTime))
+		return v
+	}, func() {
+		d.log.Debug("driver effect start", "name", name)
+		startTime := time.Now()
+		effect()
+		d.log.Debug("driver effect end", "name", name, "elapsed", time.Since(startTime))
+	})
+	dc := &DriverCondition{name: name, RepeatCond: c}
+	d.conditions = append(d.conditions, dc)
+	return dc
+}
+
+// Start starts the driver operations: all condition/effects will be applicable, and signaled once.
+func (d *DriverV2) Start() error {
+	startProcess := func(r *DriverCondition) {
+		d.closeWg.Add(1)
+
+		go func() {
+			<-r.Ctx().Done()
+			if err := context.Cause(r.Ctx()); err != nil && !errors.Is(err, context.Canceled) {
+				d.log.Error("driver process failed", "name", r.name, "err", err)
+			}
+			d.closeWg.Done()
+		}()
+
+		r.Start()
+		r.Signal() // warm up, we may already have hit the condition
+	}
+
+	d.starter.Do(func() {
+		for _, cond := range d.conditions {
+			startProcess(cond)
+		}
+	})
+	return nil
+}
+
+func (d *DriverV2) Close() error {
+	// start closing all processes
+	d.lifetimeCancel(context.Canceled)
+	// wait for all processes to close
+	d.closeWg.Wait()
+
+	// collect errors from processes
+	var result error
+	for _, cond := range d.conditions {
+		if err := cond.Ctx().Err(); err != nil && !errors.Is(err, context.Canceled) {
+			result = errors.Join(result, fmt.Errorf("engine driver process %q close error: %w", cond.name, err))
+		}
+	}
+
+	return result
+}
+
+func (d *DriverV2) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	// TODO: these read locks should be quick, but we may still want to respect the ctx,
+	// that we introduced for v1 having prolonged global contention between everything.
+
+	// We grab all locks, for a single global consistent view of the sync-status.
+	d.unsafeHead.RLock()
+	defer d.unsafeHead.RUnlock()
+	d.safeHead.RLock()
+	defer d.safeHead.RUnlock()
+	d.finalizedHead.RLock()
+	defer d.finalizedHead.RUnlock()
+	d.currentL1.RLock()
+	defer d.currentL1.RUnlock()
+	d.finalizedL1.RLock()
+	defer d.finalizedL1.RUnlock()
+
+	return &eth.SyncStatus{
+		CurrentL1:          d.currentL1.L1BlockRef,
+		CurrentL1Finalized: d.finalizedL1.L1BlockRef,
+		HeadL1:             d.headL1.L1BlockRef,
+		SafeL1:             d.safeL1.L1BlockRef,
+		FinalizedL1:        d.finalizedL1.L1BlockRef, // TODO what's the difference again?
+		UnsafeL2:           d.unsafeHead.L2BlockRef,
+		SafeL2:             d.safeHead.L2BlockRef,
+		FinalizedL2:        d.finalizedHead.L2BlockRef,
+		PendingSafeL2:      d.pendingHead.L2BlockRef,
+	}, nil
+}
+
+func (d *DriverV2) BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2BlockRef, *eth.SyncStatus, error) {
+	// special case for finalized blocks: don't lock the unsafe L2 chain, if we are fetching finalized data.
+	d.finalizedHead.RLock()
+	defer d.finalizedHead.RUnlock()
+
+	// don't lock the unsafe part if the block we are fetching is finalized and not going to change.
+	if num > d.finalizedHead.Number {
+		d.unsafeHead.RLock()
+		tip := d.unsafeHead.L2BlockRef
+		defer d.unsafeHead.RUnlock() // unlock after having fetched the block and sync-status, for consistency.
+		if tip.Number < num {
+			return eth.L2BlockRef{}, nil, ethereum.NotFound
+		}
+	}
+
+	ref, err := d.l2.L2BlockRefByNumber(ctx, num)
+	if err != nil {
+		return eth.L2BlockRef{}, nil, fmt.Errorf("failed to fetch block %d: %w", num, err)
+	}
+	status, err := d.SyncStatus(ctx)
+	if err != nil {
+		return eth.L2BlockRef{}, nil, err
+	}
+	return ref, status, nil
+}
+
+func (d *DriverV2) ResetDerivationPipeline(ctx context.Context) error {
+	d.pipelineLock.Lock()
+	defer d.pipelineLock.Unlock()
+	d.pipeline.Reset()
+	return nil
+}
+
+func (d *DriverV2) StartSequencer(ctx context.Context, blockHash common.Hash) error {
+	// Grab the lock over the tip of the chain. This ensures we aren't currently doing an open/seal sequencing step.
+	d.unsafeHead.Lock()
+	defer d.unsafeHead.Unlock()
+	if d.cfg.SequencerStopped {
+		return ErrSequencerAlreadyStopped
+	}
+	// Ensure that the request is consistent;
+	// we don't want to continue sequencing on an older part of the chain.
+	if d.unsafeHead.Hash != blockHash {
+		return fmt.Errorf("block hash does not match: head %s, received %s", d.unsafeHead.Hash, blockHash)
+	}
+	d.cfg.SequencerEnabled = true
+	d.cfg.SequencerStopped = false
+	// signal that we may start a new block sequencing job
+	d.sequencerAction.Signal()
+	return nil
+}
+
+func (d *DriverV2) StopSequencer(ctx context.Context) (common.Hash, error) {
+	// Grab the lock over the tip of the chain. This ensures we aren't currently doing an open/seal sequencing step.
+	d.unsafeHead.Lock()
+	defer d.unsafeHead.Unlock()
+
+	if d.cfg.SequencerStopped {
+		return common.Hash{}, ErrSequencerAlreadyStopped
+	}
+
+	// Cancel any inflight block building. If we don't cancel this, we can resume sequencing an old block
+	// even if we've received new unsafe heads in the interim, causing us to introduce a re-org.
+	d.sequencer.CancelBuildingBlock(ctx)
+
+	d.cfg.SequencerStopped = true
+
+	return d.unsafeHead.Hash, nil
+}
+
+func (d *DriverV2) SequencerActive(ctx context.Context) (bool, error) {
+	d.unsafeHead.RLock()
+	defer d.unsafeHead.RUnlock()
+	return d.cfg.SequencerEnabled && !d.cfg.SequencerStopped, nil
+}
+
+func (d *DriverV2) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	d.payloadsLock.Lock()
+	defer d.payloadsLock.Unlock()
+	err := d.payloads.Push(payload)
+	if err != nil {
+		return err
+	}
+	d.onNewUnsafeBlock()
+	return nil
+}
+
+func (d *DriverV2) OnL1Head(ctx context.Context, unsafe eth.L1BlockRef) error {
+	d.headL1.Lock()
+	defer d.headL1.Unlock()
+	d.headL1.L1BlockRef = unsafe
+	// signal we may be able to generate new L2 data from L1
+	d.attributesGeneration.Signal()
+	return nil
+}
+
+func (d *DriverV2) OnL1Safe(ctx context.Context, safe eth.L1BlockRef) error {
+	d.safeL1.Lock()
+	defer d.safeL1.Unlock()
+	d.safeL1.L1BlockRef = safe
+	// we only maintain the L1 safe head for debugging info, it doesn't affect L2 state or safety.
+	return nil
+}
+
+func (d *DriverV2) OnL1Finalized(ctx context.Context, finalized eth.L1BlockRef) error {
+	d.finalizedL1.Lock()
+	defer d.finalizedL1.Unlock()
+	d.finalizedL1.L1BlockRef = finalized
+	// signal we may finalize L2 now
+	d.finalityProgression.Signal()
+	return nil
+}

--- a/op-node/rollup/driver/driverv2_conditions.go
+++ b/op-node/rollup/driver/driverv2_conditions.go
@@ -1,0 +1,115 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// Design note: we can make the check/do conditions public, such that we can manually operate a driver,
+// and no longer have to duplicate the behavior in the op-e2e action tests.
+
+func (d *DriverV2) checkGenerateAttributes() bool {
+	// TODO: check if derivation is exhausted at current L1 block, and if we don't currently have attributes buffered
+	return false
+}
+
+func (d *DriverV2) doGenerateAttributes() {
+	// TODO: pull attributes from derivation, buffer for processing, signal attributes related conditions
+}
+
+func (d *DriverV2) checkUnsafeBlockSyncTrigger() bool {
+	d.payloadsLock.RLock()
+	defer d.payloadsLock.RUnlock()
+
+	// TODO check sync mode, we may not want to trigger sync, even if we can
+	maxBlock := d.payloads.Max()
+	if maxBlock == nil {
+		return false
+	}
+	// trigger sync if the latest block in the buffer is ahead of the tip by more than 1 block.
+	// Note: d.unsafeHead is locked and safe to use.
+	// TODO: maybe with separate Lock/Unlock for the condition and effect parts we can make this safe explicitly?
+	return d.unsafeHead.Number+1 < uint64(maxBlock.ExecutionPayload.BlockNumber)
+}
+
+func (d *DriverV2) doUnsafeBlockSyncTrigger() {
+	d.payloadsLock.Lock()
+	defer d.payloadsLock.Unlock()
+	maxBlock := d.payloads.Max()
+	if maxBlock == nil {
+		return
+	}
+	// TODO use timeout constants, same timeout as previously, etc.
+	ctx, cancel := context.WithTimeout(d.lifetimeCtx, time.Second*10)
+	defer cancel()
+	err := d.engineController.InsertUnsafePayload(ctx, maxBlock, d.unsafeHead.L2BlockRef)
+	if err != nil {
+		d.log.Error("failed to trigger sync with unsafe block", "block", maxBlock, "head", d.unsafeHead.L2BlockRef, "err", err)
+	}
+	d.onNewUnsafeBlock()
+}
+
+func (d *DriverV2) checkUnsafeBlockProcessing() bool {
+	d.payloadsLock.RLock()
+	defer d.payloadsLock.RUnlock()
+
+	next := d.payloads.Peek()
+	// if older: to be dropped by the effect
+	// if equal: to be processed by the effect
+	return next != nil && uint64(next.ExecutionPayload.BlockNumber) <= d.unsafeHead.Number+1
+}
+
+func (d *DriverV2) doUnsafeBlockProcessing() {
+	d.payloadsLock.Lock()
+	defer d.payloadsLock.Unlock()
+	next := d.payloads.Pop()
+	if next == nil {
+		return
+	}
+	if uint64(next.ExecutionPayload.BlockNumber) < d.unsafeHead.Number+1 {
+		// drop the old payload
+		d.log.Debug("already processed unsafe block past this height", "block", next, "head", d.unsafeHead.L2BlockRef)
+		return
+	}
+	// TODO use timeout constants, same timeout as previously, etc.
+	ctx, cancel := context.WithTimeout(d.lifetimeCtx, time.Second*10)
+	defer cancel()
+	err := d.engineController.InsertUnsafePayload(ctx, next, d.unsafeHead.L2BlockRef)
+	if err != nil {
+		d.log.Error("failed to process next unsafe block", "block", next, "head", d.unsafeHead.L2BlockRef, "err", err)
+	}
+	d.onNewUnsafeBlock()
+}
+
+func (d *DriverV2) checkSequencerAction() bool {
+	if !d.cfg.SequencerEnabled || d.cfg.SequencerStopped {
+		return false
+	}
+	next := d.sequencer.PlanNextSequencerAction()
+	if next < time.Millisecond*10 {
+		return true
+	}
+	// we can wait, just schedule a signal to check back later.
+	time.AfterFunc(next, d.sequencerAction.Signal)
+	return false
+}
+
+func (d *DriverV2) doSequencerAction() {
+	// TODO use timeout constants, same timeout as previously, etc.
+	ctx, cancel := context.WithTimeout(d.lifetimeCtx, time.Second*10)
+	defer cancel()
+	_, err := d.sequencer.RunNextSequencerAction(ctx, d.asyncGossiper, d.sequencerConductor)
+	if err != nil {
+		d.log.Error("failed to sequencer action", "head", d.unsafeHead.L2BlockRef, "err", err)
+	}
+	d.sequencerAction.Signal() // schedule the next sequencer action
+}
+
+// onNewUnsafeBlock is a helper function to signal all unsafe-block related jobs,
+// if the unsafe-head changed due to a non-sequencer action.
+func (d *DriverV2) onNewUnsafeBlock() {
+	d.unsafeHead.L2BlockRef = d.engineController.UnsafeL2Head()
+	d.unsafeBlockProcessor.Signal()
+	d.sequencerAction.Signal()
+	d.unsafeBlockSyncTrigger.Signal()
+}

--- a/op-service/async/repeat_cond.go
+++ b/op-service/async/repeat_cond.go
@@ -1,0 +1,96 @@
+package async
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+type RepeatCond struct {
+	lifeCtx    context.Context
+	lifeCancel context.CancelFunc
+
+	closeCtx    context.Context
+	closeCancel context.CancelCauseFunc
+
+	started atomic.Bool
+
+	cond        sync.Cond
+	conditional func() bool
+	effect      func()
+}
+
+func NewRepeatCond(ctx context.Context, locker sync.Locker, conditional func() bool, effect func()) *RepeatCond {
+	lifeCtx, lifeCancel := context.WithCancel(ctx)
+	closeCtx, closeCancel := context.WithCancelCause(context.Background())
+
+	return &RepeatCond{
+		lifeCtx:     lifeCtx,
+		lifeCancel:  lifeCancel,
+		closeCtx:    closeCtx,
+		closeCancel: closeCancel,
+		cond:        sync.Cond{L: locker},
+		conditional: conditional,
+		effect:      effect,
+	}
+}
+
+func (r *RepeatCond) Signal() {
+	r.cond.Signal()
+}
+
+func (r *RepeatCond) Start() {
+	// check if already started.
+	if !r.started.CompareAndSwap(false, true) {
+		return
+	}
+
+	// signal upon lifetime ctx completion, so we can awake to detect the ctx.Err() != nil
+	go func() {
+		<-r.lifeCtx.Done()
+		r.cond.Signal()
+	}()
+
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				r.closeCancel(fmt.Errorf("closed with panic: %v", err))
+			}
+		}()
+
+		// By default, assume a locked position.
+		// The Wait() will unlock it, allowing other resources to access the resource while it's waiting.
+		r.cond.L.Lock()
+
+		// repeat the condition over and over again
+		for {
+			for {
+				if r.lifeCtx.Err() != nil { // when signaled, first check if it's time to exit
+					r.closeCancel(r.lifeCtx.Err())
+				}
+				if r.conditional() { // stop waiting if we hit our condition
+					break
+				}
+				// This unlocks the lock upon calling, so others can use it.
+				// It re-locks just before the call completes.
+				r.cond.Wait()
+				// And when Signaled, it locks it again,
+				// so we can proceed to do our processing without another routine using our resource.
+			}
+			r.effect()
+		}
+	}()
+}
+
+// Ctx returns a context that is canceled when the RepeatCond is fully stopped,
+// either upon parent-lifetime context cancellation or with a cause on process panic.
+func (r *RepeatCond) Ctx() context.Context {
+	return r.closeCtx
+}
+
+// Note: we tend to use this with many other repeat-conditions,
+// and closing it through a shared context reduces boilerplate,
+// especially if we monitor the condition Ctx for errors anyway.
+// If we need to, we can later add an optional Close() method
+// that calls lifeCancel() and then awaits the closeCtx for convenience.


### PR DESCRIPTION
**Description**

On request from @sebastianst, this is a draft of the op-node driver, incomplete, but illustrative enough to show how:
- we can substitute the driver as component with a v2 version
- have different locks for unsafe/safe/finalized/L1-current etc. block heads
- implement a state that is used by conditions to determine if an action should run
- implement a few of the conditions / effects from the draft specs PR: https://github.com/ethereum-optimism/specs/blob/664e92361ab7a1b1021660a1f67db8cdd50ba887/specs/interop/driver.md#unsafe-block-addition
- implement a `RepeatCond` util, wrapping `sync.Cond`, such that it's more safe and easy to use for repeated conditions/effects.

See design-doc for reasoning about the `sync.Cond` usage and the state/condition/effect pattern.
This can also work well with testing, where we can manually check and enact the conditions, to go through things step-wise with assertions. 

