### PR TITLE
contracts-bedrock: fix warning in node js

### DIFF
--- a/packages/contracts-bedrock/scripts/autogen/generate-snapshots.ts
+++ b/packages/contracts-bedrock/scripts/autogen/generate-snapshots.ts
@@ -81,8 +81,8 @@ const main = async () => {
 
   const storageLayoutDir = path.join(outdir, 'storageLayout')
   const abiDir = path.join(outdir, 'abi')
-  fs.rmdirSync(storageLayoutDir, { recursive: true })
-  fs.rmdirSync(abiDir, { recursive: true })
+  fs.rmSync(storageLayoutDir, { recursive: true })
+  fs.rmSync(abiDir, { recursive: true })
   fs.mkdirSync(storageLayoutDir, { recursive: true })
   fs.mkdirSync(abiDir, { recursive: true })
 


### PR DESCRIPTION
**Description**

The following warning was happening in CI:

```
(node:11982) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

Simply replaces the `rmdir` with `rm`. Note that the `sync` methods
are used here instead of the async promise based methods.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

