### PR TITLE
contracts-bedrock: fix CrossL2Inbox

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -68,8 +68,8 @@
     "sourceCodeHash": "0x3a725791a0f5ed84dc46dcdae26f6170a759b2fe3dc360d704356d088b76cfd6"
   },
   "src/L2/CrossL2Inbox.sol": {
-    "initCodeHash": "0xde09fc5ef326a19c5e7542ad9756cc8bc68d857ea3009125c429228dd12ae664",
-    "sourceCodeHash": "0xabd5b4557e9152f26ac70ed8d0e2eb85503861b86b718af5c273752147e6c015"
+    "initCodeHash": "0x318b1e98f1686920e3d309390983454685aa84ed997598ead1b4c1a1938206c4",
+    "sourceCodeHash": "0xb0d2d5944f11bdf44cb6a16a9b00ab76a9b9f5ab2abb081781fb1c27927eb5ab"
   },
   "src/L2/GasPriceOracle.sol": {
     "initCodeHash": "0xb16f1e370e58c7693fd113a21a1b1e7ccebc03d4f1e5a76786fc27847ef51ead",

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -131,16 +131,43 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "encodedId",
-        "type": "bytes"
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "msgHash",
+        "type": "bytes32"
       },
       {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
         "indexed": false,
-        "internalType": "bytes",
-        "name": "message",
-        "type": "bytes"
+        "internalType": "struct ICrossL2Inbox.Identifier",
+        "name": "id",
+        "type": "tuple"
       }
     ],
     "name": "ExecutingMessage",

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -56,13 +56,13 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
     bytes32 internal constant CHAINID_SLOT = 0x6e0446e8b5098b8c8193f964f1b567ec3a2bdaeba33d36acb85c1f1d3f92d313;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.2
-    string public constant version = "1.0.0-beta.2";
+    /// @custom:semver 1.0.0-beta.3
+    string public constant version = "1.0.0-beta.3";
 
     /// @notice Emitted when a cross chain message is being executed.
-    /// @param encodedId Encoded Identifier of the message.
-    /// @param message   Message payload being executed.
-    event ExecutingMessage(bytes encodedId, bytes message);
+    /// @param msgHash Hash of message payload being executed.
+    /// @param id Encoded Identifier of the message.
+    event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
 
     /// @notice Enforces that cross domain message sender and source are set. Reverts if not.
     ///         Used to differentiate between 0 and nil in transient storage.
@@ -128,7 +128,7 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
         // Revert if the target call failed.
         if (!success) revert TargetCallFailed();
 
-        emit ExecutingMessage(abi.encode(_id), _message);
+        emit ExecutingMessage(keccak256(_message), _id);
     }
 
     /// @notice Stores the Identifier in transient storage.

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -102,7 +102,7 @@ contract CrossL2InboxTest is Test {
 
         // Look for the emit ExecutingMessage event
         vm.expectEmit(Predeploys.CROSS_L2_INBOX);
-        emit CrossL2Inbox.ExecutingMessage(abi.encode(_id), _message);
+        emit CrossL2Inbox.ExecutingMessage(keccak256(_message), _id);
 
         // Call the executeMessage function
         crossL2Inbox.executeMessage{ value: _value }({ _id: _id, _target: _target, _message: _message });


### PR DESCRIPTION
**Description**

Updates the `CrossL2Inbox` per the latest specs proposal in
https://github.com/ethereum-optimism/specs/pull/254

This reduces the cost of sending cross chain messages by
emitting the message hash as part of the event rather than
the full message itself.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

