### PR TITLE
fix(op-node): clarify rethdb flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -158,7 +158,7 @@ var (
 	}
 	L1RethDBPath = &cli.StringFlag{
 		Name:     "l1.rethdb",
-		Usage:    "The L1 RethDB path, used to fetch receipts for L1 blocks. Only applicable when using the `reth_db` RPC kind with `l1.rpckind`.",
+		Usage:    "The L1 RethDB path, used to fetch receipts for L1 blocks.",
 		EnvVars:  prefixEnvVars("L1_RETHDB"),
 		Hidden:   true,
 		Category: L1RPCCategory,


### PR DESCRIPTION
Clarifies the `l1.rethdb` flag help docs by removing the reference to a `reth_db` `RPCKIND`.  It doesn't look like this is a valid `RPCKIND` and this is supported in https://github.com/ethereum-optimism/optimism/issues/10365.
