### PR TITLE
ctb: Enable setting custom names in deploySafe()

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -273,7 +273,7 @@ contract Deploy is Deployer {
     /// @notice Internal function containing the deploy logic.
     function _run() internal {
         console.log("start of L1 Deploy!");
-        deploySafe();
+        deploySafe("SystemOwnerSafe");
         console.log("deployed Safe!");
         setupSuperchain();
         console.log("set up superchain!");
@@ -414,7 +414,7 @@ contract Deploy is Deployer {
     ////////////////////////////////////////////////////////////////
 
     /// @notice Deploy the Safe
-    function deploySafe() public broadcast returns (address addr_) {
+    function deploySafe(string memory _name) public broadcast returns (address addr_) {
         console.log("Deploying Safe");
         (SafeProxyFactory safeProxyFactory, Safe safeSingleton) = _getSafeFactory();
 
@@ -426,8 +426,14 @@ contract Deploy is Deployer {
         );
         address safe = address(safeProxyFactory.createProxyWithNonce(address(safeSingleton), initData, block.timestamp));
 
-        save("SystemOwnerSafe", address(safe));
-        console.log("New SystemOwnerSafe deployed at %s", address(safe));
+        save(_name, address(safe));
+        console.log(
+            string.concat(
+                "New safe:",
+                _name,
+                "deployed at %s\n    Note that this safe is owned by the deployer key"
+            ), address(safe)
+        );
         addr_ = safe;
     }
 

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -428,11 +428,8 @@ contract Deploy is Deployer {
 
         save(_name, address(safe));
         console.log(
-            string.concat(
-                "New safe:",
-                _name,
-                "deployed at %s\n    Note that this safe is owned by the deployer key"
-            ), address(safe)
+            string.concat("New safe:", _name, "deployed at %s\n    Note that this safe is owned by the deployer key"),
+            address(safe)
         );
         addr_ = safe;
     }

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -428,7 +428,7 @@ contract Deploy is Deployer {
 
         save(_name, address(safe));
         console.log(
-            string.concat("New safe:", _name, "deployed at %s\n    Note that this safe is owned by the deployer key"),
+            string.concat("New safe: ", _name, " deployed at %s\n    Note that this safe is owned by the deployer key"),
             address(safe)
         );
         addr_ = safe;

--- a/packages/contracts-bedrock/test/kontrol/deployment/KontrolDeployment.sol
+++ b/packages/contracts-bedrock/test/kontrol/deployment/KontrolDeployment.sol
@@ -5,7 +5,7 @@ import { Deploy } from "scripts/Deploy.s.sol";
 
 contract KontrolDeployment is Deploy {
     function runKontrolDeployment() public stateDiff {
-        deploySafe();
+        deploySafe("SystemOwnerSafe");
         setupSuperchain();
 
         // deployProxies();


### PR DESCRIPTION
**Description**

Changes the `deploySafe()` function to accept a string argument, so that the function can be reused to deploy other safe's with more descriptive names.
