### PR TITLE
op-node: abort block publishing if conductor commit fails

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -268,6 +268,7 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 	if err := d.conductor.CommitUnsafePayload(ctx, x.Envelope); err != nil {
 		d.emitter.Emit(rollup.EngineTemporaryErrorEvent{
 			Err: fmt.Errorf("failed to commit unsafe payload to conductor: %w", err)})
+		return
 	}
 
 	// begin gossiping as soon as possible


### PR DESCRIPTION

**Description**

Abort block publishing if the commit to the conductor fails.
The commit of this PR is based on the `1.8.0` tag, same commit as the `op-node/v1.8.0-rc.2` tag. This branch can be used to tag a backport release.
