### PR TITLE
contracts-bedrock: cleanup deploy script

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -284,7 +284,6 @@ contract Deploy is Deployer {
     function _run() internal virtual {
         console.log("start of L1 Deploy!");
         deploySafe("SystemOwnerSafe");
-        console.log("deployed Safe!");
         setupSuperchain();
         console.log("set up superchain!");
         if (cfg.usePlasma()) {
@@ -442,7 +441,7 @@ contract Deploy is Deployer {
         uint256 _threshold,
         bool _keepDeployer
     )
-        public
+        internal
         returns (address addr_)
     {
         console.log("Deploying safe: %s ", _name);


### PR DESCRIPTION
**Description**

Makes the `deploySafe` function that doesn't `broadcast`
`internal`. All of the `public` function do `broadcast`
so this preserves the API. Also removes a redundent log

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

