### PR TITLE
cannon: Fix exitCode for invalid cloneargs in MIPS2 contract

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -128,8 +128,8 @@
     "sourceCodeHash": "0xe28a16aad04ebcadba631a1920cac6e492c18f0d866836610be22779f3f04bfc"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0xdcd3bd4bbf8c119ca2d8a435da322ecc5c55a9e2a308789064bf19105933aa6c",
-    "sourceCodeHash": "0xa1406c94c785b094432aed8af2e1c5b42644e2a0878d48f89b488138e079ee66"
+    "initCodeHash": "0xe496b3d41f51ae6cc6e7d4fb00ca0851b0e77f9b324420f88c09385ea85b1685",
+    "sourceCodeHash": "0xce3bacc0e571fa3a63b61dde8b7aeadefa65e02bbb6de0177222d539c6721c92"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xe5db668fe41436f53995e910488c7c140766ba8745e19743773ebab508efd090",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -7,6 +7,7 @@ import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 import { MIPSInstructions as ins } from "src/cannon/libraries/MIPSInstructions.sol";
+import { VMStatuses } from "src/dispute/lib/Types.sol";
 
 /// @title MIPS2
 /// @notice The MIPS2 contract emulates a single MIPS instruction.
@@ -50,8 +51,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 0.0.1-beta
-    string public constant version = "0.0.1-beta";
+    /// @custom:semver 0.0.2-beta
+    string public constant version = "0.0.2-beta";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -70,9 +71,6 @@ contract MIPS2 is ISemver {
 
     // ThreadState memory offset allocated during step
     uint256 internal constant TC_MEM_OFFSET = 0x220;
-
-    // VM Status Panic exit code
-    uint8 internal constant VM_STATUS_PANIC = 0x3;
 
     /// @param _oracle The address of the preimage oracle contract.
     constructor(IPreimageOracle _oracle) {
@@ -262,7 +260,7 @@ contract MIPS2 is ISemver {
             } else if (syscall_no == sys.SYS_CLONE) {
                 if (sys.VALID_SYS_CLONE_FLAGS != a0) {
                     state.exited = true;
-                    state.exitCode = VM_STATUS_PANIC;
+                    state.exitCode = VMStatuses.PANIC.raw();
                     return outputState();
                 }
                 v0 = state.nextThreadID;

--- a/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
@@ -322,7 +322,7 @@ contract MIPS2_Test is CommonTest {
         expect.step = state.step + 1;
         expect.stepsSinceLastContextSwitch = state.step + 1;
         expect.exited = true;
-        expect.exitCode = 0x3;
+        expect.exitCode = VMStatuses.PANIC.raw();
 
         bytes32 postState = mips.step(encodeState(state), bytes.concat(threadWitness, memProof), 0);
         assertEq(postState, outputState(expect), "unexpected post state");


### PR DESCRIPTION
Fixes the `exitCode` returned by `SYS_CLONE` for invalid args.