### PR TITLE
Feat/unified update check

### DIFF
--- a/ops/scripts/manage-dependencies.sh
+++ b/ops/scripts/manage-dependencies.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Function to manage a specific dependency
+manage_dependency() {
+  dependency=$1
+  operation=$2
+
+  case $dependency in
+    "foundry")
+      script_prefix="foundry"
+      ;;
+    "abigen")
+      script_prefix="abigen"
+      ;;
+    "slither")
+      script_prefix="slither"
+      ;;
+    # Add more dependencies as needed
+    *)
+      echo "Unknown dependency: $dependency"
+      exit 1
+      ;;
+  esac
+
+  case $operation in
+    "install")
+      pnpm run install:$script_prefix
+      ;;
+    "verify")
+      pnpm run check:$script_prefix
+      ;;
+    "print")
+      pnpm run print:$script_prefix
+      ;;
+    *)
+      echo "Unknown operation: $operation"
+      exit 1
+      ;;
+  esac
+}
+
+# Main script logic
+if [ "$#" -eq 0 ]; then
+  # If no args, manage all dependencies
+  pnpm run install:foundry
+  pnpm run check:foundry
+  pnpm run print:foundry
+
+  pnpm run install:abigen
+  pnpm run check:abigen
+  pnpm run print:abigen
+
+  pnpm run install:slither
+  pnpm run check:slither
+  pnpm run print:slither
+
+  # Exit with a success status code
+  exit 0
+else
+  # Manage specific dependency based on arguments
+  manage_dependency "$1" "$2"
+fi

--- a/ops/scripts/manage-dependencies.sh
+++ b/ops/scripts/manage-dependencies.sh
@@ -15,7 +15,6 @@ manage_dependency() {
     "slither")
       script_prefix="slither"
       ;;
-    # Add more dependencies as needed
     *)
       echo "Unknown dependency: $dependency"
       exit 1

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "install:slither": "pip3 install slither-analyzer==$(jq -r .slither < versions.json)",
     "print:slither": "slither --version",
     "check:slither": "[[ $(pnpm -s print:slither) = $(jq -r .slither < versions.json) ]] && echo '✓ slither versions match' || (echo '✗ slither version mismatch. Run `pnpm upgrade:slither` to upgrade.' && exit 1)",
-    "upgrade:slither": "jq '.slither = $v' --arg v $(pnpm -s print:slither) <<<$(cat versions.json) > versions.json"
+    "upgrade:slither": "jq '.slither = $v' --arg v $(pnpm -s print:slither) <<<$(cat versions.json) > versions.json",
+    "manage": "bash ./ops/scripts/manage-dependencies.sh"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.10",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR introduces a unified Bash script, manage-dependencies.sh, designed to streamline the installation, verification, and version reporting of key development tools such as Foundry, Abigen, and Slither. This script enhances the development workflow by providing a centralised approach to manage these dependencies, reducing redundancy and improving maintenance efficiency.

**Key Features:**

- **Unified Management:** Single script to install, verify, and print versions of development tools.
- **Flexibility**: Supports operations on all dependencies collectively or on a specific tool as specified by command-line arguments.
- **Integration**: Seamlessly integrates into the existing package.json to leverage the npm scripts already defined for individual tools.

**Useful Commands:**

- **General Management**: To install, verify, and print versions of all tools:
```
pnpm run manage
```

- **Specific Tool Management**: To perform a specific operation (e.g., install) on a specific tool (e.g., abigen):
```
pnpm run manage abigen install
```

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #9436 
