### PR TITLE
op-txpool: external validating proxy for conditional transactions

### DIFF
--- a/op-service/rpc/error.go
+++ b/op-service/rpc/error.go
@@ -1,0 +1,21 @@
+package rpc
+
+import "github.com/ethereum/go-ethereum/rpc"
+
+var (
+	_ rpc.Error = new(JsonError)
+	_ error     = new(JsonError)
+)
+
+type JsonError struct {
+	Message string
+	Code    int
+}
+
+func (j *JsonError) Error() string {
+	return j.Message
+}
+
+func (j *JsonError) ErrorCode() int {
+	return j.Code
+}

--- a/op-txpool/cli.go
+++ b/op-txpool/cli.go
@@ -1,0 +1,50 @@
+package op_txpool
+
+import (
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	SendRawTransactionConditionalEnabledFlagName   = "sendRawTxConditional.enabled"
+	SendRawTransactionConditionalBackendsFlagName  = "sendRawTxConditional.backends"
+	SendRawTransactionConditionalRateLimitFlagName = "sendRawTxConditional.ratelimit"
+)
+
+type CLIConfig struct {
+	SendRawTransactionConditionalEnabled   bool
+	SendRawTransactionConditionalBackends  []string
+	SendRawTransactionConditionalRateLimit uint64
+}
+
+func CLIFlags(envPrefix string) []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    SendRawTransactionConditionalEnabledFlagName,
+			Usage:   "Decider if eth_sendRawTransactionConditional requests should passthrough or be rejected",
+			Value:   true,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "SENDRAWTXCONDITIONAL_ENABLED"),
+		},
+		&cli.StringSliceFlag{
+			Name:    SendRawTransactionConditionalBackendsFlagName,
+			Usage:   "List of backends to broadcast conditional transactions",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "SENDRAWTXCONDITIONAL_BACKENDS"),
+		},
+		&cli.Uint64Flag{
+			Name:    SendRawTransactionConditionalRateLimitFlagName,
+			Usage:   "Maximum cost -- storage lookups -- allowed for conditional transactions in a given second",
+			Value:   5000,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "SENDRAWTXCONDITIONAL_RATELIMIT"),
+		},
+	}
+}
+
+// TODO: Entrypoint addresses? somewhere to read preinstalls
+func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+	return CLIConfig{
+		SendRawTransactionConditionalEnabled:   ctx.Bool(SendRawTransactionConditionalEnabledFlagName),
+		SendRawTransactionConditionalBackends:  ctx.StringSlice(SendRawTransactionConditionalBackendsFlagName),
+		SendRawTransactionConditionalRateLimit: ctx.Uint64(SendRawTransactionConditionalRateLimitFlagName),
+	}
+}

--- a/op-txpool/cli.go
+++ b/op-txpool/cli.go
@@ -40,7 +40,6 @@ func CLIFlags(envPrefix string) []cli.Flag {
 	}
 }
 
-// TODO: Entrypoint addresses? somewhere to read preinstalls
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	return CLIConfig{
 		SendRawTransactionConditionalEnabled:   ctx.Bool(SendRawTransactionConditionalEnabledFlagName),

--- a/op-txpool/cmd/main.go
+++ b/op-txpool/cmd/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	optxpool "github.com/ethereum-optimism/optimism/op-txpool"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	GitCommit    = ""
+	GitDate      = ""
+	EnvVarPrefix = "OP_TXPOOL"
+)
+
+func main() {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Version = params.VersionWithCommit(GitCommit, GitDate)
+	app.Name = "op-txpool"
+	app.Usage = "Optimism TxPool Service"
+	app.Description = "Auxilliary service to supplement op-stack transaction pool management"
+	app.Action = cliapp.LifecycleCmd(TxPoolMain)
+
+	logFlags := oplog.CLIFlags(EnvVarPrefix)
+	rpcFlags := rpc.CLIFlags(EnvVarPrefix)
+	backendFlags := optxpool.CLIFlags(EnvVarPrefix)
+	app.Flags = append(append(backendFlags, rpcFlags...), logFlags...)
+
+	ctx := opio.WithInterruptBlocker(context.Background())
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		log.Crit("Application Failed", "err", err)
+	}
+}
+
+func TxPoolMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx))
+	m := metrics.With(metrics.NewRegistry())
+
+	cfg := optxpool.ReadCLIConfig(ctx)
+	txpool, err := optxpool.NewTxPool(ctx.Context, log, m, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to start superchain backend: %w", err)
+	}
+
+	rpcConfig := rpc.ReadCLIConfig(ctx)
+	rpcOpts := []rpc.ServerOption{rpc.WithAPIs(txpool.GetAPIs()), rpc.WithLogger(log)}
+	rpcServer := rpc.NewServer(rpcConfig.ListenAddr, rpcConfig.ListenPort, ctx.App.Version, rpcOpts...)
+	return rpc.NewService(log, rpcServer), nil
+}

--- a/op-txpool/conditional_txs.go
+++ b/op-txpool/conditional_txs.go
@@ -1,0 +1,178 @@
+package op_txpool
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"golang.org/x/time/rate"
+)
+
+var (
+	authHeaderKey = "x-optimism-signature"
+
+	// errs
+	rateLimitErr             = &oprpc.JsonError{Message: "rate limited", Code: types.TransactionConditionalRejectedErrCode}
+	endpointDisabledErr      = &oprpc.JsonError{Message: "endpoint disabled", Code: types.TransactionConditionalRejectedErrCode}
+	invalidAuthenticationErr = &oprpc.JsonError{Message: "invalid authentication", Code: types.TransactionConditionalRejectedErrCode}
+	entrypointSupportErr     = &oprpc.JsonError{Message: "only 4337 Entrypoint contract support", Code: types.TransactionConditionalRejectedErrCode}
+)
+
+type ConditionalTxService struct {
+	log log.Logger
+	cfg *CLIConfig
+
+	limiter             *rate.Limiter
+	backends            map[string]client.RPC
+	entrypointAddresses map[common.Address]bool
+
+	costSummary prometheus.Summary
+	requests    prometheus.Counter
+	failures    *prometheus.CounterVec
+}
+
+func NewConditionalService(ctx context.Context, log log.Logger, m metrics.Factory, cfg *CLIConfig) (*ConditionalTxService, error) {
+	backends := map[string]client.RPC{}
+	for _, addr := range cfg.SendRawTransactionConditionalBackends {
+		rpc, err := client.NewRPC(ctx, log, addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial backend %s: %w", addr, err)
+		}
+
+		rpcMetrics := metrics.MakeRPCClientMetrics(addr, m)
+		backends[addr] = client.NewInstrumentedRPC(rpc, &rpcMetrics)
+	}
+
+	limiter := rate.NewLimiter(types.TransactionConditionalMaxCost, int(cfg.SendRawTransactionConditionalRateLimit))
+	entrypointAddresses := map[common.Address]bool{predeploys.EntryPoint_v060Addr: true, predeploys.EntryPoint_v070Addr: true}
+
+	return &ConditionalTxService{
+		log: log,
+		cfg: cfg,
+
+		limiter:             limiter,
+		backends:            backends,
+		entrypointAddresses: entrypointAddresses,
+
+		costSummary: m.NewSummary(prometheus.SummaryOpts{
+			Namespace: MetricsNameSpace,
+			Name:      "txconditional_cost",
+			Help:      "summary of cost observed by *accepted* conditional txs",
+		}),
+		requests: m.NewCounter(prometheus.CounterOpts{
+			Namespace: MetricsNameSpace,
+			Name:      "txconditional_requests",
+			Help:      "number of conditional transaction requests",
+		}),
+		failures: m.NewCounterVec(prometheus.CounterOpts{
+			Namespace: MetricsNameSpace,
+			Name:      "txconditional_failures",
+			Help:      "number of conditional transaction failures",
+		}, []string{"err"}),
+	}, nil
+}
+
+func (s *ConditionalTxService) SendRawTransactionConditional(ctx context.Context, txBytes hexutil.Bytes, cond *types.TransactionConditional) (common.Hash, error) {
+	s.requests.Inc()
+	if !s.cfg.SendRawTransactionConditionalEnabled {
+		s.failures.WithLabelValues("err", "disabled").Inc()
+		return common.Hash{}, endpointDisabledErr
+	}
+
+	// Authenticate the request
+	peerInfo := rpc.PeerInfoFromContext(ctx)
+	authHeader := peerInfo.HTTP.Header.Get(authHeaderKey)
+	if authHeader == "" {
+		s.failures.WithLabelValues("err", "missing auth").Inc()
+		return common.Hash{}, invalidAuthenticationErr
+	}
+	authElems := strings.Split(authHeader, ":")
+	if len(authElems) != 2 {
+		s.failures.WithLabelValues("err", "invalid auth header").Inc()
+		return common.Hash{}, invalidAuthenticationErr
+	}
+
+	caller, signature := common.HexToAddress(authElems[0]), common.Hex2Bytes(authElems[1])
+	sigPubKey, err := crypto.SigToPub(accounts.TextHash(peerInfo.HTTP.Body), signature)
+	if err != nil {
+		s.failures.WithLabelValues("err", "invalid auth signature").Inc()
+		return common.Hash{}, invalidAuthenticationErr
+	}
+	if caller != crypto.PubkeyToAddress(*sigPubKey) {
+		s.failures.WithLabelValues("err", "mismatch auth caller").Inc()
+		return common.Hash{}, invalidAuthenticationErr
+	}
+
+	// Handle the request. For now, we do nothing with the authenticated signer
+	hash, err := s.sendCondTx(ctx, caller, txBytes, cond)
+	if err != nil {
+		s.failures.WithLabelValues("err", err.Error()).Inc()
+		s.log.Error("failed transaction conditional", "caller", caller.String(), "hash", hash.String(), "err", err)
+	}
+	return hash, err
+}
+
+func (s *ConditionalTxService) sendCondTx(ctx context.Context, caller common.Address, txBytes hexutil.Bytes, cond *types.TransactionConditional) (common.Hash, error) {
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(txBytes); err != nil {
+		return common.Hash{}, fmt.Errorf("failed to unmarshal tx: %w", err)
+	}
+
+	txHash := tx.Hash()
+
+	// external checks (tx target, conditional cost & validation)
+	if tx.To() == nil || !s.entrypointAddresses[*tx.To()] {
+		return txHash, entrypointSupportErr
+	}
+	if err := cond.Validate(); err != nil {
+		return txHash, &oprpc.JsonError{
+			Message: fmt.Sprintf("failed conditional validation: %s", err),
+			Code:    types.TransactionConditionalRejectedErrCode,
+		}
+	}
+	cost := cond.Cost()
+	if cost > types.TransactionConditionalMaxCost {
+		return txHash, &oprpc.JsonError{
+			Message: fmt.Sprintf("conditional cost, %d, exceeded max: %d", cost, types.TransactionConditionalMaxCost),
+			Code:    types.TransactionConditionalCostExceededMaxErrCode,
+		}
+	}
+
+	// enforce rate limit on the cost to be observed
+	ctxwt, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := s.limiter.WaitN(ctxwt, cost); err != nil {
+		return txHash, rateLimitErr
+	}
+
+	s.costSummary.Observe(float64(cost))
+
+	// Broadcast to the registered backends. If we observe a rejected conditional, we'll surface that to the
+	// caller. Otherwise, we broadcast with best effort and will be alerted via metrics for unhealthy backends
+	s.log.Info("broadcasting conditional transaction", "caller", caller.String(), "hash", txHash.String())
+	for addr, backend := range s.backends {
+		if err := backend.CallContext(ctx, nil, "eth_sendRawTransactionConditional", txBytes, cond); err != nil {
+			s.log.Error("error broadcasting to backend", "addr", addr, "err", err)
+			if err, ok := err.(rpc.Error); ok && err.ErrorCode() == types.TransactionConditionalRejectedErrCode {
+				return txHash, err
+			}
+		}
+	}
+	return txHash, nil
+}

--- a/op-txpool/conditional_txs.go
+++ b/op-txpool/conditional_txs.go
@@ -30,6 +30,7 @@ var (
 	// errs
 	rateLimitErr             = &oprpc.JsonError{Message: "rate limited", Code: types.TransactionConditionalRejectedErrCode}
 	endpointDisabledErr      = &oprpc.JsonError{Message: "endpoint disabled", Code: types.TransactionConditionalRejectedErrCode}
+	missingConditionalErr    = &oprpc.JsonError{Message: "missing conditional", Code: types.TransactionConditionalRejectedErrCode}
 	invalidAuthenticationErr = &oprpc.JsonError{Message: "invalid authentication", Code: types.TransactionConditionalRejectedErrCode}
 	entrypointSupportErr     = &oprpc.JsonError{Message: "only 4337 Entrypoint contract support", Code: types.TransactionConditionalRejectedErrCode}
 )
@@ -47,7 +48,7 @@ type ConditionalTxService struct {
 	failures    *prometheus.CounterVec
 }
 
-func NewConditionalService(ctx context.Context, log log.Logger, m metrics.Factory, cfg *CLIConfig) (*ConditionalTxService, error) {
+func NewConditionalTxService(ctx context.Context, log log.Logger, m metrics.Factory, cfg *CLIConfig) (*ConditionalTxService, error) {
 	backends := map[string]client.RPC{}
 	for _, addr := range cfg.SendRawTransactionConditionalBackends {
 		rpc, err := client.NewRPC(ctx, log, addr)
@@ -91,38 +92,42 @@ func NewConditionalService(ctx context.Context, log log.Logger, m metrics.Factor
 func (s *ConditionalTxService) SendRawTransactionConditional(ctx context.Context, txBytes hexutil.Bytes, cond *types.TransactionConditional) (common.Hash, error) {
 	s.requests.Inc()
 	if !s.cfg.SendRawTransactionConditionalEnabled {
-		s.failures.WithLabelValues("err", "disabled").Inc()
+		s.failures.WithLabelValues("disabled").Inc()
 		return common.Hash{}, endpointDisabledErr
+	}
+	if cond == nil {
+		s.failures.WithLabelValues("missing conditional").Inc()
+		return common.Hash{}, missingConditionalErr
 	}
 
 	// Authenticate the request
 	peerInfo := rpc.PeerInfoFromContext(ctx)
 	authHeader := peerInfo.HTTP.Header.Get(authHeaderKey)
 	if authHeader == "" {
-		s.failures.WithLabelValues("err", "missing auth").Inc()
+		s.failures.WithLabelValues("missing auth").Inc()
 		return common.Hash{}, invalidAuthenticationErr
 	}
 	authElems := strings.Split(authHeader, ":")
 	if len(authElems) != 2 {
-		s.failures.WithLabelValues("err", "invalid auth header").Inc()
+		s.failures.WithLabelValues("invalid auth header").Inc()
 		return common.Hash{}, invalidAuthenticationErr
 	}
 
 	caller, signature := common.HexToAddress(authElems[0]), common.Hex2Bytes(authElems[1])
 	sigPubKey, err := crypto.SigToPub(accounts.TextHash(peerInfo.HTTP.Body), signature)
 	if err != nil {
-		s.failures.WithLabelValues("err", "invalid auth signature").Inc()
+		s.failures.WithLabelValues("invalid auth signature").Inc()
 		return common.Hash{}, invalidAuthenticationErr
 	}
 	if caller != crypto.PubkeyToAddress(*sigPubKey) {
-		s.failures.WithLabelValues("err", "mismatch auth caller").Inc()
+		s.failures.WithLabelValues("mismatch auth caller").Inc()
 		return common.Hash{}, invalidAuthenticationErr
 	}
 
 	// Handle the request. For now, we do nothing with the authenticated signer
 	hash, err := s.sendCondTx(ctx, caller, txBytes, cond)
 	if err != nil {
-		s.failures.WithLabelValues("err", err.Error()).Inc()
+		s.failures.WithLabelValues(err.Error()).Inc()
 		s.log.Error("failed transaction conditional", "caller", caller.String(), "hash", hash.String(), "err", err)
 	}
 	return hash, err
@@ -165,6 +170,7 @@ func (s *ConditionalTxService) sendCondTx(ctx context.Context, caller common.Add
 
 	// Broadcast to the registered backends. If we observe a rejected conditional, we'll surface that to the
 	// caller. Otherwise, we broadcast with best effort and will be alerted via metrics for unhealthy backends
+	// 	NOTE: proxyd will feature this feature so in practice we wont actually need to fan-out here.
 	s.log.Info("broadcasting conditional transaction", "caller", caller.String(), "hash", txHash.String())
 	for addr, backend := range s.backends {
 		if err := backend.CallContext(ctx, nil, "eth_sendRawTransactionConditional", txBytes, cond); err != nil {

--- a/op-txpool/conditional_txs_test.go
+++ b/op-txpool/conditional_txs_test.go
@@ -1,0 +1,260 @@
+package op_txpool
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/stretchr/testify/require"
+)
+
+type authAddingTransport struct {
+	underlying     http.RoundTripper
+	invalidateAddr bool
+}
+
+func (c *authAddingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get(authHeaderKey) == "" {
+		body, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(io.NopCloser(bytes.NewBuffer(body)))
+
+		privKey, _ := crypto.GenerateKey()
+		sig, _ := crypto.Sign(accounts.TextHash(body), privKey)
+		addr := crypto.PubkeyToAddress(privKey.PublicKey)
+		if c.invalidateAddr {
+			addr = common.Address{19: 1}
+		}
+
+		req.Header.Set(authHeaderKey, fmt.Sprintf("%s:%s", addr, hex.EncodeToString(sig)))
+	}
+
+	return c.underlying.RoundTrip(req)
+}
+
+func TestSendRawTransactionConditionalDisabled(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: false}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	hash, err := svc.SendRawTransactionConditional(context.Background(), nil, nil)
+	require.Zero(t, hash)
+	require.Equal(t, endpointDisabledErr, err)
+}
+
+func TestSendRawTransactionConditionalMissingAuth(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	// by default the peer info is not set in the ctx
+	cond := &types.TransactionConditional{}
+	hash, err := svc.SendRawTransactionConditional(context.Background(), nil, cond)
+	require.Zero(t, hash)
+	require.Equal(t, invalidAuthenticationErr, err)
+}
+
+func TestSendRawTransactionConditionalMissingConditional(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	hash, err := svc.SendRawTransactionConditional(context.Background(), nil, nil)
+	require.Zero(t, hash)
+	require.Equal(t, missingConditionalErr, err)
+}
+
+func TestSendRawTransactionConditionalBadAuth(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("test", svc))
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv)
+	c, err := rpc.Dial(ts.URL)
+	require.NoError(t, err)
+	defer c.Close()
+
+	c.SetHeader(authHeaderKey, "foobarbaz")
+	err = c.Call(nil, "test_sendRawTransactionConditional", "", &types.TransactionConditional{})
+	require.NotNil(t, err)
+	require.Equal(t, invalidAuthenticationErr.Message, err.Error())
+}
+
+func TestSendRawTransactionConditionalBadSignature(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("test", svc))
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv)
+	c, err := rpc.Dial(ts.URL)
+	require.NoError(t, err)
+	defer c.Close()
+
+	c.SetHeader(authHeaderKey, fmt.Sprintf("%s:%s", common.HexToAddress("0xa"), "foobar"))
+	err = c.Call(nil, "test_sendRawTransactionConditional", "", &types.TransactionConditional{})
+	require.NotNil(t, err)
+	require.Equal(t, invalidAuthenticationErr.Message, err.Error())
+}
+
+func TestSendRawTransactionConditionalInvalidTxTarget(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true, SendRawTransactionConditionalRateLimit: 1_000_000}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("test", svc))
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv)
+	httpc := &http.Client{Transport: &authAddingTransport{http.DefaultTransport, false}}
+	c, err := rpc.DialOptions(context.Background(), ts.URL, rpc.WithHTTPClient(httpc))
+	require.NoError(t, err)
+	defer c.Close()
+
+	txBytes, _ := rlp.EncodeToBytes(types.NewTransaction(0, common.Address{19: 1}, big.NewInt(0), 0, big.NewInt(0), nil))
+	err = c.Call(nil, "test_sendRawTransactionConditional", hexutil.Encode(txBytes), &types.TransactionConditional{})
+	require.NotNil(t, err)
+	require.Equal(t, entrypointSupportErr.Message, err.Error())
+}
+
+func TestSendRawTransactionConditionalCaller(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true, SendRawTransactionConditionalRateLimit: 1_000_000}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("test", svc))
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv)
+	httpc := &http.Client{Transport: &authAddingTransport{http.DefaultTransport, true}}
+	c, err := rpc.DialOptions(context.Background(), ts.URL, rpc.WithHTTPClient(httpc))
+	require.NoError(t, err)
+	defer c.Close()
+
+	txBytes, _ := rlp.EncodeToBytes(types.NewTransaction(0, common.Address{19: 1}, big.NewInt(0), 0, big.NewInt(0), nil))
+	err = c.Call(nil, "test_sendRawTransactionConditional", hexutil.Encode(txBytes), &types.TransactionConditional{})
+	require.NotNil(t, err)
+	require.Equal(t, invalidAuthenticationErr.Message, err.Error())
+}
+
+func TestSendRawTransactionConditionalValidSignature(t *testing.T) {
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true, SendRawTransactionConditionalRateLimit: 1_000_000}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("test", svc))
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv)
+	httpc := &http.Client{Transport: &authAddingTransport{http.DefaultTransport, false}}
+	c, err := rpc.DialOptions(context.Background(), ts.URL, rpc.WithHTTPClient(httpc))
+	require.NoError(t, err)
+	defer c.Close()
+
+	txBytes, _ := rlp.EncodeToBytes(types.NewTransaction(0, predeploys.EntryPoint_v060Addr, big.NewInt(0), 0, big.NewInt(0), nil))
+	require.Nil(t, c.Call(nil, "test_sendRawTransactionConditional", hexutil.Encode(txBytes), &types.TransactionConditional{}))
+}
+
+func TestSendRawTransactionConditionalInvalidConditionals(t *testing.T) {
+	costExcessiveCond := types.TransactionConditional{KnownAccounts: make(types.KnownAccounts)}
+	for i := 0; i < (types.TransactionConditionalMaxCost + 1); i++ {
+		iBig := big.NewInt(int64(i))
+		root := common.BigToHash(iBig)
+		costExcessiveCond.KnownAccounts[common.BigToAddress(iBig)] = types.KnownAccount{StorageRoot: &root}
+	}
+
+	uint64Ptr := func(num uint64) *uint64 { return &num }
+	tests := []struct {
+		name     string
+		cond     types.TransactionConditional
+		mustFail bool
+	}{
+
+		{
+			name:     "ok validation",
+			cond:     types.TransactionConditional{BlockNumberMin: big.NewInt(1), BlockNumberMax: big.NewInt(2), TimestampMin: uint64Ptr(1), TimestampMax: uint64Ptr(2)},
+			mustFail: false,
+		},
+		{
+			name:     "validation. block min greater than max",
+			cond:     types.TransactionConditional{BlockNumberMin: big.NewInt(2), BlockNumberMax: big.NewInt(1)},
+			mustFail: true,
+		},
+		{
+			name:     "validation. timestamp min greater than max",
+			cond:     types.TransactionConditional{TimestampMin: uint64Ptr(2), TimestampMax: uint64Ptr(1)},
+			mustFail: true,
+		},
+		{
+			name:     "excessive cost",
+			cond:     costExcessiveCond,
+			mustFail: true,
+		},
+	}
+
+	log := testlog.Logger(t, log.LevelInfo)
+	cfg := &CLIConfig{SendRawTransactionConditionalEnabled: true, SendRawTransactionConditionalRateLimit: 1_000_000}
+	svc, err := NewConditionalTxService(context.Background(), log, metrics.With(metrics.NewRegistry()), cfg)
+	require.NoError(t, err)
+
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("test", svc))
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv)
+	httpc := &http.Client{Transport: &authAddingTransport{http.DefaultTransport, false}}
+	c, err := rpc.DialOptions(context.Background(), ts.URL, rpc.WithHTTPClient(httpc))
+	require.NoError(t, err)
+	defer c.Close()
+
+	txBytes, _ := rlp.EncodeToBytes(types.NewTransaction(0, predeploys.EntryPoint_v060Addr, big.NewInt(0), 0, big.NewInt(0), nil))
+	txString := hexutil.Encode(txBytes)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err = c.Call(nil, "test_sendRawTransactionConditional", txString, &test.cond)
+			if test.mustFail && err == nil {
+				t.Errorf("Test %s should fail", test.name)
+			}
+			if !test.mustFail && err != nil {
+				t.Errorf("Test %s should pass but got err: %v", test.name, err)
+			}
+		})
+	}
+}

--- a/op-txpool/txpool.go
+++ b/op-txpool/txpool.go
@@ -19,7 +19,7 @@ type TxPool struct {
 }
 
 func NewTxPool(ctx context.Context, log log.Logger, m metrics.Factory, cfg *CLIConfig) (*TxPool, error) {
-	conditionalTxService, err := NewConditionalService(ctx, log, m, cfg)
+	conditionalTxService, err := NewConditionalTxService(ctx, log, m, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create conditional tx service: %w", err)
 	}

--- a/op-txpool/txpool.go
+++ b/op-txpool/txpool.go
@@ -1,0 +1,32 @@
+package op_txpool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+
+	"github.com/ethereum/go-ethereum/log"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+)
+
+var (
+	MetricsNameSpace = "op_txpool"
+)
+
+type TxPool struct {
+	conditionalTxService *ConditionalTxService
+}
+
+func NewTxPool(ctx context.Context, log log.Logger, m metrics.Factory, cfg *CLIConfig) (*TxPool, error) {
+	conditionalTxService, err := NewConditionalService(ctx, log, m, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create conditional tx service: %w", err)
+	}
+
+	return &TxPool{conditionalTxService}, nil
+}
+
+func (txp *TxPool) GetAPIs() []gethrpc.API {
+	return []gethrpc.API{{Namespace: "eth", Service: txp.conditionalTxService}}
+}


### PR DESCRIPTION
Requires
* [ ] ethereum-optimism/op-geth#352
* [ ] ethereum-optimism/op-geth#330

This PR introduces a txpool service to proxy certain rpcs prior to reaching mempool. Primarily just the `sendRawTransactionConditional` endpoint. This implements the validation and requirements described in the [design doc](https://github.com/ethereum-optimism/design-docs/blob/main/ecosystem/sendRawTransactionConditional/proposal.md)
- Authentication
- Rate Limiting
- Metrics
- Enable/Disable Conditional Requests
- 4337 Entrypoint tx target restriction
- Basic conditional validation

Note: While this service fans out to the list of block builders specified in the config, proxyd will support this broadcast functionality
