### PR TITLE
op-e2e: Check cannnon exit status in TestPrecompiles

### DIFF
--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -155,6 +155,8 @@ func runCannon(t *testing.T, ctx context.Context, sys *op_e2e.System, inputs uti
 
 	state, err := parseState(filepath.Join(proofsDir, "final.json.gz"))
 	require.NoError(t, err, "failed to parse state")
+	require.True(t, state.Exited, "cannon did not exit")
+	require.Zero(t, state.ExitCode, "cannon failed with exit code %d", state.ExitCode)
 	t.Logf("Completed in %d steps", state.Step)
 }
 


### PR DESCRIPTION
To properly detect cases where the op-program-derived L2 output disagrees with the test sequencer.