### PR TITLE
contracts-bedrock: fix compiler warning

### DIFF
--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
@@ -17,7 +17,7 @@ contract CheckBalanceLowTest is Test {
     }
 
     /// @notice Test that the `name` function returns the correct value.
-    function test_name_succeeds() external {
+    function test_name_succeeds() external view {
         assertEq(c.name(), "CheckBalanceLow");
     }
 

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckGelatoLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckGelatoLow.t.sol
@@ -42,7 +42,7 @@ contract CheckGelatoLowTest is Test {
     }
 
     /// @notice Test that the `name` function returns the correct value.
-    function test_name_succeeds() external {
+    function test_name_succeeds() external view {
         assertEq(c.name(), "CheckGelatoLow");
     }
 

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
@@ -27,7 +27,7 @@ contract CheckSecretsTest is Test {
     }
 
     /// @notice Test that the `name` function returns the correct value.
-    function test_name_succeeds() external {
+    function test_name_succeeds() external view {
         assertEq(c.name(), "CheckSecrets");
     }
 

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
@@ -16,7 +16,7 @@ contract CheckTrueTest is Test {
     }
 
     /// @notice Test that the `name` function returns the correct value.
-    function test_name_succeeds() external {
+    function test_name_succeeds() external view {
         assertEq(c.name(), "CheckTrue");
     }
 


### PR DESCRIPTION
**Description**

Fixes the following compiler warning:

```
Compiler run successful with warnings:
Warning (2018): Function state mutability can be restricted to view
  --> test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol:20:5:
   |
20 |     function test_name_succeeds() external {
   |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
  --> test/periphery/drippie/dripchecks/CheckGelatoLow.t.sol:45:5:
   |
45 |     function test_name_succeeds() external {
   |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
  --> test/periphery/drippie/dripchecks/CheckSecrets.t.sol:30:5:
   |
30 |     function test_name_succeeds() external {
   |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
  --> test/periphery/drippie/dripchecks/CheckTrue.t.sol:19:5:
   |
19 |     function test_name_succeeds() external {
   |     ^ (Relevant source part starts here and spans across multiple lines).
```

This should be caught in CI, not sure why it wasn't

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

