### PR TITLE
fix `TestShim`: call `ec.Close()` when test completes

### DIFF
--- a/op-e2e/external_geth/main_test.go
+++ b/op-e2e/external_geth/main_test.go
@@ -39,7 +39,7 @@ func TestShim(t *testing.T) {
 		Name:    "TestShim",
 		BinPath: shimPath,
 	}).Run(t)
-	t.Cleanup(func() { _ = ec.Close })
+	t.Cleanup(func() { _ = ec.Close() })
 
 	for _, endpoint := range []string{
 		ec.HTTPEndpoint(),


### PR DESCRIPTION
The original registered function actually does nothing.