### PR TITLE
fix(op-dispute-mon): Unresolved Claim Logging

### DIFF
--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+const MaximumResolutionResponseBuffer = time.Minute
+
 type RClock interface {
 	Now() time.Time
 }
@@ -119,7 +121,7 @@ func (c *ClaimMonitor) checkGameClaims(
 			if clockExpired {
 				// SAFETY: accumulatedTime must be larger than or equal to maxChessTime since clockExpired
 				overflow := accumulatedTime - maxChessTime
-				if overflow >= time.Minute { // Give a minute response buffer to honest challengers to reduce log noise
+				if overflow >= MaximumResolutionResponseBuffer {
 					c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex, "delay", overflow)
 				}
 				if firstHalf {

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -117,7 +117,13 @@ func (c *ClaimMonitor) checkGameClaims(
 			}
 		} else {
 			if clockExpired {
-				c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+				// SAFETY: accumulatedTime must be larger than or equal to maxChessTime since clockExpired
+				overflow := accumulatedTime - maxChessTime
+				if overflow >= 10 * time.Minute {
+					c.logger.Error("Claim unresolved 10 minutes after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+				} else {
+					c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+				}
 				if firstHalf {
 					claimStatus[metrics.FirstHalfExpiredUnresolved]++
 				} else {

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -119,7 +119,7 @@ func (c *ClaimMonitor) checkGameClaims(
 			if clockExpired {
 				// SAFETY: accumulatedTime must be larger than or equal to maxChessTime since clockExpired
 				overflow := accumulatedTime - maxChessTime
-				if overflow >= 10 * time.Minute {
+				if overflow >= 10*time.Minute {
 					c.logger.Error("Claim unresolved 10 minutes after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
 				} else {
 					c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -119,10 +119,8 @@ func (c *ClaimMonitor) checkGameClaims(
 			if clockExpired {
 				// SAFETY: accumulatedTime must be larger than or equal to maxChessTime since clockExpired
 				overflow := accumulatedTime - maxChessTime
-				if overflow >= 10*time.Minute {
-					c.logger.Error("Claim unresolved 10 minutes after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
-				} else {
-					c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+				if overflow >= time.Minute { // Give a minute response buffer to honest challengers to reduce log noise
+					c.logger.Warn("Claim unresolved after clock expiration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex, "delay", overflow)
 				}
 				if firstHalf {
 					claimStatus[metrics.FirstHalfExpiredUnresolved]++


### PR DESCRIPTION
**Description**

When claims are left unresolved for a period of time, we set off an alert in grafana. To investigate this alert requires going to the `Dispute Monitor` grafana dashboard and finding the associated dispute game address that set off the alarm. Since there is no time component to warning logs once a claim is not resolved after expiry, there is a steady stream of logs that makes it non-obvious which log and associated `game` address set off the alarm. See an example screenshot below.

![Screenshot 2024-05-03 at 1.45.10 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/6VML3SXQuiMnuvYtg3Bf/780b8d46-ca5d-4537-9f3b-139917e9f977.png)

This PR fixes the dispute monitor to create the log after a minute has past after claims have failed to be resolved. This makes filtering much easier since when the alert is set off since we can add a link with the filter for `Warn` log messages where the `delay` label is greater than 60 seconds.

See the associated runbook that will be updated once this pr is merged:
https://www.notion.so/oplabs/RB-126-Alert-dispute-mon-failed-claim-resolution-a64948f1605a408d9697b05c98d404ef?pvs=4