### PR TITLE
disalow enable both plasma and fault proof

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -400,6 +400,7 @@ contract Deploy is Deployer {
         // Selectively initialize either the original OptimismPortal or the new OptimismPortal2. Since this will upgrade
         // the proxy, we cannot initialize both.
         if (cfg.useFaultProofs()) {
+            require(!cfg.usePlasma(), "Fault proof can't be used together with plasma");
             console.log("Fault proofs enabled. Initializing the OptimismPortal proxy with the OptimismPortal2.");
             initializeOptimismPortal2();
         } else {


### PR DESCRIPTION
It seem we can't enable both plasma and fault proof until plasma is enabled for op-programe [here](https://github.com/ethereum-optimism/optimism/blob/46c49968de23bbc5f820b3710de248b21b7f05c4/op-program/client/driver/driver.go#L39).

(It's `plasma.Disabled` currently.)