### PR TITLE
`SyncClient.onRangeRequest`: request unsafe blocks from start to end

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -438,10 +438,10 @@ func (s *SyncClient) onRangeRequest(ctx context.Context, req rangeRequest) {
 	s.trusted.Add(req.end.Hash, struct{}{})
 	s.trusted.Add(req.end.ParentHash, struct{}{})
 
-	// Now try to fetch lower numbers than current end, to traverse back towards the updated start.
+	// Now try to fetch higher numbers than current start, so that the queued unsafe execution payload doesn't grow too big.
 	for i := uint64(0); ; i++ {
-		num := req.end.Number - 1 - i
-		if num <= req.start {
+		num := req.start + 1 + i
+		if num >= req.end.Number {
 			return
 		}
 		// check if we have something in quarantine already


### PR DESCRIPTION
If the request range is large, like following:


`t=2024-07-30T15:11:19+0000 lvl=debug msg="requesting missing unsafe L2 block range" start=0xa9a6ef81f90c16a0d5cf3cc349877d610dbe3d81497982423de3e9a1c26ab690:661139 end=0x61337e03860c984ae95204818c0c6c595bbb02b04284b0cedfceeedf55975125:709038 size=47899`

fetching from end to start will lead to large amount of queued unsafe execution payload.

And the block height will look stuck for quite long time.

This PR makes `onRangeRequest` fetch from start to end.