### PR TITLE
chore: `fault-mon` fix on the `L2_ORACLE()` using the `l2Oracle()` for custom chains.

### DIFF
--- a/packages/chain-mon/src/fault-mon/service.ts
+++ b/packages/chain-mon/src/fault-mon/service.ts
@@ -151,7 +151,7 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
         address: portalAddress,
         signerOrProvider: this.options.l1RpcProvider,
       })
-      contracts.L2OutputOracle = await portalContract.L2_ORACLE()
+      contracts.L2OutputOracle = await portalContract.l2Oracle()
     }
 
     // ... for a known chain ids without an override, the L2OutputOracle will already


### PR DESCRIPTION
The recognized chains (op-sepolia, base, mainnet) won't be affected by                                                                                                                                                                                                       Thus fixing the custom chains.                                                                                                                                                                                                                              