### PR TITLE
contracts-bedrock: fix `SentMessage` event

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -104,8 +104,8 @@
     "sourceCodeHash": "0x8388b9b8075f31d580fed815b66b45394e40fb1a63cd8cda2272d2c390fc908c"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0x15fbb6175eb98a7d7c6b99862de49e8c3f8ac768c656e82ad7c41c0d1739bd66",
-    "sourceCodeHash": "0x1f14aafab2cb15970cccedb461b72218fca8afa6ffd0ac696a9e28ff1415a068"
+    "initCodeHash": "0xda499b71aec14976b8e133fad9ece083805f5ff520f0e88f89232fd837451954",
+    "sourceCodeHash": "0x7a9cddf5b54ac72457231f0c09b8e88398202ac29125cd63318b8389c81e119b"
   },
   "src/L2/SequencerFeeVault.sol": {
     "initCodeHash": "0xb94145f571e92ee615c6fe903b6568e8aac5fe760b6b65148ffc45d2fb0f5433",

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -171,19 +171,6 @@
     "type": "event"
   },
   {
-    "anonymous": true,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "SentMessage",
-    "type": "event"
-  },
-  {
     "inputs": [],
     "name": "CrossL2InboxOriginNotL2ToL2CrossDomainMessenger",
     "type": "error"

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -60,8 +60,8 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.1
-    string public constant version = "1.0.0-beta.1";
+    /// @custom:semver 1.0.0-beta.2
+    string public constant version = "1.0.0-beta.2";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -71,10 +71,6 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver {
     ///         which will insert the message version into the nonce to give you the actual nonce to be used for the
     ///         message.
     uint240 internal msgNonce;
-
-    /// @notice Emitted whenever a message is sent to the other chain.
-    /// @param data Encoded data of the message that was sent.
-    event SentMessage(bytes data) anonymous;
 
     /// @notice Emitted whenever a message is successfully relayed on this chain.
     /// @param messageHash Hash of the message that was relayed.
@@ -134,7 +130,9 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver {
             L2ToL2CrossDomainMessenger.relayMessage,
             (_destination, block.chainid, messageNonce(), msg.sender, _target, _message)
         );
-        emit SentMessage(data);
+        assembly {
+            log0(add(data, 0x20), mload(data))
+        }
         msgNonce++;
     }
 

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -75,7 +75,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             L2ToL2CrossDomainMessengerWithModifiableTransientStorage(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
     }
 
-    /// @dev Tests that `sendMessage` succeeds and emits the correct SentMessage event.
+    /// @dev Tests that `sendMessage` succeeds and emits the correct event.
     function testFuzz_sendMessage_succeeds(
         uint256 _destination,
         address _target,
@@ -106,11 +106,11 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             _message: _message
         });
 
-        // Check that the SentMessage event was emitted with the correct parameters
+        // Check that the event was emitted with the correct parameters
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertEq(logs.length, 1);
         assertEq(
-            abi.decode(logs[0].data, (bytes)),
+            logs[0].data,
             abi.encodeCall(
                 L2ToL2CrossDomainMessenger.relayMessage,
                 (_destination, block.chainid, messageNonce, address(this), _target, _message)


### PR DESCRIPTION
**Description**

The bytecode emitted from `SentMessage(bytes) anonymous` abi encoded
the `relayMessage` call, breaking the ability to put calldata directly
into the event data. This uses yul to not abi encode the log as `bytes`
and instead place the calldata directly into the event data.

The fact that there is no abi decoding done in the test shows that this
is correct. Previously the abi decoding done in the test was not
correct, we want the exact data in the log to be the calldata.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

