### PR TITLE
fix a few corner cases and revert last batch for `SpanBatch` when error happens

### DIFF
--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -536,10 +536,6 @@ func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 	require.ErrorIs(t, cb.FullErr(), ErrMaxFrameIndex)
 }
 
-func init() {
-	derive.SkipOptimize = true
-}
-
 // TestChannelBuilder_FullShadowCompressor is a regression test testing that
 // the shadow compressor is correctly marked as full if adding another block
 // would produce a leftover frame.

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -567,7 +567,7 @@ func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
 	a := dtest.RandomL2BlockWithChainIdAndTime(rng, 1, defaultTestRollupConfig.L2ChainID, blockTime.Add(time.Duration(1)*time.Second))
 	_, err = cb.AddBlock(a)
 	require.NoError(err)
-	require.Nil(cb.fullErr)
+	require.NoError(cb.fullErr)
 	a = dtest.RandomL2BlockWithChainIdAndTime(rng, 1, defaultTestRollupConfig.L2ChainID, blockTime.Add(time.Duration(2)*time.Second))
 	_, err = cb.AddBlock(a)
 	require.ErrorIs(err, derive.ErrCompressorFull)

--- a/op-batcher/batcher/tx_data.go
+++ b/op-batcher/batcher/tx_data.go
@@ -9,10 +9,6 @@ import (
 )
 
 // txData represents the data for a single transaction.
-//
-// Note: The batcher currently sends exactly one frame per transaction. This
-// might change in the future to allow for multiple frames from possibly
-// different channels.
 type txData struct {
 	frames []frameData
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -351,6 +351,9 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			for _, tx := range safeBlockTxs {
 				if tx[0] == types.DepositTxType {
 					depositCount++
+				} else {
+					// all deposit transactions are in the beginning
+					break
 				}
 			}
 			if len(safeBlockTxs)-depositCount != len(batchTxs) {

--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -58,7 +58,7 @@ func (ch *Channel) AddFrame(frame Frame, l1InclusionBlock eth.L1BlockRef) error 
 		return fmt.Errorf("cannot add ending frame to a closed channel. id %v", ch.id)
 	}
 	if _, ok := ch.inputs[uint64(frame.FrameNumber)]; ok {
-		return DuplicateErr
+		return ErrDuplicate
 	}
 	if ch.closed && frame.FrameNumber >= ch.endFrameNumber {
 		return fmt.Errorf("frame number (%d) is greater than or equal to end frame number (%d) of a closed channel", frame.FrameNumber, ch.endFrameNumber)

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -38,8 +38,8 @@ const MaxChannelBankSize = 100_000_000
 // a channel. This limit is set when decoding the RLP.
 const MaxRLPBytesPerChannel = 10_000_000
 
-// DuplicateErr is returned when a newly read frame is already known
-var DuplicateErr = errors.New("duplicate frame")
+// ErrDuplicate is returned when a newly read frame is already known
+var ErrDuplicate = errors.New("duplicate frame")
 
 // ChannelIDLength defines the length of the channel IDs
 const ChannelIDLength = 16

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -505,7 +505,7 @@ func (b *SpanBatch) peek(n int) *SpanBatchElement { return b.Batches[len(b.Batch
 // updates l1OriginCheck or parentCheck if needed.
 func (b *SpanBatch) AppendSingularBatch(singularBatch *SingularBatch, seqNum uint64) error {
 	// if this new element is not ordered with respect to the last element, panic
-	if len(b.Batches) > 0 && b.peek(0).Timestamp > singularBatch.Timestamp {
+	if len(b.Batches) > 0 && b.peek(0).Timestamp >= singularBatch.Timestamp {
 		panic("span batch is not ordered")
 	}
 

--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -69,7 +69,7 @@ func (tx *spanBatchTx) MarshalBinary() ([]byte, error) {
 }
 
 // setDecoded sets the inner transaction after decoding.
-func (tx *spanBatchTx) setDecoded(inner spanBatchTxData, _ /*size*/ uint64) {
+func (tx *spanBatchTx) setDecoded(inner spanBatchTxData) {
 	tx.inner = inner
 }
 
@@ -108,7 +108,7 @@ func (tx *spanBatchTx) UnmarshalBinary(b []byte) error {
 		if err != nil {
 			return fmt.Errorf("failed to decode spanBatchLegacyTxData: %w", err)
 		}
-		tx.setDecoded(&data, uint64(len(b)))
+		tx.setDecoded(&data)
 		return nil
 	}
 	// It's an EIP2718 typed transaction envelope.
@@ -116,7 +116,7 @@ func (tx *spanBatchTx) UnmarshalBinary(b []byte) error {
 	if err != nil {
 		return err
 	}
-	tx.setDecoded(inner, uint64(len(b)))
+	tx.setDecoded(inner)
 	return nil
 }
 

--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -69,7 +69,7 @@ func (tx *spanBatchTx) MarshalBinary() ([]byte, error) {
 }
 
 // setDecoded sets the inner transaction after decoding.
-func (tx *spanBatchTx) setDecoded(inner spanBatchTxData, size uint64) {
+func (tx *spanBatchTx) setDecoded(inner spanBatchTxData, _ /*size*/ uint64) {
 	tx.inner = inner
 }
 

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -469,7 +469,7 @@ func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 	return nil
 }
 
-func (sbtx *spanBatchTxs) revertLastBatch(txs []hexutil.Bytes) {
+func (sbtx *spanBatchTxs) revertLastTxs(txs []hexutil.Bytes) {
 	totalBlockTxCount := uint64(len(txs))
 	for idx := 0; idx < int(totalBlockTxCount); idx++ {
 		var tx types.Transaction

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -230,7 +230,7 @@ func (co *SpanChannelOut) checkFull() {
 	if co.full != nil {
 		return
 	}
-	if uint64(co.compressed.Len()) >= co.target {
+	if uint64(co.compressed.Len()) > co.target {
 		co.full = ErrCompressorFull
 	}
 }

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -113,9 +113,6 @@ func (co *SpanChannelOut) AddBlock(rollupCfg *rollup.Config, block *types.Block)
 	return co.AddSingularBatch(batch, l1Info.SequenceNumber)
 }
 
-// SkipOptimize is only true for test
-var SkipOptimize bool
-
 // AddSingularBatch adds a SingularBatch to the channel, compressing the data if necessary.
 // if the new batch would make the channel exceed the target size, the last batch is reverted,
 // and the compression happens on the previous RLP buffer instead
@@ -161,11 +158,9 @@ func (co *SpanChannelOut) AddSingularBatch(batch *SingularBatch, seqNum uint64) 
 
 	// if the compressed data *plus* the new rlp data is under the target size, return early
 	// this optimizes out cases where the compressor will obviously come in under the target size
-	if !SkipOptimize {
-		rlpGrowth := co.activeRLP().Len() - co.lastCompressedRLPSize
-		if uint64(co.compressed.Len()+rlpGrowth) < co.target {
-			return nil
-		}
+	rlpGrowth := co.activeRLP().Len() - co.lastCompressedRLPSize
+	if uint64(co.compressed.Len()+rlpGrowth) < co.target {
+		return nil
 	}
 
 	// we must compress the data to check if we've met or exceeded the target size


### PR DESCRIPTION
According to [this code](https://github.com/ethereum-optimism/op-geth/blob/optimism/miner/worker.go#L968-L971), `parent.Timestamp==current.Timestamp` is also invalid.

This PR also fixes `checkFull` so that it only marks `ErrCompressorFull` when `co.compressed.Len() > co.target` instead of `co.compressed.Len() >= co.target`, because when `co.compressed.Len() == co.target`, we actually want to include the current block into the channel instead of trying to [revert](https://github.com/ethereum-optimism/optimism/blob/d2263b19958f7f1e738ff79dae7ebb240cca1375/op-node/rollup/derive/span_channel_out.go#L166) to the compressed previous data.

This PR also added a call to `revertLastBatch` when error happened downstream.