### PR TITLE
docs(typo): Fix minor spelling errors in README.md and pausability-lemmas.md

### DIFF
--- a/op-chain-ops/cmd/receipt-reference-builder/README.md
+++ b/op-chain-ops/cmd/receipt-reference-builder/README.md
@@ -34,6 +34,6 @@ This tool is designed with a static range of blocks in mind, the size of which i
 
 To maximize parallel efficiency, a higher number of `-workers` can utilize more RPC requests per second. Additionally `-batch-size` can be increased to group more RPC requests together per network exchange. I am using 5 workers with 100 requests per batch.
 
-To avoid wasteful abandon of work already done, errors which are encountered by workers are noted, but do not stop the aggregation process. Jobs which fail are reinserted into the work queue with no maximum retry, and workers back off when encountering failures. This is all to allow an RPC endpoint to become temporarily unavailalbe while letting aggregation stay persistent.
+To avoid wasteful abandon of work already done, errors which are encountered by workers are noted, but do not stop the aggregation process. Jobs which fail are reinserted into the work queue with no maximum retry, and workers back off when encountering failures. This is all to allow an RPC endpoint to become temporarily unavailable while letting aggregation stay persistent.
 
 Even at high speed, collecting this much data can take several hours. You may benefit from planning a collection of smaller-sized runs, merging them with the `merge` subcommand as they become available.

--- a/packages/contracts-bedrock/scripts/fpac/README.md
+++ b/packages/contracts-bedrock/scripts/fpac/README.md
@@ -6,7 +6,7 @@ Chain-ops scripts for the Fault Proof Alpha Chad contracts.
 
 ### Generating the Cannon prestate and artifacts
 
-_Description_: Generates the cannon prestate, tars the relavent artifacts, and sets the absolute prestate field in the network's deploy config.
+_Description_: Generates the cannon prestate, tars the relevant artifacts, and sets the absolute prestate field in the network's deploy config.
 
 ```sh
 make cannon-prestate chain=<chain-name>

--- a/packages/contracts-bedrock/test/kontrol/pausability-lemmas.md
+++ b/packages/contracts-bedrock/test/kontrol/pausability-lemmas.md
@@ -22,7 +22,7 @@ module PAUSABILITY-LEMMAS
 
 ## Arithmetic
 
-Lemmas on arithmetic reasoning. Specifically, on: cancellativity, inequalites in which the two sides are of different signs; and the rounding-up mechanism of the Solidity compiler (expressed through `notMaxUInt5 &Int ( X +Int 31 )`, which rounds up `X` to the nearest multiple of 32).
+Lemmas on arithmetic reasoning. Specifically, on: cancellativity, inequalities in which the two sides are of different signs; and the rounding-up mechanism of the Solidity compiler (expressed through `notMaxUInt5 &Int ( X +Int 31 )`, which rounds up `X` to the nearest multiple of 32).
 
 ```k
     // Cancellativity #1


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR fixes some spelling errors in markdown files.

**Tests**

None needed

**Additional context**

**Metadata**

