### PR TITLE
op-challenger: Share providers across different game instances

### DIFF
--- a/op-challenger/game/fault/trace/prestates/cache.go
+++ b/op-challenger/game/fault/trace/prestates/cache.go
@@ -1,0 +1,39 @@
+package prestates
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type PrestateSource interface {
+	// PrestatePath returns the path to the prestate file to use for the game.
+	// The provided prestateHash may be used to differentiate between different states but no guarantee is made that
+	// the returned prestate matches the supplied hash.
+	PrestatePath(prestateHash common.Hash) (string, error)
+}
+
+type PrestateProviderCache struct {
+	createProvider func(prestateHash common.Hash) (types.PrestateProvider, error)
+	cache          *caching.LRUCache[common.Hash, types.PrestateProvider]
+}
+
+func NewPrestateProviderCache(m caching.Metrics, label string, createProvider func(prestateHash common.Hash) (types.PrestateProvider, error)) *PrestateProviderCache {
+	return &PrestateProviderCache{
+		createProvider: createProvider,
+		cache:          caching.NewLRUCache[common.Hash, types.PrestateProvider](m, label, 5),
+	}
+}
+
+func (p *PrestateProviderCache) GetOrCreate(prestateHash common.Hash) (types.PrestateProvider, error) {
+	provider, ok := p.cache.Get(prestateHash)
+	if ok {
+		return provider, nil
+	}
+	provider, err := p.createProvider(prestateHash)
+	if err != nil {
+		return nil, err
+	}
+	p.cache.Add(prestateHash, provider)
+	return provider, nil
+}

--- a/op-challenger/game/fault/trace/prestates/cache_test.go
+++ b/op-challenger/game/fault/trace/prestates/cache_test.go
@@ -1,0 +1,58 @@
+package prestates
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrestateProviderCache_CreateAndCache(t *testing.T) {
+	cache := NewPrestateProviderCache(nil, "", func(prestateHash common.Hash) (types.PrestateProvider, error) {
+		return &stubPrestateProvider{commitment: prestateHash}, nil
+	})
+
+	hash1 := common.Hash{0xaa}
+	hash2 := common.Hash{0xbb}
+	provider1a, err := cache.GetOrCreate(hash1)
+	require.NoError(t, err)
+	commitment, err := provider1a.AbsolutePreStateCommitment(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, hash1, commitment)
+
+	provider1b, err := cache.GetOrCreate(hash1)
+	require.NoError(t, err)
+	require.Same(t, provider1a, provider1b)
+	commitment, err = provider1b.AbsolutePreStateCommitment(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, hash1, commitment)
+
+	provider2, err := cache.GetOrCreate(hash2)
+	require.NoError(t, err)
+	require.NotSame(t, provider1a, provider2)
+	commitment, err = provider2.AbsolutePreStateCommitment(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, hash2, commitment)
+}
+
+func TestPrestateProviderCache_CreateFails(t *testing.T) {
+	hash1 := common.Hash{0xaa}
+	expectedErr := errors.New("boom")
+	cache := NewPrestateProviderCache(nil, "", func(prestateHash common.Hash) (types.PrestateProvider, error) {
+		return nil, expectedErr
+	})
+	provider, err := cache.GetOrCreate(hash1)
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, provider)
+}
+
+type stubPrestateProvider struct {
+	commitment common.Hash
+}
+
+func (s *stubPrestateProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	return s.commitment, nil
+}


### PR DESCRIPTION
**Description**

Avoids loading the full state to extract the commitment for each individual game which can be very slow when there are a lot of games to init at startup.

**Tests**

Added unit tests.
