### PR TITLE
dispute-mon: Add --network option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240522134500-19555bdbdc95
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240601004730-a4a101b1e535
 	github.com/ethereum/go-ethereum v1.13.15
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101315.1 h1:GhHlJ60h652XbRkp/MyWP355y+imNWjPm7hWlnG6+Fc=
 github.com/ethereum-optimism/op-geth v1.101315.1/go.mod h1:8tQ6r0e1NNJbSVHzYKafQqf62gV9BzZR+SKkXRckjLM=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240522134500-19555bdbdc95 h1:GjXKQg6u6WkEIcY0dvW2IKhMRY8cVjwdw+rNKhduAo8=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240522134500-19555bdbdc95/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240601004730-a4a101b1e535 h1:mHHIt9cjx02ono5ySr6gM+A6QGEMNcMVFByd6z962HM=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240601004730-a4a101b1e535/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -41,7 +41,7 @@ func CreateGame(ctx *cli.Context) error {
 	traceType := ctx.Uint64(TraceTypeFlag.Name)
 	l2BlockNum := ctx.Uint64(L2BlockNumFlag.Name)
 
-	contract, txMgr, err := NewContractWithTxMgr[*contracts.DisputeGameFactoryContract](ctx, flags.FactoryAddressFlag.Name,
+	contract, txMgr, err := NewContractWithTxMgr[*contracts.DisputeGameFactoryContract](ctx, flags.FactoryAddress,
 		func(ctx context.Context, metricer contractMetrics.ContractMetricer, address common.Address, caller *batching.MultiCaller) (*contracts.DisputeGameFactoryContract, error) {
 			return contracts.NewDisputeGameFactoryContract(metricer, address, caller), nil
 		})
@@ -61,6 +61,7 @@ func CreateGame(ctx *cli.Context) error {
 func createGameFlags() []cli.Flag {
 	cliFlags := []cli.Flag{
 		flags.L1EthRpcFlag,
+		flags.NetworkFlag,
 		flags.FactoryAddressFlag,
 		TraceTypeFlag,
 		OutputRootFlag,

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -49,7 +49,7 @@ func ListGames(ctx *cli.Context) error {
 	if rpcUrl == "" {
 		return fmt.Errorf("missing %v", flags.L1EthRpcFlag.Name)
 	}
-	factoryAddr, err := opservice.ParseAddress(ctx.String(flags.FactoryAddressFlag.Name))
+	factoryAddr, err := flags.FactoryAddress(ctx)
 	if err != nil {
 		return err
 	}
@@ -171,6 +171,7 @@ func listGamesFlags() []cli.Flag {
 		SortByFlag,
 		SortOrderFlag,
 		flags.L1EthRpcFlag,
+		flags.NetworkFlag,
 		flags.FactoryAddressFlag,
 		flags.GameWindowFlag,
 	}

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/superchain-registry/superchain"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -144,8 +145,8 @@ func TestMultipleTraceTypes(t *testing.T) {
 }
 
 func TestGameFactoryAddress(t *testing.T) {
-	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag game-factory-address is required", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address"))
+	t.Run("RequiredWhenNetworkNotSupplied", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag game-factory-address or network is required", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -156,6 +157,18 @@ func TestGameFactoryAddress(t *testing.T) {
 
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, "invalid address: foo", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address", "--game-factory-address=foo"))
+	})
+}
+
+func TestNetwork(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		opSepoliaChainId := uint64(11155420)
+		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address", "--network=op-sepolia"))
+		require.EqualValues(t, superchain.Addresses[opSepoliaChainId].DisputeGameFactoryProxy, cfg.GameFactoryAddress)
+	})
+
+	t.Run("UnknownNetwork", func(t *testing.T) {
+		verifyArgsInvalid(t, "unknown chain: not-a-network", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address", "--network=not-a-network"))
 	})
 }
 

--- a/op-challenger/cmd/move.go
+++ b/op-challenger/cmd/move.go
@@ -46,7 +46,7 @@ func Move(ctx *cli.Context) error {
 		return fmt.Errorf("both attack and defense flags cannot be set")
 	}
 
-	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, GameAddressFlag.Name, contracts.NewFaultDisputeGameContract)
+	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, AddrFromFlag(GameAddressFlag.Name), contracts.NewFaultDisputeGameContract)
 	if err != nil {
 		return fmt.Errorf("failed to create dispute game bindings: %w", err)
 	}

--- a/op-challenger/cmd/resolve.go
+++ b/op-challenger/cmd/resolve.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Resolve(ctx *cli.Context) error {
-	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, GameAddressFlag.Name, contracts.NewFaultDisputeGameContract)
+	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, AddrFromFlag(GameAddressFlag.Name), contracts.NewFaultDisputeGameContract)
 	if err != nil {
 		return fmt.Errorf("failed to create dispute game bindings: %w", err)
 	}

--- a/op-challenger/cmd/resolve_claim.go
+++ b/op-challenger/cmd/resolve_claim.go
@@ -26,7 +26,7 @@ func ResolveClaim(ctx *cli.Context) error {
 	}
 	idx := ctx.Uint64(ClaimIdxFlag.Name)
 
-	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, GameAddressFlag.Name, contracts.NewFaultDisputeGameContract)
+	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, AddrFromFlag(GameAddressFlag.Name), contracts.NewFaultDisputeGameContract)
 	if err != nil {
 		return fmt.Errorf("failed to create dispute game bindings: %w", err)
 	}

--- a/op-challenger/cmd/utils.go
+++ b/op-challenger/cmd/utils.go
@@ -17,15 +17,25 @@ import (
 
 type ContractCreator[T any] func(context.Context, contractMetrics.ContractMetricer, common.Address, *batching.MultiCaller) (T, error)
 
+func AddrFromFlag(flagName string) func(ctx *cli.Context) (common.Address, error) {
+	return func(ctx *cli.Context) (common.Address, error) {
+		gameAddr, err := opservice.ParseAddress(ctx.String(flagName))
+		if err != nil {
+			return common.Address{}, err
+		}
+		return gameAddr, nil
+	}
+}
+
 // NewContractWithTxMgr creates a new contract and a transaction manager.
-func NewContractWithTxMgr[T any](ctx *cli.Context, flagName string, creator ContractCreator[T]) (T, txmgr.TxManager, error) {
+func NewContractWithTxMgr[T any](ctx *cli.Context, getAddr func(ctx *cli.Context) (common.Address, error), creator ContractCreator[T]) (T, txmgr.TxManager, error) {
 	var contract T
 	caller, txMgr, err := newClientsFromCLI(ctx)
 	if err != nil {
 		return contract, nil, err
 	}
 
-	created, err := newContractFromCLI(ctx, flagName, caller, creator)
+	created, err := newContractFromCLI(ctx, getAddr, caller, creator)
 	if err != nil {
 		return contract, nil, err
 	}
@@ -34,9 +44,9 @@ func NewContractWithTxMgr[T any](ctx *cli.Context, flagName string, creator Cont
 }
 
 // newContractFromCLI creates a new contract from the CLI context.
-func newContractFromCLI[T any](ctx *cli.Context, flagName string, caller *batching.MultiCaller, creator ContractCreator[T]) (T, error) {
+func newContractFromCLI[T any](ctx *cli.Context, getAddr func(ctx *cli.Context) (common.Address, error), caller *batching.MultiCaller, creator ContractCreator[T]) (T, error) {
 	var contract T
-	gameAddr, err := opservice.ParseAddress(ctx.String(flagName))
+	gameAddr, err := getAddr(ctx)
 	if err != nil {
 		return contract, err
 	}

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/config"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	l1EthRpc                = "http://example.com:8545"
+	rollupRpc               = "http://example.com:8555"
+	gameFactoryAddressValue = "0xbb00000000000000000000000000000000000000"
+)
+
+func TestLogLevel(t *testing.T) {
+	t.Run("RejectInvalid", func(t *testing.T) {
+		verifyArgsInvalid(t, "unknown level: foo", addRequiredArgs("--log.level=foo"))
+	})
+
+	for _, lvl := range []string{"trace", "debug", "info", "error", "crit"} {
+		lvl := lvl
+		t.Run("AcceptValid_"+lvl, func(t *testing.T) {
+			logger, _, err := dryRunWithArgs(addRequiredArgs("--log.level", lvl))
+			require.NoError(t, err)
+			require.NotNil(t, logger)
+		})
+	}
+}
+
+func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
+	cfg := configForArgs(t, addRequiredArgs())
+	defaultCfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, rollupRpc)
+	require.Equal(t, defaultCfg, cfg)
+}
+
+func TestDefaultConfigIsValid(t *testing.T) {
+	cfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, rollupRpc)
+	require.NoError(t, cfg.Check())
+}
+
+func TestL1EthRpc(t *testing.T) {
+	t.Run("Required", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag l1-eth-rpc is required", addRequiredArgsExcept("--l1-eth-rpc"))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		url := "http://example.com:9999"
+		cfg := configForArgs(t, addRequiredArgsExcept("--l1-eth-rpc", "--l1-eth-rpc", url))
+		require.Equal(t, url, cfg.L1EthRpc)
+	})
+}
+
+func TestRollupRpc(t *testing.T) {
+	t.Run("Required", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept("--rollup-rpc"))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		url := "http://example.com:9999"
+		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--rollup-rpc", url))
+		require.Equal(t, url, cfg.RollupRpc)
+	})
+}
+
+func TestGameFactoryAddress(t *testing.T) {
+	t.Run("RequiredIfNetworkNetSet", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag game-factory-address or network is required", addRequiredArgsExcept("--game-factory-address"))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		addr := common.Address{0x11, 0x22}
+		cfg := configForArgs(t, addRequiredArgsExcept("--game-factory-address", "--game-factory-address", addr.Hex()))
+		require.Equal(t, addr, cfg.GameFactoryAddress)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(t, "invalid address: foo", addRequiredArgsExcept("--game-factory-address", "--game-factory-address", "foo"))
+	})
+}
+
+func TestNetwork(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		opSepoliaChainId := uint64(11155420)
+		cfg := configForArgs(t, addRequiredArgsExcept("--game-factory-address", "--network=op-sepolia"))
+		require.EqualValues(t, superchain.Addresses[opSepoliaChainId].DisputeGameFactoryProxy, cfg.GameFactoryAddress)
+	})
+
+	t.Run("UnknownNetwork", func(t *testing.T) {
+		verifyArgsInvalid(t, "unknown chain: not-a-network", addRequiredArgsExcept("--game-factory-address", "--network=not-a-network"))
+	})
+}
+
+func TestHonestActors(t *testing.T) {
+	t.Run("NotRequired", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs())
+		require.Empty(t, cfg.HonestActors)
+	})
+
+	t.Run("SingleValue", func(t *testing.T) {
+		addr := common.Address{0xbb}
+		cfg := configForArgs(t, addRequiredArgs("--honest-actors", addr.Hex()))
+		require.Len(t, cfg.HonestActors, 1)
+		require.Contains(t, cfg.HonestActors, addr)
+	})
+
+	t.Run("MultiValue", func(t *testing.T) {
+		addr1 := common.Address{0xaa}
+		addr2 := common.Address{0xbb}
+		addr3 := common.Address{0xcc}
+		cfg := configForArgs(t, addRequiredArgs(
+			"--honest-actors", addr1.Hex(),
+			"--honest-actors", addr2.Hex(),
+			"--honest-actors", addr3.Hex(),
+		))
+		require.Len(t, cfg.HonestActors, 3)
+		require.Contains(t, cfg.HonestActors, addr1)
+		require.Contains(t, cfg.HonestActors, addr2)
+		require.Contains(t, cfg.HonestActors, addr3)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(t,
+			"invalid honest actor address: invalid address: 0xnope",
+			addRequiredArgs("-honest-actors", "0xnope"))
+	})
+}
+
+func TestMonitorInterval(t *testing.T) {
+	t.Run("UsesDefault", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs())
+		require.Equal(t, config.DefaultMonitorInterval, cfg.MonitorInterval)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		expected := 100 * time.Second
+		cfg := configForArgs(t, addRequiredArgs("--monitor-interval", "100s"))
+		require.Equal(t, expected, cfg.MonitorInterval)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(
+			t,
+			"invalid value \"abc\" for flag -monitor-interval",
+			addRequiredArgs("--monitor-interval", "abc"))
+	})
+}
+
+func TestGameWindow(t *testing.T) {
+	t.Run("UsesDefault", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs())
+		require.Equal(t, config.DefaultGameWindow, cfg.GameWindow)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs("--game-window=1m"))
+		require.Equal(t, time.Minute, cfg.GameWindow)
+	})
+
+	t.Run("ParsesDefault", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs("--game-window=672h"))
+		require.Equal(t, config.DefaultGameWindow, cfg.GameWindow)
+	})
+}
+
+func TestIgnoredGames(t *testing.T) {
+	t.Run("NotRequired", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs())
+		require.Empty(t, cfg.IgnoredGames)
+	})
+
+	t.Run("SingleValue", func(t *testing.T) {
+		addr := common.Address{0xbb}
+		cfg := configForArgs(t, addRequiredArgs("--ignored-games", addr.Hex()))
+		require.Len(t, cfg.IgnoredGames, 1)
+		require.Contains(t, cfg.IgnoredGames, addr)
+	})
+
+	t.Run("MultiValue", func(t *testing.T) {
+		addr1 := common.Address{0xaa}
+		addr2 := common.Address{0xbb}
+		addr3 := common.Address{0xcc}
+		cfg := configForArgs(t, addRequiredArgs(
+			"--ignored-games", addr1.Hex(),
+			"--ignored-games", addr2.Hex(),
+			"--ignored-games", addr3.Hex(),
+		))
+		require.Len(t, cfg.IgnoredGames, 3)
+		require.Contains(t, cfg.IgnoredGames, addr1)
+		require.Contains(t, cfg.IgnoredGames, addr2)
+		require.Contains(t, cfg.IgnoredGames, addr3)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(t,
+			"invalid ignored game address: invalid address: 0xnope",
+			addRequiredArgs("-ignored-games", "0xnope"))
+	})
+}
+
+func TestMaxConcurrency(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		expected := uint(345)
+		cfg := configForArgs(t, addRequiredArgs("--max-concurrency", "345"))
+		require.Equal(t, expected, cfg.MaxConcurrency)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(
+			t,
+			"invalid value \"abc\" for flag -max-concurrency",
+			addRequiredArgs("--max-concurrency", "abc"))
+	})
+
+	t.Run("Zero", func(t *testing.T) {
+		verifyArgsInvalid(
+			t,
+			"max-concurrency must not be 0",
+			addRequiredArgs("--max-concurrency", "0"))
+	})
+}
+
+func verifyArgsInvalid(t *testing.T, messageContains string, cliArgs []string) {
+	_, _, err := dryRunWithArgs(cliArgs)
+	require.ErrorContains(t, err, messageContains)
+}
+
+func configForArgs(t *testing.T, cliArgs []string) config.Config {
+	_, cfg, err := dryRunWithArgs(cliArgs)
+	require.NoError(t, err)
+	return cfg
+}
+
+func dryRunWithArgs(cliArgs []string) (log.Logger, config.Config, error) {
+	cfg := new(config.Config)
+	var logger log.Logger
+	fullArgs := append([]string{"op-dispute-mon"}, cliArgs...)
+	testErr := errors.New("dry-run")
+	err := run(context.Background(), fullArgs, func(ctx context.Context, log log.Logger, config *config.Config) (cliapp.Lifecycle, error) {
+		logger = log
+		cfg = config
+		return nil, testErr
+	})
+	if errors.Is(err, testErr) { // expected error
+		err = nil
+	}
+	return logger, *cfg, err
+}
+
+func addRequiredArgs(args ...string) []string {
+	req := requiredArgs()
+	combined := toArgList(req)
+	return append(combined, args...)
+}
+
+func addRequiredArgsExcept(name string, optionalArgs ...string) []string {
+	req := requiredArgs()
+	delete(req, name)
+	return append(toArgList(req), optionalArgs...)
+}
+
+func requiredArgs() map[string]string {
+	args := map[string]string{
+		"--l1-eth-rpc":           l1EthRpc,
+		"--rollup-rpc":           rollupRpc,
+		"--game-factory-address": gameFactoryAddressValue,
+	}
+	return args
+}
+
+func toArgList(req map[string]string) []string {
+	var combined []string
+	for name, value := range req {
+		combined = append(combined, fmt.Sprintf("%s=%s", name, value))
+	}
+	return combined
+}

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -49,12 +49,12 @@ type Config struct {
 	PprofConfig   oppprof.CLIConfig
 }
 
-func NewConfig(gameFactoryAddress common.Address, l1EthRpc string) Config {
+func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc string) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
+		RollupRpc:          rollupRpc,
 		GameFactoryAddress: gameFactoryAddress,
 
-		HonestActors:    []common.Address{},
 		MonitorInterval: DefaultMonitorInterval,
 		GameWindow:      DefaultGameWindow,
 		MaxConcurrency:  DefaultMaxConcurrency,

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -15,9 +15,7 @@ var (
 )
 
 func validConfig() Config {
-	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc)
-	cfg.RollupRpc = validRollupRpc
-	return cfg
+	return NewConfig(validGameFactoryAddress, validL1EthRpc, validRollupRpc)
 }
 
 func TestValidConfigIsValid(t *testing.T) {

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -3,6 +3,8 @@ package flags
 import (
 	"fmt"
 
+	challengerFlags "github.com/ethereum-optimism/optimism/op-challenger/flags"
+	"github.com/ethereum-optimism/optimism/op-service/flags"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/config"
@@ -28,17 +30,18 @@ var (
 		Usage:   "HTTP provider URL for L1.",
 		EnvVars: prefixEnvVars("L1_ETH_RPC"),
 	}
-	GameFactoryAddressFlag = &cli.StringFlag{
-		Name:    "game-factory-address",
-		Usage:   "Address of the fault game factory contract.",
-		EnvVars: prefixEnvVars("GAME_FACTORY_ADDRESS"),
-	}
 	RollupRpcFlag = &cli.StringFlag{
 		Name:    "rollup-rpc",
 		Usage:   "HTTP provider URL for the rollup node",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
 	// Optional Flags
+	GameFactoryAddressFlag = &cli.StringFlag{
+		Name:    "game-factory-address",
+		Usage:   "Address of the fault game factory contract.",
+		EnvVars: prefixEnvVars("GAME_FACTORY_ADDRESS"),
+	}
+	NetworkFlag      = flags.CLINetworkFlag(envVarPrefix, "")
 	HonestActorsFlag = &cli.StringSliceFlag{
 		Name:    "honest-actors",
 		Usage:   "List of honest actors that are monitored for any claims that are resolved against them.",
@@ -73,12 +76,13 @@ var (
 // requiredFlags are checked by [CheckRequired]
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
-	GameFactoryAddressFlag,
 	RollupRpcFlag,
 }
 
 // optionalFlags is a list of unchecked cli flags
 var optionalFlags = []cli.Flag{
+	GameFactoryAddressFlag,
+	NetworkFlag,
 	HonestActorsFlag,
 	MonitorIntervalFlag,
 	GameWindowFlag,
@@ -111,7 +115,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 	if err := CheckRequired(ctx); err != nil {
 		return nil, err
 	}
-	gameFactoryAddress, err := opservice.ParseAddress(ctx.String(GameFactoryAddressFlag.Name))
+	gameFactoryAddress, err := challengerFlags.FactoryAddress(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -138,6 +142,11 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 		}
 	}
 
+	maxConcurrency := ctx.Uint(MaxConcurrencyFlag.Name)
+	if maxConcurrency == 0 {
+		return nil, fmt.Errorf("%v must not be 0", MaxConcurrencyFlag.Name)
+	}
+
 	metricsConfig := opmetrics.ReadCLIConfig(ctx)
 	pprofConfig := oppprof.ReadCLIConfig(ctx)
 
@@ -150,7 +159,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 		MonitorInterval: ctx.Duration(MonitorIntervalFlag.Name),
 		GameWindow:      ctx.Duration(GameWindowFlag.Name),
 		IgnoredGames:    ignoredGames,
-		MaxConcurrency:  ctx.Uint(MaxConcurrencyFlag.Name),
+		MaxConcurrency:  maxConcurrency,
 
 		MetricsConfig: metricsConfig,
 		PprofConfig:   pprofConfig,


### PR DESCRIPTION
**Description**

Loads the dispute game factory address from the superchain registry.

Builds on https://github.com/ethereum-optimism/optimism/pull/10711

**Tests**

Added unit tests for dispute-mon CLI flags.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/833
