### PR TITLE
contracts-bedrock: fix semgrep

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -189,11 +189,15 @@ contract DeployConfig is Script {
         return abi.decode(res, (bytes32));
     }
 
-    function _readOr(string memory json, string memory key, bool defaultValue) internal view returns (bool) {
-        return vm.keyExists(json, key) ? stdJson.readBool(json, key) : defaultValue;
+    function _readOr(string memory _json, string memory _key, bool _defaultValue) internal view returns (bool) {
+        return vm.keyExists(_json, _key) ? stdJson.readBool(_json, _key) : _defaultValue;
     }
 
-    function _readOr(string memory json, string memory key, uint256 defaultValue) internal view returns (uint256) {
-        return vm.keyExists(json, key) ? stdJson.readUint(json, key) : defaultValue;
+    function _readOr(string memory _json, string memory _key, uint256 _defaultValue) internal view returns (uint256) {
+        return vm.keyExists(_json, _key) ? stdJson.readUint(_json, _key) : _defaultValue;
+    }
+
+    function _readOr(string memory _json, string memory _key, address _defaultValue) internal view returns (address) {
+        return vm.keyExists(_json, _key) ? stdJson.readAddress(json, _key) : _defaultValue;
     }
 }


### PR DESCRIPTION
**Description**

Semgrep likes arguments to be prefixed with underscore, this
commit fixes a couple of existing functions that do not use
underscore for their arguments. Also adds another variant
of the function that is used to read from the deploy config
with a default value that operates on address type, which is
required for custom gas token work.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved parameter naming and handling in the `DeployConfig` contract for enhanced clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->