### PR TITLE
op-node: delete snapshot-log in docker-compose

### DIFF
--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -74,7 +74,6 @@ services:
       --p2p.listen.udp=9003
       --p2p.scoring.peers=light
       --p2p.ban.peers=true
-      --snapshotlog.file=/op_log/snapshot.log
       --p2p.priv.path=/config/p2p-node-key.txt
       --metrics.enabled
       --metrics.addr=0.0.0.0


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/pull/11008 
PR #11008 remove legacy snapshot-log. but the docker-compose is still using it. Better to remove it form that