### PR TITLE
ci: Stop running l2oo variant of devnet tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,13 +1139,6 @@ jobs:
       - checkout
       - when:
           condition:
-            equal: ['l2oo', <<parameters.variant>>]
-          steps:
-            - run:
-                name: Set DEVNET_L2OO = true
-                command: echo 'export DEVNET_L2OO=true' >> $BASH_ENV
-      - when:
-          condition:
             equal: ['plasma', <<parameters.variant>>]
           steps:
             - run:
@@ -1750,7 +1743,7 @@ workflows:
       - devnet:
           matrix:
             parameters:
-              variant: ["default", "l2oo", "plasma", "plasma-generic"]
+              variant: ["default", "plasma", "plasma-generic"]
           requires:
             - pnpm-monorepo
             - op-batcher-docker-build


### PR DESCRIPTION
**Description**

Stop running the l2oo variant of devnet tests.  The future is fault proofs.

We still need to build the devnet allocs with L2OO to support the custom gas token e2e tests, but the devnet doesn't use custom gas token so running these tests doesn't add any value.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/818
