### PR TITLE
op-challenger: Add a metric for number of l2 block numbers challenged

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -138,7 +138,8 @@ func (a *Agent) performAction(ctx context.Context, wg *sync.WaitGroup, action ty
 		a.metrics.RecordGameMove()
 	case types.ActionTypeStep:
 		a.metrics.RecordGameStep()
-		// TODO(client-pod#852): Add metrics for L2 block number challenges
+	case types.ActionTypeChallengeL2BlockNumber:
+		a.metrics.RecordGameL2Challenge()
 	}
 	actionLog.Info("Performing action")
 	err := a.responder.PerformAction(ctx, action)

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -36,6 +36,7 @@ type Metricer interface {
 
 	RecordGameStep()
 	RecordGameMove()
+	RecordGameL2Challenge()
 	RecordCannonExecutionTime(t float64)
 	RecordAsteriscExecutionTime(t float64)
 	RecordClaimResolutionTime(t float64)
@@ -83,8 +84,9 @@ type Metrics struct {
 
 	highestActedL1Block prometheus.Gauge
 
-	moves prometheus.Counter
-	steps prometheus.Counter
+	moves        prometheus.Counter
+	steps        prometheus.Counter
+	l2Challenges prometheus.Counter
 
 	claimResolutionTime   prometheus.Histogram
 	gameActTime           prometheus.Histogram
@@ -144,6 +146,11 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "steps",
 			Help:      "Number of game steps made by the challenge agent",
+		}),
+		l2Challenges: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "l2_challenges",
+			Help:      "Number of L2 challenges made by the challenge agent",
 		}),
 		cannonExecutionTime: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: Namespace,
@@ -249,6 +256,10 @@ func (m *Metrics) RecordGameMove() {
 
 func (m *Metrics) RecordGameStep() {
 	m.steps.Add(1)
+}
+
+func (m *Metrics) RecordGameL2Challenge() {
+	m.l2Challenges.Add(1)
 }
 
 func (m *Metrics) RecordPreimageChallenged() {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -25,8 +25,9 @@ var NoopMetrics Metricer = new(NoopMetricsImpl)
 func (*NoopMetricsImpl) RecordInfo(version string) {}
 func (*NoopMetricsImpl) RecordUp()                 {}
 
-func (*NoopMetricsImpl) RecordGameMove() {}
-func (*NoopMetricsImpl) RecordGameStep() {}
+func (*NoopMetricsImpl) RecordGameMove()        {}
+func (*NoopMetricsImpl) RecordGameStep()        {}
+func (*NoopMetricsImpl) RecordGameL2Challenge() {}
 
 func (*NoopMetricsImpl) RecordActedL1Block(_ uint64) {}
 


### PR DESCRIPTION
**Description**

Adds a metrics for the number of L2 block number challenges performed by `op-challenger`.  Matches up with the move and step counter metrics.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/852
