### PR TITLE
Remove the logs error to clean the output.

### DIFF
--- a/packages/chain-mon/internal/multisig-mon/service.ts
+++ b/packages/chain-mon/internal/multisig-mon/service.ts
@@ -160,18 +160,20 @@ export class MultisigMonService extends BaseServiceV2<
         `OP_SERVICE_ACCOUNT_TOKEN=${this.options.onePassServiceToken} op item list --format json --vault="${account.vault}"`,
         (error, stdout, stderr) => {
           if (error) {
-            this.logger.error(`got unexpected error from onepass: ${error}`, {
+            this.logger.error(`got unexpected error from onepass:`, {
               section: 'onePassNonce',
               name: 'getOnePassNonce',
             })
             return
           }
           if (stderr) {
-            this.logger.error(`got unexpected error from onepass`, {
-              section: 'onePassNonce',
-              name: 'getOnePassNonce',
-              stderr,
-            })
+            this.logger.error(
+              `got unexpected error (from the stderr) from onepass`,
+              {
+                section: 'onePassNonce',
+                name: 'getOnePassNonce',
+              }
+            )
             return
           }
           const items = JSON.parse(stdout)


### PR DESCRIPTION
A way to ensure that the logs that `multisig-mon` is not sending too much incorrect information is remove this by redirecting this to `/dev/null`.  
In a near future, we will rewrite this and make sure to logs this correctly with *monitorism*. But at the moment the metrics still works fine so should be fine.

At the end, we are still monitoring issues with the amount a failed command. 
So this is not an issue imo.
By redirecting the `stderr` this should be enough. 
