### PR TITLE
op-challenger: Do not resolve games in selective mode

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -155,6 +155,11 @@ func (a *Agent) tryResolve(ctx context.Context) bool {
 		a.log.Error("Failed to resolve claims", "err", err)
 		return false
 	}
+	if a.selective {
+		// Never resolve games in selective mode as it won't unlock any bonds for us.
+		// Assume the game is still in progress or the player wouldn't have told us to act.
+		return false
+	}
 	status, err := a.responder.CallResolve(ctx)
 	if err != nil || status == gameTypes.GameStatusInProgress {
 		return false


### PR DESCRIPTION
**Description**

When in selective mode, never resolve games as it won't unlock any bonds for the specified claimants.

**Tests**

Updated assertions.
