### PR TITLE
challenger/dispute-mon: Allow --game-factory-address to override value from --network

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -158,6 +158,12 @@ func TestGameFactoryAddress(t *testing.T) {
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, "invalid address: foo", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address", "--game-factory-address=foo"))
 	})
+
+	t.Run("OverridesNetwork", func(t *testing.T) {
+		addr := common.Address{0xbb, 0xcc, 0xdd}
+		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-factory-address", "--game-factory-address", addr.Hex(), "--network", "op-sepolia"))
+		require.Equal(t, addr, cfg.GameFactoryAddress)
+	})
 }
 
 func TestNetwork(t *testing.T) {

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -396,9 +396,7 @@ func getL2Rpc(ctx *cli.Context, logger log.Logger) (string, error) {
 }
 
 func FactoryAddress(ctx *cli.Context) (common.Address, error) {
-	if ctx.IsSet(FactoryAddressFlag.Name) && ctx.IsSet(flags.NetworkFlagName) {
-		return common.Address{}, fmt.Errorf("flag %v and %v must not both be set", FactoryAddressFlag.Name, flags.NetworkFlagName)
-	}
+	// Use FactoryAddressFlag in preference to Network. Allows overriding the default dispute game factory.
 	if ctx.IsSet(FactoryAddressFlag.Name) {
 		gameFactoryAddress, err := opservice.ParseAddress(ctx.String(FactoryAddressFlag.Name))
 		if err != nil {

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -85,6 +85,12 @@ func TestGameFactoryAddress(t *testing.T) {
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, "invalid address: foo", addRequiredArgsExcept("--game-factory-address", "--game-factory-address", "foo"))
 	})
+
+	t.Run("OverridesNetwork", func(t *testing.T) {
+		addr := common.Address{0xbb, 0xcc, 0xdd}
+		cfg := configForArgs(t, addRequiredArgsExcept("--game-factory-address", "--game-factory-address", addr.Hex(), "--network", "op-sepolia"))
+		require.Equal(t, addr, cfg.GameFactoryAddress)
+	})
 }
 
 func TestNetwork(t *testing.T) {


### PR DESCRIPTION
**Description**

Allow `--game-factory-address` and `--network` to be specified at the same time with `--dispute-game-factory` taking precedence.  This allows users to easily configure the cannon and asterisc rollup config and l2 genesis via the `--network` flag but manually specify a dispute game factory address.  Useful for cases like op-mainnet where the super chain registry doesn't yet contain the factory address or where we want to test with an alternate deployment of the factory.

**Tests**

Added unit tests.