### PR TITLE
op-node/p2p: add descriptive error code string

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -68,6 +68,13 @@ const (
 	ResultCodeUnknownErr  byte = 3
 )
 
+var resultCodeString = []string{
+	"success",
+	"not found",
+	"invalid request",
+	"unknown error",
+}
+
 func PayloadByNumberProtocolID(l2ChainID *big.Int) protocol.ID {
 	return protocol.ID(fmt.Sprintf("/opstack/req/payload_by_number/%d/0", l2ChainID))
 }
@@ -614,7 +621,13 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 type requestResultErr byte
 
 func (r requestResultErr) Error() string {
-	return fmt.Sprintf("peer failed to serve request with code %d", uint8(r))
+	var errStr string
+	if ri := int(r); ri < len(resultCodeString) {
+		errStr = resultCodeString[ri]
+	} else {
+		errStr = "invalid code"
+	}
+	return fmt.Sprintf("peer failed to serve request with code %d: %s", uint8(r), errStr)
 }
 
 func (r requestResultErr) ResultCode() byte {

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -2,7 +2,9 @@ package p2p
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -378,7 +380,7 @@ func TestNetworkNotifyAddPeerAndRemovePeer(t *testing.T) {
 	require.NoError(t, err, "failed to connect to peer B from peer A")
 	require.Equal(t, hostA.Network().Connectedness(hostB.ID()), network.Connected)
 
-	//wait for async add process done
+	// wait for async add process done
 	<-waitChan
 	_, ok := syncCl.peers[hostB.ID()]
 	require.True(t, ok, "peerB should exist in syncClient")
@@ -386,7 +388,7 @@ func TestNetworkNotifyAddPeerAndRemovePeer(t *testing.T) {
 	err = hostA.Network().ClosePeer(hostB.ID())
 	require.NoError(t, err, "close peer fail")
 
-	//wait for async removing process done
+	// wait for async removing process done
 	<-waitChan
 	_, peerBExist3 := syncCl.peers[hostB.ID()]
 	require.True(t, !peerBExist3, "peerB should not exist in syncClient")
@@ -400,5 +402,44 @@ func TestPanicGuard(t *testing.T) {
 		err := panicGuard(mockPanickingFn)(context.Background(), peer.ID(""), 37)
 		require.EqualError(t, err, "recovered from a panic: gotcha")
 	})
+}
 
+func TestRequestResultErr_Error(t *testing.T) {
+	for _, test := range []struct {
+		code   byte
+		expStr string
+	}{
+		{
+			code:   0,
+			expStr: "success",
+		},
+		{
+			code:   1,
+			expStr: "not found",
+		},
+		{
+			code:   2,
+			expStr: "invalid request",
+		},
+		{
+			code:   3,
+			expStr: "unknown error",
+		},
+		{
+			code:   4,
+			expStr: "invalid code",
+		},
+		{
+			code:   0xff,
+			expStr: "invalid code",
+		},
+	} {
+		t.Run(fmt.Sprintf("code %d", test.code), func(t *testing.T) {
+			err := requestResultErr(test.code)
+			errStr := err.Error()
+			if !strings.HasSuffix(errStr, test.expStr) {
+				t.Fatalf("unexpected error string %q, expted suffix %q", errStr, test.expStr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a descriptive error code string to the p2p request result error.

**Tests**

Added a test of the error string function to assert right suffix and guarantee that no out of bounds access happens.

**Additional context**

Easier to understand when reading logs.

