### PR TITLE
op-node: optimize case to handle proposer requests

### DIFF
--- a/op-e2e/e2eutils/geth/geth.go
+++ b/op-e2e/e2eutils/geth/geth.go
@@ -22,7 +22,7 @@ import (
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 )
 
-func InitL1(chainID uint64, blockTime uint64, genesis *core.Genesis, c clock.Clock, blobPoolDir string, beaconSrv Beacon, opts ...GethOption) (*node.Node, *eth.Ethereum, error) {
+func InitL1(chainID uint64, blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c clock.Clock, blobPoolDir string, beaconSrv Beacon, opts ...GethOption) (*node.Node, *eth.Ethereum, error) {
 	ethConfig := &ethconfig.Config{
 		NetworkId: chainID,
 		Genesis:   genesis,
@@ -51,12 +51,11 @@ func InitL1(chainID uint64, blockTime uint64, genesis *core.Genesis, c clock.Clo
 
 	// Instead of running a whole beacon node, we run this fake-proof-of-stake sidecar that sequences L1 blocks using the Engine API.
 	l1Node.RegisterLifecycle(&fakePoS{
-		clock:     c,
-		eth:       l1Eth,
-		log:       log.Root(), // geth logger is global anyway. Would be nice to replace with a local logger though.
-		blockTime: blockTime,
-		// for testing purposes we make it really fast, otherwise we don't see it finalize in short tests
-		finalizedDistance: 8,
+		clock:             c,
+		eth:               l1Eth,
+		log:               log.Root(), // geth logger is global anyway. Would be nice to replace with a local logger though.
+		blockTime:         blockTime,
+		finalizedDistance: finalizedDistance,
 		safeDistance:      4,
 		engineAPI:         catalyst.NewConsensusAPI(l1Eth),
 		beacon:            beaconSrv,

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -123,6 +123,7 @@ func DefaultSystemConfig(t testing.TB) SystemConfig {
 		L1InfoPredeployAddress: predeploys.L1BlockAddr,
 		JWTFilePath:            writeDefaultJWT(t),
 		JWTSecret:              testingJWTSecret,
+		L1FinalizedDistance:    8, // Short, for faster tests.
 		BlobsPath:              t.TempDir(),
 		Nodes: map[string]*rollupNode.Config{
 			RoleSeq: {
@@ -237,6 +238,9 @@ type SystemConfig struct {
 	JWTSecret   [32]byte
 
 	BlobsPath string
+
+	// L1FinalizedDistance is the distance from the L1 head that L1 blocks will be artificially finalized on.
+	L1FinalizedDistance uint64
 
 	Premine        map[common.Address]*big.Int
 	Nodes          map[string]*rollupNode.Config // Per node config. Don't use populate rollup.Config
@@ -613,7 +617,8 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	sys.L1BeaconAPIAddr = beaconApiAddr
 
 	// Initialize nodes
-	l1Node, l1Backend, err := geth.InitL1(cfg.DeployConfig.L1ChainID, cfg.DeployConfig.L1BlockTime, l1Genesis, c,
+	l1Node, l1Backend, err := geth.InitL1(cfg.DeployConfig.L1ChainID,
+		cfg.DeployConfig.L1BlockTime, cfg.L1FinalizedDistance, l1Genesis, c,
 		path.Join(cfg.BlobsPath, "l1_el"), bcn, cfg.GethOptions[RoleL1]...)
 	if err != nil {
 		return nil, err

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1045,6 +1045,7 @@ func TestWithdrawals(t *testing.T) {
 
 	cfg := DefaultSystemConfig(t)
 	cfg.DeployConfig.FinalizationPeriodSeconds = 2 // 2s finalization period
+	cfg.L1FinalizedDistance = 2                    // Finalize quick, don't make the proposer wait too long
 
 	sys, err := cfg.Start(t)
 	require.NoError(t, err, "Error starting up system")


### PR DESCRIPTION
**Description**

If the block is already finalized, then we don't need to hold the derivation work to get a consistent sync-status / block combination.

Other idea; add a custom engine RPC to op-geth, that answers; `given block numbers A and B, return blocks A and B, but error if there is a reorg in-between`. Then we can use that for reorg-consistency checks without locking the op-node at all. Probably helps optimize more different code-paths also.

**Tests**

Modified the withdrawals test, the proposer waits for finality (quick, after 2 blocks), which then triggers the hot-path.

**Additional context**

Avoids timeouts when op-node is busy

**Metadata**


