### PR TITLE
op-conductor: fixes proposer outputAtBlock rpc arg compatibility

### DIFF
--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -60,7 +60,7 @@ type ExecutionProxyAPI interface {
 // NodeProxyAPI defines the methods proxied to the node rpc backend
 // This should include all methods that are called by op-batcher or op-proposer
 type NodeProxyAPI interface {
-	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
+	OutputAtBlock(ctx context.Context, blockNumString string) (*eth.OutputResponse, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	RollupConfig(ctx context.Context) (*rollup.Config, error)
 }

--- a/op-conductor/rpc/node_proxy.go
+++ b/op-conductor/rpc/node_proxy.go
@@ -2,7 +2,9 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -40,7 +42,11 @@ func (api *NodeProxyBackend) SyncStatus(ctx context.Context) (*eth.SyncStatus, e
 	return status, err
 }
 
-func (api *NodeProxyBackend) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error) {
+func (api *NodeProxyBackend) OutputAtBlock(ctx context.Context, blockNumString string) (*eth.OutputResponse, error) {
+	blockNum, err := hexutil.DecodeUint64(blockNumString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode block number: %w", err)
+	}
 	output, err := api.client.OutputAtBlock(ctx, blockNum)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description**

Fixes an incompatibility between op-proposer and op-conductor's node rpc proxy's outputAtBlock method where proposer was passing a string when conductor was expecting an uint64. 