### PR TITLE
e2e: Convert more fault proof tests to use the custom contract bindings

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -355,7 +355,7 @@ func (f *FaultDisputeGameContractLatest) getDelayedWETH(ctx context.Context, blo
 
 func (f *FaultDisputeGameContractLatest) GetOracle(ctx context.Context) (*PreimageOracleContract, error) {
 	defer f.metrics.StartContractRequest("GetOracle")()
-	vm, err := f.vm(ctx)
+	vm, err := f.Vm(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func (f *FaultDisputeGameContractLatest) IsResolved(ctx context.Context, block r
 	return resolved, nil
 }
 
-func (f *FaultDisputeGameContractLatest) vm(ctx context.Context) (*VMContract, error) {
+func (f *FaultDisputeGameContractLatest) Vm(ctx context.Context) (*VMContract, error) {
 	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodVM))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch VM addr: %w", err)
@@ -623,4 +623,5 @@ type FaultDisputeGameContract interface {
 	ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error)
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	ResolveTx() (txmgr.TxCandidate, error)
+	Vm(ctx context.Context) (*VMContract, error)
 }

--- a/op-challenger/game/fault/contracts/vm.go
+++ b/op-challenger/game/fault/contracts/vm.go
@@ -29,6 +29,10 @@ func NewVMContract(addr common.Address, caller *batching.MultiCaller) *VMContrac
 	}
 }
 
+func (c *VMContract) Addr() common.Address {
+	return c.contract.Addr()
+}
+
 func (c *VMContract) Oracle(ctx context.Context) (*PreimageOracleContract, error) {
 	results, err := c.multiCaller.SingleCall(ctx, rpcblock.Latest, c.contract.Call(methodOracle))
 	if err != nil {

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -18,12 +18,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -233,19 +233,14 @@ func (g *OutputCannonGameHelper) VerifyPreimage(ctx context.Context, outputRootC
 		g.Require.NotNil(oracleData, "Should have had required preimage oracle data")
 		g.Require.Equal(common.Hash(preimageKey.PreimageKey()).Bytes(), oracleData.OracleKey, "Must have correct preimage key")
 
-		tx, err := g.GameBindings.AddLocalData(g.Opts,
-			oracleData.GetIdent(),
-			big.NewInt(outputRootClaim.Index),
-			new(big.Int).SetUint64(uint64(oracleData.OracleOffset)))
-		g.Require.NoError(err)
-		_, err = wait.ForReceiptOK(ctx, g.Client, tx.Hash())
-		g.Require.NoError(err)
+		candidate, err := g.Game.UpdateOracleTx(ctx, uint64(outputRootClaim.Index), oracleData)
+		g.Require.NoError(err, "failed to get oracle")
+		transactions.RequireSendTx(g.T, ctx, g.Client, candidate, g.PrivKey)
 
 		expectedPostState, err := provider.Get(ctx, pos)
 		g.Require.NoError(err, "Failed to get expected post state")
 
-		callOpts := &bind.CallOpts{Context: ctx}
-		vmAddr, err := g.GameBindings.Vm(callOpts)
+		vm, err := g.Game.Vm(ctx)
 		g.Require.NoError(err, "Failed to get VM address")
 
 		abi, err := bindings.MIPSMetaData.GetAbi()
@@ -253,7 +248,7 @@ func (g *OutputCannonGameHelper) VerifyPreimage(ctx context.Context, outputRootC
 		caller := batching.NewMultiCaller(g.Client.Client(), batching.DefaultBatchSize)
 		result, err := caller.SingleCall(ctx, rpcblock.Latest, &batching.ContractCall{
 			Abi:    abi,
-			Addr:   vmAddr,
+			Addr:   vm.Addr(),
 			Method: "step",
 			Args: []interface{}{
 				prestate, proof, localContext,

--- a/op-e2e/e2eutils/disputegame/output_honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_honest_helper.go
@@ -101,7 +101,7 @@ func (h *OutputHonestHelper) StepFails(ctx context.Context, claimIdx int64, isAt
 	}
 	prestate, proofData, _, err := h.correctTrace.GetStepData(ctx, game, claim, pos)
 	h.require.NoError(err, "Get step data")
-	h.game.StepFails(claimIdx, isAttack, prestate, proofData)
+	h.game.StepFails(ctx, claimIdx, isAttack, prestate, proofData)
 }
 
 func (h *OutputHonestHelper) loadState(ctx context.Context, claimIdx int64) (types.Game, types.Claim) {

--- a/op-e2e/e2eutils/transactions/send.go
+++ b/op-e2e/e2eutils/transactions/send.go
@@ -1,0 +1,111 @@
+package transactions
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+type SendTxOpt func(cfg *sendTxCfg)
+
+type ErrWithData interface {
+	ErrorData() interface{}
+}
+
+type sendTxCfg struct {
+	receiptStatus uint64
+}
+
+func makeSendTxCfg(opts ...SendTxOpt) *sendTxCfg {
+	cfg := &sendTxCfg{
+		receiptStatus: types.ReceiptStatusSuccessful,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+func WithReceiptFail() SendTxOpt {
+	return func(cfg *sendTxCfg) {
+		cfg.receiptStatus = types.ReceiptStatusFailed
+	}
+}
+
+func RequireSendTx(t *testing.T, ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) {
+	_, _, err := SendTx(ctx, client, candidate, privKey, opts...)
+	require.NoError(t, err, "Failed to send transaction")
+}
+
+func SendTx(ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) (*types.Transaction, *types.Receipt, error) {
+	cfg := makeSendTxCfg(opts...)
+	from := crypto.PubkeyToAddress(privKey.PublicKey)
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get chain ID: %w", err)
+	}
+	nonce, err := client.PendingNonceAt(ctx, from)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get next nonce: %w", err)
+	}
+
+	latestBlock, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get latest block: %w", err)
+	}
+	gasFeeCap := new(big.Int).Mul(latestBlock.BaseFee, big.NewInt(3))
+	gasTipCap := big.NewInt(1 * params.GWei)
+	if gasFeeCap.Cmp(gasTipCap) < 0 {
+		// gasTipCap can't be higher than gasFeeCap
+		// Since there's a minimum gasTipCap to be accepted, increase the gasFeeCap. Extra will be refunded anyway.
+		gasFeeCap = gasTipCap
+	}
+	msg := ethereum.CallMsg{
+		From:      from,
+		To:        candidate.To,
+		Value:     candidate.Value,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Data:      candidate.TxData,
+	}
+	gas, err := client.EstimateGas(ctx, msg)
+	if err != nil {
+		var errWithData ErrWithData
+		if errors.As(err, &errWithData) {
+			return nil, nil, fmt.Errorf("failed to estimate gas. errdata: %v err: %w", errWithData.ErrorData(), err)
+		}
+		return nil, nil, fmt.Errorf("failed to estimate gas: %w", err)
+	}
+
+	tx := types.MustSignNewTx(privKey, types.LatestSignerForChainID(chainID), &types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		To:        candidate.To,
+		Value:     candidate.Value,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Data:      candidate.TxData,
+		Gas:       gas,
+	})
+	err = client.SendTransaction(ctx, tx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to send transaction: %w", err)
+	}
+	receipt, err := wait.ForReceipt(ctx, client, tx.Hash(), cfg.receiptStatus)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find OK receipt: %w", err)
+	}
+	return tx, receipt, nil
+}


### PR DESCRIPTION
**Description**

Removes more dependencies on the generated fault dispute game bindings.

Introduces new helper functions to send a txmgr TxCandidate rather than depending on the generated bindings to estimate gas etc.