### PR TITLE
op-dispute-mon,op-challenger: Increase default monitoring window

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -660,7 +660,7 @@ func TestGameWindow(t *testing.T) {
 	})
 
 	t.Run("ParsesDefault", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--game-window=360h"))
+		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--game-window=672h"))
 		require.Equal(t, config.DefaultGameWindow, cfg.GameWindow)
 	})
 }

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -96,9 +96,10 @@ const (
 	DefaultAsteriscInfoFreq     = uint(10_000_000)
 	// DefaultGameWindow is the default maximum time duration in the past
 	// that the challenger will look for games to progress.
-	// The default value is 15 days, which is an 8 day resolution buffer
-	// and bond claiming buffer plus the 7 day game finalization window.
-	DefaultGameWindow   = time.Duration(15 * 24 * time.Hour)
+	// The default value is 28 days. The worst case duration for a game is 16 days
+	// (due to clock extension), plus 7 days WETH withdrawal delay leaving a 5 day
+	// buffer to monitor games to ensure bonds are claimed.
+	DefaultGameWindow   = time.Duration(28 * 24 * time.Hour)
 	DefaultMaxPendingTx = 10
 )
 

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -20,9 +20,10 @@ var (
 
 const (
 	// DefaultGameWindow is the default maximum time duration in the past
-	// to look for games to monitor. The default value is 11 days, which
-	// is a 4 day resolution buffer plus the 7 day game finalization window.
-	DefaultGameWindow = time.Duration(11 * 24 * time.Hour)
+	// to look for games to monitor. The default value is 28 days. The worst case duration
+	// for a game is 16 days (due to clock extension), plus 7 days WETH withdrawal delay
+	// leaving a 5 day buffer to monitor games after they should be fully resolved.
+	DefaultGameWindow = 28 * 24 * time.Hour
 	// DefaultMonitorInterval is the default interval at which the dispute
 	// monitor will check for new games to monitor.
 	DefaultMonitorInterval = time.Second * 30


### PR DESCRIPTION
**Description**

Ensures sufficient monitoring period even in the worst case of clock extension. There's some scope to reduce this by a couple of days, but a 28 days monitoring interval is a nice round 4 weeks which makes it easier to remember. Will have to monitor the impact on monitoring performance but should be ok - main impact will be the first round of updates by the challenger which are still reasonably expensive as they don't use batch calls well, but that's then cached once its up and running.