### PR TITLE
devnet: delete redundant import

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -13,8 +13,6 @@ import concurrent.futures
 from collections import namedtuple
 
 
-import devnet.log_setup
-
 pjoin = os.path.join
 
 parser = argparse.ArgumentParser(description='Bedrock devnet launcher')


### PR DESCRIPTION
I think this `devnet.log_setup` is not using in file