### PR TITLE
fix: check http status code when get preimage from plasma

### DIFF
--- a/op-plasma/daclient.go
+++ b/op-plasma/daclient.go
@@ -42,6 +42,9 @@ func (c *DAClient) GetInput(ctx context.Context, comm Keccak256Commitment) ([]by
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get preimage: %v", resp.StatusCode)
+	}
 	defer resp.Body.Close()
 	input, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
when http status != 200 which maybe server side issue, in this case the data is not correct, should always check http status == 200 or not 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by checking response status before processing data, ensuring reliability in data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->