### PR TITLE
cannon: Adjust initial heap

### DIFF
--- a/cannon/mipsevm/patch.go
+++ b/cannon/mipsevm/patch.go
@@ -46,7 +46,7 @@ func LoadELF(f *elf.File) (*State, error) {
 			return nil, fmt.Errorf("program %d out of 32-bit mem range: %x - %x (size: %x)", i, prog.Vaddr, prog.Vaddr+prog.Memsz, prog.Memsz)
 		}
 		if prog.Vaddr+prog.Memsz >= HEAP_START {
-			return nil, fmt.Errorf("program %d overlaps with heap: %x - %x (size: %x). The heap start offset msut be reconfigured", i, prog.Vaddr, prog.Vaddr+prog.Memsz, prog.Memsz)
+			return nil, fmt.Errorf("program %d overlaps with heap: %x - %x (size: %x). The heap start offset must be reconfigured", i, prog.Vaddr, prog.Vaddr+prog.Memsz, prog.Memsz)
 		}
 		if err := s.Memory.SetMemoryRange(uint32(prog.Vaddr), r); err != nil {
 			return nil, fmt.Errorf("failed to read program segment %d: %w", i, err)

--- a/cannon/mipsevm/patch.go
+++ b/cannon/mipsevm/patch.go
@@ -8,13 +8,15 @@ import (
 	"io"
 )
 
+const HEAP_START = 0x05000000
+
 func LoadELF(f *elf.File) (*State, error) {
 	s := &State{
 		PC:        uint32(f.Entry),
 		NextPC:    uint32(f.Entry + 4),
 		HI:        0,
 		LO:        0,
-		Heap:      0x20000000,
+		Heap:      HEAP_START,
 		Registers: [32]uint32{},
 		Memory:    NewMemory(),
 		ExitCode:  0,
@@ -42,6 +44,9 @@ func LoadELF(f *elf.File) (*State, error) {
 
 		if prog.Vaddr+prog.Memsz >= uint64(1<<32) {
 			return nil, fmt.Errorf("program %d out of 32-bit mem range: %x - %x (size: %x)", i, prog.Vaddr, prog.Vaddr+prog.Memsz, prog.Memsz)
+		}
+		if prog.Vaddr+prog.Memsz >= HEAP_START {
+			return nil, fmt.Errorf("program %d overlaps with heap: %x - %x (size: %x). The heap start offset msut be reconfigured", i, prog.Vaddr, prog.Vaddr+prog.Memsz, prog.Memsz)
 		}
 		if err := s.Memory.SetMemoryRange(uint32(prog.Vaddr), r); err != nil {
 			return nil, fmt.Errorf("failed to read program segment %d: %w", i, err)


### PR DESCRIPTION
Readjust the initial heap in cannon. This reduces the chance of the heap encroaching on stack space during high memory usage in Go programs.

Based on a couple experiments on simple programs, this change should increase the effective memory of the op-program by 400 MiB.

fixes https://github.com/ethereum-optimism/client-pod/issues/828