### PR TITLE
op-dispute-mon: Add game fetching logs

### DIFF
--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -95,6 +95,7 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 						e.logger.Error("Failed to fetch game data", "game", game.Proxy, "err", err)
 						continue
 					}
+					e.logger.Info("Fetching game", "address", game.Proxy)
 					enrichedCh <- enrichedGame
 				}
 			}

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -95,7 +95,7 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 						e.logger.Error("Failed to fetch game data", "game", game.Proxy, "err", err)
 						continue
 					}
-					e.logger.Info("Fetching game", "address", game.Proxy)
+					fmt.Printf("\rFetching game: %s", game.Proxy)
 					enrichedCh <- enrichedGame
 				}
 			}


### PR DESCRIPTION
After starting the service, there is about a ten to fifteen-minute period where it fetches data without outputting any logs. This makes it difficult to tell if the program is running correctly, so I think it's necessary to add logs for the fetching process.

I'm not sure if using 
`fmt.Printf("\rFetching game: %s", game.Proxy)` is appropriate in this context, so I opted to use `e.logger.Info("Fetching game", "address", game.Proxy)` instead.

