### PR TITLE
Update CODEOWNERS per today's meeting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Packages
-/packages/chain-mon             @ethereum-optimism/devxpod
+/packages/chain-mon             @ethereum-optimism/security-reviewers
+/packages/chain-mon/src/balance-mon             @ethereum-optimism/infra-reviewers
 /packages/common-ts             @ethereum-optimism/typescript-reviewers
 /packages/contracts-bedrock     @ethereum-optimism/contract-reviewers
 /packages/core-utils            @ethereum-optimism/legacy-reviewers


### PR DESCRIPTION
agreements:
1. security-reviewers own chain-mon as a whole, including fault-mon, wd-mon as fully supported tools for the community.
2. all other *-mon's will be moved to either internal/ or contrib/ or deleted to signfy the lack of full supports. security team own the restructuring here.
3. infra-reviewers own balance-mon for internal use, no commitment on providing full support here, so they will be moved to internal/ in a future PR.

this PR focuses on implementing the code owner changes.