### PR TITLE
fix: ensure conductor services are closed

### DIFF
--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -59,7 +59,7 @@ func (c *conductor) RPCEndpoint() string {
 	return fmt.Sprintf("http://%s:%d", localhost, c.rpcPort)
 }
 
-func setupSequencerFailoverTest(t *testing.T) (*System, map[string]*conductor) {
+func setupSequencerFailoverTest(t *testing.T) (*System, map[string]*conductor, func()) {
 	InitParallel(t)
 	ctx := context.Background()
 
@@ -129,7 +129,12 @@ func setupSequencerFailoverTest(t *testing.T) (*System, map[string]*conductor) {
 	require.True(t, healthy(t, ctx, c2))
 	require.True(t, healthy(t, ctx, c3))
 
-	return sys, conductors
+	return sys, conductors, func() {
+		sys.Close()
+		for _, c := range conductors {
+			_ = c.service.Stop(ctx)
+		}
+	}
 }
 
 func setupHAInfra(t *testing.T, ctx context.Context) (*System, map[string]*conductor, error) {


### PR DESCRIPTION
**Description**

This PR updates the conductor tests to close down the op-conductor services created during e2e tests.

When working on https://github.com/ethereum-optimism/optimism/pull/9618, we noticed the conductor tests would panic due to logging being output after the test had finished running:

 ```
panic: Log in goroutine after TestSequencerFailover_ConductorRPC has completed:             ERROR[04-30|02:54:20.066] health monitor failed to get sync status err="Post \"http://127.0.0.1:42055/\": dial tcp 127.0.0.1:42055: connect: connection refused"

goroutine 122725 [running]:
testing.(*common).logDepth(0xc0029ac9c0, {0xc003d4da20, 0xab}, 0x3)
        /usr/local/go/src/testing/testing.go:1022 +0x4c5
testing.(*common).log(...)
        /usr/local/go/src/testing/testing.go:1004
testing.(*common).Logf(0xc0029ac9c0, {0x23d214c?, 0x410be5?}, {0xc0103d00f0?, 0x1f34780?, 0xc00fff2801?})
        /usr/local/go/src/testing/testing.go:1055 +0x54
github.com/ethereum-optimism/optimism/op-service/testlog.(*logger).flush(0xc00ad11f50)
        /root/project/op-service/testlog/testlog.go:163 +0xdb
github.com/ethereum-optimism/optimism/op-service/testlog.(*logger).Error(0xc00ad11f50, {0x25a394b, 0x28}, {0xc036ace360, 0x2, 0x2})
        /root/project/op-service/testlog/testlog.go:115 +0xdb
github.com/ethereum-optimism/optimism/op-conductor/health.(*SequencerHealthMonitor).healthCheck(0xc025561360)
        /root/project/op-conductor/health/monitor.go:129 +0xe3
github.com/ethereum-optimism/optimism/op-conductor/health.(*SequencerHealthMonitor).loop(0xc025561360)
        /root/project/op-conductor/health/monitor.go:115 +0xaf
created by github.com/ethereum-optimism/optimism/op-conductor/health.(*SequencerHealthMonitor).Start in goroutine 23943
        /root/project/op-conductor/health/monitor.go:82 +0x8f
```

This seemed to consistently occur during the e2e fuzz tests that we added (likely due to them running serially/slower than the other tests).