### PR TITLE
op-challenger: Rename `--l2-rpc` to `--l2-eth-rpc` and log warning for deprecated `--cannon-l2`

### DIFF
--- a/docs/fault-proof-alpha/run-challenger.md
+++ b/docs/fault-proof-alpha/run-challenger.md
@@ -45,7 +45,7 @@ make op-challenger op-program cannon
   --cannon-bin ./cannon/bin/cannon \
   --cannon-server ./op-program/bin/op-program \
   --cannon-prestate <PRESTATE> \
-  --l2-rpc <L2_URL> \
+  --l2-eth-rpc <L2_URL> \
   --private-key <PRIVATE_KEY>
 ```
 

--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -44,7 +44,7 @@ DISPUTE_GAME_FACTORY=$(jq -r .DisputeGameFactoryProxy .devnet/addresses.json)
   --cannon-bin ./cannon/bin/cannon \
   --cannon-server ./op-program/bin/op-program \
   --cannon-prestate ./op-program/bin/prestate.json \
-  --l2-rpc http://localhost:9545 \
+  --l2-eth-rpc http://localhost:9545 \
   --mnemonic "test test test test test test test test test test test junk" \
   --hd-path "m/44'/60'/0'/0/8" \
   --num-confirmations 1

--- a/op-challenger/cmd/main.go
+++ b/op-challenger/cmd/main.go
@@ -59,7 +59,7 @@ func run(ctx context.Context, args []string, action ConfiguredLifecycle) error {
 		}
 		logger.Info("Starting op-challenger", "version", VersionWithMeta)
 
-		cfg, err := flags.NewConfigFromCLI(ctx)
+		cfg, err := flags.NewConfigFromCLI(ctx, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -23,7 +23,7 @@ var (
 	gameFactoryAddressValue = "0xbb00000000000000000000000000000000000000"
 	cannonNetwork           = "op-mainnet"
 	testNetwork             = "op-sepolia"
-	l2Rpc                   = "http://example.com:9545"
+	l2EthRpc                = "http://example.com:9545"
 	cannonBin               = "./bin/cannon"
 	cannonServer            = "./bin/op-program"
 	cannonPreState          = "./pre.json"
@@ -305,25 +305,25 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--l2-rpc"))
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--l2-eth-rpc"))
 			})
 
 			t.Run("RequiredForAsteriscTrace", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag l2-rpc is required", addRequiredArgsExcept(traceType, "--l2-rpc"))
+				verifyArgsInvalid(t, "flag l2-eth-rpc is required", addRequiredArgsExcept(traceType, "--l2-eth-rpc"))
 			})
 
 			t.Run("ValidLegacy", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--l2-rpc", fmt.Sprintf("--cannon-l2=%s", l2Rpc)))
-				require.Equal(t, l2Rpc, cfg.L2Rpc)
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--l2-eth-rpc", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
+				require.Equal(t, l2EthRpc, cfg.L2Rpc)
 			})
 
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgs(traceType))
-				require.Equal(t, l2Rpc, cfg.L2Rpc)
+				require.Equal(t, l2EthRpc, cfg.L2Rpc)
 			})
 
 			t.Run("InvalidUsingBothFlags", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag cannon-l2 and l2-rpc must not be both set", addRequiredArgsExcept(traceType, "", fmt.Sprintf("--cannon-l2=%s", l2Rpc)))
+				verifyArgsInvalid(t, "flag cannon-l2 and l2-eth-rpc must not be both set", addRequiredArgsExcept(traceType, "", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
 			})
 		})
 
@@ -492,21 +492,21 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--l2-rpc"))
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--l2-eth-rpc"))
 			})
 
 			t.Run("RequiredForCannonTrace", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag l2-rpc is required", addRequiredArgsExcept(traceType, "--l2-rpc"))
+				verifyArgsInvalid(t, "flag l2-eth-rpc is required", addRequiredArgsExcept(traceType, "--l2-eth-rpc"))
 			})
 
 			t.Run("ValidLegacy", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--l2-rpc", fmt.Sprintf("--cannon-l2=%s", l2Rpc)))
-				require.Equal(t, l2Rpc, cfg.L2Rpc)
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--l2-eth-rpc", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
+				require.Equal(t, l2EthRpc, cfg.L2Rpc)
 			})
 
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgs(traceType))
-				require.Equal(t, l2Rpc, cfg.L2Rpc)
+				require.Equal(t, l2EthRpc, cfg.L2Rpc)
 			})
 		})
 
@@ -777,7 +777,7 @@ func addRequiredCannonArgs(args map[string]string) {
 	args["--cannon-bin"] = cannonBin
 	args["--cannon-server"] = cannonServer
 	args["--cannon-prestate"] = cannonPreState
-	args["--l2-rpc"] = l2Rpc
+	args["--l2-eth-rpc"] = l2EthRpc
 	addRequiredOutputArgs(args)
 }
 
@@ -786,7 +786,7 @@ func addRequiredAsteriscArgs(args map[string]string) {
 	args["--asterisc-bin"] = asteriscBin
 	args["--asterisc-server"] = asteriscServer
 	args["--asterisc-prestate"] = asteriscPreState
-	args["--l2-rpc"] = l2Rpc
+	args["--l2-eth-rpc"] = l2EthRpc
 	addRequiredOutputArgs(args)
 }
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -73,10 +73,10 @@ var (
 		EnvVars: prefixEnvVars("MAX_CONCURRENCY"),
 		Value:   uint(runtime.NumCPU()),
 	}
-	L2RpcFlag = &cli.StringFlag{
-		Name:    "l2-rpc",
+	L2EthRpcFlag = &cli.StringFlag{
+		Name:    "l2-eth-rpc",
 		Usage:   "L2 Address of L2 JSON-RPC endpoint to use (eth and debug namespace required)  (cannon/asterisc trace type only)",
-		EnvVars: prefixEnvVars("L2_RPC"),
+		EnvVars: prefixEnvVars("L2_ETH_RPC"),
 	}
 	MaxPendingTransactionsFlag = &cli.Uint64Flag{
 		Name:    "max-pending-tx",
@@ -136,7 +136,7 @@ var (
 	}
 	CannonL2Flag = &cli.StringFlag{
 		Name:    "cannon-l2",
-		Usage:   fmt.Sprintf("Deprecated: Use %v instead", L2RpcFlag.Name),
+		Usage:   fmt.Sprintf("Deprecated: Use %v instead", L2EthRpcFlag.Name),
 		EnvVars: prefixEnvVars("CANNON_L2"),
 	}
 	CannonSnapshotFreqFlag = &cli.UintFlag{
@@ -229,7 +229,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	TraceTypeFlag,
 	MaxConcurrencyFlag,
-	L2RpcFlag,
+	L2EthRpcFlag,
 	MaxPendingTransactionsFlag,
 	HTTPPollInterval,
 	AdditionalBondClaimants,
@@ -289,9 +289,9 @@ func CheckCannonFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(CannonPreStateFlag.Name) && !ctx.IsSet(CannonPreStatesURLFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", CannonPreStatesURLFlag.Name, CannonPreStateFlag.Name)
 	}
-	// CannonL2Flag is checked because it is an alias with L2RpcFlag
-	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2RpcFlag.Name) {
-		return fmt.Errorf("flag %s is required", L2RpcFlag.Name)
+	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
+	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
+		return fmt.Errorf("flag %s is required", L2EthRpcFlag.Name)
 	}
 	return nil
 }
@@ -316,9 +316,9 @@ func CheckAsteriscFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(AsteriscPreStateFlag.Name) {
 		return fmt.Errorf("flag %s is required", AsteriscPreStateFlag.Name)
 	}
-	// CannonL2Flag is checked because it is an alias with L2RpcFlag
-	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2RpcFlag.Name) {
-		return fmt.Errorf("flag %s is required", L2RpcFlag.Name)
+	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
+	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
+		return fmt.Errorf("flag %s is required", L2EthRpcFlag.Name)
 	}
 	return nil
 }
@@ -362,16 +362,16 @@ func parseTraceTypes(ctx *cli.Context) ([]config.TraceType, error) {
 }
 
 func getL2Rpc(ctx *cli.Context, logger log.Logger) (string, error) {
-	if ctx.IsSet(CannonL2Flag.Name) && ctx.IsSet(L2RpcFlag.Name) {
-		return "", fmt.Errorf("flag %v and %v must not be both set", CannonL2Flag.Name, L2RpcFlag.Name)
+	if ctx.IsSet(CannonL2Flag.Name) && ctx.IsSet(L2EthRpcFlag.Name) {
+		return "", fmt.Errorf("flag %v and %v must not be both set", CannonL2Flag.Name, L2EthRpcFlag.Name)
 	}
 	l2Rpc := ""
 	if ctx.IsSet(CannonL2Flag.Name) {
-		logger.Warn(fmt.Sprintf("flag %v is deprecated, please use %v", CannonL2Flag.Name, L2RpcFlag.Name))
+		logger.Warn(fmt.Sprintf("flag %v is deprecated, please use %v", CannonL2Flag.Name, L2EthRpcFlag.Name))
 		l2Rpc = ctx.String(CannonL2Flag.Name)
 	}
-	if ctx.IsSet(L2RpcFlag.Name) {
-		l2Rpc = ctx.String(L2RpcFlag.Name)
+	if ctx.IsSet(L2EthRpcFlag.Name) {
+		l2Rpc = ctx.String(L2EthRpcFlag.Name)
 	}
 	return l2Rpc, nil
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
@@ -360,12 +361,13 @@ func parseTraceTypes(ctx *cli.Context) ([]config.TraceType, error) {
 	return traceTypes, nil
 }
 
-func getL2Rpc(ctx *cli.Context) (string, error) {
+func getL2Rpc(ctx *cli.Context, logger log.Logger) (string, error) {
 	if ctx.IsSet(CannonL2Flag.Name) && ctx.IsSet(L2RpcFlag.Name) {
 		return "", fmt.Errorf("flag %v and %v must not be both set", CannonL2Flag.Name, L2RpcFlag.Name)
 	}
 	l2Rpc := ""
 	if ctx.IsSet(CannonL2Flag.Name) {
+		logger.Warn(fmt.Sprintf("flag %v is deprecated, please use %v", CannonL2Flag.Name, L2RpcFlag.Name))
 		l2Rpc = ctx.String(CannonL2Flag.Name)
 	}
 	if ctx.IsSet(L2RpcFlag.Name) {
@@ -375,7 +377,7 @@ func getL2Rpc(ctx *cli.Context) (string, error) {
 }
 
 // NewConfigFromCLI parses the Config from the provided flags or environment variables.
-func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
+func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, error) {
 	traceTypes, err := parseTraceTypes(ctx)
 	if err != nil {
 		return nil, err
@@ -424,7 +426,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 		}
 		cannonPrestatesURL = parsed
 	}
-	l2Rpc, err := getL2Rpc(ctx)
+	l2Rpc, err := getL2Rpc(ctx, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -204,7 +204,7 @@ services:
       OP_CHALLENGER_CANNON_BIN: ./cannon/bin/cannon
       OP_CHALLENGER_CANNON_SERVER: /op-program/op-program
       OP_CHALLENGER_CANNON_PRESTATE: /op-program/prestate.json
-      OP_CHALLENGER_CANNON_L2: http://l2:8545
+      OP_CHALLENGER_L2_ETH_RPC: http://l2:8545
       OP_CHALLENGER_MNEMONIC: test test test test test test test test test test test junk
       OP_CHALLENGER_HD_PATH: "m/44'/60'/0'/0/4"
       OP_CHALLENGER_NUM_CONFIRMATIONS: 1


### PR DESCRIPTION
**Description**

Rename the new `--l2-rpc` option to `--l2-eth-rpc` so it's consistent with `--l1-eth-rpc`.

Log a warning when the deprecated `--cannon-l2` option is used telling uses to switch to `--l2-eth-rpc`.
