### PR TITLE
fix(op-batcher): support new fjord maxRLPBytesPerChannelFjord via rollup chain spec

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -90,11 +90,13 @@ func NewChannelBuilder(cfg ChannelConfig, rollupCfg rollup.Config, latestL1Origi
 	if err != nil {
 		return nil, err
 	}
+
+	var chainSpec = rollup.NewChainSpec(&rollupCfg)
 	var co derive.ChannelOut
 	if cfg.BatchType == derive.SpanBatchType {
-		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo)
+		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo, chainSpec)
 	} else {
-		co, err = derive.NewSingularChannelOut(c)
+		co, err = derive.NewSingularChannelOut(c, chainSpec)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("creating channel out: %w", err)

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -91,7 +91,7 @@ func NewChannelBuilder(cfg ChannelConfig, rollupCfg rollup.Config, latestL1Origi
 		return nil, err
 	}
 
-	var chainSpec = rollup.NewChainSpec(&rollupCfg)
+	chainSpec := rollup.NewChainSpec(&rollupCfg)
 	var co derive.ChannelOut
 	if cfg.BatchType == derive.SpanBatchType {
 		co, err = derive.NewSpanChannelOut(rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID, cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo, chainSpec)

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -367,7 +367,7 @@ func ChannelBuilder_OutputWrongFramePanic(t *testing.T, batchType uint) {
 	// the type of batch does not matter here because we are using it to construct a broken frame
 	c, err := channelConfig.CompressorConfig.NewCompressor()
 	require.NoError(t, err)
-	co, err := derive.NewSingularChannelOut(c)
+	co, err := derive.NewSingularChannelOut(c, rollup.NewChainSpec(&defaultTestRollupConfig))
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	fn, err := co.OutputFrame(&buf, channelConfig.MaxFrameSize)
@@ -505,7 +505,8 @@ func ChannelBuilder_OutputFrames_SpanBatch(t *testing.T, algo derive.Compression
 func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	t.Parallel()
 	channelConfig := defaultTestChannelConfig()
-	channelConfig.MaxFrameSize = rollup.SafeMaxRLPBytesPerChannel * 2
+	var chainSpec = rollup.NewChainSpec(&defaultTestRollupConfig)
+	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
 	channelConfig.InitNoneCompressor()
 	channelConfig.BatchType = batchType
 

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -505,7 +505,7 @@ func ChannelBuilder_OutputFrames_SpanBatch(t *testing.T, algo derive.Compression
 func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	t.Parallel()
 	channelConfig := defaultTestChannelConfig()
-	var chainSpec = rollup.NewChainSpec(&defaultTestRollupConfig)
+	chainSpec := rollup.NewChainSpec(&defaultTestRollupConfig)
 	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
 	channelConfig.InitNoneCompressor()
 	channelConfig.BatchType = batchType

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -82,18 +82,19 @@ func newMiniL2BlockWithNumberParentAndL1Information(numTx int, l2Number *big.Int
 
 // addTooManyBlocks adds blocks to the channel until it hits an error,
 // which is presumably ErrTooManyRLPBytes.
-func addTooManyBlocks(cb *ChannelBuilder) error {
+func addTooManyBlocks(cb *ChannelBuilder, blockCount int) (int, error) {
 	rng := rand.New(rand.NewSource(1234))
 	t := time.Now()
-	for i := 0; i < 10_000; i++ {
+
+	for i := 0; i < blockCount; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, 1000, defaultTestRollupConfig.L2ChainID, t.Add(time.Duration(i)*time.Second))
 		_, err := cb.AddBlock(block)
 		if err != nil {
-			return err
+			return i + 1, err
 		}
 	}
 
-	return nil
+	return blockCount, nil
 }
 
 // FuzzDurationTimeoutZeroMaxChannelDuration ensures that when whenever the MaxChannelDuration
@@ -292,6 +293,7 @@ func TestChannelBuilderBatchType(t *testing.T) {
 		f    func(t *testing.T, batchType uint)
 	}{
 		{"ChannelBuilder_MaxRLPBytesPerChannel", ChannelBuilder_MaxRLPBytesPerChannel},
+		{"ChannelBuilder_MaxRLPBytesPerFjord", ChannelBuilder_MaxRLPBytesPerChannelFjord},
 		{"ChannelBuilder_OutputFramesMaxFrameIndex", ChannelBuilder_OutputFramesMaxFrameIndex},
 		{"ChannelBuilder_AddBlock", ChannelBuilder_AddBlock},
 		{"ChannelBuilder_PendingFrames_TotalFrames", ChannelBuilder_PendingFrames_TotalFrames},
@@ -515,8 +517,52 @@ func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	require.NoError(t, err)
 
 	// Add a block that overflows the [ChannelOut]
-	err = addTooManyBlocks(cb)
+	_, err = addTooManyBlocks(cb, 10_000)
 	require.ErrorIs(t, err, derive.ErrTooManyRLPBytes)
+}
+
+// ChannelBuilder_MaxRLPBytesPerChannelFjord tests the [ChannelBuilder.OutputFrames]
+// function works as intended postFjord.
+// strategy:
+// check preFjord how many blocks to fill the channel
+// then check postFjord w/ double the amount of blocks
+func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
+	t.Parallel()
+	channelConfig := defaultTestChannelConfig()
+	chainSpec := rollup.NewChainSpec(&defaultTestRollupConfig)
+	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
+	channelConfig.InitNoneCompressor()
+	channelConfig.BatchType = batchType
+
+	// Construct the channel builder
+	cb, err := NewChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+
+	// Count how many a block that overflows the [ChannelOut]
+	blockCount, err := addTooManyBlocks(cb, 10_000)
+	require.ErrorIs(t, err, derive.ErrTooManyRLPBytes)
+
+	// Create a new channel builder with fjord fork
+	now := time.Now()
+	fjordTime := uint64(now.Add(-1 * time.Second).Unix())
+	rollupConfig := rollup.Config{
+		Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}},
+		L2ChainID: big.NewInt(1234),
+		FjordTime: &fjordTime,
+	}
+
+	chainSpec = rollup.NewChainSpec(&rollupConfig)
+	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(uint64(now.Unix())) * 2
+	channelConfig.InitNoneCompressor()
+	channelConfig.BatchType = batchType
+
+	cb, err = NewChannelBuilder(channelConfig, rollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+
+	// try add double the amount of block, it should not error
+	_, err = addTooManyBlocks(cb, 2*blockCount)
+
+	require.NoError(t, err)
 }
 
 // ChannelBuilder_OutputFramesMaxFrameIndex tests the [ChannelBuilder.OutputFrames]

--- a/op-e2e/actions/garbage_channel_out.go
+++ b/op-e2e/actions/garbage_channel_out.go
@@ -159,9 +159,12 @@ func (co *GarbageChannelOut) AddBlock(rollupCfg *rollup.Config, block *types.Blo
 		buf.Reset()
 		buf.Write(bufBytes)
 	}
-	if co.rlpLength+buf.Len() > rollup.SafeMaxRLPBytesPerChannel {
+
+	var chainSpec = rollup.NewChainSpec(rollupCfg)
+	var maxRLPBytesPerChannel = chainSpec.MaxRLPBytesPerChannel(block.Time())
+	if co.rlpLength+buf.Len() > int(maxRLPBytesPerChannel) {
 		return fmt.Errorf("could not add %d bytes to channel of %d bytes, max is %d. err: %w",
-			buf.Len(), co.rlpLength, rollup.SafeMaxRLPBytesPerChannel, derive.ErrTooManyRLPBytes)
+			buf.Len(), co.rlpLength, maxRLPBytesPerChannel, derive.ErrTooManyRLPBytes)
 	}
 	co.rlpLength += buf.Len()
 

--- a/op-e2e/actions/garbage_channel_out.go
+++ b/op-e2e/actions/garbage_channel_out.go
@@ -160,8 +160,8 @@ func (co *GarbageChannelOut) AddBlock(rollupCfg *rollup.Config, block *types.Blo
 		buf.Write(bufBytes)
 	}
 
-	var chainSpec = rollup.NewChainSpec(rollupCfg)
-	var maxRLPBytesPerChannel = chainSpec.MaxRLPBytesPerChannel(block.Time())
+	chainSpec := rollup.NewChainSpec(rollupCfg)
+	maxRLPBytesPerChannel := chainSpec.MaxRLPBytesPerChannel(block.Time())
 	if co.rlpLength+buf.Len() > int(maxRLPBytesPerChannel) {
 		return fmt.Errorf("could not add %d bytes to channel of %d bytes, max is %d. err: %w",
 			buf.Len(), co.rlpLength, maxRLPBytesPerChannel, derive.ErrTooManyRLPBytes)

--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -199,7 +199,7 @@ func (s *L2Batcher) Buffer(t Testing) error {
 			if s.l2BatcherCfg.ForceSubmitSingularBatch && s.l2BatcherCfg.ForceSubmitSpanBatch {
 				t.Fatalf("ForceSubmitSingularBatch and ForceSubmitSpanBatch cannot be set to true at the same time")
 			} else {
-				var chainSpec = rollup.NewChainSpec(s.rollupCfg)
+				chainSpec := rollup.NewChainSpec(s.rollupCfg)
 				// use span batch if we're forcing it or if we're at/beyond delta
 				if s.l2BatcherCfg.ForceSubmitSpanBatch || s.rollupCfg.IsDelta(block.Time()) {
 					ch, err = derive.NewSpanChannelOut(s.rollupCfg.Genesis.L2Time, s.rollupCfg.L2ChainID, target, derive.Zlib, chainSpec)

--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -199,12 +199,13 @@ func (s *L2Batcher) Buffer(t Testing) error {
 			if s.l2BatcherCfg.ForceSubmitSingularBatch && s.l2BatcherCfg.ForceSubmitSpanBatch {
 				t.Fatalf("ForceSubmitSingularBatch and ForceSubmitSpanBatch cannot be set to true at the same time")
 			} else {
+				var chainSpec = rollup.NewChainSpec(s.rollupCfg)
 				// use span batch if we're forcing it or if we're at/beyond delta
 				if s.l2BatcherCfg.ForceSubmitSpanBatch || s.rollupCfg.IsDelta(block.Time()) {
-					ch, err = derive.NewSpanChannelOut(s.rollupCfg.Genesis.L2Time, s.rollupCfg.L2ChainID, target, derive.Zlib)
+					ch, err = derive.NewSpanChannelOut(s.rollupCfg.Genesis.L2Time, s.rollupCfg.L2ChainID, target, derive.Zlib, chainSpec)
 					// use singular batches in all other cases
 				} else {
-					ch, err = derive.NewSingularChannelOut(c)
+					ch, err = derive.NewSingularChannelOut(c, chainSpec)
 				}
 			}
 		}

--- a/op-e2e/actions/sync_test.go
+++ b/op-e2e/actions/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	engine2 "github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
@@ -32,7 +33,7 @@ import (
 )
 
 func newSpanChannelOut(t StatefulTesting, e e2eutils.SetupData) derive.ChannelOut {
-	channelOut, err := derive.NewSpanChannelOut(e.RollupCfg.Genesis.L2Time, e.RollupCfg.L2ChainID, 128_000, derive.Zlib)
+	channelOut, err := derive.NewSpanChannelOut(e.RollupCfg.Genesis.L2Time, e.RollupCfg.L2ChainID, 128_000, derive.Zlib, rollup.NewChainSpec(e.RollupCfg))
 	require.NoError(t, err)
 	return channelOut
 }

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -8,9 +8,16 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
+
+var defaultTestRollupConfig = rollup.Config{
+	Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}},
+	L2ChainID: big.NewInt(1234),
+}
 
 const (
 	// a really large target output size to ensure that the compressors are never full
@@ -90,10 +97,10 @@ func channelOutByType(b *testing.B, batchType uint, cd compressorDetails) (deriv
 	if batchType == derive.SingularBatchType {
 		compressor, err := cd.Compressor()
 		require.NoError(b, err)
-		return derive.NewSingularChannelOut(compressor)
+		return derive.NewSingularChannelOut(compressor, rollup.NewChainSpec(&defaultTestRollupConfig))
 	}
 	if batchType == derive.SpanBatchType {
-		return derive.NewSpanChannelOut(0, chainID, cd.config.TargetOutputSize, cd.config.CompressionAlgo)
+		return derive.NewSpanChannelOut(0, chainID, cd.config.TargetOutputSize, cd.config.CompressionAlgo, rollup.NewChainSpec(&defaultTestRollupConfig))
 	}
 	return nil, fmt.Errorf("unsupported batch type: %d", batchType)
 }

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -10,14 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
-
-var defaultTestRollupConfig = rollup.Config{
-	Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}},
-	L2ChainID: big.NewInt(1234),
-}
 
 const (
 	// a really large target output size to ensure that the compressors are never full
@@ -94,13 +88,14 @@ var (
 // channelOutByType returns a channel out of the given type as a helper for the benchmarks
 func channelOutByType(b *testing.B, batchType uint, cd compressorDetails) (derive.ChannelOut, error) {
 	chainID := big.NewInt(333)
+	rollupConfig := new(rollup.Config)
 	if batchType == derive.SingularBatchType {
 		compressor, err := cd.Compressor()
 		require.NoError(b, err)
-		return derive.NewSingularChannelOut(compressor, rollup.NewChainSpec(&defaultTestRollupConfig))
+		return derive.NewSingularChannelOut(compressor, rollup.NewChainSpec(rollupConfig))
 	}
 	if batchType == derive.SpanBatchType {
-		return derive.NewSpanChannelOut(0, chainID, cd.config.TargetOutputSize, cd.config.CompressionAlgo, rollup.NewChainSpec(&defaultTestRollupConfig))
+		return derive.NewSpanChannelOut(0, chainID, cd.config.TargetOutputSize, cd.config.CompressionAlgo, rollup.NewChainSpec(rollupConfig))
 	}
 	return nil, fmt.Errorf("unsupported batch type: %d", batchType)
 }

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -20,11 +20,6 @@ const (
 	maxRLPBytesPerChannelFjord   = 100_000_000
 )
 
-// SafeMaxRLPBytesPerChannel is a limit of RLP Bytes per channel that is valid across every OP Stack chain.
-// The limit on certain chains at certain times may be higher
-// TODO(#10428) Remove this parameter
-const SafeMaxRLPBytesPerChannel = maxRLPBytesPerChannelBedrock
-
 // Fjord changes the max sequencer drift to a protocol constant. It was previously configurable via
 // the rollup config.
 // From Fjord, the max sequencer drift for a given block timestamp should be learned via the

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -143,10 +143,11 @@ func (co *SingularChannelOut) AddSingularBatch(batch *SingularBatch, _ uint64) e
 		return err
 	}
 
-	// it's ok to use the batch timestamp
-	// on derivation we check that l1 timestamp were this channel will be included is after the fork
-	// eventually on the boundary of the fork we might use still the old value, which is lower so its ok (minor optimization)
-	var maxRLPBytesPerChannel = co.chainSpec.MaxRLPBytesPerChannel(batch.Timestamp)
+	// Fjord increases the max RLP bytes per channel. Activation of this change in the derivation pipeline
+	// is dependent on the timestamp of the L1 block that this channel got included in. So using the timestamp
+	// of the current batch guarantees that this channel will be included in an L1 block with a timestamp well after
+	// the Fjord activation.
+	maxRLPBytesPerChannel := co.chainSpec.MaxRLPBytesPerChannel(batch.Timestamp)
 	if co.rlpLength+buf.Len() > int(maxRLPBytesPerChannel) {
 		return fmt.Errorf("could not add %d bytes to channel of %d bytes, max is %d. err: %w",
 			buf.Len(), co.rlpLength, maxRLPBytesPerChannel, ErrTooManyRLPBytes)

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -145,11 +145,11 @@ func (co *SpanChannelOut) AddSingularBatch(batch *SingularBatch, seqNum uint64) 
 		return fmt.Errorf("failed to encode RawSpanBatch into bytes: %w", err)
 	}
 
-	// check the RLP length against the max
-	// it's ok to use the batch timestamp
-	// on derivation we check that l1 timestamp were this channel will be included is after the fork
-	// eventually on the boundary of the fork we might use still the old value, which is lower so its ok (minor optimization)
-	var maxRLPBytesPerChannel = co.chainSpec.MaxRLPBytesPerChannel(batch.Timestamp)
+	// Fjord increases the max RLP bytes per channel. Activation of this change in the derivation pipeline
+	// is dependent on the timestamp of the L1 block that this channel got included in. So using the timestamp
+	// of the current batch guarantees that this channel will be included in an L1 block with a timestamp well after
+	// the Fjord activation.
+	maxRLPBytesPerChannel := co.chainSpec.MaxRLPBytesPerChannel(batch.Timestamp)
 	if co.activeRLP().Len() > int(maxRLPBytesPerChannel) {
 		return fmt.Errorf("could not take %d bytes as replacement of channel of %d bytes, max is %d. err: %w",
 			co.activeRLP().Len(), co.inactiveRLP().Len(), maxRLPBytesPerChannel, ErrTooManyRLPBytes)


### PR DESCRIPTION
Context:

Fjord bump 10x `MaxRLPBytesPerChannel` to support higher gas limits.

On derivation the new limit is supported but op-batcher still use the old value.

This can lead to situation where the batcher halt in a chain post-Fjord with high block gas limit when a block bigger than 10M(bytes) is produced (this because a block cannot span today more than 1 channel).

This fixes https://github.com/ethereum-optimism/optimism/issues/10428 using the new value when appropriated and remove legacy `SafeMaxRLPBytesPerChannel`.

In the comments on the channel builder there a note about the choice of timestamp. 