### PR TITLE
fix op-geth dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101316.0-rc.1
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101315.3-rc.2
 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101316.0-rc.1 h1:S6Nw/faA4g6AicK5oQR5p2VUjq8AyTEilLfNGgprbGU=
-github.com/ethereum-optimism/op-geth v1.101316.0-rc.1/go.mod h1:nZ3TvP4mhOsfKkrgaT3GrDO4oCn5awPXFHKpVHuO63s=
+github.com/ethereum-optimism/op-geth v1.101315.3-rc.2 h1:4Ne3RUZ09uqY5QnbVuDVD2Xt8JbxegCv3mkICt3aT6c=
+github.com/ethereum-optimism/op-geth v1.101315.3-rc.2/go.mod h1:nZ3TvP4mhOsfKkrgaT3GrDO4oCn5awPXFHKpVHuO63s=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240803025447-c92ef420eec2 h1:ySJykDUyb8RbcfLL3pz0Cs5Ji6NMVT7kmAY634DOCoE=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240803025447-c92ef420eec2/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=


### PR DESCRIPTION
This fixes the op-geth dependency tag name to fit the correct naming scheme. The `v1.101316.0-rc.1` op-geth tag will be deleted after this PR merges.