### PR TITLE
op-node: batch-decoder: Fjord Frame Timestamp fix

### DIFF
--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -25,7 +25,7 @@ type ChannelWithMetadata struct {
 	Frames         []FrameWithMetadata      `json:"frames"`
 	Batches        []derive.Batch           `json:"batches"`
 	BatchTypes     []int                    `json:"batch_types"`
-	ComprAlgos     []derive.CompressionAlgo `json:"compr_alogs"`
+	ComprAlgos     []derive.CompressionAlgo `json:"compr_algos"`
 }
 
 type FrameWithMetadata struct {

--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -101,7 +101,7 @@ func processFrames(cfg Config, rollupCfg *rollup.Config, id derive.ChannelID, fr
 			invalidFrame = true
 			break
 		}
-		if err := ch.AddFrame(frame.Frame, eth.L1BlockRef{Number: frame.InclusionBlock}); err != nil {
+		if err := ch.AddFrame(frame.Frame, eth.L1BlockRef{Number: frame.InclusionBlock, Time: frame.Timestamp}); err != nil {
 			fmt.Printf("Error adding to channel %v. Err: %v\n", id.String(), err)
 			invalidFrame = true
 		}


### PR DESCRIPTION
**Description**

Two fixes;
- `derive.BatchReader` got aware of channel's timestamp(or frame's timestamp) starting from Fjord network upgrade. Batch decoder manually reconstructs frames from json, and previously it did not supply frame timestamps because it was not necessary for pre-Fjord. Now we need the correct timestamp.
- Fixed json key typo for compression algos, for channels.

**Tests**

Manually tested at the first Fjord op-mainnet batch.

First fetch batch transaction.
```sh
./batch_decoder fetch --start=20277208 --end=20278210 --sender=0x6887246668a3b87F54DeB3b94Ba47a6f63F32985  --inbox=0xFF00000000000000000000000000000000000010 --l1=[L1_RPC] --l1.beacon=[L1_BEACON]
```

Then reassemble to make a channel.
```
./batch_decoder reassemble --inbox=0xFF00000000000000000000000000000000000010 --in=/tmp/batch_decoder/transactions_cache
```

Before this patch, batch decoder emitted `Err: cannot accept brotli compressed batch before Fjord` error, and stores channels which contains no batches. After this patch, It correctly stores batches and compression algos.

