### PR TITLE
deps: bump slither to 0.10.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,6 +3,6 @@
   "foundry": "63fff3510408b552f11efb8196f48cfe6c1da664",
   "geth": "v1.13.14",
   "nvm": "v20.9.0",
-  "slither": "0.10.0",
+  "slither": "0.10.2",
   "kontrol": "0.1.247"
 }


### PR DESCRIPTION
**Description**

slither is currently erroring in CI with a strange error.
This bumps `slither` to the latest release in an attempt to
fix that issue.

The issue is described here: https://github.com/ethereum-optimism/optimism/pull/10410

The release can be found here: https://github.com/crytic/slither/releases

This needs a release of `ci-builder` followed up to get the new version
of slither running in CI.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

