### PR TITLE
Use log label game consistently

### DIFF
--- a/op-dispute-mon/mon/bonds/monitor.go
+++ b/op-dispute-mon/mon/bonds/monitor.go
@@ -96,7 +96,7 @@ func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
 			if maxDurationReached {
 				if comparison > 0 {
 					creditMetrics[metrics.CreditAboveMaxDuration] += 1
-					b.logger.Warn("Credit above expected amount", "recipient", recipient, "expected", expected, "actual", actual, "gameAddr", game.Proxy, "duration", "reached")
+					b.logger.Warn("Credit above expected amount", "recipient", recipient, "expected", expected, "actual", actual, "game", game.Proxy, "duration", "reached")
 				} else if comparison == 0 {
 					creditMetrics[metrics.CreditEqualMaxDuration] += 1
 				} else {
@@ -105,12 +105,12 @@ func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
 			} else {
 				if comparison > 0 {
 					creditMetrics[metrics.CreditAboveNonMaxDuration] += 1
-					b.logger.Warn("Credit above expected amount", "recipient", recipient, "expected", expected, "actual", actual, "gameAddr", game.Proxy, "duration", "unreached")
+					b.logger.Warn("Credit above expected amount", "recipient", recipient, "expected", expected, "actual", actual, "game", game.Proxy, "duration", "unreached")
 				} else if comparison == 0 {
 					creditMetrics[metrics.CreditEqualNonMaxDuration] += 1
 				} else {
 					creditMetrics[metrics.CreditBelowNonMaxDuration] += 1
-					b.logger.Warn("Credit withdrawn early", "recipient", recipient, "expected", expected, "actual", actual, "gameAddr", game.Proxy, "duration", "unreached")
+					b.logger.Warn("Credit withdrawn early", "recipient", recipient, "expected", expected, "actual", actual, "game", game.Proxy, "duration", "unreached")
 				}
 			}
 		}

--- a/op-dispute-mon/mon/bonds/monitor_test.go
+++ b/op-dispute-mon/mon/bonds/monitor_test.go
@@ -348,21 +348,21 @@ func TestCheckRecipientCredit(t *testing.T) {
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit withdrawn early"),
-		testlog.NewAttributesFilter("gameAddr", game1.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game1.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr2.Hex()),
 		testlog.NewAttributesFilter("duration", "unreached")))
 	// addr3 is above expected
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit above expected amount"),
-		testlog.NewAttributesFilter("gameAddr", game1.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game1.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr3.Hex()),
 		testlog.NewAttributesFilter("duration", "unreached")))
 	// addr4 is below expected before max duration, so warn about early withdrawal
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit withdrawn early"),
-		testlog.NewAttributesFilter("gameAddr", game1.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game1.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr4.Hex()),
 		testlog.NewAttributesFilter("duration", "unreached")))
 
@@ -373,7 +373,7 @@ func TestCheckRecipientCredit(t *testing.T) {
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit above expected amount"),
-		testlog.NewAttributesFilter("gameAddr", game2.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game2.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr3.Hex()),
 		testlog.NewAttributesFilter("duration", "reached")))
 	// addr4 is correct
@@ -384,7 +384,7 @@ func TestCheckRecipientCredit(t *testing.T) {
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit withdrawn early"),
-		testlog.NewAttributesFilter("gameAddr", game3.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game3.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr2.Hex()),
 		testlog.NewAttributesFilter("duration", "unreached")))
 	// addr3 is not involved so no logs
@@ -392,7 +392,7 @@ func TestCheckRecipientCredit(t *testing.T) {
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit above expected amount"),
-		testlog.NewAttributesFilter("gameAddr", game3.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game3.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr4.Hex()),
 		testlog.NewAttributesFilter("duration", "unreached")))
 
@@ -404,7 +404,7 @@ func TestCheckRecipientCredit(t *testing.T) {
 	require.NotNil(t, logs.FindLog(
 		testlog.NewLevelFilter(log.LevelWarn),
 		testlog.NewMessageFilter("Credit above expected amount"),
-		testlog.NewAttributesFilter("gameAddr", game4.Proxy.Hex()),
+		testlog.NewAttributesFilter("game", game4.Proxy.Hex()),
 		testlog.NewAttributesFilter("recipient", addr4.Hex()),
 		testlog.NewAttributesFilter("duration", "reached")))
 }


### PR DESCRIPTION
**Description**

To make searching for messages about a particular game easily, consistently use the `game` label on logs, not `gameAddr`.
