### PR TITLE
contracts-bedrock: small fix to cleanup L2 genesis

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -160,7 +160,7 @@ def devnet_l2_allocs(paths):
     fqn = 'scripts/L2Genesis.s.sol:L2Genesis'
     # Use foundry pre-funded account #1 for the deployer
     run_command([
-        'forge', 'script', '--chain-id', '901', fqn, "--sig", "runWithAllUpgrades()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        'forge', 'script', fqn, "--sig", "runWithAllUpgrades()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     ], env={
       'CONTRACT_ADDRESSES_PATH': paths.l1_deployments_path,
     }, cwd=paths.contracts_bedrock_dir)

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -59,7 +59,7 @@
   "disputeGameFinalityDelaySeconds": 6,
   "respectedGameType": 0,
   "useFaultProofs": false,
-  "fundDevAccounts": false,
+  "fundDevAccounts": true,
   "usePlasma": false,
   "daChallengeWindow": 100,
   "daResolveWindow": 100,

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -185,6 +185,11 @@ contract DeployConfig is Script {
         useFaultProofs = _useFaultProofs;
     }
 
+    /// @notice Allow the `fundDevAccounts` config to be overridden.
+    function setFundDevAccounts(bool _fundDevAccounts) public {
+        fundDevAccounts = _fundDevAccounts;
+    }
+
     function _getBlockByTag(string memory _tag) internal returns (bytes32) {
         string[] memory cmd = new string[](3);
         cmd[0] = Executables.bash;

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -109,19 +109,27 @@ contract L2Genesis is Deployer {
         });
     }
 
-    /// @dev Sets the precompiles, proxies, and the implementation accounts to be `vm.dumpState`
-    ///      to generate a L2 genesis alloc.
     /// @notice The alloc object is sorted numerically by address.
+    ///         dev Sets the precompiles, proxies, and the implementation accounts to be `vm.dumpState`
+    ///         to generate a L2 genesis alloc.
     function runWithStateDump() public {
         runWithOptions(OutputMode.DEFAULT_LATEST, artifactDependencies());
     }
 
-    // @dev This is used by op-e2e to have a version of the L2 allocs for each upgrade.
+    /// @notice Alias for `runWithStateDump` so that no `--sig` needs to be specified.
+    function run() public {
+        runWithStateDump();
+    }
+
+    /// @notice This is used by op-e2e to have a version of the L2 allocs for each upgrade.
     function runWithAllUpgrades() public {
         runWithOptions(OutputMode.OUTPUT_ALL, artifactDependencies());
     }
 
+    /// @notice Build the L2 genesis.
     function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public {
+        vm.chainId(cfg.l2ChainID());
+
         dealEthToPrecompiles();
         setPredeployProxies();
         setPredeployImplementations(_l1Dependencies);
@@ -151,11 +159,11 @@ contract L2Genesis is Deployer {
         }
     }
 
-    /// @dev Set up the accounts that correspond to the predeploys.
-    ///      The Proxy bytecode should be set. All proxied predeploys should have
-    ///      the 1967 admin slot set to the ProxyAdmin predeploy. All defined predeploys
-    ///      should have their implementations set.
-    ///      Warning: the predeploy accounts have contract code, but 0 nonce value.
+    /// @notice Set up the accounts that correspond to the predeploys.
+    ///         The Proxy bytecode should be set. All proxied predeploys should have
+    ///         the 1967 admin slot set to the ProxyAdmin predeploy. All defined predeploys
+    ///         should have their implementations set.
+    ///         Warning: the predeploy accounts have contract code, but 0 nonce value.
     function setPredeployProxies() public {
         console.log("Setting Predeploy proxies");
         bytes memory code = vm.getDeployedCode("Proxy.sol:Proxy");
@@ -184,7 +192,7 @@ contract L2Genesis is Deployer {
         }
     }
 
-    /// @dev Sets all the implementations for the predeploy proxies. For contracts without proxies,
+    /// @notice Sets all the implementations for the predeploy proxies. For contracts without proxies,
     ///      sets the deployed bytecode at their expected predeploy address.
     ///      LEGACY_ERC20_ETH and L1_MESSAGE_SENDER are deprecated and are not set.
     function setPredeployImplementations(L1Dependencies memory _l1Dependencies) internal {

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -110,7 +110,7 @@ contract L2Genesis is Deployer {
     }
 
     /// @notice The alloc object is sorted numerically by address.
-    ///         dev Sets the precompiles, proxies, and the implementation accounts to be `vm.dumpState`
+    ///         Sets the precompiles, proxies, and the implementation accounts to be `vm.dumpState`
     ///         to generate a L2 genesis alloc.
     function runWithStateDump() public {
         runWithOptions(OutputMode.DEFAULT_LATEST, artifactDependencies());

--- a/packages/contracts-bedrock/test/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2Genesis.t.sol
@@ -165,6 +165,7 @@ contract L2GenesisTest is Test {
 
     /// @notice Tests the number of accounts in the genesis setup
     function _test_allocs_size(string memory _path) internal {
+        genesis.cfg().setFundDevAccounts(false);
         genesis.runWithOptions(OutputMode.LOCAL_LATEST, _dummyL1Deps());
         genesis.writeGenesisAllocs(_path);
 

--- a/packages/contracts-bedrock/test/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/Preinstalls.t.sol
@@ -22,8 +22,8 @@ contract PreinstallsTest is CommonTest {
         bytes memory encoded = abi.encode(typeHash, nameHash, chainId, Preinstalls.Permit2);
         bytes32 expectedDomainSeparator = keccak256(encoded);
         assertEq(domainSeparator, expectedDomainSeparator, "Domain separator mismatch");
-        assertEq(chainId, uint256(31337));
-        assertEq(domainSeparator, bytes32(0x4d553c58ae79a6c4ba64f0e690a5d1cd2deff8c6b91cf38300e0f2b76f9ee346));
+        assertEq(chainId, uint256(901)); // uses devnet config
+        assertEq(domainSeparator, bytes32(0x48deb34b39fb4b41f5c195008940d5ef510cdd7853eba5807b2fa08dfd586475));
         // Warning the Permit2 domain separator as cached in the DeployPermit2.sol bytecode is incorrect.
     }
 


### PR DESCRIPTION
**Description**

Adds a `run()` function to the L2 genesis generation script
so that its possible to run the command without the `--sig`
argument. Also resolve some linting isssues, semgrep has
a rule that prefers `@notice` over `@dev` for natspec comments.
Also use a foundry cheatcode to set the chainid during execution
to ensure that the correct chainid is set to remove the need to
set it as a cli flag.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

