### PR TITLE
fix: increase forge gas limit

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -29,6 +29,12 @@ ast = true
 evm_version = "cancun"
 ignored_error_codes = ["transient-storage", "code-size", "init-code-size"]
 
+# We set the gas limit to max int64 to avoid running out of gas during testing, since the default
+# gas limit is 1B and some of our tests require more gas than that, such as `test_callWithMinGas_noLeakageLow_succeeds`.
+# We use this gas limit since it was the default gas limit prior to https://github.com/foundry-rs/foundry/pull/8274.
+# Due to toml-rs limitations, if you increase the gas limit above this value it must be a string.
+gas_limit = 9223372036854775807
+
 # Test / Script Runner Settings
 ffi = true
 fs_permissions = [


### PR DESCRIPTION
We want to bump our foundry version (https://github.com/ethereum-optimism/optimism/pull/11325) but this causes some tests to fail. This PR resolves that. See the comments added to `foundry.toml` for details