### PR TITLE
fix(op-dispute-mon): Claim ID and Clock Logging

### DIFF
--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -94,7 +94,7 @@ func (c *ClaimMonitor) checkGameClaims(
 
 		// Check if the clock has expired
 		if firstHalf && claim.Resolved {
-			c.logger.Error("Claim resolved in the first half of the game duration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex, "id", claim.ID())
+			c.logger.Error("Claim resolved in the first half of the game duration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex, "id", claim.ID(), "clock", duration)
 		}
 
 		maxChessTime := time.Duration(game.MaxClockDuration) * time.Second

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -94,7 +94,7 @@ func (c *ClaimMonitor) checkGameClaims(
 
 		// Check if the clock has expired
 		if firstHalf && claim.Resolved {
-			c.logger.Error("Claim resolved in the first half of the game duration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex)
+			c.logger.Error("Claim resolved in the first half of the game duration", "game", game.Proxy, "claimContractIndex", claim.ContractIndex, "id", claim.ID())
 		}
 
 		maxChessTime := time.Duration(game.MaxClockDuration) * time.Second


### PR DESCRIPTION
**Description**

Updates the `op-dispute-mon` to log the claim "id" and claim's chess clock time when the claim resolves within the first half of the game.

This makes investigation easier since we can verify the claim hash matches the corresponding claim fetched from the dispute games claim list and the clock chess time is within the "first half" (less than the `MaxClockDuration`).