### PR TITLE
Added Stop API in the conductor

### DIFF
--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -23,6 +23,8 @@ type API interface {
 	Pause(ctx context.Context) error
 	// Resume resumes op-conductor.
 	Resume(ctx context.Context) error
+	// Stop stops op-conductor.
+	Stop(ctx context.Context) error
 	// Paused returns true if op-conductor is paused.
 	Paused(ctx context.Context) (bool, error)
 	// Stopped returns true if op-conductor is stopped.

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -13,6 +13,7 @@ import (
 type conductor interface {
 	Pause(ctx context.Context) error
 	Resume(ctx context.Context) error
+	Stop(ctx context.Context) error
 	Paused() bool
 	Stopped() bool
 	SequencerHealthy(ctx context.Context) bool
@@ -113,6 +114,11 @@ func (api *APIBackend) Pause(ctx context.Context) error {
 // Resume implements API.
 func (api *APIBackend) Resume(ctx context.Context) error {
 	return api.con.Resume(ctx)
+}
+
+// Stop implements API.
+func (api *APIBackend) Stop(ctx context.Context) error {
+	return api.con.Stop(ctx)
 }
 
 // TransferLeader implements API. With Raft implementation, a successful call does not mean that leadership transfer is complete

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -102,6 +102,11 @@ func (c *APIClient) Resume(ctx context.Context) error {
 	return c.c.CallContext(ctx, nil, prefixRPC("resume"))
 }
 
+// Stop implements API.
+func (c *APIClient) Stop(ctx context.Context) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("stop"))
+}
+
 // TransferLeader implements API.
 func (c *APIClient) TransferLeader(ctx context.Context) error {
 	return c.c.CallContext(ctx, nil, prefixRPC("transferLeader"))

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -162,6 +162,7 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	require.Equal(t, 2, len(membership.Servers), "Expected 2 members in cluster after removal")
 	require.NotContains(t, memberIDs(membership), fid, "Expected follower to be removed from cluster")
 
+	// Testing the stop api
 	t.Log("Testing Stop API")
 	err = c1.client.Stop(ctx)
 	require.NoError(t, err)

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -69,9 +69,8 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 
 	err = c1.client.Stop(ctx)
 	require.NoError(t, err)
-	active, err = c1.client.Active(ctx)
-	require.NoError(t, err)
-	require.False(t, active, "Expected conductor to be stopped")
+	_, err = c1.client.Active(ctx)
+	require.Error(t, err, "Expected conductor to fail to get active status after stop")
 
 	t.Log("Testing LeaderWithID")
 	leader1, err := c1.client.LeaderWithID(ctx)

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -50,7 +50,7 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	require.Equal(t, []string{Sequencer1Name, Sequencer2Name, Sequencer3Name}, ids, "Expected all sequencers to be in cluster")
 
 	// Test Active & Pause & Resume & Stop
-	t.Log("Testing Active & Pause & Resume & Stop")
+	t.Log("Testing Active & Pause & Resume")
 	active, err := c1.client.Active(ctx)
 	require.NoError(t, err)
 	require.True(t, active, "Expected conductor to be active")
@@ -66,11 +66,6 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	active, err = c1.client.Active(ctx)
 	require.NoError(t, err)
 	require.True(t, active, "Expected conductor to be active")
-
-	err = c1.client.Stop(ctx)
-	require.NoError(t, err)
-	_, err = c1.client.Active(ctx)
-	require.Error(t, err, "Expected conductor to fail to get active status after stop")
 
 	t.Log("Testing LeaderWithID")
 	leader1, err := c1.client.LeaderWithID(ctx)
@@ -166,6 +161,12 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(membership.Servers), "Expected 2 members in cluster after removal")
 	require.NotContains(t, memberIDs(membership), fid, "Expected follower to be removed from cluster")
+
+	t.Log("Testing Stop API")
+	err = c1.client.Stop(ctx)
+	require.NoError(t, err)
+	_, err = c1.client.Stopped(ctx)
+	require.Error(t, err, "Expected no connection to the conductor since it's stopped")
 }
 
 // [Category: Sequencer Failover]

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -49,8 +49,8 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	sort.Strings(ids)
 	require.Equal(t, []string{Sequencer1Name, Sequencer2Name, Sequencer3Name}, ids, "Expected all sequencers to be in cluster")
 
-	// Test Active & Pause & Resume
-	t.Log("Testing Active & Pause & Resume")
+	// Test Active & Pause & Resume & Stop
+	t.Log("Testing Active & Pause & Resume & Stop")
 	active, err := c1.client.Active(ctx)
 	require.NoError(t, err)
 	require.True(t, active, "Expected conductor to be active")
@@ -66,6 +66,12 @@ func TestSequencerFailover_ConductorRPC(t *testing.T) {
 	active, err = c1.client.Active(ctx)
 	require.NoError(t, err)
 	require.True(t, active, "Expected conductor to be active")
+
+	err = c1.client.Stop(ctx)
+	require.NoError(t, err)
+	active, err = c1.client.Active(ctx)
+	require.NoError(t, err)
+	require.False(t, active, "Expected conductor to be stopped")
 
 	t.Log("Testing LeaderWithID")
 	leader1, err := c1.client.LeaderWithID(ctx)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Added a stop api for the op conductor. 
People can manually stop conductors in the case of disaster recovery. 

**Tests**
added tests in op-e2e/sequencer_failover_test.go
