### PR TITLE
op-supervisor: Add Routine to run Maintenence

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -101,11 +101,14 @@ func (su *SupervisorBackend) Start(ctx context.Context) error {
 	if !su.started.CompareAndSwap(false, true) {
 		return errors.New("already started")
 	}
+	// start chain monitors
 	for _, monitor := range su.chainMonitors {
 		if err := monitor.Start(); err != nil {
 			return fmt.Errorf("failed to start chain monitor: %w", err)
 		}
 	}
+	// start db maintenance loop
+	su.db.StartCrossHeadMaintenance(ctx)
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -213,6 +213,10 @@ func (s *stubChecker) LocalHeadForChain(chainID types.ChainID) entrydb.EntryIdx 
 	return s.localHeadForChain
 }
 
+func (s *stubChecker) Name() string {
+	return "stubChecker"
+}
+
 func (s *stubChecker) CrossHeadForChain(chainID types.ChainID) entrydb.EntryIdx {
 	return s.crossHeadForChain
 }

--- a/op-supervisor/supervisor/backend/db/safety_checkers.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers.go
@@ -20,6 +20,7 @@ type SafetyChecker interface {
 	CrossHeadForChain(chainID types.ChainID) entrydb.EntryIdx
 	Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash backendTypes.TruncatedHash) bool
 	Update(chain types.ChainID, index entrydb.EntryIdx) heads.OperationFn
+	Name() string
 }
 
 // unsafeChecker is a SafetyChecker that uses the unsafe head as the view into the database
@@ -55,6 +56,19 @@ func NewSafetyChecker(t string, chainsDB ChainsDB) SafetyChecker {
 	default:
 		panic("unknown safety checker type")
 	}
+}
+
+// Name returns the safety checker type, using the same strings as the constants used in construction
+func (c *unsafeChecker) Name() string {
+	return Unsafe
+}
+
+func (c *safeChecker) Name() string {
+	return Safe
+}
+
+func (c *finalizedChecker) Name() string {
+	return Finalized
 }
 
 // LocalHeadForChain returns the local head for the given chain


### PR DESCRIPTION
Building on https://github.com/ethereum-optimism/optimism/pull/11458

Adds a go-routine to call the update ever 10 seconds, and sets the routine to start when the backend starts.