### PR TITLE
contracts: update deploy script to read from superchain-registry toml configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Interactions within this repository are subject to a [Code of Conduct](https://g
 | [foundry](https://github.com/foundry-rs/foundry#installation) | `^0.2.0` | `forge --version`        |
 | [make](https://linux.die.net/man/1/make)                      | `^3`     | `make --version`         |
 | [jq](https://github.com/jqlang/jq)                            | `^1.6`   | `jq --version`           |
+| [yq](https://github.com/kislyuk/yq)                           | `^3.4`   | `yq --version`           |
 | [direnv](https://direnv.net)                                  | `^2`     | `direnv --version`       |
 | [docker](https://docs.docker.com/get-docker/)                 | `^24`    | `docker --version`       |
 | [docker compose](https://docs.docker.com/compose/install/)    | `^2.23`  | `docker compose version` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Interactions within this repository are subject to a [Code of Conduct](https://g
 | [foundry](https://github.com/foundry-rs/foundry#installation) | `^0.2.0` | `forge --version`        |
 | [make](https://linux.die.net/man/1/make)                      | `^3`     | `make --version`         |
 | [jq](https://github.com/jqlang/jq)                            | `^1.6`   | `jq --version`           |
-| [yq](https://github.com/kislyuk/yq)                           | `^3.4`   | `yq --version`           |
+| [yq](https://github.com/mikefarah/yq/#install)                | `^4.44`  | `yq --version`           |
 | [direnv](https://direnv.net)                                  | `^2`     | `direnv --version`       |
 | [docker](https://docs.docker.com/get-docker/)                 | `^24`    | `docker --version`       |
 | [docker compose](https://docs.docker.com/compose/install/)    | `^2.23`  | `docker compose version` |

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -72,7 +72,7 @@ abstract contract Artifacts {
         commands[0] = "bash";
         commands[1] = "-c";
         if (hasSuffix(_path, ".toml")) {
-            commands[2] = string.concat("tomlq -cr '.addresses' < ", _path);
+            commands[2] = string.concat("yq -oj '.addresses' ", _path);
         } else {
             commands[2] = string.concat("jq -cr < ", _path);
         }

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -85,9 +85,9 @@ abstract contract Artifacts {
         }
     }
 
-    function hasSuffix(string memory fullString, string memory suffix) public pure returns (bool) {
-        bytes memory fullStringBytes = bytes(fullString);
-        bytes memory suffixBytes = bytes(suffix);
+    function hasSuffix(string memory _fullString, string memory _suffix) public pure returns (bool) {
+        bytes memory fullStringBytes = bytes(_fullString);
+        bytes memory suffixBytes = bytes(_suffix);
 
         // Check if the suffix's length is greater than the full string's length
         if (suffixBytes.length > fullStringBytes.length) {


### PR DESCRIPTION
**Description**

The current `contracts-bedrock` deploy script is able to read contract addresses from json files located in the local file system. This PR updates the deploy script such that a developer can also point to one of the new `superchain-registry/superchain/config` .toml files and the script can pull addresses from there. The code will remain backwards compatible with the old json address files.

**Tests**

None yet
