### PR TITLE
contracts-bedrock: delete name function

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -116,20 +116,15 @@ contract Deploy is Deployer {
         vm.startStateDiffRecording();
         _;
         VmSafe.AccountAccess[] memory accesses = vm.stopAndReturnStateDiff();
-        console.log("Writing %d state diff account accesses to snapshots/state-diff/%s.json", accesses.length, name());
+        console.log("Writing %d state diff account accesses to snapshots/state-diff/%s.json", accesses.length, vm.toString(block.chainid));
         string memory json = LibStateDiff.encodeAccountAccesses(accesses);
-        string memory statediffPath = string.concat(vm.projectRoot(), "/snapshots/state-diff/", name(), ".json");
+        string memory statediffPath = string.concat(vm.projectRoot(), "/snapshots/state-diff/", vm.toString(block.chainid), ".json");
         vm.writeJson({ json: json, path: statediffPath });
     }
 
     ////////////////////////////////////////////////////////////////
     //                        Accessors                           //
     ////////////////////////////////////////////////////////////////
-
-    /// @inheritdoc Deployer
-    function name() public pure override returns (string memory name_) {
-        name_ = "Deploy";
-    }
 
     /// @notice The create2 salt used for deployment of the contract implementations.
     ///         Using this helps to reduce config across networks as the implementation

--- a/packages/contracts-bedrock/scripts/DeployPeriphery.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployPeriphery.s.sol
@@ -26,11 +26,6 @@ import { Config } from "scripts/Config.sol";
 contract DeployPeriphery is Script, Artifacts {
     PeripheryDeployConfig cfg;
 
-    /// @notice The name of the script, used to ensure the right deploy artifacts are used.
-    function name() public pure returns (string memory name_) {
-        name_ = "DeployPeriphery";
-    }
-
     /// @notice Sets up the deployment script.
     function setUp() public override {
         Artifacts.setUp();

--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -22,10 +22,4 @@ abstract contract Deployer is Script, Artifacts {
         vm.allowCheatcodes(address(cfg));
         cfg.read(Config.deployConfigPath());
     }
-
-    /// @notice Returns the name of the deployment script. Children contracts
-    ///         must implement this to ensure that the deploy artifacts can be found.
-    ///         This should be the same as the name of the script and is used as the file
-    ///         name inside of the `broadcast` directory when looking up deployment artifacts.
-    function name() public pure virtual returns (string memory);
 }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -96,10 +96,6 @@ contract L2Genesis is Deployer {
         0x9DCCe783B6464611f38631e6C851bf441907c710 // 29
     ];
 
-    function name() public pure override returns (string memory) {
-        return "L2Genesis";
-    }
-
     function artifactDependencies() internal view returns (L1Dependencies memory l1Dependencies_) {
         console.log("retrieving L1 deployments from artifacts");
         return L1Dependencies({


### PR DESCRIPTION
**Description**

The `name()` function existed due to legacy
purposes when dealing with hardhat artifacts
and no longer is necessary. This commit removes
it in favor of a simpler approach of just using
the chainid instead of the name. The files that
are written are not committed into the repo.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

