### PR TITLE
cannon: Revert to original state JSON schema

### DIFF
--- a/cannon/mipsevm/state.go
+++ b/cannon/mipsevm/state.go
@@ -2,6 +2,7 @@ package mipsevm
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -45,6 +46,62 @@ type State struct {
 	// Warning: the hint MAY NOT BE COMPLETE. I.e. this is buffered,
 	// and should only be read when len(LastHint) > 4 && uint32(LastHint[:4]) <= len(LastHint[4:])
 	LastHint hexutil.Bytes `json:"lastHint,omitempty"`
+}
+
+type stateMarshaling struct {
+	Memory         *Memory       `json:"memory"`
+	PreimageKey    common.Hash   `json:"preimageKey"`
+	PreimageOffset uint32        `json:"preimageOffset"`
+	PC             uint32        `json:"pc"`
+	NextPC         uint32        `json:"nextPC"`
+	LO             uint32        `json:"lo"`
+	HI             uint32        `json:"hi"`
+	Heap           uint32        `json:"heap"`
+	ExitCode       uint8         `json:"exit"`
+	Exited         bool          `json:"exited"`
+	Step           uint64        `json:"step"`
+	Registers      [32]uint32    `json:"registers"`
+	LastHint       hexutil.Bytes `json:"lastHint,omitempty"`
+}
+
+func (s *State) MarshalJSON() ([]byte, error) { // nosemgrep
+	sm := &stateMarshaling{
+		Memory:         s.Memory,
+		PreimageKey:    s.PreimageKey,
+		PreimageOffset: s.PreimageOffset,
+		PC:             s.Cpu.PC,
+		NextPC:         s.Cpu.NextPC,
+		LO:             s.Cpu.LO,
+		HI:             s.Cpu.HI,
+		Heap:           s.Heap,
+		ExitCode:       s.ExitCode,
+		Exited:         s.Exited,
+		Step:           s.Step,
+		Registers:      s.Registers,
+		LastHint:       s.LastHint,
+	}
+	return json.Marshal(sm)
+}
+
+func (s *State) UnmarshalJSON(data []byte) error {
+	sm := new(stateMarshaling)
+	if err := json.Unmarshal(data, sm); err != nil {
+		return err
+	}
+	s.Memory = sm.Memory
+	s.PreimageKey = sm.PreimageKey
+	s.PreimageOffset = sm.PreimageOffset
+	s.Cpu.PC = sm.PC
+	s.Cpu.NextPC = sm.NextPC
+	s.Cpu.LO = sm.LO
+	s.Cpu.HI = sm.HI
+	s.Heap = sm.Heap
+	s.ExitCode = sm.ExitCode
+	s.Exited = sm.Exited
+	s.Step = sm.Step
+	s.Registers = sm.Registers
+	s.LastHint = sm.LastHint
+	return nil
 }
 
 func (s *State) GetStep() uint64 { return s.Step }

--- a/cannon/mipsevm/state_test.go
+++ b/cannon/mipsevm/state_test.go
@@ -301,3 +301,26 @@ func selectOracleFixture(t *testing.T, programName string) PreimageOracle {
 		return nil
 	}
 }
+
+func TestStateJSONCodec(t *testing.T) {
+	elfProgram, err := elf.Open("../example/bin/hello.elf")
+	require.NoError(t, err, "open ELF file")
+	state, err := LoadELF(elfProgram)
+	require.NoError(t, err, "load ELF into state")
+
+	stateJSON, err := state.MarshalJSON()
+	require.NoError(t, err)
+
+	newState := new(State)
+	require.NoError(t, newState.UnmarshalJSON(stateJSON))
+
+	require.Equal(t, state.PreimageKey, newState.PreimageKey)
+	require.Equal(t, state.PreimageOffset, newState.PreimageOffset)
+	require.Equal(t, state.Cpu, newState.Cpu)
+	require.Equal(t, state.Heap, newState.Heap)
+	require.Equal(t, state.ExitCode, newState.ExitCode)
+	require.Equal(t, state.Exited, newState.Exited)
+	require.Equal(t, state.Memory.MerkleRoot(), newState.Memory.MerkleRoot())
+	require.Equal(t, state.Registers, newState.Registers)
+	require.Equal(t, state.Step, newState.Step)
+}

--- a/op-challenger/game/fault/trace/cannon/test_data/state.json
+++ b/op-challenger/game/fault/trace/cannon/test_data/state.json
@@ -2,12 +2,10 @@
   "memory": [],
   "preimageKey": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "preimageOffset": 0,
-  "cpu": {
-    "pc": 0,
-    "nextPC": 1,
-    "lo": 0,
-    "hi": 0
-  },
+  "pc": 0,
+  "nextPC": 1,
+  "lo": 0,
+  "hi": 0,
   "heap": 0,
   "exit": 0,
   "exited": false,


### PR DESCRIPTION
In a recent change, we modified the cannon state JSON schema, which introduced incompatibility with the previous schema. This change poses a problem during the upgrade process for op-challengers.

When an op-challenger is upgraded to use the new schema, it becomes unable to read existing states found in its data directory. If a cannon execution is ongoing prior to the challenger upgrade, the new challenger won't be able to parse the old-formatted states that remain on disk. Consequently, the op-challenger may fail to participate in existing bottom games.

To address this issue, we are reverting the state JSON schema to the original schema. The `CpuScalars` field will still be retained within the `mipsevm.State` struct. However, the state JSON encoder will extract the `CpuScalars` fields to preserve the old schema, ensuring compatibility with existing states.

This reversion ensures a smooth upgrade process for op-challengers and maintains their ability to participate in ongoing cannon executions without encountering parsing errors due to the schema change.