### PR TITLE
chore: disallow specify both `--p2p.static` and `--p2p.disable`

### DIFF
--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -175,6 +175,9 @@ const maxMeshParam = 1000
 
 func (conf *Config) Check() error {
 	if conf.DisableP2P {
+		if len(conf.StaticPeers) > 0 {
+			return errors.New("both --p2p.static and --p2p.disable are specified")
+		}
 		return nil
 	}
 	if conf.Store == nil {


### PR DESCRIPTION
`--p2p.static` is useful when adding more rollup nodes. This PR tries to report an error when user specified both `--p2p.static` and `--p2p.disable` by mistake.