### PR TITLE
show tx count in log for span batch

### DIFF
--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -451,6 +451,14 @@ func (b *SpanBatch) GetTimestamp() uint64 {
 	return b.Batches[0].Timestamp
 }
 
+// TxCount returns the tx count for the batch
+func (b *SpanBatch) TxCount() (count uint64) {
+	for _, txCount := range b.blockTxCounts {
+		count += txCount
+	}
+	return
+}
+
 // LogContext creates a new log context that contains information of the batch
 func (b *SpanBatch) LogContext(log log.Logger) log.Logger {
 	if len(b.Batches) == 0 {
@@ -464,6 +472,7 @@ func (b *SpanBatch) LogContext(log log.Logger) log.Logger {
 		"start_epoch_number", b.GetStartEpochNum(),
 		"end_epoch_number", b.GetBlockEpochNum(len(b.Batches)-1),
 		"block_count", len(b.Batches),
+		"txs", b.TxCount(),
 	)
 }
 


### PR DESCRIPTION
`SingularBatch` shows [txs](https://github.com/ethereum-optimism/optimism/blob/93a24327cbe64d67484b6c43715777fb64c752c7/op-node/rollup/derive/singular_batch.go#L55) in the log, this PR do the same for `SpanBatch`.