### PR TITLE
chore(ctb): Speed up chained compilation

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -25,6 +25,7 @@ remappings = [
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 build_info_path = 'artifacts/build-info'
+ast = true
 
 # Test / Script Runner Settings
 ffi = true
@@ -87,4 +88,3 @@ src = 'test/kontrol/proofs'
 out = 'kout-proofs'
 test = 'test/kontrol/proofs'
 script = 'test/kontrol/proofs'
-ast = true

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -27,7 +27,7 @@
     "gas-snapshot:no-build": "forge snapshot --match-contract GasBenchMark",
     "statediff": "./scripts/statediff.sh && git diff --exit-code",
     "gas-snapshot": "pnpm build:go-ffi && pnpm gas-snapshot:no-build",
-    "snapshots": "forge build --ast && npx tsx scripts/autogen/generate-snapshots.ts && ./test/kontrol/scripts/make-summary-deployment.sh",
+    "snapshots": "forge build && npx tsx scripts/autogen/generate-snapshots.ts && ./test/kontrol/scripts/make-summary-deployment.sh",
     "snapshots:check": "./scripts/checks/check-snapshots.sh",
     "semver-lock": "forge script scripts/SemverLock.s.sol",
     "validate-deploy-configs": "./scripts/checks/check-deploy-configs.sh",


### PR DESCRIPTION
## Overview

Requires `ast = true` for all foundry profiles, which dramatically speeds up chaining pre-PR tasks (`bindings`, `snapshots`, etc.) together for `contracts-bedrock` due to not requiring re-compilation several times with and without generating the AST in artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted settings for handling the Abstract Syntax Tree (AST) in the project configuration.
	- Modified the build script to remove the `--ast` flag for a streamlined build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->