### PR TITLE
op-chain-ops: update bindings import

### DIFF
--- a/op-chain-ops/safe/batch_test.go
+++ b/op-chain-ops/safe/batch_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades/bindings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
**Description**

Updates another import to reference local bindings
rather than global bindings. This test isn't
going to need to worry about having its bindings be
updated.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

