### PR TITLE
op-proposer, op-batcher: Wait for sync in Start rather than loop.

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -173,6 +173,13 @@ func (l *L2OutputSubmitter) StartL2OutputSubmitting() error {
 	}
 	l.running = true
 
+	if l.Cfg.WaitNodeSync {
+		err := l.waitNodeSync()
+		if err != nil {
+			return fmt.Errorf("error waiting for node sync: %w", err)
+		}
+	}
+
 	l.wg.Add(1)
 	go l.loop()
 
@@ -417,14 +424,6 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 func (l *L2OutputSubmitter) loop() {
 	defer l.wg.Done()
 	ctx := l.ctx
-
-	if l.Cfg.WaitNodeSync {
-		err := l.waitNodeSync()
-		if err != nil {
-			l.Log.Error("Error waiting for node sync", "err", err)
-			return
-		}
-	}
 
 	if l.dgfContract == nil {
 		l.loopL2OO(ctx)


### PR DESCRIPTION
**Description**

Ensures that if it fails, the process exits with an error, rather than just exiting the runloop and continuing on in a zombie mode that doesn't do anything but doesn't exit.

Likely a better solution is to just keep retrying rather than failing on errors, but this is currently the first place the rollup-rpc is used so we may not want to keep retrying an invalid URL forever.

