### PR TITLE
fix: correct Gelato time configuration

### DIFF
--- a/packages/contracts-bedrock/periphery-deploy-config/drippie-config/sepolia-ops.json
+++ b/packages/contracts-bedrock/periphery-deploy-config/drippie-config/sepolia-ops.json
@@ -1,5 +1,5 @@
 {
-  "drippie": "0xd6F935Bd272BEE05bD64096D82970482EF16D64b",
+  "drippie": "0xa0fF2a54AdC3fB33c44a141E67d194CF249258cb",
   "gelato": "0x2A6C106ae13B558BB9E2Ec64Bd2f1f7BEFF3A5E0",
 
   "note": "Object attributes below are prefixed with numbers because of how foundry parses JSON into structs in alphabetical order",
@@ -12,8 +12,8 @@
         "02__threshold": 100000000000000000000
       },
       "03__recipient": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
-      "04__value": 20000000000000000000,
-      "05__interval": 86400,
+      "04__value": 50000000000000000000,
+      "05__interval": 3600,
       "06__data": ""
     },
     {
@@ -34,12 +34,12 @@
       "02__checkparams": {
         "00__treasury": "0x7506C12a824d73D9b08564d5Afc22c949434755e",
         "01__threshold": 1000000000000000000,
-        "02__recipient": "0x03C256F7Ae7518D0fe489F257ab4b928D37CBE16"
+        "02__recipient": "0xCd438409d5Cac9D2E076Ac7Bd0Bf2377E99BB6e4"
       },
       "03__recipient": "0x7506C12a824d73D9b08564d5Afc22c949434755e",
       "04__value": 1000000000000000000,
       "05__interval": 86400,
-      "06__data": "0x00000000000000000000000003c256f7ae7518d0fe489f257ab4b928d37cbe16"
+      "06__data": "0x0000000000000000000000000Cd438409d5Cac9D2E076Ac7Bd0Bf2377E99BB6e4"
     },
     {
       "00__name": "OperationsSecretsDrip_V1",
@@ -49,7 +49,7 @@
         "01__secretHashMustExist": "0x565fa8c7daa859353b5b328b97b12c7d66c5832b2a24d4e0f739a65ad266a46f",
         "02__secretHashMustNotExist": "0xbc362b01d69a85dff1793803dde67df1f338f37a36fdc73dddf27283d215e614"
       },
-      "03__recipient": "0x03C256F7Ae7518D0fe489F257ab4b928D37CBE16",
+      "03__recipient": "0xCd438409d5Cac9D2E076Ac7Bd0Bf2377E99BB6e4",
       "04__value": 1000000000000000000,
       "05__interval": 3600,
       "06__data": ""

--- a/packages/contracts-bedrock/periphery-deploy-config/drippie-config/sepolia-ops.json
+++ b/packages/contracts-bedrock/periphery-deploy-config/drippie-config/sepolia-ops.json
@@ -5,14 +5,14 @@
   "note": "Object attributes below are prefixed with numbers because of how foundry parses JSON into structs in alphabetical order",
   "drips": [
     {
-      "00__name": "OperationsSequencerDrip_V1",
+      "00__name": "OperationsSequencerDrip_V2",
       "01__dripcheck": "CheckBalanceLow",
       "02__checkparams": {
         "01__target": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
-        "02__threshold": 100000000000000000000
+        "02__threshold": 1000000000000000000000
       },
       "03__recipient": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
-      "04__value": 50000000000000000000,
+      "04__value": 100000000000000000000,
       "05__interval": 3600,
       "06__data": ""
     },

--- a/packages/contracts-bedrock/periphery-deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/periphery-deploy-config/sepolia.json
@@ -1,9 +1,9 @@
 {
-  "create2DeploymentSalt": "0.0.3",
+  "create2DeploymentSalt": "0.0.7",
 
   "gelatoAutomateContract": "0x2A6C106ae13B558BB9E2Ec64Bd2f1f7BEFF3A5E0",
 
-  "operationsDrippieOwner": "0x03C256F7Ae7518D0fe489F257ab4b928D37CBE16",
+  "operationsDrippieOwner": "0xCd438409d5Cac9D2E076Ac7Bd0Bf2377E99BB6e4",
   "faucetDrippieOwner": "0x10ab157483dd308f8B38aCF2ad823dfD255F56b5",
 
   "opChainAdminWalletDripValue": 1000000000000000000,

--- a/packages/contracts-bedrock/scripts/periphery/drippie/DrippieConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/periphery/drippie/DrippieConfig.s.sol
@@ -49,6 +49,9 @@ contract DrippieConfig is Script, Artifacts {
     /// @notice Drip configuration array.
     FullDripConfig[] public drips;
 
+    /// @notice Mapping of drip names in the config.
+    mapping(string => bool) public names;
+
     /// @param _path Path to the configuration file.
     constructor(string memory _path) {
         // Make sure artifacts are set up.
@@ -125,6 +128,7 @@ contract DrippieConfig is Script, Artifacts {
 
             // Ok we're good to go.
             drips.push(dripcfg);
+            names[name] = true;
         }
     }
 

--- a/packages/contracts-bedrock/scripts/periphery/drippie/ManageDrippie.s.sol
+++ b/packages/contracts-bedrock/scripts/periphery/drippie/ManageDrippie.s.sol
@@ -48,7 +48,22 @@ contract ManageDrippie is Script, Artifacts {
     /// @notice Runs the management script.
     function run() public {
         console.log("ManageDrippie: running");
+        pauseDrips();
         installDrips();
+    }
+
+    /// @notice Pauses drips that have been removed from config.
+    function pauseDrips() public broadcast {
+        console.log("ManageDrippie: pausing removed drips");
+        for (uint256 i = 0; i < cfg.drippie().getDripCount(); i++) {
+            string memory name = cfg.drippie().created(i);
+            if (!cfg.names(name)) {
+                console.log("ManageDrippie: pausing %s", name);
+                cfg.drippie().status(name, Drippie.DripStatus.PAUSED);
+                _pauseGelatoDripTask(cfg.gelato(), cfg.drippie(), name);
+                console.log("ManageDrippie: %s paused successfully", name);
+            }
+        }
     }
 
     /// @notice Installs drips in the drippie contract.


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Fixes a small bug in the drippie management script that meant gelato tasks were being created with the wrong time interval. Also modifies the script so that it pauses any tasks that have been removed from the config.