### PR TITLE
op-wheel: harden against missing safe/finalized heads

### DIFF
--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -405,10 +405,10 @@ func Rewind(ctx context.Context, lgr log.Logger, client *sources.EngineAPIClient
 
 	// when rewinding, don't increase unsafe/finalized tags
 	toSafe, toFinalized := toUnsafe, toUnsafe
-	if safe.Number.Uint64() < to {
+	if safe != nil && safe.Number.Uint64() < to {
 		toSafe = eth.HeaderBlockID(safe)
 	}
-	if finalized.Number.Uint64() < to {
+	if finalized != nil && finalized.Number.Uint64() < to {
 		toFinalized = eth.HeaderBlockID(finalized)
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

If a geth db is broken and its safe and finalized head are nil, `engine rewind` did panic before this fix. It's better to just use the provided head in this case.

