### PR TITLE
op-e2e: fix finalize flake

### DIFF
--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -132,6 +132,11 @@ func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Dur
 		case <-ticker.C:
 			block, err := client.BlockByNumber(ctx, tagBigInt)
 			if err != nil {
+				// If block is not found (e.g. upon startup of chain, when there is no "finalized block" yet)
+				// then it may be found later. Keep wait loop running.
+				if strings.Contains(err.Error(), "block not found") {
+					continue
+				}
 				return nil, err
 			}
 			if block != nil && block.NumberU64() >= number.Uint64() {


### PR DESCRIPTION
**Description**

When polling for a block-tag very close to startup / chain-genesis, the tag might not exist yet. This causes flakes in tests.
We can detect this, by checking the error code, and continue the wait loop.

**Tests**

Fixes flake of `TestFinalize`, and maybe other flakes also.
