### PR TITLE
OPSM: Deploy Superchain, alternate approach

### DIFF
--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -9,6 +9,8 @@ import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 
 /// @notice Deploys the Superchain contracts that can be shared by many chains.
+/// We intentionally use the terms "Input" and "Output" to clearly distinguish this script from the
+/// existing ones that use terms of "Config" and "Artifacts".
 contract DeploySuperchain is Script {
     struct Roles {
         address proxyAdminOwner;
@@ -31,7 +33,16 @@ contract DeploySuperchain is Script {
         ProtocolVersions protocolVersionsProxy;
     }
 
-    function run(Input memory _input) public returns (Output memory output_) {
+    /// @notice This entrypoint is for end-users to deploy from an input file and write to an output file.
+    function run(string memory _infile) public returns (Output memory output_, string memory outfile_) {
+        Input memory _input = parseInputFile(_infile);
+        output_ = runWithoutIO(_input);
+        outfile_ = writeOutputFile(_infile, _input, output_);
+        require(false, "run is not implemented");
+    }
+
+    /// @notice This entrypoint is useful for e2e testing purposes, and doesn't use any file I/O.
+    function runWithoutIO(Input memory _input) public returns (Output memory output_) {
         // Validate inputs.
         require(_input.roles.proxyAdminOwner != address(0), "zero address: proxyAdminOwner");
         require(_input.roles.protocolVersionsOwner != address(0), "zero address: protocolVersionsOwner");
@@ -95,5 +106,31 @@ contract DeploySuperchain is Script {
                 require(addresses[i] != addresses[j], err);
             }
         }
+    }
+
+    /// @notice This method is public for testing purposes, but there isn't a need for users to call this method
+    /// directly.
+    function parseInputFile(string memory _infile) public pure returns (Input memory input_) {
+        _infile;
+        input_;
+        require(false, "parseInputFile is not implemented");
+    }
+
+    /// @notice Writes an output file, where the filename is based on the input filename, e.g. an input file of
+    /// `DeploySuperchain.in.toml` results in an output file of `DeploySuperchain.out.toml`.
+    function writeOutputFile(
+        string memory _infile,
+        Input memory _input,
+        Output memory _output
+    )
+        internal
+        pure
+        returns (string memory outfile_)
+    {
+        _infile;
+        _input;
+        _output;
+        outfile_;
+        require(false, "writeOutputFile not implemented");
     }
 }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -8,10 +8,7 @@ import { ProtocolVersions, ProtocolVersion } from "src/L1/ProtocolVersions.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 
-/// @notice Deploys the Superchain contracts that can be shared by many chains.
-/// We intentionally use the terms "Input" and "Output" to clearly distinguish this script from the
-/// existing ones that use terms of "Config" and "Artifacts".
-contract DeploySuperchain is Script {
+contract DeploySuperchainInput {
     struct Roles {
         address proxyAdminOwner;
         address protocolVersionsOwner;
@@ -25,6 +22,61 @@ contract DeploySuperchain is Script {
         ProtocolVersion recommendedProtocolVersion;
     }
 
+    Input internal input;
+    bool internal inputSet = false;
+
+    // -------- Load inputs --------
+
+    function loadInput(string memory _infile) public {
+        _infile;
+        Input memory parsedInput; // TODO parse the input file.
+        loadInput(parsedInput);
+        require(false, "DeploySuperchainInput: loadInput is not implemented");
+    }
+
+    function loadInput(Input memory _input) public {
+        require(!inputSet, "DeploySuperchainInput: input already set");
+        input = _input;
+    }
+
+    // -------- Getter methods for inputs --------
+
+    function inputs() public view returns (Input memory) {
+        require(inputSet, "DeploySuperchainInput: input not set");
+        return input;
+    }
+
+    function proxyAdminOwner() public view returns (address out) {
+        out = input.roles.proxyAdminOwner;
+        require(out != address(0), "DeploySuperchainInput: proxyAdminOwner not set");
+    }
+
+    function protocolVersionsOwner() public view returns (address out) {
+        out = input.roles.protocolVersionsOwner;
+        require(out != address(0), "DeploySuperchainInput: protocolVersionsOwner not set");
+    }
+
+    function guardian() public view returns (address out) {
+        out = input.roles.guardian;
+        require(out != address(0), "DeploySuperchainInput: guardian not set");
+    }
+
+    function paused() public view returns (bool out) {
+        out = input.paused;
+    }
+
+    function requiredProtocolVersion() public view returns (ProtocolVersion out) {
+        out = input.requiredProtocolVersion;
+        require(ProtocolVersion.unwrap(out) != 0, "DeploySuperchainInput: requiredProtocolVersion not set");
+    }
+
+    function recommendedProtocolVersion() public view returns (ProtocolVersion out) {
+        out = input.recommendedProtocolVersion;
+        require(ProtocolVersion.unwrap(out) != 0, "DeploySuperchainInput: recommendedProtocolVersion not set");
+    }
+}
+
+contract DeploySuperchainOutput {
     struct Output {
         ProxyAdmin superchainProxyAdmin;
         SuperchainConfig superchainConfigImpl;
@@ -33,20 +85,101 @@ contract DeploySuperchain is Script {
         ProtocolVersions protocolVersionsProxy;
     }
 
+    Output internal output;
+    bool internal outputSet = false;
+
+    // -------- Save outputs --------
+
+    function saveOutput(Output memory _output) public {
+        require(!outputSet, "DeploySuperchainOutput: output already set");
+        output = _output;
+        outputSet = true;
+    }
+
+    function writeOutput(string memory _outfile) public view {
+        require(outputSet, "DeploySuperchainOutput: output not set");
+        _outfile; // TODO: write to file.
+        require(false, "DeploySuperchainOutput: saveOutput not implemented");
+    }
+
+    // -------- Getter methods for outputs --------
+    function outputs() public view returns (Output memory) {
+        require(outputSet, "DeploySuperchainOutput: output not set");
+        return output;
+    }
+
+    function superchainProxyAdmin() public view returns (ProxyAdmin out) {
+        out = output.superchainProxyAdmin;
+        require(address(out) != address(0), "DeploySuperchainOutput: superchainProxyAdmin not set");
+    }
+
+    function superchainConfigImpl() public view returns (SuperchainConfig out) {
+        out = output.superchainConfigImpl;
+        require(address(out) != address(0), "DeploySuperchainOutput: superchainConfigImpl not set");
+    }
+
+    function superchainConfigProxy() public view returns (SuperchainConfig out) {
+        out = output.superchainConfigProxy;
+        require(address(out) != address(0), "DeploySuperchainOutput: superchainConfigProxy not set");
+    }
+
+    function protocolVersionsImpl() public view returns (ProtocolVersions out) {
+        out = output.protocolVersionsImpl;
+        require(address(out) != address(0), "DeploySuperchainOutput: protocolVersionsImpl not set");
+    }
+
+    function protocolVersionsProxy() public view returns (ProtocolVersions out) {
+        out = output.protocolVersionsProxy;
+        require(address(out) != address(0), "DeploySuperchainOutput: protocolVersionsProxy not set");
+    }
+}
+
+/// @notice Deploys the Superchain contracts that can be shared by many chains.
+/// We intentionally use the terms "Input" and "Output" to clearly distinguish this script from the
+/// existing ones that use terms of "Config" and "Artifacts".
+contract DeploySuperchain is Script {
+    DeploySuperchainInput dsi;
+    DeploySuperchainOutput dso;
+
+    function toAddress(address _sender, string memory _identifier) public pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encode(_sender, _identifier)))));
+    }
+
+    function init() internal {
+        // Deploy the input and output contracts.
+        // This function is a no-op on subsequent calls.
+        if (address(dsi) == address(0)) {
+            dsi = DeploySuperchainInput(toAddress(msg.sender, "optimism.DeploySuperchainInput"));
+            dso = DeploySuperchainOutput(toAddress(msg.sender, "optimism.DeploySuperchainOutput"));
+            vm.etch(address(dsi), type(DeploySuperchainInput).runtimeCode);
+            vm.etch(address(dso), type(DeploySuperchainOutput).runtimeCode);
+        }
+    }
+
     /// @notice This entrypoint is for end-users to deploy from an input file and write to an output file.
-    function run(string memory _infile) public returns (Output memory output_, string memory outfile_) {
-        Input memory _input = parseInputFile(_infile);
-        output_ = runWithoutIO(_input);
-        outfile_ = writeOutputFile(_infile, _input, output_);
+    function run(string memory _infile) public {
+        init();
+        dsi.loadInput(_infile);
+
+        runWithoutIO(dsi.inputs());
+
+        string memory outfile = "";
+        dso.writeOutput(outfile);
         require(false, "DeploySuperchain: run is not implemented");
     }
 
     /// @notice This entrypoint is useful for e2e testing purposes, and doesn't use any file I/O.
-    function runWithoutIO(Input memory _input) public returns (Output memory output_) {
+    function runWithoutIO(DeploySuperchainInput.Input memory _input) public {
+        init();
+        dsi.loadInput(_input);
+
         // Validate inputs.
         require(_input.roles.proxyAdminOwner != address(0), "zero address: proxyAdminOwner");
         require(_input.roles.protocolVersionsOwner != address(0), "zero address: protocolVersionsOwner");
         require(_input.roles.guardian != address(0), "zero address: guardian");
+
+        // Initialize the output struct.
+        DeploySuperchainOutput.Output memory output;
 
         // Deploy the proxy admin, with the owner set to the deployer.
         // We explicitly specify the deployer as `msg.sender` because for testing we deploy this script from a test
@@ -54,27 +187,27 @@ contract DeploySuperchain is Script {
         // broadcaster needs to be the deployer since they are set to the initial proxy admin owner.
         vm.startBroadcast(msg.sender);
 
-        output_.superchainProxyAdmin = new ProxyAdmin(msg.sender);
-        vm.label(address(output_.superchainProxyAdmin), "SuperchainProxyAdmin");
+        output.superchainProxyAdmin = new ProxyAdmin(msg.sender);
+        vm.label(address(output.superchainProxyAdmin), "SuperchainProxyAdmin");
 
         // Deploy implementation contracts.
-        output_.superchainConfigImpl = new SuperchainConfig();
-        output_.protocolVersionsImpl = new ProtocolVersions();
+        output.superchainConfigImpl = new SuperchainConfig();
+        output.protocolVersionsImpl = new ProtocolVersions();
 
         // Deploy and initialize the proxies.
-        output_.superchainConfigProxy = SuperchainConfig(address(new Proxy(address(output_.superchainProxyAdmin))));
-        vm.label(address(output_.superchainConfigProxy), "SuperchainConfigProxy");
-        output_.superchainProxyAdmin.upgradeAndCall(
-            payable(address(output_.superchainConfigProxy)),
-            address(output_.superchainConfigImpl),
+        output.superchainConfigProxy = SuperchainConfig(address(new Proxy(address(output.superchainProxyAdmin))));
+        vm.label(address(output.superchainConfigProxy), "SuperchainConfigProxy");
+        output.superchainProxyAdmin.upgradeAndCall(
+            payable(address(output.superchainConfigProxy)),
+            address(output.superchainConfigImpl),
             abi.encodeCall(SuperchainConfig.initialize, (_input.roles.guardian, _input.paused))
         );
 
-        output_.protocolVersionsProxy = ProtocolVersions(address(new Proxy(address(output_.superchainProxyAdmin))));
-        vm.label(address(output_.protocolVersionsProxy), "ProtocolVersionsProxy");
-        output_.superchainProxyAdmin.upgradeAndCall(
-            payable(address(output_.protocolVersionsProxy)),
-            address(output_.protocolVersionsImpl),
+        output.protocolVersionsProxy = ProtocolVersions(address(new Proxy(address(output.superchainProxyAdmin))));
+        vm.label(address(output.protocolVersionsProxy), "ProtocolVersionsProxy");
+        output.superchainProxyAdmin.upgradeAndCall(
+            payable(address(output.protocolVersionsProxy)),
+            address(output.protocolVersionsImpl),
             abi.encodeCall(
                 ProtocolVersions.initialize,
                 (_input.roles.protocolVersionsOwner, _input.requiredProtocolVersion, _input.recommendedProtocolVersion)
@@ -82,17 +215,17 @@ contract DeploySuperchain is Script {
         );
 
         // Transfer ownership of the ProxyAdmin from the deployer to the specified owner.
-        output_.superchainProxyAdmin.transferOwnership(_input.roles.proxyAdminOwner);
+        output.superchainProxyAdmin.transferOwnership(_input.roles.proxyAdminOwner);
 
         vm.stopBroadcast();
 
         // Output assertions, to make sure outputs were assigned correctly.
         address[] memory addresses = new address[](5);
-        addresses[0] = address(output_.superchainProxyAdmin);
-        addresses[1] = address(output_.superchainConfigImpl);
-        addresses[2] = address(output_.superchainConfigProxy);
-        addresses[3] = address(output_.protocolVersionsImpl);
-        addresses[4] = address(output_.protocolVersionsProxy);
+        addresses[0] = address(output.superchainProxyAdmin);
+        addresses[1] = address(output.superchainConfigImpl);
+        addresses[2] = address(output.superchainConfigProxy);
+        addresses[3] = address(output.protocolVersionsImpl);
+        addresses[4] = address(output.protocolVersionsProxy);
 
         for (uint256 i = 0; i < addresses.length; i++) {
             require(addresses[i] != address(0), string.concat("zero address at index ", vm.toString(i)));
@@ -106,31 +239,8 @@ contract DeploySuperchain is Script {
                 require(addresses[i] != addresses[j], err);
             }
         }
-    }
 
-    /// @notice This method is public for testing purposes, but there isn't a need for users to call this method
-    /// directly.
-    function parseInputFile(string memory _infile) public pure returns (Input memory input_) {
-        _infile;
-        input_;
-        require(false, "DeploySuperchain: parseInputFile is not implemented");
-    }
-
-    /// @notice Writes an output file, where the filename is based on the input filename, e.g. an input file of
-    /// `DeploySuperchain.in.toml` results in an output file of `DeploySuperchain.out.toml`.
-    function writeOutputFile(
-        string memory _infile,
-        Input memory _input,
-        Output memory _output
-    )
-        internal
-        pure
-        returns (string memory outfile_)
-    {
-        _infile;
-        _input;
-        _output;
-        outfile_;
-        require(false, "DeploySuperchain: writeOutputFile not implemented");
+        // Deploy successful, save off output.
+        dso.saveOutput(output);
     }
 }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -2,19 +2,61 @@
 pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
+import { LibString } from "@solady/utils/LibString.sol";
 
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { ProtocolVersions, ProtocolVersion } from "src/L1/ProtocolVersions.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 
+/**
+ * This comment block defines the requirements and rationale for the architecture used in this forge
+ * script, along with other scripts that are being written as new Superchain-first deploy scripts to
+ * complement the OP Stack Manager. The script architecture is a bit different than a standard forge
+ * deployment script.
+ *
+ * There are three categories of users that are expected to interact with the scripts:
+ *   1. End users that want to run live contract deployments.
+ *   2. Solidity developers that want to use or test these script in a standard forge test environment.
+ *   3. Go developers that want to run the deploy scripts as part of e2e testing with other aspects of the OP Stack.
+ *
+ * We want each user to interact with the scripts in the way that's simplest for their use case:
+ *   1. End users: TOML input files that define config, and TOML output files with all output data.
+ *   2. Solidity developers: Direct calls to the script with input structs and output structs.
+ *   3. Go developers: The forge scripts can be executed directly in Go.
+ *
+ * The following architecture is used to meet the requirements of each user. We use this file's
+ * `DeploySuperchain` script as an example, but it applies to other scripts as well.
+ *
+ * This `DeploySuperchain.s.sol` file contains three contracts:
+ *   1. `DeploySuperchainInput`: Responsible for parsing, storing, and exposing the input data.
+ *   2. `DeploySuperchainOutput`: Responsible for storing and exposing the output data.
+ *   3. `DeploySuperchain`: The core script that executes the deployment. It reads inputs from the
+ *      input contract, and writes outputs to the output contract.
+ *
+ * Because the core script performs calls to the input and output contracts, Go developers can
+ * intercept calls to these addresses (analogous to how forge intercepts calls to the `Vm` address
+ * to execute cheatcodes), to avoid the need for file I/O or hardcoding the input/output structs.
+ *
+ * Public getter methods on the input and output contracts allow individual fields to be accessed
+ * in a strong, type-safe manner (as opposed to a single struct getter where the caller may
+ * inadvertently transpose two addresses, for example).
+ *
+ * Each deployment step in the core deploy script is modularized into its own function that performs
+ * the deploy and sets the output on the Output contract, allowing for easy composition and testing
+ * of deployment steps. The output setter methods requires keying off the four-byte selector of the
+ * each output field's getter method, ensuring that the output is set for the correct field and
+ * minimizing the amount of boilerplate needed for each output field.
+ *
+ * This script doubles as a reference for documenting the pattern used and therefore contains
+ * comments explaining the patterns used. Other scripts are not expected to have this level of
+ * documentation.
+ *
+ * Additionally, we intentionally use "Input" and "Output" terminology to clearly distinguish these
+ * scripts from the existing ones that "Config" and "Artifacts" terminology.
+ */
 contract DeploySuperchainInput {
-    struct Roles {
-        address proxyAdminOwner;
-        address protocolVersionsOwner;
-        address guardian;
-    }
-
+    // The input struct contains all the input data required for the deployment.
     struct Input {
         Roles roles;
         bool paused;
@@ -22,13 +64,27 @@ contract DeploySuperchainInput {
         ProtocolVersion recommendedProtocolVersion;
     }
 
-    // The data from the input struct gets stored in individual variables to make them accessible in
-    // a stronger type-safe manner (as opposed to a single struct getter where the caller may
-    // inadvertently transpose two addresses, for example) without the need for defining getters for
-    // each field.
-    bool internal inputSet = false;
-    Input internal input;
+    struct Roles {
+        address proxyAdminOwner;
+        address protocolVersionsOwner;
+        address guardian;
+    }
 
+    // This flag tells us if all inputs have been set. An `input()` getter method that returns all
+    // inputs reverts if this flag is false. This ensures the deploy script cannot proceed until all
+    // inputs are validated and set.
+    bool public inputSet = false;
+
+    // The full input struct is kept in storage. It is not exposed because the return type would be
+    // a tuple, but it's more convenient for the return type to be the struct itself. Therefore the
+    // struct is exposed via the `input()` getter method.
+    Input internal inputs;
+
+    // And each field is exposed via it's own getter method. We can equivalently remove these
+    // storage variables and add getter methods that return the input struct fields directly, but
+    // that is more verbose with more boilerplate, especially for larger scripts with many inputs.
+    // Unlike the `input()` getter, these getters do not revert if the input is not set. The caller
+    // should check the `inputSet` value before calling any of these getters.
     address public proxyAdminOwner;
     address public protocolVersionsOwner;
     address public guardian;
@@ -36,23 +92,28 @@ contract DeploySuperchainInput {
     ProtocolVersion public requiredProtocolVersion;
     ProtocolVersion public recommendedProtocolVersion;
 
-    function loadInput(string memory _infile) public {
+    // Load the input from a TOML file.
+    function loadInputFile(string memory _infile) public {
         _infile;
-        Input memory parsedInput; // TODO parse the input file.
+        Input memory parsedInput;
         loadInput(parsedInput);
         require(false, "DeploySuperchainInput: loadInput is not implemented");
     }
 
+    // Load the input from a struct.
     function loadInput(Input memory _input) public {
-        require(!inputSet, "DeploySuperchainInput: input already set");
+        // As a defensive measure, we only allow inputs to be set once.
+        require(!inputSet, "DeploySuperchainInput: Input already set");
 
-        // All assertions on inputs happen here. You cannot set any inputs unless they're all valid.
-        require(input.roles.proxyAdminOwner != address(0), "DeploySuperchainInput: empty proxyAdminOwner");
-        require(input.roles.protocolVersionsOwner != address(0), "DeploySuperchainInput: empty protocolVersionsOwner");
-        require(input.roles.guardian != address(0), "DeploySuperchainInput: empty guardian");
+        // All assertions on inputs happen here. You cannot set any inputs in Solidity unless
+        // they're all valid. For Go testing, the input and outputs
+        require(_input.roles.proxyAdminOwner != address(0), "DeploySuperchainInput: Null proxyAdminOwner");
+        require(_input.roles.protocolVersionsOwner != address(0), "DeploySuperchainInput: Null protocolVersionsOwner");
+        require(_input.roles.guardian != address(0), "DeploySuperchainInput: Null guardian");
 
+        // We now set all values in storage.
         inputSet = true;
-        input = _input;
+        inputs = _input;
 
         proxyAdminOwner = _input.roles.proxyAdminOwner;
         protocolVersionsOwner = _input.roles.protocolVersionsOwner;
@@ -62,13 +123,14 @@ contract DeploySuperchainInput {
         recommendedProtocolVersion = _input.recommendedProtocolVersion;
     }
 
-    function inputs() public view returns (Input memory) {
-        require(inputSet, "DeploySuperchainInput: input not set");
-        return input;
+    function input() public view returns (Input memory) {
+        require(inputSet, "DeploySuperchainInput: Input not set");
+        return inputs;
     }
 }
 
 contract DeploySuperchainOutput {
+    // The output struct contains all the output data from the deployment.
     struct Output {
         ProxyAdmin superchainProxyAdmin;
         SuperchainConfig superchainConfigImpl;
@@ -77,140 +139,242 @@ contract DeploySuperchainOutput {
         ProtocolVersions protocolVersionsProxy;
     }
 
-    // The data from the output struct gets stored in individual variables to make them accessible
-    // in a stronger type-safe manner (as opposed to a single struct getter where the caller may
-    // inadvertently transpose two addresses, for example) without the need for defining getters for
-    // each field.
-    bool internal outputSet = false;
-    Output internal output;
-
+    // We use a similar pattern as the input contract to expose outputs. Because outputs are set
+    // individually, and deployment steps are modular and composable, we do not have an equivalent
+    // to the overall `input` and `inputSet` variables.
     ProxyAdmin public superchainProxyAdmin;
     SuperchainConfig public superchainConfigImpl;
     SuperchainConfig public superchainConfigProxy;
     ProtocolVersions public protocolVersionsImpl;
     ProtocolVersions public protocolVersionsProxy;
 
-    function saveOutput(Output memory _output) public {
-        require(!outputSet, "DeploySuperchainOutput: output already set");
-        outputSet = true;
-
-        output = _output;
-        superchainProxyAdmin = _output.superchainProxyAdmin;
-        superchainConfigImpl = _output.superchainConfigImpl;
-        superchainConfigProxy = _output.superchainConfigProxy;
-        protocolVersionsImpl = _output.protocolVersionsImpl;
-        protocolVersionsProxy = _output.protocolVersionsProxy;
+    // This method lets each field be set individually. The selector of an output's getter method
+    // is used to determine which field to set.
+    function set(bytes4 sel, address _address) public {
+        if (sel == this.superchainProxyAdmin.selector) superchainProxyAdmin = ProxyAdmin(_address);
+        else if (sel == this.superchainConfigImpl.selector) superchainConfigImpl = SuperchainConfig(_address);
+        else if (sel == this.superchainConfigProxy.selector) superchainConfigProxy = SuperchainConfig(_address);
+        else if (sel == this.protocolVersionsImpl.selector) protocolVersionsImpl = ProtocolVersions(_address);
+        else if (sel == this.protocolVersionsProxy.selector) protocolVersionsProxy = ProtocolVersions(_address);
+        else revert("DeploySuperchainOutput: Unknown selector");
     }
 
-    function writeOutput(string memory _outfile) public view {
-        require(outputSet, "DeploySuperchainOutput: output not set");
-        _outfile; // TODO: write to file.
+    // Save the output to a TOML file.
+    function writeOutputFile(string memory _outfile) public pure {
+        _outfile;
         require(false, "DeploySuperchainOutput: saveOutput not implemented");
     }
 
-    function outputs() public view returns (Output memory) {
-        require(outputSet, "DeploySuperchainOutput: output not set");
-        return output;
-    }
-}
-
-/// @notice Deploys the Superchain contracts that can be shared by many chains.
-/// We intentionally use the terms "Input" and "Output" to clearly distinguish this script from the
-/// existing ones that use terms of "Config" and "Artifacts".
-contract DeploySuperchain is Script {
-    function toAddress(address _sender, string memory _identifier) public pure returns (address) {
-        return address(uint160(uint256(keccak256(abi.encode(_sender, _identifier)))));
+    function output() public view returns (Output memory) {
+        return Output({
+            superchainProxyAdmin: superchainProxyAdmin,
+            superchainConfigImpl: superchainConfigImpl,
+            superchainConfigProxy: superchainConfigProxy,
+            protocolVersionsImpl: protocolVersionsImpl,
+            protocolVersionsProxy: protocolVersionsProxy
+        });
     }
 
-    /// @notice This entrypoint is for end-users to deploy from an input file and write to an output file.
-    function run(string memory _infile) public {
-        // Using fileIO, so deploy the IO helper contracts.
-        DeploySuperchainInput dsi = DeploySuperchainInput(toAddress(msg.sender, "optimism.DeploySuperchainInput"));
-        DeploySuperchainOutput dso = DeploySuperchainOutput(toAddress(msg.sender, "optimism.DeploySuperchainOutput"));
-        vm.etch(address(dsi), type(DeploySuperchainInput).runtimeCode);
-        vm.etch(address(dso), type(DeploySuperchainOutput).runtimeCode);
-
-        // Parse the input file using the DeploySuperchainInput contract.
-        dsi.loadInput(_infile);
-
-        // Run the deployment script.
-        // This also writes the output to the DeploySuperchainOutput contract.
-        runWithoutIO(dsi, dso);
-
-        // Request a file to be written with the output data.
-        string memory outfile = "";
-        dso.writeOutput(outfile);
-        require(false, "DeploySuperchain: run is not implemented");
-    }
-
-    /// @notice This entrypoint is useful for e2e testing purposes, and doesn't use any file I/O.
-    function runWithoutIO(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
-        // Retrieve the input data from the input contract. This reverts if the input is not set.
-        DeploySuperchainInput.Input memory input = _dsi.inputs();
-
-        // Initialize the output struct.
-        DeploySuperchainOutput.Output memory output;
-
-        // Deploy the proxy admin, with the owner set to the deployer.
-        // We explicitly specify the deployer as `msg.sender` because for testing we deploy this script from a test
-        // contract. If we provide no argument, the foundry default sender is be the broadcaster during test, but the
-        // broadcaster needs to be the deployer since they are set to the initial proxy admin owner.
-        vm.startBroadcast(msg.sender);
-
-        output.superchainProxyAdmin = new ProxyAdmin(msg.sender);
-        vm.label(address(output.superchainProxyAdmin), "SuperchainProxyAdmin");
-
-        // Deploy implementation contracts.
-        output.superchainConfigImpl = new SuperchainConfig();
-        output.protocolVersionsImpl = new ProtocolVersions();
-
-        // Deploy and initialize the proxies.
-        output.superchainConfigProxy = SuperchainConfig(address(new Proxy(address(output.superchainProxyAdmin))));
-        vm.label(address(output.superchainConfigProxy), "SuperchainConfigProxy");
-        output.superchainProxyAdmin.upgradeAndCall(
-            payable(address(output.superchainConfigProxy)),
-            address(output.superchainConfigImpl),
-            abi.encodeCall(SuperchainConfig.initialize, (input.roles.guardian, input.paused))
-        );
-
-        output.protocolVersionsProxy = ProtocolVersions(address(new Proxy(address(output.superchainProxyAdmin))));
-        vm.label(address(output.protocolVersionsProxy), "ProtocolVersionsProxy");
-        output.superchainProxyAdmin.upgradeAndCall(
-            payable(address(output.protocolVersionsProxy)),
-            address(output.protocolVersionsImpl),
-            abi.encodeCall(
-                ProtocolVersions.initialize,
-                (input.roles.protocolVersionsOwner, input.requiredProtocolVersion, input.recommendedProtocolVersion)
-            )
-        );
-
-        // Transfer ownership of the ProxyAdmin from the deployer to the specified owner.
-        output.superchainProxyAdmin.transferOwnership(input.roles.proxyAdminOwner);
-
-        vm.stopBroadcast();
-
-        // Output assertions, to make sure outputs were assigned correctly.
+    function checkOutput() public view {
         address[] memory addresses = new address[](5);
-        addresses[0] = address(output.superchainProxyAdmin);
-        addresses[1] = address(output.superchainConfigImpl);
-        addresses[2] = address(output.superchainConfigProxy);
-        addresses[3] = address(output.protocolVersionsImpl);
-        addresses[4] = address(output.protocolVersionsProxy);
+        addresses[0] = address(superchainProxyAdmin);
+        addresses[1] = address(superchainConfigImpl);
+        addresses[2] = address(superchainConfigProxy);
+        addresses[3] = address(protocolVersionsImpl);
+        addresses[4] = address(protocolVersionsProxy);
 
+        // We use LibString to avoid the need for adding cheatcodes to this contract.
         for (uint256 i = 0; i < addresses.length; i++) {
-            require(addresses[i] != address(0), string.concat("zero address at index ", vm.toString(i)));
-            require(addresses[i].code.length > 0, string.concat("no code at index ", vm.toString(i)));
+            address who = addresses[i];
+            require(who != address(0), string.concat("zero address at index ", LibString.toString(i)));
+            require(who.code.length > 0, string.concat("no code at ", LibString.toHexStringChecksummed(who)));
         }
 
         // All addresses should be unique.
         for (uint256 i = 0; i < addresses.length; i++) {
             for (uint256 j = i + 1; j < addresses.length; j++) {
-                string memory err = string.concat("duplicates at: ", vm.toString(i), ",", vm.toString(j));
+                string memory err = string.concat("duplicates at: ", LibString.toString(i), ",", LibString.toString(j));
                 require(addresses[i] != addresses[j], err);
             }
         }
-
-        // Deploy successful, save off output.
-        _dso.saveOutput(output);
     }
 }
+
+// For all broadcasts in this script we explicitly specify the deployer as `msg.sender` because for
+// testing we deploy this script from a test contract. If we provide no argument, the foundry
+// default sender is be the broadcaster during test, but the broadcaster needs to be the deployer
+// since they are set to the initial proxy admin owner.
+contract DeploySuperchain is Script {
+    // -------- Core Deployment Methods --------
+
+    // This entrypoint is for end-users to deploy from an input file and write to an output file.
+    // In this usage, we don't need the input and output contract functionality, so we deploy them
+    // here and abstract that architectural detail away from the end user.
+    function run(string memory _infile) public {
+        // End-user without file IO, so etch the IO helper contracts.
+        DeploySuperchainInput dsi = DeploySuperchainInput(toIOAddress(msg.sender, "optimism.DeploySuperchainInput"));
+        DeploySuperchainOutput dso = DeploySuperchainOutput(toIOAddress(msg.sender, "optimism.DeploySuperchainOutput"));
+        vm.etch(address(dsi), type(DeploySuperchainInput).runtimeCode);
+        vm.etch(address(dso), type(DeploySuperchainOutput).runtimeCode);
+
+        // Load the input file into the input contract.
+        dsi.loadInputFile(_infile);
+
+        // Run the deployment script and write outputs to the DeploySuperchainOutput contract.
+        run(dsi, dso);
+
+        // Write the output data to a file. The file
+        string memory outfile = ""; // This will be derived from input file name, e.g. `foo.in.toml` -> `foo.out.toml`
+        dso.writeOutputFile(outfile);
+        require(false, "DeploySuperchain: run is not implemented");
+    }
+
+    // This entrypoint is for use with Solidity tests, where the input and outputs are structs.
+    function run(DeploySuperchainInput.Input memory _input) public returns (DeploySuperchainOutput.Output memory) {
+        // Solidity without file IO, so etch the IO helper contracts.
+        DeploySuperchainInput dsi = DeploySuperchainInput(toIOAddress(msg.sender, "optimism.DeploySuperchainInput"));
+        DeploySuperchainOutput dso = DeploySuperchainOutput(toIOAddress(msg.sender, "optimism.DeploySuperchainOutput"));
+        vm.etch(address(dsi), type(DeploySuperchainInput).runtimeCode);
+        vm.etch(address(dso), type(DeploySuperchainOutput).runtimeCode);
+
+        // Load the input struct into the input contract.
+        dsi.loadInput(_input);
+
+        // Run the deployment script and write outputs to the DeploySuperchainOutput contract.
+        run(dsi, dso);
+
+        // Return the output struct from the output contract.
+        return dso.output();
+    }
+
+    // This entrypoint is useful for testing purposes, as it doesn't use any file I/O.
+    function run(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
+        // Verify that the input contract has been set.
+        require(_dsi.inputSet(), "DeploySuperchain: Input not set");
+
+        // Deploy the proxy admin, with the owner set to the deployer.
+        deploySuperchainProxyAdmin(_dsi, _dso);
+
+        // Deploy and initialize the superchain contracts.
+        deploySuperchainImplementationContracts(_dsi, _dso);
+        deployAndInitializeSuperchainConfig(_dsi, _dso);
+        deployAndInitializeProtocolVersions(_dsi, _dso);
+
+        // Transfer ownership of the ProxyAdmin from the deployer to the specified owner.
+        transferProxyAdminOwnership(_dsi, _dso);
+
+        // Output assertions, to make sure outputs were assigned correctly.
+        _dso.checkOutput();
+    }
+
+    // -------- Deployment Steps --------
+
+    function deploySuperchainProxyAdmin(DeploySuperchainInput, DeploySuperchainOutput _dso) public {
+        // Deploy the proxy admin, with the owner set to the deployer.
+        // We explicitly specify the deployer as `msg.sender` because for testing we deploy this script from a test
+        // contract. If we provide no argument, the foundry default sender is be the broadcaster during test, but the
+        // broadcaster needs to be the deployer since they are set to the initial proxy admin owner.
+        vm.broadcast(msg.sender);
+        ProxyAdmin superchainProxyAdmin = new ProxyAdmin(msg.sender);
+
+        vm.label(address(superchainProxyAdmin), "SuperchainProxyAdmin");
+        _dso.set(_dso.superchainProxyAdmin.selector, address(superchainProxyAdmin));
+    }
+
+    function deploySuperchainImplementationContracts(DeploySuperchainInput, DeploySuperchainOutput _dso) public {
+        // Deploy implementation contracts.
+        vm.startBroadcast(msg.sender);
+        SuperchainConfig superchainConfigImpl = new SuperchainConfig();
+        ProtocolVersions protocolVersionsImpl = new ProtocolVersions();
+        vm.stopBroadcast();
+
+        vm.label(address(superchainConfigImpl), "SuperchainConfigImpl");
+        vm.label(address(protocolVersionsImpl), "ProtocolVersionsImpl");
+
+        _dso.set(_dso.superchainConfigImpl.selector, address(superchainConfigImpl));
+        _dso.set(_dso.protocolVersionsImpl.selector, address(protocolVersionsImpl));
+    }
+
+    function deployAndInitializeSuperchainConfig(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
+        require(_dsi.inputSet(), "DeploySuperchain: Input not set");
+        address guardian = _dsi.guardian();
+        bool paused = _dsi.paused();
+
+        ProxyAdmin superchainProxyAdmin = _dso.superchainProxyAdmin();
+        SuperchainConfig superchainConfigImpl = _dso.superchainConfigImpl();
+        assertValidContractAddress(address(superchainProxyAdmin));
+        assertValidContractAddress(address(superchainConfigImpl));
+
+        vm.startBroadcast(msg.sender);
+        SuperchainConfig superchainConfigProxy = SuperchainConfig(address(new Proxy(address(superchainProxyAdmin))));
+        superchainProxyAdmin.upgradeAndCall(
+            payable(address(superchainConfigProxy)),
+            address(superchainConfigImpl),
+            abi.encodeCall(SuperchainConfig.initialize, (guardian, paused))
+        );
+        vm.stopBroadcast();
+
+        vm.label(address(superchainConfigProxy), "SuperchainConfigProxy");
+        _dso.set(_dso.superchainConfigProxy.selector, address(superchainConfigProxy));
+    }
+
+    function deployAndInitializeProtocolVersions(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
+        require(_dsi.inputSet(), "DeploySuperchain: Input not set");
+
+        address protocolVersionsOwner = _dsi.protocolVersionsOwner();
+        ProtocolVersion requiredProtocolVersion = _dsi.requiredProtocolVersion();
+        ProtocolVersion recommendedProtocolVersion = _dsi.recommendedProtocolVersion();
+
+        ProxyAdmin superchainProxyAdmin = _dso.superchainProxyAdmin();
+        ProtocolVersions protocolVersionsImpl = _dso.protocolVersionsImpl();
+        assertValidContractAddress(address(superchainProxyAdmin));
+        assertValidContractAddress(address(protocolVersionsImpl));
+
+        vm.startBroadcast(msg.sender);
+        ProtocolVersions protocolVersionsProxy = ProtocolVersions(address(new Proxy(address(superchainProxyAdmin))));
+        superchainProxyAdmin.upgradeAndCall(
+            payable(address(protocolVersionsProxy)),
+            address(protocolVersionsImpl),
+            abi.encodeCall(
+                ProtocolVersions.initialize,
+                (protocolVersionsOwner, requiredProtocolVersion, recommendedProtocolVersion)
+            )
+        );
+        vm.stopBroadcast();
+
+        vm.label(address(protocolVersionsProxy), "ProtocolVersionsProxy");
+        _dso.set(_dso.protocolVersionsProxy.selector, address(protocolVersionsProxy));
+    }
+
+    function transferProxyAdminOwnership(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
+        require(_dsi.inputSet(), "DeploySuperchain: Input not set");
+        address proxyAdminOwner = _dsi.proxyAdminOwner();
+
+        ProxyAdmin superchainProxyAdmin = _dso.superchainProxyAdmin();
+        assertValidContractAddress(address(superchainProxyAdmin));
+
+        vm.broadcast(msg.sender);
+        superchainProxyAdmin.transferOwnership(proxyAdminOwner);
+    }
+
+    // -------- Utilities --------
+
+    // This takes a sender and an identifier and returns a deterministic address based on the two.
+    // The resulting used to etch the input and output contracts to a deterministic address based on
+    // those two values, where the identifier represents the input or output contract, such as
+    // `optimism.DeploySuperchainInput` or `optimism.DeployOPChainOutput`.
+    function toIOAddress(address _sender, string memory _identifier) public pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encode(_sender, _identifier)))));
+    }
+
+    function assertValidContractAddress(address _address) internal view {
+        require(_address != address(0), "DeploySuperchain: zero address");
+        require(_address.code.length > 0, "DeploySuperchain: no code");
+    }
+}
+
+// function parseFilename(string memory _filename) public pure returns (string memory) {
+//         string[] memory fileParts = vm.split(_infile, ".");
+//         bool isValidFilename = fileParts.length == 3 && fileParts[1].eq("in") && fileParts[2].eq("toml");
+//         require(isValidFilename, "DeploySuperchain: invalid file name, must be of the form '*.in.toml'");
+// }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -38,7 +38,7 @@ contract DeploySuperchain is Script {
         Input memory _input = parseInputFile(_infile);
         output_ = runWithoutIO(_input);
         outfile_ = writeOutputFile(_infile, _input, output_);
-        require(false, "run is not implemented");
+        require(false, "DeploySuperchain: run is not implemented");
     }
 
     /// @notice This entrypoint is useful for e2e testing purposes, and doesn't use any file I/O.
@@ -113,7 +113,7 @@ contract DeploySuperchain is Script {
     function parseInputFile(string memory _infile) public pure returns (Input memory input_) {
         _infile;
         input_;
-        require(false, "parseInputFile is not implemented");
+        require(false, "DeploySuperchain: parseInputFile is not implemented");
     }
 
     /// @notice Writes an output file, where the filename is based on the input filename, e.g. an input file of
@@ -131,6 +131,6 @@ contract DeploySuperchain is Script {
         _input;
         _output;
         outfile_;
-        require(false, "writeOutputFile not implemented");
+        require(false, "DeploySuperchain: writeOutputFile not implemented");
     }
 }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -176,6 +176,8 @@ contract DeploySuperchainOutput {
     }
 
     function checkOutput() public view {
+        // Assert that all addresses are non-zero and have code.
+        // We use LibString to avoid the need for adding cheatcodes to this contract.
         address[] memory addresses = new address[](5);
         addresses[0] = address(superchainProxyAdmin);
         addresses[1] = address(superchainConfigImpl);
@@ -183,17 +185,19 @@ contract DeploySuperchainOutput {
         addresses[3] = address(protocolVersionsImpl);
         addresses[4] = address(protocolVersionsProxy);
 
-        // We use LibString to avoid the need for adding cheatcodes to this contract.
         for (uint256 i = 0; i < addresses.length; i++) {
             address who = addresses[i];
-            require(who != address(0), string.concat("zero address at index ", LibString.toString(i)));
-            require(who.code.length > 0, string.concat("no code at ", LibString.toHexStringChecksummed(who)));
+            require(who != address(0), string.concat("check failed: zero address at index ", LibString.toString(i)));
+            require(
+                who.code.length > 0, string.concat("check failed: no code at ", LibString.toHexStringChecksummed(who))
+            );
         }
 
         // All addresses should be unique.
         for (uint256 i = 0; i < addresses.length; i++) {
             for (uint256 j = i + 1; j < addresses.length; j++) {
-                string memory err = string.concat("duplicates at: ", LibString.toString(i), ",", LibString.toString(j));
+                string memory err =
+                    string.concat("check failed: duplicates at ", LibString.toString(i), ",", LibString.toString(j));
                 require(addresses[i] != addresses[j], err);
             }
         }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
+import { ProtocolVersions, ProtocolVersion } from "src/L1/ProtocolVersions.sol";
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+
+/// @notice Deploys the Superchain contracts that can be shared by many chains.
+contract DeploySuperchain is Script {
+    struct Roles {
+        address proxyAdminOwner;
+        address protocolVersionsOwner;
+        address guardian;
+    }
+
+    struct Input {
+        Roles roles;
+        bool paused;
+        ProtocolVersion requiredProtocolVersion;
+        ProtocolVersion recommendedProtocolVersion;
+    }
+
+    struct Output {
+        ProxyAdmin superchainProxyAdmin;
+        SuperchainConfig superchainConfigImpl;
+        SuperchainConfig superchainConfigProxy;
+        ProtocolVersions protocolVersionsImpl;
+        ProtocolVersions protocolVersionsProxy;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        // Validate inputs.
+        require(_input.roles.proxyAdminOwner != address(0), "zero address: proxyAdminOwner");
+        require(_input.roles.protocolVersionsOwner != address(0), "zero address: protocolVersionsOwner");
+        require(_input.roles.guardian != address(0), "zero address: guardian");
+
+        // Deploy the proxy admin, with the owner set to the deployer.
+        // We explicitly specify the deployer as `msg.sender` because for testing we deploy this script from a test
+        // contract. If we provide no argument, the foundry default sender is be the broadcaster during test, but the
+        // broadcaster needs to be the deployer since they are set to the initial proxy admin owner.
+        vm.startBroadcast(msg.sender);
+
+        output_.superchainProxyAdmin = new ProxyAdmin(msg.sender);
+        vm.label(address(output_.superchainProxyAdmin), "SuperchainProxyAdmin");
+
+        // Deploy implementation contracts.
+        output_.superchainConfigImpl = new SuperchainConfig();
+        output_.protocolVersionsImpl = new ProtocolVersions();
+
+        // Deploy and initialize the proxies.
+        output_.superchainConfigProxy = SuperchainConfig(address(new Proxy(address(output_.superchainProxyAdmin))));
+        vm.label(address(output_.superchainConfigProxy), "SuperchainConfigProxy");
+        output_.superchainProxyAdmin.upgradeAndCall(
+            payable(address(output_.superchainConfigProxy)),
+            address(output_.superchainConfigImpl),
+            abi.encodeCall(SuperchainConfig.initialize, (_input.roles.guardian, _input.paused))
+        );
+
+        output_.protocolVersionsProxy = ProtocolVersions(address(new Proxy(address(output_.superchainProxyAdmin))));
+        vm.label(address(output_.protocolVersionsProxy), "ProtocolVersionsProxy");
+        output_.superchainProxyAdmin.upgradeAndCall(
+            payable(address(output_.protocolVersionsProxy)),
+            address(output_.protocolVersionsImpl),
+            abi.encodeCall(
+                ProtocolVersions.initialize,
+                (_input.roles.protocolVersionsOwner, _input.requiredProtocolVersion, _input.recommendedProtocolVersion)
+            )
+        );
+
+        // Transfer ownership of the ProxyAdmin from the deployer to the specified owner.
+        output_.superchainProxyAdmin.transferOwnership(_input.roles.proxyAdminOwner);
+
+        vm.stopBroadcast();
+
+        // Output assertions, to make sure outputs were assigned correctly.
+        address[] memory addresses = new address[](5);
+        addresses[0] = address(output_.superchainProxyAdmin);
+        addresses[1] = address(output_.superchainConfigImpl);
+        addresses[2] = address(output_.superchainConfigProxy);
+        addresses[3] = address(output_.protocolVersionsImpl);
+        addresses[4] = address(output_.protocolVersionsProxy);
+
+        for (uint256 i = 0; i < addresses.length; i++) {
+            require(addresses[i] != address(0), string.concat("zero address at index ", vm.toString(i)));
+            require(addresses[i].code.length > 0, string.concat("no code at index ", vm.toString(i)));
+        }
+
+        // All addresses should be unique.
+        for (uint256 i = 0; i < addresses.length; i++) {
+            for (uint256 j = i + 1; j < addresses.length; j++) {
+                string memory err = string.concat("duplicates at: ", vm.toString(i), ",", vm.toString(j));
+                require(addresses[i] != addresses[j], err);
+            }
+        }
+    }
+}

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 
+import { Proxy } from "src/universal/Proxy.sol";
 import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
 import { DeploySuperchain } from "scripts/DeploySuperchain.s.sol";
 
@@ -37,13 +38,24 @@ contract DeploySuperchain_Test is Test {
 
         DeploySuperchain.Output memory output = deploySuperchain.runWithoutIO(_input);
 
-        // We assert on the inputs only, as the outputs are asserts on via require statements directly in the script.
+        // Assert the inputs were properly set.
         assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
         assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
         assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
         assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
         assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
         assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
+
+        // Architecture assertions.
+        // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
+        Proxy superchainConfigProxy = Proxy(payable(address(output.superchainConfigProxy)));
+        Proxy protocolVersionsProxy = Proxy(payable(address(output.protocolVersionsProxy)));
+        vm.startPrank(address(0));
+
+        assertEq(superchainConfigProxy.implementation(), address(output.superchainConfigImpl), "700");
+        assertEq(protocolVersionsProxy.implementation(), address(output.protocolVersionsImpl), "800");
+        assertEq(superchainConfigProxy.admin(), protocolVersionsProxy.admin(), "900");
+        assertEq(superchainConfigProxy.admin(), address(output.superchainProxyAdmin), "1000");
     }
 
     function test_runWithoutIOAndZeroAddressRoles_reverts() public {

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -11,7 +11,7 @@ contract DeploySuperchain_Test is Test {
     DeploySuperchain deploySuperchain;
 
     // Define a default input struct for testing.
-    DeploySuperchain.Input input  = DeploySuperchain.Input({
+    DeploySuperchain.Input input = DeploySuperchain.Input({
         roles: DeploySuperchain.Roles({
             proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
             protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
@@ -30,12 +30,12 @@ contract DeploySuperchain_Test is Test {
         return ProtocolVersion.unwrap(_pv);
     }
 
-    function test_run_withInputStruct_succeeds(DeploySuperchain.Input memory _input) public {
+    function test_runWithoutIO_succeeds(DeploySuperchain.Input memory _input) public {
         vm.assume(_input.roles.proxyAdminOwner != address(0));
         vm.assume(_input.roles.protocolVersionsOwner != address(0));
         vm.assume(_input.roles.guardian != address(0));
 
-        DeploySuperchain.Output memory output = deploySuperchain.run(_input);
+        DeploySuperchain.Output memory output = deploySuperchain.runWithoutIO(_input);
 
         // We assert on the inputs only, as the outputs are asserts on via require statements directly in the script.
         assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
@@ -46,23 +46,23 @@ contract DeploySuperchain_Test is Test {
         assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
     }
 
-    function test_run_withInputStructAndZeroAddressRoles_reverts() public {
+    function test_runWithoutIOAndZeroAddressRoles_reverts() public {
         // Snapshot the state so we can revert to the default `input` struct between assertions.
         uint256 snapshotId = vm.snapshot();
 
         // Assert over each role being set to the zero address.
         input.roles.proxyAdminOwner = address(0);
         vm.expectRevert("zero address: proxyAdminOwner");
-        deploySuperchain.run(input);
+        deploySuperchain.runWithoutIO(input);
 
         vm.revertTo(snapshotId);
         input.roles.protocolVersionsOwner = address(0);
         vm.expectRevert("zero address: protocolVersionsOwner");
-        deploySuperchain.run(input);
+        deploySuperchain.runWithoutIO(input);
 
         vm.revertTo(snapshotId);
         input.roles.guardian = address(0);
         vm.expectRevert("zero address: guardian");
-        deploySuperchain.run(input);
+        deploySuperchain.runWithoutIO(input);
     }
 }

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
+import { DeploySuperchain } from "scripts/DeploySuperchain.s.sol";
+
+/// @notice Deploys the Superchain contracts that can be shared by many chains.
+contract DeploySuperchain_Test is Test {
+    DeploySuperchain deploySuperchain;
+
+    // Define a default input struct for testing.
+    DeploySuperchain.Input input  = DeploySuperchain.Input({
+        roles: DeploySuperchain.Roles({
+            proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
+            protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
+            guardian: makeAddr("defaultGuardian")
+        }),
+        paused: false,
+        requiredProtocolVersion: ProtocolVersion.wrap(1),
+        recommendedProtocolVersion: ProtocolVersion.wrap(2)
+    });
+
+    function setUp() public {
+        deploySuperchain = new DeploySuperchain();
+    }
+
+    function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
+        return ProtocolVersion.unwrap(_pv);
+    }
+
+    function test_run_withInputStruct_succeeds(DeploySuperchain.Input memory _input) public {
+        vm.assume(_input.roles.proxyAdminOwner != address(0));
+        vm.assume(_input.roles.protocolVersionsOwner != address(0));
+        vm.assume(_input.roles.guardian != address(0));
+
+        DeploySuperchain.Output memory output = deploySuperchain.run(_input);
+
+        // We assert on the inputs only, as the outputs are asserts on via require statements directly in the script.
+        assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
+        assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
+        assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
+        assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
+        assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
+        assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
+    }
+
+    function test_run_withInputStructAndZeroAddressRoles_reverts() public {
+        // Snapshot the state so we can revert to the default `input` struct between assertions.
+        uint256 snapshotId = vm.snapshot();
+
+        // Assert over each role being set to the zero address.
+        input.roles.proxyAdminOwner = address(0);
+        vm.expectRevert("zero address: proxyAdminOwner");
+        deploySuperchain.run(input);
+
+        vm.revertTo(snapshotId);
+        input.roles.protocolVersionsOwner = address(0);
+        vm.expectRevert("zero address: protocolVersionsOwner");
+        deploySuperchain.run(input);
+
+        vm.revertTo(snapshotId);
+        input.roles.guardian = address(0);
+        vm.expectRevert("zero address: guardian");
+        deploySuperchain.run(input);
+    }
+}

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -1,80 +1,81 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+// // SPDX-License-Identifier: MIT
+// pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// import { Test } from "forge-std/Test.sol";
 
-import { Proxy } from "src/universal/Proxy.sol";
-import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
-import { DeploySuperchain } from "scripts/DeploySuperchain.s.sol";
+// import { Proxy } from "src/universal/Proxy.sol";
+// import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
+// import { DeploySuperchainInput, DeploySuperchain, DeploySuperchainOutput } from "scripts/DeploySuperchain.s.sol";
 
-/// @notice Deploys the Superchain contracts that can be shared by many chains.
-contract DeploySuperchain_Test is Test {
-    DeploySuperchain deploySuperchain;
+// /// @notice Deploys the Superchain contracts that can be shared by many chains.
+// contract DeploySuperchain_Test is Test {
+//     DeploySuperchain deploySuperchain;
 
-    // Define a default input struct for testing.
-    DeploySuperchain.Input input = DeploySuperchain.Input({
-        roles: DeploySuperchain.Roles({
-            proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
-            protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
-            guardian: makeAddr("defaultGuardian")
-        }),
-        paused: false,
-        requiredProtocolVersion: ProtocolVersion.wrap(1),
-        recommendedProtocolVersion: ProtocolVersion.wrap(2)
-    });
+//     // Define a default input struct for testing.
+//     DeploySuperchainInput.Input input = DeploySuperchain.Input({
+//         roles: DeploySuperchain.Roles({
+//             proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
+//             protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
+//             guardian: makeAddr("defaultGuardian")
+//         }),
+//         paused: false,
+//         requiredProtocolVersion: ProtocolVersion.wrap(1),
+//         recommendedProtocolVersion: ProtocolVersion.wrap(2)
+//     });
 
-    function setUp() public {
-        deploySuperchain = new DeploySuperchain();
-    }
+//     function setUp() public {
+//         deploySuperchain = new DeploySuperchain();
+//     }
 
-    function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
-        return ProtocolVersion.unwrap(_pv);
-    }
+//     function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
+//         return ProtocolVersion.unwrap(_pv);
+//     }
 
-    function test_runWithoutIO_succeeds(DeploySuperchain.Input memory _input) public {
-        vm.assume(_input.roles.proxyAdminOwner != address(0));
-        vm.assume(_input.roles.protocolVersionsOwner != address(0));
-        vm.assume(_input.roles.guardian != address(0));
+//     function test_runWithoutIO_succeeds(DeploySuperchainInput.Input memory _input) public {
+//         vm.assume(_input.roles.proxyAdminOwner != address(0));
+//         vm.assume(_input.roles.protocolVersionsOwner != address(0));
+//         vm.assume(_input.roles.guardian != address(0));
 
-        DeploySuperchain.Output memory output = deploySuperchain.runWithoutIO(_input);
+//         DeploySuperchainOutput.Output memory output = deploySuperchain.runWithoutIO(_input);
 
-        // Assert the inputs were properly set.
-        assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
-        assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
-        assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
-        assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
-        assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
-        assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
+//         // Assert the inputs were properly set.
+//         assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
+//         assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
+//         assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
+//         assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
+//         assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
+//         assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion),
+// "600");
 
-        // Architecture assertions.
-        // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
-        Proxy superchainConfigProxy = Proxy(payable(address(output.superchainConfigProxy)));
-        Proxy protocolVersionsProxy = Proxy(payable(address(output.protocolVersionsProxy)));
-        vm.startPrank(address(0));
+//         // Architecture assertions.
+//         // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
+//         Proxy superchainConfigProxy = Proxy(payable(address(output.superchainConfigProxy)));
+//         Proxy protocolVersionsProxy = Proxy(payable(address(output.protocolVersionsProxy)));
+//         vm.startPrank(address(0));
 
-        assertEq(superchainConfigProxy.implementation(), address(output.superchainConfigImpl), "700");
-        assertEq(protocolVersionsProxy.implementation(), address(output.protocolVersionsImpl), "800");
-        assertEq(superchainConfigProxy.admin(), protocolVersionsProxy.admin(), "900");
-        assertEq(superchainConfigProxy.admin(), address(output.superchainProxyAdmin), "1000");
-    }
+//         assertEq(superchainConfigProxy.implementation(), address(output.superchainConfigImpl), "700");
+//         assertEq(protocolVersionsProxy.implementation(), address(output.protocolVersionsImpl), "800");
+//         assertEq(superchainConfigProxy.admin(), protocolVersionsProxy.admin(), "900");
+//         assertEq(superchainConfigProxy.admin(), address(output.superchainProxyAdmin), "1000");
+//     }
 
-    function test_runWithoutIOAndZeroAddressRoles_reverts() public {
-        // Snapshot the state so we can revert to the default `input` struct between assertions.
-        uint256 snapshotId = vm.snapshot();
+//     function test_runWithoutIOAndZeroAddressRoles_reverts() public {
+//         // Snapshot the state so we can revert to the default `input` struct between assertions.
+//         uint256 snapshotId = vm.snapshot();
 
-        // Assert over each role being set to the zero address.
-        input.roles.proxyAdminOwner = address(0);
-        vm.expectRevert("zero address: proxyAdminOwner");
-        deploySuperchain.runWithoutIO(input);
+//         // Assert over each role being set to the zero address.
+//         input.roles.proxyAdminOwner = address(0);
+//         vm.expectRevert("zero address: proxyAdminOwner");
+//         deploySuperchain.runWithoutIO(input);
 
-        vm.revertTo(snapshotId);
-        input.roles.protocolVersionsOwner = address(0);
-        vm.expectRevert("zero address: protocolVersionsOwner");
-        deploySuperchain.runWithoutIO(input);
+//         vm.revertTo(snapshotId);
+//         input.roles.protocolVersionsOwner = address(0);
+//         vm.expectRevert("zero address: protocolVersionsOwner");
+//         deploySuperchain.runWithoutIO(input);
 
-        vm.revertTo(snapshotId);
-        input.roles.guardian = address(0);
-        vm.expectRevert("zero address: guardian");
-        deploySuperchain.runWithoutIO(input);
-    }
-}
+//         vm.revertTo(snapshotId);
+//         input.roles.guardian = address(0);
+//         vm.expectRevert("zero address: guardian");
+//         deploySuperchain.runWithoutIO(input);
+//     }
+// }

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -27,8 +27,7 @@ contract DeploySuperchain_Test is Test {
 
     function setUp() public {
         deploySuperchain = new DeploySuperchain();
-        dsi = DeploySuperchainInput(deploySuperchain.toIOAddress(address(this), "optimism.DeploySuperchainInput"));
-        dso = DeploySuperchainOutput(deploySuperchain.toIOAddress(address(this), "optimism.DeploySuperchainOutput"));
+        (dsi, dso) = deploySuperchain.getIOContracts();
     }
 
     function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -1,81 +1,80 @@
-// // SPDX-License-Identifier: MIT
-// pragma solidity 0.8.15;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
 
-// import { Test } from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-// import { Proxy } from "src/universal/Proxy.sol";
-// import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
-// import { DeploySuperchainInput, DeploySuperchain, DeploySuperchainOutput } from "scripts/DeploySuperchain.s.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { ProtocolVersion } from "src/L1/ProtocolVersions.sol";
+import { DeploySuperchainInput, DeploySuperchain, DeploySuperchainOutput } from "scripts/DeploySuperchain.s.sol";
 
-// /// @notice Deploys the Superchain contracts that can be shared by many chains.
-// contract DeploySuperchain_Test is Test {
-//     DeploySuperchain deploySuperchain;
+/// @notice Deploys the Superchain contracts that can be shared by many chains.
+contract DeploySuperchain_Test is Test {
+    DeploySuperchain deploySuperchain;
 
-//     // Define a default input struct for testing.
-//     DeploySuperchainInput.Input input = DeploySuperchain.Input({
-//         roles: DeploySuperchain.Roles({
-//             proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
-//             protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
-//             guardian: makeAddr("defaultGuardian")
-//         }),
-//         paused: false,
-//         requiredProtocolVersion: ProtocolVersion.wrap(1),
-//         recommendedProtocolVersion: ProtocolVersion.wrap(2)
-//     });
+    // Define a default input struct for testing.
+    DeploySuperchainInput.Input input = DeploySuperchainInput.Input({
+        roles: DeploySuperchainInput.Roles({
+            proxyAdminOwner: makeAddr("defaultProxyAdminOwner"),
+            protocolVersionsOwner: makeAddr("defaultProtocolVersionsOwner"),
+            guardian: makeAddr("defaultGuardian")
+        }),
+        paused: false,
+        requiredProtocolVersion: ProtocolVersion.wrap(1),
+        recommendedProtocolVersion: ProtocolVersion.wrap(2)
+    });
 
-//     function setUp() public {
-//         deploySuperchain = new DeploySuperchain();
-//     }
+    function setUp() public {
+        deploySuperchain = new DeploySuperchain();
+    }
 
-//     function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
-//         return ProtocolVersion.unwrap(_pv);
-//     }
+    function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
+        return ProtocolVersion.unwrap(_pv);
+    }
 
-//     function test_runWithoutIO_succeeds(DeploySuperchainInput.Input memory _input) public {
-//         vm.assume(_input.roles.proxyAdminOwner != address(0));
-//         vm.assume(_input.roles.protocolVersionsOwner != address(0));
-//         vm.assume(_input.roles.guardian != address(0));
+    function test_run_succeeds(DeploySuperchainInput.Input memory _input) public {
+        vm.assume(_input.roles.proxyAdminOwner != address(0));
+        vm.assume(_input.roles.protocolVersionsOwner != address(0));
+        vm.assume(_input.roles.guardian != address(0));
 
-//         DeploySuperchainOutput.Output memory output = deploySuperchain.runWithoutIO(_input);
+        DeploySuperchainOutput.Output memory output = deploySuperchain.run(_input);
 
-//         // Assert the inputs were properly set.
-//         assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
-//         assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
-//         assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
-//         assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
-//         assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
-//         assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion),
-// "600");
+        // Assert the inputs were properly set.
+        assertEq(address(output.superchainProxyAdmin.owner()), _input.roles.proxyAdminOwner, "100");
+        assertEq(address(output.protocolVersionsProxy.owner()), _input.roles.protocolVersionsOwner, "200");
+        assertEq(address(output.superchainConfigProxy.guardian()), _input.roles.guardian, "300");
+        assertEq(output.superchainConfigProxy.paused(), _input.paused, "400");
+        assertEq(unwrap(output.protocolVersionsProxy.required()), unwrap(_input.requiredProtocolVersion), "500");
+        assertEq(unwrap(output.protocolVersionsProxy.recommended()), unwrap(_input.recommendedProtocolVersion), "600");
 
-//         // Architecture assertions.
-//         // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
-//         Proxy superchainConfigProxy = Proxy(payable(address(output.superchainConfigProxy)));
-//         Proxy protocolVersionsProxy = Proxy(payable(address(output.protocolVersionsProxy)));
-//         vm.startPrank(address(0));
+        // Architecture assertions.
+        // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
+        Proxy superchainConfigProxy = Proxy(payable(address(output.superchainConfigProxy)));
+        Proxy protocolVersionsProxy = Proxy(payable(address(output.protocolVersionsProxy)));
+        vm.startPrank(address(0));
 
-//         assertEq(superchainConfigProxy.implementation(), address(output.superchainConfigImpl), "700");
-//         assertEq(protocolVersionsProxy.implementation(), address(output.protocolVersionsImpl), "800");
-//         assertEq(superchainConfigProxy.admin(), protocolVersionsProxy.admin(), "900");
-//         assertEq(superchainConfigProxy.admin(), address(output.superchainProxyAdmin), "1000");
-//     }
+        assertEq(superchainConfigProxy.implementation(), address(output.superchainConfigImpl), "700");
+        assertEq(protocolVersionsProxy.implementation(), address(output.protocolVersionsImpl), "800");
+        assertEq(superchainConfigProxy.admin(), protocolVersionsProxy.admin(), "900");
+        assertEq(superchainConfigProxy.admin(), address(output.superchainProxyAdmin), "1000");
+    }
 
-//     function test_runWithoutIOAndZeroAddressRoles_reverts() public {
-//         // Snapshot the state so we can revert to the default `input` struct between assertions.
-//         uint256 snapshotId = vm.snapshot();
+    function test_run_ZeroAddressRoles_reverts() public {
+        // Snapshot the state so we can revert to the default `input` struct between assertions.
+        uint256 snapshotId = vm.snapshot();
 
-//         // Assert over each role being set to the zero address.
-//         input.roles.proxyAdminOwner = address(0);
-//         vm.expectRevert("zero address: proxyAdminOwner");
-//         deploySuperchain.runWithoutIO(input);
+        // Assert over each role being set to the zero address.
+        input.roles.proxyAdminOwner = address(0);
+        vm.expectRevert("DeploySuperchainInput: Null proxyAdminOwner");
+        deploySuperchain.run(input);
 
-//         vm.revertTo(snapshotId);
-//         input.roles.protocolVersionsOwner = address(0);
-//         vm.expectRevert("zero address: protocolVersionsOwner");
-//         deploySuperchain.runWithoutIO(input);
+        vm.revertTo(snapshotId);
+        input.roles.protocolVersionsOwner = address(0);
+        vm.expectRevert("DeploySuperchainInput: Null protocolVersionsOwner");
+        deploySuperchain.run(input);
 
-//         vm.revertTo(snapshotId);
-//         input.roles.guardian = address(0);
-//         vm.expectRevert("zero address: guardian");
-//         deploySuperchain.runWithoutIO(input);
-//     }
-// }
+        vm.revertTo(snapshotId);
+        input.roles.guardian = address(0);
+        vm.expectRevert("DeploySuperchainInput: Null guardian");
+        deploySuperchain.run(input);
+    }
+}


### PR DESCRIPTION
**Description**

Adds `DeploySuperchain.s.sol` which deploys and configures the superchain contracts as described in Step 1 of https://github.com/ethereum-optimism/design-docs/pull/60

This PR scaffolds the architecture for 3 methods of deployment, as detailed in the comment block of the script. It focuses on the in-memory versions of the deployment (i.e. no file-based IO required) which is useful for solidity testing and e2e testing in Go. The interfaces for where files are wrapped around this core are scaffolded, but not implemented, in this PR, and will be implemented in a future PR.

This script and it's tests exist independently of the existing `DeployConfig.s.sol`, `Deploy.s.sol`, and `Artifacts.s.sol` contracts. This is intentional, so we can start with a clean slate here and avoid tech debt. We can integrate these deploy scripts into those ones as needed later, but I don't see a reason to pull them in yet.

**Tests**

A simple fuzz test is added that ensures the provided input configuration is respected, along with another concrete test to validate that zero addresses are not allowed for the role values. 

**Additional context**

Please review the resulting Superchain architecture and ensure it's consistent with the current production architecture