### PR TITLE
make: fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint-go:
 .PHONY: lint-go
 
 build-ts: submodules
-	if [ -n "$$NVM_DIR" ]; then \
+	if [ -f "$$NVM_DIR/nvm.sh" ]; then \
 		. $$NVM_DIR/nvm.sh && nvm use; \
 	fi
 	pnpm install:ci


### PR DESCRIPTION
**Description**

Fixes the `make build` command to ensure that it
works. Previously it checked if the env var was set
for the nvm dir, but that doesn't guarantee there is
a file there. Run the nvm file if it exists after
checking that it exists. Can confirm that the
build command works for me now locally.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

