### PR TITLE
op-node: remove MaxSequencerDrift hardcode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813151825-611c7cfcd07b
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813170044-d5be5587e58f
 	github.com/ethereum/go-ethereum v1.14.7
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240812010938-34a43d577f74
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813151825-611c7cfcd07b
 	github.com/ethereum/go-ethereum v1.14.7
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a h1:OK3wB7HbdhCneSowC1XZusHaLIVdXoRLuCWgXp5Tjuc=
 github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a/go.mod h1:9pT+bF20XwCBE7WkjfRSsCg6RN6Njdbr924DtQ3+geY=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813151825-611c7cfcd07b h1:n2gakehKiQ+msUkYbB5DahiSliwgdN2I7SrGlxbbxbE=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813151825-611c7cfcd07b/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813170044-d5be5587e58f h1:JTnVOiaYVQcXc+zgsSjnTQ18k3uOLOpch8SiPjO1eTo=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813170044-d5be5587e58f/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.1.1-0.20240306133620-7d920df305f0 h1:KrE8I4reeVvf7C1tm8elRjj4BdscTYzz/WAbYyf/JI4=

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a h1:OK3wB7HbdhCneSowC1XZusHaLIVdXoRLuCWgXp5Tjuc=
 github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a/go.mod h1:9pT+bF20XwCBE7WkjfRSsCg6RN6Njdbr924DtQ3+geY=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240812010938-34a43d577f74 h1:HQZQalpPUXs9qnJgDmEDzpPO70Z1p8Le2l0bZ9eJjCk=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240812010938-34a43d577f74/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813151825-611c7cfcd07b h1:n2gakehKiQ+msUkYbB5DahiSliwgdN2I7SrGlxbbxbE=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240813151825-611c7cfcd07b/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.1.1-0.20240306133620-7d920df305f0 h1:KrE8I4reeVvf7C1tm8elRjj4BdscTYzz/WAbYyf/JI4=

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -14,10 +14,6 @@ import (
 
 var OPStackSupport = params.ProtocolVersionV0{Build: [8]byte{}, Major: 7, Minor: 0, Patch: 0, PreRelease: 0}.Encode()
 
-const (
-	pgnSepolia = 58008
-)
-
 // LoadOPStackRollupConfig loads the rollup configuration of the requested chain ID from the superchain-registry.
 // Some chains may require a SystemConfigProvider to retrieve any values not part of the registry.
 func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
@@ -76,7 +72,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		// Note: hardcoded values are not yet represented in the registry but should be
 		// soon, then will be read and set in the same fashion.
 		BlockTime:              chConfig.BlockTime,
-		MaxSequencerDrift:      600,
+		MaxSequencerDrift:      chConfig.MaxSequencerDrift,
 		SeqWindowSize:          chConfig.SequencerWindowSize,
 		ChannelTimeoutBedrock:  300,
 		ChannelTimeoutGranite:  50,
@@ -96,10 +92,6 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 
 	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address
 		cfg.ProtocolVersionsAddress = common.Address(*superChain.Config.ProtocolVersionsAddr)
-	}
-	if chainID == pgnSepolia {
-		cfg.MaxSequencerDrift = 1000
-		cfg.SeqWindowSize = 7200
 	}
 	return cfg, nil
 }

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -21,6 +21,7 @@ var (
 	ErrMissingChannelTimeout         = errors.New("channel timeout must be set, this should cover at least a L1 block time")
 	ErrInvalidGraniteChannelTimeout  = errors.New("channel timeout granite must be less than channel timeout")
 	ErrInvalidSeqWindowSize          = errors.New("sequencing window size must at least be 2")
+	ErrInvalidMaxSeqDrift            = errors.New("maximum sequencer drift must be greater than 0")
 	ErrMissingGenesisL1Hash          = errors.New("genesis L1 hash cannot be empty")
 	ErrMissingGenesisL2Hash          = errors.New("genesis L2 hash cannot be empty")
 	ErrGenesisHashesSame             = errors.New("achievement get! rollup inception: L1 and L2 genesis cannot be the same")
@@ -281,6 +282,9 @@ func (cfg *Config) Check() error {
 	}
 	if cfg.SeqWindowSize < 2 {
 		return ErrInvalidSeqWindowSize
+	}
+	if cfg.MaxSequencerDrift == 0 {
+		return ErrInvalidMaxSeqDrift
 	}
 	if cfg.Genesis.L1.Hash == (common.Hash{}) {
 		return ErrMissingGenesisL1Hash


### PR DESCRIPTION
Replaces https://github.com/ethereum-optimism/optimism/pull/11427

Within op-node's `LoadOPStackRollupConfig`, read `MaxSequencerDrift` from the superchain config file instead of using a hardcoded value. This allows chains to have some flexibility when configuring their chain.

Complementary superchain-registry pr: https://github.com/ethereum-optimism/superchain-registry/pull/469