### PR TITLE
add ability to decode ecotone scalar values into components

### DIFF
--- a/op-chain-ops/cmd/ecotone-scalar/main.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main.go
@@ -12,6 +12,8 @@ import (
 
 func main() {
 	var scalar, blobScalar uint
+	var decode string
+	flag.StringVar(&decode, "decode", "", "uint256 post-ecotone scalar value to decode into its components")
 	flag.UintVar(&scalar, "scalar", 0, "base fee scalar value for the gas config (uint32)")
 	flag.UintVar(&blobScalar, "blob-scalar", 0, "blob base fee scalar value for the gas config (uint32)")
 	flag.Parse()
@@ -27,10 +29,41 @@ func main() {
 		os.Exit(2)
 	}
 
-	encoded := eth.EncodeScalar(eth.EcostoneScalars{
-		BlobBaseFeeScalar: uint32(blobScalar),
-		BaseFeeScalar:     uint32(scalar),
-	})
+	var encoded [32]byte
+	if len(decode) > 0 {
+		if scalar != 0 || blobScalar != 0 {
+			fmt.Fprintln(flag.CommandLine.Output(), "decode parameter should not be used with scalar and blob-scalar")
+			flag.Usage()
+			os.Exit(2)
+		}
+		uint256 := new(big.Int)
+		_, ok := uint256.SetString(decode, 10)
+		if !ok {
+			fmt.Fprintln(flag.CommandLine.Output(), "failed to parse int from post-ecotone scalar")
+			flag.Usage()
+			os.Exit(2)
+		}
+		encodedSlice := uint256.Bytes()
+		if len(encodedSlice) > 32 {
+			fmt.Fprintln(flag.CommandLine.Output(), "post-ecotone scalar out of uint256 range")
+			flag.Usage()
+			os.Exit(2)
+		}
+		copy(encoded[:], encodedSlice)
+		decoded, err := eth.DecodeScalar(encoded)
+		if err != nil {
+			fmt.Fprintln(flag.CommandLine.Output(), "post-ecotone scalar could not be decoded:", err)
+			flag.Usage()
+			os.Exit(2)
+		}
+		scalar = uint(decoded.BaseFeeScalar)
+		blobScalar = uint(decoded.BlobBaseFeeScalar)
+	} else {
+		encoded = eth.EncodeScalar(eth.EcostoneScalars{
+			BlobBaseFeeScalar: uint32(blobScalar),
+			BaseFeeScalar:     uint32(scalar),
+		})
+	}
 	i := new(big.Int).SetBytes(encoded[:])
 
 	fmt.Println("# base fee scalar     :", scalar)

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -425,7 +425,7 @@ func DecodeScalar(scalar [32]byte) (EcostoneScalars, error) {
 			BaseFeeScalar:     binary.BigEndian.Uint32(scalar[28:32]),
 		}, nil
 	default:
-		return EcostoneScalars{}, fmt.Errorf("unexpected system config scalar: %s", scalar)
+		return EcostoneScalars{}, fmt.Errorf("unexpected system config scalar: %x", scalar)
 	}
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

ecotone-scalar is a script that is used to compute the post-Ecotone "scalar" value from its components.  This PR extends this script with the ability to do the opposite: take a post-Ecotone scalar and output its components.

**Tests**

Verified decoding of a previously encoded value produces the expected matching output:

```
> ./main --scalar 1101 --blob-scalar 659851
# base fee scalar     : 1101
# blob base fee scalar: 659851
# v1 hex encoding  : 0x010000000000000000000000000000000000000000000000000a118b0000044d
# uint value for the 'scalar' parameter in SystemConfigProxy.setGasConfig():
452312848583266388373324160190187140051835877600158453279134021569375896653

> ./main --decode 452312848583266388373324160190187140051835877600158453279134021569375896653
# base fee scalar     : 1101
# blob base fee scalar: 659851
# v1 hex encoding  : 0x010000000000000000000000000000000000000000000000000a118b0000044d
# uint value for the 'scalar' parameter in SystemConfigProxy.setGasConfig():
452312848583266388373324160190187140051835877600158453279134021569375896653
```