### PR TITLE
op-chain-ops: cleanup foundry package

### DIFF
--- a/op-chain-ops/foundry/artifact.go
+++ b/op-chain-ops/foundry/artifact.go
@@ -4,11 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/holiman/uint256"
+	"golang.org/x/exp/maps"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/solc"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // Artifact represents a foundry compilation artifact.
@@ -85,4 +91,54 @@ func ReadArtifact(path string) (*Artifact, error) {
 		return nil, err
 	}
 	return &artifact, nil
+}
+
+type ForgeAllocs struct {
+	Accounts types.GenesisAlloc
+}
+
+func (d *ForgeAllocs) Copy() *ForgeAllocs {
+	out := make(types.GenesisAlloc, len(d.Accounts))
+	maps.Copy(out, d.Accounts)
+	return &ForgeAllocs{Accounts: out}
+}
+
+func (d *ForgeAllocs) UnmarshalJSON(b []byte) error {
+	// forge, since integrating Alloy, likes to hex-encode everything.
+	type forgeAllocAccount struct {
+		Balance hexutil.U256                `json:"balance"`
+		Nonce   hexutil.Uint64              `json:"nonce"`
+		Code    hexutil.Bytes               `json:"code,omitempty"`
+		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+	}
+	var allocs map[common.Address]forgeAllocAccount
+	if err := json.Unmarshal(b, &allocs); err != nil {
+		return err
+	}
+	d.Accounts = make(types.GenesisAlloc, len(allocs))
+	for addr, acc := range allocs {
+		acc := acc
+		d.Accounts[addr] = types.Account{
+			Code:       acc.Code,
+			Storage:    acc.Storage,
+			Balance:    (*uint256.Int)(&acc.Balance).ToBig(),
+			Nonce:      (uint64)(acc.Nonce),
+			PrivateKey: nil,
+		}
+	}
+	return nil
+}
+
+func LoadForgeAllocs(allocsPath string) (*ForgeAllocs, error) {
+	path := filepath.Join(allocsPath)
+	f, err := os.OpenFile(path, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open forge allocs %q: %w", path, err)
+	}
+	defer f.Close()
+	var out ForgeAllocs
+	if err := json.NewDecoder(f).Decode(&out); err != nil {
+		return nil, fmt.Errorf("failed to json-decode forge allocs %q: %w", path, err)
+	}
+	return &out, nil
 }

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -10,9 +10,6 @@ import (
 	"path/filepath"
 	"reflect"
 
-	"github.com/holiman/uint256"
-	"golang.org/x/exp/maps"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -794,42 +791,6 @@ func NewL1Deployments(path string) (*L1Deployments, error) {
 	}
 
 	return &deployments, nil
-}
-
-type ForgeAllocs struct {
-	Accounts types.GenesisAlloc
-}
-
-func (d *ForgeAllocs) Copy() *ForgeAllocs {
-	out := make(types.GenesisAlloc, len(d.Accounts))
-	maps.Copy(out, d.Accounts)
-	return &ForgeAllocs{Accounts: out}
-}
-
-func (d *ForgeAllocs) UnmarshalJSON(b []byte) error {
-	// forge, since integrating Alloy, likes to hex-encode everything.
-	type forgeAllocAccount struct {
-		Balance hexutil.U256                `json:"balance"`
-		Nonce   hexutil.Uint64              `json:"nonce"`
-		Code    hexutil.Bytes               `json:"code,omitempty"`
-		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
-	}
-	var allocs map[common.Address]forgeAllocAccount
-	if err := json.Unmarshal(b, &allocs); err != nil {
-		return err
-	}
-	d.Accounts = make(types.GenesisAlloc, len(allocs))
-	for addr, acc := range allocs {
-		acc := acc
-		d.Accounts[addr] = types.Account{
-			Code:       acc.Code,
-			Storage:    acc.Storage,
-			Balance:    (*uint256.Int)(&acc.Balance).ToBig(),
-			Nonce:      (uint64)(acc.Nonce),
-			PrivateKey: nil,
-		}
-	}
-	return nil
 }
 
 type MarshalableRPCBlockNumberOrHash rpc.BlockNumberOrHash

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
@@ -18,7 +20,7 @@ const PrecompileCount = 256
 // all of the state required for an Optimism network to function.
 // It is expected that the dump contains all of the required state to bootstrap
 // the L1 chain.
-func BuildL1DeveloperGenesis(config *DeployConfig, dump *ForgeAllocs, l1Deployments *L1Deployments) (*core.Genesis, error) {
+func BuildL1DeveloperGenesis(config *DeployConfig, dump *foundry.ForgeAllocs, l1Deployments *L1Deployments) (*core.Genesis, error) {
 	log.Info("Building developer L1 genesis block")
 	genesis, err := NewL1Genesis(config)
 	if err != nil {

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -1,11 +1,8 @@
 package genesis
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
-	"os"
-	"path/filepath"
 
 	hdwallet "github.com/ethereum-optimism/go-ethereum-hdwallet"
 	"github.com/holiman/uint256"
@@ -16,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 )
 
@@ -34,10 +32,10 @@ var (
 	testMnemonic = "test test test test test test test test test test test junk"
 )
 
-type AllocsLoader func(mode L2AllocsMode) *ForgeAllocs
+type AllocsLoader func(mode L2AllocsMode) *foundry.ForgeAllocs
 
 // BuildL2Genesis will build the L2 genesis block.
-func BuildL2Genesis(config *DeployConfig, dump *ForgeAllocs, l1StartBlock *types.Block) (*core.Genesis, error) {
+func BuildL2Genesis(config *DeployConfig, dump *foundry.ForgeAllocs, l1StartBlock *types.Block) (*core.Genesis, error) {
 	genspec, err := NewL2Genesis(config, l1StartBlock)
 	if err != nil {
 		return nil, err
@@ -93,18 +91,4 @@ func HasAnyDevAccounts(allocs types.GenesisAlloc) (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-func LoadForgeAllocs(allocsPath string) (*ForgeAllocs, error) {
-	path := filepath.Join(allocsPath)
-	f, err := os.OpenFile(path, os.O_RDONLY, 0644)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open forge allocs %q: %w", path, err)
-	}
-	defer f.Close()
-	var out ForgeAllocs
-	if err := json.NewDecoder(f).Decode(&out); err != nil {
-		return nil, fmt.Errorf("failed to json-decode forge allocs %q: %w", path, err)
-	}
-	return &out, nil
 }

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/external"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
@@ -39,12 +40,12 @@ var (
 	// in end to end tests.
 
 	// L1Allocs represents the L1 genesis block state.
-	L1Allocs *genesis.ForgeAllocs
+	L1Allocs *foundry.ForgeAllocs
 	// L1Deployments maps contract names to accounts in the L1
 	// genesis block state.
 	L1Deployments *genesis.L1Deployments
 	// l2Allocs represents the L2 allocs, by hardfork/mode (e.g. delta, ecotone, interop, other)
-	l2Allocs map[genesis.L2AllocsMode]*genesis.ForgeAllocs
+	l2Allocs map[genesis.L2AllocsMode]*foundry.ForgeAllocs
 	// DeployConfig represents the deploy config used by the system.
 	DeployConfig *genesis.DeployConfig
 	// ExternalL2Shim is the shim to use if external ethereum client testing is
@@ -107,14 +108,14 @@ func init() {
 		return
 	}
 
-	L1Allocs, err = genesis.LoadForgeAllocs(l1AllocsPath)
+	L1Allocs, err = foundry.LoadForgeAllocs(l1AllocsPath)
 	if err != nil {
 		panic(err)
 	}
-	l2Allocs = make(map[genesis.L2AllocsMode]*genesis.ForgeAllocs)
+	l2Allocs = make(map[genesis.L2AllocsMode]*foundry.ForgeAllocs)
 	mustL2Allocs := func(mode genesis.L2AllocsMode) {
 		name := "allocs-l2-" + string(mode)
-		allocs, err := genesis.LoadForgeAllocs(filepath.Join(l2AllocsDir, name+".json"))
+		allocs, err := foundry.LoadForgeAllocs(filepath.Join(l2AllocsDir, name+".json"))
 		if err != nil {
 			panic(err)
 		}
@@ -153,7 +154,7 @@ func init() {
 	}
 }
 
-func L2Allocs(mode genesis.L2AllocsMode) *genesis.ForgeAllocs {
+func L2Allocs(mode genesis.L2AllocsMode) *foundry.ForgeAllocs {
 	allocs, ok := l2Allocs[mode]
 	if !ok {
 		panic(fmt.Errorf("unknown L2 allocs mode: %q", mode))

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 )
@@ -112,9 +113,9 @@ var Subcommands = cli.Commands{
 				return fmt.Errorf("deploy config at %s invalid: %w", deployConfig, err)
 			}
 
-			var dump *genesis.ForgeAllocs
+			var dump *foundry.ForgeAllocs
 			if l1Allocs := ctx.String("l1-allocs"); l1Allocs != "" {
-				dump, err = genesis.LoadForgeAllocs(l1Allocs)
+				dump, err = foundry.LoadForgeAllocs(l1Allocs)
 				if err != nil {
 					return err
 				}
@@ -169,9 +170,9 @@ var Subcommands = cli.Commands{
 				}
 			}
 
-			var l2Allocs *genesis.ForgeAllocs
+			var l2Allocs *foundry.ForgeAllocs
 			if l2AllocsPath := ctx.String("l2-allocs"); l2AllocsPath != "" {
-				l2Allocs, err = genesis.LoadForgeAllocs(l2AllocsPath)
+				l2Allocs, err = foundry.LoadForgeAllocs(l2AllocsPath)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
**Description**

Moves the foundry related code into the foundry package.
We have some code for reading the allocs that foundry writes
to disk with `vm.dumpState(string)`. It makes more sense to
have these functions and types in the `foundry` package
rather than the `genesis` package.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

