### PR TITLE
contracts-bedrock: speed up ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,17 +544,8 @@ jobs:
       - run:
           name: git submodules
           command: make submodules
-      - restore_cache:
-          name: Restore PNPM Package Cache
-          keys:
-            - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
-      - attach_workspace: { at: "." }
       - check-changed:
           patterns: contracts-bedrock,op-node
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install:ci
       - run:
           name: print forge version
           command: forge --version
@@ -1533,9 +1524,7 @@ workflows:
     jobs:
       - pnpm-monorepo:
           name: pnpm-monorepo
-      - contracts-bedrock-tests:
-          requires:
-            - pnpm-monorepo
+      - contracts-bedrock-tests
       - contracts-bedrock-coverage
       - contracts-bedrock-checks:
           requires:


### PR DESCRIPTION
**Description**

Tests for `contracts-bedrock` should no longer depend
on the JS monorepo. This should speed up the tests
by removing a step that blocks it from running.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

