### PR TITLE
add deploy-config/mainnet.json and deploy-config/sepolia.json to @eth-optimism/contracts-bedrock package

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -7,7 +7,9 @@
     "forge-artifacts/**/*.json",
     "!forge-artifacts/**/*.t.sol/*.json",
     "deployments/**/*.json",
-    "src/**/*.sol"
+    "src/**/*.sol",
+    "deploy-config/mainnet.json",
+    "deploy-config/sepolia.json"
   ],
   "scripts": {
     "prebuild": "./scripts/checks/check-foundry-install.sh",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

At the moment the package @eth-optimism/contracts-bedrock does not include deploy-config folder configurations.
We are using them in some of the monitoring program we are using in chain-mon.
In order to move chain-mon to monitorism repository we need to first make sure all monitoring we have keep working after we move.
At the moment two of these monitoring script make use of  deploy-config/mainnet.json and deploy-config/sepolia.json.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
