### PR TITLE
Apply error variable lint in op-node/p2p

### DIFF
--- a/op-node/p2p/gating/expiry.go
+++ b/op-node/p2p/gating/expiry.go
@@ -61,7 +61,7 @@ func (g *ExpiryConnectionGater) UnblockPeer(p peer.ID) error {
 func (g *ExpiryConnectionGater) peerBanExpiryCheck(p peer.ID) (allow bool) {
 	// if the peer is blocked, check if it's time to unblock
 	expiry, err := g.store.GetPeerBanExpiration(p)
-	if errors.Is(err, store.UnknownBanErr) {
+	if errors.Is(err, store.ErrUnknownBan) {
 		return true // peer is allowed if it has not been banned
 	}
 	if err != nil {
@@ -88,7 +88,7 @@ func (g *ExpiryConnectionGater) addrBanExpiryCheck(ma multiaddr.Multiaddr) (allo
 	}
 	// if just the IP is blocked, check if it's time to unblock
 	expiry, err := g.store.GetIPBanExpiration(ip)
-	if errors.Is(err, store.UnknownBanErr) {
+	if errors.Is(err, store.ErrUnknownBan) {
 		return true // IP is allowed if it has not been banned
 	}
 	if err != nil {

--- a/op-node/p2p/gating/expiry_test.go
+++ b/op-node/p2p/gating/expiry_test.go
@@ -47,7 +47,7 @@ func TestExpiryConnectionGater_InterceptPeerDial(t *testing.T) {
 	t.Run("unknown expiring ban", func(t *testing.T) {
 		_, mockExpiryStore, mockGater, gater := expiryTestSetup(t)
 		mockGater.EXPECT().InterceptPeerDial(mallory).Return(true)
-		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.UnknownBanErr)
+		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.ErrUnknownBan)
 		allow := gater.InterceptPeerDial(mallory)
 		require.True(t, allow)
 	})
@@ -68,7 +68,7 @@ func TestExpiryConnectionGater_InterceptAddrDial(t *testing.T) {
 	t.Run("expired IP ban", func(t *testing.T) {
 		cl, mockExpiryStore, mockGater, gater := expiryTestSetup(t)
 		mockGater.EXPECT().InterceptAddrDial(mallory, addr).Return(true)
-		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.UnknownBanErr)
+		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.ErrUnknownBan)
 		mockExpiryStore.EXPECT().GetIPBanExpiration(ip.To4()).Return(cl.Now().Add(-time.Second), nil)
 		mockExpiryStore.EXPECT().SetIPBanExpiration(ip.To4(), time.Time{}).Return(nil)
 		allow := gater.InterceptAddrDial(mallory, addr)
@@ -77,7 +77,7 @@ func TestExpiryConnectionGater_InterceptAddrDial(t *testing.T) {
 	t.Run("active IP ban", func(t *testing.T) {
 		cl, mockExpiryStore, mockGater, gater := expiryTestSetup(t)
 		mockGater.EXPECT().InterceptAddrDial(mallory, addr).Return(true)
-		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.UnknownBanErr)
+		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.ErrUnknownBan)
 		mockExpiryStore.EXPECT().GetIPBanExpiration(ip.To4()).Return(cl.Now().Add(time.Second), nil)
 		allow := gater.InterceptAddrDial(mallory, addr)
 		require.False(t, allow)
@@ -85,8 +85,8 @@ func TestExpiryConnectionGater_InterceptAddrDial(t *testing.T) {
 	t.Run("unknown IP ban expiry", func(t *testing.T) {
 		_, mockExpiryStore, mockGater, gater := expiryTestSetup(t)
 		mockGater.EXPECT().InterceptAddrDial(mallory, addr).Return(true)
-		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.UnknownBanErr)
-		mockExpiryStore.EXPECT().GetIPBanExpiration(ip.To4()).Return(time.Time{}, store.UnknownBanErr)
+		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.ErrUnknownBan)
+		mockExpiryStore.EXPECT().GetIPBanExpiration(ip.To4()).Return(time.Time{}, store.ErrUnknownBan)
 		allow := gater.InterceptAddrDial(mallory, addr)
 		require.True(t, allow)
 	})
@@ -165,7 +165,7 @@ func TestExpiryConnectionGater_InterceptAccept(t *testing.T) {
 	t.Run("unknown expiry", func(t *testing.T) {
 		_, mockExpiryStore, mockGater, gater := expiryTestSetup(t)
 		mockGater.EXPECT().InterceptAccept(mas).Return(true)
-		mockExpiryStore.EXPECT().GetIPBanExpiration(ip.To4()).Return(time.Time{}, store.UnknownBanErr)
+		mockExpiryStore.EXPECT().GetIPBanExpiration(ip.To4()).Return(time.Time{}, store.ErrUnknownBan)
 		allow := gater.InterceptAccept(mas)
 		require.True(t, allow)
 	})
@@ -201,7 +201,7 @@ func TestExpiryConnectionGater_InterceptSecured(t *testing.T) {
 	t.Run("unknown expiry", func(t *testing.T) {
 		_, mockExpiryStore, mockGater, gater := expiryTestSetup(t)
 		mockGater.EXPECT().InterceptSecured(network.DirInbound, mallory, mas).Return(true)
-		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.UnknownBanErr)
+		mockExpiryStore.EXPECT().GetPeerBanExpiration(mallory).Return(time.Time{}, store.ErrUnknownBan)
 		allow := gater.InterceptSecured(network.DirInbound, mallory, mas)
 		require.True(t, allow)
 	})

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -102,13 +102,13 @@ type ScoreDiff interface {
 	Apply(score *scoreRecord)
 }
 
-var UnknownBanErr = errors.New("unknown ban")
+var ErrUnknownBan = errors.New("unknown ban")
 
 type PeerBanStore interface {
 	// SetPeerBanExpiration create the peer ban with expiration time.
 	// If expiry == time.Time{} then the ban is deleted.
 	SetPeerBanExpiration(id peer.ID, expiry time.Time) error
-	// GetPeerBanExpiration gets the peer ban expiration time, or UnknownBanErr error if none exists.
+	// GetPeerBanExpiration gets the peer ban expiration time, or ErrUnknownBan error if none exists.
 	GetPeerBanExpiration(id peer.ID) (time.Time, error)
 }
 
@@ -116,7 +116,7 @@ type IPBanStore interface {
 	// SetIPBanExpiration create the IP ban with expiration time.
 	// If expiry == time.Time{} then the ban is deleted.
 	SetIPBanExpiration(ip net.IP, expiry time.Time) error
-	// GetIPBanExpiration gets the IP ban expiration time, or UnknownBanErr error if none exists.
+	// GetIPBanExpiration gets the IP ban expiration time, or ErrUnknownBan error if none exists.
 	GetIPBanExpiration(ip net.IP) (time.Time, error)
 }
 

--- a/op-node/p2p/store/ip_ban_book.go
+++ b/op-node/p2p/store/ip_ban_book.go
@@ -71,8 +71,8 @@ func (d *ipBanBook) startGC() {
 
 func (d *ipBanBook) GetIPBanExpiration(ip net.IP) (time.Time, error) {
 	rec, err := d.book.getRecord(ip.To16().String())
-	if err == UnknownRecordErr {
-		return time.Time{}, UnknownBanErr
+	if err == ErrUnknownRecord {
+		return time.Time{}, ErrUnknownBan
 	}
 	if err != nil {
 		return time.Time{}, err

--- a/op-node/p2p/store/ip_ban_book_test.go
+++ b/op-node/p2p/store/ip_ban_book_test.go
@@ -18,7 +18,7 @@ func TestGetUnknownIPBan(t *testing.T) {
 	book := createMemoryIPBanBook(t)
 	defer book.Close()
 	exp, err := book.GetIPBanExpiration(net.IPv4(1, 2, 3, 4))
-	require.Same(t, UnknownBanErr, err)
+	require.Same(t, ErrUnknownBan, err)
 	require.Equal(t, time.Time{}, exp)
 }
 

--- a/op-node/p2p/store/mdbook.go
+++ b/op-node/p2p/store/mdbook.go
@@ -69,7 +69,7 @@ func (m *metadataBook) startGC() {
 func (m *metadataBook) GetPeerMetadata(id peer.ID) (PeerMetadata, error) {
 	record, err := m.book.getRecord(id)
 	// If the record is not found, return an empty PeerMetadata
-	if err == UnknownRecordErr {
+	if err == ErrUnknownRecord {
 		return PeerMetadata{}, nil
 	}
 	if err != nil {

--- a/op-node/p2p/store/peer_ban_book.go
+++ b/op-node/p2p/store/peer_ban_book.go
@@ -67,8 +67,8 @@ func (d *peerBanBook) startGC() {
 
 func (d *peerBanBook) GetPeerBanExpiration(id peer.ID) (time.Time, error) {
 	rec, err := d.book.getRecord(id)
-	if err == UnknownRecordErr {
-		return time.Time{}, UnknownBanErr
+	if err == ErrUnknownRecord {
+		return time.Time{}, ErrUnknownBan
 	}
 	if err != nil {
 		return time.Time{}, err

--- a/op-node/p2p/store/peer_ban_book_test.go
+++ b/op-node/p2p/store/peer_ban_book_test.go
@@ -17,7 +17,7 @@ func TestGetUnknownPeerBan(t *testing.T) {
 	book := createMemoryPeerBanBook(t)
 	defer book.Close()
 	exp, err := book.GetPeerBanExpiration("a")
-	require.Same(t, UnknownBanErr, err)
+	require.Same(t, ErrUnknownBan, err)
 	require.Equal(t, time.Time{}, exp)
 }
 

--- a/op-node/p2p/store/scorebook.go
+++ b/op-node/p2p/store/scorebook.go
@@ -71,7 +71,7 @@ func (d *scoreBook) startGC() {
 
 func (d *scoreBook) GetPeerScores(id peer.ID) (PeerScores, error) {
 	record, err := d.book.getRecord(id)
-	if err == UnknownRecordErr {
+	if err == ErrUnknownRecord {
 		return PeerScores{}, nil // return zeroed scores by default
 	}
 	if err != nil {


### PR DESCRIPTION
Just a small tidy up while working on https://github.com/ethereum-optimism/optimism/pull/11353.

See https://staticcheck.dev/docs/checks#ST1012 for the lint description. It seems pretty reasonable, it's definitely the convention.

I don't think `ErrUnknownBan` is used externally to the monorepo so I don't think there's any API breakage risk.