### PR TITLE
op-batcher: Do not retry dial attempts in active l2 providers

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -171,7 +171,7 @@ func (ix *Indexer) initFromConfig(ctx context.Context, cfg *config.Config) error
 }
 
 func (ix *Indexer) initRPCClients(ctx context.Context, rpcsConfig config.RPCsConfig) error {
-	if !client.IsURLAvailable(rpcsConfig.L1RPC) {
+	if !client.IsURLAvailable(ctx, rpcsConfig.L1RPC) {
 		return fmt.Errorf("l1 rpc address unavailable (%s)", rpcsConfig.L1RPC)
 	}
 	l1Rpc, err := rpc.DialContext(ctx, rpcsConfig.L1RPC)
@@ -179,7 +179,7 @@ func (ix *Indexer) initRPCClients(ctx context.Context, rpcsConfig config.RPCsCon
 		return fmt.Errorf("failed to dial L1 client: %w", err)
 	}
 
-	if !client.IsURLAvailable(rpcsConfig.L2RPC) {
+	if !client.IsURLAvailable(ctx, rpcsConfig.L2RPC) {
 		return fmt.Errorf("l2 rpc address unavailable (%s)", rpcsConfig.L2RPC)
 	}
 	l2Rpc, err := rpc.DialContext(ctx, rpcsConfig.L2RPC)

--- a/op-service/client/dial_test.go
+++ b/op-service/client/dial_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -19,38 +20,38 @@ func TestIsURLAvailableLocal(t *testing.T) {
 	addr := fmt.Sprintf("http://localhost:%s", parts[1])
 
 	// True & False with ports
-	require.True(t, IsURLAvailable(addr))
-	require.False(t, IsURLAvailable("http://localhost:0"))
+	require.True(t, IsURLAvailable(context.Background(), addr))
+	require.False(t, IsURLAvailable(context.Background(), "http://localhost:0"))
 
 	// Fail open if we don't recognize the scheme
-	require.True(t, IsURLAvailable("mailto://example.com"))
+	require.True(t, IsURLAvailable(context.Background(), "mailto://example.com"))
 
 }
 
 func TestIsURLAvailableNonLocal(t *testing.T) {
-	if !IsURLAvailable("http://example.com") {
+	if !IsURLAvailable(context.Background(), "http://example.com") {
 		t.Skip("No internet connection found, skipping this test")
 	}
 
 	// True without ports. http & https
-	require.True(t, IsURLAvailable("http://example.com"))
-	require.True(t, IsURLAvailable("http://example.com/hello"))
-	require.True(t, IsURLAvailable("https://example.com"))
-	require.True(t, IsURLAvailable("https://example.com/hello"))
+	require.True(t, IsURLAvailable(context.Background(), "http://example.com"))
+	require.True(t, IsURLAvailable(context.Background(), "http://example.com/hello"))
+	require.True(t, IsURLAvailable(context.Background(), "https://example.com"))
+	require.True(t, IsURLAvailable(context.Background(), "https://example.com/hello"))
 
 	// True without ports. ws & wss
-	require.True(t, IsURLAvailable("ws://example.com"))
-	require.True(t, IsURLAvailable("ws://example.com/hello"))
-	require.True(t, IsURLAvailable("wss://example.com"))
-	require.True(t, IsURLAvailable("wss://example.com/hello"))
+	require.True(t, IsURLAvailable(context.Background(), "ws://example.com"))
+	require.True(t, IsURLAvailable(context.Background(), "ws://example.com/hello"))
+	require.True(t, IsURLAvailable(context.Background(), "wss://example.com"))
+	require.True(t, IsURLAvailable(context.Background(), "wss://example.com/hello"))
 
 	// False without ports
-	require.False(t, IsURLAvailable("http://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable("http://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
-	require.False(t, IsURLAvailable("https://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable("https://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
-	require.False(t, IsURLAvailable("ws://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable("ws://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
-	require.False(t, IsURLAvailable("wss://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable("wss://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
+	require.False(t, IsURLAvailable(context.Background(), "http://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
+	require.False(t, IsURLAvailable(context.Background(), "http://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
+	require.False(t, IsURLAvailable(context.Background(), "https://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
+	require.False(t, IsURLAvailable(context.Background(), "https://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
+	require.False(t, IsURLAvailable(context.Background(), "ws://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
+	require.False(t, IsURLAvailable(context.Background(), "ws://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
+	require.False(t, IsURLAvailable(context.Background(), "wss://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
+	require.False(t, IsURLAvailable(context.Background(), "wss://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
 }

--- a/op-service/dial/active_l2_provider_test.go
+++ b/op-service/dial/active_l2_provider_test.go
@@ -43,7 +43,7 @@ func setupEndpointProviderTest(t *testing.T, numSequencers int) *endpointProvide
 
 // newActiveL2EndpointProvider constructs a new ActiveL2RollupProvider using the test harness setup.
 func (et *endpointProviderTest) newActiveL2RollupProvider(checkDuration time.Duration) (*ActiveL2RollupProvider, error) {
-	mockRollupDialer := func(ctx context.Context, timeout time.Duration, log log.Logger, url string) (RollupClientInterface, error) {
+	mockRollupDialer := func(ctx context.Context, log log.Logger, url string) (RollupClientInterface, error) {
 		for i, client := range et.rollupClients {
 			if url == fmt.Sprintf("rollup%d", i) {
 				if !et.rollupDialOutcomes[i] {
@@ -74,7 +74,7 @@ func (et *endpointProviderTest) newActiveL2RollupProvider(checkDuration time.Dur
 
 // newActiveL2EndpointProvider constructs a new ActiveL2EndpointProvider using the test harness setup.
 func (et *endpointProviderTest) newActiveL2EndpointProvider(checkDuration time.Duration) (*ActiveL2EndpointProvider, error) {
-	mockRollupDialer := func(ctx context.Context, timeout time.Duration, log log.Logger, url string) (RollupClientInterface, error) {
+	mockRollupDialer := func(ctx context.Context, log log.Logger, url string) (RollupClientInterface, error) {
 		for i, client := range et.rollupClients {
 			if url == fmt.Sprintf("rollup%d", i) {
 				if !et.rollupDialOutcomes[i] {
@@ -86,7 +86,7 @@ func (et *endpointProviderTest) newActiveL2EndpointProvider(checkDuration time.D
 		return nil, fmt.Errorf("unknown test url: %s", url)
 	}
 
-	mockEthDialer := func(ctx context.Context, timeout time.Duration, log log.Logger, url string) (EthClientInterface, error) {
+	mockEthDialer := func(ctx context.Context, log log.Logger, url string) (EthClientInterface, error) {
 		for i, client := range et.ethClients {
 			if url == fmt.Sprintf("eth%d", i) {
 				if !et.ethDialOutcomes[i] {

--- a/op-service/dial/dial.go
+++ b/op-service/dial/dial.go
@@ -60,14 +60,19 @@ func DialRPCClientWithTimeout(ctx context.Context, timeout time.Duration, log lo
 func dialRPCClientWithBackoff(ctx context.Context, log log.Logger, addr string) (*rpc.Client, error) {
 	bOff := retry.Fixed(defaultRetryTime)
 	return retry.Do(ctx, defaultRetryCount, bOff, func() (*rpc.Client, error) {
-		if !client.IsURLAvailable(addr) {
-			log.Warn("failed to dial address, but may connect later", "addr", addr)
-			return nil, fmt.Errorf("address unavailable (%s)", addr)
-		}
-		client, err := rpc.DialOptions(ctx, addr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to dial address (%s): %w", addr, err)
-		}
-		return client, nil
+		return dialRPCClient(ctx, log, addr)
 	})
+}
+
+// Dials a JSON-RPC endpoint once.
+func dialRPCClient(ctx context.Context, log log.Logger, addr string) (*rpc.Client, error) {
+	if !client.IsURLAvailable(ctx, addr) {
+		log.Warn("failed to dial address, but may connect later", "addr", addr)
+		return nil, fmt.Errorf("address unavailable (%s)", addr)
+	}
+	client, err := rpc.DialOptions(ctx, addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial address (%s): %w", addr, err)
+	}
+	return client, nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Perform simple endpoint dialing in `ActiveL2RollupProvider`, as compared to the standard retrying dial flow. This allows dialing to fail quickly, and fall back to the next candidate endpoint, potentially repeating. With the default retry behavior, this will perform 30 attempts with 2 second delays in between attempts, frequently consuming all of the current context's deadline.

**Tests**

No tests added for this change.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

-Related to #10695 
