### PR TITLE
feat(op-dispute-mon): Update L2 Challenges Metrics

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -319,7 +319,7 @@ func NewMetrics() *Metrics {
 		}, []string{
 			// Agreement with the root claim, not the actual l2 block number challenge.
 			// An l2 block number challenge with an agreement means the challenge was invalid.
-			"agreement",
+			"root_agreement",
 		}),
 	}
 }
@@ -474,9 +474,9 @@ func (m *Metrics) RecordBondCollateral(addr common.Address, required *big.Int, a
 }
 
 func (m *Metrics) RecordL2Challenges(agreement bool, count int) {
-	agree := "false"
+	agree := "disagree"
 	if agreement {
-		agree = "true"
+		agree = "agree"
 	}
 	m.l2Challenges.WithLabelValues(agree).Set(float64(count))
 }

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -44,4 +44,4 @@ func (*NoopMetricsImpl) RecordFailedGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordBondCollateral(_ common.Address, _ *big.Int, _ *big.Int) {}
 
-func (*NoopMetricsImpl) RecordL2Challenges(_ int) {}
+func (*NoopMetricsImpl) RecordL2Challenges(_ bool, _ int) {}

--- a/op-dispute-mon/mon/l2_challenges.go
+++ b/op-dispute-mon/mon/l2_challenges.go
@@ -1,27 +1,42 @@
 package mon
 
-import "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
 
 type L2ChallengesMetrics interface {
-	RecordL2Challenges(count int)
+	RecordL2Challenges(agreement bool, count int)
 }
 
 type L2ChallengesMonitor struct {
+	logger  log.Logger
 	metrics L2ChallengesMetrics
 }
 
-func NewL2ChallengesMonitor(metrics L2ChallengesMetrics) *L2ChallengesMonitor {
+func NewL2ChallengesMonitor(logger log.Logger, metrics L2ChallengesMetrics) *L2ChallengesMonitor {
 	return &L2ChallengesMonitor{
+		logger:  logger,
 		metrics: metrics,
 	}
 }
 
 func (m *L2ChallengesMonitor) CheckL2Challenges(games []*types.EnrichedGameData) {
-	challengeCount := 0
+	agreeChallengeCount := 0
+	disagreeChallengeCount := 0
 	for _, game := range games {
 		if game.BlockNumberChallenged {
-			challengeCount++
+			if game.AgreeWithClaim {
+				m.logger.Warn("Found game with valid block number challenged",
+					"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
+				agreeChallengeCount++
+			} else {
+				m.logger.Debug("Found game with invalid block number challenged",
+					"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
+				disagreeChallengeCount++
+			}
 		}
 	}
-	m.metrics.RecordL2Challenges(challengeCount)
+	m.metrics.RecordL2Challenges(true, agreeChallengeCount)
+	m.metrics.RecordL2Challenges(false, disagreeChallengeCount)
 }

--- a/op-dispute-mon/mon/l2_challenges_test.go
+++ b/op-dispute-mon/mon/l2_challenges_test.go
@@ -3,29 +3,58 @@ package mon
 import (
 	"testing"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMonitorL2Challenges(t *testing.T) {
 	games := []*types.EnrichedGameData{
-		{BlockNumberChallenged: true},
-		{BlockNumberChallenged: false},
-		{BlockNumberChallenged: true},
-		{BlockNumberChallenged: false},
-		{BlockNumberChallenged: false},
-		{BlockNumberChallenged: false},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}}, BlockNumberChallenged: true, AgreeWithClaim: true, L2BlockNumber: 44, BlockNumberChallenger: common.Address{0x55}},
+		{BlockNumberChallenged: false, AgreeWithClaim: true},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, BlockNumberChallenged: true, AgreeWithClaim: false, L2BlockNumber: 22, BlockNumberChallenger: common.Address{0x33}},
+		{BlockNumberChallenged: false, AgreeWithClaim: false},
+		{BlockNumberChallenged: false, AgreeWithClaim: false},
+		{BlockNumberChallenged: false, AgreeWithClaim: true},
 	}
 	metrics := &stubL2ChallengeMetrics{}
-	monitor := NewL2ChallengesMonitor(metrics)
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewL2ChallengesMonitor(logger, metrics)
 	monitor.CheckL2Challenges(games)
-	require.Equal(t, 2, metrics.challengeCount)
+	require.Equal(t, 1, metrics.challengeCount[true])
+	require.Equal(t, 1, metrics.challengeCount[false])
+
+	// Warn log for challenged and agreement
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found game with valid block number challenged")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, common.Address{0x44}, l.AttrValue("game"))
+	require.Equal(t, uint64(44), l.AttrValue("blockNum"))
+	require.Equal(t, true, l.AttrValue("agreement"))
+	require.Equal(t, common.Address{0x55}, l.AttrValue("challenger"))
+
+	// Debug log for challenged but disagreement
+	levelFilter = testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter = testlog.NewMessageFilter("Found game with invalid block number challenged")
+	l = capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, common.Address{0x22}, l.AttrValue("game"))
+	require.Equal(t, uint64(22), l.AttrValue("blockNum"))
+	require.Equal(t, false, l.AttrValue("agreement"))
+	require.Equal(t, common.Address{0x33}, l.AttrValue("challenger"))
 }
 
 type stubL2ChallengeMetrics struct {
-	challengeCount int
+	challengeCount map[bool]int
 }
 
-func (s *stubL2ChallengeMetrics) RecordL2Challenges(count int) {
-	s.challengeCount = count
+func (s *stubL2ChallengeMetrics) RecordL2Challenges(agreement bool, count int) {
+	if s.challengeCount == nil {
+		s.challengeCount = make(map[bool]int)
+	}
+	s.challengeCount[agreement] = count
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -213,7 +213,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		}
 		return block.Hash(), nil
 	}
-	l2ChallengesMonitor := NewL2ChallengesMonitor(s.metrics)
+	l2ChallengesMonitor := NewL2ChallengesMonitor(s.logger, s.metrics)
 	s.monitor = newGameMonitor(
 		ctx,
 		s.logger,


### PR DESCRIPTION
**Description**

Increases the `l2Challenges` metric verbosity by using a gauge vec and partitioning on agreement.

This allows the downstream metric consumer to explicitly callout when the l2 block number challenge is against a block number they agree or disagree with. Although it should never happen, l2 block number challenges against a valid block number should be flagged in the dispute monitor dashboard to make investigation easy. An alert can also be configured for this metric but since the incorrect game forecast alert will fire, it could be enough to just call this out as a stat on the front page of the dashboard so it's immediately clear to an investigator if the incorrect game forecast is due to an invalid l2 block number challenge. The runbook must be updated to make note of this.