### PR TITLE
fix: makefile build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,15 @@ PYTHON?=python3
 help: ## Prints this help message
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build: build-go build-ts ## Builds both Go and TypeScript components
+build: build-go build-contracts ## Builds Go components and contracts-bedrock
 .PHONY: build
 
 build-go: submodules op-node op-proposer op-batcher ## Builds op-node, op-proposer and op-batcher
 .PHONY: build-go
+
+build-contracts:
+	(cd packages/contracts-bedrock && just build)
+.PHONY: build-contracts
 
 lint-go: ## Lints Go code with specific linters
 	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...


### PR DESCRIPTION
Build command inside of the root-level makefile was calling build-ts which no longer exists. Adds a new command to build contracts-bedrock and replaces that inside of the root build command.