### PR TITLE
fix: slice init len

### DIFF
--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -507,7 +507,7 @@ func ensureOnlyOneLeader(t *testing.T, sys *System, conductors map[string]*condu
 }
 
 func memberIDs(membership *consensus.ClusterMembership) []string {
-	ids := make([]string, len(membership.Servers))
+	ids := make([]string, 0, len(membership.Servers))
 	for _, member := range membership.Servers {
 		ids = append(ids, member.ID)
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

init slice len in memberIDs should be zero.


**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
