### PR TITLE
feat(cross-l2-inbox): add CrossL2Inbox to predeploy addresses and an abi loader to snapshots

### DIFF
--- a/op-service/predeploys/addresses.go
+++ b/op-service/predeploys/addresses.go
@@ -25,6 +25,7 @@ const (
 	L1FeeVault                    = "0x420000000000000000000000000000000000001a"
 	SchemaRegistry                = "0x4200000000000000000000000000000000000020"
 	EAS                           = "0x4200000000000000000000000000000000000021"
+	CrossL2Inbox                  = "0x4200000000000000000000000000000000000022"
 	Create2Deployer               = "0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2"
 	MultiCall3                    = "0xcA11bde05977b3631167028862bE2a173976CA11"
 	Safe_v130                     = "0x69f4D1788e39c87893C980c06EdF4b7f686e2938"
@@ -60,6 +61,7 @@ var (
 	L1FeeVaultAddr                    = common.HexToAddress(L1FeeVault)
 	SchemaRegistryAddr                = common.HexToAddress(SchemaRegistry)
 	EASAddr                           = common.HexToAddress(EAS)
+	CrossL2InboxAddr                  = common.HexToAddress(CrossL2Inbox)
 	Create2DeployerAddr               = common.HexToAddress(Create2Deployer)
 	MultiCall3Addr                    = common.HexToAddress(MultiCall3)
 	Safe_v130Addr                     = common.HexToAddress(Safe_v130)

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -25,6 +25,9 @@ var delayedWETH []byte
 //go:embed abi/SystemConfig.json
 var systemConfig []byte
 
+//go:embed abi/CrossL2Inbox.json
+var crossL2Inbox []byte
+
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
 }
@@ -43,6 +46,10 @@ func LoadDelayedWETHABI() *abi.ABI {
 
 func LoadSystemConfigABI() *abi.ABI {
 	return loadABI(systemConfig)
+}
+
+func LoadCrossL2InboxABI() *abi.ABI {
+	return loadABI(crossL2Inbox)
 }
 
 func loadABI(json []byte) *abi.ABI {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds the `CrossL2Inbox` address to `predeploys` package and an abi_loader for `CrossL2Inbox` to the `snapshots` package.
