### PR TITLE
challenger: Include game resolution time in list-claims output.

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -91,6 +92,14 @@ func listClaims(ctx context.Context, game contracts.FaultDisputeGameContract, ve
 		return fmt.Errorf("failed to retrieve claims: %w", err)
 	}
 
+	var resolutionTime time.Time
+	if status != gameTypes.GameStatusInProgress {
+		resolutionTime, err = game.GetResolvedAt(ctx, rpcblock.Latest)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve resolved at: %w", err)
+		}
+	}
+
 	// The top game runs from depth 0 to split depth *inclusive*.
 	// The - 1 here accounts for the fact that the split depth is included in the top game.
 	bottomDepth := maxDepth - splitDepth - 1
@@ -162,12 +171,16 @@ func listClaims(ctx context.Context, game contracts.FaultDisputeGameContract, ve
 		info = info + fmt.Sprintf(lineFormat,
 			i, move, parent, pos.Depth(), traceIdx, value, claim.Claimant, bond, timestamp, elapsed, countered)
 	}
-	blockNumChallenger := "L2 Block: Unchallenged"
+	blockNumChallenger := "Unchallenged"
 	if metadata.L2BlockNumberChallenged {
-		blockNumChallenger = "L2 Block: ❌ " + metadata.L2BlockNumberChallenger.Hex()
+		blockNumChallenger = "❌ " + metadata.L2BlockNumberChallenger.Hex()
 	}
-	fmt.Printf("Status: %v • L2 Blocks: %v to %v • Split Depth: %v • Max Depth: %v • %v • Claim Count: %v\n%v\n",
-		status, l2StartBlockNum, l2BlockNum, splitDepth, maxDepth, blockNumChallenger, len(claims), info)
+	statusStr := status.String()
+	if status != gameTypes.GameStatusInProgress {
+		statusStr = fmt.Sprintf("%v • Resolution Time: %v", statusStr, resolutionTime.Format(time.DateTime))
+	}
+	fmt.Printf("Status: %v • L2 Blocks: %v to %v (%v) • Split Depth: %v • Max Depth: %v • Claim Count: %v\n%v\n",
+		statusStr, l2StartBlockNum, l2BlockNum, blockNumChallenger, splitDepth, maxDepth, len(claims), info)
 	return nil
 }
 

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -35,6 +35,7 @@ var (
 	methodClaimCount              = "claimDataLen"
 	methodClaim                   = "claimData"
 	methodL1Head                  = "l1Head"
+	methodResolvedAt              = "resolvedAt"
 	methodResolvedSubgames        = "resolvedSubgames"
 	methodResolve                 = "resolve"
 	methodResolveClaim            = "resolveClaim"
@@ -219,6 +220,16 @@ func (f *FaultDisputeGameContractLatest) GetGameMetadata(ctx context.Context, bl
 		L2BlockNumberChallenged: blockChallenged,
 		L2BlockNumberChallenger: blockChallenger,
 	}, nil
+}
+
+func (f *FaultDisputeGameContractLatest) GetResolvedAt(ctx context.Context, block rpcblock.Block) (time.Time, error) {
+	defer f.metrics.StartContractRequest("GetResolvedAt")()
+	result, err := f.multiCaller.SingleCall(ctx, block, f.contract.Call(methodResolvedAt))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to retrieve resolution time: %w", err)
+	}
+	resolvedAt := time.Unix(int64(result.GetUint64(0)), 0)
+	return resolvedAt, nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetStartingRootHash(ctx context.Context) (common.Hash, error) {
@@ -595,6 +606,7 @@ type FaultDisputeGameContract interface {
 	GetBalanceAndDelay(ctx context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error)
 	GetBlockRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error)
 	GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error)
+	GetResolvedAt(ctx context.Context, block rpcblock.Block) (time.Time, error)
 	GetStartingRootHash(ctx context.Context) (common.Hash, error)
 	GetSplitDepth(ctx context.Context) (types.Depth, error)
 	GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error)

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -158,6 +158,15 @@ func TestSimpleGetters(t *testing.T) {
 				return game.CallResolve(context.Background())
 			},
 		},
+		{
+			methodAlias: "resolvedAt",
+			method:      methodResolvedAt,
+			result:      uint64(240402),
+			expected:    time.Unix(240402, 0),
+			call: func(game FaultDisputeGameContract) (any, error) {
+				return game.GetResolvedAt(context.Background(), rpcblock.Latest)
+			},
+		},
 	}
 	for _, version := range versions {
 		version := version


### PR DESCRIPTION
**Description**

Add the resolution time to list-claims output.

Fixes https://github.com/ethereum-optimism/client-pod/issues/921