### PR TITLE
cannon: Make jsonutil error when loading json payload with extra data

### DIFF
--- a/op-service/jsonutil/json.go
+++ b/op-service/jsonutil/json.go
@@ -21,8 +21,13 @@ func LoadJSON[X any](inputPath string) (*X, error) {
 	}
 	defer f.Close()
 	var state X
-	if err := json.NewDecoder(f).Decode(&state); err != nil {
+	decoder := json.NewDecoder(f)
+	if err := decoder.Decode(&state); err != nil {
 		return nil, fmt.Errorf("failed to decode file %q: %w", inputPath, err)
+	}
+	// We are only expecting 1 JSON object - confirm there is no trailing data
+	if _, err := decoder.Token(); err != io.EOF {
+		return nil, fmt.Errorf("unexpected trailing data in file %q", inputPath)
 	}
 	return &state, nil
 }

--- a/op-service/jsonutil/json_test.go
+++ b/op-service/jsonutil/json_test.go
@@ -2,6 +2,7 @@ package jsonutil
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +48,113 @@ func TestRoundTripJSONWithGzip(t *testing.T) {
 	require.EqualValues(t, data, result)
 }
 
+func TestLoadJSONWithExtraDataAppended(t *testing.T) {
+	data := &jsonTestData{A: "yay", B: 3}
+
+	cases := []struct {
+		name      string
+		extraData func() ([]byte, error)
+	}{
+		{
+			name: "duplicate json object",
+			extraData: func() ([]byte, error) {
+				return json.Marshal(data)
+			},
+		},
+		{
+			name: "duplicate comma-separated json object",
+			extraData: func() ([]byte, error) {
+				data, err := json.Marshal(data)
+				if err != nil {
+					return nil, err
+				}
+				return append([]byte(","), data...), nil
+			},
+		},
+		{
+			name: "additional characters",
+			extraData: func() ([]byte, error) {
+				return []byte("some text"), nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := filepath.Join(dir, "test.json")
+			extraData, err := tc.extraData()
+			require.NoError(t, err)
+
+			// Write primary json payload + extra data to the file
+			err = WriteJSON(file, data, 0o755)
+			require.NoError(t, err)
+			err = appendDataToFile(file, extraData)
+			require.NoError(t, err)
+
+			var result *jsonTestData
+			result, err = LoadJSON[jsonTestData](file)
+			require.ErrorContains(t, err, fmt.Sprintf("unexpected trailing data in file %q", file))
+			require.Nil(t, result)
+		})
+	}
+}
+
+func TestLoadJSONWithTrailingWhitespace(t *testing.T) {
+	cases := []struct {
+		name      string
+		extraData []byte
+	}{
+		{
+			name:      "space",
+			extraData: []byte(" "),
+		},
+		{
+			name:      "tab",
+			extraData: []byte("\t"),
+		},
+		{
+			name:      "new line",
+			extraData: []byte("\n"),
+		},
+		{
+			name:      "multiple chars",
+			extraData: []byte(" \t\n"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := filepath.Join(dir, "test.json")
+			data := &jsonTestData{A: "yay", B: 3}
+
+			// Write primary json payload + extra data to the file
+			err := WriteJSON(file, data, 0o755)
+			require.NoError(t, err)
+			err = appendDataToFile(file, tc.extraData)
+			require.NoError(t, err)
+
+			var result *jsonTestData
+			result, err = LoadJSON[jsonTestData](file)
+			require.NoError(t, err)
+			require.EqualValues(t, data, result)
+		})
+	}
+}
+
 type jsonTestData struct {
 	A string `json:"a"`
 	B int    `json:"b"`
+}
+
+func appendDataToFile(outputPath string, data []byte) error {
+	file, err := os.OpenFile(outputPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.Write(data)
+	return err
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Make `jsonutil.LoadJSON` error rather than accept a malformed file with extra data appended after a valid JSON payload. 
  This addresses the `json.Decoder.Decode` anti-pattern described [here](https://github.com/golang/go/issues/36225#issuecomment-567768053).  

**Tests**

Add some unit tests to validate the behavior of `LoadJSON` when extra data is appended to the file being processed. 

**Additional context**

This is part of the work to address the Coinbase security audit of Cannon.

**Metadata**

Part of: https://github.com/ethereum-optimism/client-pod/issues/761 (L-06)
