### PR TITLE
op-chain-ops: bindings decouple

### DIFF
--- a/op-chain-ops/cmd/check-ecotone/bindings/gaspriceoracle.go
+++ b/op-chain-ops/cmd/check-ecotone/bindings/gaspriceoracle.go
@@ -1,0 +1,657 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// GasPriceOracleMetaData contains all meta data concerning the GasPriceOracle contract.
+var GasPriceOracleMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"DECIMALS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"baseFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"baseFeeScalar\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"blobBaseFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"blobBaseFeeScalar\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decimals\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"gasPrice\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getL1Fee\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getL1GasUsed\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isEcotone\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"l1BaseFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"overhead\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"scalar\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setEcotone\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"}]",
+	Bin: "0x608060405234801561001057600080fd5b50610fb5806100206000396000f3fe608060405234801561001057600080fd5b50600436106100f55760003560e01c806354fd4d5011610097578063de26c4a111610066578063de26c4a1146101da578063f45e65d8146101ed578063f8206140146101f5578063fe173b97146101cc57600080fd5b806354fd4d501461016657806368d5dca6146101af5780636ef25c3a146101cc578063c5985918146101d257600080fd5b8063313ce567116100d3578063313ce5671461012757806349948e0e1461012e5780634ef6e22414610141578063519b4bd31461015e57600080fd5b80630c18c162146100fa57806322b90ab3146101155780632e0f26251461011f575b600080fd5b6101026101fd565b6040519081526020015b60405180910390f35b61011d61031e565b005b610102600681565b6006610102565b61010261013c366004610b73565b610541565b60005461014e9060ff1681565b604051901515815260200161010c565b610102610565565b6101a26040518060400160405280600581526020017f312e322e3000000000000000000000000000000000000000000000000000000081525081565b60405161010c9190610c42565b6101b76105c6565b60405163ffffffff909116815260200161010c565b48610102565b6101b761064b565b6101026101e8366004610b73565b6106ac565b610102610760565b610102610853565b6000805460ff1615610296576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602860248201527f47617350726963654f7261636c653a206f76657268656164282920697320646560448201527f707265636174656400000000000000000000000000000000000000000000000060648201526084015b60405180910390fd5b73420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16638b239f736040518163ffffffff1660e01b8152600401602060405180830381865afa1580156102f5573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906103199190610cb5565b905090565b73420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff1663e591b2826040518163ffffffff1660e01b8152600401602060405180830381865afa15801561037d573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906103a19190610cce565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610481576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152604160248201527f47617350726963654f7261636c653a206f6e6c7920746865206465706f73697460448201527f6f72206163636f756e742063616e2073657420697345636f746f6e6520666c6160648201527f6700000000000000000000000000000000000000000000000000000000000000608482015260a40161028d565b60005460ff1615610514576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602660248201527f47617350726963654f7261636c653a2045636f746f6e6520616c72656164792060448201527f6163746976650000000000000000000000000000000000000000000000000000606482015260840161028d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055565b6000805460ff161561055c57610556826108b4565b92915050565b61055682610958565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16635cf249696040518163ffffffff1660e01b8152600401602060405180830381865afa1580156102f5573d6000803e3d6000fd5b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff166368d5dca66040518163ffffffff1660e01b8152600401602060405180830381865afa158015610627573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906103199190610d04565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff1663c59859186040518163ffffffff1660e01b8152600401602060405180830381865afa158015610627573d6000803e3d6000fd5b6000806106b883610ab4565b60005490915060ff16156106cc5792915050565b73420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16638b239f736040518163ffffffff1660e01b8152600401602060405180830381865afa15801561072b573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061074f9190610cb5565b6107599082610d59565b9392505050565b6000805460ff16156107f4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602660248201527f47617350726963654f7261636c653a207363616c61722829206973206465707260448201527f6563617465640000000000000000000000000000000000000000000000000000606482015260840161028d565b73420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16639e8c49666040518163ffffffff1660e01b8152600401602060405180830381865afa1580156102f5573d6000803e3d6000fd5b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff1663f82061406040518163ffffffff1660e01b8152600401602060405180830381865afa1580156102f5573d6000803e3d6000fd5b6000806108c083610ab4565b905060006108cc610565565b6108d461064b565b6108df906010610d71565b63ffffffff166108ef9190610d9d565b905060006108fb610853565b6109036105c6565b63ffffffff166109139190610d9d565b905060006109218284610d59565b61092b9085610d9d565b90506109396006600a610efa565b610944906010610d9d565b61094e9082610f06565b9695505050505050565b60008061096483610ab4565b9050600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16639e8c49666040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109c7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109eb9190610cb5565b6109f3610565565b73420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16638b239f736040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a52573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a769190610cb5565b610a809085610d59565b610a8a9190610d9d565b610a949190610d9d565b9050610aa26006600a610efa565b610aac9082610f06565b949350505050565b80516000908190815b81811015610b3757848181518110610ad757610ad7610f41565b01602001517fff0000000000000000000000000000000000000000000000000000000000000016600003610b1757610b10600484610d59565b9250610b25565b610b22601084610d59565b92505b80610b2f81610f70565b915050610abd565b50610aac82610440610d59565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b600060208284031215610b8557600080fd5b813567ffffffffffffffff80821115610b9d57600080fd5b818401915084601f830112610bb157600080fd5b813581811115610bc357610bc3610b44565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f01168101908382118183101715610c0957610c09610b44565b81604052828152876020848701011115610c2257600080fd5b826020860160208301376000928101602001929092525095945050505050565b600060208083528351808285015260005b81811015610c6f57858101830151858201604001528201610c53565b81811115610c81576000604083870101525b50601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016929092016040019392505050565b600060208284031215610cc757600080fd5b5051919050565b600060208284031215610ce057600080fd5b815173ffffffffffffffffffffffffffffffffffffffff8116811461075957600080fd5b600060208284031215610d1657600080fd5b815163ffffffff8116811461075957600080fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b60008219821115610d6c57610d6c610d2a565b500190565b600063ffffffff80831681851681830481118215151615610d9457610d94610d2a565b02949350505050565b6000817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0483118215151615610dd557610dd5610d2a565b500290565b600181815b80851115610e3357817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff04821115610e1957610e19610d2a565b80851615610e2657918102915b93841c9390800290610ddf565b509250929050565b600082610e4a57506001610556565b81610e5757506000610556565b8160018114610e6d5760028114610e7757610e93565b6001915050610556565b60ff841115610e8857610e88610d2a565b50506001821b610556565b5060208310610133831016604e8410600b8410161715610eb6575081810a610556565b610ec08383610dda565b807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff04821115610ef257610ef2610d2a565b029392505050565b60006107598383610e3b565b600082610f3c577f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b500490565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fd5b60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203610fa157610fa1610d2a565b506001019056fea164736f6c634300080f000a",
+}
+
+// GasPriceOracleABI is the input ABI used to generate the binding from.
+// Deprecated: Use GasPriceOracleMetaData.ABI instead.
+var GasPriceOracleABI = GasPriceOracleMetaData.ABI
+
+// GasPriceOracleBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use GasPriceOracleMetaData.Bin instead.
+var GasPriceOracleBin = GasPriceOracleMetaData.Bin
+
+// DeployGasPriceOracle deploys a new Ethereum contract, binding an instance of GasPriceOracle to it.
+func DeployGasPriceOracle(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *GasPriceOracle, error) {
+	parsed, err := GasPriceOracleMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(GasPriceOracleBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &GasPriceOracle{GasPriceOracleCaller: GasPriceOracleCaller{contract: contract}, GasPriceOracleTransactor: GasPriceOracleTransactor{contract: contract}, GasPriceOracleFilterer: GasPriceOracleFilterer{contract: contract}}, nil
+}
+
+// GasPriceOracle is an auto generated Go binding around an Ethereum contract.
+type GasPriceOracle struct {
+	GasPriceOracleCaller     // Read-only binding to the contract
+	GasPriceOracleTransactor // Write-only binding to the contract
+	GasPriceOracleFilterer   // Log filterer for contract events
+}
+
+// GasPriceOracleCaller is an auto generated read-only Go binding around an Ethereum contract.
+type GasPriceOracleCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GasPriceOracleTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type GasPriceOracleTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GasPriceOracleFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type GasPriceOracleFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GasPriceOracleSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type GasPriceOracleSession struct {
+	Contract     *GasPriceOracle   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// GasPriceOracleCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type GasPriceOracleCallerSession struct {
+	Contract *GasPriceOracleCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// GasPriceOracleTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type GasPriceOracleTransactorSession struct {
+	Contract     *GasPriceOracleTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// GasPriceOracleRaw is an auto generated low-level Go binding around an Ethereum contract.
+type GasPriceOracleRaw struct {
+	Contract *GasPriceOracle // Generic contract binding to access the raw methods on
+}
+
+// GasPriceOracleCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type GasPriceOracleCallerRaw struct {
+	Contract *GasPriceOracleCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// GasPriceOracleTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type GasPriceOracleTransactorRaw struct {
+	Contract *GasPriceOracleTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewGasPriceOracle creates a new instance of GasPriceOracle, bound to a specific deployed contract.
+func NewGasPriceOracle(address common.Address, backend bind.ContractBackend) (*GasPriceOracle, error) {
+	contract, err := bindGasPriceOracle(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &GasPriceOracle{GasPriceOracleCaller: GasPriceOracleCaller{contract: contract}, GasPriceOracleTransactor: GasPriceOracleTransactor{contract: contract}, GasPriceOracleFilterer: GasPriceOracleFilterer{contract: contract}}, nil
+}
+
+// NewGasPriceOracleCaller creates a new read-only instance of GasPriceOracle, bound to a specific deployed contract.
+func NewGasPriceOracleCaller(address common.Address, caller bind.ContractCaller) (*GasPriceOracleCaller, error) {
+	contract, err := bindGasPriceOracle(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GasPriceOracleCaller{contract: contract}, nil
+}
+
+// NewGasPriceOracleTransactor creates a new write-only instance of GasPriceOracle, bound to a specific deployed contract.
+func NewGasPriceOracleTransactor(address common.Address, transactor bind.ContractTransactor) (*GasPriceOracleTransactor, error) {
+	contract, err := bindGasPriceOracle(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GasPriceOracleTransactor{contract: contract}, nil
+}
+
+// NewGasPriceOracleFilterer creates a new log filterer instance of GasPriceOracle, bound to a specific deployed contract.
+func NewGasPriceOracleFilterer(address common.Address, filterer bind.ContractFilterer) (*GasPriceOracleFilterer, error) {
+	contract, err := bindGasPriceOracle(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &GasPriceOracleFilterer{contract: contract}, nil
+}
+
+// bindGasPriceOracle binds a generic wrapper to an already deployed contract.
+func bindGasPriceOracle(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(GasPriceOracleABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GasPriceOracle *GasPriceOracleRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _GasPriceOracle.Contract.GasPriceOracleCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GasPriceOracle *GasPriceOracleRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.GasPriceOracleTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GasPriceOracle *GasPriceOracleRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.GasPriceOracleTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GasPriceOracle *GasPriceOracleCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _GasPriceOracle.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GasPriceOracle *GasPriceOracleTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GasPriceOracle *GasPriceOracleTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.contract.Transact(opts, method, params...)
+}
+
+// DECIMALS is a free data retrieval call binding the contract method 0x2e0f2625.
+//
+// Solidity: function DECIMALS() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) DECIMALS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "DECIMALS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DECIMALS is a free data retrieval call binding the contract method 0x2e0f2625.
+//
+// Solidity: function DECIMALS() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) DECIMALS() (*big.Int, error) {
+	return _GasPriceOracle.Contract.DECIMALS(&_GasPriceOracle.CallOpts)
+}
+
+// DECIMALS is a free data retrieval call binding the contract method 0x2e0f2625.
+//
+// Solidity: function DECIMALS() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) DECIMALS() (*big.Int, error) {
+	return _GasPriceOracle.Contract.DECIMALS(&_GasPriceOracle.CallOpts)
+}
+
+// BaseFee is a free data retrieval call binding the contract method 0x6ef25c3a.
+//
+// Solidity: function baseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) BaseFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "baseFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BaseFee is a free data retrieval call binding the contract method 0x6ef25c3a.
+//
+// Solidity: function baseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) BaseFee() (*big.Int, error) {
+	return _GasPriceOracle.Contract.BaseFee(&_GasPriceOracle.CallOpts)
+}
+
+// BaseFee is a free data retrieval call binding the contract method 0x6ef25c3a.
+//
+// Solidity: function baseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) BaseFee() (*big.Int, error) {
+	return _GasPriceOracle.Contract.BaseFee(&_GasPriceOracle.CallOpts)
+}
+
+// BaseFeeScalar is a free data retrieval call binding the contract method 0xc5985918.
+//
+// Solidity: function baseFeeScalar() view returns(uint32)
+func (_GasPriceOracle *GasPriceOracleCaller) BaseFeeScalar(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "baseFeeScalar")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// BaseFeeScalar is a free data retrieval call binding the contract method 0xc5985918.
+//
+// Solidity: function baseFeeScalar() view returns(uint32)
+func (_GasPriceOracle *GasPriceOracleSession) BaseFeeScalar() (uint32, error) {
+	return _GasPriceOracle.Contract.BaseFeeScalar(&_GasPriceOracle.CallOpts)
+}
+
+// BaseFeeScalar is a free data retrieval call binding the contract method 0xc5985918.
+//
+// Solidity: function baseFeeScalar() view returns(uint32)
+func (_GasPriceOracle *GasPriceOracleCallerSession) BaseFeeScalar() (uint32, error) {
+	return _GasPriceOracle.Contract.BaseFeeScalar(&_GasPriceOracle.CallOpts)
+}
+
+// BlobBaseFee is a free data retrieval call binding the contract method 0xf8206140.
+//
+// Solidity: function blobBaseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) BlobBaseFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "blobBaseFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BlobBaseFee is a free data retrieval call binding the contract method 0xf8206140.
+//
+// Solidity: function blobBaseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) BlobBaseFee() (*big.Int, error) {
+	return _GasPriceOracle.Contract.BlobBaseFee(&_GasPriceOracle.CallOpts)
+}
+
+// BlobBaseFee is a free data retrieval call binding the contract method 0xf8206140.
+//
+// Solidity: function blobBaseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) BlobBaseFee() (*big.Int, error) {
+	return _GasPriceOracle.Contract.BlobBaseFee(&_GasPriceOracle.CallOpts)
+}
+
+// BlobBaseFeeScalar is a free data retrieval call binding the contract method 0x68d5dca6.
+//
+// Solidity: function blobBaseFeeScalar() view returns(uint32)
+func (_GasPriceOracle *GasPriceOracleCaller) BlobBaseFeeScalar(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "blobBaseFeeScalar")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// BlobBaseFeeScalar is a free data retrieval call binding the contract method 0x68d5dca6.
+//
+// Solidity: function blobBaseFeeScalar() view returns(uint32)
+func (_GasPriceOracle *GasPriceOracleSession) BlobBaseFeeScalar() (uint32, error) {
+	return _GasPriceOracle.Contract.BlobBaseFeeScalar(&_GasPriceOracle.CallOpts)
+}
+
+// BlobBaseFeeScalar is a free data retrieval call binding the contract method 0x68d5dca6.
+//
+// Solidity: function blobBaseFeeScalar() view returns(uint32)
+func (_GasPriceOracle *GasPriceOracleCallerSession) BlobBaseFeeScalar() (uint32, error) {
+	return _GasPriceOracle.Contract.BlobBaseFeeScalar(&_GasPriceOracle.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() pure returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) Decimals(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() pure returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) Decimals() (*big.Int, error) {
+	return _GasPriceOracle.Contract.Decimals(&_GasPriceOracle.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() pure returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) Decimals() (*big.Int, error) {
+	return _GasPriceOracle.Contract.Decimals(&_GasPriceOracle.CallOpts)
+}
+
+// GasPrice is a free data retrieval call binding the contract method 0xfe173b97.
+//
+// Solidity: function gasPrice() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) GasPrice(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "gasPrice")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GasPrice is a free data retrieval call binding the contract method 0xfe173b97.
+//
+// Solidity: function gasPrice() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) GasPrice() (*big.Int, error) {
+	return _GasPriceOracle.Contract.GasPrice(&_GasPriceOracle.CallOpts)
+}
+
+// GasPrice is a free data retrieval call binding the contract method 0xfe173b97.
+//
+// Solidity: function gasPrice() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) GasPrice() (*big.Int, error) {
+	return _GasPriceOracle.Contract.GasPrice(&_GasPriceOracle.CallOpts)
+}
+
+// GetL1Fee is a free data retrieval call binding the contract method 0x49948e0e.
+//
+// Solidity: function getL1Fee(bytes _data) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) GetL1Fee(opts *bind.CallOpts, _data []byte) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "getL1Fee", _data)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetL1Fee is a free data retrieval call binding the contract method 0x49948e0e.
+//
+// Solidity: function getL1Fee(bytes _data) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) GetL1Fee(_data []byte) (*big.Int, error) {
+	return _GasPriceOracle.Contract.GetL1Fee(&_GasPriceOracle.CallOpts, _data)
+}
+
+// GetL1Fee is a free data retrieval call binding the contract method 0x49948e0e.
+//
+// Solidity: function getL1Fee(bytes _data) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) GetL1Fee(_data []byte) (*big.Int, error) {
+	return _GasPriceOracle.Contract.GetL1Fee(&_GasPriceOracle.CallOpts, _data)
+}
+
+// GetL1GasUsed is a free data retrieval call binding the contract method 0xde26c4a1.
+//
+// Solidity: function getL1GasUsed(bytes _data) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) GetL1GasUsed(opts *bind.CallOpts, _data []byte) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "getL1GasUsed", _data)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetL1GasUsed is a free data retrieval call binding the contract method 0xde26c4a1.
+//
+// Solidity: function getL1GasUsed(bytes _data) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) GetL1GasUsed(_data []byte) (*big.Int, error) {
+	return _GasPriceOracle.Contract.GetL1GasUsed(&_GasPriceOracle.CallOpts, _data)
+}
+
+// GetL1GasUsed is a free data retrieval call binding the contract method 0xde26c4a1.
+//
+// Solidity: function getL1GasUsed(bytes _data) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) GetL1GasUsed(_data []byte) (*big.Int, error) {
+	return _GasPriceOracle.Contract.GetL1GasUsed(&_GasPriceOracle.CallOpts, _data)
+}
+
+// IsEcotone is a free data retrieval call binding the contract method 0x4ef6e224.
+//
+// Solidity: function isEcotone() view returns(bool)
+func (_GasPriceOracle *GasPriceOracleCaller) IsEcotone(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "isEcotone")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsEcotone is a free data retrieval call binding the contract method 0x4ef6e224.
+//
+// Solidity: function isEcotone() view returns(bool)
+func (_GasPriceOracle *GasPriceOracleSession) IsEcotone() (bool, error) {
+	return _GasPriceOracle.Contract.IsEcotone(&_GasPriceOracle.CallOpts)
+}
+
+// IsEcotone is a free data retrieval call binding the contract method 0x4ef6e224.
+//
+// Solidity: function isEcotone() view returns(bool)
+func (_GasPriceOracle *GasPriceOracleCallerSession) IsEcotone() (bool, error) {
+	return _GasPriceOracle.Contract.IsEcotone(&_GasPriceOracle.CallOpts)
+}
+
+// L1BaseFee is a free data retrieval call binding the contract method 0x519b4bd3.
+//
+// Solidity: function l1BaseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) L1BaseFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "l1BaseFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// L1BaseFee is a free data retrieval call binding the contract method 0x519b4bd3.
+//
+// Solidity: function l1BaseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) L1BaseFee() (*big.Int, error) {
+	return _GasPriceOracle.Contract.L1BaseFee(&_GasPriceOracle.CallOpts)
+}
+
+// L1BaseFee is a free data retrieval call binding the contract method 0x519b4bd3.
+//
+// Solidity: function l1BaseFee() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) L1BaseFee() (*big.Int, error) {
+	return _GasPriceOracle.Contract.L1BaseFee(&_GasPriceOracle.CallOpts)
+}
+
+// Overhead is a free data retrieval call binding the contract method 0x0c18c162.
+//
+// Solidity: function overhead() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) Overhead(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "overhead")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Overhead is a free data retrieval call binding the contract method 0x0c18c162.
+//
+// Solidity: function overhead() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) Overhead() (*big.Int, error) {
+	return _GasPriceOracle.Contract.Overhead(&_GasPriceOracle.CallOpts)
+}
+
+// Overhead is a free data retrieval call binding the contract method 0x0c18c162.
+//
+// Solidity: function overhead() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) Overhead() (*big.Int, error) {
+	return _GasPriceOracle.Contract.Overhead(&_GasPriceOracle.CallOpts)
+}
+
+// Scalar is a free data retrieval call binding the contract method 0xf45e65d8.
+//
+// Solidity: function scalar() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) Scalar(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "scalar")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Scalar is a free data retrieval call binding the contract method 0xf45e65d8.
+//
+// Solidity: function scalar() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) Scalar() (*big.Int, error) {
+	return _GasPriceOracle.Contract.Scalar(&_GasPriceOracle.CallOpts)
+}
+
+// Scalar is a free data retrieval call binding the contract method 0xf45e65d8.
+//
+// Solidity: function scalar() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) Scalar() (*big.Int, error) {
+	return _GasPriceOracle.Contract.Scalar(&_GasPriceOracle.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_GasPriceOracle *GasPriceOracleCaller) Version(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_GasPriceOracle *GasPriceOracleSession) Version() (string, error) {
+	return _GasPriceOracle.Contract.Version(&_GasPriceOracle.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_GasPriceOracle *GasPriceOracleCallerSession) Version() (string, error) {
+	return _GasPriceOracle.Contract.Version(&_GasPriceOracle.CallOpts)
+}
+
+// SetEcotone is a paid mutator transaction binding the contract method 0x22b90ab3.
+//
+// Solidity: function setEcotone() returns()
+func (_GasPriceOracle *GasPriceOracleTransactor) SetEcotone(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GasPriceOracle.contract.Transact(opts, "setEcotone")
+}
+
+// SetEcotone is a paid mutator transaction binding the contract method 0x22b90ab3.
+//
+// Solidity: function setEcotone() returns()
+func (_GasPriceOracle *GasPriceOracleSession) SetEcotone() (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetEcotone(&_GasPriceOracle.TransactOpts)
+}
+
+// SetEcotone is a paid mutator transaction binding the contract method 0x22b90ab3.
+//
+// Solidity: function setEcotone() returns()
+func (_GasPriceOracle *GasPriceOracleTransactorSession) SetEcotone() (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetEcotone(&_GasPriceOracle.TransactOpts)
+}

--- a/op-chain-ops/cmd/check-ecotone/main.go
+++ b/op-chain-ops/cmd/check-ecotone/main.go
@@ -26,7 +26,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-ecotone/bindings"
+	nbindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -702,7 +703,7 @@ func checkUpgradeTxs(ctx context.Context, env *actionEnv) error {
 }
 
 func checkL1Block(ctx context.Context, env *actionEnv) error {
-	cl, err := bindings.NewL1Block(predeploys.L1BlockAddr, env.l2)
+	cl, err := nbindings.NewL1Block(predeploys.L1BlockAddr, env.l2)
 	if err != nil {
 		return fmt.Errorf("failed to create bindings around L1Block contract: %w", err)
 	}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -391,7 +392,7 @@ func (d *DeployConfig) Check() error {
 	}
 	// When the initial resource config is made to be configurable by the DeployConfig, ensure
 	// that this check is updated to use the values from the DeployConfig instead of the defaults.
-	if uint64(d.L2GenesisBlockGasLimit) < uint64(DefaultResourceConfig.MaxResourceLimit+DefaultResourceConfig.SystemTxMaxGas) {
+	if uint64(d.L2GenesisBlockGasLimit) < uint64(upgrades.DefaultResourceConfig.MaxResourceLimit+upgrades.DefaultResourceConfig.SystemTxMaxGas) {
 		return fmt.Errorf("%w: L2 genesis block gas limit is too small", ErrInvalidDeployConfig)
 	}
 	if d.L2GenesisBlockBaseFeePerGas == nil {

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -28,6 +27,24 @@ import (
 var (
 	ErrInvalidDeployConfig     = errors.New("invalid deploy config")
 	ErrInvalidImmutablesConfig = errors.New("invalid immutables config")
+	// MaximumBaseFee represents the max base fee for deposits, since
+	// there is an on chain EIP-1559 curve for deposits purchasing L2 gas.
+	// It is type(uint128).max in solidity.
+	MaximumBaseFee, _ = new(big.Int).SetString("ffffffffffffffffffffffffffffffff", 16)
+)
+
+const (
+	// MaxResourceLimit represents the maximum amount of L2 gas that a single deposit can use.
+	MaxResourceLimit = 20_000_000
+	// ElasticityMultiplier represents the elasticity of the deposit EIP-1559 fee market.
+	ElasticityMultiplier = 10
+	// BaseFeeMaxChangeDenominator represents the maximum change in base fee per block.
+	BaseFeeMaxChangeDenominator = 8
+	// MinimumBaseFee represents the minimum base fee for deposits.
+	MinimumBaseFee = params.GWei
+	// SystemTxMaxGas represents the maximum gas that a system transaction can use
+	// when it is included with user deposits.
+	SystemTxMaxGas = 1_000_000
 )
 
 // DeployConfig represents the deployment configuration for an OP Stack chain.

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -409,7 +409,7 @@ func (d *DeployConfig) Check() error {
 	}
 	// When the initial resource config is made to be configurable by the DeployConfig, ensure
 	// that this check is updated to use the values from the DeployConfig instead of the defaults.
-	if uint64(d.L2GenesisBlockGasLimit) < uint64(upgrades.DefaultResourceConfig.MaxResourceLimit+upgrades.DefaultResourceConfig.SystemTxMaxGas) {
+	if uint64(d.L2GenesisBlockGasLimit) < uint64(MaxResourceLimit+SystemTxMaxGas) {
 		return fmt.Errorf("%w: L2 genesis block gas limit is too small", ErrInvalidDeployConfig)
 	}
 	if d.L2GenesisBlockBaseFeePerGas == nil {

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -7,39 +7,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
-
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 )
 
 // PrecompileCount represents the number of precompile addresses
 // starting from `address(0)` to PrecompileCount that are funded
 // with a single wei in the genesis state.
 const PrecompileCount = 256
-
-var (
-	// uint128Max is type(uint128).max and is set in the init function.
-	uint128Max = new(big.Int)
-	// The default values for the ResourceConfig, used as part of
-	// an EIP-1559 curve for deposit gas.
-	DefaultResourceConfig = bindings.ResourceMeteringResourceConfig{
-		MaxResourceLimit:            20_000_000,
-		ElasticityMultiplier:        10,
-		BaseFeeMaxChangeDenominator: 8,
-		MinimumBaseFee:              params.GWei,
-		SystemTxMaxGas:              1_000_000,
-	}
-)
-
-func init() {
-	var ok bool
-	uint128Max, ok = new(big.Int).SetString("ffffffffffffffffffffffffffffffff", 16)
-	if !ok {
-		panic("bad uint128Max")
-	}
-	// Set the maximum base fee on the default config.
-	DefaultResourceConfig.MaximumBaseFee = uint128Max
-}
 
 // BuildL1DeveloperGenesis will create a L1 genesis block after creating
 // all of the state required for an Optimism network to function.

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -3,14 +3,40 @@ package upgrades
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades/bindings"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
+
+var (
+	// uint128Max is type(uint128).max and is set in the init function.
+	uint128Max = new(big.Int)
+	// The default values for the ResourceConfig, used as part of
+	// an EIP-1559 curve for deposit gas.
+	DefaultResourceConfig = bindings.ResourceMeteringResourceConfig{
+		MaxResourceLimit:            20_000_000,
+		ElasticityMultiplier:        10,
+		BaseFeeMaxChangeDenominator: 8,
+		MinimumBaseFee:              params.GWei,
+		SystemTxMaxGas:              1_000_000,
+	}
+)
+
+func init() {
+	var ok bool
+	uint128Max, ok = new(big.Int).SetString("ffffffffffffffffffffffffffffffff", 16)
+	if !ok {
+		panic("bad uint128Max")
+	}
+	// Set the maximum base fee on the default config.
+	DefaultResourceConfig.MaximumBaseFee = uint128Max
+}
 
 // CheckL1 will check that the versions of the contracts on L1 match the versions
 // in the superchain registry.

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -3,40 +3,28 @@ package upgrades
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"strings"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades/bindings"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
 var (
-	// uint128Max is type(uint128).max and is set in the init function.
-	uint128Max = new(big.Int)
 	// The default values for the ResourceConfig, used as part of
 	// an EIP-1559 curve for deposit gas.
 	DefaultResourceConfig = bindings.ResourceMeteringResourceConfig{
-		MaxResourceLimit:            20_000_000,
-		ElasticityMultiplier:        10,
-		BaseFeeMaxChangeDenominator: 8,
-		MinimumBaseFee:              params.GWei,
-		SystemTxMaxGas:              1_000_000,
+		MaxResourceLimit:            genesis.MaxResourceLimit,
+		ElasticityMultiplier:        genesis.ElasticityMultiplier,
+		BaseFeeMaxChangeDenominator: genesis.BaseFeeMaxChangeDenominator,
+		MinimumBaseFee:              genesis.MinimumBaseFee,
+		SystemTxMaxGas:              genesis.SystemTxMaxGas,
+		MaximumBaseFee:              genesis.MaximumBaseFee,
 	}
 )
-
-func init() {
-	var ok bool
-	uint128Max, ok = new(big.Int).SetString("ffffffffffffffffffffffffffffffff", 16)
-	if !ok {
-		panic("bad uint128Max")
-	}
-	// Set the maximum base fee on the default config.
-	DefaultResourceConfig.MaximumBaseFee = uint128Max
-}
 
 // CheckL1 will check that the versions of the contracts on L1 match the versions
 // in the superchain registry.

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -725,22 +725,22 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		return err
 	}
 
-	if resourceConfig.MaxResourceLimit != genesis.DefaultResourceConfig.MaxResourceLimit {
+	if resourceConfig.MaxResourceLimit != DefaultResourceConfig.MaxResourceLimit {
 		return fmt.Errorf("DefaultResourceConfig MaxResourceLimit doesn't match contract MaxResourceLimit")
 	}
-	if resourceConfig.ElasticityMultiplier != genesis.DefaultResourceConfig.ElasticityMultiplier {
+	if resourceConfig.ElasticityMultiplier != DefaultResourceConfig.ElasticityMultiplier {
 		return fmt.Errorf("DefaultResourceConfig ElasticityMultiplier doesn't match contract ElasticityMultiplier")
 	}
-	if resourceConfig.BaseFeeMaxChangeDenominator != genesis.DefaultResourceConfig.BaseFeeMaxChangeDenominator {
+	if resourceConfig.BaseFeeMaxChangeDenominator != DefaultResourceConfig.BaseFeeMaxChangeDenominator {
 		return fmt.Errorf("DefaultResourceConfig BaseFeeMaxChangeDenominator doesn't match contract BaseFeeMaxChangeDenominator")
 	}
-	if resourceConfig.MinimumBaseFee != genesis.DefaultResourceConfig.MinimumBaseFee {
+	if resourceConfig.MinimumBaseFee != DefaultResourceConfig.MinimumBaseFee {
 		return fmt.Errorf("DefaultResourceConfig MinimumBaseFee doesn't match contract MinimumBaseFee")
 	}
-	if resourceConfig.SystemTxMaxGas != genesis.DefaultResourceConfig.SystemTxMaxGas {
+	if resourceConfig.SystemTxMaxGas != DefaultResourceConfig.SystemTxMaxGas {
 		return fmt.Errorf("DefaultResourceConfig SystemTxMaxGas doesn't match contract SystemTxMaxGas")
 	}
-	if resourceConfig.MaximumBaseFee.Cmp(genesis.DefaultResourceConfig.MaximumBaseFee) != 0 {
+	if resourceConfig.MaximumBaseFee.Cmp(DefaultResourceConfig.MaximumBaseFee) != 0 {
 		return fmt.Errorf("DefaultResourceConfig MaximumBaseFee doesn't match contract MaximumBaseFee")
 	}
 
@@ -756,7 +756,7 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		batcherHash,
 		l2GenesisBlockGasLimit,
 		p2pSequencerAddress,
-		genesis.DefaultResourceConfig,
+		DefaultResourceConfig,
 		chainConfig.BatchInboxAddr,
 		bindings.SystemConfigAddresses{
 			L1CrossDomainMessenger:       common.Address(list.L1CrossDomainMessengerProxy),


### PR DESCRIPTION
**Description**

More small bindings decoupling. After this PR is merged,
it should be possible to move `op-bindings/bindings` into
`op-e2e/bindings`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
