### PR TITLE
doc: update style guide

### DIFF
--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -109,7 +109,7 @@ pattern for each new implementation contract:
     1. Call `_disableInitializers()` to ensure the implementation contract cannot be initialized.
     2. Set any immutables.
 
-Because `reinitializer(uint64 version)` is not used, the process for upgrading the implementation is:
+Because `reinitializer(uint64 version)` is not used, the process for upgrading the implementation is to atomically:
 1. Upgrade the implementation to the `StorageSetter` contract.
 2. Use that to set the initialized slot (typically slot 0) to zero.
 3. Upgrade the implementation to the desired new implementation and `initialize` it.

--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -104,9 +104,15 @@ Unless explicitly discussed otherwise, you MUST include the following basic upgr
 pattern for each new implementation contract:
 
 1. Extend OpenZeppelin's `Initializable` base contract.
-2. Include a `uint8 public constant VERSION = X` at the TOP of your contract.
-3. Include a function `initialize` with the modifier `reinitializer(VERSION)`.
-4. In the `constructor`, set any `immutable` variables and call the `initialize` function for setting mutables.
+2. Include a function `initialize` with the modifier `initializer()`.
+3. In the `constructor`:
+    1. Call `_disableInitializers()` to ensure the implementation contract cannot be initialized.
+    2. Set any immutables.
+
+Because `reinitializer(uint64 version)` is not used, the process for upgrading the implementation is:
+1. Upgrade the implementation to the `StorageSetter` contract.
+2. Use that to set the initialized slot (typically slot 0) to zero.
+3. Upgrade the implementation to the desired new implementation and `initialize` it.
 
 ### Versioning
 

--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -107,7 +107,7 @@ pattern for each new implementation contract:
 2. Include a function `initialize` with the modifier `initializer()`.
 3. In the `constructor`:
     1. Call `_disableInitializers()` to ensure the implementation contract cannot be initialized.
-    2. Set any immutables.
+    2. Set any immutables. However, we generally prefer to not use immutables to ensure the same implementation contracts can be used for all chains, and to allow chain operators to dynamically configure parameters
 
 Because `reinitializer(uint64 version)` is not used, the process for upgrading the implementation is to atomically:
 1. Upgrade the implementation to the `StorageSetter` contract.


### PR DESCRIPTION
We no longer use the reinitializer pattern, so I've updated the style guide accordingly.

Additionally, we now recommend using `_disableInitializers` in the constructor, instead of calling `initialize` with zero-values. This is preferable because:
- It is simpler and more readable
- Sometimes the dummy value to initialize cannot be zero, and you must come up with another value to avoid introducing a bug. Moving to `_disableInitializers` removes that footgun