### PR TITLE
cannon: Remove unreachable code

### DIFF
--- a/cannon/mipsevm/memory.go
+++ b/cannon/mipsevm/memory.go
@@ -114,9 +114,6 @@ func (m *Memory) MerkleizeSubtree(gindex uint64) [32]byte {
 			return zeroHashes[28-l] // page does not exist
 		}
 	}
-	if l > PageKeySize+1 {
-		panic("cannot jump into intermediate node of page")
-	}
 	n, ok := m.nodes[gindex]
 	if !ok {
 		// if the node doesn't exist, the whole sub-tree is zeroed


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Remove unreachable code.  The conditional block being removed here (`if l > PageKeySize+1`) is preceded by a block that always supersedes it (`if l > PageKeySize`). 

**Tests**

Looks like there is already good coverage of this logic in memory_test.go. 

**Additional context**

This is part of the work to address the Coinbase security audit of Cannon.

**Metadata**

Part of: https://github.com/ethereum-optimism/client-pod/issues/761 (M-01)

