### PR TITLE
op-node: cleanup driver, closer to removing stepping

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -420,6 +420,9 @@ func (s *SyncDeriver) onResetEvent(x rollup.ResetEvent) {
 func (s *SyncDeriver) SyncStep() {
 	s.Log.Debug("Sync process step")
 
+	// Drain errors are safe to ignore:
+	// it only errors on executor context-timeout,
+	// i.e. when we are shutting down and not processing events anymore.
 	if err := s.Drain(); err != nil {
 		return
 	}

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -454,7 +454,6 @@ func (s *SyncDeriver) SyncStep() {
 	// Upon the pending-safe signal the attributes deriver can then ask the pipeline
 	// to generate new attributes, if no attributes are known already.
 	s.Emitter.Emit(engine.PendingSafeRequestEvent{})
-	return
 }
 
 // ResetDerivationPipeline forces a reset of the derivation pipeline.


### PR DESCRIPTION
**Description**

This removes a bunch of legacy error handling, which wasn't handling any meaningful errors anymore, as it was wrapped around the sync-step function that is barely doing anything anymore (thanks to the event handling).

**Tests**

Existing e2e tests cover syncing.

**Additional context**

After this we could update the engine controller, to trigger updates and backup-unsafe-reorg through events.
And then when triggering the pending-safe updates at the right places, there is no sync step code left.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/10850
