### PR TITLE
op-conductor: Increase error backoff time to 0-2000 ms, set to 0 in tests

### DIFF
--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -118,6 +118,7 @@ func (s *OpConductorTestSuite) SetupTest() {
 
 	conductor, err := NewOpConductor(s.ctx, &s.cfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon)
 	s.NoError(err)
+	conductor.retryBackoff = func() time.Duration { return 0 } // disable retry backoff for tests
 	s.conductor = conductor
 
 	s.healthUpdateCh = make(chan error, 1)

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -752,7 +752,7 @@ func (s *OpConductorTestSuite) TestFailureAndRetry3() {
 			s.executeAction()
 		}
 		return res
-	}, 10*time.Millisecond, time.Millisecond)
+	}, 2*time.Second, time.Millisecond)
 }
 
 func (s *OpConductorTestSuite) TestHandleInitError() {

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -752,7 +752,7 @@ func (s *OpConductorTestSuite) TestFailureAndRetry3() {
 			s.executeAction()
 		}
 		return res
-	}, 2*time.Second, 100*time.Millisecond)
+	}, 10*time.Millisecond, time.Millisecond)
 }
 
 func (s *OpConductorTestSuite) TestHandleInitError() {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Make op-conductor backoff time configurable
* Increase standard error backoff time ~10x from 0-200ms to 0-2000ms, in order to reduce noise and resource utilization associated with error handling and failover
* Set error backoff time to 0 in tests, improving speed

**Tests**

Updated test timing to expect faster completion

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
