### PR TITLE
chore(ci): Pin `pnpm` in devnet job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1204,7 +1204,7 @@ jobs:
       - run:
           name: Install pnpm
           command: |
-            npm i pnpm --global
+            npm i pnpm@8.15.7 --global
       - run:
           name: git submodules
           command: make submodules


### PR DESCRIPTION
## Overview

`pnpm` 9 was released today, breaking our lockfile format. As CI uses pnpm 8, we need to pin the version in the devnet job so it doesn't install latest.
