### PR TITLE
op-supervisor: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 /op-program     @ethereum-optimism/go-reviewers
 /op-proposer    @ethereum-optimism/go-reviewers
 /op-service     @ethereum-optimism/go-reviewers
+/op-supervisor  @ethereum-optimism/go-reviewers
 /op-wheel       @ethereum-optimism/go-reviewers
 /ops-bedrock    @ethereum-optimism/go-reviewers
 /op-conductor   @0x00101010 @zhwrd @mslipper


### PR DESCRIPTION
**Description**

Set go-reviewers as the code owner for op-supervisor.