### PR TITLE
[op-conductor] make safe check interval optional

### DIFF
--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -74,6 +74,7 @@ var (
 		Name:    "healthcheck.safe-interval",
 		Usage:   "Interval between safe head progression measured in seconds",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_SAFE_INTERVAL"),
+		Value:   1200,
 	}
 	HealthCheckMinPeerCount = &cli.Uint64Flag{
 		Name:    "healthcheck.min-peer-count",
@@ -103,7 +104,6 @@ var requiredFlags = []cli.Flag{
 	ExecutionRPC,
 	HealthCheckInterval,
 	HealthCheckUnsafeInterval,
-	HealthCheckSafeInterval,
 	HealthCheckMinPeerCount,
 }
 
@@ -112,6 +112,7 @@ var optionalFlags = []cli.Flag{
 	RPCEnableProxy,
 	RaftBootstrap,
 	HealthCheckSafeEnabled,
+	HealthCheckSafeInterval,
 }
 
 func init() {

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -192,6 +192,7 @@ func (hm *SequencerHealthMonitor) healthCheck() error {
 		return ErrSequencerNotHealthy
 	}
 
+	hm.log.Info("sequencer is healthy")
 	return nil
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

make safe check interval optional

**Tests**

N/A

**Additional context**

Since we're not requiring safe interval check any more, make safe interval config as optional.

**Metadata**

- https://github.com/ethereum-optimism/protocol-quest/issues/44
