### PR TITLE
op-conductor: add override to disable HA mode in disaster recovery scenarios

### DIFF
--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -15,6 +15,10 @@ var ErrNotLeader = errors.New("refusing to proxy request to non-leader sequencer
 
 // API defines the interface for the op-conductor API.
 type API interface {
+	// OverrideLeader is used to override the leader status, this is only used to return true for Leader() & LeaderWithID() calls.
+	// It does not impact the actual raft consensus leadership status. It is supposed to be used when the cluster is unhealthy
+	// and the node is the only one up, to allow batcher to be able to connect to the node, so that it could download blocks from the manually started sequencer.
+	OverrideLeader(ctx context.Context) error
 	// Pause pauses op-conductor.
 	Pause(ctx context.Context) error
 	// Resume resumes op-conductor.

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -29,21 +29,28 @@ type conductor interface {
 
 // APIBackend is the backend implementation of the API.
 // TODO: (https://github.com/ethereum-optimism/protocol-quest/issues/45) Add metrics tracer here.
-// TODO: (https://github.com/ethereum-optimism/protocol-quest/issues/44) add tests after e2e setup.
 type APIBackend struct {
-	log log.Logger
-	con conductor
+	log            log.Logger
+	con            conductor
+	leaderOverride bool
 }
 
 // NewAPIBackend creates a new APIBackend instance.
 func NewAPIBackend(log log.Logger, con conductor) *APIBackend {
 	return &APIBackend{
-		log: log,
-		con: con,
+		log:            log,
+		con:            con,
+		leaderOverride: false,
 	}
 }
 
 var _ API = (*APIBackend)(nil)
+
+// OverrideLeader implements API.
+func (api *APIBackend) OverrideLeader(ctx context.Context) error {
+	api.leaderOverride = true
+	return nil
+}
 
 // Paused implements API.
 func (api *APIBackend) Paused(ctx context.Context) (bool, error) {
@@ -82,11 +89,19 @@ func (api *APIBackend) CommitUnsafePayload(ctx context.Context, payload *eth.Exe
 
 // Leader implements API, returns true if current conductor is leader of the cluster.
 func (api *APIBackend) Leader(ctx context.Context) (bool, error) {
-	return api.con.Leader(ctx), nil
+	return api.leaderOverride || api.con.Leader(ctx), nil
 }
 
 // LeaderWithID implements API, returns the leader's server ID and address (not necessarily the current conductor).
 func (api *APIBackend) LeaderWithID(ctx context.Context) (*consensus.ServerInfo, error) {
+	if api.leaderOverride {
+		return &consensus.ServerInfo{
+			ID:       "N/A (Leader overridden)",
+			Addr:     "N/A",
+			Suffrage: 0,
+		}, nil
+	}
+
 	return api.con.LeaderWithID(ctx), nil
 }
 

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -27,6 +27,11 @@ func prefixRPC(method string) string {
 	return RPCNamespace + "_" + method
 }
 
+// OverrideLeader implements API.
+func (c *APIClient) OverrideLeader(ctx context.Context) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("overrideLeader"))
+}
+
 // Paused implements API.
 func (c *APIClient) Paused(ctx context.Context) (bool, error) {
 	var paused bool

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -5,12 +5,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	gnode "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -205,6 +204,10 @@ func (s *l2VerifierBackend) StopSequencer(ctx context.Context) (common.Hash, err
 
 func (s *l2VerifierBackend) SequencerActive(ctx context.Context) (bool, error) {
 	return false, nil
+}
+
+func (s *l2VerifierBackend) OverrideLeader(ctx context.Context) error {
+	return nil
 }
 
 func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -224,4 +224,10 @@ func TestSequencerFailover_DisasterRecovery_OverrideLeader(t *testing.T) {
 	active, err = sys.RollupClient(Sequencer3Name).SequencerActive(ctx)
 	require.NoError(t, err)
 	require.True(t, active, "Expected sequencer to be active")
+
+	err = conductors[Sequencer3Name].client.OverrideLeader(ctx)
+	require.NoError(t, err)
+	leader, err := conductors[Sequencer3Name].client.Leader(ctx)
+	require.NoError(t, err)
+	require.True(t, leader, "Expected conductor to return leader true after override")
 }

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
@@ -188,4 +189,39 @@ func TestSequencerFailover_ActiveSequencerDown(t *testing.T) {
 	active, err := sys.RollupClient(newLeaderId).SequencerActive(ctx)
 	require.NoError(t, err)
 	require.True(t, active, "Expected new leader to be sequencing")
+}
+
+// [Category: Disaster Recovery]
+// Test that sequencer can successfully be started with the overrideLeader flag set to true.
+func TestSequencerFailover_DisasterRecovery_OverrideLeader(t *testing.T) {
+	sys, conductors, cleanup := setupSequencerFailoverTest(t)
+	defer cleanup()
+
+	// randomly stop 2 nodes in the cluster to simulate a disaster.
+	ctx := context.Background()
+	err := conductors[Sequencer1Name].service.Stop(ctx)
+	require.NoError(t, err)
+	err = conductors[Sequencer2Name].service.Stop(ctx)
+	require.NoError(t, err)
+
+	require.False(t, conductors[Sequencer3Name].service.Leader(ctx), "Expected sequencer to not be the leader")
+	active, err := sys.RollupClient(Sequencer3Name).SequencerActive(ctx)
+	require.NoError(t, err)
+	require.False(t, active, "Expected sequencer to be inactive")
+
+	// Start sequencer without the overrideLeader flag set to true, should fail
+	err = sys.RollupClient(Sequencer3Name).StartSequencer(ctx, common.Hash{1, 2, 3})
+	require.ErrorContains(t, err, "sequencer is not the leader, aborting.", "Expected sequencer to fail to start")
+
+	// Start sequencer with the overrideLeader flag set to true, should succeed
+	err = sys.RollupClient(Sequencer3Name).OverrideLeader(ctx)
+	require.NoError(t, err)
+	blk, err := sys.NodeClient(Sequencer3Name).BlockByNumber(ctx, nil)
+	require.NoError(t, err)
+	err = sys.RollupClient(Sequencer3Name).StartSequencer(ctx, blk.Hash())
+	require.NoError(t, err)
+
+	active, err = sys.RollupClient(Sequencer3Name).SequencerActive(ctx)
+	require.NoError(t, err)
+	require.True(t, active, "Expected sequencer to be active")
 }

--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
+
+	conductorRpc "github.com/ethereum-optimism/optimism/op-conductor/rpc"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum/go-ethereum/log"
-
-	conductorRpc "github.com/ethereum-optimism/optimism/op-conductor/rpc"
 )
 
 // ConductorClient is a client for the op-conductor RPC service.
@@ -21,13 +21,23 @@ type ConductorClient struct {
 	metrics   *metrics.Metrics
 	log       log.Logger
 	apiClient *conductorRpc.APIClient
+
+	// overrideLeader is used to override the leader check for disaster recovery purposes.
+	// During disaster situations where the cluster is unhealthy (no leader, only 1 or less nodes up),
+	// set this to true to allow the node to assume sequencing responsibilities without being the leader.
+	overrideLeader bool
 }
 
 var _ conductor.SequencerConductor = &ConductorClient{}
 
 // NewConductorClient returns a new conductor client for the op-conductor RPC service.
 func NewConductorClient(cfg *Config, log log.Logger, metrics *metrics.Metrics) *ConductorClient {
-	return &ConductorClient{cfg: cfg, metrics: metrics, log: log}
+	return &ConductorClient{
+		cfg:            cfg,
+		metrics:        metrics,
+		log:            log,
+		overrideLeader: false,
+	}
 }
 
 // Initialize initializes the conductor client.
@@ -45,6 +55,10 @@ func (c *ConductorClient) initialize() error {
 
 // Leader returns true if this node is the leader sequencer.
 func (c *ConductorClient) Leader(ctx context.Context) (bool, error) {
+	if c.overrideLeader {
+		return true, nil
+	}
+
 	if err := c.initialize(); err != nil {
 		return false, err
 	}
@@ -62,6 +76,10 @@ func (c *ConductorClient) Leader(ctx context.Context) (bool, error) {
 
 // CommitUnsafePayload commits an unsafe payload to the conductor log.
 func (c *ConductorClient) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	if c.overrideLeader {
+		return nil
+	}
+
 	if err := c.initialize(); err != nil {
 		return err
 	}
@@ -76,6 +94,12 @@ func (c *ConductorClient) CommitUnsafePayload(ctx context.Context, payload *eth.
 		return true, err
 	})
 	return err
+}
+
+// OverrideLeader implements conductor.SequencerConductor.
+func (c *ConductorClient) OverrideLeader(ctx context.Context) error {
+	c.overrideLeader = true
+	return nil
 }
 
 func (c *ConductorClient) Close() {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -283,6 +283,10 @@ func (c *mockDriverClient) OnUnsafeL2Payload(ctx context.Context, payload *eth.E
 	return c.Mock.MethodCalled("OnUnsafeL2Payload").Get(0).(error)
 }
 
+func (c *mockDriverClient) OverrideLeader(ctx context.Context) error {
+	return c.Mock.MethodCalled("OverrideLeader").Get(0).(error)
+}
+
 type mockSafeDBReader struct {
 	mock.Mock
 }

--- a/op-node/rollup/conductor/conductor.go
+++ b/op-node/rollup/conductor/conductor.go
@@ -9,13 +9,20 @@ import (
 // SequencerConductor is an interface for the driver to communicate with the sequencer conductor.
 // It is used to determine if the current node is the active sequencer, and to commit unsafe payloads to the conductor log.
 type SequencerConductor interface {
+	// Leader returns true if this node is the leader sequencer.
 	Leader(ctx context.Context) (bool, error)
+	// CommitUnsafePayload commits an unsafe payload to the conductor FSM.
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	// OverrideLeader forces current node to be considered leader and be able to start sequencing during disaster situations in HA mode.
+	OverrideLeader(ctx context.Context) error
+	// Close closes the conductor client.
 	Close()
 }
 
 // NoOpConductor is a no-op conductor that assumes this node is the leader sequencer.
 type NoOpConductor struct{}
+
+var _ SequencerConductor = &NoOpConductor{}
 
 // Leader returns true if this node is the leader sequencer. NoOpConductor always returns true.
 func (c *NoOpConductor) Leader(ctx context.Context) (bool, error) {
@@ -24,6 +31,11 @@ func (c *NoOpConductor) Leader(ctx context.Context) (bool, error) {
 
 // CommitUnsafePayload commits an unsafe payload to the conductor log.
 func (c *NoOpConductor) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	return nil
+}
+
+// OverrideLeader implements SequencerConductor.
+func (c *NoOpConductor) OverrideLeader(ctx context.Context) error {
 	return nil
 }
 

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -642,6 +642,10 @@ func (s *Driver) SequencerActive(ctx context.Context) (bool, error) {
 	}
 }
 
+func (s *Driver) OverrideLeader(ctx context.Context) error {
+	return s.sequencerConductor.OverrideLeader(ctx)
+}
+
 // syncStatus returns the current sync status, and should only be called synchronously with
 // the driver event loop to avoid retrieval of an inconsistent status.
 func (s *Driver) syncStatus() *eth.SyncStatus {

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -3,10 +3,9 @@ package sources
 import (
 	"context"
 
-	"golang.org/x/exp/slog"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"golang.org/x/exp/slog"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -69,6 +68,10 @@ func (r *RollupClient) SequencerActive(ctx context.Context) (bool, error) {
 
 func (r *RollupClient) PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
 	return r.rpc.CallContext(ctx, nil, "admin_postUnsafePayload", payload)
+}
+
+func (r *RollupClient) OverrideLeader(ctx context.Context) error {
+	return r.rpc.CallContext(ctx, nil, "admin_overrideLeader")
 }
 
 func (r *RollupClient) SetLogLevel(ctx context.Context, lvl slog.Level) error {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add override in both sequencer and conductor to allow disabling HA mode in disaster recovery scenarios.

- OverrideLeader in sequencer helps when conductor is down
- OverrideLeader in conductor API helps when there are majority of the nodes are down in the cluster and no leader could be elected. With this override, we could manually start sequencing on the local sequencer, and batcher (in active sequencer follow mode) will be able to detect the "leader" and get blocks as usual

**Tests**

Added tests in sequencer failover tests.