### PR TITLE
use copy of `config.L1Deployments`

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -120,7 +120,7 @@ func DefaultSystemConfig(t testing.TB) SystemConfig {
 		Secrets:                secrets,
 		Premine:                premine,
 		DeployConfig:           deployConfig,
-		L1Deployments:          config.L1Deployments,
+		L1Deployments:          l1Deployments,
 		L1InfoPredeployAddress: predeploys.L1BlockAddr,
 		JWTFilePath:            writeDefaultJWT(t),
 		JWTSecret:              testingJWTSecret,


### PR DESCRIPTION
The `L1Deployments` field should return a copy of `config.L1Deployments`, which is in the same spirit as the [`DeployConfig`](https://github.com/ethereum-optimism/optimism/blob/107f4d6ac4900b2fbd3458c95f088b850e47a5fe/op-e2e/setup.go#L122) field.