### PR TITLE
Don't recheck terminal type for color support

### DIFF
--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -140,7 +140,7 @@ func FormatHandler(ft FormatType, color bool) func(io.Writer) slog.Handler {
 	case FormatJSON:
 		return log.JSONHandler
 	case FormatText:
-		if term.IsTerminal(int(os.Stdout.Fd())) {
+		if color {
 			return termColorHandler
 		} else {
 			return logfmtHandler


### PR DESCRIPTION
Small change while trying to debug issues with an instance hooked up to my terminal and a log file with `tee`. There are several layers where the log output writer is checked to see if it supports color terminal escape sequences, but this check occurs at the innermost point when it's already been checked against the correct writer elsewhere. Without using the decision that's already been made (`color`) here, `--log.color` is ignored if you are piping stdout.

It could be a more advanced change but I just wanted to do the minimum fix to correct this. If there are any corner cases that spring up after this, it's pretty straightforward to fix those too (but I think it's worth deferring that).