### PR TITLE
op-conductor: removes leadership check when starting sequencer

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -475,11 +475,6 @@ func (s *Driver) StartSequencer(ctx context.Context, blockHash common.Hash) erro
 	if !s.driverConfig.SequencerEnabled {
 		return errors.New("sequencer is not enabled")
 	}
-	if isLeader, err := s.sequencerConductor.Leader(ctx); err != nil {
-		return fmt.Errorf("sequencer leader check failed: %w", err)
-	} else if !isLeader {
-		return errors.New("sequencer is not the leader, aborting.")
-	}
 	h := hashAndErrorChannel{
 		hash: blockHash,
 		err:  make(chan error, 1),


### PR DESCRIPTION
**Description**

This check actually triggers failure to elect a new leader due to a race condition where the conductor leadership status has not been updated in time for this check to pass. It should be safe to remove this check because we will check the leadership status before creating a new unsafe payload anyways.

bug observed in logs
```
op-conductor-2 obtains leadership and tries to start the sequencer.  it fails to do so due to the race condition we talked about in the meeting(op-conductor -> admin_startSequencer -> sequencer -> conductor_leader -> op-conductor)
2024-04-25 12:46:31 t=2024-04-25T19:46:31+0000 lvl=info msg="Leadership status changed" server=op-conductor-1 leader=true
2024-04-25 12:46:31 t=2024-04-25T19:46:31+0000 lvl=info msg="starting sequencer" server=op-conductor-1 leader=true healthy=true active=false
2024-04-25 12:46:31 t=2024-04-25T19:46:31+0000 lvl=error msg="failed to execute step, queueing another one to retry" err="failed to start sequencer: sequencer is not the leader, aborting."
```

**Tests**

Tested in dev environment that the leadership election works after this fix has been applied.