### PR TITLE
feat(ctb): Check `AnchorStateRegistry` validation in WD path

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x8e9221539290a9b3cfb933d30ab77b137e2a76a1481671e41469ed1014ffbdc4"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0xea32d79e8297956d4f9a4c7985bb53ff8bb3735e5b307d4e118fea71f503a38e",
-    "sourceCodeHash": "0x209d7e9ffa97a54c060f5d30e5d88684a50a7b4610336cf03880bfbc80ca669e"
+    "initCodeHash": "0xbe994f382de54feb589108952e6388fc8139dfdd2ef599ce984b2f1dccf1ce3c",
+    "sourceCodeHash": "0x9e93288f7fba4747da463a62b1b1786ab1473b73b59a2d8aaf70c80b1ea59bd6"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x72cd467e8bcf019c02675d72ab762e088bcc9cc0f1a4e9f587fa4589f7fdd1b8",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { DisputeGameFactory, IDisputeGame } from "src/dispute/DisputeGameFactory.sol";
+import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { Constants } from "src/libraries/Constants.sol";
@@ -131,8 +132,8 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.8.0
-    string public constant version = "3.8.0";
+    /// @custom:semver 3.9.0
+    string public constant version = "3.9.0";
 
     /// @notice Constructs the OptimismPortal contract.
     constructor(uint256 _proofMaturityDelaySeconds, uint256 _disputeGameFinalityDelaySeconds) {
@@ -508,6 +509,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
 
         // Check that this withdrawal has not already been finalized, this is replay protection.
         require(!finalizedWithdrawals[_withdrawalHash], "OptimismPortal: withdrawal has already been finalized");
+
+        // The dispute game must have been validated in the anchor state registry.
+        require(
+            FaultDisputeGame(address(disputeGameProxy)).anchorStateRegistry().verifiedGames(disputeGameProxy),
+            "OptimismPortal: dispute game output root has not been validated in anchor state registry"
+        );
     }
 
     /// @notice External getter for the number of proof submitters for a withdrawal hash.


### PR DESCRIPTION
## Overview

Adds a check in the withdrawal path that requires the withdrawal that was proven against to also have its L2 block number validated within the `AnchorStateRegistry`.
