### PR TITLE
Remove remaining use of Hex2Bytes

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -173,7 +173,7 @@ func TestSimpleGetters(t *testing.T) {
 
 func TestClock_EncodingDecoding(t *testing.T) {
 	t.Run("DurationAndTimestamp", func(t *testing.T) {
-		by := common.Hex2Bytes("00000000000000050000000000000002")
+		by := common.FromHex("00000000000000050000000000000002")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
 		require.Equal(t, 5*time.Second, clock.Duration)
@@ -182,7 +182,7 @@ func TestClock_EncodingDecoding(t *testing.T) {
 	})
 
 	t.Run("ZeroDuration", func(t *testing.T) {
-		by := common.Hex2Bytes("00000000000000000000000000000002")
+		by := common.FromHex("00000000000000000000000000000002")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
 		require.Equal(t, 0*time.Second, clock.Duration)
@@ -191,7 +191,7 @@ func TestClock_EncodingDecoding(t *testing.T) {
 	})
 
 	t.Run("ZeroTimestamp", func(t *testing.T) {
-		by := common.Hex2Bytes("00000000000000050000000000000000")
+		by := common.FromHex("00000000000000050000000000000000")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
 		require.Equal(t, 5*time.Second, clock.Duration)
@@ -200,7 +200,7 @@ func TestClock_EncodingDecoding(t *testing.T) {
 	})
 
 	t.Run("ZeroClock", func(t *testing.T) {
-		by := common.Hex2Bytes("00000000000000000000000000000000")
+		by := common.FromHex("00000000000000000000000000000000")
 		encoded := new(big.Int).SetBytes(by)
 		clock := decodeClock(encoded)
 		require.Equal(t, 0*time.Second, clock.Duration)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We forbid the use of `Hex2Bytes` because it silently fails on `0x` prefixed hex strings and return empty byte slices.

**Tests**

Modified tests should still pass. 

**Additional context**

This must have gotten in close to before we added the semgrep rule.

