### PR TITLE
op-supervisor: Include executing message info when storing logs

### DIFF
--- a/op-service/predeploys/addresses.go
+++ b/op-service/predeploys/addresses.go
@@ -25,6 +25,7 @@ const (
 	L1FeeVault                    = "0x420000000000000000000000000000000000001a"
 	SchemaRegistry                = "0x4200000000000000000000000000000000000020"
 	EAS                           = "0x4200000000000000000000000000000000000021"
+	CrossL2Inbox                  = "0x4200000000000000000000000000000000000022"
 	Create2Deployer               = "0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2"
 	MultiCall3                    = "0xcA11bde05977b3631167028862bE2a173976CA11"
 	Safe_v130                     = "0x69f4D1788e39c87893C980c06EdF4b7f686e2938"
@@ -60,6 +61,7 @@ var (
 	L1FeeVaultAddr                    = common.HexToAddress(L1FeeVault)
 	SchemaRegistryAddr                = common.HexToAddress(SchemaRegistry)
 	EASAddr                           = common.HexToAddress(EAS)
+	CrossL2InboxAddr                  = common.HexToAddress(CrossL2Inbox)
 	Create2DeployerAddr               = common.HexToAddress(Create2Deployer)
 	MultiCall3Addr                    = common.HexToAddress(MultiCall3)
 	Safe_v130Addr                     = common.HexToAddress(Safe_v130)

--- a/op-supervisor/supervisor/backend/source/contracts/l2inbox.go
+++ b/op-supervisor/supervisor/backend/source/contracts/l2inbox.go
@@ -1,0 +1,74 @@
+package contracts
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+const (
+	eventExecutingMessage = "ExecutingMessage"
+)
+
+var (
+	ErrEventNotFound = errors.New("event not found")
+)
+
+type contractIdentifier struct {
+	Origin      common.Address
+	BlockNumber *big.Int
+	LogIndex    *big.Int
+	Timestamp   *big.Int
+	ChainId     *big.Int
+}
+
+type CrossL2Inbox struct {
+	contract *batching.BoundContract
+}
+
+func NewCrossL2Inbox() *CrossL2Inbox {
+	abi := snapshots.LoadCrossL2InboxABI()
+	return &CrossL2Inbox{
+		contract: batching.NewBoundContract(abi, predeploys.CrossL2InboxAddr),
+	}
+}
+
+func (i *CrossL2Inbox) DecodeExecutingMessageLog(l *ethTypes.Log) (db.ExecutingMessage, error) {
+	if l.Address != i.contract.Addr() {
+		return db.ExecutingMessage{}, fmt.Errorf("%w: log not from CrossL2Inbox", ErrEventNotFound)
+	}
+	name, result, err := i.contract.DecodeEvent(l)
+	if errors.Is(err, batching.ErrUnknownEvent) {
+		return db.ExecutingMessage{}, fmt.Errorf("%w: %v", ErrEventNotFound, err.Error())
+	} else if err != nil {
+		return db.ExecutingMessage{}, fmt.Errorf("failed to decode event: %w", err)
+	}
+	if name != eventExecutingMessage {
+		return db.ExecutingMessage{}, fmt.Errorf("%w: event %v not an ExecutingMessage event", ErrEventNotFound, name)
+	}
+	var ident contractIdentifier
+	result.GetStruct(0, &ident)
+	payload := result.GetBytes(1)
+	payloadHash := crypto.Keccak256Hash(payload)
+
+	chainID, err := types.ChainIDFromBig(ident.ChainId).ToUInt32()
+	if err != nil {
+		return db.ExecutingMessage{}, fmt.Errorf("failed to convert chain ID %v to uint32: %w", ident.ChainId, err)
+	}
+	return db.ExecutingMessage{
+		Chain:     chainID,
+		BlockNum:  ident.BlockNumber.Uint64(),
+		LogIdx:    uint32(ident.LogIndex.Uint64()),
+		Timestamp: ident.Timestamp.Uint64(),
+		Hash:      db.TruncateHash(payloadHash),
+	}, nil
+}

--- a/op-supervisor/supervisor/backend/source/contracts/l2inbox_test.go
+++ b/op-supervisor/supervisor/backend/source/contracts/l2inbox_test.go
@@ -1,0 +1,74 @@
+package contracts
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeExecutingMessageEvent(t *testing.T) {
+	inbox := NewCrossL2Inbox()
+	payload := bytes.Repeat([]byte{0xaa, 0xbb}, 50)
+	payloadHash := crypto.Keccak256Hash(payload)
+	expected := db.ExecutingMessage{
+		Chain:     42424,
+		BlockNum:  12345,
+		LogIdx:    98,
+		Timestamp: 9578295,
+		Hash:      db.TruncateHash(payloadHash),
+	}
+	contractIdent := contractIdentifier{
+		Origin:      common.Address{0xbb, 0xcc},
+		BlockNumber: new(big.Int).SetUint64(expected.BlockNum),
+		LogIndex:    new(big.Int).SetUint64(uint64(expected.LogIdx)),
+		Timestamp:   new(big.Int).SetUint64(expected.Timestamp),
+		ChainId:     new(big.Int).SetUint64(uint64(expected.Chain)),
+	}
+	abi := snapshots.LoadCrossL2InboxABI()
+	validData, err := abi.Events[eventExecutingMessage].Inputs.Pack(contractIdent, payload)
+	require.NoError(t, err)
+	createValidLog := func() *ethTypes.Log {
+		return &ethTypes.Log{
+			Address: predeploys.CrossL2InboxAddr,
+			Topics:  []common.Hash{abi.Events[eventExecutingMessage].ID},
+			Data:    validData,
+		}
+	}
+
+	t.Run("ParseValid", func(t *testing.T) {
+		l := createValidLog()
+		result, err := inbox.DecodeExecutingMessageLog(l)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("IgnoreIncorrectContract", func(t *testing.T) {
+		l := createValidLog()
+		l.Address = common.Address{0xff}
+		_, err := inbox.DecodeExecutingMessageLog(l)
+		require.ErrorIs(t, err, ErrEventNotFound)
+	})
+
+	t.Run("IgnoreWrongEvent", func(t *testing.T) {
+		l := createValidLog()
+		l.Topics[0] = common.Hash{0xbb}
+		_, err := inbox.DecodeExecutingMessageLog(l)
+		require.ErrorIs(t, err, ErrEventNotFound)
+	})
+
+	t.Run("ErrorOnInvalidEvent", func(t *testing.T) {
+		l := createValidLog()
+		l.Data = []byte{0xbb, 0xcc}
+		_, err := inbox.DecodeExecutingMessageLog(l)
+		require.ErrorIs(t, err, batching.ErrInvalidEvent)
+	})
+}

--- a/op-supervisor/supervisor/backend/source/log_processor.go
+++ b/op-supervisor/supervisor/backend/source/log_processor.go
@@ -2,10 +2,12 @@ package source
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/source/contracts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -15,19 +17,34 @@ type LogStorage interface {
 	AddLog(logHash db.TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *db.ExecutingMessage) error
 }
 
+type EventDecoder interface {
+	DecodeExecutingMessageLog(log *types.Log) (db.ExecutingMessage, error)
+}
+
 type logProcessor struct {
-	logStore LogStorage
+	logStore     LogStorage
+	eventDecoder EventDecoder
 }
 
 func newLogProcessor(logStore LogStorage) *logProcessor {
-	return &logProcessor{logStore}
+	return &logProcessor{
+		logStore:     logStore,
+		eventDecoder: contracts.NewCrossL2Inbox(),
+	}
 }
 
 func (p *logProcessor) ProcessLogs(_ context.Context, block eth.L1BlockRef, rcpts types.Receipts) error {
 	for _, rcpt := range rcpts {
 		for _, l := range rcpt.Logs {
 			logHash := logToHash(l)
-			err := p.logStore.AddLog(logHash, block.ID(), block.Time, uint32(l.Index), nil)
+			var execMsg *db.ExecutingMessage
+			msg, err := p.eventDecoder.DecodeExecutingMessageLog(l)
+			if err != nil && !errors.Is(err, contracts.ErrEventNotFound) {
+				return fmt.Errorf("failed to decode executing message log: %w", err)
+			} else if err == nil {
+				execMsg = &msg
+			}
+			err = p.logStore.AddLog(logHash, block.ID(), block.Time, uint32(l.Index), execMsg)
 			if err != nil {
 				// TODO(optimism#11044): Need to roll back to the start of the block....
 				return fmt.Errorf("failed to add log %d from block %v: %w", l.Index, block.ID(), err)

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,9 +23,8 @@ func FuzzRoundtripIdentifierJSONMarshal(f *testing.F) {
 			BlockNumber: blockNumber,
 			LogIndex:    logIndex,
 			Timestamp:   timestamp,
-			ChainID:     uint256.Int{},
+			ChainID:     ChainIDFromBig(new(big.Int).SetBytes(chainID)),
 		}
-		id.ChainID.SetBytes(chainID)
 
 		raw, err := json.Marshal(&id)
 		require.NoError(t, err)

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -131,10 +131,37 @@
     "anonymous": false,
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
         "indexed": false,
-        "internalType": "bytes",
+        "internalType": "struct ICrossL2Inbox.Identifier",
         "name": "encodedId",
-        "type": "bytes"
+        "type": "tuple"
       },
       {
         "indexed": false,

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -22,6 +22,9 @@ var mips []byte
 //go:embed abi/DelayedWETH.json
 var delayedWETH []byte
 
+//go:embed abi/CrossL2Inbox.json
+var crossL2Inbox []byte
+
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
 }
@@ -36,6 +39,9 @@ func LoadMIPSABI() *abi.ABI {
 }
 func LoadDelayedWETHABI() *abi.ABI {
 	return loadABI(delayedWETH)
+}
+func LoadCrossL2InboxABI() *abi.ABI {
+	return loadABI(crossL2Inbox)
 }
 
 func loadABI(json []byte) *abi.ABI {

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -62,7 +62,7 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
     /// @notice Emitted when a cross chain message is being executed.
     /// @param encodedId Encoded Identifier of the message.
     /// @param message   Message payload being executed.
-    event ExecutingMessage(bytes encodedId, bytes message);
+    event ExecutingMessage(Identifier encodedId, bytes message);
 
     /// @notice Enforces that cross domain message sender and source are set. Reverts if not.
     ///         Used to differentiate between 0 and nil in transient storage.
@@ -128,7 +128,7 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
         // Revert if the target call failed.
         if (!success) revert TargetCallFailed();
 
-        emit ExecutingMessage(abi.encode(_id), _message);
+        emit ExecutingMessage(_id, _message);
     }
 
     /// @notice Stores the Identifier in transient storage.

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -102,7 +102,7 @@ contract CrossL2InboxTest is Test {
 
         // Look for the emit ExecutingMessage event
         vm.expectEmit(Predeploys.CROSS_L2_INBOX);
-        emit CrossL2Inbox.ExecutingMessage(abi.encode(_id), _message);
+        emit CrossL2Inbox.ExecutingMessage(_id, _message);
 
         // Call the executeMessage function
         crossL2Inbox.executeMessage{ value: _value }({ _id: _id, _target: _target, _message: _message });


### PR DESCRIPTION
**Description**

Parse `ExecutingMessage` events for logs and include it when storing in the database.

To make parsing the identifier straight forward, this changes the solidity to include `Identifier` in the event definition instead of first encoding it to `bytes`. This will conflict with the changes proposed in https://github.com/ethereum-optimism/specs/pull/254 which move to publishing the payload hash rather than the full payload but easy enough to resolve the difference.  Will need to update the spec if we're happy with this change as well.

**Tests**

Added unit tests for parsing the log info.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/11024
