### PR TITLE
op-upgrade: bump superchain registry version and fix calls 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240415164336-5ad42cbb4947
 	github.com/ethereum/go-ethereum v1.13.11
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101311.0-rc.1 h1:3JE5FyGXNQCnXUuiK3I6ZD3zbB2DBIcEMsXCpjrXUwM=
 github.com/ethereum-optimism/op-geth v1.101311.0-rc.1/go.mod h1:K23yb9efVf9DdUOv/vl/Ux57Tng00rLaFqWYlFF45CA=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d h1:K7HdD/ZAcSFhcqqnUAbvU+8vsg0DzL8pvetHw5vRLCc=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240415164336-5ad42cbb4947 h1:K0let3aILw55U/93iDB17YT9suvj1iuSb1ZuIHvSuoY=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240415164336-5ad42cbb4947/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -1,11 +1,13 @@
 package upgrades
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"os"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -574,25 +576,37 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 	l2OutputOracle, err := optimismPortal.L2Oracle(&bind.CallOpts{})
 	if err != nil {
 		// Handle legacy `L2_ORACLE()(address)` getter
-		raw := bindings.OptimismPortalCallerRaw{Contract: optimismPortal}
-		var out []interface{}
-		err := raw.Call(&bind.CallOpts{}, &out, "L2_ORACLE")
+		addr := common.Address(list.OptimismPortalProxy)
+		msg := ethereum.CallMsg{
+			To:   &addr,
+			Data: common.FromHex("0x001c2ff6"),
+		}
+		data, err := backend.CallContract(context.Background(), msg, nil)
 		if err != nil {
 			return err
 		}
-		l2OutputOracle = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+		if len(data) != 32 {
+			return fmt.Errorf("unexpected result length: %d", len(data))
+		}
+		l2OutputOracle = common.BytesToAddress(data[12:])
 	}
 
 	systemConfig, err := optimismPortal.SystemConfig(&bind.CallOpts{})
 	if err != nil {
 		// Handle legacy `SYSTEM_CONFIG()(address)` getter
-		raw := bindings.OptimismPortalCallerRaw{Contract: optimismPortal}
-		var out []interface{}
-		err := raw.Call(&bind.CallOpts{}, &out, "SYSTEM_CONFIG")
+		addr := common.Address(list.OptimismPortalProxy)
+		msg := ethereum.CallMsg{
+			To:   &addr,
+			Data: common.FromHex("0xf0498750"),
+		}
+		data, err := backend.CallContract(context.Background(), msg, nil)
 		if err != nil {
 			return err
 		}
-		systemConfig = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+		if len(data) != 32 {
+			return fmt.Errorf("unexpected result length: %d", len(data))
+		}
+		systemConfig = common.BytesToAddress(data[12:])
 	}
 
 	if l2OutputOracle != common.Address(list.L2OutputOracleProxy) {

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -21,8 +21,8 @@ import (
 // the superchain-registry is no longer deemed experimental.
 func TestGetRollupConfig(t *testing.T) {
 	configsByName := map[string]rollup.Config{
-		"mainnet":                       mainnetCfg,
-		"sepolia":                       sepoliaCfg,
+		"mainnet": mainnetCfg,
+		"sepolia": sepoliaCfg,
 		// "oplabs-devnet-0-sepolia-dev-0": sepoliaDev0Cfg,
 	}
 

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -23,7 +23,7 @@ func TestGetRollupConfig(t *testing.T) {
 	configsByName := map[string]rollup.Config{
 		"mainnet":                       mainnetCfg,
 		"sepolia":                       sepoliaCfg,
-		"oplabs-devnet-0-sepolia-dev-0": sepoliaDev0Cfg,
+		// "oplabs-devnet-0-sepolia-dev-0": sepoliaDev0Cfg,
 	}
 
 	for name, expectedCfg := range configsByName {

--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d // indirect
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240415164336-5ad42cbb4947 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/flosch/pongo2/v4 v4.0.2 // indirect

--- a/op-ufm/go.sum
+++ b/op-ufm/go.sum
@@ -102,8 +102,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum-optimism/op-geth v1.101311.0-rc.1 h1:3JE5FyGXNQCnXUuiK3I6ZD3zbB2DBIcEMsXCpjrXUwM=
 github.com/ethereum-optimism/op-geth v1.101311.0-rc.1/go.mod h1:K23yb9efVf9DdUOv/vl/Ux57Tng00rLaFqWYlFF45CA=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d h1:K7HdD/ZAcSFhcqqnUAbvU+8vsg0DzL8pvetHw5vRLCc=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240318114348-52d3dbd1605d/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240415164336-5ad42cbb4947 h1:K0let3aILw55U/93iDB17YT9suvj1iuSb1ZuIHvSuoY=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240415164336-5ad42cbb4947/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=


### PR DESCRIPTION
- Bumps the superchain registry to use the latest commit on main
- In https://github.com/ethereum-optimism/optimism/pull/10117 legacy getters were removed from the portal, so we fix how `op-upgrade` fetches data to ensure it can still use the legacy getters to read from old implementations

Intentionally leaving this PR as draft as it requires a superchain registry bug to be fixed. While we know how to do the fix, it requires coordination between this repo and the superchain registry. Since we've already started MCP L1 upgrades before that fix, we avoid changing the process mid-upgrade, and continue to use this PR's branch for those upgrades