### PR TITLE
op-challenger: Fix args for asterisc trace provider test

### DIFF
--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -185,7 +185,7 @@ func NewTraceProviderForTest(logger log.Logger, m AsteriscMetricer, cfg *config.
 		logger:         logger,
 		dir:            dir,
 		prestate:       cfg.AsteriscAbsolutePreState,
-		generator:      NewExecutor(logger, m, cfg, cfg.AsteriscNetwork, localInputs),
+		generator:      NewExecutor(logger, m, cfg, cfg.AsteriscAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
 		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(utils.PreimageDir(dir)).Get),
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Must use absolute prestate instead of network. Please refer https://github.com/ethereum-optimism/optimism/pull/10650/files#diff-cefe595503ac2dc67a0e3c951469f58d331aa8f87c611eddf9c76b2ffee3108b.

**Tests**

Found while running asterisc's e2e fault proof test suite, while syncing monorepo version at https://github.com/ethereum-optimism/asterisc/pull/62.


