### PR TITLE
op-chain-ops: add ProtocolVersionAddress to rollup.json

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -629,12 +629,9 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 		return nil, fmt.Errorf("unknown chain ID: %d", d.L2ChainID)
 	}
 
-	superChain, ok := superchain.Superchains[chConfig.Superchain]
-	if !ok {
-		return nil, fmt.Errorf("chain %d specifies unknown superchain: %q", d.L2ChainID, chConfig.Superchain)
-	}
 	protocolVersionAddress := common.Address{}
-	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address
+	superChain, ok := superchain.Superchains[chConfig.Superchain]
+	if ok && superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address
 		protocolVersionAddress = common.Address(*superChain.Config.ProtocolVersionsAddr)
 	}
 


### PR DESCRIPTION
**Description**

Currently the `rollup.json` for a new l2 chain is generated when op-node invokes [this op-chain-ops code](https://github.com/ethereum-optimism/optimism/blob/develop/op-chain-ops/genesis/config.go#L626-L659). The `ProtocolVersionsAddress` field never gets set so it is always initialized to the 0x0 address. However, when the op-node `LoadOPStackRollupConfig` function is called, it checks to see if the superchain-level ProtocolVersionsAddress is set, and if so it [overwrites the value](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/superchain.go#L95-L97) with the one read from the superchain-registry/superchain module.

This PR modifies the op-chain-ops code so that the `ProtocolVersionsAddress` is set when the `rollup.json` is first created, instead of adding that value further downstream. This helps give the chain operator more information upfront, and allows for better sanity checking within the `superchain-registry/add-chain` tests.
