### PR TITLE
chore: fix typo with double `to` in the comment.

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -141,7 +141,7 @@
   },
   "src/dispute/FaultDisputeGame.sol": {
     "initCodeHash": "0x5ea5b544b8d7b32f55f7864c25a2443a5db363ffd1c66e0799cbc7bccaf98526",
-    "sourceCodeHash": "0xe8d90f1a8f92732707e370767df260bc806be5be9808f150ebed2c6caa158734"
+    "sourceCodeHash": "0xa0d373c969b78752aefb66b56807490e16ce0d09c8514b485b3d2df29bf8d514"
   },
   "src/dispute/weth/DelayedWETH.sol": {
     "initCodeHash": "0xb9bbe005874922cd8f499e7a0a092967cfca03e012c1e41912b0c77481c71777",
@@ -196,3 +196,4 @@
     "sourceCodeHash": "0xebfc968e6b78d7ea355547d427300739f14d000a11ff35f29d9ded3ddb7882da"
   }
 }
+

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -196,4 +196,3 @@
     "sourceCodeHash": "0xebfc968e6b78d7ea355547d427300739f14d000a11ff35f29d9ded3ddb7882da"
   }
 }
-

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -370,7 +370,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
 
         // If the remaining clock time has less than `CLOCK_EXTENSION` seconds remaining, grant the potential
         // grandchild's clock `CLOCK_EXTENSION` seconds. This is to ensure that, even if a player has to inherit another
-        // team's clock to counter a freeloader claim, they will always have enough time to to respond. This extension
+        // team's clock to counter a freeloader claim, they will always have enough time to respond. This extension
         // is bounded by the depth of the tree. If the potential grandchild is an execution trace bisection root, the
         // clock extension is doubled. This is to allow for extra time for the off-chain challenge agent to generate
         // the initial instruction trace on the native FPVM.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
During reading the contract `FaultDisputeGame`,  I saw this possible typos in the comment for the `move()` function. The word `to` is written 2 times back to back, so we can remove one. 
