### PR TITLE
chore(ctb): More proof-validation tests for `MIPS.sol`

### DIFF
--- a/packages/contracts-bedrock/test/cannon/MIPS.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS.t.sol
@@ -1531,6 +1531,25 @@ contract MIPS_Test is CommonTest {
         mips.step(encodeState(state), proof, 0);
     }
 
+    function test_invalid_root_different_leaf_fails() external {
+        uint32 insn = 0x0000000c; // syscall
+
+        // Initialize the state, though for the proof, use valid proofs for the instruction
+        // and the memory address, but for a different leaf that does not contain the
+        // instruction @ pc nor the memory address being read.
+        uint32 pc = 0;
+        MIPS.State memory state;
+        bytes memory proof;
+        (state.memRoot, proof) = ffi.getCannonMemoryProofWrongLeaf(pc, insn, 0x4, 0);
+        state.pc = pc;
+        state.nextPC = pc + 4;
+        state.registers[2] = 4246; // exit_group syscall
+        state.registers[4] = 0x5; // a0
+
+        vm.expectRevert(hex"000000000000000000000000000000000000000000000000000000000badf00d");
+        mips.step(encodeState(state), proof, 0);
+    }
+
     function test_jump_inDelaySlot_fails() external {
         uint16 label = 0x2;
         uint32 insn = uint32(0x08_00_00_00) | label; // j label

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -245,6 +245,28 @@ contract FFIInterface {
         return (memRoot, proof);
     }
 
+    function getCannonMemoryProofWrongLeaf(
+        uint32 pc,
+        uint32 insn,
+        uint32 memAddr,
+        uint32 memVal
+    )
+        external
+        returns (bytes32, bytes memory)
+    {
+        string[] memory cmds = new string[](7);
+        cmds[0] = "scripts/go-ffi/go-ffi";
+        cmds[1] = "diff";
+        cmds[2] = "cannonMemoryProofWrongLeaf";
+        cmds[3] = vm.toString(pc);
+        cmds[4] = vm.toString(insn);
+        cmds[5] = vm.toString(memAddr);
+        cmds[6] = vm.toString(memVal);
+        bytes memory result = Process.run(cmds);
+        (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
+        return (memRoot, proof);
+    }
+
     function encodeScalarEcotone(uint32 _basefeeScalar, uint32 _blobbasefeeScalar) external returns (bytes32) {
         string[] memory cmds = new string[](5);
         cmds[0] = "scripts/go-ffi/go-ffi";


### PR DESCRIPTION
## Overview

Adds a test for a separate proof validity case, where the proofs provided are correct relative to the state witness' merkle root, but correspond to a separate leaf that does not contain the desired program counter address or memory address read by the instruction.
