### PR TITLE
tag-service: add da-server

### DIFF
--- a/ops/tag-service/tag-service.py
+++ b/ops/tag-service/tag-service.py
@@ -12,6 +12,7 @@ MIN_VERSIONS = {
     'ci-builder': '0.6.0',
     'ci-builder-rust': '0.1.0',
     'chain-mon': '0.2.2',
+    'da-server': '0.0.4',
     'op-node': '0.10.14',
     'op-batcher': '0.10.14',
     'op-challenger': '0.0.4',


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds `da-server` to tag service. It can already be selected in the tag service GH action.
