### PR TITLE
deploy-config: Update mainnet prestate for granite HF

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -42,7 +42,7 @@
   "systemConfigStartBlock": 17422444,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000000",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000000",
-  "faultGameAbsolutePrestate": "0x03617abec0b255dc7fc7a0513a2c2220140a1dcd7a1c8eca567659bd67e05cea",
+  "faultGameAbsolutePrestate": "0x03e806a2859a875267a563462a06d4d1d1b455a9efee959a46e21e54b6caf69a",
   "faultGameMaxDepth": 73,
   "faultGameClockExtension": 10800,
   "faultGameMaxClockDuration": 302400,


### PR DESCRIPTION
Optimistically update the Fault Dispute Game absolute prestate fort the granite HF.
To verify:
```
git checkout op-program/v1.3.1-rc.1
make absolute-prestate && cat ./op-program/bin/prestate-proof.json | jq .pre
```