### PR TITLE
cannon: Add more syscall support to fix alloc test

### DIFF
--- a/cannon/example/alloc/main.go
+++ b/cannon/example/alloc/main.go
@@ -22,10 +22,16 @@ func main() {
 		for j := 0; j < len(mem); j += 1024 {
 			mem[j] = 0xFF
 		}
-		fmt.Printf("allocated %d bytes\n", alloc)
+		printGCStats(alloc)
 	}
 
+	fmt.Println("alloc program exit")
+	printGCStats(alloc)
+}
+
+func printGCStats(alloc int) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	fmt.Printf("alloc program exit. memstats: heap_alloc=%d frees=%d mallocs=%d\n", m.HeapAlloc, m.Frees, m.Mallocs)
+	fmt.Printf("allocated %d bytes. memstats: heap_alloc=%d next_gc=%d frees=%d mallocs=%d num_gc=%d\n",
+		alloc, m.HeapAlloc, m.NextGC, m.Frees, m.Mallocs, m.NumGC)
 }

--- a/cannon/example/alloc/main.go
+++ b/cannon/example/alloc/main.go
@@ -12,11 +12,12 @@ func main() {
 	var mem []byte
 	po := preimage.NewOracleClient(preimage.ClientPreimageChannel())
 	numAllocs := binary.LittleEndian.Uint64(po.Get(preimage.LocalIndexKey(0)))
+	allocSize := binary.LittleEndian.Uint64(po.Get(preimage.LocalIndexKey(1)))
 
-	fmt.Printf("alloc program. numAllocs=%d\n", numAllocs)
+	fmt.Printf("alloc program. numAllocs=%d allocSize=%d\n", numAllocs, allocSize)
 	var alloc int
 	for i := 0; i < int(numAllocs); i++ {
-		mem = make([]byte, 32*1024*1024)
+		mem = make([]byte, allocSize)
 		alloc += len(mem)
 		// touch a couple pages to prevent the runtime from overcommitting memory
 		for j := 0; j < len(mem); j += 1024 {

--- a/cannon/mipsevm/exec/memory.go
+++ b/cannon/mipsevm/exec/memory.go
@@ -14,7 +14,10 @@ type MemoryTrackerImpl struct {
 	memory          *memory.Memory
 	lastMemAccess   uint32
 	memProofEnabled bool
+	// proof of first unique memory access
 	memProof        [memory.MEM_PROOF_SIZE]byte
+	// proof of second unique memory access
+	memProof2       [memory.MEM_PROOF_SIZE]byte
 }
 
 func NewMemoryTracker(memory *memory.Memory) *MemoryTrackerImpl {
@@ -31,6 +34,16 @@ func (m *MemoryTrackerImpl) TrackMemAccess(effAddr uint32) {
 	}
 }
 
+func (m *MemoryTrackerImpl) TrackMemAccess2(effAddr uint32) {
+	if m.memProofEnabled && m.lastMemAccess != effAddr {
+		if m.lastMemAccess != ^uint32(0) {
+			panic(fmt.Errorf("unexpected different mem access at %08x, already have access at %08x buffered", effAddr, m.lastMemAccess))
+		}
+		m.lastMemAccess = effAddr
+		m.memProof2 = m.memory.MerkleProof(effAddr)
+	}
+}
+
 func (m *MemoryTrackerImpl) Reset(enableProof bool) {
 	m.memProofEnabled = enableProof
 	m.lastMemAccess = ^uint32(0)
@@ -38,4 +51,8 @@ func (m *MemoryTrackerImpl) Reset(enableProof bool) {
 
 func (m *MemoryTrackerImpl) MemProof() [memory.MEM_PROOF_SIZE]byte {
 	return m.memProof
+}
+
+func (m *MemoryTrackerImpl) MemProof2() [memory.MEM_PROOF_SIZE]byte {
+	return m.memProof2
 }

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -13,20 +13,21 @@ import (
 
 // Syscall codes
 const (
-	SysMmap       = 4090
-	SysMunmap     = 4091
-	SysBrk        = 4045
-	SysClone      = 4120
-	SysExitGroup  = 4246
-	SysRead       = 4003
-	SysWrite      = 4004
-	SysFcntl      = 4055
-	SysExit       = 4001
-	SysSchedYield = 4162
-	SysGetTID     = 4222
-	SysFutex      = 4238
-	SysOpen       = 4005
-	SysNanosleep  = 4166
+	SysMmap         = 4090
+	SysMunmap       = 4091
+	SysBrk          = 4045
+	SysClone        = 4120
+	SysExitGroup    = 4246
+	SysRead         = 4003
+	SysWrite        = 4004
+	SysFcntl        = 4055
+	SysExit         = 4001
+	SysSchedYield   = 4162
+	SysGetTID       = 4222
+	SysFutex        = 4238
+	SysOpen         = 4005
+	SysNanosleep    = 4166
+	SysClockGetTime = 4263
 )
 
 // Noop Syscall codes
@@ -56,6 +57,7 @@ const (
 	SysLlseek        = 4140
 	SysMinCore       = 4217
 	SysTgkill        = 4266
+	SysGetpid        = 4020
 )
 
 // Profiling-related syscalls
@@ -66,7 +68,6 @@ const (
 	SysTimerCreate  = 4257
 	SysTimerSetTime = 4258
 	SysTimerDelete  = 4261
-	SysClockGetTime = 4263
 )
 
 // File descriptors
@@ -131,8 +132,10 @@ const (
 
 // Other constants
 const (
-	SchedQuantum = 100_000
-	BrkStart     = 0x40000000
+	SchedQuantum              = 100_000
+	BrkStart                  = 0x40000000
+	HZ                        = 10_000_000
+	ClockGettimeMonotonicFlag = 1
 )
 
 func GetSyscallArgs(registers *[32]uint32) (syscallNum, a0, a1, a2, a3 uint32) {

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -271,7 +271,16 @@ func HandleSysFcntl(a0, a1 uint32) (v0, v1 uint32) {
 	// args: a0 = fd, a1 = cmd
 	v1 = uint32(0)
 
-	if a1 == 3 { // F_GETFL: get file descriptor flags
+	if a1 == 1 { // F_GETFD: get file descriptor flags
+		switch a0 {
+		case FdStdin, FdStdout, FdStderr:
+			v0 = 0
+			v1 = 0
+		default:
+			v0 = 0xFFffFFff
+			v1 = MipsEBADF
+		}
+	} else if a1 == 3 { // F_GETFL: get file access mode and status
 		switch a0 {
 		case FdStdin, FdPreimageRead, FdHintRead:
 			v0 = 0 // O_RDONLY

--- a/cannon/mipsevm/multithreaded/instrumented.go
+++ b/cannon/mipsevm/multithreaded/instrumented.go
@@ -80,7 +80,9 @@ func (m *InstrumentedState) Step(proof bool) (wit *mipsevm.StepWitness, err erro
 
 	if proof {
 		memProof := m.memoryTracker.MemProof()
+		memProof2 := m.memoryTracker.MemProof2()
 		wit.ProofData = append(wit.ProofData, memProof[:]...)
+		wit.ProofData = append(wit.ProofData, memProof2[:]...)
 		lastPreimageKey, lastPreimage, lastPreimageOffset := m.preimageOracle.LastPreimage()
 		if lastPreimageOffset != ^uint32(0) {
 			wit.PreimageOffset = lastPreimageOffset

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -54,10 +54,8 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 }
 
 func TestInstrumentedState_Alloc(t *testing.T) {
-	t.Skip("TODO(client-pod#906): Currently failing - need to debug.")
-
 	state := testutil.LoadELFProgram(t, "../../example/bin/alloc.elf", CreateInitialState, false)
-	const numAllocs = 100 // where each alloc is a 32 MiB chunk
+	const numAllocs = 50 // where each alloc is a 32 MiB chunk
 	oracle := testutil.AllocOracle(t, numAllocs)
 
 	// completes in ~870 M steps
@@ -72,8 +70,9 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 			t.Logf("Completed %d steps", state.Step)
 		}
 	}
-	t.Logf("Completed in %d steps", state.Step)
+	memUsage := state.Memory.PageCount() * memory.PageSize
+	t.Logf("Completed in %d steps. memory usage: %d", state.Step, memUsage)
 	require.True(t, state.Exited, "must complete program")
 	require.Equal(t, uint8(0), state.ExitCode, "exit with 0")
-	require.Less(t, state.Memory.PageCount()*memory.PageSize, 1*1024*1024*1024, "must not allocate more than 1 GiB")
+	require.Less(t, memUsage, 1*1024*1024*1024, "must not allocate more than 1 GiB")
 }

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -148,6 +148,7 @@ func (m *InstrumentedState) handleSyscall() error {
 			nsecs := uint32((m.state.Step % exec.HZ) * (1_000_000_000 / exec.HZ))
 			effAddr := a1 & 0xFFffFFfc
 			m.memoryTracker.TrackMemAccess(effAddr)
+			m.memoryTracker.TrackMemAccess2(effAddr+4)
 			m.state.Memory.SetMemory(effAddr, secs)
 			m.state.Memory.SetMemory(effAddr+4, nsecs)
 		}

--- a/cannon/mipsevm/testutil/oracle.go
+++ b/cannon/mipsevm/testutil/oracle.go
@@ -118,14 +118,19 @@ func ClaimTestOracle(t *testing.T) (po mipsevm.PreimageOracle, stdOut string, st
 	return oracle, fmt.Sprintf("computing %d * %d + %d\nclaim %d is good!\n", s, a, b, s*a+b), "started!"
 }
 
-func AllocOracle(t *testing.T, numAllocs int) *TestOracle {
+func AllocOracle(t *testing.T, numAllocs, allocSize int) *TestOracle {
 	return &TestOracle{
 		hint: func(v []byte) {},
 		getPreimage: func(k [32]byte) []byte {
-			if k != preimage.LocalIndexKey(0).PreimageKey() {
+			switch k {
+			case preimage.LocalIndexKey(0).PreimageKey():
+				return binary.LittleEndian.AppendUint64(nil, uint64(numAllocs))
+			case preimage.LocalIndexKey(1).PreimageKey():
+				return binary.LittleEndian.AppendUint64(nil, uint64(allocSize))
+			default:
 				t.Fatalf("invalid preimage request for %x", k)
 			}
-			return binary.LittleEndian.AppendUint64(nil, uint64(numAllocs))
+			panic("unreacheable")
 		},
 	}
 }


### PR DESCRIPTION
This re-enables the skipped `TestInstrumentedState_Alloc` test whereby we assert the Go GC is invoked when making large allocations.

A couple extra syscalls had to be implemented to support the GC

### `getpid`
- Returns 0 as the FPVM runs a single program.

### `clock_gettime`

The Go GC relies on `clock_gettime` for GC "assists", whereby a mutator can perform a little bit of GC without waiting for the scheduler to do so. A monotonic clock (`runtime.nanotime`) is used to compute the current goroutine's compute budget. By modeling a MIPS32 CPU that runs at 10 MHz, we can provide a consistent emulation of monotonic time needed by the Go runtime.
All other `clock_gettime` flags are handled as unimplemented syscalls.


This change also adds limited support for reading file descriptor flags via `fcntl(fd, F_GETFD)`. The go1.22 runtime uses these flags at program startup. This change isn't necessary right now, but it unblocks local development for testing cannon against a newer Go compiler.