### PR TITLE
add missing FaultDisputeGame interface

### DIFF
--- a/packages/sdk/src/interfaces/types.ts
+++ b/packages/sdk/src/interfaces/types.ts
@@ -55,6 +55,7 @@ export interface OEL1Contracts {
   // FPAC
   OptimismPortal2?: Contract
   DisputeGameFactory?: Contract
+  FaultDisputeGame?: Contract
 }
 
 /**


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding FaultDisputeGame contract interface on sdk OEL1Contracts exported types

**Tests**

No functionalities changes, compilation errors are tested in the pipeline.

**Additional context**

FaultDisputeGame interface does not seems to be exported.

**Metadata**

- Fixes #[Link to Issue]
