### PR TITLE
contracts-bedrock: weth predeploy version

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -99,6 +99,10 @@
     "initCodeHash": "0xd62e193d89b1661d34031227a45ce1eade9c2a89b0bd7f362f511d03cceef294",
     "sourceCodeHash": "0xa304b4b556162323d69662b4dd9a1d073d55ec661494465489bb67f1e465e7b3"
   },
+  "src/L2/WETH.sol": {
+    "initCodeHash": "0xde72ae96910e95249623c2d695749847e4c4adeaf96a7a35033afd77318a528a",
+    "sourceCodeHash": "0xbe200a6cb297a3ca1a7d174a9c886e3f17eb8edf617ad014a2ac4f6c2e2ac7f1"
+  },
   "src/Safe/DeputyGuardianModule.sol": {
     "initCodeHash": "0x433eb7488e613a51c7ff05a76bbecf47f5beac8b8614f5c50001f99e39ae7ed2",
     "sourceCodeHash": "0x2919835fc15c166a027b2ff1cf801c847f139948baf2df0db3d02ac3017c09d9"

--- a/packages/contracts-bedrock/snapshots/abi/WETH.json
+++ b/packages/contracts-bedrock/snapshots/abi/WETH.json
@@ -187,6 +187,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/packages/contracts-bedrock/src/L2/WETH.sol
+++ b/packages/contracts-bedrock/src/L2/WETH.sol
@@ -4,10 +4,14 @@ pragma solidity 0.8.15;
 import { WETH98 } from "src/dispute/weth/WETH98.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { L1Block } from "src/L2/L1Block.sol";
+import { ISemver } from "src/universal/ISemver.sol";
 
 /// @title WETH contract that reads the name and symbol from the L1Block contract.
 ///        Allows for nice rendering of token names for chains using custom gas token.
-contract WETH is WETH98 {
+contract WETH is WETH98, ISemver {
+    /// @custom:semver 1.0.0
+    string public constant version = "1.0.0";
+
     /// @notice Returns the name of the wrapped native asset. Will be "Wrapped Ether"
     ///         if the native asset is Ether.
     function name() external view override returns (string memory name_) {


### PR DESCRIPTION
**Description**

Updates the weth predeploy to be versioned.
Even though the weth predeploy is not proxied, adding
a version safely lets us make small modifications to it in the
future such as updating the version of `solc` that is used
to compile it and be able to be aware offchain of the version
that the chain has without needing to keep a registry of codehashes.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

