### PR TITLE
fix(op-node): derive a finalized hash on `ELSync` when sync status is `syncStatusFinishedELButNotFinalized`

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -65,7 +65,7 @@ type safeDB interface {
 
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc derive.L1BlobsFetcher, plasmaSrc derive.PlasmaInputFetcher, eng L2API, cfg *rollup.Config, syncCfg *sync.Config, safeHeadListener safeDB) *L2Verifier {
 	metrics := &testutils.TestDerivationMetrics{}
-	engine := derive.NewEngineController(eng, log, metrics, cfg, syncCfg.SyncMode)
+	engine := derive.NewEngineController(l1, eng, log, metrics, cfg, syncCfg.SyncMode)
 	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, plasmaSrc, eng, engine, metrics, syncCfg, safeHeadListener)
 	pipeline.Reset()
 

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -286,7 +286,9 @@ func (e *EngineController) checkNewPayloadStatus(status eth.ExecutePayloadStatus
 // It returns true if the status is acceptable.
 func (e *EngineController) checkForkchoiceUpdatedStatus(status eth.ExecutePayloadStatus) bool {
 	if e.syncMode == sync.ELSync {
-		if status == eth.ExecutionValid {
+		if status == eth.ExecutionSyncing && e.syncStatus == syncStatusWillStartEL {
+			e.syncStatus = syncStatusStartedEL
+		} else if status == eth.ExecutionValid {
 			e.syncStatus = syncStatusFinishedELButNotFinalized
 		}
 		// Allow SYNCING if engine P2P sync is enabled

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -251,7 +251,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 	prev := &fakeAttributesQueue{}
 
-	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(l1F, eng, logger, metrics, &rollup.Config{}, sync.CLSync)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -487,7 +487,7 @@ func TestEngineQueue_ResetWhenUnsafeOriginNotCanonical(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refE}
 
-	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(l1F, eng, logger, metrics, &rollup.Config{}, sync.CLSync)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -817,7 +817,7 @@ func TestVerifyNewL1Origin(t *testing.T) {
 			}, nil)
 
 			prev := &fakeAttributesQueue{origin: refE}
-			ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+			ec := NewEngineController(l1F, eng, logger, metrics, &rollup.Config{}, sync.CLSync)
 			eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 			require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -914,7 +914,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	}
 
 	prev := &fakeAttributesQueue{origin: refA, attrs: attrs, islastInSpan: true}
-	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(l1F, eng, logger, metrics, &rollup.Config{}, sync.CLSync)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -1086,7 +1086,7 @@ func TestResetLoop(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA, attrs: attrs, islastInSpan: true}
 
-	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(l1F, eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics.NoopMetrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	eq.ec.SetUnsafeHead(refA2)
 	eq.ec.SetSafeHead(refA1)
@@ -1192,7 +1192,7 @@ func TestEngineQueue_StepPopOlderUnsafe(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA}
 
-	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(l1F, eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics.NoopMetrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	eq.ec.SetUnsafeHead(refA2)
 	eq.ec.SetSafeHead(refA0)
@@ -1272,7 +1272,7 @@ func TestPlasmaFinalityData(t *testing.T) {
 		SequenceNumber: 1,
 	}
 
-	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(l1F, eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
 
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics.NoopMetrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.Equal(t, expFinalityLookback, cap(eq.finalityData))

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -136,7 +136,7 @@ func NewDriver(
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
-	engine := derive.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode)
+	engine := derive.NewEngineController(l1, l2, log, metrics, cfg, syncCfg.SyncMode)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, engine, metrics, syncCfg, safeHeadListener)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log) // Only use the metered engine in the sequencer b/c it records sequencing metrics.

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -40,7 +40,7 @@ type Driver struct {
 }
 
 func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l1BlobsSource derive.L1BlobsFetcher, l2Source L2Source, targetBlockNum uint64) *Driver {
-	engine := derive.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+	engine := derive.NewEngineController(l1Source, l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync)
 	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, plasma.Disabled, l2Source, engine, metrics.NoopMetrics, &sync.Config{}, safedb.Disabled)
 	pipeline.Reset()
 	return &Driver{


### PR DESCRIPTION
The current implementation of EL sync provides an unsafe head for the EL to facilitate catch-up, with the expectation that it handles any resulting reorganizations. 

However, once the EL is caught up and while CL sync demands a finalized state, the next FCU is assigned a finalized hash that matches the unsafe one. Although the likelihood of issues arising from this is low, it is technically incorrect behavior. If a reorg occurs, it could be irreversible for the EL, given that finalized hashes are not expected to be reversible.

Additionally, op-node only uses ELSync if there are no finalized blocks in the EL; otherwise, it switches to CLSync. However, in scenarios such as a node restart after a week, it is still preferable from the EL's perspective to initiate EL sync. By enabling the derivation of a genuine finalized hash, we can eliminate this constraint and avoid the risk associated with treating an unsafe hash as finalized on every restart.

