### PR TITLE
op-challenger: Add metric to report memory used in the cannon VM

### DIFF
--- a/cannon/mipsevm/debug.go
+++ b/cannon/mipsevm/debug.go
@@ -1,7 +1,10 @@
 package mipsevm
 
+import "github.com/ethereum/go-ethereum/common/hexutil"
+
 type DebugInfo struct {
-	Pages               int `json:"pages"`
-	NumPreimageRequests int `json:"num_preimage_requests"`
-	TotalPreimageSize   int `json:"total_preimage_size"`
+	Pages               int            `json:"pages"`
+	MemoryUsed          hexutil.Uint64 `json:"memory_used"`
+	NumPreimageRequests int            `json:"num_preimage_requests"`
+	TotalPreimageSize   int            `json:"total_preimage_size"`
 }

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -323,8 +323,12 @@ func (m *Memory) ReadMemoryRange(addr uint32, count uint32) io.Reader {
 	return &memReader{m: m, addr: addr, count: count}
 }
 
+func (m *Memory) UsageRaw() uint64 {
+	return uint64(len(m.pages)) * PageSize
+}
+
 func (m *Memory) Usage() string {
-	total := uint64(len(m.pages)) * PageSize
+	total := m.UsageRaw()
 	const unit = 1024
 	if total < unit {
 		return fmt.Sprintf("%d B", total)

--- a/cannon/mipsevm/multithreaded/instrumented.go
+++ b/cannon/mipsevm/multithreaded/instrumented.go
@@ -3,6 +3,7 @@ package multithreaded
 import (
 	"io"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -106,6 +107,7 @@ func (m *InstrumentedState) GetState() mipsevm.FPVMState {
 func (m *InstrumentedState) GetDebugInfo() *mipsevm.DebugInfo {
 	return &mipsevm.DebugInfo{
 		Pages:               m.state.Memory.PageCount(),
+		MemoryUsed:          hexutil.Uint64(m.state.Memory.UsageRaw()),
 		NumPreimageRequests: m.preimageOracle.NumPreimageRequests(),
 		TotalPreimageSize:   m.preimageOracle.TotalPreimageSize(),
 	}

--- a/cannon/mipsevm/singlethreaded/instrumented.go
+++ b/cannon/mipsevm/singlethreaded/instrumented.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type InstrumentedState struct {
@@ -109,6 +110,7 @@ func (m *InstrumentedState) GetState() mipsevm.FPVMState {
 func (m *InstrumentedState) GetDebugInfo() *mipsevm.DebugInfo {
 	return &mipsevm.DebugInfo{
 		Pages:               m.state.Memory.PageCount(),
+		MemoryUsed:          hexutil.Uint64(m.state.Memory.UsageRaw()),
 		NumPreimageRequests: m.preimageOracle.NumPreimageRequests(),
 		TotalPreimageSize:   m.preimageOracle.TotalPreimageSize(),
 	}

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -142,6 +142,7 @@ func NewConfig(
 			L2:           l2EthRpc,
 			SnapshotFreq: DefaultCannonSnapshotFreq,
 			InfoFreq:     DefaultCannonInfoFreq,
+			DebugInfo:    true,
 		},
 		Asterisc: vm.Config{
 			VmType:       types.TraceTypeAsterisc,

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -213,6 +213,11 @@ func TestCannonRequiredArgs(t *testing.T) {
 			cfg.Cannon.Network = "unknown"
 			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
 		})
+
+		t.Run(fmt.Sprintf("TestDebugInfoEnabled-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			require.True(t, cfg.Cannon.DebugInfo)
+		})
 	}
 }
 
@@ -318,6 +323,11 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			cfg := validConfig(traceType)
 			cfg.Asterisc.Network = "unknown"
 			require.ErrorIs(t, cfg.Check(), ErrAsteriscNetworkUnknown)
+		})
+
+		t.Run(fmt.Sprintf("TestDebugInfoDisabled-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			require.False(t, cfg.Asterisc.DebugInfo)
 		})
 	}
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -526,6 +526,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 			L2GenesisPath:    ctx.String(CannonL2GenesisFlag.Name),
 			SnapshotFreq:     ctx.Uint(CannonSnapshotFreqFlag.Name),
 			InfoFreq:         ctx.Uint(CannonInfoFreqFlag.Name),
+			DebugInfo:        true,
 		},
 		CannonAbsolutePreState:        ctx.String(CannonPreStateFlag.Name),
 		CannonAbsolutePreStateBaseURL: cannonPrestatesURL,

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -12,11 +12,18 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	debugFilename = "debug-info.json"
 )
 
 type Metricer interface {
 	RecordVmExecutionTime(vmType string, t time.Duration)
+	RecordVmMemoryUsed(vmType string, memoryUsed uint64)
 }
 
 type Config struct {
@@ -31,6 +38,7 @@ type Config struct {
 	L2GenesisPath    string
 	SnapshotFreq     uint // Frequency of snapshots to create when executing (in VM instructions)
 	InfoFreq         uint // Frequency of progress log messages (in VM instructions)
+	DebugInfo        bool
 }
 
 type Executor struct {
@@ -86,6 +94,9 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 	if end < math.MaxUint64 {
 		args = append(args, "--stop-at", "="+strconv.FormatUint(end+1, 10))
 	}
+	if e.cfg.DebugInfo {
+		args = append(args, "--debug-info", filepath.Join(dataDir, debugFilename))
+	}
 	args = append(args, extraVmArgs...)
 	args = append(args,
 		"--",
@@ -123,5 +134,16 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 	execStart := time.Now()
 	err = e.cmdExecutor(ctx, e.logger.New("proof", end), e.cfg.VmBin, args...)
 	e.metrics.RecordVmExecutionTime(e.cfg.VmType.String(), time.Since(execStart))
+	if e.cfg.DebugInfo && err == nil {
+		if info, err := jsonutil.LoadJSON[debugInfo](filepath.Join(dataDir, debugFilename)); err != nil {
+			e.logger.Warn("Failed to load debug metrics", "err", err)
+		} else {
+			e.metrics.RecordVmMemoryUsed(e.cfg.VmType.String(), uint64(info.MemoryUsed))
+		}
+	}
 	return err
+}
+
+type debugInfo struct {
+	MemoryUsed hexutil.Uint64 `json:"memory_used"`
 }

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -40,6 +40,7 @@ func (*NoopMetricsImpl) RecordBondClaimFailed()   {}
 func (*NoopMetricsImpl) RecordBondClaimed(uint64) {}
 
 func (*NoopMetricsImpl) RecordVmExecutionTime(_ string, _ time.Duration) {}
+func (*NoopMetricsImpl) RecordVmMemoryUsed(_ string, _ uint64)           {}
 func (*NoopMetricsImpl) RecordClaimResolutionTime(t float64)             {}
 func (*NoopMetricsImpl) RecordGameActTime(t float64)                     {}
 

--- a/op-program/client/boot.go
+++ b/op-program/client/boot.go
@@ -82,6 +82,7 @@ func (br *BootstrapClient) BootInfo() *BootInfo {
 		}
 	}
 
+	rollupConfig.ChannelTimeout = 50
 	return &BootInfo{
 		L1Head:             l1Head,
 		L2OutputRoot:       l2OutputRoot,

--- a/op-program/client/boot.go
+++ b/op-program/client/boot.go
@@ -82,7 +82,6 @@ func (br *BootstrapClient) BootInfo() *BootInfo {
 		}
 	}
 
-	rollupConfig.ChannelTimeout = 50
 	return &BootInfo{
 		L1Head:             l1Head,
 		L2OutputRoot:       l2OutputRoot,


### PR DESCRIPTION
**Description**

Load the memory used in the cannon vm using the `--debug-info` option and then report it via metrics. Introduced a `vm.Config` option to control this behaviour since it's not supported by asterisc currently.
