### PR TITLE
rollup: warning when the speed of block generation is too fast for l1.http-poll-interval

### DIFF
--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -85,6 +86,8 @@ func (st *StatusTracker) OnEvent(ev event.Event) bool {
 		} else {
 			if st.data.HeadL1.Number >= x.L1Unsafe.Number {
 				st.metrics.RecordL1ReorgDepth(st.data.HeadL1.Number - x.L1Unsafe.Number)
+			} else {
+				panic(fmt.Sprintf("L1 http-poll-interval too long. Currently missing %d L1 blocks.", x.L1Unsafe.Number - st.data.HeadL1.Number - 1))
 			}
 			// New L1 block is not the same as the current head or a single step linear extension.
 			// This could either be a long L1 extension, or a reorg, or we simply missed a head update.

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -82,11 +82,11 @@ func (st *StatusTracker) OnEvent(ev event.Event) bool {
 			// We got a new L1 block whose parent hash is the same as the current L1 head. Means we're
 			// dealing with a linear extension (new block is the immediate child of the old one).
 			st.log.Debug("L1 head moved forward", "l1_head", x.L1Unsafe)
+		} else if st.data.HeadL1.Number < x.L1Unsafe.Number {
+			st.log.Warn("L1 http-poll-interval too long. Block head is missing")
 		} else {
 			if st.data.HeadL1.Number >= x.L1Unsafe.Number {
 				st.metrics.RecordL1ReorgDepth(st.data.HeadL1.Number - x.L1Unsafe.Number)
-			} else {
-				st.log.Warn("L1 http-poll-interval too long. Block head is missing")
 			}
 			// New L1 block is not the same as the current head or a single step linear extension.
 			// This could either be a long L1 extension, or a reorg, or we simply missed a head update.

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -1,7 +1,6 @@
 package status
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -87,7 +86,7 @@ func (st *StatusTracker) OnEvent(ev event.Event) bool {
 			if st.data.HeadL1.Number >= x.L1Unsafe.Number {
 				st.metrics.RecordL1ReorgDepth(st.data.HeadL1.Number - x.L1Unsafe.Number)
 			} else {
-				panic(fmt.Sprintf("L1 http-poll-interval too long. Currently missing %d L1 blocks.", x.L1Unsafe.Number - st.data.HeadL1.Number - 1))
+				st.log.Warn("L1 http-poll-interval too long. Block head is missing")
 			}
 			// New L1 block is not the same as the current head or a single step linear extension.
 			// This could either be a long L1 extension, or a reorg, or we simply missed a head update.


### PR DESCRIPTION
panic when the speed of block generation is too fast for l1.http-poll-interval

https://github.com/ethereum-optimism/specs/discussions/158#discussioncomment-9388605, when people trying to build L3 with op-stack, the speed of the block generation in DA chain is faster than mainnet.  so if the  `--l1.http-poll-interval` is too long we should panic when some new block heads are missing.
