### PR TITLE
op-batcher: Add threshold for L1 blob base fee

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -52,6 +52,11 @@ type CLIConfig struct {
 	// transactions sent to the transaction manager (0 == no limit).
 	MaxPendingTransactions uint64
 
+	// If L1 blob base fee exceeds this value, batch tx will not be sent.
+	// The unit is Wei, and if 0 is specified, there is no fee cap.
+	// The base fee may not be accurate as it is obtained from the GasPriceOracle on L2.
+	MaxL1BlobBaseFee uint64
+
 	// MaxL1TxSize is the maximum size of a batch tx submitted to L1.
 	// If using blobs, this setting is ignored and the max blob size is used.
 	MaxL1TxSize uint64
@@ -171,6 +176,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		/* Optional Flags */
 		MaxPendingTransactions:       ctx.Uint64(flags.MaxPendingTransactionsFlag.Name),
 		MaxChannelDuration:           ctx.Uint64(flags.MaxChannelDurationFlag.Name),
+		MaxL1BlobBaseFee:             ctx.Uint64(flags.MaxL1BlobBaseFeeFlag.Name),
 		MaxL1TxSize:                  ctx.Uint64(flags.MaxL1TxSizeBytesFlag.Name),
 		TargetNumFrames:              ctx.Int(flags.TargetNumFramesFlag.Name),
 		ApproxComprRatio:             ctx.Float64(flags.ApproxComprRatioFlag.Name),

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -44,6 +44,7 @@ type BatcherConfig struct {
 
 	WaitNodeSync        bool
 	CheckRecentTxsDepth int
+	MaxL1BlobBaseFee    uint64
 }
 
 // BatcherService represents a full batch-submitter instance and its resources,
@@ -100,6 +101,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	bs.NetworkTimeout = cfg.TxMgrConfig.NetworkTimeout
 	bs.CheckRecentTxsDepth = cfg.CheckRecentTxsDepth
 	bs.WaitNodeSync = cfg.WaitNodeSync
+	bs.MaxL1BlobBaseFee = cfg.MaxL1BlobBaseFee
 	if err := bs.initRPCClients(ctx, cfg); err != nil {
 		return err
 	}

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -70,6 +70,14 @@ var (
 		Value:   0,
 		EnvVars: prefixEnvVars("MAX_CHANNEL_DURATION"),
 	}
+	MaxL1BlobBaseFeeFlag = &cli.Uint64Flag{
+		Name: "max-l1-blob-base-fee",
+		Usage: "If L1 blob base fee exceeds this value, batch tx will not be sent. " +
+			"The unit is Wei, and if 0 is specified, there is no fee cap. " +
+			"The base fee may not be accurate as it is obtained from the GasPriceOracle on L2.",
+		Value:   0,
+		EnvVars: prefixEnvVars("MAX_L1_BLOB_BASE_FEE"),
+	}
 	MaxL1TxSizeBytesFlag = &cli.Uint64Flag{
 		Name:    "max-l1-tx-size-bytes",
 		Usage:   "The maximum size of a batch tx submitted to L1. Ignored for blobs, where max blob size will be used.",
@@ -168,6 +176,7 @@ var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	MaxPendingTransactionsFlag,
 	MaxChannelDurationFlag,
+	MaxL1BlobBaseFeeFlag,
 	MaxL1TxSizeBytesFlag,
 	TargetNumFramesFlag,
 	ApproxComprRatioFlag,

--- a/op-service/dial/active_l2_provider.go
+++ b/op-service/dial/active_l2_provider.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -113,6 +115,16 @@ func (p *ActiveL2EndpointProvider) EthClient(ctx context.Context) (EthClientInte
 		p.currentEthClient = ethClient
 	}
 	return p.currentEthClient, nil
+}
+
+func (p *ActiveL2EndpointProvider) GasPriceOracle(ctx context.Context) (GasPriceOracleInterface, error) {
+	if ec, err := p.EthClient(ctx); err != nil {
+		return nil, err
+	} else if t, ok := ec.(*ethclient.Client); !ok {
+		return nil, errors.New("not ethclient.Client")
+	} else {
+		return bindings.NewGasPriceOracle(predeploys.GasPriceOracleAddr, t)
+	}
 }
 
 func (p *ActiveL2EndpointProvider) Close() {

--- a/op-service/dial/gpo_interface.go
+++ b/op-service/dial/gpo_interface.go
@@ -1,0 +1,13 @@
+package dial
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+)
+
+// GasPriceOracleInterface is an interface for providing
+// an GasPriceOracle pre-deployment contract
+type GasPriceOracleInterface interface {
+	BlobBaseFee(opts *bind.CallOpts) (*big.Int, error)
+}

--- a/op-service/dial/static_l2_provider.go
+++ b/op-service/dial/static_l2_provider.go
@@ -3,6 +3,8 @@ package dial
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -16,6 +18,8 @@ type L2EndpointProvider interface {
 	// Note: ctx should be a lifecycle context without an attached timeout as client selection may involve
 	// multiple network operations, specifically in the case of failover.
 	EthClient(ctx context.Context) (EthClientInterface, error)
+	// GasPriceOracle(ctx) returns the callable GasPriceOracle contract on the L2
+	GasPriceOracle(ctx context.Context) (GasPriceOracleInterface, error)
 }
 
 // StaticL2EndpointProvider is a L2EndpointProvider that always returns the same static RollupClient and eth client
@@ -42,6 +46,10 @@ func NewStaticL2EndpointProvider(ctx context.Context, log log.Logger, ethClientU
 
 func (p *StaticL2EndpointProvider) EthClient(context.Context) (EthClientInterface, error) {
 	return p.ethClient, nil
+}
+
+func (p *StaticL2EndpointProvider) GasPriceOracle(context.Context) (GasPriceOracleInterface, error) {
+	return bindings.NewGasPriceOracle(predeploys.GasPriceOracleAddr, p.ethClient)
 }
 
 func (p *StaticL2EndpointProvider) Close() {

--- a/op-service/testutils/mock_gpo_client.go
+++ b/op-service/testutils/mock_gpo_client.go
@@ -1,0 +1,21 @@
+package testutils
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockGasPriceOracle struct {
+	mock.Mock
+}
+
+func (m *MockGasPriceOracle) BlobBaseFee(opts *bind.CallOpts) (*big.Int, error) {
+	out := m.Mock.Called(opts)
+	return out.Get(0).(*big.Int), out.Error(1)
+}
+
+func (m *MockGasPriceOracle) ExpectBlobBaseFee(blobBaseFee *big.Int, err error) {
+	m.Mock.On("BlobBaseFee", mock.Anything).Once().Return(blobBaseFee, err)
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add the new flag to op-batcher to cancel tx sending if the L1 blob base fee exceeds the threshold. The threshold value can be set using the cli argument `--max-l1-blob-base-fee=n` or the environment variable `OP_BATCHER_MAX_L1_BLOB_BASE_FEE=n`. If the threshold is set to 0 (default), no action will be taken.

This will be useful for the test L2 networks rolling up to the Sepolia network, which tends to have [high blob fee rates](https://sepolia.etherscan.io/tx/0x93cc47688a40222e71640e7d8a365fd617c8fd9c10ed5e2204d3786c45dfb0cc#blobs). 

Since no JSON-RPC method was found to get the L1 blob base fee, this implementation get the fee from the L2 GasPriceOracle contract: 
https://github.com/ethereum-optimism/optimism/blob/0db615dc8a6876fd1defb7a0f1ac3463c0db4c76/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L136-L138

**Tests**

https://github.com/ak-akiyama/optimism/commit/da79ba0262bc6ae84d170bb3cdf917c952214b09#diff-6524d10e489e31223b0801a83152fb420341719ae1fb7deab8b74597b5c437e9R129-R156