### PR TITLE
op-challenger: Read created game address from receipt

### DIFF
--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -94,7 +94,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 	fmt.Printf(lineFormat, "Idx", "Game", "Type", "Created (Local)", "L2 Block", "Output Root", "Claims", "Status")
 	for idx, game := range infos {
 		if game.err != nil {
-			return err
+			return game.err
 		}
 		created := time.Unix(int64(game.Timestamp), 0).Format(time.DateTime)
 		fmt.Printf(lineFormat,

--- a/op-challenger/tools/create_game.go
+++ b/op-challenger/tools/create_game.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type GameCreator struct {
+	contract *contracts.DisputeGameFactoryContract
+	txMgr    txmgr.TxManager
+}
+
+func NewGameCreator(contract *contracts.DisputeGameFactoryContract, txMgr txmgr.TxManager) *GameCreator {
+	return &GameCreator{
+		contract: contract,
+		txMgr:    txMgr,
+	}
+}
+
+func (g *GameCreator) CreateGame(ctx context.Context, outputRoot common.Hash, traceType uint64, l2BlockNum uint64) (common.Address, error) {
+	txCandidate, err := g.contract.CreateTx(ctx, uint32(traceType), outputRoot, l2BlockNum)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to create tx: %w", err)
+	}
+
+	rct, err := g.txMgr.Send(ctx, txCandidate)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to send tx: %w", err)
+	}
+	if rct.Status != types.ReceiptStatusSuccessful {
+		return common.Address{}, fmt.Errorf("game creation transaction (%v) reverted", rct.TxHash.Hex())
+	}
+
+	gameAddr, _, _, err := g.contract.DecodeDisputeGameCreatedLog(rct)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to decode game created: %w", err)
+	}
+	return gameAddr, nil
+}

--- a/op-service/sources/batching/bound.go
+++ b/op-service/sources/batching/bound.go
@@ -6,11 +6,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
 	ErrUnknownMethod = errors.New("unknown method")
 	ErrInvalidCall   = errors.New("invalid call")
+	ErrUnknownEvent  = errors.New("unknown event")
+	ErrInvalidEvent  = errors.New("invalid event")
 )
 
 type BoundContract struct {
@@ -47,4 +50,41 @@ func (b *BoundContract) DecodeCall(data []byte) (string, *CallResult, error) {
 		return "", nil, fmt.Errorf("%w: %v", ErrInvalidCall, err.Error())
 	}
 	return method.Name, &CallResult{args}, nil
+}
+
+func (b *BoundContract) DecodeEvent(log *types.Log) (string, *CallResult, error) {
+	if len(log.Topics) == 0 {
+		return "", nil, ErrUnknownEvent
+	}
+	event, err := b.abi.EventByID(log.Topics[0])
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %v", ErrUnknownEvent, err.Error())
+	}
+
+	argsMap := make(map[string]interface{})
+	var indexed abi.Arguments
+	for _, arg := range event.Inputs {
+		if arg.Indexed {
+			indexed = append(indexed, arg)
+		}
+	}
+	if err := abi.ParseTopicsIntoMap(argsMap, indexed, log.Topics[1:]); err != nil {
+		return "", nil, fmt.Errorf("%w indexed topics: %v", ErrInvalidEvent, err.Error())
+	}
+
+	nonIndexed := event.Inputs.NonIndexed()
+	if len(nonIndexed) > 0 {
+		if err := nonIndexed.UnpackIntoMap(argsMap, log.Data); err != nil {
+			return "", nil, fmt.Errorf("%w non-indexed topics: %v", ErrInvalidEvent, err.Error())
+		}
+	}
+	args := make([]interface{}, 0, len(event.Inputs))
+	for _, input := range event.Inputs {
+		val, ok := argsMap[input.Name]
+		if !ok {
+			return "", nil, fmt.Errorf("%w missing argument: %v", ErrUnknownEvent, input.Name)
+		}
+		args = append(args, val)
+	}
+	return event.Name, &CallResult{args}, nil
 }

--- a/op-service/sources/batching/bound_test.go
+++ b/op-service/sources/batching/bound_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,5 +50,89 @@ func TestDecodeCall(t *testing.T) {
 		require.Equal(t, name, method)
 		require.Equal(t, spender, args.GetAddress(0))
 		require.Zero(t, amount.Cmp(args.GetBigInt(1)))
+	})
+}
+
+func TestDecodeEvent(t *testing.T) {
+	testAbi, err := bindings.ERC20MetaData.GetAbi()
+	require.NoError(t, err)
+
+	// event Transfer(address indexed from, address indexed to, uint256 amount);
+	event := testAbi.Events["Transfer"]
+
+	contract := NewBoundContract(testAbi, common.Address{0xaa})
+	t.Run("NoTopics", func(t *testing.T) {
+		log := &types.Log{}
+		_, _, err := contract.DecodeEvent(log)
+		require.ErrorIs(t, err, ErrUnknownEvent)
+	})
+
+	t.Run("UnknownEvent", func(t *testing.T) {
+		log := &types.Log{
+			Topics: []common.Hash{{0xaa}},
+		}
+		_, _, err := contract.DecodeEvent(log)
+		require.ErrorIs(t, err, ErrUnknownEvent)
+	})
+
+	t.Run("InvalidTopics", func(t *testing.T) {
+		amount := big.NewInt(828274)
+		data, err := event.Inputs.NonIndexed().Pack(amount)
+		require.NoError(t, err)
+		log := &types.Log{
+			Topics: []common.Hash{
+				event.ID,
+				common.BytesToHash(common.Address{0xaa}.Bytes()),
+				// Missing topic for to indexed value
+			},
+			Data: data,
+		}
+		_, _, err = contract.DecodeEvent(log)
+		require.ErrorIs(t, err, ErrInvalidEvent)
+	})
+
+	t.Run("MissingData", func(t *testing.T) {
+		log := &types.Log{
+			Topics: []common.Hash{
+				event.ID,
+				common.BytesToHash(common.Address{0xaa}.Bytes()),
+				common.BytesToHash(common.Address{0xbb}.Bytes()),
+			},
+		}
+		_, _, err := contract.DecodeEvent(log)
+		require.ErrorIs(t, err, ErrInvalidEvent)
+	})
+
+	t.Run("InvalidData", func(t *testing.T) {
+		log := &types.Log{
+			Topics: []common.Hash{
+				event.ID,
+				common.BytesToHash(common.Address{0xaa}.Bytes()),
+				common.BytesToHash(common.Address{0xbb}.Bytes()),
+			},
+			Data: []byte{0xbb, 0xcc},
+		}
+		_, _, err := contract.DecodeEvent(log)
+		require.ErrorIs(t, err, ErrInvalidEvent)
+	})
+
+	t.Run("ValidEvent", func(t *testing.T) {
+		amount := big.NewInt(828274)
+		data, err := event.Inputs.NonIndexed().Pack(amount)
+		require.NoError(t, err)
+		log := &types.Log{
+			Topics: []common.Hash{
+				event.ID,
+				common.BytesToHash(common.Address{0xaa}.Bytes()),
+				common.BytesToHash(common.Address{0xbb}.Bytes()),
+			},
+			Data: data,
+		}
+		name, result, err := contract.DecodeEvent(log)
+		require.NoError(t, err)
+		require.Equal(t, name, event.Name)
+		require.Equal(t, common.Address{0xaa}, result.GetAddress(0))
+		require.Equal(t, common.Address{0xbb}, result.GetAddress(1))
+		require.Zerof(t, amount.Cmp(result.GetBigInt(2)), "expected %v but got %v", amount, result.GetBigInt(2))
 	})
 }


### PR DESCRIPTION
**Description**

Extracts the game creation logic into reusable code in preparation for a new subcommand to periodically create invalid games for testing.

**Tests**

Added unit tests. Confirmed with manual testing.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/715
