### PR TITLE
cannon: Cleanup logger

### DIFF
--- a/cannon/cmd/log.go
+++ b/cannon/cmd/log.go
@@ -2,12 +2,39 @@ package cmd
 
 import (
 	"io"
+	"os"
 
 	"golang.org/x/exp/slog"
+	"golang.org/x/term"
 
 	"github.com/ethereum/go-ethereum/log"
 )
 
 func Logger(w io.Writer, lvl slog.Level) log.Logger {
-	return log.NewLogger(log.LogfmtHandlerWithLevel(w, lvl))
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		return log.NewLogger(log.LogfmtHandlerWithLevel(w, lvl))
+	} else {
+		return log.NewLogger(rawLogHandler(w, lvl))
+	}
+}
+
+// rawLogHandler returns a handler that strips out the time attribute
+func rawLogHandler(wr io.Writer, lvl slog.Level) slog.Handler {
+	return slog.NewTextHandler(wr, &slog.HandlerOptions{
+		ReplaceAttr: replaceAttr,
+		Level:       &leveler{lvl},
+	})
+}
+
+type leveler struct{ minLevel slog.Level }
+
+func (l *leveler) Level() slog.Level {
+	return l.minLevel
+}
+
+func replaceAttr(_ []string, attr slog.Attr) slog.Attr {
+	if attr.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return attr
 }

--- a/cannon/mipsevm/logw.go
+++ b/cannon/mipsevm/logw.go
@@ -9,8 +9,7 @@ import (
 // and expose an io Writer interface,
 // for the program running within the VM to write to.
 type LoggingWriter struct {
-	Name string
-	Log  log.Logger
+	Log log.Logger
 }
 
 func logAsText(b string) bool {


### PR DESCRIPTION
Makes it easy to pin-point the source of cannon logs. Affects logs coming from the VM itself, the op-program guest client, and the host program.

Also cleans up log output by removing duplicate timestamp field when the Cannon CLI is executed by another slog logging program.