### PR TITLE
monorepo: remove dead indexer reference

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 packages:
   - 'packages/*'
-  - 'indexer/api-ts'


### PR DESCRIPTION
**Description**

The `pnpm-workspace.yaml` file should no longer
include a reference to the ts package that was removed
along with the `indexer`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

