### PR TITLE
Fix Circle CI docker version script when filtering tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,20 +336,20 @@ jobs:
             echo "Tags at commit:\n$tags_at_commit"
 
             filtered_tags=$(echo "$tags_at_commit" | grep "^<<parameters.docker_name>>/" || true)
-            echo "Filtered tags:\n$filtered_tags"
+            echo "Filtered tags: $filtered_tags"
 
             if [ -z "$filtered_tags" ]; then
               export GIT_VERSION="untagged"
             else
               sorted_tags=$(echo "$filtered_tags" | sed "s/<<parameters.docker_name>>\///" | sort -V)
-              echo "Sorted tags:\n$sorted_tags"
+              echo "Sorted tags: $sorted_tags"
 
               # prefer full release tag over "-rc" release candidate tag if both exist
               full_release_tag=$(echo "$sorted_tags" | grep -v -- "-rc" || true)
               if [ -z "$full_release_tag" ]; then
                 export GIT_VERSION=$(echo "$sorted_tags" | tail -n 1)
               else
-                export GIT_VERSION=$(echo "$full_release_tag")
+                export GIT_VERSION=$(echo "$full_release_tag" | tail -n 1)
               fi
             fi
 


### PR DESCRIPTION
**Description**

Fixes failure seen in [this Circle CI job](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/54383/workflows/42a7ca31-d0a8-4abb-ab97-2241289a99b0/jobs/2350838). Failure was caused by the fact that the versioning script did not correctly pipe to `tail -n 1` in the case where there are two `full_release_tag`s (i.e tags without the `-rc` string. Commit 78e1084ec14d3003cb9e546b9eb5a22db7408ac2 is a unique case where op-program has two such tags:
```
op-challenger/v0.2.8
op-dispute-mon/v0.2.6
op-program/v1.0.1
op-program/v1.1.0
```

**Tests**

Tested the fix locally by running the shell script against the same commit referenced above.

**Additional context**

PR where the CI docker versioning script was first introduced: https://github.com/ethereum-optimism/optimism/pull/10346