### PR TITLE
feat: add fork activation based on env variables - getting started script update

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -106,7 +106,7 @@ EOL
 # Append conditional environment variables with their corresponding default values
 # Activate granite fork
 if [ -n "${GRANITE_TIME_OFFSET}" ]; then
-    append_with_default "L2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
+    append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
 fi
 # Activate holocene fork
 if [ -n "${HOLOCENE_TIME_OFFSET}" ]; then

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -104,8 +104,18 @@ cat << EOL > tmp_config.json
 EOL
 
 # Append conditional environment variables with their corresponding default values
+# Activate granite fork
 if [ -n "${GRANITE_TIME_OFFSET}" ]; then
-    append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
+    append_with_default "L2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
+fi
+# Activate holocene fork
+if [ -n "${HOLOCENE_TIME_OFFSET}" ]; then
+    append_with_default "l2GenesisHoloceneTimeOffset" "HOLOCENE_TIME_OFFSET" "0x0"
+fi
+
+# Activate the interop fork
+if [ -n "${INTEROP_TIME_OFFSET}" ]; then
+    append_with_default "l2GenesisInteropTimeOffset" "INTEROP_TIME_OFFSET" "0x0"
 fi
 
 # Already forked updates
@@ -135,6 +145,6 @@ cat << EOL >> tmp_config.json
   "preimageOracleChallengePeriod": 86400
 }
 EOL
-
+cat tmp_config.json
 # Write the final config file
 mv tmp_config.json "$CONTRACTS_BASE/deploy-config/getting-started.json"

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -40,14 +40,16 @@ reqenv "L1_BLOCK_TIME"
 reqenv "L2_BLOCK_TIME"
 
 # Get the finalized block timestamp and hash
-block=$(cast block finalized --rpc-url "$L1_RPC_URL")
-timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
-blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
+#block=$(cast block finalized --rpc-url "$L1_RPC_URL")
+#timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
+#blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
 
 # Start generating the config file in a temporary file
+
+  #"l1StartingBlockTag": "$blockhash",
 cat << EOL > tmp_config.json
 {
-  "l1StartingBlockTag": "$blockhash",
+
 
   "l1ChainID": $L1_CHAIN_ID,
   "l2ChainID": $L2_CHAIN_ID,
@@ -102,7 +104,7 @@ cat << EOL > tmp_config.json
 EOL
 
 # Append conditional environment variables with their corresponding default values
-if [ -z "$GRANITE_TIME_OFFSET" ] ; then
+if [ -n "${GRANITE_TIME_OFFSET}" ]; then
     append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
 fi
 

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -102,7 +102,7 @@ cat << EOL > tmp_config.json
 EOL
 
 # Append conditional environment variables with their corresponding default values
-append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x1"
+#append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x1"
 
 # Already forked updates
 append_with_default "l2GenesisFjordTimeOffset" "FJORD_TIME_OFFSET" "0x0"

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -102,7 +102,7 @@ cat << EOL > tmp_config.json
 EOL
 
 # Append conditional environment variables with their corresponding default values
-if [ -z "$GRANITE_TIME_OFFSET" ] || [ "$GRANITE_TIME_OFFSET" == "None" ]; then
+if [ -z "$GRANITE_TIME_OFFSET" ] ; then
     append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
 fi
 

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -145,6 +145,6 @@ cat << EOL >> tmp_config.json
   "preimageOracleChallengePeriod": 86400
 }
 EOL
-cat tmp_config.json
+
 # Write the final config file
 mv tmp_config.json "$CONTRACTS_BASE/deploy-config/getting-started.json"

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -102,7 +102,9 @@ cat << EOL > tmp_config.json
 EOL
 
 # Append conditional environment variables with their corresponding default values
-#append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x1"
+if [ -z "$GRANITE_TIME_OFFSET" ] || [ "$GRANITE_TIME_OFFSET" == "None" ]; then
+    append_with_default "l2GenesisGraniteTimeOffset" "GRANITE_TIME_OFFSET" "0x0"
+fi
 
 # Already forked updates
 append_with_default "l2GenesisFjordTimeOffset" "FJORD_TIME_OFFSET" "0x0"

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -40,16 +40,16 @@ reqenv "L1_BLOCK_TIME"
 reqenv "L2_BLOCK_TIME"
 
 # Get the finalized block timestamp and hash
-#block=$(cast block finalized --rpc-url "$L1_RPC_URL")
-#timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
-#blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
+block=$(cast block finalized --rpc-url "$L1_RPC_URL")
+timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
+blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
 
 # Start generating the config file in a temporary file
 
-  #"l1StartingBlockTag": "$blockhash",
 cat << EOL > tmp_config.json
 {
 
+ "l1StartingBlockTag": "$blockhash",
 
   "l1ChainID": $L1_CHAIN_ID,
   "l2ChainID": $L2_CHAIN_ID,


### PR DESCRIPTION
This PR will enable fork activation based on different environment variables. 

- l2GenesisGraniteTimeOffset
- l2GenesisHoloceneTimeOffset
- l2GenesisInteropTimeOffset
- l2GenesisFjordTimeOffset

Fjord defaulting to 0x0, other 3 defaults to none, if env variable is not set. 