### PR TITLE
dispute-mon: Load resolved state of claims from resolvedSubgames map

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -455,6 +455,31 @@ func TestFaultDisputeGame_ClaimCreditTx(t *testing.T) {
 	})
 }
 
+func TestFaultDisputeGame_IsResolved(t *testing.T) {
+	stubRpc, game := setupFaultDisputeGameTest(t)
+
+	block := rpcblock.ByNumber(482)
+
+	claims := []faultTypes.Claim{
+		{ContractIndex: 1},
+		{ContractIndex: 5},
+		{ContractIndex: 13},
+	}
+	claimIdxs := []*big.Int{big.NewInt(1), big.NewInt(5), big.NewInt(13)}
+	expected := []bool{false, true, true}
+
+	for i, idx := range claimIdxs {
+		stubRpc.SetResponse(fdgAddr, methodResolvedSubgames, block, []interface{}{idx}, []interface{}{expected[i]})
+	}
+
+	actual, err := game.IsResolved(context.Background(), block, claims...)
+	require.NoError(t, err)
+	require.Equal(t, len(expected), len(actual))
+	for i := range expected {
+		require.Equal(t, expected[i], actual[i])
+	}
+}
+
 func setupFaultDisputeGameTest(t *testing.T) (*batchingTest.AbiBasedRpc, *FaultDisputeGameContract) {
 	fdgAbi, err := snapshots.LoadFaultDisputeGameABI()
 	require.NoError(t, err)

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -29,6 +29,7 @@ type GameCaller interface {
 	GetAllClaims(context.Context, rpcblock.Block) ([]faultTypes.Claim, error)
 	BondCaller
 	BalanceCaller
+	ClaimCaller
 }
 
 type GameCallerCreator struct {

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -196,6 +196,8 @@ type mockGameCaller struct {
 	withdrawalsCalls  int
 	withdrawalsErr    error
 	withdrawals       []*contracts.WithdrawalRequest
+	resolvedErr       error
+	resolved          map[int]bool
 }
 
 func (m *mockGameCaller) GetRequiredBonds(ctx context.Context, block rpcblock.Block, positions ...*big.Int) ([]*big.Int, error) {
@@ -264,6 +266,17 @@ func (m *mockGameCaller) GetBalance(_ context.Context, _ rpcblock.Block) (*big.I
 		return nil, common.Address{}, m.balanceErr
 	}
 	return m.balance, m.balanceAddr, nil
+}
+
+func (m *mockGameCaller) IsResolved(_ context.Context, _ rpcblock.Block, claims ...faultTypes.Claim) ([]bool, error) {
+	if m.resolvedErr != nil {
+		return nil, m.resolvedErr
+	}
+	resolved := make([]bool, len(claims))
+	for i, claim := range claims {
+		resolved[i] = m.resolved[claim.ContractIndex]
+	}
+	return resolved, nil
 }
 
 type mockEnricher struct {


### PR DESCRIPTION
**Description**

Loads the resolved status of claims from the `resolvedSubgames` map instead of checking for a sentinel `bond` value.

**Tests**

Updated unit tests. Ran against local devnet to confirm data was loaded correctly.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/791
