### PR TITLE
fix(op-challenger): Missing Flag in Create Game Subcommand

### DIFF
--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -67,6 +67,7 @@ func createGameFlags() []cli.Flag {
 	cliFlags := []cli.Flag{
 		flags.L1EthRpcFlag,
 		flags.FactoryAddressFlag,
+		TraceTypeFlag,
 		OutputRootFlag,
 		L2BlockNumFlag,
 	}


### PR DESCRIPTION
**Description**

The `--trace-type` flag for the `create-game` subcommand on the `op-challenger` binary was missing. This PR adds it to the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line flag for game creation to specify the trace type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->