### PR TITLE
deps: update foundry

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "8513f619ca6781fe62d59b1bf2a8bb1bbab19927",
+  "foundry": "63fff3510408b552f11efb8196f48cfe6c1da664",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
**Description**

Updates foundry to `63fff3510408b552f11efb8196f48cfe6c1da664`
which includes https://github.com/foundry-rs/foundry/pull/7738.
This fixes the issue https://github.com/foundry-rs/foundry/issues/7732
which was preventing https://github.com/ethereum-optimism/optimism/pull/10106
from just working.

Props to the foundry devs for fixing our issues very quickly, unblocking
our ability to ship.

Need to follow up with a bump to `ci-builder` such that it includes this
release of foundry and then rebase #10106 on top so that it can pass
tests.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

