### PR TITLE
fix(op-dispute-mon): Improve Resolution Status Granularity

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -21,7 +21,7 @@ func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
 func (*NoopMetricsImpl) RecordHonestActorClaims(_ common.Address, _ *HonestActorData) {}
 
-func (*NoopMetricsImpl) RecordGameResolutionStatus(_ bool, _ bool, _ int) {}
+func (*NoopMetricsImpl) RecordGameResolutionStatus(_ ResolutionStatus, _ int) {}
 
 func (*NoopMetricsImpl) RecordCredit(_ CreditExpectation, _ int) {}
 

--- a/op-dispute-mon/mon/resolutions.go
+++ b/op-dispute-mon/mon/resolutions.go
@@ -2,12 +2,13 @@ package mon
 
 import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 type ResolutionMetrics interface {
-	RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int)
+	RecordGameResolutionStatus(status metrics.ResolutionStatus, count int)
 }
 
 type ResolutionMonitor struct {
@@ -24,39 +25,43 @@ func NewResolutionMonitor(logger log.Logger, metrics ResolutionMetrics, clock RC
 	}
 }
 
-type resolutionStatus struct {
-	completeMaxDuration         int
-	completeBeforeMaxDuration   int
-	inProgressMaxDuration       int
-	inProgressBeforeMaxDuration int
-}
-
-func (r *resolutionStatus) Inc(complete, maxDuration bool) {
-	if complete {
-		if maxDuration {
-			r.completeMaxDuration++
-		} else {
-			r.completeBeforeMaxDuration++
-		}
-	} else {
-		if maxDuration {
-			r.inProgressMaxDuration++
-		} else {
-			r.inProgressBeforeMaxDuration++
-		}
-	}
-}
-
 func (r *ResolutionMonitor) CheckResolutions(games []*types.EnrichedGameData) {
-	status := &resolutionStatus{}
+	statusMetrics := make(map[metrics.ResolutionStatus]int)
 	for _, game := range games {
 		complete := game.Status != gameTypes.GameStatusInProgress
 		duration := uint64(r.clock.Now().Unix()) - game.Timestamp
 		maxDurationReached := duration >= game.MaxClockDuration
-		status.Inc(complete, maxDurationReached)
+		resolvable := true
+		for _, claim := range game.Claims {
+			// If any claim is not resolved, the game is not resolvable
+			resolvable = resolvable && claim.Resolved
+		}
+		if complete {
+			if maxDurationReached {
+				statusMetrics[metrics.CompleteMaxDuration]++
+			} else {
+				statusMetrics[metrics.CompleteBeforeMaxDuration]++
+			}
+		} else if resolvable {
+			if !maxDurationReached && game.MaxClockDuration <  {
+			if maxDurationReached {
+				statusMetrics[metrics.ResolvableMaxDuration]++
+			} else {
+				statusMetrics[metrics.ResolvableBeforeMaxDuration]++
+			}
+		} else {
+			if maxDurationReached {
+				statusMetrics[metrics.InProgressMaxDuration]++
+			} else {
+				statusMetrics[metrics.InProgressBeforeMaxDuration]++
+			}
+		}
 	}
-	r.metrics.RecordGameResolutionStatus(true, true, status.completeMaxDuration)
-	r.metrics.RecordGameResolutionStatus(true, false, status.completeBeforeMaxDuration)
-	r.metrics.RecordGameResolutionStatus(false, true, status.inProgressMaxDuration)
-	r.metrics.RecordGameResolutionStatus(false, false, status.inProgressBeforeMaxDuration)
+
+	r.metrics.RecordGameResolutionStatus(metrics.CompleteMaxDuration, statusMetrics[metrics.CompleteMaxDuration])
+	r.metrics.RecordGameResolutionStatus(metrics.CompleteBeforeMaxDuration, statusMetrics[metrics.CompleteBeforeMaxDuration])
+	r.metrics.RecordGameResolutionStatus(metrics.ResolvableMaxDuration, statusMetrics[metrics.ResolvableMaxDuration])
+	r.metrics.RecordGameResolutionStatus(metrics.ResolvableBeforeMaxDuration, statusMetrics[metrics.ResolvableBeforeMaxDuration])
+	r.metrics.RecordGameResolutionStatus(metrics.InProgressMaxDuration, statusMetrics[metrics.InProgressMaxDuration])
+	r.metrics.RecordGameResolutionStatus(metrics.InProgressBeforeMaxDuration, statusMetrics[metrics.InProgressBeforeMaxDuration])
 }

--- a/op-dispute-mon/mon/resolutions.go
+++ b/op-dispute-mon/mon/resolutions.go
@@ -43,7 +43,6 @@ func (r *ResolutionMonitor) CheckResolutions(games []*types.EnrichedGameData) {
 				statusMetrics[metrics.CompleteBeforeMaxDuration]++
 			}
 		} else if resolvable {
-			if !maxDurationReached && game.MaxClockDuration <  {
 			if maxDurationReached {
 				statusMetrics[metrics.ResolvableMaxDuration]++
 			} else {

--- a/op-dispute-mon/mon/resolutions_test.go
+++ b/op-dispute-mon/mon/resolutions_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -17,10 +18,12 @@ func TestResolutionMonitor_CheckResolutions(t *testing.T) {
 	games := newTestGames(uint64(cl.Now().Unix()))
 	r.CheckResolutions(games)
 
-	require.Equal(t, 1, m.calls[true][true])
-	require.Equal(t, 1, m.calls[true][false])
-	require.Equal(t, 1, m.calls[false][true])
-	require.Equal(t, 1, m.calls[false][false])
+	require.Equal(t, 1, m.calls[metrics.CompleteMaxDuration])
+	require.Equal(t, 1, m.calls[metrics.CompleteBeforeMaxDuration])
+	require.Equal(t, 1, m.calls[metrics.ResolvableMaxDuration])
+	require.Equal(t, 1, m.calls[metrics.ResolvableBeforeMaxDuration])
+	require.Equal(t, 1, m.calls[metrics.InProgressMaxDuration])
+	require.Equal(t, 1, m.calls[metrics.InProgressBeforeMaxDuration])
 }
 
 func newTestResolutionMonitor(t *testing.T) (*ResolutionMonitor, *clock.DeterministicClock, *stubResolutionMetrics) {
@@ -31,26 +34,37 @@ func newTestResolutionMonitor(t *testing.T) (*ResolutionMonitor, *clock.Determin
 }
 
 type stubResolutionMetrics struct {
-	calls map[bool]map[bool]int // completed -> max duration reached -> call count
+	calls map[metrics.ResolutionStatus]int
 }
 
-func (s *stubResolutionMetrics) RecordGameResolutionStatus(complete bool, maxDurationReached bool, count int) {
+func (s *stubResolutionMetrics) RecordGameResolutionStatus(status metrics.ResolutionStatus, count int) {
 	if s.calls == nil {
-		s.calls = make(map[bool]map[bool]int)
-		s.calls[true] = make(map[bool]int)
-		s.calls[false] = make(map[bool]int)
+		s.calls = make(map[metrics.ResolutionStatus]int)
 	}
-	s.calls[complete][maxDurationReached] += count
+	s.calls[status] += count
 }
 
 func newTestGames(duration uint64) []*types.EnrichedGameData {
-	newTestGame := func(duration uint64, status gameTypes.GameStatus) *types.EnrichedGameData {
-		return &types.EnrichedGameData{MaxClockDuration: duration, Status: status}
+	newTestGame := func(duration uint64, status gameTypes.GameStatus, resolvable bool) *types.EnrichedGameData {
+		game := &types.EnrichedGameData{
+			MaxClockDuration: duration,
+			Status:           status,
+		}
+		if !resolvable {
+			game.Claims = []types.EnrichedClaim{
+				{
+					Resolved: false,
+				},
+			}
+		}
+		return game
 	}
 	return []*types.EnrichedGameData{
-		newTestGame(duration, gameTypes.GameStatusInProgress),
-		newTestGame(duration*10, gameTypes.GameStatusInProgress),
-		newTestGame(duration, gameTypes.GameStatusDefenderWon),
-		newTestGame(duration*10, gameTypes.GameStatusChallengerWon),
+		newTestGame(duration, gameTypes.GameStatusInProgress, false),
+		newTestGame(duration*10, gameTypes.GameStatusInProgress, false),
+		newTestGame(duration, gameTypes.GameStatusInProgress, true),
+		newTestGame(duration*10, gameTypes.GameStatusInProgress, true),
+		newTestGame(duration, gameTypes.GameStatusDefenderWon, false),
+		newTestGame(duration*10, gameTypes.GameStatusChallengerWon, false),
 	}
 }

--- a/op-dispute-mon/mon/resolutions_test.go
+++ b/op-dispute-mon/mon/resolutions_test.go
@@ -60,11 +60,11 @@ func newTestGames(duration uint64) []*types.EnrichedGameData {
 		return game
 	}
 	return []*types.EnrichedGameData{
-		newTestGame(duration, gameTypes.GameStatusInProgress, false),
-		newTestGame(duration*10, gameTypes.GameStatusInProgress, false),
-		newTestGame(duration, gameTypes.GameStatusInProgress, true),
-		newTestGame(duration*10, gameTypes.GameStatusInProgress, true),
-		newTestGame(duration, gameTypes.GameStatusDefenderWon, false),
-		newTestGame(duration*10, gameTypes.GameStatusChallengerWon, false),
+		newTestGame(duration/2, gameTypes.GameStatusInProgress, false),
+		newTestGame(duration*5, gameTypes.GameStatusInProgress, false),
+		newTestGame(duration/2, gameTypes.GameStatusInProgress, true),
+		newTestGame(duration*5, gameTypes.GameStatusInProgress, true),
+		newTestGame(duration/2, gameTypes.GameStatusDefenderWon, false),
+		newTestGame(duration*5, gameTypes.GameStatusChallengerWon, false),
 	}
 }


### PR DESCRIPTION
**Description**

Updates the resolution status granularity to track when the game is able to be resolved by iterating across all its claims and checking if they're resolved.