### PR TITLE
devnet: Update expired docs link

### DIFF
--- a/packages/contracts-bedrock/CONTRIBUTING.md
+++ b/packages/contracts-bedrock/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Documentation improvements are more than welcome! If you see a typo or feel that
 
 ### Deploying on Devnet
 
-To deploy the smart contracts on a local devnet, run `make devnet-up` in the monorepo root.
+To deploy the smart contracts on a local devnet, run `make devnet-up` in the monorepo root. For more information on the local devnet, see [dev-node](https://docs.optimism.io/chain/testing/dev-node).
 
 ### Tools
 

--- a/packages/contracts-bedrock/CONTRIBUTING.md
+++ b/packages/contracts-bedrock/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Documentation improvements are more than welcome! If you see a typo or feel that
 
 ### Deploying on Devnet
 
-To deploy the smart contracts on a local devnet, run `make devnet-up` in the monorepo root. For more information on the local devnet, see [devnet.md](../../specs/meta/devnet.md).
+To deploy the smart contracts on a local devnet, run `make devnet-up` in the monorepo root.
 
 ### Tools
 


### PR DESCRIPTION
I find this [doc](https://github.com/ethereum-optimism/optimism/blob/8fc0fcbf973f76cacd2cbef401e07835797965dd/specs/meta/devnet.md#bedrock-local-devnet-setup) may be the old doc. But I think the content is too old so I decide to delete it.