### PR TITLE
devnet: enable span batches and use blobs for non-plasma

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -269,8 +269,10 @@ def devnet_deploy(paths):
 
     if DEVNET_PLASMA:
         docker_env['PLASMA_ENABLED'] = 'true'
+        docker_env['DA_TYPE'] = 'calldata'
     else:
         docker_env['PLASMA_ENABLED'] = 'false'
+        docker_env['DA_TYPE'] = 'blobs'
 
     if GENERIC_PLASMA:
         docker_env['PLASMA_GENERIC_DA'] = 'true'
@@ -278,7 +280,6 @@ def devnet_deploy(paths):
     else:
         docker_env['PLASMA_GENERIC_DA'] = 'false'
         docker_env['PLASMA_DA_SERVICE'] = 'false'
-
 
     # Bring up the rest of the services.
     log.info('Bringing up `op-node`, `op-proposer` and `op-batcher`.')

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -199,13 +199,11 @@ services:
       OP_BATCHER_PPROF_ENABLED: "true"
       OP_BATCHER_METRICS_ENABLED: "true"
       OP_BATCHER_RPC_ENABLE_ADMIN: "true"
-      OP_BATCHER_BATCH_TYPE: 0
+      OP_BATCHER_BATCH_TYPE: 1
       OP_BATCHER_PLASMA_ENABLED: "${PLASMA_ENABLED}"
       OP_BATCHER_PLASMA_DA_SERVICE: "${PLASMA_DA_SERVICE}"
       OP_BATCHER_PLASMA_DA_SERVER: "http://da-server:3100"
-      # uncomment to use blobs
-      # (requires L1 Dencun and L2 Ecotone activation first)
-      # OP_BATCHER_DATA_AVAILABILITY_TYPE: blobs
+      OP_BATCHER_DATA_AVAILABILITY_TYPE: "${DA_TYPE}"
 
   op-challenger:
     depends_on:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We use span batches and blobs by default, so the devnet should too. Plasma required calldata da-type as it just posts committments.
