### PR TITLE
abi_loader: Embed specific ABIs

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -48,10 +48,7 @@ func ListClaims(ctx *cli.Context) error {
 	defer l1Client.Close()
 
 	caller := batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize)
-	contract, err := contracts.NewFaultDisputeGameContract(metrics.NoopContractMetrics, gameAddr, caller)
-	if err != nil {
-		return fmt.Errorf("failed to create dispute game bindings: %w", err)
-	}
+	contract := contracts.NewFaultDisputeGameContract(metrics.NoopContractMetrics, gameAddr, caller)
 	return listClaims(ctx.Context, contract)
 }
 

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -40,10 +40,7 @@ func ListGames(ctx *cli.Context) error {
 	defer l1Client.Close()
 
 	caller := batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize)
-	contract, err := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
-	if err != nil {
-		return fmt.Errorf("failed to create dispute game bindings: %w", err)
-	}
+	contract := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
 	head, err := l1Client.HeaderByNumber(ctx.Context, nil)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve current head block: %w", err)
@@ -69,10 +66,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 	infos := make([]*gameInfo, len(games))
 	var wg sync.WaitGroup
 	for idx, game := range games {
-		gameContract, err := contracts.NewFaultDisputeGameContract(metrics.NoopContractMetrics, game.Proxy, caller)
-		if err != nil {
-			return fmt.Errorf("failed to bind game contract at %v: %w", game.Proxy, err)
-		}
+		gameContract := contracts.NewFaultDisputeGameContract(metrics.NoopContractMetrics, game.Proxy, caller)
 		info := gameInfo{GameMetadata: game}
 		infos[idx] = &info
 		gameProxy := game.Proxy

--- a/op-challenger/cmd/utils.go
+++ b/op-challenger/cmd/utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type ContractCreator[T any] func(contractMetrics.ContractMetricer, common.Address, *batching.MultiCaller) (T, error)
+type ContractCreator[T any] func(contractMetrics.ContractMetricer, common.Address, *batching.MultiCaller) T
 
 // NewContractWithTxMgr creates a new contract and a transaction manager.
 func NewContractWithTxMgr[T any](ctx *cli.Context, flagName string, creator ContractCreator[T]) (T, txmgr.TxManager, error) {
@@ -40,10 +40,7 @@ func newContractFromCLI[T any](ctx *cli.Context, flagName string, caller *batchi
 		return contract, err
 	}
 
-	created, err := creator(contractMetrics.NoopContractMetrics, gameAddr, caller)
-	if err != nil {
-		return contract, fmt.Errorf("failed to create dispute game bindings: %w", err)
-	}
+	created := creator(contractMetrics.NoopContractMetrics, gameAddr, caller)
 
 	return created, nil
 }

--- a/op-challenger/game/fault/claims/claimer.go
+++ b/op-challenger/game/fault/claims/claimer.go
@@ -62,8 +62,9 @@ func (c *Claimer) claimBond(ctx context.Context, game types.GameMetadata, addr c
 
 	contract, err := c.contractCreator(game)
 	if err != nil {
-		return fmt.Errorf("failed to create bond contract bindings: %w", err)
+		return fmt.Errorf("failed to create bond contract: %w", err)
 	}
+
 	credit, status, err := contract.GetCredit(ctx, addr)
 	if err != nil {
 		return fmt.Errorf("failed to get credit: %w", err)

--- a/op-challenger/game/fault/contracts/delayed_weth.go
+++ b/op-challenger/game/fault/contracts/delayed_weth.go
@@ -27,16 +27,13 @@ type WithdrawalRequest struct {
 	Timestamp *big.Int
 }
 
-func NewDelayedWETHContract(metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (*DelayedWETHContract, error) {
-	contractAbi, err := snapshots.LoadDelayedWETHABI()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load delayed weth ABI: %w", err)
-	}
+func NewDelayedWETHContract(metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) *DelayedWETHContract {
+	contractAbi := snapshots.LoadDelayedWETHABI()
 	return &DelayedWETHContract{
 		metrics:     metrics,
 		multiCaller: caller,
 		contract:    batching.NewBoundContract(contractAbi, addr),
-	}, nil
+	}
 }
 
 // GetWithdrawals returns all withdrawals made from the contract since the given block.

--- a/op-challenger/game/fault/contracts/delayed_weth_test.go
+++ b/op-challenger/game/fault/contracts/delayed_weth_test.go
@@ -42,11 +42,9 @@ func TestDelayedWeth_GetWithdrawals(t *testing.T) {
 }
 
 func setupDelayedWethTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DelayedWETHContract) {
-	delayedWethAbi, err := snapshots.LoadDelayedWETHABI()
-	require.NoError(t, err)
+	delayedWethAbi := snapshots.LoadDelayedWETHABI()
 	stubRpc := batchingTest.NewAbiBasedRpc(t, delayedWeth, delayedWethAbi)
 	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
-	weth, err := NewDelayedWETHContract(contractMetrics.NoopContractMetrics, delayedWeth, caller)
-	require.NoError(t, err)
+	weth := NewDelayedWETHContract(contractMetrics.NoopContractMetrics, delayedWeth, caller)
 	return stubRpc, weth
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -57,17 +57,14 @@ type Proposal struct {
 	OutputRoot    common.Hash
 }
 
-func NewFaultDisputeGameContract(metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (*FaultDisputeGameContract, error) {
-	contractAbi, err := snapshots.LoadFaultDisputeGameABI()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load fault dispute game ABI: %w", err)
-	}
+func NewFaultDisputeGameContract(metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) *FaultDisputeGameContract {
+	contractAbi := snapshots.LoadFaultDisputeGameABI()
 
 	return &FaultDisputeGameContract{
 		metrics:     metrics,
 		multiCaller: caller,
 		contract:    batching.NewBoundContract(contractAbi, addr),
-	}, nil
+	}
 }
 
 // GetBalance returns the total amount of ETH controlled by this contract.
@@ -262,7 +259,7 @@ func (f *FaultDisputeGameContract) getDelayedWETH(ctx context.Context) (*Delayed
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch WETH addr: %w", err)
 	}
-	return NewDelayedWETHContract(f.metrics, result.GetAddress(0), f.multiCaller)
+	return NewDelayedWETHContract(f.metrics, result.GetAddress(0), f.multiCaller), nil
 }
 
 func (f *FaultDisputeGameContract) GetOracle(ctx context.Context) (*PreimageOracleContract, error) {
@@ -359,7 +356,7 @@ func (f *FaultDisputeGameContract) vm(ctx context.Context) (*VMContract, error) 
 		return nil, fmt.Errorf("failed to fetch VM addr: %w", err)
 	}
 	vmAddr := result.GetAddress(0)
-	return NewVMContract(vmAddr, f.multiCaller)
+	return NewVMContract(vmAddr, f.multiCaller), nil
 }
 
 func (f *FaultDisputeGameContract) AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -456,19 +456,15 @@ func TestFaultDisputeGame_ClaimCreditTx(t *testing.T) {
 }
 
 func setupFaultDisputeGameTest(t *testing.T) (*batchingTest.AbiBasedRpc, *FaultDisputeGameContract) {
-	fdgAbi, err := snapshots.LoadFaultDisputeGameABI()
-	require.NoError(t, err)
+	fdgAbi := snapshots.LoadFaultDisputeGameABI()
 
-	vmAbi, err := snapshots.LoadMIPSABI()
-	require.NoError(t, err)
-	oracleAbi, err := snapshots.LoadPreimageOracleABI()
-	require.NoError(t, err)
+	vmAbi := snapshots.LoadMIPSABI()
+	oracleAbi := snapshots.LoadPreimageOracleABI()
 
 	stubRpc := batchingTest.NewAbiBasedRpc(t, fdgAddr, fdgAbi)
 	stubRpc.AddContract(vmAddr, vmAbi)
 	stubRpc.AddContract(oracleAddr, oracleAbi)
 	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
-	game, err := NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, fdgAddr, caller)
-	require.NoError(t, err)
+	game := NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, fdgAddr, caller)
 	return stubRpc, game
 }

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -29,16 +29,13 @@ type DisputeGameFactoryContract struct {
 	contract    *batching.BoundContract
 }
 
-func NewDisputeGameFactoryContract(m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (*DisputeGameFactoryContract, error) {
-	factoryAbi, err := snapshots.LoadDisputeGameFactoryABI()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load dispute game factory ABI: %w", err)
-	}
+func NewDisputeGameFactoryContract(m metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) *DisputeGameFactoryContract {
+	factoryAbi := snapshots.LoadDisputeGameFactoryABI()
 	return &DisputeGameFactoryContract{
 		metrics:     m,
 		multiCaller: caller,
 		contract:    batching.NewBoundContract(factoryAbi, addr),
-	}, nil
+	}
 }
 
 func (f *DisputeGameFactoryContract) GetGameFromParameters(ctx context.Context, traceType uint32, outputRoot common.Hash, l2BlockNum uint64) (common.Address, error) {

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -224,12 +224,10 @@ func TestCreateTx(t *testing.T) {
 }
 
 func setupDisputeGameFactoryTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameFactoryContract) {
-	fdgAbi, err := snapshots.LoadDisputeGameFactoryABI()
-	require.NoError(t, err)
+	fdgAbi := snapshots.LoadDisputeGameFactoryABI()
 
 	stubRpc := batchingTest.NewAbiBasedRpc(t, factoryAddr, fdgAbi)
 	caller := batching.NewMultiCaller(stubRpc, batchSize)
-	factory, err := NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
-	require.NoError(t, err)
+	factory := NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
 	return stubRpc, factory
 }

--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -83,17 +83,14 @@ func toPreimageOracleLeaf(l keccakTypes.Leaf) preimageOracleLeaf {
 	}
 }
 
-func NewPreimageOracleContract(addr common.Address, caller *batching.MultiCaller) (*PreimageOracleContract, error) {
-	oracleAbi, err := snapshots.LoadPreimageOracleABI()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load preimage oracle ABI: %w", err)
-	}
+func NewPreimageOracleContract(addr common.Address, caller *batching.MultiCaller) *PreimageOracleContract {
+	oracleAbi := snapshots.LoadPreimageOracleABI()
 
 	return &PreimageOracleContract{
 		addr:        addr,
 		multiCaller: caller,
 		contract:    batching.NewBoundContract(oracleAbi, addr),
-	}, nil
+	}
 }
 
 func (c *PreimageOracleContract) Addr() common.Address {

--- a/op-challenger/game/fault/contracts/oracle_test.go
+++ b/op-challenger/game/fault/contracts/oracle_test.go
@@ -355,12 +355,10 @@ func setupPreimageOracleTestWithProposals(t *testing.T, block rpcblock.Block) (*
 }
 
 func setupPreimageOracleTest(t *testing.T) (*batchingTest.AbiBasedRpc, *PreimageOracleContract) {
-	oracleAbi, err := snapshots.LoadPreimageOracleABI()
-	require.NoError(t, err)
+	oracleAbi := snapshots.LoadPreimageOracleABI()
 
 	stubRpc := batchingTest.NewAbiBasedRpc(t, oracleAddr, oracleAbi)
-	oracleContract, err := NewPreimageOracleContract(oracleAddr, batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize))
-	require.NoError(t, err)
+	oracleContract := NewPreimageOracleContract(oracleAddr, batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize))
 
 	return stubRpc, oracleContract
 }

--- a/op-challenger/game/fault/contracts/vm.go
+++ b/op-challenger/game/fault/contracts/vm.go
@@ -20,16 +20,13 @@ type VMContract struct {
 	contract    *batching.BoundContract
 }
 
-func NewVMContract(addr common.Address, caller *batching.MultiCaller) (*VMContract, error) {
-	mipsAbi, err := snapshots.LoadMIPSABI()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load VM ABI: %w", err)
-	}
+func NewVMContract(addr common.Address, caller *batching.MultiCaller) *VMContract {
+	mipsAbi := snapshots.LoadMIPSABI()
 
 	return &VMContract{
 		multiCaller: caller,
 		contract:    batching.NewBoundContract(mipsAbi, addr),
-	}, nil
+	}
 }
 
 func (c *VMContract) Oracle(ctx context.Context) (*PreimageOracleContract, error) {
@@ -37,5 +34,5 @@ func (c *VMContract) Oracle(ctx context.Context) (*PreimageOracleContract, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to load oracle address: %w", err)
 	}
-	return NewPreimageOracleContract(results.GetAddress(0), c.multiCaller)
+	return NewPreimageOracleContract(results.GetAddress(0), c.multiCaller), nil
 }

--- a/op-challenger/game/fault/contracts/vm_test.go
+++ b/op-challenger/game/fault/contracts/vm_test.go
@@ -15,12 +15,10 @@ import (
 )
 
 func TestVMContract_Oracle(t *testing.T) {
-	vmAbi, err := snapshots.LoadMIPSABI()
-	require.NoError(t, err)
+	vmAbi := snapshots.LoadMIPSABI()
 
 	stubRpc := batchingTest.NewAbiBasedRpc(t, vmAddr, vmAbi)
-	vmContract, err := NewVMContract(vmAddr, batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize))
-	require.NoError(t, err)
+	vmContract := NewVMContract(vmAddr, batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize))
 
 	stubRpc.SetResponse(vmAddr, methodOracle, rpcblock.Latest, nil, []interface{}{oracleAddr})
 

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -111,10 +111,7 @@ func registerAlphabet(
 	claimants []common.Address,
 ) error {
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		contract, err := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
-		if err != nil {
-			return nil, err
-		}
+		contract := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
 		oracle, err := contract.GetOracle(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)
@@ -151,7 +148,7 @@ func registerAlphabet(
 	registry.RegisterGameType(faultTypes.AlphabetGameType, playerCreator)
 
 	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
-		return contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
+		return contracts.NewFaultDisputeGameContract(m, game.Proxy, caller), nil
 	}
 	registry.RegisterBondContract(faultTypes.AlphabetGameType, contractCreator)
 	return nil
@@ -162,10 +159,7 @@ func registerOracle(ctx context.Context, m metrics.Metricer, oracles OracleRegis
 	if err != nil {
 		return fmt.Errorf("failed to load implementation for game type %v: %w", gameType, err)
 	}
-	contract, err := contracts.NewFaultDisputeGameContract(m, implAddr, caller)
-	if err != nil {
-		return err
-	}
+	contract := contracts.NewFaultDisputeGameContract(m, implAddr, caller)
 	oracle, err := contract.GetOracle(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load oracle address: %w", err)
@@ -264,10 +258,7 @@ func registerCannon(
 ) error {
 	cannonPrestateProvider := cannon.NewPrestateProvider(cfg.CannonAbsolutePreState)
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		contract, err := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
-		if err != nil {
-			return nil, err
-		}
+		contract := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
 		oracle, err := contract.GetOracle(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)
@@ -304,7 +295,7 @@ func registerCannon(
 	registry.RegisterGameType(gameType, playerCreator)
 
 	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
-		return contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
+		return contracts.NewFaultDisputeGameContract(m, game.Proxy, caller), nil
 	}
 	registry.RegisterBondContract(gameType, contractCreator)
 	return nil

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -190,10 +190,7 @@ func registerAsterisc(
 ) error {
 	asteriscPrestateProvider := asterisc.NewPrestateProvider(cfg.AsteriscAbsolutePreState)
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		contract, err := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
-		if err != nil {
-			return nil, err
-		}
+		contract := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
 		oracle, err := contract.GetOracle(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)
@@ -230,7 +227,7 @@ func registerAsterisc(
 	registry.RegisterGameType(gameType, playerCreator)
 
 	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
-		return contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
+		return contracts.NewFaultDisputeGameContract(m, game.Proxy, caller), nil
 	}
 	registry.RegisterBondContract(gameType, contractCreator)
 	return nil

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -198,11 +198,8 @@ func (s *Service) initMetricsServer(cfg *opmetrics.CLIConfig) error {
 }
 
 func (s *Service) initFactoryContract(cfg *config.Config) error {
-	factoryContract, err := contracts.NewDisputeGameFactoryContract(s.metrics, cfg.GameFactoryAddress,
+	factoryContract := contracts.NewDisputeGameFactoryContract(s.metrics, cfg.GameFactoryAddress,
 		batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize))
-	if err != nil {
-		return fmt.Errorf("failed to bind the fault dispute game factory contract: %w", err)
-	}
 	s.factoryContract = factoryContract
 	return nil
 }

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -51,10 +51,7 @@ func (g *GameCallerCreator) CreateContract(game gameTypes.GameMetadata) (GameCal
 	}
 	switch game.GameType {
 	case faultTypes.CannonGameType, faultTypes.AsteriscGameType, faultTypes.AlphabetGameType:
-		fdg, err := contracts.NewFaultDisputeGameContract(g.m, game.Proxy, g.caller)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create FaultDisputeGameContract: %w", err)
-		}
+		fdg := contracts.NewFaultDisputeGameContract(g.m, game.Proxy, g.caller)
 		g.cache.Add(game.Proxy, fdg)
 		return fdg, nil
 	default:

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -209,11 +209,8 @@ func (s *Service) initMetricsServer(cfg *opmetrics.CLIConfig) error {
 }
 
 func (s *Service) initFactoryContract(cfg *config.Config) error {
-	factoryContract, err := contracts.NewDisputeGameFactoryContract(s.metrics, cfg.GameFactoryAddress,
+	factoryContract := contracts.NewDisputeGameFactoryContract(s.metrics, cfg.GameFactoryAddress,
 		batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize))
-	if err != nil {
-		return fmt.Errorf("failed to bind the fault dispute game factory contract: %w", err)
-	}
 	s.factoryContract = factoryContract
 	return nil
 }

--- a/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
@@ -39,8 +39,7 @@ func (g *OutputAlphabetGameHelper) StartChallenger(
 func (g *OutputAlphabetGameHelper) CreateHonestActor(ctx context.Context, l2Node string) *OutputHonestHelper {
 	logger := testlog.Logger(g.t, log.LevelInfo).New("role", "HonestHelper", "game", g.addr)
 	caller := batching.NewMultiCaller(g.system.NodeClient("l1").Client(), batching.DefaultBatchSize)
-	contract, err := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
-	g.require.NoError(err, "Failed to create game contact")
+	contract := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
 	prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
 	g.require.NoError(err, "Get block range")
 	splitDepth := g.SplitDepth(ctx)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -64,8 +64,7 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 	logger := testlog.Logger(g.t, log.LevelInfo).New("role", "HonestHelper", "game", g.addr)
 	l2Client := g.system.NodeClient(l2Node)
 	caller := batching.NewMultiCaller(g.system.NodeClient("l1").Client(), batching.DefaultBatchSize)
-	contract, err := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
-	g.require.NoError(err, "Failed to create game contact")
+	contract := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
 
 	prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
 	g.require.NoError(err, "Failed to load block range")
@@ -296,8 +295,7 @@ func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, 
 
 	caller := batching.NewMultiCaller(g.system.NodeClient("l1").Client(), batching.DefaultBatchSize)
 	l2Client := g.system.NodeClient(l2Node)
-	contract, err := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
-	g.require.NoError(err, "Failed to create game contact")
+	contract := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
 
 	prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
 	g.require.NoError(err, "Failed to load block range")

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -702,8 +702,7 @@ func (g *OutputGameHelper) uploadPreimage(ctx context.Context, data *types.Preim
 
 func (g *OutputGameHelper) oracle(ctx context.Context) *contracts.PreimageOracleContract {
 	caller := batching.NewMultiCaller(g.system.NodeClient("l1").Client(), batching.DefaultBatchSize)
-	contract, err := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
-	g.require.NoError(err, "Failed to create game contract")
+	contract := contracts.NewFaultDisputeGameContract(contractMetrics.NoopContractMetrics, g.addr, caller)
 	oracle, err := contract.GetOracle(ctx)
 	g.require.NoError(err, "Failed to create oracle contract")
 	return oracle

--- a/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
+++ b/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
@@ -43,8 +43,7 @@ func NewHelper(t *testing.T, opts *bind.TransactOpts, client *ethclient.Client, 
 	oracleBindings, err := bindings.NewPreimageOracle(addr, client)
 	require.NoError(err)
 
-	oracle, err := contracts.NewPreimageOracleContract(addr, batching.NewMultiCaller(client.Client(), batching.DefaultBatchSize))
-	require.NoError(err)
+	oracle := contracts.NewPreimageOracleContract(addr, batching.NewMultiCaller(client.Client(), batching.DefaultBatchSize))
 	return &Helper{
 		t:              t,
 		require:        require,

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -1,41 +1,47 @@
 package snapshots
 
 import (
-	"embed"
-	"fmt"
-	"path/filepath"
+	"bytes"
+	_ "embed"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 )
 
-//go:embed abi
-var abis embed.FS
+//go:embed abi/DisputeGameFactory.json
+var disputeGameFactory []byte
 
-func LoadDisputeGameFactoryABI() (*abi.ABI, error) {
-	return loadABI("DisputeGameFactory")
+//go:embed abi/FaultDisputeGame.json
+var faultDisputeGame []byte
+
+//go:embed abi/PreimageOracle.json
+var preimageOracle []byte
+
+//go:embed abi/MIPS.json
+var mips []byte
+
+//go:embed abi/DelayedWETH.json
+var delayedWETH []byte
+
+func LoadDisputeGameFactoryABI() *abi.ABI {
+	return loadABI(disputeGameFactory)
 }
-func LoadFaultDisputeGameABI() (*abi.ABI, error) {
-	return loadABI("FaultDisputeGame")
+func LoadFaultDisputeGameABI() *abi.ABI {
+	return loadABI(faultDisputeGame)
 }
-func LoadPreimageOracleABI() (*abi.ABI, error) {
-	return loadABI("PreimageOracle")
+func LoadPreimageOracleABI() *abi.ABI {
+	return loadABI(preimageOracle)
 }
-func LoadMIPSABI() (*abi.ABI, error) {
-	return loadABI("MIPS")
+func LoadMIPSABI() *abi.ABI {
+	return loadABI(mips)
 }
-func LoadDelayedWETHABI() (*abi.ABI, error) {
-	return loadABI("DelayedWETH")
+func LoadDelayedWETHABI() *abi.ABI {
+	return loadABI(delayedWETH)
 }
 
-func loadABI(name string) (*abi.ABI, error) {
-	in, err := abis.Open(filepath.Join("abi", name+".json"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load ABI for contract %v: %w", name, err)
-	}
-	defer in.Close()
-	if parsed, err := abi.JSON(in); err != nil {
-		return nil, err
+func loadABI(json []byte) *abi.ABI {
+	if parsed, err := abi.JSON(bytes.NewReader(json)); err != nil {
+		panic(err)
 	} else {
-		return &parsed, nil
+		return &parsed
 	}
 }

--- a/packages/contracts-bedrock/snapshots/abi_loader_test.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader_test.go
@@ -10,7 +10,7 @@ import (
 func TestLoadABIs(t *testing.T) {
 	tests := []struct {
 		contract string
-		method   func() (*abi.ABI, error)
+		method   func() *abi.ABI
 	}{
 		{"DisputeGameFactory", LoadDisputeGameFactoryABI},
 		{"FaultDisputeGame", LoadFaultDisputeGameABI},
@@ -21,8 +21,7 @@ func TestLoadABIs(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.contract, func(t *testing.T) {
-			actual, err := test.method()
-			require.NoError(t, err)
+			actual := test.method()
 			require.NotNil(t, actual)
 		})
 	}


### PR DESCRIPTION
**Description**

Rather than embedding the entire ABI directory, embed just the ABI json files actually being used.

Since the file can no longer be not found and the ABI JSON is generated and checked by CI, switch to `panic` if it is invalid instead of returning an error.  Remove a lot of error handling code as a result. The `go:embed` will cause a compiler error if the file no longer exists and the unit tests confirm it can be parsed (above and beyond CI checking the content is in sync with the contracts).