### PR TITLE
op-node: implement event emitter/handler derivers, support first few Engine events

### DIFF
--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -34,7 +34,7 @@ func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bl
 // L2Sequencer is an actor that functions like a rollup node,
 // without the full P2P/API/Node stack, but just the derivation state, and simplified driver with sequencing ability.
 type L2Sequencer struct {
-	L2Verifier
+	*L2Verifier
 
 	sequencer *driver.Sequencer
 
@@ -52,7 +52,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 		actual: driver.NewL1OriginSelector(log, cfg, seqConfDepthL1),
 	}
 	return &L2Sequencer{
-		L2Verifier:              *ver,
+		L2Verifier:              ver,
 		sequencer:               driver.NewSequencer(log, cfg, ver.engine, attrBuilder, l1OriginSelector, metrics.NoopMetrics),
 		mockL1OriginSelector:    l1OriginSelector,
 		failL2GossipUnsafeBlock: nil,

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -4,6 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	gnode "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/attributes"
@@ -18,11 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/safego"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
-	gnode "github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/require"
 )
 
 // L2Verifier is an actor that functions like a rollup node,
@@ -286,12 +289,12 @@ func (s *L2Verifier) OnEvent(ev rollup.Event) {
 	case rollup.EngineTemporaryErrorEvent:
 		s.log.Warn("Derivation process temporary error", "err", x.Err)
 		if errors.Is(x.Err, sync.WrongChainErr) { // action-tests don't back off on temporary errors. Avoid a bad genesis setup from looping.
-			panic(fmt.Errorf("genesis setup issue: %v", x.Err))
+			panic(fmt.Errorf("genesis setup issue: %w", x.Err))
 		}
 	case rollup.ResetEvent:
 		s.log.Warn("Derivation pipeline is being reset", "err", x.Err)
 	case rollup.CriticalErrorEvent:
-		panic(fmt.Errorf("derivation failed critically: %v", x.Err))
+		panic(fmt.Errorf("derivation failed critically: %w", x.Err))
 	case driver.DeriverIdleEvent:
 		s.l2PipelineIdle = true
 	}

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -22,6 +22,7 @@ type Metrics interface {
 	RecordFrame()
 	RecordDerivedBatches(batchType string)
 	SetDerivationIdle(idle bool)
+	RecordPipelineReset()
 }
 
 type L1Fetcher interface {
@@ -194,6 +195,8 @@ func (dp *DerivationPipeline) Step(ctx context.Context, pendingSafeHead eth.L2Bl
 // initialReset does the initial reset work of finding the L1 point to rewind back to
 func (dp *DerivationPipeline) initialReset(ctx context.Context, resetL2Safe eth.L2BlockRef) error {
 	dp.log.Info("Rewinding derivation-pipeline L1 traversal to handle reset")
+
+	dp.metrics.RecordPipelineReset()
 
 	// Walk back L2 chain to find the L1 origin that is old enough to start buffering channel data from.
 	pipelineL2 := resetL2Safe

--- a/op-node/rollup/driver/steps.go
+++ b/op-node/rollup/driver/steps.go
@@ -1,0 +1,130 @@
+package driver
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+)
+
+type ResetStepBackoffEvent struct {
+}
+
+func (ev ResetStepBackoffEvent) String() string {
+	return "reset-step-backoff"
+}
+
+type StepReqEvent struct {
+	ResetBackoff bool
+}
+
+func (ev StepReqEvent) String() string {
+	return "step-req"
+}
+
+type StepAttemptEvent struct{}
+
+func (ev StepAttemptEvent) String() string {
+	return "step-attempt"
+}
+
+type StepEvent struct{}
+
+func (ev StepEvent) String() string {
+	return "step"
+}
+
+// StepSchedulingDeriver is a deriver that emits StepEvent events.
+// The deriver can be requested to schedule a step with a StepReqEvent.
+//
+// It is then up to the caller to translate scheduling into StepAttemptEvent emissions, by waiting for
+// NextStep or NextDelayedStep channels (nil if there is nothing to wait for, for channel-merging purposes).
+//
+// Upon StepAttemptEvent the scheduler will then emit a StepEvent,
+// while maintaining backoff state, to not spam steps.
+//
+// Backoff can be reset by sending a request with StepReqEvent.ResetBackoff
+// set to true, or by sending a ResetStepBackoffEvent.
+type StepSchedulingDeriver struct {
+
+	// keep track of consecutive failed attempts, to adjust the backoff time accordingly
+	stepAttempts int
+	bOffStrategy retry.Strategy
+
+	// channel, nil by default (not firing), but used to schedule re-attempts with delay
+	delayedStepReq <-chan time.Time
+
+	// stepReqCh is used to request that the driver attempts to step forward by one L1 block.
+	stepReqCh chan struct{}
+
+	log log.Logger
+
+	emitter rollup.EventEmitter
+}
+
+func NewStepSchedulingDeriver(log log.Logger, emitter rollup.EventEmitter) *StepSchedulingDeriver {
+	return &StepSchedulingDeriver{
+		stepAttempts:   0,
+		bOffStrategy:   retry.Exponential(),
+		stepReqCh:      make(chan struct{}, 1),
+		delayedStepReq: nil,
+		log:            log,
+		emitter:        emitter,
+	}
+}
+
+// NextStep is a channel to await, and if triggered,
+// the caller should emit a StepAttemptEvent to queue up a step while maintaining backoff.
+func (s *StepSchedulingDeriver) NextStep() <-chan struct{} {
+	return s.stepReqCh
+}
+
+// NextDelayedStep is a temporary channel to await, and if triggered,
+// the caller should emit a StepAttemptEvent to queue up a step while maintaining backoff.
+// The returned channel may be nil, if there is no requested step with delay scheduled.
+func (s *StepSchedulingDeriver) NextDelayedStep() <-chan time.Time {
+	return s.delayedStepReq
+}
+
+func (s *StepSchedulingDeriver) OnEvent(ev rollup.Event) {
+	step := func() {
+		s.delayedStepReq = nil
+		select {
+		case s.stepReqCh <- struct{}{}:
+		// Don't deadlock if the channel is already full
+		default:
+		}
+	}
+
+	switch x := ev.(type) {
+	case StepReqEvent:
+		if x.ResetBackoff {
+			s.stepAttempts = 0
+		}
+		if s.stepAttempts > 0 {
+			// if this is not the first attempt, we re-schedule with a backoff, *without blocking other events*
+			if s.delayedStepReq == nil {
+				delay := s.bOffStrategy.Duration(s.stepAttempts)
+				s.log.Debug("scheduling re-attempt with delay", "attempts", s.stepAttempts, "delay", delay)
+				s.delayedStepReq = time.After(delay)
+			} else {
+				s.log.Debug("ignoring step request, already scheduled re-attempt after previous failure", "attempts", s.stepAttempts)
+			}
+		} else {
+			step()
+		}
+	case StepAttemptEvent:
+		// clear the delayed-step channel
+		s.delayedStepReq = nil
+		if s.stepAttempts > 0 {
+			s.log.Debug("Running step retry", "attempts", s.stepAttempts)
+		}
+		// count as attempt by default. We reset to 0 if we are making healthy progress.
+		s.stepAttempts += 1
+		s.emitter.Emit(StepEvent{})
+	case ResetStepBackoffEvent:
+		s.stepAttempts = 0
+	}
+}

--- a/op-node/rollup/driver/steps_test.go
+++ b/op-node/rollup/driver/steps_test.go
@@ -1,0 +1,53 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestStepSchedulingDeriver(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	var queued []rollup.Event
+	emitter := rollup.EmitterFunc(func(ev rollup.Event) {
+		queued = append(queued, ev)
+	})
+	sched := NewStepSchedulingDeriver(logger, emitter)
+	require.Len(t, sched.NextStep(), 0, "start empty")
+	sched.OnEvent(StepReqEvent{})
+	require.Len(t, sched.NextStep(), 1, "take request")
+	sched.OnEvent(StepReqEvent{})
+	require.Len(t, sched.NextStep(), 1, "ignore duplicate request")
+	require.Empty(t, queued, "only scheduled so far, no step attempts yet")
+	<-sched.NextStep()
+	sched.OnEvent(StepAttemptEvent{})
+	require.Equal(t, []rollup.Event{StepEvent{}}, queued, "got step event")
+	require.Nil(t, sched.NextDelayedStep(), "no delayed steps yet")
+	sched.OnEvent(StepReqEvent{})
+	require.NotNil(t, sched.NextDelayedStep(), "2nd attempt before backoff reset causes delayed step to be scheduled")
+	sched.OnEvent(StepReqEvent{})
+	require.NotNil(t, sched.NextDelayedStep(), "can continue to request attempts")
+
+	sched.OnEvent(StepReqEvent{})
+	require.Len(t, sched.NextStep(), 0, "no step requests accepted without delay if backoff is counting")
+
+	sched.OnEvent(StepReqEvent{ResetBackoff: true})
+	require.Len(t, sched.NextStep(), 1, "request accepted if backoff is reset")
+	<-sched.NextStep()
+
+	sched.OnEvent(StepReqEvent{})
+	require.Len(t, sched.NextStep(), 1, "no backoff, no attempt has been made yet")
+	<-sched.NextStep()
+	sched.OnEvent(StepAttemptEvent{})
+	sched.OnEvent(StepReqEvent{})
+	require.Len(t, sched.NextStep(), 0, "backoff again")
+
+	sched.OnEvent(ResetStepBackoffEvent{})
+	sched.OnEvent(StepReqEvent{})
+	require.Len(t, sched.NextStep(), 1, "reset backoff accepted, was able to schedule non-delayed step")
+}

--- a/op-node/rollup/driver/synchronous.go
+++ b/op-node/rollup/driver/synchronous.go
@@ -1,0 +1,78 @@
+package driver
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+)
+
+// Don't queue up an endless number of events.
+// At some point it's better to drop events and warn something is exploding the number of events.
+const sanityEventLimit = 1000
+
+// SynchronousEvents is a rollup.EventEmitter that a rollup.Deriver can emit events to.
+// The events will be queued up, and can then be executed synchronously by calling the Drain function,
+// which will apply all events to the root Deriver that
+// New events may be queued up while events are being processed by the root rollup.Deriver.
+type SynchronousEvents struct {
+	// The lock is no-op in FP execution, if running in synchronous FP-VM.
+	// This lock ensures that all emitted events are merged together correctly,
+	// if this util is used in a concurrent context.
+	evLock sync.Mutex
+
+	events []rollup.Event
+
+	log log.Logger
+
+	ctx context.Context
+
+	root rollup.Deriver
+}
+
+func NewSynchronousEvents(log log.Logger, ctx context.Context, root rollup.Deriver) *SynchronousEvents {
+	return &SynchronousEvents{
+		log:  log,
+		ctx:  ctx,
+		root: root,
+	}
+}
+
+func (s *SynchronousEvents) Emit(event rollup.Event) {
+	s.evLock.Lock()
+	defer s.evLock.Unlock()
+
+	if s.ctx.Err() != nil {
+		s.log.Warn("Ignoring emitted event during shutdown", "event", event)
+		return
+	}
+
+	// sanity limit, never queue too many events
+	if len(s.events) >= sanityEventLimit {
+		s.log.Error("something is very wrong, queued up too many events! Dropping event", "ev", event)
+		return
+	}
+	s.events = append(s.events, event)
+}
+
+func (s *SynchronousEvents) Drain() error {
+	for {
+		if s.ctx.Err() != nil {
+			return s.ctx.Err()
+		}
+		if len(s.events) == 0 {
+			return nil
+		}
+
+		s.evLock.Lock()
+		first := s.events[0]
+		s.events = s.events[1:]
+		s.evLock.Unlock()
+
+		s.root.OnEvent(first)
+	}
+}
+
+var _ rollup.EventEmitter = (*SynchronousEvents)(nil)

--- a/op-node/rollup/driver/synchronous.go
+++ b/op-node/rollup/driver/synchronous.go
@@ -15,7 +15,7 @@ const sanityEventLimit = 1000
 
 // SynchronousEvents is a rollup.EventEmitter that a rollup.Deriver can emit events to.
 // The events will be queued up, and can then be executed synchronously by calling the Drain function,
-// which will apply all events to the root Deriver that
+// which will apply all events to the root Deriver.
 // New events may be queued up while events are being processed by the root rollup.Deriver.
 type SynchronousEvents struct {
 	// The lock is no-op in FP execution, if running in synchronous FP-VM.
@@ -51,7 +51,7 @@ func (s *SynchronousEvents) Emit(event rollup.Event) {
 
 	// sanity limit, never queue too many events
 	if len(s.events) >= sanityEventLimit {
-		s.log.Error("something is very wrong, queued up too many events! Dropping event", "ev", event)
+		s.log.Error("Something is very wrong, queued up too many events! Dropping event", "ev", event)
 		return
 	}
 	s.events = append(s.events, event)

--- a/op-node/rollup/driver/synchronous_test.go
+++ b/op-node/rollup/driver/synchronous_test.go
@@ -1,0 +1,65 @@
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+type TestEvent struct{}
+
+func (ev TestEvent) String() string {
+	return "X"
+}
+
+func TestSynchronousEvents(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	ctx, cancel := context.WithCancel(context.Background())
+	count := 0
+	deriver := rollup.DeriverFunc(func(ev rollup.Event) {
+		count += 1
+	})
+	syncEv := NewSynchronousEvents(logger, ctx, deriver)
+	require.NoError(t, syncEv.Drain(), "can drain, even if empty")
+
+	syncEv.Emit(TestEvent{})
+	require.Equal(t, 0, count, "no processing yet, queued event")
+	require.NoError(t, syncEv.Drain())
+	require.Equal(t, 1, count, "processed event")
+
+	syncEv.Emit(TestEvent{})
+	syncEv.Emit(TestEvent{})
+	require.Equal(t, 1, count, "no processing yet, queued events")
+	require.NoError(t, syncEv.Drain())
+	require.Equal(t, 3, count, "processed events")
+
+	cancel()
+	syncEv.Emit(TestEvent{})
+	require.Equal(t, ctx.Err(), syncEv.Drain(), "no draining after close")
+	require.Equal(t, 3, count, "didn't process event after trigger close")
+}
+
+func TestSynchronousEventsSanityLimit(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	count := 0
+	deriver := rollup.DeriverFunc(func(ev rollup.Event) {
+		count += 1
+	})
+	syncEv := NewSynchronousEvents(logger, context.Background(), deriver)
+	// emit 1 too many events
+	for i := 0; i < sanityEventLimit+1; i++ {
+		syncEv.Emit(TestEvent{})
+	}
+	require.NoError(t, syncEv.Drain())
+	require.Equal(t, sanityEventLimit, count, "processed all non-dropped events")
+
+	syncEv.Emit(TestEvent{})
+	require.NoError(t, syncEv.Drain())
+	require.Equal(t, sanityEventLimit+1, count, "back to normal after drain")
+}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+type Resource string
+
+type TryBackupUnsafeReorgEvent struct {
+}
+
+func (ev TryBackupUnsafeReorgEvent) String() string {
+	return "try-backup-unsafe-reorg"
+}
+
+type TryUpdateEngineEvent struct {
+}
+
+func (ev TryUpdateEngineEvent) String() string {
+	return "try-update-engine"
+}
+
+type NewPayloadEvent struct {
+	Envelope *eth.ExecutionPayloadEnvelope
+}
+
+type ForkchoiceState struct {
+	Unsafe    eth.L2BlockRef
+	Safe      eth.L2BlockRef
+	Finalized eth.L2BlockRef
+	// ...
+}
+
+type EngineUpdatedEvent struct {
+	State ForkchoiceState
+}
+
+type EngDeriver struct {
+	log     log.Logger
+	cfg     *rollup.Config
+	ec      *EngineController
+	ctx     context.Context
+	emitter rollup.EventEmitter
+}
+
+var _ rollup.Deriver = (*EngDeriver)(nil)
+
+func NewEngDeriver(log log.Logger, ctx context.Context, cfg *rollup.Config,
+	ec *EngineController, emitter rollup.EventEmitter) *EngDeriver {
+	return &EngDeriver{
+		log:     log,
+		cfg:     cfg,
+		ec:      ec,
+		ctx:     ctx,
+		emitter: emitter,
+	}
+}
+
+func (d *EngDeriver) OnEvent(ev rollup.Event) {
+	switch ev.(type) {
+	case TryBackupUnsafeReorgEvent:
+		// If we don't need to call FCU to restore unsafeHead using backupUnsafe, keep going b/c
+		// this was a no-op(except correcting invalid state when backupUnsafe is empty but TryBackupUnsafeReorg called).
+		fcuCalled, err := d.ec.TryBackupUnsafeReorg(d.ctx)
+		// Dealing with legacy here: it used to skip over the error-handling if fcuCalled was false.
+		// But that combination is not actually a code-path in TryBackupUnsafeReorg.
+		// We should drop fcuCalled, and make the function emit events directly,
+		// once there are no more synchronous callers.
+		if !fcuCalled && err != nil {
+			d.log.Crit("unexpected TryBackupUnsafeReorg error after no FCU call", "err", err)
+		}
+		if err != nil {
+			// If we needed to perform a network call, then we should yield even if we did not encounter an error.
+			if errors.Is(err, derive.ErrReset) {
+				d.emitter.Emit(rollup.ResetEvent{Err: err})
+			} else if errors.Is(err, derive.ErrTemporary) {
+				d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
+			} else {
+				d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unexpected TryBackupUnsafeReorg error type: %w", err)})
+			}
+		}
+	case TryUpdateEngineEvent:
+		// If we don't need to call FCU, keep going b/c this was a no-op. If we needed to
+		// perform a network call, then we should yield even if we did not encounter an error.
+		if err := d.ec.TryUpdateEngine(d.ctx); err != nil && !errors.Is(err, ErrNoFCUNeeded) {
+			if errors.Is(err, derive.ErrReset) {
+				d.emitter.Emit(rollup.ResetEvent{Err: err})
+			} else if errors.Is(err, derive.ErrTemporary) {
+				d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
+			} else {
+				d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unexpected TryUpdateEngine error type: %w", err)})
+			}
+		}
+		// TODO handle more events:
+		//case NewPayloadEvent:
+		//	ref, err := derive.PayloadToBlockRef(d.cfg, x.Envelope.ExecutionPayload)
+		//	err := d.ec.InsertUnsafePayload(ctx, x.Envelope, ref)
+		//	// TODO emit events for error / success
+		//	// CancelPayload
+		//	// SetPendingSafeL2Head
+		//	// SetBackupUnsafeL2Head
+		//	// SetSafeHead
+		//	// InsertUnsafePayload
+		//	// SetFinalizedHead
+	}
+	// TODO emit more events:
+	// Emit:
+	// - payload processing success
+	// - payload processing error
+	// - attributes processing success (incl original AttributesWithParent data)
+	// - attributes processing error
+	// - forkchoice needs update
+	// - unsafe head changed
+	// - safe head changed
+	// - finalized head changed
+	//
+}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -8,12 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
-
-type Resource string
 
 type TryBackupUnsafeReorgEvent struct {
 }
@@ -27,21 +23,6 @@ type TryUpdateEngineEvent struct {
 
 func (ev TryUpdateEngineEvent) String() string {
 	return "try-update-engine"
-}
-
-type NewPayloadEvent struct {
-	Envelope *eth.ExecutionPayloadEnvelope
-}
-
-type ForkchoiceState struct {
-	Unsafe    eth.L2BlockRef
-	Safe      eth.L2BlockRef
-	Finalized eth.L2BlockRef
-	// ...
-}
-
-type EngineUpdatedEvent struct {
-	State ForkchoiceState
 }
 
 type EngDeriver struct {
@@ -100,27 +81,5 @@ func (d *EngDeriver) OnEvent(ev rollup.Event) {
 				d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unexpected TryUpdateEngine error type: %w", err)})
 			}
 		}
-		// TODO handle more events:
-		//case NewPayloadEvent:
-		//	ref, err := derive.PayloadToBlockRef(d.cfg, x.Envelope.ExecutionPayload)
-		//	err := d.ec.InsertUnsafePayload(ctx, x.Envelope, ref)
-		//	// TODO emit events for error / success
-		//	// CancelPayload
-		//	// SetPendingSafeL2Head
-		//	// SetBackupUnsafeL2Head
-		//	// SetSafeHead
-		//	// InsertUnsafePayload
-		//	// SetFinalizedHead
 	}
-	// TODO emit more events:
-	// Emit:
-	// - payload processing success
-	// - payload processing error
-	// - attributes processing success (incl original AttributesWithParent data)
-	// - attributes processing error
-	// - forkchoice needs update
-	// - unsafe head changed
-	// - safe head changed
-	// - finalized head changed
-	//
 }

--- a/op-node/rollup/events.go
+++ b/op-node/rollup/events.go
@@ -1,0 +1,82 @@
+package rollup
+
+import "github.com/ethereum/go-ethereum/log"
+
+type Event interface {
+	String() string
+}
+
+type Deriver interface {
+	OnEvent(ev Event)
+}
+
+type EventEmitter interface {
+	Emit(ev Event)
+}
+
+type EmitterFunc func(ev Event)
+
+func (fn EmitterFunc) Emit(ev Event) {
+	fn(ev)
+}
+
+type EngineTemporaryErrorEvent struct {
+	Err error
+}
+
+var _ Event = EngineTemporaryErrorEvent{}
+
+func (ev EngineTemporaryErrorEvent) String() string {
+	return "engine-temporary-error"
+}
+
+type ResetEvent struct {
+	Err error
+}
+
+var _ Event = ResetEvent{}
+
+func (ev ResetEvent) String() string {
+	return "reset-event"
+}
+
+type CriticalErrorEvent struct {
+	Err error
+}
+
+var _ Event = CriticalErrorEvent{}
+
+func (ev CriticalErrorEvent) String() string {
+	return "critical-error"
+}
+
+type SynchronousDerivers []Deriver
+
+func (s *SynchronousDerivers) OnEvent(ev Event) {
+	for _, d := range *s {
+		d.OnEvent(ev)
+	}
+}
+
+var _ Deriver = (*SynchronousDerivers)(nil)
+
+type DebugDeriver struct {
+	Log log.Logger
+}
+
+func (d DebugDeriver) OnEvent(ev Event) {
+	d.Log.Debug("on-event", "event", ev)
+}
+
+type NoopDeriver struct{}
+
+func (d NoopDeriver) OnEvent(ev Event) {}
+
+// DeriverFunc implements the Deriver interface as a function,
+// similar to how the std-lib http HandlerFunc implements a Handler.
+// This can be used for small in-place derivers, test helpers, etc.
+type DeriverFunc func(ev Event)
+
+func (fn DeriverFunc) OnEvent(ev Event) {
+	fn(ev)
+}

--- a/op-node/rollup/events_test.go
+++ b/op-node/rollup/events_test.go
@@ -1,0 +1,50 @@
+package rollup
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TestEvent struct{}
+
+func (ev TestEvent) String() string {
+	return "X"
+}
+
+func TestSynchronousDerivers_OnEvent(t *testing.T) {
+	result := ""
+	a := DeriverFunc(func(ev Event) {
+		result += fmt.Sprintf("A:%s\n", ev)
+	})
+	b := DeriverFunc(func(ev Event) {
+		result += fmt.Sprintf("B:%s\n", ev)
+	})
+	c := DeriverFunc(func(ev Event) {
+		result += fmt.Sprintf("C:%s\n", ev)
+	})
+
+	x := SynchronousDerivers{}
+	x.OnEvent(TestEvent{})
+	require.Equal(t, "", result)
+
+	x = SynchronousDerivers{a}
+	x.OnEvent(TestEvent{})
+	require.Equal(t, "A:X\n", result)
+
+	result = ""
+	x = SynchronousDerivers{a, a}
+	x.OnEvent(TestEvent{})
+	require.Equal(t, "A:X\nA:X\n", result)
+
+	result = ""
+	x = SynchronousDerivers{a, b}
+	x.OnEvent(TestEvent{})
+	require.Equal(t, "A:X\nB:X\n", result)
+
+	result = ""
+	x = SynchronousDerivers{a, b, c}
+	x.OnEvent(TestEvent{})
+	require.Equal(t, "A:X\nB:X\nC:X\n", result)
+}

--- a/op-service/safego/nocopy.go
+++ b/op-service/safego/nocopy.go
@@ -1,0 +1,29 @@
+package safego
+
+// NoCopy is a super simple safety util taken from the Go atomic lib.
+//
+// NoCopy may be added to structs which must not be copied
+// after the first use.
+//
+// The NoCopy struct is empty, so should be a zero-cost util at runtime.
+//
+// See https://golang.org/issues/8005#issuecomment-190753527
+// for details.
+//
+// Note that it must not be embedded, due to the Lock and Unlock methods.
+//
+// Like:
+// ```
+//
+//	type Example {
+//		   V uint64
+//		   _ NoCopy
+//	}
+//
+// Then run: `go vet -copylocks .`
+// ```
+type NoCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*NoCopy) Lock()   {}
+func (*NoCopy) Unlock() {}

--- a/op-service/testutils/metrics.go
+++ b/op-service/testutils/metrics.go
@@ -69,3 +69,6 @@ func (n *TestRPCMetrics) RecordRPCClientRequest(method string) func(err error) {
 func (n *TestRPCMetrics) RecordRPCClientResponse(method string, err error) {}
 
 func (t *TestDerivationMetrics) SetDerivationIdle(idle bool) {}
+
+func (t *TestDerivationMetrics) RecordPipelineReset() {
+}


### PR DESCRIPTION
**Description**

This introduces the concept of an event emitter and event handler to the driver package.

The idea is to follow the event-pattern as descibed in the design-doc here: https://github.com/ethereum-optimism/design-docs/blob/main/protocol/op-node-derivers.md

We can't refactor all of the driver modules at once, but incrementally we can make this  work.

The first step is to support synchronous event-handling, and handle just the first few engine-updates, to get the events abstraction in place.

Note: this PR depends on #10782 

Do not merge until the base PR is merged.

This change is still relatively experimental, I may have missed some failing e2e tests. Will investigate if so.

**Tests**

- Unit-test the synchronous event processing
- Unit-test some new events utils
- `SyncDeriver` now has more code-sharing with action-test `L2Verifier`. 

**Additional context**

Compared to the design doc I opted for more simple `Events`, as interfaces around objects. We can make the derivers handle the resource-parallelism their own way. At least for now there's no need to enshrine a `Resource` data attribute yet.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/10854
