### PR TITLE
Record executing messages in log db and handle write failures

### DIFF
--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -41,7 +41,7 @@ type logContext struct {
 type entryStore interface {
 	Size() int64
 	Read(idx int64) (entrydb.Entry, error)
-	Append(entries ...entrydb.Entry) error
+	Append(entry entrydb.Entry) error
 	Truncate(idx int64) error
 	Close() error
 }

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -318,15 +318,7 @@ func (db *DB) searchCheckpoint(blockNum uint64, logIdx uint32) (int64, error) {
 	return (i - 1) * searchCheckpointFrequency, nil
 }
 
-func (db *DB) AddDependentLog(logHash TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg ExecutingMessage) error {
-	return db.addLog(logHash, block, timestamp, logIdx, &execMsg)
-}
-
-func (db *DB) AddLog(logHash TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32) error {
-	return db.addLog(logHash, block, timestamp, logIdx, nil)
-}
-
-func (db *DB) addLog(logHash TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *ExecutingMessage) error {
+func (db *DB) AddLog(logHash TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *ExecutingMessage) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 	postState := logContext{

--- a/op-supervisor/supervisor/backend/db/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/db_invariants_test.go
@@ -254,7 +254,7 @@ func invariantValidLastEntry(entryIdx int, entry entrydb.Entry, entries []entryd
 		return fmt.Errorf("final event was invalid: %w", err)
 	}
 	if evt.hasExecMsg {
-		return fmt.Errorf("ends with init event that should have exec msg but no exec msg follows")
+		return errors.New("ends with init event that should have exec msg but no exec msg follows")
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -644,22 +644,6 @@ func TestRecoverOnCreate(t *testing.T) {
 	}
 }
 
-func TestShouldRollBackInMemoryChangesOnWriteFailure(t *testing.T) {
-	t.Skip("TODO(optimism#10857)")
-}
-
-func TestShouldRecoverWhenSearchCheckpointWrittenButNotCanonicalHash(t *testing.T) {
-	t.Skip("TODO(optimism#10857)")
-}
-
-func TestShouldRecoverWhenPartialEntryWritten(t *testing.T) {
-	t.Skip("TODO(optimism#10857)")
-}
-
-func TestShouldRecoverWhenInitiatingEventWrittenButNotExecutingLink(t *testing.T) {
-	t.Skip("TODO(optimism#10857)")
-}
-
 func TestRewind(t *testing.T) {
 	t.Run("WhenEmpty", func(t *testing.T) {
 		runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {},

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -849,8 +849,8 @@ func (s *stubEntryStore) Read(idx int64) (entrydb.Entry, error) {
 	return entrydb.Entry{}, io.EOF
 }
 
-func (s *stubEntryStore) Append(entry entrydb.Entry) error {
-	s.entries = append(s.entries, entry)
+func (s *stubEntryStore) Append(entries ...entrydb.Entry) error {
+	s.entries = append(s.entries, entries...)
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -83,7 +83,7 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 0}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 0}, 5000, 0, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -91,7 +91,7 @@ func TestAddLog(t *testing.T) {
 	t.Run("FirstEntry", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -102,11 +102,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("MultipleEntriesFromSameBlock", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
+				err = db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2)
+				err = db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -120,13 +120,13 @@ func TestAddLog(t *testing.T) {
 	t.Run("MultipleEntriesFromMultipleBlocks", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
+				err = db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(16), Number: 16}, 5002, 0)
+				err = db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(16), Number: 16}, 5002, 0, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(4), eth.BlockID{Hash: createHash(16), Number: 16}, 5002, 1)
+				err = db.AddLog(createTruncatedHash(4), eth.BlockID{Hash: createHash(16), Number: 16}, 5002, 1, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -141,11 +141,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentBlock", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 0, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -153,13 +153,13 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentBlockButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(13), Number: 13}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(13), Number: 13}, 5000, 0, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4998, 0, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -167,11 +167,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentLogEvent", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1, nil))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 0, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -179,15 +179,15 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenBeforeCurrentLogEventButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1)
+				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1, nil)
 				require.NoError(t, err)
-				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2)
+				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 1)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 1, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -195,11 +195,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenAtCurrentLogEvent", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1, nil))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 1)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 1, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -207,12 +207,12 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenAtCurrentLogEventButAfterLastCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 2, nil))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 2)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 15}, 4998, 2, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -220,11 +220,11 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenSkippingLogEvent", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 2)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 2, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -232,7 +232,7 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenFirstLogIsNotLogIdxZero", func(t *testing.T) {
 		runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 5)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 5, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -240,10 +240,10 @@ func TestAddLog(t *testing.T) {
 	t.Run("ErrorWhenFirstLogOfNewBlockIsNotLogIdxZero", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4996, 0))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(14), Number: 14}, 4996, 0, nil))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 1)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 4998, 1, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder)
 			})
 	})
@@ -264,15 +264,15 @@ func TestAddLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				for i := 0; i < block1LogCount; i++ {
-					err := db.AddLog(createTruncatedHash(i), block1, 3000, uint32(i))
+					err := db.AddLog(createTruncatedHash(i), block1, 3000, uint32(i), nil)
 					require.NoErrorf(t, err, "failed to add log %v of block 1", i)
 				}
 				for i := 0; i < block2LogCount; i++ {
-					err := db.AddLog(createTruncatedHash(i), block2, 3002, uint32(i))
+					err := db.AddLog(createTruncatedHash(i), block2, 3002, uint32(i), nil)
 					require.NoErrorf(t, err, "failed to add log %v of block 2", i)
 				}
 				for i := 0; i < block3LogCount; i++ {
-					err := db.AddLog(createTruncatedHash(i), block3, 3004, uint32(i))
+					err := db.AddLog(createTruncatedHash(i), block3, 3004, uint32(i), nil)
 					require.NoErrorf(t, err, "failed to add log %v of block 3", i)
 				}
 				// Verify that we're right before the fourth checkpoint will be written.
@@ -281,7 +281,7 @@ func TestAddLog(t *testing.T) {
 				// so the fourth is at entry 3*searchCheckpointFrequency
 				require.EqualValues(t, 3*searchCheckpointFrequency, m.entryCount)
 				for i := 0; i < block4LogCount; i++ {
-					err := db.AddLog(createTruncatedHash(i), block4, 3006, uint32(i))
+					err := db.AddLog(createTruncatedHash(i), block4, 3006, uint32(i), nil)
 					require.NoErrorf(t, err, "failed to add log %v of block 4", i)
 				}
 			},
@@ -321,7 +321,7 @@ func TestAddDependentLog(t *testing.T) {
 	t.Run("FirstEntry", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddDependentLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, execMsg)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, &execMsg)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -333,9 +333,9 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				for i := uint32(0); m.entryCount < searchCheckpointFrequency-1; i++ {
-					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i))
+					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i, nil))
 				}
-				err := db.AddDependentLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, execMsg)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, &execMsg)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -348,9 +348,9 @@ func TestAddDependentLog(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 
 				for i := uint32(0); m.entryCount < searchCheckpointFrequency-1; i++ {
-					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i))
+					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i, nil))
 				}
-				err := db.AddDependentLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 1}, 5000, 253, execMsg)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 1}, 5000, 253, &execMsg)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -362,9 +362,9 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				for i := uint32(0); m.entryCount < searchCheckpointFrequency-2; i++ {
-					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i))
+					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i, nil))
 				}
-				err := db.AddDependentLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, execMsg)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 15}, 5000, 0, &execMsg)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -376,9 +376,9 @@ func TestAddDependentLog(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				for i := uint32(0); m.entryCount < searchCheckpointFrequency-2; i++ {
-					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i))
+					require.NoError(t, db.AddLog(createTruncatedHash(9), eth.BlockID{Hash: createHash(9), Number: 1}, 500, i, nil))
 				}
-				err := db.AddDependentLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 1}, 5000, 252, execMsg)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(15), Number: 1}, 5000, 252, &execMsg)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -390,11 +390,11 @@ func TestAddDependentLog(t *testing.T) {
 func TestContains(t *testing.T) {
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0))
-			require.NoError(t, db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1))
-			require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 2))
-			require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(52), Number: 52}, 500, 0))
-			require.NoError(t, db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(52), Number: 52}, 500, 1))
+			require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0, nil))
+			require.NoError(t, db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1, nil))
+			require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 2, nil))
+			require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(52), Number: 52}, 500, 0, nil))
+			require.NoError(t, db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(52), Number: 52}, 500, 1, nil))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// Should find added logs
@@ -435,7 +435,7 @@ func TestGetBlockInfo(t *testing.T) {
 	t.Run("ReturnsEOFWhenRequestedBlockBeforeFirstSearchCheckpoint", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(11), Number: 11}, 500, 0)
+				err := db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(11), Number: 11}, 500, 0, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -448,7 +448,7 @@ func TestGetBlockInfo(t *testing.T) {
 		block := eth.BlockID{Hash: createHash(11), Number: 11}
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(1), block, 500, 0)
+				err := db.AddLog(createTruncatedHash(1), block, 500, 0, nil)
 				require.NoError(t, err)
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -463,7 +463,7 @@ func TestGetBlockInfo(t *testing.T) {
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				for i := 1; i < searchCheckpointFrequency+3; i++ {
 					block := eth.BlockID{Hash: createHash(i), Number: uint64(i)}
-					err := db.AddLog(createTruncatedHash(i), block, uint64(i)*2, 0)
+					err := db.AddLog(createTruncatedHash(i), block, uint64(i)*2, 0, nil)
 					require.NoError(t, err)
 				}
 			},
@@ -672,10 +672,10 @@ func TestRewind(t *testing.T) {
 	t.Run("AfterLastBlock", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(4), eth.BlockID{Hash: createHash(74), Number: 74}, 700, 0))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(3), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(4), eth.BlockID{Hash: createHash(74), Number: 74}, 700, 0, nil))
 				require.NoError(t, db.Rewind(75))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -689,8 +689,8 @@ func TestRewind(t *testing.T) {
 	t.Run("BeforeFirstBlock", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1, nil))
 				require.NoError(t, db.Rewind(25))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -703,10 +703,10 @@ func TestRewind(t *testing.T) {
 	t.Run("AtFirstBlock", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 1, nil))
 				require.NoError(t, db.Rewind(50))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -721,12 +721,12 @@ func TestRewind(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
 				for i := uint32(0); m.entryCount < searchCheckpointFrequency; i++ {
-					require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, i))
+					require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, i, nil))
 				}
 				require.EqualValues(t, searchCheckpointFrequency, m.entryCount)
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 0))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 0, nil))
 				require.EqualValues(t, searchCheckpointFrequency+3, m.entryCount, "Should have inserted new checkpoint and extra log")
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(51), Number: 51}, 502, 1, nil))
 				require.NoError(t, db.Rewind(50))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -741,10 +741,10 @@ func TestRewind(t *testing.T) {
 	t.Run("BetweenLogEntries", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1, nil))
 				require.NoError(t, db.Rewind(55))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -758,12 +758,12 @@ func TestRewind(t *testing.T) {
 	t.Run("AtExistingLogEntry", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 1, nil))
 				require.NoError(t, db.Rewind(60))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -779,12 +779,12 @@ func TestRewind(t *testing.T) {
 	t.Run("AtLastEntry", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(70), Number: 70}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(70), Number: 70}, 502, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(50), Number: 50}, 500, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(70), Number: 70}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(70), Number: 70}, 502, 1, nil))
 				require.NoError(t, db.Rewind(70))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
@@ -800,20 +800,20 @@ func TestRewind(t *testing.T) {
 	t.Run("ReaddDeletedBlocks", func(t *testing.T) {
 		runDBTest(t,
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1))
-				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 0))
-				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 1))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 0, nil))
+				require.NoError(t, db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(61), Number: 61}, 502, 1, nil))
 				require.NoError(t, db.Rewind(60))
 			},
 			func(t *testing.T, db *DB, m *stubMetrics) {
-				err := db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 1)
+				err := db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(59), Number: 59}, 500, 1, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder, "Cannot add block before rewound head")
-				err = db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1)
+				err = db.AddLog(createTruncatedHash(2), eth.BlockID{Hash: createHash(60), Number: 60}, 502, 1, nil)
 				require.ErrorIs(t, err, ErrLogOutOfOrder, "Cannot add block that was rewound to")
-				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 61}, 502, 0)
+				err = db.AddLog(createTruncatedHash(1), eth.BlockID{Hash: createHash(60), Number: 61}, 502, 0, nil)
 				require.NoError(t, err, "Can re-add deleted block")
 			})
 	})

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -835,8 +835,7 @@ func (s *stubMetrics) RecordSearchEntriesRead(count int64) {
 var _ Metrics = (*stubMetrics)(nil)
 
 type stubEntryStore struct {
-	recoveryRequired bool
-	entries          []entrydb.Entry
+	entries []entrydb.Entry
 }
 
 func (s *stubEntryStore) Size() int64 {
@@ -844,9 +843,6 @@ func (s *stubEntryStore) Size() int64 {
 }
 
 func (s *stubEntryStore) Read(idx int64) (entrydb.Entry, error) {
-	if s.recoveryRequired {
-		return entrydb.Entry{}, entrydb.ErrRecoveryRequired
-	}
 	if idx < int64(len(s.entries)) {
 		return s.entries[idx], nil
 	}
@@ -854,27 +850,12 @@ func (s *stubEntryStore) Read(idx int64) (entrydb.Entry, error) {
 }
 
 func (s *stubEntryStore) Append(entry entrydb.Entry) error {
-	if s.recoveryRequired {
-		return entrydb.ErrRecoveryRequired
-	}
 	s.entries = append(s.entries, entry)
 	return nil
 }
 
 func (s *stubEntryStore) Truncate(idx int64) error {
-	if s.recoveryRequired {
-		return entrydb.ErrRecoveryRequired
-	}
 	s.entries = s.entries[:min(s.Size()-1, idx+1)]
-	return nil
-}
-
-func (s *stubEntryStore) RecoveryRequired() bool {
-	return s.recoveryRequired
-}
-
-func (s *stubEntryStore) Recover() error {
-	s.recoveryRequired = false
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/entries.go
+++ b/op-supervisor/supervisor/backend/db/entries.go
@@ -71,6 +71,7 @@ func (c canonicalHash) encode() entrydb.Entry {
 type initiatingEvent struct {
 	blockDiff       uint8
 	incrementLogIdx bool
+	hasExecMsg      bool
 	logHash         TruncatedHash
 }
 
@@ -83,11 +84,12 @@ func newInitiatingEventFromEntry(data entrydb.Entry) (initiatingEvent, error) {
 	return initiatingEvent{
 		blockDiff:       blockNumDiff,
 		incrementLogIdx: flags&eventFlagIncrementLogIdx != 0,
+		hasExecMsg:      flags&eventFlagHasExecutingMessage != 0,
 		logHash:         TruncatedHash(data[3:23]),
 	}, nil
 }
 
-func newInitiatingEvent(pre logContext, blockNum uint64, logIdx uint32, logHash TruncatedHash) (initiatingEvent, error) {
+func newInitiatingEvent(pre logContext, blockNum uint64, logIdx uint32, logHash TruncatedHash, hasExecMsg bool) (initiatingEvent, error) {
 	blockDiff := blockNum - pre.blockNum
 	if blockDiff > math.MaxUint8 {
 		// TODO(optimism#10857): Need to find a way to support this.
@@ -106,6 +108,7 @@ func newInitiatingEvent(pre logContext, blockNum uint64, logIdx uint32, logHash 
 	return initiatingEvent{
 		blockDiff:       uint8(blockDiff),
 		incrementLogIdx: logDiff > 0,
+		hasExecMsg:      hasExecMsg,
 		logHash:         logHash,
 	}, nil
 }
@@ -120,6 +123,9 @@ func (i initiatingEvent) encode() entrydb.Entry {
 	if i.incrementLogIdx {
 		// Set flag to indicate log idx needs to be incremented (ie we're not directly after a checkpoint)
 		flags = flags | eventFlagIncrementLogIdx
+	}
+	if i.hasExecMsg {
+		flags = flags | eventFlagHasExecutingMessage
 	}
 	data[2] = flags
 	copy(data[3:23], i.logHash[:])
@@ -138,4 +144,96 @@ func (i initiatingEvent) postContext(pre logContext) logContext {
 		post.logIdx++
 	}
 	return post
+}
+
+type executingLink struct {
+	chain     uint32
+	blockNum  uint64
+	logIdx    uint32
+	timestamp uint64
+}
+
+func newExecutingLink(msg ExecutingMessage) (executingLink, error) {
+	if msg.LogIdx > 1<<24 {
+		return executingLink{}, fmt.Errorf("log idx is too large (%v)", msg.LogIdx)
+	}
+	return executingLink{
+		chain:     msg.Chain,
+		blockNum:  msg.BlockNum,
+		logIdx:    msg.LogIdx,
+		timestamp: msg.Timestamp,
+	}, nil
+}
+
+func newExecutingLinkFromEntry(data entrydb.Entry) (executingLink, error) {
+	if data[0] != typeExecutingLink {
+		return executingLink{}, fmt.Errorf("%w: attempting to decode executing link but was type %v", ErrDataCorruption, data[0])
+	}
+	timestamp := binary.LittleEndian.Uint64(data[16:24])
+	return executingLink{
+		chain:     binary.LittleEndian.Uint32(data[1:5]),
+		blockNum:  binary.LittleEndian.Uint64(data[5:13]),
+		logIdx:    uint32(data[13]) | uint32(data[14])<<8 | uint32(data[15])<<16,
+		timestamp: timestamp,
+	}, nil
+}
+
+// encode creates an executing link entry
+// type 3: "executing link" <type><chain: 4 bytes><blocknum: 8 bytes><event index: 3 bytes><uint64 timestamp: 8 bytes> = 24 bytes
+func (e executingLink) encode() entrydb.Entry {
+	var entry entrydb.Entry
+	entry[0] = typeExecutingLink
+	binary.LittleEndian.PutUint32(entry[1:5], e.chain)
+	binary.LittleEndian.PutUint64(entry[5:13], e.blockNum)
+
+	entry[13] = byte(e.logIdx)
+	entry[14] = byte(e.logIdx >> 8)
+	entry[15] = byte(e.logIdx >> 16)
+
+	binary.LittleEndian.PutUint64(entry[16:24], e.timestamp)
+	return entry
+}
+
+type executingCheck struct {
+	hash TruncatedHash
+}
+
+func newExecutingCheck(hash TruncatedHash) executingCheck {
+	return executingCheck{hash: hash}
+}
+
+func newExecutingCheckFromEntry(entry entrydb.Entry) (executingCheck, error) {
+	if entry[0] != typeExecutingCheck {
+		return executingCheck{}, fmt.Errorf("%w: attempting to decode executing check but was type %v", ErrDataCorruption, entry[0])
+	}
+	var hash TruncatedHash
+	copy(hash[:], entry[1:21])
+	return newExecutingCheck(hash), nil
+}
+
+// encode creates an executing check entry
+// type 4: "executing check" <type><event-hash: 20 bytes> = 21 bytes
+func (e executingCheck) encode() entrydb.Entry {
+	var entry entrydb.Entry
+	entry[0] = typeExecutingCheck
+	copy(entry[1:21], e.hash[:])
+	return entry
+}
+
+func newExecutingMessageFromEntries(linkEntry entrydb.Entry, checkEntry entrydb.Entry) (ExecutingMessage, error) {
+	link, err := newExecutingLinkFromEntry(linkEntry)
+	if err != nil {
+		return ExecutingMessage{}, fmt.Errorf("invalid executing link: %w", err)
+	}
+	check, err := newExecutingCheckFromEntry(checkEntry)
+	if err != nil {
+		return ExecutingMessage{}, fmt.Errorf("invalid executing check: %w", err)
+	}
+	return ExecutingMessage{
+		Chain:     link.chain,
+		BlockNum:  link.blockNum,
+		LogIdx:    link.logIdx,
+		Timestamp: link.timestamp,
+		Hash:      check.hash,
+	}, nil
 }

--- a/op-supervisor/supervisor/backend/db/entries.go
+++ b/op-supervisor/supervisor/backend/db/entries.go
@@ -146,6 +146,17 @@ func (i initiatingEvent) postContext(pre logContext) logContext {
 	return post
 }
 
+// preContext is the reverse of postContext and calculates the logContext required as input to get the specified post
+// context after applying this init event.
+func (i initiatingEvent) preContext(post logContext) logContext {
+	pre := post
+	pre.blockNum = post.blockNum - uint64(i.blockDiff)
+	if i.incrementLogIdx {
+		pre.logIdx--
+	}
+	return pre
+}
+
 type executingLink struct {
 	chain     uint32
 	blockNum  uint64

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -28,7 +28,7 @@ type EntryDB struct {
 }
 
 func NewEntryDB(path string) (*EntryDB, error) {
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database at %v: %w", path, err)
 	}

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -13,10 +13,6 @@ const (
 	EntrySize = 24
 )
 
-var (
-	ErrRecoveryRequired = errors.New("recovery required")
-)
-
 type Entry [EntrySize]byte
 
 // dataAccess defines a minimal API required to manipulate the actual stored data.
@@ -29,9 +25,8 @@ type dataAccess interface {
 }
 
 type EntryDB struct {
-	data             dataAccess
-	size             int64
-	recoveryRequired bool
+	data dataAccess
+	size int64
 }
 
 // NewEntryDB creates an EntryDB. A new file will be created if the specified path does not exist,
@@ -55,17 +50,12 @@ func NewEntryDB(logger log.Logger, path string) (*EntryDB, error) {
 		size: size,
 	}
 	if size*EntrySize != info.Size() {
-		db.recoveryRequired = true
 		logger.Warn("File size (%v) is nut a multiple of entry size %v. Truncating to last complete entry", size, EntrySize)
-		if err := db.Recover(); err != nil {
+		if err := db.recover(); err != nil {
 			return nil, fmt.Errorf("failed to recover database at %v: %w", path, err)
 		}
 	}
 	return db, nil
-}
-
-func (e *EntryDB) RecoveryRequired() bool {
-	return e.recoveryRequired
 }
 
 func (e *EntryDB) Size() int64 {
@@ -75,9 +65,6 @@ func (e *EntryDB) Size() int64 {
 // Read an entry from the database by index. Returns io.EOF iff idx is after the last entry.
 func (e *EntryDB) Read(idx int64) (Entry, error) {
 	var out Entry
-	if e.recoveryRequired {
-		return out, ErrRecoveryRequired
-	}
 	read, err := e.data.ReadAt(out[:], idx*EntrySize)
 	// Ignore io.EOF if we read the entire last entry as ReadAt may return io.EOF or nil when it reads the last byte
 	if err != nil && !(errors.Is(err, io.EOF) && read == EntrySize) {
@@ -88,9 +75,6 @@ func (e *EntryDB) Read(idx int64) (Entry, error) {
 
 // Append an entry to the database.
 func (e *EntryDB) Append(entry Entry) error {
-	if e.recoveryRequired {
-		return ErrRecoveryRequired
-	}
 	if _, err := e.data.Write(entry[:]); err != nil {
 		// TODO(optimism#10857): When a write fails, need to revert any in memory changes and truncate back to the
 		// pre-write state. Likely need to batch writes for multiple entries into a single write akin to transactions
@@ -103,9 +87,6 @@ func (e *EntryDB) Append(entry Entry) error {
 
 // Truncate the database so that the last retained entry is idx. Any entries after idx are deleted.
 func (e *EntryDB) Truncate(idx int64) error {
-	if e.recoveryRequired {
-		return ErrRecoveryRequired
-	}
 	if err := e.data.Truncate((idx + 1) * EntrySize); err != nil {
 		return fmt.Errorf("failed to truncate to entry %v: %w", idx, err)
 	}
@@ -114,15 +95,11 @@ func (e *EntryDB) Truncate(idx int64) error {
 	return nil
 }
 
-// Recover an invalid database by truncating back to the last complete event.
-func (e *EntryDB) Recover() error {
-	if !e.recoveryRequired {
-		return nil
-	}
+// recover an invalid database by truncating back to the last complete event.
+func (e *EntryDB) recover() error {
 	if err := e.data.Truncate((e.size) * EntrySize); err != nil {
 		return fmt.Errorf("failed to truncate trailing partial entries: %w", err)
 	}
-	e.recoveryRequired = false
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,28 +42,60 @@ func TestReadWrite(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
-	db := createEntryDB(t)
-	require.NoError(t, db.Append(createEntry(1)))
-	require.NoError(t, db.Append(createEntry(2)))
-	require.NoError(t, db.Append(createEntry(3)))
-	require.NoError(t, db.Append(createEntry(4)))
-	require.NoError(t, db.Append(createEntry(5)))
-	require.EqualValues(t, 5, db.Size())
+	t.Run("Partial", func(t *testing.T) {
+		db := createEntryDB(t)
+		require.NoError(t, db.Append(createEntry(1)))
+		require.NoError(t, db.Append(createEntry(2)))
+		require.NoError(t, db.Append(createEntry(3)))
+		require.NoError(t, db.Append(createEntry(4)))
+		require.NoError(t, db.Append(createEntry(5)))
+		require.EqualValues(t, 5, db.Size())
 
-	require.NoError(t, db.Truncate(3))
-	require.EqualValues(t, 4, db.Size()) // 0, 1, 2 and 3 are preserved
-	requireRead(t, db, 0, createEntry(1))
-	requireRead(t, db, 1, createEntry(2))
-	requireRead(t, db, 2, createEntry(3))
+		require.NoError(t, db.Truncate(3))
+		require.EqualValues(t, 4, db.Size()) // 0, 1, 2 and 3 are preserved
+		requireRead(t, db, 0, createEntry(1))
+		requireRead(t, db, 1, createEntry(2))
+		requireRead(t, db, 2, createEntry(3))
 
-	// 4 and 5 have been removed
-	_, err := db.Read(4)
-	require.ErrorIs(t, err, io.EOF)
-	_, err = db.Read(5)
-	require.ErrorIs(t, err, io.EOF)
+		// 4 and 5 have been removed
+		_, err := db.Read(4)
+		require.ErrorIs(t, err, io.EOF)
+		_, err = db.Read(5)
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("Complete", func(t *testing.T) {
+		db := createEntryDB(t)
+		require.NoError(t, db.Append(createEntry(1)))
+		require.NoError(t, db.Append(createEntry(2)))
+		require.NoError(t, db.Append(createEntry(3)))
+		require.EqualValues(t, 3, db.Size())
+
+		require.NoError(t, db.Truncate(-1))
+		require.EqualValues(t, 0, db.Size()) // All items are removed
+		_, err := db.Read(0)
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("AppendAfterTruncate", func(t *testing.T) {
+		db := createEntryDB(t)
+		require.NoError(t, db.Append(createEntry(1)))
+		require.NoError(t, db.Append(createEntry(2)))
+		require.NoError(t, db.Append(createEntry(3)))
+		require.EqualValues(t, 3, db.Size())
+
+		require.NoError(t, db.Truncate(1))
+		require.EqualValues(t, 2, db.Size())
+		newEntry := createEntry(4)
+		require.NoError(t, db.Append(newEntry))
+		entry, err := db.Read(2)
+		require.NoError(t, err)
+		require.Equal(t, newEntry, entry)
+	})
 }
 
 func TestRecovery(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
 	file := filepath.Join(t.TempDir(), "entries.db")
 	entry1 := createEntry(1)
 	entry2 := createEntry(2)
@@ -70,30 +104,16 @@ func TestRecovery(t *testing.T) {
 	copy(invalidData[EntrySize:], entry2[:])
 	invalidData[len(invalidData)-1] = 3 // Some invalid trailing data
 	require.NoError(t, os.WriteFile(file, invalidData, 0o644))
-	db, err := NewEntryDB(file)
+	db, err := NewEntryDB(logger, file)
+	require.NoError(t, err)
 	defer db.Close()
-	require.ErrorIs(t, err, ErrRecoveryRequired)
-	require.NotNil(t, db)
-	require.True(t, db.RecoveryRequired())
-	require.EqualValues(t, 2, db.Size(), "size should only consider valid entries")
+	require.False(t, db.RecoveryRequired())
 
-	_, err = db.Read(0)
-	require.ErrorIs(t, err, ErrRecoveryRequired)
-	err = db.Append(entry1)
-	require.ErrorIs(t, err, ErrRecoveryRequired)
-	err = db.Truncate(2)
-	require.ErrorIs(t, err, ErrRecoveryRequired)
-
-	require.NoError(t, db.Recover())
+	// Should automatically truncate the file to remove trailing partial entries
 	require.EqualValues(t, 2, db.Size())
-
-	entry, err := db.Read(0)
-	require.Equal(t, entry1, entry)
-	_, err = db.Read(2)
-	require.ErrorIs(t, err, io.EOF)
-
-	require.NoError(t, db.Append(entry2))
-	require.NoError(t, db.Truncate(1))
+	stat, err := os.Stat(file)
+	require.NoError(t, err)
+	require.EqualValues(t, 2*EntrySize, stat.Size())
 }
 
 func requireRead(t *testing.T, db *EntryDB, idx int64, expected Entry) {
@@ -107,7 +127,8 @@ func createEntry(i byte) Entry {
 }
 
 func createEntryDB(t *testing.T) *EntryDB {
-	db, err := NewEntryDB(filepath.Join(t.TempDir(), "entries.db"))
+	logger := testlog.Logger(t, log.LvlInfo)
+	db, err := NewEntryDB(logger, filepath.Join(t.TempDir(), "entries.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -94,7 +94,7 @@ func TestTruncate(t *testing.T) {
 	})
 }
 
-func TestRecovery(t *testing.T) {
+func TestTruncateTrailingPartialEntries(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	file := filepath.Join(t.TempDir(), "entries.db")
 	entry1 := createEntry(1)
@@ -107,7 +107,6 @@ func TestRecovery(t *testing.T) {
 	db, err := NewEntryDB(logger, file)
 	require.NoError(t, err)
 	defer db.Close()
-	require.False(t, db.RecoveryRequired())
 
 	// Should automatically truncate the file to remove trailing partial entries
 	require.EqualValues(t, 2, db.Size())

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -39,6 +39,15 @@ func TestReadWrite(t *testing.T) {
 		_, err := db.Read(0)
 		require.ErrorIs(t, err, io.EOF)
 	})
+
+	t.Run("WriteMultiple", func(t *testing.T) {
+		db := createEntryDB(t)
+		require.NoError(t, db.Append(createEntry(1), createEntry(2), createEntry(3)))
+		require.EqualValues(t, 3, db.Size())
+		requireRead(t, db, 0, createEntry(1))
+		requireRead(t, db, 1, createEntry(2))
+		requireRead(t, db, 2, createEntry(3))
+	})
 }
 
 func TestTruncate(t *testing.T) {

--- a/op-supervisor/supervisor/backend/db/types.go
+++ b/op-supervisor/supervisor/backend/db/types.go
@@ -3,14 +3,12 @@ package db
 import (
 	"errors"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
-	ErrLogOutOfOrder    = errors.New("log out of order")
-	ErrDataCorruption   = errors.New("data corruption")
-	ErrRecoveryRequired = entrydb.ErrRecoveryRequired
+	ErrLogOutOfOrder  = errors.New("log out of order")
+	ErrDataCorruption = errors.New("data corruption")
 )
 
 type TruncatedHash [20]byte

--- a/op-supervisor/supervisor/backend/db/types.go
+++ b/op-supervisor/supervisor/backend/db/types.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	ErrLogOutOfOrder  = errors.New("log out of order")
+	ErrDataCorruption = errors.New("data corruption")
+)
+
+type TruncatedHash [20]byte
+
+func TruncateHash(hash common.Hash) TruncatedHash {
+	var truncated TruncatedHash
+	copy(truncated[:], hash[0:20])
+	return truncated
+}
+
+type ExecutingMessage struct {
+	Chain     uint32
+	BlockNum  uint64
+	LogIdx    uint32
+	Timestamp uint64
+	Hash      TruncatedHash
+}

--- a/op-supervisor/supervisor/backend/db/types.go
+++ b/op-supervisor/supervisor/backend/db/types.go
@@ -3,12 +3,14 @@ package db
 import (
 	"errors"
 
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
-	ErrLogOutOfOrder  = errors.New("log out of order")
-	ErrDataCorruption = errors.New("data corruption")
+	ErrLogOutOfOrder    = errors.New("log out of order")
+	ErrDataCorruption   = errors.New("data corruption")
+	ErrRecoveryRequired = entrydb.ErrRecoveryRequired
 )
 
 type TruncatedHash [20]byte

--- a/op-supervisor/supervisor/backend/db/types.go
+++ b/op-supervisor/supervisor/backend/db/types.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrLogOutOfOrder  = errors.New("log out of order")
 	ErrDataCorruption = errors.New("data corruption")
+	ErrNotFound       = errors.New("not found")
 )
 
 type TruncatedHash [20]byte


### PR DESCRIPTION
**Description**

Adds support for execution-link and execution-check event types in the log db.  The executing message is now returned when a log with one is found.

Write failures are handled by:
1. The batch of events for each log are written in a single write, prior to in-memory caches updating. If the write fails, the in memory data is left unchanged.
2. If a write fails after writing part of the data, the entry db will attempt to truncate that partially written data before returning, and then retry the truncation prior to any further writes.
3. At startup, event db will discard any partially written entries, truncating back to the last fully written entry. The log db will then delete entries until it gets back to one that is an expected end of log event (either an init event with no exec message, or an exec check event).

**Tests**

Added more unit tests and invariants.

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/10857
