### PR TITLE
op-service: add regression test for unmarshaling malicious data

### DIFF
--- a/op-service/eth/ssz_test.go
+++ b/op-service/eth/ssz_test.go
@@ -40,6 +40,15 @@ func FuzzExecutionPayloadUnmarshal(f *testing.F) {
 	})
 }
 
+func TestExecutionPayloadUnmarshalMaliciousData(t *testing.T) {
+	// Prior to https://github.com/ethereum-optimism/optimism/pull/10362 this causes a panic
+	// It should return an error and not panic
+	data := []byte("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\x00\x02\x00\x000000000000000000000000000000000000000000000000000000000000000000\x00\x02\x00\x000000")
+	var payload ExecutionPayload
+	err := payload.UnmarshalSSZ(BlockV2, uint32(len(data)), bytes.NewReader(data))
+	require.Error(t, err)
+}
+
 // FuzzExecutionPayloadMarshalUnmarshal checks that our SSZ encoding>decoding round trips properly
 func FuzzExecutionPayloadMarshalUnmarshalV1(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte, a, b, c, d uint64, extraData []byte, txs uint16, txsData []byte) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

**Tests**

Adds a regression test for a fix introduced in https://github.com/ethereum-optimism/optimism/pull/10362.

**Additional context**


**Metadata**

- Closes https://github.com/ethereum-optimism/optimism/issues/11385 
