### PR TITLE
chore: bump Solidity to 0.8.25

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -121,7 +121,8 @@ RUN npm i -g pnpm && npm i -g yarn@1 && pnpm --version && yarn --version
 
 RUN svm install 0.5.17 && \
   svm install 0.8.15 && \
-  svm install 0.8.19
+  svm install 0.8.19 && \
+  svm install 0.8.25
 
 RUN echo "downloading and verifying Codecov uploader" && \
   curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import && \

--- a/packages/contracts-bedrock/scripts/FaultDisputeGameViz.s.sol
+++ b/packages/contracts-bedrock/scripts/FaultDisputeGameViz.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/scripts/FeeVaultWithdrawal.s.sol
+++ b/packages/contracts-bedrock/scripts/FeeVaultWithdrawal.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { console } from "forge-std/console.sol";
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/scripts/SemverLock.s.sol
+++ b/packages/contracts-bedrock/scripts/SemverLock.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/scripts/fpac/FPACOPS.s.sol
+++ b/packages/contracts-bedrock/scripts/fpac/FPACOPS.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Proxy } from "src/universal/Proxy.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";

--- a/packages/contracts-bedrock/scripts/fpac/SubmitLPP.sol
+++ b/packages/contracts-bedrock/scripts/fpac/SubmitLPP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/interfaces/IAddressManager.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/IAddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.0;
 
 /// @title IAddressManager
 /// @notice Minimal interface of the Legacy AddressManager.

--- a/packages/contracts-bedrock/scripts/interfaces/ISystemConfigV0.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/ISystemConfigV0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 

--- a/packages/contracts-bedrock/scripts/libraries/LibStateDiff.sol
+++ b/packages/contracts-bedrock/scripts/libraries/LibStateDiff.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { stdJson } from "forge-std/StdJson.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/src/EAS/EAS.sol
+++ b/packages/contracts-bedrock/src/EAS/EAS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/EAS/SchemaRegistry.sol
+++ b/packages/contracts-bedrock/src/EAS/SchemaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { ISchemaResolver } from "src/EAS/resolver/ISchemaResolver.sol";

--- a/packages/contracts-bedrock/src/EAS/eip1271/EIP1271Verifier.sol
+++ b/packages/contracts-bedrock/src/EAS/eip1271/EIP1271Verifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/packages/contracts-bedrock/src/EAS/resolver/SchemaResolver.sol
+++ b/packages/contracts-bedrock/src/EAS/resolver/SchemaResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { IEAS, Attestation } from "src/EAS/IEAS.sol";
 import { AccessDenied, InvalidEAS, InvalidLength, uncheckedInc } from "src/EAS/Common.sol";

--- a/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
+++ b/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
+++ b/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";

--- a/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC721Bridge } from "src/universal/ERC721Bridge.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { StandardBridge } from "src/universal/StandardBridge.sol";

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";
 import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";

--- a/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/src/L1/ResourceMetering.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Constants } from "src/libraries/Constants.sol";
 import { OptimismPortalInterop as OptimismPortal } from "src/L1/OptimismPortalInterop.sol";

--- a/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { FeeVault } from "src/universal/FeeVault.sol";

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { L1Block } from "src/L2/L1Block.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/packages/contracts-bedrock/src/L2/L1FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/L1FeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { FeeVault } from "src/universal/FeeVault.sol";

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC721Bridge } from "src/universal/ERC721Bridge.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";

--- a/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { StandardBridge } from "src/universal/StandardBridge.sol";

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";

--- a/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { FeeVault } from "src/universal/FeeVault.sol";

--- a/packages/contracts-bedrock/src/L2/WETH.sol
+++ b/packages/contracts-bedrock/src/L2/WETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { WETH98 } from "src/dispute/weth/WETH98.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/Safe/DeputyGuardianModule.sol
+++ b/packages/contracts-bedrock/src/Safe/DeputyGuardianModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";

--- a/packages/contracts-bedrock/src/Safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/Safe/LivenessGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Guard as BaseGuard } from "safe-contracts/base/GuardManager.sol";

--- a/packages/contracts-bedrock/src/Safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/Safe/LivenessModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";

--- a/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title PreimageKeyLib
 /// @notice Shared utilities for localizing local keys in the preimage oracle.

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title IPreimageOracle
 /// @notice Interface for a preimage oracle.

--- a/packages/contracts-bedrock/src/cannon/libraries/CannonErrors.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/CannonErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @notice Thrown when a passed part offset is out of bounds.
 error PartOffsetOOB();

--- a/packages/contracts-bedrock/src/cannon/libraries/CannonTypes.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/CannonTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 using LPPMetadataLib for LPPMetaData global;
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 library MIPSMemory {
     /// @notice Reads a 32-bit value from memory.

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 library MIPSState {
     struct CpuScalars {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { LibClone } from "@solady/utils/LibClone.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { FixedPointMathLib } from "@solady/utils/FixedPointMathLib.sol";
 

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import "src/dispute/lib/LibUDT.sol";
 

--- a/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 using LibPosition for Position global;
 

--- a/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import "src/dispute/lib/LibPosition.sol";
 

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import "src/dispute/lib/LibUDT.sol";
 

--- a/packages/contracts-bedrock/src/dispute/weth/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/weth/DelayedWETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/dispute/weth/WETH98.sol
+++ b/packages/contracts-bedrock/src/dispute/weth/WETH98.sol
@@ -17,7 +17,7 @@
 // Based on WETH9 by Dapphub.
 // Modified by OP Labs.
 
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IWETH } from "src/dispute/interfaces/IWETH.sol";
 

--- a/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/packages/contracts-bedrock/src/governance/MintManager.sol
+++ b/packages/contracts-bedrock/src/governance/MintManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./GovernanceToken.sol";

--- a/packages/contracts-bedrock/src/legacy/AddressManager.sol
+++ b/packages/contracts-bedrock/src/legacy/AddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
+++ b/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 

--- a/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
+++ b/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { L1Block } from "src/L2/L1Block.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Constants } from "src/libraries/Constants.sol";
 

--- a/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 

--- a/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ILegacyMintableERC20 } from "src/universal/OptimismMintableERC20.sol";

--- a/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { AddressManager } from "src/legacy/AddressManager.sol";
 

--- a/packages/contracts-bedrock/src/libraries/Burn.sol
+++ b/packages/contracts-bedrock/src/libraries/Burn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title Burn
 /// @notice Utilities for burning stuff.

--- a/packages/contracts-bedrock/src/periphery/TransferOnion.sol
+++ b/packages/contracts-bedrock/src/periphery/TransferOnion.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { AssetReceiver } from "../AssetReceiver.sol";
 import { IDripCheck } from "./IDripCheck.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IFaucetAuthModule } from "./authmodules/IFaucetAuthModule.sol";
 import { SafeCall } from "../../libraries/SafeCall.sol";

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Faucet } from "../Faucet.sol";
 

--- a/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 

--- a/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { ERC721BurnableUpgradeable } from

--- a/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";

--- a/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/periphery/op-nft/libraries/OptimistConstants.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/libraries/OptimistConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title  OptimistConstants
 /// @notice Library for storing Optimist related constants that are shared in multiple contracts.

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";

--- a/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";

--- a/packages/contracts-bedrock/src/universal/FeeVault.sol
+++ b/packages/contracts-bedrock/src/universal/FeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { L2ToL1MessagePasser } from "src/L2/L2ToL1MessagePasser.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { OptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";
 import { ISemver } from "src/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/universal/Proxy.sol
+++ b/packages/contracts-bedrock/src/universal/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Constants } from "src/libraries/Constants.sol";
 

--- a/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
+++ b/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Proxy } from "src/universal/Proxy.sol";

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";

--- a/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { Storage } from "src/libraries/Storage.sol";

--- a/packages/contracts-bedrock/test/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/test/BenchmarkTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/ExtendedPause.t.sol
+++ b/packages/contracts-bedrock/test/ExtendedPause.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";

--- a/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
+++ b/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import {
     DataAvailabilityChallenge,

--- a/packages/contracts-bedrock/test/L1/DelayedVetoable.t.sol
+++ b/packages/contracts-bedrock/test/L1/DelayedVetoable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { DelayedVetoable } from "src/L1/DelayedVetoable.sol";

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { stdStorage, StdStorage } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/L1/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/L1/L2OutputOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { stdError } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { stdError } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { stdError } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { VmSafe } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable2.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable3.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable3.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { console } from "forge-std/console.sol";
 

--- a/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";

--- a/packages/contracts-bedrock/test/L2/L2ToL1MessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL1MessagePasser.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/WETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/WETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2Genesis.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";

--- a/packages/contracts-bedrock/test/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/Predeploys.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ForgeArtifacts } from "scripts/ForgeArtifacts.sol";

--- a/packages/contracts-bedrock/test/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/Preinstalls.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";

--- a/packages/contracts-bedrock/test/Safe/DeployOwnership.t.sol
+++ b/packages/contracts-bedrock/test/Safe/DeployOwnership.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import {
     DeployOwnership,

--- a/packages/contracts-bedrock/test/Safe/DeputyGuardianModule.t.sol
+++ b/packages/contracts-bedrock/test/Safe/DeputyGuardianModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ForgeArtifacts, Abi } from "scripts/ForgeArtifacts.sol";

--- a/packages/contracts-bedrock/test/Safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/Safe/LivenessGuard.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";

--- a/packages/contracts-bedrock/test/Safe/SafeSigners.t.sol
+++ b/packages/contracts-bedrock/test/Safe/SafeSigners.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";

--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { Executables } from "scripts/Executables.sol";

--- a/packages/contracts-bedrock/test/actors/FaultDisputeActors.sol
+++ b/packages/contracts-bedrock/test/actors/FaultDisputeActors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonBase } from "forge-std/Base.sol";
 

--- a/packages/contracts-bedrock/test/cannon/MIPS.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { MIPS } from "src/cannon/MIPS.sol";

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test, Vm, console2 as console } from "forge-std/Test.sol";
 

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/dispute/WETH98.t.sol
+++ b/packages/contracts-bedrock/test/dispute/WETH98.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { WETH98 } from "src/dispute/weth/WETH98.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { LibClock } from "src/dispute/lib/LibUDT.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";

--- a/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
+++ b/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/governance/MintManager.t.sol
+++ b/packages/contracts-bedrock/test/governance/MintManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/invariants/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/invariants/AddressAliasHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";

--- a/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/invariants/Burn.Gas.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Gas.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Encoding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";

--- a/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Vm } from "forge-std/Vm.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/test/invariants/Hashing.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Hashing.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";

--- a/packages/contracts-bedrock/test/invariants/InvariantTest.sol
+++ b/packages/contracts-bedrock/test/invariants/InvariantTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { FFIInterface } from "test/setup/FFIInterface.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";

--- a/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/invariants/ResourceMetering.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 

--- a/packages/contracts-bedrock/test/invariants/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SafeCall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";

--- a/packages/contracts-bedrock/test/kontrol/deployment/DeploymentSummary.t.sol
+++ b/packages/contracts-bedrock/test/kontrol/deployment/DeploymentSummary.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/test/kontrol/deployment/DeploymentSummaryFaultProofs.t.sol
+++ b/packages/contracts-bedrock/test/kontrol/deployment/DeploymentSummaryFaultProofs.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/test/kontrol/proofs/interfaces/KontrolInterfaces.sol
+++ b/packages/contracts-bedrock/test/kontrol/proofs/interfaces/KontrolInterfaces.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 

--- a/packages/contracts-bedrock/test/kontrol/proofs/utils/KontrolUtils.sol
+++ b/packages/contracts-bedrock/test/kontrol/proofs/utils/KontrolUtils.sol
@@ -10,7 +10,7 @@
 // need for the `copy_memory_to_memory` function and its summary, and thus this workaround.
 // For more information refer to the `copy_memory_to_memory` summary section of `pausability-lemmas.md`.
 
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Vm } from "forge-std/Vm.sol";
 import { KontrolCheats } from "kontrol-cheatcodes/KontrolCheats.sol";

--- a/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/legacy/LegacyMessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/legacy/LegacyMessagePasser.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Constants.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Constants.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
+++ b/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Target contract
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";

--- a/packages/contracts-bedrock/test/libraries/Hashing.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Hashing.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
+++ b/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Storage.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Storage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Target contract
 import { Storage } from "src/libraries/Storage.sol";

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { stdError } from "forge-std/Test.sol";
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPWriter.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPWriter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";

--- a/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
+++ b/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.25;
 
 import { IBigStepper, IPreimageOracle } from "src/dispute/interfaces/IBigStepper.sol";
 import { PreimageOracle, PreimageKeyLib } from "src/cannon/PreimageOracle.sol";

--- a/packages/contracts-bedrock/test/mocks/NextImpl.sol
+++ b/packages/contracts-bedrock/test/mocks/NextImpl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/periphery/Transactor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Drippie } from "src/periphery/drippie/Drippie.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { CheckBalanceLow } from "src/periphery/drippie/dripchecks/CheckBalanceLow.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckGelatoLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckGelatoLow.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { CheckGelatoLow, IGelatoTreasury } from "src/periphery/drippie/dripchecks/CheckGelatoLow.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { CheckSecrets } from "src/periphery/drippie/dripchecks/CheckSecrets.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";

--- a/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Faucet } from "src/periphery/faucet/Faucet.sol";

--- a/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { AdminFaucetAuthModule } from "src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";

--- a/packages/contracts-bedrock/test/periphery/op-nft/AttestationStation.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/AttestationStation.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/op-nft/OptimistAllowlist.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/OptimistAllowlist.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/op-nft/OptimistInviter.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/OptimistInviter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/setup/Bridge_Initializer.sol
+++ b/packages/contracts-bedrock/test/setup/Bridge_Initializer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Setup } from "test/setup/Setup.sol";

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 import { Vm } from "forge-std/Vm.sol";
@@ -8,7 +8,7 @@ import { Process } from "scripts/libraries/Process.sol";
 
 /// @title FFIInterface
 /// @notice This contract is set into state using `etch` and therefore must not have constructor logic.
-///         It also MUST be compiled with `0.8.15` because `vm.getDeployedCode` will break if there
+///         It also MUST be compiled with `0.8.25` because `vm.getDeployedCode` will break if there
 ///         are multiple artifacts for different compiler versions.
 contract FFIInterface {
     Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-bedrock/test/universal/FeeVault.t.sol
+++ b/packages/contracts-bedrock/test/universal/FeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";
 import { ILegacyMintableERC20, IOptimismMintableERC20 } from "src/universal/IOptimismMintableERC20.sol";

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC721.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC721, IERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC721Factory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";

--- a/packages/contracts-bedrock/test/universal/Proxy.t.sol
+++ b/packages/contracts-bedrock/test/universal/Proxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Proxy } from "src/universal/Proxy.sol";

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { Proxy } from "src/universal/Proxy.sol";

--- a/packages/contracts-bedrock/test/universal/StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/universal/StandardBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StandardBridge } from "src/universal/StandardBridge.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";
 import { Executables } from "scripts/Executables.sol";


### PR DESCRIPTION
Bumps the Solidity version to 0.8.25 globally.