### PR TITLE
Add op-dispute-mon to images to build in golang-docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ golang-docker:
 			--progress plain \
 			--load \
 			-f docker-bake.hcl \
-			op-node op-batcher op-proposer op-challenger
+			op-node op-batcher op-proposer op-challenger op-dispute-mon
 .PHONY: golang-docker
 
 chain-mon-docker:


### PR DESCRIPTION
**Description**

Adds `op-dispute-mon` to list of images to build as part of the `golang-docker` make target. Since the shared docker build image does most of the work of compiling things already, this makes almost no difference to the build time and makes it easy to get an `op-dispute-mon` docker image built locally.

No impact on CI build times as it calls docker bake directly and doesn't use this target.