### PR TITLE
fix(op-node): plasma validation config missing commitment type for legacy config

### DIFF
--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -335,6 +335,7 @@ func validatePlasmaConfig(cfg *Config) error {
 			DAChallengeAddress: cfg.LegacyDAChallengeAddress,
 			DAChallengeWindow:  cfg.LegacyDAChallengeWindow,
 			DAResolveWindow:    cfg.LegacyDAResolveWindow,
+			CommitmentType:     plasma.KeccakCommitmentString,
 		}
 	} else if cfg.LegacyUsePlasma && cfg.PlasmaConfig != nil {
 		// validate that both are the same


### PR DESCRIPTION
validatePlasmaConfig breaks compatibility with plasma legacy configurations, this will add the required param `CommitmentType` in the check logic when creating the new config.

long story:

check is invoked multiple times. 

first run create a the new structure PlasmaConfig but without CommitmentType (which for legacy conf is Kekkak)
second run, find both legacy and new config and check for consistency failing on line 351 (here the bug triggers)

workaround w/o the fix is to edit rollup cfg nesting legacy fields in the new `plasma_config` field

otoh, to consider in general to not mutate the config during checks