### PR TITLE
fast fail for span batch

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -74,6 +74,8 @@ type ChannelBuilder struct {
 	numFrames int
 	// total amount of output data of all frames created yet
 	outputBytes int
+	// expiring L1 height for span batch only
+	spanBatchExpire uint64
 }
 
 // newChannelBuilder creates a new channel builder or returns an error if the
@@ -165,6 +167,9 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 
 	c.blocks = append(c.blocks, block)
 	c.updateSwTimeout(batch)
+	if c.cfg.BatchType == derive.SpanBatchType && len(c.blocks) == 1 {
+		c.spanBatchExpire = uint64(batch.EpochNum) + c.cfg.SeqWindowSize
+	}
 
 	if l1info.Number > c.latestL1Origin.Number {
 		c.latestL1Origin = eth.BlockID{


### PR DESCRIPTION
When the channel is backed by span batch, if `L1height > firstBatch.EpochNum + c.cfg.SeqWindowSize`, there's no need to retry since it will be [dropped](https://github.com/ethereum-optimism/optimism/blob/111f3f3a3a2881899662e53e0f1b2f845b188a38/op-node/rollup/derive/batches.go#L234) anyway.

This PR also adds a useful log to indicate whether the span batch is submitted too late.
