### PR TITLE
ci: manage versions in versions.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,9 +432,9 @@ jobs:
             - run:
                 name: Sign
                 command: |
-                  git clone https://github.com/ethereum-optimism/binary_signer
-                  cd binary_signer/signer
-                  git checkout tags/v1.0.3
+                  VER=$(jq -r .binary_signer < versions.json)
+                  wget -O - "https://github.com/ethereum-optimism/binary_signer/archive/refs/tags/v${VER}.tar.gz" | tar xz
+                  cd "binary_signer-${VER}/signer"
 
                   IMAGE_PATH="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>:<<pipeline.git.revision>>"
                   echo $IMAGE_PATH
@@ -1091,19 +1091,17 @@ jobs:
       - run:
           name: Install latest golang
           command: |
-            wget https://go.dev/dl/go1.21.1.linux-amd64.tar.gz
+            VER=$(jq -r .go < versions.json)
             sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.21.1.linux-amd64.tar.gz
+            wget "https://go.dev/dl/go${VER}.linux-amd64.tar.gz" -O - | sudo tar -C /usr/local -xz
             export PATH=$PATH:/usr/local/go/bin
             go version
       - run:
           name: Install Geth
           command: |
-            wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.13.14-2bd6bd01.tar.gz
-            # geth only provides md5 sums sadly
-            echo '76a04354dba9980fcbc35bece2957b30 geth-alltools-linux-amd64-1.13.14-2bd6bd01.tar.gz' | md5sum -c -
-            tar -xzvf geth-alltools-linux-amd64-1.13.14-2bd6bd01.tar.gz
-            sudo cp geth-alltools-linux-amd64-1.13.14-2bd6bd01/* /usr/local/bin
+            VER=$(jq -r .geth_release < versions.json)
+            wget "https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-${VER}.tar.gz" -O - | tar xz
+            sudo cp "geth-alltools-linux-amd64-${VER}"/* /usr/local/bin
       - run:
           name: Install eth2-testnet-genesis
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1118,7 +1118,8 @@ jobs:
       - run:
           name: Install Just
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to $HOME/bin
+            VER=$(jq -r .just < versions.json)
+            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to $HOME/bin --tag "${VER}"
             echo 'export PATH="${PATH}:$HOME/bin"' >> $BASH_ENV
       - install-contracts-dependencies
       - attach_workspace:

--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,13 @@
 {
+  "go": "1.22.6",
   "abigen": "v1.10.25",
   "foundry": "626221f5ef44b4af950a08e09bd714650d9eb77d",
   "geth": "v1.14.7",
+  "geth_release": "1.14.7-aa55f5ea",
   "eth2_testnet_genesis": "v0.10.0",
   "nvm": "v20.9.0",
   "slither": "0.10.2",
   "kontrol": "0.1.316",
-  "just": "1.34.0"
+  "just": "1.34.0",
+  "binary_signer": "1.0.4"
 }


### PR DESCRIPTION

**Description**

* Pins more versions that are used in CI in the central `versions.json` file.
  * For geth, a second version field `geth_release` was introduced because unfortunately, official geth releases also contain a truncated git commit hash.
* The geth md5 integrity check was removed. We download all other binaries just trusting the integrity guarantees of https, so there's no point in md5-checking the geth download. If we really wanted to add another layer of security here, we should do pgp signature verification and commit the geth Linux builder key to the monorepo. But I don't think that makes sense for CI, since we also don't do this for any other archive, where we also just trust the https anchors.
* Optimizes archive downloads to directly extract by piping into `tar`.


**Additional context**

The geth version pinned in `versions.json` was not used in the "Install geth" CI step, where it was just hardcoded. This is easily forgotten when upgrading the geth version only in the `versions.json` file, as has happened recently here https://github.com/ethereum-optimism/optimism/pull/11410
