### PR TITLE
feat(proxyd): customise poller interval and enable cross origin check on web socket upgrader

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -111,8 +111,9 @@ type BackendGroupConfig struct {
 
 	WeightedRouting bool `toml:"weighted_routing"`
 
-	ConsensusAware        bool   `toml:"consensus_aware"`
-	ConsensusAsyncHandler string `toml:"consensus_handler"`
+	ConsensusAware          bool         `toml:"consensus_aware"`
+	ConsensusAsyncHandler   string       `toml:"consensus_handler"`
+	ConsensusPollerInterval TOMLDuration `toml:"consensus_poller_interval"`
 
 	ConsensusBanPeriod          TOMLDuration `toml:"consensus_ban_period"`
 	ConsensusMaxUpdateThreshold TOMLDuration `toml:"consensus_max_update_threshold"`

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -26,6 +26,7 @@ type ServerConfig struct {
 	MaxRequestBodyLogLen  int  `toml:"max_request_body_log_len"`
 	EnablePprof           bool `toml:"enable_pprof"`
 	EnableXServedByHeader bool `toml:"enable_served_by_header"`
+	AllowAllOrigins       bool `toml:"allow_all_origins"`
 }
 
 type CacheConfig struct {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	PollerInterval = 1 * time.Second
+	DefaultPollerInterval = 1 * time.Second
 )
 
 type OnConsensusBroken func()
@@ -237,7 +237,7 @@ func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller
 		maxUpdateThreshold: 30 * time.Second,
 		maxBlockLag:        8, // 8*12 seconds = 96 seconds ~ 1.6 minutes
 		minPeerCount:       3,
-		interval:           PollerInterval,
+		interval:           DefaultPollerInterval,
 	}
 
 	for _, opt := range opts {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -40,6 +40,7 @@ type ConsensusPoller struct {
 	maxUpdateThreshold time.Duration
 	maxBlockLag        uint64
 	maxBlockRange      uint64
+	interval           time.Duration
 }
 
 type backendState struct {
@@ -125,7 +126,7 @@ func (ah *PollerAsyncHandler) Init() {
 	for _, be := range ah.cp.backendGroup.Backends {
 		go func(be *Backend) {
 			for {
-				timer := time.NewTimer(PollerInterval)
+				timer := time.NewTimer(ah.cp.interval)
 				ah.cp.UpdateBackend(ah.ctx, be)
 
 				select {
@@ -141,7 +142,7 @@ func (ah *PollerAsyncHandler) Init() {
 	// create the group consensus poller
 	go func() {
 		for {
-			timer := time.NewTimer(PollerInterval)
+			timer := time.NewTimer(ah.cp.interval)
 			ah.cp.UpdateBackendGroupConsensus(ah.ctx)
 
 			select {
@@ -215,6 +216,12 @@ func WithMinPeerCount(minPeerCount uint64) ConsensusOpt {
 	}
 }
 
+func WithPollerInterval(interval time.Duration) ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.interval = interval
+	}
+}
+
 func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
@@ -230,6 +237,7 @@ func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller
 		maxUpdateThreshold: 30 * time.Second,
 		maxBlockLag:        8, // 8*12 seconds = 96 seconds ~ 1.6 minutes
 		minPeerCount:       3,
+		interval:           PollerInterval,
 	}
 
 	for _, opt := range opts {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -272,6 +272,14 @@ func Start(config *Config) (*Server, func(), error) {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)
 	}
 
+	// Enable to support browser websocket connections.
+	// See https://pkg.go.dev/github.com/gorilla/websocket#hdr-Origin_Considerations
+	if config.Server.AllowAllOrigins {
+		srv.upgrader.CheckOrigin = func(r *http.Request) bool {
+			return true
+		}
+	}
+
 	if config.Metrics.Enabled {
 		addr := fmt.Sprintf("%s:%d", config.Metrics.Host, config.Metrics.Port)
 		log.Info("starting metrics server", "addr", addr)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -338,6 +338,9 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusMaxBlockRange > 0 {
 				copts = append(copts, WithMaxBlockRange(bgcfg.ConsensusMaxBlockRange))
 			}
+			if bgcfg.ConsensusPollerInterval > 0 {
+				copts = append(copts, WithPollerInterval(time.Duration(bgcfg.ConsensusPollerInterval)))
+			}
 
 			var tracker ConsensusTracker
 			if bgcfg.ConsensusHA {
@@ -349,7 +352,7 @@ func Start(config *Config) (*Server, func(), error) {
 					topts = append(topts, WithLockPeriod(time.Duration(bgcfg.ConsensusHALockPeriod)))
 				}
 				if bgcfg.ConsensusHAHeartbeatInterval > 0 {
-					topts = append(topts, WithLockPeriod(time.Duration(bgcfg.ConsensusHAHeartbeatInterval)))
+					topts = append(topts, WithHeartbeatInterval(time.Duration(bgcfg.ConsensusHAHeartbeatInterval)))
 				}
 				consensusHARedisClient, err := NewRedisClient(bgcfg.ConsensusHARedis.URL)
 				if err != nil {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -192,8 +192,6 @@ func NewServer(
 		maxBatchSize:         maxBatchSize,
 		upgrader: &websocket.Upgrader{
 			HandshakeTimeout: defaultWSHandshakeTimeout,
-			// see https://pkg.go.dev/github.com/gorilla/websocket#hdr-Origin_Considerations
-			CheckOrigin: func(r *http.Request) bool { return true },
 		},
 		mainLim:                mainLim,
 		overrideLims:           overrideLims,

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -192,6 +192,8 @@ func NewServer(
 		maxBatchSize:         maxBatchSize,
 		upgrader: &websocket.Upgrader{
 			HandshakeTimeout: defaultWSHandshakeTimeout,
+			// see https://pkg.go.dev/github.com/gorilla/websocket#hdr-Origin_Considerations
+			CheckOrigin: func(r *http.Request) bool { return true },
 		},
 		mainLim:                mainLim,
 		overrideLims:           overrideLims,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds the ability to set a poller interval in the config instead of using hard coded value. In addition, we fix the HA heartbeat interval option. Lastly, when connecting directly from the browser via websocket, the upgrader cross origin check will reject a different origin. We enable allowing all origins in the config. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for browser websocket connections, enhancing real-time interaction capabilities.
	- Introduced configurable polling intervals for consensus operations, allowing for tailored performance tuning.

- **Enhancements**
	- Enabled the option to allow connections from all origins, increasing flexibility in network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->