### PR TITLE
op-challenger: Include resolution status in list-claims output

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -82,18 +82,27 @@ func listClaims(ctx context.Context, game contracts.FaultDisputeGameContract) er
 	// The - 1 here accounts for the fact that the split depth is included in the top game.
 	bottomDepth := maxDepth - splitDepth - 1
 
+	resolved, err := game.IsResolved(ctx, rpcblock.Latest, claims...)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve claim resolution: %w", err)
+	}
+
 	gameState := types.NewGameState(claims, maxDepth)
-	lineFormat := "%3v %-7v %6v %5v %14v %-66v %-42v %-42v\n"
-	info := fmt.Sprintf(lineFormat, "Idx", "Move", "Parent", "Depth", "Index", "Value", "Claimant", "Countered By")
+	lineFormat := "%3v %-7v %6v %5v %14v %-66v %-42v %-44v\n"
+	info := fmt.Sprintf(lineFormat, "Idx", "Move", "Parent", "Depth", "Index", "Value", "Claimant", "Resolution")
 	for i, claim := range claims {
 		pos := claim.Position
 		parent := strconv.Itoa(claim.ParentContractIndex)
 		if claim.IsRoot() {
 			parent = ""
 		}
-		countered := claim.CounteredBy.Hex()
-		if claim.CounteredBy == (common.Address{}) {
+		var countered string
+		if !resolved[i] {
 			countered = "-"
+		} else if claim.CounteredBy != (common.Address{}) {
+			countered = "❌ " + claim.CounteredBy.Hex()
+		} else {
+			countered = "✅"
 		}
 		move := "Attack"
 		if gameState.DefendsParent(claim) {


### PR DESCRIPTION
**Description**

Updates the `list-claims` subcommand to include whether the claim has been resolved or not.  Shows a ✅ for claims that are valid and ❌ for claims that are invalid along with the `CounteredBy` account. Unresolved claims show a `-`.

```
Status: Defender Won • L2 Blocks: 10804521 to 10956183 • Split Depth: 30 • Max Depth: 73 • Claim Count: 3
Idx Move    Parent Depth          Index Value                                                              Claimant                                   Resolution
  0 Attack             0     1073741823 0xad235ace6cf7d924f49bbdcb517a115f371ec64412dadede8fc759fd0f813378 0x49277EE36A024120Ee218127354c4a3591dc90A9 ✅
  1 Attack       0     1      536870911 0x0226211e7ac87473f78718497788e090079941fe5a15194c09e6e31640e80e08 0x06C1a398362ac75e3EeE6e3081Bdb620904713e2 ❌ 0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4
  2 Attack       1     2      268435455 0xad235ace6cf7d924f49bbdcb517a115f371ec64412dadede8fc759fd0f813378 0xc96775081bcA132B0E7cbECDd0B58d9Ec07Fdaa4 –
```