### PR TITLE
op-e2e: Fix flake caused by reusing a single system config across multiple tests

### DIFF
--- a/op-e2e/check_scripts_test.go
+++ b/op-e2e/check_scripts_test.go
@@ -16,16 +16,8 @@ import (
 // TestCheckFjordScript ensures the op-chain-ops/cmd/check-fjord script runs successfully
 // against a test chain with the fjord hardfork activated/unactivated
 func TestCheckFjordScript(t *testing.T) {
-	log := testlog.Logger(t, log.LevelInfo)
-
-	cfg := DefaultSystemConfig(t)
+	InitParallel(t)
 	genesisActivation := hexutil.Uint64(0)
-	cfg.DeployConfig.L1CancunTimeOffset = &genesisActivation
-	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &genesisActivation
-	cfg.DeployConfig.L2GenesisCanyonTimeOffset = &genesisActivation
-	cfg.DeployConfig.L2GenesisDeltaTimeOffset = &genesisActivation
-	cfg.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisActivation
-
 	tests := []struct {
 		name            string
 		fjordActivation *hexutil.Uint64
@@ -46,6 +38,16 @@ func TestCheckFjordScript(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			InitParallel(t)
+
+			log := testlog.Logger(t, log.LevelInfo)
+
+			cfg := DefaultSystemConfig(t)
+			cfg.DeployConfig.L1CancunTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisRegolithTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisCanyonTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisDeltaTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisActivation
+
 			cfg.DeployConfig.L2GenesisFjordTimeOffset = tt.fjordActivation
 
 			sys, err := cfg.Start(t)


### PR DESCRIPTION
**Description**

Attempt to fix a flaky test by fully encapsulating the tests. Previously the same SystemConfig was being modified by both tests in parallel, potentially leading to incorrect setup.
