### PR TITLE
op-e2e: Fix GraniteSystemConfig

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -216,7 +216,7 @@ func FjordSystemConfig(t *testing.T, fjordTimeOffset *hexutil.Uint64) SystemConf
 }
 
 func GraniteSystemConfig(t *testing.T, graniteTimeOffset *hexutil.Uint64) SystemConfig {
-	cfg := EcotoneSystemConfig(t, &genesisTime)
+	cfg := FjordSystemConfig(t, &genesisTime)
 	cfg.DeployConfig.L2GenesisGraniteTimeOffset = graniteTimeOffset
 	return cfg
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The `GraniteSystemConfig` setup didn't activate Fjord, as it was using Ecotone.

