### PR TITLE
op-dispute-mon: Publish latest valid and invalid proposal times

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -36,7 +36,7 @@ func (*NoopMetricsImpl) RecordOutputFetchTime(_ float64) {}
 
 func (*NoopMetricsImpl) RecordGameAgreement(_ GameAgreementStatus, _ int) {}
 
-func (*NoopMetricsImpl) RecordLatestInvalidProposal(_ uint64) {}
+func (*NoopMetricsImpl) RecordLatestProposals(_ uint64, _ uint64) {}
 
 func (*NoopMetricsImpl) RecordIgnoredGames(_ int) {}
 

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -263,8 +263,8 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 		{},
 		mockRootClaim,
 		{},
-		{}, // Expected latest invalid proposal (will have timestamp 7)
-		mockRootClaim,
+		{},            // Expected latest invalid proposal (will have timestamp 7)
+		mockRootClaim, // Expected latest valid proposal (will have timestamp 8)
 	}
 	games := make([]*monTypes.EnrichedGameData, 9)
 	for i := range games {
@@ -293,6 +293,7 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	require.Equal(t, 3, m.ignoredGames)
 	require.Equal(t, 4, m.contractCreationFails)
 	require.EqualValues(t, 7, m.latestInvalidProposal)
+	require.EqualValues(t, 8, m.latestValidProposal)
 }
 
 func setupForecastTest(t *testing.T) (*Forecast, *mockForecastMetrics, *testlog.CapturingHandler) {
@@ -320,6 +321,7 @@ type mockForecastMetrics struct {
 	gameAgreement         map[metrics.GameAgreementStatus]int
 	ignoredGames          int
 	latestInvalidProposal uint64
+	latestValidProposal   uint64
 	contractCreationFails int
 }
 
@@ -331,8 +333,9 @@ func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementSt
 	m.gameAgreement[status] = count
 }
 
-func (m *mockForecastMetrics) RecordLatestInvalidProposal(timestamp uint64) {
-	m.latestInvalidProposal = timestamp
+func (m *mockForecastMetrics) RecordLatestProposals(valid, invalid uint64) {
+	m.latestValidProposal = valid
+	m.latestInvalidProposal = invalid
 }
 
 func (m *mockForecastMetrics) RecordIgnoredGames(count int) {


### PR DESCRIPTION
**Description**

Changes latest_invalid_proposal metric to latest_proposal with a root_agreement label. Will enable alerting if the proposer isn't creating games on the expected schedule.

**Tests**

Updated unit tests


**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/868
