### PR TITLE
remove useless `chainSpec` from EngineController

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -49,7 +49,6 @@ type EngineController struct {
 	metrics    derive.Metrics
 	syncMode   sync.Mode
 	syncStatus syncStatusEnum
-	chainSpec  *rollup.ChainSpec
 	rollupCfg  *rollup.Config
 	elStart    time.Time
 	clock      clock.Clock
@@ -88,7 +87,6 @@ func NewEngineController(engine ExecEngine, log log.Logger, metrics derive.Metri
 		engine:     engine,
 		log:        log,
 		metrics:    metrics,
-		chainSpec:  rollup.NewChainSpec(rollupCfg),
 		rollupCfg:  rollupCfg,
 		syncMode:   syncMode,
 		syncStatus: syncStatus,
@@ -154,7 +152,6 @@ func (e *EngineController) SetUnsafeHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_unsafe", r)
 	e.unsafeHead = r
 	e.needFCUCall = true
-	e.chainSpec.CheckForkActivation(e.log, r)
 }
 
 // SetBackupUnsafeL2Head implements LocalEngineControl.


### PR DESCRIPTION
It seems `EngineController.chainSpec` is never used, the call to `CheckForkActivation` only updates `chainSpec.currentFork` which is never referenced and it doesn't handle resetting. So it's better to remove it.