### PR TITLE
feat(op-dispute-mon): Contract Creation Failure Metric

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -107,6 +107,8 @@ type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
 
+	RecordFailedGames(count int)
+
 	RecordHonestActorClaims(address common.Address, stats *HonestActorData)
 
 	RecordGameResolutionStatus(status ResolutionStatus, count int)
@@ -161,6 +163,7 @@ type Metrics struct {
 	gamesAgreement        prometheus.GaugeVec
 	latestInvalidProposal prometheus.Gauge
 	ignoredGames          prometheus.Gauge
+	failedGames           prometheus.Gauge
 
 	requiredCollateral  prometheus.GaugeVec
 	availableCollateral prometheus.GaugeVec
@@ -279,6 +282,11 @@ func NewMetrics() *Metrics {
 			// additional DelayedWETH contracts to be used by dispute games
 			"delayedWETH",
 			"balance",
+		}),
+		failedGames: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "failed_games",
+			Help:      "Number of games present in the game window but failed to be monitored",
 		}),
 		availableCollateral: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -423,6 +431,10 @@ func (m *Metrics) RecordLatestInvalidProposal(timestamp uint64) {
 
 func (m *Metrics) RecordIgnoredGames(count int) {
 	m.ignoredGames.Set(float64(count))
+}
+
+func (m *Metrics) RecordFailedGames(count int) {
+	m.failedGames.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required *big.Int, available *big.Int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -37,4 +37,6 @@ func (*NoopMetricsImpl) RecordLatestInvalidProposal(_ uint64) {}
 
 func (*NoopMetricsImpl) RecordIgnoredGames(_ int) {}
 
-func (i *NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}
+func (*NoopMetricsImpl) RecordFailedGames(_ int) {}
+
+func (*NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -51,7 +51,7 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 		return fdg, nil
 	}
 	switch game.GameType {
-	case faultTypes.CannonGameType, faultTypes.AsteriscGameType, faultTypes.AlphabetGameType:
+	case faultTypes.CannonGameType, faultTypes.PermissionedGameType, faultTypes.AsteriscGameType, faultTypes.AlphabetGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create fault dispute game contract: %w", err)

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -64,7 +64,7 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 		}
 		caller, err := e.createContract(ctx, game)
 		if err != nil {
-			e.logger.Error("Failed to create game caller", "err", err)
+			e.logger.Error("Failed to create game caller", "game", game.Proxy, "err", err)
 			failed++
 			continue
 		}

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -30,7 +30,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("NoGames", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{}, 0, 0)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -40,7 +40,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("RollupFetchFails", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
 		rollup.err = errors.New("boom")
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}}, 0, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -54,7 +54,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("ChallengerWonGame_Agree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon, RootClaim: mockRootClaim}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -69,7 +69,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("ChallengerWonGame_Disagree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusChallengerWon, RootClaim: common.Hash{0xbb}}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.Nil(t, l)
 
@@ -81,7 +81,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("DefenderWonGame_Agree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon, RootClaim: mockRootClaim}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.Nil(t, l)
 
@@ -93,7 +93,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Run("DefenderWonGame_Disagree", func(t *testing.T) {
 		forecast, m, _, logs := setupForecastTest(t)
 		expectedGame := monTypes.EnrichedGameData{Status: types.GameStatusDefenderWon, RootClaim: common.Hash{0xbb}}
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(lostGameLog))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
@@ -107,14 +107,14 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 
 	t.Run("SingleGame", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}}, 0, 0)
 		require.Equal(t, 1, rollup.calls)
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	})
 
 	t.Run("MultipleGames", func(t *testing.T) {
 		forecast, _, rollup, logs := setupForecastTest(t)
-		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}, {}, {}}, 0)
+		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{}, {}, {}}, 0, 0)
 		require.Equal(t, 3, rollup.calls)
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	})
@@ -130,7 +130,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 			RootClaim: mockRootClaim,
 			Claims:    createDeepClaimList()[:1],
 		}}
-		forecast.Forecast(context.Background(), games, 0)
+		forecast.Forecast(context.Background(), games, 0, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -151,7 +151,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 			RootClaim: mockRootClaim,
 			Claims:    createDeepClaimList()[:2],
 		}}
-		forecast.Forecast(context.Background(), games, 0)
+		forecast.Forecast(context.Background(), games, 0, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -170,7 +170,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{
 			Status: types.GameStatusInProgress,
 			Claims: createDeepClaimList()[:2],
-		}}, 0)
+		}}, 0, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -189,7 +189,7 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		forecast.Forecast(context.Background(), []*monTypes.EnrichedGameData{{
 			Status: types.GameStatusInProgress,
 			Claims: createDeepClaimList()[:1],
-		}}, 0)
+		}}, 0, 0)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
 		messageFilter := testlog.NewMessageFilter(failedForecastLog)
@@ -250,7 +250,7 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 			},
 		}
 	}
-	forecast.Forecast(context.Background(), games, 3)
+	forecast.Forecast(context.Background(), games, 3, 4)
 	require.Equal(t, len(games), rollup.calls)
 	require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelError), testlog.NewMessageFilter(failedForecastLog)))
 	expectedMetrics := zeroGameAgreement()
@@ -263,6 +263,7 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	expectedMetrics[metrics.DisagreeChallengerWins] = 2
 	require.Equal(t, expectedMetrics, m.gameAgreement)
 	require.Equal(t, 3, m.ignoredGames)
+	require.Equal(t, 4, m.contractCreationFails)
 	require.EqualValues(t, 7, m.latestInvalidProposal)
 }
 
@@ -292,6 +293,11 @@ type mockForecastMetrics struct {
 	gameAgreement         map[metrics.GameAgreementStatus]int
 	ignoredGames          int
 	latestInvalidProposal uint64
+	contractCreationFails int
+}
+
+func (m *mockForecastMetrics) RecordFailedGames(count int) {
+	m.contractCreationFails = count
 }
 
 func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementStatus, count int) {

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -13,14 +13,14 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type ForecastResolution func(ctx context.Context, games []*types.EnrichedGameData, ignoredCount int)
+type ForecastResolution func(ctx context.Context, games []*types.EnrichedGameData, ignoredCount, failedCount int)
 type Bonds func(games []*types.EnrichedGameData)
 type Resolutions func(games []*types.EnrichedGameData)
 type MonitorClaims func(games []*types.EnrichedGameData)
 type MonitorWithdrawals func(games []*types.EnrichedGameData)
 type BlockHashFetcher func(ctx context.Context, number *big.Int) (common.Hash, error)
 type BlockNumberFetcher func(ctx context.Context) (uint64, error)
-type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*types.EnrichedGameData, int, error)
+type Extract func(ctx context.Context, blockHash common.Hash, minTimestamp uint64) ([]*types.EnrichedGameData, int, int, error)
 
 type gameMonitor struct {
 	logger log.Logger
@@ -87,12 +87,12 @@ func (m *gameMonitor) monitorGames() error {
 		return fmt.Errorf("failed to fetch block hash: %w", err)
 	}
 	minGameTimestamp := clock.MinCheckedTimestamp(m.clock, m.gameWindow)
-	enrichedGames, ignored, err := m.extract(m.ctx, blockHash, minGameTimestamp)
+	enrichedGames, ignored, failed, err := m.extract(m.ctx, blockHash, minGameTimestamp)
 	if err != nil {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
 	m.resolutions(enrichedGames)
-	m.forecast(m.ctx, enrichedGames, ignored)
+	m.forecast(m.ctx, enrichedGames, ignored, failed)
 	m.bonds(enrichedGames)
 	m.claims(enrichedGames)
 	m.withdrawals(enrichedGames)

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -170,7 +170,7 @@ type mockForecast struct {
 	calls int
 }
 
-func (m *mockForecast) Forecast(_ context.Context, _ []*monTypes.EnrichedGameData, _ int) {
+func (m *mockForecast) Forecast(_ context.Context, _ []*monTypes.EnrichedGameData, _, _ int) {
 	m.calls++
 }
 
@@ -188,19 +188,20 @@ type mockExtractor struct {
 	maxSuccess   int
 	games        []*monTypes.EnrichedGameData
 	ignoredCount int
+	failedCount  int
 }
 
 func (m *mockExtractor) Extract(
 	_ context.Context,
 	_ common.Hash,
 	_ uint64,
-) ([]*monTypes.EnrichedGameData, int, error) {
+) ([]*monTypes.EnrichedGameData, int, int, error) {
 	m.calls++
 	if m.fetchErr != nil {
-		return nil, 0, m.fetchErr
+		return nil, 0, 0, m.fetchErr
 	}
 	if m.calls > m.maxSuccess && m.maxSuccess != 0 {
-		return nil, 0, mockErr
+		return nil, 0, 0, mockErr
 	}
-	return m.games, m.ignoredCount, nil
+	return m.games, m.ignoredCount, m.failedCount, nil
 }


### PR DESCRIPTION
**Description**

Adds a `failed_games` metric to the `op-dispute-mon` to track the number of contracts that failed to be created.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/851