### PR TITLE
[Hotfix] abort block publishing if conductor commit fails

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -268,6 +268,7 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 	if err := d.conductor.CommitUnsafePayload(ctx, x.Envelope); err != nil {
 		d.emitter.Emit(rollup.EngineTemporaryErrorEvent{
 			Err: fmt.Errorf("failed to commit unsafe payload to conductor: %w", err)})
+		return
 	}
 
 	// begin gossiping as soon as possible


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Abort block publishing if the commit to the conductor fails.

**Tests**

N/A, will add integration-test later, this is a hotfix
