### PR TITLE
op-e2e: Migrate more bindings away from generated bindings

### DIFF
--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -129,8 +129,17 @@ func (c *PreimageOracleContract) AddGlobalDataTx(data *types.PreimageOracleData)
 }
 
 func (c *PreimageOracleContract) InitLargePreimage(uuid *big.Int, partOffset uint32, claimedSize uint32) (txmgr.TxCandidate, error) {
+	bond, err := c.GetMinBondLPP(context.Background())
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to get min bond for large preimage proposal: %w", err)
+	}
 	call := c.contract.Call(methodInitLPP, uuid, partOffset, claimedSize)
-	return call.ToTxCandidate()
+	candidate, err := call.ToTxCandidate()
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create initLPP tx candidate: %w", err)
+	}
+	candidate.Value = bond
+	return candidate, nil
 }
 
 func (c *PreimageOracleContract) AddLeaves(uuid *big.Int, startingBlockIndex *big.Int, input []byte, commitments []common.Hash, finalize bool) (txmgr.TxCandidate, error) {

--- a/op-challenger/game/fault/contracts/oracle_test.go
+++ b/op-challenger/game/fault/contracts/oracle_test.go
@@ -164,6 +164,8 @@ func TestPreimageOracleContract_InitLargePreimage(t *testing.T) {
 	uuid := big.NewInt(123)
 	partOffset := uint32(1)
 	claimedSize := uint32(2)
+	bond := big.NewInt(42984)
+	stubRpc.SetResponse(oracleAddr, methodMinBondSizeLPP, rpcblock.Latest, nil, []interface{}{bond})
 	stubRpc.SetResponse(oracleAddr, methodInitLPP, rpcblock.Latest, []interface{}{
 		uuid,
 		partOffset,
@@ -173,6 +175,7 @@ func TestPreimageOracleContract_InitLargePreimage(t *testing.T) {
 	tx, err := oracle.InitLargePreimage(uuid, partOffset, claimedSize)
 	require.NoError(t, err)
 	stubRpc.VerifyTxCandidate(tx)
+	require.Truef(t, bond.Cmp(tx.Value) == 0, "Expected bond %v got %v", bond, tx.Value)
 }
 
 func TestPreimageOracleContract_AddLeaves(t *testing.T) {

--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -164,11 +164,6 @@ func (p *LargePreimageUploader) initLargePreimage(uuid *big.Int, partOffset uint
 	if err != nil {
 		return fmt.Errorf("failed to create pre-image oracle tx: %w", err)
 	}
-	bond, err := p.contract.GetMinBondLPP(context.Background())
-	if err != nil {
-		return fmt.Errorf("failed to get min bond for large preimage proposal: %w", err)
-	}
-	candidate.Value = bond
 	if err := p.txSender.SendAndWaitSimple("init large preimage", candidate); err != nil {
 		return fmt.Errorf("failed to populate pre-image oracle: %w", err)
 	}

--- a/op-e2e/e2eutils/transactions/send.go
+++ b/op-e2e/e2eutils/transactions/send.go
@@ -44,9 +44,10 @@ func WithReceiptFail() SendTxOpt {
 	}
 }
 
-func RequireSendTx(t *testing.T, ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) {
-	_, _, err := SendTx(ctx, client, candidate, privKey, opts...)
+func RequireSendTx(t *testing.T, ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) (*types.Transaction, *types.Receipt) {
+	tx, rcpt, err := SendTx(ctx, client, candidate, privKey, opts...)
 	require.NoError(t, err, "Failed to send transaction")
+	return tx, rcpt
 }
 
 func SendTx(ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) (*types.Transaction, *types.Receipt, error) {


### PR DESCRIPTION
**Description**

Migrate more e2e tests away from using generated bindings.

Bond for initing a large preimage upload is now automatically calculated when creating the tx candidate.