### PR TITLE
op-node: pipeline deriver wrapper

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -104,6 +104,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 	attributesHandler := attributes.NewAttributesHandler(log, cfg, ec, eng)
 
 	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, plasmaSrc, eng, metrics)
+	pipelineDeriver := derive.NewPipelineDeriver(ctx, pipeline, synchronousEvents)
 
 	syncDeriver := &driver.SyncDeriver{
 		Derivation:        pipeline,
@@ -149,6 +150,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc deri
 		engDeriv,
 		rollupNode,
 		clSync,
+		pipelineDeriver,
 	}
 
 	t.Cleanup(rollupNode.rpc.Stop)
@@ -298,7 +300,7 @@ func (s *L2Verifier) OnEvent(ev rollup.Event) {
 		s.log.Warn("Derivation pipeline is being reset", "err", x.Err)
 	case rollup.CriticalErrorEvent:
 		panic(fmt.Errorf("derivation failed critically: %w", x.Err))
-	case driver.DeriverIdleEvent:
+	case derive.DeriverIdleEvent:
 		s.l2PipelineIdle = true
 	}
 }

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -1,0 +1,98 @@
+package derive
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type DeriverIdleEvent struct{}
+
+func (d DeriverIdleEvent) String() string {
+	return "derivation-idle"
+}
+
+type DeriverMoreEvent struct{}
+
+func (d DeriverMoreEvent) String() string {
+	return "deriver-more"
+}
+
+type ConfirmPipelineResetEvent struct{}
+
+func (d ConfirmPipelineResetEvent) String() string {
+	return "confirm-pipeline-reset"
+}
+
+// DerivedAttributesEvent is emitted when new attributes are available to apply to the engine.
+type DerivedAttributesEvent struct {
+	Attributes *AttributesWithParent
+}
+
+func (ev DerivedAttributesEvent) String() string {
+	return "derived-attributes"
+}
+
+type PipelineStepEvent struct {
+	PendingSafe eth.L2BlockRef
+}
+
+func (ev PipelineStepEvent) String() string {
+	return "pipeline-step"
+}
+
+type PipelineDeriver struct {
+	pipeline *DerivationPipeline
+
+	ctx context.Context
+
+	emitter rollup.EventEmitter
+}
+
+func NewPipelineDeriver(ctx context.Context, pipeline *DerivationPipeline, emitter rollup.EventEmitter) *PipelineDeriver {
+	return &PipelineDeriver{
+		pipeline: pipeline,
+		ctx:      ctx,
+		emitter:  emitter,
+	}
+}
+
+func (d *PipelineDeriver) OnEvent(ev rollup.Event) {
+	switch x := ev.(type) {
+	case rollup.ResetEvent:
+		d.pipeline.Reset()
+	case PipelineStepEvent:
+		d.pipeline.log.Trace("Derivation pipeline step", "onto_origin", d.pipeline.Origin())
+		attrib, err := d.pipeline.Step(d.ctx, x.PendingSafe)
+		if err == io.EOF {
+			d.pipeline.log.Debug("Derivation process went idle", "progress", d.pipeline.Origin(), "err", err)
+			d.emitter.Emit(DeriverIdleEvent{})
+		} else if err != nil && errors.Is(err, EngineELSyncing) {
+			d.pipeline.log.Debug("Derivation process went idle because the engine is syncing", "progress", d.pipeline.Origin(), "err", err)
+			d.emitter.Emit(DeriverIdleEvent{})
+		} else if err != nil && errors.Is(err, ErrReset) {
+			d.emitter.Emit(rollup.ResetEvent{Err: err})
+		} else if err != nil && errors.Is(err, ErrTemporary) {
+			d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
+		} else if err != nil && errors.Is(err, ErrCritical) {
+			d.emitter.Emit(rollup.CriticalErrorEvent{Err: err})
+		} else if err != nil && errors.Is(err, NotEnoughData) {
+			// don't do a backoff for this error
+			d.emitter.Emit(DeriverMoreEvent{})
+		} else if err != nil {
+			d.pipeline.log.Error("Derivation process error", "err", err)
+			d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
+		} else {
+			if attrib != nil {
+				d.emitter.Emit(DerivedAttributesEvent{Attributes: attrib})
+			} else {
+				d.emitter.Emit(DeriverMoreEvent{}) // continue with the next step if we can
+			}
+		}
+	case ConfirmPipelineResetEvent:
+		d.pipeline.ConfirmEngineReset()
+	}
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -193,6 +193,7 @@ func NewDriver(
 
 	attributesHandler := attributes.NewAttributesHandler(log, cfg, ec, l2)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, metrics)
+	pipelineDeriver := derive.NewPipelineDeriver(driverCtx, derivationPipeline, synchronousEvents)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	meteredEngine := NewMeteredEngine(cfg, ec, metrics, log) // Only use the metered engine in the sequencer b/c it records sequencing metrics.
 	sequencer := NewSequencer(log, cfg, meteredEngine, attrBuilder, findL1Origin, metrics)
@@ -252,6 +253,7 @@ func NewDriver(
 		schedDeriv,
 		driver,
 		clSync,
+		pipelineDeriver,
 	}
 
 	return driver


### PR DESCRIPTION
**Description**

This introduces a wrapper around derivation pipeline (the L1 data -> L2 block attributes conversion process), to step/reset based on events, and return back the status with events.

This does not change the usage of the derivation pipeline in the op-program yet; that can be done together with the other changes in https://github.com/ethereum-optimism/optimism/pull/10947

**Tests**

Derivation usage is covered in almost every e2e system/action test. The wrapper around the derivation pipeline basically just maps inputs/outputs to pipeline calls to events, little point in unit-testing when it already runs through the same in e2e action tests.

**Metadata**

Fix #10957
