### PR TITLE
Add allow-empty overload field on Process.run

### DIFF
--- a/packages/contracts-bedrock/scripts/libraries/Process.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Process.sol
@@ -10,14 +10,27 @@ library Process {
     /// @notice Foundry cheatcode VM.
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function run(string[] memory cmd) internal returns (bytes memory stdout_) {
-        Vm.FfiResult memory result = vm.tryFfi(cmd);
+    /// @notice Run a command in a subprocess. Fails if no output is returned.
+    /// @param _command Command to run.
+    function run(string[] memory _command) internal returns (bytes memory stdout_) {
+        stdout_ = run({ _command: _command, _allowEmpty: false });
+    }
+
+    /// @notice Run a command in a subprocess.
+    /// @param _command Command to run.
+    /// @param _allowEmpty Allow empty output.
+    function run(string[] memory _command, bool _allowEmpty) internal returns (bytes memory stdout_) {
+        Vm.FfiResult memory result = vm.tryFfi(_command);
+        string memory command;
+        for (uint256 i = 0; i < _command.length; i++) {
+            command = string.concat(command, _command[i], " ");
+        }
         if (result.exitCode != 0) {
-            string memory command;
-            for (uint256 i = 0; i < cmd.length; i++) {
-                command = string.concat(command, cmd[i], " ");
-            }
             revert FfiFailed(string.concat("Command: ", command, "\nError: ", string(result.stderr)));
+        }
+        // If the output is empty, result.stdout is "[]".
+        if (!_allowEmpty && keccak256(result.stdout) == keccak256(bytes("[]"))) {
+            revert FfiFailed(string.concat("No output from Command: ", command));
         }
         stdout_ = result.stdout;
     }

--- a/packages/contracts-bedrock/test/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2Genesis.t.sol
@@ -37,7 +37,7 @@ contract L2GenesisTest is Test {
         commands[0] = "bash";
         commands[1] = "-c";
         commands[2] = string.concat("rm ", path);
-        Process.run(commands);
+        Process.run({ _command: commands, _allowEmpty: true });
     }
 
     /// @notice Returns the number of top level keys in a JSON object at a given


### PR DESCRIPTION
This PR updates `Process.run()` to fail by default if the command does not return any output.

~~This causes [failures](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/56370/workflows/26c9f835-6075-4078-a8da-2c5d446b31dd/jobs/2421464?invite=true#step-108-136263_0) in any test which uses [getContractFunctionAbis](https://github.com/ethereum-optimism/optimism/blob/maur/allow-empty/packages/contracts-bedrock/scripts/ForgeArtifacts.sol#L156), indicating that `getContractFunctionAbis` has been failing silently due to a zero length array of abis:~~
https://github.com/ethereum-optimism/optimism/blob/921c3ced770a1b6dfc74fad37ad0048f2dc84ace/packages/contracts-bedrock/scripts/ForgeArtifacts.sol#L188-L192

~~This PR is intended to demonstrate this. A fix is also needed to `getContractFunctionAbis`.~~ 


Update: The changes in PR #10739 fix `getContractFunctionAbis`, so this change can now be applied without breaking existing functionality.