### PR TITLE
op-bedrock: Add detail to the documentation to clarify any confusion.

### DIFF
--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -290,7 +290,8 @@ the names of the contracts and the values are the addresses the contract was dep
 
 The `DEPLOY_CONFIG_PATH` is a filepath to a deploy config file, see the `deploy-config` directory for examples and the
 [DeployConfig](https://github.com/ethereum-optimism/optimism/blob/develop/op-chain-ops/genesis/config.go) definition for
-descriptions of the values.
+descriptions of the values. 
+If you are following the official deployment tutorial, please make sure to use the `getting-started.json` file.
 
 ```bash
 DEPLOYMENT_OUTFILE=deployments/artifact.json \

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -290,7 +290,7 @@ the names of the contracts and the values are the addresses the contract was dep
 
 The `DEPLOY_CONFIG_PATH` is a filepath to a deploy config file, see the `deploy-config` directory for examples and the
 [DeployConfig](https://github.com/ethereum-optimism/optimism/blob/develop/op-chain-ops/genesis/config.go) definition for
-descriptions of the values. 
+descriptions of the values.
 If you are following the official deployment tutorial, please make sure to use the `getting-started.json` file.
 
 ```bash


### PR DESCRIPTION
When I was following the official documentation to deploy, I ran into an error that said '`must set DEPLOY_CONFIG_PATH`'. Even after checking the README, I wasn't sure which JSON to use, and I couldn't find answers on Discord either. It took me a lot of time, but eventually, I figured out that if I'm following the official docs for deployment, I need to use `getting-started.json`. This JSON is generated by `./scripts/getting-started/config.sh`.