### PR TITLE
op-challenger, op-dispute-mon: Fix chess clock calculations to match solidity implementation

### DIFF
--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -29,6 +29,7 @@ var (
 	SortByFlag = &cli.StringFlag{
 		Name:    "sort-by",
 		Usage:   "Sort games by column. Valid options: " + openum.EnumString(ColumnTypes),
+		Value:   "time",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "SORT_BY"),
 	}
 	SortOrderFlag = &cli.StringFlag{
@@ -53,7 +54,7 @@ func ListGames(ctx *cli.Context) error {
 		return err
 	}
 	sortBy := ctx.String(SortByFlag.Name)
-	if !slices.Contains(ColumnTypes, sortBy) {
+	if sortBy != "" && !slices.Contains(ColumnTypes, sortBy) {
 		return fmt.Errorf("invalid sort-by value: %v", sortBy)
 	}
 	sortOrder := ctx.String(SortOrderFlag.Name)

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -179,7 +179,11 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 
 	var resolvableClaims []uint64
 	for _, claim := range claims {
-		if claim.ChessTime(a.l1Clock.Now()) <= a.maxClockDuration {
+		var parent types.Claim
+		if !claim.IsRootPosition() {
+			parent = claims[claim.ParentContractIndex]
+		}
+		if types.ChessClock(a.l1Clock.Now(), claim, parent) <= a.maxClockDuration {
 			continue
 		}
 		if a.selective {

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -15,15 +15,18 @@ import (
 var DefaultClaimant = common.Address{0xba, 0xdb, 0xad, 0xba, 0xdb, 0xad}
 
 type claimCfg struct {
-	value         common.Hash
-	invalidValue  bool
-	claimant      common.Address
-	parentIdx     int
-	clockDuration time.Duration
+	value          common.Hash
+	invalidValue   bool
+	claimant       common.Address
+	parentIdx      int
+	clockTimestamp time.Time
+	clockDuration  time.Duration
 }
 
 func newClaimCfg(opts ...ClaimOpt) *claimCfg {
-	cfg := &claimCfg{}
+	cfg := &claimCfg{
+		clockTimestamp: time.Unix(math.MaxInt64-1, 0),
+	}
 	for _, opt := range opts {
 		opt.Apply(cfg)
 	}
@@ -64,9 +67,10 @@ func WithParent(claim types.Claim) ClaimOpt {
 	})
 }
 
-func WithExpiredClock(maxClockDuration time.Duration) ClaimOpt {
+func WithClock(timestamp time.Time, duration time.Duration) ClaimOpt {
 	return claimOptFn(func(cfg *claimCfg) {
-		cfg.clockDuration = maxClockDuration
+		cfg.clockTimestamp = timestamp
+		cfg.clockDuration = duration
 	})
 }
 
@@ -134,7 +138,7 @@ func (c *ClaimBuilder) claim(pos types.Position, opts ...ClaimOpt) types.Claim {
 		Claimant: DefaultClaimant,
 		Clock: types.Clock{
 			Duration:  cfg.clockDuration,
-			Timestamp: time.Unix(math.MaxInt64-1, 0),
+			Timestamp: cfg.clockTimestamp,
 		},
 	}
 	if cfg.claimant != (common.Address{}) {

--- a/op-challenger/game/fault/types/position.go
+++ b/op-challenger/game/fault/types/position.go
@@ -41,13 +41,13 @@ func NewPositionFromGIndex(x *big.Int) Position {
 }
 
 func (p Position) String() string {
-	return fmt.Sprintf("Position(depth: %v, indexAtDepth: %v)", p.depth, p.indexAtDepth)
+	return fmt.Sprintf("Position(depth: %v, indexAtDepth: %v)", p.depth, p.IndexAtDepth())
 }
 
 func (p Position) MoveRight() Position {
 	return Position{
 		depth:        p.depth,
-		indexAtDepth: new(big.Int).Add(p.indexAtDepth, big.NewInt(1)),
+		indexAtDepth: new(big.Int).Add(p.IndexAtDepth(), big.NewInt(1)),
 	}
 }
 
@@ -59,7 +59,7 @@ func (p Position) RelativeToAncestorAtDepth(ancestor Depth) (Position, error) {
 	}
 	newPosDepth := p.depth - ancestor
 	nodesAtDepth := 1 << newPosDepth
-	newIndexAtDepth := new(big.Int).Mod(p.indexAtDepth, big.NewInt(int64(nodesAtDepth)))
+	newIndexAtDepth := new(big.Int).Mod(p.IndexAtDepth(), big.NewInt(int64(nodesAtDepth)))
 	return NewPosition(newPosDepth, newIndexAtDepth), nil
 }
 
@@ -75,7 +75,7 @@ func (p Position) IndexAtDepth() *big.Int {
 }
 
 func (p Position) IsRootPosition() bool {
-	return p.depth == 0 && common.Big0.Cmp(p.indexAtDepth) == 0
+	return p.depth == 0 && common.Big0.Cmp(p.IndexAtDepth()) == 0
 }
 
 func (p Position) lshIndex(amount Depth) *big.Int {
@@ -140,7 +140,7 @@ func (p Position) Defend() Position {
 }
 
 func (p Position) Print(maxDepth Depth) {
-	fmt.Printf("GIN: %4b\tTrace Position is %4b\tTrace Depth is: %d\tTrace Index is: %d\n", p.ToGIndex(), p.indexAtDepth, p.depth, p.TraceIndex(maxDepth))
+	fmt.Printf("GIN: %4b\tTrace Position is %4b\tTrace Depth is: %d\tTrace Index is: %d\n", p.ToGIndex(), p.IndexAtDepth(), p.depth, p.TraceIndex(maxDepth))
 }
 
 func (p Position) ToGIndex() *big.Int {

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -185,17 +185,6 @@ func (c Claim) IsRoot() bool {
 	return c.Position.IsRootPosition()
 }
 
-// ChessTime returns the amount of time accumulated in the chess clock.
-// Does not assume the claim is countered and uses the specified time
-// to calculate the time since the claim was posted.
-func (c Claim) ChessTime(now time.Time) time.Duration {
-	timeSince := time.Duration(0)
-	if now.Compare(c.Clock.Timestamp) > 0 {
-		timeSince = now.Sub(c.Clock.Timestamp)
-	}
-	return c.Clock.Duration + timeSince
-}
-
 // Clock tracks the chess clock for a claim.
 type Clock struct {
 	// Duration is the time elapsed on the chess clock at the last update.

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -3,66 +3,9 @@ package types
 import (
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestClaim_RemainingDuration(t *testing.T) {
-	tests := []struct {
-		name      string
-		duration  time.Duration
-		timestamp int64
-		now       int64
-		expected  uint64
-	}{
-		{
-			name:      "AllZeros",
-			duration:  0,
-			timestamp: 0,
-			now:       0,
-			expected:  0,
-		},
-		{
-			name:      "ZeroTimestamp",
-			duration:  5 * time.Second,
-			timestamp: 0,
-			now:       0,
-			expected:  5,
-		},
-		{
-			name:      "ZeroTimestampWithNow",
-			duration:  5 * time.Second,
-			timestamp: 0,
-			now:       10,
-			expected:  15,
-		},
-		{
-			name:      "ZeroNow",
-			duration:  5 * time.Second,
-			timestamp: 10,
-			now:       0,
-			expected:  5,
-		},
-		{
-			name:      "ValidTimeSinze",
-			duration:  20 * time.Second,
-			timestamp: 10,
-			now:       15,
-			expected:  25,
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			claim := &Claim{
-				Clock: NewClock(test.duration, time.Unix(test.timestamp, 0)),
-			}
-			require.Equal(t, time.Duration(test.expected)*time.Second, claim.ChessTime(time.Unix(test.now, 0)))
-		})
-	}
-}
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {
@@ -102,6 +45,12 @@ func TestIsRootPosition(t *testing.T) {
 			name:     "NotRoot",
 			position: NewPositionFromGIndex(big.NewInt(2)),
 			expected: false,
+		},
+		{
+			// Mostly to avoid nil dereferences in tests which may not set a real Position
+			name:     "DefaultValue",
+			position: Position{},
+			expected: true,
 		},
 	}
 

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"time"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -100,7 +101,11 @@ func (c *ClaimMonitor) checkGameClaims(
 		}
 
 		maxChessTime := time.Duration(game.MaxClockDuration) * time.Second
-		accumulatedTime := claim.ChessTime(c.clock.Now())
+		var parent faultTypes.Claim
+		if !claim.IsRoot() {
+			parent = game.Claims[claim.ParentContractIndex].Claim
+		}
+		accumulatedTime := faultTypes.ChessClock(c.clock.Now(), claim.Claim, parent)
 		clockExpired := accumulatedTime >= maxChessTime
 
 		if claim.Resolved {


### PR DESCRIPTION
**Description**

Fixes the chess clock calculation used to determine when a claim is resolvable to match the solidity implementation. It was getting confused about which team's chess clock duration was recorded on a claim.

list-claims subcommand now includes information on the claim time, chess clocks and when claims can be resolved (if unresolved). The claim hash is now abbreviated by default so the output fits on one line in most terminals - the full hash is still available via the `-v` or `--verbose` flag.

**Tests**

Updated unit tests.  Verified against real data on op-sepolia.
