### PR TITLE
fix(op-node): p2p ipnet struct validation

### DIFF
--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -183,8 +183,19 @@ func TestP2PFull(t *testing.T) {
 
 	require.Error(t, p2pClientA.BlockAddr(ctx, nil))
 	require.Error(t, p2pClientA.UnblockAddr(ctx, nil))
+
 	require.Error(t, p2pClientA.BlockSubnet(ctx, nil))
+	require.Error(t, p2pClientA.BlockSubnet(ctx, &net.IPNet{}))
+	require.Error(t, p2pClientA.BlockSubnet(ctx, &net.IPNet{Mask: net.IPMask{255, 255, 0, 0}}))
+	require.Error(t, p2pClientA.BlockSubnet(ctx, &net.IPNet{IP: net.IP{0, 0, 0, 1}}))
+	require.NoError(t, p2pClientA.BlockSubnet(ctx, &net.IPNet{IP: net.IP{0, 0, 0, 1}, Mask: net.IPMask{255, 255, 0, 0}}))
+
 	require.Error(t, p2pClientA.UnblockSubnet(ctx, nil))
+	require.Error(t, p2pClientA.UnblockSubnet(ctx, &net.IPNet{}))
+	require.Error(t, p2pClientA.UnblockSubnet(ctx, &net.IPNet{Mask: net.IPMask{255, 255, 0, 0}}))
+	require.Error(t, p2pClientA.UnblockSubnet(ctx, &net.IPNet{IP: net.IP{0, 0, 0, 1}}))
+	require.NoError(t, p2pClientA.UnblockSubnet(ctx, &net.IPNet{IP: net.IP{0, 0, 0, 1}, Mask: net.IPMask{255, 255, 0, 0}}))
+
 	require.Error(t, p2pClientA.BlockPeer(ctx, ""))
 	require.Error(t, p2pClientA.UnblockPeer(ctx, ""))
 	require.Error(t, p2pClientA.ProtectPeer(ctx, ""))

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -248,7 +248,7 @@ func (s *APIBackend) DiscoveryTable(_ context.Context) ([]*enode.Node, error) {
 func (s *APIBackend) BlockPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_blockPeer")
 	if err := id.Validate(); err != nil {
-		log.Warn("invalid peer ID", "method", "BlockPeer", "peer", id, "err", err)
+		s.log.Warn("invalid peer ID", "method", "BlockPeer", "peer", id, "err", err)
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -262,7 +262,7 @@ func (s *APIBackend) BlockPeer(_ context.Context, id peer.ID) error {
 func (s *APIBackend) UnblockPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_unblockPeer")
 	if err := id.Validate(); err != nil {
-		log.Warn("invalid peer ID", "method", "UnblockPeer", "peer", id, "err", err)
+		s.log.Warn("invalid peer ID", "method", "UnblockPeer", "peer", id, "err", err)
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -288,7 +288,7 @@ func (s *APIBackend) ListBlockedPeers(_ context.Context) ([]peer.ID, error) {
 func (s *APIBackend) BlockAddr(_ context.Context, ip net.IP) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_blockAddr")
 	if ip == nil {
-		log.Warn("invalid IP", "method", "BlockAddr")
+		s.log.Warn("invalid IP", "method", "BlockAddr")
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -302,7 +302,7 @@ func (s *APIBackend) BlockAddr(_ context.Context, ip net.IP) error {
 func (s *APIBackend) UnblockAddr(_ context.Context, ip net.IP) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_unblockAddr")
 	if ip == nil {
-		log.Warn("invalid IP", "method", "UnblockAddr")
+		s.log.Warn("invalid IP", "method", "UnblockAddr")
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -328,7 +328,7 @@ func (s *APIBackend) ListBlockedAddrs(_ context.Context) ([]net.IP, error) {
 func (s *APIBackend) BlockSubnet(_ context.Context, ipnet *net.IPNet) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_blockSubnet")
 	if ipnet == nil || ipnet.IP == nil || ipnet.Mask == nil {
-		log.Warn("invalid IPNet", "method", "BlockSubnet")
+		s.log.Warn("invalid IPNet", "method", "BlockSubnet")
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -342,7 +342,7 @@ func (s *APIBackend) BlockSubnet(_ context.Context, ipnet *net.IPNet) error {
 func (s *APIBackend) UnblockSubnet(_ context.Context, ipnet *net.IPNet) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_unblockSubnet")
 	if ipnet == nil || ipnet.IP == nil || ipnet.Mask == nil {
-		log.Warn("invalid IPNet", "method", "UnblockSubnet")
+		s.log.Warn("invalid IPNet", "method", "UnblockSubnet")
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -366,7 +366,7 @@ func (s *APIBackend) ListBlockedSubnets(_ context.Context) ([]*net.IPNet, error)
 func (s *APIBackend) ProtectPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_protectPeer")
 	if err := id.Validate(); err != nil {
-		log.Warn("invalid peer ID", "method", "ProtectPeer", "peer", id, "err", err)
+		s.log.Warn("invalid peer ID", "method", "ProtectPeer", "peer", id, "err", err)
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -381,7 +381,7 @@ func (s *APIBackend) ProtectPeer(_ context.Context, id peer.ID) error {
 func (s *APIBackend) UnprotectPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_unprotectPeer")
 	if err := id.Validate(); err != nil {
-		log.Warn("invalid peer ID", "method", "UnprotectPeer", "peer", id, "err", err)
+		s.log.Warn("invalid peer ID", "method", "UnprotectPeer", "peer", id, "err", err)
 		return ErrInvalidRequest
 	}
 	defer recordDur()
@@ -411,7 +411,7 @@ func (s *APIBackend) ConnectPeer(ctx context.Context, addr string) error {
 func (s *APIBackend) DisconnectPeer(_ context.Context, id peer.ID) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_disconnectPeer")
 	if err := id.Validate(); err != nil {
-		log.Warn("invalid peer ID", "method", "DisconnectPeer", "peer", id, "err", err)
+		s.log.Warn("invalid peer ID", "method", "DisconnectPeer", "peer", id, "err", err)
 		return ErrInvalidRequest
 	}
 	defer recordDur()

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -327,7 +327,7 @@ func (s *APIBackend) ListBlockedAddrs(_ context.Context) ([]net.IP, error) {
 // Note: active connections to the IP subnet are not automatically closed.
 func (s *APIBackend) BlockSubnet(_ context.Context, ipnet *net.IPNet) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_blockSubnet")
-	if ipnet == nil {
+	if ipnet == nil || ipnet.IP == nil || ipnet.Mask == nil {
 		log.Warn("invalid IPNet", "method", "BlockSubnet")
 		return ErrInvalidRequest
 	}
@@ -341,7 +341,7 @@ func (s *APIBackend) BlockSubnet(_ context.Context, ipnet *net.IPNet) error {
 
 func (s *APIBackend) UnblockSubnet(_ context.Context, ipnet *net.IPNet) error {
 	recordDur := s.m.RecordRPCServerRequest("opp2p_unblockSubnet")
-	if ipnet == nil {
+	if ipnet == nil || ipnet.IP == nil || ipnet.Mask == nil {
 		log.Warn("invalid IPNet", "method", "UnblockSubnet")
 		return ErrInvalidRequest
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The `net.IPNet` struct in go core src does not validate the contents of `IP` and `Mask` fields, so it is possible to craft a struct with invalid values.

This change enhances validation to make sure the values are correctly set before consuming them in the P2P authoritative RPC calls.

**Tests**

Added new test cases.

**Additional context**

Reported from https://www.notion.so/oplabs/Minor-RPC-opp2p_blocksubnet-can-be-nil-CIDR-f65bea2b18054b4ba388c62ae85d7033

Part of https://github.com/ethereum-optimism/devinfra-pod/issues/38

