### PR TITLE
op-node: reset engine through events

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -90,6 +90,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 
 	metrics := &testutils.TestDerivationMetrics{}
 	ec := engine.NewEngineController(eng, log, metrics, cfg, syncCfg.SyncMode, synchronousEvents)
+	engineResetDeriver := engine.NewEngineResetDeriver(ctx, log, cfg, l1, eng, syncCfg, synchronousEvents)
 
 	clSync := clsync.NewCLSync(log, cfg, metrics, synchronousEvents)
 
@@ -144,6 +145,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 
 	*rootDeriver = rollup.SynchronousDerivers{
 		syncDeriver,
+		engineResetDeriver,
 		engDeriv,
 		rollupNode,
 		clSync,

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -181,6 +181,7 @@ func NewDriver(
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	ec := engine.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode, synchronousEvents)
+	engineResetDeriver := engine.NewEngineResetDeriver(driverCtx, log, cfg, l1, l2, syncCfg, synchronousEvents)
 	clSync := clsync.NewCLSync(log, cfg, metrics, synchronousEvents)
 
 	var finalizer Finalizer
@@ -246,6 +247,7 @@ func NewDriver(
 
 	*rootDeriver = []rollup.Deriver{
 		syncDeriver,
+		engineResetDeriver,
 		engDeriv,
 		schedDeriv,
 		driver,

--- a/op-node/rollup/engine/engine_reset.go
+++ b/op-node/rollup/engine/engine_reset.go
@@ -7,72 +7,54 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-type ResetL2 interface {
-	sync.L2Chain
-	derive.SystemConfigL2Fetcher
+// ResetEngineRequestEvent requests the EngineResetDeriver to walk
+// the L2 chain backwards until it finds a plausible unsafe head,
+// and find an L2 safe block that is guaranteed to still be from the L1 chain.
+type ResetEngineRequestEvent struct{}
+
+func (ev ResetEngineRequestEvent) String() string {
+	return "reset-engine-request"
 }
 
-type ResetEngineControl interface {
-	SetUnsafeHead(eth.L2BlockRef)
-	SetSafeHead(eth.L2BlockRef)
-	SetFinalizedHead(eth.L2BlockRef)
+type EngineResetDeriver struct {
+	ctx     context.Context
+	log     log.Logger
+	cfg     *rollup.Config
+	l1      sync.L1Chain
+	l2      sync.L2Chain
+	syncCfg *sync.Config
 
-	SetBackupUnsafeL2Head(block eth.L2BlockRef, triggerReorg bool)
-	SetPendingSafeL2Head(eth.L2BlockRef)
-
-	ResetBuildingState()
+	emitter rollup.EventEmitter
 }
 
-// ResetEngine walks the L2 chain backwards until it finds a plausible unsafe head,
-// and an L2 safe block that is guaranteed to still be from the L1 chain.
-func ResetEngine(ctx context.Context, log log.Logger, cfg *rollup.Config, ec ResetEngineControl, l1 sync.L1Chain, l2 ResetL2, syncCfg *sync.Config, safeHeadNotifs rollup.SafeHeadListener) error {
-	result, err := sync.FindL2Heads(ctx, cfg, l1, l2, log, syncCfg)
-	if err != nil {
-		return derive.NewTemporaryError(fmt.Errorf("failed to find the L2 Heads to start from: %w", err))
+func NewEngineResetDeriver(ctx context.Context, log log.Logger, cfg *rollup.Config,
+	l1 sync.L1Chain, l2 sync.L2Chain, syncCfg *sync.Config, emitter rollup.EventEmitter) *EngineResetDeriver {
+	return &EngineResetDeriver{
+		ctx:     ctx,
+		log:     log,
+		cfg:     cfg,
+		l1:      l1,
+		l2:      l2,
+		syncCfg: syncCfg,
+		emitter: emitter,
 	}
-	finalized, safe, unsafe := result.Finalized, result.Safe, result.Unsafe
-	l1Origin, err := l1.L1BlockRefByHash(ctx, safe.L1Origin.Hash)
-	if err != nil {
-		return derive.NewTemporaryError(fmt.Errorf("failed to fetch the new L1 progress: origin: %v; err: %w", safe.L1Origin, err))
-	}
-	if safe.Time < l1Origin.Time {
-		return derive.NewResetError(fmt.Errorf("cannot reset block derivation to start at L2 block %s with time %d older than its L1 origin %s with time %d, time invariant is broken",
-			safe, safe.Time, l1Origin, l1Origin.Time))
-	}
+}
 
-	ec.SetUnsafeHead(unsafe)
-	ec.SetSafeHead(safe)
-	ec.SetPendingSafeL2Head(safe)
-	ec.SetFinalizedHead(finalized)
-	ec.SetBackupUnsafeL2Head(eth.L2BlockRef{}, false)
-	ec.ResetBuildingState()
-
-	log.Debug("Reset of Engine is completed", "safeHead", safe, "unsafe", unsafe, "safe_timestamp", safe.Time,
-		"unsafe_timestamp", unsafe.Time, "l1Origin", l1Origin)
-
-	if safeHeadNotifs != nil {
-		if err := safeHeadNotifs.SafeHeadReset(safe); err != nil {
-			return err
+func (d *EngineResetDeriver) OnEvent(ev rollup.Event) {
+	switch ev.(type) {
+	case ResetEngineRequestEvent:
+		result, err := sync.FindL2Heads(d.ctx, d.cfg, d.l1, d.l2, d.log, d.syncCfg)
+		if err != nil {
+			d.emitter.Emit(rollup.ResetEvent{Err: fmt.Errorf("failed to find the L2 Heads to start from: %w", err)})
+			return
 		}
-		if safeHeadNotifs.Enabled() && safe.Number == cfg.Genesis.L2.Number && safe.Hash == cfg.Genesis.L2.Hash {
-			// The rollup genesis block is always safe by definition. So if the pipeline resets this far back we know
-			// we will process all safe head updates and can record genesis as always safe from L1 genesis.
-			// Note that it is not safe to use cfg.Genesis.L1 here as it is the block immediately before the L2 genesis
-			// but the contracts may have been deployed earlier than that, allowing creating a dispute game
-			// with a L1 head prior to cfg.Genesis.L1
-			l1Genesis, err := l1.L1BlockRefByNumber(ctx, 0)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve L1 genesis: %w", err)
-			}
-			if err := safeHeadNotifs.SafeHeadUpdated(safe, l1Genesis.ID()); err != nil {
-				return err
-			}
-		}
+		d.emitter.Emit(ForceEngineResetEvent{
+			Unsafe:    result.Unsafe,
+			Safe:      result.Safe,
+			Finalized: result.Finalized,
+		})
 	}
-	return nil
 }

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -68,9 +68,18 @@ func (d *MinimalSyncDeriver) SyncStep(ctx context.Context) error {
 		if err := d.engine.TryUpdateEngine(ctx); !errors.Is(err, engine.ErrNoFCUNeeded) {
 			return err
 		}
-		if err := engine.ResetEngine(ctx, d.logger, d.cfg, d.engine, d.l1Source, d.l2Source, d.syncCfg, nil); err != nil {
-			return err
+		// The below two calls emulate ResetEngine, without event-processing.
+		// This will be omitted after op-program adopts events, and the deriver code is used instead.
+		result, err := sync.FindL2Heads(ctx, d.cfg, d.l1Source, d.l2Source, d.logger, d.syncCfg)
+		if err != nil {
+			// not really a temporary error in this context, but preserves old ResetEngine behavior.
+			return derive.NewTemporaryError(fmt.Errorf("failed to determine starting point: %w", err))
 		}
+		engine.ForceEngineReset(d.engine, engine.ForceEngineResetEvent{
+			Unsafe:    result.Unsafe,
+			Safe:      result.Safe,
+			Finalized: result.Finalized,
+		})
 		d.pipeline.ConfirmEngineReset()
 		d.initialResetDone = true
 	}


### PR DESCRIPTION
**Description**

This changes the op-node to reset the engine by:
- detecting the reset error, and then emitting a request to the engine-resetter to compute where to reset to
- once computed, the reset is forced to the engine.
- once completed, the reset is confirmed to the derivation pipeline

The old `ResetEngine` function was split as follows:
- the computational part, basically just `sync.FindSyncStart` call: happens on request event
- the application of the start point to the engine: happens on force event
- the safe-head notifications: op-node driver handles it for now, when receiving the confirmation event
- reset is confirmed to pipeline

Note that events are still processed synchronously, so the code won't spawn more reset-error events from the pipeline until the reset has been confirmed. Once we make this async we'll need to hold a lock somewhere that a reset is in progress.

Now it can be composed nicely with the other event derivers.

**Tests**

The reset code-paths are used in almost every test, and no branching functionality is added, so no new tests.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/10958
