### PR TITLE
fix: Fix devnet-up build error

### DIFF
--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -205,10 +205,14 @@ services:
       OP_CHALLENGER_NUM_CONFIRMATIONS: 1
 
   da-server:
+    depends_on:
+      - op_stack_go_builder
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/da-server:devnet
     build:
       context: ../
       dockerfile: ./op-plasma/Dockerfile
+      args:
+        OP_STACK_GO_BUILDER: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:devnet
     command: >
       da-server
       --file.path=/data


### PR DESCRIPTION
**Description**

In the current develop branch, `make devnet-up` command fails with the following error during building `da-server` image.
```
failed to solve: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest: not found
```

So I added `op-stack-go` as a dependency, and add an `OP_STACK_GO_BUILDER` arg to make it use newly built op-stack-go image.

**Tests**

Tested in my local environment.
