### PR TITLE
fix: plasma finalize

### DIFF
--- a/op-plasma/damgr.go
+++ b/op-plasma/damgr.go
@@ -240,7 +240,7 @@ func (d *DA) isExpired(bn uint64) bool {
 // trigger a derivation reset.
 func (d *DA) AdvanceL1Origin(ctx context.Context, l1 L1Fetcher, block eth.BlockID) error {
 	// do not repeat for the same origin
-	if block.Number <= d.origin.Number {
+	if block.Number < d.origin.Number {
 		return nil
 	}
 	// sync challenges for the given block ID

--- a/op-plasma/dastate.go
+++ b/op-plasma/dastate.go
@@ -172,7 +172,7 @@ func (s *State) GetResolvedInput(key []byte) ([]byte, error) {
 // it returns an error to signal that a derivation pipeline reset is required.
 func (s *State) ExpireChallenges(bn uint64) (uint64, error) {
 	var err error
-	for s.activeComms.Len() > 0 && s.activeComms[0].expiresAt <= bn && s.activeComms[0].blockNumber > s.finalized {
+	for s.activeComms.Len() > 0 && s.activeComms[0].expiresAt <= bn && s.activeComms[0].blockNumber >= s.finalized {
 		// move from the active to the expired queue
 		c := heap.Pop(&s.activeComms).(*Commitment)
 		heap.Push(&s.expiredComms, c)

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -103,7 +103,7 @@ func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash
 }
 
 func (m *MockEthClient) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts types.Receipts, err error) {
-	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, err)
+	m.Mock.On("FetchReceipts", hash).Return(&info, receipts, err)
 }
 
 func (m *MockEthClient) GetProof(ctx context.Context, address common.Address, storage []common.Hash, blockTag string) (*eth.AccountResult, error) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When one block has multiple plasma commitment, the `ExpireChallenges` for loop will only execute once, which cause `activeComms` didn't get poped, and the `s.finalized` will never get updated 
