### PR TITLE
op-dispute-mon: Separate l2 challenge metric

### DIFF
--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -80,12 +80,11 @@ func ListGames(ctx *cli.Context) error {
 
 type gameInfo struct {
 	types.GameMetadata
-	claimCount         uint64
-	l2BlockNum         uint64
-	rootClaim          common.Hash
-	status             types.GameStatus
-	blockNumChallenged bool
-	err                error
+	claimCount uint64
+	l2BlockNum uint64
+	rootClaim  common.Hash
+	status     types.GameStatus
+	err        error
 }
 
 func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contracts.DisputeGameFactoryContract, block common.Hash, gameWindow time.Duration, sortBy, sortOrder string) error {
@@ -110,7 +109,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, l2BlockNum, rootClaim, status, _, blockNumChallenged, err := gameContract.GetGameMetadata(ctx, rpcblock.ByHash(block))
+			_, l2BlockNum, rootClaim, status, _, _, err := gameContract.GetGameMetadata(ctx, rpcblock.ByHash(block))
 			if err != nil {
 				info.err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
 				return
@@ -118,7 +117,6 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			infos[currIndex].status = status
 			infos[currIndex].l2BlockNum = l2BlockNum
 			infos[currIndex].rootClaim = rootClaim
-			infos[currIndex].blockNumChallenged = blockNumChallenged
 			claimCount, err := gameContract.GetClaimCount(ctx)
 			if err != nil {
 				info.err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -109,14 +109,14 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, l2BlockNum, rootClaim, status, _, _, err := gameContract.GetGameMetadata(ctx, rpcblock.ByHash(block))
+			metadata, err := gameContract.GetGameMetadata(ctx, rpcblock.ByHash(block))
 			if err != nil {
 				info.err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
 				return
 			}
-			infos[currIndex].status = status
-			infos[currIndex].l2BlockNum = l2BlockNum
-			infos[currIndex].rootClaim = rootClaim
+			infos[currIndex].status = metadata.Status
+			infos[currIndex].l2BlockNum = metadata.L2BlockNum
+			infos[currIndex].rootClaim = metadata.RootClaim
 			claimCount, err := gameContract.GetClaimCount(ctx)
 			if err != nil {
 				info.err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)

--- a/op-challenger/game/fault/contracts/faultdisputegame080.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame080.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 //go:embed abis/FaultDisputeGame-0.8.0.json
@@ -29,7 +28,7 @@ type FaultDisputeGameContract080 struct {
 }
 
 // GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, and max clock duration.
-func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block rpcblock.Block) (common.Hash, uint64, common.Hash, gameTypes.GameStatus, uint64, bool, error) {
+func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
 	defer f.metrics.StartContractRequest("GetGameMetadata")()
 	results, err := f.multiCaller.Call(ctx, block,
 		f.contract.Call(methodL1Head),
@@ -38,20 +37,27 @@ func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block
 		f.contract.Call(methodStatus),
 		f.contract.Call(methodGameDuration))
 	if err != nil {
-		return common.Hash{}, 0, common.Hash{}, 0, 0, false, fmt.Errorf("failed to retrieve game metadata: %w", err)
+		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
 	}
 	if len(results) != 5 {
-		return common.Hash{}, 0, common.Hash{}, 0, 0, false, fmt.Errorf("expected 5 results but got %v", len(results))
+		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
 	}
 	l1Head := results[0].GetHash(0)
 	l2BlockNumber := results[1].GetBigInt(0).Uint64()
 	rootClaim := results[2].GetHash(0)
 	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
 	if err != nil {
-		return common.Hash{}, 0, common.Hash{}, 0, 0, false, fmt.Errorf("failed to convert game status: %w", err)
+		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
 	}
 	duration := results[4].GetUint64(0)
-	return l1Head, l2BlockNumber, rootClaim, status, duration / 2, false, nil
+	return GameMetadata{
+		L1Head:                  l1Head,
+		L2BlockNum:              l2BlockNumber,
+		RootClaim:               rootClaim,
+		Status:                  status,
+		MaxClockDuration:        duration / 2,
+		L2BlockNumberChallenged: false,
+	}, nil
 }
 
 func (f *FaultDisputeGameContract080) GetMaxClockDuration(ctx context.Context) (time.Duration, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -476,6 +476,7 @@ func TestGetGameMetadata(t *testing.T) {
 			expectedRootClaim := common.Hash{0x01, 0x02}
 			expectedStatus := types.GameStatusChallengerWon
 			expectedL2BlockNumberChallenged := true
+			expectedL2BlockNumberChallenger := common.Address{0xee}
 			block := rpcblock.ByNumber(889)
 			stubRpc.SetResponse(fdgAddr, methodL1Head, block, nil, []interface{}{expectedL1Head})
 			stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, block, nil, []interface{}{new(big.Int).SetUint64(expectedL2BlockNumber)})
@@ -483,22 +484,29 @@ func TestGetGameMetadata(t *testing.T) {
 			stubRpc.SetResponse(fdgAddr, methodStatus, block, nil, []interface{}{expectedStatus})
 			if version.version == vers080 {
 				expectedL2BlockNumberChallenged = false
+				expectedL2BlockNumberChallenger = common.Address{}
 				stubRpc.SetResponse(fdgAddr, methodGameDuration, block, nil, []interface{}{expectedMaxClockDuration * 2})
 			} else if version.version == vers0180 {
 				expectedL2BlockNumberChallenged = false
+				expectedL2BlockNumberChallenger = common.Address{}
 				stubRpc.SetResponse(fdgAddr, methodMaxClockDuration, block, nil, []interface{}{expectedMaxClockDuration})
 			} else {
 				stubRpc.SetResponse(fdgAddr, methodMaxClockDuration, block, nil, []interface{}{expectedMaxClockDuration})
 				stubRpc.SetResponse(fdgAddr, methodL2BlockNumberChallenged, block, nil, []interface{}{expectedL2BlockNumberChallenged})
+				stubRpc.SetResponse(fdgAddr, methodL2BlockNumberChallenger, block, nil, []interface{}{expectedL2BlockNumberChallenger})
 			}
-			l1Head, l2BlockNumber, rootClaim, status, duration, blockNumChallenged, err := contract.GetGameMetadata(context.Background(), block)
+			actual, err := contract.GetGameMetadata(context.Background(), block)
+			expected := GameMetadata{
+				L1Head:                  expectedL1Head,
+				L2BlockNum:              expectedL2BlockNumber,
+				RootClaim:               expectedRootClaim,
+				Status:                  expectedStatus,
+				MaxClockDuration:        expectedMaxClockDuration,
+				L2BlockNumberChallenged: expectedL2BlockNumberChallenged,
+				L2BlockNumberChallenger: expectedL2BlockNumberChallenger,
+			}
 			require.NoError(t, err)
-			require.Equal(t, expectedL1Head, l1Head)
-			require.Equal(t, expectedL2BlockNumber, l2BlockNumber)
-			require.Equal(t, expectedRootClaim, rootClaim)
-			require.Equal(t, expectedStatus, status)
-			require.Equal(t, expectedMaxClockDuration, duration)
-			require.Equal(t, expectedL2BlockNumberChallenged, blockNumChallenged)
+			require.Equal(t, expected, actual)
 		})
 	}
 }

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -132,7 +132,7 @@ type Metricer interface {
 
 	RecordBondCollateral(addr common.Address, required *big.Int, available *big.Int)
 
-	RecordL2Challenges(count int)
+	RecordL2Challenges(agreement bool, count int)
 
 	caching.Metrics
 	contractMetrics.ContractMetricer
@@ -171,7 +171,7 @@ type Metrics struct {
 	latestInvalidProposal prometheus.Gauge
 	ignoredGames          prometheus.Gauge
 	failedGames           prometheus.Gauge
-	l2Challenges          prometheus.Gauge
+	l2Challenges          prometheus.GaugeVec
 
 	requiredCollateral  prometheus.GaugeVec
 	availableCollateral prometheus.GaugeVec
@@ -312,10 +312,14 @@ func NewMetrics() *Metrics {
 			"delayedWETH",
 			"balance",
 		}),
-		l2Challenges: factory.NewGauge(prometheus.GaugeOpts{
+		l2Challenges: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "l2_block_challenges",
 			Help:      "Number of games where the L2 block number has been successfully challenged",
+		}, []string{
+			// Agreement with the root claim, not the actual l2 block number challenge.
+			// An l2 block number challenge with an agreement means the challenge was invalid.
+			"root_agreement",
 		}),
 	}
 }
@@ -469,8 +473,12 @@ func (m *Metrics) RecordBondCollateral(addr common.Address, required *big.Int, a
 	m.availableCollateral.WithLabelValues(addr.Hex(), balance).Set(weiToEther(available))
 }
 
-func (m *Metrics) RecordL2Challenges(count int) {
-	m.l2Challenges.Set(float64(count))
+func (m *Metrics) RecordL2Challenges(agreement bool, count int) {
+	agree := "disagree"
+	if agreement {
+		agree = "agree"
+	}
+	m.l2Challenges.WithLabelValues(agree).Set(float64(count))
 }
 
 const (

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -44,4 +44,4 @@ func (*NoopMetricsImpl) RecordFailedGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}
 
-func (*NoopMetricsImpl) RecordL2Challenges(_ int) {}
+func (*NoopMetricsImpl) RecordL2Challenges(_ bool, _ int) {}

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -43,3 +43,5 @@ func (*NoopMetricsImpl) RecordIgnoredGames(_ int) {}
 func (*NoopMetricsImpl) RecordFailedGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}
+
+func (*NoopMetricsImpl) RecordL2Challenges(_ int) {}

--- a/op-dispute-mon/mon/bonds/monitor.go
+++ b/op-dispute-mon/mon/bonds/monitor.go
@@ -59,7 +59,10 @@ func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
 			}
 			// The recipient of a resolved claim is the claimant unless it's been countered.
 			recipient := claim.Claimant
-			if claim.CounteredBy != (common.Address{}) {
+			if claim.IsRoot() && game.BlockNumberChallenged {
+				// The bond for the root claim is paid to the block number challenger if present
+				recipient = game.BlockNumberChallenger
+			} else if claim.CounteredBy != (common.Address{}) {
 				recipient = claim.CounteredBy
 			}
 			current := expectedCredits[recipient]

--- a/op-dispute-mon/mon/bonds/monitor_test.go
+++ b/op-dispute-mon/mon/bonds/monitor_test.go
@@ -57,6 +57,7 @@ func TestCheckRecipientCredit(t *testing.T) {
 	addr2 := common.Address{0x2b}
 	addr3 := common.Address{0x3c}
 	addr4 := common.Address{0x4d}
+	notRootPosition := types.NewPositionFromGIndex(big.NewInt(2))
 	// Game has not reached max duration
 	game1 := &monTypes.EnrichedGameData{
 		MaxClockDuration: 50000,
@@ -68,7 +69,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 10 credits for addr1
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(10),
+						Bond:     big.NewInt(10),
+						Position: types.RootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -77,7 +79,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // No expected credits as not resolved
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(15),
+						Bond:     big.NewInt(15),
+						Position: notRootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -86,7 +89,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 5 credits for addr1
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(5),
+						Bond:     big.NewInt(5),
+						Position: notRootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -95,7 +99,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 7 credits for addr2
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(7),
+						Bond:     big.NewInt(7),
+						Position: notRootPosition,
 					},
 					Claimant:    addr3,
 					CounteredBy: addr2,
@@ -105,7 +110,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 3 credits for addr4
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(3),
+						Bond:     big.NewInt(3),
+						Position: notRootPosition,
 					},
 					Claimant: addr4,
 				},
@@ -135,7 +141,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 11 credits for addr1
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(11),
+						Bond:     big.NewInt(11),
+						Position: types.RootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -144,7 +151,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // No expected credits as not resolved
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(15),
+						Bond:     big.NewInt(15),
+						Position: notRootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -153,7 +161,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 6 credits for addr1
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(6),
+						Bond:     big.NewInt(6),
+						Position: notRootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -162,7 +171,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 8 credits for addr2
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(8),
+						Bond:     big.NewInt(8),
+						Position: notRootPosition,
 					},
 					Claimant:    addr3,
 					CounteredBy: addr2,
@@ -172,7 +182,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 4 credits for addr4
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(4),
+						Bond:     big.NewInt(4),
+						Position: notRootPosition,
 					},
 					Claimant: addr4,
 				},
@@ -204,7 +215,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 9 credits for addr1
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(9),
+						Bond:     big.NewInt(9),
+						Position: types.RootPosition,
 					},
 					Claimant: addr1,
 				},
@@ -213,7 +225,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 6 credits for addr2
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(6),
+						Bond:     big.NewInt(6),
+						Position: notRootPosition,
 					},
 					Claimant:    addr4,
 					CounteredBy: addr2,
@@ -223,7 +236,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 2 credits for addr4
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(2),
+						Bond:     big.NewInt(2),
+						Position: notRootPosition,
 					},
 					Claimant: addr4,
 				},
@@ -250,20 +264,25 @@ func TestCheckRecipientCredit(t *testing.T) {
 			Proxy:     common.Address{44},
 			Timestamp: uint64(frozen.Unix()) - 22,
 		},
+		BlockNumberChallenged: true,
+		BlockNumberChallenger: addr1,
 		Claims: []monTypes.EnrichedClaim{
-			{ // Expect 9 credits for addr1
+			{ // Expect 9 credits for addr1 as the block number challenger
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(9),
+						Bond:     big.NewInt(9),
+						Position: types.RootPosition,
 					},
-					Claimant: addr1,
+					Claimant:    addr2,
+					CounteredBy: addr3,
 				},
 				Resolved: true,
 			},
 			{ // Expect 6 credits for addr2
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(6),
+						Bond:     big.NewInt(6),
+						Position: notRootPosition,
 					},
 					Claimant:    addr4,
 					CounteredBy: addr2,
@@ -273,7 +292,8 @@ func TestCheckRecipientCredit(t *testing.T) {
 			{ // Expect 2 credits for addr4
 				Claim: types.Claim{
 					ClaimData: types.ClaimData{
-						Bond: big.NewInt(2),
+						Bond:     big.NewInt(2),
+						Position: notRootPosition,
 					},
 					Claimant: addr4,
 				},

--- a/op-dispute-mon/mon/extract/bond_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_enricher.go
@@ -27,21 +27,13 @@ func NewBondEnricher() *BondEnricher {
 }
 
 func (b *BondEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	recipients := make(map[common.Address]bool)
-	for _, claim := range game.Claims {
-		if claim.CounteredBy != (common.Address{}) {
-			recipients[claim.CounteredBy] = true
-		} else {
-			recipients[claim.Claimant] = true
-		}
-	}
-	recipientAddrs := maps.Keys(recipients)
+	recipientAddrs := maps.Keys(game.Recipients)
 	credits, err := caller.GetCredits(ctx, block, recipientAddrs...)
 	if err != nil {
 		return err
 	}
-	if len(credits) != len(recipients) {
-		return fmt.Errorf("%w, requested %v values but got %v", ErrIncorrectCreditCount, len(recipients), len(credits))
+	if len(credits) != len(recipientAddrs) {
+		return fmt.Errorf("%w, requested %v values but got %v", ErrIncorrectCreditCount, len(recipientAddrs), len(credits))
 	}
 	game.Credits = make(map[common.Address]*big.Int)
 	for i, credit := range credits {

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -25,7 +25,7 @@ type GameCallerMetrics interface {
 
 type GameCaller interface {
 	GetWithdrawals(context.Context, rpcblock.Block, common.Address, ...common.Address) ([]*contracts.WithdrawalRequest, error)
-	GetGameMetadata(context.Context, rpcblock.Block) (common.Hash, uint64, common.Hash, gameTypes.GameStatus, uint64, bool, error)
+	GetGameMetadata(context.Context, rpcblock.Block) (contracts.GameMetadata, error)
 	GetAllClaims(context.Context, rpcblock.Block) ([]faultTypes.Claim, error)
 	BondCaller
 	BalanceCaller

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -125,7 +125,7 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create contracts: %w", err)
 	}
-	l1Head, l2BlockNum, rootClaim, status, duration, blockNumChallenged, err := caller.GetGameMetadata(ctx, rpcblock.ByHash(blockHash))
+	meta, err := caller.GetGameMetadata(ctx, rpcblock.ByHash(blockHash))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch game metadata: %w", err)
 	}
@@ -139,12 +139,13 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 	}
 	enrichedGame := &monTypes.EnrichedGameData{
 		GameMetadata:          game,
-		L1Head:                l1Head,
-		L2BlockNumber:         l2BlockNum,
-		RootClaim:             rootClaim,
-		Status:                status,
-		MaxClockDuration:      duration,
-		BlockNumberChallenged: blockNumChallenged,
+		L1Head:                meta.L1Head,
+		L2BlockNumber:         meta.L2BlockNum,
+		RootClaim:             meta.RootClaim,
+		Status:                meta.Status,
+		MaxClockDuration:      meta.MaxClockDuration,
+		BlockNumberChallenged: meta.L2BlockNumberChallenged,
+		BlockNumberChallenger: meta.L2BlockNumberChallenger,
 		Claims:                enrichedClaims,
 	}
 	if err := e.applyEnrichers(ctx, blockHash, caller, enrichedGame); err != nil {

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -254,12 +254,15 @@ func (m *mockGameCaller) GetWithdrawals(_ context.Context, _ rpcblock.Block, _ c
 	}, nil
 }
 
-func (m *mockGameCaller) GetGameMetadata(_ context.Context, _ rpcblock.Block) (common.Hash, uint64, common.Hash, gameTypes.GameStatus, uint64, bool, error) {
+func (m *mockGameCaller) GetGameMetadata(_ context.Context, _ rpcblock.Block) (contracts.GameMetadata, error) {
 	m.metadataCalls++
 	if m.metadataErr != nil {
-		return common.Hash{}, 0, common.Hash{}, 0, 0, false, m.metadataErr
+		return contracts.GameMetadata{}, m.metadataErr
 	}
-	return common.Hash{0xaa}, 0, mockRootClaim, 0, 0, false, nil
+	return contracts.GameMetadata{
+		L1Head:    common.Hash{0xaa},
+		RootClaim: mockRootClaim,
+	}, nil
 }
 
 func (m *mockGameCaller) GetAllClaims(_ context.Context, _ rpcblock.Block) ([]faultTypes.Claim, error) {

--- a/op-dispute-mon/mon/extract/recipient_enricher.go
+++ b/op-dispute-mon/mon/extract/recipient_enricher.go
@@ -25,6 +25,9 @@ func (w *RecipientEnricher) Enrich(_ context.Context, _ rpcblock.Block, _ GameCa
 			recipients[claim.Claimant] = true
 		}
 	}
+	if game.BlockNumberChallenger != (common.Address{}) {
+		recipients[game.BlockNumberChallenger] = true
+	}
 	game.Recipients = recipients
 	return nil
 }

--- a/op-dispute-mon/mon/extract/recipient_enricher_test.go
+++ b/op-dispute-mon/mon/extract/recipient_enricher_test.go
@@ -12,6 +12,7 @@ import (
 func TestRecipientEnricher(t *testing.T) {
 	game, recipients := makeTestGame()
 	game.Recipients = make(map[common.Address]bool)
+	game.BlockNumberChallenger = common.Address{0xff, 0xee, 0xdd}
 	enricher := NewRecipientEnricher()
 	caller := &mockGameCaller{}
 	ctx := context.Background()
@@ -20,4 +21,5 @@ func TestRecipientEnricher(t *testing.T) {
 	for _, recipient := range recipients {
 		require.Contains(t, game.Recipients, recipient)
 	}
+	require.Contains(t, game.Recipients, game.BlockNumberChallenger)
 }

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -120,7 +120,8 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		require.Equal(t, false, l.AttrValue("agreement"))
 
 		expectedMetrics := zeroGameAgreement()
-		expectedMetrics[metrics.AgreeChallengerAhead] = 1
+		// We disagree with the root claim and the challenger is ahead
+		expectedMetrics[metrics.DisagreeChallengerAhead] = 1
 		require.Equal(t, expectedMetrics, m.gameAgreement)
 	})
 
@@ -140,8 +141,8 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		require.Equal(t, true, l.AttrValue("agreement"))
 
 		expectedMetrics := zeroGameAgreement()
-		expectedMetrics[metrics.DisagreeChallengerAhead] = 1
-		expectedMetrics[metrics.DisagreeL2BlockChallenge] = 1
+		// We agree with the root claim and the challenger is ahead
+		expectedMetrics[metrics.AgreeChallengerAhead] = 1
 		require.Equal(t, expectedMetrics, m.gameAgreement)
 	})
 
@@ -304,15 +305,14 @@ func setupForecastTest(t *testing.T) (*Forecast, *mockForecastMetrics, *testlog.
 
 func zeroGameAgreement() map[metrics.GameAgreementStatus]int {
 	return map[metrics.GameAgreementStatus]int{
-		metrics.AgreeChallengerAhead:     0,
-		metrics.DisagreeChallengerAhead:  0,
-		metrics.AgreeDefenderAhead:       0,
-		metrics.DisagreeDefenderAhead:    0,
-		metrics.AgreeDefenderWins:        0,
-		metrics.DisagreeDefenderWins:     0,
-		metrics.AgreeChallengerWins:      0,
-		metrics.DisagreeChallengerWins:   0,
-		metrics.DisagreeL2BlockChallenge: 0,
+		metrics.AgreeChallengerAhead:    0,
+		metrics.DisagreeChallengerAhead: 0,
+		metrics.AgreeDefenderAhead:      0,
+		metrics.DisagreeDefenderAhead:   0,
+		metrics.AgreeDefenderWins:       0,
+		metrics.DisagreeDefenderWins:    0,
+		metrics.AgreeChallengerWins:     0,
+		metrics.DisagreeChallengerWins:  0,
 	}
 }
 

--- a/op-dispute-mon/mon/l2_challenges.go
+++ b/op-dispute-mon/mon/l2_challenges.go
@@ -1,27 +1,42 @@
 package mon
 
-import "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
 
 type L2ChallengesMetrics interface {
-	RecordL2Challenges(count int)
+	RecordL2Challenges(agreement bool, count int)
 }
 
 type L2ChallengesMonitor struct {
+	logger  log.Logger
 	metrics L2ChallengesMetrics
 }
 
-func NewL2ChallengesMonitor(metrics L2ChallengesMetrics) *L2ChallengesMonitor {
+func NewL2ChallengesMonitor(logger log.Logger, metrics L2ChallengesMetrics) *L2ChallengesMonitor {
 	return &L2ChallengesMonitor{
+		logger:  logger,
 		metrics: metrics,
 	}
 }
 
 func (m *L2ChallengesMonitor) CheckL2Challenges(games []*types.EnrichedGameData) {
-	challengeCount := 0
+	agreeChallengeCount := 0
+	disagreeChallengeCount := 0
 	for _, game := range games {
 		if game.BlockNumberChallenged {
-			challengeCount++
+			if game.AgreeWithClaim {
+				m.logger.Warn("Found game with valid block number challenged",
+					"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
+				agreeChallengeCount++
+			} else {
+				m.logger.Debug("Found game with invalid block number challenged",
+					"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
+				disagreeChallengeCount++
+			}
 		}
 	}
-	m.metrics.RecordL2Challenges(challengeCount)
+	m.metrics.RecordL2Challenges(true, agreeChallengeCount)
+	m.metrics.RecordL2Challenges(false, disagreeChallengeCount)
 }

--- a/op-dispute-mon/mon/l2_challenges.go
+++ b/op-dispute-mon/mon/l2_challenges.go
@@ -1,0 +1,27 @@
+package mon
+
+import "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+
+type L2ChallengesMetrics interface {
+	RecordL2Challenges(count int)
+}
+
+type L2ChallengesMonitor struct {
+	metrics L2ChallengesMetrics
+}
+
+func NewL2ChallengesMonitor(metrics L2ChallengesMetrics) *L2ChallengesMonitor {
+	return &L2ChallengesMonitor{
+		metrics: metrics,
+	}
+}
+
+func (m *L2ChallengesMonitor) CheckL2Challenges(games []*types.EnrichedGameData) {
+	challengeCount := 0
+	for _, game := range games {
+		if game.BlockNumberChallenged {
+			challengeCount++
+		}
+	}
+	m.metrics.RecordL2Challenges(challengeCount)
+}

--- a/op-dispute-mon/mon/l2_challenges_test.go
+++ b/op-dispute-mon/mon/l2_challenges_test.go
@@ -1,0 +1,31 @@
+package mon
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitorL2Challenges(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{BlockNumberChallenged: true},
+		{BlockNumberChallenged: false},
+		{BlockNumberChallenged: true},
+		{BlockNumberChallenged: false},
+		{BlockNumberChallenged: false},
+		{BlockNumberChallenged: false},
+	}
+	metrics := &stubL2ChallengeMetrics{}
+	monitor := NewL2ChallengesMonitor(metrics)
+	monitor.CheckL2Challenges(games)
+	require.Equal(t, 2, metrics.challengeCount)
+}
+
+type stubL2ChallengeMetrics struct {
+	challengeCount int
+}
+
+func (s *stubL2ChallengeMetrics) RecordL2Challenges(count int) {
+	s.challengeCount = count
+}

--- a/op-dispute-mon/mon/l2_challenges_test.go
+++ b/op-dispute-mon/mon/l2_challenges_test.go
@@ -3,29 +3,58 @@ package mon
 import (
 	"testing"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMonitorL2Challenges(t *testing.T) {
 	games := []*types.EnrichedGameData{
-		{BlockNumberChallenged: true},
-		{BlockNumberChallenged: false},
-		{BlockNumberChallenged: true},
-		{BlockNumberChallenged: false},
-		{BlockNumberChallenged: false},
-		{BlockNumberChallenged: false},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}}, BlockNumberChallenged: true, AgreeWithClaim: true, L2BlockNumber: 44, BlockNumberChallenger: common.Address{0x55}},
+		{BlockNumberChallenged: false, AgreeWithClaim: true},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, BlockNumberChallenged: true, AgreeWithClaim: false, L2BlockNumber: 22, BlockNumberChallenger: common.Address{0x33}},
+		{BlockNumberChallenged: false, AgreeWithClaim: false},
+		{BlockNumberChallenged: false, AgreeWithClaim: false},
+		{BlockNumberChallenged: false, AgreeWithClaim: true},
 	}
 	metrics := &stubL2ChallengeMetrics{}
-	monitor := NewL2ChallengesMonitor(metrics)
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewL2ChallengesMonitor(logger, metrics)
 	monitor.CheckL2Challenges(games)
-	require.Equal(t, 2, metrics.challengeCount)
+	require.Equal(t, 1, metrics.challengeCount[true])
+	require.Equal(t, 1, metrics.challengeCount[false])
+
+	// Warn log for challenged and agreement
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found game with valid block number challenged")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, common.Address{0x44}, l.AttrValue("game"))
+	require.Equal(t, uint64(44), l.AttrValue("blockNum"))
+	require.Equal(t, true, l.AttrValue("agreement"))
+	require.Equal(t, common.Address{0x55}, l.AttrValue("challenger"))
+
+	// Debug log for challenged but disagreement
+	levelFilter = testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter = testlog.NewMessageFilter("Found game with invalid block number challenged")
+	l = capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, common.Address{0x22}, l.AttrValue("game"))
+	require.Equal(t, uint64(22), l.AttrValue("blockNum"))
+	require.Equal(t, false, l.AttrValue("agreement"))
+	require.Equal(t, common.Address{0x33}, l.AttrValue("challenger"))
 }
 
 type stubL2ChallengeMetrics struct {
-	challengeCount int
+	challengeCount map[bool]int
 }
 
-func (s *stubL2ChallengeMetrics) RecordL2Challenges(count int) {
-	s.challengeCount = count
+func (s *stubL2ChallengeMetrics) RecordL2Challenges(agreement bool, count int) {
+	if s.challengeCount == nil {
+		s.challengeCount = make(map[bool]int)
+	}
+	s.challengeCount[agreement] = count
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -128,7 +128,7 @@ func (s *Service) initExtractor(cfg *config.Config) {
 		cfg.IgnoredGames,
 		cfg.MaxConcurrency,
 		extract.NewClaimEnricher(),
-		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher
+		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
 		extract.NewWithdrawalsEnricher(),
 		extract.NewBondEnricher(),
 		extract.NewBalanceEnricher(),

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -213,6 +213,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		}
 		return block.Hash(), nil
 	}
+	l2ChallengesMonitor := NewL2ChallengesMonitor(s.metrics)
 	s.monitor = newGameMonitor(
 		ctx,
 		s.logger,
@@ -225,6 +226,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.resolutions.CheckResolutions,
 		s.claims.CheckClaims,
 		s.withdrawals.CheckWithdrawals,
+		l2ChallengesMonitor.CheckL2Challenges,
 		s.extractor.Extract,
 		s.l1Client.BlockNumber,
 		blockHashFetcher,

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -213,7 +213,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		}
 		return block.Hash(), nil
 	}
-	l2ChallengesMonitor := NewL2ChallengesMonitor(s.metrics)
+	l2ChallengesMonitor := NewL2ChallengesMonitor(s.logger, s.metrics)
 	s.monitor = newGameMonitor(
 		ctx,
 		s.logger,

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -24,6 +24,7 @@ type EnrichedGameData struct {
 	Status                types.GameStatus
 	MaxClockDuration      uint64
 	BlockNumberChallenged bool
+	BlockNumberChallenger common.Address
 	Claims                []EnrichedClaim
 
 	AgreeWithClaim    bool


### PR DESCRIPTION
**Description**

Implement feedback on https://github.com/ethereum-optimism/optimism/pull/10451 to reuse the existing expected game status handling and report the number of l2 block number challenges as a separate metric.
