### PR TITLE
fix: remove the `payable` from the `sendMessage`

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -108,8 +108,8 @@
     "sourceCodeHash": "0x8388b9b8075f31d580fed815b66b45394e40fb1a63cd8cda2272d2c390fc908c"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0xe390be1390edc38fd879d7620538560076d7fcf3ef9debce327a1877d96d3ff0",
-    "sourceCodeHash": "0x20f77dc5a02869c6885b73347fa9e7d2bbc4eaf8a2313f7e7435e456001f7a75"
+    "initCodeHash": "0x3a18ecd5415ddcb7c26023f29f3acb3bc4e8a261091c3bc529b8b4d497b92469",
+    "sourceCodeHash": "0x972564d2e2fab111cd431f3c78d00c7b0f0ae422fa5e9a8bf5b202cdaef89bf9"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
     "initCodeHash": "0xd49214518ea1a30a43fac09f28b2cee9be570894a500cef342762c9820a070b0",

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -109,7 +109,7 @@
     ],
     "name": "sendMessage",
     "outputs": [],
-    "stateMutability": "payable",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/src/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/IL2ToL2CrossDomainMessenger.sol
@@ -19,7 +19,7 @@ interface IL2ToL2CrossDomainMessenger {
     /// @param _destination Chain ID of the destination chain.
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message to trigger the target address with.
-    function sendMessage(uint256 _destination, address _target, bytes calldata _message) external payable;
+    function sendMessage(uint256 _destination, address _target, bytes calldata _message) external;
 
     /// @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
     ///         be executed via cross-chain call from the other messenger OR if the message was

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -57,8 +57,8 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.2
-    string public constant version = "1.0.0-beta.2";
+    /// @custom:semver 1.0.0-beta.3
+    string public constant version = "1.0.0-beta.3";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -99,7 +99,7 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     /// @param _destination Chain ID of the destination chain.
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message payload to call target with.
-    function sendMessage(uint256 _destination, address _target, bytes calldata _message) external payable {
+    function sendMessage(uint256 _destination, address _target, bytes calldata _message) external {
         if (_destination == block.chainid) revert MessageDestinationSameChain();
         if (_target == Predeploys.CROSS_L2_INBOX) revert MessageTargetCrossL2Inbox();
         if (_target == Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER) revert MessageTargetL2ToL2CrossDomainMessenger();

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -76,14 +76,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
     }
 
     /// @dev Tests that `sendMessage` succeeds and emits the correct event.
-    function testFuzz_sendMessage_succeeds(
-        uint256 _destination,
-        address _target,
-        bytes calldata _message,
-        uint256 _value
-    )
-        external
-    {
+    function testFuzz_sendMessage_succeeds(uint256 _destination, address _target, bytes calldata _message) external {
         // Ensure the destination is not the same as the source, otherwise the function will revert
         vm.assume(_destination != block.chainid);
 
@@ -93,18 +86,11 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Get the current message nonce
         uint256 messageNonce = l2ToL2CrossDomainMessenger.messageNonce();
 
-        // Add sufficient value to the contract to send the message with
-        vm.deal(address(this), _value);
-
         // Look for correct emitted event
         vm.recordLogs();
 
         // Call the sendMessage function
-        l2ToL2CrossDomainMessenger.sendMessage{ value: _value }({
-            _destination: _destination,
-            _target: _target,
-            _message: _message
-        });
+        l2ToL2CrossDomainMessenger.sendMessage({ _destination: _destination, _target: _target, _message: _message });
 
         // Check that the event was emitted with the correct parameters
         Vm.Log[] memory logs = vm.getRecordedLogs();

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -130,7 +130,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
 
         // Call the sendMessage function with value to provoke revert
         (bool success,) = address(l2ToL2CrossDomainMessenger).call{ value: _value }(
-            abi.encodeWithSelector(l2ToL2CrossDomainMessenger.sendMessage.selector, _destination, _target, _message)
+            abi.encodeCall(l2ToL2CrossDomainMessenger.sendMessage, (_destination, _target, _message))
         );
 
         // Check that the function reverts


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

remove the `payable` modifier from the `sendMessage`

ensure this implementation stays consistent with the [specs](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/predeploys.md?plain=1#L262)

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
