### PR TITLE
ctb: Move _getL1ContractFunctionAbis to CommonTest

### DIFF
--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
+import { Abi, AbiEntry } from "scripts/ForgeArtifacts.sol";
 import { Executables } from "scripts/Executables.sol";
 import { console2 as console } from "forge-std/console2.sol";
 import { ProtocolVersions } from "src/L1/ProtocolVersions.sol";
@@ -18,16 +19,6 @@ import { ForgeArtifacts } from "scripts/ForgeArtifacts.sol";
 ///      properties of the new function. The `Spec` struct reppresents this documentation. However, this contract does
 ///      not actually test to verify these properties, only that a spec is defined.
 contract Specification_Test is CommonTest {
-    struct AbiEntry {
-        string fnName;
-        bytes4 sel;
-    }
-
-    struct Abi {
-        string contractName;
-        AbiEntry[] entries;
-    }
-
     enum Role {
         NOAUTH,
         PROPOSER,
@@ -485,7 +476,7 @@ contract Specification_Test is CommonTest {
 
     /// @notice Ensures that there's an auth spec for every L1 contract function.
     function testContractAuth() public {
-        Abi[] memory abis = _getL1ContractFunctionAbis();
+        Abi[] memory abis = ForgeArtifacts.getL1ContractFunctionAbis();
 
         for (uint256 i = 0; i < abis.length; i++) {
             string memory contractName = abis[i].contractName;
@@ -501,38 +492,6 @@ contract Specification_Test is CommonTest {
                 Spec memory spec = specs[contractName][abiEntry.sel];
                 assertTrue(spec.sel != bytes4(0), "Specification_Test: missing spec definition");
                 assertEq(abiEntry.sel, spec.sel, "Specification_Test: invalid ABI");
-            }
-        }
-    }
-
-    /// @dev Returns the function ABIs of all L1 contracts.
-    function _getL1ContractFunctionAbis() internal returns (Abi[] memory abis_) {
-        string[] memory command = new string[](3);
-        command[0] = Executables.bash;
-        command[1] = "-c";
-        command[2] = string.concat(
-            Executables.find,
-            " src/{L1,governance,universal/ProxyAdmin.sol} -type f -exec basename {} \\;",
-            " | ",
-            Executables.sed,
-            " 's/\\.[^.]*$//'",
-            " | ",
-            Executables.jq,
-            " -R -s 'split(\"\n\")[:-1]'"
-        );
-        string[] memory contractNames = abi.decode(vm.parseJson(string(vm.ffi(command))), (string[]));
-
-        abis_ = new Abi[](contractNames.length);
-
-        for (uint256 i; i < contractNames.length; i++) {
-            string memory contractName = contractNames[i];
-            string[] memory methodIdentifiers = ForgeArtifacts.getMethodIdentifiers(contractName);
-            abis_[i].contractName = contractName;
-            abis_[i].entries = new AbiEntry[](methodIdentifiers.length);
-            for (uint256 j; j < methodIdentifiers.length; j++) {
-                string memory fnName = methodIdentifiers[j];
-                bytes4 sel = bytes4(keccak256(abi.encodePacked(fnName)));
-                abis_[i].entries[j] = AbiEntry({ fnName: fnName, sel: sel });
             }
         }
     }


### PR DESCRIPTION
### TL;DR

Moved `getL1ContractFunctionAbis` into CommonTest.sol.
It is kept as a free function to avoid increasing the size of the `CommonTest` contract itself. 

This change enables me to reuse the function in another test in #9982.