### PR TITLE
devtools: Add lint-go-fix command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ lint-go:
 	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
 .PHONY: lint-go
 
+lint-go-fix:
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: lint-go-fix
+
 build-ts: submodules
 	if [ -f "$$NVM_DIR/nvm.sh" ]; then \
 		. $$NVM_DIR/nvm.sh && nvm use; \


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add a `lint-go-fix` target to the root Makefile.  This makes it straightforward to fix linting errors highlighted by the `lint-go` target.
