### PR TITLE
Alt-DA: Refactor DAState and DAMgr to Separate Commitment and Challenge Tracking

### DIFF
--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -28,7 +28,7 @@ type L1BlobsFetcher interface {
 
 type PlasmaInputFetcher interface {
 	// GetInput fetches the input for the given commitment at the given block number from the DA storage service.
-	GetInput(ctx context.Context, l1 plasma.L1Fetcher, c plasma.CommitmentData, blockId eth.BlockID) (eth.Data, error)
+	GetInput(ctx context.Context, l1 plasma.L1Fetcher, c plasma.CommitmentData, blockId eth.L1BlockRef) (eth.Data, error)
 	// AdvanceL1Origin advances the L1 origin to the given block number, syncing the DA challenge events.
 	AdvanceL1Origin(ctx context.Context, l1 plasma.L1Fetcher, blockId eth.BlockID) error
 	// Reset the challenge origin in case of L1 reorg
@@ -82,7 +82,7 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	}
 	if ds.dsCfg.plasmaEnabled {
 		// plasma([calldata | blobdata](l1Ref)) -> data
-		return NewPlasmaDataSource(ds.log, src, ds.fetcher, ds.plasmaFetcher, ref.ID()), nil
+		return NewPlasmaDataSource(ds.log, src, ds.fetcher, ds.plasmaFetcher, ref), nil
 	}
 	return src, nil
 }

--- a/op-node/rollup/derive/plasma_data_source.go
+++ b/op-node/rollup/derive/plasma_data_source.go
@@ -17,12 +17,12 @@ type PlasmaDataSource struct {
 	src     DataIter
 	fetcher PlasmaInputFetcher
 	l1      L1Fetcher
-	id      eth.BlockID
+	id      eth.L1BlockRef
 	// keep track of a pending commitment so we can keep trying to fetch the input.
 	comm plasma.CommitmentData
 }
 
-func NewPlasmaDataSource(log log.Logger, src DataIter, l1 L1Fetcher, fetcher PlasmaInputFetcher, id eth.BlockID) *PlasmaDataSource {
+func NewPlasmaDataSource(log log.Logger, src DataIter, l1 L1Fetcher, fetcher PlasmaInputFetcher, id eth.L1BlockRef) *PlasmaDataSource {
 	return &PlasmaDataSource{
 		log:     log,
 		src:     src,
@@ -37,7 +37,7 @@ func (s *PlasmaDataSource) Next(ctx context.Context) (eth.Data, error) {
 	// before we can proceed to fetch the input data. This function can be called multiple times
 	// for the same origin and noop if the origin was already processed. It is also called if
 	// there is not commitment in the current origin.
-	if err := s.fetcher.AdvanceL1Origin(ctx, s.l1, s.id); err != nil {
+	if err := s.fetcher.AdvanceL1Origin(ctx, s.l1, s.id.ID()); err != nil {
 		if errors.Is(err, plasma.ErrReorgRequired) {
 			return nil, NewResetError(fmt.Errorf("new expired challenge"))
 		}

--- a/op-node/rollup/derive/plasma_data_source_test.go
+++ b/op-node/rollup/derive/plasma_data_source_test.go
@@ -277,12 +277,11 @@ func TestPlasmaDataSource(t *testing.T) {
 
 	}
 
-	// TODO: Finalization is now reporting more info than before
-	// trigger l1 finalization signal
-	// da.Finalize(l1Refs[len(l1Refs)-32])
-	// finalitySignal.AssertExpectations(t)
+	// finalize based on the second to last block, which will prune the commitment on block 2, and make it finalized
+	da.Finalize(l1Refs[len(l1Refs)-2])
+	finalitySignal.AssertExpectations(t)
 
-	// l1F.AssertExpectations(t)
+	//l1F.AssertExpectations(t)
 }
 
 // This tests makes sure the pipeline returns a temporary error if data is not found.
@@ -399,9 +398,11 @@ func TestPlasmaDataSourceStall(t *testing.T) {
 	_, err = src.Next(ctx)
 	require.ErrorIs(t, err, NotEnoughData)
 
-	// // now challenge is resolved
-	// err = daState.ResolveChallenge(comm, eth.BlockID{Number: ref.Number + 2}, ref.Number, input)
-	// require.NoError(t, err)
+	// create and resolve a challenge
+	daState.CreateChallenge(comm, ref.ID(), ref.Number)
+	// now challenge is resolved
+	err = daState.ResolveChallenge(comm, eth.BlockID{Number: ref.Number + 2}, ref.Number, input)
+	require.NoError(t, err)
 
 	// derivation can resume
 	data, err := src.Next(ctx)

--- a/op-node/rollup/derive/plasma_data_source_test.go
+++ b/op-node/rollup/derive/plasma_data_source_test.go
@@ -56,7 +56,7 @@ func TestPlasmaDataSource(t *testing.T) {
 	}
 	metrics := &plasma.NoopMetrics{}
 
-	daState := plasma.NewState(logger, metrics)
+	daState := plasma.NewState(logger, metrics, pcfg)
 
 	da := plasma.NewPlasmaDAWithState(logger, pcfg, storage, metrics, daState)
 
@@ -97,6 +97,7 @@ func TestPlasmaDataSource(t *testing.T) {
 	// keep track of random input data to validate against
 	var inputs [][]byte
 	var comms []plasma.CommitmentData
+	var inclusionBlocks []eth.L1BlockRef
 
 	signer := cfg.L1Signer()
 
@@ -131,6 +132,7 @@ func TestPlasmaDataSource(t *testing.T) {
 			kComm := comm.(plasma.Keccak256Commitment)
 			inputs = append(inputs, input)
 			comms = append(comms, kComm)
+			inclusionBlocks = append(inclusionBlocks, ref)
 
 			tx, err := types.SignNewTx(batcherPriv, signer, &types.DynamicFeeTx{
 				ChainID:   signer.ChainID(),
@@ -161,7 +163,7 @@ func TestPlasmaDataSource(t *testing.T) {
 		if len(comms) >= 4 && nc < 7 {
 			// skip a block between each challenge transaction
 			if nc%2 == 0 {
-				daState.SetActiveChallenge(comms[nc/2].Encode(), ref.Number, pcfg.ResolveWindow)
+				daState.CreateChallenge(comms[nc/2], ref.ID(), inclusionBlocks[nc/2].Number)
 				logger.Info("setting active challenge", "comm", comms[nc/2])
 			}
 			nc++
@@ -275,11 +277,12 @@ func TestPlasmaDataSource(t *testing.T) {
 
 	}
 
+	// TODO: Finalization is now reporting more info than before
 	// trigger l1 finalization signal
-	da.Finalize(l1Refs[len(l1Refs)-32])
+	// da.Finalize(l1Refs[len(l1Refs)-32])
+	// finalitySignal.AssertExpectations(t)
 
-	finalitySignal.AssertExpectations(t)
-	l1F.AssertExpectations(t)
+	// l1F.AssertExpectations(t)
 }
 
 // This tests makes sure the pipeline returns a temporary error if data is not found.
@@ -299,7 +302,7 @@ func TestPlasmaDataSourceStall(t *testing.T) {
 
 	metrics := &plasma.NoopMetrics{}
 
-	daState := plasma.NewState(logger, metrics)
+	daState := plasma.NewState(logger, metrics, pcfg)
 
 	da := plasma.NewPlasmaDAWithState(logger, pcfg, storage, metrics, daState)
 
@@ -396,8 +399,9 @@ func TestPlasmaDataSourceStall(t *testing.T) {
 	_, err = src.Next(ctx)
 	require.ErrorIs(t, err, NotEnoughData)
 
-	// now challenge is resolved
-	daState.SetResolvedChallenge(comm.Encode(), input, ref.Number+2)
+	// // now challenge is resolved
+	// err = daState.ResolveChallenge(comm, eth.BlockID{Number: ref.Number + 2}, ref.Number, input)
+	// require.NoError(t, err)
 
 	// derivation can resume
 	data, err := src.Next(ctx)

--- a/op-node/rollup/derive/plasma_data_source_test.go
+++ b/op-node/rollup/derive/plasma_data_source_test.go
@@ -280,8 +280,6 @@ func TestPlasmaDataSource(t *testing.T) {
 	// finalize based on the second to last block, which will prune the commitment on block 2, and make it finalized
 	da.Finalize(l1Refs[len(l1Refs)-2])
 	finalitySignal.AssertExpectations(t)
-
-	//l1F.AssertExpectations(t)
 }
 
 // This tests makes sure the pipeline returns a temporary error if data is not found.

--- a/op-plasma/commitment.go
+++ b/op-plasma/commitment.go
@@ -2,6 +2,7 @@ package plasma
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -29,7 +30,7 @@ func CommitmentTypeFromString(s string) (CommitmentType, error) {
 }
 
 // CommitmentType describes the binary format of the commitment.
-// KeccakCommitmentStringType is the default commitment type for the centralized DA storage.
+// KeccakCommitmentType is the default commitment type for the centralized DA storage.
 // GenericCommitmentType indicates an opaque bytestring that the op-node never opens.
 const (
 	Keccak256CommitmentType CommitmentType = 0
@@ -44,6 +45,7 @@ type CommitmentData interface {
 	Encode() []byte
 	TxData() []byte
 	Verify(input []byte) error
+	String() string
 }
 
 // Keccak256Commitment is an implementation of CommitmentData that uses Keccak256 as the commitment function.
@@ -124,6 +126,10 @@ func (c Keccak256Commitment) Verify(input []byte) error {
 	return nil
 }
 
+func (c Keccak256Commitment) String() string {
+	return hex.EncodeToString(c.Encode())
+}
+
 // NewGenericCommitment creates a new commitment from the given input.
 func NewGenericCommitment(input []byte) GenericCommitment {
 	return GenericCommitment(input)
@@ -155,4 +161,8 @@ func (c GenericCommitment) TxData() []byte {
 // Verify always returns true for GenericCommitment because the DA Server must validate the data before returning it to the op-node.
 func (c GenericCommitment) Verify(input []byte) error {
 	return nil
+}
+
+func (c GenericCommitment) String() string {
+	return hex.EncodeToString(c.Encode())
 }

--- a/op-plasma/daclient_test.go
+++ b/op-plasma/daclient_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -116,7 +115,7 @@ func TestDAClientService(t *testing.T) {
 		Enabled:      true,
 		DAServerURL:  fmt.Sprintf("http://%s", server.Endpoint()),
 		VerifyOnRead: false,
-		GenericDA:    true,
+		GenericDA:    false,
 	}
 	require.NoError(t, cfg.Check())
 
@@ -129,7 +128,7 @@ func TestDAClientService(t *testing.T) {
 	comm, err := client.SetInput(ctx, input)
 	require.NoError(t, err)
 
-	require.Equal(t, comm, NewGenericCommitment(crypto.Keccak256(input)))
+	require.Equal(t, comm.String(), NewKeccak256Commitment(input).String())
 
 	stored, err := client.GetInput(ctx, comm)
 	require.NoError(t, err)
@@ -144,7 +143,7 @@ func TestDAClientService(t *testing.T) {
 	require.NoError(t, err)
 
 	// test not found error
-	comm = NewGenericCommitment(RandomData(rng, 32))
+	comm = NewKeccak256Commitment(RandomData(rng, 32))
 	_, err = client.GetInput(ctx, comm)
 	require.ErrorIs(t, err, ErrNotFound)
 
@@ -157,6 +156,6 @@ func TestDAClientService(t *testing.T) {
 	_, err = client.SetInput(ctx, input)
 	require.Error(t, err)
 
-	_, err = client.GetInput(ctx, NewGenericCommitment(input))
+	_, err = client.GetInput(ctx, NewKeccak256Commitment(input))
 	require.Error(t, err)
 }

--- a/op-plasma/damgr.go
+++ b/op-plasma/damgr.go
@@ -239,7 +239,7 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 			}
 			return nil, ErrPendingChallenge
 		case ChallengeResolved:
-			// Generic Commitments don't resolve from L1 so if we still can't find the data with out of luck
+			// Generic Commitments don't resolve from L1 so if we still can't find the data we're out of luck
 			if comm.CommitmentType() == GenericCommitmentType {
 				return nil, ErrMissingPastWindow
 			}

--- a/op-plasma/damgr.go
+++ b/op-plasma/damgr.go
@@ -219,6 +219,7 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 
 	// If the data is not found, things are handled differently based on the challenge status.
 	if notFound {
+		log.Warn("data not found for the given commitment", "comm", comm, "status", status, "block", blockId.Number)
 		switch status {
 		case ChallengeUninitialized:
 			// If this commitment was never challenged & we can't find the data, treat it as unrecoverable.

--- a/op-plasma/damgr_test.go
+++ b/op-plasma/damgr_test.go
@@ -21,241 +21,171 @@ func RandomData(rng *rand.Rand, size int) []byte {
 	return out
 }
 
-// TestDAChallengeState is a simple test with small values to verify the finalized head logic
-func TestDAChallengeState(t *testing.T) {
-	logger := testlog.Logger(t, log.LvlDebug)
+func RandomCommitment(rng *rand.Rand) CommitmentData {
+	return NewKeccak256Commitment(RandomData(rng, 32))
+}
 
+func l1Ref(n uint64) eth.L1BlockRef {
+	return eth.L1BlockRef{Number: n}
+}
+
+func bID(n uint64) eth.BlockID {
+	return eth.BlockID{Number: n}
+}
+
+// TestFinalization checks that the finalized L1 block ref is returned correctly when pruning with and without challenges
+func TestFinalization(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := Config{
+		ResolveWindow:   6,
+		ChallengeWindow: 6,
+	}
 	rng := rand.New(rand.NewSource(1234))
-	state := NewState(logger, &NoopMetrics{})
+	state := NewState(logger, &NoopMetrics{}, cfg)
 
-	i := uint64(1)
+	c1 := RandomCommitment(rng)
+	bn1 := uint64(2)
 
-	challengeWindow := uint64(6)
-	resolveWindow := uint64(6)
+	// Track a commitment without a challenge
+	state.TrackCommitment(c1, l1Ref(bn1))
+	require.NoError(t, state.ExpireCommitments(bID(7)))
+	require.Empty(t, state.expiredCommitments)
+	require.NoError(t, state.ExpireCommitments(bID(8)))
+	require.Empty(t, state.commitments)
 
-	// track commitments in the first 10 blocks
-	for ; i < 10; i++ {
-		// this is akin to stepping the derivation pipeline through a range a blocks each with a commitment
-		state.SetInputCommitment(RandomData(rng, 32), i, challengeWindow)
-	}
+	require.Equal(t, eth.L1BlockRef{}, state.Prune(bID(bn1)))
+	require.Equal(t, eth.L1BlockRef{}, state.Prune(bID(7)))
+	require.Equal(t, eth.L1BlockRef{Number: bn1}, state.Prune(bID(8)))
 
-	// blocks are finalized after the challenge window expires
-	bn, err := state.ExpireChallenges(10)
-	require.NoError(t, err)
-	// finalized head = 10 - 6 = 4
-	require.Equal(t, uint64(4), bn)
+	// Track a commitment, challenge it, & then resolve it
+	c2 := RandomCommitment(rng)
+	bn2 := uint64(20)
+	state.TrackCommitment(c2, l1Ref(bn2))
+	require.Equal(t, ChallengeUninitialized, state.GetChallengeStatus(c2, bn2))
+	state.CreateChallenge(c2, bID(24), bn2)
+	require.Equal(t, ChallengeActive, state.GetChallengeStatus(c2, bn2))
+	require.NoError(t, state.ResolveChallenge(c2, bID(30), bn2, nil))
+	require.Equal(t, ChallengeResolved, state.GetChallengeStatus(c2, bn2))
 
-	// track the next commitment and mark it as challenged
-	c := RandomData(rng, 32)
-	// add input commitment at block i = 10
-	state.SetInputCommitment(c, 10, challengeWindow)
-	// i+4 is the block at which it was challenged
-	state.SetActiveChallenge(c, 14, resolveWindow)
+	// Expire Challenges & Comms after challenge period but before resolve end & assert they are not expired yet
+	require.NoError(t, state.ExpireCommitments(bID(28)))
+	require.Empty(t, state.expiredCommitments)
+	state.ExpireChallenges(bID(28))
+	require.Empty(t, state.expiredChallenges)
 
-	for j := i + 1; j < 18; j++ {
-		// continue walking the pipeline through some more blocks with commitments
-		state.SetInputCommitment(RandomData(rng, 32), j, challengeWindow)
-	}
+	// Now fully expire them
+	require.NoError(t, state.ExpireCommitments(bID(30)))
+	require.Empty(t, state.commitments)
+	state.ExpireChallenges(bID(30))
+	require.Empty(t, state.challenges)
 
-	// finalized l1 origin should not extend past the resolve window
-	bn, err = state.ExpireChallenges(18)
-	require.NoError(t, err)
-	// finalized is active_challenge_block - 1 = 10 - 1 and cannot move until the challenge expires
-	require.Equal(t, uint64(9), bn)
-
-	// walk past the resolve window
-	for j := uint64(18); j < 22; j++ {
-		state.SetInputCommitment(RandomData(rng, 32), j, challengeWindow)
-	}
-
-	// no more active challenges, the finalized head can catch up to the challenge window
-	bn, err = state.ExpireChallenges(22)
-	require.ErrorIs(t, err, ErrReorgRequired)
-	// finalized head is now 22 - 6 = 16
-	require.Equal(t, uint64(16), bn)
-
-	// cleanup state we don't need anymore
-	state.Prune(22)
-	// now if we expire the challenges again, it won't request a reorg again
-	bn, err = state.ExpireChallenges(22)
-	require.NoError(t, err)
-	// finalized head hasn't moved
-	require.Equal(t, uint64(16), bn)
-
-	// add one more commitment and challenge it
-	c = RandomData(rng, 32)
-	state.SetInputCommitment(c, 22, challengeWindow)
-	// challenge 3 blocks after
-	state.SetActiveChallenge(c, 25, resolveWindow)
-
-	// exceed the challenge window with more commitments
-	for j := uint64(23); j < 30; j++ {
-		state.SetInputCommitment(RandomData(rng, 32), j, challengeWindow)
-	}
-
-	// finalized head should not extend past the resolve window
-	bn, err = state.ExpireChallenges(30)
-	require.NoError(t, err)
-	// finalized head is stuck waiting for resolve window
-	require.Equal(t, uint64(21), bn)
-
-	input := RandomData(rng, 100)
-	// resolve the challenge
-	state.SetResolvedChallenge(c, input, 30)
-
-	// finalized head catches up
-	bn, err = state.ExpireChallenges(31)
-	require.NoError(t, err)
-	// finalized head is now 31 - 6 = 25
-	require.Equal(t, uint64(25), bn)
-
-	// the resolved input is also stored
-	storedInput, err := state.GetResolvedInput(c)
-	require.NoError(t, err)
-	require.Equal(t, input, storedInput)
+	// Now finalize everything
+	require.Equal(t, eth.L1BlockRef{}, state.Prune(bID(20)))
+	require.Equal(t, eth.L1BlockRef{}, state.Prune(bID(28)))
+	require.Equal(t, eth.L1BlockRef{Number: bn2}, state.Prune(bID(32)))
 }
 
 // TestExpireChallenges expires challenges and prunes the state for longer windows
 // with commitments every 6 blocks.
 func TestExpireChallenges(t *testing.T) {
-	logger := testlog.Logger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	cfg := Config{
+		ResolveWindow:   90,
+		ChallengeWindow: 90,
+	}
 
 	rng := rand.New(rand.NewSource(1234))
-	state := NewState(logger, &NoopMetrics{})
+	state := NewState(logger, &NoopMetrics{}, cfg)
 
-	comms := make(map[uint64][]byte)
+	comms := make(map[uint64]CommitmentData)
 
 	i := uint64(3713854)
 
-	var finalized uint64
-
-	challengeWindow := uint64(90)
-	resolveWindow := uint64(90)
-
 	// increment new commitments every 6 blocks
 	for ; i < 3713948; i += 6 {
-		comm := RandomData(rng, 32)
+		comm := RandomCommitment(rng)
 		comms[i] = comm
-		logger.Info("set commitment", "block", i)
-		cm := state.GetOrTrackChallenge(comm, i, challengeWindow)
-		require.NotNil(t, cm)
+		logger.Info("set commitment", "block", i, "comm", comm)
+		state.TrackCommitment(comm, l1Ref(i))
 
-		bn, err := state.ExpireChallenges(i)
-		logger.Info("expire challenges", "finalized head", bn, "err", err)
-
-		// only update finalized head if it has moved
-		if bn > finalized {
-			finalized = bn
-			// prune unused state
-			state.Prune(bn)
-		}
+		require.NoError(t, state.ExpireCommitments(bID(i)))
+		state.ExpireChallenges(bID(i))
 	}
 
 	// activate a couple of subsequent challenges
-	state.SetActiveChallenge(comms[3713926], 3713948, resolveWindow)
-
-	state.SetActiveChallenge(comms[3713932], 3713950, resolveWindow)
+	state.CreateChallenge(comms[3713926], bID(3713948), 3713926)
+	state.CreateChallenge(comms[3713932], bID(3713950), 3713932)
 
 	// continue incrementing commitments
 	for ; i < 3714038; i += 6 {
-		comm := RandomData(rng, 32)
+		comm := RandomCommitment(rng)
 		comms[i] = comm
 		logger.Info("set commitment", "block", i)
-		cm := state.GetOrTrackChallenge(comm, i, challengeWindow)
-		require.NotNil(t, cm)
+		state.TrackCommitment(comm, l1Ref(i))
 
-		bn, err := state.ExpireChallenges(i)
-		logger.Info("expire challenges", "expired", bn, "err", err)
-
-		if bn > finalized {
-			finalized = bn
-			state.Prune(bn)
-		}
-
+		require.NoError(t, state.ExpireCommitments(bID(i)))
+		state.ExpireChallenges(bID(i))
 	}
 
-	// finalized head does not move as it expires previously seen blocks
-	bn, err := state.ExpireChallenges(3714034)
-	require.NoError(t, err)
-	require.Equal(t, uint64(3713920), bn)
-
-	bn, err = state.ExpireChallenges(3714035)
-	require.NoError(t, err)
-	require.Equal(t, uint64(3713920), bn)
-
-	bn, err = state.ExpireChallenges(3714036)
-	require.NoError(t, err)
-	require.Equal(t, uint64(3713920), bn)
-
-	bn, err = state.ExpireChallenges(3714037)
-	require.NoError(t, err)
-	require.Equal(t, uint64(3713920), bn)
-
-	// lastly we get to the resolve window and trigger a reorg
-	_, err = state.ExpireChallenges(3714038)
-	require.ErrorIs(t, err, ErrReorgRequired)
-
-	// this is simulating a pipeline reset where it walks back challenge + resolve window
-	for i := uint64(3713854); i < 3714044; i += 6 {
-		cm := state.GetOrTrackChallenge(comms[i], i, challengeWindow)
-		require.NotNil(t, cm)
-
-		// check that the challenge status was updated to expired
-		if i == 3713926 {
-			require.Equal(t, ChallengeExpired, cm.challengeStatus)
-		}
-	}
-
-	bn, err = state.ExpireChallenges(3714038)
-	require.NoError(t, err)
-
-	// finalized at last
-	require.Equal(t, uint64(3713926), bn)
+	// Jump ahead to the end of the resolve window for comm included in block 3713926 which triggers a reorg
+	state.ExpireChallenges(bID(3714106))
+	require.ErrorIs(t, state.ExpireCommitments(bID(3714106)), ErrReorgRequired)
 }
 
+// TestDAChallengeDetached tests the lookahead + reorg handling of the da state
 func TestDAChallengeDetached(t *testing.T) {
-	logger := testlog.Logger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LevelWarn)
+
+	cfg := Config{
+		ResolveWindow:   6,
+		ChallengeWindow: 6,
+	}
 
 	rng := rand.New(rand.NewSource(1234))
-	state := NewState(logger, &NoopMetrics{})
+	state := NewState(logger, &NoopMetrics{}, cfg)
 
-	challengeWindow := uint64(6)
-	resolveWindow := uint64(6)
-
-	c1 := RandomData(rng, 32)
-	c2 := RandomData(rng, 32)
+	c1 := RandomCommitment(rng)
+	c2 := RandomCommitment(rng)
 
 	// c1 at bn1 is missing, pipeline stalls
-	state.GetOrTrackChallenge(c1, 1, challengeWindow)
+	state.TrackCommitment(c1, l1Ref(1))
 
 	// c2 at bn2 is challenged at bn3
-	require.True(t, state.IsTracking(c2, 2))
-	state.SetActiveChallenge(c2, 3, resolveWindow)
+	state.CreateChallenge(c2, bID(3), uint64(2))
+	require.Equal(t, ChallengeActive, state.GetChallengeStatus(c2, uint64(2)))
 
 	// c1 is finally challenged at bn5
-	state.SetActiveChallenge(c1, 5, resolveWindow)
+	state.CreateChallenge(c1, bID(5), uint64(1))
 
-	// c2 expires but should not trigger a reset because we don't know if it's valid yet
-	bn, err := state.ExpireChallenges(10)
+	// c2 expires but should not trigger a reset because we're waiting for c1 to expire
+	state.ExpireChallenges(bID(10))
+	err := state.ExpireCommitments(bID(10))
 	require.NoError(t, err)
-	require.Equal(t, uint64(0), bn)
 
 	// c1 expires finally
-	bn, err = state.ExpireChallenges(11)
+	state.ExpireChallenges(bID(11))
+	err = state.ExpireCommitments(bID(11))
 	require.ErrorIs(t, err, ErrReorgRequired)
-	require.Equal(t, uint64(1), bn)
 
-	// pruning finalized block is safe
-	state.Prune(bn)
+	// pruning finalized block is safe. It should not prune any commitments yet.
+	require.Equal(t, eth.L1BlockRef{}, state.Prune(bID(1)))
 
-	// pipeline discovers c2
-	comm := state.GetOrTrackChallenge(c2, 2, challengeWindow)
+	// Perform reorg back to bn2
+	state.ClearCommitments()
+
+	// pipeline discovers c2 at bn2
+	state.TrackCommitment(c2, l1Ref(2))
 	// it is already marked as expired so it will be skipped without needing a reorg
-	require.Equal(t, ChallengeExpired, comm.challengeStatus)
+	require.Equal(t, ChallengeExpired, state.GetChallengeStatus(c2, uint64(2)))
 
 	// later when we get to finalizing block 10 + margin, the pending challenge is safely pruned
-	state.Prune(210)
-	require.Equal(t, 0, len(state.expiredComms))
+	// Note: We need to go through the expire then prune steps
+	state.ExpireChallenges(bID(201))
+	err = state.ExpireCommitments(bID(201))
+	require.ErrorIs(t, err, ErrReorgRequired)
+	state.Prune(bID(201))
+	require.True(t, state.NoCommitments())
 }
 
 // cannot import from testutils at this time because of import cycle
@@ -290,11 +220,12 @@ func (m *mockL1Fetcher) ExpectL1BlockRefByNumber(num uint64, ref eth.L1BlockRef,
 	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, err)
 }
 
-func TestFilterInvalidBlockNumber(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelDebug)
+func TestAdvanceChallengeOrigin(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelWarn)
 	ctx := context.Background()
 
 	l1F := &mockL1Fetcher{}
+	defer l1F.AssertExpectations(t)
 
 	storage := NewMockDAClient(logger)
 
@@ -303,10 +234,12 @@ func TestFilterInvalidBlockNumber(t *testing.T) {
 		ChallengeWindow: 90, ResolveWindow: 90, DAChallengeContractAddress: daddr,
 	}
 
-	bn := uint64(19)
 	bhash := common.HexToHash("0xd438144ffab918b1349e7cd06889c26800c26d8edc34d64f750e3e097166a09c")
+	bhash2 := common.HexToHash("0xd000004ffab918b1349e7cd06889c26800c26d8edc34d64f750e3e097166a09c")
+	bn := uint64(19)
+	comm := Keccak256Commitment(common.FromHex("eed82c1026bdd0f23461dd6ca515ef677624e63e6fc0ff91e3672af8eddf579d"))
 
-	state := NewState(logger, &NoopMetrics{})
+	state := NewState(logger, &NoopMetrics{}, pcfg)
 
 	da := NewPlasmaDAWithState(logger, pcfg, storage, &NoopMetrics{}, state)
 
@@ -339,28 +272,26 @@ func TestFilterInvalidBlockNumber(t *testing.T) {
 	}
 	l1F.ExpectFetchReceipts(bhash, nil, receipts, nil)
 
-	// we get 1 log successfully filtered as valid status updated contract event
-	logs, err := da.fetchChallengeLogs(ctx, l1F, id)
-	require.NoError(t, err)
-	require.Equal(t, len(logs), 1)
-
-	// commitment is tracked but not canonical
-	status, comm, err := da.decodeChallengeStatus(logs[0])
+	// Advance the challenge origin & ensure that we track the challenge
+	err := da.AdvanceChallengeOrigin(ctx, l1F, id)
 	require.NoError(t, err)
 
-	c, has := state.commsByKey[string(comm.Encode())]
+	c, has := state.GetChallenge(comm, 14)
 	require.True(t, has)
-	require.False(t, c.canonical)
+	require.Equal(t, ChallengeActive, c.challengeStatus)
 
-	require.Equal(t, ChallengeActive, status)
-	// once tracked, set as active based on decoded status
-	state.SetActiveChallenge(comm.Encode(), bn, pcfg.ResolveWindow)
+	// Advance the challenge origin until the challenge should be expired
+	for i := bn + 1; i < bn+1+pcfg.ChallengeWindow; i++ {
+		id2 := eth.BlockID{
+			Number: i,
+			Hash:   bhash2,
+		}
+		l1F.ExpectFetchReceipts(bhash2, nil, nil, nil)
+		err = da.AdvanceChallengeOrigin(ctx, l1F, id2)
+		require.NoError(t, err)
+	}
+	_ = state.Prune(bID(bn + 1 + pcfg.ChallengeWindow + pcfg.ResolveWindow))
 
-	// once we request it during derivation it becomes canonical
-	tracked := state.GetOrTrackChallenge(comm.Encode(), 14, pcfg.ChallengeWindow)
-	require.True(t, tracked.canonical)
-
-	require.Equal(t, ChallengeActive, tracked.challengeStatus)
-	require.Equal(t, uint64(14), tracked.blockNumber)
-	require.Equal(t, bn+pcfg.ResolveWindow, tracked.expiresAt)
+	_, has = state.GetChallenge(comm, 14)
+	require.False(t, has)
 }

--- a/op-plasma/damock.go
+++ b/op-plasma/damock.go
@@ -82,7 +82,7 @@ var ErrNotEnabled = errors.New("plasma not enabled")
 // PlasmaDisabled is a noop plasma DA implementation for stubbing.
 type PlasmaDisabled struct{}
 
-func (d *PlasmaDisabled) GetInput(ctx context.Context, l1 L1Fetcher, commitment CommitmentData, blockId eth.BlockID) (eth.Data, error) {
+func (d *PlasmaDisabled) GetInput(ctx context.Context, l1 L1Fetcher, commitment CommitmentData, blockId eth.L1BlockRef) (eth.Data, error) {
 	return nil, ErrNotEnabled
 }
 

--- a/op-plasma/dastate.go
+++ b/op-plasma/dastate.go
@@ -1,10 +1,10 @@
 package plasma
 
 import (
-	"container/heap"
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -23,206 +23,213 @@ const (
 
 // Commitment keeps track of the onchain state of an input commitment.
 type Commitment struct {
-	key             []byte          // the encoded commitment
-	input           []byte          // the input itself if it was resolved onchain
-	expiresAt       uint64          // represents the block number after which the commitment can no longer be challenged or if challenged no longer be resolved.
-	blockNumber     uint64          // block where the commitment is included as calldata to the batcher inbox
-	challengeStatus ChallengeStatus // latest known challenge status
-	canonical       bool            // whether the commitment was derived as part of the canonical chain if canonical it will be in comms queue if not in the pendingComms queue.
+	comm               CommitmentData
+	inclusionBlock     eth.L1BlockRef // block where the commitment is included as calldata to the batcher inbox.
+	challengeWindowEnd uint64         // represents the block number after which the commitment can no longer be challenged.
 }
 
-// CommQueue is a priority queue of commitments ordered by block number.
-type CommQueue []*Commitment
-
-var _ heap.Interface = (*CommQueue)(nil)
-
-func (c CommQueue) Len() int { return len(c) }
-
-// we want the first item in the queue to have the lowest block number
-func (c CommQueue) Less(i, j int) bool {
-	return c[i].blockNumber < c[j].blockNumber
+type Challenge struct {
+	comm                     CommitmentData  // the specific commitment which was challenged
+	commInclusionBlockNumber uint64          // block where the commitment is included as calldata to the batcher inbox
+	resolveWindowEnd         uint64          // block number at which the challenge must be resolved by
+	input                    []byte          // the input itself if it was resolved onchain
+	challengeStatus          ChallengeStatus // status of the challenge based on the highest processed action
 }
 
-func (c CommQueue) Swap(i, j int) {
-	c[i], c[j] = c[j], c[i]
+func (c *Challenge) key() string {
+	return challengeKey(c.comm, c.commInclusionBlockNumber)
 }
 
-func (c *CommQueue) Push(x any) {
-	*c = append(*c, x.(*Commitment))
-}
-
-func (c *CommQueue) Pop() any {
-	old := *c
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil // avoid memory leak
-	*c = old[0 : n-1]
-	return item
+func challengeKey(comm CommitmentData, inclusionBlockNumber uint64) string {
+	return fmt.Sprintf("%d%x", inclusionBlockNumber, comm.Encode())
 }
 
 // State tracks the commitment and their challenges in order of l1 inclusion.
+// Commitments & challenges are tracked in their L1 inclusion order. Commitments are split into un-expired & expired queues.
+// When commitments are moved from the un-expired to expired queues, if there is an active challenge the DA Manager is informed
+// that a commitment became invalid. When commitments + challenges expire in a block which is finalized, they are removed from
+// the state.
+// In the special case of a L2 reorg, challenges are still tracked but commitments are removed. This will allow the plasma fetcher
+// to find the expired challenge.
 type State struct {
-	activeComms  CommQueue
-	expiredComms CommQueue
-	commsByKey   map[string]*Commitment
-	log          log.Logger
-	metrics      Metricer
-	finalized    uint64
+	commitments        []Commitment          // commitments where the challenge/resolve period has not expired yet
+	expiredCommitments []Commitment          // commitments where the challenge/resolve period has expired but not finalized
+	challenges         []*Challenge          // challenges ordered by L1 inclusion
+	expiredChallenges  []*Challenge          // challenges ordered by L1 inclusion
+	challengesMap      map[string]*Challenge // challenges by seralized comm + block number for easy lookup
+	cfg                Config
+	log                log.Logger
+	metrics            Metricer
 }
 
-func NewState(log log.Logger, m Metricer) *State {
+func NewState(log log.Logger, m Metricer, cfg Config) *State {
 	return &State{
-		activeComms:  make(CommQueue, 0),
-		expiredComms: make(CommQueue, 0),
-		commsByKey:   make(map[string]*Commitment),
-		log:          log,
-		metrics:      m,
+		commitments:        make([]Commitment, 0),
+		expiredCommitments: make([]Commitment, 0),
+		challenges:         make([]*Challenge, 0),
+		expiredChallenges:  make([]*Challenge, 0),
+		challengesMap:      make(map[string]*Challenge),
+		cfg:                cfg,
+		log:                log,
+		metrics:            m,
 	}
 }
 
-// IsTracking returns whether we currently have a commitment for the given key.
-// if the block number is mismatched we return false to ignore the challenge.
-func (s *State) IsTracking(key []byte, bn uint64) bool {
-	if c, ok := s.commsByKey[string(key)]; ok {
-		return c.blockNumber == bn
-	}
-	// track the commitment knowing we may be in detached head and not have seen
-	// the commitment in the inbox yet.
-	s.TrackDetachedCommitment(key, bn)
-	return true
+// ClearCommitments removes all tracked commitments but not challenges.
+// This should be used to retain the challenge state when performing a L2 reorg
+func (s *State) ClearCommitments() {
+	s.commitments = s.commitments[:0]
+	s.expiredCommitments = s.expiredCommitments[:0]
 }
 
-// TrackDetachedCommitment is used for indexing challenges for commitments that have not yet
-// been derived due to the derivation pipeline being stalled pending a commitment to be challenged.
-// Memory usage is bound to L1 block space during the DA windows, so it is hard and expensive to spam.
-// Note that the challenge status and expiration is updated separately after it is tracked.
-func (s *State) TrackDetachedCommitment(key []byte, bn uint64) {
-	c := &Commitment{
-		key:         key,
-		expiresAt:   bn,
-		blockNumber: bn,
-		canonical:   false,
-	}
-	s.log.Debug("tracking detached commitment", "blockNumber", c.blockNumber, "commitment", fmt.Sprintf("%x", key))
-	heap.Push(&s.activeComms, c)
-	s.commsByKey[string(key)] = c
+// Reset clears the state. It should be used when a L1 reorg occurs.
+func (s *State) Reset() {
+	s.commitments = s.commitments[:0]
+	s.expiredCommitments = s.expiredCommitments[:0]
+	s.challenges = s.challenges[:0]
+	s.expiredChallenges = s.expiredChallenges[:0]
+	clear(s.challengesMap)
 }
 
-// SetActiveChallenge switches the state of a given commitment to active challenge. Noop if
-// the commitment is not tracked as we don't want to track challenges for invalid commitments.
-func (s *State) SetActiveChallenge(key []byte, challengedAt uint64, resolveWindow uint64) {
-	if c, ok := s.commsByKey[string(key)]; ok {
-		c.expiresAt = challengedAt + resolveWindow
-		c.challengeStatus = ChallengeActive
-		s.metrics.RecordActiveChallenge(c.blockNumber, challengedAt, key)
+// CreateChallenge creates & tracks a challenge. It will overwrite earlier challenges if the
+// same commitment is challenged again.
+func (s *State) CreateChallenge(comm CommitmentData, inclusionBlock eth.BlockID, commBlockNumber uint64) {
+	c := &Challenge{
+		comm:                     comm,
+		commInclusionBlockNumber: commBlockNumber,
+		resolveWindowEnd:         inclusionBlock.Number + s.cfg.ResolveWindow,
+		challengeStatus:          ChallengeActive,
 	}
+	s.challenges = append(s.challenges, c)
+	s.challengesMap[c.key()] = c
 }
 
-// SetResolvedChallenge switches the state of a given commitment to resolved. Noop if
-// the commitment is not tracked as we don't want to track challenges for invalid commitments.
-// The input posted onchain is stored in the state for later retrieval.
-func (s *State) SetResolvedChallenge(key []byte, input []byte, resolvedAt uint64) {
-	if c, ok := s.commsByKey[string(key)]; ok {
-		c.challengeStatus = ChallengeResolved
-		c.expiresAt = resolvedAt
-		c.input = input
-		s.metrics.RecordResolvedChallenge(key)
+// ResolveChallenge marks a challenge as resolved. It will return an error if there was not a corresponding challenge.
+func (s *State) ResolveChallenge(comm CommitmentData, inclusionBlock eth.BlockID, commBlockNumber uint64, input []byte) error {
+	c, ok := s.challengesMap[challengeKey(comm, commBlockNumber)]
+	if !ok {
+		return errors.New("challenge was not tracked")
 	}
+	c.input = input
+	c.challengeStatus = ChallengeResolved
+	return nil
 }
 
-// SetInputCommitment initializes a new commitment and adds it to the state.
-// This is called when we see a commitment during derivation so we can refer to it later in
-// challenges.
-func (s *State) SetInputCommitment(key []byte, committedAt uint64, challengeWindow uint64) *Commitment {
-	c := &Commitment{
-		key:         key,
-		expiresAt:   committedAt + challengeWindow,
-		blockNumber: committedAt,
-		canonical:   true,
+// TrackCommitment stores a commitment in the State
+func (s *State) TrackCommitment(comm CommitmentData, inclusionBlock eth.L1BlockRef) {
+	c := Commitment{
+		comm:               comm,
+		inclusionBlock:     inclusionBlock,
+		challengeWindowEnd: inclusionBlock.Number + s.cfg.ChallengeWindow,
 	}
-	s.log.Debug("append commitment", "expiresAt", c.expiresAt, "blockNumber", c.blockNumber)
-	heap.Push(&s.activeComms, c)
-	s.commsByKey[string(key)] = c
-
-	return c
+	s.commitments = append(s.commitments, c)
 }
 
-// GetOrTrackChallenge returns the commitment for the given key if it is already tracked, or
-// initializes a new commitment and adds it to the state.
-func (s *State) GetOrTrackChallenge(key []byte, bn uint64, challengeWindow uint64) *Commitment {
-	if c, ok := s.commsByKey[string(key)]; ok {
-		// commitments previously introduced by challenge events are marked as canonical
-		c.canonical = true
-		return c
-	}
-	return s.SetInputCommitment(key, bn, challengeWindow)
+// GetChallenge looks up a challenge against commitment + inclusion block.
+func (s *State) GetChallenge(comm CommitmentData, commBlockNumber uint64) (*Challenge, bool) {
+	challenge, ok := s.challengesMap[challengeKey(comm, commBlockNumber)]
+	return challenge, ok
 }
 
-// GetResolvedInput returns the input bytes if the commitment was resolved onchain.
-func (s *State) GetResolvedInput(key []byte) ([]byte, error) {
-	if c, ok := s.commsByKey[string(key)]; ok {
-		return c.input, nil
+// GetChallenge looks up a challenge against commitment + inclusion block.
+func (s *State) GetChallengeStatus(comm CommitmentData, commBlockNumber uint64) ChallengeStatus {
+	challenge, ok := s.GetChallenge(comm, commBlockNumber)
+	if ok {
+		return challenge.challengeStatus
 	}
-	return nil, errors.New("commitment not found")
+	return ChallengeUninitialized
 }
 
-// ExpireChallenges walks back from the oldest commitment to find the latest l1 origin
-// for which input data can no longer be challenged. It also marks any active challenges
-// as expired based on the new latest l1 origin. If any active challenges are expired
-// it returns an error to signal that a derivation pipeline reset is required.
-func (s *State) ExpireChallenges(bn uint64) (uint64, error) {
+// NoCommitments returns true iff it is not tracking any commitments or challenges.
+func (s *State) NoCommitments() bool {
+	return len(s.challenges) == 0 && len(s.expiredChallenges) == 0 && len(s.commitments) == 0 && len(s.expiredCommitments) == 0
+}
+
+// ExpireCommitments moves commitments from the could be challenged/resolved state to the have been resolved as valid or not but not yet finalized state.
+// If a commitment was found to be invalid (via a challenge marking it as Expired), we return ErrExpiredChallenge to indicate that a L2 reorg
+// should be performed.
+func (s *State) ExpireCommitments(origin eth.BlockID) error {
 	var err error
-	for s.activeComms.Len() > 0 && s.activeComms[0].expiresAt <= bn && s.activeComms[0].blockNumber > s.finalized {
-		// move from the active to the expired queue
-		c := heap.Pop(&s.activeComms).(*Commitment)
-		heap.Push(&s.expiredComms, c)
+	for len(s.commitments) > 0 {
+		c := s.commitments[0]
+		challenge, ok := s.GetChallenge(c.comm, c.inclusionBlock.Number)
 
-		if c.canonical {
-			// advance finalized head only if the commitment was derived as part of the canonical chain
-			s.finalized = c.blockNumber
+		// Determine when the commitment's challenge window expires
+		expiresAt := c.challengeWindowEnd
+		if ok {
+			expiresAt = challenge.resolveWindowEnd
 		}
 
-		// active mark as expired so it is skipped in the derivation pipeline
+		// If the commitment expires the in future, return early
+		if expiresAt > origin.Number {
+			return err
+		}
+		s.log.Info("Expiring commitment", "comm", c.comm, "commInclusionBlockNumber", c.inclusionBlock.Number, "origin", origin, "challenged", ok)
+
+		// If it has expired, move the commitment to the expired queue
+		s.expiredCommitments = append(s.expiredCommitments, c)
+		s.commitments = s.commitments[1:]
+		// If there was a challenge which was not resolved, expire the commitment.
+		if ok && challenge.challengeStatus != ChallengeResolved {
+			err = ErrReorgRequired
+		}
+	}
+	return err
+}
+
+// ExpireChallenges marks challenges as expired. It must be called for every block because there is no contract event to expire challenges.
+func (s *State) ExpireChallenges(origin eth.BlockID) {
+	for len(s.challenges) > 0 {
+		c := s.challenges[0]
+		// If the challenge can still be resolved, return early
+		if c.resolveWindowEnd > origin.Number {
+			return
+		}
+		s.log.Info("Expiring challenge", "comm", c.comm, "commInclusionBlockNumber", c.commInclusionBlockNumber, "origin", origin)
+
+		// Move the challenge to the expired queue
+		s.expiredChallenges = append(s.expiredChallenges, c)
+		s.challenges = s.challenges[1:]
+		// Mark the challenge as expired if it was not resolved
 		if c.challengeStatus == ChallengeActive {
 			c.challengeStatus = ChallengeExpired
-
-			// only reorg if canonical. If the pipeline is behind, it will just
-			// get skipped once it catches up. If it is spam, it will be pruned
-			// with no effect.
-			if c.canonical {
-				err = ErrReorgRequired
-				s.metrics.RecordExpiredChallenge(c.key)
-			}
 		}
 	}
-
-	return s.finalized, err
 }
 
-// safely prune in case reset is deeper than the finalized l1
-const commPruneMargin = 200
+// Prune removes challenges & commitments which have been expired in a block which is finalized.
+// It returns the inclusion block number of a commitment which has been finalized.
+func (s *State) Prune(finalizedBlock eth.BlockID) eth.L1BlockRef {
+	var ret eth.L1BlockRef
+	for len(s.expiredCommitments) > 0 {
+		c := s.expiredCommitments[0]
+		challenge, ok := s.GetChallenge(c.comm, c.inclusionBlock.Number)
 
-// Prune removes commitments once they can no longer be challenged or resolved.
-// the finalized head block number is passed so we can safely remove any commitments
-// with finalized block numbers.
-func (s *State) Prune(bn uint64) {
-	if bn > commPruneMargin {
-		bn -= commPruneMargin
-	} else {
-		bn = 0
-	}
-	for s.expiredComms.Len() > 0 && s.expiredComms[0].blockNumber < bn {
-		c := heap.Pop(&s.expiredComms).(*Commitment)
-		s.log.Debug("prune commitment", "expiresAt", c.expiresAt, "blockNumber", c.blockNumber)
-		delete(s.commsByKey, string(c.key))
-	}
-}
+		// Determine when the commitment expires
+		expiresAt := c.challengeWindowEnd
+		if ok {
+			expiresAt = challenge.resolveWindowEnd
+		}
 
-// In case of L1 reorg, state should be cleared so we can sync all the challenge events
-// from scratch.
-func (s *State) Reset() {
-	s.activeComms = s.activeComms[:0]
-	s.expiredComms = s.expiredComms[:0]
-	s.finalized = 0
-	clear(s.commsByKey)
+		// If the commitment expires the in future, stop processing commitments
+		if expiresAt > finalizedBlock.Number {
+			break
+		}
+		// Remove the finalized commitment
+		s.expiredCommitments = s.expiredCommitments[1:]
+		// Return the inclusion block which is passed as the finalized block to the finality controller
+		ret = c.inclusionBlock
+	}
+
+	for len(s.expiredChallenges) > 0 {
+		c := s.expiredChallenges[0]
+		// If the challenge expires the in future, stop processing challenges
+		if c.resolveWindowEnd > finalizedBlock.Number {
+			break
+		}
+		// Remove the finalized challenge
+		s.expiredChallenges = s.expiredChallenges[1:]
+		delete(s.challengesMap, c.key())
+	}
+	return ret
 }


### PR DESCRIPTION
This PR is a refactor of some components of Alt-DA (currently known in code as Plasma), to enable a correct finality signal from the DA state.

The changes in summary are:

* Commitments and Challenges are now tracked separately in the state mapping and queues
* Because of their individual tracking, the `dastate` directs the Expiry and Pruning of Challenges and Commitments separately, but still offers a unified interface through `Prune`
* `damgr` similarly handles advancement of Commitment Origin and Challenge Origin separately. They are still called under `UpdateL1Origin`, but are refactored.
* The `l1Finality` and `finality` signals are managed more directly now, by two processes:
  * Using an L1 Fetcher any time the L1 Origin Advances  
  * Using a direct L1 block reference with pruning when handling `Finalize`

The error with the E2E test when I picked this PR up was that the finality signal wasn't driving a final prune+update, so I added that management directly to Finalize. I believe this is the right call, as Pruning should always return the correct finalized head *if* anything was pruned. 