### PR TITLE
dispute-mon: Add metric to report the total withdrawable ETH for each honest actor

### DIFF
--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -28,6 +28,8 @@ func (*NoopMetricsImpl) RecordGameResolutionStatus(_ ResolutionStatus, _ int) {}
 
 func (*NoopMetricsImpl) RecordCredit(_ CreditExpectation, _ int) {}
 
+func (*NoopMetricsImpl) RecordHonestWithdrawableAmounts(map[common.Address]*big.Int) {}
+
 func (*NoopMetricsImpl) RecordClaims(_ *ClaimStatuses) {}
 
 func (*NoopMetricsImpl) RecordWithdrawalRequests(_ common.Address, _ bool, _ int) {}

--- a/op-dispute-mon/mon/bonds/monitor.go
+++ b/op-dispute-mon/mon/bonds/monitor.go
@@ -17,19 +17,22 @@ type RClock interface {
 type BondMetrics interface {
 	RecordCredit(expectation metrics.CreditExpectation, count int)
 	RecordBondCollateral(addr common.Address, required *big.Int, available *big.Int)
+	RecordHonestWithdrawableAmounts(map[common.Address]*big.Int)
 }
 
 type Bonds struct {
-	logger  log.Logger
-	clock   RClock
-	metrics BondMetrics
+	logger       log.Logger
+	clock        RClock
+	metrics      BondMetrics
+	honestActors types.HonestActors
 }
 
-func NewBonds(logger log.Logger, metrics BondMetrics, clock RClock) *Bonds {
+func NewBonds(logger log.Logger, metrics BondMetrics, honestActors types.HonestActors, clock RClock) *Bonds {
 	return &Bonds{
-		logger:  logger,
-		clock:   clock,
-		metrics: metrics,
+		logger:       logger,
+		clock:        clock,
+		metrics:      metrics,
+		honestActors: honestActors,
 	}
 }
 
@@ -47,6 +50,10 @@ func (b *Bonds) CheckBonds(games []*types.EnrichedGameData) {
 
 func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
 	creditMetrics := make(map[metrics.CreditExpectation]int)
+	honestWithdrawableAmounts := make(map[common.Address]*big.Int)
+	for address := range b.honestActors {
+		honestWithdrawableAmounts[address] = big.NewInt(0)
+	}
 
 	for _, game := range games {
 		// Check if the max duration has been reached for this game
@@ -94,6 +101,12 @@ func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
 			}
 			comparison := actual.Cmp(expected)
 			if maxDurationReached {
+				if actual.Cmp(big.NewInt(0)) > 0 && b.honestActors.Contains(recipient) {
+					total := honestWithdrawableAmounts[recipient]
+					total = new(big.Int).Add(total, actual)
+					honestWithdrawableAmounts[recipient] = total
+					b.logger.Warn("Found unclaimed credit", "recipient", recipient, "game", game.Proxy, "amount", actual)
+				}
 				if comparison > 0 {
 					creditMetrics[metrics.CreditAboveWithdrawable] += 1
 					b.logger.Warn("Credit above expected amount", "recipient", recipient, "expected", expected, "actual", actual, "game", game.Proxy, "withdrawable", "withdrawable")
@@ -123,4 +136,5 @@ func (b *Bonds) checkCredits(games []*types.EnrichedGameData) {
 	b.metrics.RecordCredit(metrics.CreditBelowNonWithdrawable, creditMetrics[metrics.CreditBelowNonWithdrawable])
 	b.metrics.RecordCredit(metrics.CreditEqualNonWithdrawable, creditMetrics[metrics.CreditEqualNonWithdrawable])
 	b.metrics.RecordCredit(metrics.CreditAboveNonWithdrawable, creditMetrics[metrics.CreditAboveNonWithdrawable])
+	b.metrics.RecordHonestWithdrawableAmounts(honestWithdrawableAmounts)
 }

--- a/op-dispute-mon/mon/claims.go
+++ b/op-dispute-mon/mon/claims.go
@@ -25,16 +25,12 @@ type ClaimMetrics interface {
 type ClaimMonitor struct {
 	logger       log.Logger
 	clock        RClock
-	honestActors map[common.Address]bool // Map for efficient lookup
+	honestActors types.HonestActors
 	metrics      ClaimMetrics
 }
 
-func NewClaimMonitor(logger log.Logger, clock RClock, honestActors []common.Address, metrics ClaimMetrics) *ClaimMonitor {
-	actors := make(map[common.Address]bool)
-	for _, actor := range honestActors {
-		actors[actor] = true
-	}
-	return &ClaimMonitor{logger, clock, actors, metrics}
+func NewClaimMonitor(logger log.Logger, clock RClock, honestActors types.HonestActors, metrics ClaimMetrics) *ClaimMonitor {
+	return &ClaimMonitor{logger, clock, honestActors, metrics}
 }
 
 func (c *ClaimMonitor) CheckClaims(games []*types.EnrichedGameData) {

--- a/op-dispute-mon/mon/claims_test.go
+++ b/op-dispute-mon/mon/claims_test.go
@@ -194,10 +194,10 @@ func newTestClaimMonitor(t *testing.T) (*ClaimMonitor, *clock.DeterministicClock
 	logger, handler := testlog.CaptureLogger(t, log.LvlInfo)
 	cl := clock.NewDeterministicClock(frozen)
 	metrics := &stubClaimMetrics{}
-	honestActors := []common.Address{
+	honestActors := types.NewHonestActors([]common.Address{
 		{0x01},
 		{0x02},
-	}
+	})
 	monitor := NewClaimMonitor(logger, cl, honestActors, metrics)
 	return monitor, cl, metrics, handler
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/bonds"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -28,9 +29,10 @@ import (
 )
 
 type Service struct {
-	logger  log.Logger
-	metrics metrics.Metricer
-	monitor *gameMonitor
+	logger       log.Logger
+	metrics      metrics.Metricer
+	monitor      *gameMonitor
+	honestActors types.HonestActors
 
 	factoryContract *contracts.DisputeGameFactoryContract
 
@@ -56,9 +58,10 @@ type Service struct {
 // NewService creates a new Service.
 func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Service, error) {
 	s := &Service{
-		cl:      clock.SystemClock,
-		logger:  logger,
-		metrics: metrics.NewMetrics(),
+		cl:           clock.SystemClock,
+		logger:       logger,
+		metrics:      metrics.NewMetrics(),
+		honestActors: types.NewHonestActors(cfg.HonestActors),
 	}
 
 	if err := s.initFromConfig(ctx, cfg); err != nil {
@@ -105,7 +108,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 }
 
 func (s *Service) initClaimMonitor(cfg *config.Config) {
-	s.claims = NewClaimMonitor(s.logger, s.cl, cfg.HonestActors, s.metrics)
+	s.claims = NewClaimMonitor(s.logger, s.cl, s.honestActors, s.metrics)
 }
 
 func (s *Service) initResolutionMonitor() {
@@ -142,7 +145,7 @@ func (s *Service) initForecast(cfg *config.Config) {
 }
 
 func (s *Service) initBonds() {
-	s.bonds = bonds.NewBonds(s.logger, s.metrics, s.cl)
+	s.bonds = bonds.NewBonds(s.logger, s.metrics, s.honestActors, s.cl)
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {

--- a/op-dispute-mon/mon/types/honest_actors.go
+++ b/op-dispute-mon/mon/types/honest_actors.go
@@ -1,0 +1,17 @@
+package types
+
+import "github.com/ethereum/go-ethereum/common"
+
+type HonestActors map[common.Address]bool // Map for efficient lookup
+
+func NewHonestActors(honestActors []common.Address) HonestActors {
+	actors := make(map[common.Address]bool)
+	for _, actor := range honestActors {
+		actors[actor] = true
+	}
+	return actors
+}
+
+func (h HonestActors) Contains(addr common.Address) bool {
+	return h[addr]
+}


### PR DESCRIPTION
**Description**

Adds a metric and warning log when dispute-mon detects a game where an honest actor has credits that are withdrawable but not yet claimed.

**Tests**

Added unit tests.
