### PR TITLE
txmgr: rename Get|SetPriorityFee to Get|SetMinPriorityFee

### DIFF
--- a/op-service/txmgr/rpc.go
+++ b/op-service/txmgr/rpc.go
@@ -21,12 +21,12 @@ func (a *SimpleTxmgrAPI) SetMinBaseFee(_ context.Context, val *big.Int) {
 	a.mgr.SetMinBaseFee(val)
 }
 
-func (a *SimpleTxmgrAPI) GetPriorityFee(_ context.Context) *big.Int {
-	return a.mgr.GetPriorityFee()
+func (a *SimpleTxmgrAPI) GetMinPriorityFee(_ context.Context) *big.Int {
+	return a.mgr.GetMinPriorityFee()
 }
 
-func (a *SimpleTxmgrAPI) SetPriorityFee(_ context.Context, val *big.Int) {
-	a.mgr.SetPriorityFee(val)
+func (a *SimpleTxmgrAPI) SetMinPriorityFee(_ context.Context, val *big.Int) {
+	a.mgr.SetMinPriorityFee(val)
 }
 
 func (a *SimpleTxmgrAPI) GetMinBlobFee(_ context.Context) *big.Int {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -340,13 +340,13 @@ func (m *SimpleTxManager) SetMinBaseFee(val *big.Int) {
 	m.l.Info("txmgr config val changed: SetMinBaseFee", "newVal", val)
 }
 
-func (m *SimpleTxManager) GetPriorityFee() *big.Int {
+func (m *SimpleTxManager) GetMinPriorityFee() *big.Int {
 	return m.cfg.MinTipCap.Load()
 }
 
-func (m *SimpleTxManager) SetPriorityFee(val *big.Int) {
+func (m *SimpleTxManager) SetMinPriorityFee(val *big.Int) {
 	m.cfg.MinTipCap.Store(val)
-	m.l.Info("txmgr config val changed: SetPriorityFee", "newVal", val)
+	m.l.Info("txmgr config val changed: SetMinPriorityFee", "newVal", val)
 }
 
 func (m *SimpleTxManager) GetMinBlobFee() *big.Int {


### PR DESCRIPTION
Renames two txmgr admin rpc methods