### PR TITLE
contracts-bedrock: explicit deploy config

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -146,6 +146,7 @@ def devnet_l1_allocs(paths):
     run_command([
         'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     ], env={
+      'DEPLOYMENT_OUTFILE': paths.l1_deployments_path,
       'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
     }, cwd=paths.contracts_bedrock_dir)
 

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -145,7 +145,9 @@ def devnet_l1_allocs(paths):
     # Use foundry pre-funded account #1 for the deployer
     run_command([
         'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-    ], env={}, cwd=paths.contracts_bedrock_dir)
+    ], env={
+      'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
+    }, cwd=paths.contracts_bedrock_dir)
 
     forge_dump = read_json(paths.forge_l1_dump_path)
     write_json(paths.allocs_l1_path, { "accounts": forge_dump })
@@ -163,6 +165,7 @@ def devnet_l2_allocs(paths):
         'forge', 'script', fqn, "--sig", "runWithAllUpgrades()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     ], env={
       'CONTRACT_ADDRESSES_PATH': paths.l1_deployments_path,
+      'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
     }, cwd=paths.contracts_bedrock_dir)
 
     # For the previous forks, and the latest fork (default, thus empty prefix),

--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -29,6 +29,7 @@ deployments/hardhat
 deployments/getting-started
 deployments/*/.deploy
 deployments/1337
+deployments/31337-deploy.json
 
 # Devnet config which changes with each 'make devnet-up'
 deploy-config/devnetL1.json

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -14,7 +14,7 @@
     "build": "forge build",
     "build:go-ffi": "(cd scripts/go-ffi && go build)",
     "autogen:invariant-docs": "npx tsx scripts/autogen/generate-invariant-docs.ts",
-    "test": "pnpm build:go-ffi && forge test",
+    "test": "pnpm build:go-ffi && DEPLOY_CONFIG_PATH=deploy-config/hardhat.json forge test",
     "test:kontrol": "./test/kontrol/scripts/run-kontrol.sh script",
     "genesis": "forge script scripts/L2Genesis.s.sol:L2Genesis --sig 'runWithStateDump()'",
     "coverage": "pnpm build:go-ffi && (forge coverage || (bash -c \"forge coverage 2>&1 | grep -q 'Stack too deep' && echo -e '\\033[1;33mWARNING\\033[0m: Coverage failed with stack too deep, so overriding and exiting successfully' && exit 0 || exit 1\"))",

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { Vm } from "forge-std/Vm.sol";
-import { Chains } from "scripts/Chains.sol";
 
 /// @title Config
 /// @notice Contains all env var based config. Add any new env var parsing to this file
@@ -15,15 +14,14 @@ library Config {
     ///         written to disk after doing a deployment.
     function deploymentOutfile() internal view returns (string memory _env) {
         _env = vm.envOr(
-            "DEPLOYMENT_OUTFILE", string.concat(vm.projectRoot(), "/deployments/", _getDeploymentContext(), "/.deploy")
+            "DEPLOYMENT_OUTFILE", string.concat(vm.projectRoot(), "/deployments/", vm.toString(block.chainid), "/deploy.json")
         );
     }
 
     /// @notice Returns the path on the local filesystem where the deploy config is
     function deployConfigPath() internal view returns (string memory _env) {
-        _env = vm.envOr(
-            "DEPLOY_CONFIG_PATH", string.concat(vm.projectRoot(), "/deploy-config/", _getDeploymentContext(), ".json")
-        );
+        require(vm.envExists("DEPLOY_CONFIG_PATH"), "Config: must set DEPLOY_CONFIG_PATH to filesystem path of deploy config");
+        _env = vm.envString("DEPLOY_CONFIG_PATH");
     }
 
     /// @notice Returns the chainid from the EVM context or the value of the CHAIN_ID env var as
@@ -37,12 +35,6 @@ library Config {
     ///         which then backs the `getAddress` function.
     function contractAddressesPath() internal view returns (string memory _env) {
         _env = vm.envOr("CONTRACT_ADDRESSES_PATH", string(""));
-    }
-
-    /// @notice Returns the deployment context which was only useful in the hardhat deploy style
-    ///         of deployments. It is now DEPRECATED and will be removed in the future.
-    function deploymentContext() internal view returns (string memory _env) {
-        _env = vm.envOr("DEPLOYMENT_CONTEXT", string(""));
     }
 
     /// @notice The CREATE2 salt to be used when deploying the implementations.
@@ -59,12 +51,6 @@ library Config {
         );
     }
 
-    /// @notice Returns the sig of the entrypoint to the deploy script. By default, it is `run`.
-    ///         This was useful for creating hardhat deploy style artifacts and will be removed in a future release.
-    function sig() internal view returns (string memory _env) {
-        _env = vm.envOr("SIG", string("run"));
-    }
-
     /// @notice Returns the name of the file that the forge deployment artifact is written to on the local
     ///         filesystem. By default, it is the name of the deploy script with the suffix `-latest.json`.
     ///         This was useful for creating hardhat deploy style artifacts and will be removed in a future release.
@@ -75,36 +61,5 @@ library Config {
     /// @notice Returns the private key that is used to configure drippie.
     function drippieOwnerPrivateKey() internal view returns (uint256 _env) {
         _env = vm.envUint("DRIPPIE_OWNER_PRIVATE_KEY");
-    }
-
-    /// @notice The context of the deployment is used to namespace the artifacts.
-    ///         An unknown context will use the chainid as the context name.
-    ///         This is legacy code and should be removed in the future.
-    function _getDeploymentContext() private view returns (string memory) {
-        string memory context = deploymentContext();
-        if (bytes(context).length > 0) {
-            return context;
-        }
-
-        uint256 chainid = Config.chainID();
-        if (chainid == Chains.Mainnet) {
-            return "mainnet";
-        } else if (chainid == Chains.Goerli) {
-            return "goerli";
-        } else if (chainid == Chains.OPGoerli) {
-            return "optimism-goerli";
-        } else if (chainid == Chains.OPMainnet) {
-            return "optimism-mainnet";
-        } else if (chainid == Chains.LocalDevnet || chainid == Chains.GethDevnet || chainid == Chains.OPLocalDevnet) {
-            return "devnetL1";
-        } else if (chainid == Chains.Hardhat) {
-            return "hardhat";
-        } else if (chainid == Chains.Sepolia) {
-            return "sepolia";
-        } else if (chainid == Chains.OPSepolia) {
-            return "optimism-sepolia";
-        } else {
-            return vm.toString(chainid);
-        }
     }
 }

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -20,8 +20,8 @@ library Config {
 
     /// @notice Returns the path on the local filesystem where the deploy config is
     function deployConfigPath() internal view returns (string memory _env) {
-        require(vm.envExists("DEPLOY_CONFIG_PATH"), "Config: must set DEPLOY_CONFIG_PATH to filesystem path of deploy config");
-        _env = vm.envString("DEPLOY_CONFIG_PATH");
+        _env = vm.envOr("DEPLOY_CONFIG_PATH", string(""));
+        require(bytes(_env).length > 0, "Config: must set DEPLOY_CONFIG_PATH to filesystem path of deploy config");
     }
 
     /// @notice Returns the chainid from the EVM context or the value of the CHAIN_ID env var as

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -14,7 +14,7 @@ library Config {
     ///         written to disk after doing a deployment.
     function deploymentOutfile() internal view returns (string memory _env) {
         _env = vm.envOr(
-            "DEPLOYMENT_OUTFILE", string.concat(vm.projectRoot(), "/deployments/", vm.toString(block.chainid), "/deploy.json")
+            "DEPLOYMENT_OUTFILE", string.concat(vm.projectRoot(), "/deployments/", vm.toString(block.chainid), "-deploy.json")
         );
     }
 


### PR DESCRIPTION
**Description**

Remove the concept of implicit deploy config for explicit deploy config.
This removes confusing implicit behavior as well as makes it much
more straight forward for deploying multiple superchain targets
to the same L1. This is a breaking change but the error message
makes it very obvious and the docs are being updated in a way
that should include this information.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

