### PR TITLE
deploy-config: delete duplicate keys

### DIFF
--- a/packages/contracts-bedrock/deploy-config/base-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/base-sepolia.json
@@ -52,7 +52,6 @@
 
   "l2GenesisRegolithTimeOffset": "0x0",
 
-  "finalSystemOwner": "0x608081689Fe46936fB2fBDF7552CbB1D80ad4822",
   "superchainConfigGuardian": "0xA9FF930151130fd19DA1F03E5077AFB7C78F8503",
 
   "systemConfigStartBlock": 0,

--- a/packages/core-utils/tsconfig.json
+++ b/packages/core-utils/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
-  },
-  "compilerOptions": {
+    "outDir": "./dist",
     "typeRoots": ["node_modules/@types"]
   },
   "include": [


### PR DESCRIPTION
**Description**

Based on https://github.com/ethereum-optimism/optimism/pull/10166

- **fix: delete duplicate keys in base-sepolia.json**
- **fix: delete duplicate keys in tsconfig.json**

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

