### PR TITLE
Bedrock/dispute: The implement of `Step()` in  `FaultDisputeGame.sol` looks weird. (DO NOT MERGE)

### DIFF
--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -287,21 +287,10 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         // Compute the local preimage context for the step.
         Hash uuid = _findLocalContext(_claimIndex);
 
-        // INVARIANT: If a step is an attack, the poststate is valid if the step produces
-        //            the same poststate hash as the parent claim's value.
-        //            If a step is a defense:
-        //              1. If the parent claim and the found post state agree with each other
-        //                 (depth diff % 2 == 0), the step is valid if it produces the same
-        //                 state hash as the post state's claim.
-        //              2. If the parent claim and the found post state disagree with each other
-        //                 (depth diff % 2 != 0), the parent cannot be countered unless the step
-        //                 produces the same state hash as `postState.claim`.
-        // SAFETY:    While the `attack` path does not need an extra check for the post
-        //            state's depth in relation to the parent, we don't need another
-        //            branch because (n - n) % 2 == 0.
+        // INVARIANT: No matter the step is an attack or defend. If the step claim equal postStateClaim
+        // The parentClaim can not be countered.
         bool validStep = VM.step(_stateData, _proof, uuid.raw()) == postState.claim.raw();
-        bool parentPostAgree = (parentPos.depth() - postState.position.depth()) % 2 == 0;
-        if (parentPostAgree == validStep) revert ValidStep();
+        if (validStep) revert ValidStep();
 
         // INVARIANT: A step cannot be made against a claim for a second time.
         if (parent.counteredBy != address(0)) revert DuplicateStep();


### PR DESCRIPTION
1. According to the [spces](https://github.com/ethereum-optimism/specs/blob/dfa8ea9568b0e35827be763fa8e6a2eeb9d90704/specs/fault-proof/stage-one/fault-dispute-game.md#step-types)

According to the specifications, the operations "attack" and "defend" are used for countering claims at the finest granularity, i.e., at the maximum game depth. Specifically, an "attack" begins from the left by comparing the claim with the output to prove its validity, while a "defend" starts from the right, using the claim as the input and then comparing it with the output. However, the expression `bool parentPostAgree = (parentPos.depth() - postState.position.depth()) % 2 == 0`; in the code, I believe, always returns true, thus it seems to be meaningless. The explanation in the comments is also confusing. To better illustrate these scenarios, I have created some diagrams for demonstration.
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/ed4d3fda-9270-4d33-abc3-5e78a828aca1">
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/a623cbf0-907d-4b90-a907-158121983de6">


2.  [this line](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol#L252)        ` Position stepPos = parentPos.move(_isAttack);`

In my view, the use of the variable stepPos in the entire function is solely to determine whether to use the absolute state later on, which can make the usage and logic of variables misleading. I understand that the step function is designed to finally counter the moves made at the finest granularity. However, the current naming of variables in step might give the impression that there is another layer beneath the maximum game depth, and that this layer is the trace layer, as suggested by names like stepPos.
