### PR TITLE
op-batcher/op-proposer: Only pass lifecycle contexts into RollupProvider.RollupClient

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -208,13 +208,15 @@ func (l *BatchSubmitter) loadBlockIntoState(ctx context.Context, blockNumber uin
 // calculateL2BlockRangeToStore determines the range (start,end] that should be loaded into the local state.
 // It also takes care of initializing some local state (i.e. will modify l.lastStoredBlock in certain conditions)
 func (l *BatchSubmitter) calculateL2BlockRangeToStore(ctx context.Context) (eth.BlockID, eth.BlockID, error) {
-	ctx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
-	defer cancel()
 	rollupClient, err := l.EndpointProvider.RollupClient(ctx)
 	if err != nil {
 		return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("getting rollup client: %w", err)
 	}
-	syncStatus, err := rollupClient.SyncStatus(ctx)
+
+	cCtx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
+	defer cancel()
+
+	syncStatus, err := rollupClient.SyncStatus(cCtx)
 	// Ensure that we have the sync status
 	if err != nil {
 		return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("failed to get sync status: %w", err)
@@ -337,15 +339,16 @@ func (l *BatchSubmitter) loop() {
 // waitNodeSync Check to see if there was a batcher tx sent recently that
 // still needs more block confirmations before being considered finalized
 func (l *BatchSubmitter) waitNodeSync() error {
-	ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
-	defer cancel()
-
+	ctx := l.shutdownCtx
 	rollupClient, err := l.EndpointProvider.RollupClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get rollup client: %w", err)
 	}
 
-	l1Tip, err := l.l1Tip(ctx)
+	cCtx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
+	defer cancel()
+
+	l1Tip, err := l.l1Tip(cCtx)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve l1 tip: %w", err)
 	}
@@ -353,7 +356,7 @@ func (l *BatchSubmitter) waitNodeSync() error {
 	l1TargetBlock := l1Tip.Number
 	if l.Config.CheckRecentTxsDepth != 0 {
 		l.Log.Info("Checking for recently submitted batcher transactions on L1")
-		recentBlock, found, err := eth.CheckRecentTxs(ctx, l.L1Client, l.Config.CheckRecentTxsDepth, l.Txmgr.From())
+		recentBlock, found, err := eth.CheckRecentTxs(cCtx, l.L1Client, l.Config.CheckRecentTxsDepth, l.Txmgr.From())
 		if err != nil {
 			return fmt.Errorf("failed checking recent batcher txs: %w", err)
 		}
@@ -451,16 +454,16 @@ func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[t
 }
 
 func (l *BatchSubmitter) safeL1Origin(ctx context.Context) (eth.BlockID, error) {
-	ctx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
-	defer cancel()
-
 	c, err := l.EndpointProvider.RollupClient(ctx)
 	if err != nil {
 		log.Error("Failed to get rollup client", "err", err)
 		return eth.BlockID{}, fmt.Errorf("safe l1 origin: error getting rollup client: %w", err)
 	}
 
-	status, err := c.SyncStatus(ctx)
+	cCtx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
+	defer cancel()
+
+	status, err := c.SyncStatus(cCtx)
 	if err != nil {
 		log.Error("Failed to get sync status", "err", err)
 		return eth.BlockID{}, fmt.Errorf("safe l1 origin: error getting sync status: %w", err)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -186,13 +186,15 @@ func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context) error {
 
 // loadBlockIntoState fetches & stores a single block into `state`. It returns the block it loaded.
 func (l *BatchSubmitter) loadBlockIntoState(ctx context.Context, blockNumber uint64) (*types.Block, error) {
-	ctx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
-	defer cancel()
 	l2Client, err := l.EndpointProvider.EthClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting L2 client: %w", err)
 	}
-	block, err := l2Client.BlockByNumber(ctx, new(big.Int).SetUint64(blockNumber))
+
+	cCtx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
+	defer cancel()
+
+	block, err := l2Client.BlockByNumber(cCtx, new(big.Int).SetUint64(blockNumber))
 	if err != nil {
 		return nil, fmt.Errorf("getting L2 block: %w", err)
 	}

--- a/op-service/dial/static_l2_provider.go
+++ b/op-service/dial/static_l2_provider.go
@@ -12,7 +12,9 @@ import (
 // It does this by extending the RollupProvider interface to add the ability to get an EthClient
 type L2EndpointProvider interface {
 	RollupProvider
-	// EthClient(ctx) returns the underlying ethclient pointing to the L2 execution node
+	// EthClient(ctx) returns the underlying ethclient pointing to the L2 execution node.
+	// Note: ctx should be a lifecycle context without an attached timeout as client selection may involve
+	// multiple network operations, specifically in the case of failover.
 	EthClient(ctx context.Context) (EthClientInterface, error)
 }
 

--- a/op-service/dial/static_rollup_provider.go
+++ b/op-service/dial/static_rollup_provider.go
@@ -10,7 +10,9 @@ import (
 // RollupProvider is an interface for providing a RollupClient
 // It manages the lifecycle of the RollupClient for callers
 type RollupProvider interface {
-	// RollupClient(ctx) returns the underlying sources.RollupClient pointing to the L2 rollup consensus node
+	// RollupClient(ctx) returns the underlying sources.RollupClient pointing to the L2 rollup consensus node.
+	// Note: ctx should be a lifecycle context as client selection may involve multiple network operations,
+	// specifically in the case of failover.
 	RollupClient(ctx context.Context) (RollupClientInterface, error)
 	// Close() closes the underlying client or clients
 	Close()

--- a/op-service/dial/static_rollup_provider.go
+++ b/op-service/dial/static_rollup_provider.go
@@ -11,8 +11,8 @@ import (
 // It manages the lifecycle of the RollupClient for callers
 type RollupProvider interface {
 	// RollupClient(ctx) returns the underlying sources.RollupClient pointing to the L2 rollup consensus node.
-	// Note: ctx should be a lifecycle context as client selection may involve multiple network operations,
-	// specifically in the case of failover.
+	// Note: ctx should be a lifecycle context without an attached timeout as client selection may involve
+	// multiple network operations, specifically in the case of failover.
 	RollupClient(ctx context.Context) (RollupClientInterface, error)
 	// Close() closes the underlying client or clients
 	Close()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Ensures that only lifecycle contexts are passed into `RollupProvider.RollupClient` in order to provide sufficient time for endpoint failover.

If a deadlined context is passed in, a single unresponsive host could singlehandedly consume the entire context deadline due to long timeouts and/or retries, causing each call to RollupClient to repeatedly fail when querying this host. With this change, the `RollupProvider`'s own network deadlines will be utilized, which in active failover mode may consume up to `2 * NumURLs * NetworkTimeout` time, or `NumURLs * 2 minutes` with present configurations.

**Tests**

No tests added, as this simply modifies the contexts passed into existing code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
