### PR TITLE
fix: `getting-started` deploy config

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -135,14 +135,14 @@ cat << EOL >> tmp_config.json
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 44,
   "faultGameClockExtension": 0,
-  "faultGameMaxClockDuration": 600,
+  "faultGameMaxClockDuration": 1200,
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 14,
-  "faultGameWithdrawalDelay": 604800,
+  "faultGameWithdrawalDelay": 600,
 
   "preimageOracleMinProposalSize": 1800000,
-  "preimageOracleChallengePeriod": 86400
+  "preimageOracleChallengePeriod": 300
 }
 EOL
 


### PR DESCRIPTION
## Overview

Fixes the parameters of the `getting-started` configuration to meet the clock extension rules of the `FaultDisputeGame`.

Also decreases the withdrawal delay to 10 minutes.