### PR TITLE
ci: remove geth external tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1808,16 +1808,6 @@ workflows:
           requires:
             - pnpm-monorepo
             - cannon-prestate
-      - go-e2e-test:
-          name: op-e2e-ext-geth-tests<< matrix.fpac >>
-          matrix:
-            parameters:
-              fpac: ["", "-fault-proofs"]
-          module: op-e2e
-          target: test-external-geth
-          requires:
-            - go-mod-download
-            - pnpm-monorepo
       - op-service-rethdb-tests:
           requires:
             - go-mod-download
@@ -1847,7 +1837,6 @@ workflows:
             - op-e2e-HTTP-tests
             - op-e2e-fault-proof-tests
             - op-e2e-action-tests
-            - op-e2e-ext-geth-tests
       - docker-build:
           name: op-node-docker-build
           docker_name: op-node


### PR DESCRIPTION
**Description**

This removes running the external geth tests in CI since they
are particularly flakey. These were added to enable running
the e2e tests against external clients more easily. This does
not remove that ability from the monorepo as the package is not
touched. External clients can still run the e2e tests against their
client, we just no longer run these tests in CI. There isn't a ton
of value running these in CI as everything in process tests the
same things and the value of removing them is the reduce in flakes.

A change to docs or smart contracts should not need to rerun
CI for unrelated tests flaking. Since there is no clear ownership
for these tests, they should be removed. This is not reducing test
coverage.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

