### PR TITLE
op-chain-ops: Fix the bug in op-version-check

### DIFF
--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -141,12 +141,22 @@ func entrypoint(ctx *cli.Context) error {
 			contracts["L1CrossDomainMessenger"] = Contract{Version: versions.L1CrossDomainMessenger, Address: addresses.L1CrossDomainMessengerProxy}
 			contracts["L1ERC721Bridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1ERC721BridgeProxy}
 			contracts["L1StandardBridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1StandardBridgeProxy}
-			contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
 			contracts["OptimismMintableERC20Factory"] = Contract{Version: versions.OptimismMintableERC20Factory, Address: addresses.OptimismMintableERC20FactoryProxy}
 			contracts["OptimismPortal"] = Contract{Version: versions.OptimismPortal, Address: addresses.OptimismPortalProxy}
 			contracts["SystemConfig"] = Contract{Version: versions.SystemConfig, Address: addresses.SystemConfigProxy}
 			contracts["ProxyAdmin"] = Contract{Version: "null", Address: addresses.ProxyAdmin}
-
+			// If L2OutputOracle is the nil, it indicates that the fault-proof system is enabled.
+			if versions.L2OutputOracle == "" {
+				contracts["AnchorStateRegistry"] = Contract{Version: versions.AnchorStateRegistry, Address: addresses.AnchorStateRegistryProxy}
+				contracts["DelayedWETH"] = Contract{Version: versions.DelayedWETH, Address: addresses.DelayedWETHProxy}
+				contracts["DisputeGameFactory"] = Contract{Version: versions.DisputeGameFactory, Address: addresses.DisputeGameFactoryProxy}
+				contracts["FaultDisputeGame"] = Contract{Version: versions.FaultDisputeGame, Address: addresses.FaultDisputeGame}
+				contracts["MIPS"] = Contract{Version: versions.MIPS, Address: addresses.MIPS}
+				contracts["PermissionedDisputeGame"] = Contract{Version: versions.PermissionedDisputeGame, Address: addresses.PermissionedDisputeGame}
+				contracts["PreimageOracle"] = Contract{Version: versions.PreimageOracle, Address: addresses.PreimageOracle}
+			} else {
+				contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
+			}
 			output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: l2ChainID, Contracts: contracts})
 
 			log.Info("Successfully processed contract versions", "chain", chainConfig.Name, "l1-chain-id", l1ChainID, "l2-chain-id", l2ChainID)

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -91,10 +91,6 @@ func GetContractVersions(ctx context.Context, addresses *superchain.AddressList,
 	if err != nil {
 		return versions, fmt.Errorf("L1StandardBridge: %w", err)
 	}
-	versions.L2OutputOracle, err = getVersion(ctx, common.Address(addresses.L2OutputOracleProxy), backend)
-	if err != nil {
-		return versions, fmt.Errorf("L2OutputOracle: %w", err)
-	}
 	versions.OptimismMintableERC20Factory, err = getVersion(ctx, common.Address(addresses.OptimismMintableERC20FactoryProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("OptimismMintableERC20Factory: %w", err)
@@ -106,6 +102,49 @@ func GetContractVersions(ctx context.Context, addresses *superchain.AddressList,
 	versions.SystemConfig, err = getVersion(ctx, common.Address(addresses.SystemConfigProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("SystemConfig: %w", err)
+	}
+	// If L2OutputOracleProxy is the zero address, it indicates that the fault-proof system is enabled.
+    l2OutputOracleAddress := common.Address(addresses.L2OutputOracleProxy)
+    if l2OutputOracleAddress == (common.Address{}) {
+		versions.AnchorStateRegistry, err = getVersion(ctx, common.Address(addresses.AnchorStateRegistryProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("AnchorStateRegistryProxy: %w", err)
+		}
+
+		versions.DelayedWETH, err = getVersion(ctx, common.Address(addresses.DelayedWETHProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("DelayedWETHProxy: %w", err)
+		}
+
+		versions.DisputeGameFactory, err = getVersion(ctx, common.Address(addresses.DisputeGameFactoryProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("DisputeGameFactoryProxy: %w", err)
+		}
+
+		versions.FaultDisputeGame, err = getVersion(ctx, common.Address(addresses.FaultDisputeGame), backend)
+		if err != nil {
+			return versions, fmt.Errorf("FaultDisputeGame: %w", err)
+		}
+
+		versions.MIPS, err = getVersion(ctx, common.Address(addresses.MIPS), backend)
+		if err != nil {
+			return versions, fmt.Errorf("MIPS: %w", err)
+		}
+
+		versions.PermissionedDisputeGame, err = getVersion(ctx, common.Address(addresses.PermissionedDisputeGame), backend)
+		if err != nil {
+			return versions, fmt.Errorf("PermissionedDisputeGame: %w", err)
+		}
+
+		versions.PreimageOracle, err = getVersion(ctx, common.Address(addresses.PreimageOracle), backend)
+		if err != nil {
+			return versions, fmt.Errorf("PreimageOracle: %w", err)
+		}
+    } else {
+		versions.L2OutputOracle, err = getVersion(ctx, common.Address(addresses.L2OutputOracleProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("L2OutputOracle: %w", err)
+		}
 	}
 	return versions, err
 }


### PR DESCRIPTION
Fix the bug in `op-version-check` caused by the fault-proof update.

In the recent update at [this commit](https://github.com/ethereum-optimism/superchain-registry/commit/583ceb57407d77c46e2661818347b2a90ca34713#diff-38c105f0595daebd2bbe9a001a3d9d6d92ffd79f941542ef185994f674197693), the `L2OutputOracle` address was removed in preparation for the fault-proof's deployment on the OP mainnet. However, the **`op-version-check`** was not updated accordingly, leading to the retrieval of a zero address, which causes the program to crash. ⬇️
![image](https://github.com/ethereum-optimism/optimism/assets/153717436/d0c13703-f4a6-4835-9fb8-162dcd477486)


Proposed Fix:
Modify the logic to interpret the zero address of `L2OutputOracle` as an indicator of whether the fault-proof update has been applied. This change will prevent the system from attempting to access an undefined address and ensure stability post-update.
![image](https://github.com/ethereum-optimism/optimism/assets/153717436/4e495b37-3501-464f-8733-00260239954d)
![image](https://github.com/ethereum-optimism/optimism/assets/153717436/4cd4745c-573e-4ef6-aac3-c8da26ca4425)
