### PR TITLE
op-node/derive: linter fix

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -30,6 +30,7 @@ var (
 	L1InfoFuncEcotoneBytes4 = crypto.Keccak256([]byte(L1InfoFuncEcotoneSignature))[:4]
 	L1InfoDepositerAddress  = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 	L1BlockAddress          = predeploys.L1BlockAddr
+	ErrInvalidFormat	    = errors.New("invalid ecotone l1 block info format")
 )
 
 const (
@@ -209,21 +210,21 @@ func (info *L1BlockInfo) unmarshalBinaryEcotone(data []byte) error {
 	if _, err := solabi.ReadAndValidateSignature(r, L1InfoFuncEcotoneBytes4); err != nil {
 		return err
 	}
-	if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
-		return errors.New("invalid ecotone l1 block info format")
-	}
-	if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
-		return errors.New("invalid ecotone l1 block info format")
-	}
-	if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
-		return errors.New("invalid ecotone l1 block info format")
-	}
-	if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
-		return errors.New("invalid ecotone l1 block info format")
-	}
-	if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
-		return errors.New("invalid ecotone l1 block info format")
-	}
+    if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
+        return ErrInvalidFormat
+    }
+    if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
+        return ErrInvalidFormat
+    }
+    if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
+        return ErrInvalidFormat
+    }
+    if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
+        return ErrInvalidFormat
+    }
+    if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
+        return ErrInvalidFormat
+    }
 	if info.BaseFee, err = solabi.ReadUint256(r); err != nil {
 		return err
 	}

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -30,7 +30,7 @@ var (
 	L1InfoFuncEcotoneBytes4 = crypto.Keccak256([]byte(L1InfoFuncEcotoneSignature))[:4]
 	L1InfoDepositerAddress  = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 	L1BlockAddress          = predeploys.L1BlockAddr
-	ErrInvalidFormat	    = errors.New("invalid ecotone l1 block info format")
+	ErrInvalidFormat        = errors.New("invalid ecotone l1 block info format")
 )
 
 const (
@@ -210,21 +210,21 @@ func (info *L1BlockInfo) unmarshalBinaryEcotone(data []byte) error {
 	if _, err := solabi.ReadAndValidateSignature(r, L1InfoFuncEcotoneBytes4); err != nil {
 		return err
 	}
-    if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
-        return ErrInvalidFormat
-    }
-    if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
-        return ErrInvalidFormat
-    }
-    if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
-        return ErrInvalidFormat
-    }
-    if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
-        return ErrInvalidFormat
-    }
-    if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
-        return ErrInvalidFormat
-    }
+	if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
+		return ErrInvalidFormat
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
+		return ErrInvalidFormat
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
+		return ErrInvalidFormat
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
+		return ErrInvalidFormat
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
+		return ErrInvalidFormat
+	}
 	if info.BaseFee, err = solabi.ReadUint256(r); err != nil {
 		return err
 	}

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -210,19 +210,19 @@ func (info *L1BlockInfo) unmarshalBinaryEcotone(data []byte) error {
 		return err
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.BaseFeeScalar); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.BlobBaseFeeScalar); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.SequenceNumber); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.Time); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.Number); err != nil {
-		return fmt.Errorf("invalid ecotone l1 block info format")
+		return errors.New("invalid ecotone l1 block info format")
 	}
 	if info.BaseFee, err = solabi.ReadUint256(r); err != nil {
 		return err

--- a/op-node/rollup/derive/plasma_data_source.go
+++ b/op-node/rollup/derive/plasma_data_source.go
@@ -39,7 +39,7 @@ func (s *PlasmaDataSource) Next(ctx context.Context) (eth.Data, error) {
 	// there is not commitment in the current origin.
 	if err := s.fetcher.AdvanceL1Origin(ctx, s.l1, s.id.ID()); err != nil {
 		if errors.Is(err, plasma.ErrReorgRequired) {
-			return nil, NewResetError(fmt.Errorf("new expired challenge"))
+			return nil, NewResetError(errors.New("new expired challenge"))
 		}
 		return nil, NewTemporaryError(fmt.Errorf("failed to advance plasma L1 origin: %w", err))
 	}


### PR DESCRIPTION
linter fix, replace `fmt.Errorf` with `errors.New` when pure content