### PR TITLE
Add op-node, op-batcher, op-proposer dockerfiles

### DIFF
--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update && apk add --no-cache git make
 COPY . .
 
 # Build the op-node binary
-RUN cd op-node && make op-node
+RUN cd op-batcher && make op-batcher
 
 # Use a minimal image for the runtime environment
 FROM golang:1.21-alpine
@@ -20,7 +20,7 @@ FROM golang:1.21-alpine
 WORKDIR /app
 
 # Copy the binary from the builder stage
-COPY --from=builder /app/op-node/bin/op-node /usr/local/bin/op-node
+COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin/op-batcher
 
 # Set the entrypoint to the built binary
-ENTRYPOINT ["op-node"]
+ENTRYPOINT ["op-batcher"]

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN cd op-batcher && make op-batcher
 
 # Use a minimal image for the runtime environment
-FROM golang:1.21-alpine
+FROM alpine:latest
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/op-batcher/README.md
+++ b/op-batcher/README.md
@@ -1,0 +1,7 @@
+# op-batcher
+### Docker image
+To build the docker image, run the following command:
+
+```shell
+ docker build .. -f Dockerfile -t op-batcher
+```

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN cd op-node && make op-node
 
 # Use a minimal image for the runtime environment
-FROM golang:1.21-alpine
+FROM alpine:latest
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -1,0 +1,29 @@
+# Use the official Golang image as the base image
+FROM golang:1.21-alpine AS builder
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Install git and other dependencies
+RUN apk update && apk add --no-cache git make
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the op-node binary
+RUN cd op-node && make op-node
+
+# Use a minimal image for the runtime environment
+FROM golang:1.21-alpine
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/op-node/bin/op-node /usr/local/bin/op-node
+
+# Expose the necessary port (change as needed)
+EXPOSE 8080
+
+# Set the entrypoint to the built binary
+ENTRYPOINT ["op-node"]

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -25,6 +25,13 @@ Compile a binary:
 make op-node
 ```
 
+### Docker image
+To build the docker image, run the following command:
+
+```shell
+ docker build .. -f Dockerfile -t op-node
+```
+
 ## Testing
 
 Run op-node unit tests:

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN cd op-proposer && make op-proposer
 
 # Use a minimal image for the runtime environment
-FROM golang:1.21-alpine
+FROM alpine:latest
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -23,4 +23,4 @@ WORKDIR /app
 COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin/op-proposer
 
 # Set the entrypoint to the built binary
-ENTRYPOINT ["op-batcher"]
+ENTRYPOINT ["op-proposer"]

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update && apk add --no-cache git make
 COPY . .
 
 # Build the op-node binary
-RUN cd op-node && make op-node
+RUN cd op-proposer && make op-proposer
 
 # Use a minimal image for the runtime environment
 FROM golang:1.21-alpine
@@ -20,7 +20,7 @@ FROM golang:1.21-alpine
 WORKDIR /app
 
 # Copy the binary from the builder stage
-COPY --from=builder /app/op-node/bin/op-node /usr/local/bin/op-node
+COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin/op-proposer
 
 # Set the entrypoint to the built binary
-ENTRYPOINT ["op-node"]
+ENTRYPOINT ["op-batcher"]

--- a/op-proposer/README.md
+++ b/op-proposer/README.md
@@ -1,0 +1,7 @@
+# op-proposer
+### Docker image
+To build the docker image, run the following command:
+
+```shell
+ docker build .. -f Dockerfile -t op-proposer
+```


### PR DESCRIPTION
**Description**

This PR adds standalone Dockerfiles for various components in the op stack. This allows for local image building and integration into testing stacks.

**Tests**
No test added since its a dockerfile

**Additional context**
The official op-node image found [here](us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:93a24327cbe64d67484b6c43715777fb64c752c7) fails on the Mac M1 with a rosetta error. I was unable to build my own image, hence wrote the Dockerfile. The image built with this dockerfile works on macOS. 

