### PR TITLE
[op-conductor] Add retry to avoid port in use error

### DIFF
--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
 // [Category: Initial Setup]
@@ -95,14 +96,17 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	// Test AddServerAsNonvoter, do not start a new sequencer just for this purpose, use Sequencer3's rpc to start conductor.
 	// This is fine as this mainly tests conductor's ability to add itself into the raft consensus cluster as a nonvoter.
 	t.Log("Testing AddServerAsNonvoter")
-	nonvoter := setupConductor(
-		t, VerifierName, t.TempDir(),
-		sys.RollupEndpoint(Sequencer3Name),
-		sys.NodeEndpoint(Sequencer3Name),
-		findAvailablePort(t),
-		false,
-		*sys.RollupConfig,
-	)
+	nonvoter, err := retry.Do[*conductor](ctx, maxSetupRetries, retryStrategy, func() (*conductor, error) {
+		return setupConductor(
+			t, VerifierName, t.TempDir(),
+			sys.RollupEndpoint(Sequencer3Name),
+			sys.NodeEndpoint(Sequencer3Name),
+			findAvailablePort(t),
+			false,
+			*sys.RollupConfig,
+		)
+	})
+	require.NoError(t, err)
 
 	err = leader.client.AddServerAsNonvoter(ctx, VerifierName, nonvoter.ConsensusEndpoint())
 	require.NoError(t, err, "Expected leader to add non-voter")


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

For some [test runs](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/49535/workflows/2d1bb41c-1b66-431c-8465-cf01591b8021/jobs/2164322/tests), we're encountering `bind: address already in use` error while running sequencer HA e2e tests.

After discussions in https://github.com/ethereum-optimism/optimism/pull/9543#discussion_r1490214235, we decided to go with the route to retry starting conductor / sequencers until the randomly selected ports are not occupied (of course, we're limiting the max amount of retries).

```
Error:      	Received unexpected error:
failed to listen: listen tcp 127.0.0.1:56356: bind: address already in use
failed to start JSON-RPC server
```

**Tests**

This should dramatically reduce the flaky tests occurance.

**Metadata**

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a retry mechanism for setting up high-availability infrastructure, enhancing robustness in handling setup failures due to port conflicts.
- **Refactor**
	- Encapsulated setup logic for high-availability infrastructure with retry handling.
- **Tests**
	- Updated the `TestSequencerFailover_ConductorRPC` to utilize the new retry mechanism, ensuring a more reliable setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->