### PR TITLE
Log when a hardfork is first activated

### DIFF
--- a/op-node/rollup/chain_spec_test.go
+++ b/op-node/rollup/chain_spec_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
 )
 
 func u64ptr(n uint64) *uint64 {
@@ -139,6 +141,58 @@ func TestChainSpec_MaxSequencerDrift(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := c.MaxSequencerDrift(tt.blockNum)
 			require.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestCheckForkActivation(t *testing.T) {
+	tests := []struct {
+		name                string
+		block               eth.L2BlockRef
+		expectedCurrentFork ForkName
+		expectedLog         string
+	}{
+		{
+			name:                "Regolith activation",
+			block:               eth.L2BlockRef{Time: 10, Number: 5, Hash: common.Hash{0x5}},
+			expectedCurrentFork: Regolith,
+			expectedLog:         "Detected hardfork activation block",
+		},
+		{
+			name:                "Still Regolith",
+			block:               eth.L2BlockRef{Time: 11, Number: 6, Hash: common.Hash{0x6}},
+			expectedCurrentFork: Regolith,
+			expectedLog:         "",
+		},
+		{
+			name:                "Canyon activation",
+			block:               eth.L2BlockRef{Time: 20, Number: 7, Hash: common.Hash{0x7}},
+			expectedCurrentFork: Canyon,
+			expectedLog:         "Detected hardfork activation block",
+		},
+		{
+			name:                "No more hardforks",
+			block:               eth.L2BlockRef{Time: 700, Number: 8, Hash: common.Hash{0x8}},
+			expectedCurrentFork: Fjord,
+			expectedLog:         "",
+		},
+	}
+
+	hasInfoLevel := testlog.NewLevelFilter(slog.LevelInfo)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lgr, logs := testlog.CaptureLogger(t, slog.LevelDebug)
+
+			chainSpec := NewChainSpec(&testConfig)
+			// First call initializes chainSpec.currentFork value
+			chainSpec.CheckForkActivation(lgr, eth.L2BlockRef{Time: tt.block.Time - 1, Number: 1, Hash: common.Hash{0x1}})
+			chainSpec.CheckForkActivation(lgr, tt.block)
+			require.Equal(t, tt.expectedCurrentFork, chainSpec.currentFork)
+			if tt.expectedLog != "" {
+				require.NotNil(t, logs.FindLog(
+					hasInfoLevel,
+					testlog.NewMessageContainsFilter(tt.expectedLog)))
+			}
 		})
 	}
 }

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -50,6 +50,7 @@ type EngineController struct {
 	metrics    Metrics
 	syncMode   sync.Mode
 	syncStatus syncStatusEnum
+	chainSpec  *rollup.ChainSpec
 	rollupCfg  *rollup.Config
 	elStart    time.Time
 	clock      clock.Clock
@@ -85,6 +86,7 @@ func NewEngineController(engine ExecEngine, log log.Logger, metrics Metrics, rol
 		engine:     engine,
 		log:        log,
 		metrics:    metrics,
+		chainSpec:  rollup.NewChainSpec(rollupCfg),
 		rollupCfg:  rollupCfg,
 		syncMode:   syncMode,
 		syncStatus: syncStatus,
@@ -149,7 +151,7 @@ func (e *EngineController) SetUnsafeHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_unsafe", r)
 	e.unsafeHead = r
 	e.needFCUCall = true
-	e.rollupCfg.CheckForkActivation(e.log, r)
+	e.chainSpec.CheckForkActivation(e.log, r)
 }
 
 // SetBackupUnsafeL2Head implements LocalEngineControl.

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -149,6 +149,7 @@ func (e *EngineController) SetUnsafeHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_unsafe", r)
 	e.unsafeHead = r
 	e.needFCUCall = true
+	e.rollupCfg.CheckForkActivation(e.log, r)
 }
 
 // SetBackupUnsafeL2Head implements LocalEngineControl.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -61,7 +61,27 @@ type PlasmaConfig struct {
 	DAResolveWindow uint64 `json:"da_resolve_window"`
 }
 
+type ForkName string
+
+const (
+	Regolith ForkName = "regolith"
+	Canyon   ForkName = "canyon"
+	Delta    ForkName = "delta"
+	Ecotone  ForkName = "ecotone"
+	Fjord    ForkName = "fjord"
+	Interop  ForkName = "interop"
+)
+
+var nextFork = map[ForkName]ForkName{
+	Regolith: Canyon,
+	Canyon:   Delta,
+	Delta:    Ecotone,
+	Ecotone:  Fjord,
+	Fjord:    Interop,
+}
+
 type Config struct {
+	nextFork ForkName
 	// Genesis anchor point of the rollup
 	Genesis Genesis `json:"genesis"`
 	// Seconds per L2 block
@@ -312,16 +332,16 @@ func (cfg *Config) Check() error {
 		return err
 	}
 
-	if err := checkFork(cfg.RegolithTime, cfg.CanyonTime, "regolith", "canyon"); err != nil {
+	if err := checkFork(cfg.RegolithTime, cfg.CanyonTime, Regolith, Canyon); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.CanyonTime, cfg.DeltaTime, "canyon", "delta"); err != nil {
+	if err := checkFork(cfg.CanyonTime, cfg.DeltaTime, Canyon, Delta); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.DeltaTime, cfg.EcotoneTime, "delta", "ecotone"); err != nil {
+	if err := checkFork(cfg.DeltaTime, cfg.EcotoneTime, Delta, Ecotone); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.EcotoneTime, cfg.FjordTime, "ecotone", "fjord"); err != nil {
+	if err := checkFork(cfg.EcotoneTime, cfg.FjordTime, Ecotone, Fjord); err != nil {
 		return err
 	}
 
@@ -354,7 +374,7 @@ func validatePlasmaConfig(cfg *Config) error {
 }
 
 // checkFork checks that fork A is before or at the same time as fork B
-func checkFork(a, b *uint64, aName, bName string) error {
+func checkFork(a, b *uint64, aName, bName ForkName) error {
 	if a == nil && b == nil {
 		return nil
 	}
@@ -394,14 +414,6 @@ func (c *Config) IsEcotone(timestamp uint64) bool {
 	return c.EcotoneTime != nil && timestamp >= *c.EcotoneTime
 }
 
-// IsEcotoneActivationBlock returns whether the specified block is the first block subject to the
-// Ecotone upgrade. Ecotone activation at genesis does not count.
-func (c *Config) IsEcotoneActivationBlock(l2BlockTime uint64) bool {
-	return c.IsEcotone(l2BlockTime) &&
-		l2BlockTime >= c.BlockTime &&
-		!c.IsEcotone(l2BlockTime-c.BlockTime)
-}
-
 // IsFjord returns true if the Fjord hardfork is active at or past the given timestamp.
 func (c *Config) IsFjord(timestamp uint64) bool {
 	return c.FjordTime != nil && timestamp >= *c.FjordTime
@@ -418,6 +430,66 @@ func (c *Config) IsFjordActivationBlock(l2BlockTime uint64) bool {
 // IsInterop returns true if the Interop hardfork is active at or past the given timestamp.
 func (c *Config) IsInterop(timestamp uint64) bool {
 	return c.InteropTime != nil && timestamp >= *c.InteropTime
+}
+
+func (c *Config) CheckForkActivation(log log.Logger, block eth.L2BlockRef) {
+	if c.nextFork == "" {
+		c.nextFork = Regolith
+	}
+
+	foundActivationBlock := false
+
+	switch c.nextFork {
+	case Regolith:
+		foundActivationBlock = c.IsRegolithActivationBlock(block.Time)
+	case Canyon:
+		foundActivationBlock = c.IsCanyonActivationBlock(block.Time)
+	case Delta:
+		foundActivationBlock = c.IsDeltaActivationBlock(block.Time)
+	case Ecotone:
+		foundActivationBlock = c.IsEcotoneActivationBlock(block.Time)
+	case Fjord:
+		foundActivationBlock = c.IsFjordActivationBlock(block.Time)
+	case Interop:
+		foundActivationBlock = c.IsInteropActivationBlock(block.Time)
+	}
+
+	if foundActivationBlock {
+		log.Info("Detected hardfork activation block", "forkName", c.nextFork, "timestamp", block.Time, "blockNum", block.Number, "hash", block.Hash)
+		c.nextFork = nextFork[c.nextFork]
+	}
+}
+
+func (c *Config) IsRegolithActivationBlock(l2BlockTime uint64) bool {
+	return c.IsRegolith(l2BlockTime) &&
+		l2BlockTime >= c.BlockTime &&
+		!c.IsRegolith(l2BlockTime-c.BlockTime)
+}
+
+func (c *Config) IsCanyonActivationBlock(l2BlockTime uint64) bool {
+	return c.IsCanyon(l2BlockTime) &&
+		l2BlockTime >= c.BlockTime &&
+		!c.IsCanyon(l2BlockTime-c.BlockTime)
+}
+
+func (c *Config) IsDeltaActivationBlock(l2BlockTime uint64) bool {
+	return c.IsDelta(l2BlockTime) &&
+		l2BlockTime >= c.BlockTime &&
+		!c.IsDelta(l2BlockTime-c.BlockTime)
+}
+
+// IsEcotoneActivationBlock returns whether the specified block is the first block subject to the
+// Ecotone upgrade. Ecotone activation at genesis does not count.
+func (c *Config) IsEcotoneActivationBlock(l2BlockTime uint64) bool {
+	return c.IsEcotone(l2BlockTime) &&
+		l2BlockTime >= c.BlockTime &&
+		!c.IsEcotone(l2BlockTime-c.BlockTime)
+}
+
+func (c *Config) IsInteropActivationBlock(l2BlockTime uint64) bool {
+	return c.IsInterop(l2BlockTime) &&
+		l2BlockTime >= c.BlockTime &&
+		!c.IsInterop(l2BlockTime-c.BlockTime)
 }
 
 // ForkchoiceUpdatedVersion returns the EngineAPIMethod suitable for the chain hard fork version.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -70,6 +70,7 @@ const (
 	Ecotone  ForkName = "ecotone"
 	Fjord    ForkName = "fjord"
 	Interop  ForkName = "interop"
+	None     ForkName = "none"
 )
 
 var nextFork = map[ForkName]ForkName{
@@ -78,6 +79,7 @@ var nextFork = map[ForkName]ForkName{
 	Delta:    Ecotone,
 	Ecotone:  Fjord,
 	Fjord:    Interop,
+	Interop:  None,
 }
 
 type Config struct {
@@ -433,8 +435,28 @@ func (c *Config) IsInterop(timestamp uint64) bool {
 }
 
 func (c *Config) CheckForkActivation(log log.Logger, block eth.L2BlockRef) {
+	if c.nextFork == None {
+		return
+	}
+
 	if c.nextFork == "" {
-		c.nextFork = Regolith
+		// Initialize c.nextFork if it is not set yet
+		if !c.IsRegolith(block.Time) {
+			c.nextFork = Regolith
+		} else if !c.IsCanyon(block.Time) {
+			c.nextFork = Canyon
+		} else if !c.IsDelta(block.Time) {
+			c.nextFork = Delta
+		} else if !c.IsEcotone(block.Time) {
+			c.nextFork = Ecotone
+		} else if !c.IsFjord(block.Time) {
+			c.nextFork = Fjord
+		} else if !c.IsInterop(block.Time) {
+			c.nextFork = Interop
+		} else {
+			c.nextFork = None
+			return
+		}
 	}
 
 	foundActivationBlock := false


### PR DESCRIPTION
**Description**

To give node operators more insight into their chains, we should log when a new hardfork is first activated. 

**Assumptions**

Hardforks must always be activated in the same, sequential order, starting with `regolith`. Therefore we know upfront what hardfork we should be looking for next based on the current hardfork.

**Tests**

Added unit tests for new `CheckForkActivation` function.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/606
