### PR TITLE
add jomo optimist allowlist attestation resolver

### DIFF
--- a/packages/contracts-bedrock/src/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/src/L1/ResourceMetering.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/packages/contracts-bedrock/src/libraries/Burn.sol
+++ b/packages/contracts-bedrock/src/libraries/Burn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 /// @title Burn
 /// @notice Utilities for burning stuff.

--- a/packages/contracts-bedrock/src/periphery/TransferOnion.sol
+++ b/packages/contracts-bedrock/src/periphery/TransferOnion.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import {IEAS} from "src/EAS/IEAS.sol";
 import {Attestation} from "src/EAS/Common.sol";
 

--- a/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {IEAS} from "src/EAS/IEAS.sol";
+import {Attestation} from "src/EAS/Common.sol";
+
+import {AllowlistResolverUpgradeable} from "src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol";
+import {SchemaResolverUpgradeable} from "src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol";
+
+/**
+ * @title EAS Schema Resolver for Optimist Attestation Resolver
+ * @notice Manages schemas related to Optimist attestations.
+ * @dev Only allowlisted entities can attest; successful attestations are record and allow to mint.
+ */
+contract OptimistAllowlistAttestationResolver is
+    SchemaResolverUpgradeable,
+    AllowlistResolverUpgradeable,
+    AccessControlUpgradeable,
+    PausableUpgradeable,
+    ReentrancyGuardUpgradeable
+{
+    event AttestationCreated(address indexed recipient);
+    event AttestationRevoked(address indexed recipient);
+
+    bytes32 public constant PAUSE_ROLE = keccak256("optimist.allowlist-attestation-issuer.pause-role");
+    bytes32 public constant ADMIN_ROLE = keccak256("optimist.allowlist-attestation-issuer.admin-role");
+    bytes32 public constant ALLOWLIST_ROLE = keccak256("optimist.allowlist-attestation-issuer.allowlist-role");
+
+    /// @notice track recipient attestationUid
+    mapping (address => bytes32) private attestationUidByRecipient;
+
+    /**
+    * @dev Locks the contract, preventing any future reinitialization. This implementation contract was designed to be called through proxies.
+    * @custom:oz-upgrades-unsafe-allow constructor
+    */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+    * @dev Initializes the contract.
+    * @param admin The address to be granted with the default admin Role.
+    * @param eas The address of the EAS attestation contract.
+    */
+    function initialize(address admin, IEAS eas) initializer public {
+        __SchemaResolver_init(eas);
+        __AccessControl_init();
+        __Pausable_init();
+        __ReentrancyGuard_init();
+        __AllowlistResolver_init();
+
+        require(_grantRole(ADMIN_ROLE, admin));
+        _setRoleAdmin(PAUSE_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(ALLOWLIST_ROLE, ADMIN_ROLE);
+    }
+
+    /// @notice check user has attestation
+    function hasAttestation(address user) public view returns (bool) {
+        return attestationUidByRecipient[user] != bytes32(0);
+    }
+
+    /// @notice get user attestationUid
+    function getAttestationUid(address user) public view returns (bytes32) {
+        return attestationUidByRecipient[user];
+    }
+
+    /// @inheritdoc SchemaResolverUpgradeable
+    function onAttest(
+        Attestation calldata attestationInput,
+        uint256 value
+    ) internal
+    whenNotPaused
+    override(SchemaResolverUpgradeable, AllowlistResolverUpgradeable)
+    returns (bool)
+    {
+        require(AllowlistResolverUpgradeable.onAttest(attestationInput, value), "OptimistAttestationResolver: attester is not allowed");
+        require(attestationUidByRecipient[attestationInput.recipient] == bytes32(0), "OptimistAttestationResolver: recipient already has an attestation");
+        attestationUidByRecipient[attestationInput.recipient] = attestationInput.uid;
+        emit AttestationCreated(attestationInput.recipient);
+        return true;
+    }
+
+    /// @inheritdoc SchemaResolverUpgradeable
+    function onRevoke(
+        Attestation calldata attestationInput,
+        uint256 value
+    ) internal whenNotPaused override(SchemaResolverUpgradeable, AllowlistResolverUpgradeable) returns (bool) {
+        require(AllowlistResolverUpgradeable.onRevoke(attestationInput, value), "OptimistAttestationResolver: attester is not allowed");
+        require(attestationUidByRecipient[attestationInput.recipient] != bytes32(0), "OptimistAttestationResolver: recipient does not have an attestation");
+        attestationUidByRecipient[attestationInput.recipient] = bytes32(0);
+        emit AttestationRevoked(attestationInput.recipient);
+        return true;
+    }
+
+    /**
+    * @dev Pause the contract.
+    */
+    function pause() external onlyRole(PAUSE_ROLE) {
+        _pause();
+    }
+
+    /**
+    * @dev UnPause the contract.
+    */
+    function unpause() external onlyRole(PAUSE_ROLE) {
+        _unpause();
+    }
+
+    /*
+    * @dev Add a new attester to allowedAttesters
+    */
+    function addAttesterToAttesterAllowlist(address _newAttester)
+        external
+        onlyRole(ALLOWLIST_ROLE)
+    {
+        _allowAttester(_newAttester);
+    }
+
+    /*
+    * @dev remove a attester from allowedAttesters
+    */
+    function removeAttesterFromAttesterAllowlist(address _attesterToRemove)
+        external
+        onlyRole(ALLOWLIST_ROLE)
+    {
+        _removeAttester(_attesterToRemove);
+    }
+}

--- a/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.20;
 
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/OptimistAllowlistAttestationResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.15;
 
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
@@ -52,7 +52,7 @@ contract OptimistAllowlistAttestationResolver is
         __ReentrancyGuard_init();
         __AllowlistResolver_init();
 
-        require(_grantRole(ADMIN_ROLE, admin));
+        _grantRole(ADMIN_ROLE, admin);
         _setRoleAdmin(PAUSE_ROLE, ADMIN_ROLE);
         _setRoleAdmin(ALLOWLIST_ROLE, ADMIN_ROLE);
     }
@@ -76,8 +76,8 @@ contract OptimistAllowlistAttestationResolver is
     override(SchemaResolverUpgradeable, AllowlistResolverUpgradeable)
     returns (bool)
     {
-        require(AllowlistResolverUpgradeable.onAttest(attestationInput, value), "OptimistAttestationResolver: attester is not allowed");
-        require(attestationUidByRecipient[attestationInput.recipient] == bytes32(0), "OptimistAttestationResolver: recipient already has an attestation");
+        require(AllowlistResolverUpgradeable.onAttest(attestationInput, value), "OptimistAllowlistAttestationResolver: attester is not allowed");
+        require(attestationUidByRecipient[attestationInput.recipient] == bytes32(0), "OptimistAllowlistAttestationResolver: recipient already has an attestation");
         attestationUidByRecipient[attestationInput.recipient] = attestationInput.uid;
         emit AttestationCreated(attestationInput.recipient);
         return true;
@@ -88,8 +88,8 @@ contract OptimistAllowlistAttestationResolver is
         Attestation calldata attestationInput,
         uint256 value
     ) internal whenNotPaused override(SchemaResolverUpgradeable, AllowlistResolverUpgradeable) returns (bool) {
-        require(AllowlistResolverUpgradeable.onRevoke(attestationInput, value), "OptimistAttestationResolver: attester is not allowed");
-        require(attestationUidByRecipient[attestationInput.recipient] != bytes32(0), "OptimistAttestationResolver: recipient does not have an attestation");
+        require(AllowlistResolverUpgradeable.onRevoke(attestationInput, value), "OptimistAllowlistAttestationResolver: attester is not allowed");
+        require(attestationUidByRecipient[attestationInput.recipient] != bytes32(0), "OptimistAllowlistAttestationResolver: recipient does not have an attestation");
         attestationUidByRecipient[attestationInput.recipient] = bytes32(0);
         emit AttestationRevoked(attestationInput.recipient);
         return true;

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.20;
 
 import {Initializable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {SchemaResolverUpgradeable} from "./SchemaResolverUpgradeable.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Initializable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {SchemaResolverUpgradeable} from "./SchemaResolverUpgradeable.sol";
+import {Attestation} from "src/EAS/Common.sol";
+
+/**
+ * @title Allowlist Schema Resolver for EAS
+ * @dev A base contract for creating an EAS Schema Resolver that can guard
+ * a schema's usage based on the attester. Only attester(s) on the allowlist
+ * can create attestations when this base contract is used for a schema's resolver.
+ */
+abstract contract AllowlistResolverUpgradeable is Initializable, SchemaResolverUpgradeable {
+    /// @notice Emitted when an attester is allowed.
+    event AttesterAllowed(address indexed attester);
+    /// @notice Emitted when an attester is removed.
+    event AttesterRemoved(address indexed attester);
+
+    /// @notice Attester already in allowlist.
+    error AttesterAlreadyAllowed(address attester);
+    /// @notice Attester not in allowlist.
+    error AttesterAlreadyNotAllowed(address attester);
+
+    /// @notice Addresses that are allowed to attest using the schema this resolver is associated with.
+    mapping(address => bool) public allowedAttesters;
+
+    /// @dev Internal initialization function, only meant to be called once.
+    function __AllowlistResolver_init() internal onlyInitializing {
+        __AllowlistResolver_init_unchained();
+    }
+
+    function __AllowlistResolver_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Processes a new attestation, and checks if the attester is in the allowlist.
+     * See {SchemaResolverUpgradeable-onAttest}.
+     *
+     * @param attestation The new attestation.
+     * @return bool True if the attestation is allowed based on the attester.
+     */
+    function onAttest(Attestation calldata attestation, uint256) internal virtual override returns (bool) {
+        return allowedAttesters[attestation.attester];
+    }
+
+    /**
+     * @dev Not implemented as EAS already ensures that only the attester
+     * who created an attestation can revoke it. We do not need an additional allowlist.
+     * See {SchemaResolverUpgradeable-onRevoke}.
+     *
+     * @return bool Always true as EAS already ensures that only the attester can revoke.
+     */
+    function onRevoke(Attestation calldata, uint256) internal virtual override returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev Adds a new allowed attester.
+     *
+     * If this function were to be made public or external,
+     * it should be protected to only allow authorized callers.
+     *
+     * @param attester The address of the attester to be added to allowlist.
+     */
+    function _allowAttester(address attester) internal {
+        if (allowedAttesters[attester]) {
+            revert AttesterAlreadyAllowed(attester);
+        }
+        allowedAttesters[attester] = true;
+        emit AttesterAllowed(attester);
+    }
+
+    /**
+     * @dev Removes an existing allowed attester.
+     *
+     * If this function were to be made public or external,
+     * it should be protected to only allow authorized callers.
+     *
+     * @param attester The address of the attester to be removed from allowlist.
+     */
+    function _removeAttester(address attester) internal {
+        if (!allowedAttesters[attester]) {
+            revert AttesterAlreadyNotAllowed(attester);
+        }
+        allowedAttesters[attester] = false;
+        emit AttesterRemoved(attester);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[49] private __gap;
+}

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import {Initializable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {SchemaResolverUpgradeable} from "./SchemaResolverUpgradeable.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/AllowlistResolverUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.15;
 
 import {Initializable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {SchemaResolverUpgradeable} from "./SchemaResolverUpgradeable.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.20;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ISchemaResolver} from "eas-contracts/resolver/ISchemaResolver.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.15;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {ISchemaResolver} from "eas-contracts/resolver/ISchemaResolver.sol";
-import {ISemver} from "eas-contracts/ISemver.sol";
+import {ISchemaResolver} from "src/EAS/resolver/ISchemaResolver.sol";
+import {ISemver} from "src/universal/ISemver.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IEAS} from "src/EAS/IEAS.sol";
 import "src/EAS/Common.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ISchemaResolver} from "eas-contracts/resolver/ISchemaResolver.sol";

--- a/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
+++ b/packages/contracts-bedrock/src/periphery/jomo/abstract/SchemaResolverUpgradeable.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {ISchemaResolver} from "eas-contracts/resolver/ISchemaResolver.sol";
+import {ISemver} from "eas-contracts/ISemver.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IEAS} from "src/EAS/IEAS.sol";
+import "src/EAS/Common.sol";
+
+abstract contract SchemaResolverUpgradeable is
+    ISchemaResolver,
+    Initializable
+{
+    // Errors
+    error InsufficientValue();
+    error NotPayable();
+
+    // The global EAS contract.
+    IEAS internal _eas;
+
+    // Contract's major version number.
+    uint256 private constant _major = 1;
+
+    // Contract's minor version number.
+    uint256 private constant _minor = 3;
+
+    // Contract's patch version number.
+    uint256 private constant _path = 0;
+
+    /// @dev Create a new Semver instance.
+    /// @param major Major version number.
+    /// @param minor Minor version number.
+    /// @param patch Patch version number.
+
+    /**
+   * @dev Creates a new resolver.
+     */
+    function __SchemaResolver_init(IEAS eas) internal onlyInitializing {
+        __SchemaResolver_init_unchained(eas);
+    }
+
+    function __SchemaResolver_init_unchained(IEAS eas) internal onlyInitializing {
+        if (address(eas) == address(0)) {
+            revert InvalidEAS();
+        }
+        _eas = eas;
+    }
+
+    /// @notice Returns the full semver contract version.
+    /// @return Semver contract version as a string.
+    function version() external pure returns (string memory) {
+        return
+            string(
+            abi.encodePacked(Strings.toString(_major), ".", Strings.toString(_minor), ".", Strings.toString(_path))
+        );
+    }
+
+    /// @dev Ensures that only the EAS contract can make this call.
+    modifier onlyEAS() {
+        _onlyEAS();
+
+        _;
+    }
+
+    /// @inheritdoc ISchemaResolver
+    function isPayable() public pure virtual returns (bool) {
+        return false;
+    }
+
+    /// @dev ETH callback.
+    receive() external payable virtual {
+        if (!isPayable()) {
+            revert NotPayable();
+        }
+    }
+
+    /// @inheritdoc ISchemaResolver
+    function attest(Attestation calldata attestation) external payable onlyEAS returns (bool) {
+        return onAttest(attestation, msg.value);
+    }
+
+    /// @inheritdoc ISchemaResolver
+    function multiAttest(
+        Attestation[] calldata attestations,
+        uint256[] calldata values
+    ) external payable onlyEAS returns (bool) {
+        uint256 length = attestations.length;
+        if (length != values.length) {
+            revert InvalidLength();
+        }
+
+        // We are keeping track of the remaining ETH amount that can be sent to resolvers and will keep deducting
+        // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
+        // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
+        // possible to send too much ETH anyway.
+        uint256 remainingValue = msg.value;
+
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            // Ensure that the attester/revoker doesn't try to spend more than available.
+            uint256 value = values[i];
+            if (value > remainingValue) {
+                revert InsufficientValue();
+            }
+
+            // Forward the attestation to the underlying resolver and return false in case it isn't approved.
+            if (!onAttest(attestations[i], value)) {
+                return false;
+            }
+
+            unchecked {
+            // Subtract the ETH amount, that was provided to this attestation, from the global remaining ETH amount.
+                remainingValue -= value;
+            }
+        }
+
+        return true;
+    }
+
+    /// @inheritdoc ISchemaResolver
+    function revoke(Attestation calldata attestation) external payable onlyEAS returns (bool) {
+        return onRevoke(attestation, msg.value);
+    }
+
+    /// @inheritdoc ISchemaResolver
+    function multiRevoke(
+        Attestation[] calldata attestations,
+        uint256[] calldata values
+    ) external payable onlyEAS returns (bool) {
+        uint256 length = attestations.length;
+        if (length != values.length) {
+            revert InvalidLength();
+        }
+
+        // We are keeping track of the remaining ETH amount that can be sent to resolvers and will keep deducting
+        // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
+        // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
+        // possible to send too much ETH anyway.
+        uint256 remainingValue = msg.value;
+
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            // Ensure that the attester/revoker doesn't try to spend more than available.
+            uint256 value = values[i];
+            if (value > remainingValue) {
+                revert InsufficientValue();
+            }
+
+            // Forward the revocation to the underlying resolver and return false in case it isn't approved.
+            if (!onRevoke(attestations[i], value)) {
+                return false;
+            }
+
+            unchecked {
+            // Subtract the ETH amount, that was provided to this attestation, from the global remaining ETH amount.
+                remainingValue -= value;
+            }
+        }
+
+        return true;
+    }
+
+    /// @notice A resolver callback that should be implemented by child contracts.
+    /// @param attestation The new attestation.
+    /// @param value An explicit ETH amount that was sent to the resolver. Please note that this value is verified in
+    ///     both attest() and multiAttest() callbacks EAS-only callbacks and that in case of multi attestations, it'll
+    ///     usually hold that msg.value != value, since msg.value aggregated the sent ETH amounts for all the
+    ///     attestations in the batch.
+    /// @return Whether the attestation is valid.
+    function onAttest(Attestation calldata attestation, uint256 value) internal virtual returns (bool);
+
+    /// @notice Processes an attestation revocation and verifies if it can be revoked.
+    /// @param attestation The existing attestation to be revoked.
+    /// @param value An explicit ETH amount that was sent to the resolver. Please note that this value is verified in
+    ///     both revoke() and multiRevoke() callbacks EAS-only callbacks and that in case of multi attestations, it'll
+    ///     usually hold that msg.value != value, since msg.value aggregated the sent ETH amounts for all the
+    ///     attestations in the batch.
+    /// @return Whether the attestation can be revoked.
+    function onRevoke(Attestation calldata attestation, uint256 value) internal virtual returns (bool);
+
+    /// @dev Ensures that only the EAS contract can make this call.
+    function _onlyEAS() private view {
+        if (msg.sender != address(_eas)) {
+            revert AccessDenied();
+        }
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;
+}

--- a/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 import { ISemver } from "src/universal/ISemver.sol";
 

--- a/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { ERC721BurnableUpgradeable } from

--- a/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";

--- a/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/periphery/op-nft/libraries/OptimistConstants.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/libraries/OptimistConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 /// @title  OptimistConstants
 /// @notice Library for storing Optimist related constants that are shared in multiple contracts.

--- a/packages/contracts-bedrock/src/universal/Proxy.sol
+++ b/packages/contracts-bedrock/src/universal/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import { Constants } from "src/libraries/Constants.sol";
 

--- a/packages/contracts-bedrock/test/mocks/MockEAS.sol
+++ b/packages/contracts-bedrock/test/mocks/MockEAS.sol
@@ -1,0 +1,627 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+
+import "src/EAS/IEAS.sol";
+import { ISchemaRegistry, SchemaRecord } from "src/EAS/ISchemaRegistry.sol";
+import "src/EAS/resolver/ISchemaResolver.sol";
+import "src/EAS/Common.sol";
+
+contract MockEAS is IEAS {
+    using Address for address payable;
+
+    error AlreadyRevoked();
+    error AlreadyRevokedOffchain();
+    error AlreadyTimestamped();
+    error InsufficientValue();
+    error InvalidAttestation();
+    error InvalidAttestations();
+    error InvalidExpirationTime();
+    error InvalidOffset();
+    error InvalidRegistry();
+    error InvalidRevocation();
+    error InvalidRevocations();
+    error InvalidSchema();
+    error InvalidVerifier();
+    error Irrevocable();
+    error NotPayable();
+    error WrongSchema();
+
+    /// @notice A struct representing an internal attestation result.
+    struct AttestationsResult {
+        uint256 usedValue; // Total ETH amount that was sent to resolvers.
+        bytes32[] uids; // UIDs of the new attestations.
+    }
+
+    // The global schema registry.
+    ISchemaRegistry private immutable _schemaRegistry;
+
+    // The global mapping between attestations and their UIDs.
+    mapping(bytes32 uid => Attestation attestation) private _db;
+
+    // The global mapping between data and their timestamps.
+    mapping(bytes32 data => uint64 timestamp) private _timestamps;
+
+    // The global mapping between data and their revocation timestamps.
+    mapping(address revoker => mapping(bytes32 data => uint64 timestamp) timestamps) private _revocationsOffchain;
+
+    /// @dev Creates a new EAS instance.
+    /// @param registry The address of the global schema registry.
+    constructor(ISchemaRegistry registry) {
+        if (address(registry) == address(0)) {
+            revert InvalidRegistry();
+        }
+
+        _schemaRegistry = registry;
+    }
+
+    /// @inheritdoc IEAS
+    function getSchemaRegistry() external view returns (ISchemaRegistry) {
+        return _schemaRegistry;
+    }
+
+    /// @inheritdoc IEAS
+    function attest(AttestationRequest calldata request) external payable returns (bytes32) {
+        AttestationRequestData[] memory data = new AttestationRequestData[](1);
+        data[0] = request.data;
+
+        return _attest(request.schema, data, msg.sender, msg.value, true).uids[0];
+    }
+
+    /// @inheritdoc IEAS
+    function attestByDelegation(
+        DelegatedAttestationRequest calldata delegatedRequest
+    ) external payable returns (bytes32 result) {
+    }
+
+    /// @inheritdoc IEAS
+    function multiAttest(MultiAttestationRequest[] calldata multiRequests) external payable returns (bytes32[] memory) {
+        // Since a multi-attest call is going to make multiple attestations for multiple schemas, we'd need to collect
+        // all the returned UIDs into a single list.
+        uint256 length = multiRequests.length;
+        bytes32[][] memory totalUIDs = new bytes32[][](length);
+        uint256 totalUIDCount = 0;
+
+        // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
+        // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
+        // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
+        // possible to send too much ETH anyway.
+        uint256 availableValue = msg.value;
+
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            // The last batch is handled slightly differently: if the total available ETH wasn't spent in full and there
+            // is a remainder - it will be refunded back to the attester (something that we can only verify during the
+            // last and final batch).
+            bool last;
+            unchecked {
+                last = i == length - 1;
+            }
+
+            // Process the current batch of attestations.
+            MultiAttestationRequest calldata multiRequest = multiRequests[i];
+
+            // Ensure that data isn't empty.
+            if (multiRequest.data.length == 0) {
+                revert InvalidLength();
+            }
+
+            AttestationsResult memory res = _attest(
+                multiRequest.schema,
+                multiRequest.data,
+                msg.sender,
+                availableValue,
+                last
+            );
+
+            // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
+            availableValue -= res.usedValue;
+
+            // Collect UIDs (and merge them later).
+            totalUIDs[i] = res.uids;
+            unchecked {
+                totalUIDCount += res.uids.length;
+            }
+        }
+
+        // Merge all the collected UIDs and return them as a flatten array.
+        return _mergeUIDs(totalUIDs, totalUIDCount);
+    }
+
+    /// @inheritdoc IEAS
+    function multiAttestByDelegation(
+        MultiDelegatedAttestationRequest[] calldata multiDelegatedRequests
+    ) external payable returns (bytes32[] memory _result) {}
+
+    /// @inheritdoc IEAS
+    function revoke(RevocationRequest calldata request) external payable {
+        RevocationRequestData[] memory data = new RevocationRequestData[](1);
+        data[0] = request.data;
+
+        _revoke(request.schema, data, msg.sender, msg.value, true);
+    }
+
+    /// @inheritdoc IEAS
+    function revokeByDelegation(DelegatedRevocationRequest calldata delegatedRequest) external payable {}
+
+    /// @inheritdoc IEAS
+    function multiRevoke(MultiRevocationRequest[] calldata multiRequests) external payable {
+        // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
+        // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
+        // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
+        // possible to send too much ETH anyway.
+        uint256 availableValue = msg.value;
+
+        uint256 length = multiRequests.length;
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            // The last batch is handled slightly differently: if the total available ETH wasn't spent in full and there
+            // is a remainder - it will be refunded back to the attester (something that we can only verify during the
+            // last and final batch).
+            bool last;
+            unchecked {
+                last = i == length - 1;
+            }
+
+            MultiRevocationRequest calldata multiRequest = multiRequests[i];
+
+            // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
+            availableValue -= _revoke(multiRequest.schema, multiRequest.data, msg.sender, availableValue, last);
+        }
+    }
+
+    /// @inheritdoc IEAS
+    function multiRevokeByDelegation(
+        MultiDelegatedRevocationRequest[] calldata multiDelegatedRequests
+    ) external payable {
+    }
+
+    /// @inheritdoc IEAS
+    function timestamp(bytes32 data) external returns (uint64) {
+        uint64 time = _time();
+
+        _timestamp(data, time);
+
+        return time;
+    }
+
+    /// @inheritdoc IEAS
+    function revokeOffchain(bytes32 data) external returns (uint64) {
+        uint64 time = _time();
+
+        _revokeOffchain(msg.sender, data, time);
+
+        return time;
+    }
+
+    /// @inheritdoc IEAS
+    function multiRevokeOffchain(bytes32[] calldata data) external returns (uint64) {
+        uint64 time = _time();
+
+        uint256 length = data.length;
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            _revokeOffchain(msg.sender, data[i], time);
+        }
+
+        return time;
+    }
+
+    /// @inheritdoc IEAS
+    function multiTimestamp(bytes32[] calldata data) external returns (uint64) {
+        uint64 time = _time();
+
+        uint256 length = data.length;
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            _timestamp(data[i], time);
+        }
+
+        return time;
+    }
+
+    /// @inheritdoc IEAS
+    function getAttestation(bytes32 uid) external view returns (Attestation memory) {
+        return _db[uid];
+    }
+
+    /// @inheritdoc IEAS
+    function isAttestationValid(bytes32 uid) public view returns (bool) {
+        return _db[uid].uid != EMPTY_UID;
+    }
+
+    /// @inheritdoc IEAS
+    function getTimestamp(bytes32 data) external view returns (uint64) {
+        return _timestamps[data];
+    }
+
+    /// @inheritdoc IEAS
+    function getRevokeOffchain(address revoker, bytes32 data) external view returns (uint64) {
+        return _revocationsOffchain[revoker][data];
+    }
+
+    /// @dev Attests to a specific schema.
+    /// @param schemaUID The unique identifier of the schema to attest to.
+    /// @param data The arguments of the attestation requests.
+    /// @param attester The attesting account.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return The UID of the new attestations and the total sent ETH amount.
+    function _attest(
+        bytes32 schemaUID,
+        AttestationRequestData[] memory data,
+        address attester,
+        uint256 availableValue,
+        bool last
+    ) private returns (AttestationsResult memory) {
+        uint256 length = data.length;
+
+        AttestationsResult memory res;
+        res.uids = new bytes32[](length);
+
+        // Ensure that we aren't attempting to attest to a non-existing schema.
+        SchemaRecord memory schemaRecord = _schemaRegistry.getSchema(schemaUID);
+        if (schemaRecord.uid == EMPTY_UID) {
+            revert InvalidSchema();
+        }
+
+        Attestation[] memory attestations = new Attestation[](length);
+        uint256[] memory values = new uint256[](length);
+
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            AttestationRequestData memory request = data[i];
+
+            // Ensure that either no expiration time was set or that it was set in the future.
+            if (request.expirationTime != NO_EXPIRATION_TIME && request.expirationTime <= _time()) {
+                revert InvalidExpirationTime();
+            }
+
+            // Ensure that we aren't trying to make a revocable attestation for a non-revocable schema.
+            if (!schemaRecord.revocable && request.revocable) {
+                revert Irrevocable();
+            }
+
+            Attestation memory attestation = Attestation({
+                uid: EMPTY_UID,
+                schema: schemaUID,
+                refUID: request.refUID,
+                time: _time(),
+                expirationTime: request.expirationTime,
+                revocationTime: 0,
+                recipient: request.recipient,
+                attester: attester,
+                revocable: request.revocable,
+                data: request.data
+            });
+
+            // Look for the first non-existing UID (and use a bump seed/nonce in the rare case of a conflict).
+            bytes32 uid;
+            uint32 bump = 0;
+            while (true) {
+                uid = _getUID(attestation, bump);
+                if (_db[uid].uid == EMPTY_UID) {
+                    break;
+                }
+
+                unchecked {
+                    ++bump;
+                }
+            }
+            attestation.uid = uid;
+
+            _db[uid] = attestation;
+
+            if (request.refUID != EMPTY_UID) {
+                // Ensure that we aren't trying to attest to a non-existing referenced UID.
+                if (!isAttestationValid(request.refUID)) {
+                    revert NotFound();
+                }
+            }
+
+            attestations[i] = attestation;
+            values[i] = request.value;
+
+            res.uids[i] = uid;
+
+            emit Attested(request.recipient, attester, uid, schemaUID);
+        }
+
+        res.usedValue = _resolveAttestations(schemaRecord, attestations, values, false, availableValue, last);
+
+        return res;
+    }
+
+    /// @dev Revokes an existing attestation to a specific schema.
+    /// @param schemaUID The unique identifier of the schema to attest to.
+    /// @param data The arguments of the revocation requests.
+    /// @param revoker The revoking account.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return Returns the total sent ETH amount.
+    function _revoke(
+        bytes32 schemaUID,
+        RevocationRequestData[] memory data,
+        address revoker,
+        uint256 availableValue,
+        bool last
+    ) private returns (uint256) {
+        // Ensure that a non-existing schema ID wasn't passed by accident.
+        SchemaRecord memory schemaRecord = _schemaRegistry.getSchema(schemaUID);
+        if (schemaRecord.uid == EMPTY_UID) {
+            revert InvalidSchema();
+        }
+
+        uint256 length = data.length;
+        Attestation[] memory attestations = new Attestation[](length);
+        uint256[] memory values = new uint256[](length);
+
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            RevocationRequestData memory request = data[i];
+
+            Attestation storage attestation = _db[request.uid];
+
+            // Ensure that we aren't attempting to revoke a non-existing attestation.
+            if (attestation.uid == EMPTY_UID) {
+                revert NotFound();
+            }
+
+            // Ensure that a wrong schema ID wasn't passed by accident.
+            if (attestation.schema != schemaUID) {
+                revert InvalidSchema();
+            }
+
+            // Allow only original attesters to revoke their attestations.
+            if (attestation.attester != revoker) {
+                revert AccessDenied();
+            }
+
+            // Please note that also checking of the schema itself is revocable is unnecessary, since it's not possible to
+            // make revocable attestations to an irrevocable schema.
+            if (!attestation.revocable) {
+                revert Irrevocable();
+            }
+
+            // Ensure that we aren't trying to revoke the same attestation twice.
+            if (attestation.revocationTime != 0) {
+                revert AlreadyRevoked();
+            }
+            attestation.revocationTime = _time();
+
+            attestations[i] = attestation;
+            values[i] = request.value;
+
+            emit Revoked(attestations[i].recipient, revoker, request.uid, schemaUID);
+        }
+
+        return _resolveAttestations(schemaRecord, attestations, values, true, availableValue, last);
+    }
+
+    /// @dev Resolves a new attestation or a revocation of an existing attestation.
+    /// @param schemaRecord The schema of the attestation.
+    /// @param attestation The data of the attestation to make/revoke.
+    /// @param value An explicit ETH amount to send to the resolver.
+    /// @param isRevocation Whether to resolve an attestation or its revocation.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return Returns the total sent ETH amount.
+    function _resolveAttestation(
+        SchemaRecord memory schemaRecord,
+        Attestation memory attestation,
+        uint256 value,
+        bool isRevocation,
+        uint256 availableValue,
+        bool last
+    ) private returns (uint256) {
+        ISchemaResolver resolver = schemaRecord.resolver;
+        if (address(resolver) == address(0)) {
+            // Ensure that we don't accept payments if there is no resolver.
+            if (value != 0) {
+                revert NotPayable();
+            }
+
+            if (last) {
+                _refund(availableValue);
+            }
+
+            return 0;
+        }
+
+        // Ensure that we don't accept payments which can't be forwarded to the resolver.
+        if (value != 0) {
+            if (!resolver.isPayable()) {
+                revert NotPayable();
+            }
+
+            // Ensure that the attester/revoker doesn't try to spend more than available.
+            if (value > availableValue) {
+                revert InsufficientValue();
+            }
+
+            // Ensure to deduct the sent value explicitly.
+            unchecked {
+                availableValue -= value;
+            }
+        }
+
+        if (isRevocation) {
+            if (!resolver.revoke{ value: value }(attestation)) {
+                revert InvalidRevocation();
+            }
+        } else if (!resolver.attest{ value: value }(attestation)) {
+            revert InvalidAttestation();
+        }
+
+        if (last) {
+            _refund(availableValue);
+        }
+
+        return value;
+    }
+
+    /// @dev Resolves multiple attestations or revocations of existing attestations.
+    /// @param schemaRecord The schema of the attestation.
+    /// @param attestations The data of the attestations to make/revoke.
+    /// @param values Explicit ETH amounts to send to the resolver.
+    /// @param isRevocation Whether to resolve an attestation or its revocation.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return Returns the total sent ETH amount.
+    function _resolveAttestations(
+        SchemaRecord memory schemaRecord,
+        Attestation[] memory attestations,
+        uint256[] memory values,
+        bool isRevocation,
+        uint256 availableValue,
+        bool last
+    ) private returns (uint256) {
+        uint256 length = attestations.length;
+        if (length == 1) {
+            return _resolveAttestation(schemaRecord, attestations[0], values[0], isRevocation, availableValue, last);
+        }
+
+        ISchemaResolver resolver = schemaRecord.resolver;
+        if (address(resolver) == address(0)) {
+            // Ensure that we don't accept payments if there is no resolver.
+            for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+                if (values[i] != 0) {
+                    revert NotPayable();
+                }
+            }
+
+            if (last) {
+                _refund(availableValue);
+            }
+
+            return 0;
+        }
+
+        uint256 totalUsedValue = 0;
+        bool isResolverPayable = resolver.isPayable();
+
+        for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
+            uint256 value = values[i];
+
+            // Ensure that we don't accept payments which can't be forwarded to the resolver.
+            if (value == 0) {
+                continue;
+            }
+
+            if (!isResolverPayable) {
+                revert NotPayable();
+            }
+
+            // Ensure that the attester/revoker doesn't try to spend more than available.
+            if (value > availableValue) {
+                revert InsufficientValue();
+            }
+
+            // Ensure to deduct the sent value explicitly and add it to the total used value by the batch.
+            unchecked {
+                availableValue -= value;
+                totalUsedValue += value;
+            }
+        }
+
+        if (isRevocation) {
+            if (!resolver.multiRevoke{ value: totalUsedValue }(attestations, values)) {
+                revert InvalidRevocations();
+            }
+        } else if (!resolver.multiAttest{ value: totalUsedValue }(attestations, values)) {
+            revert InvalidAttestations();
+        }
+
+        if (last) {
+            _refund(availableValue);
+        }
+
+        return totalUsedValue;
+    }
+
+    /// @dev Calculates a UID for a given attestation.
+    /// @param attestation The input attestation.
+    /// @param bump A bump value to use in case of a UID conflict.
+    /// @return Attestation UID.
+    function _getUID(Attestation memory attestation, uint32 bump) private pure returns (bytes32) {
+        return
+            keccak256(
+            abi.encodePacked(
+                attestation.schema,
+                attestation.recipient,
+                attestation.attester,
+                attestation.time,
+                attestation.expirationTime,
+                attestation.revocable,
+                attestation.refUID,
+                attestation.data,
+                bump
+            )
+        );
+    }
+
+    /// @dev Refunds remaining ETH amount to the attester.
+    /// @param remainingValue The remaining ETH amount that was not sent to the resolver.
+    function _refund(uint256 remainingValue) private {
+        if (remainingValue > 0) {
+            // Using a regular transfer here might revert, for some non-EOA attesters, due to exceeding of the 2300
+            // gas limit which is why we're using call instead (via sendValue), which the 2300 gas limit does not
+            // apply for.
+            payable(msg.sender).sendValue(remainingValue);
+        }
+    }
+
+    /// @dev Timestamps the specified bytes32 data.
+    /// @param data The data to timestamp.
+    /// @param time The timestamp.
+    function _timestamp(bytes32 data, uint64 time) private {
+        if (_timestamps[data] != 0) {
+            revert AlreadyTimestamped();
+        }
+
+        _timestamps[data] = time;
+
+        emit Timestamped(data, time);
+    }
+
+    /// @dev Revokes the specified bytes32 data.
+    /// @param revoker The revoking account.
+    /// @param data The data to revoke.
+    /// @param time The timestamp the data was revoked with.
+    function _revokeOffchain(address revoker, bytes32 data, uint64 time) private {
+        mapping(bytes32 data => uint64 timestamp) storage revocations = _revocationsOffchain[revoker];
+
+        if (revocations[data] != 0) {
+            revert AlreadyRevokedOffchain();
+        }
+
+        revocations[data] = time;
+
+        emit RevokedOffchain(revoker, data, time);
+    }
+
+    /// @dev Merges lists of UIDs.
+    /// @param uidLists The provided lists of UIDs.
+    /// @param uidCount Total UID count.
+    /// @return A merged and flatten list of all the UIDs.
+    function _mergeUIDs(bytes32[][] memory uidLists, uint256 uidCount) private pure returns (bytes32[] memory) {
+        bytes32[] memory uids = new bytes32[](uidCount);
+
+        uint256 currentIndex = 0;
+        uint256 uidListLength = uidLists.length;
+        for (uint256 i = 0; i < uidListLength; i = uncheckedInc(i)) {
+            bytes32[] memory currentUIDs = uidLists[i];
+            uint256 currentUIDsLength = currentUIDs.length;
+            for (uint256 j = 0; j < currentUIDsLength; j = uncheckedInc(j)) {
+                uids[currentIndex] = currentUIDs[j];
+
+                unchecked {
+                    ++currentIndex;
+                }
+            }
+        }
+
+        return uids;
+    }
+
+    /// @dev Returns the current's block timestamp. This method is overridden during tests and used to simulate the
+    ///     current block time.
+    function _time() internal view virtual returns (uint64) {
+        return uint64(block.timestamp);
+    }
+}

--- a/packages/contracts-bedrock/test/mocks/MockSchemaRegistry.sol
+++ b/packages/contracts-bedrock/test/mocks/MockSchemaRegistry.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "src/EAS/ISchemaRegistry.sol";
+import "src/EAS/Common.sol";
+
+/// @title SchemaRegistry
+/// @notice The global schema registry.
+contract MockSchemaRegistry is ISchemaRegistry {
+    error AlreadyExists();
+
+    // The global mapping between schema records and their IDs.
+    mapping(bytes32 uid => SchemaRecord schemaRecord) private _registry;
+
+    /// @dev Creates a new SchemaRegistry instance.
+    constructor() {}
+
+    /// @inheritdoc ISchemaRegistry
+    function register(string calldata schema, ISchemaResolver resolver, bool revocable) external returns (bytes32) {
+        SchemaRecord memory schemaRecord = SchemaRecord({
+            uid: EMPTY_UID,
+            schema: schema,
+            resolver: resolver,
+            revocable: revocable
+        });
+
+        bytes32 uid = _getUID(schemaRecord);
+        if (_registry[uid].uid != EMPTY_UID) {
+            revert AlreadyExists();
+        }
+
+        schemaRecord.uid = uid;
+        _registry[uid] = schemaRecord;
+
+        emit Registered(uid, msg.sender, schemaRecord);
+
+        return uid;
+    }
+
+    /// @inheritdoc ISchemaRegistry
+    function getSchema(bytes32 uid) external view returns (SchemaRecord memory) {
+        return _registry[uid];
+    }
+
+    /// @dev Calculates a UID for a given schema.
+    /// @param schemaRecord The input schema.
+    /// @return schema UID.
+    function _getUID(SchemaRecord memory schemaRecord) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(schemaRecord.schema, schemaRecord.resolver, schemaRecord.revocable));
+    }
+}
+

--- a/packages/contracts-bedrock/test/mocks/MockSchemaRegistry.sol
+++ b/packages/contracts-bedrock/test/mocks/MockSchemaRegistry.sol
@@ -25,9 +25,7 @@ contract MockSchemaRegistry is ISchemaRegistry {
         });
 
         bytes32 uid = _getUID(schemaRecord);
-        if (_registry[uid].uid != EMPTY_UID) {
-            revert AlreadyExists();
-        }
+        require(_registry[uid].uid == EMPTY_UID, "AlreadyExists");
 
         schemaRecord.uid = uid;
         _registry[uid] = schemaRecord;

--- a/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+//spdx-license-identifier: mit
+pragma solidity ^0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
@@ -1,4 +1,4 @@
-//spdx-license-identifier: mit
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 // Testing utilities

--- a/packages/contracts-bedrock/test/periphery/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/periphery/Transactor.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+//spdx-license-identifier: mit
+pragma solidity ^0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/periphery/Transactor.t.sol
@@ -1,4 +1,4 @@
-//spdx-license-identifier: mit
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 // Testing utilities

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+//spdx-license-identifier: mit
+pragma solidity ^0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -1,4 +1,4 @@
-//spdx-license-identifier: mit
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 // Testing utilities

--- a/packages/contracts-bedrock/test/periphery/jomo/OptimistAllowlistAttestationResolver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/jomo/OptimistAllowlistAttestationResolver.t.sol
@@ -92,13 +92,13 @@ contract OptimistAllowlistAttestationResolverTest is Test {
 
     }
 
-    function test_mint_failed_before_attestation() external {
+    function testMintFailedBeforeAttestation() external {
         vm.prank(bob);
         vm.expectRevert("Optimist: address is not on allowList");
         optimistNFT.mint(bob);
     }
 
-    function test_mint_success_after_attestation() external {
+    function testMintSuccessAfterAttestation() external {
         _createAttestation();
         _checkAliceNotInAllowList();
         _checkBobInAllowlist();
@@ -137,11 +137,5 @@ contract OptimistAllowlistAttestationResolverTest is Test {
         bytes32 id2 = eas.attest(request);
         assertNotEq(id2, bytes32(0));
         assertTrue(optimistAllowlistAttestationResolver.hasAttestation(bob));
-    }
-
-    function test_isemver_version() view external {
-        assertEq(optimistAllowlistAttestationResolver.version(), string(
-            abi.encodePacked(Strings.toString(1), ".", Strings.toString(3), ".", Strings.toString(0))
-        ));
     }
 }

--- a/packages/contracts-bedrock/test/periphery/jomo/OptimistAllowlistAttestationResolver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/jomo/OptimistAllowlistAttestationResolver.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.15;
 
 import {Test} from "forge-std/Test.sol";
 import "src/EAS/IEAS.sol";
-import {ISchemaRegistry} from "src/EAS/ISchemaRegistry.sol";
-import {EAS} from "src/EAS/EAS.sol";
+import { MockSchemaRegistry } from "test/mocks/MockSchemaRegistry.sol";
+import { MockEAS } from "test/mocks/MockEAS.sol";
 import {OptimistAllowlistAttestationResolver} from "src/periphery/jomo/OptimistAllowlistAttestationResolver.sol";
 import {AttestationStation} from "src/periphery/op-nft/AttestationStation.sol";
 import {OptimistAllowlist} from "src/periphery/op-nft/OptimistAllowlist.sol";
@@ -21,8 +21,8 @@ contract OptimistAllowlistAttestationResolverTest is Test {
 
     OptimistAllowlistAttestationResolver optimistAllowlistAttestationResolver;
     Optimist optimistNFT;
-    EAS eas;
-    ISchemaRegistry registry;
+    MockEAS eas;
+    MockSchemaRegistry registry;
     AttestationStation attestationStation;
     OptimistAllowlist optimistAllowlist;
 
@@ -70,8 +70,8 @@ contract OptimistAllowlistAttestationResolverTest is Test {
 
     function _initializeContracts() internal {
         attestationStation = new AttestationStation();
-        eas = new EAS();
-        registry = eas.getSchemaRegistry();
+        registry = new MockSchemaRegistry();
+        eas = new MockEAS(registry);
 
         _initializeOptimistAllowlistAttestationResolver();
 

--- a/packages/contracts-bedrock/test/periphery/jomo/OptimistAllowlistAttestationResolver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/jomo/OptimistAllowlistAttestationResolver.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import "src/EAS/IEAS.sol";
+import {SchemaRegistry} from "src/EAS/SchemaRegistry.sol";
+import {EAS} from "src/EAS/EAS.sol";
+import {OptimistAllowlistAttestationResolver} from "../src/OptimistAllowlistAttestationResolver.sol";
+import {Optimist} from "src/periphery/op-nft/Optimist.sol";
+
+contract OptimistAllowlistAttestationResolverTest is Test {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    string constant name = "Optimist name";
+    string constant symbol = "OPTIMISTSYMBOL";
+    string constant base_uri = "https://storageapi.fleek.co/6442819a1b05-bucket/optimist-nft/attributes";
+    bytes32 public constant ALLOWLIST_ROLE = keccak256("optimist.allowlist-attestation-issuer.allowlist-role");
+
+    OptimistAllowlistAttestationResolver optimistAllowlistAttestationResolver;
+    Optimist optimistNFT;
+    EAS eas;
+    SchemaRegistry registry;
+    AttestationStation attestationStation;
+    OptimistAllowlist optimistAllowlist;
+
+    address resolverProxy;
+    address optimistProxy;
+    address admin = makeAddr("owner");
+    address alice = address(10086);
+    address bob = address(10090);
+
+    address attester = makeAddr("attester0x01");
+    address allowlist_role = makeAddr("allowlist_role");
+    address carol_baseURIAttestor = makeAddr("carol_baseURIAttestor");
+    address eve_inviteGranter = makeAddr("eve_inviteGranter");
+    address fish_allowlistAttestor = makeAddr("fish_allowlist");
+    address gong_coinbaseAttestor = makeAddr("gong_coinbaseAttestor");
+
+    function setUp() public {
+        // fill users some gas
+        vm.deal(admin, 1 ether);
+        vm.deal(alice, 1 ether);
+        vm.deal(bob, 1 ether);
+        vm.deal(carol_baseURIAttestor, 1 ether);
+        vm.deal(eve_inviteGranter, 1 ether);
+        vm.deal(fish_allowlistAttestor, 1 ether);
+        vm.deal(gong_coinbaseAttestor, 1 ether);
+        _initializeContracts();
+    }
+
+    /// @notice Returns address as uint256.
+    function _getTokenId(address _owner) internal pure returns (uint256) {
+        return uint256(uint160(address(_owner)));
+    }
+
+    function _initializeContracts() internal {
+        attestationStation = new AttestationStation();
+        registry = new SchemaRegistry();
+        eas = new EAS(registry);
+        resolverProxy = Upgrades.deployTransparentProxy(
+            "OptimistAllowlistAttestationResolver.sol:OptimistAllowlistAttestationResolver",
+            admin,
+            abi.encodeCall(OptimistAllowlistAttestationResolver.initialize, (admin, eas))
+        );
+        optimistAllowlistAttestationResolver = OptimistAllowlistAttestationResolver(payable(resolverProxy));
+        vm.prank(admin);
+        optimistAllowlistAttestationResolver.grantRole(ALLOWLIST_ROLE, allowlist_role);
+        vm.prank(allowlist_role);
+        optimistAllowlistAttestationResolver.addAttesterToAttesterAllowlist(attester);
+        optimistAllowlist = new OptimistAllowlist({
+            _attestationStation: attestationStation ,
+            _allowlistAttestor: fish_allowlistAttestor,
+            _coinbaseQuestAttestor: gong_coinbaseAttestor,
+            _optimistInviter: eve_inviteGranter,
+            _easOptimistAllowlistAttestationResolver: optimistAllowlistAttestationResolver
+        });
+        Options memory options;
+        options.constructorData = abi.encode(
+            name, symbol,
+            carol_baseURIAttestor,
+            attestationStation,
+            optimistAllowlist
+        );
+        optimistProxy = Upgrades.deployTransparentProxy(
+            "Optimist.sol:Optimist",
+            admin,
+            "",
+            options
+        );
+        optimistNFT = Optimist(optimistProxy);
+
+    }
+
+    function test_mint_failed_before_attestation() external {
+        vm.prank(bob);
+        vm.expectRevert("Optimist: address is not on allowList");
+        optimistNFT.mint(bob);
+    }
+
+    function test_mint_success_after_attestation() external {
+        _createAttestation();
+        _checkAliceNotInAllowList();
+        _checkBobInAllowlist();
+    }
+
+    function _checkBobInAllowlist() internal {
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), bob, _getTokenId(bob));
+        optimistNFT.mint(bob);
+    }
+
+    function _checkAliceNotInAllowList() internal {
+        vm.prank(alice);
+        vm.expectRevert("Optimist: address is not on allowList");
+        optimistNFT.mint(alice);
+    }
+
+    function _createAttestation() internal {
+        string memory schema = "";
+        bytes32 id = registry.register(schema, optimistAllowlistAttestationResolver, false);
+        assertNotEq(id, bytes32(0));
+        AttestationRequestData memory requestData = AttestationRequestData({
+            recipient: bob,
+            expirationTime: uint64(block.timestamp + 120),
+            revocable: false,
+            refUID: bytes32(0),
+            data: new bytes(0),
+            value: 0
+        });
+        AttestationRequest memory request = AttestationRequest({
+            schema: id,
+            data: requestData
+        });
+        vm.prank(attester);
+        bytes32 id2 = eas.attest(request);
+        assertNotEq(id2, bytes32(0));
+        assertTrue(optimistAllowlistAttestationResolver.hasAttestation(bob));
+    }
+
+    function test_isemver_version() view external {
+        assertEq(optimistAllowlistAttestationResolver.version(), string(
+            abi.encodePacked(Strings.toString(1), ".", Strings.toString(3), ".", Strings.toString(0))
+        ));
+    }
+}

--- a/packages/contracts-bedrock/test/periphery/op-nft/AttestationStation.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/AttestationStation.t.sol
@@ -1,4 +1,4 @@
-//spdx-license-identifier: mit
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 /* Testing utilities */

--- a/packages/contracts-bedrock/test/periphery/op-nft/AttestationStation.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/AttestationStation.t.sol
@@ -1,5 +1,5 @@
-//SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+//spdx-license-identifier: mit
+pragma solidity ^0.8.15;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/op-nft/Optimist.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/Optimist.t.sol
@@ -7,6 +7,7 @@ import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol"
 import { Optimist } from "src/periphery/op-nft/Optimist.sol";
 import { OptimistAllowlist } from "src/periphery/op-nft/OptimistAllowlist.sol";
 import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
+import { OptimistAllowlistAttestationResolver } from "src/periphery/jomo/OptimistAllowlistAttestationResolver.sol";
 import { OptimistInviterHelper } from "test/mocks/OptimistInviterHelper.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -44,6 +45,7 @@ contract Optimist_Initializer is Test {
     Optimist optimist;
     OptimistAllowlist optimistAllowlist;
     OptimistInviter optimistInviter;
+    OptimistAllowlistAttestationResolver optimistAllowlistAttestationResolver;
 
     // Helps with EIP-712 signature generation
     OptimistInviterHelper optimistInviterHelper;
@@ -163,6 +165,7 @@ contract Optimist_Initializer is Test {
         alice_allowlistAttestor = makeAddr("alice_allowlistAttestor");
         eve_inviteGranter = makeAddr("eve_inviteGranter");
         ted_coinbaseAttestor = makeAddr("ted_coinbaseAttestor");
+        optimistAllowlistAttestationResolver = OptimistAllowlistAttestationResolver(payable(makeAddr("optimistAllowlistAttestationResolver")));
         bob = makeAddr("bob");
         sally = makeAddr("sally");
         _initializeContracts();
@@ -185,7 +188,8 @@ contract Optimist_Initializer is Test {
             _attestationStation: attestationStation,
             _allowlistAttestor: alice_allowlistAttestor,
             _coinbaseQuestAttestor: ted_coinbaseAttestor,
-            _optimistInviter: address(optimistInviter)
+            _optimistInviter: address(optimistInviter),
+            _easOptimistAllowlistAttestationResolver: optimistAllowlistAttestationResolver
         });
 
         optimist = new Optimist({

--- a/packages/contracts-bedrock/test/periphery/op-nft/OptimistAllowlist.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/OptimistAllowlist.t.sol
@@ -1,4 +1,4 @@
-//spdx-license-identifier: mit
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 // Testing utilities

--- a/packages/contracts-bedrock/test/periphery/op-nft/OptimistAllowlist.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/OptimistAllowlist.t.sol
@@ -1,11 +1,12 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+//spdx-license-identifier: mit
+pragma solidity ^0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
 import { OptimistAllowlist } from "src/periphery/op-nft/OptimistAllowlist.sol";
 import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
+import { OptimistAllowlistAttestationResolver } from "src/periphery/jomo/OptimistAllowlistAttestationResolver.sol";
 import { OptimistInviterHelper } from "test/mocks/OptimistInviterHelper.sol";
 import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
 
@@ -25,11 +26,13 @@ contract OptimistAllowlist_Initializer is Test {
 
     // Helps with EIP-712 signature generation
     OptimistInviterHelper optimistInviterHelper;
+    OptimistAllowlistAttestationResolver optimistAllowlistAttestationResolver;
 
     function setUp() public {
         alice_allowlistAttestor = makeAddr("alice_allowlistAttestor");
         sally_coinbaseQuestAttestor = makeAddr("sally_coinbaseQuestAttestor");
         ted = makeAddr("ted");
+        optimistAllowlistAttestationResolver = OptimistAllowlistAttestationResolver(payable(makeAddr("optimistAllowlistAttestationResolver")));
 
         bobPrivateKey = 0xB0B0B0B0;
         bob = vm.addr(bobPrivateKey);
@@ -112,7 +115,7 @@ contract OptimistAllowlist_Initializer is Test {
         optimistInviter.initialize("OptimistInviter");
 
         optimistAllowlist = new OptimistAllowlist(
-            attestationStation, alice_allowlistAttestor, sally_coinbaseQuestAttestor, address(optimistInviter)
+            attestationStation, alice_allowlistAttestor, sally_coinbaseQuestAttestor, address(optimistInviter), optimistAllowlistAttestationResolver
         );
 
         optimistInviterHelper = new OptimistInviterHelper(optimistInviter, "OptimistInviter");

--- a/packages/contracts-bedrock/test/periphery/op-nft/OptimistInviter.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/OptimistInviter.t.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+//spdx-license-identifier: mit
+pragma solidity ^0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/op-nft/OptimistInviter.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/OptimistInviter.t.sol
@@ -1,4 +1,4 @@
-//spdx-license-identifier: mit
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 // Testing utilities


### PR DESCRIPTION
Description

Part of RFP Proof of Attendence: https://github.com/ethereum-optimism/ecosystem-contributions/issues/115

This PR edits the OptimistAllowlistAttestationResolver smart contract, so that we allow a new role to whitelist users to mint OptimistNFT.

Users who has attended IRL Optimism events will get an EAS Attestation, and then the custom OptimistAllowlistAttestationResolver will be triggered and add the user into OptimistAllowlist.

This will require the OptimistAllowlist to allow our OptimistAllowlistAttestationResolver to edit the whitelist. Upon discussion with the Op team, we have agreed on the solution in the PR.

Tests

Tested manually on local setup.

Metadata