### PR TITLE
dispute-mon: Set claim statuses that no longer have games back to 0

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -65,6 +65,19 @@ const (
 	SecondHalfNotExpiredUnresolved
 )
 
+func ZeroClaimStatuses() map[ClaimStatus]int {
+	return map[ClaimStatus]int{
+		FirstHalfExpiredResolved:       0,
+		FirstHalfExpiredUnresolved:     0,
+		FirstHalfNotExpiredResolved:    0,
+		FirstHalfNotExpiredUnresolved:  0,
+		SecondHalfExpiredResolved:      0,
+		SecondHalfExpiredUnresolved:    0,
+		SecondHalfNotExpiredResolved:   0,
+		SecondHalfNotExpiredUnresolved: 0,
+	}
+}
+
 type HonestActorData struct {
 	PendingClaimCount int
 	ValidClaimCount   int

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -35,7 +35,7 @@ func NewClaimMonitor(logger log.Logger, clock RClock, honestActors []common.Addr
 }
 
 func (c *ClaimMonitor) CheckClaims(games []*types.EnrichedGameData) {
-	claimStatus := make(map[metrics.ClaimStatus]int)
+	claimStatus := metrics.ZeroClaimStatuses()
 	honest := make(map[common.Address]*metrics.HonestActorData)
 	for actor := range c.honestActors {
 		honest[actor] = &metrics.HonestActorData{

--- a/op-dispute-mon/mon/claims_test.go
+++ b/op-dispute-mon/mon/claims_test.go
@@ -34,6 +34,22 @@ func TestClaimMonitor_CheckClaims(t *testing.T) {
 		require.Equal(t, 1, cMetrics.calls[metrics.SecondHalfNotExpiredUnresolved])
 	})
 
+	t.Run("ZeroRecordsClaims", func(t *testing.T) {
+		monitor, _, cMetrics := newTestClaimMonitor(t)
+		var games []*types.EnrichedGameData
+		monitor.CheckClaims(games)
+		// Check we zero'd out any categories that didn't have games in them (otherwise they retain their previous value)
+		require.Contains(t, cMetrics.calls, metrics.FirstHalfExpiredResolved)
+		require.Contains(t, cMetrics.calls, metrics.FirstHalfExpiredUnresolved)
+		require.Contains(t, cMetrics.calls, metrics.FirstHalfNotExpiredResolved)
+		require.Contains(t, cMetrics.calls, metrics.FirstHalfNotExpiredUnresolved)
+
+		require.Contains(t, cMetrics.calls, metrics.SecondHalfExpiredResolved)
+		require.Contains(t, cMetrics.calls, metrics.SecondHalfExpiredUnresolved)
+		require.Contains(t, cMetrics.calls, metrics.SecondHalfNotExpiredResolved)
+		require.Contains(t, cMetrics.calls, metrics.SecondHalfNotExpiredUnresolved)
+	})
+
 	t.Run("RecordsUnexpectedClaimResolution", func(t *testing.T) {
 		monitor, cl, cMetrics := newTestClaimMonitor(t)
 		games := makeMultipleTestGames(uint64(cl.Now().Unix()))


### PR DESCRIPTION
**Description**

Previously once there was a claim in a particular status, the value never got set back to zero.

**Tests**

Updated unit tests.
