### PR TITLE
fix: remove step from husky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ build-ts: submodules
 		. $$NVM_DIR/nvm.sh && nvm use; \
 	fi
 	pnpm install:ci
-	pnpm prepare
 	pnpm build
 .PHONY: build-ts
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

With monorepo: remove husky #10795 merged, `prepare` package.json script was removed but there is still a reference on Makefile `make build` target.