### PR TITLE
op-chain-ops: Fix the bug in op-version-check with on-chain check

### DIFF
--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -141,11 +144,29 @@ func entrypoint(ctx *cli.Context) error {
 			contracts["L1CrossDomainMessenger"] = Contract{Version: versions.L1CrossDomainMessenger, Address: addresses.L1CrossDomainMessengerProxy}
 			contracts["L1ERC721Bridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1ERC721BridgeProxy}
 			contracts["L1StandardBridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1StandardBridgeProxy}
-			contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
 			contracts["OptimismMintableERC20Factory"] = Contract{Version: versions.OptimismMintableERC20Factory, Address: addresses.OptimismMintableERC20FactoryProxy}
 			contracts["OptimismPortal"] = Contract{Version: versions.OptimismPortal, Address: addresses.OptimismPortalProxy}
 			contracts["SystemConfig"] = Contract{Version: versions.SystemConfig, Address: addresses.SystemConfigProxy}
 			contracts["ProxyAdmin"] = Contract{Version: "null", Address: addresses.ProxyAdmin}
+			majorVersion, err := strconv.ParseInt(strings.Split(versions.OptimismPortal, ".")[0], 10, 32)
+			if err != nil {
+				fmt.Println("Error parsing major version:", err)
+				return fmt.Errorf("error parsing major version: %w", err)
+			}
+			// Portal version `3` is the first version of the `OptimismPortal` that supported the fault proof system.
+			isFPAC := majorVersion >= 3
+
+			if isFPAC {
+				contracts["AnchorStateRegistry"] = Contract{Version: versions.AnchorStateRegistry, Address: addresses.AnchorStateRegistryProxy}
+				contracts["DelayedWETH"] = Contract{Version: versions.DelayedWETH, Address: addresses.DelayedWETHProxy}
+				contracts["DisputeGameFactory"] = Contract{Version: versions.DisputeGameFactory, Address: addresses.DisputeGameFactoryProxy}
+				contracts["FaultDisputeGame"] = Contract{Version: versions.FaultDisputeGame, Address: addresses.FaultDisputeGame}
+				contracts["MIPS"] = Contract{Version: versions.MIPS, Address: addresses.MIPS}
+				contracts["PermissionedDisputeGame"] = Contract{Version: versions.PermissionedDisputeGame, Address: addresses.PermissionedDisputeGame}
+				contracts["PreimageOracle"] = Contract{Version: versions.PreimageOracle, Address: addresses.PreimageOracle}
+			} else {
+				contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
+			}
 
 			output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: l2ChainID, Contracts: contracts})
 

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/mattn/go-isatty"

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -142,7 +142,7 @@ func entrypoint(ctx *cli.Context) error {
 			contracts["AddressManager"] = Contract{Version: "null", Address: addresses.AddressManager}
 			contracts["L1CrossDomainMessenger"] = Contract{Version: versions.L1CrossDomainMessenger, Address: addresses.L1CrossDomainMessengerProxy}
 			contracts["L1ERC721Bridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1ERC721BridgeProxy}
-			contracts["L1StandardBridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1StandardBridgeProxy}
+			contracts["L1StandardBridge"] = Contract{Version: versions.L1StandardBridge, Address: addresses.L1StandardBridgeProxy}
 			contracts["OptimismMintableERC20Factory"] = Contract{Version: versions.OptimismMintableERC20Factory, Address: addresses.OptimismMintableERC20FactoryProxy}
 			contracts["OptimismPortal"] = Contract{Version: versions.OptimismPortal, Address: addresses.OptimismPortalProxy}
 			contracts["SystemConfig"] = Contract{Version: versions.SystemConfig, Address: addresses.SystemConfigProxy}

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -3,6 +3,7 @@ package upgrades
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -91,10 +92,6 @@ func GetContractVersions(ctx context.Context, addresses *superchain.AddressList,
 	if err != nil {
 		return versions, fmt.Errorf("L1StandardBridge: %w", err)
 	}
-	versions.L2OutputOracle, err = getVersion(ctx, common.Address(addresses.L2OutputOracleProxy), backend)
-	if err != nil {
-		return versions, fmt.Errorf("L2OutputOracle: %w", err)
-	}
 	versions.OptimismMintableERC20Factory, err = getVersion(ctx, common.Address(addresses.OptimismMintableERC20FactoryProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("OptimismMintableERC20Factory: %w", err)
@@ -106,6 +103,55 @@ func GetContractVersions(ctx context.Context, addresses *superchain.AddressList,
 	versions.SystemConfig, err = getVersion(ctx, common.Address(addresses.SystemConfigProxy), backend)
 	if err != nil {
 		return versions, fmt.Errorf("SystemConfig: %w", err)
+	}
+	majorVersion, err := strconv.ParseInt(strings.Split(versions.OptimismPortal, ".")[0], 10, 32)
+	if err != nil {
+		fmt.Println("Error parsing major version:", err)
+		return versions, fmt.Errorf("error parsing major version: %w", err)
+	}
+	// Portal version `3` is the first version of the `OptimismPortal` that supported the fault proof system.
+	isFPAC := majorVersion >= 3
+
+    if isFPAC {
+		versions.AnchorStateRegistry, err = getVersion(ctx, common.Address(addresses.AnchorStateRegistryProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("AnchorStateRegistryProxy: %w", err)
+		}
+
+		versions.DelayedWETH, err = getVersion(ctx, common.Address(addresses.DelayedWETHProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("DelayedWETHProxy: %w", err)
+		}
+
+		versions.DisputeGameFactory, err = getVersion(ctx, common.Address(addresses.DisputeGameFactoryProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("DisputeGameFactoryProxy: %w", err)
+		}
+
+		versions.FaultDisputeGame, err = getVersion(ctx, common.Address(addresses.FaultDisputeGame), backend)
+		if err != nil {
+			return versions, fmt.Errorf("FaultDisputeGame: %w", err)
+		}
+
+		versions.MIPS, err = getVersion(ctx, common.Address(addresses.MIPS), backend)
+		if err != nil {
+			return versions, fmt.Errorf("MIPS: %w", err)
+		}
+
+		versions.PermissionedDisputeGame, err = getVersion(ctx, common.Address(addresses.PermissionedDisputeGame), backend)
+		if err != nil {
+			return versions, fmt.Errorf("PermissionedDisputeGame: %w", err)
+		}
+
+		versions.PreimageOracle, err = getVersion(ctx, common.Address(addresses.PreimageOracle), backend)
+		if err != nil {
+			return versions, fmt.Errorf("PreimageOracle: %w", err)
+		}
+    } else {
+		versions.L2OutputOracle, err = getVersion(ctx, common.Address(addresses.L2OutputOracleProxy), backend)
+		if err != nil {
+			return versions, fmt.Errorf("L2OutputOracle: %w", err)
+		}
 	}
 	return versions, err
 }


### PR DESCRIPTION
An alternative implementation in [issue 10815](https://github.com/ethereum-optimism/optimism/pull/10815) uses the version information from the on-chain Portal to determine whether to enable fault proof. Thanks to @geoknee for the suggestion.

Since I'm not sure about your thoughts, issue 10815 is still open. Feel free to close any of the implementations.