### PR TITLE
op-batcher: log oldest l1 origin when channel close

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -226,6 +226,11 @@ func (c *channel) LatestL1Origin() eth.BlockID {
 	return c.channelBuilder.LatestL1Origin()
 }
 
+// OldestL1Origin returns the oldest L1 block origin from all the L2 blocks that have been added to the channel
+func (c *channel) OldestL1Origin() eth.BlockID {
+	return c.channelBuilder.OldestL1Origin()
+}
+
 func (s *channel) Close() {
 	s.channelBuilder.Close()
 }

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -231,6 +231,16 @@ func (c *channel) OldestL1Origin() eth.BlockID {
 	return c.channelBuilder.OldestL1Origin()
 }
 
+// LatestL2 returns the latest L2 block from all the L2 blocks that have been added to the channel
+func (c *channel) LatestL2() eth.BlockID {
+	return c.channelBuilder.LatestL2()
+}
+
+// OldestL2 returns the oldest L2 block from all the L2 blocks that have been added to the channel
+func (c *channel) OldestL2() eth.BlockID {
+	return c.channelBuilder.OldestL2()
+}
+
 func (s *channel) Close() {
 	s.channelBuilder.Close()
 }

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -143,7 +143,7 @@ func (c *ChannelBuilder) LatestL1Origin() eth.BlockID {
 
 // OldestL1Origin returns the oldest L1 block origin from all the L2 blocks that have been added to the channel
 func (c *ChannelBuilder) OldestL1Origin() eth.BlockID {
-	return c.latestL1Origin
+	return c.oldestL1Origin
 }
 
 // LatestL2 returns the latest L2 block from all the L2 blocks that have been added to the channel

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -70,6 +70,10 @@ type ChannelBuilder struct {
 	latestL1Origin eth.BlockID
 	// oldestL1Origin is the oldest L1 origin of all the L2 blocks that have been added to the channel
 	oldestL1Origin eth.BlockID
+	// latestL2 is the latest L2 block of all the L2 blocks that have been added to the channel
+	latestL2 eth.BlockID
+	// oldestL2 is the oldest L2 block of all the L2 blocks that have been added to the channel
+	oldestL2 eth.BlockID
 	// frames data queue, to be send as txs
 	frames []frameData
 	// total frames counter
@@ -142,6 +146,16 @@ func (c *ChannelBuilder) OldestL1Origin() eth.BlockID {
 	return c.latestL1Origin
 }
 
+// LatestL2 returns the latest L2 block from all the L2 blocks that have been added to the channel
+func (c *ChannelBuilder) LatestL2() eth.BlockID {
+	return c.latestL2
+}
+
+// OldestL2 returns the oldest L2 block from all the L2 blocks that have been added to the channel
+func (c *ChannelBuilder) OldestL2() eth.BlockID {
+	return c.oldestL2
+}
+
 // AddBlock adds a block to the channel compression pipeline. IsFull should be
 // called afterwards to test whether the channel is full. If full, a new channel
 // must be started.
@@ -183,6 +197,18 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,
+		}
+	}
+	if block.NumberU64() > c.latestL2.Number {
+		c.latestL2 = eth.BlockID{
+			Hash:   block.Hash(),
+			Number: block.NumberU64(),
+		}
+	}
+	if c.oldestL2.Number == 0 || block.NumberU64() < c.oldestL2.Number {
+		c.oldestL2 = eth.BlockID{
+			Hash:   block.Hash(),
+			Number: block.NumberU64(),
 		}
 	}
 

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -68,6 +68,8 @@ type ChannelBuilder struct {
 	blocks []*types.Block
 	// latestL1Origin is the latest L1 origin of all the L2 blocks that have been added to the channel
 	latestL1Origin eth.BlockID
+	// oldestL1Origin is the oldest L1 origin of all the L2 blocks that have been added to the channel
+	oldestL1Origin eth.BlockID
 	// frames data queue, to be send as txs
 	frames []frameData
 	// total frames counter
@@ -135,6 +137,11 @@ func (c *ChannelBuilder) LatestL1Origin() eth.BlockID {
 	return c.latestL1Origin
 }
 
+// OldestL1Origin returns the oldest L1 block origin from all the L2 blocks that have been added to the channel
+func (c *ChannelBuilder) OldestL1Origin() eth.BlockID {
+	return c.latestL1Origin
+}
+
 // AddBlock adds a block to the channel compression pipeline. IsFull should be
 // called afterwards to test whether the channel is full. If full, a new channel
 // must be started.
@@ -168,6 +175,12 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 
 	if l1info.Number > c.latestL1Origin.Number {
 		c.latestL1Origin = eth.BlockID{
+			Hash:   l1info.BlockHash,
+			Number: l1info.Number,
+		}
+	}
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,
 		}

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -200,16 +200,10 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 		}
 	}
 	if block.NumberU64() > c.latestL2.Number {
-		c.latestL2 = eth.BlockID{
-			Hash:   block.Hash(),
-			Number: block.NumberU64(),
-		}
+		c.latestL2 = eth.ToBlockID(block)
 	}
 	if c.oldestL2.Number == 0 || block.NumberU64() < c.oldestL2.Number {
-		c.oldestL2 = eth.BlockID{
-			Hash:   block.Hash(),
-			Number: block.NumberU64(),
-		}
+		c.oldestL2 = eth.ToBlockID(block)
 	}
 
 	if err = c.co.FullErr(); err != nil {

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -712,6 +712,72 @@ func TestChannelBuilder_LatestL1Origin(t *testing.T) {
 	require.Equal(t, uint64(2), cb.LatestL1Origin().Number)
 }
 
+func TestChannelBuilder_OldestL1Origin(t *testing.T) {
+	cb, err := NewChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+	require.Equal(t, eth.BlockID{}, cb.OldestL1Origin())
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
+}
+
+func TestChannelBuilder_LatestL2(t *testing.T) {
+	cb, err := NewChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+	require.Equal(t, eth.BlockID{}, cb.LatestL2())
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.LatestL2().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cb.LatestL2().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cb.LatestL2().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cb.LatestL2().Number)
+}
+
+func TestChannelBuilder_OldestL2(t *testing.T) {
+	cb, err := NewChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+	require.Equal(t, eth.BlockID{}, cb.OldestL2())
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL2().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL2().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL2().Number)
+
+	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cb.OldestL2().Number)
+}
+
 func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
 	const tnf = 9
 	rng := rand.New(rand.NewSource(94572314))

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -320,6 +320,7 @@ func (s *channelManager) outputFrames() error {
 		"num_frames", s.currentChannel.TotalFrames(),
 		"input_bytes", inBytes,
 		"output_bytes", outBytes,
+		"oldest_l1_origin", s.currentChannel.OldestL1Origin(),
 		"l1_origin", lastClosedL1Origin,
 		"full_reason", s.currentChannel.FullErr(),
 		"compr_ratio", comprRatio,

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -322,6 +322,8 @@ func (s *channelManager) outputFrames() error {
 		"output_bytes", outBytes,
 		"oldest_l1_origin", s.currentChannel.OldestL1Origin(),
 		"l1_origin", lastClosedL1Origin,
+		"oldest_l2", s.currentChannel.OldestL2(),
+		"latest_l2", s.currentChannel.LatestL2(),
 		"full_reason", s.currentChannel.FullErr(),
 		"compr_ratio", comprRatio,
 		"latest_l1_origin", s.l1OriginLastClosedChannel,


### PR DESCRIPTION
Currently when channel closes, only the latest l1 origin is logged.

It may be helpful to also output the oldest l1 origin in channel, e.g., when reasoning why `close to sequencer window timeout` is happening more often than expected sometimes.

