### PR TITLE
fix: set version during build process for op-node,batcher,proposer

### DIFF
--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -1,6 +1,12 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-VERSION := v0.0.0
+# Find the latest github tag that contains this commit. If none are found, set the version string to "untagged"
+VERSION ?= $(shell tag=$$(git tag --contains $(GITCOMMIT) | grep '^op-batcher/' | sort -V | tail -n 1 | sed 's/op-batcher\///'); \
+             if [ -z "$$tag" ]; then \
+                 echo "untagged"; \
+             else \
+                 echo $$tag; \
+             fi)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -1,11 +1,17 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
 # Find the github tag that points to this commit. If none are found, set the version string to "untagged"
-VERSION ?= $(shell tag=$$(git tag --points-at $(GITCOMMIT) | grep '^op-batcher/' | sort -V | tail -n 1 | sed 's/op-batcher\///'); \
-             if [ -z "$$tag" ]; then \
-                 echo "untagged"; \
+# Prioritizes release tag, if one exists, over tags suffixed with "-rc"
+VERSION ?= $(shell tags=$$(git tag --points-at $(GITCOMMIT) | grep '^op-batcher/' | sed 's/op-batcher\///' | sort -V); \
+             preferred_tag=$$(echo "$$tags" | grep -v -- '-rc' | tail -n 1); \
+             if [ -z "$$preferred_tag" ]; then \
+                 if [ -z "$$tags" ]; then \
+                     echo "untagged"; \
+                 else \
+                     echo "$$tags" | tail -n 1; \
+                 fi \
              else \
-                 echo $$tag; \
+                 echo $$preferred_tag; \
              fi)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -1,7 +1,7 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-# Find the latest github tag that contains this commit. If none are found, set the version string to "untagged"
-VERSION ?= $(shell tag=$$(git tag --contains $(GITCOMMIT) | grep '^op-batcher/' | sort -V | tail -n 1 | sed 's/op-batcher\///'); \
+# Find the github tag that points to this commit. If none are found, set the version string to "untagged"
+VERSION ?= $(shell tag=$$(git tag --points-at $(GITCOMMIT) | grep '^op-batcher/' | sort -V | tail -n 1 | sed 's/op-batcher\///'); \
              if [ -z "$$tag" ]; then \
                  echo "untagged"; \
              else \

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -1,7 +1,7 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-# Find the latest github tag that contains this commit. If none are found, set the version string to "untagged"
-VERSION ?= $(shell tag=$$(git tag --contains $(GITCOMMIT) | grep '^op-node/' | sort -V | tail -n 1 | sed 's/op-node\///'); \
+# Find the github tag that points to this commit. If none are found, set the version string to "untagged"
+VERSION ?= $(shell tag=$$(git tag --points-at $(GITCOMMIT) | grep '^op-node/' | sort -V | tail -n 1 | sed 's/op-node\///'); \
              if [ -z "$$tag" ]; then \
                  echo "untagged"; \
              else \

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -1,11 +1,17 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
 # Find the github tag that points to this commit. If none are found, set the version string to "untagged"
-VERSION ?= $(shell tag=$$(git tag --points-at $(GITCOMMIT) | grep '^op-node/' | sort -V | tail -n 1 | sed 's/op-node\///'); \
-             if [ -z "$$tag" ]; then \
-                 echo "untagged"; \
+# Prioritizes release tag, if one exists, over tags suffixed with "-rc"
+VERSION ?= $(shell tags=$$(git tag --points-at $(GITCOMMIT) | grep '^op-node/' | sed 's/op-node\///' | sort -V); \
+             preferred_tag=$$(echo "$$tags" | grep -v -- '-rc' | tail -n 1); \
+             if [ -z "$$preferred_tag" ]; then \
+                 if [ -z "$$tags" ]; then \
+                     echo "untagged"; \
+                 else \
+                     echo "$$tags" | tail -n 1; \
+                 fi \
              else \
-                 echo $$tag; \
+                 echo $$preferred_tag; \
              fi)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -1,6 +1,12 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-VERSION := v0.0.0
+# Find the latest github tag that contains this commit. If none are found, set the version string to "untagged"
+VERSION ?= $(shell tag=$$(git tag --contains $(GITCOMMIT) | grep '^op-node/' | sort -V | tail -n 1 | sed 's/op-node\///'); \
+             if [ -z "$$tag" ]; then \
+                 echo "untagged"; \
+             else \
+                 echo $$tag; \
+             fi)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -1,6 +1,12 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-VERSION := v0.0.0
+# Find the latest github tag that contains this commit. If none are found, set the version string to "untagged"
+VERSION ?= $(shell tag=$$(git tag --contains $(GITCOMMIT) | grep '^op-proposer/' | sort -V | tail -n 1 | sed 's/op-proposer\///'); \
+             if [ -z "$$tag" ]; then \
+                 echo "untagged"; \
+             else \
+                 echo $$tag; \
+             fi)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -1,7 +1,7 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-# Find the latest github tag that contains this commit. If none are found, set the version string to "untagged"
-VERSION ?= $(shell tag=$$(git tag --contains $(GITCOMMIT) | grep '^op-proposer/' | sort -V | tail -n 1 | sed 's/op-proposer\///'); \
+# Find the github tag that points to this commit. If none are found, set the version string to "untagged"
+VERSION ?= $(shell tag=$$(git tag --points-at $(GITCOMMIT) | grep '^op-proposer/' | sort -V | tail -n 1 | sed 's/op-proposer\///'); \
              if [ -z "$$tag" ]; then \
                  echo "untagged"; \
              else \

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -1,11 +1,17 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
 # Find the github tag that points to this commit. If none are found, set the version string to "untagged"
-VERSION ?= $(shell tag=$$(git tag --points-at $(GITCOMMIT) | grep '^op-proposer/' | sort -V | tail -n 1 | sed 's/op-proposer\///'); \
-             if [ -z "$$tag" ]; then \
-                 echo "untagged"; \
+# Prioritizes release tag, if one exists, over tags suffixed with "-rc"
+VERSION ?= $(shell tags=$$(git tag --points-at $(GITCOMMIT) | grep '^op-proposer/' | sed 's/op-proposer\///' | sort -V); \
+             preferred_tag=$$(echo "$$tags" | grep -v -- '-rc' | tail -n 1); \
+             if [ -z "$$preferred_tag" ]; then \
+                 if [ -z "$$tags" ]; then \
+                     echo "untagged"; \
+                 else \
+                     echo "$$tags" | tail -n 1; \
+                 fi \
              else \
-                 echo $$tag; \
+                 echo $$preferred_tag; \
              fi)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)


### PR DESCRIPTION
**Description**

Dynamically set the `VERSION` within the Makefile by looking up the latest `git tag` that points-at the commit hash on the current branch. If no tags are found, the `VERSION` string will be set to `untagged`. If multiple tags are found, prioritize the release tag, if one exists, otherwise use the latest tag suffixed with `-rc.X`.

Previously the `VERSION` was hardcoded to "v0.0.0".

**Tests**

No tests are currently part of this PR. I manually tested the Makefiles. Please let me know if there is a standard way to test Makefile commands.

Manual test procedure:
```
cd op-node
make op-node
./bin/op-node --version
```

**Metadata**

- Addresses https://github.com/ethereum-optimism/client-pod/issues/664
- Follow-on PR will be opened in `op-geth` to make the same change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
    - Improved version determination in Makefiles to dynamically fetch the latest GitHub tag or default to "untagged."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->