### PR TITLE
op-supervisor: Refactor types

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/config"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/source"
+	backendTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -22,7 +23,7 @@ import (
 
 type LogStore interface {
 	io.Closer
-	ClosestBlockInfo(blockNum uint64) (uint64, db.TruncatedHash, error)
+	ClosestBlockInfo(blockNum uint64) (uint64, backendTypes.TruncatedHash, error)
 	Rewind(headBlockNum uint64) error
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,11 +56,11 @@ func (s *stubLogStore) Close() error {
 	return nil
 }
 
-func (s *stubLogStore) ClosestBlockInfo(blockNum uint64) (uint64, db.TruncatedHash, error) {
+func (s *stubLogStore) ClosestBlockInfo(blockNum uint64) (uint64, types.TruncatedHash, error) {
 	if s.closestBlockErr != nil {
-		return 0, db.TruncatedHash{}, s.closestBlockErr
+		return 0, types.TruncatedHash{}, s.closestBlockErr
 	}
-	return s.closestBlockNumber, db.TruncatedHash{}, nil
+	return s.closestBlockNumber, types.TruncatedHash{}, nil
 }
 
 func (s *stubLogStore) Rewind(headBlockNum uint64) error {

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -900,8 +900,12 @@ func (s *stubEntryStore) Size() int64 {
 	return int64(len(s.entries))
 }
 
-func (s *stubEntryStore) Read(idx int64) (entrydb.Entry, error) {
-	if idx < int64(len(s.entries)) {
+func (s *stubEntryStore) LastEntryIdx() entrydb.EntryIdx {
+	return entrydb.EntryIdx(s.Size() - 1)
+}
+
+func (s *stubEntryStore) Read(idx entrydb.EntryIdx) (entrydb.Entry, error) {
+	if idx < entrydb.EntryIdx(len(s.entries)) {
 		return s.entries[idx], nil
 	}
 	return entrydb.Entry{}, io.EOF
@@ -912,8 +916,8 @@ func (s *stubEntryStore) Append(entries ...entrydb.Entry) error {
 	return nil
 }
 
-func (s *stubEntryStore) Truncate(idx int64) error {
-	s.entries = s.entries[:min(s.Size()-1, idx+1)]
+func (s *stubEntryStore) Truncate(idx entrydb.EntryIdx) error {
+	s.entries = s.entries[:min(s.Size()-1, int64(idx+1))]
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -177,7 +177,7 @@ func TestWriteErrors(t *testing.T) {
 	})
 }
 
-func requireRead(t *testing.T, db *EntryDB, idx int64, expected Entry) {
+func requireRead(t *testing.T, db *EntryDB, idx EntryIdx, expected Entry) {
 	actual, err := db.Read(idx)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
@@ -199,7 +199,7 @@ func createEntryDB(t *testing.T) *EntryDB {
 
 func createEntryDBWithStubData() (*EntryDB, *stubDataAccess) {
 	stubData := &stubDataAccess{}
-	db := &EntryDB{data: stubData, size: 0}
+	db := &EntryDB{data: stubData, lastEntryIdx: -1}
 	return db, stubData
 }
 

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 )
 
 type iterator struct {
@@ -16,7 +18,7 @@ type iterator struct {
 	entriesRead int64
 }
 
-func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedHash, outErr error) {
+func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash types.TruncatedHash, outErr error) {
 	for i.nextEntryIdx <= i.db.lastEntryIdx() {
 		entryIdx := i.nextEntryIdx
 		entry, err := i.db.store.Read(entryIdx)
@@ -60,29 +62,29 @@ func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash TruncatedH
 	return
 }
 
-func (i *iterator) ExecMessage() (ExecutingMessage, error) {
+func (i *iterator) ExecMessage() (types.ExecutingMessage, error) {
 	if !i.hasExecMsg {
-		return ExecutingMessage{}, nil
+		return types.ExecutingMessage{}, nil
 	}
 	// Look ahead to find the exec message info
 	logEntryIdx := i.nextEntryIdx - 1
 	execMsg, err := i.readExecMessage(logEntryIdx)
 	if err != nil {
-		return ExecutingMessage{}, fmt.Errorf("failed to read exec message for initiating event at %v: %w", logEntryIdx, err)
+		return types.ExecutingMessage{}, fmt.Errorf("failed to read exec message for initiating event at %v: %w", logEntryIdx, err)
 	}
 	return execMsg, nil
 }
 
-func (i *iterator) readExecMessage(initEntryIdx int64) (ExecutingMessage, error) {
+func (i *iterator) readExecMessage(initEntryIdx int64) (types.ExecutingMessage, error) {
 	linkIdx := initEntryIdx + 1
 	if linkIdx%searchCheckpointFrequency == 0 {
 		linkIdx += 2 // skip the search checkpoint and canonical hash entries
 	}
 	linkEntry, err := i.db.store.Read(linkIdx)
 	if errors.Is(err, io.EOF) {
-		return ExecutingMessage{}, fmt.Errorf("%w: missing expected executing link event at idx %v", ErrDataCorruption, linkIdx)
+		return types.ExecutingMessage{}, fmt.Errorf("%w: missing expected executing link event at idx %v", ErrDataCorruption, linkIdx)
 	} else if err != nil {
-		return ExecutingMessage{}, fmt.Errorf("failed to read executing link event at idx %v: %w", linkIdx, err)
+		return types.ExecutingMessage{}, fmt.Errorf("failed to read executing link event at idx %v: %w", linkIdx, err)
 	}
 
 	checkIdx := linkIdx + 1
@@ -91,9 +93,9 @@ func (i *iterator) readExecMessage(initEntryIdx int64) (ExecutingMessage, error)
 	}
 	checkEntry, err := i.db.store.Read(checkIdx)
 	if errors.Is(err, io.EOF) {
-		return ExecutingMessage{}, fmt.Errorf("%w: missing expected executing check event at idx %v", ErrDataCorruption, checkIdx)
+		return types.ExecutingMessage{}, fmt.Errorf("%w: missing expected executing check event at idx %v", ErrDataCorruption, checkIdx)
 	} else if err != nil {
-		return ExecutingMessage{}, fmt.Errorf("failed to read executing check event at idx %v: %w", checkIdx, err)
+		return types.ExecutingMessage{}, fmt.Errorf("failed to read executing check event at idx %v: %w", checkIdx, err)
 	}
 	return newExecutingMessageFromEntries(linkEntry, checkEntry)
 }

--- a/op-supervisor/supervisor/backend/db/iterator.go
+++ b/op-supervisor/supervisor/backend/db/iterator.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 )
 
 type iterator struct {
 	db           *DB
-	nextEntryIdx int64
+	nextEntryIdx entrydb.EntryIdx
 
 	current    logContext
 	hasExecMsg bool
@@ -75,7 +76,7 @@ func (i *iterator) ExecMessage() (types.ExecutingMessage, error) {
 	return execMsg, nil
 }
 
-func (i *iterator) readExecMessage(initEntryIdx int64) (types.ExecutingMessage, error) {
+func (i *iterator) readExecMessage(initEntryIdx entrydb.EntryIdx) (types.ExecutingMessage, error) {
 	linkIdx := initEntryIdx + 1
 	if linkIdx%searchCheckpointFrequency == 0 {
 		linkIdx += 2 // skip the search checkpoint and canonical hash entries

--- a/op-supervisor/supervisor/backend/source/log_processor.go
+++ b/op-supervisor/supervisor/backend/source/log_processor.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type LogStorage interface {
-	AddLog(logHash db.TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *db.ExecutingMessage) error
+	AddLog(logHash types.TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *types.ExecutingMessage) error
 }
 
 type logProcessor struct {
@@ -23,7 +23,7 @@ func newLogProcessor(logStore LogStorage) *logProcessor {
 	return &logProcessor{logStore}
 }
 
-func (p *logProcessor) ProcessLogs(_ context.Context, block eth.L1BlockRef, rcpts types.Receipts) error {
+func (p *logProcessor) ProcessLogs(_ context.Context, block eth.L1BlockRef, rcpts ethTypes.Receipts) error {
 	for _, rcpt := range rcpts {
 		for _, l := range rcpt.Logs {
 			logHash := logToHash(l)
@@ -36,15 +36,15 @@ func (p *logProcessor) ProcessLogs(_ context.Context, block eth.L1BlockRef, rcpt
 	return nil
 }
 
-func logToHash(l *types.Log) db.TruncatedHash {
+func logToHash(l *ethTypes.Log) types.TruncatedHash {
 	payloadHash := crypto.Keccak256(logToPayload(l))
 	msg := make([]byte, 0, 2*common.HashLength)
 	msg = append(msg, l.Address.Bytes()...)
 	msg = append(msg, payloadHash...)
-	return db.TruncateHash(crypto.Keccak256Hash(msg))
+	return types.TruncateHash(crypto.Keccak256Hash(msg))
 }
 
-func logToPayload(l *types.Log) []byte {
+func logToPayload(l *ethTypes.Log) []byte {
 	msg := make([]byte, 0)
 	for _, topic := range l.Topics {
 		msg = append(msg, topic.Bytes()...)

--- a/op-supervisor/supervisor/backend/source/log_processor_test.go
+++ b/op-supervisor/supervisor/backend/source/log_processor_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,15 +18,15 @@ func TestLogProcessor(t *testing.T) {
 		store := &stubLogStorage{}
 		processor := newLogProcessor(store)
 
-		err := processor.ProcessLogs(ctx, block1, types.Receipts{})
+		err := processor.ProcessLogs(ctx, block1, ethTypes.Receipts{})
 		require.NoError(t, err)
 		require.Empty(t, store.logs)
 	})
 
 	t.Run("OutputLogs", func(t *testing.T) {
-		rcpts := types.Receipts{
+		rcpts := ethTypes.Receipts{
 			{
-				Logs: []*types.Log{
+				Logs: []*ethTypes.Log{
 					{
 						Address: common.Address{0x11},
 						Topics:  []common.Hash{{0xaa}},
@@ -40,7 +40,7 @@ func TestLogProcessor(t *testing.T) {
 				},
 			},
 			{
-				Logs: []*types.Log{
+				Logs: []*ethTypes.Log{
 					{
 						Address: common.Address{0x33},
 						Topics:  []common.Hash{{0xee}},
@@ -82,8 +82,8 @@ func TestLogProcessor(t *testing.T) {
 }
 
 func TestToLogHash(t *testing.T) {
-	mkLog := func() *types.Log {
-		return &types.Log{
+	mkLog := func() *ethTypes.Log {
+		return &ethTypes.Log{
 			Address: common.Address{0xaa, 0xbb},
 			Topics: []common.Hash{
 				{0xcc},
@@ -98,27 +98,27 @@ func TestToLogHash(t *testing.T) {
 			Removed:     false,
 		}
 	}
-	relevantMods := []func(l *types.Log){
-		func(l *types.Log) { l.Address = common.Address{0xab, 0xcd} },
-		func(l *types.Log) { l.Topics = append(l.Topics, common.Hash{0x12, 0x34}) },
-		func(l *types.Log) { l.Topics = l.Topics[:len(l.Topics)-1] },
-		func(l *types.Log) { l.Topics[0] = common.Hash{0x12, 0x34} },
-		func(l *types.Log) { l.Data = append(l.Data, 0x56) },
-		func(l *types.Log) { l.Data = l.Data[:len(l.Data)-1] },
-		func(l *types.Log) { l.Data[0] = 0x45 },
+	relevantMods := []func(l *ethTypes.Log){
+		func(l *ethTypes.Log) { l.Address = common.Address{0xab, 0xcd} },
+		func(l *ethTypes.Log) { l.Topics = append(l.Topics, common.Hash{0x12, 0x34}) },
+		func(l *ethTypes.Log) { l.Topics = l.Topics[:len(l.Topics)-1] },
+		func(l *ethTypes.Log) { l.Topics[0] = common.Hash{0x12, 0x34} },
+		func(l *ethTypes.Log) { l.Data = append(l.Data, 0x56) },
+		func(l *ethTypes.Log) { l.Data = l.Data[:len(l.Data)-1] },
+		func(l *ethTypes.Log) { l.Data[0] = 0x45 },
 	}
-	irrelevantMods := []func(l *types.Log){
-		func(l *types.Log) { l.BlockNumber = 987 },
-		func(l *types.Log) { l.TxHash = common.Hash{0xab, 0xcd} },
-		func(l *types.Log) { l.TxIndex = 99 },
-		func(l *types.Log) { l.BlockHash = common.Hash{0xab, 0xcd} },
-		func(l *types.Log) { l.Index = 98 },
-		func(l *types.Log) { l.Removed = true },
+	irrelevantMods := []func(l *ethTypes.Log){
+		func(l *ethTypes.Log) { l.BlockNumber = 987 },
+		func(l *ethTypes.Log) { l.TxHash = common.Hash{0xab, 0xcd} },
+		func(l *ethTypes.Log) { l.TxIndex = 99 },
+		func(l *ethTypes.Log) { l.BlockHash = common.Hash{0xab, 0xcd} },
+		func(l *ethTypes.Log) { l.Index = 98 },
+		func(l *ethTypes.Log) { l.Removed = true },
 	}
 	refHash := logToHash(mkLog())
 	// The log hash is stored in the database so test that it matches the actual value.
 	// If this changes compatibility with existing databases may be affected
-	expectedRefHash := db.TruncateHash(common.HexToHash("0x4e1dc08fddeb273275f787762cdfe945cf47bb4e80a1fabbc7a825801e81b73f"))
+	expectedRefHash := types.TruncateHash(common.HexToHash("0x4e1dc08fddeb273275f787762cdfe945cf47bb4e80a1fabbc7a825801e81b73f"))
 	require.Equal(t, expectedRefHash, refHash, "reference hash changed, check that database compatibility is not broken")
 
 	// Check that the hash is changed when any data it should include changes
@@ -141,7 +141,7 @@ type stubLogStorage struct {
 	logs []storedLog
 }
 
-func (s *stubLogStorage) AddLog(logHash db.TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *db.ExecutingMessage) error {
+func (s *stubLogStorage) AddLog(logHash types.TruncatedHash, block eth.BlockID, timestamp uint64, logIdx uint32, execMsg *types.ExecutingMessage) error {
 	s.logs = append(s.logs, storedLog{
 		block:     block,
 		timestamp: timestamp,
@@ -156,6 +156,6 @@ type storedLog struct {
 	block     eth.BlockID
 	timestamp uint64
 	logIdx    uint32
-	logHash   db.TruncatedHash
-	execMsg   *db.ExecutingMessage
+	logHash   types.TruncatedHash
+	execMsg   *types.ExecutingMessage
 }

--- a/op-supervisor/supervisor/backend/types/types.go
+++ b/op-supervisor/supervisor/backend/types/types.go
@@ -1,16 +1,9 @@
-package db
+package types
 
 import (
 	"encoding/hex"
-	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
-)
-
-var (
-	ErrLogOutOfOrder  = errors.New("log out of order")
-	ErrDataCorruption = errors.New("data corruption")
-	ErrNotFound       = errors.New("not found")
 )
 
 type TruncatedHash [20]byte


### PR DESCRIPTION
**Description**

Two changes to the types used in the op-supervisor types:

1. Move the `TruncatedHash` and `ExecutionMessage` types to a backend/types package instead of being under the db package.  They wind up being used outside the database more than expected and in ways that are pretty core to the backend rather than just being a storage format (largely because you can't convert back from them to the original Hash and Identifier).
2. Introduce a `EntryIdx` type for indexing into the entry store database. This is just an alias for `int64` but reduces the confusion about whether a value is a block number or entry index as we move forward to tracking heads (I'm already getting confused).