### PR TITLE
op-dispute-mon: Consider chess clocks of descendant claims when checking resolvable status

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -28,7 +28,7 @@ func (*NoopMetricsImpl) RecordGameResolutionStatus(_ ResolutionStatus, _ int) {}
 
 func (*NoopMetricsImpl) RecordCredit(_ CreditExpectation, _ int) {}
 
-func (*NoopMetricsImpl) RecordClaims(_ ClaimStatus, _ int) {}
+func (*NoopMetricsImpl) RecordClaims(_ *ClaimStatuses) {}
 
 func (*NoopMetricsImpl) RecordWithdrawalRequests(_ common.Address, _ bool, _ int) {}
 


### PR DESCRIPTION
**Description**

Adds a new `resolvable` label to the claims metric which indicates if a claim is actually resolvable.  A claim's clock may expire (meaning no new counter-claims can be posted for it) but still not be resolvable because child claim chess clocks are yet to expire. Previously this caused false alarms from dispute-mon.

The resolution delay reported in logs is now the time since the claim first became resolvable, not the time since its clock expired.

**Tests**

Added unit test based on real-world example where this metric caused a false alarm.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/889
