### PR TITLE
CI: Less verbose output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,8 @@ jobs:
           name: Cannon Go tests
           command: |
             mkdir -p /testlogs
-            gotestsum --format=standard-quiet --junitfile=/tmp/test-results/cannon.xml \
-            -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./... 2>&1 | tee /testlogs/test.log
+            gotestsum --format=testname --junitfile=/tmp/test-results/cannon.xml --jsonfile=/testlogs/log.json \
+            -- -parallel=2 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./...
           working_directory: cannon
       - run:
           name: upload Cannon coverage
@@ -146,7 +146,7 @@ jobs:
           path: /tmp/test-results
       - store_artifacts:
           path: /testlogs
-          when: on_fail
+          when: always
   cannon-build-test-vectors:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -851,11 +851,11 @@ jobs:
             - golang-build-cache-
       - run:
           name: prep results dir
-          command: mkdir -p /tmp/test-results
+          command: mkdir -p /tmp/test-results &&  mkdir -p /testlogs
       - run:
           name: run tests
           command: |
-            gotestsum --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>.xml \
+            gotestsum --format=testname --junitfile=/tmp/test-results/<<parameters.module>>.xml --jsonfile=/testlogs/log.json \
             -- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out ./...
           working_directory: <<parameters.module>>
       - save_cache:
@@ -868,6 +868,9 @@ jobs:
           #command: codecov --verbose --clean --flags bedrock-go-tests
       - store_test_results:
           path: /tmp/test-results
+      - store_artifacts:
+          path: /testlogs
+          when: always
 
   go-e2e-test:
     parameters:
@@ -954,7 +957,7 @@ jobs:
             export OP_E2E_CANNON_ENABLED="false"
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
-            JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>> 2>&1 | tee /testlogs/test.log
+            JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml JSON_LOG_FILE=/testlogs/test.log make <<parameters.target>>
           working_directory: <<parameters.module>>
       - store_artifacts:
           path: /testlogs
@@ -998,10 +1001,13 @@ jobs:
           name: Test
           command: |
             mkdir -p /test-results
-            gotestsum  --format=standard-verbose --junitfile /test-results/tests.xml -- -parallel=2
+            gotestsum  --format=testname --junitfile /test-results/tests.xml --jsonfile /test-results/log.json -- -parallel=2
           working_directory: <<parameters.working_directory>>
       - store_test_results:
           path: /test-results
+      - store_artifacts:
+          path: /testlogs
+          when: always
       - when:
           condition:
             equal: [ true, <<parameters.build>> ]

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -1,6 +1,7 @@
 # Generally, JUNIT_FILE is set in CI but may be specified to an arbitrary file location to emulate CI locally
+# If JUNIT_FILE is set, JSON_LOG_FILE should also be set
 ifdef JUNIT_FILE
-	go_test = OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose --junitfile=$(JUNIT_FILE) -- -failfast
+	go_test = OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=testname --junitfile=$(JUNIT_FILE) --jsonfile=$(JSON_LOG_FILE) -- -failfast
   # Note: -parallel must be set to match the number of cores in the resource class
 	go_test_flags = -timeout=60m -parallel=8
 else

--- a/ops/scripts/parse_json_test_output.sh
+++ b/ops/scripts/parse_json_test_output.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <test name> <json file>"
+    exit 1
+fi
+
+TEST_NAME="$1"
+JSON_FILE="$2"
+
+jq --raw-output --join-output --arg testName "${TEST_NAME}" 'select(.Test == $testName and .Action == "output").Output' "${JSON_FILE}"


### PR DESCRIPTION
**Description**

This switches from the `standard-verbose` format to `testname` format. When tests fail, the `testname` format still logs. In addition, the raw `log.json` file is uploaded via the artifacts step. I added a script to parse the json output to show all of the output for a specific test.
