### PR TITLE
feat: add cgo tags for only working on partial tests

### DIFF
--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -70,7 +70,7 @@ clean:
 .PHONY: clean
 
 fuzz:
-	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzFjordCostFunction ./
-	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzFastLzGethSolidity ./
-	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzFastLzCgo ./
+	go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFjordCostFunction ./
+	go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzGethSolidity ./
+	go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzCgo ./
 

--- a/op-e2e/fastlz/fastlz.go
+++ b/op-e2e/fastlz/fastlz.go
@@ -1,3 +1,6 @@
+//go:build cgo_test
+// +build cgo_test
+
 package fastlz
 
 // #include <stdlib.h>

--- a/op-e2e/fastlz_test.go
+++ b/op-e2e/fastlz_test.go
@@ -1,3 +1,6 @@
+//go:build cgo_test
+// +build cgo_test
+
 package op_e2e
 
 import (


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Append cgo_test tag for fastlz and related tests. It can disable cgo dependency for other builds.
Maybe it can simplify build processes.

**Tests**

**Additional context**

It is bad choice that import cgo only for test. Anyway it seems best solution for now.

**Metadata**
