### PR TITLE
Update deploy-config for fjord

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -42,7 +42,7 @@
   "systemConfigStartBlock": 17422444,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000000",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000000",
-  "faultGameAbsolutePrestate": "0x037ef3c1a487960b0e633d3e513df020c43432769f41a634d18a9595cbf53c55",
+  "faultGameAbsolutePrestate": "0x03617abec0b255dc7fc7a0513a2c2220140a1dcd7a1c8eca567659bd67e05cea",
   "faultGameMaxDepth": 73,
   "faultGameClockExtension": 10800,
   "faultGameMaxClockDuration": 302400,


### PR DESCRIPTION
Update the absolute prestate for mainnet in preparation of the Fjord upgrade.

The absolute prestate was built on `op-program/v1.2.0` (see the [fjord gov post](https://gov.optimism.io/t/upgrade-proposal-9-fjord-network-upgrade/8236)). Verify this by checking out `op-program/v1.2.0` and running `make reproducible-prestate`.