### PR TITLE
challenger: Close bond claimer on shutdown.

### DIFF
--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -281,6 +281,11 @@ func (s *Service) Stop(ctx context.Context) error {
 	if s.monitor != nil {
 		s.monitor.StopMonitoring()
 	}
+	if s.claimer != nil {
+		if err := s.claimer.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close claimer: %w", err))
+		}
+	}
 	if s.faultGamesCloser != nil {
 		s.faultGamesCloser()
 	}


### PR DESCRIPTION
**Description**

Fixes flaky tests by ensuring the bond claimer is closed on shutdown and doesn't post further logs after the test completes.