### PR TITLE
Fix: add backoff to driver.go alt-da put request fail logic 

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -576,7 +576,7 @@ func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, que
 				l.Log.Error("Failed to post input to Alt DA", "error", err)
 				// requeue frame if we fail to post to the DA Provider so it can be retried
 				l.recordFailedTx(txdata.ID(), err)
-				return nil
+				return err
 			}
 			l.Log.Info("Set AltDA input", "commitment", comm, "tx", txdata.ID())
 			// signal AltDA commitment tx with TxDataVersion1


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When the put request to the da-server fails, it the batch submitter puts back the frames into their respective channel builder, and returns `nil` (instead of err). This was probably added to allow the driver to retry sending the blob to the server immediately, without having to wait until the next poll. However, this is very bad behavior as clients should typically linear or exponential backoff when retrying requests, which this code doesn't do. 

** Solution **

Returning the err will make the [for loop](https://github.com/ethereum-optimism/optimism/blob/d1e1c25383cd21cd1eecec53f829b2f7adbdbd57/op-batcher/batcher/driver.go#L430) return, and wait for the next poll before retrying to send blobs to the da server.

**Tests**

Have not added any tests. This is a fairly simple change.
It might have unintended consequences though, so I'd be happy to know if there's some tests I should run.

**Additional context**

Here is my op-batcher sending a gazillion (500 returning) requests in a very short amount of time to the eigenda-proxy (our da-server):
![image](https://github.com/user-attachments/assets/d91b0ef2-d6dd-4165-8363-bcbd973195ef)
![image](https://github.com/user-attachments/assets/cc8baef5-af0e-41ca-a8aa-ee727bf43595)


**Metadata**

- Fixes #[Link to Issue]
