### PR TITLE
op-conductor: adds flag to enable safe head progression checks

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -118,6 +118,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		HealthCheck: HealthCheckConfig{
 			Interval:       ctx.Uint64(flags.HealthCheckInterval.Name),
 			UnsafeInterval: ctx.Uint64(flags.HealthCheckUnsafeInterval.Name),
+			SafeEnabled:    ctx.Bool(flags.HealthCheckSafeEnabled.Name),
 			SafeInterval:   ctx.Uint64(flags.HealthCheckSafeInterval.Name),
 			MinPeerCount:   ctx.Uint64(flags.HealthCheckMinPeerCount.Name),
 		},
@@ -137,6 +138,9 @@ type HealthCheckConfig struct {
 
 	// UnsafeInterval is the interval allowed between unsafe head and now in seconds.
 	UnsafeInterval uint64
+
+	// SafeEnabled is whether to enable safe head progression checks.
+	SafeEnabled bool
 
 	// SafeInterval is the interval between safe head progression measured in seconds.
 	SafeInterval uint64

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -176,6 +176,7 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 		c.cfg.HealthCheck.UnsafeInterval,
 		c.cfg.HealthCheck.SafeInterval,
 		c.cfg.HealthCheck.MinPeerCount,
+		c.cfg.HealthCheck.SafeEnabled,
 		&c.cfg.RollupCfg,
 		node,
 		p2p,

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -64,6 +64,12 @@ var (
 		Usage:   "Interval allowed between unsafe head and now measured in seconds",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_UNSAFE_INTERVAL"),
 	}
+	HealthCheckSafeEnabled = &cli.BoolFlag{
+		Name:    "healthcheck.safe-enabled",
+		Usage:   "Whether to enable safe head progression checks",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_SAFE_ENABLED"),
+		Value:   false,
+	}
 	HealthCheckSafeInterval = &cli.Uint64Flag{
 		Name:    "healthcheck.safe-interval",
 		Usage:   "Interval between safe head progression measured in seconds",
@@ -105,6 +111,7 @@ var optionalFlags = []cli.Flag{
 	Paused,
 	RPCEnableProxy,
 	RaftBootstrap,
+	HealthCheckSafeEnabled,
 }
 
 func init() {

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -34,7 +34,7 @@ type HealthMonitor interface {
 // interval is the interval between health checks measured in seconds.
 // safeInterval is the interval between safe head progress measured in seconds.
 // minPeerCount is the minimum number of peers required for the sequencer to be healthy.
-func NewSequencerHealthMonitor(log log.Logger, interval, unsafeInterval, safeInterval, minPeerCount uint64, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p p2p.API) HealthMonitor {
+func NewSequencerHealthMonitor(log log.Logger, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p p2p.API) HealthMonitor {
 	return &SequencerHealthMonitor{
 		log:            log,
 		done:           make(chan struct{}),
@@ -42,6 +42,7 @@ func NewSequencerHealthMonitor(log log.Logger, interval, unsafeInterval, safeInt
 		healthUpdateCh: make(chan error),
 		rollupCfg:      rollupCfg,
 		unsafeInterval: unsafeInterval,
+		safeEnabled:    safeEnabled,
 		safeInterval:   safeInterval,
 		minPeerCount:   minPeerCount,
 		timeProviderFn: currentTimeProvicer,
@@ -58,6 +59,7 @@ type SequencerHealthMonitor struct {
 
 	rollupCfg          *rollup.Config
 	unsafeInterval     uint64
+	safeEnabled        bool
 	safeInterval       uint64
 	minPeerCount       uint64
 	interval           uint64
@@ -169,7 +171,7 @@ func (hm *SequencerHealthMonitor) healthCheck() error {
 		return ErrSequencerNotHealthy
 	}
 
-	if now-status.SafeL2.Time > hm.safeInterval {
+	if hm.safeEnabled && now-status.SafeL2.Time > hm.safeInterval {
 		hm.log.Error(
 			"safe head is not progressing as expected",
 			"now", now,

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -62,6 +62,7 @@ func (s *HealthMonitorTestSuite) SetupMonitor(
 		rollupCfg:      s.rollupCfg,
 		unsafeInterval: unsafeInterval,
 		safeInterval:   safeInterval,
+		safeEnabled:    true,
 		minPeerCount:   s.minPeerCount,
 		timeProviderFn: tp.Now,
 		node:           mockRollupClient,
@@ -146,6 +147,13 @@ func (s *HealthMonitorTestSuite) TestUnhealthySafeHeadNotProgressing() {
 			s.NotNil(healthy)
 		}
 	}
+
+	// test that the safeEnabled flag works
+	monitor.safeEnabled = false
+	rc.ExpectSyncStatus(mockSyncStatus(now+6, 4, now, 1), nil)
+	rc.ExpectSyncStatus(mockSyncStatus(now+6, 4, now, 1), nil)
+	healthy := <-healthUpdateCh
+	s.Nil(healthy)
 
 	s.NoError(monitor.Stop())
 }


### PR DESCRIPTION
**Description**

Sequencer health shouldn't depend on if batcher is behaving correctly or not, so disable the safe head check by default by introducing a new flag to enable it.
