### PR TITLE
chore: Clean up details in new abi_loader

### DIFF
--- a/ops/scripts/find-version.sh
+++ b/ops/scripts/find-version.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-NAME=${1:?Must specify release name}
-
-git describe --tags --candidates=100 --match="${NAME}/*" | sed "s/${NAME}\///"

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -32,6 +32,7 @@ func loadABI(name string) (*abi.ABI, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load ABI for contract %v: %w", name, err)
 	}
+	defer in.Close()
 	if parsed, err := abi.JSON(in); err != nil {
 		return nil, err
 	} else {


### PR DESCRIPTION
**Description**

A couple of comments in https://github.com/ethereum-optimism/optimism/pull/10225/ got missed so clean up those details.
* Close the file reader
* Remove the `find-version.sh` script that was originally from another experiment and accidentally got added to the PR.