### PR TITLE
op-dispute-mon: Report valid and invalid claims and bonds by honest actors

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -69,7 +69,7 @@ type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
 
-	RecordUnexpectedClaimResolution(address common.Address, count int)
+	RecordHonestActorClaimResolution(address common.Address, unexpected int, expected int)
 
 	RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int)
 
@@ -106,7 +106,7 @@ type Metrics struct {
 
 	claims prometheus.GaugeVec
 
-	unexpectedClaimResolutions prometheus.GaugeVec
+	honestActorClaimResolutions prometheus.GaugeVec
 
 	withdrawalRequests prometheus.GaugeVec
 
@@ -165,11 +165,12 @@ func NewMetrics() *Metrics {
 			Name:      "claim_resolution_delay_max",
 			Help:      "Maximum claim resolution delay in seconds",
 		}),
-		unexpectedClaimResolutions: *factory.NewGaugeVec(prometheus.GaugeOpts{
+		honestActorClaimResolutions: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
-			Name:      "unexpected_claim_resolutions",
+			Name:      "honest_actor_claim_resolutions",
 			Help:      "Total number of unexpected claim resolutions against an honest actor",
 		}, []string{
+			"resolution",
 			"honest_actor_address",
 		}),
 		resolutionStatus: *factory.NewGaugeVec(prometheus.GaugeOpts{
@@ -262,8 +263,9 @@ func (m *Metrics) RecordUp() {
 	m.up.Set(1)
 }
 
-func (m *Metrics) RecordUnexpectedClaimResolution(address common.Address, count int) {
-	m.unexpectedClaimResolutions.WithLabelValues(address.Hex()).Set(float64(count))
+func (m *Metrics) RecordHonestActorClaimResolution(address common.Address, unexpected int, expected int) {
+	m.honestActorClaimResolutions.WithLabelValues("invalid", address.Hex()).Set(float64(unexpected))
+	m.honestActorClaimResolutions.WithLabelValues("valid", address.Hex()).Set(float64(expected))
 }
 
 func (m *Metrics) RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -19,7 +19,7 @@ func (*NoopMetricsImpl) RecordUp()           {}
 func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
-func (*NoopMetricsImpl) RecordHonestActorClaimResolution(_ common.Address, _ int, _ int) {}
+func (*NoopMetricsImpl) RecordHonestActorClaims(_ common.Address, _ *HonestActorData) {}
 
 func (*NoopMetricsImpl) RecordGameResolutionStatus(_ bool, _ bool, _ int) {}
 

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -19,7 +19,7 @@ func (*NoopMetricsImpl) RecordUp()           {}
 func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
-func (*NoopMetricsImpl) RecordUnexpectedClaimResolution(_ common.Address, _ int) {}
+func (*NoopMetricsImpl) RecordHonestActorClaimResolution(_ common.Address, _ int, _ int) {}
 
 func (*NoopMetricsImpl) RecordGameResolutionStatus(_ bool, _ bool, _ int) {}
 

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -71,7 +71,7 @@ func (c *ClaimMonitor) checkUpdateHonestActorStats(proxy common.Address, claim *
 			c.logger.Error("Claim resolved against honest actor", "game", proxy, "honest_actor", actor, "countered_by", claim.CounteredBy, "claim_contract_index", claim.ContractIndex)
 		} else {
 			honest[actor].ValidClaimCount++
-			honest[actor].WonBonds = new(big.Int).Add(honest[actor].WonBonds, claim.Bond)
+			// Note that we don't count refunded bonds as won
 		}
 	}
 	if c.honestActors[claim.CounteredBy] {

--- a/op-dispute-mon/mon/claims_test.go
+++ b/op-dispute-mon/mon/claims_test.go
@@ -59,7 +59,7 @@ func TestClaimMonitor_CheckClaims(t *testing.T) {
 		require.Equal(t, 2, actor2.ValidClaimCount)
 		require.Equal(t, 0, actor2.PendingClaimCount)
 		require.EqualValues(t, 0, actor2.LostBonds.Int64())
-		require.EqualValues(t, 8, actor2.WonBonds.Int64())
+		require.EqualValues(t, 6, actor2.WonBonds.Int64())
 		require.EqualValues(t, 0, actor2.PendingBonds.Int64())
 	})
 }


### PR DESCRIPTION
**Description**

Enhances the metrics published for honest actors to include pending, valid and invalid claims as well as pending, won and lost bonds.

This lets us see how many claims we're posting, whether they're valid or not as well as how much the honest actors have locked up in bonds, how much they're losing (by posting invalid claims) and how much they're winning (by countering invalid claims).

**Tests**

Added unit tests, verified results manually.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/519
