### PR TITLE
feat(sdk): add DGF address for OP Mainnet

### DIFF
--- a/.changeset/silver-onions-battle.md
+++ b/.changeset/silver-onions-battle.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Updates address for DGF on Mainnet

--- a/packages/sdk/src/utils/chain-constants.ts
+++ b/packages/sdk/src/utils/chain-constants.ts
@@ -34,7 +34,7 @@ const l1CrossDomainMessengerAddresses = {
 }
 
 const disputeGameFactoryAddresses = {
-  mainnet: ethers.constants.AddressZero,
+  mainnet: '0xe5965Ab5962eDc7477C8520243A95517CD252fA9',
   goerli: ethers.constants.AddressZero,
   sepolia: '0x05F9613aDB30026FFd634f38e5C4dFd30a197Fa1',
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds the DGF address for OP Mainnet.
