### PR TITLE
challenger: Allow interrupting subcommands

### DIFF
--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -76,6 +76,6 @@ var CreateGameCommand = &cli.Command{
 	Name:        "create-game",
 	Usage:       "Creates a dispute game via the factory",
 	Description: "Creates a dispute game via the factory",
-	Action:      CreateGame,
+	Action:      Interruptible(CreateGame),
 	Flags:       createGameFlags(),
 }

--- a/op-challenger/cmd/credits.go
+++ b/op-challenger/cmd/credits.go
@@ -112,6 +112,6 @@ var ListCreditsCommand = &cli.Command{
 	Name:        "list-credits",
 	Usage:       "List the credits in a dispute game",
 	Description: "Lists the credits in a dispute game",
-	Action:      ListCredits,
+	Action:      Interruptible(ListCredits),
 	Flags:       listCreditsFlags(),
 }

--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -198,6 +198,6 @@ var ListClaimsCommand = &cli.Command{
 	Name:        "list-claims",
 	Usage:       "List the claims in a dispute game",
 	Description: "Lists the claims in a dispute game",
-	Action:      ListClaims,
+	Action:      Interruptible(ListClaims),
 	Flags:       listClaimsFlags(),
 }

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -183,6 +183,6 @@ var ListGamesCommand = &cli.Command{
 	Name:        "list-games",
 	Usage:       "List the games created by a dispute game factory",
 	Description: "Lists the games created by a dispute game factory",
-	Action:      ListGames,
+	Action:      Interruptible(ListGames),
 	Flags:       listGamesFlags(),
 }

--- a/op-challenger/cmd/move.go
+++ b/op-challenger/cmd/move.go
@@ -97,6 +97,6 @@ var MoveCommand = &cli.Command{
 	Name:        "move",
 	Usage:       "Creates and sends a move transaction to the dispute game",
 	Description: "Creates and sends a move transaction to the dispute game",
-	Action:      Move,
+	Action:      Interruptible(Move),
 	Flags:       moveFlags(),
 }

--- a/op-challenger/cmd/resolve.go
+++ b/op-challenger/cmd/resolve.go
@@ -46,6 +46,6 @@ var ResolveCommand = &cli.Command{
 	Name:        "resolve",
 	Usage:       "Resolves the specified dispute game if possible",
 	Description: "Resolves the specified dispute game if possible",
-	Action:      Resolve,
+	Action:      Interruptible(Resolve),
 	Flags:       resolveFlags(),
 }

--- a/op-challenger/cmd/resolve_claim.go
+++ b/op-challenger/cmd/resolve_claim.go
@@ -66,6 +66,6 @@ var ResolveClaimCommand = &cli.Command{
 	Name:        "resolve-claim",
 	Usage:       "Resolves the specified claim if possible",
 	Description: "Resolves the specified claim if possible",
-	Action:      ResolveClaim,
+	Action:      Interruptible(ResolveClaim),
 	Flags:       resolveClaimFlags(),
 }

--- a/op-challenger/cmd/utils.go
+++ b/op-challenger/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
@@ -17,6 +18,12 @@ import (
 
 type ContractCreator[T any] func(context.Context, contractMetrics.ContractMetricer, common.Address, *batching.MultiCaller) (T, error)
 
+func Interruptible(action cli.ActionFunc) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		ctx.Context = opio.CancelOnInterrupt(ctx.Context)
+		return action(ctx)
+	}
+}
 func AddrFromFlag(flagName string) func(ctx *cli.Context) (common.Address, error) {
 	return func(ctx *cli.Context) (common.Address, error) {
 		gameAddr, err := opservice.ParseAddress(ctx.String(flagName))


### PR DESCRIPTION
**Description**

Support interrupting the execution of challenger sub-commands with ctrl-C. Just uses a very simple Context cancellation which doesn't for managing the shutdown process but that's not required for these subcommands.

Builds on https://github.com/ethereum-optimism/optimism/pull/10757

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/920