### PR TITLE
ci: speed up contracts bedrock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,17 +580,12 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - install-contracts-dependencies
-      - restore_cache:
-          name: Restore PNPM Package Cache
-          keys:
-            - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
-      - attach_workspace: { at: "." }
       - check-changed:
           patterns: contracts-bedrock,op-node
+      - attach_workspace: { at: "." }
+      - install-contracts-dependencies
       - setup_remote_docker:
           docker_layer_caching: true
-      # populate node modules from the cache
       - run:
           name: Install dependencies
           command: pnpm install
@@ -1521,9 +1516,7 @@ workflows:
           name: pnpm-monorepo
       - contracts-bedrock-tests
       - contracts-bedrock-coverage
-      - contracts-bedrock-checks:
-          requires:
-            - pnpm-monorepo
+      - contracts-bedrock-checks
       - contracts-bedrock-validate-spaces:
           requires:
             - pnpm-monorepo


### PR DESCRIPTION
**Description**

Continue to clean up the ci for the contracts to make ci
faster for `contracts-bedrock`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

