### PR TITLE
op-program: Add v1.0.0 to set of reproducibility checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1149,6 +1149,8 @@ jobs:
               echo 'export EXPECTED_PRESTATE_HASH="0x031e3b504740d0b1264e8cf72b6dde0d497184cfb3f98e451c6be8b33bd3f808"' >> $BASH_ENV
             elif [[ "<<parameters.version>>" == "0.3.0" ]]; then
               echo 'export EXPECTED_PRESTATE_HASH="0x034c8cc69f22c35ae386a97136715dd48aaf97fd190942a111bfa680c2f2f421"' >> $BASH_ENV
+            elif [[ "<<parameters.version>>" == "1.0.0" ]]; then
+              echo 'export EXPECTED_PRESTATE_HASH="0x037ef3c1a487960b0e633d3e513df020c43432769f41a634d18a9595cbf53c55"' >> $BASH_ENV
             else
               echo "Unknown prestate version <<parameters.version>>"
               exit 1
@@ -2368,6 +2370,6 @@ workflows:
       - preimage-reproducibility:
           matrix:
             parameters:
-              version: ["0.1.0", "0.2.0", "0.3.0"]
+              version: ["0.1.0", "0.2.0", "0.3.0", "1.0.0"]
           context:
             slack


### PR DESCRIPTION
**Description**

Adds op-program/v1.0.0 to the set of versions to check reproducibility for.  The hash is what `make reproducible-prestate` built for me locally so hopefully CI agrees with it. 