### PR TITLE
fix: wrong MaxSequencerDrift comment

### DIFF
--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -70,7 +70,7 @@ type Config struct {
 	// Seconds per L2 block
 	BlockTime uint64 `json:"block_time"`
 	// Sequencer batches may not be more than MaxSequencerDrift seconds after
-	// the L1 timestamp of the sequencing window end.
+	// the L1 timestamp of their L1 origin time.
 	//
 	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
 	// the L2 time may still grow beyond this difference.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I'm interpreting `L1 timestamp of the sequencing window end` to mean:
```
batchOrigin + SeqWindowSize + MaxSequencerDrift < batch.timestamp
```

However the [code](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/batches.go#L128) reads:
```
batchOrigin + MaxSequencerDrift < batch.timestamp
```

so I fixed the comment according to this interpretation. Hopefully I'm not misunderstanding what "sequencing window end" means, but if I am then it's probably still worth editing the comment to not cause this confusion.