### PR TITLE
refactor(op-node, proxyd): using errors.Is for error comparison

### DIFF
--- a/op-node/p2p/store/ip_ban_book.go
+++ b/op-node/p2p/store/ip_ban_book.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"time"
 
@@ -71,7 +72,7 @@ func (d *ipBanBook) startGC() {
 
 func (d *ipBanBook) GetIPBanExpiration(ip net.IP) (time.Time, error) {
 	rec, err := d.book.getRecord(ip.To16().String())
-	if err == UnknownRecordErr {
+	if errors.Is(err, UnknownRecordErr) {
 		return time.Time{}, UnknownBanErr
 	}
 	if err != nil {

--- a/op-node/p2p/store/mdbook.go
+++ b/op-node/p2p/store/mdbook.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -69,7 +70,7 @@ func (m *metadataBook) startGC() {
 func (m *metadataBook) GetPeerMetadata(id peer.ID) (PeerMetadata, error) {
 	record, err := m.book.getRecord(id)
 	// If the record is not found, return an empty PeerMetadata
-	if err == UnknownRecordErr {
+	if errors.Is(err, UnknownRecordErr) {
 		return PeerMetadata{}, nil
 	}
 	if err != nil {

--- a/op-node/p2p/store/peer_ban_book.go
+++ b/op-node/p2p/store/peer_ban_book.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -67,7 +68,7 @@ func (d *peerBanBook) startGC() {
 
 func (d *peerBanBook) GetPeerBanExpiration(id peer.ID) (time.Time, error) {
 	rec, err := d.book.getRecord(id)
-	if err == UnknownRecordErr {
+	if errors.Is(err, UnknownRecordErr) {
 		return time.Time{}, UnknownBanErr
 	}
 	if err != nil {

--- a/op-node/p2p/store/records_book.go
+++ b/op-node/p2p/store/records_book.go
@@ -128,7 +128,7 @@ func (d *recordsBook[K, V]) SetRecord(key K, diff recordDiff[V]) (V, error) {
 	d.Lock()
 	defer d.Unlock()
 	rec, err := d.getRecord(key)
-	if err == UnknownRecordErr { // instantiate new record if it does not exist yet
+	if errors.Is(err, UnknownRecordErr) { // instantiate new record if it does not exist yet
 		rec = d.newRecord()
 	} else if err != nil {
 		return d.newRecord(), err

--- a/op-node/p2p/store/scorebook.go
+++ b/op-node/p2p/store/scorebook.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -71,7 +72,7 @@ func (d *scoreBook) startGC() {
 
 func (d *scoreBook) GetPeerScores(id peer.ID) (PeerScores, error) {
 	record, err := d.book.getRecord(id)
-	if err == UnknownRecordErr {
+	if errors.Is(err, UnknownRecordErr) {
 		return PeerScores{}, nil // return zeroed scores by default
 	}
 	if err != nil {

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
@@ -66,7 +67,7 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 	val, err := c.rdb.Get(ctx, c.namespaced(key)).Result()
 	redisCacheDurationSumm.WithLabelValues("GET").Observe(float64(time.Since(start).Milliseconds()))
 
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return "", nil
 	} else if err != nil {
 		RecordRedisError("CacheGet")

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -192,7 +193,7 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 	key := ct.key("mutex")
 
 	val, err := ct.client.Get(ct.ctx, key).Result()
-	if err != nil && err != redis.Nil {
+	if err != nil && !errors.Is(err, redis.Nil) {
 		log.Error("failed to read the lock", "err", err)
 		RecordGroupConsensusError(ct.backendGroup, "read_lock", err)
 		if ct.leader {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -369,7 +369,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		}
 
 		batchRes, batchContainsCached, servedBy, err := s.handleBatchRPC(ctx, reqs, isLimited, true)
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			writeRPCError(ctx, w, nil, ErrGatewayTimeout)
 			return
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR uses errors.Is() function instead of directive errors comparison

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
