### PR TITLE
op-node: fix potential resource leaks

### DIFF
--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -201,6 +201,7 @@ func loadTransactionsFile(file string) fetch.TransactionWithMetadata {
 	dec := json.NewDecoder(f)
 	var txm fetch.TransactionWithMetadata
 	if err := dec.Decode(&txm); err != nil {
+		f.Close()
 		log.Fatalf("Failed to decode %v. Err: %v\n", file, err)
 	}
 	return txm


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

log.Fatalf will exit, and `defer f.Close()` will not run


**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
