### PR TITLE
Add txmgr rpc api

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -320,6 +320,7 @@ func (bs *BatcherService) initRPCServer(cfg *CLIConfig) error {
 	if cfg.RPC.EnableAdmin {
 		adminAPI := rpc.NewAdminAPI(bs.driver, bs.Metrics, bs.Log)
 		server.AddAPI(rpc.GetAdminAPI(adminAPI))
+		server.AddAPI(txmgr.NewTxmgrApi(bs.TxManager, bs.Metrics, bs.Log))
 		bs.Log.Info("Admin RPC enabled")
 	}
 	bs.Log.Info("Starting JSON-RPC server")

--- a/op-challenger/sender/sender_test.go
+++ b/op-challenger/sender/sender_test.go
@@ -175,7 +175,7 @@ func (s *stubTxMgr) GetPendingTxs(bool, bool) ([]txmgr.PendingTxRPC, error) {
 	panic("unsupported")
 }
 
-func (s *stubTxMgr) CancelPendingNonce(uint64) error {
+func (s *stubTxMgr) CancelPendingTx(uint64) error {
 	panic("unsupported")
 }
 

--- a/op-challenger/sender/sender_test.go
+++ b/op-challenger/sender/sender_test.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -168,6 +169,54 @@ func (s *stubTxMgr) From() common.Address {
 
 func (s *stubTxMgr) BlockNumber(_ context.Context) (uint64, error) {
 	panic("unsupported")
+}
+
+func (s *stubTxMgr) GetPendingTxs(bool, bool) ([]txmgr.PendingTxRPC, error) {
+	panic("unsupported")
+}
+
+func (s *stubTxMgr) CancelPendingNonce(uint64) error {
+	panic("unsupported")
+}
+
+func (s *stubTxMgr) GetMinBaseFee() *big.Int {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) SetMinBaseFee(*big.Int) {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) GetPriorityFee() *big.Int {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) SetPriorityFee(*big.Int) {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) GetMinBlobFee() *big.Int {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) SetMinBlobFee(*big.Int) {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) GetFeeThreshold() *big.Int {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) SetFeeThreshold(*big.Int) {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) GetBumpFeeRetryTime() time.Duration {
+	panic("unimplemented")
+}
+
+func (s *stubTxMgr) SetBumpFeeRetryTime(time.Duration) {
+	panic("unimplemented")
 }
 
 func (s *stubTxMgr) Close() {

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -65,11 +65,59 @@ func (f fakeTxMgr) Send(_ context.Context, _ txmgr.TxCandidate) (*types.Receipt,
 	panic("unimplemented")
 }
 
+func (f fakeTxMgr) GetPendingTxs(bool, bool) ([]txmgr.PendingTxRPC, error) {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) CancelPendingNonce(uint64) error {
+	panic("unsupported")
+}
+
 func (f fakeTxMgr) Close() {
 }
 
 func (f fakeTxMgr) IsClosed() bool {
 	return false
+}
+
+func (f fakeTxMgr) GetMinBaseFee() *big.Int {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) SetMinBaseFee(*big.Int) {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) GetPriorityFee() *big.Int {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) SetPriorityFee(*big.Int) {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) GetMinBlobFee() *big.Int {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) SetMinBlobFee(*big.Int) {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) GetFeeThreshold() *big.Int {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) SetFeeThreshold(*big.Int) {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) GetBumpFeeRetryTime() time.Duration {
+	panic("unimplemented")
+}
+
+func (f fakeTxMgr) SetBumpFeeRetryTime(time.Duration) {
+	panic("unimplemented")
 }
 
 func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -69,7 +69,7 @@ func (f fakeTxMgr) GetPendingTxs(bool, bool) ([]txmgr.PendingTxRPC, error) {
 	panic("unimplemented")
 }
 
-func (f fakeTxMgr) CancelPendingNonce(uint64) error {
+func (f fakeTxMgr) CancelPendingTx(uint64) error {
 	panic("unsupported")
 }
 

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -249,6 +249,7 @@ func (ps *ProposerService) initRPCServer(cfg *CLIConfig) error {
 	if cfg.RPCConfig.EnableAdmin {
 		adminAPI := rpc.NewAdminAPI(ps.driver, ps.Metrics, ps.Log)
 		server.AddAPI(rpc.GetAdminAPI(adminAPI))
+		server.AddAPI(txmgr.NewTxmgrApi(ps.TxManager, ps.Metrics, ps.Log))
 		ps.Log.Info("Admin RPC enabled")
 	}
 	ps.Log.Info("Starting JSON-RPC server")

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )
 
@@ -94,6 +95,8 @@ var (
 		TxNotInMempoolTimeout:     1 * time.Minute,
 		ReceiptQueryInterval:      12 * time.Second,
 	}
+	// geth enforces a 1 gwei minimum for blob tx fee
+	defaultMinBlobTxFee = big.NewInt(params.GWei)
 )
 
 func CLIFlags(envPrefix string) []cli.Flag {
@@ -340,6 +343,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (Config, error) {
 		FeeLimitThreshold:         feeLimitThreshold,
 		MinBaseFee:                minBaseFee,
 		MinTipCap:                 minTipCap,
+		MinBlobTxFee:              defaultMinBlobTxFee,
 		ChainID:                   chainID,
 		TxSendTimeout:             cfg.TxSendTimeout,
 		TxNotInMempoolTimeout:     cfg.TxNotInMempoolTimeout,
@@ -374,6 +378,8 @@ type Config struct {
 
 	// Minimum tip cap (in Wei) to enforce when determining tx fees.
 	MinTipCap *big.Int
+
+	MinBlobTxFee *big.Int
 
 	// ChainID is the chain ID of the L1 chain.
 	ChainID *big.Int

--- a/op-service/txmgr/mocks/TxManager.go
+++ b/op-service/txmgr/mocks/TxManager.go
@@ -4,10 +4,13 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 
 	common "github.com/ethereum/go-ethereum/common"
 
 	mock "github.com/stretchr/testify/mock"
+
+	time "time"
 
 	txmgr "github.com/ethereum-optimism/optimism/op-service/txmgr"
 
@@ -64,6 +67,110 @@ func (_m *TxManager) From() common.Address {
 	return r0
 }
 
+// GetBumpFeeRetryTime provides a mock function with given fields:
+func (_m *TxManager) GetBumpFeeRetryTime() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// GetFeeThreshold provides a mock function with given fields:
+func (_m *TxManager) GetFeeThreshold() *big.Int {
+	ret := _m.Called()
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	return r0
+}
+
+// GetMinBaseFee provides a mock function with given fields:
+func (_m *TxManager) GetMinBaseFee() *big.Int {
+	ret := _m.Called()
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	return r0
+}
+
+// GetMinBlobFee provides a mock function with given fields:
+func (_m *TxManager) GetMinBlobFee() *big.Int {
+	ret := _m.Called()
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	return r0
+}
+
+// GetPendingTxs provides a mock function with given fields:
+func (_m *TxManager) GetPendingTxs() ([]*types.Transaction, error) {
+	ret := _m.Called()
+
+	var r0 []*types.Transaction
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]*types.Transaction, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []*types.Transaction); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*types.Transaction)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPriorityFee provides a mock function with given fields:
+func (_m *TxManager) GetPriorityFee() *big.Int {
+	ret := _m.Called()
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	return r0
+}
+
 // IsClosed provides a mock function with given fields:
 func (_m *TxManager) IsClosed() bool {
 	ret := _m.Called()
@@ -102,6 +209,31 @@ func (_m *TxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*ty
 	}
 
 	return r0, r1
+}
+
+// SetBumpFeeRetryTime provides a mock function with given fields: _a0
+func (_m *TxManager) SetBumpFeeRetryTime(_a0 time.Duration) {
+	_m.Called(_a0)
+}
+
+// SetFeeThreshold provides a mock function with given fields: _a0
+func (_m *TxManager) SetFeeThreshold(_a0 *big.Int) {
+	_m.Called(_a0)
+}
+
+// SetMinBaseFee provides a mock function with given fields: _a0
+func (_m *TxManager) SetMinBaseFee(_a0 *big.Int) {
+	_m.Called(_a0)
+}
+
+// SetMinBlobFee provides a mock function with given fields: _a0
+func (_m *TxManager) SetMinBlobFee(_a0 *big.Int) {
+	_m.Called(_a0)
+}
+
+// SetPriorityFee provides a mock function with given fields: _a0
+func (_m *TxManager) SetPriorityFee(_a0 *big.Int) {
+	_m.Called(_a0)
 }
 
 type mockConstructorTestingTNewTxManager interface {

--- a/op-service/txmgr/mocks/TxManager.go
+++ b/op-service/txmgr/mocks/TxManager.go
@@ -46,8 +46,8 @@ func (_m *TxManager) BlockNumber(ctx context.Context) (uint64, error) {
 	return r0, r1
 }
 
-// CancelPendingNonce provides a mock function with given fields: _a0
-func (_m *TxManager) CancelPendingNonce(_a0 uint64) error {
+// CancelPendingTx provides a mock function with given fields: _a0
+func (_m *TxManager) CancelPendingTx(_a0 uint64) error {
 	ret := _m.Called(_a0)
 
 	var r0 error

--- a/op-service/txmgr/mocks/TxManager.go
+++ b/op-service/txmgr/mocks/TxManager.go
@@ -46,6 +46,20 @@ func (_m *TxManager) BlockNumber(ctx context.Context) (uint64, error) {
 	return r0, r1
 }
 
+// CancelPendingNonce provides a mock function with given fields: _a0
+func (_m *TxManager) CancelPendingNonce(_a0 uint64) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint64) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Close provides a mock function with given fields:
 func (_m *TxManager) Close() {
 	_m.Called()
@@ -129,25 +143,25 @@ func (_m *TxManager) GetMinBlobFee() *big.Int {
 	return r0
 }
 
-// GetPendingTxs provides a mock function with given fields:
-func (_m *TxManager) GetPendingTxs() ([]*types.Transaction, error) {
-	ret := _m.Called()
+// GetPendingTxs provides a mock function with given fields: _a0, _a1
+func (_m *TxManager) GetPendingTxs(_a0 bool, _a1 bool) ([]txmgr.PendingTxRPC, error) {
+	ret := _m.Called(_a0, _a1)
 
-	var r0 []*types.Transaction
+	var r0 []txmgr.PendingTxRPC
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]*types.Transaction, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(bool, bool) ([]txmgr.PendingTxRPC, error)); ok {
+		return rf(_a0, _a1)
 	}
-	if rf, ok := ret.Get(0).(func() []*types.Transaction); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(bool, bool) []txmgr.PendingTxRPC); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*types.Transaction)
+			r0 = ret.Get(0).([]txmgr.PendingTxRPC)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(bool, bool) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -173,12 +173,13 @@ func TestQueue_Send(t *testing.T) {
 			conf.SafeAbortNonceTooLowCount = 1
 			backend := newMockBackendWithNonce(newGasPricer(3))
 			mgr := &SimpleTxManager{
-				chainID: conf.ChainID,
-				name:    "TEST",
-				cfg:     conf,
-				backend: backend,
-				l:       testlog.Logger(t, log.LevelCrit),
-				metr:    &metrics.NoopTxMetrics{},
+				chainID:    conf.ChainID,
+				name:       "TEST",
+				cfg:        conf,
+				backend:    backend,
+				l:          testlog.Logger(t, log.LevelCrit),
+				metr:       &metrics.NoopTxMetrics{},
+				pendingTxs: make(map[uint64]*PendingTxWithCancel),
 			}
 
 			// track the nonces, and return any expected errors from tx sending

--- a/op-service/txmgr/rpc.go
+++ b/op-service/txmgr/rpc.go
@@ -1,0 +1,100 @@
+package txmgr
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func NewTxmgrApi(txmgr TxManager, m metrics.RPCMetricer, l log.Logger) rpc.API {
+	return rpc.API{
+		Namespace: "txmgr",
+		Service: &TxmgrApi{
+			mgr: txmgr,
+			m:   m,
+			l:   l,
+		},
+	}
+}
+
+type TxmgrApi struct {
+	mgr TxManager
+	m   metrics.RPCMetricer
+	l   log.Logger
+}
+
+func (t *TxmgrApi) GetMinBaseFee(ctx context.Context) *big.Int {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_getMinBaseFee")
+	defer recordDur()
+	return t.mgr.GetMinBaseFee()
+}
+
+func (t *TxmgrApi) SetMinBaseFee(ctx context.Context, val *big.Int) {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_setMinBaseFee")
+	defer recordDur()
+	t.mgr.SetMinBaseFee(val)
+}
+
+func (t *TxmgrApi) GetPriorityFee(ctx context.Context) *big.Int {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_getPriorityFee")
+	defer recordDur()
+	return t.mgr.GetPriorityFee()
+}
+
+func (t *TxmgrApi) SetPriorityFee(ctx context.Context, val *big.Int) {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_setPriorityFee")
+	defer recordDur()
+	t.mgr.SetPriorityFee(val)
+}
+
+func (t *TxmgrApi) GetMinBlobFee(ctx context.Context) *big.Int {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_getMinBlobFee")
+	defer recordDur()
+	return t.mgr.GetMinBlobFee()
+}
+
+func (t *TxmgrApi) SetMinBlobFee(ctx context.Context, val *big.Int) {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_setMinBlobFee")
+	defer recordDur()
+	t.mgr.SetMinBlobFee(val)
+}
+
+func (t *TxmgrApi) GetFeeThreshold(ctx context.Context) *big.Int {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_getFeeThreshold")
+	defer recordDur()
+	return t.mgr.GetFeeThreshold()
+}
+
+func (t *TxmgrApi) SetFeeThreshold(ctx context.Context, val *big.Int) {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_setFeeThreshold")
+	defer recordDur()
+	t.mgr.SetFeeThreshold(val)
+}
+
+func (t *TxmgrApi) GetBumpFeeRetryTime(ctx context.Context) time.Duration {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_getBumpFeeRetryTime")
+	defer recordDur()
+	return t.mgr.GetBumpFeeRetryTime()
+}
+
+func (t *TxmgrApi) SetBumpFeeRetryTime(ctx context.Context, val time.Duration) {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_setBumpFeeRetryTime")
+	defer recordDur()
+	t.mgr.SetBumpFeeRetryTime(val)
+}
+
+func (t *TxmgrApi) GetPendingTxs(ctx context.Context, includeData, includeEncodedBytes bool) ([]PendingTxRPC, error) {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_getPendingTxs")
+	defer recordDur()
+	return t.mgr.GetPendingTxs(includeData, includeEncodedBytes)
+}
+
+func (t *TxmgrApi) CancelPendingNonce(ctx context.Context, nonce uint64) error {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_cancelPendingNonce")
+	defer recordDur()
+	return t.mgr.CancelPendingNonce(nonce)
+}

--- a/op-service/txmgr/rpc.go
+++ b/op-service/txmgr/rpc.go
@@ -93,8 +93,8 @@ func (t *TxmgrApi) GetPendingTxs(ctx context.Context, includeData, includeEncode
 	return t.mgr.GetPendingTxs(includeData, includeEncodedBytes)
 }
 
-func (t *TxmgrApi) CancelPendingNonce(ctx context.Context, nonce uint64) error {
-	recordDur := t.m.RecordRPCServerRequest("txmgr_cancelPendingNonce")
+func (t *TxmgrApi) CancelPendingTx(ctx context.Context, nonce uint64) error {
+	recordDur := t.m.RecordRPCServerRequest("txmgr_cancelPendingTx")
 	defer recordDur()
-	return t.mgr.CancelPendingNonce(nonce)
+	return t.mgr.CancelPendingTx(nonce)
 }

--- a/op-service/txmgr/rpc_test.go
+++ b/op-service/txmgr/rpc_test.go
@@ -1,0 +1,122 @@
+package txmgr
+
+import (
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"testing"
+
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxmgrRPC(t *testing.T) {
+	minBaseFee := big.NewInt(1000)
+	priorityFee := big.NewInt(2000)
+	minBlobFee := big.NewInt(3000)
+	feeThreshold := big.NewInt(4000)
+
+	cfg := Config{
+		MinBaseFee:        minBaseFee,
+		MinTipCap:         priorityFee,
+		MinBlobTxFee:      minBlobFee,
+		FeeLimitThreshold: feeThreshold,
+	}
+	h := newTestHarnessWithConfig(t, cfg)
+
+	appVersion := "test"
+	m := &testutils.TestRPCMetrics{}
+	l := testlog.Logger(t, log.LevelDebug)
+
+	server := oprpc.NewServer(
+		"127.0.0.1",
+		0,
+		appVersion,
+		oprpc.WithAPIs([]rpc.API{
+			NewTxmgrApi(h.mgr, m, l),
+		}),
+	)
+	require.NoError(t, server.Start())
+	defer func() {
+		_ = server.Stop()
+	}()
+
+	rpcClient, err := rpc.Dial(fmt.Sprintf("http://%s", server.Endpoint()))
+	require.NoError(t, err)
+
+	t.Run("supports GET /healthz", func(t *testing.T) {
+		res, err := http.Get(fmt.Sprintf("http://%s/healthz", server.Endpoint()))
+		require.NoError(t, err)
+		defer res.Body.Close()
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.EqualValues(t, fmt.Sprintf("{\"version\":\"%s\"}\n", appVersion), string(body))
+	})
+
+	t.Run("supports health_status", func(t *testing.T) {
+		var res string
+		require.NoError(t, rpcClient.Call(&res, "health_status"))
+		require.Equal(t, appVersion, res)
+	})
+
+	t.Run("txmgr_getMinBaseFee", func(t *testing.T) {
+		var res *big.Int
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getMinBaseFee"))
+		require.Equal(t, minBaseFee, res)
+	})
+
+	t.Run("txmgr_setMinBaseFee", func(t *testing.T) {
+		var res *big.Int
+		minBaseFee.Add(minBaseFee, big.NewInt(1))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_setMinBaseFee", minBaseFee))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getMinBaseFee"))
+		require.Equal(t, minBaseFee, res)
+	})
+
+	t.Run("txmgr_getPriorityFee", func(t *testing.T) {
+		var res *big.Int
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getPriorityFee"))
+		require.Equal(t, priorityFee, res)
+	})
+
+	t.Run("txmgr_setPriorityFee", func(t *testing.T) {
+		var res *big.Int
+		priorityFee.Add(priorityFee, big.NewInt(1))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_setPriorityFee", priorityFee))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getPriorityFee"))
+		require.Equal(t, priorityFee, res)
+	})
+
+	t.Run("txmgr_getMinBlobFee", func(t *testing.T) {
+		var res *big.Int
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getMinBlobFee"))
+		require.Equal(t, minBlobFee, res)
+	})
+
+	t.Run("txmgr_setMinBlobFee", func(t *testing.T) {
+		var res *big.Int
+		minBlobFee.Add(minBlobFee, big.NewInt(1))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_setMinBlobFee", minBlobFee))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getMinBlobFee"))
+		require.Equal(t, minBlobFee, res)
+	})
+
+	t.Run("txmgr_getFeeThreshold", func(t *testing.T) {
+		var res *big.Int
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getFeeThreshold"))
+		require.Equal(t, feeThreshold, res)
+	})
+
+	t.Run("txmgr_setFeeThreshold", func(t *testing.T) {
+		var res *big.Int
+		feeThreshold.Add(feeThreshold, big.NewInt(1))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_setFeeThreshold", feeThreshold))
+		require.NoError(t, rpcClient.Call(&res, "txmgr_getFeeThreshold"))
+		require.Equal(t, feeThreshold, res)
+	})
+}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -581,6 +581,7 @@ func (m *SimpleTxManager) sendTx(ctx context.Context, tx *types.Transaction) (*t
 				return nil, fmt.Errorf("nonce does not exist in pendingTxs: %d", tx.Nonce())
 			}
 			m.pendingTxs[tx.Nonce()].tx = tx
+			m.pendingTxs[tx.Nonce()].status = "published"
 			m.pendingTxMu.Unlock()
 			go func() {
 				defer wg.Done()

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -71,8 +71,8 @@ type TxManager interface {
 
 	// GetPendingTxs returns all tx that have been initiated via Send(), but have not been mined yet
 	GetPendingTxs(bool, bool) ([]PendingTxRPC, error)
-	// CancelPendingNonce calls the ctx.cancel() func on a pending tx with the provided nonce
-	CancelPendingNonce(uint64) error
+	// CancelPendingTx calls the ctx.cancel() func on a pending tx with the provided nonce
+	CancelPendingTx(uint64) error
 
 	GetMinBaseFee() *big.Int
 	SetMinBaseFee(*big.Int)
@@ -298,7 +298,7 @@ type PendingTxRPC struct {
 	GasFeeCap    *big.Int        `json:"gas_fee_cap"`
 }
 
-func (m *SimpleTxManager) CancelPendingNonce(nonce uint64) error {
+func (m *SimpleTxManager) CancelPendingTx(nonce uint64) error {
 	m.pendingTxMu.Lock()
 	pendingTx, exists := m.pendingTxs[nonce]
 	m.pendingTxMu.Unlock()

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -378,7 +378,7 @@ func TestTxMgrPendingTxs(t *testing.T) {
 	numTxs := 3
 	for i := 0; i < numTxs; i++ {
 		go func() {
-			h.mgr.Send(context.Background(), TxCandidate{To: &common.Address{}})
+			_, _ = h.mgr.Send(context.Background(), TxCandidate{To: &common.Address{}})
 		}()
 	}
 	time.Sleep(time.Millisecond * 100)

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -407,7 +407,7 @@ func TestTxMgrPendingTxs(t *testing.T) {
 	t.Run("CancelPendingTx", func(t *testing.T) {
 		// After cancelling a tx, it should be removed from the pendingTxs
 		cancelledNonce := uint64(2)
-		err = h.mgr.CancelPendingNonce(cancelledNonce)
+		err = h.mgr.CancelPendingTx(cancelledNonce)
 		require.NoError(t, err)
 		time.Sleep(time.Millisecond * 100)
 		numTxs--


### PR DESCRIPTION
## Description

Chain operators have hit issues in the past where txs get stuck in their nodes. This PR adds a new `txmgr_` json rpc interface for nodes that use the `TxManager` (i.e. `op-batcher`, `op-challenger`, `op-proposer`) to give them more flexibility/insight when troubleshooting tx submission issues.

## Tests

Added unit tests to the `op-service/txmgr` package. Updated `op-e2e` tests to ensure their use of mocked `TxManager` adheres to the new interface with its additional methods.

## Additional context

### Config rpc methods:
* `txmgr_getMinBaseFee`
* `txmgr_setMinBaseFee`
* `txmgr_getPriorityFee`
* `txmgr_setPriorityFee`
* `txmgr_getMinBlobFee`
* `txmgr_setMinBlobFee`
* `txmgr_getFeeThreshold`
* `txmgr_setFeeThreshold`
* `txmgr_getBumpFeeRetryTime`
* `txmgr_setBumpFeeRetryTime`

### Pending tx rpc method:
* `txmgr_getPendingTxs`
* `txmgr_cancelPendingTx`

## Metadata

- Fixes https://github.com/ethereum-optimism/optimism/issues/10929
