### PR TITLE
ci-builder: fix build

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -84,12 +84,14 @@ COPY --from=go-build /go/bin/mockery /go/bin/mockery
 COPY --from=go-build /go/bin/golangci-lint /go/bin/golangci-lint
 COPY --from=go-build /go/bin/abigen /usr/local/bin/abigen
 COPY --from=go-build /go/bin/geth /usr/local/bin/geth
+COPY --from=go-build /go/bin/yq /go/bin/yq
 
 # copy tools
 COPY --from=rust-build /root/.foundry/bin/forge /usr/local/bin/forge
 COPY --from=rust-build /root/.foundry/bin/cast /usr/local/bin/cast
 COPY --from=rust-build /root/.foundry/bin/anvil /usr/local/bin/anvil
 COPY --from=rust-build /root/.cargo/bin/svm /usr/local/bin/svm
+COPY --from=rust-build /root/.cargo/bin/just /usr/local/bin/just
 
 COPY .nvmrc .nvmrc
 COPY ./versions.json ./versions.json


### PR DESCRIPTION
**Description**

Copies over `yq` and `just` into the final docker image. Older
versions of `ci-builder` are known to contain `just`, something
must have changed to have them no longer fully include it.
We need to tie the release of `ci-builder` with a bump of
the foundry version unless the foundry version we are using
is still available via nightly binary download. This is because
every time we build foundry in CI it produces a bad build
that results in an "illegal instruction" error.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

