### PR TITLE
op-challenger: Separate oracle server executor

### DIFF
--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -75,25 +75,25 @@ func RegisterGameTypes(
 	syncValidator := newSyncStatusValidator(rollupClient)
 
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeCannon) {
-		vmConfig := vm.NewOpProgramVmConfig(cfg.Cannon)
+		vmConfig := vm.NewOpProgramVmConfig(&cfg.Cannon)
 		if err := registerCannon(faultTypes.CannonGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register cannon game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypePermissioned) {
-		vmConfig := vm.NewOpProgramVmConfig(cfg.Cannon)
+		vmConfig := vm.NewOpProgramVmConfig(&cfg.Cannon)
 		if err := registerCannon(faultTypes.PermissionedGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register permissioned cannon game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsterisc) {
-		vmConfig := vm.NewOpProgramVmConfig(cfg.Asterisc)
+		vmConfig := vm.NewOpProgramVmConfig(&cfg.Asterisc)
 		if err := registerAsterisc(faultTypes.AsteriscGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register asterisc game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsteriscKona) {
-		vmConfig := vm.NewKonaVmConfig(cfg.Asterisc)
+		vmConfig := vm.NewKonaVmConfig(&cfg.Asterisc)
 		if err := registerAsterisc(faultTypes.AsteriscKonaGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register asterisc kona game type: %w", err)
 		}
@@ -265,7 +265,7 @@ func registerAsterisc(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get asterisc prestate: %w", err)
 			}
-			accessor, err := outputs.NewOutputAsteriscTraceAccessor(logger, m, vmCfg, l2Client, prestateProvider, asteriscPrestate, rollupClient, dir, l1HeadID, splitDepth, prestateBlock, poststateBlock)
+			accessor, err := outputs.NewOutputAsteriscTraceAccessor(logger, m, cfg.Asterisc, vmCfg, l2Client, prestateProvider, asteriscPrestate, rollupClient, dir, l1HeadID, splitDepth, prestateBlock, poststateBlock)
 			if err != nil {
 				return nil, err
 			}
@@ -360,7 +360,7 @@ func registerCannon(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get cannon prestate: %w", err)
 			}
-			accessor, err := outputs.NewOutputCannonTraceAccessor(logger, m, vmCfg, l2Client, prestateProvider, cannonPrestate, rollupClient, dir, l1HeadID, splitDepth, prestateBlock, poststateBlock)
+			accessor, err := outputs.NewOutputCannonTraceAccessor(logger, m, cfg.Cannon, vmCfg, l2Client, prestateProvider, cannonPrestate, rollupClient, dir, l1HeadID, splitDepth, prestateBlock, poststateBlock)
 			if err != nil {
 				return nil, err
 			}

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -75,25 +75,25 @@ func RegisterGameTypes(
 	syncValidator := newSyncStatusValidator(rollupClient)
 
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeCannon) {
-		vmConfig := vm.NewOpProgramVmConfig(&cfg.Cannon)
+		vmConfig := vm.NewOpProgramVmConfig()
 		if err := registerCannon(faultTypes.CannonGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register cannon game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypePermissioned) {
-		vmConfig := vm.NewOpProgramVmConfig(&cfg.Cannon)
+		vmConfig := vm.NewOpProgramVmConfig()
 		if err := registerCannon(faultTypes.PermissionedGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register permissioned cannon game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsterisc) {
-		vmConfig := vm.NewOpProgramVmConfig(&cfg.Asterisc)
+		vmConfig := vm.NewOpProgramVmConfig()
 		if err := registerAsterisc(faultTypes.AsteriscGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register asterisc game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsteriscKona) {
-		vmConfig := vm.NewKonaVmConfig(&cfg.Asterisc)
+		vmConfig := vm.NewKonaVmConfig()
 		if err := registerAsterisc(faultTypes.AsteriscKonaGameType, registry, oracles, ctx, systemClock, l1Clock, logger, m, cfg, vmConfig, syncValidator, rollupClient, txSender, gameFactory, caller, l2Client, l1HeaderSource, selective, claimants); err != nil {
 			return nil, fmt.Errorf("failed to register asterisc kona game type: %w", err)
 		}
@@ -204,7 +204,7 @@ func registerAsterisc(
 	logger log.Logger,
 	m metrics.Metricer,
 	cfg *config.Config,
-	vmCfg vm.VmConfig,
+	vmCfg vm.OracleServerExecutor,
 	syncValidator SyncValidator,
 	rollupClient outputs.OutputRollupClient,
 	txSender TxSender,
@@ -298,7 +298,7 @@ func registerCannon(
 	logger log.Logger,
 	m metrics.Metricer,
 	cfg *config.Config,
-	vmCfg vm.VmConfig,
+	vmCfg vm.OracleServerExecutor,
 	syncValidator SyncValidator,
 	rollupClient outputs.OutputRollupClient,
 	txSender TxSender,

--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -35,12 +35,12 @@ type AsteriscTraceProvider struct {
 	lastStep uint64
 }
 
-func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.VmConfig, prestateProvider types.PrestateProvider, asteriscPrestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *AsteriscTraceProvider {
+func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.VmConfig, prestateProvider types.PrestateProvider, asteriscPrestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *AsteriscTraceProvider {
 	return &AsteriscTraceProvider{
 		logger:           logger,
 		dir:              dir,
 		prestate:         asteriscPrestate,
-		generator:        vm.NewExecutor(logger, m, cfg, asteriscPrestate, localInputs),
+		generator:        vm.NewExecutor(logger, m, cfg, vmCfg, asteriscPrestate, localInputs),
 		gameDepth:        gameDepth,
 		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 		PrestateProvider: prestateProvider,
@@ -177,7 +177,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		logger:         logger,
 		dir:            dir,
 		prestate:       cfg.AsteriscAbsolutePreState,
-		generator:      vm.NewExecutor(logger, m, vm.NewOpProgramVmConfig(cfg.Asterisc), cfg.AsteriscAbsolutePreState, localInputs),
+		generator:      vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramVmConfig(&cfg.Asterisc), cfg.AsteriscAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
 		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 	}

--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -35,7 +35,7 @@ type AsteriscTraceProvider struct {
 	lastStep uint64
 }
 
-func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.VmConfig, prestateProvider types.PrestateProvider, asteriscPrestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *AsteriscTraceProvider {
+func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.OracleServerExecutor, prestateProvider types.PrestateProvider, asteriscPrestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *AsteriscTraceProvider {
 	return &AsteriscTraceProvider{
 		logger:           logger,
 		dir:              dir,
@@ -177,7 +177,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		logger:         logger,
 		dir:            dir,
 		prestate:       cfg.AsteriscAbsolutePreState,
-		generator:      vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramVmConfig(&cfg.Asterisc), cfg.AsteriscAbsolutePreState, localInputs),
+		generator:      vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramVmConfig(), cfg.AsteriscAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
 		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 	}

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -38,12 +38,12 @@ type CannonTraceProvider struct {
 	lastStep uint64
 }
 
-func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.VmConfig, prestateProvider types.PrestateProvider, prestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *CannonTraceProvider {
+func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.VmConfig, prestateProvider types.PrestateProvider, prestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *CannonTraceProvider {
 	return &CannonTraceProvider{
 		logger:           logger,
 		dir:              dir,
 		prestate:         prestate,
-		generator:        vm.NewExecutor(logger, m, cfg, prestate, localInputs),
+		generator:        vm.NewExecutor(logger, m, cfg, vmCfg, prestate, localInputs),
 		gameDepth:        gameDepth,
 		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 		PrestateProvider: prestateProvider,
@@ -181,7 +181,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		logger:         logger,
 		dir:            dir,
 		prestate:       cfg.CannonAbsolutePreState,
-		generator:      vm.NewExecutor(logger, m, vm.NewOpProgramVmConfig(cfg.Cannon), cfg.CannonAbsolutePreState, localInputs),
+		generator:      vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramVmConfig(&cfg.Cannon), cfg.CannonAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
 		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 	}

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -38,7 +38,7 @@ type CannonTraceProvider struct {
 	lastStep uint64
 }
 
-func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.VmConfig, prestateProvider types.PrestateProvider, prestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *CannonTraceProvider {
+func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.OracleServerExecutor, prestateProvider types.PrestateProvider, prestate string, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *CannonTraceProvider {
 	return &CannonTraceProvider{
 		logger:           logger,
 		dir:              dir,
@@ -181,7 +181,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		logger:         logger,
 		dir:            dir,
 		prestate:       cfg.CannonAbsolutePreState,
-		generator:      vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramVmConfig(&cfg.Cannon), cfg.CannonAbsolutePreState, localInputs),
+		generator:      vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramVmConfig(), cfg.CannonAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
 		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 	}

--- a/op-challenger/game/fault/trace/outputs/output_asterisc.go
+++ b/op-challenger/game/fault/trace/outputs/output_asterisc.go
@@ -21,7 +21,8 @@ import (
 func NewOutputAsteriscTraceAccessor(
 	logger log.Logger,
 	m metrics.Metricer,
-	cfg vm.VmConfig,
+	cfg vm.Config,
+	vmCfg vm.VmConfig,
 	l2Client utils.L2HeaderSource,
 	prestateProvider types.PrestateProvider,
 	asteriscPrestate string,
@@ -40,7 +41,7 @@ func NewOutputAsteriscTraceAccessor(
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch asterisc local inputs: %w", err)
 		}
-		provider := asterisc.NewTraceProvider(logger, m, cfg, prestateProvider, asteriscPrestate, localInputs, subdir, depth)
+		provider := asterisc.NewTraceProvider(logger, m, cfg, vmCfg, prestateProvider, asteriscPrestate, localInputs, subdir, depth)
 		return provider, nil
 	}
 

--- a/op-challenger/game/fault/trace/outputs/output_asterisc.go
+++ b/op-challenger/game/fault/trace/outputs/output_asterisc.go
@@ -22,7 +22,7 @@ func NewOutputAsteriscTraceAccessor(
 	logger log.Logger,
 	m metrics.Metricer,
 	cfg vm.Config,
-	vmCfg vm.VmConfig,
+	vmCfg vm.OracleServerExecutor,
 	l2Client utils.L2HeaderSource,
 	prestateProvider types.PrestateProvider,
 	asteriscPrestate string,

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -22,7 +22,7 @@ func NewOutputCannonTraceAccessor(
 	logger log.Logger,
 	m metrics.Metricer,
 	cfg vm.Config,
-	vmCfg vm.VmConfig,
+	vmCfg vm.OracleServerExecutor,
 	l2Client utils.L2HeaderSource,
 	prestateProvider types.PrestateProvider,
 	cannonPrestate string,

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -21,7 +21,8 @@ import (
 func NewOutputCannonTraceAccessor(
 	logger log.Logger,
 	m metrics.Metricer,
-	cfg vm.VmConfig,
+	cfg vm.Config,
+	vmCfg vm.VmConfig,
 	l2Client utils.L2HeaderSource,
 	prestateProvider types.PrestateProvider,
 	cannonPrestate string,
@@ -40,7 +41,7 @@ func NewOutputCannonTraceAccessor(
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
 		}
-		provider := cannon.NewTraceProvider(logger, m, cfg, prestateProvider, cannonPrestate, localInputs, subdir, depth)
+		provider := cannon.NewTraceProvider(logger, m, cfg, vmCfg, prestateProvider, cannonPrestate, localInputs, subdir, depth)
 		return provider, nil
 	}
 

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 type OracleServerExecutor interface {
-	OracleCommand(cfg Config, args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error)
+	OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error)
 }
 
 type Executor struct {
@@ -97,10 +97,11 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 	}
 	args = append(args, extraVmArgs...)
 	args = append(args, "--")
-	args, err = e.oracleServer.OracleCommand(e.cfg, args, dataDir, e.inputs)
+	oracleArgs, err := e.oracleServer.OracleCommand(e.cfg, dataDir, e.inputs)
 	if err != nil {
 		return err
 	}
+	args = append(args, oracleArgs...)
 
 	if err := os.MkdirAll(snapshotDir, 0755); err != nil {
 		return fmt.Errorf("could not create snapshot directory %v: %w", snapshotDir, err)

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -36,13 +36,13 @@ type Config struct {
 	L2GenesisPath    string
 }
 
-type VmConfig interface {
-	FillHostCommand(args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error)
+type OracleServerExecutor interface {
+	OracleCommand(cfg Config, args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error)
 }
 
 type Executor struct {
 	cfg              Config
-	vmCfg            VmConfig
+	oracleServer     OracleServerExecutor
 	logger           log.Logger
 	metrics          Metricer
 	absolutePreState string
@@ -51,10 +51,10 @@ type Executor struct {
 	cmdExecutor      CmdExecutor
 }
 
-func NewExecutor(logger log.Logger, m Metricer, cfg Config, vmConfig VmConfig, prestate string, inputs utils.LocalGameInputs) *Executor {
+func NewExecutor(logger log.Logger, m Metricer, cfg Config, oracleServer OracleServerExecutor, prestate string, inputs utils.LocalGameInputs) *Executor {
 	return &Executor{
 		cfg:              cfg,
-		vmCfg:            vmConfig,
+		oracleServer:     oracleServer,
 		logger:           logger,
 		metrics:          m,
 		inputs:           inputs,
@@ -97,7 +97,7 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 	}
 	args = append(args, extraVmArgs...)
 	args = append(args, "--")
-	args, err = e.vmCfg.FillHostCommand(args, dataDir, e.inputs)
+	args, err = e.oracleServer.OracleCommand(e.cfg, args, dataDir, e.inputs)
 	if err != nil {
 		return err
 	}

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -20,26 +20,29 @@ type Metricer interface {
 }
 
 type Config struct {
-	VmType           types.TraceType
+	// VM Configuration
+	VmType       types.TraceType
+	VmBin        string // Path to the vm executable to run when generating trace data
+	SnapshotFreq uint   // Frequency of snapshots to create when executing (in VM instructions)
+	InfoFreq     uint   // Frequency of progress log messages (in VM instructions)
+
+	// Host Configuration
 	L1               string
 	L1Beacon         string
 	L2               string
-	VmBin            string // Path to the vm executable to run when generating trace data
 	Server           string // Path to the executable that provides the pre-image oracle server
 	Network          string
 	RollupConfigPath string
 	L2GenesisPath    string
-	SnapshotFreq     uint // Frequency of snapshots to create when executing (in VM instructions)
-	InfoFreq         uint // Frequency of progress log messages (in VM instructions)
 }
 
 type VmConfig interface {
-	Cfg() Config
 	FillHostCommand(args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error)
 }
 
 type Executor struct {
-	cfg              VmConfig
+	cfg              Config
+	vmCfg            VmConfig
 	logger           log.Logger
 	metrics          Metricer
 	absolutePreState string
@@ -48,9 +51,10 @@ type Executor struct {
 	cmdExecutor      CmdExecutor
 }
 
-func NewExecutor(logger log.Logger, m Metricer, cfg VmConfig, prestate string, inputs utils.LocalGameInputs) *Executor {
+func NewExecutor(logger log.Logger, m Metricer, cfg Config, vmConfig VmConfig, prestate string, inputs utils.LocalGameInputs) *Executor {
 	return &Executor{
 		cfg:              cfg,
+		vmCfg:            vmConfig,
 		logger:           logger,
 		metrics:          m,
 		inputs:           inputs,
@@ -82,17 +86,18 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 		"--input", start,
 		"--output", lastGeneratedState,
 		"--meta", "",
-		"--info-at", "%" + strconv.FormatUint(uint64(e.cfg.Cfg().InfoFreq), 10),
+		"--info-at", "%" + strconv.FormatUint(uint64(e.cfg.InfoFreq), 10),
 		"--proof-at", "=" + strconv.FormatUint(end, 10),
 		"--proof-fmt", filepath.Join(proofDir, "%d.json.gz"),
-		"--snapshot-at", "%" + strconv.FormatUint(uint64(e.cfg.Cfg().SnapshotFreq), 10),
+		"--snapshot-at", "%" + strconv.FormatUint(uint64(e.cfg.SnapshotFreq), 10),
 		"--snapshot-fmt", filepath.Join(snapshotDir, "%d.json.gz"),
 	}
 	if end < math.MaxUint64 {
 		args = append(args, "--stop-at", "="+strconv.FormatUint(end+1, 10))
 	}
 	args = append(args, extraVmArgs...)
-	args, err = e.cfg.FillHostCommand(args, dataDir, e.inputs)
+	args = append(args, "--")
+	args, err = e.vmCfg.FillHostCommand(args, dataDir, e.inputs)
 	if err != nil {
 		return err
 	}
@@ -106,9 +111,9 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 	if err := os.MkdirAll(proofDir, 0755); err != nil {
 		return fmt.Errorf("could not create proofs directory %v: %w", proofDir, err)
 	}
-	e.logger.Info("Generating trace", "proof", end, "cmd", e.cfg.Cfg().VmBin, "args", strings.Join(args, ", "))
+	e.logger.Info("Generating trace", "proof", end, "cmd", e.cfg.VmBin, "args", strings.Join(args, ", "))
 	execStart := time.Now()
-	err = e.cmdExecutor(ctx, e.logger.New("proof", end), e.cfg.Cfg().VmBin, args...)
-	e.metrics.RecordVmExecutionTime(e.cfg.Cfg().VmType.String(), time.Since(execStart))
+	err = e.cmdExecutor(ctx, e.logger.New("proof", end), e.cfg.VmBin, args...)
+	e.metrics.RecordVmExecutionTime(e.cfg.VmType.String(), time.Since(execStart))
 	return err
 }

--- a/op-challenger/game/fault/trace/vm/executor_test.go
+++ b/op-challenger/game/fault/trace/vm/executor_test.go
@@ -42,7 +42,7 @@ func TestGenerateProof(t *testing.T) {
 	}
 	captureExec := func(t *testing.T, cfg Config, proofAt uint64) (string, string, map[string]string) {
 		m := &stubVmMetrics{}
-		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, NewOpProgramVmConfig(cfg), prestate, inputs)
+		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, NewOpProgramVmConfig(&cfg), prestate, inputs)
 		executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64) (string, error) {
 			return input, nil
 		}

--- a/op-challenger/game/fault/trace/vm/executor_test.go
+++ b/op-challenger/game/fault/trace/vm/executor_test.go
@@ -42,7 +42,7 @@ func TestGenerateProof(t *testing.T) {
 	}
 	captureExec := func(t *testing.T, cfg Config, proofAt uint64) (string, string, map[string]string) {
 		m := &stubVmMetrics{}
-		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, NewOpProgramVmConfig(&cfg), prestate, inputs)
+		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, NewOpProgramVmConfig(), prestate, inputs)
 		executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64) (string, error) {
 			return input, nil
 		}

--- a/op-challenger/game/fault/trace/vm/kona_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/kona_vm_config.go
@@ -9,39 +9,28 @@ import (
 )
 
 type KonaVmConfig struct {
-	L1       string
-	L1Beacon string
-	L2       string
-	Server   string // Path to the executable that provides the pre-image oracle server
-	Network  string
 }
 
-var _ VmConfig = (*KonaVmConfig)(nil)
+var _ OracleServerExecutor = (*KonaVmConfig)(nil)
 
-func NewKonaVmConfig(cfg *Config) *KonaVmConfig {
-	return &KonaVmConfig{
-		L1:       cfg.L1,
-		L1Beacon: cfg.L1Beacon,
-		L2:       cfg.L2,
-		Server:   cfg.Server,
-		Network:  cfg.Network,
-	}
+func NewKonaVmConfig() *KonaVmConfig {
+	return &KonaVmConfig{}
 }
 
-func (s *KonaVmConfig) FillHostCommand(args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
+func (s *KonaVmConfig) OracleCommand(cfg Config, args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
 	if args == nil {
 		return nil, errors.New("args is nil")
 	}
-	if s.Network == "" {
-		return nil, errors.New("Network is not defined")
+	if cfg.Network == "" {
+		return nil, errors.New("network is not defined")
 	}
 
-	chainCfg := chaincfg.ChainByName(s.Network)
+	chainCfg := chaincfg.ChainByName(cfg.Network)
 	args = append(args,
-		s.Server, "--server",
-		"--l1-node-address", s.L1,
-		"--l1-beacon-address", s.L1Beacon,
-		"--l2-node-address", s.L2,
+		cfg.Server, "--server",
+		"--l1-node-address", cfg.L1,
+		"--l1-beacon-address", cfg.L1Beacon,
+		"--l2-node-address", cfg.L2,
 		"--data-dir", dataDir,
 		"--l2-chain-id", strconv.FormatUint(chainCfg.ChainID, 10),
 		"--l1-head", inputs.L1Head.Hex(),

--- a/op-challenger/game/fault/trace/vm/kona_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/kona_vm_config.go
@@ -17,16 +17,13 @@ func NewKonaVmConfig() *KonaVmConfig {
 	return &KonaVmConfig{}
 }
 
-func (s *KonaVmConfig) OracleCommand(cfg Config, args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
-	if args == nil {
-		return nil, errors.New("args is nil")
-	}
+func (s *KonaVmConfig) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
 	if cfg.Network == "" {
 		return nil, errors.New("network is not defined")
 	}
 
 	chainCfg := chaincfg.ChainByName(cfg.Network)
-	args = append(args,
+	return []string{
 		cfg.Server, "--server",
 		"--l1-node-address", cfg.L1,
 		"--l1-beacon-address", cfg.L1Beacon,
@@ -38,6 +35,5 @@ func (s *KonaVmConfig) OracleCommand(cfg Config, args []string, dataDir string, 
 		"--l2-output-root", inputs.L2OutputRoot.Hex(),
 		"--l2-claim", inputs.L2Claim.Hex(),
 		"--l2-block-number", inputs.L2BlockNumber.Text(10),
-	)
-	return args, nil
+	}, nil
 }

--- a/op-challenger/game/fault/trace/vm/kona_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/kona_vm_config.go
@@ -9,19 +9,23 @@ import (
 )
 
 type KonaVmConfig struct {
-	Config
+	L1       string
+	L1Beacon string
+	L2       string
+	Server   string // Path to the executable that provides the pre-image oracle server
+	Network  string
 }
 
 var _ VmConfig = (*KonaVmConfig)(nil)
 
-func NewKonaVmConfig(vmConfig Config) *KonaVmConfig {
+func NewKonaVmConfig(cfg *Config) *KonaVmConfig {
 	return &KonaVmConfig{
-		vmConfig,
+		L1:       cfg.L1,
+		L1Beacon: cfg.L1Beacon,
+		L2:       cfg.L2,
+		Server:   cfg.Server,
+		Network:  cfg.Network,
 	}
-}
-
-func (s *KonaVmConfig) Cfg() Config {
-	return s.Config
 }
 
 func (s *KonaVmConfig) FillHostCommand(args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
@@ -34,11 +38,10 @@ func (s *KonaVmConfig) FillHostCommand(args []string, dataDir string, inputs uti
 
 	chainCfg := chaincfg.ChainByName(s.Network)
 	args = append(args,
-		"--",
-		s.Cfg().Server, "--server",
-		"--l1-node-address", s.Cfg().L1,
-		"--l1-beacon-address", s.Cfg().L1Beacon,
-		"--l2-node-address", s.Cfg().L2,
+		s.Server, "--server",
+		"--l1-node-address", s.L1,
+		"--l1-beacon-address", s.L1Beacon,
+		"--l2-node-address", s.L2,
 		"--data-dir", dataDir,
 		"--l2-chain-id", strconv.FormatUint(chainCfg.ChainID, 10),
 		"--l1-head", inputs.L1Head.Hex(),

--- a/op-challenger/game/fault/trace/vm/kona_vm_config_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_vm_config_test.go
@@ -26,12 +26,11 @@ func TestKonaFillHostCommand(t *testing.T) {
 		L2Claim:       common.Hash{0x44},
 		L2BlockNumber: big.NewInt(3333),
 	}
-	vmConfig := NewKonaVmConfig(cfg)
+	vmConfig := NewKonaVmConfig(&cfg)
 
 	args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
 	require.NoError(t, err)
 
-	require.True(t, slices.Contains(args, "--"))
 	require.True(t, slices.Contains(args, "--server"))
 	require.True(t, slices.Contains(args, "--l1-node-address"))
 	require.True(t, slices.Contains(args, "--l1-beacon-address"))

--- a/op-challenger/game/fault/trace/vm/kona_vm_config_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_vm_config_test.go
@@ -26,9 +26,9 @@ func TestKonaFillHostCommand(t *testing.T) {
 		L2Claim:       common.Hash{0x44},
 		L2BlockNumber: big.NewInt(3333),
 	}
-	vmConfig := NewKonaVmConfig(&cfg)
+	vmConfig := NewKonaVmConfig()
 
-	args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
+	args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
 	require.NoError(t, err)
 
 	require.True(t, slices.Contains(args, "--server"))

--- a/op-challenger/game/fault/trace/vm/kona_vm_config_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_vm_config_test.go
@@ -28,7 +28,7 @@ func TestKonaFillHostCommand(t *testing.T) {
 	}
 	vmConfig := NewKonaVmConfig()
 
-	args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
+	args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 	require.NoError(t, err)
 
 	require.True(t, slices.Contains(args, "--server"))

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config.go
@@ -1,8 +1,6 @@
 package vm
 
 import (
-	"errors"
-
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 )
 
@@ -15,12 +13,8 @@ func NewOpProgramVmConfig() *OpProgramVmConfig {
 	return &OpProgramVmConfig{}
 }
 
-func (s *OpProgramVmConfig) OracleCommand(cfg Config, args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
-	if args == nil {
-		return nil, errors.New("args is nil")
-	}
-
-	args = append(args,
+func (s *OpProgramVmConfig) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
+	args := []string{
 		"--",
 		cfg.Server, "--server",
 		"--l1", cfg.L1,
@@ -32,7 +26,7 @@ func (s *OpProgramVmConfig) OracleCommand(cfg Config, args []string, dataDir str
 		"--l2.outputroot", inputs.L2OutputRoot.Hex(),
 		"--l2.claim", inputs.L2Claim.Hex(),
 		"--l2.blocknumber", inputs.L2BlockNumber.Text(10),
-	)
+	}
 	if cfg.Network != "" {
 		args = append(args, "--network", cfg.Network)
 	}

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config.go
@@ -7,40 +7,25 @@ import (
 )
 
 type OpProgramVmConfig struct {
-	L1               string
-	L1Beacon         string
-	L2               string
-	Server           string // Path to the executable that provides the pre-image oracle server
-	Network          string
-	RollupConfigPath string
-	L2GenesisPath    string
 }
 
-var _ VmConfig = (*OpProgramVmConfig)(nil)
+var _ OracleServerExecutor = (*OpProgramVmConfig)(nil)
 
-func NewOpProgramVmConfig(cfg *Config) *OpProgramVmConfig {
-	return &OpProgramVmConfig{
-		L1:               cfg.L1,
-		L1Beacon:         cfg.L1Beacon,
-		L2:               cfg.L2,
-		Server:           cfg.Server,
-		Network:          cfg.Network,
-		RollupConfigPath: cfg.RollupConfigPath,
-		L2GenesisPath:    cfg.L2GenesisPath,
-	}
+func NewOpProgramVmConfig() *OpProgramVmConfig {
+	return &OpProgramVmConfig{}
 }
 
-func (s *OpProgramVmConfig) FillHostCommand(args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
+func (s *OpProgramVmConfig) OracleCommand(cfg Config, args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
 	if args == nil {
 		return nil, errors.New("args is nil")
 	}
 
 	args = append(args,
 		"--",
-		s.Server, "--server",
-		"--l1", s.L1,
-		"--l1.beacon", s.L1Beacon,
-		"--l2", s.L2,
+		cfg.Server, "--server",
+		"--l1", cfg.L1,
+		"--l1.beacon", cfg.L1Beacon,
+		"--l2", cfg.L2,
 		"--datadir", dataDir,
 		"--l1.head", inputs.L1Head.Hex(),
 		"--l2.head", inputs.L2Head.Hex(),
@@ -48,14 +33,14 @@ func (s *OpProgramVmConfig) FillHostCommand(args []string, dataDir string, input
 		"--l2.claim", inputs.L2Claim.Hex(),
 		"--l2.blocknumber", inputs.L2BlockNumber.Text(10),
 	)
-	if s.Network != "" {
-		args = append(args, "--network", s.Network)
+	if cfg.Network != "" {
+		args = append(args, "--network", cfg.Network)
 	}
-	if s.RollupConfigPath != "" {
-		args = append(args, "--rollup.config", s.RollupConfigPath)
+	if cfg.RollupConfigPath != "" {
+		args = append(args, "--rollup.config", cfg.RollupConfigPath)
 	}
-	if s.L2GenesisPath != "" {
-		args = append(args, "--l2.genesis", s.L2GenesisPath)
+	if cfg.L2GenesisPath != "" {
+		args = append(args, "--l2.genesis", cfg.L2GenesisPath)
 	}
 	return args, nil
 }

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config.go
@@ -7,19 +7,27 @@ import (
 )
 
 type OpProgramVmConfig struct {
-	Config
+	L1               string
+	L1Beacon         string
+	L2               string
+	Server           string // Path to the executable that provides the pre-image oracle server
+	Network          string
+	RollupConfigPath string
+	L2GenesisPath    string
 }
 
 var _ VmConfig = (*OpProgramVmConfig)(nil)
 
-func NewOpProgramVmConfig(vmConfig Config) *OpProgramVmConfig {
+func NewOpProgramVmConfig(cfg *Config) *OpProgramVmConfig {
 	return &OpProgramVmConfig{
-		vmConfig,
+		L1:               cfg.L1,
+		L1Beacon:         cfg.L1Beacon,
+		L2:               cfg.L2,
+		Server:           cfg.Server,
+		Network:          cfg.Network,
+		RollupConfigPath: cfg.RollupConfigPath,
+		L2GenesisPath:    cfg.L2GenesisPath,
 	}
-}
-
-func (s *OpProgramVmConfig) Cfg() Config {
-	return s.Config
 }
 
 func (s *OpProgramVmConfig) FillHostCommand(args []string, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
@@ -29,10 +37,10 @@ func (s *OpProgramVmConfig) FillHostCommand(args []string, dataDir string, input
 
 	args = append(args,
 		"--",
-		s.Cfg().Server, "--server",
-		"--l1", s.Cfg().L1,
-		"--l1.beacon", s.Cfg().L1Beacon,
-		"--l2", s.Cfg().L2,
+		s.Server, "--server",
+		"--l1", s.L1,
+		"--l1.beacon", s.L1Beacon,
+		"--l2", s.L2,
 		"--datadir", dataDir,
 		"--l1.head", inputs.L1Head.Hex(),
 		"--l2.head", inputs.L2Head.Hex(),

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config.go
@@ -15,7 +15,6 @@ func NewOpProgramVmConfig() *OpProgramVmConfig {
 
 func (s *OpProgramVmConfig) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
 	args := []string{
-		"--",
 		cfg.Server, "--server",
 		"--l1", cfg.L1,
 		"--l1.beacon", cfg.L1Beacon,

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config_test.go
@@ -40,9 +40,9 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	}
 
 	t.Run("NoExtras", func(t *testing.T) {
-		vmConfig := NewOpProgramVmConfig(&cfg)
+		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -50,9 +50,9 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithNetwork", func(t *testing.T) {
 		cfg.Network = "op-test"
-		vmConfig := NewOpProgramVmConfig(&cfg)
+		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -61,9 +61,9 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithRollupConfigPath", func(t *testing.T) {
 		cfg.RollupConfigPath = "rollup.config"
-		vmConfig := NewOpProgramVmConfig(&cfg)
+		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -72,9 +72,9 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithL2GenesisPath", func(t *testing.T) {
 		cfg.L2GenesisPath = "l2.genesis"
-		vmConfig := NewOpProgramVmConfig(&cfg)
+		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -85,9 +85,9 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		cfg.Network = "op-test"
 		cfg.RollupConfigPath = "rollup.config"
 		cfg.L2GenesisPath = "l2.genesis"
-		vmConfig := NewOpProgramVmConfig(&cfg)
+		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config_test.go
@@ -27,7 +27,6 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	}
 
 	validateStandard := func(t *testing.T, args []string) {
-		require.True(t, slices.Contains(args, "--"))
 		require.True(t, slices.Contains(args, "--server"))
 		require.True(t, slices.Contains(args, "--l1"))
 		require.True(t, slices.Contains(args, "--l1.beacon"))
@@ -41,7 +40,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	}
 
 	t.Run("NoExtras", func(t *testing.T) {
-		vmConfig := NewOpProgramVmConfig(cfg)
+		vmConfig := NewOpProgramVmConfig(&cfg)
 
 		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
 		require.NoError(t, err)
@@ -51,7 +50,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithNetwork", func(t *testing.T) {
 		cfg.Network = "op-test"
-		vmConfig := NewOpProgramVmConfig(cfg)
+		vmConfig := NewOpProgramVmConfig(&cfg)
 
 		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
 		require.NoError(t, err)
@@ -62,7 +61,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithRollupConfigPath", func(t *testing.T) {
 		cfg.RollupConfigPath = "rollup.config"
-		vmConfig := NewOpProgramVmConfig(cfg)
+		vmConfig := NewOpProgramVmConfig(&cfg)
 
 		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
 		require.NoError(t, err)
@@ -73,7 +72,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithL2GenesisPath", func(t *testing.T) {
 		cfg.L2GenesisPath = "l2.genesis"
-		vmConfig := NewOpProgramVmConfig(cfg)
+		vmConfig := NewOpProgramVmConfig(&cfg)
 
 		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
 		require.NoError(t, err)
@@ -86,7 +85,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		cfg.Network = "op-test"
 		cfg.RollupConfigPath = "rollup.config"
 		cfg.L2GenesisPath = "l2.genesis"
-		vmConfig := NewOpProgramVmConfig(cfg)
+		vmConfig := NewOpProgramVmConfig(&cfg)
 
 		args, err := vmConfig.FillHostCommand([]string{}, dir, inputs)
 		require.NoError(t, err)

--- a/op-challenger/game/fault/trace/vm/op_program_vm_config_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_vm_config_test.go
@@ -42,7 +42,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	t.Run("NoExtras", func(t *testing.T) {
 		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -52,7 +52,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		cfg.Network = "op-test"
 		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -63,7 +63,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		cfg.RollupConfigPath = "rollup.config"
 		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -74,7 +74,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		cfg.L2GenesisPath = "l2.genesis"
 		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)
@@ -87,7 +87,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		cfg.L2GenesisPath = "l2.genesis"
 		vmConfig := NewOpProgramVmConfig()
 
-		args, err := vmConfig.OracleCommand(cfg, []string{}, dir, inputs)
+		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 		require.NoError(t, err)
 
 		validateStandard(t, args)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -63,7 +63,7 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)
 	l1Head := g.GetL1Head(ctx)
 	accessor, err := outputs.NewOutputCannonTraceAccessor(
-		logger, metrics.NoopMetrics, vm.NewOpProgramVmConfig(cfg.Cannon), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, prestateBlock, poststateBlock)
+		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramVmConfig(&cfg.Cannon), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, prestateBlock, poststateBlock)
 	g.Require.NoError(err, "Failed to create output cannon trace accessor")
 	return NewOutputHonestHelper(g.T, g.Require, &g.OutputGameHelper, g.Game, accessor)
 }

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -63,7 +63,7 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)
 	l1Head := g.GetL1Head(ctx)
 	accessor, err := outputs.NewOutputCannonTraceAccessor(
-		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramVmConfig(&cfg.Cannon), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, prestateBlock, poststateBlock)
+		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramVmConfig(), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, prestateBlock, poststateBlock)
 	g.Require.NoError(err, "Failed to create output cannon trace accessor")
 	return NewOutputHonestHelper(g.T, g.Require, &g.OutputGameHelper, g.Game, accessor)
 }

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -147,7 +147,7 @@ func runCannon(t *testing.T, ctx context.Context, sys *op_e2e.System, inputs uti
 	cannonOpts(&cfg)
 
 	logger := testlog.Logger(t, log.LevelInfo).New("role", "cannon")
-	executor := vm.NewExecutor(logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramVmConfig(&cfg.Cannon), cfg.CannonAbsolutePreState, inputs)
+	executor := vm.NewExecutor(logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramVmConfig(), cfg.CannonAbsolutePreState, inputs)
 
 	t.Log("Running cannon")
 	err := executor.DoGenerateProof(ctx, proofsDir, math.MaxUint, math.MaxUint, extraVmArgs...)

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -147,7 +147,7 @@ func runCannon(t *testing.T, ctx context.Context, sys *op_e2e.System, inputs uti
 	cannonOpts(&cfg)
 
 	logger := testlog.Logger(t, log.LevelInfo).New("role", "cannon")
-	executor := vm.NewExecutor(logger, metrics.NoopMetrics, vm.NewOpProgramVmConfig(cfg.Cannon), cfg.CannonAbsolutePreState, inputs)
+	executor := vm.NewExecutor(logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramVmConfig(&cfg.Cannon), cfg.CannonAbsolutePreState, inputs)
 
 	t.Log("Running cannon")
 	err := executor.DoGenerateProof(ctx, proofsDir, math.MaxUint, math.MaxUint, extraVmArgs...)


### PR DESCRIPTION
**Description**

An alternative to https://github.com/ethereum-optimism/optimism/pull/11309 (pulling in some of those changes) building on https://github.com/ethereum-optimism/optimism/pull/11140

Moves the global `Config` out of what used to be `VmConfig` but rather than winding up with both `vm.Config` and `vm.VmConfig` that duplicate a bunch of fields, the `vm.Config` is now just passed into a `OracleServerExecutor` (previously called `vm.VmConfig`).