### PR TITLE
Kill the AI rabbit

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -16,7 +16,7 @@ reviews:
         - Removing unnecessary code
       "
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - "develop"


### PR DESCRIPTION
**Description**

Disable automatic code reviews by the CodeRabbit AI. It creates way more noise than signal. People who really like it can still trigger a review manually and the existing config will still apply.