### PR TITLE
Plasma: Add Disclaimers at Config, and on Enable

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -247,6 +247,9 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		"max_channel_duration", cc.MaxChannelDuration,
 		"channel_timeout", cc.ChannelTimeout,
 		"sub_safety_margin", cc.SubSafetyMargin)
+	if bs.UsePlasma {
+		bs.Log.Warn("Plasma Mode is a Beta feature of the MIT licensed OP Stack.  While it has received initial review from core contributors, it is still undergoing testing, and may have bugs or other issues.")
+	}
 	bs.ChannelConfig = cc
 	return nil
 }

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -174,5 +174,8 @@ func (cfg *Config) Check() error {
 	if err := cfg.Plasma.Check(); err != nil {
 		return fmt.Errorf("plasma config error: %w", err)
 	}
+	if cfg.Plasma.Enabled {
+		log.Warn("Plasma Mode is a Beta feature of the MIT licensed OP Stack.  While it has received initial review from core contributors, it is still undergoing testing, and may have bugs or other issues.")
+	}
 	return nil
 }

--- a/op-plasma/cli.go
+++ b/op-plasma/cli.go
@@ -22,7 +22,7 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
 			Name:     EnabledFlagName,
-			Usage:    "Enable plasma mode",
+			Usage:    "Enable plasma mode\nPlasma Mode is a Beta feature of the MIT licensed OP Stack.  While it has received initial review from core contributors, it is still undergoing testing, and may have bugs or other issues.",
 			Value:    false,
 			EnvVars:  plasmaEnv(envPrefix, "ENABLED"),
 			Category: category,


### PR DESCRIPTION
* The Config item itself contains the disclaimer message
* When the Plasma Mode is enabled during Channel Config Initialization (for the batcher), the disclaimer is emitted as a warning
* When the node is validating configuration, if Plasma Mode is enabled, the disclaimer is emitted as a warning.