### PR TITLE
Fix blob sidecar req indices query param

### DIFF
--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -87,15 +87,16 @@ func (f *FakeBeacon) Start(addr string) error {
 		}
 
 		query := r.URL.Query()
-		rawIndices := query["indices"]
+		rawIndices := query.Get("indices")
 		indices := make([]uint64, 0, len(bundle.Blobs))
-		if len(rawIndices) == 0 {
+		if rawIndices == "" {
 			// request is for all blobs
 			for i := range bundle.Blobs {
 				indices = append(indices, uint64(i))
 			}
 		} else {
-			for _, raw := range rawIndices {
+			rawIndexSlice := strings.Split(rawIndices, ",")
+			for _, raw := range rawIndexSlice {
 				ix, err := strconv.ParseUint(raw, 10, 64)
 				if err != nil {
 					f.log.Error("could not parse index from request", "url", r.URL)

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -120,10 +120,16 @@ func (cl *BeaconHTTPClient) BeaconBlobSideCars(ctx context.Context, fetchAllSide
 	reqPath := path.Join(sidecarsMethodPrefix, strconv.FormatUint(slot, 10))
 	var reqQuery url.Values
 	if !fetchAllSidecars {
-		reqQuery = url.Values{}
+		indexString := ""
 		for i := range hashes {
-			reqQuery.Add("indices", strconv.FormatUint(hashes[i].Index, 10))
+			if i != 0 {
+				// Prepend a comma for all but the first index in comma-separated list
+				indexString += ","
+			}
+			indexString += strconv.FormatUint(hashes[i].Index, 10)
 		}
+		reqQuery = url.Values{}
+		reqQuery.Add("indices", indexString)
 	}
 	var resp eth.APIGetBlobSidecarsResponse
 	if err := cl.apiReq(ctx, &resp, reqPath, reqQuery); err != nil {

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum"
@@ -120,16 +121,12 @@ func (cl *BeaconHTTPClient) BeaconBlobSideCars(ctx context.Context, fetchAllSide
 	reqPath := path.Join(sidecarsMethodPrefix, strconv.FormatUint(slot, 10))
 	var reqQuery url.Values
 	if !fetchAllSidecars {
-		indexString := ""
+		indices := []string{}
 		for i := range hashes {
-			if i != 0 {
-				// Prepend a comma for all but the first index in comma-separated list
-				indexString += ","
-			}
-			indexString += strconv.FormatUint(hashes[i].Index, 10)
+			indices = append(indices, strconv.FormatUint(hashes[i].Index, 10))
 		}
 		reqQuery = url.Values{}
-		reqQuery.Add("indices", indexString)
+		reqQuery.Add("indices", strings.Join(indices, ","))
 	}
 	var resp eth.APIGetBlobSidecarsResponse
 	if err := cl.apiReq(ctx, &resp, reqPath, reqQuery); err != nil {


### PR DESCRIPTION
**Description**

Fix a bug that causes op-node to stall syncing L2 safe/unsafe when requesting multiple specific indices from the same slot (instead of requesting the ALL indices within the same slot).

**Tests**

Manually tested the request in question with both the old format and new format to confirm the expected response. The faulty request looked this, and only returned index `0`.
```
curl -X GET 'https://blob-api-sepolia.primary.client.dev.oplabs.cloud/eth/v1/beacon/blob_sidecars/4594316?indices=0&indices=1' -H 'accept: application/json' | jq
```

Fixed req returns the two blobs indices we want:
```
curl -X GET 'https://blob-api-sepolia.primary.client.dev.oplabs.cloud/eth/v1/beacon/blob_sidecars/4594316?indices=0,1' -H 'accept: application/json' | jq
```

**Additional context**

Found this log in our dev `blob-archiver-sepolia`:
```
2024/05/14 19:00:41 "GET http://blob-api-sepolia.primary.client.dev.oplabs.cloud/eth/v1/beacon/blob_sidecars/4594316?indices=0&indices=1 HTTP/1.1" from 10.192.0.207:45338 - 200 1686B in 553.564431ms
```
This aligns with logs in the `replica-blob` that look like this:
```
2024-05-14 16:02:03.516	
t=2024-05-14T20:02:03+0000 lvl=warn msg="Derivation process temporary error" attempts=413 err="engine stage failed: temp: failed to fetch blobs: failed to get blob sidecars for L1BlockRef 0x36980b874790ac79c9c9685ca9b0396bea5ef376cbae2c1332ced29a5c31e59e:5518642: expected 2 sidecars but got 0"
```

The error is in the way the query param is structured: `?indices=0&indices=1`. Instead that query param should be `?indices=0,1`
