### PR TITLE
op-node: Finalizer events

### DIFF
--- a/op-e2e/actions/l2_batcher_test.go
+++ b/op-e2e/actions/l2_batcher_test.go
@@ -17,6 +17,7 @@ import (
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -246,7 +247,7 @@ func L2Finalization(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	// If we get this false signal, we shouldn't finalize the L2 chain.
 	altBlock4 := sequencer.SyncStatus().SafeL1
 	altBlock4.Hash = common.HexToHash("0xdead")
-	sequencer.finalizer.Finalize(t.Ctx(), altBlock4)
+	sequencer.synchronousEvents.Emit(finality.FinalizeL1Event{FinalizedL1: altBlock4})
 	sequencer.ActL2PipelineFull(t)
 	require.Equal(t, uint64(3), sequencer.SyncStatus().FinalizedL1.Number)
 	require.Equal(t, heightToSubmit, sequencer.SyncStatus().FinalizedL2.Number, "unknown/bad finalized L1 blocks are ignored")

--- a/op-e2e/actions/l2_proposer_test.go
+++ b/op-e2e/actions/l2_proposer_test.go
@@ -96,6 +96,7 @@ func RunProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	sequencer.ActL2PipelineFull(t)
 	sequencer.ActL1SafeSignal(t)
 	sequencer.ActL1FinalizedSignal(t)
+	sequencer.ActL2PipelineFull(t)
 	require.Equal(t, sequencer.SyncStatus().UnsafeL2, sequencer.SyncStatus().FinalizedL2)
 	require.True(t, proposer.CanPropose(t))
 

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -147,8 +147,9 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 			return
 		}
 		eq.emitter.Emit(engine.PromotePendingSafeEvent{
-			Ref:  ref,
-			Safe: attributes.IsLastInSpan,
+			Ref:         ref,
+			Safe:        attributes.IsLastInSpan,
+			DerivedFrom: attributes.DerivedFrom,
 		})
 	}
 

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -25,6 +25,13 @@ func TestAttributesHandler(t *testing.T) {
 	rng := rand.New(rand.NewSource(1234))
 	refA := testutils.RandomBlockRef(rng)
 
+	refB := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refA.Number + 1,
+		ParentHash: refA.Hash,
+		Time:       refA.Time + 12,
+	}
+
 	aL1Info := &testutils.MockBlockInfo{
 		InfoParentHash:  refA.ParentHash,
 		InfoNum:         refA.Number,
@@ -263,6 +270,7 @@ func TestAttributesHandler(t *testing.T) {
 					Attributes:   attrA1.Attributes, // attributes will match, passing consolidation
 					Parent:       attrA1.Parent,
 					IsLastInSpan: lastInSpan,
+					DerivedFrom:  refB,
 				}
 				emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 				emitter.ExpectOnce(engine.PendingSafeRequestEvent{})
@@ -274,8 +282,9 @@ func TestAttributesHandler(t *testing.T) {
 				l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
 
 				emitter.ExpectOnce(engine.PromotePendingSafeEvent{
-					Ref:  refA1,
-					Safe: lastInSpan, // last in span becomes safe instantaneously
+					Ref:         refA1,
+					Safe:        lastInSpan, // last in span becomes safe instantaneously
+					DerivedFrom: refB,
 				})
 				ah.OnEvent(engine.PendingSafeUpdateEvent{
 					PendingSafe: refA0,

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -9,7 +9,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-type DeriverIdleEvent struct{}
+type DeriverIdleEvent struct {
+	Origin eth.L1BlockRef
+}
 
 func (d DeriverIdleEvent) String() string {
 	return "derivation-idle"
@@ -84,10 +86,10 @@ func (d *PipelineDeriver) OnEvent(ev rollup.Event) {
 		attrib, err := d.pipeline.Step(d.ctx, x.PendingSafe)
 		if err == io.EOF {
 			d.pipeline.log.Debug("Derivation process went idle", "progress", d.pipeline.Origin(), "err", err)
-			d.emitter.Emit(DeriverIdleEvent{})
+			d.emitter.Emit(DeriverIdleEvent{Origin: d.pipeline.Origin()})
 		} else if err != nil && errors.Is(err, EngineELSyncing) {
 			d.pipeline.log.Debug("Derivation process went idle because the engine is syncing", "progress", d.pipeline.Origin(), "err", err)
-			d.emitter.Emit(DeriverIdleEvent{})
+			d.emitter.Emit(DeriverIdleEvent{Origin: d.pipeline.Origin()})
 		} else if err != nil && errors.Is(err, ErrReset) {
 			d.emitter.Emit(rollup.ResetEvent{Err: err})
 		} else if err != nil && errors.Is(err, ErrTemporary) {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -91,9 +91,8 @@ type AttributesHandler interface {
 }
 
 type Finalizer interface {
-	Finalize(ctx context.Context, ref eth.L1BlockRef)
 	FinalizedL1() eth.L1BlockRef
-	engine.FinalizerHooks
+	rollup.Deriver
 }
 
 type PlasmaIface interface {
@@ -186,9 +185,9 @@ func NewDriver(
 
 	var finalizer Finalizer
 	if cfg.PlasmaEnabled() {
-		finalizer = finality.NewPlasmaFinalizer(log, cfg, l1, ec, plasma)
+		finalizer = finality.NewPlasmaFinalizer(driverCtx, log, cfg, l1, synchronousEvents, plasma)
 	} else {
-		finalizer = finality.NewFinalizer(log, cfg, l1, ec)
+		finalizer = finality.NewFinalizer(driverCtx, log, cfg, l1, synchronousEvents)
 	}
 
 	attributesHandler := attributes.NewAttributesHandler(log, cfg, driverCtx, l2, synchronousEvents)
@@ -254,6 +253,7 @@ func NewDriver(
 		clSync,
 		pipelineDeriver,
 		attributesHandler,
+		finalizer,
 	}
 
 	return driver

--- a/op-node/rollup/events.go
+++ b/op-node/rollup/events.go
@@ -20,6 +20,21 @@ func (fn EmitterFunc) Emit(ev Event) {
 	fn(ev)
 }
 
+// L1TemporaryErrorEvent identifies a temporary issue with the L1 data.
+type L1TemporaryErrorEvent struct {
+	Err error
+}
+
+var _ Event = L1TemporaryErrorEvent{}
+
+func (ev L1TemporaryErrorEvent) String() string {
+	return "l1-temporary-error"
+}
+
+// EngineTemporaryErrorEvent identifies a temporary processing issue.
+// It applies to both L1 and L2 data, often inter-related.
+// This scope will be reduced over time, to only capture L2-engine specific temporary errors.
+// See L1TemporaryErrorEvent for L1 related temporary errors.
 type EngineTemporaryErrorEvent struct {
 	Err error
 }

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -68,6 +68,9 @@ func (d *ProgramDeriver) OnEvent(ev rollup.Event) {
 	case rollup.ResetEvent:
 		d.closing = true
 		d.result = fmt.Errorf("unexpected reset error: %w", x.Err)
+	case rollup.L1TemporaryErrorEvent:
+		d.closing = true
+		d.result = fmt.Errorf("unexpected L1 error: %w", x.Err)
 	case rollup.EngineTemporaryErrorEvent:
 		// (Legacy case): While most temporary errors are due to requests for external data failing which can't happen,
 		// they may also be returned due to other events like channels timing out so need to be handled

--- a/op-program/client/driver/program_test.go
+++ b/op-program/client/driver/program_test.go
@@ -120,8 +120,16 @@ func TestProgramDeriver(t *testing.T) {
 		require.True(t, p.closing)
 		require.NotNil(t, p.result)
 	})
-	// on temporary error: continue derivation.
-	t.Run("temp error event", func(t *testing.T) {
+	// on L1 temporary error: stop with error
+	t.Run("L1 temporary error event", func(t *testing.T) {
+		p, m := newProgram(t, 1000)
+		p.OnEvent(rollup.L1TemporaryErrorEvent{Err: errors.New("temp test err")})
+		m.AssertExpectations(t)
+		require.True(t, p.closing)
+		require.NotNil(t, p.result)
+	})
+	// on engine temporary error: continue derivation (because legacy, not all connection related)
+	t.Run("engine temp error event", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
 		m.ExpectOnce(engine.PendingSafeRequestEvent{})
 		p.OnEvent(rollup.EngineTemporaryErrorEvent{Err: errors.New("temp test err")})

--- a/op-service/testutils/mock_emitter.go
+++ b/op-service/testutils/mock_emitter.go
@@ -18,8 +18,20 @@ func (m *MockEmitter) ExpectOnce(expected rollup.Event) {
 	m.Mock.On("Emit", expected).Once()
 }
 
+func (m *MockEmitter) ExpectMaybeRun(fn func(ev rollup.Event)) {
+	m.Mock.On("Emit", mock.Anything).Maybe().Run(func(args mock.Arguments) {
+		fn(args.Get(0).(rollup.Event))
+	})
+}
+
 func (m *MockEmitter) ExpectOnceType(typ string) {
 	m.Mock.On("Emit", mock.AnythingOfType(typ)).Once()
+}
+
+func (m *MockEmitter) ExpectOnceRun(fn func(ev rollup.Event)) {
+	m.Mock.On("Emit", mock.Anything).Once().Run(func(args mock.Arguments) {
+		fn(args.Get(0).(rollup.Event))
+	})
 }
 
 func (m *MockEmitter) AssertExpectations(t mock.TestingT) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Refactors the finalizer module in op-node to an events deriver.

This also cleans up the safe-head notifications, which are closely related to the idea of safe-blocks being derived from L1 blocks, which is now expressed through events.

~Depends on #10947~

**Tests**

- Updated finalizer unit tests
- Updated plasma-finalizer test (and fixed a lingering bug in it, it wasn't triggering the plasma-backend-forwards finalization step, due to absolute vs relative number inconsistency in the if branch)
- All existing finalizer tests should still still pass

**Metadata**

Fix #10851
