### PR TITLE
[op-conductor] Queue an action after conductor start

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -96,7 +96,6 @@ func NewOpConductor(
 		}
 		return nil, err
 	}
-	oc.prevState = NewState(oc.leader.Load(), oc.healthy.Load(), oc.seqActive.Load())
 
 	return oc, nil
 }
@@ -341,6 +340,10 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 	oc.metrics.RecordUp()
 
 	oc.log.Info("OpConductor started")
+	// queue an action in case sequencer is not in the desired state.
+	oc.prevState = NewState(oc.leader.Load(), oc.healthy.Load(), oc.seqActive.Load())
+	oc.queueAction()
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This is used to fix a bug when 
1. leader conductor restarted 
2. came back as follower
3. but node is still sequencing

At this phase, conductor won't queue an action to fix the state (stop sequencing on node), we solve this by queuing an action right after start (health status / read sequencer status are already refreshed before this) to try to bring it to the correct state.

**Tests**

N/A