### PR TITLE
contracts-bedrock: log the commit hash in deploy script

### DIFF
--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -5,6 +5,8 @@ import { Script } from "forge-std/Script.sol";
 import { Artifacts } from "scripts/Artifacts.s.sol";
 import { Config } from "scripts/Config.sol";
 import { DeployConfig } from "scripts/DeployConfig.s.sol";
+import { Executables } from "scripts/Executables.sol";
+import { console } from "forge-std/console.sol";
 
 /// @title Deployer
 /// @author tynes
@@ -16,6 +18,8 @@ abstract contract Deployer is Script, Artifacts {
     /// @notice Sets up the artifacts contract.
     function setUp() public virtual override {
         Artifacts.setUp();
+
+        console.log("Commit hash: %s", Executables.gitCommitHash());
 
         vm.etch(address(cfg), vm.getDeployedCode("DeployConfig.s.sol:DeployConfig"));
         vm.label(address(cfg), "DeployConfig");

--- a/packages/contracts-bedrock/scripts/Executables.sol
+++ b/packages/contracts-bedrock/scripts/Executables.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { Vm } from "forge-std/Vm.sol";
+
 /// @notice The executables used in ffi commands. These are set here
 ///         to have a single source of truth in case absolute paths
 ///         need to be used.
 library Executables {
+    /// @notice Foundry cheatcode VM.
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
     string internal constant bash = "bash";
     string internal constant jq = "jq";
     string internal constant forge = "forge";
@@ -12,4 +16,14 @@ library Executables {
     string internal constant sed = "sed";
     string internal constant find = "find";
     string internal constant ls = "ls";
+    string internal constant git = "git";
+
+    /// @notice Returns the commit hash of HEAD.
+    function gitCommitHash() internal returns (string memory) {
+        string[] memory commands = new string[](3);
+        commands[0] = bash;
+        commands[1] = "-c";
+        commands[2] = "git rev-parse HEAD";
+        return string(vm.ffi(commands));
+    }
 }


### PR DESCRIPTION
**Description**

Ensures that the commit hash is logged as part of
the deploy script's execution so its easier to help
debug issues with it.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

