### PR TITLE
txmgr: add tx-type metric

### DIFF
--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -24,11 +24,12 @@ type TxMetricer interface {
 }
 
 type TxMetrics struct {
-	TxL1GasFee         prometheus.Gauge
-	txFees             prometheus.Counter
-	TxGasBump          prometheus.Gauge
+	txL1GasFee         prometheus.Gauge
+	txFeesTotal        prometheus.Counter
+	txGasBump          prometheus.Gauge
 	txFeeHistogram     prometheus.Histogram
-	LatencyConfirmedTx prometheus.Gauge
+	txType             prometheus.Gauge
+	latencyConfirmedTx prometheus.Gauge
 	currentNonce       prometheus.Gauge
 	pendingTxs         prometheus.Gauge
 	txPublishError     *prometheus.CounterVec
@@ -55,16 +56,22 @@ var _ TxMetricer = (*TxMetrics)(nil)
 
 func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
 	return TxMetrics{
-		TxL1GasFee: factory.NewGauge(prometheus.GaugeOpts{
+		txL1GasFee: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "tx_fee_gwei",
 			Help:      "L1 gas fee for transactions in GWEI",
 			Subsystem: "txmgr",
 		}),
-		txFees: factory.NewCounter(prometheus.CounterOpts{
+		txFeesTotal: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      "tx_fee_gwei_total",
 			Help:      "Sum of fees spent for all transactions in GWEI",
+			Subsystem: "txmgr",
+		}),
+		txGasBump: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "tx_gas_bump",
+			Help:      "Number of times a transaction gas needed to be bumped before it got included",
 			Subsystem: "txmgr",
 		}),
 		txFeeHistogram: factory.NewHistogram(prometheus.HistogramOpts{
@@ -74,13 +81,13 @@ func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
 			Subsystem: "txmgr",
 			Buckets:   []float64{0.5, 1, 2, 5, 10, 20, 40, 60, 80, 100, 200, 400, 800, 1600},
 		}),
-		TxGasBump: factory.NewGauge(prometheus.GaugeOpts{
+		txType: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
-			Name:      "tx_gas_bump",
-			Help:      "Number of times a transaction gas needed to be bumped before it got included",
+			Name:      "tx_type",
+			Help:      "Transaction type (receipt field uint8)",
 			Subsystem: "txmgr",
 		}),
-		LatencyConfirmedTx: factory.NewGauge(prometheus.GaugeOpts{
+		latencyConfirmedTx: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "tx_confirmed_latency_ms",
 			Help:      "Latency of a confirmed transaction in milliseconds",
@@ -145,17 +152,18 @@ func (t *TxMetrics) RecordPendingTx(pending int64) {
 func (t *TxMetrics) TxConfirmed(receipt *types.Receipt) {
 	fee := float64(receipt.EffectiveGasPrice.Uint64() * receipt.GasUsed / params.GWei)
 	t.confirmEvent.Record(receiptStatusString(receipt))
-	t.TxL1GasFee.Set(fee)
-	t.txFees.Add(fee)
+	t.txL1GasFee.Set(fee)
+	t.txFeesTotal.Add(fee)
 	t.txFeeHistogram.Observe(fee)
+	t.txType.Set(float64(receipt.Type))
 }
 
 func (t *TxMetrics) RecordGasBumpCount(times int) {
-	t.TxGasBump.Set(float64(times))
+	t.txGasBump.Set(float64(times))
 }
 
 func (t *TxMetrics) RecordTxConfirmationLatency(latency int64) {
-	t.LatencyConfirmedTx.Set(float64(latency))
+	t.latencyConfirmedTx.Set(float64(latency))
 }
 
 func (t *TxMetrics) TxPublished(errString string) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a transaction type metric to the txmgr.

Also cleans up some field names, to make all lower case.

**Additional context**

Can be used in dashboards to track what tx types are in use, in particular blobs vs non-blobs.

**Metadata**

Towards https://github.com/ethereum-optimism/client-pod/issues/9701
