### PR TITLE
op-challenger: Fix highest_acted_l1_block metric

### DIFF
--- a/op-challenger/game/scheduler/coordinator.go
+++ b/op-challenger/game/scheduler/coordinator.go
@@ -146,6 +146,7 @@ func (c *coordinator) createJob(ctx context.Context, game types.GameMetadata, bl
 	state.inflight = true
 	if state.status != types.GameStatusInProgress {
 		c.logger.Debug("Not rescheduling resolved game", "game", game.Proxy, "status", state.status)
+		state.lastProcessedBlockNum = blockNumber
 		return nil, nil
 	}
 	return newJob(blockNumber, game.Proxy, state.player, state.status), nil

--- a/op-challenger/game/scheduler/coordinator_test.go
+++ b/op-challenger/game/scheduler/coordinator_test.go
@@ -225,7 +225,8 @@ func TestSchedule_RecordActedL1Block(t *testing.T) {
 	require.NoError(t, c.schedule(ctx, asGames(gameAddr3), 2))
 
 	// Verify that the block number is recorded by the metricer as acted upon
-	require.Equal(t, uint64(1), c.m.(*stubSchedulerMetrics).actedL1Blocks)
+	// The one game is now complete so its block number is updated immediately because it doesn't get scheduled
+	require.Equal(t, uint64(2), c.m.(*stubSchedulerMetrics).actedL1Blocks)
 }
 
 func TestSchedule_RecordActedL1BlockMultipleGames(t *testing.T) {


### PR DESCRIPTION
**Description**

Completed games weren't updating their latest acted block because they don't get scheduled which meant the metric always reported 0.

**Tests**

Updated unit tests.
