### PR TITLE
feat: enable customization of L1/L2 chain info

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -18,6 +18,19 @@ export GS_PROPOSER_PRIVATE_KEY=
 export GS_SEQUENCER_ADDRESS=
 export GS_SEQUENCER_PRIVATE_KEY=
 
+
+##################################################
+#                Chain Information               #
+##################################################
+
+# L1 chain information
+export L1_CHAIN_ID=11155111
+export L1_BLOCK_TIME=12
+
+# L2 chain information
+export L2_CHAIN_ID=42069
+export L2_BLOCK_TIME=2
+
 ##################################################
 #              op-node Configuration             #
 ##################################################

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -18,6 +18,10 @@ reqenv "GS_BATCHER_ADDRESS"
 reqenv "GS_PROPOSER_ADDRESS"
 reqenv "GS_SEQUENCER_ADDRESS"
 reqenv "L1_RPC_URL"
+reqenv "L1_CHAIN_ID"
+reqenv "L2_CHAIN_ID"
+reqenv "L1_BLOCK_TIME"
+reqenv "L2_BLOCK_TIME"
 
 # Get the finalized block timestamp and hash
 block=$(cast block finalized --rpc-url "$L1_RPC_URL")
@@ -29,10 +33,10 @@ config=$(cat << EOL
 {
   "l1StartingBlockTag": "$blockhash",
 
-  "l1ChainID": 11155111,
-  "l2ChainID": 42069,
-  "l2BlockTime": 2,
-  "l1BlockTime": 12,
+  "l1ChainID": $L1_CHAIN_ID,
+  "l2ChainID": $L2_CHAIN_ID,
+  "l2BlockTime": $L2_BLOCK_TIME,
+  "l1BlockTime": $L1_BLOCK_TIME,
 
   "maxSequencerDrift": 600,
   "sequencerWindowSize": 3600,
@@ -49,7 +53,7 @@ config=$(cat << EOL
   "l2OutputOracleProposer": "$GS_PROPOSER_ADDRESS",
   "l2OutputOracleChallenger": "$GS_ADMIN_ADDRESS",
 
-  "finalizationPeriodSeconds": 12,
+  "finalizationPeriodSeconds": $L1_BLOCK_TIME,
 
   "proxyAdminOwner": "$GS_ADMIN_ADDRESS",
   "baseFeeVaultRecipient": "$GS_ADMIN_ADDRESS",

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -101,6 +101,7 @@ config=$(cat << EOL
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 14,
+  "faultGameWithdrawalDelay": 604800,
 
   "preimageOracleMinProposalSize": 1800000,
   "preimageOracleChallengePeriod": 86400

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -53,7 +53,7 @@ config=$(cat << EOL
   "l2OutputOracleProposer": "$GS_PROPOSER_ADDRESS",
   "l2OutputOracleChallenger": "$GS_ADMIN_ADDRESS",
 
-  "finalizationPeriodSeconds": $L1_BLOCK_TIME,
+  "finalizationPeriodSeconds": 12,
 
   "proxyAdminOwner": "$GS_ADMIN_ADDRESS",
   "baseFeeVaultRecipient": "$GS_ADMIN_ADDRESS",


### PR DESCRIPTION
This PR enables anyone to customize the L1 ChainID and L1 block time. (As well as for L2)

This is useful when you want to deploy on a custom L1 network. (Possibly with a different seconds per slot config parameter). 

Not sure where this value plays a role in. Would be good to verify that this could be dynamically adjusted based on the L1s seconds_per_slot param. 

`"finalizationPeriodSeconds": 12,`