### PR TITLE
Interop: Add new role for dependency set management

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -60,8 +60,8 @@
     "sourceCodeHash": "0xaed39fb8a0ce4b8d7a97ead42074e0c672fa18a58a57227b9d32abe2c3600223"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0x1dc552f6abaac121b5c557904ceb7b1e0be41263bcce41d5b69a61a29c38b903",
-    "sourceCodeHash": "0x30014b6a79105227bb9cef5f293a8b9f2dbd117ce44a86efd337da1467b940c7"
+    "initCodeHash": "0x84f39c32415a5fc4311949f87aeabca52cb272d6185777dba12f836537b24616",
+    "sourceCodeHash": "0xca005a9e327b6b72466aff75bc4851c49c30b270029614ccd3fab53d8f7d1d94"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0x623bf6892f0bdb536f2916bc9eb45e52012ad2c80893ff87d750757966b9be68",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -60,8 +60,8 @@
     "sourceCodeHash": "0xaed39fb8a0ce4b8d7a97ead42074e0c672fa18a58a57227b9d32abe2c3600223"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0x710484da188ec16a0ade97d99ecd4f5e910bc87ad01e448db4cf3f0e5050aaee",
-    "sourceCodeHash": "0x40d708140ee6345e146e358c169a191dbbc991782560a2dcbf90ba45a82f7117"
+    "initCodeHash": "0x1dc552f6abaac121b5c557904ceb7b1e0be41263bcce41d5b69a61a29c38b903",
+    "sourceCodeHash": "0x30014b6a79105227bb9cef5f293a8b9f2dbd117ce44a86efd337da1467b940c7"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0x623bf6892f0bdb536f2916bc9eb45e52012ad2c80893ff87d750757966b9be68",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -60,8 +60,8 @@
     "sourceCodeHash": "0xaed39fb8a0ce4b8d7a97ead42074e0c672fa18a58a57227b9d32abe2c3600223"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0x84f39c32415a5fc4311949f87aeabca52cb272d6185777dba12f836537b24616",
-    "sourceCodeHash": "0xca005a9e327b6b72466aff75bc4851c49c30b270029614ccd3fab53d8f7d1d94"
+    "initCodeHash": "0x42e1000d8542f9cbb197314d423760543d4d716d9640b2134c0d881557b22f4f",
+    "sourceCodeHash": "0xccb5b1ea5f1d5c4a583a2a6941db072fc3ad60ac3d08d085f17a672f6a7e2851"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0x623bf6892f0bdb536f2916bc9eb45e52012ad2c80893ff87d750757966b9be68",

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfigInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfigInterop.json
@@ -196,6 +196,19 @@
   },
   {
     "inputs": [],
+    "name": "dependencyManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "disputeGameFactory",
     "outputs": [
       {
@@ -262,6 +275,133 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_basefeeScalar",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_blobbasefeeScalar",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_batcherHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_gasLimit",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "_unsafeBlockSigner",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "maxResourceLimit",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint8",
+            "name": "elasticityMultiplier",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint8",
+            "name": "baseFeeMaxChangeDenominator",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minimumBaseFee",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "systemTxMaxGas",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint128",
+            "name": "maximumBaseFee",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct ResourceMetering.ResourceConfig",
+        "name": "_config",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_batchInbox",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "l1CrossDomainMessenger",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1ERC721Bridge",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1StandardBridge",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "disputeGameFactory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismPortal",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC20Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "gasPayingToken",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct SystemConfig.Addresses",
+        "name": "_addresses",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_dependencyManager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -5,9 +5,11 @@ import { Constants } from "src/libraries/Constants.sol";
 import { OptimismPortalInterop as OptimismPortal } from "src/L1/OptimismPortalInterop.sol";
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { SystemConfig, ResourceMetering, Storage } from "src/L1/SystemConfig.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { ConfigType } from "src/L2/L1BlockInterop.sol";
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
+import { Storage } from "src/libraries/Storage.sol";
 
 /// @title SystemConfigInterop
 /// @notice The SystemConfig contract is used to manage configuration of an Optimism network.
@@ -97,10 +99,7 @@ contract SystemConfigInterop is SystemConfig {
     /// @notice Adds a chain to the interop dependency set. Can only be called by the dependency manager.
     /// @param _chainId Chain ID of chain to add.
     function addDependency(uint256 _chainId) external {
-        require(
-            msg.sender == Storage.getAddress(DEPENDENCY_MANAGER_SLOT),
-            "SystemConfig: caller is not the dependency manager"
-        );
+        require(msg.sender == dependencyManager(), "SystemConfig: caller is not the dependency manager");
         OptimismPortal(payable(optimismPortal())).setConfig(
             ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId)
         );
@@ -109,17 +108,14 @@ contract SystemConfigInterop is SystemConfig {
     /// @notice Removes a chain from the interop dependency set. Can only be called by the dependency manager
     /// @param _chainId Chain ID of the chain to remove.
     function removeDependency(uint256 _chainId) external {
-        require(
-            msg.sender == Storage.getAddress(DEPENDENCY_MANAGER_SLOT),
-            "SystemConfig: caller is not the dependency manager"
-        );
+        require(msg.sender == dependencyManager(), "SystemConfig: caller is not the dependency manager");
         OptimismPortal(payable(optimismPortal())).setConfig(
             ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(_chainId)
         );
     }
 
     /// @notice getter for the dependency manager address
-    function dependencyManager() external view returns (address) {
+    function dependencyManager() public view returns (address) {
         return Storage.getAddress(DEPENDENCY_MANAGER_SLOT);
     }
 }

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -14,14 +14,6 @@ import { StaticConfig } from "src/libraries/StaticConfig.sol";
 ///         All configuration is stored on L1 and picked up by L2 as part of the derviation of
 ///         the L2 chain.
 contract SystemConfigInterop is SystemConfig {
-    /// @notice Storage slot where the address authorized to call `addDependency` is stored
-    bytes32 internal constant ADD_DEPENDENCY_ROLE_HOLDER_SLOT =
-        bytes32(uint256(keccak256("systemconfig.adddependencyrole")) - 1);
-
-    /// @notice Storage slot where the address authorized to call `removeDependency` is stored
-    bytes32 internal constant REMOVE_DEPENDENCY_ROLE_HOLDER_SLOT =
-        bytes32(uint256(keccak256("systemconfig.removedependencyrole")) - 1);
-
     /// @notice Storage slot where the dependency manager address is stored
     bytes32 internal constant DEPENDENCY_MANAGER_SLOT =
         bytes32(uint256(keccak256("systemconfig.dependencymanager")) - 1);
@@ -37,7 +29,7 @@ contract SystemConfigInterop is SystemConfig {
     /// @param _batchInbox        Batch inbox address. An identifier for the op-node to find
     ///                           canonical data.
     /// @param _addresses         Set of L1 contract addresses. These should be the proxies.
-    /// @param _dependencyManager The addressed allowed to modify dependency role holders
+    /// @param _dependencyManager The addressed allowed to add/remove from the dependency set
     function initialize(
         address _owner,
         uint32 _basefeeScalar,
@@ -101,59 +93,28 @@ contract SystemConfigInterop is SystemConfig {
         }
     }
 
-    /// @notice Adds a chain to the interop dependency set. Can only be called by the add dependency role address.
+    /// @notice Adds a chain to the interop dependency set. Can only be called by the dependency manager.
     /// @param _chainId Chain ID of chain to add.
     function addDependency(uint256 _chainId) external {
         require(
-            msg.sender == Storage.getAddress(ADD_DEPENDENCY_ROLE_HOLDER_SLOT),
-            "SystemConfig: caller is not add dependency role address"
+            msg.sender == Storage.getAddress(DEPENDENCY_MANAGER_SLOT),
+            "SystemConfig: caller is not the dependency manager"
         );
         OptimismPortal(payable(optimismPortal())).setConfig(
             ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId)
         );
     }
 
-    /// @notice Removes a chain from the interop dependency set. Can only be called by the remove dependency role
-    /// address.
+    /// @notice Removes a chain from the interop dependency set. Can only be called by the dependency manager
     /// @param _chainId Chain ID of the chain to remove.
     function removeDependency(uint256 _chainId) external {
         require(
-            msg.sender == Storage.getAddress(REMOVE_DEPENDENCY_ROLE_HOLDER_SLOT),
-            "SystemConfig: caller is not remove dependency role address"
+            msg.sender == Storage.getAddress(DEPENDENCY_MANAGER_SLOT),
+            "SystemConfig: caller is not the dependency manager"
         );
         OptimismPortal(payable(optimismPortal())).setConfig(
             ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(_chainId)
         );
-    }
-
-    /// @notice Sets the address that can call addDependency. Can only be called by the dependency manager.
-    /// @param _addDependencyRoleHolder New address authorized to call addDependency
-    function setAddDependencyRoleHolder(address _addDependencyRoleHolder) external {
-        require(
-            msg.sender == Storage.getAddress(DEPENDENCY_MANAGER_SLOT),
-            "SystemConfig: caller is not the dependency manager address"
-        );
-        Storage.setAddress(ADD_DEPENDENCY_ROLE_HOLDER_SLOT, _addDependencyRoleHolder);
-    }
-
-    /// @notice Sets the address that can call removeDependency. Can only be called by the dependency manager.
-    /// @param _removeDependencyRoleHolder New address authorized to call removeDependency
-    function setRemoveDependencyRoleHolder(address _removeDependencyRoleHolder) external {
-        require(
-            msg.sender == Storage.getAddress(DEPENDENCY_MANAGER_SLOT),
-            "SystemConfig: caller is not the dependency manager address"
-        );
-        Storage.setAddress(REMOVE_DEPENDENCY_ROLE_HOLDER_SLOT, _removeDependencyRoleHolder);
-    }
-
-    /// @notice getter for the sole address authorized to call addDependency
-    function addDependencyRoleHolder() external view returns (address) {
-        return Storage.getAddress(ADD_DEPENDENCY_ROLE_HOLDER_SLOT);
-    }
-
-    /// @notice getter for the sole address authorized to call removeDependency
-    function removeDependencyRoleHolder() external view returns (address) {
-        return Storage.getAddress(REMOVE_DEPENDENCY_ROLE_HOLDER_SLOT);
     }
 
     /// @notice getter for the dependency manager address

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -15,8 +15,9 @@ import { StaticConfig } from "src/libraries/StaticConfig.sol";
 ///         the L2 chain.
 contract SystemConfigInterop is SystemConfig {
     /// @notice Storage slot where the dependency manager address is stored
+    /// @dev    Equal to bytes32(uint256(keccak256("systemconfig.dependencymanager")) - 1)
     bytes32 internal constant DEPENDENCY_MANAGER_SLOT =
-        bytes32(uint256(keccak256("systemconfig.dependencymanager")) - 1);
+        0x1708e077affb93e89be2665fb0fb72581be66f84dc00d25fed755ae911905b1c;
 
     /// @notice Initializer.
     /// @param _owner             Initial owner of the contract.

--- a/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -71,13 +71,13 @@ contract SystemConfigInterop_Test is CommonTest {
             )
         );
 
-        vm.prank(_systemConfigInterop().addDependencyRoleHolder());
+        vm.prank(_systemConfigInterop().dependencyManager());
         _systemConfigInterop().addDependency(_chainId);
     }
 
-    /// @dev Tests that adding a dependency as not the owner reverts.
-    function testFuzz_addDependency_notOwner_reverts(uint256 _chainId) public {
-        vm.expectRevert("SystemConfig: caller is not add dependency role address");
+    /// @dev Tests that adding a dependency as not the dependency manager reverts.
+    function testFuzz_addDependency_notDependencyManager_reverts(uint256 _chainId) public {
+        vm.expectRevert("SystemConfig: caller is not the dependency manager");
         _systemConfigInterop().addDependency(_chainId);
     }
 
@@ -91,60 +91,14 @@ contract SystemConfigInterop_Test is CommonTest {
             )
         );
 
-        vm.prank(_systemConfigInterop().removeDependencyRoleHolder());
+        vm.prank(_systemConfigInterop().dependencyManager());
         _systemConfigInterop().removeDependency(_chainId);
     }
 
-    /// @dev Tests that removing a dependency as not the owner reverts.
-    function testFuzz_removeDependency_notOwner_reverts(uint256 _chainId) public {
-        vm.expectRevert("SystemConfig: caller is not remove dependency role address");
+    /// @dev Tests that removing a dependency as not the dependency manager reverts.
+    function testFuzz_removeDependency_notDependencyManager_reverts(uint256 _chainId) public {
+        vm.expectRevert("SystemConfig: caller is not the dependency manager");
         _systemConfigInterop().removeDependency(_chainId);
-    }
-
-    /// @dev Tests that the addDependencyRole holder can be set.
-    function testFuzz_setAddDependencyRoleHolder_succeeds(address _addDependencyRoleHolder) public {
-        // Impersonate the dependency manager
-        vm.prank(_systemConfigInterop().dependencyManager());
-
-        // Call setAddDependencyRoleHolder
-        _systemConfigInterop().setAddDependencyRoleHolder(_addDependencyRoleHolder);
-
-        // Ensure it was set correctly
-        assertEq(_systemConfigInterop().addDependencyRoleHolder(), _addDependencyRoleHolder);
-    }
-
-    /// @dev Tests that an address different from the dependency manager cannot set the addDependencyRole holder
-    function testFuzz_setAddDependencyRoleHolder_notFoundationMultisig_reverts(address _addDependencyRoleHolder)
-        public
-    {
-        // Expect revert with exact string error since caller is not dependency manager
-        vm.expectRevert("SystemConfig: caller is not the dependency manager address");
-
-        // Call setAddDependencyRoleHolder
-        _systemConfigInterop().setAddDependencyRoleHolder(_addDependencyRoleHolder);
-    }
-
-    /// @dev Tests that the removeDependencyRole holder can be set.
-    function testFuzz_setRemoveDependencyRoleHolder_succeeds(address _removeDependencyRoleHolder) public {
-        // Impersonate the dependency manager
-        vm.prank(_systemConfigInterop().dependencyManager());
-
-        // Call setRemoveDependencyRoleHolder
-        _systemConfigInterop().setRemoveDependencyRoleHolder(_removeDependencyRoleHolder);
-
-        // Ensure it was set correctly
-        assertEq(_systemConfigInterop().removeDependencyRoleHolder(), _removeDependencyRoleHolder);
-    }
-
-    /// @dev Tests that an address different from the dependency manager cannot set the removeDependencyRole holder
-    function testFuzz_setRemoveDependencyRoleHolder_notFoundationMultisig_reverts(address _removeDependencyRoleHolder)
-        public
-    {
-        // Expect revert with exact string error since caller is not dependency manager
-        vm.expectRevert("SystemConfig: caller is not the dependency manager address");
-
-        // Call setRemoveDependencyRoleHolder
-        _systemConfigInterop().setRemoveDependencyRoleHolder(_removeDependencyRoleHolder);
     }
 
     /// @dev Helper to clean storage and then initialize the system config with an arbitrary gas token address.

--- a/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -71,13 +71,13 @@ contract SystemConfigInterop_Test is CommonTest {
             )
         );
 
-        vm.prank(systemConfig.owner());
+        vm.prank(_systemConfigInterop().addDependencyRoleHolder());
         _systemConfigInterop().addDependency(_chainId);
     }
 
     /// @dev Tests that adding a dependency as not the owner reverts.
     function testFuzz_addDependency_notOwner_reverts(uint256 _chainId) public {
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert("SystemConfig: caller is not add dependency role address");
         _systemConfigInterop().addDependency(_chainId);
     }
 
@@ -91,14 +91,60 @@ contract SystemConfigInterop_Test is CommonTest {
             )
         );
 
-        vm.prank(systemConfig.owner());
+        vm.prank(_systemConfigInterop().removeDependencyRoleHolder());
         _systemConfigInterop().removeDependency(_chainId);
     }
 
     /// @dev Tests that removing a dependency as not the owner reverts.
     function testFuzz_removeDependency_notOwner_reverts(uint256 _chainId) public {
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert("SystemConfig: caller is not remove dependency role address");
         _systemConfigInterop().removeDependency(_chainId);
+    }
+
+    /// @dev Tests that the addDependencyRole holder can be set.
+    function testFuzz_setAddDependencyRoleHolder_succeeds(address _addDependencyRoleHolder) public {
+        // Impersonate the foundation multisig
+        vm.prank(_systemConfigInterop().foundationMultisig());
+
+        // Call setAddDependencyRoleHolder
+        _systemConfigInterop().setAddDependencyRoleHolder(_addDependencyRoleHolder);
+
+        // Ensure it was set correctly
+        assertEq(_systemConfigInterop().addDependencyRoleHolder(), _addDependencyRoleHolder);
+    }
+
+    /// @dev Tests that an address different from the foundation multisig cannot set the addDependencyRole holder
+    function testFuzz_setAddDependencyRoleHolder_notFoundationMultisig_reverts(address _addDependencyRoleHolder)
+        public
+    {
+        // Expect revert with exact string error since caller is not foundation multisig
+        vm.expectRevert("SystemConfig: caller is not foundation multisig address");
+
+        // Call setAddDependencyRoleHolder
+        _systemConfigInterop().setAddDependencyRoleHolder(_addDependencyRoleHolder);
+    }
+
+    /// @dev Tests that the removeDependencyRole holder can be set.
+    function testFuzz_setRemoveDependencyRoleHolder_succeeds(address _removeDependencyRoleHolder) public {
+        // Impersonate the foundation multisig
+        vm.prank(_systemConfigInterop().foundationMultisig());
+
+        // Call setRemoveDependencyRoleHolder
+        _systemConfigInterop().setRemoveDependencyRoleHolder(_removeDependencyRoleHolder);
+
+        // Ensure it was set correctly
+        assertEq(_systemConfigInterop().removeDependencyRoleHolder(), _removeDependencyRoleHolder);
+    }
+
+    /// @dev Tests that an address different from the foundation multisig cannot set the removeDependencyRole holder
+    function testFuzz_setRemoveDependencyRoleHolder_notFoundationMultisig_reverts(address _removeDependencyRoleHolder)
+        public
+    {
+        // Expect revert with exact string error since caller is not foundation multisig
+        vm.expectRevert("SystemConfig: caller is not foundation multisig address");
+
+        // Call setRemoveDependencyRoleHolder
+        _systemConfigInterop().setRemoveDependencyRoleHolder(_removeDependencyRoleHolder);
     }
 
     /// @dev Helper to clean storage and then initialize the system config with an arbitrary gas token address.

--- a/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -103,8 +103,8 @@ contract SystemConfigInterop_Test is CommonTest {
 
     /// @dev Tests that the addDependencyRole holder can be set.
     function testFuzz_setAddDependencyRoleHolder_succeeds(address _addDependencyRoleHolder) public {
-        // Impersonate the foundation multisig
-        vm.prank(_systemConfigInterop().foundationMultisig());
+        // Impersonate the dependency manager
+        vm.prank(_systemConfigInterop().dependencyManager());
 
         // Call setAddDependencyRoleHolder
         _systemConfigInterop().setAddDependencyRoleHolder(_addDependencyRoleHolder);
@@ -113,12 +113,12 @@ contract SystemConfigInterop_Test is CommonTest {
         assertEq(_systemConfigInterop().addDependencyRoleHolder(), _addDependencyRoleHolder);
     }
 
-    /// @dev Tests that an address different from the foundation multisig cannot set the addDependencyRole holder
+    /// @dev Tests that an address different from the dependency manager cannot set the addDependencyRole holder
     function testFuzz_setAddDependencyRoleHolder_notFoundationMultisig_reverts(address _addDependencyRoleHolder)
         public
     {
-        // Expect revert with exact string error since caller is not foundation multisig
-        vm.expectRevert("SystemConfig: caller is not foundation multisig address");
+        // Expect revert with exact string error since caller is not dependency manager
+        vm.expectRevert("SystemConfig: caller is not the dependency manager address");
 
         // Call setAddDependencyRoleHolder
         _systemConfigInterop().setAddDependencyRoleHolder(_addDependencyRoleHolder);
@@ -126,8 +126,8 @@ contract SystemConfigInterop_Test is CommonTest {
 
     /// @dev Tests that the removeDependencyRole holder can be set.
     function testFuzz_setRemoveDependencyRoleHolder_succeeds(address _removeDependencyRoleHolder) public {
-        // Impersonate the foundation multisig
-        vm.prank(_systemConfigInterop().foundationMultisig());
+        // Impersonate the dependency manager
+        vm.prank(_systemConfigInterop().dependencyManager());
 
         // Call setRemoveDependencyRoleHolder
         _systemConfigInterop().setRemoveDependencyRoleHolder(_removeDependencyRoleHolder);
@@ -136,12 +136,12 @@ contract SystemConfigInterop_Test is CommonTest {
         assertEq(_systemConfigInterop().removeDependencyRoleHolder(), _removeDependencyRoleHolder);
     }
 
-    /// @dev Tests that an address different from the foundation multisig cannot set the removeDependencyRole holder
+    /// @dev Tests that an address different from the dependency manager cannot set the removeDependencyRole holder
     function testFuzz_setRemoveDependencyRoleHolder_notFoundationMultisig_reverts(address _removeDependencyRoleHolder)
         public
     {
-        // Expect revert with exact string error since caller is not foundation multisig
-        vm.expectRevert("SystemConfig: caller is not foundation multisig address");
+        // Expect revert with exact string error since caller is not dependency manager
+        vm.expectRevert("SystemConfig: caller is not the dependency manager address");
 
         // Call setRemoveDependencyRoleHolder
         _systemConfigInterop().setRemoveDependencyRoleHolder(_removeDependencyRoleHolder);

--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -35,7 +35,8 @@ contract Specification_Test is CommonTest {
         DISPUTEGAMEFACTORYOWNER,
         DELAYEDWETHOWNER,
         COUNCILSAFE,
-        COUNCILSAFEOWNER
+        COUNCILSAFEOWNER,
+        DEPENDENCYMANAGER
     }
 
     /// @notice Represents the specification of a function.
@@ -528,11 +529,18 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("basefeeScalar()") });
         _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("blobbasefeeScalar()") });
         _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("maximumGasLimit()") });
-        _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("addDependency(uint256)"), _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("addDependency(uint256)"), _auth: Role.DEPENDENCYMANAGER });
         _addSpec({
             _name: "SystemConfigInterop",
             _sel: _getSel("removeDependency(uint256)"),
-            _auth: Role.SYSTEMCONFIGOWNER
+            _auth: Role.DEPENDENCYMANAGER
+        });
+        _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("dependencyManager()") });
+        _addSpec({
+            _name: "SystemConfigInterop",
+            _sel: _getSel(
+                "initialize(address,uint32,uint32,bytes32,uint64,address,(uint32,uint8,uint8,uint32,uint32,uint128),address,(address,address,address,address,address,address,address),address)"
+            )
         });
 
         // ProxyAdmin


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR adds support for:
- Separate role for the address allowed to call `addDependency`
- Separate role for the address allowed to call `removeDependency`
- A `setAddDependencyRoleHolder` function that sets the address that can call `addDependency`. Only callable by the foundation multisig
- A `setRemoveDependencyRoleHolder` function that sets the address that can call `removeDependency`. Only callable by the foundation multisig
- The foundation multisig address is set in a `initialize` function (only callable once, during upgrade) and stored in storage.
- [Reference Issue](https://github.com/ethereum-optimism/optimism/issues/11366)