### PR TITLE
ctb: Add safe extension contract auth to Specs.t.sol

### DIFF
--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -25,13 +25,16 @@ contract Specification_Test is CommonTest {
         CHALLENGER,
         SYSTEMCONFIGOWNER,
         GUARDIAN,
+        DEPUTYGUARDIAN,
         MESSENGER,
         L1PROXYADMINOWNER,
         GOVERNANCETOKENOWNER,
         MINTMANAGEROWNER,
         DATAAVAILABILITYCHALLENGEOWNER,
         DISPUTEGAMEFACTORYOWNER,
-        DELAYEDWETHOWNER
+        DELAYEDWETHOWNER,
+        COUNCILSAFE,
+        COUNCILSAFEOWNER
     }
 
     /// @notice Represents the specification of a function.
@@ -776,6 +779,51 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "WETH98", _sel: _getSel("transfer(address,uint256)") });
         _addSpec({ _name: "WETH98", _sel: _getSel("transferFrom(address,address,uint256)") });
         _addSpec({ _name: "WETH98", _sel: _getSel("withdraw(uint256)") });
+
+        // DeputyGuardianModule
+        _addSpec({
+            _name: "DeputyGuardianModule",
+            _sel: _getSel("blacklistDisputeGame(address,address)"),
+            _auth: Role.DEPUTYGUARDIAN
+        });
+        _addSpec({
+            _name: "DeputyGuardianModule",
+            _sel: _getSel("setRespectedGameType(address,uint32)"),
+            _auth: Role.DEPUTYGUARDIAN
+        });
+        _addSpec({ _name: "DeputyGuardianModule", _sel: _getSel("pause()"), _auth: Role.DEPUTYGUARDIAN });
+        _addSpec({ _name: "DeputyGuardianModule", _sel: _getSel("unpause()"), _auth: Role.DEPUTYGUARDIAN });
+        _addSpec({ _name: "DeputyGuardianModule", _sel: _getSel("deputyGuardian()") });
+        _addSpec({ _name: "DeputyGuardianModule", _sel: _getSel("safe()") });
+        _addSpec({ _name: "DeputyGuardianModule", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "DeputyGuardianModule", _sel: _getSel("version()") });
+
+        // LivenessGuard
+        _addSpec({ _name: "LivenessGuard", _sel: _getSel("checkAfterExecution(bytes32,bool)"), _auth: Role.COUNCILSAFE });
+        _addSpec({
+            _name: "LivenessGuard",
+            _sel: _getSel(
+                "checkTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes,address)"
+            ),
+            _auth: Role.COUNCILSAFE
+        });
+        _addSpec({ _name: "LivenessGuard", _sel: _getSel("lastLive(address)") });
+        _addSpec({ _name: "LivenessGuard", _sel: _getSel("safe()") });
+        _addSpec({ _name: "LivenessGuard", _sel: _getSel("showLiveness()"), _auth: Role.COUNCILSAFEOWNER });
+        _addSpec({ _name: "LivenessGuard", _sel: _getSel("version()") });
+
+        // LivenessModule
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("canRemove(address)") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("fallbackOwner()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("getRequiredThreshold(uint256)") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("livenessGuard()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("livenessInterval()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("minOwners()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("ownershipTransferredToFallback()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("removeOwners(address[],address[])") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("safe()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("thresholdPercentage()") });
+        _addSpec({ _name: "LivenessModule", _sel: _getSel("version()") });
     }
 
     /// @dev Computes the selector from a function signature.
@@ -807,11 +855,13 @@ contract Specification_Test is CommonTest {
 
     /// @notice Ensures that there's an auth spec for every L1 contract function.
     function testContractAuth() public {
-        string[] memory pathExcludes = new string[](2);
+        string[] memory pathExcludes = new string[](3);
         pathExcludes[0] = "src/dispute/interfaces/*";
         pathExcludes[1] = "src/dispute/lib/*";
-        Abi[] memory abis =
-            ForgeArtifacts.getContractFunctionAbis("src/{L1,dispute,governance,universal/ProxyAdmin.sol}", pathExcludes);
+        pathExcludes[2] = "src/safe/SafeSigners.sol";
+        Abi[] memory abis = ForgeArtifacts.getContractFunctionAbis(
+            "src/{L1,dispute,governance,safe,universal/ProxyAdmin.sol}", pathExcludes
+        );
 
         uint256 numCheckedEntries = 0;
         for (uint256 i = 0; i < abis.length; i++) {

--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -858,9 +858,9 @@ contract Specification_Test is CommonTest {
         string[] memory pathExcludes = new string[](3);
         pathExcludes[0] = "src/dispute/interfaces/*";
         pathExcludes[1] = "src/dispute/lib/*";
-        pathExcludes[2] = "src/safe/SafeSigners.sol";
+        pathExcludes[2] = "src/Safe/SafeSigners.sol";
         Abi[] memory abis = ForgeArtifacts.getContractFunctionAbis(
-            "src/{L1,dispute,governance,safe,universal/ProxyAdmin.sol}", pathExcludes
+            "src/{L1,dispute,governance,Safe,universal/ProxyAdmin.sol}", pathExcludes
         );
 
         uint256 numCheckedEntries = 0;


### PR DESCRIPTION
1. Added `Role` enumeration with new roles: `DEPUTYGUARDIAN`, `COUNCILSAFE`, and `COUNCILSAFEOWNER`.
2. Added specifications for `DeputyGuardianModule`, `LivenessGuard`, and `LivenessModule` functions.
3. Included authorization roles for certain functions in `DeputyGuardianModule`, `LivenessGuard`, and `LivenessModule`.
4. Updated the `testContractAuth` function to exclude specific paths including `src/safe/SafeSigners.sol` and added a safe directory.
5. Enhanced artifact fetching in `testContractAuth` to account for the new safe directory.

