### PR TITLE
perf: remove defer inside loop

### DIFF
--- a/op-node/cmd/batch_decoder/fetch/fetch.go
+++ b/op-node/cmd/batch_decoder/fetch/fetch.go
@@ -134,11 +134,12 @@ func fetchBatchesPerBlock(ctx context.Context, client *ethclient.Client, number 
 			if err != nil {
 				return 0, 0, err
 			}
-			defer file.Close()
 			enc := json.NewEncoder(file)
 			if err := enc.Encode(txm); err != nil {
+				file.Close()
 				return 0, 0, err
 			}
+			file.Close()
 		}
 	}
 	return validBatchCount, invalidBatchCount, nil


### PR DESCRIPTION
**Description**
This PR removes  defer function inside the loop

The defer file.Close() statement is inside a loop that iterates over transactions. This means that each iteration potentially opens a new file, and the defer statement schedules the file to be closed when the function fetchBatchesPerBlock exits, not immediately after the loop iteration completes. This could cause resource exhaustion and delayed resource release

