### PR TITLE
op-dispute-mon: Add metric to report timestamp of last invalid proposal

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -92,6 +92,8 @@ type Metricer interface {
 
 	RecordGameAgreement(status GameAgreementStatus, count int)
 
+	RecordLatestInvalidProposal(timestamp uint64)
+
 	RecordIgnoredGames(count int)
 
 	RecordBondCollateral(addr common.Address, required *big.Int, available *big.Int)
@@ -127,8 +129,9 @@ type Metrics struct {
 
 	lastOutputFetch prometheus.Gauge
 
-	gamesAgreement prometheus.GaugeVec
-	ignoredGames   prometheus.Gauge
+	gamesAgreement        prometheus.GaugeVec
+	latestInvalidProposal prometheus.Gauge
+	ignoredGames          prometheus.Gauge
 
 	requiredCollateral  prometheus.GaugeVec
 	availableCollateral prometheus.GaugeVec
@@ -227,6 +230,11 @@ func NewMetrics() *Metrics {
 			"completion",
 			"result_correctness",
 			"root_agreement",
+		}),
+		latestInvalidProposal: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "latest_invalid_proposal",
+			Help:      "Timestamp of the most recent game with an invalid root claim in unix seconds",
 		}),
 		ignoredGames: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -368,6 +376,10 @@ func (m *Metrics) RecordOutputFetchTime(timestamp float64) {
 
 func (m *Metrics) RecordGameAgreement(status GameAgreementStatus, count int) {
 	m.gamesAgreement.WithLabelValues(labelValuesFor(status)...).Set(float64(count))
+}
+
+func (m *Metrics) RecordLatestInvalidProposal(timestamp uint64) {
+	m.latestInvalidProposal.Set(float64(timestamp))
 }
 
 func (m *Metrics) RecordIgnoredGames(count int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -33,6 +33,8 @@ func (*NoopMetricsImpl) RecordOutputFetchTime(_ float64) {}
 
 func (*NoopMetricsImpl) RecordGameAgreement(_ GameAgreementStatus, _ int) {}
 
+func (*NoopMetricsImpl) RecordLatestInvalidProposal(_ uint64) {}
+
 func (*NoopMetricsImpl) RecordIgnoredGames(_ int) {}
 
 func (i *NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -236,8 +236,8 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 		{},
 		mockRootClaim,
 		{},
-		{},
-		{},
+		{}, // Expected latest invalid proposal (will have timestamp 7)
+		mockRootClaim,
 	}
 	games := make([]*monTypes.EnrichedGameData, 9)
 	for i := range games {
@@ -245,6 +245,9 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 			Status:    gameStatus[i],
 			Claims:    claims[i],
 			RootClaim: rootClaims[i],
+			GameMetadata: types.GameMetadata{
+				Timestamp: uint64(i),
+			},
 		}
 	}
 	forecast.Forecast(context.Background(), games, 3)
@@ -255,10 +258,12 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	expectedMetrics[metrics.DisagreeChallengerAhead] = 1
 	expectedMetrics[metrics.AgreeDefenderAhead] = 1
 	expectedMetrics[metrics.DisagreeDefenderAhead] = 1
+	expectedMetrics[metrics.AgreeChallengerWins] = 1
 	expectedMetrics[metrics.DisagreeDefenderWins] = 2
-	expectedMetrics[metrics.DisagreeChallengerWins] = 3
+	expectedMetrics[metrics.DisagreeChallengerWins] = 2
 	require.Equal(t, expectedMetrics, m.gameAgreement)
 	require.Equal(t, 3, m.ignoredGames)
+	require.EqualValues(t, 7, m.latestInvalidProposal)
 }
 
 func setupForecastTest(t *testing.T) (*forecast, *mockForecastMetrics, *stubOutputValidator, *testlog.CapturingHandler) {
@@ -284,12 +289,17 @@ func zeroGameAgreement() map[metrics.GameAgreementStatus]int {
 }
 
 type mockForecastMetrics struct {
-	gameAgreement map[metrics.GameAgreementStatus]int
-	ignoredGames  int
+	gameAgreement         map[metrics.GameAgreementStatus]int
+	ignoredGames          int
+	latestInvalidProposal uint64
 }
 
 func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementStatus, count int) {
 	m.gameAgreement[status] = count
+}
+
+func (m *mockForecastMetrics) RecordLatestInvalidProposal(timestamp uint64) {
+	m.latestInvalidProposal = timestamp
 }
 
 func (m *mockForecastMetrics) RecordIgnoredGames(count int) {

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -54,15 +54,3 @@ type BidirectionalClaim struct {
 	Claim    *faultTypes.Claim
 	Children []*BidirectionalClaim
 }
-
-type ForecastBatch struct {
-	AgreeDefenderAhead      int
-	DisagreeDefenderAhead   int
-	AgreeChallengerAhead    int
-	DisagreeChallengerAhead int
-
-	AgreeDefenderWins      int
-	DisagreeDefenderWins   int
-	AgreeChallengerWins    int
-	DisagreeChallengerWins int
-}


### PR DESCRIPTION
**Description**

Adds a metric to report the timestamp of the last invalid proposal. This allows setting up alerts if there are no invalid alerts for a period (assuming there's a service deliberately posting invalid output roots to test the system is responding).

**Tests**

Ran locally and updated unit tests.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/715
