### PR TITLE
Fjord: Implement max sequencer drift change to a constant

### DIFF
--- a/op-e2e/actions/l2_sequencer_test.go
+++ b/op-e2e/actions/l2_sequencer_test.go
@@ -111,7 +111,7 @@ func TestL2Sequencer_SequencerDrift(gt *testing.T) {
 	sequencer.ActL1HeadSignal(t)
 
 	// Make blocks up till the sequencer drift is about to surpass, but keep the old L1 origin
-	for sequencer.SyncStatus().UnsafeL2.Time+sd.RollupCfg.BlockTime <= origin.Time+sd.RollupCfg.MaxSequencerDrift {
+	for sequencer.SyncStatus().UnsafeL2.Time+sd.RollupCfg.BlockTime <= origin.Time+sd.ChainSpec.MaxSequencerDrift(origin.Time) {
 		sequencer.ActL2KeepL1Origin(t)
 		makeL2BlockWithAliceTx()
 		require.Equal(t, uint64(1), sequencer.SyncStatus().UnsafeL2.L1Origin.Number, "expected to keep old L1 origin")

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -80,6 +80,7 @@ type SetupData struct {
 	L1Cfg         *core.Genesis
 	L2Cfg         *core.Genesis
 	RollupCfg     *rollup.Config
+	ChainSpec     *rollup.ChainSpec
 	DeploymentsL1 *genesis.L1Deployments
 }
 
@@ -187,6 +188,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		L1Cfg:         l1Genesis,
 		L2Cfg:         l2Genesis,
 		RollupCfg:     rollupCfg,
+		ChainSpec:     rollup.NewChainSpec(rollupCfg),
 		DeploymentsL1: l1Deployments,
 	}
 }

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -20,6 +20,12 @@ const (
 // TODO(#10428) Remove this parameter
 const SafeMaxRLPBytesPerChannel = maxRLPBytesPerChannelBedrock
 
+// Fjord changes the max sequencer drift to a protocol constant. It was previously configurable via
+// the rollup config.
+// From Fjord, the max sequencer drift for a given block timestamp should be learned via the
+// ChainSpec instead of reading the rollup configuration field directly.
+const maxSequencerDriftFjord = 1800
+
 type ChainSpec struct {
 	config *Config
 }
@@ -54,4 +60,14 @@ func (s *ChainSpec) MaxRLPBytesPerChannel(t uint64) uint64 {
 		return maxRLPBytesPerChannelFjord
 	}
 	return maxRLPBytesPerChannelBedrock
+}
+
+// MaxSequencerDrift returns the maximum sequencer drift for the given block timestamp. Until Fjord,
+// this was a rollup configuration parameter. Since Fjord, it is a constant, so its effective value
+// should always be queried via the ChainSpec.
+func (s *ChainSpec) MaxSequencerDrift(t uint64) uint64 {
+	if s.config.IsFjord(t) {
+		return maxSequencerDriftFjord
+	}
+	return s.config.MaxSequencerDrift
 }

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -62,11 +62,17 @@ func (s *ChainSpec) MaxRLPBytesPerChannel(t uint64) uint64 {
 	return maxRLPBytesPerChannelBedrock
 }
 
+// IsFeatMaxSequencerDriftConstant specifies in which fork the max sequencer drift change to a
+// constant will be performed.
+func (s *ChainSpec) IsFeatMaxSequencerDriftConstant(t uint64) bool {
+	return s.config.IsFjord(t)
+}
+
 // MaxSequencerDrift returns the maximum sequencer drift for the given block timestamp. Until Fjord,
 // this was a rollup configuration parameter. Since Fjord, it is a constant, so its effective value
 // should always be queried via the ChainSpec.
 func (s *ChainSpec) MaxSequencerDrift(t uint64) uint64 {
-	if s.config.IsFjord(t) {
+	if s.IsFeatMaxSequencerDriftConstant(t) {
 		return maxSequencerDriftFjord
 	}
 	return s.config.MaxSequencerDrift

--- a/op-node/rollup/chain_spec_test.go
+++ b/op-node/rollup/chain_spec_test.go
@@ -50,7 +50,7 @@ var testConfig = Config{
 	UsePlasma:               false,
 }
 
-func TestCanyonForkActivation(t *testing.T) {
+func TestChainSpec_CanyonForkActivation(t *testing.T) {
 	c := NewChainSpec(&testConfig)
 	tests := []struct {
 		name     string
@@ -74,7 +74,7 @@ func TestCanyonForkActivation(t *testing.T) {
 	}
 }
 
-func TestMaxChannelBankSize(t *testing.T) {
+func TestChainSpec_MaxChannelBankSize(t *testing.T) {
 	c := NewChainSpec(&testConfig)
 	tests := []struct {
 		name        string
@@ -97,7 +97,7 @@ func TestMaxChannelBankSize(t *testing.T) {
 	}
 }
 
-func TestMaxRLPBytesPerChannel(t *testing.T) {
+func TestChainSpec_MaxRLPBytesPerChannel(t *testing.T) {
 	c := NewChainSpec(&testConfig)
 	tests := []struct {
 		name        string
@@ -115,6 +115,29 @@ func TestMaxRLPBytesPerChannel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := c.MaxRLPBytesPerChannel(tt.blockNum)
+			require.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestChainSpec_MaxSequencerDrift(t *testing.T) {
+	c := NewChainSpec(&testConfig)
+	tests := []struct {
+		name        string
+		blockNum    uint64
+		expected    uint64
+		description string
+	}{
+		{"Genesis", 0, testConfig.MaxSequencerDrift, "Before Fjord activation, should use rollup config value"},
+		{"FjordTimeMinusOne", 49, testConfig.MaxSequencerDrift, "Just before Fjord, should still use rollup config value"},
+		{"FjordTime", 50, maxSequencerDriftFjord, "At Fjord activation, should switch to Fjord constant"},
+		{"FjordTimePlusOne", 51, maxSequencerDriftFjord, "After Fjord activation, should use Fjord constant"},
+		{"NextForkTime", 60, maxSequencerDriftFjord, "Well after Fjord, should continue to use Fjord constant"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := c.MaxSequencerDrift(tt.blockNum)
 			require.Equal(t, tt.expected, result, tt.description)
 		})
 	}

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -32,7 +32,8 @@ const (
 // The first entry of the l1Blocks should match the origin of the l2SafeHead. One or more consecutive l1Blocks should be provided.
 // In case of only a single L1 block, the decision whether a batch is valid may have to stay undecided.
 func CheckBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef,
-	l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l2Fetcher SafeBlockFetcher) BatchValidity {
+	l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
 	switch batch.Batch.GetBatchType() {
 	case SingularBatchType:
 		singularBatch, ok := batch.Batch.(*SingularBatch)
@@ -122,8 +123,9 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 		return BatchDrop
 	}
 
+	spec := rollup.NewChainSpec(cfg)
 	// Check if we ran out of sequencer time drift
-	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Timestamp > max {
+	if max := batchOrigin.Time + spec.MaxSequencerDrift(batchOrigin.Time); batch.Timestamp > max {
 		if len(batch.Transactions) == 0 {
 			// If the sequencer is co-operating by producing an empty batch,
 			// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.
@@ -166,7 +168,8 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 
 // checkSpanBatch implements SpanBatch validation rule.
 func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
-	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher) BatchValidity {
+	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
 	// add details to the log
 	log = batch.LogContext(log)
 
@@ -266,10 +269,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 	}
 
 	originIdx := 0
-	originAdvanced := false
-	if startEpochNum == parentBlock.L1Origin.Number+1 {
-		originAdvanced = true
-	}
+	originAdvanced := startEpochNum == parentBlock.L1Origin.Number+1
 
 	for i := 0; i < batch.GetBlockCount(); i++ {
 		if batch.GetBlockTimestamp(i) <= l2SafeHead.Time {
@@ -282,7 +282,6 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 				originIdx = j
 				break
 			}
-
 		}
 		if i > 0 {
 			originAdvanced = false
@@ -296,8 +295,9 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			return BatchDrop
 		}
 
+		spec := rollup.NewChainSpec(cfg)
 		// Check if we ran out of sequencer time drift
-		if max := l1Origin.Time + cfg.MaxSequencerDrift; blockTimestamp > max {
+		if max := l1Origin.Time + spec.MaxSequencerDrift(l1Origin.Time); blockTimestamp > max {
 			if len(batch.GetBlockTransactions(i)) == 0 {
 				// If the sequencer is co-operating by producing an empty batch,
 				// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.

--- a/op-node/rollup/driver/origin_selector.go
+++ b/op-node/rollup/driver/origin_selector.go
@@ -19,17 +19,19 @@ type L1Blocks interface {
 }
 
 type L1OriginSelector struct {
-	log log.Logger
-	cfg *rollup.Config
+	log  log.Logger
+	cfg  *rollup.Config
+	spec *rollup.ChainSpec
 
 	l1 L1Blocks
 }
 
 func NewL1OriginSelector(log log.Logger, cfg *rollup.Config, l1 L1Blocks) *L1OriginSelector {
 	return &L1OriginSelector{
-		log: log,
-		cfg: cfg,
-		l1:  l1,
+		log:  log,
+		cfg:  cfg,
+		spec: rollup.NewChainSpec(cfg),
+		l1:   l1,
 	}
 }
 
@@ -42,12 +44,13 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 	if err != nil {
 		return eth.L1BlockRef{}, err
 	}
+	msd := los.spec.MaxSequencerDrift(currentOrigin.Time)
 	log := los.log.New("current", currentOrigin, "current_time", currentOrigin.Time,
-		"l2_head", l2Head, "l2_head_time", l2Head.Time)
+		"l2_head", l2Head, "l2_head_time", l2Head.Time, "max_seq_drift", msd)
 
 	// If we are past the sequencer depth, we may want to advance the origin, but need to still
 	// check the time of the next origin.
-	pastSeqDrift := l2Head.Time+los.cfg.BlockTime > currentOrigin.Time+los.cfg.MaxSequencerDrift
+	pastSeqDrift := l2Head.Time+los.cfg.BlockTime > currentOrigin.Time+msd
 	if pastSeqDrift {
 		log.Warn("Next L2 block time is past the sequencer drift + current origin time")
 	}

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -35,6 +35,7 @@ type SequencerMetrics interface {
 type Sequencer struct {
 	log       log.Logger
 	rollupCfg *rollup.Config
+	spec      *rollup.ChainSpec
 
 	engine derive.EngineControl
 
@@ -53,6 +54,7 @@ func NewSequencer(log log.Logger, rollupCfg *rollup.Config, engine derive.Engine
 	return &Sequencer{
 		log:              log,
 		rollupCfg:        rollupCfg,
+		spec:             rollup.NewChainSpec(rollupCfg),
 		engine:           engine,
 		timeNow:          time.Now,
 		attrBuilder:      attributesBuilder,
@@ -91,7 +93,7 @@ func (d *Sequencer) StartBuildingBlock(ctx context.Context) error {
 	// empty blocks (other than the L1 info deposit and any user deposits). We handle this by
 	// setting NoTxPool to true, which will cause the Sequencer to not include any transactions
 	// from the transaction pool.
-	attrs.NoTxPool = uint64(attrs.Timestamp) > l1Origin.Time+d.rollupCfg.MaxSequencerDrift
+	attrs.NoTxPool = uint64(attrs.Timestamp) > l1Origin.Time+d.spec.MaxSequencerDrift(l1Origin.Time)
 
 	// For the Ecotone activation block we shouldn't include any sequencer transactions.
 	if d.rollupCfg.IsEcotoneActivationBlock(uint64(attrs.Timestamp)) {

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -61,9 +61,9 @@ type Config struct {
 	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
 	// the L2 time may still grow beyond this difference.
 	//
-	// With Fjord, the MaxSequencerDrift becomes a constant. Learn the correct
-	// max sequencer drift for a given block timestamp via the ChainSpec instead
-	// of reading this rollup configuration field directly.
+	// With Fjord, the MaxSequencerDrift becomes a constant. Use the ChainSpec
+	// instead of reading this rollup configuration field directly to determine
+	// the max sequencer drift for a given block based on the block's L1 origin.
 	// Chains that activate Fjord at genesis may leave this field empty.
 	MaxSequencerDrift uint64 `json:"max_sequencer_drift,omitempty"`
 	// Number of epochs (L1 blocks) per sequencing window, including the epoch L1 origin block itself

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -60,7 +60,12 @@ type Config struct {
 	//
 	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
 	// the L2 time may still grow beyond this difference.
-	MaxSequencerDrift uint64 `json:"max_sequencer_drift"`
+	//
+	// With Fjord, the MaxSequencerDrift becomes a constant. Learn the correct
+	// max sequencer drift for a given block timestamp via the ChainSpec instead
+	// of reading this rollup configuration field directly.
+	// Chains that activate Fjord at genesis may leave this field empty.
+	MaxSequencerDrift uint64 `json:"max_sequencer_drift,omitempty"`
 	// Number of epochs (L1 blocks) per sequencing window, including the epoch L1 origin block itself
 	SeqWindowSize uint64 `json:"seq_window_size"`
 	// Number of L1 blocks between when a channel can be opened and when it must be closed by.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Changes the max sequencer drift from a rollup config parameter to a constant, as part of the upcoming Fjord protocol upgrade.

**Tests**

I've used the new `ChainSpec` to implement this change, and added a test for it.

Added two tests to the batch validation and l1 origin selector that it correctly behaves with the Fjord seq drift.

**Additional context**

Also see [specs](https://github.com/ethereum-optimism/specs/blob/main/specs/fjord/derivation.md#constant-maximum-sequencer-drift).

**Metadata**

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/205
