### PR TITLE
op-program: Prune L1 blocks after advancing origin

### DIFF
--- a/op-e2e/actions/batch_queue_test.go
+++ b/op-e2e/actions/batch_queue_test.go
@@ -92,4 +92,7 @@ func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
 	verifier.ActL2PipelineFull(t) // Should not get stuck in a reset loop forever
 	require.EqualValues(gt, l2BlockNum, seqEngine.l2Chain.CurrentSafeBlock().Number.Uint64())
 	require.EqualValues(gt, l2BlockNum, seqEngine.l2Chain.CurrentFinalBlock().Number.Uint64())
+	syncStatus := verifier.syncStatus.SyncStatus()
+	require.EqualValues(gt, l2BlockNum, syncStatus.SafeL2.Number)
+	require.EqualValues(gt, l2BlockNum, syncStatus.FinalizedL2.Number)
 }

--- a/op-e2e/actions/batch_queue_test.go
+++ b/op-e2e/actions/batch_queue_test.go
@@ -1,0 +1,95 @@
+package actions
+
+import (
+	"testing"
+
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeriveChainFromNearL1Genesis tests a corner case where when the derivation pipeline starts, the
+// safe head has an L1 origin of block 1. The derivation then starts with pipeline origin of L1 genesis,
+// just one block prior to the origin of the safe head.
+// This is a regression test, previously the pipeline encountered got stuck in a reset loop with the error:
+// buffered L1 chain epoch %s in batch queue does not match safe head origin %s
+func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	p := &e2eutils.TestParams{
+		MaxSequencerDrift:   20, // larger than L1 block time we simulate in this test (12)
+		SequencerWindowSize: 24,
+		ChannelTimeout:      20,
+		L1BlockTime:         12,
+	}
+	dp := e2eutils.MakeDeployParams(t, p)
+	// do not activate Delta hardfork for verifier
+	applyDeltaTimeOffset(dp, nil)
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+	logger := testlog.Logger(t, log.LevelInfo)
+	miner, seqEngine, sequencer := setupSequencerTest(t, sd, logger)
+
+	miner.ActEmptyBlock(t)
+	require.EqualValues(gt, 1, miner.l1Chain.CurrentBlock().Number.Uint64())
+
+	ref, err := derive.L2BlockToBlockRef(sequencer.rollupCfg, seqEngine.l2Chain.Genesis())
+	require.NoError(gt, err)
+	require.EqualValues(gt, 0, ref.L1Origin.Number)
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+	l2BlockNum := seqEngine.l2Chain.CurrentBlock().Number.Uint64()
+	ref, err = derive.L2BlockToBlockRef(sequencer.rollupCfg, seqEngine.l2Chain.GetBlockByNumber(l2BlockNum))
+	require.NoError(gt, err)
+	require.EqualValues(gt, 1, ref.L1Origin.Number)
+
+	miner.ActEmptyBlock(t)
+
+	rollupSeqCl := sequencer.RollupClient()
+	// Force batcher to submit SingularBatches to L1.
+	batcher := NewL2Batcher(logger, sd.RollupCfg, &BatcherCfg{
+		MinL1TxSize:          0,
+		MaxL1TxSize:          128_000,
+		BatcherKey:           dp.Secrets.Batcher,
+		DataAvailabilityType: batcherFlags.CalldataType,
+	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
+
+	batcher.ActSubmitAll(t)
+	require.EqualValues(gt, l2BlockNum, batcher.l2BufferedBlock.Number)
+
+	// confirm batch on L1
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
+	miner.ActL1EndBlock(t)
+	bl := miner.l1Chain.CurrentBlock()
+	logger.Info("Produced L1 block with batch",
+		"num", miner.l1Chain.CurrentBlock().Number.Uint64(),
+		"txs", len(miner.l1Chain.GetBlockByHash(bl.Hash()).Transactions()))
+
+	// Process batches so safe head updates
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	require.EqualValues(gt, l2BlockNum, seqEngine.l2Chain.CurrentSafeBlock().Number.Uint64())
+
+	// Finalize L1 and process so L2 finalized updates
+	miner.ActL1Safe(t, miner.l1Chain.CurrentBlock().Number.Uint64())
+	miner.ActL1Finalize(t, miner.l1Chain.CurrentBlock().Number.Uint64())
+	sequencer.ActL1SafeSignal(t)
+	sequencer.ActL1FinalizedSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	require.EqualValues(gt, l2BlockNum, seqEngine.l2Chain.CurrentFinalBlock().Number.Uint64())
+
+	// Create a new verifier using the existing engine so it already has the safe and finalized heads set.
+	// This is the same situation as if op-node restarted at this point.
+	l2Cl, err := sources.NewEngineClient(seqEngine.RPCClient(), logger, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))
+	require.NoError(gt, err)
+	verifier := NewL2Verifier(t, logger, sequencer.l1, miner.BlobStore(), altda.Disabled, l2Cl, sequencer.rollupCfg, sequencer.syncCfg, safedb.Disabled)
+	verifier.ActL2PipelineFull(t) // Should not get stuck in a reset loop forever
+	require.EqualValues(gt, l2BlockNum, seqEngine.l2Chain.CurrentSafeBlock().Number.Uint64())
+	require.EqualValues(gt, l2BlockNum, seqEngine.l2Chain.CurrentFinalBlock().Number.Uint64())
+}

--- a/op-e2e/e2eutils/disputegame/claim_helper.go
+++ b/op-e2e/e2eutils/disputegame/claim_helper.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
@@ -96,6 +97,10 @@ func (c *ClaimHelper) RequireCorrectOutputRoot(ctx context.Context) {
 	expected, err := c.game.CorrectOutputProvider.Get(ctx, c.Position)
 	c.require.NoError(err, "Failed to get correct output root")
 	c.require.Equalf(expected, c.claim, "Should have correct output root in claim %v and position %v", c.Index, c.Position)
+}
+
+func (c *ClaimHelper) RequireInvalidStatusCode() {
+	c.require.Equal(byte(mipsevm.VMStatusInvalid), c.claim[0], "should have had valid status code")
 }
 
 func (c *ClaimHelper) Attack(ctx context.Context, value common.Hash, opts ...MoveOpt) *ClaimHelper {

--- a/op-e2e/e2eutils/disputegame/claim_helper.go
+++ b/op-e2e/e2eutils/disputegame/claim_helper.go
@@ -100,7 +100,7 @@ func (c *ClaimHelper) RequireCorrectOutputRoot(ctx context.Context) {
 }
 
 func (c *ClaimHelper) RequireInvalidStatusCode() {
-	c.require.Equal(byte(mipsevm.VMStatusInvalid), c.claim[0], "should have had valid status code")
+	c.require.Equal(byte(mipsevm.VMStatusInvalid), c.claim[0], "should have had invalid status code")
 }
 
 func (c *ClaimHelper) Attack(ctx context.Context, value common.Hash, opts ...MoveOpt) *ClaimHelper {

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -135,7 +135,6 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 	// Advancing epoch must be done after the pipeline successfully apply the entire span batch to the chain.
 	// Because the span batch can be reverted during processing the batch, then we must preserve existing l1Blocks
 	// to verify the epochs of the next candidate batch.
-	// It also
 	if len(bq.l1Blocks) > 0 && parent.L1Origin.Number > bq.l1Blocks[0].Number {
 		for i, l1Block := range bq.l1Blocks {
 			if parent.L1Origin.Number == l1Block.Number {

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -109,24 +109,6 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		}
 	}
 
-	trimL1Blocks := func() {
-		// If the epoch is advanced, update bq.l1Blocks
-		// Advancing epoch must be done after the pipeline successfully apply the entire span batch to the chain.
-		// Because the span batch can be reverted during processing the batch, then we must preserve existing l1Blocks
-		// to verify the epochs of the next candidate batch.
-		if len(bq.l1Blocks) > 0 && parent.L1Origin.Number > bq.l1Blocks[0].Number {
-			for i, l1Block := range bq.l1Blocks {
-				if parent.L1Origin.Number == l1Block.Number {
-					bq.l1Blocks = bq.l1Blocks[i:]
-					bq.log.Debug("Advancing internal L1 blocks", "next_epoch", bq.l1Blocks[0].ID(), "next_epoch_time", bq.l1Blocks[0].Time)
-					break
-				}
-			}
-			// If we can't find the origin of parent block, we have to advance bq.origin.
-		}
-	}
-	trimL1Blocks()
-
 	// Note: We use the origin that we will have to determine if it's behind. This is important
 	// because it's the future origin that gets saved into the l1Blocks array.
 	// We always update the origin of this stage if it is not the same so after the update code
@@ -140,11 +122,6 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		bq.origin = bq.prev.Origin()
 		if !originBehind {
 			bq.l1Blocks = append(bq.l1Blocks, bq.origin)
-			// Maintain the invariant:
-			// If every L2 block corresponding to single L1 block becomes safe, it will be popped from l1Blocks.
-			// The previous attempt to trim may not have found the parent origin in l1Blocks so couldn't trim
-			// But now that we have added a block, it might have been the one we were looking for so we should re-trim
-			trimL1Blocks() // See if we can find the parent origin in l1Blocks now
 		} else {
 			// This is to handle the special case of startup. At startup we call Reset & include
 			// the L1 origin. That is the only time where immediately after `Reset` is called
@@ -152,6 +129,22 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 			bq.l1Blocks = bq.l1Blocks[:0]
 		}
 		bq.log.Info("Advancing bq origin", "origin", bq.origin, "originBehind", originBehind)
+	}
+
+	// If the epoch is advanced, update bq.l1Blocks
+	// Advancing epoch must be done after the pipeline successfully apply the entire span batch to the chain.
+	// Because the span batch can be reverted during processing the batch, then we must preserve existing l1Blocks
+	// to verify the epochs of the next candidate batch.
+	// It also
+	if len(bq.l1Blocks) > 0 && parent.L1Origin.Number > bq.l1Blocks[0].Number {
+		for i, l1Block := range bq.l1Blocks {
+			if parent.L1Origin.Number == l1Block.Number {
+				bq.l1Blocks = bq.l1Blocks[i:]
+				bq.log.Debug("Advancing internal L1 blocks", "next_epoch", bq.l1Blocks[0].ID(), "next_epoch_time", bq.l1Blocks[0].Time)
+				break
+			}
+		}
+		// If we can't find the origin of parent block, we have to advance bq.origin.
 	}
 
 	// Load more data into the batch queue


### PR DESCRIPTION
**Description**

Prune the L1 blocks array in batch queue after advancing origin since the advancement may have added the parent L1 origin which is required to prune successfully. Previously if the initial L1 block used as origin was exactly 1 block prior to the L1 origin of the safe head, the batch queue broke its invariant for `l1Blocks` field and failed to pop off the initial L1 block because the safe head L1 origin wasn't in `l1Blocks` when the trim happened but was then added as part of advancing the origin (indicating that all L2 blocks with the initial L1 block as their origin were already safe).

Add e2e test to reproduce corner case when deploying a chain at L1 genesis.

**Tests**

Added unit test and action test.

**Additional context**

Fixes flaky test `TestPrecompiles/DisputePrecompile-ecrecover`