### PR TITLE
go.mod: fix go build in Intellij IDEA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -232,3 +232,6 @@ replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 
 // replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain-registry/superchain
+
+// This release keeps breaking Go builds. Stop that.
+exclude github.com/kataras/iris/v12 v12.2.0-beta5


### PR DESCRIPTION
**Description**

Fixes full-project Go build in Intellij IDEA.

There's something in the `op-ufm` relative relation to parent-dir that throws of Intellij when syncing dependencies, causing it to hang up on this older release. (which was fixed months ago in upstream geth with a dependency bump, but not resolved somehow).
