### PR TITLE
op-e2e: Fix flaky fault proof tests

### DIFF
--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -50,15 +50,15 @@ func WithSequencerWindowSize(size uint64) faultDisputeConfigOpts {
 func StartFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts) (*op_e2e.System, *ethclient.Client) {
 	cfg := op_e2e.DefaultSystemConfig(t)
 	delete(cfg.Nodes, "verifier")
-	for _, opt := range opts {
-		opt(&cfg)
-	}
 	cfg.Nodes["sequencer"].SafeDBPath = t.TempDir()
 	cfg.DeployConfig.SequencerWindowSize = 4
 	cfg.DeployConfig.FinalizationPeriodSeconds = 2
 	cfg.SupportL1TimeTravel = true
 	cfg.DeployConfig.L2OutputOracleSubmissionInterval = 1
 	cfg.NonFinalizedProposals = true // Submit output proposals asap
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")
 	return sys, sys.Clients["l1"]


### PR DESCRIPTION
**Description**

Custom config options were being applied before the defaults, causing them to be overwritten.
In particular this meant there was a small sequencer window and safe head progressed rapidly.
