### PR TITLE
op-proposer: Add option to wait for rollup sync during startup

### DIFF
--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -72,6 +72,13 @@ var (
 		Value:   2 * time.Minute,
 		EnvVars: prefixEnvVars("ACTIVE_SEQUENCER_CHECK_DURATION"),
 	}
+	WaitNodeSyncFlag = &cli.BoolFlag{
+		Name: "wait-node-sync",
+		Usage: "Indicates if, during startup, the proposer should wait for the rollup node to sync to " +
+			"the current L1 tip before proceeding with its driver loop.",
+		Value:   false,
+		EnvVars: prefixEnvVars("WAIT_NODE_SYNC"),
+	}
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
@@ -90,6 +97,7 @@ var optionalFlags = []cli.Flag{
 	ProposalIntervalFlag,
 	DisputeGameTypeFlag,
 	ActiveSequencerCheckDurationFlag,
+	WaitNodeSyncFlag,
 }
 
 func init() {

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -58,6 +58,9 @@ type CLIConfig struct {
 
 	// ActiveSequencerCheckDuration is the duration between checks to determine the active sequencer endpoint.
 	ActiveSequencerCheckDuration time.Duration
+
+	// Whether to wait for the sequencer to sync to a recent block at startup.
+	WaitNodeSync bool
 }
 
 func (c *CLIConfig) Check() error {
@@ -106,5 +109,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ProposalInterval:             ctx.Duration(flags.ProposalIntervalFlag.Name),
 		DisputeGameType:              uint32(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
 		ActiveSequencerCheckDuration: ctx.Duration(flags.ActiveSequencerCheckDurationFlag.Name),
+		WaitNodeSync:                 ctx.Bool(flags.WaitNodeSyncFlag.Name),
 	}
 }

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -44,6 +44,8 @@ type ProposerConfig struct {
 	// is never valid on an alternative L1 chain that would produce different L2 data.
 	// This option is not necessary when higher proposal latency is acceptable and L1 is healthy.
 	AllowNonFinalized bool
+
+	WaitNodeSync bool
 }
 
 type ProposerService struct {
@@ -89,6 +91,7 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	ps.PollInterval = cfg.PollInterval
 	ps.NetworkTimeout = cfg.TxMgrConfig.NetworkTimeout
 	ps.AllowNonFinalized = cfg.AllowNonFinalized
+	ps.WaitNodeSync = cfg.WaitNodeSync
 
 	ps.initL2ooAddress(cfg)
 	ps.initDGF(cfg)


### PR DESCRIPTION
**Description**

Adds an optional flag to wait for the rollup node to sync to the current L1 tip during the op-proposer's startup.

**Tests**

No tests added. Main functionality is implemented by `op-service/dial` package's `WaitNodeSync` function, which is already tested within that package.

**Additional context**

Same basic idea as https://github.com/ethereum-optimism/optimism/pull/10193, which added the same flag and option to run `WaitNodeSync` during the `op-batcher` startup.