### PR TITLE
op-e2e: fix tx-gossip flake

### DIFF
--- a/op-e2e/l2_gossip_test.go
+++ b/op-e2e/l2_gossip_test.go
@@ -1,7 +1,9 @@
 package op_e2e
 
 import (
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum/go-ethereum/common"
@@ -22,6 +24,10 @@ func TestTxGossip(t *testing.T) {
 	seqClient := sys.Clients["sequencer"]
 	verifClient := sys.Clients["verifier"]
 	geth.ConnectP2P(t, seqClient, verifClient)
+
+	// This prevents the below tx-sending from flaking in CI
+	_, err = geth.WaitForBlock(big.NewInt(10), verifClient, time.Minute)
+	require.NoError(t, err)
 
 	// Send a transaction to the verifier and it should be gossiped to the sequencer and included in a block.
 	SendL2Tx(t, cfg, verifClient, cfg.Secrets.Alice, func(opts *TxOpts) {


### PR DESCRIPTION
**Description**

Not the prettiest fix, but tx-gossip just appears unstable in the first few blocks between verifier and sequencer.
By waiting for the verifier to sync blocks of the sequencer, the test reliably passes, whereas otherwise it would fail often, even locally.
