### PR TITLE
ci: update geth tool to v1.14.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,9 +184,9 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run:
-          name: "Check L1 geth version"
-          command: ./ops/scripts/geth-version-checker.sh || (echo "geth version is wrong, update ci-builder"; false)
+#      - run:  # temporarily disabled, to update ci-builder.
+#          name: "Check L1 geth version"
+#          command: ./ops/scripts/geth-version-checker.sh || (echo "geth version is wrong, update ci-builder"; false)
       - install-contracts-dependencies
       - restore_cache:
           name: Restore PNPM Package Cache

--- a/ops-bedrock/l1-geth-entrypoint.sh
+++ b/ops-bedrock/l1-geth-entrypoint.sh
@@ -14,6 +14,7 @@ if [ ! -d "$GETH_CHAINDATA_DIR" ]; then
 	echo "Initializing genesis."
 	geth --verbosity="$VERBOSITY" init \
 		--datadir="$GETH_DATA_DIR" \
+		--state.scheme=hash \
 		"$GENESIS_FILE_PATH"
 else
 	echo "$GETH_CHAINDATA_DIR exists."
@@ -45,6 +46,7 @@ exec geth \
 	--authrpc.vhosts="*" \
 	--authrpc.jwtsecret=/config/jwt-secret.txt \
 	--gcmode=archive \
+  --state.scheme=hash \
 	--metrics \
 	--metrics.addr=0.0.0.0 \
 	--metrics.port=6060 \

--- a/ops-bedrock/l2-op-geth-entrypoint.sh
+++ b/ops-bedrock/l2-op-geth-entrypoint.sh
@@ -14,6 +14,7 @@ if [ ! -d "$GETH_CHAINDATA_DIR" ]; then
 	echo "Initializing genesis."
 	geth --verbosity="$VERBOSITY" init \
 		--datadir="$GETH_DATA_DIR" \
+		--state.scheme=hash \
 		"$GENESIS_FILE_PATH"
 else
 	echo "$GETH_CHAINDATA_DIR exists."
@@ -46,6 +47,7 @@ exec geth \
 	--authrpc.vhosts="*" \
 	--authrpc.jwtsecret=/config/jwt-secret.txt \
 	--gcmode=archive \
+  --state.scheme=hash \
 	--metrics \
 	--metrics.addr=0.0.0.0 \
 	--metrics.port=6060 \

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "abigen": "v1.10.25",
   "foundry": "626221f5ef44b4af950a08e09bd714650d9eb77d",
-  "geth": "v1.13.14",
+  "geth": "v1.14.7",
   "eth2_testnet_genesis": "v0.10.0",
   "nvm": "v20.9.0",
   "slither": "0.10.2",


### PR DESCRIPTION
**Description**

Update geth tool to 1.14.7

This unblocks https://github.com/ethereum-optimism/optimism/pull/11382

After this we'll need to tag a new ci-builder release
