### PR TITLE
external-geth: Fix lint error by checking error

### DIFF
--- a/op-e2e/external_geth/main.go
+++ b/op-e2e/external_geth/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -176,7 +177,9 @@ func execute(binPath string, config external.Config) (*gethSession, error) {
 		}
 		var authString string
 		var port int
-		fmt.Fscanf(sess.Err, "%d %s", &port, &authString)
+		if _, err := fmt.Fscanf(sess.Err, "%d %s", &port, &authString); err != nil && !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("error while reading auth string: %w", err)
+		}
 		switch authString {
 		case "auth=true":
 			enginePort = port


### PR DESCRIPTION
**Description**

Fix a linter error by checking the error returned by `Fscanf` in external-geth main. Seems to only be picked up by a more recent version of the linter as its not failing in CI but it has a point and is worth fixing.