### PR TITLE
op-supervisor: Fix startup from empty database

### DIFF
--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -1,0 +1,69 @@
+package backend
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecover(t *testing.T) {
+	tests := []struct {
+		name             string
+		stubDB           *stubLogStore
+		expectedBlockNum uint64
+		expectRewoundTo  uint64
+	}{
+		{
+			name:             "emptydb",
+			stubDB:           &stubLogStore{closestBlockErr: fmt.Errorf("no entries: %w", io.EOF)},
+			expectedBlockNum: 0,
+			expectRewoundTo:  0,
+		},
+		{
+			name:             "genesis",
+			stubDB:           &stubLogStore{},
+			expectedBlockNum: 0,
+			expectRewoundTo:  0,
+		},
+		{
+			name:             "with_blocks",
+			stubDB:           &stubLogStore{closestBlockNumber: 15},
+			expectedBlockNum: 14,
+			expectRewoundTo:  14,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			block, err := Resume(test.stubDB)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedBlockNum, block)
+			require.Equal(t, test.expectRewoundTo, test.stubDB.rewoundTo)
+		})
+	}
+}
+
+type stubLogStore struct {
+	closestBlockNumber uint64
+	closestBlockErr    error
+	rewoundTo          uint64
+}
+
+func (s *stubLogStore) Close() error {
+	return nil
+}
+
+func (s *stubLogStore) ClosestBlockInfo(blockNum uint64) (uint64, db.TruncatedHash, error) {
+	if s.closestBlockErr != nil {
+		return 0, db.TruncatedHash{}, s.closestBlockErr
+	}
+	return s.closestBlockNumber, db.TruncatedHash{}, nil
+}
+
+func (s *stubLogStore) Rewind(headBlockNum uint64) error {
+	s.rewoundTo = headBlockNum
+	return nil
+}

--- a/op-supervisor/supervisor/backend/init.go
+++ b/op-supervisor/supervisor/backend/init.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+)
+
+// Resume prepares the given LogStore to resume recording events.
+// It returns the block number of the last block that is guaranteed to have been fully recorded to the database
+// and rewinds the database to ensure it can resume recording from the first log of the next block.
+func Resume(logDB LogStore) (uint64, error) {
+	// Get the last checkpoint that was written then Rewind the db
+	// to the block prior to that block and start from there.
+	// Guarantees we will always roll back at least one block
+	// so we know we're always starting from a fully written block.
+	checkPointBlock, _, err := logDB.ClosestBlockInfo(math.MaxUint64)
+	if errors.Is(err, io.EOF) {
+		// No blocks recorded in the database, start from genesis
+		return 0, nil
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to get block from checkpoint: %w", err)
+	}
+	if checkPointBlock == 0 {
+		return 0, nil
+	}
+	block := checkPointBlock - 1
+	err = logDB.Rewind(block)
+	if err != nil {
+		return 0, fmt.Errorf("failed to 'Rewind' the database: %w", err)
+	}
+	return block, nil
+}


### PR DESCRIPTION
**Description**

The code to determine the first block to begin recording from didn't handle the `io.EOF` error when the db was empty.  Fix that and add tests.
