### PR TITLE
contracts-bedrock: delete findings

### DIFF
--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -387,10 +387,5 @@ CI will fail if there are any new findings of medium or higher severity, as conf
 There are two corresponding jobs in CI: one calls "Slither Analysis" and one called "Code scanning results / Slither".
 The former will always pass if Slither runs successfully, and the latter will fail if there are any new findings of medium or higher severity.
 
-Existing findings can be found in the repo's Security tab > [Code Scanning](https://github.com/ethereum-optimism/optimism/security/code-scanning) section.
-You can view findings for a specific PR using the `pr:{number}` filter, such [`pr:9405`](https://github.com/ethereum-optimism/optimism/security/code-scanning?query=is:open+pr:9405).
-
-For each finding, either fix it locally and push a new commit, or dismiss it through the PR comment's UI.
-
 Note that you can run slither locally by running `slither .`, but because it does not contain the triaged results from GitHub, it will be noisy.
 Instead, you should run `slither ./path/to/contract.sol` to run it against a specific file.


### PR DESCRIPTION
The security tag was moved. The path is not working anymore.
