### PR TITLE
op-supervisor: Add log db

### DIFF
--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -5,15 +5,35 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"slices"
 	"sync"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	entrySize                 = 24
+	searchCheckpointFrequency = 256
+)
+
+const (
+	typeSearchCheckpoint byte = iota
+	typeCanonicalHash
+	typeInitiatingEvent
+	typeExecutingLink
+	typeExecutingCheck
 )
 
 var (
-	ErrBlockOutOfOrder = errors.New("block out of order")
+	ErrLogOutOfOrder  = errors.New("log out of order")
+	ErrDataCorruption = errors.New("data corruption")
 )
+
+type truncatedHash []byte
 
 // dataAccess defines a minimal API required to manipulate the actual stored data.
 // It is a subset of the os.File API but could (theoretically) be satisfied by an in-memory implementation for testing.
@@ -24,15 +44,61 @@ type dataAccess interface {
 	Truncate(size int64) error
 }
 
+type Metrics interface {
+	RecordEntryCount(count int64)
+	RecordSearchEntriesRead(count int64)
+}
+
+type checkpointData struct {
+	blockNum  uint64
+	logIdx    uint32
+	timestamp uint64
+}
+
+type state struct {
+	blockNum  uint64
+	blockHash truncatedHash
+	timestamp uint64
+	logIdx    uint32
+}
+
+// DB implements an append only database for log data and cross-chain dependencies.
+//
+// To keep the append-only format, reduce data size, and support reorg detection and registering of executing-messages:
+//
+// Use a fixed 24 bytes per entry.
+//
+// Data is an append-only log, that can be binary searched for any necessary event data.
+//
+// Rules:
+// if entry_index % 256 == 0: must be type 0. For easy binary search.
+// type 1 always adjacent to type 0
+// type 2 "diff" values are offsets from type 0 values (always within 256 entries range)
+// type 3 always after type 2
+// type 4 always after type 3
+//
+// Types (<type> = 1 byte):
+// type 0: "search checkpoint" <type><uint64 block number: 8 bytes><uint32 event index offset: 4 bytes><uint64 timestamp: 8 bytes> = 20 bytes
+// type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
+// type 2: "initiating event" <type><blocknum diff: 1 byte><log idx diff: 1 byte><event-hash: 20 bytes> = 23 bytes
+// type 3: "executing link" <type><chain: 4 bytes><blocknum: 8 bytes><event index: 3 bytes><uint64 timestamp: 8 bytes> = 24 bytes
+// type 4: "executing check" <type><event-hash: 20 bytes> = 21 bytes
+// other types: future compat. E.g. for linking to L1, registering block-headers as a kind of initiating-event, tracking safe-head progression, etc.
+//
+// Right-pad each entry that is not 24 bytes.
+//
+// event-hash: H(origin, timestamp, payloadhash); enough to check identifier matches & payload matches.
 type DB struct {
+	log    log.Logger
+	m      Metrics
 	data   dataAccess
 	rwLock sync.RWMutex
 
-	lastEntryIdx int64
-	lastBlockNum uint64
+	lastEntryIdx   int64
+	lastEntryState state
 }
 
-func NewFromFile(path string) (*DB, error) {
+func NewFromFile(logger log.Logger, m Metrics, path string) (*DB, error) {
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database at %v: %w", path, err)
@@ -41,8 +107,10 @@ func NewFromFile(path string) (*DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat database at %v: %w", path, err)
 	}
-	lastEntryIdx := info.Size()/common.HashLength - 1
+	lastEntryIdx := info.Size()/entrySize - 1
 	db := &DB{
+		log:          logger,
+		m:            m,
 		data:         file,
 		lastEntryIdx: lastEntryIdx,
 	}
@@ -57,12 +125,28 @@ func (db *DB) init() error {
 		// Database is empty so nothing to init
 		return nil
 	}
-	entry, err := db.readEntry(db.lastEntryIdx)
+	lastCheckpoint := (db.lastEntryIdx / searchCheckpointFrequency) * searchCheckpointFrequency
+	checkpoint, err := db.readSearchCheckpoint(lastCheckpoint)
 	if err != nil {
-		return fmt.Errorf("failed to read last entry: %w", err)
+		return fmt.Errorf("failed to read last search checkpoint: %w", err)
 	}
-	db.lastBlockNum = db.blockNum(entry)
+	//blockHash, err := db.readCanonicalHash(lastCheckpoint + 1)
+	//if err != nil {
+	//	return fmt.Errorf("failed to read last canonical hash: %w", err)
+	//}
+	// TODO: This is broken - we need to consider any log events after the previous checkpoint which may increment blocks
+	db.lastEntryState = state{
+		blockNum: checkpoint.blockNum,
+		//blockHash: blockHash, // TODO: This should be set - need a test for it.
+		timestamp: checkpoint.timestamp,
+		logIdx:    checkpoint.logIdx,
+	}
+	db.updateEntryCountMetric()
 	return nil
+}
+
+func (db *DB) updateEntryCountMetric() {
+	db.m.RecordEntryCount(db.lastEntryIdx + 1)
 }
 
 // Contains return true iff the specified logHash is recorded in the specified blockNum and logIdx.
@@ -70,122 +154,277 @@ func (db *DB) init() error {
 func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (bool, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, entry, found, err := db.search(blockNum, logIdx)
-	if err != nil {
+	db.log.Trace("Checking for log", "blockNum", blockNum, "logIdx", logIdx, "hash", truncateHash(logHash))
+	entryIdx, err := db.searchCheckpoint(blockNum, logIdx)
+	if errors.Is(err, io.EOF) {
+		// Did not find a checkpoint to start reading from so the log cannot be present.
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
-	if !found {
-		return false, nil
+
+	current, err := db.readSearchCheckpoint(entryIdx)
+	if err != nil {
+		return false, fmt.Errorf("failed to read search checkpoint entry %v: %w", entryIdx, err)
 	}
-	searchFor := db.combine(blockNum, logIdx, logHash)
-	return entry == searchFor, nil
+	db.log.Trace("Starting search", "entry", entryIdx, "blockNum", current.blockNum, "logIdx", current.logIdx)
+	entriesRead := int64(0)
+	defer func() {
+		db.m.RecordSearchEntriesRead(entriesRead)
+	}()
+	for i := entryIdx + 2; i <= db.lastEntryIdx; i++ {
+		entry, err := db.readEntry(i)
+		if err != nil {
+			return false, fmt.Errorf("failed to read entry %v: %w", i, err)
+		}
+		entriesRead++
+		switch entry[0] {
+		case typeSearchCheckpoint:
+			current = db.parseSearchCheckpoint(entry)
+		case typeCanonicalHash:
+			// Skip
+		case typeInitiatingEvent:
+			evtBlockNum, evtLogIdx, evtHash := db.parseInitiatingEvent(current, entry)
+			if evtBlockNum == blockNum && evtLogIdx == logIdx {
+				db.log.Trace("Found initiatingEvent", "blockNum", evtBlockNum, "logIdx", evtLogIdx, "hash", evtHash)
+				// Found the requested block and log index, check if the hash matches
+				return slices.Equal(evtHash, truncateHash(logHash)), nil
+			}
+			if evtBlockNum > blockNum || (evtBlockNum == blockNum && evtLogIdx > logIdx) {
+				// Progressed past the requested log without finding it.
+				return false, nil
+			}
+			current.blockNum = evtBlockNum
+			current.logIdx = evtLogIdx
+		case typeExecutingCheck:
+		// TODO: Handle this properly
+		case typeExecutingLink:
+		// TODO: Handle this properly
+		default:
+			return false, fmt.Errorf("unknown entry type %v", entry[0])
+		}
+	}
+
+	return false, nil
 }
 
-// search performs a binary search to find the entry at blockNum, logIdx.
-// Returns the index that the entry would be found at if present, the matching entry (or common.Hash{})
-// and a bool indicating whether an entry at the specified blockNum and logIdx was found.
-// An error is returned if an error occurs reading from the data store.
-func (db *DB) search(blockNum uint64, logIdx uint32) (int64, common.Hash, bool, error) {
-	n := db.lastEntryIdx + 1
+// searchCheckpoint performs a binary search of the searchCheckpoint entries to find the closest one at or before
+// the requested log.
+// Returns the index of the searchCheckpoint to begin reading from or an error
+func (db *DB) searchCheckpoint(blockNum uint64, logIdx uint32) (int64, error) {
+	n := (db.lastEntryIdx / searchCheckpointFrequency) + 1
 	// Define x[-1] < target and x[n] >= target.
 	// Invariant: x[i-1] < target, x[j] >= target.
 	i, j := int64(0), n
 	for i < j {
 		h := int64(uint64(i+j) >> 1) // avoid overflow when computing h
-		entry, err := db.readEntry(h)
+		checkpoint, err := db.readSearchCheckpoint(h * searchCheckpointFrequency)
 		if err != nil {
-			return 0, common.Hash{}, false, fmt.Errorf("failed to read entry %v: %w", h, err)
+			return 0, fmt.Errorf("failed to read entry %v: %w", h, err)
 		}
-		entryBlock := db.blockNum(entry)
 		// i ≤ h < j
-		if entryBlock < blockNum || (entryBlock == blockNum && db.logIdx(entry) < logIdx) {
+		if checkpoint.blockNum < blockNum || (checkpoint.blockNum == blockNum && checkpoint.logIdx < logIdx) {
 			i = h + 1 // preserves x[i-1] < target
 		} else {
 			j = h // preserves x[j] >= target
 		}
 	}
 	if i < n {
-		entry, err := db.readEntry(i)
+		checkpoint, err := db.readSearchCheckpoint(i * searchCheckpointFrequency)
 		if err != nil {
-			return 0, common.Hash{}, false, fmt.Errorf("failed to read entry %v: %w", i, err)
+			return 0, fmt.Errorf("failed to read entry %v: %w", i, err)
 		}
-		if db.blockNum(entry) == blockNum && db.logIdx(entry) == logIdx {
+		if checkpoint.blockNum == blockNum && checkpoint.logIdx == logIdx {
 			// Found entry at requested block number and log index
-			return i, entry, true, nil
+			return i * searchCheckpointFrequency, nil
 		}
 	}
-	// Not found, only return where it would be inserted
-	return i, common.Hash{}, false, nil
+	if i == 0 {
+		// There are no checkpoints before the requested blocks
+		return 0, io.EOF
+	}
+	// Not found, need to start reading from the entry prior
+	return (i - 1) * searchCheckpointFrequency, nil
 }
 
-// Add a block to the database with the specified logHashes. The logs are recorded in the order they are specified
-// and must be the full set of logs for the block.
-func (db *DB) Add(blockNum uint64, logHashes []common.Hash) error {
+func (db *DB) AddLog(log common.Hash, block eth.BlockID, timestamp uint64, logIdx uint32) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
-	if db.lastBlockNum >= blockNum {
-		return fmt.Errorf("%w: adding %v, head: %v", ErrBlockOutOfOrder, blockNum, db.lastBlockNum)
+	postState := state{
+		blockNum:  block.Number,
+		blockHash: truncateHash(block.Hash),
+		timestamp: timestamp,
+		logIdx:    logIdx,
 	}
-	for logIdx, logHash := range logHashes {
-		entry := db.combine(blockNum, uint32(logIdx), logHash)
-		if _, err := db.data.Write(entry[:]); err != nil {
-			return fmt.Errorf("failed to write logs for block %v: %w", blockNum, err)
+	if block.Number == 0 {
+		return fmt.Errorf("%w: should not have logs in block 0", ErrLogOutOfOrder)
+	}
+	if db.lastEntryState.blockNum > block.Number {
+		return fmt.Errorf("%w: adding block %v, head block: %v", ErrLogOutOfOrder, block.Number, db.lastEntryState.blockNum)
+	}
+	if db.lastEntryState.blockNum == block.Number && db.lastEntryState.logIdx >= logIdx {
+		return fmt.Errorf("%w: adding log %v in block %v, but already at log %v", ErrLogOutOfOrder, logIdx, block.Number, db.lastEntryState.logIdx)
+	}
+	if (db.lastEntryIdx+1)%searchCheckpointFrequency == 0 {
+		if err := db.writeSearchCheckpoint(postState); err != nil {
+			return fmt.Errorf("failed to write search checkpoint: %w", err)
 		}
+		db.lastEntryState = postState
 	}
-	db.lastBlockNum = blockNum
-	db.lastEntryIdx += int64(len(logHashes))
+
+	if err := db.writeInitiatingEvent(postState, log); err != nil {
+		return err
+	}
+	db.lastEntryState = postState
+	db.updateEntryCountMetric()
+	return nil
+}
+
+// writeSearchCheckpoint appends search checkpoint and canonical hash entry to the log
+// type 0: "search checkpoint" <type><uint64 block number: 8 bytes><uint32 event index offset: 4 bytes><uint64 timestamp: 8 bytes> = 20 bytes
+// type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
+func (db *DB) writeSearchCheckpoint(currentState state) error {
+	var entry [entrySize]byte
+	entry[0] = typeSearchCheckpoint
+	binary.LittleEndian.PutUint64(entry[1:9], currentState.blockNum)
+	binary.LittleEndian.PutUint32(entry[9:13], currentState.logIdx)
+	binary.LittleEndian.PutUint64(entry[13:21], currentState.timestamp)
+	if err := db.writeEntry(entry); err != nil {
+		return err
+	}
+	return db.writeCanonicalHash(currentState)
+}
+
+func (db *DB) readSearchCheckpoint(entryIdx int64) (checkpointData, error) {
+	data, err := db.readEntry(entryIdx)
+	if err != nil {
+		return checkpointData{}, fmt.Errorf("failed to read entry %v: %w", entryIdx, err)
+	}
+	if data[0] != typeSearchCheckpoint {
+		return checkpointData{}, fmt.Errorf("%w: expected search checkpoint at entry %v but was type %v", ErrDataCorruption, entryIdx, data[0])
+	}
+	return db.parseSearchCheckpoint(data), nil
+}
+
+func (db *DB) parseSearchCheckpoint(data [entrySize]byte) checkpointData {
+	return checkpointData{
+		blockNum:  binary.LittleEndian.Uint64(data[1:9]),
+		logIdx:    binary.LittleEndian.Uint32(data[9:13]),
+		timestamp: binary.LittleEndian.Uint64(data[13:21]),
+	}
+}
+
+// writeCanonicalHash appends a canonical hash entry to the log
+// type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
+func (db *DB) writeCanonicalHash(currentState state) error {
+	var entry [entrySize]byte
+	entry[0] = typeCanonicalHash
+	copy(entry[1:21], currentState.blockHash[:])
+	return db.writeEntry(entry)
+}
+
+func (db *DB) readCanonicalHash(entryIdx int64) (truncatedHash, error) {
+	data, err := db.readEntry(entryIdx)
+	if err != nil {
+		return truncatedHash{}, fmt.Errorf("failed to read entry %v: %w", entryIdx, err)
+	}
+	if data[0] != typeCanonicalHash {
+		return truncatedHash{}, fmt.Errorf("%w: expected canonical hash at entry %v but was type %v", ErrDataCorruption, entryIdx, data[0])
+	}
+	return db.parseCanonicalHash(data), nil
+}
+
+func (db *DB) parseCanonicalHash(data [24]byte) truncatedHash {
+	return data[1:21]
+}
+
+// writeInitiatingEvent appends an initiating event to the log
+// type 2: "initiating event" <type><blocknum diff: 1 byte><event index diff: 1 byte><event-hash: 20 bytes> = 23 bytes
+func (db *DB) writeInitiatingEvent(postState state, log common.Hash) error {
+	var entry [entrySize]byte
+	entry[0] = typeInitiatingEvent
+	blockDiff := postState.blockNum - db.lastEntryState.blockNum
+	if blockDiff > math.MaxUint8 {
+		// TODO: Need to find a way to support this.
+		return fmt.Errorf("too many block skipped between %v and %v", db.lastEntryState.blockNum, postState.blockNum)
+	}
+	entry[1] = byte(blockDiff)
+	// TODO: Probably shouldn't allow skipping logs as that indicates we missed data
+	currLogIdx := db.lastEntryState.logIdx
+	if blockDiff > 0 {
+		currLogIdx = 0
+	}
+	logDiff := postState.logIdx - currLogIdx
+	if logDiff > math.MaxUint8 {
+		return fmt.Errorf("too many logs skipped between %v and %v", db.lastEntryState.logIdx, postState.logIdx)
+	}
+	entry[2] = byte(logDiff)
+	truncated := truncateHash(log)
+	copy(entry[3:23], truncated[:])
+	return db.writeEntry(entry)
+}
+
+func (db *DB) parseInitiatingEvent(checkpoint checkpointData, entry [entrySize]byte) (uint64, uint32, []byte) {
+	blockNumDiff := entry[1]
+	logIdxDiff := entry[2]
+	blockNum := checkpoint.blockNum + uint64(blockNumDiff)
+	logIdx := checkpoint.logIdx
+	if blockNumDiff > 0 {
+		logIdx = 0
+	}
+	logIdx = logIdx + uint32(logIdxDiff)
+	eventHash := entry[3:23]
+	return blockNum, logIdx, eventHash
+}
+
+func (db *DB) writeEntry(entry [entrySize]byte) error {
+	// TODO: Automatically insert search checkpoint
+	if _, err := db.data.Write(entry[:]); err != nil {
+		// TODO: Truncate to the start of the entry?
+		// TODO: Roll back any updates to memory state
+		return err
+	}
+	db.lastEntryIdx++
 	return nil
 }
 
 // Rewind the database to remove any blocks after headBlockNum
 // The block at headBlockNum itself is not removed.
-func (db *DB) Rewind(headBlockNum uint64) error {
-	db.rwLock.Lock()
-	defer db.rwLock.Unlock()
-	if headBlockNum > db.lastBlockNum {
-		// Nothing to do
-		return nil
-	}
-	// Find the first index we should delete
-	idx, _, _, err := db.search(headBlockNum+1, 0)
-	if err != nil {
-		return fmt.Errorf("failed to find entry index for block %v: %w", headBlockNum, err)
-	}
-	// Truncate to contain exactly idx entries, since indices are 0 based, this deletes idx and everything after it
-	err = db.data.Truncate(idx * common.HashLength)
-	if err != nil {
-		return fmt.Errorf("failed to truncate to block %v: %w", headBlockNum, err)
-	}
-	// The first remaining entry is one before the first deleted entry
-	db.lastEntryIdx = idx - 1
-	db.lastBlockNum = headBlockNum
-	return nil
-}
+//func (db *DB) Rewind(headBlockNum uint64) error {
+//	db.rwLock.Lock()
+//	defer db.rwLock.Unlock()
+//	if headBlockNum > db.lastBlockNum {
+//		// Nothing to do
+//		return nil
+//	}
+//	// Find the first index we should delete
+//	idx, _, _, err := db.search(headBlockNum+1, 0)
+//	if err != nil {
+//		return fmt.Errorf("failed to find entry index for block %v: %w", headBlockNum, err)
+//	}
+//	// Truncate to contain exactly idx entries, since indices are 0 based, this deletes idx and everything after it
+//	err = db.data.Truncate(idx * common.HashLength)
+//	if err != nil {
+//		return fmt.Errorf("failed to truncate to block %v: %w", headBlockNum, err)
+//	}
+//	// The first remaining entry is one before the first deleted entry
+//	db.lastEntryIdx = idx - 1
+//	db.lastBlockNum = headBlockNum
+//	return nil
+//}
 
-func (db *DB) readEntry(idx int64) (common.Hash, error) {
-	var out common.Hash
-	read, err := db.data.ReadAt(out[:], idx*common.HashLength)
+func (db *DB) readEntry(idx int64) ([entrySize]byte, error) {
+	var out [entrySize]byte
+	read, err := db.data.ReadAt(out[:], idx*entrySize)
 	// Ignore io.EOF if we read the entire last entry as ReadAt may return io.EOF or nil when it reads the last byte
-	if err != nil && !(errors.Is(err, io.EOF) && read == common.HashLength) {
-		return common.Hash{}, fmt.Errorf("failed to read entry %v: %w", idx, err)
+	if err != nil && !(errors.Is(err, io.EOF) && read == entrySize) {
+		return [entrySize]byte{}, fmt.Errorf("failed to read entry %v: %w", idx, err)
 	}
 	return out, nil
 }
 
-func (db *DB) combine(blockNum uint64, logIdx uint32, hash common.Hash) common.Hash {
-	var result common.Hash
-	binary.LittleEndian.PutUint64(result[0:8], blockNum)
-	binary.LittleEndian.PutUint32(result[8:12], logIdx)
-	copy(result[12:], hash[12:])
-	return result
-}
-
-func (db *DB) blockNum(entry common.Hash) uint64 {
-	return binary.LittleEndian.Uint64(entry[:8])
-}
-
-func (db *DB) logIdx(entry common.Hash) uint32 {
-	return binary.LittleEndian.Uint32(entry[8:12])
+func truncateHash(hash common.Hash) truncatedHash {
+	return hash[0:20]
 }
 
 func (db *DB) Close() error {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -273,7 +273,6 @@ func (db *DB) searchCheckpoint(blockNum uint64, logIdx uint32) (int64, error) {
 }
 
 func (db *DB) AddLog(log common.Hash, block eth.BlockID, timestamp uint64, logIdx uint32) error {
-	// TODO: Error if first log in a block is not index 0.
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 	postState := logContext{

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -289,6 +289,9 @@ func (db *DB) AddLog(log common.Hash, block eth.BlockID, timestamp uint64, logId
 	if db.lastEntryContext.blockNum == block.Number && db.lastEntryContext.logIdx+1 != logIdx {
 		return fmt.Errorf("%w: adding log %v in block %v, but currently at log %v", ErrLogOutOfOrder, logIdx, block.Number, db.lastEntryContext.logIdx)
 	}
+	if db.lastEntryContext.blockNum < block.Number && logIdx != 0 {
+		return fmt.Errorf("%w: adding log %v as first log in block %v", ErrLogOutOfOrder, logIdx, block.Number)
+	}
 	if (db.lastEntryIdx+1)%searchCheckpointFrequency == 0 {
 		if err := db.writeSearchCheckpoint(block.Number, logIdx, timestamp, block.Hash); err != nil {
 			return fmt.Errorf("failed to write search checkpoint: %w", err)

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -15,6 +15,8 @@ var (
 	ErrBlockOutOfOrder = errors.New("block out of order")
 )
 
+// dataAccess defines a minimal API required to manipulate the actual stored data.
+// It is a subset of the os.File API but could (theoretically) be satisfied by an in-memory implementation for testing.
 type dataAccess interface {
 	io.ReaderAt
 	io.Writer

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -461,7 +461,6 @@ func (db *DB) parseInitiatingEvent(blockNum uint64, logIdx uint32, entry [entryS
 }
 
 func (db *DB) writeEntry(entry [entrySize]byte) error {
-	// TODO: Automatically insert search checkpoint
 	if _, err := db.data.Write(entry[:]); err != nil {
 		// TODO: Truncate to the start of the entry?
 		// TODO: Roll back any updates to memory state

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -217,7 +217,7 @@ func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (boo
 }
 
 func (db *DB) newIterator(startCheckpointEntry int64) (*iterator, error) {
-	// TODO: Handle starting from a checkpoint after initiating-event but before its executing-link
+	// TODO(optimism#10857): Handle starting from a checkpoint after initiating-event but before its executing-link
 	// Will need to read the entry prior to the checkpoint to get the initiating event info
 	current, err := db.readSearchCheckpoint(startCheckpointEntry)
 	if err != nil {
@@ -425,7 +425,7 @@ func (db *DB) writeInitiatingEvent(postState logContext, log common.Hash) error 
 	entry[0] = typeInitiatingEvent
 	blockDiff := postState.blockNum - db.lastEntryContext.blockNum
 	if blockDiff > math.MaxUint8 {
-		// TODO: Need to find a way to support this.
+		// TODO(optimism#10857): Need to find a way to support this.
 		return fmt.Errorf("too many block skipped between %v and %v", db.lastEntryContext.blockNum, postState.blockNum)
 	}
 	entry[1] = byte(blockDiff)
@@ -464,8 +464,9 @@ func (db *DB) parseInitiatingEvent(blockNum uint64, logIdx uint32, entry [entryS
 
 func (db *DB) writeEntry(entry [entrySize]byte) error {
 	if _, err := db.data.Write(entry[:]); err != nil {
-		// TODO: Truncate to the start of the entry?
-		// TODO: Roll back any updates to memory state
+		// TODO(optimism#10857): When a write fails, need to revert any in memory changes and truncate back to the
+		// pre-write state. Likely need to batch writes for multiple entries into a single write akin to transactions
+		// to avoid leaving hanging entries without the entry that should follow them.
 		return err
 	}
 	db.lastEntryIdx++

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -1,0 +1,183 @@
+package db
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	ErrBlockOutOfOrder = errors.New("block out of order")
+)
+
+type dataAccess interface {
+	io.ReaderAt
+	io.Writer
+	io.Closer
+	Truncate(size int64) error
+}
+
+type DB struct {
+	data dataAccess
+
+	lastEntryIdx int64
+	lastBlockNum uint64
+}
+
+func NewFromFile(path string) (*DB, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database at %v: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat database at %v: %w", path, err)
+	}
+	lastEntryIdx := info.Size()/common.HashLength - 1
+	db := &DB{
+		data:         file,
+		lastEntryIdx: lastEntryIdx,
+	}
+	if err := db.init(); err != nil {
+		return nil, fmt.Errorf("failed to init database: %w", err)
+	}
+	return db, nil
+}
+
+func (db *DB) init() error {
+	if db.lastEntryIdx < 0 {
+		// Database is empty so nothing to init
+		return nil
+	}
+	entry, err := db.readEntry(db.lastEntryIdx)
+	if err != nil {
+		return fmt.Errorf("failed to read last entry: %w", err)
+	}
+	db.lastBlockNum = db.blockNum(entry)
+	return nil
+}
+
+// Contains return true iff the specified logHash is recorded in the specified blockNum and logIdx.
+// logIdx is the index of the log in the array of all logs the block.
+func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (bool, error) {
+	_, entry, found, err := db.search(blockNum, logIdx)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	searchFor := db.combine(blockNum, logIdx, logHash)
+	return entry == searchFor, nil
+}
+
+// search performs a binary search to find the entry at blockNum, logIdx.
+// Returns the index that the entry would be found at if present, the matching entry (or common.Hash{})
+// and a bool indicating whether an entry at the specified blockNum and logIdx was found.
+// An error is returned if an error occurs reading from the data store.
+func (db *DB) search(blockNum uint64, logIdx uint32) (int64, common.Hash, bool, error) {
+	n := db.lastEntryIdx + 1
+	// Define x[-1] < target and x[n] >= target.
+	// Invariant: x[i-1] < target, x[j] >= target.
+	i, j := int64(0), n
+	for i < j {
+		h := int64(uint64(i+j) >> 1) // avoid overflow when computing h
+		entry, err := db.readEntry(h)
+		if err != nil {
+			return 0, common.Hash{}, false, fmt.Errorf("failed to read entry %v: %w", h, err)
+		}
+		entryBlock := db.blockNum(entry)
+		// i ≤ h < j
+		if entryBlock < blockNum || (entryBlock == blockNum && db.logIdx(entry) < logIdx) {
+			i = h + 1 // preserves x[i-1] < target
+		} else {
+			j = h // preserves x[j] >= target
+		}
+	}
+	if i < n {
+		entry, err := db.readEntry(i)
+		if err != nil {
+			return 0, common.Hash{}, false, fmt.Errorf("failed to read entry %v: %w", i, err)
+		}
+		if db.blockNum(entry) == blockNum && db.logIdx(entry) == logIdx {
+			// Found entry at requested block number and log index
+			return i, entry, true, nil
+		}
+	}
+	// Not found, only return where it would be inserted
+	return i, common.Hash{}, false, nil
+}
+
+// Add a block to the database with the specified logHashes. The logs are recorded in the order they are specified
+// and must be the full set of logs for the block.
+func (db *DB) Add(blockNum uint64, logHashes []common.Hash) error {
+	if db.lastBlockNum >= blockNum {
+		return fmt.Errorf("%w: adding %v, head: %v", ErrBlockOutOfOrder, blockNum, db.lastBlockNum)
+	}
+	for logIdx, logHash := range logHashes {
+		entry := db.combine(blockNum, uint32(logIdx), logHash)
+		if _, err := db.data.Write(entry[:]); err != nil {
+			return fmt.Errorf("failed to write logs for block %v: %w", blockNum, err)
+		}
+	}
+	db.lastBlockNum = blockNum
+	db.lastEntryIdx += int64(len(logHashes))
+	return nil
+}
+
+// Rewind the database to remove any blocks after headBlockNum
+// The block at headBlockNum itself is not removed.
+func (db *DB) Rewind(headBlockNum uint64) error {
+	if headBlockNum > db.lastBlockNum {
+		// Nothing to do
+		return nil
+	}
+	// Find the first index we should delete
+	idx, _, _, err := db.search(headBlockNum+1, 0)
+	if err != nil {
+		return fmt.Errorf("failed to find entry index for block %v: %w", headBlockNum, err)
+	}
+	// Truncate to contain exactly idx entries, since indices are 0 based, this deletes idx and everything after it
+	err = db.data.Truncate(idx * common.HashLength)
+	if err != nil {
+		return fmt.Errorf("failed to truncate to block %v: %w", headBlockNum, err)
+	}
+	// The first remaining entry is one before the first deleted entry
+	db.lastEntryIdx = idx - 1
+	db.lastBlockNum = headBlockNum
+	return nil
+}
+
+func (db *DB) readEntry(idx int64) (common.Hash, error) {
+	var out common.Hash
+	read, err := db.data.ReadAt(out[:], idx*common.HashLength)
+	// Ignore io.EOF if we read the entire last entry as ReadAt may return io.EOF or nil when it reads the last byte
+	if err != nil && !(errors.Is(err, io.EOF) && read == common.HashLength) {
+		return common.Hash{}, fmt.Errorf("failed to read entry %v: %w", idx, err)
+	}
+	return out, nil
+}
+
+func (db *DB) combine(blockNum uint64, logIdx uint32, hash common.Hash) common.Hash {
+	var result common.Hash
+	binary.LittleEndian.PutUint64(result[0:8], blockNum)
+	binary.LittleEndian.PutUint32(result[8:12], logIdx)
+	copy(result[12:], hash[12:])
+	return result
+}
+
+func (db *DB) blockNum(entry common.Hash) uint64 {
+	return binary.LittleEndian.Uint64(entry[:8])
+}
+
+func (db *DB) logIdx(entry common.Hash) uint32 {
+	return binary.LittleEndian.Uint32(entry[8:12])
+}
+
+func (db *DB) Close() error {
+	return db.data.Close()
+}

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -159,6 +159,8 @@ func (db *DB) updateEntryCountMetric() {
 // Since block data is only recorded in search checkpoints, this may return an earlier block even if log data is
 // recorded for the requested block.
 func (db *DB) ClosestBlockInfo(blockNum uint64) (uint64, TruncatedHash, error) {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
 	checkpointIdx, err := db.searchCheckpoint(blockNum, math.MaxUint32)
 	if err != nil {
 		return 0, TruncatedHash{}, fmt.Errorf("no checkpoint at or before block %v found: %w", blockNum, err)

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -19,8 +19,8 @@ const (
 	entrySize                 = 24
 	searchCheckpointFrequency = 256
 
-	eventFlagIncrementLogIdx     = byte(1)
-	eventFlagHasExecutingMessage = byte(1) << 1
+	eventFlagIncrementLogIdx = byte(1)
+	//eventFlagHasExecutingMessage = byte(1) << 1
 )
 
 const (
@@ -329,20 +329,20 @@ func (db *DB) writeCanonicalHash(currentState state) error {
 	return db.writeEntry(entry)
 }
 
-func (db *DB) readCanonicalHash(entryIdx int64) (truncatedHash, error) {
-	data, err := db.readEntry(entryIdx)
-	if err != nil {
-		return truncatedHash{}, fmt.Errorf("failed to read entry %v: %w", entryIdx, err)
-	}
-	if data[0] != typeCanonicalHash {
-		return truncatedHash{}, fmt.Errorf("%w: expected canonical hash at entry %v but was type %v", ErrDataCorruption, entryIdx, data[0])
-	}
-	return db.parseCanonicalHash(data), nil
-}
-
-func (db *DB) parseCanonicalHash(data [24]byte) truncatedHash {
-	return data[1:21]
-}
+//func (db *DB) readCanonicalHash(entryIdx int64) (truncatedHash, error) {
+//	data, err := db.readEntry(entryIdx)
+//	if err != nil {
+//		return truncatedHash{}, fmt.Errorf("failed to read entry %v: %w", entryIdx, err)
+//	}
+//	if data[0] != typeCanonicalHash {
+//		return truncatedHash{}, fmt.Errorf("%w: expected canonical hash at entry %v but was type %v", ErrDataCorruption, entryIdx, data[0])
+//	}
+//	return db.parseCanonicalHash(data), nil
+//}
+//
+//func (db *DB) parseCanonicalHash(data [24]byte) truncatedHash {
+//	return data[1:21]
+//}
 
 // writeInitiatingEvent appends an initiating event to the log
 // type 2: "initiating event" <type><blocknum diff: 1 byte><event flags: 1 byte><event-hash: 20 bytes> = 23 bytes

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -90,7 +90,7 @@ type logContext struct {
 //
 // event-flags: each bit represents a boolean value, currently only two are defined
 // * event-flags & 0x01 - true if the log index should increment. Should only be false when the event is immediately after a search checkpoint and canonical hash
-// * event-falgs & 0x02 - true if the initiating event has an executing link that should follow. Allows detecting when the executing link failed to write.
+// * event-flags & 0x02 - true if the initiating event has an executing link that should follow. Allows detecting when the executing link failed to write.
 // event-hash: H(origin, timestamp, payloadhash); enough to check identifier matches & payload matches.
 type DB struct {
 	log    log.Logger

--- a/op-supervisor/supervisor/backend/db/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/db_invariants_test.go
@@ -1,0 +1,147 @@
+package db
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type statInvariant func(stat os.FileInfo, m *stubMetrics) error
+type entryInvariant func(entryIdx int, entry [entrySize]byte, entries [][entrySize]byte, m *stubMetrics) error
+
+// checkDBInvariants reads the database log directly and asserts a set of invariants on the data.
+func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
+	stat, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	statInvariants := []statInvariant{
+		invariantFileSizeMultipleOfEntrySize,
+		invariantFileSizeMatchesEntryCountMetric,
+	}
+	for _, invariant := range statInvariants {
+		require.NoError(t, invariant(stat, m))
+	}
+
+	// Read all entries as binary blobs
+	file, err := os.OpenFile(dbPath, os.O_RDONLY, 0o644)
+	require.NoError(t, err)
+	entries := make([][entrySize]byte, stat.Size()/entrySize)
+	for i := range entries {
+		n, err := io.ReadFull(file, entries[i][:])
+		require.NoErrorf(t, err, "failed to read entry %v", i)
+		require.EqualValuesf(t, entrySize, n, "read wrong length for entry %v", i)
+	}
+
+	entryInvariants := []entryInvariant{
+		invariantSearchCheckpointOnlyAtFrequency,
+		invariantSearchCheckpointAtEverySearchCheckpointFrequency,
+		invariantCanonicalHashAfterEverySearchCheckpoint,
+		invariantSearchCheckpointBeforeEveryCanonicalHash,
+		invariantIncrementLogIdxIfNotImmediatelyAfterCanonicalHash,
+	}
+	for i, entry := range entries {
+		for _, invariant := range entryInvariants {
+			err := invariant(i, entry, entries, m)
+			if err != nil {
+				require.NoErrorf(t, err, "Invariant breached: \n%v", fmtEntries(entries))
+			}
+		}
+	}
+}
+
+func fmtEntries(entries [][entrySize]byte) string {
+	out := ""
+	for i, entry := range entries {
+		out += fmt.Sprintf("%v: %x\n", i, entry)
+	}
+	return out
+}
+
+func invariantFileSizeMultipleOfEntrySize(stat os.FileInfo, _ *stubMetrics) error {
+	size := stat.Size()
+	if size%entrySize != 0 {
+		return fmt.Errorf("expected file size to be a multiple of entry size (%v) but was %v", entrySize, size)
+	}
+	return nil
+}
+
+func invariantFileSizeMatchesEntryCountMetric(stat os.FileInfo, m *stubMetrics) error {
+	size := stat.Size()
+	if m.entryCount*entrySize != size {
+		return fmt.Errorf("expected file size to be entryCount (%v) * entrySize (%v) = %v but was %v", m.entryCount, entrySize, m.entryCount*entrySize, size)
+	}
+	return nil
+}
+
+func invariantSearchCheckpointOnlyAtFrequency(entryIdx int, entry [entrySize]byte, entries [][entrySize]byte, m *stubMetrics) error {
+	if entry[0] != typeSearchCheckpoint {
+		return nil
+	}
+	if entryIdx%searchCheckpointFrequency != 0 {
+		return fmt.Errorf("should only have search checkpoints every %v entries but found at entry %v", searchCheckpointFrequency, entryIdx)
+	}
+	return nil
+}
+
+func invariantSearchCheckpointAtEverySearchCheckpointFrequency(entryIdx int, entry [entrySize]byte, entries [][entrySize]byte, m *stubMetrics) error {
+	if entryIdx%searchCheckpointFrequency == 0 && entry[0] != typeSearchCheckpoint {
+		return fmt.Errorf("should have search checkpoints every %v entries but entry %v was %x", searchCheckpointFrequency, entryIdx, entry)
+	}
+	return nil
+}
+
+func invariantCanonicalHashAfterEverySearchCheckpoint(entryIdx int, entry [entrySize]byte, entries [][entrySize]byte, m *stubMetrics) error {
+	if entry[0] != typeSearchCheckpoint {
+		return nil
+	}
+	if entryIdx+1 >= len(entries) {
+		return fmt.Errorf("expected canonical hash after search checkpoint at entry %v but no further entries found", entryIdx)
+	}
+	nextEntry := entries[entryIdx+1]
+	if nextEntry[0] != typeCanonicalHash {
+		return fmt.Errorf("expected canonical hash after search checkpoint at entry %v but got %x", entryIdx, nextEntry)
+	}
+	return nil
+}
+
+// invariantSearchCheckpointBeforeEveryCanonicalHash ensures we don't have extra canonical-hash entries
+func invariantSearchCheckpointBeforeEveryCanonicalHash(entryIdx int, entry [entrySize]byte, entries [][entrySize]byte, m *stubMetrics) error {
+	if entry[0] != typeCanonicalHash {
+		return nil
+	}
+	if entryIdx == 0 {
+		return fmt.Errorf("expected search checkpoint before canonical hash at entry %v but no previous entries present", entryIdx)
+	}
+	prevEntry := entries[entryIdx-1]
+	if prevEntry[0] != typeSearchCheckpoint {
+		return fmt.Errorf("expected search checkpoint before canonical hash at entry %v but got %x", entryIdx, prevEntry)
+	}
+	return nil
+}
+
+func invariantIncrementLogIdxIfNotImmediatelyAfterCanonicalHash(entryIdx int, entry [entrySize]byte, entries [][entrySize]byte, m *stubMetrics) error {
+	if entry[0] != typeInitiatingEvent {
+		return nil
+	}
+	if entryIdx == 0 {
+		return fmt.Errorf("found initiating event at index %v before any search checkpoint", entryIdx)
+	}
+	blockDiff := entry[1]
+	flags := entry[2]
+	incrementsLogIdx := flags&eventFlagIncrementLogIdx != 0
+	prevEntry := entries[entryIdx-1]
+	prevEntryIsCanonicalHash := prevEntry[0] == typeCanonicalHash
+	if incrementsLogIdx && prevEntryIsCanonicalHash {
+		return fmt.Errorf("initiating event at index %v increments logIdx despite being immediately after canonical hash (prev entry %x)", entryIdx, prevEntry)
+	}
+	if incrementsLogIdx && blockDiff > 0 {
+		return fmt.Errorf("initiating event at index %v increments logIdx despite starting a new block", entryIdx)
+	}
+	if !incrementsLogIdx && !prevEntryIsCanonicalHash && blockDiff == 0 {
+		return fmt.Errorf("initiating event at index %v does not increment logIdx when block unchanged and not after canonical hash (prev entry %x)", entryIdx, prevEntry)
+	}
+	return nil
+}

--- a/op-supervisor/supervisor/backend/db/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/db_invariants_test.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/stretchr/testify/require"
 )
 
 type statInvariant func(stat os.FileInfo, m *stubMetrics) error
-type entryInvariant func(entryIdx int, entry entry, entries []entry, m *stubMetrics) error
+type entryInvariant func(entryIdx int, entry entrydb.Entry, entries []entrydb.Entry, m *stubMetrics) error
 
 // checkDBInvariants reads the database log directly and asserts a set of invariants on the data.
 func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
@@ -28,11 +29,11 @@ func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
 	// Read all entries as binary blobs
 	file, err := os.OpenFile(dbPath, os.O_RDONLY, 0o644)
 	require.NoError(t, err)
-	entries := make([]entry, stat.Size()/entrySize)
+	entries := make([]entrydb.Entry, stat.Size()/entrydb.EntrySize)
 	for i := range entries {
 		n, err := io.ReadFull(file, entries[i][:])
 		require.NoErrorf(t, err, "failed to read entry %v", i)
-		require.EqualValuesf(t, entrySize, n, "read wrong length for entry %v", i)
+		require.EqualValuesf(t, entrydb.EntrySize, n, "read wrong length for entry %v", i)
 	}
 
 	entryInvariants := []entryInvariant{
@@ -52,7 +53,7 @@ func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
 	}
 }
 
-func fmtEntries(entries []entry) string {
+func fmtEntries(entries []entrydb.Entry) string {
 	out := ""
 	for i, entry := range entries {
 		out += fmt.Sprintf("%v: %x\n", i, entry)
@@ -62,21 +63,21 @@ func fmtEntries(entries []entry) string {
 
 func invariantFileSizeMultipleOfEntrySize(stat os.FileInfo, _ *stubMetrics) error {
 	size := stat.Size()
-	if size%entrySize != 0 {
-		return fmt.Errorf("expected file size to be a multiple of entry size (%v) but was %v", entrySize, size)
+	if size%entrydb.EntrySize != 0 {
+		return fmt.Errorf("expected file size to be a multiple of entry size (%v) but was %v", entrydb.EntrySize, size)
 	}
 	return nil
 }
 
 func invariantFileSizeMatchesEntryCountMetric(stat os.FileInfo, m *stubMetrics) error {
 	size := stat.Size()
-	if m.entryCount*entrySize != size {
-		return fmt.Errorf("expected file size to be entryCount (%v) * entrySize (%v) = %v but was %v", m.entryCount, entrySize, m.entryCount*entrySize, size)
+	if m.entryCount*entrydb.EntrySize != size {
+		return fmt.Errorf("expected file size to be entryCount (%v) * entrySize (%v) = %v but was %v", m.entryCount, entrydb.EntrySize, m.entryCount*entrydb.EntrySize, size)
 	}
 	return nil
 }
 
-func invariantSearchCheckpointOnlyAtFrequency(entryIdx int, entry entry, entries []entry, m *stubMetrics) error {
+func invariantSearchCheckpointOnlyAtFrequency(entryIdx int, entry entrydb.Entry, entries []entrydb.Entry, m *stubMetrics) error {
 	if entry[0] != typeSearchCheckpoint {
 		return nil
 	}
@@ -86,14 +87,14 @@ func invariantSearchCheckpointOnlyAtFrequency(entryIdx int, entry entry, entries
 	return nil
 }
 
-func invariantSearchCheckpointAtEverySearchCheckpointFrequency(entryIdx int, entry entry, entries []entry, m *stubMetrics) error {
+func invariantSearchCheckpointAtEverySearchCheckpointFrequency(entryIdx int, entry entrydb.Entry, entries []entrydb.Entry, m *stubMetrics) error {
 	if entryIdx%searchCheckpointFrequency == 0 && entry[0] != typeSearchCheckpoint {
 		return fmt.Errorf("should have search checkpoints every %v entries but entry %v was %x", searchCheckpointFrequency, entryIdx, entry)
 	}
 	return nil
 }
 
-func invariantCanonicalHashAfterEverySearchCheckpoint(entryIdx int, entry entry, entries []entry, m *stubMetrics) error {
+func invariantCanonicalHashAfterEverySearchCheckpoint(entryIdx int, entry entrydb.Entry, entries []entrydb.Entry, m *stubMetrics) error {
 	if entry[0] != typeSearchCheckpoint {
 		return nil
 	}
@@ -108,7 +109,7 @@ func invariantCanonicalHashAfterEverySearchCheckpoint(entryIdx int, entry entry,
 }
 
 // invariantSearchCheckpointBeforeEveryCanonicalHash ensures we don't have extra canonical-hash entries
-func invariantSearchCheckpointBeforeEveryCanonicalHash(entryIdx int, entry entry, entries []entry, m *stubMetrics) error {
+func invariantSearchCheckpointBeforeEveryCanonicalHash(entryIdx int, entry entrydb.Entry, entries []entrydb.Entry, m *stubMetrics) error {
 	if entry[0] != typeCanonicalHash {
 		return nil
 	}
@@ -122,7 +123,7 @@ func invariantSearchCheckpointBeforeEveryCanonicalHash(entryIdx int, entry entry
 	return nil
 }
 
-func invariantIncrementLogIdxIfNotImmediatelyAfterCanonicalHash(entryIdx int, entry entry, entries []entry, m *stubMetrics) error {
+func invariantIncrementLogIdxIfNotImmediatelyAfterCanonicalHash(entryIdx int, entry entrydb.Entry, entries []entrydb.Entry, m *stubMetrics) error {
 	if entry[0] != typeInitiatingEvent {
 		return nil
 	}

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -7,7 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,14 +21,16 @@ func createHash(i int) common.Hash {
 
 func TestErrorOpeningDatabase(t *testing.T) {
 	dir := t.TempDir()
-	_, err := NewFromFile(filepath.Join(dir, "missing-dir", "file.db"))
+	_, err := NewFromFile(testlog.Logger(t, log.LvlInfo), &stubMetrics{}, filepath.Join(dir, "missing-dir", "file.db"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func runDBTest(t *testing.T, setup func(t *testing.T, db *DB), assert func(t *testing.T, db *DB)) {
-	createDb := func(t *testing.T, dir string) *DB {
+func runDBTest(t *testing.T, setup func(t *testing.T, db *DB, m *stubMetrics), assert func(t *testing.T, db *DB, m *stubMetrics)) {
+	createDb := func(t *testing.T, dir string) (*DB, *stubMetrics) {
+		logger := testlog.Logger(t, log.LvlInfo)
 		path := filepath.Join(dir, "test.db")
-		db, err := NewFromFile(path)
+		m := &stubMetrics{}
+		db, err := NewFromFile(logger, m, path)
 		require.NoError(t, err, "Failed to create database")
 		t.Cleanup(func() {
 			err := db.Close()
@@ -33,31 +38,31 @@ func runDBTest(t *testing.T, setup func(t *testing.T, db *DB), assert func(t *te
 				require.ErrorIs(t, err, fs.ErrClosed)
 			}
 		})
-		return db
+		return db, m
 	}
 
 	t.Run("New", func(t *testing.T) {
-		db := createDb(t, t.TempDir())
-		setup(t, db)
-		assert(t, db)
+		db, m := createDb(t, t.TempDir())
+		setup(t, db, m)
+		assert(t, db, m)
 	})
 
 	t.Run("Existing", func(t *testing.T) {
 		dir := t.TempDir()
-		db := createDb(t, dir)
-		setup(t, db)
+		db, m := createDb(t, dir)
+		setup(t, db, m)
 		// Close and recreate the database
 		require.NoError(t, db.Close())
 
-		db2 := createDb(t, dir)
-		assert(t, db2)
+		db2, m := createDb(t, dir)
+		assert(t, db2, m)
 	})
 }
 
 func TestEmptyDbDoesNotFindEntry(t *testing.T) {
 	runDBTest(t,
-		func(t *testing.T, db *DB) {},
-		func(t *testing.T, db *DB) {
+		func(t *testing.T, db *DB, m *stubMetrics) {},
+		func(t *testing.T, db *DB, m *stubMetrics) {
 			result, err := db.Contains(0, 0, createHash(1))
 			require.NoError(t, err)
 			require.False(t, result)
@@ -69,252 +74,415 @@ func TestEmptyDbDoesNotFindEntry(t *testing.T) {
 		})
 }
 
-func TestContainsRecordedLog(t *testing.T) {
-	runDBTest(t,
-		func(t *testing.T, db *DB) {
-			err := db.Add(50, []common.Hash{createHash(0), createHash(2), createHash(1)})
-			require.NoError(t, err)
-		},
-		func(t *testing.T, db *DB) {
-			actual, err := db.Contains(50, 0, createHash(0))
-			require.NoError(t, err)
-			require.True(t, actual)
+//func TestContainsRecordedLog(t *testing.T) {
+//	t.Skip("TODO")
+//	runDBTest(t,
+//		func(t *testing.T, db *DB) {
+//			err := db.Add(50, []common.Hash{createHash(0), createHash(2), createHash(1)})
+//			require.NoError(t, err)
+//		},
+//		func(t *testing.T, db *DB) {
+//			actual, err := db.Contains(50, 0, createHash(0))
+//			require.NoError(t, err)
+//			require.True(t, actual)
+//
+//			actual, err = db.Contains(50, 1, createHash(2))
+//			require.NoError(t, err)
+//			require.True(t, actual)
+//
+//			actual, err = db.Contains(50, 2, createHash(1))
+//			require.NoError(t, err)
+//			require.True(t, actual)
+//
+//			actual, err = db.Contains(49, 0, createHash(0))
+//			require.NoError(t, err)
+//			require.False(t, actual)
+//
+//			actual, err = db.Contains(51, 0, createHash(0))
+//			require.NoError(t, err)
+//			require.False(t, actual)
+//
+//			actual, err = db.Contains(50, 3, createHash(3))
+//			require.NoError(t, err)
+//			require.False(t, actual)
+//
+//			// Existing log hash, wrong log index
+//			actual, err = db.Contains(50, 1, createHash(0))
+//			require.NoError(t, err)
+//			require.False(t, actual)
+//		})
+//}
 
-			actual, err = db.Contains(50, 1, createHash(2))
-			require.NoError(t, err)
-			require.True(t, actual)
-
-			actual, err = db.Contains(50, 2, createHash(1))
-			require.NoError(t, err)
-			require.True(t, actual)
-
-			actual, err = db.Contains(49, 0, createHash(0))
-			require.NoError(t, err)
-			require.False(t, actual)
-
-			actual, err = db.Contains(51, 0, createHash(0))
-			require.NoError(t, err)
-			require.False(t, actual)
-
-			actual, err = db.Contains(50, 3, createHash(3))
-			require.NoError(t, err)
-			require.False(t, actual)
-
-			// Existing log hash, wrong log index
-			actual, err = db.Contains(50, 1, createHash(0))
-			require.NoError(t, err)
-			require.False(t, actual)
-		})
-}
-
-func TestErrorWhenAddingBlockOutOfOrder(t *testing.T) {
-	runDBTest(t,
-		func(t *testing.T, db *DB) {
-			err := db.Add(5, []common.Hash{createHash(1)})
-			require.NoError(t, err)
-		},
-		func(t *testing.T, db *DB) {
-			// Can't add block before head
-			err := db.Add(4, []common.Hash{createHash(2)})
-			require.ErrorIs(t, err, ErrBlockOutOfOrder)
-
-			// Can't replace head block
-			err = db.Add(5, []common.Hash{createHash(1)})
-			require.ErrorIs(t, err, ErrBlockOutOfOrder)
-		})
-}
-
-func TestAddBlockZero(t *testing.T) {
-	runDBTest(t,
-		func(t *testing.T, db *DB) {},
-		func(t *testing.T, db *DB) {
-			// There are never any logs in the genesis block, so forbid adding a block 0
-			err := db.Add(0, []common.Hash{createHash(2)})
-			require.ErrorIs(t, err, ErrBlockOutOfOrder)
-		})
-}
-
-func TestRewind(t *testing.T) {
-	t.Run("WhenEmpty", func(t *testing.T) {
-		runDBTest(t, func(t *testing.T, db *DB) {},
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Rewind(100))
-				require.NoError(t, db.Rewind(0))
-			})
-	})
-
-	t.Run("AfterLastEntry", func(t *testing.T) {
+func TestAddLog(t *testing.T) {
+	t.Run("BlockZero", func(t *testing.T) {
+		// There are no logs in the genesis block so recording an entry for block 0 should be rejected.
 		runDBTest(t,
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(51, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(74, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Rewind(75))
-			},
-			func(t *testing.T, db *DB) {
-				contains, err := db.Contains(50, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(50, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
+			func(t *testing.T, db *DB, m *stubMetrics) {},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 0}, 5000, 0)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
 
-	t.Run("BeforeFirstEntry", func(t *testing.T) {
+	t.Run("FirstEntry", func(t *testing.T) {
 		runDBTest(t,
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Rewind(25))
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				require.NoError(t, err)
 			},
-			func(t *testing.T, db *DB) {
-				contains, err := db.Contains(50, 0, createHash(1))
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				result, err := db.Contains(15, 0, createHash(1))
 				require.NoError(t, err)
-				require.False(t, contains)
-
-				contains, err = db.Contains(50, 1, createHash(2))
-				require.NoError(t, err)
-				require.False(t, contains)
+				require.True(t, result)
 			})
 	})
 
-	t.Run("AtFirstEntry", func(t *testing.T) {
+	t.Run("MultipleEntriesFromSameBlock", func(t *testing.T) {
 		runDBTest(t,
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(51, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Rewind(50))
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				require.NoError(t, err)
+				err = db.AddLog(createHash(2), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
+				require.NoError(t, err)
+				err = db.AddLog(createHash(3), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2)
+				require.NoError(t, err)
 			},
-			func(t *testing.T, db *DB) {
-				contains, err := db.Contains(50, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(50, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(51, 0, createHash(1))
-				require.NoError(t, err)
-				require.False(t, contains)
-
-				contains, err = db.Contains(51, 1, createHash(2))
-				require.NoError(t, err)
-				require.False(t, contains)
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				require.EqualValues(t, 5, m.entryCount, "should not output new searchCheckpoint for every log")
+				requireContains(t, db, 15, 0, createHash(1))
+				requireContains(t, db, 15, 1, createHash(2))
+				requireContains(t, db, 15, 2, createHash(3))
 			})
 	})
 
-	t.Run("BetweenEntries", func(t *testing.T) {
+	t.Run("MultipleEntriesFromMultipleBlocks", func(t *testing.T) {
 		runDBTest(t,
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Rewind(55))
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				require.NoError(t, err)
+				err = db.AddLog(createHash(2), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
+				require.NoError(t, err)
+				err = db.AddLog(createHash(3), eth.BlockID{Hash: createHash(16), Number: 16}, 5002, 0)
+				require.NoError(t, err)
+				err = db.AddLog(createHash(4), eth.BlockID{Hash: createHash(16), Number: 16}, 5002, 1)
+				require.NoError(t, err)
 			},
-			func(t *testing.T, db *DB) {
-				contains, err := db.Contains(50, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(50, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(60, 0, createHash(1))
-				require.NoError(t, err)
-				require.False(t, contains)
-
-				contains, err = db.Contains(60, 1, createHash(2))
-				require.NoError(t, err)
-				require.False(t, contains)
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				require.EqualValues(t, 6, m.entryCount, "should not output new searchCheckpoint for every block")
+				requireContains(t, db, 15, 0, createHash(1))
+				requireContains(t, db, 15, 1, createHash(2))
+				requireContains(t, db, 16, 0, createHash(3))
+				requireContains(t, db, 16, 1, createHash(4))
 			})
 	})
 
-	t.Run("AtExistingEntry", func(t *testing.T) {
+	t.Run("ErrorWhenBeforeCurrentBlock", func(t *testing.T) {
 		runDBTest(t,
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Add(59, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(61, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Rewind(60))
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
+				require.NoError(t, err)
 			},
-			func(t *testing.T, db *DB) {
-				contains, err := db.Contains(59, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(59, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(60, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(60, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(61, 0, createHash(1))
-				require.NoError(t, err)
-				require.False(t, contains)
-
-				contains, err = db.Contains(61, 1, createHash(2))
-				require.NoError(t, err)
-				require.False(t, contains)
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 3)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
 
-	t.Run("AtLastEntry", func(t *testing.T) {
+	t.Run("ErrorWhenBeforeCurrentLogEvent", func(t *testing.T) {
 		runDBTest(t,
-			func(t *testing.T, db *DB) {
-				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Add(70, []common.Hash{createHash(1), createHash(2)}))
-				require.NoError(t, db.Rewind(70))
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
+				require.NoError(t, err)
 			},
-			func(t *testing.T, db *DB) {
-				contains, err := db.Contains(50, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(50, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(60, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(60, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(70, 0, createHash(1))
-				require.NoError(t, err)
-				require.True(t, contains)
-
-				contains, err = db.Contains(70, 1, createHash(2))
-				require.NoError(t, err)
-				require.True(t, contains)
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 2)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
 
-	t.Run("ReaddDeletedBlocks", func(t *testing.T) {
-		runDBTest(t, func(t *testing.T, db *DB) {
-			require.NoError(t, db.Add(59, []common.Hash{createHash(1), createHash(2)}))
-			require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
-			require.NoError(t, db.Add(61, []common.Hash{createHash(1), createHash(2)}))
-			require.NoError(t, db.Rewind(60))
-		},
-			func(t *testing.T, db *DB) {
-				err := db.Add(59, []common.Hash{createHash(1), createHash(2)})
-				require.ErrorIs(t, err, ErrBlockOutOfOrder, "Cannot add block before rewound head")
-				err = db.Add(60, []common.Hash{createHash(1), createHash(2)})
-				require.ErrorIs(t, err, ErrBlockOutOfOrder, "Cannot add block that was rewound to")
-				err = db.Add(61, []common.Hash{createHash(1), createHash(2)})
-				require.NoError(t, err, "Can re-add deleted block")
+	t.Run("ErrorWhenAtCurrentLogEvent", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
+				require.NoError(t, err)
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 3)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
+			})
+	})
+
+	t.Run("MultipleSearchCheckpoints", func(t *testing.T) {
+		block1 := eth.BlockID{Hash: createHash(11), Number: 11}
+		block2 := eth.BlockID{Hash: createHash(12), Number: 12}
+		block3 := eth.BlockID{Hash: createHash(15), Number: 15}
+		// First checkpoint is at entry idx 0
+		// Block 1 logs don't reach the second checkpoint
+		block1LogCount := searchCheckpointFrequency - 10
+		// Block 2 logs extend to just after the third checkpoint
+		block2LogCount := searchCheckpointFrequency + 20
+		// Block 3 logs extend to just after the fourth checkpoint
+		block3LogCount := searchCheckpointFrequency
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				for i := 0; i < block1LogCount; i++ {
+					err := db.AddLog(createHash(i), block1, 3000, uint32(i))
+					require.NoErrorf(t, err, "failed to add log %v of block 1", i)
+				}
+				for i := 0; i < block2LogCount; i++ {
+					err := db.AddLog(createHash(i), block2, 3002, uint32(i))
+					require.NoErrorf(t, err, "failed to add log %v of block 2", i)
+				}
+				for i := 0; i < block3LogCount; i++ {
+					err := db.AddLog(createHash(i), block3, 3004, uint32(i))
+					require.NoErrorf(t, err, "failed to add log %v of block 3", i)
+				}
+				// Verify the expected number of checkpoints were written.
+				// This is a counter so doesn't get reloaded on load so can only be verified in setup
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				// Check that we wrote additional search checkpoints
+				expectedCheckpointCount := 4
+				expectedEntryCount := block1LogCount + block2LogCount + block3LogCount + (2 * expectedCheckpointCount)
+				require.EqualValues(t, expectedEntryCount, m.entryCount)
+				// Check we can find all the logs.
+				for i := 0; i < block1LogCount; i++ {
+					requireContains(t, db, block1.Number, uint32(i), createHash(i))
+				}
+				// Block 2 logs extend to just after the third checkpoint
+				for i := 0; i < block2LogCount; i++ {
+					requireContains(t, db, block2.Number, uint32(i), createHash(i))
+				}
+				// Block 3 logs extend to just after the fourth checkpoint
+				for i := 0; i < block3LogCount; i++ {
+					requireContains(t, db, block3.Number, uint32(i), createHash(i))
+				}
 			})
 	})
 }
+
+func requireContains(t *testing.T, db *DB, blockNum uint64, logIdx uint32, logHash common.Hash) {
+	m, ok := db.m.(*stubMetrics)
+	require.True(t, ok, "Did not get the expected metrics type")
+	result, err := db.Contains(blockNum, logIdx, logHash)
+	require.NoErrorf(t, err, "Error searching for log %v in block %v", logIdx, blockNum)
+	require.Truef(t, result, "Did not find log %v in block %v with hash %v", logIdx, blockNum, logHash)
+	require.LessOrEqual(t, m.entriesReadForSearch, int64(searchCheckpointFrequency), "Should not need to read more than between two checkpoints")
+	require.NotZero(t, m.entriesReadForSearch, "Must read at least some entries to find the log")
+}
+
+func TestShouldRollBackInMemoryChangesOnWriteFailure(t *testing.T) {
+
+}
+
+func TestShouldRecoverWhenSearchCheckpointWrittenButNotCanonicalHash(t *testing.T) {
+
+}
+
+func TestShouldRecoverWhenPartialEntryWritten(t *testing.T) {
+
+}
+
+func TestShouldRecoverWhenInitiatingEventWrittenButNotExecutingLink(t *testing.T) {
+
+}
+
+//func TestRewind(t *testing.T) {
+//	t.Run("WhenEmpty", func(t *testing.T) {
+//		runDBTest(t, func(t *testing.T, db *DB) {},
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Rewind(100))
+//				require.NoError(t, db.Rewind(0))
+//			})
+//	})
+//
+//	t.Run("AfterLastEntry", func(t *testing.T) {
+//		runDBTest(t,
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(51, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(74, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Rewind(75))
+//			},
+//			func(t *testing.T, db *DB) {
+//				contains, err := db.Contains(50, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(50, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//			})
+//	})
+//
+//	t.Run("BeforeFirstEntry", func(t *testing.T) {
+//		runDBTest(t,
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Rewind(25))
+//			},
+//			func(t *testing.T, db *DB) {
+//				contains, err := db.Contains(50, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//
+//				contains, err = db.Contains(50, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//			})
+//	})
+//
+//	t.Run("AtFirstEntry", func(t *testing.T) {
+//		runDBTest(t,
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(51, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Rewind(50))
+//			},
+//			func(t *testing.T, db *DB) {
+//				contains, err := db.Contains(50, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(50, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(51, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//
+//				contains, err = db.Contains(51, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//			})
+//	})
+//
+//	t.Run("BetweenEntries", func(t *testing.T) {
+//		runDBTest(t,
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Rewind(55))
+//			},
+//			func(t *testing.T, db *DB) {
+//				contains, err := db.Contains(50, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(50, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(60, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//
+//				contains, err = db.Contains(60, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//			})
+//	})
+//
+//	t.Run("AtExistingEntry", func(t *testing.T) {
+//		runDBTest(t,
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Add(59, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(61, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Rewind(60))
+//			},
+//			func(t *testing.T, db *DB) {
+//				contains, err := db.Contains(59, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(59, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(60, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(60, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(61, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//
+//				contains, err = db.Contains(61, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.False(t, contains)
+//			})
+//	})
+//
+//	t.Run("AtLastEntry", func(t *testing.T) {
+//		runDBTest(t,
+//			func(t *testing.T, db *DB) {
+//				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Add(70, []common.Hash{createHash(1), createHash(2)}))
+//				require.NoError(t, db.Rewind(70))
+//			},
+//			func(t *testing.T, db *DB) {
+//				contains, err := db.Contains(50, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(50, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(60, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(60, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(70, 0, createHash(1))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//
+//				contains, err = db.Contains(70, 1, createHash(2))
+//				require.NoError(t, err)
+//				require.True(t, contains)
+//			})
+//	})
+//
+//	t.Run("ReaddDeletedBlocks", func(t *testing.T) {
+//		runDBTest(t, func(t *testing.T, db *DB) {
+//			require.NoError(t, db.Add(59, []common.Hash{createHash(1), createHash(2)}))
+//			require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+//			require.NoError(t, db.Add(61, []common.Hash{createHash(1), createHash(2)}))
+//			require.NoError(t, db.Rewind(60))
+//		},
+//			func(t *testing.T, db *DB) {
+//				err := db.Add(59, []common.Hash{createHash(1), createHash(2)})
+//				require.ErrorIs(t, err, ErrLogOutOfOrder, "Cannot add block before rewound head")
+//				err = db.Add(60, []common.Hash{createHash(1), createHash(2)})
+//				require.ErrorIs(t, err, ErrLogOutOfOrder, "Cannot add block that was rewound to")
+//				err = db.Add(61, []common.Hash{createHash(1), createHash(2)})
+//				require.NoError(t, err, "Can re-add deleted block")
+//			})
+//	})
+//}
+
+type stubMetrics struct {
+	entryCount           int64
+	entriesReadForSearch int64
+}
+
+func (s *stubMetrics) RecordEntryCount(count int64) {
+	s.entryCount = count
+}
+
+func (s *stubMetrics) RecordSearchEntriesRead(count int64) {
+	s.entriesReadForSearch = count
+}
+
+var _ Metrics = (*stubMetrics)(nil)

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -180,11 +180,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentBlock", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 3)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 0)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -192,13 +192,13 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentBlockButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 13}, 5000, 3)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(13), Number: 13}, 5000, 0)
 				require.NoError(t, err)
 				err = db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 3)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 0)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -206,11 +206,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentLogEvent", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
-				require.NoError(t, err)
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0))
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 2)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 0)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -218,15 +218,15 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentLogEventButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				require.NoError(t, err)
+				err = db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
 				require.NoError(t, err)
 				err = db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2)
 				require.NoError(t, err)
-				err = db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
-				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 2)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 1)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -234,11 +234,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenAtCurrentLogEvent", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
-				require.NoError(t, err)
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0))
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 3)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 1)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -246,10 +246,9 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenAtCurrentLogEventButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
-				require.NoError(t, err)
-				err = db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2)
-				require.NoError(t, err)
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0))
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1))
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 2)
@@ -260,11 +259,30 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenSkippingLogEvent", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 2)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
+			})
+	})
+
+	t.Run("ErrorWhenFirstLogIsNotLogIdxZero", func(t *testing.T) {
+		runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {},
+			func(t *testing.T, db *DB, m *stubMetrics) {
 				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 5)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
+			})
+	})
+
+	t.Run("ErrorWhenFirstLogOfNewBlockIsNotLogIdxZero", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				require.NoError(t, db.AddLog(createHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4996, 0))
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 1)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -32,7 +32,7 @@ func TestErrorOpeningDatabase(t *testing.T) {
 
 func runDBTest(t *testing.T, setup func(t *testing.T, db *DB, m *stubMetrics), assert func(t *testing.T, db *DB, m *stubMetrics)) {
 	createDb := func(t *testing.T, dir string) (*DB, *stubMetrics, string) {
-		logger := testlog.Logger(t, log.LvlInfo)
+		logger := testlog.Logger(t, log.LvlTrace)
 		path := filepath.Join(dir, "test.db")
 		m := &stubMetrics{}
 		db, err := NewFromFile(logger, m, path)

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -1,0 +1,320 @@
+package db
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func createHash(i int) common.Hash {
+	data := bytes.Repeat([]byte{byte(i)}, common.HashLength)
+	return common.BytesToHash(data)
+}
+
+func TestErrorOpeningDatabase(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NewFromFile(filepath.Join(dir, "missing-dir", "file.db"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func runDBTest(t *testing.T, setup func(t *testing.T, db *DB), assert func(t *testing.T, db *DB)) {
+	createDb := func(t *testing.T, dir string) *DB {
+		path := filepath.Join(dir, "test.db")
+		db, err := NewFromFile(path)
+		require.NoError(t, err, "Failed to create database")
+		t.Cleanup(func() {
+			err := db.Close()
+			if err != nil {
+				require.ErrorIs(t, err, fs.ErrClosed)
+			}
+		})
+		return db
+	}
+
+	t.Run("New", func(t *testing.T) {
+		db := createDb(t, t.TempDir())
+		setup(t, db)
+		assert(t, db)
+	})
+
+	t.Run("Existing", func(t *testing.T) {
+		dir := t.TempDir()
+		db := createDb(t, dir)
+		setup(t, db)
+		// Close and recreate the database
+		require.NoError(t, db.Close())
+
+		db2 := createDb(t, dir)
+		assert(t, db2)
+	})
+}
+
+func TestEmptyDbDoesNotFindEntry(t *testing.T) {
+	runDBTest(t,
+		func(t *testing.T, db *DB) {},
+		func(t *testing.T, db *DB) {
+			result, err := db.Contains(0, 0, createHash(1))
+			require.NoError(t, err)
+			require.False(t, result)
+
+			// Should not contain the empty hash
+			result, err = db.Contains(0, 0, common.Hash{})
+			require.NoError(t, err)
+			require.False(t, result)
+		})
+}
+
+func TestContainsRecordedLog(t *testing.T) {
+	runDBTest(t,
+		func(t *testing.T, db *DB) {
+			err := db.Add(50, []common.Hash{createHash(0), createHash(2), createHash(1)})
+			require.NoError(t, err)
+		},
+		func(t *testing.T, db *DB) {
+			actual, err := db.Contains(50, 0, createHash(0))
+			require.NoError(t, err)
+			require.True(t, actual)
+
+			actual, err = db.Contains(50, 1, createHash(2))
+			require.NoError(t, err)
+			require.True(t, actual)
+
+			actual, err = db.Contains(50, 2, createHash(1))
+			require.NoError(t, err)
+			require.True(t, actual)
+
+			actual, err = db.Contains(49, 0, createHash(0))
+			require.NoError(t, err)
+			require.False(t, actual)
+
+			actual, err = db.Contains(51, 0, createHash(0))
+			require.NoError(t, err)
+			require.False(t, actual)
+
+			actual, err = db.Contains(50, 3, createHash(3))
+			require.NoError(t, err)
+			require.False(t, actual)
+
+			// Existing log hash, wrong log index
+			actual, err = db.Contains(50, 1, createHash(0))
+			require.NoError(t, err)
+			require.False(t, actual)
+		})
+}
+
+func TestErrorWhenAddingBlockOutOfOrder(t *testing.T) {
+	runDBTest(t,
+		func(t *testing.T, db *DB) {
+			err := db.Add(5, []common.Hash{createHash(1)})
+			require.NoError(t, err)
+		},
+		func(t *testing.T, db *DB) {
+			// Can't add block before head
+			err := db.Add(4, []common.Hash{createHash(2)})
+			require.ErrorIs(t, err, ErrBlockOutOfOrder)
+
+			// Can't replace head block
+			err = db.Add(5, []common.Hash{createHash(1)})
+			require.ErrorIs(t, err, ErrBlockOutOfOrder)
+		})
+}
+
+func TestAddBlockZero(t *testing.T) {
+	runDBTest(t,
+		func(t *testing.T, db *DB) {},
+		func(t *testing.T, db *DB) {
+			// There are never any logs in the genesis block, so forbid adding a block 0
+			err := db.Add(0, []common.Hash{createHash(2)})
+			require.ErrorIs(t, err, ErrBlockOutOfOrder)
+		})
+}
+
+func TestRewind(t *testing.T) {
+	t.Run("WhenEmpty", func(t *testing.T) {
+		runDBTest(t, func(t *testing.T, db *DB) {},
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Rewind(100))
+				require.NoError(t, db.Rewind(0))
+			})
+	})
+
+	t.Run("AfterLastEntry", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(51, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(74, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Rewind(75))
+			},
+			func(t *testing.T, db *DB) {
+				contains, err := db.Contains(50, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(50, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+			})
+	})
+
+	t.Run("BeforeFirstEntry", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Rewind(25))
+			},
+			func(t *testing.T, db *DB) {
+				contains, err := db.Contains(50, 0, createHash(1))
+				require.NoError(t, err)
+				require.False(t, contains)
+
+				contains, err = db.Contains(50, 1, createHash(2))
+				require.NoError(t, err)
+				require.False(t, contains)
+			})
+	})
+
+	t.Run("AtFirstEntry", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(51, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Rewind(50))
+			},
+			func(t *testing.T, db *DB) {
+				contains, err := db.Contains(50, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(50, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(51, 0, createHash(1))
+				require.NoError(t, err)
+				require.False(t, contains)
+
+				contains, err = db.Contains(51, 1, createHash(2))
+				require.NoError(t, err)
+				require.False(t, contains)
+			})
+	})
+
+	t.Run("BetweenEntries", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Rewind(55))
+			},
+			func(t *testing.T, db *DB) {
+				contains, err := db.Contains(50, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(50, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(60, 0, createHash(1))
+				require.NoError(t, err)
+				require.False(t, contains)
+
+				contains, err = db.Contains(60, 1, createHash(2))
+				require.NoError(t, err)
+				require.False(t, contains)
+			})
+	})
+
+	t.Run("AtExistingEntry", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Add(59, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(61, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Rewind(60))
+			},
+			func(t *testing.T, db *DB) {
+				contains, err := db.Contains(59, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(59, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(60, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(60, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(61, 0, createHash(1))
+				require.NoError(t, err)
+				require.False(t, contains)
+
+				contains, err = db.Contains(61, 1, createHash(2))
+				require.NoError(t, err)
+				require.False(t, contains)
+			})
+	})
+
+	t.Run("AtLastEntry", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB) {
+				require.NoError(t, db.Add(50, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Add(70, []common.Hash{createHash(1), createHash(2)}))
+				require.NoError(t, db.Rewind(70))
+			},
+			func(t *testing.T, db *DB) {
+				contains, err := db.Contains(50, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(50, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(60, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(60, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(70, 0, createHash(1))
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				contains, err = db.Contains(70, 1, createHash(2))
+				require.NoError(t, err)
+				require.True(t, contains)
+			})
+	})
+
+	t.Run("ReaddDeletedBlocks", func(t *testing.T) {
+		runDBTest(t, func(t *testing.T, db *DB) {
+			require.NoError(t, db.Add(59, []common.Hash{createHash(1), createHash(2)}))
+			require.NoError(t, db.Add(60, []common.Hash{createHash(1), createHash(2)}))
+			require.NoError(t, db.Add(61, []common.Hash{createHash(1), createHash(2)}))
+			require.NoError(t, db.Rewind(60))
+		},
+			func(t *testing.T, db *DB) {
+				err := db.Add(59, []common.Hash{createHash(1), createHash(2)})
+				require.ErrorIs(t, err, ErrBlockOutOfOrder, "Cannot add block before rewound head")
+				err = db.Add(60, []common.Hash{createHash(1), createHash(2)})
+				require.ErrorIs(t, err, ErrBlockOutOfOrder, "Cannot add block that was rewound to")
+				err = db.Add(61, []common.Hash{createHash(1), createHash(2)})
+				require.NoError(t, err, "Can re-add deleted block")
+			})
+	})
+}

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -212,6 +212,18 @@ func TestAddLog(t *testing.T) {
 			})
 	})
 
+	t.Run("ErrorWhenSkippingLogEvent", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 3)
+				require.NoError(t, err)
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				err := db.AddLog(createHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 5)
+				require.ErrorIs(t, err, ErrLogOutOfOrder)
+			})
+	})
+
 	t.Run("MultipleSearchCheckpoints", func(t *testing.T) {
 		block1 := eth.BlockID{Hash: createHash(11), Number: 11}
 		block2 := eth.BlockID{Hash: createHash(12), Number: 12}

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -433,19 +433,19 @@ func requireNotContains(t *testing.T, db *DB, blockNum uint64, logIdx uint32, lo
 }
 
 func TestShouldRollBackInMemoryChangesOnWriteFailure(t *testing.T) {
-
+	t.Skip("TODO(optimism#10857)")
 }
 
 func TestShouldRecoverWhenSearchCheckpointWrittenButNotCanonicalHash(t *testing.T) {
-
+	t.Skip("TODO(optimism#10857)")
 }
 
 func TestShouldRecoverWhenPartialEntryWritten(t *testing.T) {
-
+	t.Skip("TODO(optimism#10857)")
 }
 
 func TestShouldRecoverWhenInitiatingEventWrittenButNotExecutingLink(t *testing.T) {
-
+	t.Skip("TODO(optimism#10857)")
 }
 
 func TestRewind(t *testing.T) {

--- a/op-supervisor/supervisor/backend/db/entries.go
+++ b/op-supervisor/supervisor/backend/db/entries.go
@@ -6,58 +6,64 @@ import (
 	"math"
 )
 
+const (
+	entrySize = 24
+)
+
+type entry [entrySize]byte
+
 // createSearchCheckpoint creates a search checkpoint entry
 // type 0: "search checkpoint" <type><uint64 block number: 8 bytes><uint32 event index offset: 4 bytes><uint64 timestamp: 8 bytes> = 20 bytes
 // type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
-func createSearchCheckpoint(blockNum uint64, logIdx uint32, timestamp uint64) [entrySize]byte {
-	var entry [entrySize]byte
-	entry[0] = typeSearchCheckpoint
-	binary.LittleEndian.PutUint64(entry[1:9], blockNum)
-	binary.LittleEndian.PutUint32(entry[9:13], logIdx)
-	binary.LittleEndian.PutUint64(entry[13:21], timestamp)
-	return entry
+func createSearchCheckpoint(blockNum uint64, logIdx uint32, timestamp uint64) entry {
+	var data entry
+	data[0] = typeSearchCheckpoint
+	binary.LittleEndian.PutUint64(data[1:9], blockNum)
+	binary.LittleEndian.PutUint32(data[9:13], logIdx)
+	binary.LittleEndian.PutUint64(data[13:21], timestamp)
+	return data
 }
 
-func parseSearchCheckpoint(entry [entrySize]byte) (checkpointData, error) {
-	if entry[0] != typeSearchCheckpoint {
-		return checkpointData{}, fmt.Errorf("%w: attempting to decode search checkpoint but was type %v", ErrDataCorruption, entry[0])
+func parseSearchCheckpoint(data entry) (checkpointData, error) {
+	if data[0] != typeSearchCheckpoint {
+		return checkpointData{}, fmt.Errorf("%w: attempting to decode search checkpoint but was type %v", ErrDataCorruption, data[0])
 	}
 	return checkpointData{
-		blockNum:  binary.LittleEndian.Uint64(entry[1:9]),
-		logIdx:    binary.LittleEndian.Uint32(entry[9:13]),
-		timestamp: binary.LittleEndian.Uint64(entry[13:21]),
+		blockNum:  binary.LittleEndian.Uint64(data[1:9]),
+		logIdx:    binary.LittleEndian.Uint32(data[9:13]),
+		timestamp: binary.LittleEndian.Uint64(data[13:21]),
 	}, nil
 }
 
 // createCanonicalHash creates a canonical hash entry
 // type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
-func createCanonicalHash(hash TruncatedHash) [entrySize]byte {
-	var entry [entrySize]byte
+func createCanonicalHash(hash TruncatedHash) entry {
+	var entry entry
 	entry[0] = typeCanonicalHash
 	copy(entry[1:21], hash[:])
 	return entry
 }
 
-func parseCanonicalHash(entry [entrySize]byte) (TruncatedHash, error) {
-	if entry[0] != typeCanonicalHash {
-		return TruncatedHash{}, fmt.Errorf("%w: attempting to decode canonical hash but was type %v", ErrDataCorruption, entry[0])
+func parseCanonicalHash(data entry) (TruncatedHash, error) {
+	if data[0] != typeCanonicalHash {
+		return TruncatedHash{}, fmt.Errorf("%w: attempting to decode canonical hash but was type %v", ErrDataCorruption, data[0])
 	}
 	var truncated TruncatedHash
-	copy(truncated[:], entry[1:21])
+	copy(truncated[:], data[1:21])
 	return truncated, nil
 }
 
 // createInitiatingEvent creates an initiating event
 // type 2: "initiating event" <type><blocknum diff: 1 byte><event flags: 1 byte><event-hash: 20 bytes> = 23 bytes
-func createInitiatingEvent(pre logContext, post logContext, logHash TruncatedHash) ([entrySize]byte, error) {
-	var entry [entrySize]byte
-	entry[0] = typeInitiatingEvent
+func createInitiatingEvent(pre logContext, post logContext, logHash TruncatedHash) (entry, error) {
+	var data entry
+	data[0] = typeInitiatingEvent
 	blockDiff := post.blockNum - pre.blockNum
 	if blockDiff > math.MaxUint8 {
 		// TODO(optimism#10857): Need to find a way to support this.
-		return entry, fmt.Errorf("too many block skipped between %v and %v", pre.blockNum, post.blockNum)
+		return data, fmt.Errorf("too many block skipped between %v and %v", pre.blockNum, post.blockNum)
 	}
-	entry[1] = byte(blockDiff)
+	data[1] = byte(blockDiff)
 	currLogIdx := pre.logIdx
 	if blockDiff > 0 {
 		currLogIdx = 0
@@ -65,23 +71,23 @@ func createInitiatingEvent(pre logContext, post logContext, logHash TruncatedHas
 	flags := byte(0)
 	logDiff := post.logIdx - currLogIdx
 	if logDiff > 1 {
-		return entry, fmt.Errorf("skipped logs between %v and %v", currLogIdx, post.logIdx)
+		return data, fmt.Errorf("skipped logs between %v and %v", currLogIdx, post.logIdx)
 	}
 	if logDiff > 0 {
 		// Set flag to indicate log idx needs to be incremented (ie we're not directly after a checkpoint)
 		flags = flags | eventFlagIncrementLogIdx
 	}
-	entry[2] = flags
-	copy(entry[3:23], logHash[:])
-	return entry, nil
+	data[2] = flags
+	copy(data[3:23], logHash[:])
+	return data, nil
 }
 
-func parseInitiatingEvent(pre logContext, entry [entrySize]byte) (logContext, TruncatedHash, error) {
-	if entry[0] != typeInitiatingEvent {
-		return logContext{}, TruncatedHash{}, fmt.Errorf("%w: attempting to decode initiating event but was type %v", ErrDataCorruption, entry[0])
+func parseInitiatingEvent(pre logContext, data entry) (logContext, TruncatedHash, error) {
+	if data[0] != typeInitiatingEvent {
+		return logContext{}, TruncatedHash{}, fmt.Errorf("%w: attempting to decode initiating event but was type %v", ErrDataCorruption, data[0])
 	}
-	blockNumDiff := entry[1]
-	flags := entry[2]
+	blockNumDiff := data[1]
+	flags := data[2]
 	blockNum := pre.blockNum + uint64(blockNumDiff)
 	logIdx := pre.logIdx
 	if blockNumDiff > 0 {
@@ -90,7 +96,7 @@ func parseInitiatingEvent(pre logContext, entry [entrySize]byte) (logContext, Tr
 	if flags&0x01 != 0 {
 		logIdx++
 	}
-	eventHash := TruncatedHash(entry[3:23])
+	eventHash := TruncatedHash(data[3:23])
 	logCtx := logContext{
 		blockNum: blockNum,
 		logIdx:   logIdx,

--- a/op-supervisor/supervisor/backend/db/entries.go
+++ b/op-supervisor/supervisor/backend/db/entries.go
@@ -1,9 +1,51 @@
 package db
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math"
 )
+
+// createSearchCheckpoint creates a search checkpoint entry
+// type 0: "search checkpoint" <type><uint64 block number: 8 bytes><uint32 event index offset: 4 bytes><uint64 timestamp: 8 bytes> = 20 bytes
+// type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
+func createSearchCheckpoint(blockNum uint64, logIdx uint32, timestamp uint64) [entrySize]byte {
+	var entry [entrySize]byte
+	entry[0] = typeSearchCheckpoint
+	binary.LittleEndian.PutUint64(entry[1:9], blockNum)
+	binary.LittleEndian.PutUint32(entry[9:13], logIdx)
+	binary.LittleEndian.PutUint64(entry[13:21], timestamp)
+	return entry
+}
+
+func parseSearchCheckpoint(entry [entrySize]byte) (checkpointData, error) {
+	if entry[0] != typeSearchCheckpoint {
+		return checkpointData{}, fmt.Errorf("%w: attempting to decode search checkpoint but was type %v", ErrDataCorruption, entry[0])
+	}
+	return checkpointData{
+		blockNum:  binary.LittleEndian.Uint64(entry[1:9]),
+		logIdx:    binary.LittleEndian.Uint32(entry[9:13]),
+		timestamp: binary.LittleEndian.Uint64(entry[13:21]),
+	}, nil
+}
+
+// createCanonicalHash creates a canonical hash entry
+// type 1: "canonical hash" <type><parent blockhash truncated: 20 bytes> = 21 bytes
+func createCanonicalHash(hash TruncatedHash) [entrySize]byte {
+	var entry [entrySize]byte
+	entry[0] = typeCanonicalHash
+	copy(entry[1:21], hash[:])
+	return entry
+}
+
+func parseCanonicalHash(entry [entrySize]byte) (TruncatedHash, error) {
+	if entry[0] != typeCanonicalHash {
+		return TruncatedHash{}, fmt.Errorf("%w: attempting to decode canonical hash but was type %v", ErrDataCorruption, entry[0])
+	}
+	var truncated TruncatedHash
+	copy(truncated[:], entry[1:21])
+	return truncated, nil
+}
 
 // createInitiatingEvent creates an initiating event
 // type 2: "initiating event" <type><blocknum diff: 1 byte><event flags: 1 byte><event-hash: 20 bytes> = 23 bytes
@@ -34,7 +76,10 @@ func createInitiatingEvent(pre logContext, post logContext, logHash TruncatedHas
 	return entry, nil
 }
 
-func parseInitiatingEvent(pre logContext, entry [entrySize]byte) (logContext, TruncatedHash) {
+func parseInitiatingEvent(pre logContext, entry [entrySize]byte) (logContext, TruncatedHash, error) {
+	if entry[0] != typeInitiatingEvent {
+		return logContext{}, TruncatedHash{}, fmt.Errorf("%w: attempting to decode initiating event but was type %v", ErrDataCorruption, entry[0])
+	}
 	blockNumDiff := entry[1]
 	flags := entry[2]
 	blockNum := pre.blockNum + uint64(blockNumDiff)
@@ -46,8 +91,9 @@ func parseInitiatingEvent(pre logContext, entry [entrySize]byte) (logContext, Tr
 		logIdx++
 	}
 	eventHash := TruncatedHash(entry[3:23])
-	return logContext{
+	logCtx := logContext{
 		blockNum: blockNum,
 		logIdx:   logIdx,
-	}, eventHash
+	}
+	return logCtx, eventHash, nil
 }

--- a/op-supervisor/supervisor/backend/db/entries.go
+++ b/op-supervisor/supervisor/backend/db/entries.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"fmt"
+	"math"
+)
+
+// createInitiatingEvent creates an initiating event
+// type 2: "initiating event" <type><blocknum diff: 1 byte><event flags: 1 byte><event-hash: 20 bytes> = 23 bytes
+func createInitiatingEvent(pre logContext, post logContext, logHash TruncatedHash) ([entrySize]byte, error) {
+	var entry [entrySize]byte
+	entry[0] = typeInitiatingEvent
+	blockDiff := post.blockNum - pre.blockNum
+	if blockDiff > math.MaxUint8 {
+		// TODO(optimism#10857): Need to find a way to support this.
+		return entry, fmt.Errorf("too many block skipped between %v and %v", pre.blockNum, post.blockNum)
+	}
+	entry[1] = byte(blockDiff)
+	currLogIdx := pre.logIdx
+	if blockDiff > 0 {
+		currLogIdx = 0
+	}
+	flags := byte(0)
+	logDiff := post.logIdx - currLogIdx
+	if logDiff > 1 {
+		return entry, fmt.Errorf("skipped logs between %v and %v", currLogIdx, post.logIdx)
+	}
+	if logDiff > 0 {
+		// Set flag to indicate log idx needs to be incremented (ie we're not directly after a checkpoint)
+		flags = flags | eventFlagIncrementLogIdx
+	}
+	entry[2] = flags
+	copy(entry[3:23], logHash[:])
+	return entry, nil
+}
+
+func parseInitiatingEvent(pre logContext, entry [entrySize]byte) (logContext, TruncatedHash) {
+	blockNumDiff := entry[1]
+	flags := entry[2]
+	blockNum := pre.blockNum + uint64(blockNumDiff)
+	logIdx := pre.logIdx
+	if blockNumDiff > 0 {
+		logIdx = 0
+	}
+	if flags&0x01 != 0 {
+		logIdx++
+	}
+	eventHash := TruncatedHash(entry[3:23])
+	return logContext{
+		blockNum: blockNum,
+		logIdx:   logIdx,
+	}, eventHash
+}

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -1,0 +1,82 @@
+package entrydb
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	EntrySize = 24
+)
+
+type Entry [EntrySize]byte
+
+// dataAccess defines a minimal API required to manipulate the actual stored data.
+// It is a subset of the os.File API but could (theoretically) be satisfied by an in-memory implementation for testing.
+type dataAccess interface {
+	io.ReaderAt
+	io.Writer
+	io.Closer
+	Truncate(size int64) error
+}
+
+type EntryDB struct {
+	data         dataAccess
+	lastEntryIdx int64
+}
+
+func NewEntryDB(path string) (*EntryDB, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database at %v: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat database at %v: %w", path, err)
+	}
+	lastEntryIdx := info.Size()/EntrySize - 1
+	return &EntryDB{
+		data:         file,
+		lastEntryIdx: lastEntryIdx,
+	}, nil
+}
+
+func (e *EntryDB) Size() int64 {
+	return e.lastEntryIdx + 1
+}
+
+func (e *EntryDB) Read(idx int64) (Entry, error) {
+	var out Entry
+	read, err := e.data.ReadAt(out[:], idx*EntrySize)
+	// Ignore io.EOF if we read the entire last entry as ReadAt may return io.EOF or nil when it reads the last byte
+	if err != nil && !(errors.Is(err, io.EOF) && read == EntrySize) {
+		return Entry{}, fmt.Errorf("failed to read entry %v: %w", idx, err)
+	}
+	return out, nil
+}
+
+func (e *EntryDB) Append(data Entry) error {
+	if _, err := e.data.Write(data[:]); err != nil {
+		// TODO(optimism#10857): When a write fails, need to revert any in memory changes and truncate back to the
+		// pre-write state. Likely need to batch writes for multiple entries into a single write akin to transactions
+		// to avoid leaving hanging entries without the entry that should follow them.
+		return err
+	}
+	e.lastEntryIdx++
+	return nil
+}
+
+func (e *EntryDB) Truncate(idx int64) error {
+	if err := e.data.Truncate((idx + 1) * EntrySize); err != nil {
+		return fmt.Errorf("failed to truncate to entry %v: %w", idx, err)
+	}
+	// Update the lastEntryIdx cache and then use db.init() to find the log context for the new latest log entry
+	e.lastEntryIdx = idx
+	return nil
+}
+
+func (e *EntryDB) Close() error {
+	return e.data.Close()
+}

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -57,14 +57,16 @@ func (e *EntryDB) Read(idx int64) (Entry, error) {
 	return out, nil
 }
 
-func (e *EntryDB) Append(data Entry) error {
-	if _, err := e.data.Write(data[:]); err != nil {
-		// TODO(optimism#10857): When a write fails, need to revert any in memory changes and truncate back to the
-		// pre-write state. Likely need to batch writes for multiple entries into a single write akin to transactions
-		// to avoid leaving hanging entries without the entry that should follow them.
-		return err
+func (e *EntryDB) Append(entries ...Entry) error {
+	for _, entry := range entries {
+		if _, err := e.data.Write(entry[:]); err != nil {
+			// TODO(optimism#10857): When a write fails, need to revert any in memory changes and truncate back to the
+			// pre-write state. Likely need to batch writes for multiple entries into a single write akin to transactions
+			// to avoid leaving hanging entries without the entry that should follow them.
+			return err
+		}
+		e.lastEntryIdx++
 	}
-	e.lastEntryIdx++
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -1,0 +1,72 @@
+package entrydb
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadWrite(t *testing.T) {
+	t.Run("BasicReadWrite", func(t *testing.T) {
+		db := createEntryDB(t)
+		require.NoError(t, db.Append(createEntry(1)))
+		require.NoError(t, db.Append(createEntry(2)))
+		require.NoError(t, db.Append(createEntry(3)))
+		require.NoError(t, db.Append(createEntry(4)))
+		requireRead(t, db, 0, createEntry(1))
+		requireRead(t, db, 1, createEntry(2))
+		requireRead(t, db, 2, createEntry(3))
+		requireRead(t, db, 3, createEntry(4))
+
+		// Check we can read out of order
+		requireRead(t, db, 1, createEntry(2))
+	})
+
+	t.Run("ReadPastEndOfFileReturnsEOF", func(t *testing.T) {
+		db := createEntryDB(t)
+		_, err := db.Read(0)
+		require.ErrorIs(t, err, io.EOF)
+	})
+}
+
+func TestTruncate(t *testing.T) {
+	db := createEntryDB(t)
+	require.NoError(t, db.Append(createEntry(1)))
+	require.NoError(t, db.Append(createEntry(2)))
+	require.NoError(t, db.Append(createEntry(3)))
+	require.NoError(t, db.Append(createEntry(4)))
+	require.NoError(t, db.Append(createEntry(5)))
+
+	require.NoError(t, db.Truncate(3))
+	requireRead(t, db, 0, createEntry(1))
+	requireRead(t, db, 1, createEntry(2))
+	requireRead(t, db, 2, createEntry(3))
+
+	// 4 and 5 have been removed
+	_, err := db.Read(4)
+	require.ErrorIs(t, err, io.EOF)
+	_, err = db.Read(5)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func requireRead(t *testing.T, db *EntryDB, idx int64, expected Entry) {
+	actual, err := db.Read(idx)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func createEntry(i byte) Entry {
+	return Entry(bytes.Repeat([]byte{i}, EntrySize))
+}
+
+func createEntryDB(t *testing.T) *EntryDB {
+	db, err := NewEntryDB(filepath.Join(t.TempDir(), "entries.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db
+}

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -30,6 +30,18 @@ func TestReadWrite(t *testing.T) {
 		_, err := db.Read(0)
 		require.ErrorIs(t, err, io.EOF)
 	})
+
+	t.Run("WriteMultiple", func(t *testing.T) {
+		db := createEntryDB(t)
+		require.NoError(t, db.Append(
+			createEntry(1),
+			createEntry(2),
+			createEntry(3),
+		))
+		requireRead(t, db, 0, createEntry(1))
+		requireRead(t, db, 1, createEntry(2))
+		requireRead(t, db, 2, createEntry(3))
+	})
 }
 
 func TestTruncate(t *testing.T) {

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"fmt"
+	"io"
+)
+
+type iterator struct {
+	db           *DB
+	nextEntryIdx int64
+	blockNum     uint64
+	logIdx       uint32
+
+	entriesRead int64
+}
+
+func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedHash, outErr error) {
+	for i.nextEntryIdx <= i.db.lastEntryIdx {
+		entry, err := i.db.readEntry(i.nextEntryIdx)
+		if err != nil {
+			outErr = fmt.Errorf("failed to read entry %v: %w", i, err)
+			return
+		}
+		i.nextEntryIdx++
+		i.entriesRead++
+		switch entry[0] {
+		case typeSearchCheckpoint:
+			current := i.db.parseSearchCheckpoint(entry)
+			i.blockNum = current.blockNum
+			i.logIdx = current.logIdx
+		case typeCanonicalHash:
+			// Skip
+		case typeInitiatingEvent:
+			blockNum, logIdx, evtHash = i.db.parseInitiatingEvent(i.blockNum, i.logIdx, entry)
+			i.blockNum = blockNum
+			i.logIdx = logIdx
+			return
+		case typeExecutingCheck:
+		// TODO: Handle this properly
+		case typeExecutingLink:
+		// TODO: Handle this properly
+		default:
+			outErr = fmt.Errorf("unknown entry type %v", entry[0])
+			return
+		}
+	}
+	outErr = io.EOF
+	return
+}

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -26,7 +26,7 @@ func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedH
 		i.entriesRead++
 		switch entry[0] {
 		case typeSearchCheckpoint:
-			current, err := parseSearchCheckpoint(entry)
+			current, err := newSearchCheckpointFromEntry(entry)
 			if err != nil {
 				outErr = fmt.Errorf("failed to parse search checkpoint at idx %v: %w", entryIdx, err)
 				return
@@ -36,7 +36,7 @@ func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedH
 		case typeCanonicalHash:
 			// Skip
 		case typeInitiatingEvent:
-			evt, err := parseInitiatingEvent(entry)
+			evt, err := newInitiatingEventFromEntry(entry)
 			if err != nil {
 				outErr = fmt.Errorf("failed to parse initiating event at idx %v: %w", entryIdx, err)
 				return

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -36,13 +36,15 @@ func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedH
 		case typeCanonicalHash:
 			// Skip
 		case typeInitiatingEvent:
-			i.current, evtHash, err = parseInitiatingEvent(i.current, entry)
+			evt, err := parseInitiatingEvent(entry)
 			if err != nil {
 				outErr = fmt.Errorf("failed to parse initiating event at idx %v: %w", entryIdx, err)
 				return
 			}
+			i.current = evt.postContext(i.current)
 			blockNum = i.current.blockNum
 			logIdx = i.current.logIdx
+			evtHash = evt.logHash
 			return
 		case typeExecutingCheck:
 		// TODO(optimism#10857): Handle this properly

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -36,9 +36,9 @@ func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedH
 			i.logIdx = logIdx
 			return
 		case typeExecutingCheck:
-		// TODO: Handle this properly
+		// TODO(optimism#10857): Handle this properly
 		case typeExecutingLink:
-		// TODO: Handle this properly
+		// TODO(optimism#10857): Handle this properly
 		default:
 			outErr = fmt.Errorf("unknown entry type %v", entry[0])
 			return

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -15,9 +15,9 @@ type iterator struct {
 }
 
 func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedHash, outErr error) {
-	for i.nextEntryIdx <= i.db.lastEntryIdx {
+	for i.nextEntryIdx <= i.db.lastEntryIdx() {
 		entryIdx := i.nextEntryIdx
-		entry, err := i.db.readEntry(entryIdx)
+		entry, err := i.db.store.Read(entryIdx)
 		if err != nil {
 			outErr = fmt.Errorf("failed to read entry %v: %w", i, err)
 			return


### PR DESCRIPTION
**Description**

Introduces an append only database to record logs for a single chain. Reorgs can be handled by rewinding the chain back to a specific block then adding the new canonical logs.

This implements the basic log storage and search functionality but has two key pieces not yet implemented:
1. Storing and returning executing message dependencies for logs
2. Recovering the database after write errors, particularly when a partial write occurs. An error is returned to the caller to indicate the write failed, but there's no code to handle truncating any partially written data or ensuring the data cached in memory is rolled back.

These items will be added in a follow up PR.

Also note that this doesn't attempt to track different levels of safety. Ideally an outer wrapper can track that based on block number. Storing those head levels to disk may require them being handled inside this struct though ideally I'd like them to just be a prefix and manage to keep this struct completely focussed on storing the log data.

A simple RWMutex is used to provide thread safety, it may be better to remove that again in the future and have thread safety be handled by the wrapper. Or if we want to maximise performance it may be possible to have more fine-grained locking so that checking if logs exist can be safely done in parallel with adding blocks, with only rewinds needing exclusive access. Going to avoid adding that complexity until we know it's needed.

**Tests**

Added unit tests. Each test is run first by writing and reading from the same DB instance, then writes and performs the reads from a separate instance to confirm it can be reread purely from the information on disk. Also implemented a set of invariant checks that are run after each test to verify key properties of the database format.

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/10857
