### PR TITLE
op-e2e: Add forge clean to README.md troubleshooting section

### DIFF
--- a/op-e2e/README.md
+++ b/op-e2e/README.md
@@ -31,4 +31,4 @@ make test-http
 If you encounter errors:
 * ensure you have the latest version of foundry installed: `just update-foundry`
 * try deleting the `packages/contracts-bedrock/forge-artifacts` directory
-* try `forge clean && rm -rf lib && forge install` within directory `packages/contracts-bedrock`
+* try `forge clean && rm -rf lib && forge install` within the `packages/contracts-bedrock` directory

--- a/op-e2e/README.md
+++ b/op-e2e/README.md
@@ -31,4 +31,4 @@ make test-http
 If you encounter errors:
 * ensure you have the latest version of foundry installed: `just update-foundry`
 * try deleting the `packages/contracts-bedrock/forge-artifacts` directory
-* if the above step doesn't fix the error, try `pnpm clean`
+* try `forge clean && rm -rf lib && forge install` within directory `packages/contracts-bedrock`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

... and removed the outdated `pnpm clean` item.

This recently helped me repair a repo with some old contract artifacts that failed with
```
2024-08-13T19:13:17.136400Z ERROR foundry_compilers_artifacts_solc::sources: error="/<redacted>/optimism/packages/contracts-bedrock/scripts/Chains.sol": No such file or directory (os error 2)
Error:
failed to read artifact source file for `/<redacted>/optimism/packages/contracts-bedrock/scripts/Chains.sol`
```