### PR TITLE
fix: adjust plasma test params for smaller challenge window sizes

### DIFF
--- a/op-e2e/actions/plasma_test.go
+++ b/op-e2e/actions/plasma_test.go
@@ -49,8 +49,8 @@ type PlasmaParam func(p *e2eutils.TestParams)
 func NewL2PlasmaDA(t Testing, params ...PlasmaParam) *L2PlasmaDA {
 	p := &e2eutils.TestParams{
 		MaxSequencerDrift:   40,
-		SequencerWindowSize: 120,
-		ChannelTimeout:      120,
+		SequencerWindowSize: 12,
+		ChannelTimeout:      12,
 		L1BlockTime:         12,
 		UsePlasma:           true,
 	}
@@ -453,10 +453,6 @@ func TestPlasma_SequencerStalledMultiChallenges(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	a := NewL2PlasmaDA(t)
 
-	// generate some initial L1 blocks.
-	a.ActL1Blocks(t, 5)
-	a.sequencer.ActL1HeadSignal(t)
-
 	// create a new tx on l2 and commit it to l1
 	a.ActNewL2Tx(t)
 
@@ -489,7 +485,7 @@ func TestPlasma_SequencerStalledMultiChallenges(gt *testing.T) {
 	})
 
 	// include it in L1
-	a.miner.ActL1StartBlock(120)(t)
+	a.miner.ActL1StartBlock(12)(t)
 	a.miner.ActL1IncludeTx(a.dp.Addresses.Batcher)(t)
 	a.miner.ActL1EndBlock(t)
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Shortening the plasma challenge and resolve windows requires a smaller sequencer window size otherwise the EL does not reorg properly in case of expired challenges.

**Tests**

Fixes existing tests.
