### PR TITLE
contracts: Make L2 genesis script configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,25 +243,25 @@ jobs:
             - "packages/contracts-bedrock/tsconfig.tsbuildinfo"
             - "packages/contracts-bedrock/tsconfig.build.tsbuildinfo"
             - ".devnet/allocs-l1.json"
-            - ".devnet/allocs-l2.json"
             - ".devnet/allocs-l2-delta.json"
             - ".devnet/allocs-l2-ecotone.json"
+            - ".devnet/allocs-l2-fjord.json"
             - ".devnet/addresses.json"
             - ".devnet-l2oo/allocs-l1.json"
             - ".devnet-l2oo/addresses.json"
-            - ".devnet-l2oo/allocs-l2.json"
             - ".devnet-l2oo/allocs-l2-delta.json"
             - ".devnet-l2oo/allocs-l2-ecotone.json"
+            - ".devnet-l2oo/allocs-l2-fjord.json"
             - ".devnet-plasma/allocs-l1.json"
             - ".devnet-plasma/addresses.json"
-            - ".devnet-plasma/allocs-l2.json"
             - ".devnet-plasma/allocs-l2-delta.json"
             - ".devnet-plasma/allocs-l2-ecotone.json"
+            - ".devnet-plasma/allocs-l2-fjord.json"
             - ".devnet-plasma-generic/allocs-l1.json"
             - ".devnet-plasma-generic/addresses.json"
-            - ".devnet-plasma-generic/allocs-l2.json"
             - ".devnet-plasma-generic/allocs-l2-delta.json"
             - ".devnet-plasma-generic/allocs-l2-ecotone.json"
+            - ".devnet-plasma-generic/allocs-l2-fjord.json"
             - "packages/contracts-bedrock/deploy-config/devnetL1.json"
             - "packages/contracts-bedrock/deployments/devnetL1"
       - notify-failures-on-develop
@@ -928,9 +928,9 @@ jobs:
           name: Load devnet-allocs
           command: |
             mkdir -p .devnet
-            cp /tmp/workspace/.devnet<<parameters.variant>>/allocs-l2.json .devnet/allocs-l2.json
             cp /tmp/workspace/.devnet<<parameters.variant>>/allocs-l2-delta.json .devnet/allocs-l2-delta.json
             cp /tmp/workspace/.devnet<<parameters.variant>>/allocs-l2-ecotone.json .devnet/allocs-l2-ecotone.json
+            cp /tmp/workspace/.devnet<<parameters.variant>>/allocs-l2-fjord.json .devnet/allocs-l2-fjord.json
             cp /tmp/workspace/.devnet<<parameters.variant>>/allocs-l1.json .devnet/allocs-l1.json
             cp /tmp/workspace/.devnet<<parameters.variant>>/addresses.json .devnet/addresses.json
             cp /tmp/workspace/packages/contracts-bedrock/deploy-config/devnetL1.json packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -1113,9 +1113,9 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ".devnet/allocs-l2.json"
             - ".devnet/allocs-l2-delta.json"
             - ".devnet/allocs-l2-ecotone.json"
+            - ".devnet/allocs-l2-fjord.json"
             - ".devnet/allocs-l1.json"
             - ".devnet/addresses.json"
             - "packages/contracts-bedrock/deploy-config/devnetL1.json"

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -26,6 +26,9 @@ parser.add_argument('--test', help='Tests the deployment, must already be deploy
 
 log = logging.getLogger()
 
+# Global constants
+FORKS = ["delta", "ecotone", "fjord"]
+
 # Global environment variables
 DEVNET_NO_BUILD = os.getenv('DEVNET_NO_BUILD') == "true"
 DEVNET_L2OO = os.getenv('DEVNET_L2OO') == "true"
@@ -171,9 +174,9 @@ def devnet_l2_allocs(paths):
 
     # For the previous forks, and the latest fork (default, thus empty prefix),
     # move the forge-dumps into place as .devnet allocs.
-    for suffix in ["-delta", "-ecotone", ""]:
-        input_path = pjoin(paths.contracts_bedrock_dir, f"state-dump-901{suffix}.json")
-        output_path = pjoin(paths.devnet_dir, f'allocs-l2{suffix}.json')
+    for fork in FORKS:
+        input_path = pjoin(paths.contracts_bedrock_dir, f"state-dump-901-{fork}.json")
+        output_path = pjoin(paths.devnet_dir, f'allocs-l2-{fork}.json')
         shutil.move(src=input_path, dst=output_path)
         log.info("Generated L2 allocs: "+output_path)
 
@@ -218,7 +221,7 @@ def devnet_deploy(paths):
         log.info('L2 genesis and rollup configs already generated.')
     else:
         log.info('Generating L2 genesis and rollup configs.')
-        l2_allocs_path = pjoin(paths.devnet_dir, 'allocs-l2.json')
+        l2_allocs_path = pjoin(paths.devnet_dir, f'allocs-l2-{FORKS[-1]}.json')
         if os.path.exists(l2_allocs_path) == False or DEVNET_L2OO == True:
             # Also regenerate if L2OO.
             # The L2OO flag may affect the L1 deployments addresses, which may affect the L2 genesis.

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -24,7 +24,7 @@ type L2AllocsMode string
 const (
 	L2AllocsDelta   L2AllocsMode = "delta"
 	L2AllocsEcotone L2AllocsMode = "ecotone"
-	L2AllocsFjord   L2AllocsMode = "" // the default in solidity scripting / testing
+	L2AllocsFjord   L2AllocsMode = "fjord"
 )
 
 var (

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -113,10 +113,7 @@ func init() {
 	}
 	l2Allocs = make(map[genesis.L2AllocsMode]*genesis.ForgeAllocs)
 	mustL2Allocs := func(mode genesis.L2AllocsMode) {
-		name := "allocs-l2"
-		if mode != "" {
-			name += "-" + string(mode)
-		}
+		name := "allocs-l2-" + string(mode)
 		allocs, err := genesis.LoadForgeAllocs(filepath.Join(l2AllocsDir, name+".json"))
 		if err != nil {
 			panic(err)

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -319,6 +319,18 @@ STATE_DUMP_PATH=<PATH_TO_WRITE_L2_ALLOCS> \
 Create or modify a file `<network-name>.json` inside of the [`deploy-config`](./deploy-config/) folder.
 Use the env var `DEPLOY_CONFIG_PATH` to use a particular deploy config file at runtime.
 
+The script will read the latest active fork from the deploy config and the L2 genesis allocs generated will be
+compatible with this fork. The automatically detected fork can be overwritten by setting the environment variable
+`FORK` either to the lower-case fork name (currently `delta`, `ecotone`, or `fjord`) or to `latest`, which will select
+the latest fork available (currently `fjord`).
+
+By default, the script will dump the L2 genesis allocs of the detected or selected fork only, to the file at `STATE_DUMP_PATH`.
+The optional environment variable `OUTPUT_MODE` allows to modify this behavior by setting it to one of the following values:
+* `latest` (default) - only dump the selected fork's allocs.
+* `all` - also dump all intermediary fork's allocs. This only works if `STATE_DUMP_PATH` is _not_ set. In this case, all allocs
+          will be written to files `/state-dump-<fork>.json`. Another path cannot currently be specified for this use case.
+* `none` - won't dump any allocs. Only makes sense for internal test usage.
+
 #### Custom Gas Token
 
 The Custom Gas Token feature is a Beta feature of the MIT licensed OP Stack.

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -92,7 +92,7 @@ library Config {
     ///         It reads the mode from the environment variable OUTPUT_MODE.
     ///         If it is unset, OutputMode.ALL is returned.
     function outputMode() internal view returns (OutputMode) {
-        string memory modeStr = vm.envOr("OUTPUT_MODE", string("all"));
+        string memory modeStr = vm.envOr("OUTPUT_MODE", string("latest"));
         bytes32 modeHash = keccak256(bytes(modeStr));
         if (modeHash == keccak256(bytes("none"))) {
             return OutputMode.NONE;

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -15,12 +15,12 @@ enum OutputMode {
 
 /// @notice Enum of forks available for selection when generating genesis allocs.
 enum Fork {
+    NONE,
     DELTA,
     ECOTONE,
     FJORD
 }
 
-/// @notice Always points to the latest fork.
 Fork constant LATEST_FORK = Fork.FJORD;
 
 /// @title Config
@@ -89,6 +89,8 @@ library Config {
     }
 
     /// @notice Returns the OutputMode for genesis allocs generation.
+    ///         It reads the mode from the environment variable OUTPUT_MODE.
+    ///         If it is unset, OutputMode.ALL is returned.
     function outputMode() internal view returns (OutputMode) {
         string memory modeStr = vm.envOr("OUTPUT_MODE", string("all"));
         bytes32 modeHash = keccak256(bytes(modeStr));
@@ -104,8 +106,14 @@ library Config {
     }
 
     /// @notice Returns the latest fork to use for genesis allocs generation.
+    ///         It reads the fork from the environment variable FORK. If it is
+    ///         unset, NONE is returned.
+    ///         If set to the special value "latest", the latest fork is returned.
     function fork() internal view returns (Fork) {
-        string memory forkStr = vm.envOr("FORK", string("latest"));
+        string memory forkStr = vm.envOr("FORK", string(""));
+        if (bytes(forkStr).length == 0) {
+            return Fork.NONE;
+        }
         bytes32 forkHash = keccak256(bytes(forkStr));
         if (forkHash == keccak256(bytes("latest"))) {
             return LATEST_FORK;

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -13,6 +13,20 @@ enum OutputMode {
     ALL
 }
 
+library OutputModeUtils {
+    function toString(OutputMode _mode) internal pure returns (string memory) {
+        if (_mode == OutputMode.NONE) {
+            return "none";
+        } else if (_mode == OutputMode.LATEST) {
+            return "latest";
+        } else if (_mode == OutputMode.ALL) {
+            return "all";
+        } else {
+            return "unknown";
+        }
+    }
+}
+
 /// @notice Enum of forks available for selection when generating genesis allocs.
 enum Fork {
     NONE,
@@ -22,6 +36,22 @@ enum Fork {
 }
 
 Fork constant LATEST_FORK = Fork.FJORD;
+
+library ForkUtils {
+    function toString(Fork _fork) internal pure returns (string memory) {
+        if (_fork == Fork.NONE) {
+            return "none";
+        } else if (_fork == Fork.DELTA) {
+            return "delta";
+        } else if (_fork == Fork.ECOTONE) {
+            return "ecotone";
+        } else if (_fork == Fork.FJORD) {
+            return "fjord";
+        } else {
+            return "unknown";
+        }
+    }
+}
 
 /// @title Config
 /// @notice Contains all env var based config. Add any new env var parsing to this file

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -7,12 +7,18 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { Executables } from "scripts/Executables.sol";
 import { Process } from "scripts/libraries/Process.sol";
 import { Chains } from "scripts/Chains.sol";
+import { Fork } from "scripts/Config.sol";
 
 /// @title DeployConfig
 /// @notice Represents the configuration required to deploy the system. It is expected
 ///         to read the file from JSON. A future improvement would be to have fallback
 ///         values if they are not defined in the JSON themselves.
 contract DeployConfig is Script {
+    using stdJson for string;
+
+    /// @notice Represents an unset offset value, as opposed to 0, which denotes no-offset.
+    uint256 constant NULL_OFFSET = type(uint256).max;
+
     string internal _json;
 
     address public finalSystemOwner;
@@ -20,6 +26,9 @@ contract DeployConfig is Script {
     uint256 public l1ChainID;
     uint256 public l2ChainID;
     uint256 public l2BlockTime;
+    uint256 public l2GenesisDeltaTimeOffset;
+    uint256 public l2GenesisEcotoneTimeOffset;
+    uint256 public l2GenesisFjordTimeOffset;
     uint256 public maxSequencerDrift;
     uint256 public sequencerWindowSize;
     uint256 public channelTimeout;
@@ -94,6 +103,11 @@ contract DeployConfig is Script {
         l1ChainID = stdJson.readUint(_json, "$.l1ChainID");
         l2ChainID = stdJson.readUint(_json, "$.l2ChainID");
         l2BlockTime = stdJson.readUint(_json, "$.l2BlockTime");
+
+        l2GenesisDeltaTimeOffset = _readOr(_json, "$.l2GenesisDeltaTimeOffset", NULL_OFFSET);
+        l2GenesisEcotoneTimeOffset = _readOr(_json, "$.l2GenesisEcotoneTimeOffset", NULL_OFFSET);
+        l2GenesisFjordTimeOffset = _readOr(_json, "$.l2GenesisFjordTimeOffset", NULL_OFFSET);
+
         maxSequencerDrift = stdJson.readUint(_json, "$.maxSequencerDrift");
         sequencerWindowSize = stdJson.readUint(_json, "$.sequencerWindowSize");
         channelTimeout = stdJson.readUint(_json, "$.channelTimeout");
@@ -161,6 +175,17 @@ contract DeployConfig is Script {
         useInterop = _readOr(_json, "$.useInterop", false);
     }
 
+    function latestGenesisFork() public view returns (Fork) {
+        if (l2GenesisFjordTimeOffset == 0) {
+            return Fork.FJORD;
+        } else if (l2GenesisEcotoneTimeOffset == 0) {
+            return Fork.ECOTONE;
+        } else if (l2GenesisDeltaTimeOffset == 0) {
+            return Fork.DELTA;
+        }
+        revert("DeployConfig: no supported fork active at genesis");
+    }
+
     function l1StartingBlockTag() public returns (bytes32) {
         try vm.parseJsonBytes32(_json, "$.l1StartingBlockTag") returns (bytes32 tag) {
             return tag;
@@ -225,15 +250,20 @@ contract DeployConfig is Script {
     }
 
     function _readOr(string memory json, string memory key, bool defaultValue) internal view returns (bool) {
-        return vm.keyExists(json, key) ? stdJson.readBool(json, key) : defaultValue;
+        return vm.keyExistsJson(json, key) ? json.readBool(key) : defaultValue;
     }
 
     function _readOr(string memory json, string memory key, uint256 defaultValue) internal view returns (uint256) {
-        return vm.keyExists(json, key) ? stdJson.readUint(json, key) : defaultValue;
+        return (vm.keyExistsJson(json, key) && !_isNull(json, key)) ? json.readUint(key) : defaultValue;
     }
 
     function _readOr(string memory json, string memory key, address defaultValue) internal view returns (address) {
-        return vm.keyExists(json, key) ? stdJson.readAddress(json, key) : defaultValue;
+        return vm.keyExistsJson(json, key) ? json.readAddress(key) : defaultValue;
+    }
+
+    function _isNull(string memory json, string memory key) internal pure returns (bool) {
+        string memory value = json.readString(key);
+        return (keccak256(bytes(value)) == keccak256(bytes("null")));
     }
 
     function _readOr(
@@ -245,6 +275,6 @@ contract DeployConfig is Script {
         view
         returns (string memory)
     {
-        return vm.keyExists(json, key) ? stdJson.readString(json, key) : defaultValue;
+        return vm.keyExists(json, key) ? json.readString(key) : defaultValue;
     }
 }

--- a/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { OutputMode } from "scripts/L2Genesis.s.sol";
+import { Fork } from "scripts/Config.sol";
 
 // Libraries
 import { Encoding } from "src/libraries/Encoding.sol";
@@ -39,7 +39,7 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
     /// @dev Sets up the test suite.
     function setUp() public virtual override {
         // The gasPriceOracle tests rely on an L2 genesis that is not past Ecotone.
-        l2OutputMode = OutputMode.LOCAL_DELTA;
+        l2Fork = Fork.DELTA;
         super.setUp();
         assertEq(gasPriceOracle.isEcotone(), false);
 
@@ -120,7 +120,7 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
 contract GasPriceOracleEcotone_Test is GasPriceOracle_Test {
     /// @dev Sets up the test suite.
     function setUp() public virtual override {
-        l2OutputMode = OutputMode.LOCAL_ECOTONE; // activate ecotone
+        l2Fork = Fork.ECOTONE;
         super.setUp();
         assertEq(gasPriceOracle.isEcotone(), true);
 
@@ -213,7 +213,7 @@ contract GasPriceOracleEcotone_Test is GasPriceOracle_Test {
 contract GasPriceOracleFjordActive_Test is GasPriceOracle_Test {
     /// @dev Sets up the test suite.
     function setUp() public virtual override {
-        l2OutputMode = OutputMode.LOCAL_LATEST; // activate fjord
+        l2Fork = Fork.FJORD;
         super.setUp();
 
         bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesEcotone(

--- a/packages/contracts-bedrock/test/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2Genesis.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { L2Genesis, OutputMode, L1Dependencies } from "scripts/L2Genesis.s.sol";
+import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Process } from "scripts/libraries/Process.sol";
@@ -181,7 +181,7 @@ contract L2GenesisTest is Test {
     /// @notice Tests the number of accounts in the genesis setup
     function _test_allocs_size(string memory _path) internal {
         genesis.cfg().setFundDevAccounts(false);
-        genesis.runWithOptions(OutputMode.LOCAL_LATEST, _dummyL1Deps());
+        genesis.runWithLatestLocal(_dummyL1Deps());
         genesis.writeGenesisAllocs(_path);
 
         uint256 expected = 0;

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -25,8 +25,10 @@ import { DelayedWETH } from "src/dispute/weth/DelayedWETH.sol";
 import { AnchorStateRegistry } from "src/dispute/AnchorStateRegistry.sol";
 import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 import { DeployConfig } from "scripts/DeployConfig.s.sol";
+import { Fork, LATEST_FORK } from "scripts/Config.sol";
 import { Deploy } from "scripts/Deploy.s.sol";
-import { L2Genesis, L1Dependencies, OutputMode } from "scripts/L2Genesis.s.sol";
+import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
+import { OutputMode, Fork } from "scripts/Config.sol";
 import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
 import { ProtocolVersions } from "src/L1/ProtocolVersions.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
@@ -57,7 +59,7 @@ contract Setup {
         L2Genesis(address(uint160(uint256(keccak256(abi.encode("optimism.l2genesis"))))));
 
     // @notice Allows users of Setup to override what L2 genesis is being created.
-    OutputMode l2OutputMode = OutputMode.LOCAL_LATEST;
+    Fork l2Fork = LATEST_FORK;
 
     OptimismPortal optimismPortal;
     OptimismPortal2 optimismPortal2;
@@ -175,9 +177,10 @@ contract Setup {
 
     /// @dev Sets up the L2 contracts. Depends on `L1()` being called first.
     function L2() public {
-        console.log("Setup: creating L2 genesis, with output mode %d", uint256(l2OutputMode));
+        console.log("Setup: creating L2 genesis with fork %d", uint256(l2Fork));
         l2Genesis.runWithOptions(
-            l2OutputMode,
+            OutputMode.NONE,
+            l2Fork,
             L1Dependencies({
                 l1CrossDomainMessengerProxy: payable(address(l1CrossDomainMessenger)),
                 l1StandardBridgeProxy: payable(address(l1StandardBridge)),

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -28,7 +28,7 @@ import { DeployConfig } from "scripts/DeployConfig.s.sol";
 import { Fork, LATEST_FORK } from "scripts/Config.sol";
 import { Deploy } from "scripts/Deploy.s.sol";
 import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
-import { OutputMode, Fork } from "scripts/Config.sol";
+import { OutputMode, Fork, ForkUtils } from "scripts/Config.sol";
 import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
 import { ProtocolVersions } from "src/L1/ProtocolVersions.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
@@ -48,6 +48,8 @@ import { WETH } from "src/L2/WETH.sol";
 ///      up behind proxies. In the future we will migrate to importing the genesis JSON
 ///      file that is created to set up the L2 contracts instead of setting them up manually.
 contract Setup {
+    using ForkUtils for Fork;
+
     /// @notice The address of the foundry Vm contract.
     Vm private constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
@@ -177,7 +179,7 @@ contract Setup {
 
     /// @dev Sets up the L2 contracts. Depends on `L1()` being called first.
     function L2() public {
-        console.log("Setup: creating L2 genesis with fork %d", uint256(l2Fork));
+        console.log("Setup: creating L2 genesis with fork %s", l2Fork.toString());
         l2Genesis.runWithOptions(
             OutputMode.NONE,
             l2Fork,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Makes the L2 genesis script configurable via two new env vars
* `OUTPUT_MODE`
    * `none` - no state dump file written, used in tests
    * `latest` - only dump state of latest fork
    * `all` - dump states of all forks (default)
* `FORK` - for fork selection (`delta`, `ecotone`,`fjord` or `latest` (default, always selects latest fork))

All generated devnet allocs now explicitly have their fork as suffix, also the latest (no suffix previously).

Still WIP:
- [ ] solidity documentation needs update

**Additional context**

The L2 genesis script before had the latest fork hardcoded.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/895
