### PR TITLE
[op-conductor] Add status check apis

### DIFF
--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -19,6 +19,10 @@ type API interface {
 	Pause(ctx context.Context) error
 	// Resume resumes op-conductor.
 	Resume(ctx context.Context) error
+	// Paused returns true if op-conductor is paused.
+	Paused(ctx context.Context) (bool, error)
+	// Stopped returns true if op-conductor is stopped.
+	Stopped(ctx context.Context) (bool, error)
 	// SequencerHealthy returns true if the sequencer is healthy.
 	SequencerHealthy(ctx context.Context) (bool, error)
 
@@ -41,7 +45,7 @@ type API interface {
 	ClusterMembership(ctx context.Context) ([]*consensus.ServerInfo, error)
 
 	// APIs called by op-node
-	// Active returns true if op-conductor is active.
+	// Active returns true if op-conductor is active (not paused or stopped).
 	Active(ctx context.Context) (bool, error)
 	// CommitUnsafePayload commits a unsafe payload (latest head) to the consensus layer.
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -45,6 +45,16 @@ func NewAPIBackend(log log.Logger, con conductor) *APIBackend {
 
 var _ API = (*APIBackend)(nil)
 
+// Paused implements API.
+func (api *APIBackend) Paused(ctx context.Context) (bool, error) {
+	return api.con.Paused(), nil
+}
+
+// Stopped implements API.
+func (api *APIBackend) Stopped(ctx context.Context) (bool, error) {
+	return api.con.Stopped(), nil
+}
+
 // Active implements API.
 func (api *APIBackend) Active(_ context.Context) (bool, error) {
 	return !api.con.Stopped() && !api.con.Paused(), nil

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -27,6 +27,20 @@ func prefixRPC(method string) string {
 	return RPCNamespace + "_" + method
 }
 
+// Paused implements API.
+func (c *APIClient) Paused(ctx context.Context) (bool, error) {
+	var paused bool
+	err := c.c.CallContext(ctx, &paused, prefixRPC("paused"))
+	return paused, err
+}
+
+// Stopped implements API.
+func (c *APIClient) Stopped(ctx context.Context) (bool, error) {
+	var stopped bool
+	err := c.c.CallContext(ctx, &stopped, prefixRPC("stopped"))
+	return stopped, err
+}
+
 // Active implements API.
 func (c *APIClient) Active(ctx context.Context) (bool, error) {
 	var active bool

--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -111,6 +111,12 @@ func setupSequencerFailoverTest(t *testing.T) (*System, map[string]*conductor) {
 	require.NoError(t, c3.client.Resume(ctx))
 
 	// final check, make sure everything is in the right place
+	require.True(t, conductorResumed(t, ctx, c1))
+	require.True(t, conductorResumed(t, ctx, c2))
+	require.True(t, conductorResumed(t, ctx, c3))
+	require.False(t, conductorStopped(t, ctx, c1))
+	require.False(t, conductorStopped(t, ctx, c2))
+	require.False(t, conductorStopped(t, ctx, c3))
 	require.True(t, conductorActive(t, ctx, c1))
 	require.True(t, conductorActive(t, ctx, c2))
 	require.True(t, conductorActive(t, ctx, c3))
@@ -409,6 +415,18 @@ func conductorActive(t *testing.T, ctx context.Context, con *conductor) bool {
 	active, err := con.client.Active(ctx)
 	require.NoError(t, err)
 	return active
+}
+
+func conductorResumed(t *testing.T, ctx context.Context, con *conductor) bool {
+	paused, err := con.client.Paused(ctx)
+	require.NoError(t, err)
+	return !paused
+}
+
+func conductorStopped(t *testing.T, ctx context.Context, con *conductor) bool {
+	stopped, err := con.client.Stopped(ctx)
+	require.NoError(t, err)
+	return stopped
 }
 
 func sequencerActive(t *testing.T, ctx context.Context, rollupClient *sources.RollupClient) bool {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add status check apis, this will be used during deployment phase to check on conductor state to make sure everything's correct.

**Tests**

N/A

**Metadata**

- https://github.com/ethereum-optimism/protocol-quest/issues/44
