### PR TITLE
op-challenger: Remove unused blockNumberFetcher

### DIFF
--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -19,8 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type blockNumberFetcher func(ctx context.Context) (uint64, error)
-
 // gameSource loads information about the games available to play
 type gameSource interface {
 	GetGamesAtOrAfter(ctx context.Context, blockHash common.Hash, earliestTimestamp uint64) ([]types.GameMetadata, error)
@@ -44,18 +42,17 @@ type claimer interface {
 }
 
 type gameMonitor struct {
-	logger           log.Logger
-	clock            RWClock
-	source           gameSource
-	scheduler        gameScheduler
-	preimages        preimageScheduler
-	gameWindow       time.Duration
-	claimer          claimer
-	fetchBlockNumber blockNumberFetcher
-	allowedGames     []common.Address
-	l1HeadsSub       ethereum.Subscription
-	l1Source         *headSource
-	runState         sync.Mutex
+	logger       log.Logger
+	clock        RWClock
+	source       gameSource
+	scheduler    gameScheduler
+	preimages    preimageScheduler
+	gameWindow   time.Duration
+	claimer      claimer
+	allowedGames []common.Address
+	l1HeadsSub   ethereum.Subscription
+	l1Source     *headSource
+	runState     sync.Mutex
 }
 
 type MinimalSubscriber interface {
@@ -78,21 +75,19 @@ func newGameMonitor(
 	preimages preimageScheduler,
 	gameWindow time.Duration,
 	claimer claimer,
-	fetchBlockNumber blockNumberFetcher,
 	allowedGames []common.Address,
 	l1Source MinimalSubscriber,
 ) *gameMonitor {
 	return &gameMonitor{
-		logger:           logger,
-		clock:            cl,
-		scheduler:        scheduler,
-		preimages:        preimages,
-		source:           source,
-		gameWindow:       gameWindow,
-		claimer:          claimer,
-		fetchBlockNumber: fetchBlockNumber,
-		allowedGames:     allowedGames,
-		l1Source:         &headSource{inner: l1Source},
+		logger:       logger,
+		clock:        cl,
+		scheduler:    scheduler,
+		preimages:    preimages,
+		source:       source,
+		gameWindow:   gameWindow,
+		claimer:      claimer,
+		allowedGames: allowedGames,
+		l1Source:     &headSource{inner: l1Source},
 	}
 }
 

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -155,11 +155,6 @@ func setupMonitorTest(
 ) (*gameMonitor, *stubGameSource, *stubScheduler, *mockNewHeadSource, *stubPreimageScheduler, *mockScheduler) {
 	logger := testlog.Logger(t, log.LevelDebug)
 	source := &stubGameSource{}
-	i := uint64(1)
-	fetchBlockNum := func(ctx context.Context) (uint64, error) {
-		i++
-		return i, nil
-	}
 	sched := &stubScheduler{}
 	preimages := &stubPreimageScheduler{}
 	mockHeadSource := &mockNewHeadSource{}
@@ -172,7 +167,6 @@ func setupMonitorTest(
 		preimages,
 		time.Duration(0),
 		stubClaimer,
-		fetchBlockNum,
 		allowedGames,
 		mockHeadSource,
 	)

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -251,7 +251,7 @@ func (s *Service) initLargePreimages() error {
 }
 
 func (s *Service) initMonitor(cfg *config.Config) {
-	s.monitor = newGameMonitor(s.logger, s.l1Clock, s.factoryContract, s.sched, s.preimages, cfg.GameWindow, s.claimer, s.l1Client.BlockNumber, cfg.GameAllowlist, s.pollClient)
+	s.monitor = newGameMonitor(s.logger, s.l1Clock, s.factoryContract, s.sched, s.preimages, cfg.GameWindow, s.claimer, cfg.GameAllowlist, s.pollClient)
 }
 
 func (s *Service) Start(ctx context.Context) error {


### PR DESCRIPTION
**Description**

Quick cleanup I noticed while using this code as reference for something else - we don't actually use the `blockNumberFetcher` so can remove the field and type declaration.
