### PR TITLE
feat: update supported chains in op-upgrade

### DIFF
--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -36,14 +36,22 @@ func isAllowedChainID(chainId uint64) {
 	// mainnet/metal: 1750
 	// mainnet/mode: 34443
 	// mainnet/zora: 7777777
+	// mainnet/base: 8453
 	// sepolia/metal: 1740
 	// sepolia/mode: 919
 	// sepolia/zora: 999999999
-	allowed := chainId == 1750 || chainId == 34443 || chainId == 7777777 || chainId == 1740 || chainId == 919 || chainId == 999999999
+	// sepolia/base: 84532
+	allowed := chainId == 1750 ||
+		chainId == 34443 ||
+		chainId == 7777777 ||
+		chainId == 1740 ||
+		chainId == 919 ||
+		chainId == 999999999 ||
+		chainId == 8453 ||
+		chainId == 84532
 	if !allowed {
 		panic(fmt.Sprintf("Chain ID %d is not allowed. We panic if the chain ID does not correspond to the mainnet or sepolia versions of Metal, Mode, or Zora. This is because OP Sepolia is currently on FPAC, which corresponds to OptimismPortal v3.3.0. However, we do not want to upgrade other chains to that yet. A proper fix to op-upgrade to allow specifying the targets versions of contracts is a large change, and we might end up deprecating op-upgrade anyway. Therefore, we instead hardcode the chain IDs this script can be used for and panic if the chain ID is not one of them. This way it's not possible to erroneously upgrade a chain to an unexpected version.", chainId))
 	}
-
 }
 
 func main() {
@@ -218,7 +226,6 @@ func entrypoint(ctx *cli.Context) error {
 		targetUpgrade.OptimismPortal = "2.5.0"
 
 		list, err := implementations.Resolve(targetUpgrade)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This tool is for upgrades for standard chains in the superchain registry, and Base was missing from this list