### PR TITLE
op-node: Extract contract binding for SystemConfig

### DIFF
--- a/op-node/cmd/genesis/systemconfig.go
+++ b/op-node/cmd/genesis/systemconfig.go
@@ -1,0 +1,36 @@
+package genesis
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	methodStartBlock = "startBlock"
+)
+
+type SystemConfigContract struct {
+	caller   *batching.MultiCaller
+	contract *batching.BoundContract
+}
+
+func NewSystemConfigContract(caller *batching.MultiCaller, addr common.Address) *SystemConfigContract {
+	return &SystemConfigContract{
+		caller:   caller,
+		contract: batching.NewBoundContract(snapshots.LoadSystemConfigABI(), addr),
+	}
+}
+
+func (c *SystemConfigContract) StartBlock(ctx context.Context) (*big.Int, error) {
+	result, err := c.caller.SingleCall(ctx, rpcblock.Latest, c.contract.Call(methodStartBlock))
+	if err != nil {
+		return nil, fmt.Errorf("failed to call startBlock: %w", err)
+	}
+	return result.GetBigInt(0), nil
+}

--- a/op-node/cmd/genesis/systemconfig_test.go
+++ b/op-node/cmd/genesis/systemconfig_test.go
@@ -1,0 +1,28 @@
+package genesis
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemConfigContract_StartBlock(t *testing.T) {
+	addr := common.Address{0xaa}
+	sysCfgAbi := snapshots.LoadSystemConfigABI()
+	stubRpc := batchingTest.NewAbiBasedRpc(t, addr, sysCfgAbi)
+	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
+	sysCfg := NewSystemConfigContract(caller, addr)
+	expected := big.NewInt(56)
+	stubRpc.SetResponse(addr, methodStartBlock, rpcblock.Latest, nil, []interface{}{expected})
+
+	result, err := sysCfg.StartBlock(context.Background())
+	require.NoError(t, err)
+	require.Truef(t, result.Cmp(expected) == 0, "expected %v, got %v", expected, result)
+}

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -22,6 +22,9 @@ var mips []byte
 //go:embed abi/DelayedWETH.json
 var delayedWETH []byte
 
+//go:embed abi/SystemConfig.json
+var systemConfig []byte
+
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
 }
@@ -36,6 +39,10 @@ func LoadMIPSABI() *abi.ABI {
 }
 func LoadDelayedWETHABI() *abi.ABI {
 	return loadABI(delayedWETH)
+}
+
+func LoadSystemConfigABI() *abi.ABI {
+	return loadABI(systemConfig)
 }
 
 func loadABI(json []byte) *abi.ABI {


### PR DESCRIPTION
**Description**

Switches the call to `startBlock()` on the `SystemConfig` contract to use the newer custom bindings approach rather than manually calculating the method sig. Ensures that the contract and this caller stay in sync and allows writing a unit test for the call.
