### PR TITLE
OPSM: Deploy Superchain

### DIFF
--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -9,6 +9,8 @@ import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 
 /// @notice Deploys the Superchain contracts that can be shared by many chains.
+/// We intentionally use the terms "Input" and "Output" to clearly distinguish this script from the
+/// existing ones that use terms of "Config" and "Artifacts".
 contract DeploySuperchain is Script {
     struct Roles {
         address proxyAdminOwner;
@@ -31,7 +33,16 @@ contract DeploySuperchain is Script {
         ProtocolVersions protocolVersionsProxy;
     }
 
-    function run(Input memory _input) public returns (Output memory output_) {
+    /// @notice This entrypoint is for end-users to deploy from an input file and write to an output file.
+    function run(string memory _infile) public returns (Output memory output_, string memory outfile_) {
+        Input memory _input = parseInputFile(_infile);
+        output_ = runWithoutIO(_input);
+        outfile_ = writeOutputFile(_infile, _input, output_);
+        require(false, "run is not implemented");
+    }
+
+    /// @notice This entrypoint is useful for e2e testing purposes, and doesn't use any file I/O.
+    function runWithoutIO(Input memory _input) public returns (Output memory output_) {
         // Validate inputs.
         require(_input.roles.proxyAdminOwner != address(0), "zero address: proxyAdminOwner");
         require(_input.roles.protocolVersionsOwner != address(0), "zero address: protocolVersionsOwner");
@@ -95,5 +106,31 @@ contract DeploySuperchain is Script {
                 require(addresses[i] != addresses[j], err);
             }
         }
+    }
+
+    /// @notice This method is public for testing purposes, but there isn't a need for users to call this method
+    /// directly.
+    function parseInputFile(string memory _infile) public pure returns (Input memory input_) {
+        _infile;
+        input_;
+        require(false, "parseInputFile is not implemented");
+    }
+
+    /// @notice Writes an output file, where the filename is based on the input filename, e.g. an input file of
+    /// `DeploySuperchain.in.toml` results in an output file of `DeploySuperchain.out.toml`.
+    function writeOutputFile(
+        string memory _infile,
+        Input memory _input,
+        Output memory _output
+    )
+        internal
+        pure
+        returns (string memory outfile_)
+    {
+        _infile;
+        _input;
+        _output;
+        outfile_;
+        require(false, "writeOutputFile not implemented");
     }
 }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -38,7 +38,7 @@ contract DeploySuperchain is Script {
         Input memory _input = parseInputFile(_infile);
         output_ = runWithoutIO(_input);
         outfile_ = writeOutputFile(_infile, _input, output_);
-        require(false, "run is not implemented");
+        require(false, "DeploySuperchain: run is not implemented");
     }
 
     /// @notice This entrypoint is useful for e2e testing purposes, and doesn't use any file I/O.
@@ -113,7 +113,7 @@ contract DeploySuperchain is Script {
     function parseInputFile(string memory _infile) public pure returns (Input memory input_) {
         _infile;
         input_;
-        require(false, "parseInputFile is not implemented");
+        require(false, "DeploySuperchain: parseInputFile is not implemented");
     }
 
     /// @notice Writes an output file, where the filename is based on the input filename, e.g. an input file of
@@ -131,6 +131,6 @@ contract DeploySuperchain is Script {
         _input;
         _output;
         outfile_;
-        require(false, "writeOutputFile not implemented");
+        require(false, "DeploySuperchain: writeOutputFile not implemented");
     }
 }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
+import { ProtocolVersions, ProtocolVersion } from "src/L1/ProtocolVersions.sol";
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+
+/// @notice Deploys the Superchain contracts that can be shared by many chains.
+contract DeploySuperchain is Script {
+    struct Roles {
+        address proxyAdminOwner;
+        address protocolVersionsOwner;
+        address guardian;
+    }
+
+    struct Input {
+        Roles roles;
+        bool paused;
+        ProtocolVersion requiredProtocolVersion;
+        ProtocolVersion recommendedProtocolVersion;
+    }
+
+    struct Output {
+        ProxyAdmin superchainProxyAdmin;
+        SuperchainConfig superchainConfigImpl;
+        SuperchainConfig superchainConfigProxy;
+        ProtocolVersions protocolVersionsImpl;
+        ProtocolVersions protocolVersionsProxy;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        // Validate inputs.
+        require(_input.roles.proxyAdminOwner != address(0), "zero address: proxyAdminOwner");
+        require(_input.roles.protocolVersionsOwner != address(0), "zero address: protocolVersionsOwner");
+        require(_input.roles.guardian != address(0), "zero address: guardian");
+
+        // Deploy the proxy admin, with the owner set to the deployer.
+        // We explicitly specify the deployer as `msg.sender` because for testing we deploy this script from a test
+        // contract. If we provide no argument, the foundry default sender is be the broadcaster during test, but the
+        // broadcaster needs to be the deployer since they are set to the initial proxy admin owner.
+        vm.startBroadcast(msg.sender);
+
+        output_.superchainProxyAdmin = new ProxyAdmin(msg.sender);
+        vm.label(address(output_.superchainProxyAdmin), "SuperchainProxyAdmin");
+
+        // Deploy implementation contracts.
+        output_.superchainConfigImpl = new SuperchainConfig();
+        output_.protocolVersionsImpl = new ProtocolVersions();
+
+        // Deploy and initialize the proxies.
+        output_.superchainConfigProxy = SuperchainConfig(address(new Proxy(address(output_.superchainProxyAdmin))));
+        vm.label(address(output_.superchainConfigProxy), "SuperchainConfigProxy");
+        output_.superchainProxyAdmin.upgradeAndCall(
+            payable(address(output_.superchainConfigProxy)),
+            address(output_.superchainConfigImpl),
+            abi.encodeCall(SuperchainConfig.initialize, (_input.roles.guardian, _input.paused))
+        );
+
+        output_.protocolVersionsProxy = ProtocolVersions(address(new Proxy(address(output_.superchainProxyAdmin))));
+        vm.label(address(output_.protocolVersionsProxy), "ProtocolVersionsProxy");
+        output_.superchainProxyAdmin.upgradeAndCall(
+            payable(address(output_.protocolVersionsProxy)),
+            address(output_.protocolVersionsImpl),
+            abi.encodeCall(
+                ProtocolVersions.initialize,
+                (_input.roles.protocolVersionsOwner, _input.requiredProtocolVersion, _input.recommendedProtocolVersion)
+            )
+        );
+
+        // Transfer ownership of the ProxyAdmin from the deployer to the specified owner.
+        output_.superchainProxyAdmin.transferOwnership(_input.roles.proxyAdminOwner);
+
+        vm.stopBroadcast();
+
+        // Output assertions, to make sure outputs were assigned correctly.
+        address[] memory addresses = new address[](5);
+        addresses[0] = address(output_.superchainProxyAdmin);
+        addresses[1] = address(output_.superchainConfigImpl);
+        addresses[2] = address(output_.superchainConfigProxy);
+        addresses[3] = address(output_.protocolVersionsImpl);
+        addresses[4] = address(output_.protocolVersionsProxy);
+
+        for (uint256 i = 0; i < addresses.length; i++) {
+            require(addresses[i] != address(0), string.concat("zero address at index ", vm.toString(i)));
+            require(addresses[i].code.length > 0, string.concat("no code at index ", vm.toString(i)));
+        }
+
+        // All addresses should be unique.
+        for (uint256 i = 0; i < addresses.length; i++) {
+            for (uint256 j = i + 1; j < addresses.length; j++) {
+                string memory err = string.concat("duplicates at: ", vm.toString(i), ",", vm.toString(j));
+                require(addresses[i] != addresses[j], err);
+            }
+        }
+    }
+}

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 
+import { Proxy } from "src/universal/Proxy.sol";
 import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
 import { DeploySuperchain } from "scripts/DeploySuperchain.s.sol";
 
@@ -37,13 +38,24 @@ contract DeploySuperchain_Test is Test {
 
         DeploySuperchain.Output memory output = deploySuperchain.runWithoutIO(_input);
 
-        // We assert on the inputs only, as the outputs are asserts on via require statements directly in the script.
+        // Assert the inputs were properly set.
         assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
         assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
         assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
         assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
         assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
         assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
+
+        // Architecture assertions.
+        // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
+        Proxy superchainConfigProxy = Proxy(payable(address(output.superchainConfigProxy)));
+        Proxy protocolVersionsProxy = Proxy(payable(address(output.protocolVersionsProxy)));
+        vm.startPrank(address(0));
+
+        assertEq(superchainConfigProxy.implementation(), address(output.superchainConfigImpl), "700");
+        assertEq(protocolVersionsProxy.implementation(), address(output.protocolVersionsImpl), "800");
+        assertEq(superchainConfigProxy.admin(), protocolVersionsProxy.admin(), "900");
+        assertEq(superchainConfigProxy.admin(), address(output.superchainProxyAdmin), "1000");
     }
 
     function test_runWithoutIOAndZeroAddressRoles_reverts() public {

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -11,7 +11,7 @@ contract DeploySuperchain_Test is Test {
     DeploySuperchain deploySuperchain;
 
     // Define a default input struct for testing.
-    DeploySuperchain.Input input  = DeploySuperchain.Input({
+    DeploySuperchain.Input input = DeploySuperchain.Input({
         roles: DeploySuperchain.Roles({
             proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
             protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
@@ -30,12 +30,12 @@ contract DeploySuperchain_Test is Test {
         return ProtocolVersion.unwrap(_pv);
     }
 
-    function test_run_withInputStruct_succeeds(DeploySuperchain.Input memory _input) public {
+    function test_runWithoutIO_succeeds(DeploySuperchain.Input memory _input) public {
         vm.assume(_input.roles.proxyAdminOwner != address(0));
         vm.assume(_input.roles.protocolVersionsOwner != address(0));
         vm.assume(_input.roles.guardian != address(0));
 
-        DeploySuperchain.Output memory output = deploySuperchain.run(_input);
+        DeploySuperchain.Output memory output = deploySuperchain.runWithoutIO(_input);
 
         // We assert on the inputs only, as the outputs are asserts on via require statements directly in the script.
         assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
@@ -46,23 +46,23 @@ contract DeploySuperchain_Test is Test {
         assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
     }
 
-    function test_run_withInputStructAndZeroAddressRoles_reverts() public {
+    function test_runWithoutIOAndZeroAddressRoles_reverts() public {
         // Snapshot the state so we can revert to the default `input` struct between assertions.
         uint256 snapshotId = vm.snapshot();
 
         // Assert over each role being set to the zero address.
         input.roles.proxyAdminOwner = address(0);
         vm.expectRevert("zero address: proxyAdminOwner");
-        deploySuperchain.run(input);
+        deploySuperchain.runWithoutIO(input);
 
         vm.revertTo(snapshotId);
         input.roles.protocolVersionsOwner = address(0);
         vm.expectRevert("zero address: protocolVersionsOwner");
-        deploySuperchain.run(input);
+        deploySuperchain.runWithoutIO(input);
 
         vm.revertTo(snapshotId);
         input.roles.guardian = address(0);
         vm.expectRevert("zero address: guardian");
-        deploySuperchain.run(input);
+        deploySuperchain.runWithoutIO(input);
     }
 }

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
+import { DeploySuperchain } from "scripts/DeploySuperchain.s.sol";
+
+/// @notice Deploys the Superchain contracts that can be shared by many chains.
+contract DeploySuperchain_Test is Test {
+    DeploySuperchain deploySuperchain;
+
+    // Define a default input struct for testing.
+    DeploySuperchain.Input input  = DeploySuperchain.Input({
+        roles: DeploySuperchain.Roles({
+            proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
+            protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
+            guardian: makeAddr("defaultGuardian")
+        }),
+        paused: false,
+        requiredProtocolVersion: ProtocolVersion.wrap(1),
+        recommendedProtocolVersion: ProtocolVersion.wrap(2)
+    });
+
+    function setUp() public {
+        deploySuperchain = new DeploySuperchain();
+    }
+
+    function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
+        return ProtocolVersion.unwrap(_pv);
+    }
+
+    function test_run_withInputStruct_succeeds(DeploySuperchain.Input memory _input) public {
+        vm.assume(_input.roles.proxyAdminOwner != address(0));
+        vm.assume(_input.roles.protocolVersionsOwner != address(0));
+        vm.assume(_input.roles.guardian != address(0));
+
+        DeploySuperchain.Output memory output = deploySuperchain.run(_input);
+
+        // We assert on the inputs only, as the outputs are asserts on via require statements directly in the script.
+        assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
+        assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
+        assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
+        assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
+        assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
+        assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
+    }
+
+    function test_run_withInputStructAndZeroAddressRoles_reverts() public {
+        // Snapshot the state so we can revert to the default `input` struct between assertions.
+        uint256 snapshotId = vm.snapshot();
+
+        // Assert over each role being set to the zero address.
+        input.roles.proxyAdminOwner = address(0);
+        vm.expectRevert("zero address: proxyAdminOwner");
+        deploySuperchain.run(input);
+
+        vm.revertTo(snapshotId);
+        input.roles.protocolVersionsOwner = address(0);
+        vm.expectRevert("zero address: protocolVersionsOwner");
+        deploySuperchain.run(input);
+
+        vm.revertTo(snapshotId);
+        input.roles.guardian = address(0);
+        vm.expectRevert("zero address: guardian");
+        deploySuperchain.run(input);
+    }
+}


### PR DESCRIPTION
**Description**

Adds `DeploySuperchain.s.sol` which deploys and configures the superchain contracts as described in Step 1 of https://github.com/ethereum-optimism/design-docs/pull/60

This PR is focused on the in-memory version of the deployment (i.e. no file-based IO required) which is useful for e2e testing in Go. The interfaces for where files are wrapped around this core are scaffolded, but not implemented, in this PR, and will be implemented in a future PR.

This script and it's tests exist independently of the existing `DeployConfig.s.sol`, `Deploy.s.sol`, and `Artifacts.s.sol` contracts. This is intentional, so we can start with a clean slate here and avoid tech debt. We can integrate these deploy scripts into those ones as needed later, but I don't see a reason to pull them in yet.

**Tests**

A simple fuzz test is added that ensures the provided input configuration is respected, along with another concrete test to validate that zero addresses are not allowed for the role values. 

**Additional context**

Please review the resulting Superchain architecture and ensure it's consistent with the current production architecture