### PR TITLE
op-challenger: Support multiple asterisc prestates

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -290,12 +290,27 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
+				verifyArgsInvalid(t, "flag asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
 			})
 
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-prestate", "--asterisc-prestate=./pre.json"))
 				require.Equal(t, "./pre.json", cfg.AsteriscAbsolutePreState)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestateBaseURL-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--asterisc-prestates-url"))
+			})
+
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-prestates-url", "--asterisc-prestates-url=http://localhost/bar"))
+				require.Equal(t, "http://localhost/bar", cfg.AsteriscAbsolutePreStateBaseURL.String())
 			})
 		})
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -184,6 +184,12 @@ var (
 		Usage:   "Path to absolute prestate to use when generating trace data (asterisc trace type only)",
 		EnvVars: prefixEnvVars("ASTERISC_PRESTATE"),
 	}
+	AsteriscPreStatesURLFlag = &cli.StringFlag{
+		Name: "asterisc-prestates-url",
+		Usage: "Base URL to absolute prestates to use when generating trace data. " +
+			"Prestates in this directory should be name as <commitment>.json (asterisc trace type only)",
+		EnvVars: prefixEnvVars("ASTERISC_PRESTATES_URL"),
+	}
 	AsteriscSnapshotFreqFlag = &cli.UintFlag{
 		Name:    "asterisc-snapshot-freq",
 		Usage:   "Frequency of asterisc snapshots to generate in VM steps (asterisc trace type only)",
@@ -250,6 +256,7 @@ var optionalFlags = []cli.Flag{
 	AsteriscBinFlag,
 	AsteriscServerFlag,
 	AsteriscPreStateFlag,
+	AsteriscPreStatesURLFlag,
 	AsteriscSnapshotFreqFlag,
 	AsteriscInfoFreqFlag,
 	GameWindowFlag,
@@ -313,8 +320,8 @@ func CheckAsteriscFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(AsteriscServerFlag.Name) {
 		return fmt.Errorf("flag %s is required", AsteriscServerFlag.Name)
 	}
-	if !ctx.IsSet(AsteriscPreStateFlag.Name) {
-		return fmt.Errorf("flag %s is required", AsteriscPreStateFlag.Name)
+	if !ctx.IsSet(AsteriscPreStateFlag.Name) && !ctx.IsSet(AsteriscPreStatesURLFlag.Name) {
+		return fmt.Errorf("flag %s or %s is required", AsteriscPreStatesURLFlag.Name, AsteriscPreStateFlag.Name)
 	}
 	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
 	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
@@ -426,46 +433,55 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 		}
 		cannonPrestatesURL = parsed
 	}
+	var asteriscPreStatesURL *url.URL
+	if ctx.IsSet(AsteriscPreStatesURLFlag.Name) {
+		parsed, err := url.Parse(ctx.String(AsteriscPreStatesURLFlag.Name))
+		if err != nil {
+			return nil, fmt.Errorf("invalid asterisc pre states url (%v): %w", ctx.String(CannonPreStatesURLFlag.Name), err)
+		}
+		asteriscPreStatesURL = parsed
+	}
 	l2Rpc, err := getL2Rpc(ctx, logger)
 	if err != nil {
 		return nil, err
 	}
 	return &config.Config{
 		// Required Flags
-		L1EthRpc:                      ctx.String(L1EthRpcFlag.Name),
-		L1Beacon:                      ctx.String(L1BeaconFlag.Name),
-		TraceTypes:                    traceTypes,
-		GameFactoryAddress:            gameFactoryAddress,
-		GameAllowlist:                 allowedGames,
-		GameWindow:                    ctx.Duration(GameWindowFlag.Name),
-		MaxConcurrency:                maxConcurrency,
-		L2Rpc:                         l2Rpc,
-		MaxPendingTx:                  ctx.Uint64(MaxPendingTransactionsFlag.Name),
-		PollInterval:                  ctx.Duration(HTTPPollInterval.Name),
-		AdditionalBondClaimants:       claimants,
-		RollupRpc:                     ctx.String(RollupRpcFlag.Name),
-		CannonNetwork:                 ctx.String(CannonNetworkFlag.Name),
-		CannonRollupConfigPath:        ctx.String(CannonRollupConfigFlag.Name),
-		CannonL2GenesisPath:           ctx.String(CannonL2GenesisFlag.Name),
-		CannonBin:                     ctx.String(CannonBinFlag.Name),
-		CannonServer:                  ctx.String(CannonServerFlag.Name),
-		CannonAbsolutePreState:        ctx.String(CannonPreStateFlag.Name),
-		CannonAbsolutePreStateBaseURL: cannonPrestatesURL,
-		Datadir:                       ctx.String(DatadirFlag.Name),
-		CannonSnapshotFreq:            ctx.Uint(CannonSnapshotFreqFlag.Name),
-		CannonInfoFreq:                ctx.Uint(CannonInfoFreqFlag.Name),
-		AsteriscNetwork:               ctx.String(AsteriscNetworkFlag.Name),
-		AsteriscRollupConfigPath:      ctx.String(AsteriscRollupConfigFlag.Name),
-		AsteriscL2GenesisPath:         ctx.String(AsteriscL2GenesisFlag.Name),
-		AsteriscBin:                   ctx.String(AsteriscBinFlag.Name),
-		AsteriscServer:                ctx.String(AsteriscServerFlag.Name),
-		AsteriscAbsolutePreState:      ctx.String(AsteriscPreStateFlag.Name),
-		AsteriscSnapshotFreq:          ctx.Uint(AsteriscSnapshotFreqFlag.Name),
-		AsteriscInfoFreq:              ctx.Uint(AsteriscInfoFreqFlag.Name),
-		TxMgrConfig:                   txMgrConfig,
-		MetricsConfig:                 metricsConfig,
-		PprofConfig:                   pprofConfig,
-		SelectiveClaimResolution:      ctx.Bool(SelectiveClaimResolutionFlag.Name),
-		AllowInvalidPrestate:          ctx.Bool(UnsafeAllowInvalidPrestate.Name),
+		L1EthRpc:                        ctx.String(L1EthRpcFlag.Name),
+		L1Beacon:                        ctx.String(L1BeaconFlag.Name),
+		TraceTypes:                      traceTypes,
+		GameFactoryAddress:              gameFactoryAddress,
+		GameAllowlist:                   allowedGames,
+		GameWindow:                      ctx.Duration(GameWindowFlag.Name),
+		MaxConcurrency:                  maxConcurrency,
+		L2Rpc:                           l2Rpc,
+		MaxPendingTx:                    ctx.Uint64(MaxPendingTransactionsFlag.Name),
+		PollInterval:                    ctx.Duration(HTTPPollInterval.Name),
+		AdditionalBondClaimants:         claimants,
+		RollupRpc:                       ctx.String(RollupRpcFlag.Name),
+		CannonNetwork:                   ctx.String(CannonNetworkFlag.Name),
+		CannonRollupConfigPath:          ctx.String(CannonRollupConfigFlag.Name),
+		CannonL2GenesisPath:             ctx.String(CannonL2GenesisFlag.Name),
+		CannonBin:                       ctx.String(CannonBinFlag.Name),
+		CannonServer:                    ctx.String(CannonServerFlag.Name),
+		CannonAbsolutePreState:          ctx.String(CannonPreStateFlag.Name),
+		CannonAbsolutePreStateBaseURL:   cannonPrestatesURL,
+		Datadir:                         ctx.String(DatadirFlag.Name),
+		CannonSnapshotFreq:              ctx.Uint(CannonSnapshotFreqFlag.Name),
+		CannonInfoFreq:                  ctx.Uint(CannonInfoFreqFlag.Name),
+		AsteriscNetwork:                 ctx.String(AsteriscNetworkFlag.Name),
+		AsteriscRollupConfigPath:        ctx.String(AsteriscRollupConfigFlag.Name),
+		AsteriscL2GenesisPath:           ctx.String(AsteriscL2GenesisFlag.Name),
+		AsteriscBin:                     ctx.String(AsteriscBinFlag.Name),
+		AsteriscServer:                  ctx.String(AsteriscServerFlag.Name),
+		AsteriscAbsolutePreState:        ctx.String(AsteriscPreStateFlag.Name),
+		AsteriscAbsolutePreStateBaseURL: asteriscPreStatesURL,
+		AsteriscSnapshotFreq:            ctx.Uint(AsteriscSnapshotFreqFlag.Name),
+		AsteriscInfoFreq:                ctx.Uint(AsteriscInfoFreqFlag.Name),
+		TxMgrConfig:                     txMgrConfig,
+		MetricsConfig:                   metricsConfig,
+		PprofConfig:                     pprofConfig,
+		SelectiveClaimResolution:        ctx.Bool(SelectiveClaimResolutionFlag.Name),
+		AllowInvalidPrestate:            ctx.Bool(UnsafeAllowInvalidPrestate.Name),
 	}, nil
 }

--- a/op-challenger/game/fault/trace/asterisc/state.go
+++ b/op-challenger/game/fault/trace/asterisc/state.go
@@ -3,6 +3,7 @@ package asterisc
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -57,13 +58,17 @@ func parseState(path string) (*VMState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot open state file (%v): %w", path, err)
 	}
-	defer file.Close()
+	return parseStateFromReader(file)
+}
+
+func parseStateFromReader(in io.ReadCloser) (*VMState, error) {
+	defer in.Close()
 	var state VMState
-	if err := json.NewDecoder(file).Decode(&state); err != nil {
-		return nil, fmt.Errorf("invalid asterisc VM state (%v): %w", path, err)
+	if err := json.NewDecoder(in).Decode(&state); err != nil {
+		return nil, fmt.Errorf("invalid asterisc VM state %w", err)
 	}
 	if err := state.validateState(); err != nil {
-		return nil, fmt.Errorf("invalid asterisc VM state (%v): %w", path, err)
+		return nil, fmt.Errorf("invalid asterisc VM state %w", err)
 	}
 	return &state, nil
 }

--- a/op-challenger/game/fault/trace/outputs/output_asterisc.go
+++ b/op-challenger/game/fault/trace/outputs/output_asterisc.go
@@ -39,7 +39,7 @@ func NewOutputAsteriscTraceAccessor(
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch asterisc local inputs: %w", err)
 		}
-		provider := asterisc.NewTraceProvider(logger, m, cfg, localInputs, subdir, depth)
+		provider := asterisc.NewTraceProvider(logger, m, cfg, prestateProvider, localInputs, subdir, depth)
 		return provider, nil
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixes https://github.com/ethereum-optimism/optimism/issues/10283. Most of codes mirrored from https://github.com/ethereum-optimism/optimism/pull/10282.

One thing that is not mirrored is the test added at `op-challenger/config/config_test.go::TestAsteriscRequiredArgs`. This should have been added at https://github.com/ethereum-optimism/optimism/pull/10214, but I missed to add it.