### PR TITLE
disallow unknown fields in rollup config

### DIFF
--- a/op-node/service.go
+++ b/op-node/service.go
@@ -235,7 +235,9 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	defer file.Close()
 
 	var rollupConfig rollup.Config
-	if err := json.NewDecoder(file).Decode(&rollupConfig); err != nil {
+	dec := json.NewDecoder(file)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
 	return &rollupConfig, nil


### PR DESCRIPTION
`rollup.Config` is very critical, it's better to disallow unknowns fields, which is most probably caused by typo.

It's already done for `DeployConfig`.