### PR TITLE
fix: Ensure concurrency safety for latestHeader field

### DIFF
--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -138,6 +138,8 @@ func (l2Etl *L2ETL) Start() error {
 }
 
 func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
+	l2Etl.mu.Lock()
+	defer l2Etl.mu.Unlock()
 	l2BlockHeaders := make([]database.L2BlockHeader, len(batch.Headers))
 	for i := range batch.Headers {
 		l2BlockHeaders[i] = database.L2BlockHeader{BlockHeader: database.BlockHeaderFromHeader(&batch.Headers[i])}
@@ -184,8 +186,6 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 	l2Etl.ETL.metrics.RecordEtlLatestHeight(l2Etl.latestHeader.Number)
 
 	// Notify Listeners
-	l2Etl.mu.Lock()
-	defer l2Etl.mu.Unlock()
 	for i := range l2Etl.listeners {
 		select {
 		case l2Etl.listeners[i] <- l2Etl.latestHeader:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR addresses the concurrency safety issue by ensuring proper synchronization for the `latestHeader` field in the `L2ETL` struct. Access to the `latestHeader` field is now protected by a mutex, preventing potential race conditions during concurrent access.

**Tests**

No new tests were added in this PR as it focuses on concurrency safety improvements rather than functional changes. Existing tests cover the behavior of the modified code.

**Additional context**

Ensuring concurrency safety is crucial for preventing race conditions and data corruption in multi-threaded environments. By synchronizing access to the `latestHeader` field, we prevent potential issues that could arise from concurrent reads and writes.

