### PR TITLE
Use install-foundry.sh to get correct version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1313,11 +1313,11 @@ jobs:
             tar -xzvf geth-alltools-linux-amd64-1.13.14-2bd6bd01.tar.gz
             sudo cp geth-alltools-linux-amd64-1.13.14-2bd6bd01/* /usr/local/bin
       - run:
-          name: foundryup
+          name: Install Foundry
           command: |
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
-            foundryup
+            ./ops/scripts/install-foundry.sh
             echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
             source $HOME/.bashrc
             forge --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1317,8 +1317,9 @@ jobs:
           command: |
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
-            ./ops/scripts/install-foundry.sh
-            echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
+            SHA=$(jq -r .foundry < versions.json)
+            foundryup -C $SHA
+            echo 'export PATH=$HOME/ foundry/bin:$PATH' >> $BASH_ENV
             source $HOME/.bashrc
             forge --version
       - run:


### PR DESCRIPTION
**Description**

Noticed that we're not using the pinned version of foundry in this job.