### PR TITLE
ci: Require op-e2e-action-tests-plasma to pass before merging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1695,6 +1695,7 @@ workflows:
             - op-e2e-HTTP-tests
             - op-e2e-fault-proof-tests
             - op-e2e-action-tests
+            - op-e2e-action-tests-plasma
       - docker-build:
           name: op-node-docker-build
           docker_name: op-node


### PR DESCRIPTION
**Description**

Include `op-e2e-action-tests-plasma` in the dependencies for `bedrock-go-tests` so it is required to pass before PRs merge.
