### PR TITLE
op-challenger: Fix vm execution time metric name

### DIFF
--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -167,8 +167,8 @@ func NewMetrics() *Metrics {
 		}),
 		vmExecutionTime: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: Namespace,
-			Name:      "asterisc_execution_time",
-			Help:      "Time (in seconds) to execute asterisc",
+			Name:      "vm_execution_time",
+			Help:      "Time (in seconds) to execute the fault proof VM",
 			Buckets: append(
 				[]float64{1.0, 10.0},
 				prometheus.ExponentialBuckets(30.0, 2.0, 14)...),


### PR DESCRIPTION
**Description**

Fix the metric name and description for VM execution time. It was incorrectly asterisc specific but is actually a labelled histogram with the VM type as the label.