### PR TITLE
contracts-bedrock: deployer as msg.sender

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -158,9 +158,8 @@ def devnet_l2_allocs(paths):
     log.info('Generating L2 genesis allocs, with L1 addresses: '+paths.l1_deployments_path)
 
     fqn = 'scripts/L2Genesis.s.sol:L2Genesis'
-    # Use foundry pre-funded account #1 for the deployer
     run_command([
-        'forge', 'script', fqn, "--sig", "runWithAllUpgrades()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        'forge', 'script', fqn, "--sig", "runWithAllUpgrades()"
     ], env={
       'CONTRACT_ADDRESSES_PATH': paths.l1_deployments_path,
     }, cwd=paths.contracts_bedrock_dir)

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -137,8 +137,8 @@ contract L2Genesis is Deployer {
 
     /// @notice Build the L2 genesis.
     function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public {
-        vm.chainId(cfg.l2ChainID());
         vm.startPrank(deployer);
+        vm.chainId(cfg.l2ChainID());
 
         dealEthToPrecompiles();
         setPredeployProxies();

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -155,7 +155,7 @@ contract L2Genesis is Deployer {
         if (_mode == OutputMode.OUTPUT_ALL) {
             writeGenesisAllocs(Config.stateDumpPath("-delta"));
         }
-        vm.endPrank();
+        vm.stopPrank();
 
         activateEcotone();
         if (_mode == OutputMode.OUTPUT_ALL || _mode == OutputMode.DEFAULT_LATEST) {

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -109,7 +109,7 @@ contract L2Genesis is Deployer {
     modifier asDeployer() {
         vm.startPrank(deployer);
         _;
-        vm.endPrank();
+        vm.stopPrank();
     }
 
     function name() public pure override returns (string memory) {

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -147,6 +147,8 @@ contract L2Genesis is Deployer {
         if (cfg.fundDevAccounts()) {
             fundDevAccounts();
         }
+        vm.stopPrank();
+
         // Genesis is "complete" at this point, but some hardfork activation steps remain.
         // Depending on the "Output Mode" we perform the activations and output the necessary state dumps.
         if (_mode == OutputMode.LOCAL_DELTA) {
@@ -155,7 +157,6 @@ contract L2Genesis is Deployer {
         if (_mode == OutputMode.OUTPUT_ALL) {
             writeGenesisAllocs(Config.stateDumpPath("-delta"));
         }
-        vm.stopPrank();
 
         activateEcotone();
         if (_mode == OutputMode.OUTPUT_ALL || _mode == OutputMode.DEFAULT_LATEST) {

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -105,13 +105,6 @@ contract L2Genesis is Deployer {
         super.setUp();
     }
 
-    /// @notice Modifier that starts and ends a prank around the function call.
-    modifier prank(address _addr) {
-        vm.startPrank(_addr);
-        _;
-        vm.stopPrank();
-    }
-
     function name() public pure override returns (string memory) {
         return "L2Genesis";
     }
@@ -143,7 +136,8 @@ contract L2Genesis is Deployer {
     }
 
     /// @notice Build the L2 genesis.
-    function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public prank(deployer) {
+    function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public {
+        vm.startPrank(deployer);
         vm.chainId(cfg.l2ChainID());
 
         dealEthToPrecompiles();
@@ -161,6 +155,8 @@ contract L2Genesis is Deployer {
         if (_mode == OutputMode.OUTPUT_ALL) {
             writeGenesisAllocs(Config.stateDumpPath("-delta"));
         }
+        vm.endPrank();
+
         activateEcotone();
         if (_mode == OutputMode.OUTPUT_ALL || _mode == OutputMode.DEFAULT_LATEST) {
             writeGenesisAllocs(Config.stateDumpPath(""));
@@ -500,9 +496,8 @@ contract L2Genesis is Deployer {
         require(Preinstalls.BeaconBlockRoots.code.length > 0, "L2Genesis: must have beacon-block-roots contract");
         console.log("Activating ecotone in GasPriceOracle contract");
 
-        vm.startPrank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
+        vm.prank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         GasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setEcotone();
-        vm.stopPrank();
     }
 
     /// @notice Sets the bytecode in state

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -96,6 +96,16 @@ contract L2Genesis is Deployer {
         0x9DCCe783B6464611f38631e6C851bf441907c710 // 29
     ];
 
+    /// @notice The address of the deployer account.
+    address internal deployer;
+
+    /// @notice Sets up the script and ensures the deployer account is used to make calls.
+    function setUp() public override {
+        deployer = makeAddr("deployer");
+        vm.startPrank(deployer);
+        super.setUp();
+    }
+
     function name() public pure override returns (string memory) {
         return "L2Genesis";
     }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -107,7 +107,7 @@ contract L2Genesis is Deployer {
 
     /// @notice Modifier that starts and ends a prank around the function call.
     modifier asDeployer() {
-        vm.startPrank(deployer)
+        vm.startPrank(deployer);
         _;
         vm.endPrank();
     }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -137,8 +137,8 @@ contract L2Genesis is Deployer {
 
     /// @notice Build the L2 genesis.
     function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public {
-        vm.startPrank(deployer);
         vm.chainId(cfg.l2ChainID());
+        vm.startPrank(deployer);
 
         dealEthToPrecompiles();
         setPredeployProxies();
@@ -496,8 +496,9 @@ contract L2Genesis is Deployer {
         require(Preinstalls.BeaconBlockRoots.code.length > 0, "L2Genesis: must have beacon-block-roots contract");
         console.log("Activating ecotone in GasPriceOracle contract");
 
-        vm.prank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
+        vm.startPrank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         GasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setEcotone();
+        vm.stopPrank();
     }
 
     /// @notice Sets the bytecode in state

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -533,6 +533,9 @@ contract L2Genesis is Deployer {
         vm.resetNonce(msg.sender);
         vm.deal(msg.sender, 0);
 
+        vm.deal(deployer, 0);
+        vm.resetNonce(deployer);
+
         console.log("Writing state dump to: %s", _path);
         vm.dumpState(_path);
         sortJsonByKeys(_path);

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -106,8 +106,8 @@ contract L2Genesis is Deployer {
     }
 
     /// @notice Modifier that starts and ends a prank around the function call.
-    modifier asDeployer() {
-        vm.startPrank(deployer);
+    modifier prank(address _addr) {
+        vm.startPrank(_addr);
         _;
         vm.stopPrank();
     }
@@ -143,7 +143,7 @@ contract L2Genesis is Deployer {
     }
 
     /// @notice Build the L2 genesis.
-    function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public asDeployer {
+    function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public prank(deployer) {
         vm.chainId(cfg.l2ChainID());
 
         dealEthToPrecompiles();
@@ -495,10 +495,9 @@ contract L2Genesis is Deployer {
         vm.setNonce(Preinstalls.BeaconBlockRootsSender, 1);
     }
 
-    function activateEcotone() public {
+    function activateEcotone() public prank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT()) {
         require(Preinstalls.BeaconBlockRoots.code.length > 0, "L2Genesis: must have beacon-block-roots contract");
         console.log("Activating ecotone in GasPriceOracle contract");
-        vm.prank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         GasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setEcotone();
     }
 

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -495,10 +495,14 @@ contract L2Genesis is Deployer {
         vm.setNonce(Preinstalls.BeaconBlockRootsSender, 1);
     }
 
-    function activateEcotone() public prank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT()) {
+    /// @notice Activate Ecotone network upgrade.
+    function activateEcotone() public {
         require(Preinstalls.BeaconBlockRoots.code.length > 0, "L2Genesis: must have beacon-block-roots contract");
         console.log("Activating ecotone in GasPriceOracle contract");
+
+        vm.startPrank(L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         GasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setEcotone();
+        vm.stopPrank();
     }
 
     /// @notice Sets the bytecode in state

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -102,8 +102,14 @@ contract L2Genesis is Deployer {
     /// @notice Sets up the script and ensures the deployer account is used to make calls.
     function setUp() public override {
         deployer = makeAddr("deployer");
-        vm.startPrank(deployer);
         super.setUp();
+    }
+
+    /// @notice Modifier that starts and ends a prank around the function call.
+    modifier asDeployer() {
+        vm.startPrank(deployer)
+        _;
+        vm.endPrank();
     }
 
     function name() public pure override returns (string memory) {
@@ -137,7 +143,7 @@ contract L2Genesis is Deployer {
     }
 
     /// @notice Build the L2 genesis.
-    function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public {
+    function runWithOptions(OutputMode _mode, L1Dependencies memory _l1Dependencies) public asDeployer {
         vm.chainId(cfg.l2ChainID());
 
         dealEthToPrecompiles();

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -187,8 +187,9 @@ contract Setup {
 
         // Set the governance token's owner to be the final system owner
         address finalSystemOwner = deploy.cfg().finalSystemOwner();
-        vm.prank(governanceToken.owner());
+        vm.startPrank(governanceToken.owner());
         governanceToken.transferOwnership(finalSystemOwner);
+        vm.stopPrank();
 
         // L2 predeploys
         labelPredeploy(Predeploys.L2_STANDARD_BRIDGE);


### PR DESCRIPTION
**Description**

Use a special deployer account for the execution of the L2 genesis
script. This should remove the need to set the sender as part
of the devnet.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

