### PR TITLE
feat(op-dispute-mon): Log Lost Bond Amount

### DIFF
--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -68,7 +68,7 @@ func (c *ClaimMonitor) checkUpdateHonestActorStats(proxy common.Address, claim *
 		if claim.CounteredBy != (common.Address{}) {
 			honest[actor].InvalidClaimCount++
 			honest[actor].LostBonds = new(big.Int).Add(honest[actor].LostBonds, claim.Bond)
-			c.logger.Error("Claim resolved against honest actor", "game", proxy, "honest_actor", actor, "countered_by", claim.CounteredBy, "claim_contract_index", claim.ContractIndex)
+			c.logger.Error("Claim resolved against honest actor", "game", proxy, "honestActor", actor, "counteredBy", claim.CounteredBy, "claimContractIndex", claim.ContractIndex, "boundAmount", claim.Bond)
 		} else {
 			honest[actor].ValidClaimCount++
 			// Note that we don't count refunded bonds as won

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -68,7 +68,7 @@ func (c *ClaimMonitor) checkUpdateHonestActorStats(proxy common.Address, claim *
 		if claim.CounteredBy != (common.Address{}) {
 			honest[actor].InvalidClaimCount++
 			honest[actor].LostBonds = new(big.Int).Add(honest[actor].LostBonds, claim.Bond)
-			c.logger.Error("Claim resolved against honest actor", "game", proxy, "honestActor", actor, "counteredBy", claim.CounteredBy, "claimContractIndex", claim.ContractIndex, "boundAmount", claim.Bond)
+			c.logger.Error("Claim resolved against honest actor", "game", proxy, "honestActor", actor, "counteredBy", claim.CounteredBy, "claimContractIndex", claim.ContractIndex, "bondAmount", claim.Bond)
 		} else {
 			honest[actor].ValidClaimCount++
 			// Note that we don't count refunded bonds as won


### PR DESCRIPTION
**Description**

Small PR to add the bond amount as a log field when an honest actor loses a claim bond.

This is for the run book for honest actors losing bonds/having their claims invalidated, this log will just show the bond amount. Since the bond metric is cumulative, this just makes it a bit easier to find the bond amount. 