### PR TITLE
op-conductor: metrics

### DIFF
--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -19,6 +19,7 @@ import (
 	consensusmocks "github.com/ethereum-optimism/optimism/op-conductor/consensus/mocks"
 	"github.com/ethereum-optimism/optimism/op-conductor/health"
 	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
+	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -88,6 +89,7 @@ type OpConductorTestSuite struct {
 	err     error
 	log     log.Logger
 	cfg     Config
+	metrics metrics.Metricer
 	version string
 	ctrl    *clientmocks.SequencerControl
 	cons    *consensusmocks.Consensus
@@ -101,6 +103,7 @@ type OpConductorTestSuite struct {
 func (s *OpConductorTestSuite) SetupSuite() {
 	s.ctx = context.Background()
 	s.log = testlog.Logger(s.T(), log.LevelDebug)
+	s.metrics = &metrics.NoopMetricsImpl{}
 	s.cfg = mockConfig(s.T())
 	s.version = "v0.0.1"
 	s.next = make(chan struct{}, 1)
@@ -113,7 +116,7 @@ func (s *OpConductorTestSuite) SetupTest() {
 	s.hmon = &healthmocks.HealthMonitor{}
 	s.cons.EXPECT().ServerID().Return("SequencerA")
 
-	conductor, err := NewOpConductor(s.ctx, &s.cfg, s.log, s.version, s.ctrl, s.cons, s.hmon)
+	conductor, err := NewOpConductor(s.ctx, &s.cfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon)
 	s.NoError(err)
 	s.conductor = conductor
 

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -34,9 +35,10 @@ type HealthMonitor interface {
 // interval is the interval between health checks measured in seconds.
 // safeInterval is the interval between safe head progress measured in seconds.
 // minPeerCount is the minimum number of peers required for the sequencer to be healthy.
-func NewSequencerHealthMonitor(log log.Logger, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p p2p.API) HealthMonitor {
+func NewSequencerHealthMonitor(log log.Logger, metrics metrics.Metricer, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p p2p.API) HealthMonitor {
 	return &SequencerHealthMonitor{
 		log:            log,
+		metrics:        metrics,
 		done:           make(chan struct{}),
 		interval:       interval,
 		healthUpdateCh: make(chan error),
@@ -53,9 +55,10 @@ func NewSequencerHealthMonitor(log log.Logger, interval, unsafeInterval, safeInt
 
 // SequencerHealthMonitor monitors sequencer health.
 type SequencerHealthMonitor struct {
-	log  log.Logger
-	done chan struct{}
-	wg   sync.WaitGroup
+	log     log.Logger
+	metrics metrics.Metricer
+	done    chan struct{}
+	wg      sync.WaitGroup
 
 	rollupCfg          *rollup.Config
 	unsafeInterval     uint64
@@ -112,7 +115,9 @@ func (hm *SequencerHealthMonitor) loop() {
 		case <-hm.done:
 			return
 		case <-ticker.C:
-			hm.healthUpdateCh <- hm.healthCheck()
+			err := hm.healthCheck()
+			hm.metrics.RecordHealthCheck(err == nil, err)
+			hm.healthUpdateCh <- err
 		}
 	}
 }

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	p2pMocks "github.com/ethereum-optimism/optimism/op-node/p2p/mocks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -58,6 +59,7 @@ func (s *HealthMonitorTestSuite) SetupMonitor(
 		log:            s.log,
 		done:           make(chan struct{}),
 		interval:       s.interval,
+		metrics:        &metrics.NoopMetricsImpl{},
 		healthUpdateCh: make(chan error),
 		rollupCfg:      s.rollupCfg,
 		unsafeInterval: unsafeInterval,

--- a/op-conductor/metrics/metrics.go
+++ b/op-conductor/metrics/metrics.go
@@ -1,0 +1,157 @@
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const Namespace = "op_conductor"
+
+type Metricer interface {
+	RecordInfo(version string)
+	RecordUp()
+	RecordStateChange(leader bool, healthy bool, active bool)
+	RecordLeaderTransfer(success bool)
+	RecordStartSequencer(success bool)
+	RecordStopSequencer(success bool)
+	RecordHealthCheck(success bool, err error)
+	RecordLoopExecutionTime(duration float64)
+}
+
+// Metrics implementation must implement RegistryMetricer to allow the metrics server to work.
+var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
+
+type Metrics struct {
+	ns       string
+	registry *prometheus.Registry
+	factory  opmetrics.Factory
+
+	info prometheus.GaugeVec
+	up   prometheus.Gauge
+
+	healthChecks    *prometheus.CounterVec
+	leaderTransfers *prometheus.CounterVec
+	sequencerStarts *prometheus.CounterVec
+	sequencerStops  *prometheus.CounterVec
+	stateChanges    *prometheus.CounterVec
+
+	loopExecutionTime prometheus.Histogram
+}
+
+func (m *Metrics) Registry() *prometheus.Registry {
+	return m.registry
+}
+
+var _ Metricer = (*Metrics)(nil)
+
+func NewMetrics() *Metrics {
+	registry := opmetrics.NewRegistry()
+	factory := opmetrics.With(registry)
+
+	return &Metrics{
+		ns:       Namespace,
+		registry: registry,
+		factory:  factory,
+
+		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "info",
+			Help:      "Pseudo-metric tracking version and config info",
+		}, []string{
+			"version",
+		}),
+		up: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "up",
+			Help:      "1 if the op-conductor has finished starting up",
+		}),
+		healthChecks: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "healthchecks_count",
+			Help:      "Number of healthchecks",
+		}, []string{"success", "error"}),
+		leaderTransfers: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "leader_transfers_count",
+			Help:      "Number of leader transfers",
+		}, []string{"success"}),
+		sequencerStarts: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "sequencer_starts_count",
+			Help:      "Number of sequencer starts",
+		}, []string{"success"}),
+		sequencerStops: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "sequencer_stops_count",
+			Help:      "Number of sequencer stops",
+		}, []string{"success"}),
+		stateChanges: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "state_changes_count",
+			Help:      "Number of state changes",
+		}, []string{
+			"leader",
+			"healthy",
+			"active",
+		}),
+		loopExecutionTime: factory.NewHistogram(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "loop_execution_time",
+			Help:      "Time (in seconds) to execute conductor loop iteration",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}),
+	}
+}
+
+func (m *Metrics) Start(host string, port int) (*httputil.HTTPServer, error) {
+	return opmetrics.StartServer(m.registry, host, port)
+}
+
+// RecordInfo sets a pseudo-metric that contains versioning and
+// config info for the op-proposer.
+func (m *Metrics) RecordInfo(version string) {
+	m.info.WithLabelValues(version).Set(1)
+}
+
+// RecordUp sets the up metric to 1.
+func (m *Metrics) RecordUp() {
+	prometheus.MustRegister()
+	m.up.Set(1)
+}
+
+// RecordHealthCheck increments the healthChecks counter.
+func (m *Metrics) RecordHealthCheck(success bool, err error) {
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	m.healthChecks.WithLabelValues(strconv.FormatBool(success), errStr).Inc()
+}
+
+// RecordLeaderTransfer increments the leaderTransfers counter.
+func (m *Metrics) RecordLeaderTransfer(success bool) {
+	m.leaderTransfers.WithLabelValues(strconv.FormatBool(success)).Inc()
+}
+
+// RecordStateChange increments the stateChanges counter.
+func (m *Metrics) RecordStateChange(leader bool, healthy bool, active bool) {
+	m.stateChanges.WithLabelValues(strconv.FormatBool(leader), strconv.FormatBool(healthy), strconv.FormatBool(active)).Inc()
+}
+
+// RecordStartSequencer increments the sequencerStarts counter.
+func (m *Metrics) RecordStartSequencer(success bool) {
+	m.sequencerStarts.WithLabelValues(strconv.FormatBool(success)).Inc()
+}
+
+// RecordStopSequencer increments the sequencerStops counter.
+func (m *Metrics) RecordStopSequencer(success bool) {
+	m.sequencerStops.WithLabelValues(strconv.FormatBool(success)).Inc()
+}
+
+// RecordLoopExecutionTime records the time it took to execute the conductor loop.
+func (m *Metrics) RecordLoopExecutionTime(duration float64) {
+	m.loopExecutionTime.Observe(duration)
+}

--- a/op-conductor/metrics/noop.go
+++ b/op-conductor/metrics/noop.go
@@ -1,0 +1,14 @@
+package metrics
+
+type NoopMetricsImpl struct{}
+
+var NoopMetrics Metricer = new(NoopMetricsImpl)
+
+func (*NoopMetricsImpl) RecordInfo(version string)                                {}
+func (*NoopMetricsImpl) RecordUp()                                                {}
+func (*NoopMetricsImpl) RecordStateChange(leader bool, healthy bool, active bool) {}
+func (*NoopMetricsImpl) RecordLeaderTransfer(success bool)                        {}
+func (*NoopMetricsImpl) RecordStartSequencer(success bool)                        {}
+func (*NoopMetricsImpl) RecordStopSequencer(success bool)                         {}
+func (*NoopMetricsImpl) RecordHealthCheck(success bool, err error)                {}
+func (*NoopMetricsImpl) RecordLoopExecutionTime(duration float64)                 {}


### PR DESCRIPTION
**Description**

Adds metrics emitted in conductor's execution and healthcheck loops including:
- healthchecks count
- leadership transfer count
- sequencer / start stops
- state changes
- conductor loop execution times