### PR TITLE
Block the gas paying token deposited from L1StandardBridge

### DIFF
--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -269,6 +269,8 @@ contract L1StandardBridge is StandardBridge, ISemver {
     )
         internal
     {
+        (address token,) = gasPayingToken();
+         require(_l1Token != token, "Cannot deposit gas paying token from L1StandardBridge");
         _initiateBridgeERC20(_l1Token, _l2Token, _from, _to, _amount, _minGasLimit, _extraData);
     }
 

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -591,6 +591,23 @@ contract L1StandardBridge_DepositERC20_TestFail is Bridge_Initializer {
         vm.prank(alice, alice);
         l1StandardBridge.depositERC20(address(0), address(0), 100, 100, hex"");
     }
+
+    /// @dev Tests that depositing an ERC20 to the bridge reverts
+    ///      if the gas paying token is a custom gas token.
+    function test_depositERC20_gasPayingToken_reverts() external {
+        // Deal Alice's ERC20 State
+        deal(address(L1Token), alice, 100000, true);
+        vm.prank(alice);
+        L1Token.approve(address(l1StandardBridge), type(uint256).max);
+
+        vm.mockCall(
+            address(systemConfig), abi.encodeWithSignature("gasPayingToken()"), abi.encode(address(L1Token), uint8(18))
+        );
+
+        vm.expectRevert("Cannot deposit gas paying token from L1StandardBridge");
+        vm.prank(alice, alice);
+        l1StandardBridge.depositERC20(address(L1Token), address(0), 100, 100, hex"");
+    }
 }
 
 contract L1StandardBridge_DepositERC20To_Test is Bridge_Initializer {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

This PR blocks the gas token deposited from L1StandardBridge if it is enabled

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

The unit test is added

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
