### PR TITLE
op-node: Add dedicated PlasmaConfig struct to rollup.Config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240510200259-4be7024d2ba7
 	github.com/ethereum/go-ethereum v1.13.15
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101315.1-rc.2 h1:uUrcs8fGrdDnVELB66GcMZRvwIeJow64DOtF+VFdAzY=
 github.com/ethereum-optimism/op-geth v1.101315.1-rc.2/go.mod h1:VXVFzx1mr/JyJac5M4k5W/+0cqHZMkqKsIVDsOyj2rs=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232 h1:jRdLJs4E3ilsDGK7+k39QPi3QKL/b1cLnyv8mfOCVo4=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240510200259-4be7024d2ba7 h1:e7oXWZwODAMM2TLo9beGDXaX2cCw7uM7qAqamYBHV40=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240510200259-4be7024d2ba7/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -614,6 +614,14 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 	if d.SystemConfigProxy == (common.Address{}) {
 		return nil, errors.New("SystemConfigProxy cannot be address(0)")
 	}
+	var plasma *rollup.PlasmaConfig
+	if d.UsePlasma {
+		plasma = &rollup.PlasmaConfig{
+			DAChallengeAddress: d.DAChallengeProxy,
+			DAChallengeWindow:  d.DAChallengeWindow,
+			DAResolveWindow:    d.DAResolveWindow,
+		}
+	}
 
 	return &rollup.Config{
 		Genesis: rollup.Genesis{
@@ -648,10 +656,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 		EcotoneTime:            d.EcotoneTime(l1StartBlock.Time()),
 		FjordTime:              d.FjordTime(l1StartBlock.Time()),
 		InteropTime:            d.InteropTime(l1StartBlock.Time()),
-		UsePlasma:              d.UsePlasma,
-		DAChallengeAddress:     d.DAChallengeProxy,
-		DAChallengeWindow:      d.DAChallengeWindow,
-		DAResolveWindow:        d.DAResolveWindow,
+		PlasmaConfig:           plasma,
 	}, nil
 }
 

--- a/op-e2e/actions/plasma_test.go
+++ b/op-e2e/actions/plasma_test.go
@@ -58,7 +58,7 @@ func NewL2PlasmaDA(t Testing, params ...PlasmaParam) *L2PlasmaDA {
 	dp := e2eutils.MakeDeployParams(t, p)
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 
-	require.True(t, sd.RollupCfg.UsePlasma)
+	require.True(t, sd.RollupCfg.PlasmaEnabled())
 
 	miner := NewL1Miner(t, log, sd.L1Cfg)
 	l1Client := miner.EthClient()
@@ -72,7 +72,7 @@ func NewL2PlasmaDA(t Testing, params ...PlasmaParam) *L2PlasmaDA {
 	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindBasic))
 	require.NoError(t, err)
 
-	plasmaCfg, err := sd.RollupCfg.PlasmaConfig()
+	plasmaCfg, err := sd.RollupCfg.GetOPPlasmaConfig()
 	require.NoError(t, err)
 
 	daMgr := plasma.NewPlasmaDAWithStorage(log, plasmaCfg, storage, &plasma.NoopMetrics{})
@@ -94,7 +94,7 @@ func NewL2PlasmaDA(t Testing, params ...PlasmaParam) *L2PlasmaDA {
 	alice := NewCrossLayerUser(log, dp.Secrets.Alice, rand.New(rand.NewSource(0xa57b)))
 	alice.L2.SetUserEnv(l2UserEnv)
 
-	contract, err := bindings.NewDataAvailabilityChallenge(sd.RollupCfg.DAChallengeAddress, l1Client)
+	contract, err := bindings.NewDataAvailabilityChallenge(sd.RollupCfg.PlasmaConfig.DAChallengeAddress, l1Client)
 	require.NoError(t, err)
 
 	challengeWindow, err := contract.ChallengeWindow(nil)

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -143,6 +143,15 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		l2Genesis.Alloc[addr] = val
 	}
 
+	var plasma *rollup.PlasmaConfig
+	if deployConf.UsePlasma {
+		plasma = &rollup.PlasmaConfig{
+			DAChallengeAddress: l1Deployments.DataAvailabilityChallengeProxy,
+			DAChallengeWindow:  deployConf.DAChallengeWindow,
+			DAResolveWindow:    deployConf.DAResolveWindow,
+		}
+	}
+
 	rollupCfg := &rollup.Config{
 		Genesis: rollup.Genesis{
 			L1: eth.BlockID{
@@ -171,10 +180,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		EcotoneTime:            deployConf.EcotoneTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 		FjordTime:              deployConf.FjordTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 		InteropTime:            deployConf.InteropTime(uint64(deployConf.L1GenesisBlockTimestamp)),
-		DAChallengeAddress:     l1Deployments.DataAvailabilityChallengeProxy,
-		DAChallengeWindow:      deployConf.DAChallengeWindow,
-		DAResolveWindow:        deployConf.DAResolveWindow,
-		UsePlasma:              deployConf.UsePlasma,
+		PlasmaConfig:           plasma,
 	}
 
 	require.NoError(t, rollupCfg.Check())

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -387,7 +387,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 	}
 
 	// if plasma is not explicitly activated in the node CLI, the config + any error will be ignored.
-	rpCfg, err := cfg.Rollup.PlasmaConfig()
+	rpCfg, err := cfg.Rollup.GetOPPlasmaConfig()
 	if cfg.Plasma.Enabled && err != nil {
 		return fmt.Errorf("failed to get plasma config: %w", err)
 	}

--- a/op-node/rollup/chain_spec_test.go
+++ b/op-node/rollup/chain_spec_test.go
@@ -47,7 +47,7 @@ var testConfig = Config{
 	DepositContractAddress:  common.HexToAddress("0xbEb5Fc579115071764c7423A4f12eDde41f106Ed"),
 	L1SystemConfigAddress:   common.HexToAddress("0x229047fed2591dbec1eF1118d64F7aF3dB9EB290"),
 	ProtocolVersionsAddress: common.HexToAddress("0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"),
-	UsePlasma:               false,
+	PlasmaConfig:            nil,
 }
 
 func TestChainSpec_CanyonForkActivation(t *testing.T) {

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -55,7 +55,7 @@ func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher,
 	config := DataSourceConfig{
 		l1Signer:          cfg.L1Signer(),
 		batchInboxAddress: cfg.BatchInboxAddress,
-		plasmaEnabled:     cfg.UsePlasma,
+		plasmaEnabled:     cfg.PlasmaEnabled(),
 	}
 	return &DataSourceFactory{
 		log:           log,

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -141,8 +141,8 @@ const finalityDelay = 64
 func calcFinalityLookback(cfg *rollup.Config) uint64 {
 	// in plasma mode the longest finality lookback is a commitment is challenged on the last block of
 	// the challenge window in which case it will be both challenge + resolve window.
-	if cfg.UsePlasma {
-		lkb := cfg.DAChallengeWindow + cfg.DAResolveWindow + 1
+	if cfg.PlasmaEnabled() {
+		lkb := cfg.PlasmaConfig.DAChallengeWindow + cfg.PlasmaConfig.DAResolveWindow + 1
 		// in the case only if the plasma windows are longer than the default finality lookback
 		if lkb > finalityLookback {
 			return lkb

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -1250,16 +1250,17 @@ func TestPlasmaFinalityData(t *testing.T) {
 				GasLimit:    20_000_000,
 			},
 		},
-		BlockTime:         1,
-		SeqWindowSize:     2,
-		UsePlasma:         false,
+		BlockTime:     1,
+		SeqWindowSize: 2,
+	}
+	plasmaCfg := &rollup.PlasmaConfig{
 		DAChallengeWindow: 90,
 		DAResolveWindow:   90,
 	}
 	// shoud return l1 finality if plasma is not enabled
 	require.Equal(t, uint64(finalityLookback), calcFinalityLookback(cfg))
 
-	cfg.UsePlasma = true
+	cfg.PlasmaConfig = plasmaCfg
 	expFinalityLookback := 181
 	require.Equal(t, uint64(expFinalityLookback), calcFinalityLookback(cfg))
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -127,7 +127,7 @@ func (dp *DerivationPipeline) Origin() eth.L1BlockRef {
 func (dp *DerivationPipeline) Finalize(l1Origin eth.L1BlockRef) {
 	// In plasma mode, the finalization signal is proxied through the plasma manager.
 	// Finality signal will come from the DA contract or L1 finality whichever is last.
-	if dp.rollupCfg.UsePlasma {
+	if dp.rollupCfg.PlasmaEnabled() {
 		dp.plasma.Finalize(l1Origin)
 	} else {
 		dp.eng.Finalize(l1Origin)

--- a/op-node/rollup/derive/plasma_data_source_test.go
+++ b/op-node/rollup/derive/plasma_data_source_test.go
@@ -88,7 +88,10 @@ func TestPlasmaDataSource(t *testing.T) {
 		BlockTime:         1,
 		SeqWindowSize:     20,
 		BatchInboxAddress: batcherInbox,
-		UsePlasma:         true,
+		PlasmaConfig: &rollup.PlasmaConfig{
+			DAChallengeWindow: pcfg.ChallengeWindow,
+			DAResolveWindow:   pcfg.ResolveWindow,
+		},
 	}
 	// keep track of random input data to validate against
 	var inputs [][]byte
@@ -327,7 +330,7 @@ func TestPlasmaDataSourceStall(t *testing.T) {
 		BlockTime:         1,
 		SeqWindowSize:     20,
 		BatchInboxAddress: batcherInbox,
-		UsePlasma:         true,
+		LegacyUsePlasma:   true,
 	}
 
 	signer := cfg.L1Signer()
@@ -442,7 +445,7 @@ func TestPlasmaDataSourceInvalidData(t *testing.T) {
 		BlockTime:         1,
 		SeqWindowSize:     20,
 		BatchInboxAddress: batcherInbox,
-		UsePlasma:         true,
+		LegacyUsePlasma:   true,
 	}
 
 	signer := cfg.L1Signer()

--- a/op-node/rollup/derive/plasma_data_source_test.go
+++ b/op-node/rollup/derive/plasma_data_source_test.go
@@ -330,7 +330,10 @@ func TestPlasmaDataSourceStall(t *testing.T) {
 		BlockTime:         1,
 		SeqWindowSize:     20,
 		BatchInboxAddress: batcherInbox,
-		LegacyUsePlasma:   true,
+		PlasmaConfig: &rollup.PlasmaConfig{
+			DAChallengeWindow: pcfg.ChallengeWindow,
+			DAResolveWindow:   pcfg.ResolveWindow,
+		},
 	}
 
 	signer := cfg.L1Signer()
@@ -445,7 +448,10 @@ func TestPlasmaDataSourceInvalidData(t *testing.T) {
 		BlockTime:         1,
 		SeqWindowSize:     20,
 		BatchInboxAddress: batcherInbox,
-		LegacyUsePlasma:   true,
+		PlasmaConfig: &rollup.PlasmaConfig{
+			DAChallengeWindow: pcfg.ChallengeWindow,
+			DAResolveWindow:   pcfg.ResolveWindow,
+		},
 	}
 
 	signer := cfg.L1Signer()

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -48,6 +48,15 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		return nil, fmt.Errorf("unable to retrieve deposit contract address")
 	}
 
+	var plasma *PlasmaConfig
+	if chConfig.Plasma != nil {
+		plasma = &PlasmaConfig{
+			DAChallengeAddress: common.Address(*chConfig.Plasma.DAChallengeAddress),
+			DAChallengeWindow:  *chConfig.Plasma.DAChallengeWindow,
+			DAResolveWindow:    *chConfig.Plasma.DAResolveWindow,
+		}
+	}
+
 	regolithTime := uint64(0)
 	cfg := &Config{
 		Genesis: Genesis{
@@ -80,6 +89,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		BatchInboxAddress:      common.Address(chConfig.BatchInboxAddr),
 		DepositContractAddress: common.Address(addrs.OptimismPortalProxy),
 		L1SystemConfigAddress:  common.Address(addrs.SystemConfigProxy),
+		PlasmaConfig:           plasma,
 	}
 
 	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -50,6 +50,17 @@ type Genesis struct {
 	SystemConfig eth.SystemConfig `json:"system_config"`
 }
 
+type PlasmaConfig struct {
+	// L1 DataAvailabilityChallenge contract proxy address
+	DAChallengeAddress common.Address `json:"da_challenge_contract_address,omitempty"`
+	// DA challenge window value set on the DAC contract. Used in plasma mode
+	// to compute when a commitment can no longer be challenged.
+	DAChallengeWindow uint64 `json:"da_challenge_window"`
+	// DA resolve window value set on the DAC contract. Used in plasma mode
+	// to compute when a challenge expires and trigger a reorg if needed.
+	DAResolveWindow uint64 `json:"da_resolve_window"`
+}
+
 type Config struct {
 	// Genesis anchor point of the rollup
 	Genesis Genesis `json:"genesis"`
@@ -114,19 +125,22 @@ type Config struct {
 	// L1 address that declares the protocol versions, optional (Beta feature)
 	ProtocolVersionsAddress common.Address `json:"protocol_versions_address,omitempty"`
 
+	// Plasma Config. We are in the process of migrating to the PlasmaConfig from these legacy top level values
+	PlasmaConfig *PlasmaConfig `json:"plasma_config,omitempty"`
+
 	// L1 DataAvailabilityChallenge contract proxy address
-	DAChallengeAddress common.Address `json:"da_challenge_contract_address,omitempty"`
+	LegacyDAChallengeAddress common.Address `json:"da_challenge_contract_address,omitempty"`
 
 	// DA challenge window value set on the DAC contract. Used in plasma mode
 	// to compute when a commitment can no longer be challenged.
-	DAChallengeWindow uint64 `json:"da_challenge_window"`
+	LegacyDAChallengeWindow uint64 `json:"da_challenge_window,omitempty"`
 
 	// DA resolve window value set on the DAC contract. Used in plasma mode
 	// to compute when a challenge expires and trigger a reorg if needed.
-	DAResolveWindow uint64 `json:"da_resolve_window"`
+	LegacyDAResolveWindow uint64 `json:"da_resolve_window,omitempty"`
 
-	// UsePlasma is activated when the chain is in plasma mode.
-	UsePlasma bool `json:"use_plasma"`
+	// LegacyUsePlasma is activated when the chain is in plasma mode.
+	LegacyUsePlasma bool `json:"use_plasma,omitempty"`
 }
 
 // ValidateL1Config checks L1 config variables for errors.
@@ -294,6 +308,9 @@ func (cfg *Config) Check() error {
 	if cfg.L2ChainID.Sign() < 1 {
 		return ErrL2ChainIDNotPositive
 	}
+	if err := validatePlasmaConfig(cfg); err != nil {
+		return err
+	}
 
 	if err := checkFork(cfg.RegolithTime, cfg.CanyonTime, "regolith", "canyon"); err != nil {
 		return err
@@ -308,6 +325,31 @@ func (cfg *Config) Check() error {
 		return err
 	}
 
+	return nil
+}
+
+// validatePlasmaConfig checks the two approaches to configuring plasma mode.
+// If the legacy values are set, they are copied to the new location. If both are set, they are check for consistency.
+func validatePlasmaConfig(cfg *Config) error {
+	if cfg.LegacyUsePlasma && cfg.PlasmaConfig == nil {
+		// copy from top level to plasma config
+		cfg.PlasmaConfig = &PlasmaConfig{
+			DAChallengeAddress: cfg.LegacyDAChallengeAddress,
+			DAChallengeWindow:  cfg.LegacyDAChallengeWindow,
+			DAResolveWindow:    cfg.LegacyDAResolveWindow,
+		}
+	} else if cfg.LegacyUsePlasma && cfg.PlasmaConfig != nil {
+		// validate that both are the same
+		if cfg.LegacyDAChallengeAddress != cfg.PlasmaConfig.DAChallengeAddress {
+			return fmt.Errorf("LegacyDAChallengeAddress (%v) !=  PlasmaConfig.DAChallengeAddress (%v)", cfg.LegacyDAChallengeAddress, cfg.PlasmaConfig.DAChallengeAddress)
+		}
+		if cfg.LegacyDAChallengeWindow != cfg.PlasmaConfig.DAChallengeWindow {
+			return fmt.Errorf("LegacyDAChallengeWindow (%v) !=  PlasmaConfig.DAChallengeWindow (%v)", cfg.LegacyDAChallengeWindow, cfg.PlasmaConfig.DAChallengeWindow)
+		}
+		if cfg.LegacyDAResolveWindow != cfg.PlasmaConfig.DAResolveWindow {
+			return fmt.Errorf("LegacyDAResolveWindow (%v) !=  PlasmaConfig.DAResolveWindow (%v)", cfg.LegacyDAResolveWindow, cfg.PlasmaConfig.DAResolveWindow)
+		}
+	}
 	return nil
 }
 
@@ -410,29 +452,36 @@ func (c *Config) GetPayloadVersion(timestamp uint64) eth.EngineAPIMethod {
 	}
 }
 
-// PlasmaConfig validates and returns the plasma config from the rollup config.
-func (c *Config) PlasmaConfig() (plasma.Config, error) {
-	if c.DAChallengeAddress == (common.Address{}) {
-		return plasma.Config{}, fmt.Errorf("missing DAChallengeAddress")
+// GetOPPlasmaConfig validates and returns the plasma config from the rollup config.
+func (c *Config) GetOPPlasmaConfig() (plasma.Config, error) {
+	if c.PlasmaConfig == nil {
+		return plasma.Config{}, errors.New("no plasma config")
 	}
-	if c.DAChallengeWindow == uint64(0) {
-		return plasma.Config{}, fmt.Errorf("missing DAChallengeWindow")
+	if c.PlasmaConfig.DAChallengeAddress == (common.Address{}) {
+		return plasma.Config{}, errors.New("missing DAChallengeAddress")
 	}
-	if c.DAResolveWindow == uint64(0) {
-		return plasma.Config{}, fmt.Errorf("missing DAResolveWindow")
+	if c.PlasmaConfig.DAChallengeWindow == uint64(0) {
+		return plasma.Config{}, errors.New("missing DAChallengeWindow")
+	}
+	if c.PlasmaConfig.DAResolveWindow == uint64(0) {
+		return plasma.Config{}, errors.New("missing DAResolveWindow")
 	}
 	return plasma.Config{
-		DAChallengeContractAddress: c.DAChallengeAddress,
-		ChallengeWindow:            c.DAChallengeWindow,
-		ResolveWindow:              c.DAResolveWindow,
+		DAChallengeContractAddress: c.PlasmaConfig.DAChallengeAddress,
+		ChallengeWindow:            c.PlasmaConfig.DAChallengeWindow,
+		ResolveWindow:              c.PlasmaConfig.DAResolveWindow,
 	}, nil
+}
+
+func (c *Config) PlasmaEnabled() bool {
+	return c.PlasmaConfig != nil
 }
 
 // SyncLookback computes the number of blocks to walk back in order to find the correct L1 origin.
 // In plasma mode longest possible window is challenge + resolve windows.
 func (c *Config) SyncLookback() uint64 {
-	if c.UsePlasma {
-		if win := (c.DAChallengeWindow + c.DAResolveWindow); win > c.SeqWindowSize {
+	if c.PlasmaEnabled() {
+		if win := (c.PlasmaConfig.DAChallengeWindow + c.PlasmaConfig.DAResolveWindow); win > c.SeqWindowSize {
 			return win
 		}
 	}

--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232 // indirect
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240510200259-4be7024d2ba7 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 // indirect

--- a/op-ufm/go.sum
+++ b/op-ufm/go.sum
@@ -86,8 +86,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum-optimism/op-geth v1.101315.0-rc.1 h1:UozruCEuXwdhOIezpIqthjzCXH1DQCbaFL9snLVb0Ew=
 github.com/ethereum-optimism/op-geth v1.101315.0-rc.1/go.mod h1:VXVFzx1mr/JyJac5M4k5W/+0cqHZMkqKsIVDsOyj2rs=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232 h1:jRdLJs4E3ilsDGK7+k39QPi3QKL/b1cLnyv8mfOCVo4=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240418160534-4156733e7232/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240510200259-4be7024d2ba7 h1:e7oXWZwODAMM2TLo9beGDXaX2cCw7uM7qAqamYBHV40=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240510200259-4be7024d2ba7/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fjl/memsize v0.0.2 h1:27txuSD9or+NZlnOWdKUxeBzTAUkWCVh+4Gf2dWFOzA=


### PR DESCRIPTION
**Description**

This commit adds a dedicated PlasmaConfig section to the rollup config. This collects all Plasma Mode configuration to the same place and enables future expansion of Plasma Mode configuration to be confined to a single location.

In the interim, the op-node can read from both the legacy fields and the dedicated struct. If both are set, they must be consistent. The genesis creation tooling currently only writes with the new config.

This also updates to a new version of the superchain registry to enable Plasma Mode chains in the superchain registry to properly set the rollup config when configured by the superchain flag name.

**Tests**

Tested locally & the output JSON looks good. Unfortunately `omitempty` does not work on the address type.


**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/10472