### PR TITLE
perf(op-service/dial/rollup_sync): init timer outside of the  loop 

### DIFF
--- a/op-service/dial/rollup_sync.go
+++ b/op-service/dial/rollup_sync.go
@@ -15,8 +15,8 @@ func WaitRollupSync(
 	l1BlockTarget uint64,
 	pollInterval time.Duration,
 ) error {
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
+	timer := time.NewTimer(pollInterval)
+	defer timer.Stop()
 
 	for {
 		syncst, err := rollup.SyncStatus(ctx)
@@ -33,8 +33,10 @@ func WaitRollupSync(
 
 		lgr.Info("rollup current L1 block still behind target, retrying")
 
+		timer.Reset(pollInterval)
+
 		select {
-		case <-ticker.C: // next try
+		case <-timer.C: // next try
 		case <-ctx.Done():
 			lgr.Warn("waiting for rollup sync timed out")
 			return ctx.Err()

--- a/op-service/dial/rollup_sync.go
+++ b/op-service/dial/rollup_sync.go
@@ -34,7 +34,6 @@ func WaitRollupSync(
 		lgr.Info("rollup current L1 block still behind target, retrying")
 
 		timer.Reset(pollInterval)
-
 		select {
 		case <-timer.C: // next try
 		case <-ctx.Done():

--- a/op-service/dial/rollup_sync.go
+++ b/op-service/dial/rollup_sync.go
@@ -15,6 +15,9 @@ func WaitRollupSync(
 	l1BlockTarget uint64,
 	pollInterval time.Duration,
 ) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
 	for {
 		syncst, err := rollup.SyncStatus(ctx)
 		if err != nil {
@@ -29,12 +32,11 @@ func WaitRollupSync(
 		}
 
 		lgr.Info("rollup current L1 block still behind target, retrying")
-		timer := time.NewTimer(pollInterval)
+
 		select {
-		case <-timer.C: // next try
+		case <-ticker.C: // next try
 		case <-ctx.Done():
 			lgr.Warn("waiting for rollup sync timed out")
-			timer.Stop()
 			return ctx.Err()
 		}
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Creating a new timer on each iteration causes unnecessary allocation

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
