### PR TITLE
op-batcher,op-node,batch_decoder: add logging of compression algo

### DIFF
--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -430,7 +430,7 @@ func TestChannelBuilder_OutputFrames(t *testing.T) {
 }
 
 func TestChannelBuilder_OutputFrames_SpanBatch(t *testing.T) {
-	for _, algo := range derive.CompressionAlgoTypes {
+	for _, algo := range derive.CompressionAlgos {
 		t.Run("ChannelBuilder_OutputFrames_SpanBatch_"+algo.String(), func(t *testing.T) {
 			if algo.IsBrotli() {
 				ChannelBuilder_OutputFrames_SpanBatch(t, algo) // to fill faster for brotli

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -204,7 +204,6 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 	}
 
 	pc, err := newChannel(s.log, s.metr, s.cfg, s.rollupCfg, s.l1OriginLastClosedChannel.Number)
-
 	if err != nil {
 		return fmt.Errorf("creating new channel: %w", err)
 	}
@@ -218,6 +217,8 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		"l1OriginLastClosedChannel", s.l1OriginLastClosedChannel,
 		"blocks_pending", len(s.blocks),
 		"batch_type", s.cfg.BatchType,
+		"compresion_algo", s.cfg.CompressorConfig.CompressionAlgo,
+		"target_num_frames", s.cfg.TargetNumFrames,
 		"max_frame_size", s.cfg.MaxFrameSize,
 	)
 	s.metr.RecordChannelOpened(pc.ID(), len(s.blocks))

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -217,7 +217,7 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		"l1OriginLastClosedChannel", s.l1OriginLastClosedChannel,
 		"blocks_pending", len(s.blocks),
 		"batch_type", s.cfg.BatchType,
-		"compresion_algo", s.cfg.CompressorConfig.CompressionAlgo,
+		"compression_algo", s.cfg.CompressorConfig.CompressionAlgo,
 		"target_num_frames", s.cfg.TargetNumFrames,
 		"max_frame_size", s.cfg.MaxFrameSize,
 	)

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -128,7 +128,7 @@ func (c *CLIConfig) Check() error {
 	if c.Compressor == compressor.RatioKind && (c.ApproxComprRatio <= 0 || c.ApproxComprRatio > 1) {
 		return fmt.Errorf("invalid ApproxComprRatio %v for ratio compressor", c.ApproxComprRatio)
 	}
-	if !derive.ValidCompressionAlgoType(c.CompressionAlgo) {
+	if !derive.ValidCompressionAlgo(c.CompressionAlgo) {
 		return fmt.Errorf("invalid compression algo %v", c.CompressionAlgo)
 	}
 	if c.BatchType > 1 {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -242,9 +242,10 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		"max_frame_size", cc.MaxFrameSize,
 		"target_num_frames", cc.TargetNumFrames,
 		"compressor", cc.CompressorConfig.Kind,
+		"compresion_algo", cc.CompressorConfig.CompressionAlgo,
+		"batch_type", cc.BatchType,
 		"max_channel_duration", cc.MaxChannelDuration,
 		"channel_timeout", cc.ChannelTimeout,
-		"batch_type", cc.BatchType,
 		"sub_safety_margin", cc.SubSafetyMargin)
 	bs.ChannelConfig = cc
 	return nil

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -242,7 +242,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		"max_frame_size", cc.MaxFrameSize,
 		"target_num_frames", cc.TargetNumFrames,
 		"compressor", cc.CompressorConfig.Kind,
-		"compresion_algo", cc.CompressorConfig.CompressionAlgo,
+		"compression_algo", cc.CompressorConfig.CompressionAlgo,
 		"batch_type", cc.BatchType,
 		"max_channel_duration", cc.MaxChannelDuration,
 		"channel_timeout", cc.ChannelTimeout,

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -102,7 +102,7 @@ var (
 	}
 	CompressionAlgoFlag = &cli.GenericFlag{
 		Name:    "compression-algo",
-		Usage:   "The compression algorithm to use. Valid options: " + openum.EnumString(derive.CompressionAlgoTypes),
+		Usage:   "The compression algorithm to use. Valid options: " + openum.EnumString(derive.CompressionAlgos),
 		EnvVars: prefixEnvVars("COMPRESSION_ALGO"),
 		Value: func() *derive.CompressionAlgo {
 			out := derive.Zlib

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -48,7 +48,7 @@ var (
 		derive.SpanBatchType,
 		// uncomment to include singular batches in the benchmark
 		// singular batches are not included by default because they are not the target of the benchmark
-		//derive.SingularBatchType,
+		// derive.SingularBatchType,
 	}
 )
 
@@ -129,7 +129,7 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 			// to leverage optimizations in the Batch Linked List
 			batches[i].Timestamp = uint64(t.Add(time.Duration(i) * time.Second).Unix())
 		}
-		for _, algo := range derive.CompressionAlgoTypes {
+		for _, algo := range derive.CompressionAlgos {
 			b.Run(tc.String()+"_"+algo.String(), func(b *testing.B) {
 				// reset the compressor used in the test case
 				for bn := 0; bn < b.N; bn++ {
@@ -168,7 +168,7 @@ func BenchmarkIncremental(b *testing.B) {
 		{derive.SpanBatchType, 5, 1, "RealBlindCompressor"},
 		//{derive.SingularBatchType, 100, 1, "RealShadowCompressor"},
 	}
-	for _, algo := range derive.CompressionAlgoTypes {
+	for _, algo := range derive.CompressionAlgos {
 		for _, tc := range tcs {
 			cout, err := channelOutByType(tc.BatchType, tc.compKey, algo)
 			if err != nil {
@@ -231,7 +231,7 @@ func BenchmarkAllBatchesChannelOut(b *testing.B) {
 		}
 	}
 
-	for _, algo := range derive.CompressionAlgoTypes {
+	for _, algo := range derive.CompressionAlgos {
 		for _, tc := range tests {
 			chainID := big.NewInt(333)
 			rng := rand.New(rand.NewSource(0x543331))

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -37,6 +37,8 @@ type Batch interface {
 	GetBatchType() int
 	GetTimestamp() uint64
 	LogContext(log.Logger) log.Logger
+	AsSingularBatch() (*SingularBatch, bool)
+	AsSpanBatch() (*SpanBatch, bool)
 }
 
 type batchWithMetadata struct {

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -45,7 +45,11 @@ type batchWithMetadata struct {
 }
 
 func (b batchWithMetadata) LogContext(l log.Logger) log.Logger {
-	return b.Batch.LogContext(l).With("compression_algo", b.comprAlgo)
+	lgr := b.Batch.LogContext(l)
+	if b.comprAlgo == "" {
+		return lgr
+	}
+	return lgr.With("compression_algo", b.comprAlgo)
 }
 
 // BatchData is used to represent the typed encoding & decoding.

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -39,12 +39,22 @@ type Batch interface {
 	LogContext(log.Logger) log.Logger
 }
 
+type batchWithMetadata struct {
+	Batch
+	comprAlgo CompressionAlgo
+}
+
+func (b batchWithMetadata) LogContext(l log.Logger) log.Logger {
+	return b.Batch.LogContext(l).With("compression_algo", b.comprAlgo)
+}
+
 // BatchData is used to represent the typed encoding & decoding.
 // and wraps around a single interface InnerBatchData.
 // Further fields such as cache can be added in the future, without embedding each type of InnerBatchData.
 // Similar design with op-geth's types.Transaction struct.
 type BatchData struct {
-	inner InnerBatchData
+	inner     InnerBatchData
+	ComprAlgo CompressionAlgo
 }
 
 // InnerBatchData is the underlying data of a BatchData.

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -177,15 +177,15 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 	}
 
 	var nextBatch *SingularBatch
-	switch batch.GetBatchType() {
+	switch typ := batch.GetBatchType(); typ {
 	case SingularBatchType:
-		singularBatch, ok := batch.(*SingularBatch)
+		singularBatch, ok := batch.AsSingularBatch()
 		if !ok {
 			return nil, false, NewCriticalError(errors.New("failed type assertion to SingularBatch"))
 		}
 		nextBatch = singularBatch
 	case SpanBatchType:
-		spanBatch, ok := batch.(*SpanBatch)
+		spanBatch, ok := batch.AsSpanBatch()
 		if !ok {
 			return nil, false, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
@@ -198,7 +198,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		// span-batches are non-empty, so the below pop is safe.
 		nextBatch = bq.popNextBatch(parent)
 	default:
-		return nil, false, NewCriticalError(fmt.Errorf("unrecognized batch type: %d", batch.GetBatchType()))
+		return nil, false, NewCriticalError(fmt.Errorf("unrecognized batch type: %d", typ))
 	}
 
 	// If the nextBatch is derived from the span batch, len(bq.nextSpan) == 0 means it's the last batch of the span.

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -11,8 +11,8 @@ import (
 )
 
 type BatchWithL1InclusionBlock struct {
+	Batch
 	L1InclusionBlock eth.L1BlockRef
-	Batch            Batch
 }
 
 type BatchValidity uint8
@@ -34,23 +34,23 @@ const (
 func CheckBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef,
 	l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l2Fetcher SafeBlockFetcher,
 ) BatchValidity {
-	switch batch.Batch.GetBatchType() {
+	switch typ := batch.GetBatchType(); typ {
 	case SingularBatchType:
-		singularBatch, ok := batch.Batch.(*SingularBatch)
+		singularBatch, ok := batch.AsSingularBatch()
 		if !ok {
 			log.Error("failed type assertion to SingularBatch")
 			return BatchDrop
 		}
 		return checkSingularBatch(cfg, log, l1Blocks, l2SafeHead, singularBatch, batch.L1InclusionBlock)
 	case SpanBatchType:
-		spanBatch, ok := batch.Batch.(*SpanBatch)
+		spanBatch, ok := batch.AsSpanBatch()
 		if !ok {
 			log.Error("failed type assertion to SpanBatch")
 			return BatchDrop
 		}
 		return checkSpanBatch(ctx, cfg, log, l1Blocks, l2SafeHead, spanBatch, batch.L1InclusionBlock, l2Fetcher)
 	default:
-		log.Warn("Unrecognized batch type: %d", batch.Batch.GetBatchType())
+		log.Warn("Unrecognized batch type: %d", typ)
 		return BatchDrop
 	}
 }

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -15,9 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
-var (
-	rollupCfg rollup.Config
-)
+var rollupCfg rollup.Config
 
 // basic implementation of the Compressor interface that does no compression
 type nonCompressor struct {
@@ -248,7 +246,7 @@ func TestSpanChannelOut(t *testing.T) {
 	}
 	for _, test := range tests {
 		test := test
-		for _, algo := range CompressionAlgoTypes {
+		for _, algo := range CompressionAlgos {
 			t.Run(test.name+"_"+algo.String(), func(t *testing.T) {
 				test.f(t, algo)
 			})

--- a/op-node/rollup/derive/singular_batch.go
+++ b/op-node/rollup/derive/singular_batch.go
@@ -27,6 +27,9 @@ type SingularBatch struct {
 	Transactions []hexutil.Bytes
 }
 
+func (b *SingularBatch) AsSingularBatch() (*SingularBatch, bool) { return b, true }
+func (b *SingularBatch) AsSpanBatch() (*SpanBatch, bool)         { return nil, false }
+
 // GetBatchType returns its batch type (batch_version)
 func (b *SingularBatch) GetBatchType() int {
 	return SingularBatchType

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -422,6 +422,9 @@ type SpanBatch struct {
 	sbtxs         *spanBatchTxs
 }
 
+func (b *SpanBatch) AsSingularBatch() (*SingularBatch, bool) { return nil, false }
+func (b *SpanBatch) AsSpanBatch() (*SpanBatch, bool)         { return b, true }
+
 // spanBatchMarshaling is a helper type used for JSON marshaling.
 type spanBatchMarshaling struct {
 	ParentCheck   []hexutil.Bytes     `json:"parent_check"`

--- a/op-node/rollup/derive/types.go
+++ b/op-node/rollup/derive/types.go
@@ -10,26 +10,28 @@ type CompressionAlgo string
 const (
 	// compression algo types
 	Zlib     CompressionAlgo = "zlib"
+	Brotli   CompressionAlgo = "brotli" // default level
 	Brotli9  CompressionAlgo = "brotli-9"
 	Brotli10 CompressionAlgo = "brotli-10"
 	Brotli11 CompressionAlgo = "brotli-11"
 )
 
-var CompressionAlgoTypes = []CompressionAlgo{
+var CompressionAlgos = []CompressionAlgo{
 	Zlib,
+	Brotli,
 	Brotli9,
 	Brotli10,
 	Brotli11,
 }
 
-var brotliRegexp = regexp.MustCompile(`^brotli-(9|10|11)$`)
+var brotliRegexp = regexp.MustCompile(`^brotli(|-(9|10|11))$`)
 
 func (algo CompressionAlgo) String() string {
 	return string(algo)
 }
 
 func (algo *CompressionAlgo) Set(value string) error {
-	if !ValidCompressionAlgoType(CompressionAlgo(value)) {
+	if !ValidCompressionAlgo(CompressionAlgo(value)) {
 		return fmt.Errorf("unknown compression algo type: %q", value)
 	}
 	*algo = CompressionAlgo(value)
@@ -49,7 +51,7 @@ func GetBrotliLevel(algo CompressionAlgo) int {
 	switch algo {
 	case Brotli9:
 		return 9
-	case Brotli10:
+	case Brotli10, Brotli: // make level 10 the default
 		return 10
 	case Brotli11:
 		return 11
@@ -58,8 +60,8 @@ func GetBrotliLevel(algo CompressionAlgo) int {
 	}
 }
 
-func ValidCompressionAlgoType(value CompressionAlgo) bool {
-	for _, k := range CompressionAlgoTypes {
+func ValidCompressionAlgo(value CompressionAlgo) bool {
+	for _, k := range CompressionAlgos {
 		if k == value {
 			return true
 		}

--- a/op-node/rollup/derive/types_test.go
+++ b/op-node/rollup/derive/types_test.go
@@ -10,49 +10,64 @@ func TestCompressionAlgo(t *testing.T) {
 	testCases := []struct {
 		name                       string
 		algo                       CompressionAlgo
-		isBrotli                   bool
 		isValidCompressionAlgoType bool
+		isBrotli                   bool
+		brotliLevel                int
 	}{
 		{
 			name:                       "zlib",
 			algo:                       Zlib,
-			isBrotli:                   false,
 			isValidCompressionAlgoType: true,
+			isBrotli:                   false,
+		},
+		{
+			name:                       "brotli",
+			algo:                       Brotli,
+			isValidCompressionAlgoType: true,
+			isBrotli:                   true,
+			brotliLevel:                10,
 		},
 		{
 			name:                       "brotli-9",
 			algo:                       Brotli9,
-			isBrotli:                   true,
 			isValidCompressionAlgoType: true,
+			isBrotli:                   true,
+			brotliLevel:                9,
 		},
 		{
 			name:                       "brotli-10",
 			algo:                       Brotli10,
-			isBrotli:                   true,
 			isValidCompressionAlgoType: true,
+			isBrotli:                   true,
+			brotliLevel:                10,
 		},
 		{
 			name:                       "brotli-11",
 			algo:                       Brotli11,
-			isBrotli:                   true,
 			isValidCompressionAlgoType: true,
+			isBrotli:                   true,
+			brotliLevel:                11,
 		},
 		{
 			name:                       "invalid",
 			algo:                       CompressionAlgo("invalid"),
-			isBrotli:                   false,
 			isValidCompressionAlgoType: false,
-		}}
+			isBrotli:                   false,
+		},
+	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.isBrotli, tc.algo.IsBrotli())
 			if tc.isBrotli {
-				require.NotPanics(t, func() { GetBrotliLevel((tc.algo)) })
+				require.NotPanics(t, func() {
+					blvl := GetBrotliLevel((tc.algo))
+					require.Equal(t, tc.brotliLevel, blvl)
+				})
 			} else {
 				require.Panics(t, func() { GetBrotliLevel(tc.algo) })
 			}
-			require.Equal(t, tc.isValidCompressionAlgoType, ValidCompressionAlgoType(tc.algo))
+			require.Equal(t, tc.isValidCompressionAlgoType, ValidCompressionAlgo(tc.algo))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds logging of the used compression algo to the op-batcher and op-node.
    * To get the compression algo info to the right places in op-node, I added a `Batch` wrapper type `batchWithMetadata` that appends the algo to the log context.
* Adds the algo to the batch decoder tool's output data.
* Fixing some naming around compression algos.
* Adds `brotli` as a valid default selector for `brotli-10` compression

**Tests**

Added the default brotli compression algo string to tests. Remaining changes are logging (or the untested `batch_decoder`)

**Additional context**

There's currently no way to know from batcher or node logs what compression algo is actually in use for (de)compression.

