### PR TITLE
op-node: prevent spamming of reqs for blocks triggered by `checkForGapInUnsafeQueue`

### DIFF
--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -176,7 +176,8 @@ func (n *NodeP2P) RequestL2Range(ctx context.Context, start, end eth.L2BlockRef)
 	if !n.AltSyncEnabled() {
 		return fmt.Errorf("cannot request range %s - %s, req-resp sync is not enabled", start, end)
 	}
-	return n.syncCl.RequestL2Range(ctx, start, end)
+	_, err := n.syncCl.RequestL2Range(ctx, start, end)
+	return err
 }
 
 func (n *NodeP2P) Host() host.Host {

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -388,9 +388,9 @@ func (s *SyncClient) onRangeRequest(ctx context.Context, req rangeRequest) {
 	log.Info("processing new L2 range request")
 
 	// clean up the completed in-flight requests
-	for k, v := range s.inFlight {
-		if v.Load() {
-			delete(s.inFlight, k)
+	for blockNum, stillInFlight := range s.inFlight {
+		if !stillInFlight.Load() {
+			delete(s.inFlight, blockNum)
 		}
 	}
 

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -131,13 +131,8 @@ func (s *inFlight) set(key uint64, value bool) {
 
 func (s *inFlight) get(key uint64) bool {
 	s.mu.Lock()
-	value, exists := s.requests[key]
-	s.mu.Unlock()
-	if !exists {
-		return false
-	} else {
-		return value
-	}
+	defer s.mu.Unlock()
+	return s.requests[key]
 }
 
 func (s *inFlight) delete(key uint64) {

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -274,10 +274,8 @@ func TestMultiPeerSync(t *testing.T) {
 	payloads.deletePayload(25)
 	rangeReqId, err := clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(30))
 
-	clB.activeRangeRequestsMu.Lock()
 	require.NoError(t, err)
-	require.True(t, clB.activeRangeRequests[rangeReqId], "expecting range request to be active")
-	clB.activeRangeRequestsMu.Unlock()
+	require.True(t, clB.activeRangeRequests.get(rangeReqId), "expecting range request to be active")
 
 	for i := uint64(29); i > 25; i-- {
 		p := <-recvB
@@ -320,9 +318,7 @@ func TestMultiPeerSync(t *testing.T) {
 			break
 		}
 	}
-	clB.activeRangeRequestsMu.Lock()
-	require.False(t, clB.activeRangeRequests[rangeReqId], "expecting range request to be cancelled")
-	clB.activeRangeRequestsMu.Unlock()
+	require.False(t, clB.activeRangeRequests.get(rangeReqId), "expecting range request to be cancelled")
 
 	// Add back the block
 	payloads.addPayload(bl25)

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -169,7 +169,8 @@ func TestSinglePeerSync(t *testing.T) {
 	defer cl.Close()
 
 	// request to start syncing between 10 and 20
-	require.NoError(t, cl.RequestL2Range(ctx, payloads.getBlockRef(10), payloads.getBlockRef(20)))
+	_, err = cl.RequestL2Range(ctx, payloads.getBlockRef(10), payloads.getBlockRef(20))
+	require.NoError(t, err)
 
 	// and wait for the sync results to come in (in reverse order)
 	for i := uint64(19); i > 10; i-- {
@@ -255,7 +256,8 @@ func TestMultiPeerSync(t *testing.T) {
 	defer clC.Close()
 
 	// request to start syncing between 10 and 90
-	require.NoError(t, clA.RequestL2Range(ctx, payloads.getBlockRef(10), payloads.getBlockRef(90)))
+	_, err = clA.RequestL2Range(ctx, payloads.getBlockRef(10), payloads.getBlockRef(90))
+	require.NoError(t, err)
 
 	// With such large range to request we are going to hit the rate-limits of B and C,
 	// but that means we'll balance the work between the peers.
@@ -270,13 +272,20 @@ func TestMultiPeerSync(t *testing.T) {
 	// now see if B can sync a range, and fill the gap with a re-request
 	bl25, _ := payloads.getPayload(25) // temporarily remove it from the available payloads. This will create a gap
 	payloads.deletePayload(25)
-	require.NoError(t, clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(30)))
+	rangeReqId, err := clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(30))
+
+	clB.activeRangeRequestsMu.Lock()
+	require.NoError(t, err)
+	require.True(t, clB.activeRangeRequests[rangeReqId], "expecting range request to be active")
+	clB.activeRangeRequestsMu.Unlock()
+
 	for i := uint64(29); i > 25; i-- {
 		p := <-recvB
 		exp, ok := payloads.getPayload(uint64(p.ExecutionPayload.BlockNumber))
 		require.True(t, ok, "expecting known payload")
 		require.Equal(t, exp.ExecutionPayload.BlockHash, p.ExecutionPayload.BlockHash, "expecting the correct payload")
 	}
+
 	// Wait for the request for block 25 to be made
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFunc()
@@ -291,12 +300,12 @@ func TestMultiPeerSync(t *testing.T) {
 			t.Fatal("Did not request block 25 in a reasonable time")
 		}
 	}
+
 	// the request for 25 should fail. See:
 	// server: WARN  peer requested unknown block by number   num=25
 	// client: WARN  failed p2p sync request    num=25 err="peer failed to serve request with code 1"
 	require.Zero(t, len(recvB), "there is a gap, should not see other payloads yet")
-	// Add back the block
-	payloads.addPayload(bl25)
+
 	// race-condition fix: the request for 25 is expected to error, but is marked as complete in the peer-loop.
 	// But the re-request checks the status in the main loop, and it may thus look like it's still in-flight,
 	// and thus not run the new request.
@@ -306,13 +315,20 @@ func TestMultiPeerSync(t *testing.T) {
 	for {
 		isInFlight, err := clB.isInFlight(ctx, 25)
 		require.NoError(t, err)
+		time.Sleep(time.Second)
 		if !isInFlight {
 			break
 		}
-		time.Sleep(time.Second)
 	}
+	clB.activeRangeRequestsMu.Lock()
+	require.False(t, clB.activeRangeRequests[rangeReqId], "expecting range request to be cancelled")
+	clB.activeRangeRequestsMu.Unlock()
+
+	// Add back the block
+	payloads.addPayload(bl25)
 	// And request a range again, 25 is there now, and 21-24 should follow quickly (some may already have been fetched and wait in quarantine)
-	require.NoError(t, clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(26)))
+	_, err = clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(26))
+	require.NoError(t, err)
 	for i := uint64(25); i > 20; i-- {
 		p := <-recvB
 		exp, ok := payloads.getPayload(uint64(p.ExecutionPayload.BlockNumber))


### PR DESCRIPTION
**Description**

Based on this [comment](https://github.com/ethereum-optimism/optimism/pull/5179#discussion_r1139598660), we would like to bail on a batch of block requests when we receive a `block not found` error from one of the blocks in the range. That will prevent the op-node from spamming its peers with block requests in the event that the sequencer is offline and unsafe blocks cannot be found, meaning the requests are destined-to-fail. This PR adds a `rangeRequestId` field to the `peerRequest` struct so that when we detect the aforementioned error, we can set a flag mapped to that `rangeRequestId`, which allows us to drop all other requests with that same id instead of continuing to send those requests to peers.

**Tests**

The existing `TestMultiPeerSync` covers the updated code, as evidenced by the logs generated by that test. I added some checks within that same test to verify that a `rangeReq` was properly cancelled. 

<img width="1654" alt="image" src="https://github.com/ethereum-optimism/optimism/assets/35908605/408264c9-cc9f-40a1-9090-72a0883206ed">


**Additional context**

I considered an alternative approach that attached a shared `context` and `cancel` function to the `peerRequest` struct instead of the `rangeRequestId`. However, the use of `rangeRequestId` seemed more straightforward and less prone to errors such as accidentally canceling block requests if the parent context is cancelled.

In the linked issue and associated comment thread, it was also suggested that we consider backing off the `altSync` timer when a `block not found` error is produced. In the worst case scenario, with this updated code, we would send a single destined-to-fail request every (2 * blockTime) seconds to each peer before the entire batch of requests is cancelled. This doesn't seem like a very heavy load to put on any given peer so backoff logic is not currently included in this PR.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced peer synchronization capabilities with improved tracking and handling of active range requests.
	- Improved logging for canceled sync requests to aid in debugging and optimization.
	- Modified channel names for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->