### PR TITLE
ci: fix pnpm version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,9 +4,9 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v3
       with:
-        version: 8.6.5
+        version: 9
     - name: Setup node
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
**Description**

Fixes broken release CI: https://github.com/ethereum-optimism/optimism/actions/runs/8788831115/job/24117187007

We have too many dependencies in the monorepo to manage them all without
accidentally breaking things. We will remove `pnpm` soon TM.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

