### PR TITLE
op-challenger: clarify the output

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -116,13 +116,13 @@ func listClaims(ctx context.Context, game contracts.FaultDisputeGameContract, ve
 	}
 	now := time.Now()
 	lineFormat := "%3v %-7v %6v %5v %14v " + valueFormat + " %-42v %12v %-19v %10v %v\n"
-	info := fmt.Sprintf(lineFormat, "Idx", "Move", "Parent", "Depth", "Index", "Value", "Claimant", "Bond (ETH)", "Time", "Clock Used", "Resolution")
+	info := fmt.Sprintf(lineFormat, "Idx", "Move", "Parent", "Depth", "Trace_Index", "Claim_Value", "Claimant", "Bond (ETH)", "Time", "Clock_Used", "Resolution")
 	for i, claim := range claims {
 		pos := claim.Position
 		parent := strconv.Itoa(claim.ParentContractIndex)
 		var elapsed time.Duration // Root claim does not accumulate any time on its team's chess clock
 		if claim.IsRoot() {
-			parent = ""
+			parent = "N/A"
 		} else {
 			parentClaim, err := gameState.GetParent(claim)
 			if err != nil {

--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -116,13 +116,13 @@ func listClaims(ctx context.Context, game contracts.FaultDisputeGameContract, ve
 	}
 	now := time.Now()
 	lineFormat := "%3v %-7v %6v %5v %14v " + valueFormat + " %-42v %12v %-19v %10v %v\n"
-	info := fmt.Sprintf(lineFormat, "Idx", "Move", "Parent", "Depth", "Trace_Index", "Claim_Value", "Claimant", "Bond (ETH)", "Time", "Clock_Used", "Resolution")
+	info := fmt.Sprintf(lineFormat, "Idx", "Move", "Parent", "Depth", "Trace", "Value", "Claimant", "Bond (ETH)", "Time", "Clock Used", "Resolution")
 	for i, claim := range claims {
 		pos := claim.Position
 		parent := strconv.Itoa(claim.ParentContractIndex)
 		var elapsed time.Duration // Root claim does not accumulate any time on its team's chess clock
 		if claim.IsRoot() {
-			parent = "N/A"
+			parent = "-"
 		} else {
 			parentClaim, err := gameState.GetParent(claim)
 			if err != nil {


### PR DESCRIPTION
For my first time to use `./bin/op-challenger list-claims`
The data name really confuses me, after I check the spces, I found the index means for Trace_Index, we should clarify it. And the parent for the root shouldn't be `NIL`, Because of the missing data, I mistakenly thought that `Parent Depth` was a whole data, not two data. 