### PR TITLE
reduce scope of `expandedOwners`

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -455,8 +455,8 @@ contract Deploy is Deployer {
         console.log("Deploying safe: %s with salt %s", _name, vm.toString(salt));
         (SafeProxyFactory safeProxyFactory, Safe safeSingleton) = _getSafeFactory();
 
-        address[] memory expandedOwners = new address[](_owners.length + 1);
         if (_keepDeployer) {
+            address[] memory expandedOwners = new address[](_owners.length + 1);
             // By always adding msg.sender first we know that the previousOwner will be SENTINEL_OWNERS, which makes it
             // easier to call removeOwner later.
             expandedOwners[0] = msg.sender;


### PR DESCRIPTION
The `expandedOwners` is only used when `_keepDeployer` is true.