### PR TITLE
fixing binary signer condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,11 +427,13 @@ jobs:
                   ./ops/scripts/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
       - when:
           condition:
-            and:
-              - or:
+            or:
+              - and:
                 - "<<parameters.publish>>"
                 - "<<parameters.release>>"
-              - equal: [develop, << pipeline.git.branch >>]
+              - and:
+                - "<<parameters.publish>>"
+                - equal: [develop, << pipeline.git.branch >>]
           steps:
             - gcp-oidc-authenticate:
                 service_account_email: GCP_SERVICE_ATTESTOR_ACCOUNT_EMAIL


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
images shall only be signed when using develop branch or when tagging release.
The change express this condition.
            or:
              - and:
                - "<<parameters.publish>>"
                - "<<parameters.release>>"
              - and:
                - "<<parameters.publish>>"
                - equal: [develop, << pipeline.git.branch >>]
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
