### PR TITLE
fix `AsyncGossiper` hangup

### DIFF
--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -90,6 +90,11 @@ func (p *SimpleAsyncGossiper) Clear() {
 // Stop is a synchronous function to stop the async routine
 // it blocks until the async routine accepts the signal
 func (p *SimpleAsyncGossiper) Stop() {
+	// if the gossiping isn't running, nothing to do
+	if !p.running.Load() {
+		return
+	}
+
 	p.stop <- struct{}{}
 }
 

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -102,10 +102,9 @@ func (p *SimpleAsyncGossiper) Stop() {
 // each behavior of the loop is handled by a select case on a channel, plus an internal handler function call
 func (p *SimpleAsyncGossiper) Start() {
 	// if the gossiping is already running, return
-	if p.running.Load() {
+	if !p.running.CompareAndSwap(false, true) {
 		return
 	}
-	p.running.Store(true)
 	// else, start the handling loop
 	go func() {
 		defer p.running.Store(false)


### PR DESCRIPTION
I stumbled upon a code path in which `op-node` hangs up like this:

```bash
ERROR[05-27|12:37:43.807] Error initializing the rollup node       err="failed to init the RPC server: unable to start RPC server: failed to start HTTP RPC server: failed to bind to address \"0.0.0.0:8547\": listen tcp 0.0.0.0:8547: bind: address already in use"
```

The reason for the hangup is that when `OpNode.Stop` is called(which calls `AsyncGossiper.Stop`) from [here](https://github.com/ethereum-optimism/optimism/blob/329b8699bd8dd94285b8117304f20d37564ed873/op-node/node/node.go#L112), `SimpleAsyncGossiper.Start` hasn't been called yet.

This PR fixes this issue.