### PR TITLE
fix(ctb): remove linked libraries from scripts and tests

### DIFF
--- a/packages/contracts-bedrock/scripts/ForgeArtifacts.sol
+++ b/packages/contracts-bedrock/scripts/ForgeArtifacts.sol
@@ -54,7 +54,7 @@ library ForgeArtifacts {
     }
 
     /// @notice Returns the storage layout for a deployed contract.
-    function getStorageLayout(string memory _name) public returns (string memory layout_) {
+    function getStorageLayout(string memory _name) internal returns (string memory layout_) {
         string[] memory cmd = new string[](3);
         cmd[0] = Executables.bash;
         cmd[1] = "-c";
@@ -64,7 +64,7 @@ library ForgeArtifacts {
     }
 
     /// @notice Returns the abi from a the forge artifact
-    function getAbi(string memory _name) public returns (string memory abi_) {
+    function getAbi(string memory _name) internal returns (string memory abi_) {
         string[] memory cmd = new string[](3);
         cmd[0] = Executables.bash;
         cmd[1] = "-c";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -99,7 +99,7 @@ library MIPSSyscalls {
 
     uint32 internal constant SCHED_QUANTUM = 100_000;
     /// @notice Start of the data segment.
-    uint32 public constant BRK_START = 0x40000000;
+    uint32 internal constant BRK_START = 0x40000000;
 
     // SYS_CLONE flags
     uint32 internal constant CLONE_VM = 0x100;

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -13,7 +13,6 @@ contract SafeCall_Test is Test {
     function assumeNot(address _addr) internal {
         vm.assume(_addr.balance == 0);
         vm.assume(_addr != address(this));
-        vm.assume(_addr != 0x5F65cD7D792E9746EF82929D60de9a1C526f93A5); // Identified as ForgeArtifacts in traces
         vm.assume(uint256(uint160(_addr)) > uint256(256)); // TODO temp fix until new forge-std release with modern
             // precompiles: https://github.com/foundry-rs/forge-std/pull/594
         assumeAddressIsNot(_addr, StdCheatsSafe.AddressType.ForgeAddress, StdCheatsSafe.AddressType.Precompile);

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -13,6 +13,7 @@ contract SafeCall_Test is Test {
     function assumeNot(address _addr) internal {
         vm.assume(_addr.balance == 0);
         vm.assume(_addr != address(this));
+        vm.assume(_addr != 0x5F65cD7D792E9746EF82929D60de9a1C526f93A5); // Identified as ForgeArtifacts in traces
         vm.assume(uint256(uint160(_addr)) > uint256(256)); // TODO temp fix until new forge-std release with modern
             // precompiles: https://github.com/foundry-rs/forge-std/pull/594
         assumeAddressIsNot(_addr, StdCheatsSafe.AddressType.ForgeAddress, StdCheatsSafe.AddressType.Precompile);

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -62,9 +62,9 @@ library Sort {
 
 library SafeTestLib {
     /// @dev The address of foundry's VM contract
-    address constant internal VM_ADDR = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+    address internal constant VM_ADDR = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
     /// @dev The address of the first owner in the linked list of owners
-    address constant internal SENTINEL_OWNERS = address(0x1);
+    address internal constant SENTINEL_OWNERS = address(0x1);
 
     /// @dev Get the address from a private key
     function getAddr(uint256 pk) internal pure returns (address) {

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -54,7 +54,7 @@ struct SafeInstance {
 
 library Sort {
     /// @dev Sorts an array of addresses in place
-    function sort(address[] memory arr) public pure returns (address[] memory) {
+    function sort(address[] memory arr) internal pure returns (address[] memory) {
         LibSort.sort(arr);
         return arr;
     }

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -62,9 +62,9 @@ library Sort {
 
 library SafeTestLib {
     /// @dev The address of foundry's VM contract
-    address constant VM_ADDR = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+    address constant internal VM_ADDR = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
     /// @dev The address of the first owner in the linked list of owners
-    address constant SENTINEL_OWNERS = address(0x1);
+    address constant internal SENTINEL_OWNERS = address(0x1);
 
     /// @dev Get the address from a private key
     function getAddr(uint256 pk) internal pure returns (address) {


### PR DESCRIPTION
I believe this should fix the flaky SafeCall CI tests. Here is what I believe is happening:
- When we run all tests, somewhere a contract gets deployed to `0x5F65cD7D792E9746EF82929D60de9a1C526f93A5`. I am still unsure exactly what this address is, but the trace labels it `ForgeArtifacts`
- Fuzzer picks up that address
- SafeCall tests use that as the `to` address along with random calldata. If that address has code, this revert because that contract doesn't have a matching selector or fallback (standard solidity behavior). If that address has no code, the test pasess.
- So when we `--rerun`, we only run a single test and therefore nothing is deployed to `0x5F65cD7D792E9746EF82929D60de9a1C526f93A5`, so the test passes

Therefore it seems like forge is leaking state between tests, so I have opened an issue upstream as well: https://github.com/foundry-rs/foundry/issues/8639

It is possible other contracts caused this same issue, so if we get additional flakes look at the `to` address in the call and add consider adding it to the exclude list IF the forge trace shows that address has code (e.g. it's labeled/known).

## Edit: Update

I have since removed the hardcoded assumption to remove `0x5F65cD7D792E9746EF82929D60de9a1C526f93A5`, because it appears that the bug is solved once we remove all public library methods from tests

Once merged, this should fix the recent contract flakes. I also updated https://github.com/ethereum-optimism/client-pod/issues/846 to track adding a semgrep rule to avoid library linking