### PR TITLE
op-challenger: Fix prestate loading for asterisc in run-trace

### DIFF
--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/asterisc"
@@ -19,24 +21,39 @@ func createTraceProvider(
 	logger log.Logger,
 	m vm.Metricer,
 	cfg *config.Config,
-	prestateSource prestates.PrestateSource,
 	prestateHash common.Hash,
 	traceType types.TraceType,
 	localInputs utils.LocalGameInputs,
 	dir string,
 ) (types.TraceProvider, error) {
-	prestate, err := prestateSource.PrestatePath(prestateHash)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get prestate %v: %w", prestateHash, err)
-	}
-
 	switch traceType {
 	case types.TraceTypeCannon:
+		prestate, err := getPrestate(prestateHash, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState, dir)
+		if err != nil {
+			return nil, err
+		}
 		prestateProvider := cannon.NewPrestateProvider(prestate)
 		return cannon.NewTraceProvider(logger, m, cfg.Cannon, prestateProvider, prestate, localInputs, dir, 42), nil
 	case types.TraceTypeAsterisc:
+		prestate, err := getPrestate(prestateHash, cfg.AsteriscAbsolutePreStateBaseURL, cfg.AsteriscAbsolutePreState, dir)
+		if err != nil {
+			return nil, err
+		}
 		prestateProvider := asterisc.NewPrestateProvider(prestate)
 		return asterisc.NewTraceProvider(logger, m, cfg.Asterisc, prestateProvider, prestate, localInputs, dir, 42), nil
 	}
 	return nil, errors.New("invalid trace type")
+}
+
+func getPrestate(prestateHash common.Hash, prestateBaseUrl *url.URL, prestatePath string, dataDir string) (string, error) {
+	prestateSource := prestates.NewPrestateSource(
+		prestateBaseUrl,
+		prestatePath,
+		filepath.Join(dataDir, "prestates"))
+
+	prestate, err := prestateSource.PrestatePath(prestateHash)
+	if err != nil {
+		return "", fmt.Errorf("failed to get prestate %v: %w", prestateHash, err)
+	}
+	return prestate, nil
 }


### PR DESCRIPTION
**Description**

Fixes the `run-trace` subcommand to load prestates correctly for asterisc and handle the case where no implementation is specified for a specific game type (e.g. asterisc) so the absolute prestate hash can't be retrieved.