### PR TITLE
ctb: Prevent calls to foundry's contracts in test

### DIFF
--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -362,7 +362,13 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
     )
         external
     {
+        // don't use vm's address
         vm.assume(_token != address(vm));
+        // don't use console's address
+        vm.assume(_token != address(0x000000000000000000636F6e736F6c652e6c6f67));
+        // don't use create2 deployer's address
+        vm.assume(_token != address(0x4e59b44847b379578588920cA78FbF26c0B4956C));
+
         vm.assume(bytes(_name).length <= 32);
         vm.assume(bytes(_symbol).length <= 32);
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -365,9 +365,13 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
         // don't use vm's address
         vm.assume(_token != address(vm));
         // don't use console's address
-        vm.assume(_token != address(0x000000000000000000636F6e736F6c652e6c6f67));
+        vm.assume(_token != CONSOLE);
         // don't use create2 deployer's address
-        vm.assume(_token != address(0x4e59b44847b379578588920cA78FbF26c0B4956C));
+        vm.assume(_token != CREATE2_FACTORY);
+        // don't use default test's address
+        vm.assume(_token != DEFAULT_TEST_CONTRACT);
+        // don't use multicall3's address
+        vm.assume(_token != MULTICALL3_ADDRESS);
 
         vm.assume(bytes(_name).length <= 32);
         vm.assume(bytes(_symbol).length <= 32);


### PR DESCRIPTION
add assume preventing calls to contracts `CONSOLE`, `CREATE2_FACTORY`, `DEFAULT_TEST_CONTRACT`, and `MULTICALL3_ADDRESS`