### PR TITLE
contracts: use create2 for deploying SafeSingleton and SafeProxyFactory for L1-allocs

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -200,10 +200,12 @@ contract Deploy is Deployer {
         address safeSingleton = 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552;
 
         safeProxyFactory.code.length == 0
-            ? safeProxyFactory_ = new SafeProxyFactory()
+            ? safeProxyFactory_ = new SafeProxyFactory{ salt: _implSalt() }()
             : safeProxyFactory_ = SafeProxyFactory(safeProxyFactory);
 
-        safeSingleton.code.length == 0 ? safeSingleton_ = new Safe() : safeSingleton_ = Safe(payable(safeSingleton));
+        safeSingleton.code.length == 0
+            ? safeSingleton_ = new Safe{ salt: _implSalt() }()
+            : safeSingleton_ = Safe(payable(safeSingleton));
 
         save("SafeProxyFactory", address(safeProxyFactory_));
         save("SafeSingleton", address(safeSingleton_));


### PR DESCRIPTION
When generating devnet l1 allocs, the deploy script deploys using CREATE, resulting in the following issues

- this uses up the contract addresses for the dev account that the script is run with, causing subsequent deploys to fail (see https://github.com/ethereum-optimism/supersim/issues/91)
- L1 allocs for multiple L2s result in multiple safe deployments if the sender is different 

solution: use create2 with the _implSalt() to deploy the safe contracts