### PR TITLE
op-e2e: Avoid panics on conductor startup failure

### DIFF
--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -147,7 +147,9 @@ func setupHAInfra(t *testing.T, ctx context.Context) (*System, map[string]*condu
 			}
 
 			for _, c := range conductors {
-				if serr := c.service.Stop(ctx); serr != nil {
+				if c == nil || c.service == nil {
+					// pass. Sometimes we can get nil in this map
+				} else if serr := c.service.Stop(ctx); serr != nil {
 					t.Log("Failed to stop conductor", "error", serr)
 				}
 			}


### PR DESCRIPTION
**Description**

This attempts to fix a panic that occurs during op-conductor test failures. If op-conductor cannot start up, it closes down, but it appears to panic on those shutdowns.

**Additional context**

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1cdccdf]

goroutine 33175 [running]:
testing.tRunner.func1.2({0x203b000, 0x4606f00})
        /usr/local/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1548 +0x397
panic({0x203b000?, 0x4606f00?})
        /usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/ethereum-optimism/optimism/op-e2e.setupHAInfra.func1()
        /root/project/op-e2e/sequencer_failover_setup.go:150 +0x13f
github.com/ethereum-optimism/optimism/op-e2e.setupHAInfra(0xc005883040, {0x3461520, 0x4ba9220})
        /root/project/op-e2e/sequencer_failover_setup.go:188 +0x70f
github.com/ethereum-optimism/optimism/op-e2e.setupSequencerFailoverTest.func1()
        /root/project/op-e2e/sequencer_failover_setup.go:67 +0x1f
github.com/ethereum-optimism/optimism/op-service/retry.Do2[...].func1()
        /root/project/op-service/retry/operation.go:31 +0x13
github.com/ethereum-optimism/optimism/op-service/retry.Do[...]({0x3461520?, 0x4ba9220}, 0x5, {0x3449280, 0x48d9178}, 0xc01c1b1c48)
        /root/project/op-service/retry/operation.go:52 +0x109
github.com/ethereum-optimism/optimism/op-service/retry.Do2[...]({0x3461520?, 0x4ba9220?}, 0x0?, {0x3449280?, 0x48d9178?}, 0xc0000691a7?)
        /root/project/op-service/retry/operation.go:34 +0x5a
github.com/ethereum-optimism/optimism/op-e2e.setupSequencerFailoverTest(0xc005883040)
        /root/project/op-e2e/sequencer_failover_setup.go:66 +0xb1
github.com/ethereum-optimism/optimism/op-e2e.TestSequencerFailover_ConductorRPC(0xc005883040)
        /root/project/op-e2e/sequencer_failover_test.go:30 +0x39
testing.tRunner(0xc005883040, 0x3163a10)
        /usr/local/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1648 +0x3ad
```