### PR TITLE
ci: Move sdk-next-test to run on develop only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ parameters:
   kontrol_dispatch:
     type: boolean
     default: false
+  sdk_dispatch:
+    type: boolean
+    default: false
 
 orbs:
   go: circleci/go@1.8.0
@@ -247,6 +250,7 @@ jobs:
             - ".devnet-plasma/allocs-l2-delta.json"
             - "packages/contracts-bedrock/deploy-config/devnetL1.json"
             - "packages/contracts-bedrock/deployments/devnetL1"
+      - notify-failures-on-develop
 
   docker-build:
     environment:
@@ -728,6 +732,7 @@ jobs:
             VITE_E2E_PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
             VITE_E2E_RPC_URL_L1: http://localhost:8545
             VITE_E2E_RPC_URL_L2: http://localhost:9545
+      - notify-failures-on-develop
 
   todo-issues:
     machine:
@@ -1648,10 +1653,6 @@ workflows:
           name: proxyd-tests
           binary_name: proxyd
           working_directory: proxyd
-      - sdk-next-tests:
-          name: sdk-next-tests
-          requires:
-            - pnpm-monorepo
       - indexer-tests:
           name: indexer-tests<< matrix.fpac >>
           matrix:
@@ -2205,6 +2206,26 @@ workflows:
            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - kontrol-tests:
+          context:
+            - slack
+
+  develop-sdk-next-tests:
+    when:
+      and:
+        - or:
+          - equal: [ "develop", <<pipeline.git.branch>> ]
+          - equal: [ true, <<pipeline.parameters.sdk_dispatch>> ]
+        - not:
+           equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - pnpm-monorepo:
+          name: pnpm-monorepo
+          context:
+            - slack
+      - sdk-next-tests:
+          name: sdk-next-tests
+          requires:
+            - pnpm-monorepo
           context:
             - slack
 


### PR DESCRIPTION
**Description**

Job requires env vars that aren't set for external PRs so not appropriate to run on every PR. We've also deprecated the SDK so there's no ongoing development of it.

Will notify slack on failures so it doesn't get silently ignored, and it can be manually triggered on branches by setting the `sdk_dispatch` pipeline param when manually triggering the pipeline.