### PR TITLE
op-dispute-mon: Identify unclaimed credits based on the withdrawal request timestamp

### DIFF
--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -116,7 +116,7 @@ func (s *Service) initResolutionMonitor() {
 }
 
 func (s *Service) initWithdrawalMonitor() {
-	s.withdrawals = NewWithdrawalMonitor(s.logger, s.metrics)
+	s.withdrawals = NewWithdrawalMonitor(s.logger, s.cl, s.metrics, s.honestActors)
 }
 
 func (s *Service) initGameCallerCreator() {
@@ -145,7 +145,7 @@ func (s *Service) initForecast(cfg *config.Config) {
 }
 
 func (s *Service) initBonds() {
-	s.bonds = bonds.NewBonds(s.logger, s.metrics, s.honestActors, s.cl)
+	s.bonds = bonds.NewBonds(s.logger, s.metrics, s.cl)
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {

--- a/op-dispute-mon/mon/withdrawals.go
+++ b/op-dispute-mon/mon/withdrawals.go
@@ -1,6 +1,9 @@
 package mon
 
 import (
+	"math/big"
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -8,25 +11,35 @@ import (
 
 type WithdrawalMetrics interface {
 	RecordWithdrawalRequests(delayedWeth common.Address, matches bool, count int)
+	RecordHonestWithdrawableAmounts(map[common.Address]*big.Int)
 }
 
 type WithdrawalMonitor struct {
-	logger  log.Logger
-	metrics WithdrawalMetrics
+	logger       log.Logger
+	clock        RClock
+	metrics      WithdrawalMetrics
+	honestActors types.HonestActors
 }
 
-func NewWithdrawalMonitor(logger log.Logger, metrics WithdrawalMetrics) *WithdrawalMonitor {
+func NewWithdrawalMonitor(logger log.Logger, clock RClock, metrics WithdrawalMetrics, honestActors types.HonestActors) *WithdrawalMonitor {
 	return &WithdrawalMonitor{
-		logger:  logger,
-		metrics: metrics,
+		logger:       logger,
+		clock:        clock,
+		metrics:      metrics,
+		honestActors: honestActors,
 	}
 }
 
 func (w *WithdrawalMonitor) CheckWithdrawals(games []*types.EnrichedGameData) {
+	now := w.clock.Now() // Use a consistent time for all checks
 	matching := make(map[common.Address]int)
 	divergent := make(map[common.Address]int)
+	honestWithdrawableAmounts := make(map[common.Address]*big.Int)
+	for address := range w.honestActors {
+		honestWithdrawableAmounts[address] = big.NewInt(0)
+	}
 	for _, game := range games {
-		matches, diverges := w.validateGameWithdrawals(game)
+		matches, diverges := w.validateGameWithdrawals(game, now, honestWithdrawableAmounts)
 		matching[game.WETHContract] += matches
 		divergent[game.WETHContract] += diverges
 	}
@@ -36,9 +49,10 @@ func (w *WithdrawalMonitor) CheckWithdrawals(games []*types.EnrichedGameData) {
 	for contract, count := range divergent {
 		w.metrics.RecordWithdrawalRequests(contract, false, count)
 	}
+	w.metrics.RecordHonestWithdrawableAmounts(honestWithdrawableAmounts)
 }
 
-func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.EnrichedGameData) (int, int) {
+func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.EnrichedGameData, now time.Time, honestWithdrawableAmounts map[common.Address]*big.Int) (int, int) {
 	matching := 0
 	divergent := 0
 	for recipient, withdrawalAmount := range game.WithdrawalRequests {
@@ -47,6 +61,16 @@ func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.EnrichedGameData
 		} else {
 			divergent++
 			w.logger.Error("Withdrawal request amount does not match credit", "game", game.Proxy, "recipient", recipient, "credit", game.Credits[recipient], "withdrawal", game.WithdrawalRequests[recipient].Amount)
+		}
+
+		if withdrawalAmount.Amount.Cmp(big.NewInt(0)) > 0 && w.honestActors.Contains(recipient) {
+			if time.Unix(withdrawalAmount.Timestamp.Int64(), 0).Add(game.WETHDelay).Before(now) {
+				// Credits are withdrawable
+				total := honestWithdrawableAmounts[recipient]
+				total = new(big.Int).Add(total, withdrawalAmount.Amount)
+				honestWithdrawableAmounts[recipient] = total
+				w.logger.Warn("Found unclaimed credit", "recipient", recipient, "game", game.Proxy, "amount", withdrawalAmount.Amount)
+			}
 		}
 	}
 	return matching, divergent

--- a/op-dispute-mon/mon/withdrawals_test.go
+++ b/op-dispute-mon/mon/withdrawals_test.go
@@ -3,9 +3,12 @@ package mon
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -15,58 +18,76 @@ import (
 var (
 	weth1 = common.Address{0x1a}
 	weth2 = common.Address{0x2b}
+
+	honestActor1    = common.Address{0x11, 0xaa}
+	honestActor2    = common.Address{0x22, 0xbb}
+	honestActor3    = common.Address{0x33, 0xcc}
+	dishonestActor4 = common.Address{0x44, 0xdd}
+
+	nowUnix = int64(10_000)
 )
 
 func makeGames() []*monTypes.EnrichedGameData {
 	weth1Balance := big.NewInt(4200)
 	weth2Balance := big.NewInt(6000)
+
 	game1 := &monTypes.EnrichedGameData{
+		GameMetadata: types.GameMetadata{Proxy: common.Address{0x11, 0x11, 0x11}},
 		Credits: map[common.Address]*big.Int{
-			common.Address{0x01}: big.NewInt(3),
-			common.Address{0x02}: big.NewInt(1),
+			honestActor1: big.NewInt(3),
+			honestActor2: big.NewInt(1),
 		},
 		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
-			common.Address{0x01}: &contracts.WithdrawalRequest{Amount: big.NewInt(3)},
-			common.Address{0x02}: &contracts.WithdrawalRequest{Amount: big.NewInt(1)},
+			honestActor1: {Amount: big.NewInt(3), Timestamp: big.NewInt(nowUnix - 101)}, // Claimable
+			honestActor2: {Amount: big.NewInt(1), Timestamp: big.NewInt(nowUnix - 99)},  // Not claimable
 		},
 		WETHContract:  weth1,
 		ETHCollateral: weth1Balance,
+		WETHDelay:     100 * time.Second,
 	}
 	game2 := &monTypes.EnrichedGameData{
+		GameMetadata: types.GameMetadata{Proxy: common.Address{0x22, 0x22, 0x22}},
 		Credits: map[common.Address]*big.Int{
-			common.Address{0x01}: big.NewInt(46),
-			common.Address{0x02}: big.NewInt(1),
+			honestActor1: big.NewInt(46),
+			honestActor2: big.NewInt(1),
 		},
 		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
-			common.Address{0x01}: &contracts.WithdrawalRequest{Amount: big.NewInt(3)},
-			common.Address{0x02}: &contracts.WithdrawalRequest{Amount: big.NewInt(1)},
+			honestActor1: {Amount: big.NewInt(3), Timestamp: big.NewInt(nowUnix - 501)}, // Claimable
+			honestActor2: {Amount: big.NewInt(1), Timestamp: big.NewInt(nowUnix)},       // Not claimable
 		},
 		WETHContract:  weth2,
 		ETHCollateral: weth2Balance,
+		WETHDelay:     500 * time.Second,
 	}
 	game3 := &monTypes.EnrichedGameData{
+		GameMetadata: types.GameMetadata{Proxy: common.Address{0x33, 0x33, 0x33}},
 		Credits: map[common.Address]*big.Int{
-			common.Address{0x03}: big.NewInt(2),
-			common.Address{0x04}: big.NewInt(4),
+			honestActor3:    big.NewInt(2),
+			dishonestActor4: big.NewInt(4),
 		},
 		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
-			common.Address{0x03}: &contracts.WithdrawalRequest{Amount: big.NewInt(2)},
-			common.Address{0x04}: &contracts.WithdrawalRequest{Amount: big.NewInt(4)},
+			honestActor3:    {Amount: big.NewInt(2), Timestamp: big.NewInt(nowUnix - 1)}, // Claimable
+			dishonestActor4: {Amount: big.NewInt(4), Timestamp: big.NewInt(nowUnix - 5)}, // Claimable
 		},
 		WETHContract:  weth2,
 		ETHCollateral: weth2Balance,
+		WETHDelay:     0 * time.Second,
 	}
 	return []*monTypes.EnrichedGameData{game1, game2, game3}
 }
 
 func TestCheckWithdrawals(t *testing.T) {
-	logger := testlog.Logger(t, log.LvlInfo)
+	now := time.Unix(nowUnix, 0)
+	cl := clock.NewDeterministicClock(now)
+	logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
 	metrics := &stubWithdrawalsMetrics{
 		matching:  make(map[common.Address]int),
 		divergent: make(map[common.Address]int),
 	}
-	withdrawals := NewWithdrawalMonitor(logger, metrics)
-	withdrawals.CheckWithdrawals(makeGames())
+	honestActors := monTypes.NewHonestActors([]common.Address{honestActor1, honestActor2, honestActor3})
+	withdrawals := NewWithdrawalMonitor(logger, cl, metrics, honestActors)
+	games := makeGames()
+	withdrawals.CheckWithdrawals(games)
 
 	require.Equal(t, metrics.matchCalls, 2)
 	require.Equal(t, metrics.divergeCalls, 2)
@@ -80,13 +101,59 @@ func TestCheckWithdrawals(t *testing.T) {
 	require.Equal(t, metrics.matching[weth2], 3)
 	require.Equal(t, metrics.divergent[weth1], 0)
 	require.Equal(t, metrics.divergent[weth2], 1)
+
+	require.Len(t, metrics.honestWithdrawable, 3)
+	requireBigInt := func(name string, expected, actual *big.Int) {
+		require.Truef(t, expected.Cmp(actual) == 0, "Expected %v withdrawable to be %v but was %v", name, expected, actual)
+	}
+	requireBigInt("honest addr1", big.NewInt(6), metrics.honestWithdrawable[honestActor1])
+	requireBigInt("honest addr2", big.NewInt(0), metrics.honestWithdrawable[honestActor2])
+	requireBigInt("honest addr3", big.NewInt(2), metrics.honestWithdrawable[honestActor3])
+	require.Nil(t, metrics.honestWithdrawable[dishonestActor4], "should only report withdrawable credits for honest actors")
+
+	findUnclaimedCreditWarning := func(game common.Address, actor common.Address) *testlog.CapturedRecord {
+		return logs.FindLog(
+			testlog.NewLevelFilter(log.LevelWarn),
+			testlog.NewMessageFilter("Found unclaimed credit"),
+			testlog.NewAttributesFilter("game", game.Hex()),
+			testlog.NewAttributesFilter("recipient", actor.Hex()))
+	}
+	requireUnclaimedWarning := func(game common.Address, actor common.Address) {
+		require.NotNil(t, findUnclaimedCreditWarning(game, actor))
+	}
+	noUnclaimedWarning := func(game common.Address, actor common.Address) {
+		require.Nil(t, findUnclaimedCreditWarning(game, actor))
+	}
+	// Game 1, unclaimed for honestActor1 only
+	requireUnclaimedWarning(games[0].Proxy, honestActor1)
+	noUnclaimedWarning(games[0].Proxy, honestActor2)
+	noUnclaimedWarning(games[0].Proxy, honestActor3)
+	noUnclaimedWarning(games[0].Proxy, dishonestActor4)
+
+	// Game 2, unclaimed for honestActor1 only
+	requireUnclaimedWarning(games[1].Proxy, honestActor1)
+	noUnclaimedWarning(games[1].Proxy, honestActor2)
+	noUnclaimedWarning(games[1].Proxy, honestActor3)
+	noUnclaimedWarning(games[1].Proxy, dishonestActor4)
+
+	// Game 3, unclaimed for honestActor3 only
+	// dishonestActor4 has unclaimed credits but we don't track them
+	noUnclaimedWarning(games[2].Proxy, honestActor1)
+	noUnclaimedWarning(games[2].Proxy, honestActor2)
+	requireUnclaimedWarning(games[2].Proxy, honestActor3)
+	noUnclaimedWarning(games[2].Proxy, dishonestActor4)
 }
 
 type stubWithdrawalsMetrics struct {
-	matchCalls   int
-	divergeCalls int
-	matching     map[common.Address]int
-	divergent    map[common.Address]int
+	matchCalls         int
+	divergeCalls       int
+	matching           map[common.Address]int
+	divergent          map[common.Address]int
+	honestWithdrawable map[common.Address]*big.Int
+}
+
+func (s *stubWithdrawalsMetrics) RecordHonestWithdrawableAmounts(honestWithdrawable map[common.Address]*big.Int) {
+	s.honestWithdrawable = honestWithdrawable
 }
 
 func (s *stubWithdrawalsMetrics) RecordWithdrawalRequests(addr common.Address, matches bool, count int) {


### PR DESCRIPTION
**Description**

Moves detection of unclaimed credits from the bonds monitor to the withdrawals monitor. It now uses the actual withdrawal request timestamp to calculate if the credit is withdrawable. 

**Tests**

Moved tests over to the withdrawals monitor.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/11487
