### PR TITLE
op-proposer: update test to use local bindings

### DIFF
--- a/op-proposer/proposer/abi_test.go
+++ b/op-proposer/proposer/abi_test.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-proposer/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"


### PR DESCRIPTION
**Description**

Updates a single import to use the `op-proposer` bindings
instead of the global monorepo bindings. The big consumer
of the bindings after this are `op-e2e` and some tests
in `op-service`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

