### PR TITLE
op-node: fix ecotone upgrade test

### DIFF
--- a/op-node/rollup/derive/ecotone_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/ecotone_upgrade_transactions_test.go
@@ -69,14 +69,14 @@ func TestEcotoneNetworkTransactions(t *testing.T) {
 	require.Equal(t, deployL1BlockSource.SourceHash(), deployL1Block.SourceHash())
 	require.Nil(t, deployL1Block.To())
 	require.Equal(t, uint64(375_000), deployL1Block.Gas())
-	require.Equal(t, l1BlockDeploymentBytecode, hexutil.Bytes(deployL1Block.Data()).String())
+	require.Equal(t, l1BlockDeploymentBytecode, deployL1Block.Data())
 
 	deployGasPriceOracleSender, deployGasPriceOracle := toDepositTxn(t, upgradeTxns[1])
 	require.Equal(t, deployGasPriceOracleSender, common.HexToAddress("0x4210000000000000000000000000000000000001"))
 	require.Equal(t, deployGasPriceOracleSource.SourceHash(), deployGasPriceOracle.SourceHash())
 	require.Nil(t, deployGasPriceOracle.To())
 	require.Equal(t, uint64(1_000_000), deployGasPriceOracle.Gas())
-	require.Equal(t, gasPriceOracleDeploymentBytecode, hexutil.Bytes(deployGasPriceOracle.Data()).String())
+	require.Equal(t, gasPriceOracleDeploymentBytecode, deployGasPriceOracle.Data())
 
 	updateL1BlockProxySender, updateL1BlockProxy := toDepositTxn(t, upgradeTxns[2])
 	require.Equal(t, updateL1BlockProxySender, common.Address{})

--- a/op-node/rollup/derive/ecotone_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/ecotone_upgrade_transactions_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 )
 
 func TestSourcesMatchSpec(t *testing.T) {
@@ -71,14 +69,14 @@ func TestEcotoneNetworkTransactions(t *testing.T) {
 	require.Equal(t, deployL1BlockSource.SourceHash(), deployL1Block.SourceHash())
 	require.Nil(t, deployL1Block.To())
 	require.Equal(t, uint64(375_000), deployL1Block.Gas())
-	require.Equal(t, bindings.L1BlockMetaData.Bin, hexutil.Bytes(deployL1Block.Data()).String())
+	require.Equal(t, l1BlockDeploymentBytecode, hexutil.Bytes(deployL1Block.Data()).String())
 
 	deployGasPriceOracleSender, deployGasPriceOracle := toDepositTxn(t, upgradeTxns[1])
 	require.Equal(t, deployGasPriceOracleSender, common.HexToAddress("0x4210000000000000000000000000000000000001"))
 	require.Equal(t, deployGasPriceOracleSource.SourceHash(), deployGasPriceOracle.SourceHash())
 	require.Nil(t, deployGasPriceOracle.To())
 	require.Equal(t, uint64(1_000_000), deployGasPriceOracle.Gas())
-	require.Equal(t, bindings.GasPriceOracleMetaData.Bin, hexutil.Bytes(deployGasPriceOracle.Data()).String())
+	require.Equal(t, gasPriceOracleDeploymentBytecode, hexutil.Bytes(deployGasPriceOracle.Data()).String())
 
 	updateL1BlockProxySender, updateL1BlockProxy := toDepositTxn(t, upgradeTxns[2])
 	require.Equal(t, updateL1BlockProxySender, common.Address{})


### PR DESCRIPTION
**Description**

Previously the upgrade transactions test made an assertion against
the bytecode that is in the bindings. This needs to be modified
because the upgrade txs cannot ever change as they are part of
consensus. Any modification to the bindings means that the assertion
will fail. We should test against the expected value directly
instead of going through the binding that has no guarantee
to be on a particular version and will change over time.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced transaction tests by using custom variables for bytecode comparison, improving the reliability and clarity of test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->