### PR TITLE
op-service: fix bad spell in op-service

### DIFF
--- a/op-chain-ops/foundry/artifact.go
+++ b/op-chain-ops/foundry/artifact.go
@@ -49,7 +49,7 @@ func (a Artifact) MarshalJSON() ([]byte, error) {
 	return json.Marshal(artifact)
 }
 
-// artifactMarshaling is a helper struct for marshaling and unmarshaling
+// artifactMarshaling is a helper struct for marshaling and unmarshalling
 // foundry artifacts.
 type artifactMarshaling struct {
 	ABI              json.RawMessage    `json:"abi"`

--- a/op-service/eth/blobs_api_test.go
+++ b/op-service/eth/blobs_api_test.go
@@ -16,7 +16,7 @@ type dataJson struct {
 	Data map[string]any `json:"data"`
 }
 
-// TestAPIGenesisResponse tests that json unmarshaling a json response from a
+// TestAPIGenesisResponse tests that json unmarshalling a json response from a
 // eth/v1/beacon/genesis beacon node call into a APIGenesisResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
@@ -41,7 +41,7 @@ func TestAPIGenesisResponse(t *testing.T) {
 	require.Equal(jsonMap.Data["genesis_time"].(string), string(genesisTime))
 }
 
-// TestAPIConfigResponse tests that json unmarshaling a json response from a
+// TestAPIConfigResponse tests that json unmarshalling a json response from a
 // eth/v1/config/spec beacon node call into a APIConfigResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
@@ -66,7 +66,7 @@ func TestAPIConfigResponse(t *testing.T) {
 	require.Equal(jsonMap.Data["SECONDS_PER_SLOT"].(string), string(secPerSlot))
 }
 
-// TestAPIGetBlobSidecarsResponse tests that json unmarshaling a json response from a
+// TestAPIGetBlobSidecarsResponse tests that json unmarshalling a json response from a
 // eth/v1/beacon/blob_sidecars/<X> beacon node call into a APIGetBlobSidecarsResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.

--- a/op-service/metrics/balance.go
+++ b/op-service/metrics/balance.go
@@ -19,7 +19,7 @@ import (
 // to the "balance" metric of the namespace. The balance of the account is recorded in Ether (not Wei).
 // Cancel the supplied context to shut down the go routine
 func LaunchBalanceMetrics(log log.Logger, r *prometheus.Registry, ns string, client *ethclient.Client, account common.Address) *clock.LoopFn {
-	balanceGuage := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+	balanceGauge := promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Namespace: ns,
 		Name:      "balance",
 		Help:      "balance (in ether) of account " + account.String(),
@@ -33,7 +33,7 @@ func LaunchBalanceMetrics(log log.Logger, r *prometheus.Registry, ns string, cli
 			return
 		}
 		bal := eth.WeiToEther(bigBal)
-		balanceGuage.Set(bal)
+		balanceGauge.Set(bal)
 	}, func() error {
 		log.Info("balance metrics shutting down")
 		return nil

--- a/op-service/txmgr/send_state.go
+++ b/op-service/txmgr/send_state.go
@@ -16,7 +16,7 @@ var (
 	ErrAlreadyReserved = errors.New("address already reserved")
 
 	// Returned by CriticalError when the system is unable to get the tx into the mempool in the
-	// alloted time
+	// allotted time
 	ErrMempoolDeadlineExpired = errors.New("failed to get tx into the mempool")
 )
 
@@ -125,7 +125,7 @@ func (s *SendState) CriticalError() error {
 		// we have exceeded the nonce too low count
 		return core.ErrNonceTooLow
 	case s.successFullPublishCount == 0 && s.now().After(s.txInMempoolDeadline):
-		// unable to get the tx into the mempool in the alloted time
+		// unable to get the tx into the mempool in the allotted time
 		return ErrMempoolDeadlineExpired
 	case s.alreadyReserved:
 		// incompatible tx type in mempool


### PR DESCRIPTION
While looking into the code of op-service part, I found some typos, not just in the comments but also in a variable name. I did a global search for all the typos, so I included an error from outside the title in op-chain-ops as well.