### PR TITLE
deploy-config: Update OP Sepolia absolute prestate

### DIFF
--- a/packages/contracts-bedrock/deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia.json
@@ -41,7 +41,7 @@
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000004000000000000000000000001",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000004000000000000000000000001",
   "fundDevAccounts": false,
-  "faultGameAbsolutePrestate": "0x03e69d3de5155f4a80da99dd534561cbddd4f9dd56c9ecc704d6886625711d2b",
+  "faultGameAbsolutePrestate": "0x0385c3f8ee78491001d92b90b07d0cf387b7b52ab9b83b4d87c994e92cf823ba",
   "faultGameMaxDepth": 73,
   "faultGameClockExtension": 10800,
   "faultGameMaxClockDuration": 302400,


### PR DESCRIPTION
## Overview

Updates the absolute prestate configuration value for the OP Sepolia deploy config to the `op-program/v1.3.0-rc.2` tag.

### Validation

```sh
git checkout op-program/v1.3.0-rc.2 && \
  make reproducible-prestate && \
  cat ./op-program/bin/prestate-proof.json | jq -r .pre
```