### PR TITLE
op-node: cl-sync using events

### DIFF
--- a/op-e2e/actions/reorg_test.go
+++ b/op-e2e/actions/reorg_test.go
@@ -767,7 +767,7 @@ func ConflictingL2Blocks(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	// give the unsafe block to the verifier, and see if it reorgs because of any unsafe inputs
 	head, err := altSeqEngCl.PayloadByLabel(t.Ctx(), eth.Unsafe)
 	require.NoError(t, err)
-	verifier.ActL2UnsafeGossipReceive(head)
+	verifier.ActL2UnsafeGossipReceive(head)(t)
 
 	// make sure verifier has processed everything
 	verifier.ActL2PipelineFull(t)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -617,7 +617,6 @@ func L1InfoFromState(ctx context.Context, contract *bindings.L1Block, l2Number *
 // TestSystemMockP2P sets up a L1 Geth node, a rollup node, and a L2 geth node and then confirms that
 // the nodes can sync L2 blocks before they are confirmed on L1.
 func TestSystemMockP2P(t *testing.T) {
-	t.Skip("flaky in CI") // TODO(CLI-3859): Re-enable this test.
 	InitParallel(t)
 
 	cfg := DefaultSystemConfig(t)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -582,7 +582,8 @@ func (n *OpNode) OnUnsafeL2Payload(ctx context.Context, from peer.ID, envelope *
 
 	n.tracer.OnUnsafeL2Payload(ctx, from, envelope)
 
-	n.log.Info("Received signed execution payload from p2p", "id", envelope.ExecutionPayload.ID(), "peer", from)
+	n.log.Info("Received signed execution payload from p2p", "id", envelope.ExecutionPayload.ID(), "peer", from,
+		"txs", len(envelope.ExecutionPayload.Transactions))
 
 	// Pass on the event to the L2 Engine
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -182,7 +182,7 @@ func TestAttributesHandler(t *testing.T) {
 	t.Run("drop stale attributes", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		eng := &testutils.MockEngine{}
-		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 		ah := NewAttributesHandler(logger, cfg, ec, eng)
 		defer eng.AssertExpectations(t)
 
@@ -196,7 +196,7 @@ func TestAttributesHandler(t *testing.T) {
 	t.Run("pending gets reorged", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		eng := &testutils.MockEngine{}
-		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 		ah := NewAttributesHandler(logger, cfg, ec, eng)
 		defer eng.AssertExpectations(t)
 
@@ -211,7 +211,7 @@ func TestAttributesHandler(t *testing.T) {
 		t.Run("consolidation fails", func(t *testing.T) {
 			logger := testlog.Logger(t, log.LevelInfo)
 			eng := &testutils.MockEngine{}
-			ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+			ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 			ah := NewAttributesHandler(logger, cfg, ec, eng)
 
 			ec.SetUnsafeHead(refA1)
@@ -265,7 +265,7 @@ func TestAttributesHandler(t *testing.T) {
 			fn := func(t *testing.T, lastInSpan bool) {
 				logger := testlog.Logger(t, log.LevelInfo)
 				eng := &testutils.MockEngine{}
-				ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+				ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 				ah := NewAttributesHandler(logger, cfg, ec, eng)
 
 				ec.SetUnsafeHead(refA1)
@@ -324,7 +324,7 @@ func TestAttributesHandler(t *testing.T) {
 
 		logger := testlog.Logger(t, log.LevelInfo)
 		eng := &testutils.MockEngine{}
-		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 		ah := NewAttributesHandler(logger, cfg, ec, eng)
 
 		ec.SetUnsafeHead(refA0)
@@ -375,7 +375,7 @@ func TestAttributesHandler(t *testing.T) {
 
 		logger := testlog.Logger(t, log.LevelInfo)
 		eng := &testutils.MockEngine{}
-		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 		ah := NewAttributesHandler(logger, cfg, ec, eng)
 
 		ec.SetUnsafeHead(refA0)
@@ -399,7 +399,7 @@ func TestAttributesHandler(t *testing.T) {
 	t.Run("no attributes", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		eng := &testutils.MockEngine{}
-		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+		ec := engine.NewEngineController(eng, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 		ah := NewAttributesHandler(logger, cfg, ec, eng)
 		defer eng.AssertExpectations(t)
 

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -1,9 +1,7 @@
 package clsync
 
 import (
-	"context"
-	"errors"
-	"io"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -20,27 +18,26 @@ type Metrics interface {
 	RecordUnsafePayloadsBuffer(length uint64, memSize uint64, next eth.BlockID)
 }
 
-type Engine interface {
-	engine.EngineState
-	InsertUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error
-}
-
 // CLSync holds on to a queue of received unsafe payloads,
 // and tries to apply them to the tip of the chain when requested to.
 type CLSync struct {
-	log            log.Logger
-	cfg            *rollup.Config
-	metrics        Metrics
-	ec             Engine
+	log     log.Logger
+	cfg     *rollup.Config
+	metrics Metrics
+
+	emitter rollup.EventEmitter
+
+	mu sync.Mutex
+
 	unsafePayloads *PayloadsQueue // queue of unsafe payloads, ordered by ascending block number, may have gaps and duplicates
 }
 
-func NewCLSync(log log.Logger, cfg *rollup.Config, metrics Metrics, ec Engine) *CLSync {
+func NewCLSync(log log.Logger, cfg *rollup.Config, metrics Metrics, emitter rollup.EventEmitter) *CLSync {
 	return &CLSync{
 		log:            log,
 		cfg:            cfg,
 		metrics:        metrics,
-		ec:             ec,
+		emitter:        emitter,
 		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
 	}
 }
@@ -58,8 +55,111 @@ func (eq *CLSync) LowestQueuedUnsafeBlock() eth.L2BlockRef {
 	return ref
 }
 
+type ReceivedUnsafePayloadEvent struct {
+	Envelope *eth.ExecutionPayloadEnvelope
+}
+
+func (ev ReceivedUnsafePayloadEvent) String() string {
+	return "received-unsafe-payload"
+}
+
+func (eq *CLSync) OnEvent(ev rollup.Event) {
+	// Events may be concurrent in the future. Prevent unsafe concurrent modifications to the payloads queue.
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	switch x := ev.(type) {
+	case engine.InvalidPayloadEvent:
+		eq.onInvalidPayload(x)
+	case engine.ForkchoiceUpdateEvent:
+		eq.onForkchoiceUpdate(x)
+	case ReceivedUnsafePayloadEvent:
+		eq.onUnsafePayload(x)
+	}
+}
+
+// onInvalidPayload checks if the first next-up payload matches the invalid payload.
+// If so, the payload is dropped, to give the next payloads a try.
+func (eq *CLSync) onInvalidPayload(x engine.InvalidPayloadEvent) {
+	eq.log.Debug("CL sync received invalid-payload report", x.Envelope.ExecutionPayload.ID())
+
+	block := x.Envelope.ExecutionPayload
+	if peek := eq.unsafePayloads.Peek(); peek != nil &&
+		block.BlockHash == peek.ExecutionPayload.BlockHash {
+		eq.log.Warn("Dropping invalid unsafe payload",
+			"hash", block.BlockHash, "number", uint64(block.BlockNumber),
+			"timestamp", uint64(block.Timestamp))
+		eq.unsafePayloads.Pop()
+	}
+}
+
+// onForkchoiceUpdate peeks at the next applicable unsafe payload, if any,
+// to apply on top of the received forkchoice pre-state.
+// The payload is held on to until the forkchoice changes (success case) or the payload is reported to be invalid.
+func (eq *CLSync) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
+	eq.log.Debug("CL sync received forkchoice update",
+		"unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
+
+	for {
+		pop, abort := eq.fromQueue(x)
+		if abort {
+			return
+		}
+		if pop {
+			eq.unsafePayloads.Pop()
+		} else {
+			break
+		}
+	}
+
+	firstEnvelope := eq.unsafePayloads.Peek()
+
+	// We don't pop from the queue. If there is a temporary error then we can retry.
+	// Upon next forkchoice update or invalid-payload event we can remove it from the queue.
+	eq.emitter.Emit(engine.ProcessUnsafePayloadEvent{Envelope: firstEnvelope})
+}
+
+// fromQueue determines what to do with the tip of the payloads-queue, given the forkchoice pre-state.
+// If abort, there is nothing to process (either due to empty queue, or unsuitable tip).
+// If pop, the tip should be dropped, and processing can repeat from there.
+// If not abort or pop, the tip is ready to process.
+func (eq *CLSync) fromQueue(x engine.ForkchoiceUpdateEvent) (pop bool, abort bool) {
+	if eq.unsafePayloads.Len() == 0 {
+		return false, true
+	}
+	firstEnvelope := eq.unsafePayloads.Peek()
+	first := firstEnvelope.ExecutionPayload
+
+	if first.BlockHash == x.UnsafeL2Head.Hash {
+		eq.log.Debug("successfully processed payload, removing it from the payloads queue now")
+		return true, false
+	}
+
+	if uint64(first.BlockNumber) <= x.SafeL2Head.Number {
+		eq.log.Info("skipping unsafe payload, since it is older than safe head", "safe", x.SafeL2Head.ID(), "unsafe", x.UnsafeL2Head.ID(), "unsafe_payload", first.ID())
+		return true, false
+	}
+	if uint64(first.BlockNumber) <= x.UnsafeL2Head.Number {
+		eq.log.Info("skipping unsafe payload, since it is older than unsafe head", "unsafe", x.UnsafeL2Head.ID(), "unsafe_payload", first.ID())
+		return true, false
+	}
+
+	// Ensure that the unsafe payload builds upon the current unsafe head
+	if first.ParentHash != x.UnsafeL2Head.Hash {
+		if uint64(first.BlockNumber) == x.UnsafeL2Head.Number+1 {
+			eq.log.Info("skipping unsafe payload, since it does not build onto the existing unsafe chain", "safe", x.SafeL2Head.ID(), "unsafe", x.UnsafeL2Head.ID(), "unsafe_payload", first.ID())
+			return true, false
+		}
+		return false, true // rollup-node should try something different if it cannot process the first unsafe payload
+	}
+
+	return false, false
+}
+
 // AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1.
-func (eq *CLSync) AddUnsafePayload(envelope *eth.ExecutionPayloadEnvelope) {
+func (eq *CLSync) onUnsafePayload(x ReceivedUnsafePayloadEvent) {
+	eq.log.Debug("CL sync received payload", "payload", x.Envelope.ExecutionPayload.ID())
+	envelope := x.Envelope
 	if envelope == nil {
 		eq.log.Warn("cannot add nil unsafe payload")
 		return
@@ -72,53 +172,7 @@ func (eq *CLSync) AddUnsafePayload(envelope *eth.ExecutionPayloadEnvelope) {
 	p := eq.unsafePayloads.Peek()
 	eq.metrics.RecordUnsafePayloadsBuffer(uint64(eq.unsafePayloads.Len()), eq.unsafePayloads.MemSize(), p.ExecutionPayload.ID())
 	eq.log.Trace("Next unsafe payload to process", "next", p.ExecutionPayload.ID(), "timestamp", uint64(p.ExecutionPayload.Timestamp))
-}
 
-// Proceed dequeues the next applicable unsafe payload, if any, to apply to the tip of the chain.
-// EOF error means we can't process the next unsafe payload. The caller should then try a different form of syncing.
-func (eq *CLSync) Proceed(ctx context.Context) error {
-	if eq.unsafePayloads.Len() == 0 {
-		return io.EOF
-	}
-	firstEnvelope := eq.unsafePayloads.Peek()
-	first := firstEnvelope.ExecutionPayload
-
-	if uint64(first.BlockNumber) <= eq.ec.SafeL2Head().Number {
-		eq.log.Info("skipping unsafe payload, since it is older than safe head", "safe", eq.ec.SafeL2Head().ID(), "unsafe", eq.ec.UnsafeL2Head().ID(), "unsafe_payload", first.ID())
-		eq.unsafePayloads.Pop()
-		return nil
-	}
-	if uint64(first.BlockNumber) <= eq.ec.UnsafeL2Head().Number {
-		eq.log.Info("skipping unsafe payload, since it is older than unsafe head", "unsafe", eq.ec.UnsafeL2Head().ID(), "unsafe_payload", first.ID())
-		eq.unsafePayloads.Pop()
-		return nil
-	}
-
-	// Ensure that the unsafe payload builds upon the current unsafe head
-	if first.ParentHash != eq.ec.UnsafeL2Head().Hash {
-		if uint64(first.BlockNumber) == eq.ec.UnsafeL2Head().Number+1 {
-			eq.log.Info("skipping unsafe payload, since it does not build onto the existing unsafe chain", "safe", eq.ec.SafeL2Head().ID(), "unsafe", eq.ec.UnsafeL2Head().ID(), "unsafe_payload", first.ID())
-			eq.unsafePayloads.Pop()
-		}
-		return io.EOF // time to go to next stage if we cannot process the first unsafe payload
-	}
-
-	ref, err := derive.PayloadToBlockRef(eq.cfg, first)
-	if err != nil {
-		eq.log.Error("failed to decode L2 block ref from payload", "err", err)
-		eq.unsafePayloads.Pop()
-		return nil
-	}
-
-	if err := eq.ec.InsertUnsafePayload(ctx, firstEnvelope, ref); errors.Is(err, derive.ErrTemporary) {
-		eq.log.Debug("Temporary error while inserting unsafe payload", "hash", ref.Hash, "number", ref.Number, "timestamp", ref.Time, "l1Origin", ref.L1Origin)
-		return err
-	} else if err != nil {
-		eq.log.Warn("Dropping invalid unsafe payload", "hash", ref.Hash, "number", ref.Number, "timestamp", ref.Time, "l1Origin", ref.L1Origin)
-		eq.unsafePayloads.Pop()
-		return err
-	}
-	eq.unsafePayloads.Pop()
-	eq.log.Trace("Executed unsafe payload", "hash", ref.Hash, "number", ref.Number, "timestamp", ref.Time, "l1Origin", ref.L1Origin)
-	return nil
+	// request forkchoice signal, so we can process the payload maybe
+	eq.emitter.Emit(engine.ForkchoiceRequestEvent{})
 }

--- a/op-node/rollup/events.go
+++ b/op-node/rollup/events.go
@@ -80,3 +80,7 @@ type DeriverFunc func(ev Event)
 func (fn DeriverFunc) OnEvent(ev Event) {
 	fn(ev)
 }
+
+type NoopEmitter struct{}
+
+func (e NoopEmitter) Emit(ev Event) {}

--- a/op-node/rollup/synchronous.go
+++ b/op-node/rollup/synchronous.go
@@ -1,12 +1,10 @@
-package driver
+package rollup
 
 import (
 	"context"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 // Don't queue up an endless number of events.
@@ -23,16 +21,16 @@ type SynchronousEvents struct {
 	// if this util is used in a concurrent context.
 	evLock sync.Mutex
 
-	events []rollup.Event
+	events []Event
 
 	log log.Logger
 
 	ctx context.Context
 
-	root rollup.Deriver
+	root Deriver
 }
 
-func NewSynchronousEvents(log log.Logger, ctx context.Context, root rollup.Deriver) *SynchronousEvents {
+func NewSynchronousEvents(log log.Logger, ctx context.Context, root Deriver) *SynchronousEvents {
 	return &SynchronousEvents{
 		log:  log,
 		ctx:  ctx,
@@ -40,7 +38,7 @@ func NewSynchronousEvents(log log.Logger, ctx context.Context, root rollup.Deriv
 	}
 }
 
-func (s *SynchronousEvents) Emit(event rollup.Event) {
+func (s *SynchronousEvents) Emit(event Event) {
 	s.evLock.Lock()
 	defer s.evLock.Unlock()
 
@@ -75,4 +73,4 @@ func (s *SynchronousEvents) Drain() error {
 	}
 }
 
-var _ rollup.EventEmitter = (*SynchronousEvents)(nil)
+var _ EventEmitter = (*SynchronousEvents)(nil)

--- a/op-node/rollup/synchronous_test.go
+++ b/op-node/rollup/synchronous_test.go
@@ -1,4 +1,4 @@
-package driver
+package rollup
 
 import (
 	"context"
@@ -8,21 +8,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
-
-type TestEvent struct{}
-
-func (ev TestEvent) String() string {
-	return "X"
-}
 
 func TestSynchronousEvents(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)
 	ctx, cancel := context.WithCancel(context.Background())
 	count := 0
-	deriver := rollup.DeriverFunc(func(ev rollup.Event) {
+	deriver := DeriverFunc(func(ev Event) {
 		count += 1
 	})
 	syncEv := NewSynchronousEvents(logger, ctx, deriver)
@@ -48,7 +41,7 @@ func TestSynchronousEvents(t *testing.T) {
 func TestSynchronousEventsSanityLimit(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)
 	count := 0
-	deriver := rollup.DeriverFunc(func(ev rollup.Event) {
+	deriver := DeriverFunc(func(ev Event) {
 		count += 1
 	})
 	syncEv := NewSynchronousEvents(logger, context.Background(), deriver)
@@ -74,9 +67,9 @@ func (ev CyclicEvent) String() string {
 
 func TestSynchronousCyclic(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)
-	var emitter rollup.EventEmitter
+	var emitter EventEmitter
 	result := false
-	deriver := rollup.DeriverFunc(func(ev rollup.Event) {
+	deriver := DeriverFunc(func(ev Event) {
 		logger.Info("received event", "event", ev)
 		switch x := ev.(type) {
 		case CyclicEvent:

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -101,7 +101,7 @@ type Driver struct {
 }
 
 func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l1BlobsSource derive.L1BlobsFetcher, l2Source L2Source, targetBlockNum uint64) *Driver {
-	engine := engine.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+	engine := engine.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync, rollup.NoopEmitter{})
 	attributesHandler := attributes.NewAttributesHandler(logger, cfg, engine, l2Source)
 	syncCfg := &sync.Config{SyncMode: sync.CLSync}
 	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, plasma.Disabled, l2Source, metrics.NoopMetrics)

--- a/op-service/testutils/mock_emitter.go
+++ b/op-service/testutils/mock_emitter.go
@@ -1,0 +1,25 @@
+package testutils
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+)
+
+type MockEmitter struct {
+	mock.Mock
+}
+
+func (m *MockEmitter) Emit(ev rollup.Event) {
+	m.Mock.MethodCalled("Emit", ev)
+}
+
+func (m *MockEmitter) ExpectOnce(expected rollup.Event) {
+	m.Mock.On("Emit", expected).Once()
+}
+
+func (m *MockEmitter) AssertExpectations(t mock.TestingT) {
+	m.Mock.AssertExpectations(t)
+}
+
+var _ rollup.EventEmitter = (*MockEmitter)(nil)


### PR DESCRIPTION
**Description**

This is a step closer to making each driver-component communicate with events, and not attach synchronously to the engine-controller.

The CL-sync now monitors forkchoice updates and invalid-payload reports to maintain what payload should be suggested to the execution engine next.
It no longer directly interfaces with the engine-controller state.

The CL-sync checks are also robust enough to just drop payloads if the forkchoice moves past these at a later point. I.e. the node does not get stuck when a forkchoice-update event is missed.

Temporary errors are assumed to not bubble back any useful events, and instead the CL-sync waits for the next forkchoice-update to re-attempt.

TODO: should we poke it more explicitly after a temporary error, to not rely on new incoming blocks for the retry attempt?
Going to draft stacked PR on top of this first, the engine-controller really needs some simplification/improvement/testing.

To handle the "dead" moment when there's a new payload, but no forkchoice-updates to trigger processing, the CL-sync can request from the engine to communicate the latest forkchoice. That way no state is shared, and the CL-sync can continue processing.

Note: the engine-controller is enhanced with event-emits of forkchoice changes and payload-insertion (in the full payload case, not when building a payload from block-attributes).

Side-note: also moved the syncronous-events-emitter from `driver` into `rollup` package, but did not end up needing it for cl-sync unit-testing. Added a mock-emitter instead, to catch/check emitted events.

**Tests**

- updated CL-sync unit tests
- updated op-e2e action-test verifier to make cl-sync a deriver.
- re-enabled op-e2e system gossip test to confirm that block gossip sync still works.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/10853
