### PR TITLE
remove trailing comma in the getting-started config

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -97,7 +97,7 @@ config=$(cat << EOL
   "faultGameSplitDepth": 14,
 
   "preimageOracleMinProposalSize": 1800000,
-  "preimageOracleChallengePeriod": 86400,
+  "preimageOracleChallengePeriod": 86400
 }
 EOL
 )


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

remove the trailing comma to solve parsing errors in the contract deploy script
```
VM::readFile("/home/ubuntu/optimism/packages/contracts-bedrock/deploy-config/getting-started.json") [staticcall]
    │   │   └─ ← <file>
    │   ├─ [0] VM::parseJsonAddress("<stringified JSON>", "$.finalSystemOwner") [staticcall]
    │   │   └─ ← failed parsing JSON: trailing comma at line 73 column 1
    │   └─ ← failed parsing JSON: trailing comma at line 73 column 1
    └─ ← failed parsing JSON: trailing comma at line 73 column 1
   ```

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
