### PR TITLE
op-dispute-mon: Ensure a zero value is set for sufficient/insufficient labels

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -453,12 +453,18 @@ func (m *Metrics) RecordFailedGames(count int) {
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required *big.Int, available *big.Int) {
-	balance := "sufficient"
+	balanceLabel := "sufficient"
+	zeroBalanceLabel := "insufficient"
 	if required.Cmp(available) > 0 {
-		balance = "insufficient"
+		balanceLabel = "insufficient"
+		zeroBalanceLabel = "sufficient"
 	}
-	m.requiredCollateral.WithLabelValues(addr.Hex(), balance).Set(weiToEther(required))
-	m.availableCollateral.WithLabelValues(addr.Hex(), balance).Set(weiToEther(available))
+	m.requiredCollateral.WithLabelValues(addr.Hex(), balanceLabel).Set(weiToEther(required))
+	m.availableCollateral.WithLabelValues(addr.Hex(), balanceLabel).Set(weiToEther(available))
+
+	// If the balance is sufficient, make sure the insufficient label is zeroed out and vice versa.
+	m.requiredCollateral.WithLabelValues(addr.Hex(), zeroBalanceLabel).Set(0)
+	m.availableCollateral.WithLabelValues(addr.Hex(), zeroBalanceLabel).Set(0)
 }
 
 const (


### PR DESCRIPTION
**Description**

If the collateral for a DelayedWETH contract is sufficient and then becomes insufficient, we need to zero out the metric with the sufficient label and set the values on the insufficient labelled version.
