### PR TITLE
build: bump min pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "engines": {
     "node": ">=16",
-    "pnpm": ">=8"
+    "pnpm": ">=9"
   },
   "scripts": {
     "clean": "pnpm recursive run clean; rm -rf node_modules packages/*/node_modules && echo 'Finished cleaning. Run `pnpm install && pnpm build` from root of repo to rebuild the repo.'",


### PR DESCRIPTION
chain-mon-docker-publish is [failing](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/51620/workflows/86237fd2-c32e-42a2-9093-0832d06569a9/jobs/2244200) with pnpm issues. I think this might fix it 

Related to https://github.com/ethereum-optimism/optimism/pull/10179 where we bumped to pnpm v9

Edit: This does not fix it, but we'll merge anyway since `>=8` is no longer true. #10217 will help us debug the issue