### PR TITLE
op-e2e: harden WaitForTransaction against tx indexing in progress errors

### DIFF
--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -16,10 +17,10 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-var (
-	// errTimeout represents a timeout
-	errTimeout = errors.New("timeout")
-)
+const errStrTxIdxingInProgress = "transaction indexing is in progress"
+
+// errTimeout represents a timeout
+var errTimeout = errors.New("timeout")
 
 func WaitForL1OriginOnL2(rollupCfg *rollup.Config, l1BlockNum uint64, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
 	timeoutCh := time.After(timeout)
@@ -65,7 +66,8 @@ func WaitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 		receipt, err := client.TransactionReceipt(ctx, hash)
 		if receipt != nil && err == nil {
 			return receipt, nil
-		} else if err != nil && !errors.Is(err, ethereum.NotFound) {
+		} else if err != nil &&
+			!(errors.Is(err, ethereum.NotFound) || strings.Contains(err.Error(), errStrTxIdxingInProgress)) {
 			return nil, err
 		}
 


### PR DESCRIPTION
**Description**

This is a new error by geth that hasn't an exported error type yet, but it indicates that geth is still indexing and so one more try should be done.

**Tests**

This is used in all e2e tests. If they still pass, and we see a reduction in flakes, then it works.

**Additional context**

Creates random flakyness in tests. Tried to fix this as part of https://github.com/ethereum-optimism/optimism/pull/10589 but it then made lots of tests fail, so split it out into its own PR. Edit: it's actually that other PR that makes tests fail, not this one.
