### PR TITLE
Unstuck unsuccessful & non-replayable messages by sending the ETH back

### DIFF
--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -184,6 +184,9 @@ abstract contract CrossDomainMessenger is
         // message is the amount of gas requested by the user PLUS the base gas value. We want to
         // guarantee the property that the call to the target contract will always have at least
         // the minimum gas limit specified by the user.
+        if (isCustomGasToken()) {
+            require(msg.value == 0, "CrossDomainMessenger: cannot send value with custom gas token");
+        }
         _sendMessage({
             _to: address(otherMessenger),
             _gasLimit: baseGas(_message, _minGasLimit),

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -367,6 +367,15 @@ abstract contract CrossDomainMessenger is
         + RELAY_GAS_CHECK_BUFFER;
     }
 
+    /// @notice Returns the address of the gas token and the token's decimals.
+    function gasPayingToken() internal view virtual returns (address, uint8);
+
+    /// @notice Returns whether the chain uses a custom gas token or not.
+    function isCustomGasToken() internal view returns (bool) {
+        (address token,) = gasPayingToken();
+        return token != Constants.ETHER;
+    }
+
     /// @notice Initializer.
     /// @param _otherMessenger CrossDomainMessenger contract on the other chain.
     function __CrossDomainMessenger_init(CrossDomainMessenger _otherMessenger) internal onlyInitializing {


### PR DESCRIPTION
- make the internal function for `sendMessage` so that `relayMessage` can call it
