### PR TITLE
error message should not punctuation

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -492,7 +492,7 @@ func (s *Driver) StartSequencer(ctx context.Context, blockHash common.Hash) erro
 	if isLeader, err := s.sequencerConductor.Leader(ctx); err != nil {
 		return fmt.Errorf("sequencer leader check failed: %w", err)
 	} else if !isLeader {
-		return errors.New("sequencer is not the leader, aborting.")
+		return errors.New("sequencer is not the leader, aborting")
 	}
 	h := hashAndErrorChannel{
 		hash: blockHash,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

error strings should not end with punctuation or newlines 

it might bring some unexpected results

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
