### PR TITLE
contracts-bedrock: update optimism portal guardian usage

### DIFF
--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -72,7 +72,7 @@ contract OptimismPortal_Test is CommonTest {
     /// @dev Tests that `pause` successfully pauses
     ///      when called by the GUARDIAN.
     function test_pause_succeeds() external {
-        address guardian = optimismPortal.GUARDIAN();
+        address guardian = optimismPortal.guardian();
 
         assertEq(optimismPortal.paused(), false);
 
@@ -89,7 +89,7 @@ contract OptimismPortal_Test is CommonTest {
     function test_pause_onlyGuardian_reverts() external {
         assertEq(optimismPortal.paused(), false);
 
-        assertTrue(optimismPortal.GUARDIAN() != alice);
+        assertTrue(optimismPortal.guardian() != alice);
         vm.expectRevert("SuperchainConfig: only guardian can pause");
         vm.prank(alice);
         superchainConfig.pause("identifier");
@@ -100,7 +100,7 @@ contract OptimismPortal_Test is CommonTest {
     /// @dev Tests that `unpause` successfully unpauses
     ///      when called by the GUARDIAN.
     function test_unpause_succeeds() external {
-        address guardian = optimismPortal.GUARDIAN();
+        address guardian = optimismPortal.guardian();
 
         vm.prank(guardian);
         superchainConfig.pause("identifier");
@@ -116,13 +116,13 @@ contract OptimismPortal_Test is CommonTest {
 
     /// @dev Tests that `unpause` reverts when called by a non-GUARDIAN.
     function test_unpause_onlyGuardian_reverts() external {
-        address guardian = optimismPortal.GUARDIAN();
+        address guardian = optimismPortal.guardian();
 
         vm.prank(guardian);
         superchainConfig.pause("identifier");
         assertEq(optimismPortal.paused(), true);
 
-        assertTrue(optimismPortal.GUARDIAN() != alice);
+        assertTrue(optimismPortal.guardian() != alice);
         vm.expectRevert("SuperchainConfig: only guardian can unpause");
         vm.prank(alice);
         superchainConfig.unpause();
@@ -413,7 +413,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
 
     /// @dev Tests that `proveWithdrawalTransaction` reverts when paused.
     function test_proveWithdrawalTransaction_paused_reverts() external {
-        vm.prank(optimismPortal.GUARDIAN());
+        vm.prank(optimismPortal.guardian());
         superchainConfig.pause("identifier");
 
         vm.expectRevert("OptimismPortal: paused");
@@ -565,7 +565,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
 
     /// @dev Tests that `finalizeWithdrawalTransaction` reverts if the contract is paused.
     function test_finalizeWithdrawalTransaction_paused_reverts() external {
-        vm.prank(optimismPortal.GUARDIAN());
+        vm.prank(optimismPortal.guardian());
         superchainConfig.pause("identifier");
 
         vm.expectRevert("OptimismPortal: paused");

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -158,7 +158,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         vm.warp(block.timestamp + delayedWeth.delay() + 1);
 
         // Pause the contract.
-        address guardian = optimismPortal.GUARDIAN();
+        address guardian = optimismPortal.guardian();
         vm.prank(guardian);
         superchainConfig.pause("identifier");
 


### PR DESCRIPTION
**Description**

Migrate to the modern `guardian()(address)` instead of using
`GUARDIAN()(address)`  which is deprecated. This will make
a future removal of the ABI easier to manage by reducing the
diff required when the legacy methods are removed.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

