### PR TITLE
fix(op-challenger): Subcommand Env Var Prefix

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -133,7 +133,7 @@ func listClaimsFlags() []cli.Flag {
 		flags.L1EthRpcFlag,
 		GameAddressFlag,
 	}
-	cliFlags = append(cliFlags, oplog.CLIFlags("OP_CHALLENGER")...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
 	return cliFlags
 }
 

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -118,7 +118,7 @@ func listGamesFlags() []cli.Flag {
 		flags.FactoryAddressFlag,
 		flags.GameWindowFlag,
 	}
-	cliFlags = append(cliFlags, oplog.CLIFlags("OP_CHALLENGER")...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
 	return cliFlags
 }
 


### PR DESCRIPTION
**Description**

Use the `flags` env var prefix for subcommand flags instead of manually specifying `"OP_CHALLENGER"`.