### PR TITLE
geth: update to v1.13.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
 	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232
-	github.com/ethereum/go-ethereum v1.13.13
+	github.com/ethereum/go-ethereum v1.13.14
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/docgen v1.2.0
@@ -253,7 +253,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.13 => github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164506-2248c7add29f
+replace github.com/ethereum/go-ethereum v1.13.14 => github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164737-040566d9b6db
 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164506-2248c7add29f h1:iA9euhmIgVXwApP8f8T7qpYZh2r1S7y60ILMnhAAGCE=
-github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164506-2248c7add29f/go.mod h1:VXVFzx1mr/JyJac5M4k5W/+0cqHZMkqKsIVDsOyj2rs=
+github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164737-040566d9b6db h1:H0WGSiIKKC6DLOH+0wc5nB969EPisv6B8UHeVHeKx9I=
+github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164737-040566d9b6db/go.mod h1:VXVFzx1mr/JyJac5M4k5W/+0cqHZMkqKsIVDsOyj2rs=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232 h1:jRdLJs4E3ilsDGK7+k39QPi3QKL/b1cLnyv8mfOCVo4=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=

--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/kms v1.12.1
 	github.com/BurntSushi/toml v1.3.2
 	github.com/ethereum-optimism/optimism v1.6.2-0.20240222202618-f707883038d5
-	github.com/ethereum/go-ethereum v1.13.13
+	github.com/ethereum/go-ethereum v1.13.14
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
@@ -130,6 +130,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.13 => github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240423152303-521c8102b5de
+replace github.com/ethereum/go-ethereum v1.13.14 => github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164737-040566d9b6db
 
 replace github.com/ethereum-optimism/optimism => ../.

--- a/op-ufm/go.sum
+++ b/op-ufm/go.sum
@@ -100,8 +100,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240423152303-521c8102b5de h1:a8HkRKycSXoD3nFMcaOngQgp4nfDmT6OEuG79/T0QZU=
-github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240423152303-521c8102b5de/go.mod h1:VXVFzx1mr/JyJac5M4k5W/+0cqHZMkqKsIVDsOyj2rs=
+github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164737-040566d9b6db h1:H0WGSiIKKC6DLOH+0wc5nB969EPisv6B8UHeVHeKx9I=
+github.com/ethereum-optimism/op-geth v1.101312.0-synctest.0.0.20240430164737-040566d9b6db/go.mod h1:VXVFzx1mr/JyJac5M4k5W/+0cqHZMkqKsIVDsOyj2rs=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232 h1:jRdLJs4E3ilsDGK7+k39QPi3QKL/b1cLnyv8mfOCVo4=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=


### PR DESCRIPTION
Updates the `go.mod` to use `op-geth` based on upstream version `v1.13.14`

This PR is made against `v1.13.13` branch because there were are required changes to support the previous version which must be built on.

No additional changes required to support the new version beyond changes made in previous updates:
* `trie` pakcage updated to `triedb` package
* `core` types deprecated for `types` types