### PR TITLE
Update batch_queue.go

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -166,7 +166,8 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		}
 	}
 
-	// Finally attempt to derive more batches
+	// Finally attempt to derive and validate batches per
+	// https://specs.optimism.io/protocol/derivation.html#batch-queue
 	batch, err := bq.deriveNextBatch(ctx, outOfData, parent)
 	if err == io.EOF && outOfData {
 		return nil, false, io.EOF


### PR DESCRIPTION
**Description**

This comment is very confusing. "derive more batches" implies adding more batches into `bq.batches` but that's not the case

- `NextBatch`: first decode data from the channel reader stage and call `deriveNextBatch`
- `deriveNextBatch`: is more about validating the batches