### PR TITLE
op-batcher: Randomize ordering of rollupUrl failover

### DIFF
--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/rpc"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -131,7 +132,7 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	var rollupProvider dial.RollupProvider
 	if strings.Contains(cfg.RollupRpc, ",") {
 		rollupUrls := strings.Split(cfg.RollupRpc, ",")
-		rollupProvider, err = dial.NewActiveL2RollupProvider(ctx, rollupUrls, cfg.ActiveSequencerCheckDuration, dial.DefaultDialTimeout, ps.Log)
+		rollupProvider, err = dial.NewActiveL2RollupProvider(ctx, op_service.NewRandomizedIterable(rollupUrls), cfg.ActiveSequencerCheckDuration, dial.DefaultDialTimeout, ps.Log)
 	} else {
 		rollupProvider, err = dial.NewStaticL2RollupProvider(ctx, ps.Log, cfg.RollupRpc)
 	}

--- a/op-service/dial/active_l2_provider_test.go
+++ b/op-service/dial/active_l2_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/log"
@@ -64,7 +65,7 @@ func (et *endpointProviderTest) newActiveL2RollupProvider(checkDuration time.Dur
 
 	return newActiveL2RollupProvider(
 		context.Background(),
-		rollupUrls,
+		op_service.NewOrderedIterable(rollupUrls),
 		checkDuration,
 		1*time.Minute,
 		testlog.Logger(et.t, log.LevelDebug),
@@ -112,8 +113,8 @@ func (et *endpointProviderTest) newActiveL2EndpointProvider(checkDuration time.D
 
 	return newActiveL2EndpointProvider(
 		context.Background(),
-		ethUrls,
-		rollupUrls,
+		op_service.NewOrderedIterable(ethUrls),
+		op_service.NewOrderedIterable(rollupUrls),
 		checkDuration,
 		1*time.Minute,
 		testlog.Logger(et.t, log.LevelDebug),


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates the `ActiveL2RollupProvider` to fallback to alternative candidate `rollupUrls` in a randomized order, instead of always iterating through the list in the same order.
This prevents a subset of bad/misconfigured endpoints from permanently blocking failover behavior, as these endpoints could otherwise consume the entire context timeout on each iteration of `ActiveL2RollupProvider.RollupClient()`

Using a randomized ordering also allows the `rollupUrls` set to grow independent of the contextual deadline, as each new iteration attempt has an equal chance of trying new URLs, instead of always checking the next N.

**Tests**

No new tests added, but the existing `ActiveL2Provider` tests have been updated to continue to use a deterministic URL ordering, ensuring that these tests can remain easy to maintain.

**Additional context**

An alternative fix for the above issue is to tune the context timeouts and retry logic in order to better handle unresponsive endpoints. With current defaults, `ActiveL2RollupProvider` uses a 1 minute `networkTimeout`, which is guaranteed to be consumed by a single call to `DialRollupClientWithTimeout`. This means that no other candidate sequencers will be checked, preventing failover if only 2 sequential instances are unhealthy.

**Metadata**

- Fixes #[Link to Issue]
