### PR TITLE
op-challenger: Add a metric to report the number of large preimage proposals

### DIFF
--- a/op-challenger/game/keccak/scheduler_test.go
+++ b/op-challenger/game/keccak/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -50,7 +51,7 @@ func TestScheduleNextCheck(t *testing.T) {
 	}
 	cl := clock.NewDeterministicClock(time.Unix(int64(currentTimestamp), 0))
 	challenger := &stubChallenger{}
-	scheduler := NewLargePreimageScheduler(logger, cl, OracleSourceArray{oracle}, challenger)
+	scheduler := NewLargePreimageScheduler(logger, metrics.NoopMetrics, cl, OracleSourceArray{oracle}, challenger)
 	scheduler.Start(ctx)
 	defer scheduler.Close()
 	err := scheduler.Schedule(common.Hash{0xaa}, 3)

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -246,7 +246,7 @@ func (s *Service) initLargePreimages() error {
 	fetcher := fetcher.NewPreimageFetcher(s.logger, s.l1Client)
 	verifier := keccak.NewPreimageVerifier(s.logger, fetcher)
 	challenger := keccak.NewPreimageChallenger(s.logger, s.metrics, verifier, s.txSender)
-	s.preimages = keccak.NewLargePreimageScheduler(s.logger, s.l1Clock, s.oracles, challenger)
+	s.preimages = keccak.NewLargePreimageScheduler(s.logger, s.metrics, s.l1Clock, s.oracles, challenger)
 	return nil
 }
 

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -53,6 +53,8 @@ type Metricer interface {
 	RecordGameUpdateScheduled()
 	RecordGameUpdateCompleted()
 
+	RecordLargePreimageCount(count int)
+
 	IncActiveExecutors()
 	DecActiveExecutors()
 	IncIdleExecutors()
@@ -81,6 +83,7 @@ type Metrics struct {
 
 	preimageChallenged      prometheus.Counter
 	preimageChallengeFailed prometheus.Counter
+	preimageCount           prometheus.Gauge
 
 	highestActedL1Block prometheus.Gauge
 
@@ -193,6 +196,11 @@ func NewMetrics() *Metrics {
 			Name:      "preimage_challenge_failed",
 			Help:      "Number of preimage challenges that failed",
 		}),
+		preimageCount: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "preimage_count",
+			Help:      "Number of large preimage proposals being tracked by the challenger",
+		}),
 		trackedGames: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "tracked_games",
@@ -259,6 +267,10 @@ func (m *Metrics) RecordPreimageChallenged() {
 
 func (m *Metrics) RecordPreimageChallengeFailed() {
 	m.preimageChallengeFailed.Add(1)
+}
+
+func (m *Metrics) RecordLargePreimageCount(count int) {
+	m.preimageCount.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondClaimFailed() {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -34,6 +34,7 @@ func (*NoopMetricsImpl) RecordActedL1Block(_ uint64) {}
 
 func (*NoopMetricsImpl) RecordPreimageChallenged()      {}
 func (*NoopMetricsImpl) RecordPreimageChallengeFailed() {}
+func (*NoopMetricsImpl) RecordLargePreimageCount(_ int) {}
 
 func (*NoopMetricsImpl) RecordBondClaimFailed()   {}
 func (*NoopMetricsImpl) RecordBondClaimed(uint64) {}


### PR DESCRIPTION
**Description**

Add a gauge metric to report the number of large preimage proposals being tracked by the challenger. Previously only the number of challenges were reported but that excludes any valid proposals.
