### PR TITLE
op-challenger: Support multiple prestates

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -462,12 +462,27 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
+				verifyArgsInvalid(t, "flag cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
 			})
 
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-prestate", "--cannon-prestate=./pre.json"))
 				require.Equal(t, "./pre.json", cfg.CannonAbsolutePreState)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonAbsolutePrestateBaseURL-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-prestates-url"))
+			})
+
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-prestates-url", "--cannon-prestates-url=http://localhost/foo"))
+				require.Equal(t, "http://localhost/foo", cfg.CannonAbsolutePreStateBaseURL.String())
 			})
 		})
 

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -3,6 +3,7 @@ package fault
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
@@ -261,7 +262,12 @@ func registerCannon(
 	selective bool,
 	claimants []common.Address,
 ) error {
-	prestateSource := prestates.NewSinglePrestateSource(cfg.CannonAbsolutePreState)
+	var prestateSource PrestateSource
+	if cfg.CannonAbsolutePreStateBaseURL != nil {
+		prestateSource = prestates.NewMultiPrestateProvider(cfg.CannonAbsolutePreStateBaseURL, filepath.Join(cfg.Datadir, "cannon-prestates"))
+	} else {
+		prestateSource = prestates.NewSinglePrestateSource(cfg.CannonAbsolutePreState)
+	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		contract := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
 		requiredPrestatehash, err := contract.GetAbsolutePrestateHash(ctx)

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/asterisc"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/cannon"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/prestates"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
@@ -34,6 +35,13 @@ type Registry interface {
 
 type OracleRegistry interface {
 	RegisterOracle(oracle keccakTypes.LargePreimageOracle)
+}
+
+type PrestateSource interface {
+	// PrestatePath returns the path to the prestate file to use for the game.
+	// The provided prestateHash may be used to differentiate between different states but no guarantee is made that
+	// the returned prestate matches the supplied hash.
+	PrestatePath(prestateHash common.Hash) (string, error)
 }
 
 type RollupClient interface {
@@ -253,9 +261,20 @@ func registerCannon(
 	selective bool,
 	claimants []common.Address,
 ) error {
-	cannonPrestateProvider := cannon.NewPrestateProvider(cfg.CannonAbsolutePreState)
+	prestateSource := prestates.NewSinglePrestateSource(cfg.CannonAbsolutePreState)
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		contract := contracts.NewFaultDisputeGameContract(m, game.Proxy, caller)
+		requiredPrestatehash, err := contract.GetAbsolutePrestateHash(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load prestate hash for game %v: %w", game.Proxy, err)
+		}
+
+		prestatePath, err := prestateSource.PrestatePath(requiredPrestatehash)
+		if err != nil {
+			return nil, fmt.Errorf("required prestate %v not available for game %v: %w", requiredPrestatehash, game.Proxy, err)
+		}
+		cannonPrestateProvider := cannon.NewPrestateProvider(prestatePath)
+
 		oracle, err := contract.GetOracle(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)

--- a/op-challenger/game/fault/trace/cannon/state.go
+++ b/op-challenger/game/fault/trace/cannon/state.go
@@ -3,6 +3,7 @@ package cannon
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -13,11 +14,14 @@ func parseState(path string) (*mipsevm.State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot open state file (%v): %w", path, err)
 	}
-	defer file.Close()
+	return parseStateFromReader(file)
+}
+
+func parseStateFromReader(in io.ReadCloser) (*mipsevm.State, error) {
+	defer in.Close()
 	var state mipsevm.State
-	err = json.NewDecoder(file).Decode(&state)
-	if err != nil {
-		return nil, fmt.Errorf("invalid mipsevm state (%v): %w", path, err)
+	if err := json.NewDecoder(in).Decode(&state); err != nil {
+		return nil, fmt.Errorf("invalid mipsevm state: %w", err)
 	}
 	return &state, nil
 }

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -39,7 +39,7 @@ func NewOutputCannonTraceAccessor(
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
 		}
-		provider := cannon.NewTraceProvider(logger, m, cfg, localInputs, subdir, depth)
+		provider := cannon.NewTraceProvider(logger, m, cfg, prestateProvider, localInputs, subdir, depth)
 		return provider, nil
 	}
 

--- a/op-challenger/game/fault/trace/prestates/multi.go
+++ b/op-challenger/game/fault/trace/prestates/multi.go
@@ -1,0 +1,70 @@
+package prestates
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	ErrPrestateUnavailable = errors.New("prestate unavailable")
+)
+
+type MultiPrestateProvider struct {
+	baseUrl *url.URL
+	dataDir string
+}
+
+func NewMultiPrestateProvider(baseUrl string, dataDir string) (*MultiPrestateProvider, error) {
+	url, err := url.Parse(baseUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL (%v): %w", baseUrl, err)
+	}
+	return &MultiPrestateProvider{
+		baseUrl: url,
+		dataDir: dataDir,
+	}, nil
+}
+
+func (m *MultiPrestateProvider) PrestatePath(hash common.Hash) (string, error) {
+	path := filepath.Join(m.dataDir, hash.Hex()+".json.gz")
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		if err := m.fetchPrestate(hash, path); err != nil {
+			return "", fmt.Errorf("failed to fetch prestate: %w", err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("error checking for existing prestate %v: %w", hash, err)
+	}
+	return path, nil
+}
+
+func (m *MultiPrestateProvider) fetchPrestate(hash common.Hash, dest string) error {
+	prestateUrl := m.baseUrl.JoinPath(hash.Hex() + ".json")
+	resp, err := http.Get(prestateUrl.String())
+	if err != nil {
+		return fmt.Errorf("failed to fetch prestate from %v: %w", prestateUrl, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w from url %v: status %v", ErrPrestateUnavailable, prestateUrl, resp.StatusCode)
+	}
+	out, err := ioutil.NewAtomicWriterCompressed(dest, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open atomic writer for %v: %w", dest, err)
+	}
+	defer out.Abort() // If errors occur, don't rename the file into place
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("failed to write file %v: %w", dest, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close file %v: %w", dest, err)
+	}
+	return nil
+}

--- a/op-challenger/game/fault/trace/prestates/multi_test.go
+++ b/op-challenger/game/fault/trace/prestates/multi_test.go
@@ -1,0 +1,66 @@
+package prestates
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadPrestate(t *testing.T) {
+	dir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(r.URL.Path))
+	}))
+	defer server.Close()
+	provider, err := NewMultiPrestateProvider(server.URL, dir)
+	require.NoError(t, err)
+	hash := common.Hash{0xaa}
+	path, err := provider.PrestatePath(hash)
+	require.NoError(t, err)
+	in, err := ioutil.OpenDecompressed(path)
+	require.NoError(t, err)
+	defer in.Close()
+	content, err := io.ReadAll(in)
+	require.Equal(t, "/"+hash.Hex()+".json", string(content))
+}
+
+func TestExistingPrestate(t *testing.T) {
+	dir := t.TempDir()
+	provider, err := NewMultiPrestateProvider("http://127.0.0.1:1", dir)
+	require.NoError(t, err)
+	hash := common.Hash{0xaa}
+	expectedFile := filepath.Join(dir, hash.Hex()+".json.gz")
+	err = ioutil.WriteCompressedBytes(expectedFile, []byte("expected content"), os.O_WRONLY|os.O_CREATE, 0o644)
+	require.NoError(t, err)
+
+	path, err := provider.PrestatePath(hash)
+	require.NoError(t, err)
+	require.Equal(t, expectedFile, path)
+	in, err := ioutil.OpenDecompressed(path)
+	require.NoError(t, err)
+	defer in.Close()
+	content, err := io.ReadAll(in)
+	require.Equal(t, "expected content", string(content))
+}
+
+func TestMissingPrestate(t *testing.T) {
+	dir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer server.Close()
+	provider, err := NewMultiPrestateProvider(server.URL, dir)
+	require.NoError(t, err)
+	hash := common.Hash{0xaa}
+	path, err := provider.PrestatePath(hash)
+	require.ErrorIs(t, err, ErrPrestateUnavailable)
+	_, err = os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/op-challenger/game/fault/trace/prestates/single.go
+++ b/op-challenger/game/fault/trace/prestates/single.go
@@ -1,0 +1,15 @@
+package prestates
+
+import "github.com/ethereum/go-ethereum/common"
+
+type SinglePrestateSource struct {
+	path string
+}
+
+func NewSinglePrestateSource(path string) *SinglePrestateSource {
+	return &SinglePrestateSource{path: path}
+}
+
+func (s *SinglePrestateSource) PrestatePath(_ common.Hash) (string, error) {
+	return s.path, nil
+}

--- a/op-service/ioutil/atomic.go
+++ b/op-service/ioutil/atomic.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 
-type atomicWriter struct {
+type AtomicWriter struct {
 	dest string
 	temp string
 	out  io.WriteCloser
@@ -16,7 +16,7 @@ type atomicWriter struct {
 // The contents are initially written to a temporary file and only renamed into place when the writer is closed.
 // NOTE: It's vital to check if an error is returned from Close() as it may indicate the file could not be renamed
 // If path ends in .gz the contents written will be gzipped.
-func NewAtomicWriterCompressed(path string, perm os.FileMode) (io.WriteCloser, error) {
+func NewAtomicWriterCompressed(path string, perm os.FileMode) (*AtomicWriter, error) {
 	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return nil, err
@@ -25,18 +25,26 @@ func NewAtomicWriterCompressed(path string, perm os.FileMode) (io.WriteCloser, e
 		_ = f.Close()
 		return nil, err
 	}
-	return &atomicWriter{
+	return &AtomicWriter{
 		dest: path,
 		temp: f.Name(),
 		out:  CompressByFileType(path, f),
 	}, nil
 }
 
-func (a *atomicWriter) Write(p []byte) (n int, err error) {
+func (a *AtomicWriter) Write(p []byte) (n int, err error) {
 	return a.out.Write(p)
 }
 
-func (a *atomicWriter) Close() error {
+// Abort releases any open resources and cleans up temporary files without renaming them into place.
+// Does nothing if the writer has already been closed.
+func (a *AtomicWriter) Abort() error {
+	// Attempt to clean up the temp file even if Close fails.
+	defer os.Remove(a.temp)
+	return a.out.Close()
+}
+
+func (a *AtomicWriter) Close() error {
 	// Attempt to clean up the temp file even if it can't be renamed into place.
 	defer os.Remove(a.temp)
 	if err := a.out.Close(); err != nil {


### PR DESCRIPTION
**Description**

Adds a `--cannon-prestates-url` that points to a directory of prestates named by their commit hash. This allows the challenger to play games with different prestates by loading the required prestate on demand.

Note that this currently only applies to cannon prestates. Logged https://github.com/ethereum-optimism/optimism/issues/10283 for the asterisc prestates.

**Tests**

Added unit tests. Ran locally.


**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/796
