### PR TITLE
fix: SuperchainWETH fuzz testing chain ID error

### DIFF
--- a/packages/contracts-bedrock/invariant-docs/SuperchainWETH.md
+++ b/packages/contracts-bedrock/invariant-docs/SuperchainWETH.md
@@ -1,5 +1,5 @@
 # `SuperchainWETH` Invariants
 
 ## Calls to sendERC20 should always succeed as long as the actor has less than uint248 wei which is much greater than the total ETH supply. Actor's balance should also not increase out of nowhere.
-**Test:** [`SuperchainWETH.t.sol#L171`](../test/invariants/SuperchainWETH.t.sol#L171)
+**Test:** [`SuperchainWETH.t.sol#L174`](../test/invariants/SuperchainWETH.t.sol#L174)
 

--- a/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
@@ -133,6 +133,7 @@ contract SuperchainWETH_Test is CommonTest {
         public
     {
         // Assume
+        vm.assume(_chainId != block.chainid);
         _amount = bound(_amount, 0, type(uint248).max - 1);
 
         // Arrange
@@ -169,6 +170,7 @@ contract SuperchainWETH_Test is CommonTest {
     /// @param _chainId The chain ID to send the WETH to.
     function testFuzz_sendERC20_sufficientFromCustomGasTokenChain_succeeds(uint256 _amount, uint256 _chainId) public {
         // Assume
+        vm.assume(_chainId != block.chainid);
         _amount = bound(_amount, 0, type(uint248).max - 1);
 
         // Arrange
@@ -204,6 +206,7 @@ contract SuperchainWETH_Test is CommonTest {
     /// @param _chainId The chain ID to send the WETH to.
     function testFuzz_sendERC20_insufficientBalance_fails(uint256 _amount, uint256 _chainId) public {
         // Assume
+        vm.assume(_chainId != block.chainid);
         _amount = bound(_amount, 0, type(uint248).max - 1);
 
         // Arrange

--- a/packages/contracts-bedrock/test/invariants/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SuperchainWETH.t.sol
@@ -87,6 +87,9 @@ contract SuperchainWETH_User is StdUtils {
         // Bound send amount to our WETH balance.
         _amount = bound(_amount, 0, weth.balanceOf(address(this)));
 
+        // Prevent receiving chain ID from being the same as the current chain ID.
+        _chainId = _chainId == block.chainid ? _chainId + 1 : _chainId;
+
         // Send the amount.
         try weth.sendERC20(address(this), _amount, _chainId) {
             // Success.


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Minor fix to fuzz testing for SuperchainWETH and related contracts. Recipient chain ID cannot be the same as the sending chain ID. Contracts throw an error when this is the case, causing fuzz tests to fail.