### PR TITLE
fix(ci-builder): Build `foundry` from source

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 docker as buildx
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 RUN docker buildx version
 
-FROM --platform=linux/amd64 debian:bullseye-slim as rust-build
+FROM --platform=linux/amd64 debian:buster-slim as rust-build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -37,7 +37,7 @@ RUN strip /root/.foundry/bin/forge && \
   strip /root/.foundry/bin/anvil && \
   strip /root/.cargo/bin/svm
 
-FROM --platform=linux/amd64 debian:bullseye-slim as go-build
+FROM --platform=linux/amd64 debian:buster-slim as go-build
 
 RUN apt-get update && apt-get install -y curl ca-certificates jq binutils
 
@@ -68,7 +68,7 @@ RUN strip /go/bin/gotestsum && \
   strip /go/bin/geth && \
   strip /go/bin/yq
 
-FROM --platform=linux/amd64 debian:bullseye-slim as base-builder
+FROM --platform=linux/amd64 debian:buster-slim as base-builder
 
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 docker as buildx
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 RUN docker buildx version
 
-FROM --platform=linux/amd64 debian:buster-slim as rust-build
+FROM --platform=linux/amd64 debian:bullseye-slim as rust-build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -28,16 +28,15 @@ COPY ./versions.json ./versions.json
 COPY ./ops/scripts/install-foundry.sh ./install-foundry.sh
 
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN source $HOME/.profile && \
-    ./install-foundry.sh && \
-    cargo install svm-rs
+RUN source $HOME/.profile && ./install-foundry.sh
 
 RUN strip /root/.foundry/bin/forge && \
   strip /root/.foundry/bin/cast && \
   strip /root/.foundry/bin/anvil && \
-  strip /root/.cargo/bin/svm
+  strip /root/.cargo/bin/svm && \
+  strip /root/.cargo/bin/just
 
-FROM --platform=linux/amd64 debian:buster-slim as go-build
+FROM --platform=linux/amd64 debian:bullseye-slim as go-build
 
 RUN apt-get update && apt-get install -y curl ca-certificates jq binutils
 
@@ -68,7 +67,7 @@ RUN strip /go/bin/gotestsum && \
   strip /go/bin/geth && \
   strip /go/bin/yq
 
-FROM --platform=linux/amd64 debian:buster-slim as base-builder
+FROM --platform=linux/amd64 debian:bullseye-slim as base-builder
 
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
@@ -100,7 +99,7 @@ ENV NODE_MAJOR=20
 
 RUN /bin/sh -c set -eux; \
   apt-get update; \
-  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential ca-certificates jq gnupg binutils-mips-linux-gnu python3 python3-pip; \
+  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential ca-certificates jq gnupg binutils-mips-linux-gnu python3 python3-pip python3-setuptools; \
   mkdir -p /etc/apt/keyrings; \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \

--- a/ops/scripts/install-foundry.sh
+++ b/ops/scripts/install-foundry.sh
@@ -39,7 +39,17 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
   foundryup -v "$TAG"
 else
   echo "Nightly tag doesn't exist! Building from source..."
-  foundryup -C "$SHA"
+  git checkout "$SHA"
+
+  # Use native `cargo` build to avoid any rustc environment variables `foundryup` sets. We explicitly
+  # ignore chisel, as it is not a part of `ci-builder`.
+  cargo build --bin forge --release
+  cargo build --bin cast --release
+  cargo build --bin anvil --release
+  mkdir -p ~/.foundry/bin
+  mv target/release/forge ~/.foundry/bin
+  mv target/release/cast ~/.foundry/bin
+  mv target/release/anvil ~/.foundry/bin
 fi
 
 # Remove the temporary foundry repo; Used just for checking the nightly tag's existence.

--- a/ops/scripts/install-foundry.sh
+++ b/ops/scripts/install-foundry.sh
@@ -45,5 +45,3 @@ fi
 # Remove the temporary foundry repo; Used just for checking the nightly tag's existence.
 rm -rf "$TMP_DIR"
 echo "Removed tempdir @ $TMP_DIR"
-
-

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "bdc04c278f8ac716ed5fd3994bc0da841807b5cf",
+  "foundry": "8513f619ca6781fe62d59b1bf2a8bb1bbab19927",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
## Overview

Fixes `ci-builder`'s ability to compile foundry from source when need be. Previously, we used `foundryup`, which set `RUSTFLAGS=-C target-cpu=native`. This flag fell through to the host of the container, causing invalid instruction errors. Instead, we just build with `cargo`.
