### PR TITLE
cannon: Add traceback debugger

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -345,7 +345,9 @@ func Run(ctx *cli.Context) error {
 		if metaPath := ctx.Path(RunMetaFlag.Name); metaPath == "" {
 			return fmt.Errorf("cannot enable debug mode without a metadata file")
 		}
-		us.InitDebug(meta)
+		if err := us.InitDebug(meta); err != nil {
+			return fmt.Errorf("failed to initialize debug mode: %w", err)
+		}
 	}
 	proofFmt := ctx.String(RunProofFmtFlag.Name)
 	snapshotFmt := ctx.String(RunSnapshotFmtFlag.Name)

--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -101,7 +101,7 @@ var (
 	}
 	RunDebugFlag = &cli.BoolFlag{
 		Name:  "debug",
-		Usage: "enable debug mode, which includes stack traces and other debug info in the output.",
+		Usage: "enable debug mode, which includes stack traces and other debug info in the output. Requires --meta.",
 	}
 
 	OutFilePerm = os.FileMode(0o755)
@@ -342,6 +342,9 @@ func Run(ctx *cli.Context) error {
 	us := mipsevm.NewInstrumentedState(state, po, outLog, errLog)
 	debugProgram := ctx.Bool(RunDebugFlag.Name)
 	if debugProgram {
+		if metaPath := ctx.Path(RunMetaFlag.Name); metaPath == "" {
+			return fmt.Errorf("cannot enable debug mode without a metadata file")
+		}
 		us.InitDebug(meta)
 	}
 	proofFmt := ctx.String(RunProofFmtFlag.Name)

--- a/cannon/mipsevm/instrumented.go
+++ b/cannon/mipsevm/instrumented.go
@@ -9,6 +9,12 @@ type PreimageOracle interface {
 	GetPreimage(k [32]byte) []byte
 }
 
+type Debug struct {
+	stack  []uint32
+	caller []uint32
+	meta   *Metadata
+}
+
 type InstrumentedState struct {
 	state *State
 
@@ -27,6 +33,9 @@ type InstrumentedState struct {
 	lastPreimageKey [32]byte
 	// offset we last read from, or max uint32 if nothing is read this step
 	lastPreimageOffset uint32
+
+	debug        Debug
+	debugEnabled bool
 }
 
 const (
@@ -51,6 +60,11 @@ func NewInstrumentedState(state *State, po PreimageOracle, stdOut, stdErr io.Wri
 		stdErr:         stdErr,
 		preimageOracle: po,
 	}
+}
+
+func (m *InstrumentedState) InitDebug(meta *Metadata) {
+	m.debugEnabled = true
+	m.debug.meta = meta
 }
 
 func (m *InstrumentedState) Step(proof bool) (wit *StepWitness, err error) {

--- a/cannon/mipsevm/instrumented.go
+++ b/cannon/mipsevm/instrumented.go
@@ -1,6 +1,7 @@
 package mipsevm
 
 import (
+	"errors"
 	"io"
 )
 
@@ -62,9 +63,13 @@ func NewInstrumentedState(state *State, po PreimageOracle, stdOut, stdErr io.Wri
 	}
 }
 
-func (m *InstrumentedState) InitDebug(meta *Metadata) {
+func (m *InstrumentedState) InitDebug(meta *Metadata) error {
+	if meta == nil {
+		return errors.New("metadata is nil")
+	}
 	m.debugEnabled = true
 	m.debug.meta = meta
+	return nil
 }
 
 func (m *InstrumentedState) Step(proof bool) (wit *StepWitness, err error) {

--- a/cannon/mipsevm/mips.go
+++ b/cannon/mipsevm/mips.go
@@ -208,6 +208,8 @@ func (m *InstrumentedState) popStack() {
 			m.debug.stack = m.debug.stack[:len(m.debug.stack)-1]
 			m.debug.caller = m.debug.caller[:len(m.debug.caller)-1]
 		}
+	} else {
+		fmt.Printf("ERROR: stack underflow at pc=%x. step=%d\n", m.state.PC, m.state.Step)
 	}
 }
 

--- a/cannon/mipsevm/mips.go
+++ b/cannon/mipsevm/mips.go
@@ -179,6 +179,47 @@ func (m *InstrumentedState) handleSyscall() error {
 	return nil
 }
 
+func (m *InstrumentedState) pushStack(target uint32) {
+	if !m.debugEnabled {
+		return
+	}
+	m.debug.stack = append(m.debug.stack, target)
+	m.debug.caller = append(m.debug.caller, m.state.PC)
+}
+
+func (m *InstrumentedState) popStack() {
+	if !m.debugEnabled {
+		return
+	}
+	if len(m.debug.stack) != 0 {
+		fn := m.debug.meta.LookupSymbol(m.state.PC)
+		topFn := m.debug.meta.LookupSymbol(m.debug.stack[len(m.debug.stack)-1])
+		if fn != topFn {
+			// most likely the function was inlined. Snap back to the last return.
+			i := len(m.debug.stack) - 1
+			for ; i >= 0; i-- {
+				if m.debug.meta.LookupSymbol(m.debug.stack[i]) == fn {
+					m.debug.stack = m.debug.stack[:i]
+					m.debug.caller = m.debug.caller[:i]
+					break
+				}
+			}
+		} else {
+			m.debug.stack = m.debug.stack[:len(m.debug.stack)-1]
+			m.debug.caller = m.debug.caller[:len(m.debug.caller)-1]
+		}
+	}
+}
+
+func (m *InstrumentedState) Traceback() {
+	fmt.Printf("traceback at pc=%x. step=%d\n", m.state.PC, m.state.Step)
+	for i := len(m.debug.stack) - 1; i >= 0; i-- {
+		s := m.debug.stack[i]
+		idx := len(m.debug.stack) - i - 1
+		fmt.Printf("\t%d %x in %s caller=%08x\n", idx, s, m.debug.meta.LookupSymbol(s), m.debug.caller[i])
+	}
+}
+
 func (m *InstrumentedState) handleBranch(opcode uint32, insn uint32, rtReg uint32, rs uint32) error {
 	if m.state.NextPC != m.state.PC+4 {
 		panic("branch in delay slot")
@@ -291,6 +332,7 @@ func (m *InstrumentedState) mipsStep() error {
 		}
 		// Take top 4 bits of the next PC (its 256 MB region), and concatenate with the 26-bit offset
 		target := (m.state.NextPC & 0xF0000000) | ((insn & 0x03FFFFFF) << 2)
+		m.pushStack(target)
 		return m.handleJump(linkReg, target)
 	}
 
@@ -356,6 +398,7 @@ func (m *InstrumentedState) mipsStep() error {
 			if fun == 9 {
 				linkReg = rdReg
 			}
+			m.popStack()
 			return m.handleJump(linkReg, rs)
 		}
 


### PR DESCRIPTION
Adds a simple traceback feature to the cannon VM. This makes it easy to debug fault proof programs by dumping a stack trace of its execution.

A new flag `--debug` is added to the cannon runner to enable this feature.