### PR TITLE
ci: remove dead `op-bindings` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1750,7 +1750,7 @@ workflows:
       - fuzz-golang:
           name: op-chain-ops-fuzz
           package_name: op-chain-ops
-          on_changes: op-chain-ops,op-bindings
+          on_changes: op-chain-ops
           requires: ["go-mod-download"]
       - fuzz-golang:
           name: cannon-fuzz
@@ -1765,10 +1765,6 @@ workflows:
       - go-test:
           name: op-batcher-tests
           module: op-batcher
-          requires: ["go-mod-download"]
-      - go-test:
-          name: op-bindings-tests
-          module: op-bindings
           requires: ["go-mod-download"]
       - go-test:
           name: op-chain-ops-tests
@@ -1857,7 +1853,6 @@ workflows:
             - check-generated-mocks-op-service
             - go-mod-download
             - op-batcher-tests
-            - op-bindings-tests
             - op-chain-ops-tests
             - op-heartbeat-tests
             - op-node-tests


### PR DESCRIPTION
**Description**

The `op-bindings` package has no tests in it, therefore
it doesn't need a job in CI. You can see in [this](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/54620/workflows/1ce56b22-29ac-46e8-9001-d419767756be/jobs/2361188)
job, there is nothing that runs.

```
gotestsum --format=testname --junitfile=/tmp/test-results/op-bindings.xml --jsonfile=/testlogs/log.json \
-- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out ./...

EMPTY op-bindings/bindings
EMPTY op-bindings/bindingspreview

DONE 0 tests in 17.694s
```

`op-bindings` is deprecated and on its way out of the monorepo, services
are responsible for their own bindings management now.

The following see [here](https://github.com/ethereum-optimism/optimism/blob/9047beb54c66a5c572784efec8984f259302ec92/op-chain-ops/justfile)
for an example on how to generate bindings in a simple way.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

