### PR TITLE
ci: better solc warnings check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,12 +599,9 @@ jobs:
           name: forge version
           command: forge --version
       - run:
-          # The solc warnings check must be the first step to build the contracts, that way the
-          # warnings are output here. On subsequent runs, forge will read artifacts from the cache
-          # so warnings would not occur.
           name: solc warnings check
           command: |
-            forge build --deny-warnings || echo "export SOLC_WARNINGS_CHECK=1" >> "$BASH_ENV"
+            forge build --force --deny-warnings || echo "export SOLC_WARNINGS_CHECK=1" >> "$BASH_ENV"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -27,7 +27,8 @@ bytecode_hash = 'none'
 build_info_path = 'artifacts/build-info'
 ast = true
 evm_version = "cancun"
-ignored_error_codes = ["transient-storage", "code-size", "init-code-size"]
+# 5159 error code is selfdestruct error code
+ignored_error_codes = ["transient-storage", "code-size", "init-code-size", 5159]
 
 # We set the gas limit to max int64 to avoid running out of gas during testing, since the default
 # gas limit is 1B and some of our tests require more gas than that, such as `test_callWithMinGas_noLeakageLow_succeeds`.

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -870,7 +870,6 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(5);
         gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
         (,,,, disputed,,) = gameProxy.claimData(6);
-        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
         gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, postState_);
         (,,,, disputed,,) = gameProxy.claimData(7);
 


### PR DESCRIPTION
**Description**

Use `forge build --force` to force a build so that the warning check can
be observed. CI should fail on this commit

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

