### PR TITLE
fpac: reserve spacer slot in OptimismPortal2

### DIFF
--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -352,6 +352,9 @@ library ChainAssertions {
             require(address(portal.superchainConfig()) == address(0));
             require(portal.l2Sender() == Constants.DEFAULT_L2_SENDER);
         }
+        // This slot is the custom gas token _balance and this check ensures
+        // that it stays unset for forwards compatibility with custom gas token.
+        require(vm.load(address(portal), bytes32(uint256(61))) == bytes32(0));
     }
 
     /// @notice Asserts that the ProtocolVersions is setup correctly

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -37,7 +37,7 @@
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x34432a932e5deaebb856320d6e5d243a3db5d9a8e5e572915346875923ba70be",
-    "sourceCodeHash": "0x16ac8757439b3045a08476d7486a420ff6ed53db519b0191442a6dff8cd1ed79"
+    "sourceCodeHash": "0x308aee7a9c1a782ce630ca52c613738b78250789f5bd97d627cfe598342dd86c"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x72cd467e8bcf019c02675d72ab762e088bcc9cc0f1a4e9f587fa4589f7fdd1b8",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -37,7 +37,7 @@
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x34432a932e5deaebb856320d6e5d243a3db5d9a8e5e572915346875923ba70be",
-    "sourceCodeHash": "0x308aee7a9c1a782ce630ca52c613738b78250789f5bd97d627cfe598342dd86c"
+    "sourceCodeHash": "0xe90774d3f89f937c56439fb7d567106bef0be0fc298fe07bbbc74f2b08445aa5"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x72cd467e8bcf019c02675d72ab762e088bcc9cc0f1a4e9f587fa4589f7fdd1b8",

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
@@ -117,5 +117,12 @@
     "offset": 0,
     "slot": "60",
     "type": "mapping(bytes32 => address[])"
+  },
+  {
+    "bytes": "32",
+    "label": "spacer_61_0_32",
+    "offset": 0,
+    "slot": "61",
+    "type": "bytes32"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -94,6 +94,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     /// @notice Mapping of withdrawal hashes to addresses that have submitted a proof for the withdrawal.
     mapping(bytes32 => address[]) public proofSubmitters;
 
+    /// @custom:spacer _balance (custom gas token)
+    /// @notice Spacer for backwards compatibility.
+    bytes32 private spacer_61_0_32;
+
     /// @notice Emitted when a transaction is deposited from L1 to L2.
     ///         The parameters of this event are read by the rollup node and used to derive deposit
     ///         transactions on L2.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -95,7 +95,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     mapping(bytes32 => address[]) public proofSubmitters;
 
     /// @custom:spacer _balance (custom gas token)
-    /// @notice Spacer for backwards compatibility.
+    /// @notice Spacer for forwards compatibility.
     bytes32 private spacer_61_0_32;
 
     /// @notice Emitted when a transaction is deposited from L1 to L2.


### PR DESCRIPTION
**Description**

Allows for merging of `OptimismPortal` that supports
custom gas token and also `OptimismPortal2` that has
a modified storage layout. The `OptimismPortal` has
spacers to account for the storage layout changes in
`OptimismPortal2` and it adds its new storage slot
at the location that the spacer is added in.

This faciliates the ability to merge the portal
codebases in the future.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

