### PR TITLE
ctb: Prevent calls to foundry's vm address

### DIFF
--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -264,6 +264,7 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
     )
         external
     {
+        vm.assume(_token != address(vm));
         vm.assume(bytes(_name).length <= 32);
         vm.assume(bytes(_symbol).length <= 32);
 


### PR DESCRIPTION
**Description**

Fixes an issue causing flakes in CI where `address(vm)` was being used as a fuzzing input.