### PR TITLE
call `FundDevAccounts` only when `DeployConfig.FundDevAccounts` is `true`

### DIFF
--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -57,7 +57,9 @@ func BuildL1DeveloperGenesis(config *DeployConfig, dump *ForgeAllocs, l1Deployme
 	}
 	// copy, for safety when the dump is reused (like in e2e testing)
 	genesis.Alloc = dump.Copy().Accounts
-	FundDevAccounts(genesis)
+	if config.FundDevAccounts {
+		FundDevAccounts(genesis)
+	}
 	SetPrecompileBalances(genesis)
 
 	l1Deployments.ForEach(func(name string, addr common.Address) {

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -125,7 +125,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 
 	var allocsMode genesis.L2AllocsMode
 	allocsMode = genesis.L2AllocsDelta
-	if ecotoneTime := deployConf.EcotoneTime(l1Block.Time()); ecotoneTime != nil && *ecotoneTime <= 0 {
+	if ecotoneTime := deployConf.EcotoneTime(l1Block.Time()); ecotoneTime != nil && *ecotoneTime == 0 {
 		allocsMode = genesis.L2AllocsEcotone
 	}
 	l2Allocs := config.L2Allocs(allocsMode)


### PR DESCRIPTION
1. call `FundDevAccounts` only when `DeployConfig.FundDevAccounts` is `true`
2. `*ecotoneTime` is `uint64`, so it'll never `<0`