### PR TITLE
op-e2e: Disable proposer in dispute game tests

### DIFF
--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -303,7 +303,7 @@ func TestHighestActedL1BlockMetric(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	honestChallenger := disputeGameFactory.StartChallenger(ctx, "Honest", challenger.WithAlphabet(), challenger.WithFastGames(), challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+	honestChallenger := disputeGameFactory.StartChallenger(ctx, "Honest", challenger.WithAlphabet(), challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
 	game1 := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, common.Hash{0xaa})
 	sys.AdvanceTime(game1.MaxClockDuration(ctx))

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -54,8 +54,8 @@ func StartFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts) (*op_
 	cfg.DeployConfig.SequencerWindowSize = 4
 	cfg.DeployConfig.FinalizationPeriodSeconds = 2
 	cfg.SupportL1TimeTravel = true
-	cfg.DeployConfig.L2OutputOracleSubmissionInterval = 1
-	cfg.NonFinalizedProposals = true // Submit output proposals asap
+	// Disable proposer creating fast games automatically - required games are manually created
+	cfg.DisableProposer = true
 	for _, opt := range opts {
 		opt(&cfg)
 	}

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -270,6 +270,9 @@ type SystemConfig struct {
 	// If the proposer can make proposals for L2 blocks derived from L1 blocks which are not finalized on L1 yet.
 	NonFinalizedProposals bool
 
+	// Explicitly disable proposer, for tests that don't want dispute games automatically created
+	DisableProposer bool
+
 	// Explicitly disable batcher, for tests that rely on unsafe L2 payloads
 	DisableBatcher bool
 
@@ -878,8 +881,10 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	if err != nil {
 		return nil, fmt.Errorf("unable to setup l2 output submitter: %w", err)
 	}
-	if err := proposer.Start(context.Background()); err != nil {
-		return nil, fmt.Errorf("unable to start l2 output submitter: %w", err)
+	if !cfg.DisableProposer {
+		if err := proposer.Start(context.Background()); err != nil {
+			return nil, fmt.Errorf("unable to start l2 output submitter: %w", err)
+		}
 	}
 	sys.L2OutputSubmitter = proposer
 


### PR DESCRIPTION
**Description**

The games being tested are created manually and the automated proposals at best waste time and can interfere with tsts like TestHighestActedL1BlockMetric which expects the challenger to acton all games.