### PR TITLE
contracts-bedrock: fix commit hash serialization

### DIFF
--- a/packages/contracts-bedrock/scripts/Executables.sol
+++ b/packages/contracts-bedrock/scripts/Executables.sol
@@ -23,7 +23,7 @@ library Executables {
         string[] memory commands = new string[](3);
         commands[0] = bash;
         commands[1] = "-c";
-        commands[2] = "git rev-parse HEAD";
-        return string(vm.ffi(commands));
+        commands[2] = "cast abi-encode 'f(string)' $(git rev-parse HEAD)";
+        return abi.decode(vm.ffi(commands), (string));
     }
 }


### PR DESCRIPTION
**Description**

Previous implementation didn't correctly serialize as string
so it came out as unreadable, now we make sure to abi encode
and decode correctly. Enables us to know which commit the code
runs on to help with debugging.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

