### PR TITLE
op-conductor: Skip flaky TestSequencerFailover_ActiveSequencerDown test

### DIFF
--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -148,6 +148,7 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 // [Category: Sequencer Failover]
 // Test that the sequencer can successfully failover to a new sequencer once the active sequencer goes down.
 func TestSequencerFailover_ActiveSequencerDown(t *testing.T) {
+	t.Skip("Triggers a deadlock in shutdown")
 	sys, conductors, cleanup := setupSequencerFailoverTest(t)
 	defer cleanup()
 


### PR DESCRIPTION
**Description**

Skip the test that's deadlocking in CI all the time. https://github.com/ethereum-optimism/optimism/pull/10728 patches the underlying issue and can reenable the test but will need specific user's approvals.