### PR TITLE
op-e2e: use deposit method on weth

### DIFF
--- a/op-e2e/bridge_test.go
+++ b/op-e2e/bridge_test.go
@@ -48,7 +48,7 @@ func TestERC20BridgeDeposits(t *testing.T) {
 
 	// Get some WETH
 	opts.Value = big.NewInt(params.Ether)
-	tx, err = WETH9.Fallback(opts, []byte{})
+	tx, err = WETH9.Deposit(opts)
 	require.NoError(t, err)
 	_, err = wait.ForReceiptOK(context.Background(), l1Client, tx.Hash())
 	require.NoError(t, err)


### PR DESCRIPTION
**Description**

Move away from using the fallback function on weth9 towards instead
using the explicit deposit method. This is to reduce diff with the
custom gas token project, just a very small change.

The weth98 contract doesn't have a fallback function, if it did
then this change would not be required.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the method for handling ERC20 bridge deposits to enhance transaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->