### PR TITLE
feat(supervisor): separate out chain monitor config 

### DIFF
--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"errors"
+	"time"
 
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
 var (
@@ -25,8 +27,18 @@ type Config struct {
 	// MockRun runs the service with a mock backend
 	MockRun bool
 
-	L2RPCs  []string
+	// TODO(protocol-quest#288): configure list of chains and their RPC endpoints / potential alternative data sources
+	L2RPCs             []string
+	ChainMonitorConfig ChainMonitorConfig
+
 	Datadir string
+}
+
+type ChainMonitorConfig struct {
+	EpochPollInterval time.Duration
+	PollInterval      time.Duration
+	ShouldTrustRpc    bool
+	RpcKind           sources.RPCProviderKind
 }
 
 func (c *Config) Check() error {
@@ -54,5 +66,11 @@ func NewConfig(l2RPCs []string, datadir string) *Config {
 		MockRun:       false,
 		L2RPCs:        l2RPCs,
 		Datadir:       datadir,
+		ChainMonitorConfig: ChainMonitorConfig{
+			EpochPollInterval: 30 * time.Second,
+			PollInterval:      2 * time.Second,
+			ShouldTrustRpc:    false,
+			RpcKind:           sources.RPCKindStandard,
+		},
 	}
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -72,7 +72,7 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger, m Metrics, cfg
 	chainMonitors := make([]*source.ChainMonitor, 0, len(cfg.L2RPCs))
 	for chainID, rpc := range chainRPCs {
 		cm := newChainMetrics(chainID, m)
-		monitor, err := source.NewChainMonitor(ctx, logger, cm, chainID, rpc, chainClients[chainID], chainsDB)
+		monitor, err := source.NewChainMonitor(ctx, logger, cm, chainID, rpc, chainClients[chainID], chainsDB, cfg.ChainMonitorConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create monitor for rpc %v: %w", rpc, err)
 		}

--- a/op-supervisor/supervisor/backend/config.go
+++ b/op-supervisor/supervisor/backend/config.go
@@ -1,5 +1,0 @@
-package backend
-
-type Config struct {
-	// TODO(protocol-quest#288): configure list of chains and their RPC endpoints / potential alternative data sources
-}


### PR DESCRIPTION

**Description**
This PR separates out hardcoded ChainMonitor RPC default configs into a separate config. The global values are loaded upfront when the program is loaded. 

**Alternative Design**
a) Recommended. This is what I think the code should do in long term. but I didn't go with this as it is a rather big change that changes the interface of cli arguments. 

Rationale: Rather than having a global config for all L2 chain monitors, I think each should have its own RPC config that sets to default value unless overridden. 

Not sure what would be the best way to load this. It might be a bit tricky to use the best to read as a json file, 

```go
&Config{
	L2RPCConfigs:        [
	        L2RPCConfig {
		        Url: "http-some-alchemchy-url",
		        EpochPollInterval: 30 * time.Second,
		        PollInterval:      2 * time.Second,
		        ShouldTrustRpc:    false,
		        RpcKind:           sources.RPCKindStandard,
	        },
	        L2RPCConfig{
	                // use default if not filled
	                Url:  "some other url",
	        }
	]
}
```

b) Load ChainMonitorConfig as CLIConfig. This introduces new cli args that globally sets all L2 monitors. I think this will lead to changing the cli inputs multiple times if you need to modify the settings in the future for each chain.

```go
&Config{
	L2RPC: []string,,
	ChainMonitorConfig: CLIConfig{
		EpochPollInterval: 30 * time.Second,
		PollInterval:      2 * time.Second,
		ShouldTrustRpc:    false,
		RpcKind:           sources.RPCKindStandard,
	}
}
```

**Tests**

I've ran service_test

**Additional context**

I've read https://github.com/ethereum-optimism/specs/blob/main/specs/background.md, and understand what this module is designed for.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/11032 
