### PR TITLE
op-e2e: use util for RPC dial, and ensure op-node is on localhost RPC

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -139,6 +139,11 @@ func DefaultSystemConfig(t testing.TB) SystemConfig {
 					SequencerConfDepth: 0,
 					SequencerEnabled:   false,
 				},
+				RPC: rollupNode.RPCConfig{
+					ListenAddr:  "127.0.0.1",
+					ListenPort:  0,
+					EnableAdmin: true,
+				},
 				L1EpochPollInterval:         time.Second * 4,
 				RuntimeConfigReloadInterval: time.Minute * 10,
 				ConfigPersistence:           &rollupNode.DisabledConfigPersistence{},

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1420,9 +1420,7 @@ func StopStartBatcher(t *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	require.NoError(t, err, "Error starting up system")
 	defer sys.Close()
 
-	rollupRPCClient, err := rpc.DialContext(context.Background(), sys.RollupNodes["verifier"].HTTPEndpoint())
-	require.NoError(t, err)
-	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+	rollupClient := sys.RollupClient("verifier")
 
 	l2Seq := sys.Clients["sequencer"]
 	l2Verif := sys.Clients["verifier"]


### PR DESCRIPTION
Try to resolve an unexpected connection error in op-e2e tests, reported by Coinbase eng.