### PR TITLE
contracts-bedrock: simplify L1 state dump

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -144,7 +144,7 @@ def devnet_l1_allocs(paths):
     fqn = 'scripts/Deploy.s.sol:Deploy'
     # Use foundry pre-funded account #1 for the deployer
     run_command([
-        'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        'forge', 'script', fqn, "--sig", "runWithStateDump()", "--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     ], env={}, cwd=paths.contracts_bedrock_dir)
 
     forge_dump = read_json(paths.forge_l1_dump_path)

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -261,6 +261,7 @@ contract Deploy is Deployer {
     }
 
     function runWithStateDump() public {
+        vm.chainId(cfg.l1ChainID());
         _run();
         vm.dumpState(Config.stateDumpPath(""));
     }


### PR DESCRIPTION
**Description**

Removes the need to specify the L1 chainid via CLI.
Follows similar patterns to L2 genesis generation that
were done recently.

Follow up PRs can potentially use the same sort of deployer pattern
as in https://github.com/ethereum-optimism/optimism/pull/10343
for when doing the L1 genesis dump to remove the need to specify the
private key.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

