### PR TITLE
use `iota` properly

### DIFF
--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -14,7 +14,7 @@ type Mode int
 //     It will consolidate the chain as usual. This allows execution clients to snap sync if they are capable of it.
 const (
 	CLSync Mode = iota
-	ELSync Mode = iota
+	ELSync
 )
 
 const (


### PR DESCRIPTION
This PR makes the usage of `iota` consistent with other places in the codebase.

Note the numerical value of `ELSync` is the same before and after the change.