### PR TITLE
contracts-bedrock: portal opaque data test

### DIFF
--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -128,8 +128,8 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.7.0
-    string public constant version = "2.7.0";
+    /// @custom:semver 2.8.0
+    string public constant version = "2.8.0";
 
     /// @notice Constructs the OptimismPortal contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -546,10 +546,14 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
             from = AddressAliasHelper.applyL1ToL2Alias(msg.sender);
         }
 
-        // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
-        // We use opaque data so that we can update the TransactionDeposited event in the future
-        // without breaking the current interface.
-        bytes memory opaqueData = abi.encodePacked(_mint, _value, _gasLimit, _isCreation, _data);
+        // Compute the opaque data.
+        bytes memory opaqueData = _encodeDepositData({
+            _mint: _mint,
+            _value: _value,
+            _gasLimit: _gasLimit,
+            _isCreation: _isCreation,
+            _data: _data
+        });
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
@@ -565,20 +569,36 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
         // This value must be large enough to cover the cost of calling `L1Block.setGasPayingToken`.
         useGas(SYSTEM_DEPOSIT_GAS_LIMIT);
 
+        // Compute the opaque data.
+        bytes memory opaqueData = _encodeDepositData({
+            _mint: 0,
+            _value: 0,
+            _gasLimit: uint64(SYSTEM_DEPOSIT_GAS_LIMIT),
+            _isCreation: false,
+            _data: abi.encodeCall(L1Block.setGasPayingToken, (_token, _decimals, _name, _symbol))
+        });
+
         // Emit the special deposit transaction directly that sets the gas paying
         // token in the L1Block predeploy contract.
         emit TransactionDeposited(
             Constants.DEPOSITOR_ACCOUNT,
             Predeploys.L1_BLOCK_ATTRIBUTES,
             DEPOSIT_VERSION,
-            abi.encodePacked(
-                uint256(0), // mint
-                uint256(0), // value
-                uint64(SYSTEM_DEPOSIT_GAS_LIMIT), // gasLimit
-                false, // isCreation,
-                abi.encodeCall(L1Block.setGasPayingToken, (_token, _decimals, _name, _symbol))
-            )
+            opaqueData
         );
+    }
+
+    // @notice Compute the opaque data that will be emitted as part of the TransactionDeposited event.
+    //         We use opaque data so that we can update the TransactionDeposited event in the future
+    //         without breaking the current interface.
+    function _encodeDepositData(
+        uint256 _mint,
+        uint256 _value,
+        uint64 _gasLimit,
+        bool _isCreation,
+        bytes memory _data
+    ) internal pure returns (bytes memory data_) {
+        data_ = abi.encodePacked(_mint, _value, _gasLimit, _isCreation, _data);
     }
 
     /// @notice Determine if a given output is finalized.

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -478,12 +478,7 @@ contract OptimismPortal_Test is CommonTest {
         vm.recordLogs();
 
         vm.prank(address(systemConfig));
-        optimismPortal.setGasPayingToken({
-            _token: address(0x9999),
-            _decimals: 19,
-            _name: "",
-            _symbol: ""
-        });
+        optimismPortal.setGasPayingToken({ _token: address(0x9999), _decimals: 19, _name: "", _symbol: "" });
 
         vm.prank(address(Constants.DEPOSITOR_ACCOUNT));
         optimismPortal.depositTransaction({

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -494,7 +494,7 @@ contract OptimismPortal_Test is CommonTest {
         optimismPortal.depositTransaction({
             _to: Predeploys.L1_BLOCK_ATTRIBUTES,
             _value: 0,
-            _gasLimit: 80_000,
+            _gasLimit: 200_000,
             _isCreation: false,
             _data: abi.encodeCall(L1Block.setGasPayingToken, (_token, 18, name, symbol))
         });
@@ -505,6 +505,9 @@ contract OptimismPortal_Test is CommonTest {
         VmSafe.Log memory systemPath = logs[0];
         VmSafe.Log memory userPath = logs[1];
 
+        assertEq(systemPath.topics.length, userPath.topics.length);
+        //assertEq(systemPath.topics[0], userPath.topics[0]);
+        //assertEq(systemPath.topics[1], userPath.topics[1]);
         assertEq(systemPath.data, userPath.data);
     }
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -490,7 +490,7 @@ contract OptimismPortal_Test is CommonTest {
         vm.prank(address(systemConfig));
         optimismPortal.setGasPayingToken({ _token: _token, _decimals: 18, _name: name, _symbol: symbol });
 
-        vm.prank(address(Constants.DEPOSITOR_ACCOUNT));
+        vm.prank(Constants.DEPOSITOR_ACCOUNT, Constants.DEPOSITOR_ACCOUNT);
         optimismPortal.depositTransaction({
             _to: Predeploys.L1_BLOCK_ATTRIBUTES,
             _value: 0,
@@ -505,9 +505,12 @@ contract OptimismPortal_Test is CommonTest {
         VmSafe.Log memory systemPath = logs[0];
         VmSafe.Log memory userPath = logs[1];
 
+        assertEq(systemPath.topics.length, 4);
         assertEq(systemPath.topics.length, userPath.topics.length);
-        //assertEq(systemPath.topics[0], userPath.topics[0]);
-        //assertEq(systemPath.topics[1], userPath.topics[1]);
+        assertEq(systemPath.topics[0], userPath.topics[0]);
+        assertEq(systemPath.topics[1], userPath.topics[1]);
+        assertEq(systemPath.topics[2], userPath.topics[2]);
+        assertEq(systemPath.topics[3], userPath.topics[3]);
         assertEq(systemPath.data, userPath.data);
     }
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -478,7 +478,9 @@ contract OptimismPortal_Test is CommonTest {
         address _token,
         string memory _name,
         string memory _symbol
-    ) external {
+    )
+        external
+    {
         vm.assume(bytes(_name).length <= 32);
         vm.assume(bytes(_symbol).length <= 32);
 


### PR DESCRIPTION
**Description**

- **contracts-bedrock: add deposit event coverage**
- **contracts-bedrock: revert diff to portal**

contracts-bedrock: add deposit event coverage

Adds deposit event differential coverage for the two
different places where the deposit tx event exists.
This ensures that a valid event ends up getting emitted.

A commit 372ec6bd0ae4fd1d23db74bffa5eb7335ed4dbeb
is reverted that modularizes the code for serializing
the event so that there are not footguns when computing
the "opaque data". We can bring this back easily if
we would like.


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

