### PR TITLE
Store cannon-go-lint-and-test logs on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             gotestsum --format=standard-quiet --junitfile=/tmp/test-results/cannon.xml \
             -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./... 2>&1 | tee /testlogs/test.log
           working_directory: cannon
-     - run:
+      - run:
           name: upload Cannon coverage
           command: codecov --verbose --clean --flags cannon-go-tests
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
   cannon-go-lint-and-test:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: large
+    resource_class: medium
     steps:
       - checkout
       - check-changed:
@@ -137,8 +137,11 @@ jobs:
           command: |
             mkdir -p /testlogs
             gotestsum --format=standard-quiet --junitfile=/tmp/test-results/cannon.xml \
-            -- -parallel=2 ./... 2>&1 | tee /testlogs/test.log
+            -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./... 2>&1 | tee /testlogs/test.log
           working_directory: cannon
+     - run:
+          name: upload Cannon coverage
+          command: codecov --verbose --clean --flags cannon-go-tests
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           name: Cannon Go tests
           command: |
             mkdir -p /testlogs
-            gotestsum --format=standard-verbose --junitfile=/tmp/test-results/cannon.xml \
+            gotestsum --format=standard-quiet --junitfile=/tmp/test-results/cannon.xml \
             -- -parallel=2 ./... 2>&1 | tee /testlogs/test.log
           working_directory: cannon
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
   cannon-go-lint-and-test:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - check-changed:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
       - run:
           name: Cannon Go tests
           command: |
+            mkdir -p /testlogs
             gotestsum --format=standard-verbose --junitfile=/tmp/test-results/cannon.xml \
             -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./... 2>&1 | tee /testlogs/test.log
           working_directory: cannon

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,13 +136,16 @@ jobs:
           name: Cannon Go tests
           command: |
             gotestsum --format=standard-verbose --junitfile=/tmp/test-results/cannon.xml \
-            -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./...
+            -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./... 2>&1 | tee /testlogs/test.log
           working_directory: cannon
       - run:
           name: upload Cannon coverage
           command: codecov --verbose --clean --flags cannon-go-tests
       - store_test_results:
           path: /tmp/test-results
+      - store_artifacts:
+          path: /testlogs
+          when: on_fail
   cannon-build-test-vectors:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,11 +137,8 @@ jobs:
           command: |
             mkdir -p /testlogs
             gotestsum --format=standard-verbose --junitfile=/tmp/test-results/cannon.xml \
-            -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./... 2>&1 | tee /testlogs/test.log
+            -- -parallel=2 ./... 2>&1 | tee /testlogs/test.log
           working_directory: cannon
-      - run:
-          name: upload Cannon coverage
-          command: codecov --verbose --clean --flags cannon-go-tests
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:


### PR DESCRIPTION
**Description**

I also switched to quiet logs to help this test pass. Otherwise it was randomly failing after dumping out a huge amount of logs. If a test fails, it will log & then the logs will be saved for further inspection.

