### PR TITLE
op-batcher: Log on successful Plasma SetInput

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -509,6 +509,7 @@ func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, que
 				l.recordFailedTx(txdata.ID(), err)
 				return nil
 			}
+			l.Log.Info("Set plasma input", "commitment", comm, "tx", txdata.ID())
 			// signal plasma commitment tx with TxDataVersion1
 			data = comm.TxData()
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Log on successful Plasma SetInput.

**Additional context**

The batcher doesn't currently log anything about a submitted input to Alt-DA, in particular not the commitment anywhere.

