### PR TITLE
op-node: remove unnecessary cgo binding in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ethereum-optimism/optimism
 go 1.21
 
 require (
-	github.com/DataDog/zstd v1.5.5
 	github.com/andybalholm/brotli v1.1.0
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
@@ -25,6 +24,7 @@ require (
 	github.com/holiman/uint256 v1.2.4
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
+	github.com/klauspost/compress v1.17.8
 	github.com/libp2p/go-libp2p v0.35.0
 	github.com/libp2p/go-libp2p-mplex v0.9.0
 	github.com/libp2p/go-libp2p-pubsub v0.11.0
@@ -49,6 +49,7 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
 	github.com/allegro/bigcache v1.2.1 // indirect
@@ -126,7 +127,6 @@ require (
 	github.com/jbenet/goprocess v0.1.4 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
 	github.com/karalabe/usb v0.0.3-0.20230711191512-61db3e06439c // indirect
-	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect

--- a/op-node/rollup/derive/channel_test.go
+++ b/op-node/rollup/derive/channel_test.go
@@ -7,9 +7,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/DataDog/zstd"
 	"github.com/andybalholm/brotli"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,8 +143,9 @@ func TestBatchReader(t *testing.T) {
 		case ca == Zstd: // invalid algo
 			return func(buf *bytes.Buffer, t *testing.T) {
 				buf.WriteByte(0x02) // invalid channel version byte
-				writer := zstd.NewWriter(buf)
-				_, err := writer.Write(encodedBatch.Bytes())
+				writer, err := zstd.NewWriter(buf)
+				require.NoError(t, err)
+				_, err = writer.Write(encodedBatch.Bytes())
 				require.NoError(t, err)
 				require.NoError(t, writer.Close())
 			}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
remove unnecessary cgo binding in test.

**Additional context**
cgo makes build more complicated and disable cross-compile.
I think it is not good idea using cgo binding without any discussion.

**Metadata**

https://github.com/ethereum-optimism/optimism/pull/10750
https://github.com/ethereum-optimism/optimism/pull/10358
https://dave.cheney.net/2016/01/18/cgo-is-not-go
[dgraph-io/badger#1162 - Use pure Go zstd implementation](https://github.com/dgraph-io/badger/issues/1162)