### PR TITLE
feat: add array of created drips to Drippie

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/Drippie.json
+++ b/packages/contracts-bedrock/snapshots/abi/Drippie.json
@@ -142,6 +142,25 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "created",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "_name",
         "type": "string"
@@ -244,6 +263,19 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDripCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/storageLayout/Drippie.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/Drippie.json
@@ -12,5 +12,12 @@
     "offset": 0,
     "slot": "1",
     "type": "mapping(string => struct Drippie.DripState)"
+  },
+  {
+    "bytes": "32",
+    "label": "created",
+    "offset": 0,
+    "slot": "2",
+    "type": "string[]"
   }
 ]

--- a/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
@@ -76,6 +76,11 @@ contract Drippie is AssetReceiver {
     /// @notice Maps from drip names to drip states.
     mapping(string => DripState) public drips;
 
+    /// @notice Array of created drips. Used so offchain services can easily iterate over all drips
+    ///         without resorting to event queries. Convenience feature and shouldn't really be
+    ///         used onchain because the array will grow indefinitely.
+    string[] public created;
+
     //// @param _owner Initial contract owner.
     constructor(address _owner) AssetReceiver(_owner) { }
 
@@ -111,6 +116,9 @@ contract Drippie is AssetReceiver {
         for (uint256 i = 0; i < _config.actions.length; i++) {
             state.config.actions.push(_config.actions[i]);
         }
+
+        // Add the name of the drip to the array of created drips.
+        created.push(_name);
 
         // Tell the world!
         emit DripCreated(_name, _name, _config);
@@ -257,5 +265,11 @@ contract Drippie is AssetReceiver {
     /// @return Interval of the given drip.
     function getDripInterval(string calldata _name) public view returns (uint256) {
         return drips[_name].config.interval;
+    }
+
+    /// @notice Returns the number of created drips.
+    /// @return Number of created drips.
+    function getDripCount() public view returns (uint256) {
+        return created.length;
     }
 }

--- a/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
@@ -125,6 +125,9 @@ contract Drippie_Test is Test {
             assertTrue(cfg.interval > 0);
         }
 
+        // Drip count is 0 before creating the drip.
+        assertEq(drippie.getDripCount(), 0);
+
         vm.prank(drippie.owner());
         drippie.create(dripName, cfg);
 
@@ -148,6 +151,12 @@ contract Drippie_Test is Test {
             assertEq(a.data, b.data);
             assertEq(a.value, b.value);
         }
+
+        // Drip count is 1 after creating the drip.
+        assertEq(drippie.getDripCount(), 1);
+
+        // Name of the first created drip is the same as the name of the drip.
+        assertEq(drippie.created(0), dripName);
     }
 
     /// @notice Ensures that the same drip cannot be created two times.


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds a simple array that keeps track of all the drip names created inside of the Drippie contract. Can be used by offchain services to avoid needing event queries which are slow and expensive.