### PR TITLE
op-node: Add an alias to the import to pass the 'make lint-go-fix check'.

### DIFF
--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	ds "github.com/ipfs/go-datastore"
-	"github.com/libp2p/go-libp2p"
+	libp2p "github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/connmgr"

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -11,7 +11,7 @@ import (
 
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
-	"github.com/libp2p/go-libp2p"
+	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"


### PR DESCRIPTION
Based on https://github.com/ethereum-optimism/optimism/pull/11120
```
op-node/p2p/config.go:101:24: undefined: libp2p (typecheck)
        HostMux             []libp2p.Option
                              ^
op-node/p2p/config.go:102:24: undefined: libp2p (typecheck)
        HostSecurity        []libp2p.Option
                              ^
op-node/p2p/host_test.go:46:26: undefined: libp2p (typecheck)
                HostMux:             []libp2p.Option{YamuxC()},
```