### PR TITLE
feat(op-upgrade): tweaks to allow no deploy-config file

### DIFF
--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -148,7 +148,7 @@ func entrypoint(ctx *cli.Context) error {
 		name, _ := toDeployConfigName(chainConfig)
 		config, err := genesis.NewDeployConfigWithNetwork(name, deployConfig)
 		if err != nil {
-			log.Warn("Cannot find deploy config for network", "name", chainConfig.Name, "deploy-config-name", name, "path", deployConfig, "err", err)
+			log.Warn("Cannot find deploy config for network, so validity checks will be skipped", "name", chainConfig.Name, "deploy-config-name", name, "path", deployConfig, "err", err)
 		}
 
 		if config != nil {

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -70,9 +70,9 @@ func main() {
 				EnvVars: []string{"SUPERCHAIN_TARGET"},
 			},
 			&cli.PathFlag{
-				Name:     "deploy-config",
-				Usage:    "The path to the deploy config file",
-				EnvVars:  []string{"DEPLOY_CONFIG"},
+				Name:    "deploy-config",
+				Usage:   "The path to the deploy config file",
+				EnvVars: []string{"DEPLOY_CONFIG"},
 			},
 			&cli.PathFlag{
 				Name:    "outfile",

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -24,6 +24,28 @@ import (
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
+func isAllowedChainID(chainId uint64) {
+	// TODO We panic if the chain ID does not correspond to the mainnet or sepolia versions
+	// of Metal, Mode, or Zora. This is because OP Sepolia is currently on FPAC, which corresponds
+	// to OptimismPortal v3.3.0. However, we do not want to upgrade other chains to that yet. A
+	// proper fix to op-upgrade to allow specifying the targets versions of contracts is a large
+	// change, and we might end up deprecating op-upgrade anyway. Therefore, we instead hardcode
+	// the chain IDs this script can be used for and panic if the chain ID is not one of them. This
+	// way it's not possible to erroneously upgrade a chain to an unexpected version.
+	//
+	// mainnet/metal: 1750
+	// mainnet/mode: 34443
+	// mainnet/zora: 7777777
+	// sepolia/metal: 1740
+	// sepolia/mode: 919
+	// sepolia/zora: 999999999
+	allowed := chainId == 1750 || chainId == 34443 || chainId == 7777777 || chainId == 1740 || chainId == 919 || chainId == 999999999
+	if !allowed {
+		panic(fmt.Sprintf("Chain ID %d is not allowed. We panic if the chain ID does not correspond to the mainnet or sepolia versions of Metal, Mode, or Zora. This is because OP Sepolia is currently on FPAC, which corresponds to OptimismPortal v3.3.0. However, we do not want to upgrade other chains to that yet. A proper fix to op-upgrade to allow specifying the targets versions of contracts is a large change, and we might end up deprecating op-upgrade anyway. Therefore, we instead hardcode the chain IDs this script can be used for and panic if the chain ID is not one of them. This way it's not possible to erroneously upgrade a chain to an unexpected version.", chainId))
+	}
+
+}
+
 func main() {
 	color := isatty.IsTerminal(os.Stderr.Fd())
 	oplog.SetGlobalLogHandler(log.NewTerminalHandler(os.Stderr, color))
@@ -50,7 +72,6 @@ func main() {
 			&cli.PathFlag{
 				Name:     "deploy-config",
 				Usage:    "The path to the deploy config file",
-				Required: true,
 				EnvVars:  []string{"DEPLOY_CONFIG"},
 			},
 			&cli.PathFlag{
@@ -109,6 +130,10 @@ func entrypoint(ctx *cli.Context) error {
 		}
 	}
 
+	if len(targets) == 0 {
+		return fmt.Errorf("no chains found for superchain target %s with chain IDs %v, are you sure this chain is in the superchain registry?", superchainName, chainIDs)
+	}
+
 	slices.SortFunc(targets, func(i, j *superchain.ChainConfig) int {
 		return int(i.ChainID) - int(j.ChainID)
 	})
@@ -117,6 +142,9 @@ func entrypoint(ctx *cli.Context) error {
 	batch := safe.Batch{}
 
 	for _, chainConfig := range targets {
+		// Panic if this chain ID is not allowed. See comments in isAllowedChainID to learn more.
+		isAllowedChainID(chainConfig.ChainID)
+
 		name, _ := toDeployConfigName(chainConfig)
 		config, err := genesis.NewDeployConfigWithNetwork(name, deployConfig)
 		if err != nil {
@@ -182,7 +210,15 @@ func entrypoint(ctx *cli.Context) error {
 			return fmt.Errorf("no implementations for chain ID %d", l1ChainID.Uint64())
 		}
 
-		list, err := implementations.Resolve(superchain.SuperchainSemver[superchainName])
+		// TODO This looks for the latest implementations defined for each contract, and for
+		// OptimismPortal that's the FPAC v3.3.0. However we do not want to upgrade other chains to
+		// that yet so we hardcode v2.5.0 which corresponds to the pre-FPAC op-contracts/v1.3.0 tag.
+		// See comments in isAllowedChainID to learn more.
+		targetUpgrade := superchain.SuperchainSemver[superchainName]
+		targetUpgrade.OptimismPortal = "2.5.0"
+
+		list, err := implementations.Resolve(targetUpgrade)
+
 		if err != nil {
 			return err
 		}

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -3,6 +3,8 @@ package upgrades
 import (
 	"fmt"
 	"math/big"
+	"os"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -621,6 +623,12 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 
 		if config != nil {
 			startBlock = common.BigToHash(new(big.Int).SetUint64(config.SystemConfigStartBlock))
+		} else {
+			val, err := strconv.ParseUint(os.Getenv("SYSTEM_CONFIG_START_BLOCK"), 10, 64)
+			if err != nil {
+				return err
+			}
+			startBlock = common.BigToHash(new(big.Int).SetUint64(val))
 		}
 
 		input := []bindings.StorageSetterSlot{
@@ -691,23 +699,25 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		return err
 	}
 
-	if gasPriceOracleOverhead.Uint64() != config.GasPriceOracleOverhead {
-		return fmt.Errorf("GasPriceOracleOverhead address doesn't match config")
-	}
-	if gasPriceOracleScalar.Uint64() != config.GasPriceOracleScalar {
-		return fmt.Errorf("GasPriceOracleScalar address doesn't match config")
-	}
-	if batcherHash != common.BytesToHash(config.BatchSenderAddress.Bytes()) {
-		return fmt.Errorf("BatchSenderAddress address doesn't match config")
-	}
-	if l2GenesisBlockGasLimit != uint64(config.L2GenesisBlockGasLimit) {
-		return fmt.Errorf("L2GenesisBlockGasLimit address doesn't match config")
-	}
-	if p2pSequencerAddress != config.P2PSequencerAddress {
-		return fmt.Errorf("P2PSequencerAddress address doesn't match config")
-	}
-	if finalSystemOwner != config.FinalSystemOwner {
-		return fmt.Errorf("FinalSystemOwner address doesn't match config")
+	if config != nil {
+		if gasPriceOracleOverhead.Uint64() != config.GasPriceOracleOverhead {
+			return fmt.Errorf("GasPriceOracleOverhead address doesn't match config")
+		}
+		if gasPriceOracleScalar.Uint64() != config.GasPriceOracleScalar {
+			return fmt.Errorf("GasPriceOracleScalar address doesn't match config")
+		}
+		if batcherHash != common.BytesToHash(config.BatchSenderAddress.Bytes()) {
+			return fmt.Errorf("BatchSenderAddress address doesn't match config")
+		}
+		if l2GenesisBlockGasLimit != uint64(config.L2GenesisBlockGasLimit) {
+			return fmt.Errorf("L2GenesisBlockGasLimit address doesn't match config")
+		}
+		if p2pSequencerAddress != config.P2PSequencerAddress {
+			return fmt.Errorf("P2PSequencerAddress address doesn't match config")
+		}
+		if finalSystemOwner != config.FinalSystemOwner {
+			return fmt.Errorf("FinalSystemOwner address doesn't match config")
+		}
 	}
 
 	resourceConfig, err := systemConfig.ResourceConfig(&bind.CallOpts{})

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -619,8 +619,7 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 			return err
 		}
 
-		startBlock := common.Hash{}
-
+		var startBlock common.Hash
 		if config != nil {
 			startBlock = common.BigToHash(new(big.Int).SetUint64(config.SystemConfigStartBlock))
 		} else {


### PR DESCRIPTION
To facilitate upgrading various chains in the registry from Bedrock directly to MCP L1, the following changes were made to op-upgrade:
1. A deploy-config file is no longer required: We don't have this file for other chains, and it's simpler if we can remove reliance on it.
2. When no config file exists, a `SYSTEM_CONFIG_START_BLOCK` must be passed to ensure that value is set correctly. This value must be fetched by the caller manually.
3. We add a hacks to avoid upgrading to FPAC
4. We panic if the chain ID does not match one of the 6 chains we plan to use op-upgrade for. This is for safety reasons, to avoid accidentally generating a bad bundle due to (3). We likely will deprecate op-upgrade soon anyway, so this is ok.

I've discussed these changes with @tynes before opening the PR to ensure he is onboard with them