### PR TITLE
op-program: Treat reaching the safe head as a success not a failure.

### DIFF
--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -1,7 +1,6 @@
 package driver
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -54,13 +53,13 @@ func (d *ProgramDeriver) OnEvent(ev rollup.Event) {
 		d.Emitter.Emit(engine.PendingSafeRequestEvent{})
 	case engine.ForkchoiceUpdateEvent:
 		if x.SafeL2Head.Number >= d.targetBlockNum {
-			d.logger.Info("Derivation complete: reached L2 block", "head", x.UnsafeL2Head)
+			d.logger.Info("Derivation complete: reached L2 block", "head", x.SafeL2Head)
 			d.closing = true
 		}
 	case derive.DeriverIdleEvent:
 		// Not enough data to reach target
 		d.closing = true
-		d.result = errors.New("not enough data to reach target")
+		d.logger.Info("Derivation complete: no further data to process")
 	case rollup.ResetEvent:
 		d.closing = true
 		d.result = fmt.Errorf("unexpected reset error: %w", x.Err)

--- a/op-program/client/driver/program_test.go
+++ b/op-program/client/driver/program_test.go
@@ -103,13 +103,13 @@ func TestProgramDeriver(t *testing.T) {
 			require.NoError(t, p.result)
 		})
 	})
-	// on exhaustion of input data: stop with error
+	// on exhaustion of input data: stop without error
 	t.Run("deriver idle", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
 		p.OnEvent(derive.DeriverIdleEvent{})
 		m.AssertExpectations(t)
 		require.True(t, p.closing)
-		require.NotNil(t, p.result)
+		require.Nil(t, p.result)
 	})
 	// on inconsistent chain data: stop with error
 	t.Run("reset event", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Current fault dispute rules are that the safe head is extended to the end of the trace. In https://github.com/ethereum-optimism/optimism/pull/10971 this behaviour was changed to return an error which is translated to mean the claimed output root is invalid. Honest challengers are then unable to defend their honest claim that the safe head was reached because the program results in an error.

Should fix the cannon e2e tests.