### PR TITLE
op-challenger: fix a bug in TestMonitorGames

### DIFF
--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -35,7 +35,6 @@ func TestMonitorGames(t *testing.T) {
 		go func() {
 			headerNotSent := true
 
-		loop:
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break
@@ -51,7 +50,7 @@ func TestMonitorGames(t *testing.T) {
 					}:
 						headerNotSent = false
 					case <-ctx.Done():
-						break loop
+						return
 					default:
 					}
 				}
@@ -87,7 +86,6 @@ func TestMonitorGames(t *testing.T) {
 			require.NoError(t, waitErr)
 			mockHeadSource.Sub().errChan <- fmt.Errorf("test error")
 
-		loop:
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break
@@ -101,13 +99,12 @@ func TestMonitorGames(t *testing.T) {
 					Number: big.NewInt(1),
 				}:
 				case <-ctx.Done():
-					break loop
+					return
 				default:
 				}
 				// Just to avoid a tight loop
 				time.Sleep(100 * time.Millisecond)
 			}
-			require.NoError(t, waitErr)
 			mockHeadSource.SetErr(fmt.Errorf("eth subscribe test error"))
 			cancel()
 		}()

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -34,7 +34,6 @@ func TestMonitorGames(t *testing.T) {
 
 		go func() {
 			headerNotSent := true
-
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break
@@ -85,7 +84,6 @@ func TestMonitorGames(t *testing.T) {
 			})
 			require.NoError(t, waitErr)
 			mockHeadSource.Sub().errChan <- fmt.Errorf("test error")
-
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -34,6 +34,8 @@ func TestMonitorGames(t *testing.T) {
 
 		go func() {
 			headerNotSent := true
+
+		loop:
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break
@@ -49,7 +51,7 @@ func TestMonitorGames(t *testing.T) {
 					}:
 						headerNotSent = false
 					case <-ctx.Done():
-						break
+						break loop
 					default:
 					}
 				}
@@ -84,6 +86,8 @@ func TestMonitorGames(t *testing.T) {
 			})
 			require.NoError(t, waitErr)
 			mockHeadSource.Sub().errChan <- fmt.Errorf("test error")
+
+		loop:
 			for {
 				if len(sched.Scheduled()) >= 1 {
 					break
@@ -97,7 +101,7 @@ func TestMonitorGames(t *testing.T) {
 					Number: big.NewInt(1),
 				}:
 				case <-ctx.Done():
-					break
+					break loop
 				default:
 				}
 				// Just to avoid a tight loop


### PR DESCRIPTION
The `break` inside `select` should be used with label to break out of `for` loop.