### PR TITLE
Fix chain-mon docker image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,18 @@ golang-docker:
 			op-node op-batcher op-proposer op-challenger
 .PHONY: golang-docker
 
+chain-mon-docker:
+	# We don't use a buildx builder here, and just load directly into regular docker, for convenience.
+	GIT_COMMIT=$$(git rev-parse HEAD) \
+	GIT_DATE=$$(git show -s --format='%ct') \
+	IMAGE_TAGS=$$(git rev-parse HEAD),latest \
+	docker buildx bake \
+			--progress plain \
+			--load \
+			-f docker-bake.hcl \
+			chain-mon
+.PHONY: chain-mon-docker
+
 contracts-bedrock-docker:
 	IMAGE_TAGS=$$(git rev-parse HEAD),latest \
 	docker buildx bake \

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -17,7 +17,7 @@ FROM alpine:3.16 as manifests
 RUN apk add coreutils
 
 WORKDIR /tmp
-COPY pnpm-lock.yaml pnpm-workspace.yaml .nvmrc package.json ./src/
+COPY pnpm-lock.yaml pnpm-workspace.yaml .nvmrc package.json .pnpmfile.cjs ./src/
 COPY packages src/packages/
 RUN mkdir manifests && \
   cd src && \
@@ -28,7 +28,9 @@ RUN mkdir manifests && \
   # pnpm-workspace.yaml
   cp pnpm-workspace.yaml ../manifests/ && \
   # .nvmrc
-  cp .nvmrc ../manifests/
+  cp .nvmrc ../manifests/ && \
+  # .pnpmfile.cjs
+  cp .pnpmfile.cjs ../manifests/
 
 FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest as foundry
 # bullseye-slim is debian based


### PR DESCRIPTION
**Description**

Adds a make target to build the chain-mon docker image and includes `.pnpmfile.cjs` in the build process which seems to be required by pnpm v9.