### PR TITLE
check deploy config consistency by `DEPLOY_CONFIG_SNAP`

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -660,6 +660,21 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 	}, nil
 }
 
+func CheckFileNotChanged(beforePath, afterPath string) (err error) {
+	beforeBytes, err := os.ReadFile(beforePath)
+	if err != nil {
+		return
+	}
+	afterBytes, err := os.ReadFile(afterPath)
+	if err != nil {
+		return
+	}
+	if !bytes.Equal(beforeBytes, afterBytes) {
+		return fmt.Errorf("file has changed, %s vs %s", beforePath, afterPath)
+	}
+	return nil
+}
+
 // NewDeployConfig reads a config file given a path on the filesystem.
 func NewDeployConfig(path string) (*DeployConfig, error) {
 	file, err := os.ReadFile(path)

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -141,6 +141,14 @@ var Subcommands = cli.Commands{
 		Action: func(ctx *cli.Context) error {
 			deployConfig := ctx.Path("deploy-config")
 			log.Info("Deploy config", "path", deployConfig)
+			// if DEPLOY_CONFIG_SNAP is specified, we want to check that deployConfig is not changed.
+			snapPath := os.Getenv("DEPLOY_CONFIG_SNAP")
+			if len(snapPath) > 0 {
+				err := genesis.CheckFileNotChanged(snapPath, deployConfig)
+				if err != nil {
+					return err
+				}
+			}
 			config, err := genesis.NewDeployConfig(deployConfig)
 			if err != nil {
 				return err

--- a/packages/contracts-bedrock/scripts/deploy/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deployer.sol
@@ -25,5 +25,13 @@ abstract contract Deployer is Script, Artifacts {
         vm.label(address(cfg), "DeployConfig");
         vm.allowCheatcodes(address(cfg));
         cfg.read(Config.deployConfigPath());
+        string memory snapPath = vm.envOr("DEPLOY_CONFIG_SNAP", string(""));
+        if (bytes(snapPath).length > 0) {
+            string[] memory commands = new string[](3);
+            commands[0] = Executables.bash;
+            commands[1] = "-c";
+            commands[2] = string.concat("cp ", Config.deployConfigPath(), " ", snapPath);
+            Process.run(cmd);
+        }
     }
 }


### PR DESCRIPTION
This PR tries to fix [this issue](https://github.com/ethereum-optimism/optimism/issues/11144) by introducing a `DEPLOY_CONFIG_SNAP` environment variable.

When generating `l2_allocs.json`, if `DEPLOY_CONFIG_SNAP` is set, a copy of deploy config will be stored there.

When generating l2 genesis, if `DEPLOY_CONFIG_SNAP` is set, will check that the content of deploy config hasn't changed.