### PR TITLE
ops: fix build

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Install node dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
       uses: nrwl/nx-set-shas@v3
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Install node dependencies
       shell: bash
-      run: pnpm install:ci
+      run: pnpm install
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
       uses: nrwl/nx-set-shas@v3
       with:

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -73,7 +73,7 @@ WORKDIR /opt/optimism
 COPY --from=manifests /tmp/manifests  ./
 COPY *.json ./
 
-RUN pnpm install:ci
+RUN pnpm install
 
 COPY ./packages ./packages
 

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -73,7 +73,7 @@ WORKDIR /opt/optimism
 COPY --from=manifests /tmp/manifests  ./
 COPY *.json ./
 
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 COPY ./packages ./packages
 


### PR DESCRIPTION
**Description**

Migrates to a different `pnpm build` command that broke
as part of removing JS from the monorepo.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

