### PR TITLE
fix: add missing assume condition

### DIFF
--- a/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
@@ -57,6 +57,7 @@ contract ETHLiquidity_Test is CommonTest {
     function testFuzz_burn_fromUnauthorizedCaller_fails(uint256 _amount, address _caller) public {
         // Assume
         vm.assume(_caller != address(superchainWeth));
+        vm.assume(_caller != address(ethLiquidity));
         _amount = bound(_amount, 0, type(uint248).max - 1);
 
         // Arrange


### PR DESCRIPTION
When the fuzzer sets `_caller` to the ETHLiquidity contract, `vm.deal(_caller, _amount)` overwrites the balance of the ETHLiquidity contract from `STARTING_LIQUIDITY_BALANCE` to `_amount`, causing the `assertEq(address(ethLiquidity).balance, STARTING_LIQUIDITY_BALANCE)` test to fail even though the burn transaction reverted as expected. 

We solve this by disallowing the ETHLiquidity as a caller