### PR TITLE
op-supervisor: Add IDs to database entries

### DIFF
--- a/op-supervisor/supervisor/backend/db/heads/heads_test.go
+++ b/op-supervisor/supervisor/backend/db/heads/heads_test.go
@@ -15,21 +15,21 @@ func TestHeads_SaveAndReload(t *testing.T) {
 	path := filepath.Join(dir, "heads.json")
 	chainA := types.ChainIDFromUInt64(3)
 	chainAHeads := ChainHeads{
-		Unsafe:         1,
-		CrossUnsafe:    2,
-		LocalSafe:      3,
-		CrossSafe:      4,
-		LocalFinalized: 5,
-		CrossFinalized: 6,
+		Unsafe:         ChainHead{Index: 10, ID: 100},
+		CrossUnsafe:    ChainHead{Index: 9, ID: 99},
+		LocalSafe:      ChainHead{Index: 8, ID: 98},
+		CrossSafe:      ChainHead{Index: 7, ID: 97},
+		LocalFinalized: ChainHead{Index: 6, ID: 96},
+		CrossFinalized: ChainHead{Index: 5, ID: 95},
 	}
 	chainB := types.ChainIDFromUInt64(5)
 	chainBHeads := ChainHeads{
-		Unsafe:         11,
-		CrossUnsafe:    12,
-		LocalSafe:      13,
-		CrossSafe:      14,
-		LocalFinalized: 15,
-		CrossFinalized: 16,
+		Unsafe:         ChainHead{Index: 90, ID: 9},
+		CrossUnsafe:    ChainHead{Index: 80, ID: 8},
+		LocalSafe:      ChainHead{Index: 70, ID: 7},
+		CrossSafe:      ChainHead{Index: 60, ID: 6},
+		LocalFinalized: ChainHead{Index: 50, ID: 5},
+		CrossFinalized: ChainHead{Index: 40, ID: 4},
 	}
 
 	orig, err := NewHeadTracker(path)
@@ -53,12 +53,12 @@ func TestHeads_NoChangesMadeIfOperationFails(t *testing.T) {
 	path := filepath.Join(dir, "heads.json")
 	chainA := types.ChainIDFromUInt64(3)
 	chainAHeads := ChainHeads{
-		Unsafe:         1,
-		CrossUnsafe:    2,
-		LocalSafe:      3,
-		CrossSafe:      4,
-		LocalFinalized: 5,
-		CrossFinalized: 6,
+		Unsafe:         ChainHead{Index: 10, ID: 100},
+		CrossUnsafe:    ChainHead{Index: 9, ID: 99},
+		LocalSafe:      ChainHead{Index: 8, ID: 98},
+		CrossSafe:      ChainHead{Index: 7, ID: 97},
+		LocalFinalized: ChainHead{Index: 6, ID: 96},
+		CrossFinalized: ChainHead{Index: 5, ID: 95},
 	}
 
 	orig, err := NewHeadTracker(path)
@@ -79,15 +79,16 @@ func TestHeads_NoChangesMadeIfOperationFails(t *testing.T) {
 
 func TestHeads_NoChangesMadeIfWriteFails(t *testing.T) {
 	dir := t.TempDir()
+	// Write will fail because directory doesn't exist.
 	path := filepath.Join(dir, "invalid/heads.json")
 	chainA := types.ChainIDFromUInt64(3)
 	chainAHeads := ChainHeads{
-		Unsafe:         1,
-		CrossUnsafe:    2,
-		LocalSafe:      3,
-		CrossSafe:      4,
-		LocalFinalized: 5,
-		CrossFinalized: 6,
+		Unsafe:         ChainHead{Index: 10, ID: 100},
+		CrossUnsafe:    ChainHead{Index: 9, ID: 99},
+		LocalSafe:      ChainHead{Index: 8, ID: 98},
+		CrossSafe:      ChainHead{Index: 7, ID: 97},
+		LocalFinalized: ChainHead{Index: 6, ID: 96},
+		CrossFinalized: ChainHead{Index: 5, ID: 95},
 	}
 
 	orig, err := NewHeadTracker(path)

--- a/op-supervisor/supervisor/backend/db/heads/types.go
+++ b/op-supervisor/supervisor/backend/db/heads/types.go
@@ -14,12 +14,17 @@ import (
 // So we probably need to store actual block IDs here... but then we don't have the block hash for every block in the log db.
 // Only jumping the head forward on checkpoint blocks doesn't work though...
 type ChainHeads struct {
-	Unsafe         entrydb.EntryIdx `json:"localUnsafe"`
-	CrossUnsafe    entrydb.EntryIdx `json:"crossUnsafe"`
-	LocalSafe      entrydb.EntryIdx `json:"localSafe"`
-	CrossSafe      entrydb.EntryIdx `json:"crossSafe"`
-	LocalFinalized entrydb.EntryIdx `json:"localFinalized"`
-	CrossFinalized entrydb.EntryIdx `json:"crossFinalized"`
+	Unsafe         ChainHead `json:"localUnsafe"`
+	CrossUnsafe    ChainHead `json:"crossUnsafe"`
+	LocalSafe      ChainHead `json:"localSafe"`
+	CrossSafe      ChainHead `json:"crossSafe"`
+	LocalFinalized ChainHead `json:"localFinalized"`
+	CrossFinalized ChainHead `json:"crossFinalized"`
+}
+
+type ChainHead struct {
+	Index entrydb.EntryIdx `json:"index"`
+	ID    entrydb.EntryID  `json:"id"`
 }
 
 type Heads struct {

--- a/op-supervisor/supervisor/backend/db/heads/types_test.go
+++ b/op-supervisor/supervisor/backend/db/heads/types_test.go
@@ -13,28 +13,28 @@ func TestHeads(t *testing.T) {
 	t.Run("RoundTripViaJson", func(t *testing.T) {
 		heads := NewHeads()
 		heads.Put(types.ChainIDFromUInt64(3), ChainHeads{
-			Unsafe:         10,
-			CrossUnsafe:    9,
-			LocalSafe:      8,
-			CrossSafe:      7,
-			LocalFinalized: 6,
-			CrossFinalized: 5,
+			Unsafe:         ChainHead{Index: 10, ID: 100},
+			CrossUnsafe:    ChainHead{Index: 9, ID: 99},
+			LocalSafe:      ChainHead{Index: 8, ID: 98},
+			CrossSafe:      ChainHead{Index: 7, ID: 97},
+			LocalFinalized: ChainHead{Index: 6, ID: 96},
+			CrossFinalized: ChainHead{Index: 5, ID: 95},
 		})
 		heads.Put(types.ChainIDFromUInt64(9), ChainHeads{
-			Unsafe:         90,
-			CrossUnsafe:    80,
-			LocalSafe:      70,
-			CrossSafe:      60,
-			LocalFinalized: 50,
-			CrossFinalized: 40,
+			Unsafe:         ChainHead{Index: 90, ID: 9},
+			CrossUnsafe:    ChainHead{Index: 80, ID: 8},
+			LocalSafe:      ChainHead{Index: 70, ID: 7},
+			CrossSafe:      ChainHead{Index: 60, ID: 6},
+			LocalFinalized: ChainHead{Index: 50, ID: 5},
+			CrossFinalized: ChainHead{Index: 40, ID: 4},
 		})
 		heads.Put(types.ChainIDFromUInt64(4892497242424), ChainHeads{
-			Unsafe:         1000,
-			CrossUnsafe:    900,
-			LocalSafe:      800,
-			CrossSafe:      700,
-			LocalFinalized: 600,
-			CrossFinalized: 400,
+			Unsafe:         ChainHead{Index: 1000, ID: 11},
+			CrossUnsafe:    ChainHead{Index: 900, ID: 22},
+			LocalSafe:      ChainHead{Index: 800, ID: 33},
+			CrossSafe:      ChainHead{Index: 700, ID: 44},
+			LocalFinalized: ChainHead{Index: 600, ID: 55},
+			CrossFinalized: ChainHead{Index: 400, ID: 66},
 		})
 
 		j, err := json.Marshal(heads)
@@ -51,16 +51,16 @@ func TestHeads(t *testing.T) {
 		chainA := types.ChainIDFromUInt64(3)
 		chainB := types.ChainIDFromUInt64(4)
 		chainAOrigHeads := ChainHeads{
-			Unsafe: 1,
+			Unsafe: ChainHead{Index: 1, ID: 10},
 		}
 		chainAModifiedHeads1 := ChainHeads{
-			Unsafe: 2,
+			Unsafe: ChainHead{Index: 2, ID: 20},
 		}
 		chainAModifiedHeads2 := ChainHeads{
-			Unsafe: 4,
+			Unsafe: ChainHead{Index: 4, ID: 40},
 		}
 		chainBModifiedHeads := ChainHeads{
-			Unsafe: 2,
+			Unsafe: ChainHead{Index: 2, ID: 50},
 		}
 
 		heads := NewHeads()

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -904,11 +904,11 @@ func (s *stubEntryStore) LastEntryIdx() entrydb.EntryIdx {
 	return entrydb.EntryIdx(s.Size() - 1)
 }
 
-func (s *stubEntryStore) Read(idx entrydb.EntryIdx) (entrydb.Entry, error) {
+func (s *stubEntryStore) Read(idx entrydb.EntryIdx) (entrydb.Entry, entrydb.EntryID, error) {
 	if idx < entrydb.EntryIdx(len(s.entries)) {
-		return s.entries[idx], nil
+		return s.entries[idx], entrydb.EntryID(len(s.entries)), nil
 	}
-	return entrydb.Entry{}, io.EOF
+	return entrydb.Entry{}, 0, io.EOF
 }
 
 func (s *stubEntryStore) Append(entries ...entrydb.Entry) error {

--- a/op-supervisor/supervisor/backend/db/logs/iterator.go
+++ b/op-supervisor/supervisor/backend/db/logs/iterator.go
@@ -22,7 +22,7 @@ type iterator struct {
 func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash types.TruncatedHash, outErr error) {
 	for i.nextEntryIdx <= i.db.lastEntryIdx() {
 		entryIdx := i.nextEntryIdx
-		entry, err := i.db.store.Read(entryIdx)
+		entry, _, err := i.db.store.Read(entryIdx)
 		if err != nil {
 			outErr = fmt.Errorf("failed to read entry %v: %w", i, err)
 			return
@@ -81,7 +81,7 @@ func (i *iterator) readExecMessage(initEntryIdx entrydb.EntryIdx) (types.Executi
 	if linkIdx%searchCheckpointFrequency == 0 {
 		linkIdx += 2 // skip the search checkpoint and canonical hash entries
 	}
-	linkEntry, err := i.db.store.Read(linkIdx)
+	linkEntry, _, err := i.db.store.Read(linkIdx)
 	if errors.Is(err, io.EOF) {
 		return types.ExecutingMessage{}, fmt.Errorf("%w: missing expected executing link event at idx %v", ErrDataCorruption, linkIdx)
 	} else if err != nil {
@@ -92,7 +92,7 @@ func (i *iterator) readExecMessage(initEntryIdx entrydb.EntryIdx) (types.Executi
 	if checkIdx%searchCheckpointFrequency == 0 {
 		checkIdx += 2 // skip the search checkpoint and canonical hash entries
 	}
-	checkEntry, err := i.db.store.Read(checkIdx)
+	checkEntry, _, err := i.db.store.Read(checkIdx)
 	if errors.Is(err, io.EOF) {
 		return types.ExecutingMessage{}, fmt.Errorf("%w: missing expected executing check event at idx %v", ErrDataCorruption, checkIdx)
 	} else if err != nil {


### PR DESCRIPTION
**Description**

Adds a single byte ID to each entry written to the database so that it is possible to detect if chain heads were not updated correctly after the log db was truncated and new entries written.  ie

We might have a write sequence like:
1. Write logs a,b,c
2. Update cross-unsafe to point to c (idx 2)
3. Rewind database to b (removing c)
4. Update cross-unsafe to point to b (ie idx 1)
5. Append x to the log db (so we now have a,b,x)

If we crash at that point it's possible that we come back and have cross-unsafe  at idx 2 because the head rollback didn't get flushed, but log db with a,b,x because the log db writes did get flushed.  This can now be detected because while `x` is at the same index as the previous `c` it will have a different ID.

Not yet implemented is recovering from such a situation - for the `unsafe` head, it should just point to the last entry in the log db. For other heads it's not possible to know exactly how far to roll them back, so they will need to drop back to the earliest head that still has a valid index and ID.  If the cross-finalised head is also invalidated, it needs to be set to the final entry for the current finalized block (which will need to be loaded via RPC) because while the finalized head tracked by op-node may decrease on pipeline reset or restarts, the block data and thus the logs never actually change. For devnet 1 we may just consider that case unrecoverable.

**Tests**

Added unit tests.

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/11028
