### PR TITLE
chore: remove test-integration rule from root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,11 +217,6 @@ test-unit:
 	pnpm test
 .PHONY: test-unit
 
-test-integration:
-	bash ./ops-bedrock/test-integration.sh \
-		./packages/contracts-bedrock/deployments/devnetL1
-.PHONY: test-integration
-
 # Remove the baseline-commit to generate a base reading & show all issues
 semgrep:
 	$(eval DEV_REF := $(shell git rev-parse develop))


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

[Trivial]
Removes the (seemingly) obsolete rule to make
integration tests from the root Makefile.
Appears that integration tests have been deprecated 
so this rule no longer works.

**Tests**

N/A

**Additional context**

Appears to be related to PR #5926 