### PR TITLE
fix: op-batcher batch-tx-submitted metric double count

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -66,7 +66,6 @@ func (c *channel) TxFailed(id string) {
 // resubmitted.
 // This function may reset the pending channel if the pending channel has timed out.
 func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockID) (bool, []*types.Block) {
-	c.metr.RecordBatchTxSubmitted()
 	c.log.Debug("marked transaction as confirmed", "id", id, "block", inclusionBlock)
 	if _, ok := c.pendingTransactions[id]; !ok {
 		c.log.Warn("unknown transaction marked as confirmed", "id", id, "block", inclusionBlock)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Noticed when playing around with the devnet that the batchtx-submitted metric count was always 2x the nonce of the txmgr, which doesn't make sense.

Realized that `RecordBatchTxSubmitted` is called twice:
1. https://github.com/ethereum-optimism/optimism/blob/5a4fbce2bc780a908afeab255513aa38ca3c49b8/op-batcher/batcher/channel_manager.go#L113
2. https://github.com/ethereum-optimism/optimism/blob/5a4fbce2bc780a908afeab255513aa38ca3c49b8/op-batcher/batcher/channel.go#L75
whereas `RecordBatchTxSuccess` is never called. So potentially one of the two calls to `RecordBatchTxSubmitted` should have been a call to `RecordBatchTxSuccess` instead?
![image](https://github.com/user-attachments/assets/206e0974-f192-4b84-93ec-6c8356c3dfa3)

I just deleted one of them, but probably someone with more context will be able to understand the best fix here. Happy to make any modifications to this PR. :)

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
