### PR TITLE
improving the op-upgrade docs

### DIFF
--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -7,6 +7,9 @@ ecotone-scalar:
 receipt-reference-builder:
 	go build -o ./bin/receipt-reference-builder ./cmd/receipt-reference-builder/*.go
 
+op-upgrade:
+	go build -o ./bin/op-upgrade ./cmd/op-upgrade/main.go
+
 test:
 	go test ./...
 

--- a/op-chain-ops/cmd/op-upgrade/README.md
+++ b/op-chain-ops/cmd/op-upgrade/README.md
@@ -40,17 +40,17 @@ will be written to stdout.
 #### Usage
 
 Build and run using the [Makefile](../../Makefile) `op-upgrade` target.
-Inside of `/op-chain-ops`, run:
+Inside `/op-chain-ops`, run:
 
 ```sh
 make op-upgrade
 ```
 
 to create a binary in [../../bin/op-upgrade](../../bin/op-upgrade) that can
-be executed. Execute the following command inside of `/op-chain-ops` to
+be executed. Execute the following command inside `/op-chain-ops` to
 create the Safe transaction bundle in an output file called `input.json`.
 
-```
+```sh
 ./bin/op-upgrade \
   --l1-rpc-url https://ethereum-rpc.publicnode.com  \
   --chain-ids 10 \

--- a/op-chain-ops/cmd/op-upgrade/README.md
+++ b/op-chain-ops/cmd/op-upgrade/README.md
@@ -36,3 +36,25 @@ be read out of the directory as needed.
 
 The file that the bundle should be written to. If omitted, the file
 will be written to stdout.
+
+#### Usage
+
+Build and run using the [Makefile](../../Makefile) `op-upgrade` target.
+Inside of `/op-chain-ops`, run:
+
+```sh
+make op-upgrade
+```
+
+to create a binary in [../../bin/op-upgrade](../../bin/op-upgrade) that can
+be executed. Execute the following command inside of `/op-chain-ops` to
+create the Safe transaction bundle in an output file called `input.json`.
+
+```
+./bin/op-upgrade \
+  --l1-rpc-url https://ethereum-rpc.publicnode.com  \
+  --chain-ids 10 \
+  --superchain-target mainnet \
+  --outfile input.json \
+  --deploy-config ../packages/contracts-bedrock/deploy-config
+```

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -44,7 +44,7 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:    "superchain-target",
-				Usage:   "The name of the superchain to upgrade",
+				Usage:   "The name of the superchain target to upgrade. For example: mainnet or sepolia.",
 				EnvVars: []string{"SUPERCHAIN_TARGET"},
 			},
 			&cli.PathFlag{


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Added `op-upgrade` target in `op-chain-ops`
- Added some context to the manual for the superchain target option
- Added documentation in the `op-upgrade` README

**Tests**

n/a

**Additional context**

Improving the `op-upgrade` docs for chain operators performing smart contract upgrades.

**Metadata**

- Fixes #[Link to Issue]
