### PR TITLE
proposer: replace gametype from uint32 to faultTypes.GameType

### DIFF
--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-proposer/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -54,7 +55,7 @@ type CLIConfig struct {
 	ProposalInterval time.Duration
 
 	// DisputeGameType is the type of dispute game to create when submitting an output proposal.
-	DisputeGameType uint32
+	DisputeGameType faultTypes.GameType
 
 	// ActiveSequencerCheckDuration is the duration between checks to determine the active sequencer endpoint.
 	ActiveSequencerCheckDuration time.Duration
@@ -110,7 +111,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		PprofConfig:                  oppprof.ReadCLIConfig(ctx),
 		DGFAddress:                   ctx.String(flags.DisputeGameFactoryAddressFlag.Name),
 		ProposalInterval:             ctx.Duration(flags.ProposalIntervalFlag.Name),
-		DisputeGameType:              uint32(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
+		DisputeGameType:              faultTypes.GameType(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
 		ActiveSequencerCheckDuration: ctx.Duration(flags.ActiveSequencerCheckDurationFlag.Name),
 		WaitNodeSync:                 ctx.Bool(flags.WaitNodeSyncFlag.Name),
 	}

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-proposer/bindings"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -320,7 +321,7 @@ func proposeL2OutputTxData(abi *abi.ABI, output *eth.OutputResponse) ([]byte, er
 }
 
 func (l *L2OutputSubmitter) ProposeL2OutputDGFTxData(output *eth.OutputResponse) ([]byte, *big.Int, error) {
-	bond, err := l.dgfContract.InitBonds(&bind.CallOpts{}, l.Cfg.DisputeGameType)
+	bond, err := l.dgfContract.InitBonds(&bind.CallOpts{}, uint32(l.Cfg.DisputeGameType))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -332,7 +333,7 @@ func (l *L2OutputSubmitter) ProposeL2OutputDGFTxData(output *eth.OutputResponse)
 }
 
 // proposeL2OutputDGFTxData creates the transaction data for the DisputeGameFactory's `create` function
-func proposeL2OutputDGFTxData(abi *abi.ABI, gameType uint32, output *eth.OutputResponse) ([]byte, error) {
+func proposeL2OutputDGFTxData(abi *abi.ABI, gameType faultTypes.GameType, output *eth.OutputResponse) ([]byte, error) {
 	return abi.Pack("create", gameType, output.OutputRoot, math.U256Bytes(new(big.Int).SetUint64(output.BlockRef.Number)))
 }
 

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/rpc"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
@@ -37,7 +38,7 @@ type ProposerConfig struct {
 
 	L2OutputOracleAddr     *common.Address
 	DisputeGameFactoryAddr *common.Address
-	DisputeGameType        uint32
+	DisputeGameType        faultTypes.GameType
 
 	// AllowNonFinalized enables the proposal of safe, but non-finalized L2 blocks.
 	// The L1 block-hash embedded in the proposal TX is checked and should ensure the proposal


### PR DESCRIPTION
reference https://github.com/ethereum-optimism/optimism/pull/11012/files#diff-e185c601854d05064e3287f87b5fe932fae27358ad934c328b5779b5fee1a609R80

replace `gametype` from `uint32` to `faultTypes.GameType`