### PR TITLE
minor refactor about plasma

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -516,10 +516,13 @@ func (d *DeployConfig) CheckAddresses() error {
 	if d.OptimismPortalProxy == (common.Address{}) {
 		return fmt.Errorf("%w: OptimismPortalProxy cannot be address(0)", ErrInvalidDeployConfig)
 	}
-	if d.UsePlasma && d.DACommitmentType == plasma.KeccakCommitmentString && d.DAChallengeProxy == (common.Address{}) {
-		return fmt.Errorf("%w: DAChallengeContract cannot be address(0) when using alt-da mode", ErrInvalidDeployConfig)
-	} else if d.UsePlasma && d.DACommitmentType == plasma.GenericCommitmentString && d.DAChallengeProxy != (common.Address{}) {
-		return fmt.Errorf("%w: DAChallengeContract must be address(0) when using generic commitments in alt-da mode", ErrInvalidDeployConfig)
+	if d.UsePlasma {
+		if d.DACommitmentType == plasma.KeccakCommitmentString && d.DAChallengeProxy == (common.Address{}) {
+			return fmt.Errorf("%w: DAChallengeContract cannot be address(0) when using alt-da mode", ErrInvalidDeployConfig)
+		}
+		if d.DACommitmentType == plasma.GenericCommitmentString && d.DAChallengeProxy != (common.Address{}) {
+			return fmt.Errorf("%w: DAChallengeContract must be address(0) when using generic commitments in alt-da mode", ErrInvalidDeployConfig)
+		}
 	}
 	return nil
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -385,12 +385,15 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		sequencerConductor = NewConductorClient(cfg, n.log, n.metrics)
 	}
 
-	// if plasma is not explicitly activated in the node CLI, the config + any error will be ignored.
-	rpCfg, err := cfg.Rollup.GetOPPlasmaConfig()
-	if cfg.Plasma.Enabled && err != nil {
-		return fmt.Errorf("failed to get plasma config: %w", err)
+	var plasmaDA driver.PlasmaIface
+	if cfg.Plasma.Enabled {
+		rpCfg, err := cfg.Rollup.GetOPPlasmaConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get plasma config: %w", err)
+		}
+		plasmaDA = plasma.NewPlasmaDA(n.log, cfg.Plasma, rpCfg, n.metrics.PlasmaMetrics)
 	}
-	plasmaDA := plasma.NewPlasmaDA(n.log, cfg.Plasma, rpCfg, n.metrics.PlasmaMetrics)
+
 	if cfg.SafeDBPath != "" {
 		n.log.Info("Safe head database enabled", "path", cfg.SafeDBPath)
 		safeDB, err := safedb.NewSafeDB(n.log, cfg.SafeDBPath)

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -52,7 +52,6 @@ type DerivationPipeline struct {
 	log       log.Logger
 	rollupCfg *rollup.Config
 	l1Fetcher L1Fetcher
-	plasma    PlasmaInputFetcher
 
 	l2 L2Source
 
@@ -99,7 +98,6 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 		log:       log,
 		rollupCfg: rollupCfg,
 		l1Fetcher: l1Fetcher,
-		plasma:    plasma,
 		resetting: 0,
 		stages:    stages,
 		metrics:   metrics,

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -92,7 +92,12 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 	// Reset from ResetEngine then up from L1 Traversal. The stages do not talk to each other during
 	// the ResetEngine, but after the ResetEngine, this is the order in which the stages could talk to each other.
 	// Note: The ResetEngine is the only reset that can fail.
-	stages := []ResettableStage{l1Traversal, l1Src, plasma, frameQueue, bank, chInReader, batchQueue, attributesQueue}
+	var stages []ResettableStage
+	if plasma != nil {
+		stages = []ResettableStage{l1Traversal, l1Src, plasma, frameQueue, bank, chInReader, batchQueue, attributesQueue}
+	} else {
+		stages = []ResettableStage{l1Traversal, l1Src, frameQueue, bank, chInReader, batchQueue, attributesQueue}
+	}
 
 	return &DerivationPipeline{
 		log:       log,

--- a/op-plasma/damgr.go
+++ b/op-plasma/damgr.go
@@ -306,7 +306,7 @@ func (d *DA) AdvanceCommitmentOrigin(ctx context.Context, l1 L1Fetcher, block et
 
 // AdvanceL1Origin syncs any challenge events included in the l1 block, expires any active challenges
 // after the new resolveWindow, computes and signals the new finalized head and sets the l1 block
-// as the new head for tracking challenges and commitments. If forwards an error if any new challenge have expired to
+// as the new head for tracking challenges and commitments. It forwards an error if any new challenge have expired to
 // trigger a derivation reset.
 func (d *DA) AdvanceL1Origin(ctx context.Context, l1 L1Fetcher, block eth.BlockID) error {
 	if err := d.AdvanceChallengeOrigin(ctx, l1, block); err != nil {


### PR DESCRIPTION
This PR does 3 things:

1. remove the `DerivationPipeline.plasma` field which is never used.
2. only instantiate plasma if enabled. It looks very strange to instantiate it when not enabled.
3. extract the common condition `d.UsePlasma` for `DeployConfig.CheckAddresses`