### PR TITLE
op-batcher: Always use recent block from startup tx check

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -355,11 +355,11 @@ func (l *BatchSubmitter) waitNodeSync() error {
 		l.Log.Info("Checking for recently submitted batcher transactions on L1")
 		recentBlock, found, err := eth.CheckRecentTxs(ctx, l.L1Client, l.Config.CheckRecentTxsDepth, l.Txmgr.From())
 		if err != nil {
-			return fmt.Errorf("failed when checking recent batcher txs: %w", err)
+			return fmt.Errorf("failed checking recent batcher txs: %w", err)
 		}
-		if found {
-			l1TargetBlock = recentBlock
-		}
+		l.Log.Info("Checked for recently submitted batcher transactions on L1",
+			"l1_head", l1Tip, "l1_recent", recentBlock, "found", found)
+		l1TargetBlock = recentBlock
 	}
 
 	return dial.WaitRollupSync(l.shutdownCtx, l.Log, rollupClient, l1TargetBlock, time.Second*12)


### PR DESCRIPTION
**Description**

Changes the startup recent-tx-check to always use the returned block number by the check, also in the case that no recent tx was found. If we don't find a recent batcher transaction, we can safely wait for the node to sync to that oldest checked block, which will be quicker than waiting for it to sync to the current head. 

**Tests**

The underlying recent tx and node syncing functions are tested. This is just changing how they're tied together and we don't test this yet.

**Additional context**

This shortcut is actually the reason why we implemented recent tx checking.

