### PR TITLE
add `p2p.sync.onlyreqtostatic` flag to p2p flags

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -14,46 +14,47 @@ func p2pEnv(envprefix, v string) []string {
 }
 
 var (
-	DisableP2PName         = "p2p.disable"
-	NoDiscoveryName        = "p2p.no-discovery"
-	ScoringName            = "p2p.scoring"
-	PeerScoringName        = "p2p.scoring.peers"
-	PeerScoreBandsName     = "p2p.score.bands"
-	BanningName            = "p2p.ban.peers"
-	BanningThresholdName   = "p2p.ban.threshold"
-	BanningDurationName    = "p2p.ban.duration"
-	TopicScoringName       = "p2p.scoring.topics"
-	P2PPrivPathName        = "p2p.priv.path"
-	P2PPrivRawName         = "p2p.priv.raw"
-	ListenIPName           = "p2p.listen.ip"
-	ListenTCPPortName      = "p2p.listen.tcp"
-	ListenUDPPortName      = "p2p.listen.udp"
-	AdvertiseIPName        = "p2p.advertise.ip"
-	AdvertiseTCPPortName   = "p2p.advertise.tcp"
-	AdvertiseUDPPortName   = "p2p.advertise.udp"
-	BootnodesName          = "p2p.bootnodes"
-	StaticPeersName        = "p2p.static"
-	NetRestrictName        = "p2p.netrestrict"
-	HostMuxName            = "p2p.mux"
-	HostSecurityName       = "p2p.security"
-	PeersLoName            = "p2p.peers.lo"
-	PeersHiName            = "p2p.peers.hi"
-	PeersGraceName         = "p2p.peers.grace"
-	NATName                = "p2p.nat"
-	UserAgentName          = "p2p.useragent"
-	TimeoutNegotiationName = "p2p.timeout.negotiation"
-	TimeoutAcceptName      = "p2p.timeout.accept"
-	TimeoutDialName        = "p2p.timeout.dial"
-	PeerstorePathName      = "p2p.peerstore.path"
-	DiscoveryPathName      = "p2p.discovery.path"
-	SequencerP2PKeyName    = "p2p.sequencer.key"
-	GossipMeshDName        = "p2p.gossip.mesh.d"
-	GossipMeshDloName      = "p2p.gossip.mesh.lo"
-	GossipMeshDhiName      = "p2p.gossip.mesh.dhi"
-	GossipMeshDlazyName    = "p2p.gossip.mesh.dlazy"
-	GossipFloodPublishName = "p2p.gossip.mesh.floodpublish"
-	SyncReqRespName        = "p2p.sync.req-resp"
-	P2PPingName            = "p2p.ping"
+	DisableP2PName          = "p2p.disable"
+	NoDiscoveryName         = "p2p.no-discovery"
+	ScoringName             = "p2p.scoring"
+	PeerScoringName         = "p2p.scoring.peers"
+	PeerScoreBandsName      = "p2p.score.bands"
+	BanningName             = "p2p.ban.peers"
+	BanningThresholdName    = "p2p.ban.threshold"
+	BanningDurationName     = "p2p.ban.duration"
+	TopicScoringName        = "p2p.scoring.topics"
+	P2PPrivPathName         = "p2p.priv.path"
+	P2PPrivRawName          = "p2p.priv.raw"
+	ListenIPName            = "p2p.listen.ip"
+	ListenTCPPortName       = "p2p.listen.tcp"
+	ListenUDPPortName       = "p2p.listen.udp"
+	AdvertiseIPName         = "p2p.advertise.ip"
+	AdvertiseTCPPortName    = "p2p.advertise.tcp"
+	AdvertiseUDPPortName    = "p2p.advertise.udp"
+	BootnodesName           = "p2p.bootnodes"
+	StaticPeersName         = "p2p.static"
+	NetRestrictName         = "p2p.netrestrict"
+	HostMuxName             = "p2p.mux"
+	HostSecurityName        = "p2p.security"
+	PeersLoName             = "p2p.peers.lo"
+	PeersHiName             = "p2p.peers.hi"
+	PeersGraceName          = "p2p.peers.grace"
+	NATName                 = "p2p.nat"
+	UserAgentName           = "p2p.useragent"
+	TimeoutNegotiationName  = "p2p.timeout.negotiation"
+	TimeoutAcceptName       = "p2p.timeout.accept"
+	TimeoutDialName         = "p2p.timeout.dial"
+	PeerstorePathName       = "p2p.peerstore.path"
+	DiscoveryPathName       = "p2p.discovery.path"
+	SequencerP2PKeyName     = "p2p.sequencer.key"
+	GossipMeshDName         = "p2p.gossip.mesh.d"
+	GossipMeshDloName       = "p2p.gossip.mesh.lo"
+	GossipMeshDhiName       = "p2p.gossip.mesh.dhi"
+	GossipMeshDlazyName     = "p2p.gossip.mesh.dlazy"
+	GossipFloodPublishName  = "p2p.gossip.mesh.floodpublish"
+	SyncReqRespName         = "p2p.sync.req-resp"
+	SyncOnlyReqToStaticName = "p2p.sync.onlyreqtostatic"
+	P2PPingName             = "p2p.ping"
 )
 
 func deprecatedP2PFlags(envPrefix string) []cli.Flag {
@@ -391,6 +392,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Value:    true,
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "SYNC_REQ_RESP"),
+			Category: P2PCategory,
+		},
+		&cli.BoolFlag{
+			Name:     SyncOnlyReqToStaticName,
+			Usage:    "Configure P2P to forward RequestL2Range requests to static peers only.",
+			Value:    false,
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "SYNC_ONLYREQTOSTATIC"),
 			Category: P2PCategory,
 		},
 		&cli.BoolFlag{

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -66,6 +66,7 @@ func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) 
 
 	conf.EnableReqRespSync = ctx.Bool(flags.SyncReqRespName)
 	conf.EnablePingService = ctx.Bool(flags.P2PPingName)
+	conf.SyncOnlyReqToStatic = ctx.Bool(flags.SyncOnlyReqToStaticName)
 
 	return conf, nil
 }

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -126,7 +126,8 @@ type Config struct {
 	// Underlying store that hosts connection-gater and peerstore data.
 	Store ds.Batching
 
-	EnableReqRespSync bool
+	EnableReqRespSync   bool
+	SyncOnlyReqToStatic bool
 
 	EnablePingService bool
 }

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -18,6 +18,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/sec/insecure"
 	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
@@ -38,6 +39,10 @@ import (
 const (
 	staticPeerTag = "static"
 )
+
+type HostNewStream interface {
+	NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (network.Stream, error)
+}
 
 type ExtraHostFeatures interface {
 	host.Host

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -43,6 +43,8 @@ type ExtraHostFeatures interface {
 	host.Host
 	ConnectionGater() gating.BlockingConnectionGater
 	ConnectionManager() connmgr.ConnManager
+	IsStatic(peerID peer.ID) bool
+	SyncOnlyReqToStatic() bool
 }
 
 type extraHost struct {
@@ -51,11 +53,14 @@ type extraHost struct {
 	connMgr connmgr.ConnManager
 	log     log.Logger
 
-	staticPeers []*peer.AddrInfo
+	staticPeers   []*peer.AddrInfo
+	staticPeerIDs map[peer.ID]struct{}
 
 	pinging *PingService
 
 	quitC chan struct{}
+
+	syncOnlyReqToStatic bool
 }
 
 func (e *extraHost) ConnectionGater() gating.BlockingConnectionGater {
@@ -64,6 +69,15 @@ func (e *extraHost) ConnectionGater() gating.BlockingConnectionGater {
 
 func (e *extraHost) ConnectionManager() connmgr.ConnManager {
 	return e.connMgr
+}
+
+func (e *extraHost) IsStatic(peerID peer.ID) bool {
+	_, exists := e.staticPeerIDs[peerID]
+	return exists
+}
+
+func (e *extraHost) SyncOnlyReqToStatic() bool {
+	return e.syncOnlyReqToStatic
 }
 
 func (e *extraHost) Close() error {
@@ -236,6 +250,7 @@ func (conf *Config) Host(log log.Logger, reporter metrics.Reporter, metrics Host
 	}
 
 	staticPeers := make([]*peer.AddrInfo, 0, len(conf.StaticPeers))
+	staticPeerIDs := make(map[peer.ID]struct{})
 	for _, peerAddr := range conf.StaticPeers {
 		addr, err := peer.AddrInfoFromP2pAddr(peerAddr)
 		if err != nil {
@@ -246,14 +261,17 @@ func (conf *Config) Host(log log.Logger, reporter metrics.Reporter, metrics Host
 			continue
 		}
 		staticPeers = append(staticPeers, addr)
+		staticPeerIDs[addr.ID] = struct{}{}
 	}
 
 	out := &extraHost{
-		Host:        h,
-		connMgr:     connMngr,
-		log:         log,
-		staticPeers: staticPeers,
-		quitC:       make(chan struct{}),
+		Host:                h,
+		connMgr:             connMngr,
+		log:                 log,
+		staticPeers:         staticPeers,
+		staticPeerIDs:       staticPeerIDs,
+		quitC:               make(chan struct{}),
+		syncOnlyReqToStatic: conf.SyncOnlyReqToStatic,
 	}
 
 	if conf.EnablePingService {

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -106,7 +106,7 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, l
 		}
 		// Activate the P2P req-resp sync if enabled by feature-flag.
 		if setup.ReqRespSyncEnabled() && !elSyncEnabled {
-			n.syncCl = NewSyncClient(log, rollupCfg, n.host.NewStream, gossipIn.OnUnsafeL2Payload, metrics, n.appScorer)
+			n.syncCl = NewSyncClient(log, rollupCfg, n.host, gossipIn.OnUnsafeL2Payload, metrics, n.appScorer)
 			n.host.Network().Notify(&network.NotifyBundle{
 				ConnectedF: func(nw network.Network, conn network.Conn) {
 					n.syncCl.AddPeer(conn.RemotePeer())

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -282,7 +281,7 @@ type SyncClient struct {
 	syncOnlyReqToStatic bool
 }
 
-func NewSyncClient(log log.Logger, cfg *rollup.Config, host host.Host, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer) *SyncClient {
+func NewSyncClient(log log.Logger, cfg *rollup.Config, host HostNewStream, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer) *SyncClient {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &SyncClient{
@@ -568,6 +567,8 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	peerRequests := s.peerRequests
 	if s.syncOnlyReqToStatic && !s.extra.IsStatic(id) {
 		// for non-static peers, set peerRequests to nil
+		// this will effectively make the peer loop not perform outgoing sync-requests.
+		// while sync-requests will block, the loop may still process other events (if added in the future).
 		peerRequests = nil
 	}
 

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -276,9 +277,12 @@ type SyncClient struct {
 	// Don't allow anything to be added to the wait-group while, or after, we are shutting down.
 	// This is protected by peersLock.
 	closingPeers bool
+
+	extra               ExtraHostFeatures
+	syncOnlyReqToStatic bool
 }
 
-func NewSyncClient(log log.Logger, cfg *rollup.Config, newStream newStreamFn, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer) *SyncClient {
+func NewSyncClient(log log.Logger, cfg *rollup.Config, host host.Host, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer) *SyncClient {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &SyncClient{
@@ -286,7 +290,7 @@ func NewSyncClient(log log.Logger, cfg *rollup.Config, newStream newStreamFn, rc
 		cfg:                 cfg,
 		metrics:             metrics,
 		appScorer:           appScorer,
-		newStreamFn:         newStream,
+		newStreamFn:         host.NewStream,
 		payloadByNumber:     PayloadByNumberProtocolID(cfg.L2ChainID),
 		peers:               make(map[peer.ID]context.CancelFunc),
 		quarantineByNum:     make(map[uint64]common.Hash),
@@ -300,6 +304,10 @@ func NewSyncClient(log log.Logger, cfg *rollup.Config, newStream newStreamFn, rc
 		resCtx:              ctx,
 		resCancel:           cancel,
 		receivePayload:      rcv,
+	}
+	if extra, ok := host.(ExtraHostFeatures); ok && extra.SyncOnlyReqToStatic() {
+		c.extra = extra
+		c.syncOnlyReqToStatic = true
 	}
 
 	// never errors with positive LRU cache size
@@ -556,6 +564,13 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	// so we don't be too aggressive to the server.
 	rl := rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst)
 
+	// if onlyReqToStatic is on, ensure that only static peers are dealing with the request
+	peerRequests := s.peerRequests
+	if s.syncOnlyReqToStatic && !s.extra.IsStatic(id) {
+		// for non-static peers, set peerRequests to nil
+		peerRequests = nil
+	}
+
 	for {
 		// wait for a global allocation to be available
 		if err := s.globalRL.Wait(ctx); err != nil {
@@ -568,7 +583,7 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 
 		// once the peer is available, wait for a sync request.
 		select {
-		case pr := <-s.peerRequests:
+		case pr := <-peerRequests:
 			if !s.activeRangeRequests.get(pr.rangeReqId) {
 				log.Debug("dropping cancelled p2p sync request", "num", pr.num)
 				s.inFlight.delete(pr.num)

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -163,7 +163,7 @@ func TestSinglePeerSync(t *testing.T) {
 	hostA.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
 
 	// Setup host B as the client
-	cl := NewSyncClient(log.New("role", "client"), cfg, hostB.NewStream, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
+	cl := NewSyncClient(log.New("role", "client"), cfg, hostB, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
 
 	// Setup host B (client) to sync from its peer Host A (server)
 	cl.AddPeer(hostA.ID())
@@ -224,7 +224,7 @@ func TestMultiPeerSync(t *testing.T) {
 		payloadByNumber := MakeStreamHandler(ctx, log.New("serve", "payloads_by_number"), srv.HandleSyncRequest)
 		h.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
 
-		cl := NewSyncClient(log.New("role", "client"), cfg, h.NewStream, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
+		cl := NewSyncClient(log.New("role", "client"), cfg, h, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
 		return cl, received
 	}
 
@@ -356,7 +356,7 @@ func TestNetworkNotifyAddPeerAndRemovePeer(t *testing.T) {
 	require.NoError(t, err, "failed to launch host B")
 	defer hostB.Close()
 
-	syncCl := NewSyncClient(log, cfg, hostA.NewStream, func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
+	syncCl := NewSyncClient(log, cfg, hostA, func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
 		return nil
 	}, metrics.NoopMetrics, &NoopApplicationScorer{})
 


### PR DESCRIPTION
This PR adds a `p2p.sync.onlyreqtostatic` flag to op-node so that when enabled, `RequestL2Range` will only forward requests to static peers.

This is handy for new nodes to increase the success rate for [`checkForGapInUnsafeQueue`](https://github.com/ethereum-optimism/optimism/blob/036a14a0e8b529211051a46e5ae70261dd238bbe/op-node/rollup/driver/state.go#L721), otherwise it often happens that bad peers received the request(peers race to handle the request by receiving from `peerRequests` channel) and thus report "failed to check for unsafe L2 blocks to sync".

This flag is especially useful for opstack instances with large batcher submit interval(e.g, 12h).

(The big flag diff is caused by goformat, only a new flag `SyncOnlyReqToStaticName` was added)