### PR TITLE
[op-service] Check if actually fetched any blobs, then move onto next client

### DIFF
--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -223,7 +223,7 @@ func (cl *L1BeaconClient) fetchSidecars(ctx context.Context, slot uint64, hashes
 	for i := 0; i < cl.pool.Len(); i++ {
 		f := cl.pool.Get()
 		resp, err := f.BeaconBlobSideCars(ctx, cl.cfg.FetchAllSidecars, slot, hashes)
-		if err != nil {
+		if err != nil || len(resp.Data) == 0 {
 			cl.pool.MoveToNext()
 			errs = append(errs, err)
 		} else {


### PR DESCRIPTION
Verified with a beacon API provided by chainstack, although error was nil, the resp was empty as well so next client never picked. 