### PR TITLE
op-node: attributes-handler with events

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -307,11 +307,6 @@ func (s *L2Verifier) OnEvent(ev rollup.Event) {
 	}
 }
 
-func (s *L2Verifier) ActL2PipelineStep(t Testing) {
-	t.Helper()
-	t.Fatal("ActL2PipelineStep is not supported anymore")
-}
-
 func (s *L2Verifier) ActL2EventsUntilPending(t Testing, num uint64) {
 	s.ActL2EventsUntil(t, func(ev rollup.Event) bool {
 		x, ok := ev.(engine.PendingSafeUpdateEvent)

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/stretchr/testify/require"
 
@@ -38,6 +39,8 @@ type L2Verifier struct {
 		L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	}
 
+	synchronousEvents *rollup.SynchronousEvents
+
 	syncDeriver *driver.SyncDeriver
 
 	// L2 rollup
@@ -45,10 +48,9 @@ type L2Verifier struct {
 	derivation *derive.DerivationPipeline
 	clSync     *clsync.CLSync
 
-	attributesHandler driver.AttributesHandler
-	safeHeadListener  rollup.SafeHeadListener
-	finalizer         driver.Finalizer
-	syncCfg           *sync.Config
+	safeHeadListener rollup.SafeHeadListener
+	finalizer        driver.Finalizer
+	syncCfg          *sync.Config
 
 	l1      derive.L1Fetcher
 	l1State *driver.L1State
@@ -101,26 +103,25 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 		finalizer = finality.NewFinalizer(log, cfg, l1, ec)
 	}
 
-	attributesHandler := attributes.NewAttributesHandler(log, cfg, ec, eng)
+	attributesHandler := attributes.NewAttributesHandler(log, cfg, ctx, eng, synchronousEvents)
 
 	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, plasmaSrc, eng, metrics)
 	pipelineDeriver := derive.NewPipelineDeriver(ctx, pipeline, synchronousEvents)
 
 	syncDeriver := &driver.SyncDeriver{
-		Derivation:        pipeline,
-		Finalizer:         finalizer,
-		AttributesHandler: attributesHandler,
-		SafeHeadNotifs:    safeHeadListener,
-		CLSync:            clSync,
-		Engine:            ec,
-		SyncCfg:           syncCfg,
-		Config:            cfg,
-		L1:                l1,
-		L2:                eng,
-		Emitter:           synchronousEvents,
-		Log:               log,
-		Ctx:               ctx,
-		Drain:             synchronousEvents.Drain,
+		Derivation:     pipeline,
+		Finalizer:      finalizer,
+		SafeHeadNotifs: safeHeadListener,
+		CLSync:         clSync,
+		Engine:         ec,
+		SyncCfg:        syncCfg,
+		Config:         cfg,
+		L1:             l1,
+		L2:             eng,
+		Emitter:        synchronousEvents,
+		Log:            log,
+		Ctx:            ctx,
+		Drain:          synchronousEvents.Drain,
 	}
 
 	engDeriv := engine.NewEngDeriver(log, ctx, cfg, ec, synchronousEvents)
@@ -132,7 +133,6 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 		clSync:            clSync,
 		derivation:        pipeline,
 		finalizer:         finalizer,
-		attributesHandler: attributesHandler,
 		safeHeadListener:  safeHeadListener,
 		syncCfg:           syncCfg,
 		syncDeriver:       syncDeriver,
@@ -142,6 +142,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 		l2Building:        false,
 		rollupCfg:         cfg,
 		rpc:               rpc.NewServer(),
+		synchronousEvents: synchronousEvents,
 	}
 
 	*rootDeriver = rollup.SynchronousDerivers{
@@ -151,6 +152,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 		rollupNode,
 		clSync,
 		pipelineDeriver,
+		attributesHandler,
 	}
 
 	t.Cleanup(rollupNode.rpc.Stop)
@@ -305,14 +307,34 @@ func (s *L2Verifier) OnEvent(ev rollup.Event) {
 	}
 }
 
-// ActL2PipelineStep runs one iteration of the L2 derivation pipeline
 func (s *L2Verifier) ActL2PipelineStep(t Testing) {
+	t.Helper()
+	t.Fatal("ActL2PipelineStep is not supported anymore")
+}
+
+func (s *L2Verifier) ActL2EventsUntilPending(t Testing, num uint64) {
+	s.ActL2EventsUntil(t, func(ev rollup.Event) bool {
+		x, ok := ev.(engine.PendingSafeUpdateEvent)
+		return ok && x.PendingSafe.Number == num
+	}, 1000, false)
+}
+
+func (s *L2Verifier) ActL2EventsUntil(t Testing, fn func(ev rollup.Event) bool, max int, excl bool) {
+	t.Helper()
 	if s.l2Building {
 		t.InvalidAction("cannot derive new data while building L2 block")
 		return
 	}
-	s.syncDeriver.Emitter.Emit(driver.StepEvent{})
-	require.NoError(t, s.syncDeriver.Drain(), "complete all event processing triggered by deriver step")
+	for i := 0; i < max; i++ {
+		err := s.synchronousEvents.DrainUntil(fn, excl)
+		if err == nil {
+			return
+		}
+		if err == io.EOF {
+			s.synchronousEvents.Emit(driver.StepEvent{})
+		}
+	}
+	t.Fatalf("event condition did not hit, ran maximum number of steps: %d", max)
 }
 
 func (s *L2Verifier) ActL2PipelineFull(t Testing) {
@@ -326,14 +348,19 @@ func (s *L2Verifier) ActL2PipelineFull(t Testing) {
 		if i > 10_000 {
 			t.Fatalf("ActL2PipelineFull running for too long. Is a deriver looping?")
 		}
-		s.ActL2PipelineStep(t)
+		if s.l2Building {
+			t.InvalidAction("cannot derive new data while building L2 block")
+			return
+		}
+		s.syncDeriver.Emitter.Emit(driver.StepEvent{})
+		require.NoError(t, s.syncDeriver.Drain(), "complete all event processing triggered by deriver step")
 	}
 }
 
 // ActL2UnsafeGossipReceive creates an action that can receive an unsafe execution payload, like gossipsub
 func (s *L2Verifier) ActL2UnsafeGossipReceive(payload *eth.ExecutionPayloadEnvelope) Action {
 	return func(t Testing) {
-		s.syncDeriver.Emitter.Emit(clsync.ReceivedUnsafePayloadEvent{Envelope: payload})
+		s.synchronousEvents.Emit(clsync.ReceivedUnsafePayloadEvent{Envelope: payload})
 	}
 }
 

--- a/op-node/rollup/derive/plasma_data_source.go
+++ b/op-node/rollup/derive/plasma_data_source.go
@@ -83,13 +83,13 @@ func (s *PlasmaDataSource) Next(ctx context.Context) (eth.Data, error) {
 		// skip the input
 		return s.Next(ctx)
 	} else if errors.Is(err, plasma.ErrMissingPastWindow) {
-		return nil, NewCriticalError(fmt.Errorf("data for comm %x not available: %w", s.comm, err))
+		return nil, NewCriticalError(fmt.Errorf("data for comm %s not available: %w", s.comm, err))
 	} else if errors.Is(err, plasma.ErrPendingChallenge) {
 		// continue stepping without slowing down.
 		return nil, NotEnoughData
 	} else if err != nil {
 		// return temporary error so we can keep retrying.
-		return nil, NewTemporaryError(fmt.Errorf("failed to fetch input data with comm %x from da service: %w", s.comm, err))
+		return nil, NewTemporaryError(fmt.Errorf("failed to fetch input data with comm %s from da service: %w", s.comm, err))
 	}
 	// inputs are limited to a max size to ensure they can be challenged in the DA contract.
 	if s.comm.CommitmentType() == plasma.Keccak256CommitmentType && len(data) > plasma.MaxInputSize {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -191,7 +191,7 @@ func NewDriver(
 		finalizer = finality.NewFinalizer(log, cfg, l1, ec)
 	}
 
-	attributesHandler := attributes.NewAttributesHandler(log, cfg, ec, l2)
+	attributesHandler := attributes.NewAttributesHandler(log, cfg, driverCtx, l2, synchronousEvents)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, metrics)
 	pipelineDeriver := derive.NewPipelineDeriver(driverCtx, derivationPipeline, synchronousEvents)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
@@ -200,20 +200,19 @@ func NewDriver(
 	asyncGossiper := async.NewAsyncGossiper(driverCtx, network, log, metrics)
 
 	syncDeriver := &SyncDeriver{
-		Derivation:        derivationPipeline,
-		Finalizer:         finalizer,
-		AttributesHandler: attributesHandler,
-		SafeHeadNotifs:    safeHeadListener,
-		CLSync:            clSync,
-		Engine:            ec,
-		SyncCfg:           syncCfg,
-		Config:            cfg,
-		L1:                l1,
-		L2:                l2,
-		Emitter:           synchronousEvents,
-		Log:               log,
-		Ctx:               driverCtx,
-		Drain:             synchronousEvents.Drain,
+		Derivation:     derivationPipeline,
+		Finalizer:      finalizer,
+		SafeHeadNotifs: safeHeadListener,
+		CLSync:         clSync,
+		Engine:         ec,
+		SyncCfg:        syncCfg,
+		Config:         cfg,
+		L1:             l1,
+		L2:             l2,
+		Emitter:        synchronousEvents,
+		Log:            log,
+		Ctx:            driverCtx,
+		Drain:          synchronousEvents.Drain,
 	}
 	engDeriv := engine.NewEngDeriver(log, driverCtx, cfg, ec, synchronousEvents)
 	schedDeriv := NewStepSchedulingDeriver(log, synchronousEvents)
@@ -254,6 +253,7 @@ func NewDriver(
 		driver,
 		clSync,
 		pipelineDeriver,
+		attributesHandler,
 	}
 
 	return driver

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -44,6 +44,11 @@ func (d *ProgramDeriver) OnEvent(ev rollup.Event) {
 	case derive.DeriverMoreEvent:
 		d.Emitter.Emit(engine.PendingSafeRequestEvent{})
 	case derive.DerivedAttributesEvent:
+		// Allow new attributes to be generated.
+		// We will process the current attributes synchronously,
+		// triggering a single PendingSafeUpdateEvent or InvalidPayloadAttributesEvent,
+		// to continue derivation from.
+		d.Emitter.Emit(derive.ConfirmReceivedAttributesEvent{})
 		// No need to queue the attributes, since there is no unsafe chain to consolidate against,
 		// and no temporary-error retry to perform on block processing.
 		d.Emitter.Emit(engine.ProcessAttributesEvent{Attributes: x.Attributes})

--- a/op-program/client/driver/program_test.go
+++ b/op-program/client/driver/program_test.go
@@ -63,6 +63,7 @@ func TestProgramDeriver(t *testing.T) {
 	t.Run("derived attributes", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
 		attrib := &derive.AttributesWithParent{Parent: eth.L2BlockRef{Number: 123}}
+		m.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 		m.ExpectOnce(engine.ProcessAttributesEvent{Attributes: attrib})
 		p.OnEvent(derive.DerivedAttributesEvent{Attributes: attrib})
 		m.AssertExpectations(t)

--- a/op-service/testutils/mock_emitter.go
+++ b/op-service/testutils/mock_emitter.go
@@ -18,6 +18,10 @@ func (m *MockEmitter) ExpectOnce(expected rollup.Event) {
 	m.Mock.On("Emit", expected).Once()
 }
 
+func (m *MockEmitter) ExpectOnceType(typ string) {
+	m.Mock.On("Emit", mock.AnythingOfType(typ)).Once()
+}
+
 func (m *MockEmitter) AssertExpectations(t mock.TestingT) {
 	m.Mock.AssertExpectations(t)
 }


### PR DESCRIPTION
**Description**

One more step towards separating every components with events.

This turns the `AttributesHandler` into a Deriver, processing and emitting events to interact with the other things around it.

~Depends on #10971~

**Tests**

- Attributes handler unit tests are cleaner now, abstract away engine-controller internals
- Updated some op-e2e tests to deal with the move away from immediate attributes-processing coupled to pipeline-steps.
  After we have events, there's no single synchronous notion of a derivation-step anymore. Thus in the e2e action tests I instead fixed up tests to run the derivation till a certain event, rather than an arbitrary step that leaks internal behavior of the derivation progression.

**Metadata**

Fix #10852