### PR TITLE
opservice: rpc server into a cliapp service

### DIFF
--- a/op-service/rpc/service.go
+++ b/op-service/rpc/service.go
@@ -1,0 +1,45 @@
+package rpc
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+)
+
+var _ cliapp.Lifecycle = &Service{}
+
+type Service struct {
+	log     log.Logger
+	srv     *Server
+	stopped atomic.Bool
+}
+
+func NewService(log log.Logger, srv *Server) *Service {
+	return &Service{log: log, srv: srv, stopped: atomic.Bool{}}
+}
+
+func (s *Service) Start(_ context.Context) error {
+	s.log.Info("starting rpc server")
+	return s.srv.Start()
+}
+
+func (s *Service) Stop(_ context.Context) error {
+	if s.stopped.Load() {
+		return nil
+	}
+
+	s.log.Info("stopping rpc server")
+	err := s.srv.Stop()
+	if err == nil {
+		s.stopped.Store(true)
+	}
+
+	return err
+}
+
+func (s *Service) Stopped() bool {
+	return s.stopped.Load()
+}


### PR DESCRIPTION
opservice rpc server does not exactly conform to the cliapp Lifecycle interface. Add a utility such that an rpc server can be converted to one.

Later on we may want to refactor the rpc server interface & its usages to remove the need for this