### PR TITLE
feat(ctb): `AnchorStateRegistry` output root verification [rfc]

### DIFF
--- a/op-challenger/game/fault/contracts/abis/FaultDisputeGame-0.8.0.json
+++ b/op-challenger/game/fault/contracts/abis/FaultDisputeGame-0.8.0.json
@@ -346,6 +346,11 @@
         "internalType": "uint256",
         "name": "l2BlockNumber_",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isVerified_",
+        "type": "bool"
       }
     ],
     "stateMutability": "pure",

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -430,7 +430,7 @@ func TestGetBlockRange(t *testing.T) {
 			expectedStart := uint64(65)
 			expectedEnd := uint64(102)
 			stubRpc.SetResponse(fdgAddr, methodStartingBlockNumber, rpcblock.Latest, nil, []interface{}{new(big.Int).SetUint64(expectedStart)})
-			stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, rpcblock.Latest, nil, []interface{}{new(big.Int).SetUint64(expectedEnd)})
+			stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, rpcblock.Latest, nil, []interface{}{new(big.Int).SetUint64(expectedEnd), false})
 			start, end, err := contract.GetBlockRange(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, expectedStart, start)
@@ -465,7 +465,7 @@ func TestGetGameMetadata(t *testing.T) {
 			expectedStatus := types.GameStatusChallengerWon
 			block := rpcblock.ByNumber(889)
 			stubRpc.SetResponse(fdgAddr, methodL1Head, block, nil, []interface{}{expectedL1Head})
-			stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, block, nil, []interface{}{new(big.Int).SetUint64(expectedL2BlockNumber)})
+			stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, block, nil, []interface{}{new(big.Int).SetUint64(expectedL2BlockNumber), false})
 			stubRpc.SetResponse(fdgAddr, methodRootClaim, block, nil, []interface{}{expectedRootClaim})
 			stubRpc.SetResponse(fdgAddr, methodStatus, block, nil, []interface{}{expectedStatus})
 			if version.version == vers080 {

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -774,8 +774,10 @@ contract Deploy is Deployer {
     /// @notice Deploy the AnchorStateRegistry
     function deployAnchorStateRegistry() public broadcast returns (address addr_) {
         console.log("Deploying AnchorStateRegistry implementation");
-        AnchorStateRegistry anchorStateRegistry =
-            new AnchorStateRegistry{ salt: _implSalt() }(DisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy")));
+        AnchorStateRegistry anchorStateRegistry = new AnchorStateRegistry{ salt: _implSalt() }(
+            DisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy")),
+            Duration.wrap(uint64(cfg.disputeGameFinalityDelaySeconds()))
+        );
         save("AnchorStateRegistry", address(anchorStateRegistry));
         console.log("AnchorStateRegistry deployed at %s", address(anchorStateRegistry));
 

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -120,16 +120,16 @@
     "sourceCodeHash": "0x7c8b26cd263f6be144bace1f3faf0ec9265df0efb68ac34fa1fa7df7f608ab42"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0x0305c21e50829b9e07d43358d8c2c82f1449534c90d4391400d46e76d0503a49",
-    "sourceCodeHash": "0x56b069b33d080c2a45ee6fd340e5c5824ab4dc866eadb5b481b9026ebb12aa7c"
+    "initCodeHash": "0x18810917b72e7fda8a019a9be7fcb360d3b64e0291d506e9425728db3af877e9",
+    "sourceCodeHash": "0xa49560af1223ffe862383c58ad4b55ec9c3e34c3bd5358db1e7346922d71ff92"
   },
   "src/dispute/DisputeGameFactory.sol": {
     "initCodeHash": "0x7a7cb8f2c95df2f9afb3ce9eaefe4a6f997ccce7ed8ffda5d425a65a2474a792",
     "sourceCodeHash": "0x918c395ac5d77357f2551616aad0613e68893862edd14e554623eb16ee6ba148"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x8398caaff1da5d81730c95104c15b14c2fb7ff394bab005d9ec77372a2b1f5ca",
-    "sourceCodeHash": "0x5888aea16645a18ce54032c1787644afcdf07c6df2b7c6546caa957a047f03fc"
+    "initCodeHash": "0xae975410648f724f8c234d9d9f55f69fff66f25d184eafec828eb6873fad1473",
+    "sourceCodeHash": "0x91340f4dd0b5f70d9aebd8072d8b07595cc9b1fa46bdb857ff66b7d55fcec7ff"
   },
   "src/dispute/weth/DelayedWETH.sol": {
     "initCodeHash": "0xb9bbe005874922cd8f499e7a0a092967cfca03e012c1e41912b0c77481c71777",

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -5,6 +5,11 @@
         "internalType": "contract IDisputeGameFactory",
         "name": "_disputeGameFactory",
         "type": "address"
+      },
+      {
+        "internalType": "Duration",
+        "name": "_gameFinalizationDelay",
+        "type": "uint64"
       }
     ],
     "stateMutability": "nonpayable",
@@ -85,8 +90,65 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "tryUpdateAnchorState",
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "verifiedGames",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IFaultDisputeGame",
+        "name": "_disputeGame",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "version",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "stateRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "_outputRootProof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_headerRLP",
+        "type": "bytes"
+      }
+    ],
+    "name": "verifyAnchor",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
@@ -426,9 +426,14 @@
         "internalType": "uint256",
         "name": "l2BlockNumber_",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isVerified_",
+        "type": "bool"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
@@ -449,9 +449,14 @@
         "internalType": "uint256",
         "name": "l2BlockNumber_",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isVerified_",
+        "type": "bool"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/storageLayout/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/AnchorStateRegistry.json
@@ -19,5 +19,12 @@
     "offset": 0,
     "slot": "1",
     "type": "mapping(GameType => struct OutputRoot)"
+  },
+  {
+    "bytes": "32",
+    "label": "verifiedGames",
+    "offset": 0,
+    "slot": "2",
+    "type": "mapping(contract IDisputeGame => bool)"
   }
 ]

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -9,6 +9,9 @@ import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol"
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.sol";
 
+import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { Types } from "src/libraries/Types.sol";
 import "src/dispute/lib/Types.sol";
 
 /// @title AnchorStateRegistry
@@ -24,18 +27,30 @@ contract AnchorStateRegistry is Initializable, IAnchorStateRegistry, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.1.0
+    string public constant version = "1.1.0";
+
+    /// @notice The index of the block number in the RLP-encoded block header.
+    /// @dev Consensus encoding reference:
+    /// https://github.com/paradigmxyz/reth/blob/5f82993c23164ce8ccdc7bf3ae5085205383a5c8/crates/primitives/src/header.rs#L368
+    uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice DisputeGameFactory address.
     IDisputeGameFactory internal immutable DISPUTE_GAME_FACTORY;
 
+    /// @notice Dispute game finalization delay.
+    Duration internal immutable DISPUTE_GAME_FINALIZATION_DELAY;
+
     /// @inheritdoc IAnchorStateRegistry
     mapping(GameType => OutputRoot) public anchors;
 
+    /// @inheritdoc IAnchorStateRegistry
+    mapping(IDisputeGame => bool) public verifiedGames;
+
     /// @param _disputeGameFactory DisputeGameFactory address.
-    constructor(IDisputeGameFactory _disputeGameFactory) {
+    constructor(IDisputeGameFactory _disputeGameFactory, Duration _gameFinalizationDelay) {
         DISPUTE_GAME_FACTORY = _disputeGameFactory;
+        DISPUTE_GAME_FINALIZATION_DELAY = _gameFinalizationDelay;
 
         // Initialize the implementation with an empty array of starting anchor roots.
         initialize(new StartingAnchorRoot[](0));
@@ -55,34 +70,80 @@ contract AnchorStateRegistry is Initializable, IAnchorStateRegistry, ISemver {
         return DISPUTE_GAME_FACTORY;
     }
 
-    /// @inheritdoc IAnchorStateRegistry
-    function tryUpdateAnchorState() external {
-        // Grab the game and game data.
-        IFaultDisputeGame game = IFaultDisputeGame(msg.sender);
-        (GameType gameType, Claim rootClaim, bytes memory extraData) = game.gameData();
+    /// @notice Verifies that the output root proposed as the root claim of a dispute game corresponds to the claimed
+    ///         L2 block number.
+    /// @param _disputeGame The dispute game contract.
+    /// @param _outputRootProof The output root proof corresponding to the proposed output root in the dispute game.
+    /// @param _headerRLP The RLP-encoded block header corresponding to the L2 block in the output root proof.
+    function verifyAnchor(
+        IFaultDisputeGame _disputeGame,
+        Types.OutputRootProof calldata _outputRootProof,
+        bytes calldata _headerRLP
+    )
+        external
+    {
+        (GameType gameType, Claim rootClaim, bytes memory extraData) = _disputeGame.gameData();
+        (uint256 l2BlockNumber) = abi.decode(extraData, (uint256));
 
         // Grab the verified address of the game based on the game data.
-        // slither-disable-next-line unused-return
         (IDisputeGame factoryRegisteredGame,) =
             DISPUTE_GAME_FACTORY.games({ _gameType: gameType, _rootClaim: rootClaim, _extraData: extraData });
 
         // Must be a valid game.
         require(
-            address(factoryRegisteredGame) == address(game),
+            address(factoryRegisteredGame) == address(_disputeGame),
             "AnchorStateRegistry: fault dispute game not registered with factory"
         );
 
         // No need to update anything if the anchor state is already newer.
-        if (game.l2BlockNumber() <= anchors[gameType].l2BlockNumber) {
-            return;
-        }
+        require(
+            l2BlockNumber > anchors[gameType].l2BlockNumber,
+            "AnchorStateRegistry: block number of proposal does not advance anchor"
+        );
 
         // Must be a game that resolved in favor of the state.
-        if (game.status() != GameStatus.DEFENDER_WINS) {
-            return;
+        require(
+            _disputeGame.status() == GameStatus.DEFENDER_WINS,
+            "AnchorStateRegistry: status of proposal is not DEFENDER_WINS"
+        );
+
+        require(
+            _disputeGame.resolvedAt().raw() + DISPUTE_GAME_FINALIZATION_DELAY.raw() <= block.timestamp,
+            "AnchorStateRegistry: proposal not finalized"
+        );
+
+        // Verify the output root preimage.
+        require(
+            Hashing.hashOutputRootProof(_outputRootProof) == _disputeGame.rootClaim().raw(),
+            "AnchorStateRegistry: output root proof invalid"
+        );
+
+        // Verify the block preimage.
+        require(keccak256(_headerRLP) == _outputRootProof.latestBlockhash, "AnchorStateRegistry: header rlp invalid");
+
+        // Decode the header RLP to find the number of the block. In the consensus encoding, the timestamp
+        // is the 9th element in the list that represents the block header.
+        RLPReader.RLPItem memory headerRLP = RLPReader.toRLPItem(_headerRLP);
+        RLPReader.RLPItem[] memory headerContents = RLPReader.readList(headerRLP);
+        bytes memory rawBlockNumber = RLPReader.readBytes(headerContents[HEADER_BLOCK_NUMBER_INDEX]);
+
+        require(rawBlockNumber.length <= 32, "AnchorStateRegistry: bad block header timestamp");
+
+        // Convert the raw, left-aligned block number to a uint256 by aligning it as a big-endian
+        // number in the low-order bytes of a 32-byte word.
+        //
+        // SAFETY: The length of `rawBlockNumber` is checked above to ensure it is at most 32 bytes.
+        uint256 blockNumber;
+        assembly {
+            blockNumber := shr(shl(0x03, sub(0x20, mload(rawBlockNumber))), mload(add(rawBlockNumber, 0x20)))
         }
 
-        // Actually update the anchor state.
-        anchors[gameType] = OutputRoot({ l2BlockNumber: game.l2BlockNumber(), root: Hash.wrap(game.rootClaim().raw()) });
+        require(blockNumber == l2BlockNumber, "AnchorStateRegistry: block number mismatch");
+
+        // Update the anchor state.
+        anchors[gameType] = OutputRoot({ l2BlockNumber: l2BlockNumber, root: Hash.wrap(rootClaim.raw()) });
+
+        // Flag the game as verified.
+        verifiedGames[_disputeGame] = true;
     }
 }

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -61,8 +61,8 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
     Position internal constant ROOT_POSITION = Position.wrap(1);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.1.0
+    string public constant version = "1.1.0";
 
     /// @notice The starting timestamp of the game
     Timestamp public createdAt;
@@ -186,7 +186,8 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
-        if (l2BlockNumber() <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
+        (uint256 l2Number,) = l2BlockNumber();
+        if (l2Number <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
 
         // Set the root claim
         claimData.push(
@@ -448,8 +449,9 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
     }
 
     /// @inheritdoc IFaultDisputeGame
-    function l2BlockNumber() public pure returns (uint256 l2BlockNumber_) {
+    function l2BlockNumber() public view returns (uint256 l2BlockNumber_, bool isVerified_) {
         l2BlockNumber_ = _getArgUint256(0x54);
+        isVerified_ = ANCHOR_STATE_REGISTRY.verifiedGames(IDisputeGame(address(this)));
     }
 
     /// @inheritdoc IFaultDisputeGame
@@ -480,9 +482,6 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
         // Update the status and emit the resolved event, note that we're performing an assignment here.
         emit Resolved(status = status_);
-
-        // Try to update the anchor state, this should not revert.
-        ANCHOR_STATE_REGISTRY.tryUpdateAnchorState();
     }
 
     /// @inheritdoc IFaultDisputeGame

--- a/packages/contracts-bedrock/src/dispute/interfaces/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IAnchorStateRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.sol";
+import { IDisputeGameFactory, IDisputeGame } from "src/dispute/interfaces/IDisputeGameFactory.sol";
 
 import "src/dispute/lib/Types.sol";
 
@@ -10,15 +10,16 @@ import "src/dispute/lib/Types.sol";
 interface IAnchorStateRegistry {
     /// @notice Returns the anchor state for the given game type.
     /// @param _gameType The game type to get the anchor state for.
-    /// @return The anchor state for the given game type.
-    function anchors(GameType _gameType) external view returns (Hash, uint256);
+    /// @return outputRoot_ The output root of the anchor state for the given game type.
+    /// @return blockNumber_ The L2 block number at which the output root was generated.
+    function anchors(GameType _gameType) external view returns (Hash outputRoot_, uint256 blockNumber_);
+
+    /// @notice Returns true if the passed dispute game has been verified.
+    /// @param _disputeGame The game type to check.
+    /// @return isVerified_ True if the dispute game has been verified.
+    function verifiedGames(IDisputeGame _disputeGame) external view returns (bool isVerified_);
 
     /// @notice Returns the DisputeGameFactory address.
-    /// @return DisputeGameFactory address.
-    function disputeGameFactory() external view returns (IDisputeGameFactory);
-
-    /// @notice Callable by FaultDisputeGame contracts to update the anchor state. Pulls the anchor state directly from
-    ///         the FaultDisputeGame contract and stores it in the registry if the new anchor state is valid and the
-    ///         state is newer than the current anchor state.
-    function tryUpdateAnchorState() external;
+    /// @return factory_ DisputeGameFactory address.
+    function disputeGameFactory() external view returns (IDisputeGameFactory factory_);
 }

--- a/packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
@@ -81,8 +81,10 @@ interface IFaultDisputeGame is IDisputeGame {
     /// @return numRemainingChildren_ The number of children that still need to be checked to resolve the subgame.
     function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
 
-    /// @notice The l2BlockNumber of the disputed output root in the `L2OutputOracle`.
-    function l2BlockNumber() external view returns (uint256 l2BlockNumber_);
+    /// @notice The l2BlockNumber of the disputed output root in the `L2OutputOracle`. If the game has not had the
+    ///         L2 block number verified in the AnchorStateRegistry, this function will return `false` for
+    ///         `isVerified_`. If this is the case, the value should not be trusted.
+    function l2BlockNumber() external view returns (uint256 l2BlockNumber_, bool isVerified_);
 
     /// @notice Starting output root and block number of the game.
     function startingOutputRoot() external view returns (Hash startingRoot_, uint256 l2BlockNumber_);

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -6,6 +6,11 @@ import "src/dispute/lib/Errors.sol";
 
 import { Test } from "forge-std/Test.sol";
 import { FaultDisputeGame_Init, _changeClaimStatus } from "test/dispute/FaultDisputeGame.t.sol";
+import { FaultDisputeGame, IFaultDisputeGame, IDisputeGame } from "src/dispute/FaultDisputeGame.sol";
+import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
+import { Types } from "src/libraries/Types.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
 
 contract AnchorStateRegistry_Init is FaultDisputeGame_Init {
     function setUp() public virtual override {
@@ -39,97 +44,330 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_Init {
     }
 }
 
-contract AnchorStateRegistry_TryUpdateAnchorState_Test is AnchorStateRegistry_Init {
-    /// @dev Tests that updating the anchor state succeeds when the game state is valid and newer.
-    function test_tryUpdateAnchorState_validNewerState_succeeds() public {
-        // Confirm that the anchor state is older than the game state.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assert(l2BlockNumber < gameProxy.l2BlockNumber());
+contract AnchorStateRegistry_VerifyAnchor_Test is AnchorStateRegistry_Init {
+    address mockGameAddress;
 
-        // Mock the state that we want.
-        vm.mockCall(
-            address(gameProxy), abi.encodeWithSelector(gameProxy.status.selector), abi.encode(GameStatus.DEFENDER_WINS)
-        );
-
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        anchorStateRegistry.tryUpdateAnchorState();
-
-        // Confirm that the anchor state is now the same as the game state.
-        (root, l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(l2BlockNumber, gameProxy.l2BlockNumber());
-        assertEq(root.raw(), gameProxy.rootClaim().raw());
+    function setUp() public virtual override {
+        super.setUp();
+        mockGameAddress = vm.addr(0xFACADE);
     }
 
-    /// @dev Tests that updating the anchor state fails when the game state is valid but older.
-    function test_tryUpdateAnchorState_validOlderState_fails() public {
-        // Confirm that the anchor state is newer than the game state.
-        vm.mockCall(address(gameProxy), abi.encodeWithSelector(gameProxy.l2BlockNumber.selector), abi.encode(0));
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assert(l2BlockNumber >= gameProxy.l2BlockNumber());
+    /// @dev Tests that verifying an output root succeeds when the root is valid.
+    function test_staticVerifyAnchor_validRoot_succeeds() public {
+        // Raw header RLP
+        bytes memory headerRLP =
+            hex"f901fca0102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887da01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347944200000000000000000000000000000000000011a04c0f6050836fd6788a0a15f3569b192def4cb8d2734399a31e4ad6be421eb3dca04df094c413f499eaaabf48b96fd1d83c23b30b5cec95a5eff9c96b2d5d2ee875a03c715dd96d2597ccd46fde046da5e4b13e0a5b7d0a2ff60c3ee6c92fee9600eab901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401c9c38082f9f58464d6dbae80a032e4469959675ceed3d1a9f43709a8055d689d712844f820aa34dbc9f49e286c880000000000000000843a699d00";
 
-        // Mock the state that we want.
-        vm.mockCall(address(gameProxy), abi.encodeWithSelector(gameProxy.l2BlockNumber.selector), abi.encode(0));
-        vm.mockCall(
-            address(gameProxy), abi.encodeWithSelector(gameProxy.status.selector), abi.encode(GameStatus.DEFENDER_WINS)
-        );
+        // Output root
+        bytes32 bh = 0xe460dd641f493c0184f2544c9bcfe3b4dcfe69cfa8054f8aed291b0ddda0025e;
+        bytes32 wdr = 0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12;
+        bytes32 sr = 0x4c0f6050836fd6788a0a15f3569b192def4cb8d2734399a31e4ad6be421eb3dc;
+        Types.OutputRootProof memory outputRootProof =
+            Types.OutputRootProof({ version: 0, stateRoot: sr, messagePasserStorageRoot: wdr, latestBlockhash: bh });
+        bytes32 outputRoot = Hashing.hashOutputRootProof(outputRootProof);
 
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        anchorStateRegistry.tryUpdateAnchorState();
+        // Create a mock dispute game.
+        IDisputeGame game = disputeGameFactory.create(GameTypes.CANNON, Claim.wrap(outputRoot), abi.encode(1));
+        FaultDisputeGame prox = FaultDisputeGame(address(game));
 
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        // Warp past the clock time and resolve.
+        vm.warp(block.timestamp + prox.maxClockDuration().raw() + 1 seconds);
+        prox.resolveClaim(0, 0);
+        prox.resolve();
+        // Warp past the finalization delay.
+        vm.warp(block.timestamp + prox.maxClockDuration().raw() + 1 seconds);
+
+        anchorStateRegistry.verifyAnchor(IFaultDisputeGame(address(prox)), outputRootProof, headerRLP);
     }
 
-    /// @dev Tests that updating the anchor state fails when the game state is invalid.
-    function test_tryUpdateAnchorState_invalidNewerState_fails() public {
-        // Confirm that the anchor state is older than the game state.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assert(l2BlockNumber < gameProxy.l2BlockNumber());
+    /// @dev Tests that verifying an output root succeeds when the root is valid.
+    function testFuzz_verifyAnchor_validRoot_succeeds(
+        bytes32 withdrawalRoot,
+        bytes32 storageRoot,
+        uint64 l2BlockNumber
+    )
+        public
+    {
+        l2BlockNumber = uint64(bound(l2BlockNumber, 1, type(uint64).max));
 
-        // Mock the state that we want.
-        vm.mockCall(
-            address(gameProxy),
-            abi.encodeWithSelector(gameProxy.status.selector),
-            abi.encode(GameStatus.CHALLENGER_WINS)
-        );
+        // L2 Block header
+        bytes[] memory rawHeaderRLP = new bytes[](12);
+        rawHeaderRLP[0] = hex"83FACADE";
+        rawHeaderRLP[1] = hex"83FACADE";
+        rawHeaderRLP[2] = hex"83FACADE";
+        rawHeaderRLP[3] = hex"83FACADE";
+        rawHeaderRLP[4] = hex"83FACADE";
+        rawHeaderRLP[5] = hex"83FACADE";
+        rawHeaderRLP[6] = hex"83FACADE";
+        rawHeaderRLP[7] = hex"83FACADE";
+        rawHeaderRLP[8] = RLPWriter.writeBytes(abi.encodePacked(l2BlockNumber));
+        rawHeaderRLP[9] = hex"83FACADE";
+        rawHeaderRLP[10] = hex"83FACADE";
+        rawHeaderRLP[11] = hex"83FACADE";
+        bytes memory headerRLP = RLPWriter.writeList(rawHeaderRLP);
 
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        anchorStateRegistry.tryUpdateAnchorState();
+        // Output root
+        Types.OutputRootProof memory outputRootProof = Types.OutputRootProof({
+            version: 0,
+            stateRoot: storageRoot,
+            messagePasserStorageRoot: withdrawalRoot,
+            latestBlockhash: keccak256(headerRLP)
+        });
+        bytes32 outputRoot = Hashing.hashOutputRootProof(outputRootProof);
 
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        // Create a mock dispute game.
+        IDisputeGame game =
+            disputeGameFactory.create(GameTypes.CANNON, Claim.wrap(outputRoot), abi.encode(l2BlockNumber));
+        FaultDisputeGame prox = FaultDisputeGame(address(game));
+
+        // Warp past the clock time and resolve.
+        vm.warp(block.timestamp + prox.maxClockDuration().raw() + 1 seconds);
+        prox.resolveClaim(0, 0);
+        prox.resolve();
+        // Warp past the finalization delay.
+        vm.warp(block.timestamp + prox.maxClockDuration().raw() + 1 seconds);
+
+        anchorStateRegistry.verifyAnchor(IFaultDisputeGame(address(prox)), outputRootProof, headerRLP);
     }
 
-    /// @dev Tests that updating the anchor state fails when the game is not registered with the factory.
-    function test_tryUpdateAnchorState_invalidGame_fails() public {
-        // Confirm that the anchor state is older than the game state.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assert(l2BlockNumber < gameProxy.l2BlockNumber());
+    /// @dev Tests that verifying an output root fails when the game is not registered.
+    function test_verifyAnchor_gameNotValid_reverts() public {
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(0))
+        );
 
-        // Mock the state that we want.
+        vm.expectRevert("AnchorStateRegistry: fault dispute game not registered with factory");
+        anchorStateRegistry.verifyAnchor(
+            IFaultDisputeGame(mockGameAddress),
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 }),
+            ""
+        );
+    }
+
+    /// @dev Tests that verifying an output root fails when the game is not proposing an output that advances the
+    /// anchor.
+    function test_verifyAnchor_gameDoesntAdvanceAnchor_reverts() public {
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(0))
+        );
         vm.mockCall(
             address(disputeGameFactory),
-            abi.encodeWithSelector(
-                disputeGameFactory.games.selector, gameProxy.gameType(), gameProxy.rootClaim(), gameProxy.extraData()
-            ),
-            abi.encode(address(0), 0)
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(0))),
+            abi.encode(mockGameAddress, false)
+        );
+        _setAnchor(GameTypes.CANNON, Hash.wrap(0), 0xFF);
+
+        vm.expectRevert("AnchorStateRegistry: block number of proposal does not advance anchor");
+        anchorStateRegistry.verifyAnchor(
+            IFaultDisputeGame(mockGameAddress),
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 }),
+            ""
+        );
+    }
+
+    /// @dev Tests that verifying an output root fails when the game is not resolved yet.
+    function test_verifyAnchor_gameNotResolved_reverts() public {
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(1))
+        );
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.status, ()), abi.encode(GameStatus.IN_PROGRESS));
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(1))),
+            abi.encode(mockGameAddress, false)
         );
 
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert("AnchorStateRegistry: fault dispute game not registered with factory");
-        anchorStateRegistry.tryUpdateAnchorState();
+        vm.expectRevert("AnchorStateRegistry: status of proposal is not DEFENDER_WINS");
+        anchorStateRegistry.verifyAnchor(
+            IFaultDisputeGame(mockGameAddress),
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 }),
+            ""
+        );
+    }
 
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+    /// @dev Tests that verifying an output root fails when the game is not resolved yet.
+    function test_verifyAnchor_gameNotFinalized_reverts() public {
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(1))
+        );
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.resolvedAt, ()), abi.encode(block.timestamp));
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(1))),
+            abi.encode(mockGameAddress, false)
+        );
+
+        vm.expectRevert("AnchorStateRegistry: proposal not finalized");
+        anchorStateRegistry.verifyAnchor(
+            IFaultDisputeGame(mockGameAddress),
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 }),
+            ""
+        );
+    }
+
+    /// @dev Tests that verifying an output root fails when the output root proof is invalid.
+    function test_verifyAnchor_badOutputRootProof_reverts() public {
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(1))
+        );
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.rootClaim, ()), abi.encode(0));
+        vm.mockCall(
+            mockGameAddress, abi.encodeCall(IDisputeGame.resolvedAt, ()), abi.encode(block.timestamp - 3.5 days)
+        );
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(1))),
+            abi.encode(mockGameAddress, false)
+        );
+
+        vm.expectRevert("AnchorStateRegistry: output root proof invalid");
+        anchorStateRegistry.verifyAnchor(
+            IFaultDisputeGame(mockGameAddress),
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 }),
+            ""
+        );
+    }
+
+    /// @dev Tests that verifying an output root fails when the header RLP is invalid with respect to the output root's
+    ///      latest blockhash.
+    function test_verifyAnchor_badHeaderRLP_reverts() public {
+        Types.OutputRootProof memory outputRootProof =
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 });
+        bytes32 outputRoot = Hashing.hashOutputRootProof(outputRootProof);
+
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(1))
+        );
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.rootClaim, ()), abi.encode(outputRoot));
+        vm.mockCall(
+            mockGameAddress, abi.encodeCall(IDisputeGame.resolvedAt, ()), abi.encode(block.timestamp - 3.5 days)
+        );
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(1))),
+            abi.encode(mockGameAddress, false)
+        );
+
+        vm.expectRevert("AnchorStateRegistry: header rlp invalid");
+        anchorStateRegistry.verifyAnchor(IFaultDisputeGame(mockGameAddress), outputRootProof, "");
+    }
+
+    /// @dev Tests that verifying an output root fails when the header timestamp is incorrectly formatted.
+    function test_verifyAnchor_badBlockHeaderTimestamp_reverts() public {
+        // L2 Block header
+        bytes[] memory rawHeaderRLP = new bytes[](9);
+        rawHeaderRLP[0] = hex"83FACADE";
+        rawHeaderRLP[1] = hex"83FACADE";
+        rawHeaderRLP[2] = hex"83FACADE";
+        rawHeaderRLP[3] = hex"83FACADE";
+        rawHeaderRLP[4] = hex"83FACADE";
+        rawHeaderRLP[5] = hex"83FACADE";
+        rawHeaderRLP[6] = hex"83FACADE";
+        rawHeaderRLP[7] = hex"83FACADE";
+        rawHeaderRLP[8] = RLPWriter.writeBytes(new bytes(0xFF));
+        bytes memory headerRLP = RLPWriter.writeList(rawHeaderRLP);
+
+        // output root
+        Types.OutputRootProof memory outputRootProof = Types.OutputRootProof({
+            version: 0,
+            stateRoot: 0,
+            messagePasserStorageRoot: 0,
+            latestBlockhash: keccak256(headerRLP)
+        });
+        bytes32 outputRoot = Hashing.hashOutputRootProof(outputRootProof);
+
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(1))
+        );
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.rootClaim, ()), abi.encode(outputRoot));
+        vm.mockCall(
+            mockGameAddress, abi.encodeCall(IDisputeGame.resolvedAt, ()), abi.encode(block.timestamp - 3.5 days)
+        );
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(1))),
+            abi.encode(mockGameAddress, false)
+        );
+
+        vm.expectRevert("AnchorStateRegistry: bad block header timestamp");
+        anchorStateRegistry.verifyAnchor(IFaultDisputeGame(mockGameAddress), outputRootProof, headerRLP);
+    }
+
+    /// @dev Tests that verifying an output root fails when the block in the output root does not correspond to the
+    ///     claimed L2 block number.
+    function test_verifyAnchor_badBlockNumber_reverts() public {
+        // L2 Block header
+        bytes[] memory rawHeaderRLP = new bytes[](9);
+        rawHeaderRLP[0] = hex"83FACADE";
+        rawHeaderRLP[1] = hex"83FACADE";
+        rawHeaderRLP[2] = hex"83FACADE";
+        rawHeaderRLP[3] = hex"83FACADE";
+        rawHeaderRLP[4] = hex"83FACADE";
+        rawHeaderRLP[5] = hex"83FACADE";
+        rawHeaderRLP[6] = hex"83FACADE";
+        rawHeaderRLP[7] = hex"83FACADE";
+        rawHeaderRLP[8] = RLPWriter.writeBytes(abi.encode(0));
+        bytes memory headerRLP = RLPWriter.writeList(rawHeaderRLP);
+
+        // output root
+        Types.OutputRootProof memory outputRootProof = Types.OutputRootProof({
+            version: 0,
+            stateRoot: 0,
+            messagePasserStorageRoot: 0,
+            latestBlockhash: keccak256(headerRLP)
+        });
+        bytes32 outputRoot = Hashing.hashOutputRootProof(outputRootProof);
+
+        vm.mockCall(
+            mockGameAddress,
+            abi.encodeCall(IDisputeGame.gameData, ()),
+            abi.encode(GameType.wrap(0), Claim.wrap(0), abi.encode(1))
+        );
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        vm.mockCall(mockGameAddress, abi.encodeCall(IDisputeGame.rootClaim, ()), abi.encode(outputRoot));
+        vm.mockCall(
+            mockGameAddress, abi.encodeCall(IDisputeGame.resolvedAt, ()), abi.encode(block.timestamp - 3.5 days)
+        );
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(DisputeGameFactory.games, (GameType.wrap(0), Claim.wrap(0), abi.encode(1))),
+            abi.encode(mockGameAddress, false)
+        );
+
+        vm.expectRevert("AnchorStateRegistry: block number mismatch");
+        anchorStateRegistry.verifyAnchor(IFaultDisputeGame(mockGameAddress), outputRootProof, headerRLP);
+    }
+
+    /// @dev Tests that the `_setAnchor` helper function works as expected.
+    function testFuzz_setAnchor_succeeds(GameType gameType, Hash root, uint256 l2BlockNumber) public {
+        _setAnchor(gameType, root, l2BlockNumber);
+
+        (Hash _root, uint256 _l2BlockNumber) = anchorStateRegistry.anchors(gameType);
+        assertEq(_root.raw(), root.raw());
+        assertEq(_l2BlockNumber, l2BlockNumber);
+    }
+
+    function _setAnchor(GameType gameType, Hash root, uint256 l2BlockNumber) internal {
+        bytes32 startMapSlot = keccak256(abi.encode(gameType, uint256(1)));
+        vm.store(address(anchorStateRegistry), startMapSlot, root.raw());
+        vm.store(address(anchorStateRegistry), bytes32(uint256(startMapSlot) + 1), bytes32(l2BlockNumber));
     }
 }


### PR DESCRIPTION
## Overview

Adds a new function to the `AnchorStateRegistry` that allows for users to update the anchor state of a game type through revealing the block header within the output root and verifying its block number.
