### PR TITLE
op-conductor: Fix leader promotion when node is behind consensus by 1 block

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -703,20 +703,20 @@ func (oc *OpConductor) startSequencer() error {
 	// If not, then we wait for the unsafe head to catch up or gossip it to op-node manually from op-conductor.
 	unsafeInCons, unsafeInNode, err := oc.compareUnsafeHead(ctx)
 	// if there's a mismatch, try to post the unsafe head to op-node
-	if err != nil {
-		if errors.Is(err, ErrUnsafeHeadMismatch) && uint64(unsafeInCons.ExecutionPayload.BlockNumber)-unsafeInNode.NumberU64() == 1 {
-			// tries to post the unsafe head to op-node when head is only 1 block behind (most likely due to gossip delay)
-			oc.log.Debug(
-				"posting unsafe head to op-node",
-				"consensus_num", uint64(unsafeInCons.ExecutionPayload.BlockNumber),
-				"consensus_hash", unsafeInCons.ExecutionPayload.BlockHash.Hex(),
-				"node_num", unsafeInNode.NumberU64(),
-				"node_hash", unsafeInNode.Hash().Hex(),
-			)
-			if innerErr := oc.ctrl.PostUnsafePayload(ctx, unsafeInCons); innerErr != nil {
-				oc.log.Error("failed to post unsafe head payload envelope to op-node", "err", innerErr)
-			}
+	if errors.Is(err, ErrUnsafeHeadMismatch) && uint64(unsafeInCons.ExecutionPayload.BlockNumber)-unsafeInNode.NumberU64() == 1 {
+		// tries to post the unsafe head to op-node when head is only 1 block behind (most likely due to gossip delay)
+		oc.log.Debug(
+			"posting unsafe head to op-node",
+			"consensus_num", uint64(unsafeInCons.ExecutionPayload.BlockNumber),
+			"consensus_hash", unsafeInCons.ExecutionPayload.BlockHash.Hex(),
+			"node_num", unsafeInNode.NumberU64(),
+			"node_hash", unsafeInNode.Hash().Hex(),
+		)
+		if err := oc.ctrl.PostUnsafePayload(ctx, unsafeInCons); err != nil {
+			oc.log.Error("failed to post unsafe head payload envelope to op-node", "err", err)
+			return err
 		}
+	} else if err != nil {
 		return err
 	}
 

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -322,55 +322,6 @@ func (s *OpConductorTestSuite) TestScenario1() {
 }
 
 // In this test, we have a follower that is not healthy and not sequencing, it becomes leader through election.
-// But since its unsafe head is one block behind consensus, we expect it to post the unsafe payload and then transfer leadership to another node.
-// [follower, not healthy, not sequencing] -- become leader --> [leader, not healthy, not sequencing] -- transfer leadership --> [follower, not healthy, not sequencing]
-func (s *OpConductorTestSuite) TestScenario1ConsensusAheadByOneBlock() {
-	s.enableSynchronization()
-
-	// set initial state
-	s.conductor.leader.Store(false)
-	s.conductor.healthy.Store(false)
-	s.conductor.seqActive.Store(false)
-	s.conductor.hcerr = health.ErrSequencerNotHealthy
-	s.conductor.prevState = &state{
-		leader:  false,
-		healthy: false,
-		active:  false,
-	}
-
-	// unsafe in consensus is different than unsafe in node.
-	mockPayload := &eth.ExecutionPayloadEnvelope{
-		ExecutionPayload: &eth.ExecutionPayload{
-			BlockNumber: 2,
-			BlockHash:   [32]byte{4, 5, 6},
-		},
-	}
-	mockBlockInfo := &testutils.MockBlockInfo{
-		InfoNum:  1,
-		InfoHash: [32]byte{1, 2, 3},
-	}
-	s.cons.EXPECT().TransferLeader().Return(nil)
-	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
-	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
-	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(nil).Times(1)
-
-	// become leader
-	s.updateLeaderStatusAndExecuteAction(true)
-
-	// expect to transfer leadership, go back to [follower, not healthy, not sequencing]
-	s.False(s.conductor.leader.Load())
-	s.False(s.conductor.healthy.Load())
-	s.False(s.conductor.seqActive.Load())
-	s.Equal(health.ErrSequencerNotHealthy, s.conductor.hcerr)
-	s.Equal(&state{
-		leader:  true,
-		healthy: false,
-		active:  false,
-	}, s.conductor.prevState)
-	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
-}
-
-// In this test, we have a follower that is not healthy and not sequencing, it becomes leader through election.
 // But since it fails to compare the unsafe head to the value stored in consensus, we expect it to transfer leadership to another node.
 // [follower, not healthy, not sequencing] -- become leader --> [leader, not healthy, not sequencing] -- transfer leadership --> [follower, not healthy, not sequencing]
 func (s *OpConductorTestSuite) TestScenario1Err() {
@@ -483,7 +434,8 @@ func (s *OpConductorTestSuite) TestScenario4() {
 	}
 	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
 	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
-	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mock.Anything).Return(nil).Times(1)
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(errors.New("simulated PostUnsafePayload failure")).Times(1)
+	s.ctrl.EXPECT().StartSequencer(mock.Anything, mockPayload.ExecutionPayload.BlockHash).Return(nil).Times(1)
 
 	s.updateLeaderStatusAndExecuteAction(true)
 
@@ -491,16 +443,14 @@ func (s *OpConductorTestSuite) TestScenario4() {
 	s.True(s.conductor.leader.Load())
 	s.True(s.conductor.healthy.Load())
 	s.False(s.conductor.seqActive.Load())
-	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
+	s.cons.AssertNumberOfCalls(s.T(), "LatestUnsafePayload", 1)
 	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 1)
 	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 1)
-	s.cons.AssertNumberOfCalls(s.T(), "LatestUnsafePayload", 1)
+	s.ctrl.AssertNotCalled(s.T(), "StartSequencer", mock.Anything, mock.Anything)
 
-	// unsafe caught up, we try to start sequencer at specified block and succeeds
-	mockBlockInfo.InfoNum = 2
-	mockBlockInfo.InfoHash = [32]byte{1, 2, 3}
 	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(1)
 	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(1)
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(nil).Times(1)
 	s.ctrl.EXPECT().StartSequencer(mock.Anything, mockBlockInfo.InfoHash).Return(nil).Times(1)
 
 	s.executeAction()
@@ -509,10 +459,10 @@ func (s *OpConductorTestSuite) TestScenario4() {
 	s.True(s.conductor.leader.Load())
 	s.True(s.conductor.healthy.Load())
 	s.True(s.conductor.seqActive.Load())
-	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 2)
-	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 1)
-	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
 	s.cons.AssertNumberOfCalls(s.T(), "LatestUnsafePayload", 2)
+	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 2)
+	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 2)
+	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
 }
 
 // In this test, we have a follower that is healthy and not sequencing, we send a unhealthy update to it and expect it to stay as follower and not start sequencing.
@@ -802,6 +752,102 @@ func (s *OpConductorTestSuite) TestFailureAndRetry3() {
 		}
 		return res
 	}, 2*time.Second, time.Millisecond)
+}
+
+// This test is similar to TestFailureAndRetry3, but the consensus payload is one block ahead of the new leader's unsafe head.
+// Then leadership transfer happened, and the follower became leader. We expect it to start sequencing and catch up eventually.
+// 1. [follower, healthy, not sequencing] -- become unhealthy -->
+// 2. [follower, unhealthy, not sequencing] -- gained leadership -->
+// 3. [leader, unhealthy, not sequencing] -- start sequencing -->
+// 4. [leader, unhealthy, sequencing] -> become healthy again -->
+// 5. [leader, healthy, sequencing]
+func (s *OpConductorTestSuite) TestFailureAndRetry4() {
+	s.enableSynchronization()
+
+	// set initial state, healthy follower
+	s.conductor.leader.Store(false)
+	s.conductor.healthy.Store(true)
+	s.conductor.seqActive.Store(false)
+	s.conductor.prevState = &state{
+		leader:  false,
+		healthy: true,
+		active:  false,
+	}
+
+	s.log.Info("1. become unhealthy")
+	s.updateHealthStatusAndExecuteAction(health.ErrSequencerNotHealthy)
+
+	s.False(s.conductor.leader.Load())
+	s.False(s.conductor.healthy.Load())
+	s.False(s.conductor.seqActive.Load())
+	s.Equal(&state{
+		leader:  false,
+		healthy: false,
+		active:  false,
+	}, s.conductor.prevState)
+
+	s.log.Info("2 & 3. gained leadership, post unsafe payload and start sequencing")
+	mockPayload := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: 2,
+			BlockHash:   [32]byte{4, 5, 6},
+		},
+	}
+	mockBlockInfo := &testutils.MockBlockInfo{
+		InfoNum:  1,
+		InfoHash: [32]byte{1, 2, 3},
+	}
+	s.cons.EXPECT().LatestUnsafePayload().Return(mockPayload, nil).Times(2)
+	s.ctrl.EXPECT().LatestUnsafeBlock(mock.Anything).Return(mockBlockInfo, nil).Times(2)
+	s.ctrl.EXPECT().PostUnsafePayload(mock.Anything, mockPayload).Return(nil).Times(1)
+	s.ctrl.EXPECT().StartSequencer(mock.Anything, mockPayload.ExecutionPayload.BlockHash).Return(nil).Times(1)
+
+	s.updateLeaderStatusAndExecuteAction(true)
+
+	s.True(s.conductor.leader.Load())
+	s.False(s.conductor.healthy.Load())
+	s.True(s.conductor.seqActive.Load())
+	s.Equal(&state{
+		leader:  true,
+		healthy: false,
+		active:  false,
+	}, s.conductor.prevState)
+	s.cons.AssertNumberOfCalls(s.T(), "LatestUnsafePayload", 1)
+	s.ctrl.AssertNumberOfCalls(s.T(), "LatestUnsafeBlock", 1)
+	s.ctrl.AssertNumberOfCalls(s.T(), "PostUnsafePayload", 1)
+	s.ctrl.AssertNumberOfCalls(s.T(), "StartSequencer", 1)
+
+	s.log.Info("4. stay unhealthy for a bit while catching up")
+	s.updateHealthStatusAndExecuteAction(health.ErrSequencerNotHealthy)
+
+	s.True(s.conductor.leader.Load())
+	s.False(s.conductor.healthy.Load())
+	s.True(s.conductor.seqActive.Load())
+	s.Equal(&state{
+		leader:  true,
+		healthy: false,
+		active:  false,
+	}, s.conductor.prevState)
+
+	s.log.Info("5. become healthy again")
+	s.updateHealthStatusAndExecuteAction(nil)
+
+	// need to use eventually here because starting from step 4, the loop is gonna queue an action and retry until it became healthy again.
+	// use eventually here avoids the situation where health update is consumed after the action is executed.
+	s.Eventually(func() bool {
+		res := s.conductor.leader.Load() == true &&
+			s.conductor.healthy.Load() == true &&
+			s.conductor.seqActive.Load() == true &&
+			s.conductor.prevState.Equal(&state{
+				leader:  true,
+				healthy: true,
+				active:  true,
+			})
+		if !res {
+			s.executeAction()
+		}
+		return res
+	}, 2*time.Second, 100*time.Millisecond)
 }
 
 func (s *OpConductorTestSuite) TestHandleInitError() {

--- a/op-service/dial/active_rollup_provider.go
+++ b/op-service/dial/active_rollup_provider.go
@@ -114,7 +114,7 @@ func (p *ActiveL2RollupProvider) findActiveEndpoints(ctx context.Context) error 
 		if offset != 0 || p.currentRollupClient == nil {
 			if err := p.dialSequencer(ctx, idx); err != nil {
 				errs = errors.Join(errs, err)
-				p.log.Warn("Error dialing next sequencer.", "err", err, "index", p.rollupIndex)
+				p.log.Warn("Error dialing next sequencer.", "err", err, "index", idx)
 				continue
 			}
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Ensure that a new lead sequencer is able to post the unsafe payload from consensus when this is ahead of the local node's storage by 1 block, and then begin sequencing.

This addresses the following failover scenario:
* Current leader builds a new block
* Current leader commits this new block payload to the raft consensus, but receives a false-positive (possibly network-related) error
* Current leader forfeits position, failing over to a new leader

At this point, the block payload stored in raft is guaranteed to be ahead of each of the nodes' unsafe heads, meaning that the new leader must post the new unsafe head in order for the cluster to recover.

Note: This condition was intended to be handled in the prior state of the code, but was not actually supported due to a duplicate check to `compareUnsafeHead`.

**Tests**

Added a new test case to discern between the leader promotion scenarios that involve a call to `PostUnsafePayload` (raft leads by 1 block) and other unsafe head mismatches.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 