### PR TITLE
fix(op-dispute-mon): Logging for Outputs Not Found

### DIFF
--- a/op-dispute-mon/mon/validator.go
+++ b/op-dispute-mon/mon/validator.go
@@ -42,7 +42,7 @@ func (o *outputValidator) CheckRootAgreement(ctx context.Context, l1HeadNum uint
 		// string match as the error comes from the remote server so we can't use Errors.Is sadly.
 		if strings.Contains(err.Error(), "not found") {
 			// Output root doesn't exist, so we must disagree with it.
-			o.log.Warn("Output root not found", "l1HeadNum", l1HeadNum, "l2BlockNum", l2BlockNum, "rootClaim", rootClaim)
+			o.log.Warn("Output root not found", "l1HeadNum", l1HeadNum, "l2BlockNum", l2BlockNum, "rootClaim", rootClaim, "err", err)
 			return false, common.Hash{}, nil
 		}
 		return false, common.Hash{}, fmt.Errorf("failed to get output at block: %w", err)

--- a/op-dispute-mon/mon/validator.go
+++ b/op-dispute-mon/mon/validator.go
@@ -42,6 +42,7 @@ func (o *outputValidator) CheckRootAgreement(ctx context.Context, l1HeadNum uint
 		// string match as the error comes from the remote server so we can't use Errors.Is sadly.
 		if strings.Contains(err.Error(), "not found") {
 			// Output root doesn't exist, so we must disagree with it.
+			o.log.Warn("Output root not found", "l1HeadNum", l1HeadNum, "l2BlockNum", l2BlockNum, "rootClaim", rootClaim)
 			return false, common.Hash{}, nil
 		}
 		return false, common.Hash{}, fmt.Errorf("failed to get output at block: %w", err)


### PR DESCRIPTION
**Description**

Adds a warning log to the `op-dispute-mon` when outputs are "not found".

This makes investigation easier.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/854