### PR TITLE
op-node: Support multiple beacon archiver/fallbacks

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -34,8 +34,12 @@ func init() {
 	cli.VersionFlag.(*cli.BoolFlag).Category = MiscCategory
 }
 
-func prefixEnvVars(name string) []string {
-	return []string{EnvVarPrefix + "_" + name}
+func prefixEnvVars(names ...string) []string {
+	envs := make([]string, 0, len(names))
+	for _, name := range names {
+		envs = append(envs, EnvVarPrefix+"_"+name)
+	}
+	return envs
 }
 
 var (
@@ -76,11 +80,11 @@ var (
 		EnvVars:  prefixEnvVars("L1_BEACON_HEADER"),
 		Category: L1RPCCategory,
 	}
-	BeaconArchiverAddr = &cli.StringFlag{
-		Name:     "l1.beacon-archiver",
-		Usage:    "Address of L1 Beacon-node compatible HTTP endpoint to use. This is used to fetch blobs that the --l1.beacon does not have (i.e expired blobs).",
-		Required: false,
-		EnvVars:  prefixEnvVars("L1_BEACON_ARCHIVER"),
+	BeaconFallbackAddrs = &cli.StringSliceFlag{
+		Name:     "l1.beacon-fallbacks",
+		Aliases:  []string{"l1.beacon-archiver"},
+		Usage:    "Addresses of L1 Beacon-API compatible HTTP fallback endpoints. Used to fetch blob sidecars not availalbe at the l1.beacon (e.g. expired blobs).",
+		EnvVars:  prefixEnvVars("L1_BEACON_FALLBACKS", "L1_BEACON_ARCHIVER"),
 		Category: L1RPCCategory,
 	}
 	BeaconCheckIgnore = &cli.BoolFlag{
@@ -364,7 +368,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	BeaconAddr,
 	BeaconHeader,
-	BeaconArchiverAddr,
+	BeaconFallbackAddrs,
 	BeaconCheckIgnore,
 	BeaconFetchAllSidecars,
 	SyncModeFlag,

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -197,11 +197,15 @@ func (cfg *L1BeaconEndpointConfig) Setup(ctx context.Context, log log.Logger) (c
 		opts = append(opts, client.WithHeader(hdr))
 	}
 
-	a := client.NewBasicHTTPClient(cfg.BeaconAddr, log, opts...)
 	if cfg.BeaconArchiverAddr != "" {
-		b := client.NewBasicHTTPClient(cfg.BeaconArchiverAddr, log)
-		fb = append(fb, sources.NewBeaconHTTPClient(b))
+		addrs := strings.Split(cfg.BeaconArchiverAddr, ",")
+		for _, addr := range addrs {
+			b := client.NewBasicHTTPClient(addr, log)
+			fb = append(fb, sources.NewBeaconHTTPClient(b))
+		}
 	}
+
+	a := client.NewBasicHTTPClient(cfg.BeaconAddr, log, opts...)
 	return sources.NewBeaconHTTPClient(a), fb, nil
 }
 

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -178,11 +178,11 @@ func (cfg *PreparedL1Endpoint) Check() error {
 }
 
 type L1BeaconEndpointConfig struct {
-	BeaconAddr             string // Address of L1 User Beacon-API endpoint to use (beacon namespace required)
-	BeaconHeader           string // Optional HTTP header for all requests to L1 Beacon
-	BeaconArchiverAddr     string // Address of L1 User Beacon-API Archive endpoint to use for expired blobs (beacon namespace required)
-	BeaconCheckIgnore      bool   // When false, halt startup if the beacon version endpoint fails
-	BeaconFetchAllSidecars bool   // Whether to fetch all blob sidecars and filter locally
+	BeaconAddr             string   // Address of L1 User Beacon-API endpoint to use (beacon namespace required)
+	BeaconHeader           string   // Optional HTTP header for all requests to L1 Beacon
+	BeaconFallbackAddrs    []string // Addresses of L1 Beacon-API fallback endpoints (only for blob sidecars retrieval)
+	BeaconCheckIgnore      bool     // When false, halt startup if the beacon version endpoint fails
+	BeaconFetchAllSidecars bool     // Whether to fetch all blob sidecars and filter locally
 }
 
 var _ L1BeaconEndpointSetup = (*L1BeaconEndpointConfig)(nil)
@@ -197,12 +197,9 @@ func (cfg *L1BeaconEndpointConfig) Setup(ctx context.Context, log log.Logger) (c
 		opts = append(opts, client.WithHeader(hdr))
 	}
 
-	if cfg.BeaconArchiverAddr != "" {
-		addrs := strings.Split(cfg.BeaconArchiverAddr, ",")
-		for _, addr := range addrs {
-			b := client.NewBasicHTTPClient(addr, log)
-			fb = append(fb, sources.NewBeaconHTTPClient(b))
-		}
+	for _, addr := range cfg.BeaconFallbackAddrs {
+		b := client.NewBasicHTTPClient(addr, log)
+		fb = append(fb, sources.NewBeaconHTTPClient(b))
 	}
 
 	a := client.NewBasicHTTPClient(cfg.BeaconAddr, log, opts...)

--- a/op-node/node/client_test.go
+++ b/op-node/node/client_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -57,6 +58,35 @@ func TestParseHTTPHeader(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, test.expHdr, h)
 			}
+		})
+	}
+}
+
+func TestL1BeaconEndpointConfig_Setup(t *testing.T) {
+	for _, test := range []struct {
+		desc string
+		baa  string
+		len  int
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc: "one",
+			baa:  "http://foo.bar",
+			len:  1,
+		},
+		{
+			desc: "three",
+			baa:  "http://foo.bar,http://op.ti,http://ba.se",
+			len:  3,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			cfg := L1BeaconEndpointConfig{BeaconArchiverAddr: test.baa}
+			_, fb, err := cfg.Setup(context.TODO(), nil)
+			require.NoError(t, err)
+			require.Len(t, fb, test.len)
 		})
 	}
 }

--- a/op-node/node/client_test.go
+++ b/op-node/node/client_test.go
@@ -84,7 +84,7 @@ func TestL1BeaconEndpointConfig_Setup(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			cfg := L1BeaconEndpointConfig{BeaconFallbackAddrs: test.baa}
-			_, fb, err := cfg.Setup(context.TODO(), nil)
+			_, fb, err := cfg.Setup(context.Background(), nil)
 			require.NoError(t, err)
 			require.Len(t, fb, test.len)
 		})

--- a/op-node/node/client_test.go
+++ b/op-node/node/client_test.go
@@ -65,7 +65,7 @@ func TestParseHTTPHeader(t *testing.T) {
 func TestL1BeaconEndpointConfig_Setup(t *testing.T) {
 	for _, test := range []struct {
 		desc string
-		baa  string
+		baa  []string
 		len  int
 	}{
 		{
@@ -73,17 +73,17 @@ func TestL1BeaconEndpointConfig_Setup(t *testing.T) {
 		},
 		{
 			desc: "one",
-			baa:  "http://foo.bar",
+			baa:  []string{"http://foo.bar"},
 			len:  1,
 		},
 		{
 			desc: "three",
-			baa:  "http://foo.bar,http://op.ti,http://ba.se",
+			baa:  []string{"http://foo.bar", "http://op.ti", "http://ba.se"},
 			len:  3,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			cfg := L1BeaconEndpointConfig{BeaconArchiverAddr: test.baa}
+			cfg := L1BeaconEndpointConfig{BeaconFallbackAddrs: test.baa}
 			_, fb, err := cfg.Setup(context.TODO(), nil)
 			require.NoError(t, err)
 			require.Len(t, fb, test.len)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -132,7 +132,7 @@ func NewBeaconEndpointConfig(ctx *cli.Context) node.L1BeaconEndpointSetup {
 	return &node.L1BeaconEndpointConfig{
 		BeaconAddr:             ctx.String(flags.BeaconAddr.Name),
 		BeaconHeader:           ctx.String(flags.BeaconHeader.Name),
-		BeaconArchiverAddr:     ctx.String(flags.BeaconArchiverAddr.Name),
+		BeaconFallbackAddrs:    ctx.StringSlice(flags.BeaconFallbackAddrs.Name),
 		BeaconCheckIgnore:      ctx.Bool(flags.BeaconCheckIgnore.Name),
 		BeaconFetchAllSidecars: ctx.Bool(flags.BeaconFetchAllSidecars.Name),
 	}

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -179,8 +179,9 @@ func NewL1BeaconClient(cl BeaconClient, cfg L1BeaconClientConfig, fallbacks ...B
 	cs := append([]BlobSideCarsFetcher{cl}, fallbacks...)
 	return &L1BeaconClient{
 		cl:   cl,
-		pool: NewClientPool[BlobSideCarsFetcher](cs...),
-		cfg:  cfg}
+		pool: NewClientPool(cs...),
+		cfg:  cfg,
+	}
 }
 
 type TimeToSlotFn func(timestamp uint64) (uint64, error)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add support for specifying multiple beacon fallbacks/archivers via op-node's cmdline flags. The underlying support in the L1 Beacon client was already there, this just adds support for parsing multiple comma-separated endpoint addresses from the `l1.beacon-archiver` flag.

The flag is also renamed to `l1.beacon-fallbacks`, but the old name is preserved as an alias for backwards compatibility.

**Tests**

Added test that the string parsing works as expected and creates multiple L1 beacon http clients. The underlying fallback logic is already tested in its own tests.

**Additional context**

With this addition, the `l1.beacon-archiver` flag can be used to provide a list of fallback beacon l1 clients, instead of just falling back between the main `l1.beacon` endpoint and the one endpoint specified in `l1.beacon-archiver`. 
