### PR TITLE
op-challenger/op-dispute-mon: Support version 1.0.0 of fault dispute game contracts

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -99,7 +99,7 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 				contract:    batching.NewBoundContract(legacyAbi, addr),
 			},
 		}, nil
-	} else if strings.HasPrefix(version, "0.18.") {
+	} else if strings.HasPrefix(version, "0.18.") || strings.HasPrefix(version, "1.0.") {
 		// Detected an older version of contracts, use a compatibility shim.
 		legacyAbi := mustParseAbi(faultDisputeGameAbi0180)
 		return &FaultDisputeGameContract0180{


### PR DESCRIPTION
**Description**

Support version 1.0 of contracts which was deployed to devnet.  Functionally the same as 0.18.0