### PR TITLE
op-challenger: Integrate challenging L2 block numbers

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -159,12 +159,16 @@ func NewConfig(
 	gameFactoryAddress common.Address,
 	l1EthRpc string,
 	l1BeaconApi string,
+	l2RollupRpc string,
+	l2EthRpc string,
 	datadir string,
 	supportedTraceTypes ...TraceType,
 ) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
 		L1Beacon:           l1BeaconApi,
+		RollupRpc:          l2RollupRpc,
+		L2Rpc:              l2EthRpc,
 		GameFactoryAddress: gameFactoryAddress,
 		MaxConcurrency:     uint(runtime.NumCPU()),
 		PollInterval:       DefaultPollInterval,
@@ -200,6 +204,9 @@ func (c Config) Check() error {
 	}
 	if c.RollupRpc == "" {
 		return ErrMissingRollupRpc
+	}
+	if c.L2Rpc == "" {
+		return ErrMissingL2Rpc
 	}
 	if c.GameFactoryAddress == (common.Address{}) {
 		return ErrMissingGameFactoryAddress
@@ -244,9 +251,6 @@ func (c Config) Check() error {
 		if c.CannonAbsolutePreState != "" && c.CannonAbsolutePreStateBaseURL != nil {
 			return ErrCannonAbsolutePreStateAndBaseURL
 		}
-		if c.L2Rpc == "" {
-			return ErrMissingL2Rpc
-		}
 		if c.CannonSnapshotFreq == 0 {
 			return ErrMissingCannonSnapshotFreq
 		}
@@ -284,9 +288,6 @@ func (c Config) Check() error {
 		}
 		if c.AsteriscAbsolutePreState != "" && c.AsteriscAbsolutePreStateBaseURL != nil {
 			return ErrAsteriscAbsolutePreStateAndBaseURL
-		}
-		if c.L2Rpc == "" {
-			return ErrMissingL2Rpc
 		}
 		if c.AsteriscSnapshotFreq == 0 {
 			return ErrMissingAsteriscSnapshotFreq

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -40,7 +40,6 @@ func applyValidConfigForCannon(cfg *Config) {
 	cfg.CannonServer = validCannonOpProgramBin
 	cfg.CannonAbsolutePreStateBaseURL = validCannonAbsolutPreStateBaseURL
 	cfg.CannonNetwork = validCannonNetwork
-	cfg.L2Rpc = validL2Rpc
 }
 
 func applyValidConfigForAsterisc(cfg *Config) {
@@ -48,18 +47,16 @@ func applyValidConfigForAsterisc(cfg *Config) {
 	cfg.AsteriscServer = validAsteriscOpProgramBin
 	cfg.AsteriscAbsolutePreStateBaseURL = validAsteriscAbsolutPreStateBaseURL
 	cfg.AsteriscNetwork = validAsteriscNetwork
-	cfg.L2Rpc = validL2Rpc
 }
 
 func validConfig(traceType TraceType) Config {
-	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validDatadir, traceType)
+	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validRollupRpc, validL2Rpc, validDatadir, traceType)
 	if traceType == TraceTypeCannon || traceType == TraceTypePermissioned {
 		applyValidConfigForCannon(&cfg)
 	}
 	if traceType == TraceTypeAsterisc {
 		applyValidConfigForAsterisc(&cfg)
 	}
-	cfg.RollupRpc = validRollupRpc
 	return cfg
 }
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -296,10 +296,6 @@ func CheckCannonFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(CannonPreStateFlag.Name) && !ctx.IsSet(CannonPreStatesURLFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", CannonPreStatesURLFlag.Name, CannonPreStateFlag.Name)
 	}
-	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
-	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
-		return fmt.Errorf("flag %s is required", L2EthRpcFlag.Name)
-	}
 	return nil
 }
 
@@ -323,10 +319,6 @@ func CheckAsteriscFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(AsteriscPreStateFlag.Name) && !ctx.IsSet(AsteriscPreStatesURLFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", AsteriscPreStatesURLFlag.Name, AsteriscPreStateFlag.Name)
 	}
-	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
-	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
-		return fmt.Errorf("flag %s is required", L2EthRpcFlag.Name)
-	}
 	return nil
 }
 
@@ -335,6 +327,10 @@ func CheckRequired(ctx *cli.Context, traceTypes []config.TraceType) error {
 		if !ctx.IsSet(f.Names()[0]) {
 			return fmt.Errorf("flag %s is required", f.Names()[0])
 		}
+	}
+	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
+	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
+		return fmt.Errorf("flag %s is required", L2EthRpcFlag.Name)
 	}
 	for _, traceType := range traceTypes {
 		switch traceType {

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -30,6 +30,7 @@ type Responder interface {
 
 type ClaimLoader interface {
 	GetAllClaims(ctx context.Context, block rpcblock.Block) ([]types.Claim, error)
+	IsL2BlockNumberChallenged(ctx context.Context, block rpcblock.Block) (bool, error)
 }
 
 type Agent struct {
@@ -84,6 +85,14 @@ func (a *Agent) Act(ctx context.Context) error {
 	defer func() {
 		a.metrics.RecordGameActTime(a.systemClock.Since(start).Seconds())
 	}()
+
+	if challenged, err := a.loader.IsL2BlockNumberChallenged(ctx, rpcblock.Latest); err != nil {
+		return fmt.Errorf("failed to check if L2 block number already challenged: %w", err)
+	} else if challenged {
+		a.log.Debug("Skipping game with already challenged L2 block number")
+		return nil
+	}
+
 	game, err := a.newGameFromContracts(ctx)
 	if err != nil {
 		return fmt.Errorf("create game from contracts: %w", err)
@@ -105,11 +114,13 @@ func (a *Agent) Act(ctx context.Context) error {
 
 func (a *Agent) performAction(ctx context.Context, wg *sync.WaitGroup, action types.Action) {
 	defer wg.Done()
-	actionLog := a.log.New("action", action.Type, "is_attack", action.IsAttack, "parent", action.ParentIdx)
+	actionLog := a.log.New("action", action.Type)
 	if action.Type == types.ActionTypeStep {
 		containsOracleData := action.OracleData != nil
 		isLocal := containsOracleData && action.OracleData.IsLocal
 		actionLog = actionLog.New(
+			"is_attack", action.IsAttack,
+			"parent", action.ParentIdx,
 			"prestate", common.Bytes2Hex(action.PreState),
 			"proof", common.Bytes2Hex(action.ProofData),
 			"containsOracleData", containsOracleData,
@@ -118,8 +129,8 @@ func (a *Agent) performAction(ctx context.Context, wg *sync.WaitGroup, action ty
 		if action.OracleData != nil {
 			actionLog = actionLog.New("oracleKey", common.Bytes2Hex(action.OracleData.OracleKey))
 		}
-	} else {
-		actionLog = actionLog.New("value", action.Value)
+	} else if action.Type == types.ActionTypeMove {
+		actionLog = actionLog.New("is_attack", action.IsAttack, "parent", action.ParentIdx, "value", action.Value)
 	}
 
 	switch action.Type {
@@ -127,6 +138,7 @@ func (a *Agent) performAction(ctx context.Context, wg *sync.WaitGroup, action ty
 		a.metrics.RecordGameMove()
 	case types.ActionTypeStep:
 		a.metrics.RecordGameStep()
+		// TODO(client-pod#852): Add metrics for L2 block number challenges
 	}
 	actionLog.Info("Performing action")
 	err := a.responder.PerformAction(ctx, action)

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -652,6 +652,30 @@ func TestFaultDisputeGame_IsResolved(t *testing.T) {
 	}
 }
 
+func TestFaultDisputeGameContractLatest_IsL2BlockNumberChallenged(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			_, game := setupFaultDisputeGameTest(t, version)
+			challenged, err := game.IsL2BlockNumberChallenged(context.Background(), rpcblock.Latest)
+			require.NoError(t, err)
+			require.False(t, challenged)
+		})
+	}
+}
+
+func TestFaultDisputeGameContractLatest_ChallengeL2BlockNumberTx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			_, game := setupFaultDisputeGameTest(t, version)
+			tx, err := game.ChallengeL2BlockNumberTx(&faultTypes.InvalidL2BlockNumberChallenge{})
+			require.ErrorIs(t, err, ErrChallengeL2BlockNotSupported)
+			require.Equal(t, txmgr.TxCandidate{}, tx)
+		})
+	}
+}
+
 func setupFaultDisputeGameTest(t *testing.T, version contractVersion) (*batchingTest.AbiBasedRpc, FaultDisputeGameContract) {
 	fdgAbi := version.loadAbi()
 

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -11,7 +11,6 @@ import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -23,6 +22,7 @@ type GameContract interface {
 	AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error)
 	DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error)
 	StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error)
+	ChallengeL2BlockNumberTx(challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error)
 	GetRequiredBond(ctx context.Context, position types.Position) (*big.Int, error)
 }
 
@@ -130,6 +130,8 @@ func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action)
 		candidate.Value = bondValue
 	case types.ActionTypeStep:
 		candidate, err = r.contract.StepTx(uint64(action.ParentIdx), action.IsAttack, action.PreState, action.ProofData)
+	case types.ActionTypeChallengeL2BlockNumber:
+		candidate, err = r.contract.ChallengeL2BlockNumberTx(action.InvalidL2BlockNumberChallenge)
 	}
 	if err != nil {
 		return err

--- a/op-challenger/game/fault/trace/access.go
+++ b/op-challenger/game/fault/trace/access.go
@@ -40,4 +40,12 @@ func (t *Accessor) GetStepData(ctx context.Context, game types.Game, ref types.C
 	return provider.GetStepData(ctx, pos)
 }
 
+func (t *Accessor) GetL2BlockNumberChallenge(ctx context.Context, game types.Game) (*types.InvalidL2BlockNumberChallenge, error) {
+	provider, err := t.selector(ctx, game, game.Claims()[0], types.RootPosition)
+	if err != nil {
+		return nil, err
+	}
+	return provider.GetL2BlockNumberChallenge(ctx)
+}
+
 var _ types.TraceAccessor = (*Accessor)(nil)

--- a/op-challenger/game/fault/trace/access_test.go
+++ b/op-challenger/game/fault/trace/access_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,4 +68,32 @@ func TestAccessor_UsesSelector(t *testing.T) {
 		require.Equal(t, expectedProofData, actualProofData)
 		require.Equal(t, expectedPreimageData, actualPreimageData)
 	})
+
+	t.Run("GetL2BlockNumberChallenge", func(t *testing.T) {
+		provider := &ChallengeTraceProvider{
+			TraceProvider: provider1,
+		}
+		accessor := &Accessor{
+			selector: func(ctx context.Context, actualGame types.Game, ref types.Claim, pos types.Position) (types.TraceProvider, error) {
+				require.Equal(t, game, actualGame)
+				require.Equal(t, game.Claims()[0], ref)
+				require.Equal(t, types.RootPosition, pos)
+				return provider, nil
+			},
+		}
+		challenge, err := accessor.GetL2BlockNumberChallenge(ctx, game)
+		require.NoError(t, err)
+		require.NotNil(t, challenge)
+		require.Equal(t, eth.Bytes32{0xaa, 0xbb}, challenge.Output.OutputRoot)
+	})
+}
+
+type ChallengeTraceProvider struct {
+	types.TraceProvider
+}
+
+func (c *ChallengeTraceProvider) GetL2BlockNumberChallenge(_ context.Context) (*types.InvalidL2BlockNumberChallenge, error) {
+	return &types.InvalidL2BlockNumberChallenge{
+		Output: &eth.OutputResponse{OutputRoot: eth.Bytes32{0xaa, 0xbb}},
+	}, nil
 }

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -75,6 +75,10 @@ func (ap *AlphabetTraceProvider) Get(ctx context.Context, i types.Position) (com
 	return alphabetStateHash(claimBytes), nil
 }
 
+func (ap *AlphabetTraceProvider) GetL2BlockNumberChallenge(_ context.Context) (*types.InvalidL2BlockNumberChallenge, error) {
+	return nil, types.ErrL2BlockNumberValid
+}
+
 // BuildAlphabetPreimage constructs the claim bytes for the index and claim.
 func BuildAlphabetPreimage(traceIndex *big.Int, claim *big.Int) []byte {
 	return append(traceIndex.FillBytes(make([]byte, 32)), claim.FillBytes(make([]byte, 32))...)

--- a/op-challenger/game/fault/trace/asterisc/executor_test.go
+++ b/op-challenger/game/fault/trace/asterisc/executor_test.go
@@ -20,7 +20,7 @@ func TestGenerateProof(t *testing.T) {
 	input := "starting.json"
 	tempDir := t.TempDir()
 	dir := filepath.Join(tempDir, "gameDir")
-	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", "http://localhost:9000", tempDir, config.TraceTypeAsterisc)
+	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", "http://localhost:9000", "http://localhost:9096", "http://localhost:9095", tempDir, config.TraceTypeAsterisc)
 	cfg.L2Rpc = "http://localhost:9999"
 	cfg.AsteriscAbsolutePreState = "pre.json"
 	cfg.AsteriscBin = "./bin/asterisc"

--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -96,6 +96,10 @@ func (p *AsteriscTraceProvider) GetStepData(ctx context.Context, pos types.Posit
 	return value, data, oracleData, nil
 }
 
+func (p *AsteriscTraceProvider) GetL2BlockNumberChallenge(_ context.Context) (*types.InvalidL2BlockNumberChallenge, error) {
+	return nil, types.ErrL2BlockNumberValid
+}
+
 // loadProof will attempt to load or generate the proof data at the specified index
 // If the requested index is beyond the end of the actual trace it is extended with no-op instructions.
 func (p *AsteriscTraceProvider) loadProof(ctx context.Context, i uint64) (*utils.ProofData, error) {

--- a/op-challenger/game/fault/trace/cannon/executor_test.go
+++ b/op-challenger/game/fault/trace/cannon/executor_test.go
@@ -25,7 +25,7 @@ func TestGenerateProof(t *testing.T) {
 	input := "starting.json"
 	tempDir := t.TempDir()
 	dir := filepath.Join(tempDir, "gameDir")
-	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", "http://localhost:9000", tempDir, config.TraceTypeCannon)
+	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", "http://localhost:9000", "http://localhost:9096", "http://localhost:9095", tempDir, config.TraceTypeCannon)
 	cfg.L2Rpc = "http://localhost:9999"
 	cfg.CannonAbsolutePreState = "pre.json"
 	cfg.CannonBin = "./bin/cannon"

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -94,6 +94,10 @@ func (p *CannonTraceProvider) GetStepData(ctx context.Context, pos types.Positio
 	return value, data, oracleData, nil
 }
 
+func (p *CannonTraceProvider) GetL2BlockNumberChallenge(_ context.Context) (*types.InvalidL2BlockNumberChallenge, error) {
+	return nil, types.ErrL2BlockNumberValid
+}
+
 // loadProof will attempt to load or generate the proof data at the specified index
 // If the requested index is beyond the end of the actual trace it is extended with no-op instructions.
 func (p *CannonTraceProvider) loadProof(ctx context.Context, i uint64) (*utils.ProofData, error) {

--- a/op-challenger/game/fault/trace/outputs/output_alphabet.go
+++ b/op-challenger/game/fault/trace/outputs/output_alphabet.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/split"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -19,12 +20,13 @@ func NewOutputAlphabetTraceAccessor(
 	m metrics.Metricer,
 	prestateProvider types.PrestateProvider,
 	rollupClient OutputRollupClient,
+	l2Client utils.L2HeaderSource,
 	l1Head eth.BlockID,
 	splitDepth types.Depth,
 	prestateBlock uint64,
 	poststateBlock uint64,
 ) (*trace.Accessor, error) {
-	outputProvider := NewTraceProvider(logger, prestateProvider, rollupClient, l1Head, splitDepth, prestateBlock, poststateBlock)
+	outputProvider := NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, splitDepth, prestateBlock, poststateBlock)
 	alphabetCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
 		provider := alphabet.NewTraceProvider(agreed.L2BlockNumber, depth)
 		return provider, nil

--- a/op-challenger/game/fault/trace/outputs/output_asterisc.go
+++ b/op-challenger/game/fault/trace/outputs/output_asterisc.go
@@ -31,7 +31,7 @@ func NewOutputAsteriscTraceAccessor(
 	prestateBlock uint64,
 	poststateBlock uint64,
 ) (*trace.Accessor, error) {
-	outputProvider := NewTraceProvider(logger, prestateProvider, rollupClient, l1Head, splitDepth, prestateBlock, poststateBlock)
+	outputProvider := NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, splitDepth, prestateBlock, poststateBlock)
 	asteriscCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
 		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)
 		subdir := filepath.Join(dir, localContext.Hex())

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -31,7 +31,7 @@ func NewOutputCannonTraceAccessor(
 	prestateBlock uint64,
 	poststateBlock uint64,
 ) (*trace.Accessor, error) {
-	outputProvider := NewTraceProvider(logger, prestateProvider, rollupClient, l1Head, splitDepth, prestateBlock, poststateBlock)
+	outputProvider := NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, splitDepth, prestateBlock, poststateBlock)
 	cannonCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
 		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)
 		subdir := filepath.Join(dir, localContext.Hex())

--- a/op-challenger/game/fault/trace/outputs/split_adapter_test.go
+++ b/op-challenger/game/fault/trace/outputs/split_adapter_test.go
@@ -139,7 +139,7 @@ func setupAdapterTest(t *testing.T, topDepth types.Depth) (split.ProviderCreator
 	prestateProvider := &stubPrestateProvider{
 		absolutePrestate: prestateOutputRoot,
 	}
-	topProvider := NewTraceProvider(testlog.Logger(t, log.LevelInfo), prestateProvider, rollupClient, l1Head, topDepth, prestateBlock, poststateBlock)
+	topProvider := NewTraceProvider(testlog.Logger(t, log.LevelInfo), prestateProvider, rollupClient, nil, l1Head, topDepth, prestateBlock, poststateBlock)
 	adapter := OutputRootSplitAdapter(topProvider, creator.Create)
 	return adapter, creator
 }

--- a/op-challenger/game/fault/trace/translate.go
+++ b/op-challenger/game/fault/trace/translate.go
@@ -46,4 +46,8 @@ func (p *TranslatingProvider) AbsolutePreStateCommitment(ctx context.Context) (h
 	return p.provider.AbsolutePreStateCommitment(ctx)
 }
 
+func (p *TranslatingProvider) GetL2BlockNumberChallenge(ctx context.Context) (*types.InvalidL2BlockNumberChallenge, error) {
+	return p.provider.GetL2BlockNumberChallenge(ctx)
+}
+
 var _ types.TraceProvider = (*TranslatingProvider)(nil)

--- a/op-challenger/game/fault/types/actions.go
+++ b/op-challenger/game/fault/types/actions.go
@@ -9,12 +9,15 @@ func (a ActionType) String() string {
 }
 
 const (
-	ActionTypeMove ActionType = "move"
-	ActionTypeStep ActionType = "step"
+	ActionTypeMove                   ActionType = "move"
+	ActionTypeStep                   ActionType = "step"
+	ActionTypeChallengeL2BlockNumber ActionType = "challenge-l2-block-number"
 )
 
 type Action struct {
-	Type           ActionType
+	Type ActionType
+
+	// Moves and Steps
 	ParentIdx      int
 	ParentPosition Position
 	IsAttack       bool
@@ -26,4 +29,7 @@ type Action struct {
 	PreState   []byte
 	ProofData  []byte
 	OracleData *PreimageOracleData
+
+	// Challenge L2 Block Number
+	InvalidL2BlockNumberChallenge *InvalidL2BlockNumberChallenge
 }

--- a/op-challenger/game/fault/types/position.go
+++ b/op-challenger/game/fault/types/position.go
@@ -10,6 +10,8 @@ import (
 
 var (
 	ErrPositionDepthTooSmall = errors.New("position depth is too small")
+
+	RootPosition = NewPositionFromGIndex(big.NewInt(1))
 )
 
 // Depth is the depth of a position in a game tree where the root level has

--- a/op-challenger/game/fault/types/position_test.go
+++ b/op-challenger/game/fault/types/position_test.go
@@ -13,6 +13,10 @@ func bi(i int) *big.Int {
 	return big.NewInt(int64(i))
 }
 
+func TestRootPosition(t *testing.T) {
+	require.True(t, RootPosition.IsRootPosition())
+}
+
 func TestBigMSB(t *testing.T) {
 	large, ok := new(big.Int).SetString("18446744073709551615", 10)
 	require.True(t, ok)

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -96,15 +96,8 @@ func FindMonorepoRoot(t *testing.T) string {
 	return ""
 }
 
-func applyCannonConfig(
-	c *config.Config,
-	t *testing.T,
-	rollupCfg *rollup.Config,
-	l2Genesis *core.Genesis,
-	l2Endpoint string,
-) {
+func applyCannonConfig(c *config.Config, t *testing.T, rollupCfg *rollup.Config, l2Genesis *core.Genesis) {
 	require := require.New(t)
-	c.L2Rpc = l2Endpoint
 	root := FindMonorepoRoot(t)
 	c.CannonBin = root + "cannon/bin/cannon"
 	c.CannonServer = root + "op-program/bin/op-program"
@@ -124,24 +117,16 @@ func applyCannonConfig(
 	c.CannonRollupConfigPath = rollupFile
 }
 
-func WithCannon(
-	t *testing.T,
-	rollupCfg *rollup.Config,
-	l2Genesis *core.Genesis,
-	rollupEndpoint string,
-	l2Endpoint string,
-) Option {
+func WithCannon(t *testing.T, rollupCfg *rollup.Config, l2Genesis *core.Genesis) Option {
 	return func(c *config.Config) {
 		c.TraceTypes = append(c.TraceTypes, config.TraceTypeCannon)
-		c.RollupRpc = rollupEndpoint
-		applyCannonConfig(c, t, rollupCfg, l2Genesis, l2Endpoint)
+		applyCannonConfig(c, t, rollupCfg, l2Genesis)
 	}
 }
 
-func WithAlphabet(rollupEndpoint string) Option {
+func WithAlphabet() Option {
 	return func(c *config.Config) {
 		c.TraceTypes = append(c.TraceTypes, config.TraceTypeAlphabet)
-		c.RollupRpc = rollupEndpoint
 	}
 }
 

--- a/op-e2e/e2eutils/disputegame/alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/alphabet_helper.go
@@ -17,7 +17,7 @@ func (g *AlphabetGameHelper) StartChallenger(ctx context.Context, sys challenger
 	opts := []challenger.Option{
 		challenger.WithFactoryAddress(g.factoryAddr),
 		challenger.WithGameAddress(g.addr),
-		challenger.WithAlphabet(g.system.RollupEndpoint("sequencer")),
+		challenger.WithAlphabet(),
 	}
 	opts = append(opts, options...)
 	c := challenger.NewChallenger(g.t, ctx, sys, name, opts...)

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -25,7 +25,6 @@ type FaultGameHelper struct {
 	game        *bindings.FaultDisputeGame
 	factoryAddr common.Address
 	addr        common.Address
-	system      DisputeSystem
 }
 
 func (g *FaultGameHelper) Addr() common.Address {

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -172,6 +172,7 @@ func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string
 	cfg := NewGameCfg(opts...)
 	logger := testlog.Logger(h.T, log.LevelInfo).New("role", "OutputCannonGameHelper")
 	rollupClient := h.System.RollupClient(l2Node)
+	l2Client := h.System.NodeClient(l2Node)
 
 	extraData := h.CreateBisectionGameExtraData(l2Node, l2BlockNumber, cfg)
 
@@ -200,7 +201,7 @@ func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string
 	l1Head := h.GetL1Head(ctx, game)
 
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock.Uint64())
-	provider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l1Head, faultTypes.Depth(splitDepth.Uint64()), prestateBlock.Uint64(), poststateBlock.Uint64())
+	provider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, faultTypes.Depth(splitDepth.Uint64()), prestateBlock.Uint64(), poststateBlock.Uint64())
 
 	return &OutputCannonGameHelper{
 		OutputGameHelper: *NewOutputGameHelper(h.T, h.Require, h.Client, h.Opts, game, h.FactoryAddr, createdEvent.DisputeProxy, provider, h.System),
@@ -228,6 +229,7 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	cfg := NewGameCfg(opts...)
 	logger := testlog.Logger(h.T, log.LevelInfo).New("role", "OutputAlphabetGameHelper")
 	rollupClient := h.System.RollupClient(l2Node)
+	l2Client := h.System.NodeClient(l2Node)
 
 	extraData := h.CreateBisectionGameExtraData(l2Node, l2BlockNumber, cfg)
 
@@ -256,7 +258,7 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	l1Head := h.GetL1Head(ctx, game)
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock.Uint64())
 
-	provider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l1Head, faultTypes.Depth(splitDepth.Uint64()), prestateBlock.Uint64(), poststateBlock.Uint64())
+	provider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, faultTypes.Depth(splitDepth.Uint64()), prestateBlock.Uint64(), poststateBlock.Uint64())
 
 	return &OutputAlphabetGameHelper{
 		OutputGameHelper: *NewOutputGameHelper(h.T, h.Require, h.Client, h.Opts, game, h.FactoryAddr, createdEvent.DisputeProxy, provider, h.System),

--- a/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
@@ -46,8 +46,9 @@ func (g *OutputAlphabetGameHelper) CreateHonestActor(ctx context.Context, l2Node
 	splitDepth := g.SplitDepth(ctx)
 	l1Head := g.GetL1Head(ctx)
 	rollupClient := g.System.RollupClient(l2Node)
+	l2Client := g.System.NodeClient(l2Node)
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)
-	correctTrace, err := outputs.NewOutputAlphabetTraceAccessor(logger, metrics.NoopMetrics, prestateProvider, rollupClient, l1Head, splitDepth, prestateBlock, poststateBlock)
+	correctTrace, err := outputs.NewOutputAlphabetTraceAccessor(logger, metrics.NoopMetrics, prestateProvider, rollupClient, l2Client, l1Head, splitDepth, prestateBlock, poststateBlock)
 	g.Require.NoError(err, "Create trace accessor")
 	return NewOutputHonestHelper(g.T, g.Require, &g.OutputGameHelper, contract, correctTrace)
 }

--- a/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
@@ -24,7 +24,7 @@ func (g *OutputAlphabetGameHelper) StartChallenger(
 	options ...challenger.Option,
 ) *challenger.Helper {
 	opts := []challenger.Option{
-		challenger.WithAlphabet(g.System.RollupEndpoint(l2Node)),
+		challenger.WithAlphabet(),
 		challenger.WithFactoryAddress(g.FactoryAddr),
 		challenger.WithGameAddress(g.Addr),
 	}

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -290,7 +290,7 @@ func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, 
 	rollupClient := g.System.RollupClient(l2Node)
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)
 	l1Head := g.GetL1Head(ctx)
-	outputProvider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l1Head, splitDepth, prestateBlock, poststateBlock)
+	outputProvider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, splitDepth, prestateBlock, poststateBlock)
 
 	var localContext common.Hash
 	selector := split.NewSplitProviderSelector(outputProvider, splitDepth, func(ctx context.Context, depth types.Depth, pre types.Claim, post types.Claim) (types.TraceProvider, error) {

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -58,7 +58,7 @@ func (g *OutputCannonGameHelper) StartChallenger(
 func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node string, options ...challenger.Option) *OutputHonestHelper {
 	opts := g.defaultChallengerOptions(l2Node)
 	opts = append(opts, options...)
-	cfg := challenger.NewChallengerConfig(g.T, g.System, opts...)
+	cfg := challenger.NewChallengerConfig(g.T, g.System, l2Node, opts...)
 
 	logger := testlog.Logger(g.T, log.LevelInfo).New("role", "HonestHelper", "game", g.Addr)
 	l2Client := g.System.NodeClient(l2Node)
@@ -285,7 +285,7 @@ func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, 
 	logger := testlog.Logger(g.T, log.LevelInfo).New("role", "CannonTraceProvider", "game", g.Addr)
 	opt := g.defaultChallengerOptions(l2Node)
 	opt = append(opt, options...)
-	cfg := challenger.NewChallengerConfig(g.T, g.System, opt...)
+	cfg := challenger.NewChallengerConfig(g.T, g.System, l2Node, opt...)
 
 	caller := batching.NewMultiCaller(g.System.NodeClient("l1").Client(), batching.DefaultBatchSize)
 	l2Client := g.System.NodeClient(l2Node)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -34,16 +34,9 @@ type OutputCannonGameHelper struct {
 	OutputGameHelper
 }
 
-func (g *OutputCannonGameHelper) StartChallenger(
-	ctx context.Context,
-	l2Node string,
-	name string,
-	options ...challenger.Option,
-) *challenger.Helper {
-	rollupEndpoint := g.System.RollupEndpoint(l2Node)
-	l2Endpoint := g.System.NodeEndpoint(l2Node)
+func (g *OutputCannonGameHelper) StartChallenger(ctx context.Context, name string, options ...challenger.Option) *challenger.Helper {
 	opts := []challenger.Option{
-		challenger.WithCannon(g.T, g.System.RollupCfg(), g.System.L2Genesis(), rollupEndpoint, l2Endpoint),
+		challenger.WithCannon(g.T, g.System.RollupCfg(), g.System.L2Genesis()),
 		challenger.WithFactoryAddress(g.FactoryAddr),
 		challenger.WithGameAddress(g.Addr),
 	}
@@ -56,7 +49,7 @@ func (g *OutputCannonGameHelper) StartChallenger(
 }
 
 func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node string, options ...challenger.Option) *OutputHonestHelper {
-	opts := g.defaultChallengerOptions(l2Node)
+	opts := g.defaultChallengerOptions()
 	opts = append(opts, options...)
 	cfg := challenger.NewChallengerConfig(g.T, g.System, l2Node, opts...)
 
@@ -283,7 +276,7 @@ func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, 
 	g.Require.EqualValues(outputRootClaim.Depth(), splitDepth+1, "outputRootClaim must be the root of an execution game")
 
 	logger := testlog.Logger(g.T, log.LevelInfo).New("role", "CannonTraceProvider", "game", g.Addr)
-	opt := g.defaultChallengerOptions(l2Node)
+	opt := g.defaultChallengerOptions()
 	opt = append(opt, options...)
 	cfg := challenger.NewChallengerConfig(g.T, g.System, l2Node, opt...)
 
@@ -322,9 +315,9 @@ func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, 
 	return translatingProvider.Original().(*cannon.CannonTraceProviderForTest), localContext
 }
 
-func (g *OutputCannonGameHelper) defaultChallengerOptions(l2Node string) []challenger.Option {
+func (g *OutputCannonGameHelper) defaultChallengerOptions() []challenger.Option {
 	return []challenger.Option{
-		challenger.WithCannon(g.T, g.System.RollupCfg(), g.System.L2Genesis(), g.System.RollupEndpoint(l2Node), g.System.NodeEndpoint(l2Node)),
+		challenger.WithCannon(g.T, g.System.RollupCfg(), g.System.L2Genesis()),
 		challenger.WithFactoryAddress(g.FactoryAddr),
 		challenger.WithGameAddress(g.Addr),
 	}

--- a/op-e2e/faultproofs/challenge_preimage_test.go
+++ b/op-e2e/faultproofs/challenge_preimage_test.go
@@ -20,7 +20,7 @@ func TestChallengeLargePreimages_ChallengeFirst(t *testing.T) {
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	disputeGameFactory.StartChallenger(ctx, "Challenger",
-		challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
+		challenger.WithAlphabet(),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 	preimageHelper := disputeGameFactory.PreimageHelper(ctx)
 	ident := preimageHelper.UploadLargePreimage(ctx, preimage.MinPreimageSize,
@@ -38,7 +38,7 @@ func TestChallengeLargePreimages_ChallengeMiddle(t *testing.T) {
 	t.Cleanup(sys.Close)
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	disputeGameFactory.StartChallenger(ctx, "Challenger",
-		challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
+		challenger.WithAlphabet(),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 	preimageHelper := disputeGameFactory.PreimageHelper(ctx)
 	ident := preimageHelper.UploadLargePreimage(ctx, preimage.MinPreimageSize,
@@ -56,7 +56,7 @@ func TestChallengeLargePreimages_ChallengeLast(t *testing.T) {
 	t.Cleanup(sys.Close)
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	disputeGameFactory.StartChallenger(ctx, "Challenger",
-		challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
+		challenger.WithAlphabet(),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 	preimageHelper := disputeGameFactory.PreimageHelper(ctx)
 	ident := preimageHelper.UploadLargePreimage(ctx, preimage.MinPreimageSize,

--- a/op-e2e/faultproofs/multi_test.go
+++ b/op-e2e/faultproofs/multi_test.go
@@ -26,8 +26,8 @@ func TestMultipleGameTypes(t *testing.T) {
 
 	// Start a challenger with both cannon and alphabet support
 	gameFactory.StartChallenger(ctx, "TowerDefense",
-		challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg, sys.RollupEndpoint("sequencer"), sys.NodeEndpoint("sequencer")),
-		challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
+		challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg),
+		challenger.WithAlphabet(),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 	)
 

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -185,7 +185,7 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 
 		// Start honest challenger
 		game.StartChallenger(ctx, "sequencer", "Challenger",
-			challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
+			challenger.WithAlphabet(),
 			challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 			// Ensures the challenger responds to all claims before test timeout
 			challenger.WithPollInterval(time.Millisecond*400),

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -28,7 +28,7 @@ func TestOutputCannonGame(t *testing.T) {
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 4, common.Hash{0x01})
 	game.LogGameData(ctx)
 
-	game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	game.LogGameData(ctx)
 
@@ -85,7 +85,7 @@ func TestOutputCannon_ChallengeAllZeroClaim(t *testing.T) {
 	game.LogGameData(ctx)
 
 	claim := game.DisputeLastBlock(ctx)
-	game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	game.DefendClaim(ctx, claim, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 		if parent.IsBottomGameRoot(ctx) {
@@ -123,7 +123,7 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 			game.DisputeLastBlock(ctx)
 			game.LogGameData(ctx)
 
-			game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 			splitDepth := game.SplitDepth(ctx)
 			game.WaitForClaimAtDepth(ctx, splitDepth+1)
@@ -158,7 +158,7 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 			outputClaim := game.DisputeLastBlock(ctx)
 			splitDepth := game.SplitDepth(ctx)
 
-			game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 			game.DefendClaim(
 				ctx,
@@ -193,7 +193,7 @@ func TestOutputCannonDefendStep(t *testing.T) {
 	outputRootClaim := game.DisputeLastBlock(ctx)
 	game.LogGameData(ctx)
 
-	game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 
@@ -240,7 +240,7 @@ func TestOutputCannonStepWithLargePreimage(t *testing.T) {
 	outputRootClaim := game.DisputeBlock(ctx, l2BlockNumber)
 	game.LogGameData(ctx)
 
-	game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	// Wait for the honest challenger to dispute the outputRootClaim.
 	// This creates a root of an execution game that we challenge by
@@ -272,7 +272,7 @@ func TestOutputCannonStepWithPreimage(t *testing.T) {
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)
 
-		game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+		game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 		// Wait for the honest challenger to dispute the outputRootClaim. This creates a root of an execution game that we challenge by coercing
 		// a step at a preimage trace index.
@@ -325,7 +325,7 @@ func TestOutputCannonStepWithKZGPointEvaluation(t *testing.T) {
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)
 
-		game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+		game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 		// Wait for the honest challenger to dispute the outputRootClaim. This creates a root of an execution game that we challenge by coercing
 		// a step at a preimage trace index.
@@ -413,7 +413,7 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 			game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
 			correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 
-			game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 			// Now maliciously play the game and it should be impossible to win
 			game.ChallengeClaim(ctx,
@@ -462,7 +462,7 @@ func TestOutputCannonPoisonedPostState(t *testing.T) {
 	game.LogGameData(ctx)
 
 	// Start the honest challenger
-	game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
 
 	// Start dishonest challenger that posts correct claims
 	for {
@@ -512,7 +512,7 @@ func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot(t *testing.T) {
 	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
 	correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 	// Start the honest challenger
-	game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
 
 	claim := game.RootClaim(ctx)
 	// Attack the output root
@@ -563,7 +563,7 @@ func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot(t *testing.T) {
 	correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	// Start the honest challenger
-	game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
 
 	claim := game.RootClaim(ctx)
 	// Wait for the honest challenger to counter the root
@@ -614,7 +614,7 @@ func TestDisputeOutputRoot_ChangeClaimedOutputRoot(t *testing.T) {
 	correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	// Start the honest challenger
-	game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
 
 	claim := game.RootClaim(ctx)
 	// Wait for the honest challenger to counter the root
@@ -704,7 +704,7 @@ func TestInvalidateUnsafeProposal(t *testing.T) {
 			correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 			// Start the honest challenger
-			game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
 
 			game.DefendClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 				if parent.IsBottomGameRoot(ctx) {
@@ -766,7 +766,7 @@ func TestInvalidateProposalForFutureBlock(t *testing.T) {
 			correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 			// Start the honest challenger
-			game.StartChallenger(ctx, "sequencer", "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
+			game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
 
 			game.DefendClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 				if parent.IsBottomGameRoot(ctx) {

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -138,10 +138,12 @@ func TestPrecompiles(t *testing.T) {
 func runCannon(t *testing.T, ctx context.Context, sys *op_e2e.System, inputs utils.LocalGameInputs, l2Node string) {
 	l1Endpoint := sys.NodeEndpoint("l1")
 	l1Beacon := sys.L1BeaconEndpoint()
+	rollupEndpoint := sys.RollupEndpoint("sequencer")
+	l2Endpoint := sys.NodeEndpoint("sequencer")
 	cannonOpts := challenger.WithCannon(t, sys.RollupCfg(), sys.L2Genesis(), sys.RollupEndpoint(l2Node), sys.NodeEndpoint(l2Node))
 	dir := t.TempDir()
 	proofsDir := filepath.Join(dir, "cannon-proofs")
-	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, dir)
+	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, rollupEndpoint, l2Endpoint, dir)
 	cannonOpts(&cfg)
 
 	logger := testlog.Logger(t, log.LevelInfo).New("role", "cannon")

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -140,7 +140,7 @@ func runCannon(t *testing.T, ctx context.Context, sys *op_e2e.System, inputs uti
 	l1Beacon := sys.L1BeaconEndpoint()
 	rollupEndpoint := sys.RollupEndpoint("sequencer")
 	l2Endpoint := sys.NodeEndpoint("sequencer")
-	cannonOpts := challenger.WithCannon(t, sys.RollupCfg(), sys.L2Genesis(), sys.RollupEndpoint(l2Node), sys.NodeEndpoint(l2Node))
+	cannonOpts := challenger.WithCannon(t, sys.RollupCfg(), sys.L2Genesis())
 	dir := t.TempDir()
 	proofsDir := filepath.Join(dir, "cannon-proofs")
 	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, rollupEndpoint, l2Endpoint, dir)

--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -658,7 +658,7 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 					// Start a challenger to resolve claims and games once the clock expires
 					factoryHelper := disputegame.NewFactoryHelper(t, ctx, sys)
 					factoryHelper.StartChallenger(ctx, "Challenger",
-						challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg, sys.RollupEndpoint("sequencer"), sys.NodeEndpoint("sequencer")),
+						challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg),
 						challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 				}
 				receipt, err = wait.ForReceiptOK(ctx, l1Client, tx.Hash())


### PR DESCRIPTION
**Description**

Updates op-challenger logic to check if the l2 block number has been challenged before participating in a game (ignore game if it has been successfully challenged) and to check if the l2 block number can be challenged before playing.

The actual contract bindings are currently just setup for compatibility with the existing contracts which don't support directly challenging the l2 block number. This should result in no change in behaviour.  Once the contract changes land a follow up PR can add support for actually calling the new functions.

Builds on https://github.com/ethereum-optimism/optimism/pull/10445

**Tests**

Updated unit tests.  e2e tests should confirm backwards compatibility works...

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/852
