### PR TITLE
ci: less resource intensive proofs

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -136,9 +136,8 @@ regen=
 test_list=()
 if [ "$SCRIPT_TESTS" == true ]; then
   test_list=( "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused0" \
+              "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused1(" \
               "OptimismPortalKontrol.prove_finalizeWithdrawalTransaction_paused" \
-              "OptimismPortal2Kontrol.prove_proveWithdrawalTransaction_paused1(" \
-              "OptimismPortal2Kontrol.prove_finalizeWithdrawalTransaction_paused" \
               "L1StandardBridgeKontrol.prove_finalizeBridgeERC20_paused" \
               "L1StandardBridgeKontrol.prove_finalizeBridgeETH_paused" \
               "L1ERC721BridgeKontrol.prove_finalizeBridgeERC721_paused" \


### PR DESCRIPTION
The OptimismPortal2 proofs [still](https://github.com/ethereum-optimism/optimism/pull/10563) might be too resource intensive for these runners—in the below screenshot I ran all proofs locally and you can see the OptimismPortal2 proofs are much slower than OptimismPortal1. I'm going to run proofs overnight again with a different config to get some insight into the performance difference. In the meantime this PR changes CI to only run OptimismPortal proofs to avoid the infrastructure fail errors. cc @clabby 

![image](https://github.com/ethereum-optimism/optimism/assets/17163988/e92dcb0d-c838-44b3-bac4-c524e2c0c015)
