### PR TITLE
challenger: Log txmgr sender for subcommands that execute transactions

### DIFF
--- a/op-challenger/cmd/utils.go
+++ b/op-challenger/cmd/utils.go
@@ -74,5 +74,6 @@ func newClientsFromCLI(ctx *cli.Context) (*batching.MultiCaller, txmgr.TxManager
 		return nil, nil, fmt.Errorf("failed to create the transaction manager: %w", err)
 	}
 
+	logger.Info("Configured transaction manager", "sender", txMgr.From())
 	return caller, txMgr, nil
 }


### PR DESCRIPTION
**Description**

Small thing to make it easier to debug why tx fail to send.