### PR TITLE
op-conductor: Fix deadlock in shutdown

### DIFF
--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -124,7 +124,7 @@ func (hm *SequencerHealthMonitor) loop() {
 				case hm.healthUpdateCh <- err:
 					break loop
 				case <-hm.done:
-					break loop
+					return
 				}
 			}
 		}

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -118,14 +118,11 @@ func (hm *SequencerHealthMonitor) loop() {
 			err := hm.healthCheck()
 			hm.metrics.RecordHealthCheck(err == nil, err)
 			// Ensure that we exit cleanly if told to shutdown while still waiting to publish the health update
-		loop:
-			for {
-				select {
-				case hm.healthUpdateCh <- err:
-					break loop
-				case <-hm.done:
-					return
-				}
+			select {
+			case hm.healthUpdateCh <- err:
+				continue
+			case <-hm.done:
+				return
 			}
 		}
 	}

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -148,7 +148,6 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 // [Category: Sequencer Failover]
 // Test that the sequencer can successfully failover to a new sequencer once the active sequencer goes down.
 func TestSequencerFailover_ActiveSequencerDown(t *testing.T) {
-	t.Skip("Triggers a deadlock in shutdown")
 	sys, conductors, cleanup := setupSequencerFailoverTest(t)
 	defer cleanup()
 


### PR DESCRIPTION
**Description**

Fixes a deadlock in op-conductor shutdown that was causing e2e tests to hang forever.
