### PR TITLE
op-e2e: Improve timeout behavior for sequencer failover tests

### DIFF
--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -356,30 +356,32 @@ func sequencerCfg(rpcPort int) *rollupNode.Config {
 }
 
 func waitForLeadership(t *testing.T, c *conductor) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	condition := func() (bool, error) {
-		isLeader, err := c.client.Leader(context.Background())
+		isLeader, err := c.client.Leader(ctx)
 		if err != nil {
 			return false, err
 		}
 		return isLeader, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	return wait.For(ctx, 1*time.Second, condition)
 }
 
 func waitForLeadershipChange(t *testing.T, prev *conductor, prevID string, conductors map[string]*conductor, sys *System) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	condition := func() (bool, error) {
-		isLeader, err := prev.client.Leader(context.Background())
+		isLeader, err := prev.client.Leader(ctx)
 		if err != nil {
 			return false, err
 		}
 		return !isLeader, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	err := wait.For(ctx, 1*time.Second, condition)
 	require.NoError(t, err)
 
@@ -394,16 +396,17 @@ func waitForLeadershipChange(t *testing.T, prev *conductor, prevID string, condu
 }
 
 func waitForSequencerStatusChange(t *testing.T, rollupClient *sources.RollupClient, active bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	condition := func() (bool, error) {
-		isActive, err := rollupClient.SequencerActive(context.Background())
+		isActive, err := rollupClient.SequencerActive(ctx)
 		if err != nil {
 			return false, err
 		}
 		return isActive == active, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	return wait.For(ctx, 1*time.Second, condition)
 }
 
@@ -482,9 +485,11 @@ func findFollower(t *testing.T, conductors map[string]*conductor) (string, *cond
 }
 
 func ensureOnlyOneLeader(t *testing.T, sys *System, conductors map[string]*conductor) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	condition := func() (bool, error) {
 		leaders := 0
-		ctx := context.Background()
 		for name, con := range conductors {
 			leader, err := con.client.Leader(ctx)
 			if err != nil {
@@ -501,8 +506,5 @@ func ensureOnlyOneLeader(t *testing.T, sys *System, conductors map[string]*condu
 		}
 		return leaders == 1, nil
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	require.NoError(t, wait.For(ctx, 1*time.Second, condition))
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Ensure that contexts with timeouts are passed into the wait condition loops in the sequencer failover tests. This will allow the tests to properly time out and fail instead of hanging silently and indefinitely, which should make it easier to diagnose regressions.

**Tests**

See above. No new tests, but adjusted the behavior of the sequencer failover e2e tests

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
