### PR TITLE
docs: broken links in op-preimage

### DIFF
--- a/op-preimage/README.md
+++ b/op-preimage/README.md
@@ -2,7 +2,7 @@
 
 `op-preimage` offers simple Go bindings to interact as client or server over the Pre-image Oracle ABI.
 
-Read more about the Preimage Oracle in the [specs](../specs/fault-proof.md).
+Read more about the Preimage Oracle in the [specs](https://github.com/ethereum-optimism/specs/blob/main/specs/fault-proof/index.md#pre-image-oracle).
 
 See [op-program](../op-program) and [Cannon client examples](../cannon/example) for client-side usage.
 See [Cannon `mipsevm`](../cannon/mipsevm) for server-side usage.


### PR DESCRIPTION
fix broken links in op-preimage