### PR TITLE
op-node: L1Block interop

### DIFF
--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -43,6 +43,7 @@ fuzz:
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzParseL1InfoDepositTxDataBadLength ./rollup/derive
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzRejectCreateBlockBadTimestamp ./rollup/driver
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzDecodeDepositTxDataToL1Info ./rollup/driver
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzL1InfoInteropRoundTrip ./rollup/derive
 
 generate-mocks:
 	go generate ./...

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -20,6 +20,7 @@ import (
 const (
 	L1InfoFuncBedrockSignature = "setL1BlockValues(uint64,uint64,uint256,bytes32,uint64,bytes32,uint256,uint256)"
 	L1InfoFuncEcotoneSignature = "setL1BlockValuesEcotone()"
+	L1InfoFuncInteropSignature = "setL1BlockValuesInterop()"
 	L1InfoArguments            = 8
 	L1InfoBedrockLen           = 4 + 32*L1InfoArguments
 	L1InfoEcotoneLen           = 4 + 32*5 // after Ecotone upgrade, args are packed into 5 32-byte slots
@@ -28,12 +29,18 @@ const (
 var (
 	L1InfoFuncBedrockBytes4 = crypto.Keccak256([]byte(L1InfoFuncBedrockSignature))[:4]
 	L1InfoFuncEcotoneBytes4 = crypto.Keccak256([]byte(L1InfoFuncEcotoneSignature))[:4]
+	L1InfoFuncInteropBytes4 = crypto.Keccak256([]byte(L1InfoFuncInteropSignature))[:4]
 	L1InfoDepositerAddress  = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 	L1BlockAddress          = predeploys.L1BlockAddr
 )
 
 const (
 	RegolithSystemTxGas = 1_000_000
+)
+
+// The following hardcoded chain IDs are for the first devnet release of interop
+var (
+	InteropDependencySet = []*big.Int{big.NewInt(10666), big.NewInt(10777), big.NewInt(10888)}
 )
 
 // L1BlockInfo presents the information stored in a L1Block.setL1BlockValues call
@@ -54,6 +61,8 @@ type L1BlockInfo struct {
 	BlobBaseFee       *big.Int // added by Ecotone upgrade
 	BaseFeeScalar     uint32   // added by Ecotone upgrade
 	BlobBaseFeeScalar uint32   // added by Ecotone upgrade
+
+	DependencySet []*big.Int // added by Interop upgrade
 }
 
 // Bedrock Binary Format
@@ -243,6 +252,138 @@ func (info *L1BlockInfo) unmarshalBinaryEcotone(data []byte) error {
 	return nil
 }
 
+// Interop Binary Format
+// +----------------------+----------------------+
+// | Bytes                | Field                |
+// +----------------------+----------------------+
+// | 4                    | Function signature   |
+// | 4                    | BaseFeeScalar        |
+// | 4                    | BlobBaseFeeScalar    |
+// | 8                    | SequenceNumber       |
+// | 8                    | Timestamp            |
+// | 8                    | L1BlockNumber        |
+// | 32                   | BaseFee              |
+// | 32                   | BlobBaseFee          |
+// | 32                   | BlockHash            |
+// | 32                   | BatcherHash          |
+// | 1       		      | DependencySetSize    |
+// | 32*DependencySetSize | DependencySet        |
+// +----------------------+----------------------+
+
+func (info *L1BlockInfo) marshalBinaryInterop() ([]byte, error) {
+	w := bytes.NewBuffer(make([]byte, 0, L1InfoInteropLen(uint8(len(info.DependencySet)))))
+	if err := solabi.WriteSignature(w, L1InfoFuncInteropBytes4); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.BaseFeeScalar); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.BlobBaseFeeScalar); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.SequenceNumber); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.Time); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.Number); err != nil {
+		return nil, err
+	}
+	if err := solabi.WriteUint256(w, info.BaseFee); err != nil {
+		return nil, err
+	}
+	blobBasefee := info.BlobBaseFee
+	if blobBasefee == nil {
+		blobBasefee = big.NewInt(1) // set to 1, to match the min blob basefee as defined in EIP-4844
+	}
+	if err := solabi.WriteUint256(w, blobBasefee); err != nil {
+		return nil, err
+	}
+	if err := solabi.WriteHash(w, info.BlockHash); err != nil {
+		return nil, err
+	}
+	// ABI encoding will perform the left-padding with zeroes to 32 bytes, matching the "batcherHash" SystemConfig format and version 0 byte.
+	if err := solabi.WriteAddress(w, info.BatcherAddr); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(w, binary.BigEndian, info.DependencySetSize()); err != nil {
+		return nil, err
+	}
+	for _, chainID := range info.DependencySet {
+		if err := solabi.WriteUint256(w, chainID); err != nil {
+			return nil, err
+		}
+	}
+
+	return w.Bytes(), nil
+}
+
+func (info *L1BlockInfo) unmarshalBinaryInterop(data []byte) error {
+	r := bytes.NewReader(data)
+
+	var err error
+	if _, err := solabi.ReadAndValidateSignature(r, L1InfoFuncInteropBytes4); err != nil {
+		return err
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
+		return fmt.Errorf("invalid interop l1 block info format")
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
+		return fmt.Errorf("invalid interop l1 block info format")
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
+		return fmt.Errorf("invalid interop l1 block info format")
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
+		return fmt.Errorf("invalid interop l1 block info format")
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
+		return fmt.Errorf("invalid interop l1 block info format")
+	}
+	if info.BaseFee, err = solabi.ReadUint256(r); err != nil {
+		return err
+	}
+	if info.BlobBaseFee, err = solabi.ReadUint256(r); err != nil {
+		return err
+	}
+	if info.BlockHash, err = solabi.ReadHash(r); err != nil {
+		return err
+	}
+	// The "batcherHash" will be correctly parsed as address, since the version 0 and left-padding matches the ABI encoding format.
+	if info.BatcherAddr, err = solabi.ReadAddress(r); err != nil {
+		return err
+	}
+
+	var dependencySetSize uint8
+
+	if err := binary.Read(r, binary.BigEndian, &dependencySetSize); err != nil {
+		return fmt.Errorf("invalid interop l1 block info format")
+	}
+
+	// we make the check here because it's the soonest InteroptSetSize is available, which is needed to calculate the expected length
+	l1InfoLen := L1InfoInteropLen(dependencySetSize)
+	if len(data) != l1InfoLen {
+		return fmt.Errorf("data is unexpected length: got %d, expected %d", len(data), l1InfoLen)
+	}
+
+	info.DependencySet = make([]*big.Int, dependencySetSize)
+	for i := uint8(0); i < dependencySetSize; i++ {
+		if info.DependencySet[i], err = solabi.ReadUint256(r); err != nil {
+			return err
+		}
+	}
+
+	if !solabi.EmptyReader(r) {
+		return errors.New("too many bytes")
+	}
+	return nil
+}
+
+func (info *L1BlockInfo) DependencySetSize() uint8 {
+	return uint8(len(info.DependencySet))
+}
+
 // isEcotoneButNotFirstBlock returns whether the specified block is subject to the Ecotone upgrade,
 // but is not the actiation block itself.
 func isEcotoneButNotFirstBlock(rollupCfg *rollup.Config, l2BlockTime uint64) bool {
@@ -321,6 +462,60 @@ func L1InfoDeposit(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNumber 
 	return out, nil
 }
 
+// L1InfoInteropDeposit creates a L1 Info deposit transaction based on the L1 block,
+// and the L2 block-height difference with the start of the epoch under the Interop upgrade.
+func L1InfoInteropDeposit(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNumber uint64, block eth.BlockInfo, l2BlockTime uint64) (*types.DepositTx, error) {
+	l1BlockInfo := L1BlockInfo{
+		Number:         block.NumberU64(),
+		Time:           block.Time(),
+		BaseFee:        block.BaseFee(),
+		BlockHash:      block.Hash(),
+		SequenceNumber: seqNumber,
+		BatcherAddr:    sysCfg.BatcherAddr,
+	}
+	var data []byte
+	l1BlockInfo.BlobBaseFee = block.BlobBaseFee()
+	if l1BlockInfo.BlobBaseFee == nil {
+		// The L2 spec states to use the MIN_BLOB_GASPRICE from EIP-4844 if not yet active on L1.
+		l1BlockInfo.BlobBaseFee = big.NewInt(1)
+	}
+	scalars, err := sysCfg.EcotoneScalars()
+	if err != nil {
+		return nil, err
+	}
+	l1BlockInfo.BlobBaseFeeScalar = scalars.BlobBaseFeeScalar
+	l1BlockInfo.BaseFeeScalar = scalars.BaseFeeScalar
+	l1BlockInfo.DependencySet = InteropDependencySet
+	dataOut, err := l1BlockInfo.marshalBinaryInterop()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Interop l1 block info: %w", err)
+	}
+	data = dataOut
+
+	source := L1InfoDepositSource{
+		L1BlockHash: block.Hash(),
+		SeqNumber:   seqNumber,
+	}
+	// Set a very large gas limit with `IsSystemTransaction` to ensure
+	// that the L1 Attributes Transaction does not run out of gas.
+	out := &types.DepositTx{
+		SourceHash:          source.SourceHash(),
+		From:                L1InfoDepositerAddress,
+		To:                  &L1BlockAddress,
+		Mint:                nil,
+		Value:               big.NewInt(0),
+		Gas:                 150_000_000,
+		IsSystemTransaction: true,
+		Data:                data,
+	}
+	// With the regolith fork we disable the IsSystemTx functionality, and allocate real gas
+	if rollupCfg.IsRegolith(l2BlockTime) {
+		out.IsSystemTransaction = false
+		out.Gas = RegolithSystemTxGas
+	}
+	return out, nil
+}
+
 // L1InfoDepositBytes returns a serialized L1-info attributes transaction.
 func L1InfoDepositBytes(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNumber uint64, l1Info eth.BlockInfo, l2BlockTime uint64) ([]byte, error) {
 	dep, err := L1InfoDeposit(rollupCfg, sysCfg, seqNumber, l1Info, l2BlockTime)
@@ -333,4 +528,9 @@ func L1InfoDepositBytes(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNu
 		return nil, fmt.Errorf("failed to encode L1 info tx: %w", err)
 	}
 	return opaqueL1Tx, nil
+}
+
+// L1InfoInteropLen returns the length of the L1 block under the Interop upgrade.
+func L1InfoInteropLen(dependencySetSize uint8) int {
+	return 4 + 32*5 + 1 + 32*int(dependencySetSize)
 }

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -399,6 +399,12 @@ func L1BlockInfoFromBytes(rollupCfg *rollup.Config, l2BlockTime uint64, data []b
 	return &info, info.unmarshalBinaryBedrock(data)
 }
 
+// L1BlockInteropInfoFromBytes is the inverse of L1InfoDeposit, to see where the L2 chain is derived from, under the Interop upgrade
+func L1BlockInteropInfoFromBytes(rollupCfg *rollup.Config, l2BlockTime uint64, data []byte) (*L1BlockInfo, error) {
+	var info L1BlockInfo
+	return &info, info.unmarshalBinaryInterop(data)
+}
+
 // L1InfoDeposit creates a L1 Info deposit transaction based on the L1 block,
 // and the L2 block-height difference with the start of the epoch.
 func L1InfoDeposit(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNumber uint64, block eth.BlockInfo, l2BlockTime uint64) (*types.DepositTx, error) {

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -162,4 +162,49 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		require.Equal(t, depTx.Gas, uint64(RegolithSystemTxGas))
 		require.Equal(t, L1InfoEcotoneLen, len(depTx.Data))
 	})
+	t.Run("interop", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		info := testutils.MakeBlockInfo(nil)(rng)
+		zero := uint64(0)
+		rollupCfg := rollup.Config{
+			RegolithTime: &zero,
+			EcotoneTime:  &zero,
+		}
+		depTx, err := L1InfoInteropDeposit(&rollupCfg, randomL1Cfg(rng, info), randomSeqNr(rng), info, 1)
+		require.NoError(t, err)
+		require.False(t, depTx.IsSystemTransaction)
+		require.Equal(t, depTx.Gas, uint64(RegolithSystemTxGas))
+		require.Equal(t, L1InfoInteropLen(uint8(len(InteropDependencySet))), len(depTx.Data))
+	})
+	t.Run("invalid dependency set size, not matching", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		info := testutils.MakeBlockInfo(nil)(rng)
+		zero := uint64(0)
+		rollupCfg := rollup.Config{
+			RegolithTime: &zero,
+			EcotoneTime:  &zero,
+		}
+		depTx, err := L1InfoInteropDeposit(&rollupCfg, randomL1Cfg(rng, info), randomSeqNr(rng), info, 1)
+		require.NoError(t, err)
+		depTx.Data[164] = 0
+		_, err = L1BlockInteropInfoFromBytes(&rollupCfg, info.Time(), depTx.Data)
+		assert.Error(t, err)
+	})
+	t.Run("invalid dependency set size, too large", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		info := testutils.MakeBlockInfo(nil)(rng)
+		zero := uint64(0)
+		rollupCfg := rollup.Config{
+			RegolithTime: &zero,
+			EcotoneTime:  &zero,
+		}
+		depTx, err := L1InfoInteropDeposit(&rollupCfg, randomL1Cfg(rng, info), randomSeqNr(rng), info, 1)
+		require.NoError(t, err)
+		// insert another byte after dependency set size to make dependency set size greater than uint8
+		// this will make the dependency set size invalid because unmarshalBinaryInterop reads only one byte at index 165
+		depTx.Data = append(depTx.Data[:165+1], depTx.Data[165:]...)
+		depTx.Data[165] = 10
+		_, err = L1BlockInteropInfoFromBytes(&rollupCfg, info.Time(), depTx.Data)
+		assert.Error(t, err)
+	})
 }

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -64,8 +64,12 @@
     "sourceCodeHash": "0xde06becce9514f46ba78b4cb0732c7a714d49ba8f131258d56a5f5b22b51be7e"
   },
   "src/L2/L1Block.sol": {
-    "initCodeHash": "0xda6828a2a6e02d9fde7d5d9947f51b207f31abf5dbb538dd968cd491164e2115",
-    "sourceCodeHash": "0x775c399d93a729e1d3fe9a67c015f529f0c17a5986f93cd8d0f7806414fc5cdc"
+    "initCodeHash": "0x42d17698899f06e6cf38823bea3dbaff32ba32ebcb2974f928f93d005a3ea91b",
+    "sourceCodeHash": "0xdcf5b0e1334c900a84d820ed2f359c5ccf52ccdf3a078f8fb884f7f940fb29c1"
+  },
+  "src/L2/L1BlockInterop.sol": {
+    "initCodeHash": "0xddac768887de4053c8e8b92bc9bc621c9bb31df90018be4308dd4e21b1b1085f",
+    "sourceCodeHash": "0xc93a12fbf00ace5f92051f4a57bb3584b5b773c33fd3c40be771c3b4fbf878e9"
   },
   "src/L2/L1FeeVault.sol": {
     "initCodeHash": "0x2744d34573be83206d1b75d049d18a7bb37f9058e68c0803e5008c46b0dc2474",

--- a/packages/contracts-bedrock/snapshots/abi/L1BlockInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1BlockInterop.json
@@ -78,6 +78,38 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "dependencySet",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dependencySetSize",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "hash",
     "outputs": [
@@ -85,6 +117,25 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "isInDependencySet",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -193,6 +244,13 @@
   {
     "inputs": [],
     "name": "setL1BlockValuesEcotone",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "setL1BlockValuesInterop",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1BlockInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1BlockInterop.json
@@ -1,0 +1,86 @@
+[
+  {
+    "bytes": "8",
+    "label": "number",
+    "offset": 0,
+    "slot": "0",
+    "type": "uint64"
+  },
+  {
+    "bytes": "8",
+    "label": "timestamp",
+    "offset": 8,
+    "slot": "0",
+    "type": "uint64"
+  },
+  {
+    "bytes": "32",
+    "label": "basefee",
+    "offset": 0,
+    "slot": "1",
+    "type": "uint256"
+  },
+  {
+    "bytes": "32",
+    "label": "hash",
+    "offset": 0,
+    "slot": "2",
+    "type": "bytes32"
+  },
+  {
+    "bytes": "8",
+    "label": "sequenceNumber",
+    "offset": 0,
+    "slot": "3",
+    "type": "uint64"
+  },
+  {
+    "bytes": "4",
+    "label": "blobBaseFeeScalar",
+    "offset": 8,
+    "slot": "3",
+    "type": "uint32"
+  },
+  {
+    "bytes": "4",
+    "label": "baseFeeScalar",
+    "offset": 12,
+    "slot": "3",
+    "type": "uint32"
+  },
+  {
+    "bytes": "32",
+    "label": "batcherHash",
+    "offset": 0,
+    "slot": "4",
+    "type": "bytes32"
+  },
+  {
+    "bytes": "32",
+    "label": "l1FeeOverhead",
+    "offset": 0,
+    "slot": "5",
+    "type": "uint256"
+  },
+  {
+    "bytes": "32",
+    "label": "l1FeeScalar",
+    "offset": 0,
+    "slot": "6",
+    "type": "uint256"
+  },
+  {
+    "bytes": "32",
+    "label": "blobBaseFee",
+    "offset": 0,
+    "slot": "7",
+    "type": "uint256"
+  },
+  {
+    "bytes": "32",
+    "label": "dependencySet",
+    "offset": 0,
+    "slot": "8",
+    "type": "uint256[]"
+  }
+]

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -49,8 +49,10 @@ contract L1Block is ISemver {
     /// @notice The latest L1 blob base fee.
     uint256 public blobBaseFee;
 
-    /// @custom:semver 1.2.0
-    string public constant version = "1.2.0";
+    /// @custom:semver 1.3.0
+    function version() public virtual pure returns (string memory) {
+        return "1.3.0";
+    }
 
     /// @custom:legacy
     /// @notice Updates the L1 block values.
@@ -105,7 +107,6 @@ contract L1Block is ISemver {
                 mstore(0x00, 0x3cc50b45) // 0x3cc50b45 is the 4-byte selector of "NotDepositor()"
                 revert(0x1C, 0x04) // returns the stored 4-byte selector from above
             }
-            let data := calldataload(4)
             // sequencenum (uint64), blobBaseFeeScalar (uint32), baseFeeScalar (uint32)
             sstore(sequenceNumber.slot, shr(128, calldataload(4)))
             // number (uint64) and timestamp (uint64)

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { L1Block } from "src/L2/L1Block.sol";
+
+/// @notice Thrown when a non-depositor account attempts to set L1 block values.
+error NotDepositor();
+
+/// @notice Thrown when dependencySetSize does not match the length of the dependency set.
+error DependencySetSizeMismatch();
+
+/// @custom:proxied
+/// @custom:predeploy 0x4200000000000000000000000000000000000015
+/// @title L1BlockInterop
+/// @notice Interop extenstions of L1Block.
+contract L1BlockInterop is L1Block {
+    /// @notice The chain IDs of the interop dependency set.
+    uint256[] public dependencySet;
+
+    /// @custom:semver 1.3.0+interop
+    function version() public override pure returns (string memory) {
+        return string.concat(super.version(), "+interop");
+    }
+
+    /// @notice Updates the L1 block values for an Interop upgraded chain.
+    /// Params are packed and passed in as raw msg.data instead of ABI to reduce calldata size.
+    /// Params are expected to be in the following order:
+    ///   1. _baseFeeScalar      L1 base fee scalar
+    ///   2. _blobBaseFeeScalar  L1 blob base fee scalar
+    ///   3. _sequenceNumber     Number of L2 blocks since epoch start.
+    ///   4. _timestamp          L1 timestamp.
+    ///   5. _number             L1 blocknumber.
+    ///   6. _basefee            L1 base fee.
+    ///   7. _blobBaseFee        L1 blob base fee.
+    ///   8. _hash               L1 blockhash.
+    ///   9. _batcherHash        Versioned hash to authenticate batcher by.
+    ///  10. _dependencySetSize  Size of the interop dependency set.
+    ///  11. _dependencySet      Array of chain IDs for the interop dependency set.
+    function setL1BlockValuesInterop() external {
+        assembly {
+            // Revert if the caller is not the depositor account.
+            if xor(caller(), DEPOSITOR_ACCOUNT) {
+                mstore(0x00, 0x3cc50b45) // 0x3cc50b45 is the 4-byte selector of "NotDepositor()"
+                revert(0x1C, 0x04) // returns the stored 4-byte selector from above
+            }
+            // sequencenum (uint64), blobBaseFeeScalar (uint32), baseFeeScalar (uint32)
+            sstore(sequenceNumber.slot, shr(128, calldataload(4)))
+            // number (uint64) and timestamp (uint64)
+            sstore(number.slot, shr(128, calldataload(20)))
+            sstore(basefee.slot, calldataload(36)) // uint256
+            sstore(blobBaseFee.slot, calldataload(68)) // uint256
+            sstore(hash.slot, calldataload(100)) // bytes32
+            sstore(batcherHash.slot, calldataload(132)) // bytes32
+
+            // Load dependencySetSize from calldata (at offset 164 after calldata for setL1BlockValuesEcotone ends)
+            let dependencySetSize_ := shr(248, calldataload(164))
+
+            // Revert if dependencySetSize_ doesn't match the length of dependencySet in calldata
+            if xor(add(165, mul(dependencySetSize_, 0x20)), calldatasize()) {
+                mstore(0x00, 0x44165b6a) // 0x44165b6a is the 4-byte selector of "DependencySetSizeMismatch()"
+                revert(0x1C, 0x04) // returns the stored 4-byte selector from above
+            }
+
+            // Use memory to hash and get the start index of dependencySet
+            mstore(0x00, dependencySet.slot)
+            let dependencySetStartIndex := keccak256(0x00, 0x20)
+
+            // Iterate over calldata dependencySet and write to store dependencySet
+            for { let i := 0 } lt(i, dependencySetSize_) { i := add(i, 1) } {
+                // Load value from calldata and write to storage (dependencySet) at index
+                let val := calldataload(add(165, mul(i, 0x20)))
+                sstore(add(dependencySetStartIndex, i), val)
+            }
+
+            // Update length of dependencySet array
+            sstore(dependencySet.slot, dependencySetSize_)
+        }
+    }
+
+    /// @notice Returns true if a chain ID is in the interop dependency set and false otherwise.
+    ///         Every chain ID is in the interop dependency set of itself.
+    /// @param _chainId The chain ID to check.
+    /// @return True if the chain ID to check is in the interop dependency set. False otherwise.
+    function isInDependencySet(uint256 _chainId) public view returns (bool) {
+        // Every chain ID is in the interop dependency set of itself.
+        if (_chainId == block.chainid) {
+            return true;
+        }
+
+        uint256 length = dependencySet.length;
+        for (uint256 i = 0; i < length;) {
+            if (dependencySet[i] == _chainId) {
+                return true;
+            }
+            unchecked {
+                i++;
+            }
+        }
+
+        return false;
+    }
+
+    /// @notice Returns the size of the interop dependency set.
+    /// @return The size of the interop dependency set.
+    function dependencySetSize() external view returns (uint8) {
+        return uint8(dependencySet.length);
+    }
+}

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -18,7 +18,7 @@ contract L1BlockInterop is L1Block {
     uint256[] public dependencySet;
 
     /// @custom:semver 1.3.0+interop
-    function version() public override pure returns (string memory) {
+    function version() public pure override returns (string memory) {
         return string.concat(super.version(), "+interop");
     }
 

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -173,4 +173,52 @@ library Encoding {
             batcherHash
         );
     }
+
+    /// @notice Returns an appropriately encoded call to L1Block.setL1BlockValuesInterop
+    /// @param _baseFeeScalar       L1 base fee Scalar
+    /// @param _blobBaseFeeScalar   L1 blob base fee Scalar
+    /// @param _sequenceNumber      Number of L2 blocks since epoch start.
+    /// @param _timestamp           L1 timestamp.
+    /// @param _number              L1 blocknumber.
+    /// @param _baseFee             L1 base fee.
+    /// @param _blobBaseFee         L1 blob base fee.
+    /// @param _hash                L1 blockhash.
+    /// @param _batcherHash         Versioned hash to authenticate batcher by.
+    /// @param _dependencySet       Array of the chain IDs in the interop dependency set.
+    function encodeSetL1BlockValuesInterop(
+        uint32 _baseFeeScalar,
+        uint32 _blobBaseFeeScalar,
+        uint64 _sequenceNumber,
+        uint64 _timestamp,
+        uint64 _number,
+        uint256 _baseFee,
+        uint256 _blobBaseFee,
+        bytes32 _hash,
+        bytes32 _batcherHash,
+        uint256[] memory _dependencySet
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        require(_dependencySet.length <= type(uint8).max, "Encoding: dependency set length is too large");
+        // Check that the batcher hash is just the address with 0 padding to the left for version 0.
+        require(uint160(uint256(_batcherHash)) == uint256(_batcherHash), "Encoding: invalid batcher hash");
+
+        bytes4 functionSignature = bytes4(keccak256("setL1BlockValuesInterop()"));
+        return abi.encodePacked(
+            functionSignature,
+            _baseFeeScalar,
+            _blobBaseFeeScalar,
+            _sequenceNumber,
+            _timestamp,
+            _number,
+            _baseFee,
+            _blobBaseFee,
+            _hash,
+            _batcherHash,
+            uint8(_dependencySet.length),
+            _dependencySet
+        );
+    }
 }

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -60,6 +60,21 @@ contract L1BlockBedrock_Test is L1BlockTest {
             _l1FeeScalar: type(uint256).max
         });
     }
+
+    /// @dev Tests that `setL1BlockValues` reverts if sender address is not the depositor
+    function test_updatesValues_notDepositor_reverts() external {
+        vm.expectRevert("L1Block: only the depositor account can set L1 block values");
+        l1Block.setL1BlockValues({
+            _number: type(uint64).max,
+            _timestamp: type(uint64).max,
+            _basefee: type(uint256).max,
+            _hash: keccak256(abi.encode(1)),
+            _sequenceNumber: type(uint64).max,
+            _batcherHash: bytes32(type(uint256).max),
+            _l1FeeOverhead: type(uint256).max,
+            _l1FeeScalar: type(uint256).max
+        });
+    }
 }
 
 contract L1BlockEcotone_Test is L1BlockTest {
@@ -127,8 +142,8 @@ contract L1BlockEcotone_Test is L1BlockTest {
         assertTrue(success, "function call failed");
     }
 
-    /// @dev Tests that `setL1BlockValuesEcotone` fails if sender address is not the depositor
-    function test_setL1BlockValuesEcotone_notDepositor_fails() external {
+    /// @dev Tests that `setL1BlockValuesEcotone` reverts if sender address is not the depositor
+    function test_setL1BlockValuesEcotone_notDepositor_reverts() external {
         bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesEcotone(
             type(uint32).max,
             type(uint32).max,

--- a/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
+import { L1BlockInterop, DependencySetSizeMismatch, NotDepositor } from "src/L2/L1BlockInterop.sol";
+
+contract L1BlockInterop_Test is Test {
+    L1BlockInterop l1Block;
+    address depositor;
+
+    function setUp() public {
+        l1Block = new L1BlockInterop();
+        depositor = l1Block.DEPOSITOR_ACCOUNT();
+    }
+
+    /// @dev Tests that setL1BlockValuesInterop updates the values appropriately.
+    function testFuzz_setL1BlockValuesInterop_succeeds(
+        uint32 baseFeeScalar,
+        uint32 blobBaseFeeScalar,
+        uint64 sequenceNumber,
+        uint64 timestamp,
+        uint64 number,
+        uint256 baseFee,
+        uint256 blobBaseFee,
+        bytes32 hash,
+        bytes32 batcherHash,
+        uint256[] calldata dependencySet
+    )
+        external
+    {
+        vm.assume(dependencySet.length <= type(uint8).max);
+        vm.assume(uint160(uint256(batcherHash)) == uint256(batcherHash));
+
+
+        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
+            _baseFeeScalar: baseFeeScalar,
+            _blobBaseFeeScalar: blobBaseFeeScalar,
+            _sequenceNumber: sequenceNumber,
+            _timestamp: timestamp,
+            _number: number,
+            _baseFee: baseFee,
+            _blobBaseFee: blobBaseFee,
+            _hash: hash,
+            _batcherHash: batcherHash,
+            _dependencySet: dependencySet
+        });
+
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(success, "Function call failed");
+
+
+        assertEq(l1Block.baseFeeScalar(), baseFeeScalar);
+        assertEq(l1Block.blobBaseFeeScalar(), blobBaseFeeScalar);
+        assertEq(l1Block.sequenceNumber(), sequenceNumber);
+        assertEq(l1Block.timestamp(), timestamp);
+        assertEq(l1Block.number(), number);
+        assertEq(l1Block.basefee(), baseFee);
+        assertEq(l1Block.blobBaseFee(), blobBaseFee);
+        assertEq(l1Block.hash(), hash);
+        assertEq(l1Block.batcherHash(), batcherHash);
+        assertEq(l1Block.dependencySetSize(), dependencySet.length);
+        for (uint256 i = 0; i < dependencySet.length; i++) {
+            assertEq(l1Block.dependencySet(i), dependencySet[i]);
+            assertTrue(l1Block.isInDependencySet(dependencySet[i]));
+        }
+
+
+        // ensure we didn't accidentally pollute the 128 bits of the sequencenum+scalars slot that
+        // should be empty
+        bytes32 scalarsSlot = vm.load(address(l1Block), bytes32(uint256(3)));
+        bytes32 mask128 = hex"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000";
+
+
+        assertEq(0, scalarsSlot & mask128);
+
+
+        // ensure we didn't accidentally pollute the 128 bits of the number & timestamp slot that
+        // should be empty
+        bytes32 numberTimestampSlot = vm.load(address(l1Block), bytes32(uint256(0)));
+        assertEq(0, numberTimestampSlot & mask128);
+    }
+
+
+    /// @dev Tests that `setL1BlockValuesInterop` succeeds if sender address is the depositor
+    function test_setL1BlockValuesInterop_isDepositor_succeeds() external {
+        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
+            _baseFeeScalar: type(uint32).max,
+            _blobBaseFeeScalar: type(uint32).max,
+            _sequenceNumber: type(uint64).max,
+            _timestamp: type(uint64).max,
+            _number: type(uint64).max,
+            _baseFee: type(uint256).max,
+            _blobBaseFee: type(uint256).max,
+            _hash: bytes32(type(uint256).max),
+            _batcherHash: bytes32(0),
+            _dependencySet: new uint256[](0)
+        });
+
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(success, "function call failed");
+    }
+
+
+    /// @dev Tests that `setL1BlockValuesInterop` fails if sender address is not the depositor
+    function test_setL1BlockValuesInterop_isDepositor_fails() external {
+        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
+            _baseFeeScalar: type(uint32).max,
+            _blobBaseFeeScalar: type(uint32).max,
+            _sequenceNumber: type(uint64).max,
+            _timestamp: type(uint64).max,
+            _number: type(uint64).max,
+            _baseFee: type(uint256).max,
+            _blobBaseFee: type(uint256).max,
+            _hash: bytes32(type(uint256).max),
+            _batcherHash: bytes32(0),
+            _dependencySet: new uint256[](0)
+        });
+
+
+        (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(!success, "function call should have failed");
+        // make sure return value is the expected function selector for "NotDepositor()"
+        assertEq(bytes4(data), NotDepositor.selector);
+    }
+
+
+    /// @dev Tests that `setL1BlockValuesInterop` succeeds if _dependencySetSize is the same as
+    ///      the length of _dependencySet. (happy path)
+    function testFuzz_setL1BlockValuesInterop_dependencySetSizeMatch_succeeds(uint256[] calldata dependencySet)
+        external
+    {
+        vm.assume(dependencySet.length <= type(uint8).max);
+
+
+        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
+            _baseFeeScalar: type(uint32).max,
+            _blobBaseFeeScalar: type(uint32).max,
+            _sequenceNumber: type(uint64).max,
+            _timestamp: type(uint64).max,
+            _number: type(uint64).max,
+            _baseFee: type(uint256).max,
+            _blobBaseFee: type(uint256).max,
+            _hash: bytes32(type(uint256).max),
+            _batcherHash: bytes32(0),
+            _dependencySet: dependencySet
+        });
+
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(success, "function call failed");
+    }
+
+
+    /// @dev Tests that `setL1BlockValuesInterop` fails if _dependencySetSize is not the same as
+    ///      the length of _dependencySet. (bad path)
+    function testFuzz_setL1BlockValuesInterop_dependencySetSizeMatch_fails(
+        uint8 notDependencySetSize,
+        uint256[] calldata dependencySet
+    )
+        external
+    {
+        vm.assume(dependencySet.length <= type(uint8).max);
+        vm.assume(notDependencySetSize != dependencySet.length);
+
+
+        bytes memory functionCallDataPacked = abi.encodePacked(
+            bytes4(keccak256("setL1BlockValuesInterop()")),
+            type(uint32).max,
+            type(uint32).max,
+            type(uint64).max,
+            type(uint256).max,
+            type(uint256).max,
+            bytes32(type(uint256).max),
+            bytes32(type(uint256).max),
+            notDependencySetSize,
+            dependencySet
+        );
+
+
+        vm.prank(depositor);
+        (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(!success, "function call should have failed");
+        // make sure return value is the expected function selector for "DependencySetSizeMismatch()"
+        assertEq(bytes4(data), DependencySetSizeMismatch.selector);
+    }
+
+
+    /// @dev Tests that an arbitrary dependency set can be set and that ìsInDependencySet returns
+    ///      the expected results.
+    function testFuzz_isInDependencySet_succeeds(
+        uint32 baseFeeScalar,
+        uint32 blobBaseFeeScalar,
+        uint64 sequenceNumber,
+        uint64 timestamp,
+        uint64 number,
+        uint256 baseFee,
+        uint256 blobBaseFee,
+        bytes32 hash,
+        bytes32 batcherHash,
+        uint256[] calldata dependencySet
+    )
+        external
+    {
+        vm.assume(dependencySet.length <= type(uint8).max);
+        vm.assume(uint160(uint256(batcherHash)) == uint256(batcherHash));
+
+
+        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
+            _baseFeeScalar: baseFeeScalar,
+            _blobBaseFeeScalar: blobBaseFeeScalar,
+            _sequenceNumber: sequenceNumber,
+            _timestamp: timestamp,
+            _number: number,
+            _baseFee: baseFee,
+            _blobBaseFee: blobBaseFee,
+            _hash: hash,
+            _batcherHash: batcherHash,
+            _dependencySet: dependencySet
+        });
+
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(success, "Function call failed");
+
+
+        assertEq(l1Block.dependencySetSize(), dependencySet.length);
+
+
+        for (uint256 i = 0; i < dependencySet.length; i++) {
+            assertTrue(l1Block.isInDependencySet(dependencySet[i]));
+        }
+    }
+
+
+    /// @dev Tests that `isInDependencySet` returns true when the current chain ID is passed as the input
+    function test_isInDependencySet_isChainId_succeeds() external view {
+        assertTrue(l1Block.isInDependencySet(block.chainid));
+    }
+
+
+    /// @dev Tests that `isInDependencySet` fails when the input chain ID is not in the dependency set
+    function testFuzz_isInDependencySet_fails(uint256 chainId) external {
+        vm.assume(chainId != 1);
+
+
+        uint256[] memory dependencySet = new uint256[](1);
+        dependencySet[0] = 1;
+
+
+        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
+            _baseFeeScalar: 0,
+            _blobBaseFeeScalar: 0,
+            _sequenceNumber: 0,
+            _timestamp: 0,
+            _number: 0,
+            _baseFee: 0,
+            _blobBaseFee: 0,
+            _hash: bytes32(0),
+            _batcherHash: bytes32(0),
+            _dependencySet: dependencySet
+        });
+
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(functionCallDataPacked);
+        assertTrue(success, "Function call failed");
+
+
+        assertFalse(l1Block.isInDependencySet(chainId));
+    }
+
+
+    /// @dev Tests that `isInDependencySet` returns false when the dependency set is empty
+    function testFuzz_isInDependencySet_dependencySetEmpty_fails(uint256 chainId) external view {
+        assertTrue(l1Block.dependencySetSize() == 0);
+        assertFalse(l1Block.isInDependencySet(chainId));
+    }
+}

--- a/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
@@ -32,7 +32,6 @@ contract L1BlockInterop_Test is Test {
         vm.assume(dependencySet.length <= type(uint8).max);
         vm.assume(uint160(uint256(batcherHash)) == uint256(batcherHash));
 
-
         bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
             _baseFeeScalar: baseFeeScalar,
             _blobBaseFeeScalar: blobBaseFeeScalar,
@@ -46,11 +45,9 @@ contract L1BlockInterop_Test is Test {
             _dependencySet: dependencySet
         });
 
-
         vm.prank(depositor);
         (bool success,) = address(l1Block).call(functionCallDataPacked);
         assertTrue(success, "Function call failed");
-
 
         assertEq(l1Block.baseFeeScalar(), baseFeeScalar);
         assertEq(l1Block.blobBaseFeeScalar(), blobBaseFeeScalar);
@@ -67,22 +64,18 @@ contract L1BlockInterop_Test is Test {
             assertTrue(l1Block.isInDependencySet(dependencySet[i]));
         }
 
-
         // ensure we didn't accidentally pollute the 128 bits of the sequencenum+scalars slot that
         // should be empty
         bytes32 scalarsSlot = vm.load(address(l1Block), bytes32(uint256(3)));
         bytes32 mask128 = hex"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000";
 
-
         assertEq(0, scalarsSlot & mask128);
-
 
         // ensure we didn't accidentally pollute the 128 bits of the number & timestamp slot that
         // should be empty
         bytes32 numberTimestampSlot = vm.load(address(l1Block), bytes32(uint256(0)));
         assertEq(0, numberTimestampSlot & mask128);
     }
-
 
     /// @dev Tests that `setL1BlockValuesInterop` succeeds if sender address is the depositor
     function test_setL1BlockValuesInterop_isDepositor_succeeds() external {
@@ -99,15 +92,13 @@ contract L1BlockInterop_Test is Test {
             _dependencySet: new uint256[](0)
         });
 
-
         vm.prank(depositor);
         (bool success,) = address(l1Block).call(functionCallDataPacked);
         assertTrue(success, "function call failed");
     }
 
-
-    /// @dev Tests that `setL1BlockValuesInterop` fails if sender address is not the depositor
-    function test_setL1BlockValuesInterop_isDepositor_fails() external {
+    /// @dev Tests that `setL1BlockValuesInterop` reverts if sender address is not the depositor
+    function test_setL1BlockValuesInterop_isDepositor_reverts() external {
         bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
             _baseFeeScalar: type(uint32).max,
             _blobBaseFeeScalar: type(uint32).max,
@@ -121,13 +112,11 @@ contract L1BlockInterop_Test is Test {
             _dependencySet: new uint256[](0)
         });
 
-
         (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
         assertTrue(!success, "function call should have failed");
         // make sure return value is the expected function selector for "NotDepositor()"
         assertEq(bytes4(data), NotDepositor.selector);
     }
-
 
     /// @dev Tests that `setL1BlockValuesInterop` succeeds if _dependencySetSize is the same as
     ///      the length of _dependencySet. (happy path)
@@ -135,7 +124,6 @@ contract L1BlockInterop_Test is Test {
         external
     {
         vm.assume(dependencySet.length <= type(uint8).max);
-
 
         bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
             _baseFeeScalar: type(uint32).max,
@@ -150,16 +138,14 @@ contract L1BlockInterop_Test is Test {
             _dependencySet: dependencySet
         });
 
-
         vm.prank(depositor);
         (bool success,) = address(l1Block).call(functionCallDataPacked);
         assertTrue(success, "function call failed");
     }
 
-
-    /// @dev Tests that `setL1BlockValuesInterop` fails if _dependencySetSize is not the same as
+    /// @dev Tests that `setL1BlockValuesInterop` reverts if _dependencySetSize is not the same as
     ///      the length of _dependencySet. (bad path)
-    function testFuzz_setL1BlockValuesInterop_dependencySetSizeMatch_fails(
+    function testFuzz_setL1BlockValuesInterop_dependencySetSizeMatch_reverts(
         uint8 notDependencySetSize,
         uint256[] calldata dependencySet
     )
@@ -168,11 +154,12 @@ contract L1BlockInterop_Test is Test {
         vm.assume(dependencySet.length <= type(uint8).max);
         vm.assume(notDependencySetSize != dependencySet.length);
 
-
         bytes memory functionCallDataPacked = abi.encodePacked(
             bytes4(keccak256("setL1BlockValuesInterop()")),
             type(uint32).max,
             type(uint32).max,
+            type(uint64).max,
+            type(uint64).max,
             type(uint64).max,
             type(uint256).max,
             type(uint256).max,
@@ -182,14 +169,12 @@ contract L1BlockInterop_Test is Test {
             dependencySet
         );
 
-
         vm.prank(depositor);
         (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
         assertTrue(!success, "function call should have failed");
         // make sure return value is the expected function selector for "DependencySetSizeMismatch()"
         assertEq(bytes4(data), DependencySetSizeMismatch.selector);
     }
-
 
     /// @dev Tests that an arbitrary dependency set can be set and that ìsInDependencySet returns
     ///      the expected results.
@@ -210,7 +195,6 @@ contract L1BlockInterop_Test is Test {
         vm.assume(dependencySet.length <= type(uint8).max);
         vm.assume(uint160(uint256(batcherHash)) == uint256(batcherHash));
 
-
         bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
             _baseFeeScalar: baseFeeScalar,
             _blobBaseFeeScalar: blobBaseFeeScalar,
@@ -224,35 +208,28 @@ contract L1BlockInterop_Test is Test {
             _dependencySet: dependencySet
         });
 
-
         vm.prank(depositor);
         (bool success,) = address(l1Block).call(functionCallDataPacked);
         assertTrue(success, "Function call failed");
 
-
         assertEq(l1Block.dependencySetSize(), dependencySet.length);
-
 
         for (uint256 i = 0; i < dependencySet.length; i++) {
             assertTrue(l1Block.isInDependencySet(dependencySet[i]));
         }
     }
 
-
     /// @dev Tests that `isInDependencySet` returns true when the current chain ID is passed as the input
     function test_isInDependencySet_isChainId_succeeds() external view {
         assertTrue(l1Block.isInDependencySet(block.chainid));
     }
 
-
-    /// @dev Tests that `isInDependencySet` fails when the input chain ID is not in the dependency set
-    function testFuzz_isInDependencySet_fails(uint256 chainId) external {
+    /// @dev Tests that `isInDependencySet` reverts when the input chain ID is not in the dependency set
+    function testFuzz_isInDependencySet_reverts(uint256 chainId) external {
         vm.assume(chainId != 1);
-
 
         uint256[] memory dependencySet = new uint256[](1);
         dependencySet[0] = 1;
-
 
         bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesInterop({
             _baseFeeScalar: 0,
@@ -267,18 +244,15 @@ contract L1BlockInterop_Test is Test {
             _dependencySet: dependencySet
         });
 
-
         vm.prank(depositor);
         (bool success,) = address(l1Block).call(functionCallDataPacked);
         assertTrue(success, "Function call failed");
 
-
         assertFalse(l1Block.isInDependencySet(chainId));
     }
 
-
     /// @dev Tests that `isInDependencySet` returns false when the dependency set is empty
-    function testFuzz_isInDependencySet_dependencySetEmpty_fails(uint256 chainId) external view {
+    function testFuzz_isInDependencySet_dependencySetEmpty_succeeds(uint256 chainId) external view {
         assertTrue(l1Block.dependencySetSize() == 0);
         assertFalse(l1Block.isInDependencySet(chainId));
     }

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -243,4 +243,42 @@ contract FFIInterface {
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
     }
+
+    function encodeSetL1BlockValuesInterop(
+        uint32 _baseFeeScalar,
+        uint32 _blobBaseFeeScalar,
+        uint64 _sequenceNumber,
+        uint64 _timestamp,
+        uint64 _number,
+        uint256 _baseFee,
+        uint256 _blobBaseFee,
+        bytes32 _hash,
+        bytes32 _batcherHash,
+        uint256[] memory _dependencySet
+    )
+        external
+        returns (bytes memory)
+    {
+        string[] memory cmds = new string[](13 + _dependencySet.length);
+        cmds[0] = "scripts/go-ffi/go-ffi";
+        cmds[1] = "diff";
+        cmds[2] = "encodeSetL1BlockValuesInterop";
+        cmds[3] = vm.toString(_number);
+        cmds[4] = vm.toString(_timestamp);
+        cmds[5] = vm.toString(_baseFee);
+        cmds[6] = vm.toString(_hash);
+        cmds[7] = vm.toString(_sequenceNumber);
+        cmds[8] = vm.toString(_batcherHash);
+        cmds[9] = vm.toString(_blobBaseFee);
+        cmds[10] = vm.toString(_baseFeeScalar);
+        cmds[11] = vm.toString(_blobBaseFeeScalar);
+        cmds[12] = vm.toString(_dependencySet.length);
+        // Add the dependency set
+        for (uint256 i = 0; i < _dependencySet.length; i++) {
+            cmds[13 + i] = vm.toString(_dependencySet[i]);
+        }
+
+        bytes memory result = vm.ffi(cmds);
+        return abi.decode(result, (bytes));
+    }
 }


### PR DESCRIPTION
extends https://github.com/ethereum-optimism/optimism/pull/10344 with changes to op-node and a differential test for `Encoding.sol`