### PR TITLE
Cannon: optimize the example

### DIFF
--- a/cannon/README.md
+++ b/cannon/README.md
@@ -39,23 +39,27 @@ make cannon
 # Note:
 #  - The L2 RPC is an archive L2 node on OP goerli.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
-./bin/cannon run \
+./cannon/bin/cannon run \
     --pprof.cpu \
     --info-at '%10000000' \
-    --proof-at never \
-    --input ./state.json \
+    --proof-at '=<TRACE_INDEX>' \
+    --stop-at '=<STOP_INDEX>' \
+    --proof-fmt 'temp/cannon/proofs/%d.json' \
+    --snapshot-at '%1000000000' \
+    --snapshot-fmt 'temp/cannon/snapshots/%d.json.gz' \
+    --input <PRESTATE> \
+    --output temp/cannon/stop-state.json \
     -- \
-    ../op-program/bin/op-program \
+    ./op-program/bin/op-program \
     --network goerli \
-    --l1.trustrpc \
-    --l1.rpckind debug_geth \
-    --l1 http://127.0.0.1:8645 \
-    --l2 http://127.0.0.1:8745 \
-    --l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab \
-    --l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816 \
-    --l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9 \
-    --l2.blocknumber 8813570 \
-    --datadir /tmp/fpp-database \
+    --l1 <L1_URL> \
+    --l2 <L2_URL> \
+    --l1.head <L1_HEAD> \
+    --l2.claim <L2_CLAIM> \
+    --l2.head <L2_HEAD> \
+    --l2.blocknumber <L2_BLOCK_NUMBER> \
+    --l2.outputroot <L2_OUTPUT_ROOT>
+    --datadir temp/cannon/preimages \
     --log.format terminal \
     --server
 

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -37,7 +37,7 @@ make cannon
 # it runs as sub-process to provide the pre-image data.
 #
 # Note:
-#  - The L2 RPC is an archive L2 node on OP goerli.
+#  - The L2 RPC is an archive L2 node on OP MAINNET.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
 ./bin/cannon run \
     --pprof.cpu \

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -39,7 +39,7 @@ make cannon
 # Note:
 #  - The L2 RPC is an archive L2 node on OP goerli.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
-./cannon/bin/cannon run \
+./bin/cannon run \
     --pprof.cpu \
     --info-at '%10000000' \
     --proof-at '=<TRACE_INDEX>' \
@@ -50,7 +50,7 @@ make cannon
     --input <PRESTATE> \
     --output temp/cannon/stop-state.json \
     -- \
-    ./op-program/bin/op-program \
+    ../op-program/bin/op-program \
     --network goerli \
     --l1 <L1_URL> \
     --l2 <L2_URL> \

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -48,7 +48,7 @@ make cannon
     --input ./state.json \
     -- \
     ../op-program/bin/op-program \
-    --network goerli \
+    --network op-mainnet \
     --l1 <L1_URL> \
     --l2 <L2_URL> \
     --l1.head <L1_HEAD> \

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -44,11 +44,8 @@ make cannon
     --info-at '%10000000' \
     --proof-at '=<TRACE_INDEX>' \
     --stop-at '=<STOP_INDEX>' \
-    --proof-fmt 'temp/cannon/proofs/%d.json' \
     --snapshot-at '%1000000000' \
-    --snapshot-fmt 'temp/cannon/snapshots/%d.json.gz' \
-    --input <PRESTATE> \
-    --output temp/cannon/stop-state.json \
+    --input ./state.json \
     -- \
     ../op-program/bin/op-program \
     --network goerli \
@@ -59,7 +56,7 @@ make cannon
     --l2.head <L2_HEAD> \
     --l2.blocknumber <L2_BLOCK_NUMBER> \
     --l2.outputroot <L2_OUTPUT_ROOT>
-    --datadir temp/cannon/preimages \
+    --datadir /tmp/fpp-database \
     --log.format terminal \
     --server
 


### PR DESCRIPTION
Use better-suited examples and make sure to add the required flag `l2.outputroot`