### PR TITLE
Fix docker cross-platform builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,10 @@ jobs:
       - run:
           command: mkdir -p /tmp/docker_images
       - when:
-          condition: "<<parameters.release>>"
+          condition:
+            or:
+              - "<<parameters.publish>>"
+              - "<<parameters.release>>"
           steps:
             - gcp-cli/install
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1703,16 +1703,7 @@ workflows:
           name: op-node-docker-build
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          #save_image_tag: <<pipeline.git.revision>> # for devnet later
-          platforms: "linux/amd64,linux/arm64"
-          publish: true
-          context:
-            - oplabs-gcr
-      - check-cross-platform:
-          name: op-node-cross-platform
-          op_component: op-node
-          requires:
-            - op-node-docker-build
+          save_image_tag: <<pipeline.git.revision>> # for devnet later
       - docker-build:
           name: op-batcher-docker-build
           docker_name: op-batcher
@@ -2116,6 +2107,11 @@ workflows:
           context:
             - oplabs-gcr
             - slack
+      - check-cross-platform:
+          name: op-node-cross-platform
+          op_component: op-node
+          requires:
+            - op-node-docker-publish
       - docker-build:
           name: op-batcher-docker-publish
           docker_name: op-batcher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1706,6 +1706,8 @@ workflows:
           save_image_tag: <<pipeline.git.revision>> # for devnet later
           platforms: "linux/amd64,linux/arm64"
           publish: true
+          context:
+            - oplabs-gcr
       - check-cross-platform:
           name: op-node-cross-platform
           op_component: op-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2096,7 +2096,14 @@ workflows:
 
   scheduled-docker-publish:
     when:
-      equal: [ build_hourly, <<pipeline.schedule.name>> ]
+      and:
+        - or:
+            # Trigger on new commits
+          - equal: [ webhook, << pipeline.trigger_source >> ]
+            # Trigger on manual triggers if explicitly requested
+          - equal: [ true, << pipeline.parameters.main_dispatch >> ]
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - docker-build:
           name: op-node-docker-publish
@@ -2106,7 +2113,6 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
       - check-cross-platform:
           name: op-node-cross-platform
           op_component: op-node
@@ -2120,7 +2126,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-batcher-cross-platform
+          op_component: op-batcher
+          requires:
+            - op-batcher-docker-publish
       - docker-build:
           name: op-program-docker-publish
           docker_name: op-program
@@ -2129,7 +2139,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-program-cross-platform
+          op_component: op-program
+          requires:
+            - op-program-docker-publish
       - docker-build:
           name: op-proposer-docker-publish
           docker_name: op-proposer
@@ -2138,7 +2152,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-proposer-cross-platform
+          op_component: op-proposer
+          requires:
+            - op-proposer-docker-publish
       - docker-build:
           name: op-challenger-docker-publish
           docker_name: op-challenger
@@ -2147,7 +2165,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-challenger-cross-platform
+          op_component: op-challenger
+          requires:
+            - op-challenger-docker-publish
       - docker-build:
           name: op-dispute-mon-docker-publish
           docker_name: op-dispute-mon
@@ -2156,7 +2178,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-dispute-mon-cross-platform
+          op_component: op-dispute-mon
+          requires:
+            - op-dispute-mon-docker-publish
       - docker-build:
           name: op-conductor-docker-publish
           docker_name: op-conductor
@@ -2165,7 +2191,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-conductor-cross-platform
+          op_component: op-conductor
+          requires:
+            - op-conductor-docker-publish
       - docker-build:
           name: op-heartbeat-docker-publish
           docker_name: op-heartbeat
@@ -2174,7 +2204,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-heartbeat-cross-platform
+          op_component: op-heartbeat
+          requires:
+            - op-heartbeat-docker-publish
       - docker-build:
           name: op-supervisor-docker-publish
           docker_name: op-supervisor
@@ -2183,7 +2217,11 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
+      - check-cross-platform:
+          name: op-supervisor-cross-platform
+          op_component: op-supervisor
+          requires:
+            - op-supervisor-docker-publish
       - docker-build:
           name: chain-mon-docker-publish
           docker_name: chain-mon
@@ -2192,7 +2230,6 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
       - docker-build:
           name: contracts-bedrock-docker-publish
           docker_name: contracts-bedrock
@@ -2202,7 +2239,6 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
 
   scheduled-preimage-reproducibility:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1703,7 +1703,7 @@ workflows:
           name: op-node-docker-build
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          save_image_tag: <<pipeline.git.revision>> # for devnet later
+          #save_image_tag: <<pipeline.git.revision>> # for devnet later
           platforms: "linux/amd64,linux/arm64"
           publish: true
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ parameters:
   sdk_dispatch:
     type: boolean
     default: false
+  docker_publish_dispatch:
+    type: boolean
+    default: false
 
 orbs:
   go: circleci/go@1.8.0
@@ -2096,14 +2099,10 @@ workflows:
 
   scheduled-docker-publish:
     when:
-      and:
-        - or:
-            # Trigger on new commits
-          - equal: [ webhook, << pipeline.trigger_source >> ]
-            # Trigger on manual triggers if explicitly requested
-          - equal: [ true, << pipeline.parameters.main_dispatch >> ]
-        - not:
-            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      - or:
+        - equal: [ build_hourly, <<pipeline.schedule.name>> ]
+        # Trigger on manual triggers if explicitly requested
+        - equal: [ true, << pipeline.parameters.docker_publish_dispatch >> ]
     jobs:
       - docker-build:
           name: op-node-docker-publish
@@ -2113,6 +2112,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-node-cross-platform
           op_component: op-node
@@ -2126,6 +2126,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-batcher-cross-platform
           op_component: op-batcher
@@ -2139,6 +2140,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-program-cross-platform
           op_component: op-program
@@ -2152,6 +2154,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-proposer-cross-platform
           op_component: op-proposer
@@ -2165,6 +2168,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-challenger-cross-platform
           op_component: op-challenger
@@ -2178,6 +2182,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-dispute-mon-cross-platform
           op_component: op-dispute-mon
@@ -2191,6 +2196,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-conductor-cross-platform
           op_component: op-conductor
@@ -2204,6 +2210,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-heartbeat-cross-platform
           op_component: op-heartbeat
@@ -2217,6 +2224,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - check-cross-platform:
           name: op-supervisor-cross-platform
           op_component: op-supervisor
@@ -2230,6 +2238,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: contracts-bedrock-docker-publish
           docker_name: contracts-bedrock
@@ -2239,6 +2248,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
 
   scheduled-preimage-reproducibility:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2099,7 +2099,7 @@ workflows:
 
   scheduled-docker-publish:
     when:
-      - or:
+      or:
         - equal: [ build_hourly, <<pipeline.schedule.name>> ]
         # Trigger on manual triggers if explicitly requested
         - equal: [ true, << pipeline.parameters.docker_publish_dispatch >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1701,6 +1701,13 @@ workflows:
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           save_image_tag: <<pipeline.git.revision>> # for devnet later
+          platforms: "linux/amd64,linux/arm64"
+          publish: true
+      - check-cross-platform:
+          name: op-node-cross-platform
+          op_component: op-node
+          requires:
+            - op-node-docker-build
       - docker-build:
           name: op-batcher-docker-build
           docker_name: op-batcher

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,7 +26,7 @@ variable "IMAGE_TAGS" {
 
 variable "PLATFORMS" {
   // You can override this as "linux/amd64,linux/arm64".
-  // Only a specify a single platform when `--load` ing into docker.
+  // Only specify a single platform when `--load` ing into docker.
   // Multi-platform is supported when outputting to disk or pushing to a registry.
   // Multi-platform builds can be tested locally with:  --set="*.output=type=image,push=false"
   default = ""

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -24,14 +24,8 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-batcher:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
 
 clean:
 	rm bin/op-batcher

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -31,7 +31,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-batcher:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
 
 clean:
 	rm bin/op-batcher

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -24,8 +24,14 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-batcher:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
 
 clean:
 	rm bin/op-batcher

--- a/op-challenger/Makefile
+++ b/op-challenger/Makefile
@@ -13,8 +13,14 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-challenger:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-challenger ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-challenger ./cmd
 
 fuzz:
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzKeccak ./game/keccak/matrix

--- a/op-challenger/Makefile
+++ b/op-challenger/Makefile
@@ -20,7 +20,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-challenger:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-challenger ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-challenger ./cmd
 
 fuzz:
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzKeccak ./game/keccak/matrix

--- a/op-challenger/Makefile
+++ b/op-challenger/Makefile
@@ -13,14 +13,8 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-challenger:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-challenger ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-challenger ./cmd
 
 fuzz:
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzKeccak ./game/keccak/matrix

--- a/op-conductor/Makefile
+++ b/op-conductor/Makefile
@@ -7,14 +7,8 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-conductor:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-conductor ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-conductor ./cmd
 
 clean:
 	rm bin/op-conductor

--- a/op-conductor/Makefile
+++ b/op-conductor/Makefile
@@ -14,7 +14,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-conductor:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-conductor ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-conductor ./cmd
 
 clean:
 	rm bin/op-conductor

--- a/op-conductor/Makefile
+++ b/op-conductor/Makefile
@@ -7,8 +7,14 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-conductor:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-conductor ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-conductor ./cmd
 
 clean:
 	rm bin/op-conductor

--- a/op-dispute-mon/Makefile
+++ b/op-dispute-mon/Makefile
@@ -8,8 +8,14 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-dispute-mon/version.
 LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-dispute-mon/version.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-dispute-mon:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-dispute-mon ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-dispute-mon ./cmd
 .PHONY: op-dispute-mon
 
 clean:

--- a/op-dispute-mon/Makefile
+++ b/op-dispute-mon/Makefile
@@ -8,14 +8,8 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-dispute-mon/version.
 LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-dispute-mon/version.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-dispute-mon:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-dispute-mon ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-dispute-mon ./cmd
 .PHONY: op-dispute-mon
 
 clean:

--- a/op-dispute-mon/Makefile
+++ b/op-dispute-mon/Makefile
@@ -15,7 +15,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-dispute-mon:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-dispute-mon ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-dispute-mon ./cmd
 .PHONY: op-dispute-mon
 
 clean:

--- a/op-heartbeat/Makefile
+++ b/op-heartbeat/Makefile
@@ -7,8 +7,14 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-heartbeat:
-	env GO111MODULE=on go build -v $(LDFLAGS) -o ./bin/op-heartbeat ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-heartbeat ./cmd
 
 clean:
 	rm bin/op-heartbeat

--- a/op-heartbeat/Makefile
+++ b/op-heartbeat/Makefile
@@ -7,14 +7,8 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-heartbeat:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-heartbeat ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-heartbeat ./cmd
 
 clean:
 	rm bin/op-heartbeat

--- a/op-heartbeat/Makefile
+++ b/op-heartbeat/Makefile
@@ -14,7 +14,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-heartbeat:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-heartbeat ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-heartbeat ./cmd
 
 clean:
 	rm bin/op-heartbeat

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -26,7 +26,7 @@ ifeq ($(shell uname),Darwin)
 endif
 
 op-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:
 	rm bin/op-node

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -26,7 +26,7 @@ ifeq ($(shell uname),Darwin)
 endif
 
 op-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:
 	rm bin/op-node

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -26,7 +26,7 @@ ifeq ($(shell uname),Darwin)
 endif
 
 op-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:
 	rm bin/op-node

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -25,14 +25,8 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:
 	rm bin/op-node

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -25,10 +25,6 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
-# Default values for compilers
-CC := gcc
-CXX := g++
-
 # Check if TARGETARCH is set to arm64 and adjust compilers accordingly
 ifeq ($(TARGETARCH),arm64)
     CC := aarch64-linux-gnu-gcc

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -36,6 +36,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-node:
+	@echo "Compiling for $(TARGETARCH) with CC=$(CC) and CXX=$(CXX)"
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -25,6 +25,16 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
+# Default values for compilers
+CC := gcc
+CXX := g++
+
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-node:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -36,7 +36,6 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-node:
-	@echo "Compiling for $(TARGETARCH) with CC=$(CC) and CXX=$(CXX)"
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -32,7 +32,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:
 	rm bin/op-node

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -26,7 +26,7 @@ ifeq ($(shell uname),Darwin)
 endif
 
 op-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 
 clean:
 	rm bin/op-node

--- a/op-plasma/Makefile
+++ b/op-plasma/Makefile
@@ -7,14 +7,8 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 da-server:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/da-server ./cmd/daserver
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/da-server ./cmd/daserver
 
 clean:
 	rm bin/da-server

--- a/op-plasma/Makefile
+++ b/op-plasma/Makefile
@@ -7,8 +7,14 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 da-server:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/da-server ./cmd/daserver
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/da-server ./cmd/daserver
 
 clean:
 	rm bin/da-server

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -27,7 +27,7 @@ op-program: \
 	op-program-client-mips
 
 op-program-host:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v -ldflags "$(LDFLAGSSTRING)" -o ./bin/op-program ./host/cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v -ldflags "$(LDFLAGSSTRING)" -o ./bin/op-program ./host/cmd/main.go
 
 op-program-client:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client ./client/cmd/main.go

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -15,13 +15,19 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta
 
 COMPAT_DIR := temp/compat
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-program: \
 	op-program-host \
 	op-program-client \
 	op-program-client-mips
 
 op-program-host:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(LDFLAGSSTRING)" -o ./bin/op-program ./host/cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v -ldflags "$(LDFLAGSSTRING)" -o ./bin/op-program ./host/cmd/main.go
 
 op-program-client:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client ./client/cmd/main.go

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -15,19 +15,13 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta
 
 COMPAT_DIR := temp/compat
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-program: \
 	op-program-host \
 	op-program-client \
 	op-program-client-mips
 
 op-program-host:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v -ldflags "$(LDFLAGSSTRING)" -o ./bin/op-program ./host/cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v -ldflags "$(LDFLAGSSTRING)" -o ./bin/op-program ./host/cmd/main.go
 
 op-program-client:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client ./client/cmd/main.go

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -26,7 +26,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-proposer:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
 
 clean:
 	rm bin/op-proposer

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -19,8 +19,14 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
+
 op-proposer:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
 
 clean:
 	rm bin/op-proposer

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -19,14 +19,8 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-proposer:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
 
 clean:
 	rm bin/op-proposer

--- a/op-supervisor/Makefile
+++ b/op-supervisor/Makefile
@@ -8,9 +8,14 @@ LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
+ifeq ($(TARGETARCH),arm64)
+    CC := aarch64-linux-gnu-gcc
+    CXX := aarch64-linux-gnu-g++
+endif
 
 op-supervisor:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-supervisor ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-supervisor ./cmd
 
 clean:
 	rm bin/op-supervisor

--- a/op-supervisor/Makefile
+++ b/op-supervisor/Makefile
@@ -15,7 +15,7 @@ ifeq ($(TARGETARCH),arm64)
 endif
 
 op-supervisor:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) go build -v $(LDFLAGS) -o ./bin/op-supervisor ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-supervisor ./cmd
 
 clean:
 	rm bin/op-supervisor

--- a/op-supervisor/Makefile
+++ b/op-supervisor/Makefile
@@ -8,14 +8,8 @@ LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-# Check if TARGETARCH is set to arm64 and adjust compilers accordingly
-ifeq ($(TARGETARCH),arm64)
-    CC := aarch64-linux-gnu-gcc
-    CXX := aarch64-linux-gnu-g++
-endif
-
 op-supervisor:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=$(CC) CXX=$(CXX) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-supervisor ./cmd
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build -v $(LDFLAGS) -o ./bin/op-supervisor ./cmd
 
 clean:
 	rm bin/op-supervisor

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -6,32 +6,18 @@ ARG TARGETARCH
 ARG TARGET_BASE_IMAGE=alpine:3.18
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
 
-#RUN apk add --no-cache make gcc g++ musl-dev linux-headers git jq bash
-#RUN apk add --no-cache crossbuild-essential-arm64 crossbuild-essential-amd64
-
-# Update package lists
-RUN apt-get update && apt-get install -y \
-    make gcc g++ \
-    git jq bash \
-    crossbuild-essential-arm64 crossbuild-essential-amd64
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash cross-build
 
 # Default values for TARGETARCH="amd64"
-ENV CC=gcc
-ENV CXX=g++
+ARG CC=gcc
+ARG CXX=g++
 
-# Conditional installation of linux-headers based on architecture
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get install -y linux-headers-amd64; \
-    else \
-        apt-get install -y linux-headers-arm64 && \
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
         CC=aarch64-linux-gnu-gcc && \
         CXX=aarch64-linux-gnu-g++; \
     fi
-
-# Clean up to reduce image size
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -10,16 +10,9 @@
 ARG TARGET_BASE_IMAGE=alpine:3.18
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
 
-# Install cross-compilation tools
-RUN apt-get update && apt-get install -y \
-    crossbuild-essential-arm64 \
-    gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu
-
-# Install other necessary tools and libraries
-RUN apt-get install -y make git jq bash
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -23,7 +23,7 @@ ENV CXX=g++
 
 # Conditional installation of linux-headers based on architecture
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get install -y linux-headers-amd64 &&  \
+        apt-get install -y linux-headers-amd64; \
     else \
         apt-get install -y linux-headers-arm64 && \
         CC=aarch64-linux-gnu-gcc && \

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -7,7 +7,7 @@
 
 # All target images use this as base image, and add the final build results.
 # It will default to the target platform.
-ARG TARGET_BASE_IMAGE=debian:bullseye-slim
+ARG TARGET_BASE_IMAGE=alpine:3.18
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
 FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as builder

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -1,3 +1,9 @@
+# automatically set by buildkit, can be changed with --platform flag
+# see https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+# TARGETOS
+# TARGETARCH
+# TARGETPLATFORM
+# BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -9,14 +15,15 @@ ARG TARGET_BASE_IMAGE=alpine:3.18
 FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash cross-build
+RUN apk add --no-cache aarch64-linux-gnu-gcc aarch64-linux-gnu-g++
 
 # Default values for TARGETARCH="amd64"
 ARG CC=gcc
 ARG CXX=g++
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        CC=aarch64-linux-gnu-gcc && \
-        CXX=aarch64-linux-gnu-g++; \
+      CC=aarch64-linux-gnu-gcc && \
+      CXX=aarch64-linux-gnu-g++; \
     fi
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -14,7 +14,7 @@ ARG TARGET_BASE_IMAGE=alpine:3.18
 # We may be cross-building for another platform. Specify which platform we need as builder.
 FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash cross-build
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 RUN apk add --no-cache aarch64-linux-gnu-gcc aarch64-linux-gnu-g++
 
 # Default values for TARGETARCH="amd64"

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -10,7 +10,7 @@
 ARG TARGET_BASE_IMAGE=alpine:3.18
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
@@ -46,87 +46,87 @@ ARG TARGETARCH
 # Build the Go services, utilizing caches and share the many common packages.
 # The "id" defaults to the value of "target", the cache will thus be reused during this build.
 # "sharing" defaults to "shared", the cache will thus be available to other concurrent docker builds.
-FROM --platform=$BUILDPLATFORM builder as cannon-builder
+FROM --platform=$BUILDPLATFORM builder AS cannon-builder
 ARG CANNON_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-program-builder
+FROM --platform=$BUILDPLATFORM builder AS op-program-builder
 ARG OP_PROGRAM_VERSION=v0.0.0
 # note: we only build the host, that's all the user needs. No Go MIPS cross-build in docker
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-host  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-heartbeat-builder
+FROM --platform=$BUILDPLATFORM builder AS op-heartbeat-builder
 ARG OP_HEARTBEAT_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-heartbeat && make op-heartbeat  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_HEARTBEAT_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-wheel-builder
+FROM --platform=$BUILDPLATFORM builder AS op-wheel-builder
 ARG OP_WHEEL_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-wheel && make op-wheel  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_WHEEL_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-node-builder
+FROM --platform=$BUILDPLATFORM builder AS op-node-builder
 ARG OP_NODE_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-node && make op-node  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_NODE_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-challenger-builder
+FROM --platform=$BUILDPLATFORM builder AS op-challenger-builder
 ARG OP_CHALLENGER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-challenger && make op-challenger  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_CHALLENGER_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-dispute-mon-builder
+FROM --platform=$BUILDPLATFORM builder AS op-dispute-mon-builder
 ARG OP_DISPUTE_MON_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-dispute-mon && make op-dispute-mon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_DISPUTE_MON_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-batcher-builder
+FROM --platform=$BUILDPLATFORM builder AS op-batcher-builder
 ARG OP_BATCHER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-batcher && make op-batcher  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_BATCHER_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-proposer-builder
+FROM --platform=$BUILDPLATFORM builder AS op-proposer-builder
 ARG OP_PROPOSER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-proposer && make op-proposer  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_PROPOSER_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as op-conductor-builder
+FROM --platform=$BUILDPLATFORM builder AS op-conductor-builder
 ARG OP_CONDUCTOR_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-conductor && make op-conductor  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_CONDUCTOR_VERSION"
 
-FROM --platform=$BUILDPLATFORM builder as da-server-builder
+FROM --platform=$BUILDPLATFORM builder AS da-server-builder
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-plasma && make da-server  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE
 
-FROM --platform=$BUILDPLATFORM builder as op-supervisor-builder
+FROM --platform=$BUILDPLATFORM builder AS op-supervisor-builder
 ARG OP_SUPERVISOR_VERSION=v0.0.0
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-supervisor && make op-supervisor  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_SUPERVISOR_VERSION"
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as cannon-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS cannon-target
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 CMD ["cannon"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-program-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-program-target
 COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
 CMD ["op-program"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-heartbeat-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-heartbeat-target
 COPY --from=op-heartbeat-builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin/
 CMD ["op-heartbeat"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-wheel-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-wheel-target
 COPY --from=op-wheel-builder /app/op-wheel/bin/op-wheel /usr/local/bin/
 CMD ["op-wheel"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-node-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-node-target
 COPY --from=op-node-builder /app/op-node/bin/op-node /usr/local/bin/
 CMD ["op-node"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-challenger-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-challenger-target
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
 # Make the bundled op-program the default cannon server
 COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
@@ -136,26 +136,26 @@ COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 ENV OP_CHALLENGER_CANNON_BIN /usr/local/bin/cannon
 CMD ["op-challenger"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-dispute-mon-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-dispute-mon-target
 COPY --from=op-dispute-mon-builder /app/op-dispute-mon/bin/op-dispute-mon /usr/local/bin/
 CMD ["op-dispute-mon"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-batcher-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-batcher-target
 COPY --from=op-batcher-builder /app/op-batcher/bin/op-batcher /usr/local/bin/
 CMD ["op-batcher"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-proposer-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-proposer-target
 COPY --from=op-proposer-builder /app/op-proposer/bin/op-proposer /usr/local/bin/
 CMD ["op-proposer"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-conductor-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-conductor-target
 COPY --from=op-conductor-builder /app/op-conductor/bin/op-conductor /usr/local/bin/
 CMD ["op-conductor"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as da-server-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS da-server-target
 COPY --from=da-server-builder /app/op-plasma/bin/da-server /usr/local/bin/
 CMD ["da-server"]
 
-FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-supervisor-target
+FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-supervisor-target
 COPY --from=op-supervisor-builder /app/op-supervisor/bin/op-supervisor /usr/local/bin/
 CMD ["op-supervisor"]

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -57,7 +57,6 @@ ARG TARGETARCH
 # "sharing" defaults to "shared", the cache will thus be available to other concurrent docker builds.
 FROM --platform=$BUILDPLATFORM builder as cannon-builder
 ARG CANNON_VERSION=v0.0.0
-RUN echo "hello"
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -12,10 +12,16 @@ ARG TARGETARCH
 ARG TARGET_BASE_IMAGE=alpine:3.18
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-RUN apk add --no-cache aarch64-linux-gnu-gcc aarch64-linux-gnu-g++
+# Install cross-compilation tools
+RUN apt-get update && apt-get install -y \
+    crossbuild-essential-arm64 \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu
+
+# Install other necessary tools and libraries
+RUN apt-get install -y make git jq bash
 
 # Default values for TARGETARCH="amd64"
 ARG CC=gcc

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -1,6 +1,5 @@
 ARG TARGETOS
 ARG TARGETARCH
-ARG BUILDPLATFORM
 
 # All target images use this as base image, and add the final build results.
 # It will default to the target platform.

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -1,20 +1,38 @@
-# automatically set by buildkit, can be changed with --platform flag
-# see https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
-# TARGETOS
-# TARGETARCH
-# TARGETPLATFORM
-# BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDPLATFORM
 
 # All target images use this as base image, and add the final build results.
 # It will default to the target platform.
 ARG TARGET_BASE_IMAGE=alpine:3.18
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
+#RUN apk add --no-cache make gcc g++ musl-dev linux-headers git jq bash
+#RUN apk add --no-cache crossbuild-essential-arm64 crossbuild-essential-amd64
+
+# Update package lists
+RUN apt-get update && apt-get install -y \
+    make gcc g++ \
+    git jq bash \
+    crossbuild-essential-arm64 crossbuild-essential-amd64
+
+# Default values for TARGETARCH="amd64"
+ENV CC=gcc
+ENV CXX=g++
+
+# Conditional installation of linux-headers based on architecture
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        apt-get install -y linux-headers-amd64 &&  \
+    else \
+        apt-get install -y linux-headers-arm64 && \
+        CC=aarch64-linux-gnu-gcc && \
+        CXX=aarch64-linux-gnu-g++; \
+    fi
+
+# Clean up to reduce image size
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod
@@ -42,13 +60,6 @@ ARG GIT_DATE
 # - proxyd
 # - any JS/TS/smart-contract builds
 
-# TODO: if the build involves optional CGO, then:
-# 1) we may have to disable CGO explicitly
-# 3) apk install cross-build gcc,
-#    and specify to go to use that, with the CC flag
-
-ARG TARGETOS TARGETARCH
-
 # Build the Go services, utilizing caches and share the many common packages.
 # The "id" defaults to the value of "target", the cache will thus be reused during this build.
 # "sharing" defaults to "shared", the cache will thus be available to other concurrent docker builds.
@@ -75,7 +86,6 @@ RUN --mount=type=cache,target=/root/.cache/go-build cd op-wheel && make op-wheel
 
 FROM --platform=$BUILDPLATFORM builder as op-node-builder
 ARG OP_NODE_VERSION=v0.0.0
-RUN echo TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH BUILDPLATFORM=$BUILDPLATFORM TARGETPLATFORM=$TARGETPLATFORM OP_NODE_VERSION=$OP_NODE_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-node && make op-node  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_NODE_VERSION"
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -4,12 +4,10 @@
 # TARGETARCH
 # TARGETPLATFORM
 # BUILDPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
 
 # All target images use this as base image, and add the final build results.
 # It will default to the target platform.
-ARG TARGET_BASE_IMAGE=alpine:3.18
+ARG TARGET_BASE_IMAGE=debian:bullseye-slim
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
 FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as builder

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -4,8 +4,6 @@
 # TARGETARCH
 # TARGETPLATFORM
 # BUILDPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
 
 # All target images use this as base image, and add the final build results.
 # It will default to the target platform.
@@ -22,15 +20,6 @@ RUN apt-get update && apt-get install -y \
 
 # Install other necessary tools and libraries
 RUN apt-get install -y make git jq bash
-
-# Default values for TARGETARCH="amd64"
-ARG CC=gcc
-ARG CXX=g++
-
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      CC=aarch64-linux-gnu-gcc && \
-      CXX=aarch64-linux-gnu-g++; \
-    fi
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod
@@ -53,6 +42,9 @@ COPY . /app
 # --build-arg GIT_DATE=$(git show -s --format='%ct')
 ARG GIT_COMMIT
 ARG GIT_DATE
+
+ARG TARGETOS
+ARG TARGETARCH
 
 # separate docker-builds:
 # - proxyd

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -4,6 +4,8 @@
 # TARGETARCH
 # TARGETPLATFORM
 # BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 # All target images use this as base image, and add the final build results.
 # It will default to the target platform.
@@ -55,6 +57,7 @@ ARG TARGETARCH
 # "sharing" defaults to "shared", the cache will thus be available to other concurrent docker builds.
 FROM --platform=$BUILDPLATFORM builder as cannon-builder
 ARG CANNON_VERSION=v0.0.0
+RUN echo "hello"
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -165,4 +165,4 @@ CMD ["da-server"]
 
 FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE as op-supervisor-target
 COPY --from=op-supervisor-builder /app/op-supervisor/bin/op-supervisor /usr/local/bin/
-ENTRYPOINT ["op-supervisor"]
+CMD ["op-supervisor"]


### PR DESCRIPTION
The docker images being pushed to docker registry by our CI do not work on arm64 machines. This PR attempts to fix that.

Fixes https://github.com/ethereum-optimism/optimism/issues/11081

### Key change to fix cross compiling issues
Removed `TARGETOS` and `TARGETARCH` declarations from the top of the dockerfile. These args both get set automatically by the docker build kit, and the global declarations in the dockerfile caused an issue where the values were not set or passed to the underlying `make` commands which invoke `go build`.

### Additional context
Also added `CGO_ENABLED=0` to docker images that are being built for cross-platform. This will cause the **build** to fail if C code is included in the go source code. This seems better than allowing the build to pass and only catching the failure further downstream when the image is pulled and attempted to run on an arm64 machine. If we want the cross-platform builds to work with C code included, we will have to spend some more effort adding appropriate `CC` and `CXX` packages to our docker builder, then allow `CGO_ENABLED=1`. I'm open to removing this part if reviewers feel this is a bad idea

### Tests

Added `check-cross-platform` ci jobs for every image published during `scheduled-docker-publish` that is built for multiple platforms (i.e. `platforms: "linux/amd64,linux/arm64"` for the `docker-build` job)