### PR TITLE
fix: Fix the error judgment when obtaining the finalized/safe block o…

### DIFF
--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -102,7 +102,7 @@ func (s *L2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) 
 	if err != nil {
 		// Both geth and erigon like to serve non-standard errors for the safe and finalized heads, correct that.
 		// This happens when the chain just started and nothing is marked as safe/finalized yet.
-		if strings.Contains(err.Error(), "block not found") || strings.Contains(err.Error(), "Unknown block") {
+		if strings.Contains(err.Error(), "block not found") || strings.Contains(err.Error(), "Unknown block") || strings.Contains(err.Error(), "unknown block") {
 			err = ethereum.NotFound
 		}
 		// w%: wrap to preserve ethereum.NotFound case


### PR DESCRIPTION
When the chain just starts and nothing is marked as safe/finalized yet, it should also support Reth's non-standard errors.
The errors defined by reth is [here](https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/error.rs#L46)