### PR TITLE
ci: reduce kontrol tests

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -110,7 +110,7 @@ regen=
 #################################
 
 # Temporarily unexecuted tests
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused0" \
+# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused0" \ -- This one is executed below.
 # "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused1" \
 # "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused2" \
 # "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused3" \
@@ -121,13 +121,22 @@ regen=
 # "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused8" \
 # "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused9" \
 # "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused10" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused0" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused1" \ -- This one is executed below.
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused2" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused3" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused4" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused5" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused6" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused7" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused8" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused9" \
+# "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused10" \
 
 test_list=()
 if [ "$SCRIPT_TESTS" == true ]; then
   test_list=( "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused0" \
-              "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused1(" \
               "OptimismPortalKontrol.prove_finalizeWithdrawalTransaction_paused" \
-              "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused0" \
               "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused1(" \
               "OptimismPortal2Kontrol.prove_finalizeWithdrawalTransaction_paused" \
               "L1StandardBridgeKontrol.prove_finalizeBridgeERC20_paused" \


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/pull/10429 added Kontrol proofs for OptimismPortal2. However, proofs use a lot of RAM and we now exceed the 32GB memory limit on xlarge runners, causing the "Infrastructure Fail. This job appears to have stopped responding, try re-running it" [failures](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/54541/workflows/07189202-4ca7-40d7-8b04-a774878ca5a8/jobs/2357600).

Soon, RV will open a PR to offload proof execution to them which will run all proofs to mitigate this. For now, we remove 2 more proofs from CI to attempt to get back below the resource usage limit.