### PR TITLE
op-dispute-mon: Add option to ignore games

### DIFF
--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	RollupRpc       string           // The rollup node RPC URL.
 	MonitorInterval time.Duration    // Frequency to check for new games to monitor.
 	GameWindow      time.Duration    // Maximum window to look for games to monitor.
+	IgnoredGames    []common.Address // Games to exclude from monitoring
 
 	MetricsConfig opmetrics.CLIConfig
 	PprofConfig   oppprof.CLIConfig

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -35,4 +35,6 @@ func (*NoopMetricsImpl) RecordOutputFetchTime(_ float64) {}
 
 func (*NoopMetricsImpl) RecordGameAgreement(_ GameAgreementStatus, _ int) {}
 
+func (*NoopMetricsImpl) RecordIgnoredGames(_ int) {}
+
 func (i *NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -30,7 +30,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("NoGames", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{}, 0)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -40,7 +40,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("RollupFetchFails", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
 		rollup.err = errors.New("boom")
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}}, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -54,7 +54,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("ChallengerWonGame_Agree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon, RootClaim: mockRootClaim}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -69,7 +69,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("ChallengerWonGame_Disagree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon, RootClaim: common.Hash{0xbb}}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.Nil(t, l)
 
@@ -81,7 +81,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("DefenderWonGame_Agree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon, RootClaim: mockRootClaim}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.Nil(t, l)
 
@@ -93,7 +93,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("DefenderWonGame_Disagree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon, RootClaim: common.Hash{0xbb}}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -107,14 +107,14 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("SingleGame", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}}, 0)
 		require.Equal(t, 1, rollup.calls)
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	})
 
 	t.Run("MultipleGames", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}, {}, {}})
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}, {}, {}}, 0)
 		require.Equal(t, 3, rollup.calls)
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	})
@@ -130,7 +130,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 			RootClaim: mockRootClaim,
 			Claims:    createDeepClaimList()[:1],
 		}}
-		forecast.Forecast(context.Background(), games)
+		forecast.Forecast(context.Background(), games, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -151,7 +151,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 			RootClaim: mockRootClaim,
 			Claims:    createDeepClaimList()[:2],
 		}}
-		forecast.Forecast(context.Background(), games)
+		forecast.Forecast(context.Background(), games, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -170,7 +170,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{
 			Status: types.GameStatusInProgress,
 			Claims: createDeepClaimList()[:2],
-		}})
+		}}, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -189,7 +189,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{
 			Status: types.GameStatusInProgress,
 			Claims: createDeepClaimList()[:1],
-		}})
+		}}, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -205,7 +205,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 }
 
 func TestForecast_Forecast_MultipleGames(t *testing.T) {
-	forecast, _, rollup, logs := setupForecastTest(t)
+	forecast, m, rollup, logs := setupForecastTest(t)
 	gameStatus := []types.GameStatus{
 		types.GameStatusChallengerWon,
 		types.GameStatusInProgress,
@@ -247,20 +247,27 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 			RootClaim: rootClaims[i],
 		}
 	}
-	forecast.Forecast(context.Background(), games)
+	forecast.Forecast(context.Background(), games, 3)
 	require.Equal(t, len(games), rollup.calls)
-	levelFilter := testlog.NewLevelFilter(log.LevelError)
-	messageFilter := testlog.NewMessageFilter(failedForecastLog)
-	require.Nil(t, logs.FindLog(levelFilter, messageFilter))
+	require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
+	expectedMetrics := zeroGameAgreement()
+	expectedMetrics[metrics.AgreeChallengerAhead] = 1
+	expectedMetrics[metrics.DisagreeChallengerAhead] = 1
+	expectedMetrics[metrics.AgreeDefenderAhead] = 1
+	expectedMetrics[metrics.DisagreeDefenderAhead] = 1
+	expectedMetrics[metrics.DisagreeDefenderWins] = 2
+	expectedMetrics[metrics.DisagreeChallengerWins] = 3
+	require.Equal(t, expectedMetrics, m.gameAgreement)
+	require.Equal(t, 3, m.ignoredGames)
 }
 
 func setupForecastTest(t *testing.T) (*forecast, *mockForecastMetrics, *stubOutputValidator, *testlog.CapturingHandler) {
 	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
 	validator := &stubOutputValidator{}
-	metrics := &mockForecastMetrics{
+	m := &mockForecastMetrics{
 		gameAgreement: zeroGameAgreement(),
 	}
-	return newForecast(logger, metrics, validator), metrics, validator, capturedLogs
+	return newForecast(logger, m, validator), m, validator, capturedLogs
 }
 
 func zeroGameAgreement() map[metrics.GameAgreementStatus]int {
@@ -278,11 +285,16 @@ func zeroGameAgreement() map[metrics.GameAgreementStatus]int {
 
 type mockForecastMetrics struct {
 	gameAgreement           map[metrics.GameAgreementStatus]int
+	ignoredGames            int
 	claimResolutionDelayMax float64
 }
 
 func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementStatus, count int) {
 	m.gameAgreement[status] = count
+}
+
+func (m *mockForecastMetrics) RecordIgnoredGames(count int) {
+	m.ignoredGames = count
 }
 
 func (m *mockForecastMetrics) RecordClaimResolutionDelayMax(delay float64) {

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -182,7 +182,7 @@ type mockForecast struct {
 	calls int
 }
 
-func (m *mockForecast) Forecast(ctx context.Context, games []*monTypes.EnrichedGameData) {
+func (m *mockForecast) Forecast(_ context.Context, _ []*monTypes.EnrichedGameData, _ int) {
 	m.calls++
 }
 
@@ -195,23 +195,24 @@ func (m *mockBonds) CheckBonds(_ []*monTypes.EnrichedGameData) {
 }
 
 type mockExtractor struct {
-	fetchErr   error
-	calls      int
-	maxSuccess int
-	games      []*monTypes.EnrichedGameData
+	fetchErr     error
+	calls        int
+	maxSuccess   int
+	games        []*monTypes.EnrichedGameData
+	ignoredCount int
 }
 
 func (m *mockExtractor) Extract(
 	_ context.Context,
 	_ common.Hash,
 	_ uint64,
-) ([]*monTypes.EnrichedGameData, error) {
+) ([]*monTypes.EnrichedGameData, int, error) {
 	m.calls++
 	if m.fetchErr != nil {
-		return nil, m.fetchErr
+		return nil, 0, m.fetchErr
 	}
 	if m.calls > m.maxSuccess && m.maxSuccess != 0 {
-		return nil, mockErr
+		return nil, 0, mockErr
 	}
-	return m.games, nil
+	return m.games, m.ignoredCount, nil
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -96,7 +96,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.initGameCallerCreator() // Must be called before initForecast
 
 	s.initDelayCalculator()
-	s.initExtractor()
+	s.initExtractor(cfg)
 
 	s.initForecast(cfg)
 	s.initBonds()
@@ -133,11 +133,12 @@ func (s *Service) initDelayCalculator() {
 	s.delays = resolution.NewDelayCalculator(s.metrics, s.cl)
 }
 
-func (s *Service) initExtractor() {
+func (s *Service) initExtractor(cfg *config.Config) {
 	s.extractor = extract.NewExtractor(
 		s.logger,
 		s.game.CreateContract,
 		s.factoryContract.GetGamesAtOrAfter,
+		cfg.IgnoredGames,
 		extract.NewClaimEnricher(),
 		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher
 		extract.NewWithdrawalsEnricher(),


### PR DESCRIPTION
**Description**

When a game is ignored because of this option it logs a warning and reports a count of ignored games via a new metric. Note that this logging is deliberately pretty noisy - ignoring a game is something we need to do carefully and should be extremely rare. It will stop logging once the game is old enough to be outside the monitoring interval.

This allows us to silence alerts from games that are known to have some issue which has been addressed in some way outside the `DisputeGameFactory` (e.g manual overrides or determining that the anomalous result is harmless).

**Tests**

Updated unit tests.

