### PR TITLE
Update README.md to describe new ecotone-scalar decode flag

### DIFF
--- a/op-chain-ops/cmd/ecotone-scalar/README.md
+++ b/op-chain-ops/cmd/ecotone-scalar/README.md
@@ -18,3 +18,9 @@ blob base fee parameters respectively, for example:
 ```sh
 ./bin/ecotone-scalar --scalar=7600 --blob-scalar=862000
 ```
+
+You can also use the utility to decode a versioned value into its components:
+
+```sh
+./bin/ecotone-scalar --decode=452312848583266388373324160190187140051835877600158453279134021569375896653
+```

--- a/op-chain-ops/cmd/ecotone-scalar/main.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main.go
@@ -37,7 +37,7 @@ func main() {
 			os.Exit(2)
 		}
 		uint256 := new(big.Int)
-		_, ok := uint256.SetString(decode, 10)
+		_, ok := uint256.SetString(decode, 0)
 		if !ok {
 			fmt.Fprintln(flag.CommandLine.Output(), "failed to parse int from post-ecotone scalar")
 			flag.Usage()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The ecotone-scalar utility was updated in https://github.com/ethereum-optimism/optimism/pull/10547 to support value decoding but didn't include an update to this documentation.