### PR TITLE
add `channelClosed` to channel.HasTxData

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -173,8 +173,8 @@ func (s *channel) NextTxData() txData {
 	return txdata
 }
 
-func (s *channel) HasTxData() bool {
-	if s.IsFull() || !s.cfg.MultiFrameTxs {
+func (s *channel) HasTxData(channelClosed bool) bool {
+	if channelClosed || s.IsFull() || !s.cfg.MultiFrameTxs {
 		return s.channelBuilder.HasFrame()
 	}
 	// collect enough frames if channel is not full yet

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -160,7 +160,7 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 		}
 	}
 
-	dataPending := firstWithTxData != nil && firstWithTxData.HasTxData(s.closed)
+	dataPending := firstWithTxData != nil
 	s.log.Debug("Requested tx data", "l1Head", l1Head, "txdata_pending", dataPending, "blocks_pending", len(s.blocks))
 
 	// Short circuit if there is pending tx data or the channel manager is closed.

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -136,7 +136,7 @@ func TestChannel_NextTxData_singleFrameTx(t *testing.T) {
 	ch.channelBuilder.PushFrames(mockframes[:n-1]...)
 
 	requireTxData := func(i int) {
-		require.True(ch.HasTxData(), "expected tx data %d", i)
+		require.True(ch.HasTxData(false), "expected tx data %d", i)
 		txdata := ch.NextTxData()
 		require.Len(txdata.frames, 1)
 		frame := txdata.frames[0]
@@ -148,14 +148,14 @@ func TestChannel_NextTxData_singleFrameTx(t *testing.T) {
 	for i := 0; i < n-1; i++ {
 		requireTxData(i)
 	}
-	require.False(ch.HasTxData())
+	require.False(ch.HasTxData(false))
 
 	// put in last two
 	ch.channelBuilder.PushFrames(mockframes[n-1 : n+1]...)
 	for i := n - 1; i < n+1; i++ {
 		requireTxData(i)
 	}
-	require.False(ch.HasTxData())
+	require.False(ch.HasTxData(false))
 }
 
 func TestChannel_NextTxData_multiFrameTx(t *testing.T) {
@@ -175,11 +175,11 @@ func TestChannel_NextTxData_multiFrameTx(t *testing.T) {
 	mockframes := makeMockFrameDatas(chID, n+1)
 	// put multiple frames into channel, but less than target
 	ch.channelBuilder.PushFrames(mockframes[:n-1]...)
-	require.False(ch.HasTxData())
+	require.False(ch.HasTxData(false))
 
 	// put in last two
 	ch.channelBuilder.PushFrames(mockframes[n-1 : n+1]...)
-	require.True(ch.HasTxData())
+	require.True(ch.HasTxData(false))
 	txdata := ch.NextTxData()
 	require.Len(txdata.frames, n)
 	for i := 0; i < n; i++ {
@@ -188,7 +188,7 @@ func TestChannel_NextTxData_multiFrameTx(t *testing.T) {
 		require.EqualValues(i, frame.data[0])
 		require.Equal(frameID{chID: chID, frameNumber: uint16(i)}, frame.id)
 	}
-	require.False(ch.HasTxData(), "no tx data expected with single pending frame")
+	require.False(ch.HasTxData(false), "no tx data expected with single pending frame")
 }
 
 func makeMockFrameDatas(id derive.ChannelID, n int) []frameData {


### PR DESCRIPTION
If `HasTxData` is called after `state.Close()` is [called](https://github.com/ethereum-optimism/optimism/blob/e7d447e39acb3dfa760a1ff1aaa211f7c76c30a9/op-batcher/batcher/driver.go#L300), it should not try to collect *enough* frames.  It should return `true` as long as there're any frames left according to the comment [here](https://github.com/ethereum-optimism/optimism/blob/93a24327cbe64d67484b6c43715777fb64c752c7/op-batcher/batcher/driver.go#L312).