### PR TITLE
[op-dispute-mon] Track the latest proposed L2 block number

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -173,6 +173,8 @@ type Metricer interface {
 
 	RecordGameAgreement(status GameAgreementStatus, count int)
 
+	RecordLatestValidProposalL2Block(latestValid uint64)
+
 	RecordLatestProposals(latestValid, latestInvalid uint64)
 
 	RecordIgnoredGames(count int)
@@ -215,11 +217,12 @@ type Metrics struct {
 
 	lastOutputFetch prometheus.Gauge
 
-	gamesAgreement  prometheus.GaugeVec
-	latestProposals prometheus.GaugeVec
-	ignoredGames    prometheus.Gauge
-	failedGames     prometheus.Gauge
-	l2Challenges    prometheus.GaugeVec
+	gamesAgreement             prometheus.GaugeVec
+	latestValidProposalL2Block prometheus.Gauge
+	latestProposals            prometheus.GaugeVec
+	ignoredGames               prometheus.Gauge
+	failedGames                prometheus.Gauge
+	l2Challenges               prometheus.GaugeVec
 
 	requiredCollateral  prometheus.GaugeVec
 	availableCollateral prometheus.GaugeVec
@@ -332,6 +335,11 @@ func NewMetrics() *Metrics {
 			"completion",
 			"result_correctness",
 			"root_agreement",
+		}),
+		latestValidProposalL2Block: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "latest_valid_proposal_l2_block",
+			Help:      "L2 block number proposed by the latest game with a valid root claim",
 		}),
 		latestProposals: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -493,6 +501,10 @@ func (m *Metrics) RecordOutputFetchTime(timestamp float64) {
 
 func (m *Metrics) RecordGameAgreement(status GameAgreementStatus, count int) {
 	m.gamesAgreement.WithLabelValues(labelValuesFor(status)...).Set(float64(count))
+}
+
+func (m *Metrics) RecordLatestValidProposalL2Block(latestValid uint64) {
+	m.latestValidProposalL2Block.Set(float64(latestValid))
 }
 
 func (m *Metrics) RecordLatestProposals(latestValid, latestInvalid uint64) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -38,6 +38,8 @@ func (*NoopMetricsImpl) RecordOutputFetchTime(_ float64) {}
 
 func (*NoopMetricsImpl) RecordGameAgreement(_ GameAgreementStatus, _ int) {}
 
+func (*NoopMetricsImpl) RecordLatestValidProposalL2Block(_ uint64) {}
+
 func (*NoopMetricsImpl) RecordLatestProposals(_, _ uint64) {}
 
 func (*NoopMetricsImpl) RecordIgnoredGames(_ int) {}

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -16,6 +16,7 @@ var (
 
 type ForecastMetrics interface {
 	RecordGameAgreement(status metrics.GameAgreementStatus, count int)
+	RecordLatestValidProposalL2Block(validL2Block uint64)
 	RecordLatestProposals(validTimestamp, invalidTimestamp uint64)
 	RecordIgnoredGames(count int)
 	RecordFailedGames(count int)
@@ -32,8 +33,9 @@ type forecastBatch struct {
 	AgreeChallengerWins    int
 	DisagreeChallengerWins int
 
-	LatestInvalidProposal uint64
-	LatestValidProposal   uint64
+	LatestValidProposalL2Block uint64
+	LatestInvalidProposal      uint64
+	LatestValidProposal        uint64
 }
 
 type Forecast struct {
@@ -69,6 +71,7 @@ func (f *Forecast) recordBatch(batch forecastBatch, ignoredCount, failedCount in
 	f.metrics.RecordGameAgreement(metrics.AgreeDefenderAhead, batch.AgreeDefenderAhead)
 	f.metrics.RecordGameAgreement(metrics.DisagreeDefenderAhead, batch.DisagreeDefenderAhead)
 
+	f.metrics.RecordLatestValidProposalL2Block(batch.LatestValidProposalL2Block)
 	f.metrics.RecordLatestProposals(batch.LatestValidProposal, batch.LatestInvalidProposal)
 
 	f.metrics.RecordIgnoredGames(ignoredCount)
@@ -89,6 +92,9 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 	} else {
 		if metrics.LatestValidProposal < game.Timestamp {
 			metrics.LatestValidProposal = game.Timestamp
+		}
+		if metrics.LatestValidProposalL2Block < game.L2BlockNumber {
+			metrics.LatestValidProposalL2Block = game.L2BlockNumber
 		}
 	}
 

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -269,9 +269,10 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	games := make([]*monTypes.EnrichedGameData, 9)
 	for i := range games {
 		games[i] = &monTypes.EnrichedGameData{
-			Status:    gameStatus[i],
-			Claims:    claims[i],
-			RootClaim: rootClaims[i],
+			Status:        gameStatus[i],
+			Claims:        claims[i],
+			RootClaim:     rootClaims[i],
+			L2BlockNumber: uint64(i),
 			GameMetadata: types.GameMetadata{
 				Timestamp: uint64(i),
 			},
@@ -292,6 +293,7 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	require.Equal(t, expectedMetrics, m.gameAgreement)
 	require.Equal(t, 3, m.ignoredGames)
 	require.Equal(t, 4, m.contractCreationFails)
+	require.EqualValues(t, 8, m.latestValidProposalL2Block)
 	require.EqualValues(t, 7, m.latestInvalidProposal)
 	require.EqualValues(t, 8, m.latestValidProposal)
 }
@@ -318,11 +320,12 @@ func zeroGameAgreement() map[metrics.GameAgreementStatus]int {
 }
 
 type mockForecastMetrics struct {
-	gameAgreement         map[metrics.GameAgreementStatus]int
-	ignoredGames          int
-	latestInvalidProposal uint64
-	latestValidProposal   uint64
-	contractCreationFails int
+	gameAgreement              map[metrics.GameAgreementStatus]int
+	ignoredGames               int
+	latestValidProposalL2Block uint64
+	latestInvalidProposal      uint64
+	latestValidProposal        uint64
+	contractCreationFails      int
 }
 
 func (m *mockForecastMetrics) RecordFailedGames(count int) {
@@ -331,6 +334,10 @@ func (m *mockForecastMetrics) RecordFailedGames(count int) {
 
 func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementStatus, count int) {
 	m.gameAgreement[status] = count
+}
+
+func (m *mockForecastMetrics) RecordLatestValidProposalL2Block(valid uint64) {
+	m.latestValidProposalL2Block = valid
 }
 
 func (m *mockForecastMetrics) RecordLatestProposals(valid, invalid uint64) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We'd like to know the latest valid block number associated with a valid dispute game. This would be the equivalent of getting the latest block number from `L2OutputOracle`. We could look into the `AnchorStateRegistry`, but this does not give us quick enough feedback to know if we are keeping up with "proposing" correct root hashes for the most recent L2 blocks, as dispute games resolves approximately 3.5 days (assuming happy path).

There can be many dispute games at any given time, and they may be valid or invalid. This metric captures only valid block numbers from dispute games that we "agree" with based on the root claim.

**Tests**

Updated the forecast test to capture this new metric.

**Additional context**

There are alternative metrics we can look at, e.g. within `op-proposer`, but this metric would come straight from the onchain state.

**Metadata**

- Fixes #[Link to Issue]
