### PR TITLE
chore: update vitalik blog link 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ update-op-geth:
 
 bedrock-markdown-links:
 	docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback \
-		--exclude twitter.com --exclude explorer.optimism.io --exclude linux-mips.org --exclude vitalik.ca \
+		--exclude twitter.com --exclude explorer.optimism.io --exclude linux-mips.org --exclude vitalik.eth.limo \
 		--exclude-mail /input/README.md "/input/specs/**/*.md"
 .PHONY: bedrock-markdown-links
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

According to https://github.com/vbuterin/blog, the blog site now is https://vitalik.eth.limo/. The link in `Makefile` should be updated to ensure the blog site is excluded from lychee check.