### PR TITLE
op-batcher: Secure and Delete pprof Usage in Production

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	_ "net/http/pprof"
 	"sync"
 	"time"
 

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	_ "net/http/pprof"
 	"strings"
 	"sync/atomic"
 	"time"

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	_ "net/http/pprof"
 	"sync"
 	"time"
 


### PR DESCRIPTION
Importing net/http/pprof automatically exposes a debug endpoint /debug/pprof, which reveals sensitive application information, such as heap and CPU profiles, potentially impacting application performance. It is recommended to remove the net/http/pprof import in production builds.

limited use of pprof to mitigate potential risks:

if we need pprof in production, we need to Implement authentication and IP restrictions.
Conditional Enablement: Activate pprof only for specific troubleshooting sessions.
