### PR TITLE
cannon: add test dependence in Makefile

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -23,7 +23,7 @@ elf:
 	make -C ./example elf
 
 contract:
-	cd .. && forge build
+	cd ../packages/contracts-bedrock && forge build
 
 test: elf contract
 	go test -v ./...

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -22,7 +22,10 @@ clean:
 elf:
 	make -C ./example elf
 
-test: elf
+contract:
+	cd .. && forge build
+
+test: elf contract
 	go test -v ./...
 
 fuzz:


### PR DESCRIPTION
Add the `forge build` to compile smart contract for test, in case `../../packages/contracts-bedrock/forge-artifacts/MIPS.sol/MIPS.json` is missing