### PR TITLE
op-e2e: Test Granite EVM rules in op-program

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -218,6 +218,7 @@ func FjordSystemConfig(t *testing.T, fjordTimeOffset *hexutil.Uint64) SystemConf
 func GraniteSystemConfig(t *testing.T, graniteTimeOffset *hexutil.Uint64) SystemConfig {
 	cfg := FjordSystemConfig(t, &genesisTime)
 	cfg.DeployConfig.L2GenesisGraniteTimeOffset = graniteTimeOffset
+	cfg.DeployConfig.ChannelTimeoutGranite = 20
 	return cfg
 }
 


### PR DESCRIPTION
Add a test asserting that the op-program applies `bn256Pairing` checks post granite.