### PR TITLE
cannon: Refactor and add test utils

### DIFF
--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -187,7 +187,7 @@ func HandleSysRead(a0, a1, a2 uint32, preimageKey [32]byte, preimageOffset uint3
 		memTracker.TrackMemAccess(effAddr)
 		mem := memory.GetMemory(effAddr)
 		dat, datLen := preimageReader.ReadPreimage(preimageKey, preimageOffset)
-		//fmt.Printf("reading pre-image data: addr: %08x, offset: %d, datLen: %d, data: %x, key: %s  count: %d\n", a1, m.state.PreimageOffset, datLen, dat[:datLen], m.state.PreimageKey, a2)
+		//fmt.Printf("reading pre-image data: addr: %08x, offset: %d, datLen: %d, data: %x, key: %s  count: %d\n", a1, preimageOffset, datLen, dat[:datLen], preimageKey, a2)
 		alignment := a1 & 3
 		space := 4 - alignment
 		if space < datLen {

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -42,7 +42,7 @@ type FPVMState interface {
 	// so a VM can start from any state without fetching prior pre-images,
 	// and instead just repeat the last hint on setup,
 	// to make sure pre-image requests can be served.
-	// The first 4 bytes are a uin32 length prefix.
+	// The first 4 bytes are a uint32 length prefix.
 	// Warning: the hint MAY NOT BE COMPLETE. I.e. this is buffered,
 	// and should only be read when len(LastHint) > 4 && uint32(LastHint[:4]) <= len(LastHint[4:])
 	GetLastHint() hexutil.Bytes

--- a/cannon/mipsevm/multithreaded/testutil/state.go
+++ b/cannon/mipsevm/multithreaded/testutil/state.go
@@ -1,0 +1,65 @@
+package testutil
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
+)
+
+type StateMutatorMultiThreaded struct {
+	state *multithreaded.State
+}
+
+var _ testutil.StateMutator = (*StateMutatorMultiThreaded)(nil)
+
+func NewStateMutatorMultiThreaded(state *multithreaded.State) testutil.StateMutator {
+	return &StateMutatorMultiThreaded{state: state}
+}
+
+func (m *StateMutatorMultiThreaded) SetHI(val uint32) {
+	m.state.GetCurrentThread().Cpu.HI = val
+}
+
+func (m *StateMutatorMultiThreaded) SetLO(val uint32) {
+	m.state.GetCurrentThread().Cpu.LO = val
+}
+
+func (m *StateMutatorMultiThreaded) SetExitCode(val uint8) {
+	m.state.ExitCode = val
+}
+
+func (m *StateMutatorMultiThreaded) SetExited(val bool) {
+	m.state.Exited = val
+}
+
+func (m *StateMutatorMultiThreaded) SetPC(val uint32) {
+	thread := m.state.GetCurrentThread()
+	thread.Cpu.PC = val
+}
+
+func (m *StateMutatorMultiThreaded) SetHeap(val uint32) {
+	m.state.Heap = val
+}
+
+func (m *StateMutatorMultiThreaded) SetNextPC(val uint32) {
+	thread := m.state.GetCurrentThread()
+	thread.Cpu.NextPC = val
+}
+
+func (m *StateMutatorMultiThreaded) SetLastHint(val hexutil.Bytes) {
+	m.state.LastHint = val
+}
+
+func (m *StateMutatorMultiThreaded) SetPreimageKey(val common.Hash) {
+	m.state.PreimageKey = val
+}
+
+func (m *StateMutatorMultiThreaded) SetPreimageOffset(val uint32) {
+	m.state.PreimageOffset = val
+}
+
+func (m *StateMutatorMultiThreaded) SetStep(val uint64) {
+	m.state.Step = val
+}

--- a/cannon/mipsevm/multithreaded/testutil/state.go
+++ b/cannon/mipsevm/multithreaded/testutil/state.go
@@ -63,3 +63,7 @@ func (m *StateMutatorMultiThreaded) SetPreimageOffset(val uint32) {
 func (m *StateMutatorMultiThreaded) SetStep(val uint64) {
 	m.state.Step = val
 }
+
+func (m *StateMutatorMultiThreaded) GetRegistersRef() *[32]uint32 {
+	return m.state.GetRegistersRef()
+}

--- a/cannon/mipsevm/singlethreaded/testutil/state.go
+++ b/cannon/mipsevm/singlethreaded/testutil/state.go
@@ -61,3 +61,7 @@ func (m *StateMutatorSingleThreaded) SetPreimageOffset(val uint32) {
 func (m *StateMutatorSingleThreaded) SetStep(val uint64) {
 	m.state.Step = val
 }
+
+func (m *StateMutatorSingleThreaded) GetRegistersRef() *[32]uint32 {
+	return m.state.GetRegistersRef()
+}

--- a/cannon/mipsevm/singlethreaded/testutil/state.go
+++ b/cannon/mipsevm/singlethreaded/testutil/state.go
@@ -1,0 +1,63 @@
+package testutil
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
+)
+
+type StateMutatorSingleThreaded struct {
+	state *singlethreaded.State
+}
+
+var _ testutil.StateMutator = (*StateMutatorSingleThreaded)(nil)
+
+func NewStateMutatorSingleThreaded(state *singlethreaded.State) testutil.StateMutator {
+	return &StateMutatorSingleThreaded{state: state}
+}
+
+func (m *StateMutatorSingleThreaded) SetPC(val uint32) {
+	m.state.Cpu.PC = val
+}
+
+func (m *StateMutatorSingleThreaded) SetNextPC(val uint32) {
+	m.state.Cpu.NextPC = val
+}
+
+func (m *StateMutatorSingleThreaded) SetHI(val uint32) {
+	m.state.Cpu.HI = val
+}
+
+func (m *StateMutatorSingleThreaded) SetLO(val uint32) {
+	m.state.Cpu.LO = val
+}
+
+func (m *StateMutatorSingleThreaded) SetHeap(val uint32) {
+	m.state.Heap = val
+}
+
+func (m *StateMutatorSingleThreaded) SetExitCode(val uint8) {
+	m.state.ExitCode = val
+}
+
+func (m *StateMutatorSingleThreaded) SetExited(val bool) {
+	m.state.Exited = val
+}
+
+func (m *StateMutatorSingleThreaded) SetLastHint(val hexutil.Bytes) {
+	m.state.LastHint = val
+}
+
+func (m *StateMutatorSingleThreaded) SetPreimageKey(val common.Hash) {
+	m.state.PreimageKey = val
+}
+
+func (m *StateMutatorSingleThreaded) SetPreimageOffset(val uint32) {
+	m.state.PreimageOffset = val
+}
+
+func (m *StateMutatorSingleThreaded) SetStep(val uint64) {
+	m.state.Step = val
+}

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -204,7 +204,6 @@ func TestEVM_MMap(t *testing.T) {
 				state := goVm.GetState()
 
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
-				*state.GetRegistersRef() = testutil.RandomRegisters(77)
 				state.GetRegistersRef()[2] = exec.SysMmap
 				state.GetRegistersRef()[4] = c.address
 				state.GetRegistersRef()[5] = c.size

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -138,7 +138,7 @@ func TestEVMSingleStep(t *testing.T) {
 		for _, tt := range cases {
 			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
 			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), WithPC(tt.pc), WithNextPC(tt.nextPC))
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithPC(tt.pc), testutil.WithNextPC(tt.nextPC))
 				state := goVm.GetState()
 				state.GetMemory().SetMemory(tt.pc, tt.insn)
 				curStep := state.GetStep()
@@ -186,7 +186,7 @@ func TestEVM_MMap(t *testing.T) {
 		for _, c := range cases {
 			testName := fmt.Sprintf("%v (%v)", c.name, v.Name)
 			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), WithHeap(c.heap))
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithHeap(c.heap))
 				state := goVm.GetState()
 
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
@@ -397,7 +397,7 @@ func TestEVMSysWriteHint(t *testing.T) {
 			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
 			t.Run(testName, func(t *testing.T) {
 				oracle := hintTrackingOracle{}
-				goVm := v.VMFactory(&oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), WithLastHint(tt.lastHint))
+				goVm := v.VMFactory(&oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithLastHint(tt.lastHint))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysWrite
 				state.GetRegistersRef()[4] = exec.FdHintWrite
@@ -448,7 +448,7 @@ func TestEVMFault(t *testing.T) {
 				env, evmState := testutil.NewEVMEnv(v.Contracts)
 				env.Config.Tracer = tracer
 
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), WithNextPC(tt.nextPC))
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithNextPC(tt.nextPC))
 				state := goVm.GetState()
 				state.GetMemory().SetMemory(0, tt.insn)
 				// set the return address ($ra) to jump into when test completes

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -285,7 +285,7 @@ func FuzzStatePreimageRead(f *testing.F) {
 				require.NoError(t, err)
 				require.True(t, stepWitness.HasPreimage())
 
-				// TODO - Do stricter validation of expected memory
+				// TODO(cp-983) - Do stricter validation of expected memory
 				expected.Validate(t, state, testutil.SkipMemoryValidation)
 				if writeLen == 0 {
 					// With a non-zero writeLen, we may not modify memory because the length prefix is just writing zeroes
@@ -309,7 +309,7 @@ func FuzzStateHintWrite(f *testing.F) {
 			t.Run(v.Name, func(t *testing.T) {
 				preimageData := []byte("hello world")
 				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
-				// TODO - use HintTrackingOracle
+				// TODO(cp-983) - use testutil.HintTrackingOracle, validate expected hints
 				oracle := testutil.StaticOracle(t, preimageData) // only used for hinting
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
@@ -339,7 +339,7 @@ func FuzzStateHintWrite(f *testing.F) {
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				// TODO - validate expected hints
+				// TODO(cp-983) - validate expected hints
 				expected.Validate(t, state, testutil.SkipHintValidation)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
@@ -388,7 +388,7 @@ func FuzzStatePreimageWrite(f *testing.F) {
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				// TODO - validate preimage key
+				// TODO(cp-983) - validate preimage key
 				expected.Validate(t, state, testutil.SkipPreimageKeyValidation)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -29,7 +29,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 				nextPC := pc + 4
 
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithPC(pc), WithNextPC(nextPC), WithStep(step), WithPreimageOffset(preimageOffset))
+					testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step), testutil.WithPreimageOffset(preimageOffset))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysBrk
 				state.GetMemory().SetMemory(pc, syscallInsn)
@@ -78,7 +78,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 			t.Run(v.Name, func(t *testing.T) {
 				step := uint64(0)
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithStep(step), WithHeap(heap))
+					testutil.WithStep(step), testutil.WithHeap(heap))
 				state := goVm.GetState()
 				*state.GetRegistersRef() = testutil.RandomRegisters(seed)
 				state.GetRegistersRef()[2] = exec.SysMmap
@@ -147,7 +147,7 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 				pc = pc & 0xFF_FF_FF_FC // align PC
 				nextPC := pc + 4
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithPC(pc), WithNextPC(nextPC), WithStep(step))
+					testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysExitGroup
 				state.GetRegistersRef()[4] = uint32(exitCode)
@@ -190,7 +190,7 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 			t.Run(v.Name, func(t *testing.T) {
 				step := uint64(0)
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithStep(step))
+					testutil.WithStep(step))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysFcntl
 				state.GetRegistersRef()[4] = fd
@@ -255,7 +255,7 @@ func FuzzStateHintRead(f *testing.F) {
 				oracle := testutil.StaticOracle(t, preimageData) // only used for hinting
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithStep(step), WithPreimageKey(preimageKey))
+					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysRead
 				state.GetRegistersRef()[4] = exec.FdHintRead
@@ -308,7 +308,7 @@ func FuzzStatePreimageRead(f *testing.F) {
 				oracle := testutil.StaticOracle(t, preimageData)
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithStep(step), WithPreimageKey(preimageKey), WithPreimageOffset(preimageOffset))
+					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(preimageOffset))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysRead
 				state.GetRegistersRef()[4] = exec.FdPreimageRead
@@ -369,7 +369,7 @@ func FuzzStateHintWrite(f *testing.F) {
 				oracle := testutil.StaticOracle(t, preimageData) // only used for hinting
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithStep(step), WithPreimageKey(preimageKey))
+					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysWrite
 				state.GetRegistersRef()[4] = exec.FdHintWrite
@@ -426,7 +426,7 @@ func FuzzStatePreimageWrite(f *testing.F) {
 				oracle := testutil.StaticOracle(t, preimageData)
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					WithStep(step), WithPreimageKey(preimageKey), WithPreimageOffset(128))
+					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(128))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysWrite
 				state.GetRegistersRef()[4] = exec.FdPreimageWrite

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"math/rand"
 	"os"
 	"testing"
 
@@ -22,38 +21,27 @@ const syscallInsn = uint32(0x00_00_00_0c)
 
 func FuzzStateSyscallBrk(f *testing.F) {
 	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, pc uint32, step uint64, preimageOffset uint32) {
+	f.Fuzz(func(t *testing.T, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				pc = pc & 0xFF_FF_FF_FC // align PC
-				nextPC := pc + 4
-
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step), testutil.WithPreimageOffset(preimageOffset))
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysBrk
-				state.GetMemory().SetMemory(pc, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+				step := state.GetStep()
 
-				preStateRoot := state.GetMemory().MerkleRoot()
-				expectedRegisters := testutil.CopyRegisters(state)
-				expectedRegisters[2] = program.PROGRAM_BREAK
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
+				expected.Registers[2] = program.PROGRAM_BREAK // Return fixed BRK value
+				expected.Registers[7] = 0                     // No error
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				require.Equal(t, pc+4, state.GetPC())
-				require.Equal(t, nextPC+4, state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, expectedRegisters, state.GetRegistersRef())
-				require.Equal(t, step+1, state.GetStep())
-				require.Equal(t, common.Hash{}, state.GetPreimageKey())
-				require.Equal(t, preimageOffset, state.GetPreimageOffset())
+				expected.Validate(t, state)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -76,25 +64,20 @@ func FuzzStateSyscallMmap(f *testing.F) {
 	f.Fuzz(func(t *testing.T, addr uint32, siz uint32, heap uint32, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				step := uint64(0)
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithStep(step), testutil.WithHeap(heap))
+					testutil.WithRandomization(seed), testutil.WithHeap(heap))
 				state := goVm.GetState()
-				*state.GetRegistersRef() = testutil.RandomRegisters(seed)
+				step := state.GetStep()
+
 				state.GetRegistersRef()[2] = exec.SysMmap
 				state.GetRegistersRef()[4] = addr
 				state.GetRegistersRef()[5] = siz
-				state.GetMemory().SetMemory(0, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
 
-				preStateRoot := state.GetMemory().MerkleRoot()
-				preStateRegisters := testutil.CopyRegisters(state)
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				var expectedHeap uint32
-				expectedRegisters := preStateRegisters
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
 				if addr == 0 {
 					sizAlign := siz
 					if sizAlign&memory.PageAddrMask != 0 { // adjust size to align with page size
@@ -102,32 +85,23 @@ func FuzzStateSyscallMmap(f *testing.F) {
 					}
 					newHeap := heap + sizAlign
 					if newHeap > program.HEAP_END || newHeap < heap || sizAlign < siz {
-						expectedHeap = heap
-						expectedRegisters[2] = exec.SysErrorSignal
-						expectedRegisters[7] = exec.MipsEINVAL
+						expected.Registers[2] = exec.SysErrorSignal
+						expected.Registers[7] = exec.MipsEINVAL
 					} else {
-						expectedRegisters[2] = heap
-						expectedRegisters[7] = 0 // no error
-						expectedHeap = heap + sizAlign
+						expected.Heap = heap + sizAlign
+						expected.Registers[2] = heap
+						expected.Registers[7] = 0 // no error
 					}
 				} else {
-					expectedRegisters[2] = addr
-					expectedRegisters[7] = 0 // no error
-					expectedHeap = heap
+					expected.Registers[2] = addr
+					expected.Registers[7] = 0 // no error
 				}
 
-				require.Equal(t, uint32(4), state.GetCpu().PC)
-				require.Equal(t, uint32(8), state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, uint64(1), state.GetStep())
-				require.Equal(t, common.Hash{}, state.GetPreimageKey())
-				require.Equal(t, uint32(0), state.GetPreimageOffset())
-				require.Equal(t, expectedHeap, state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				require.Equal(t, expectedRegisters, state.GetRegistersRef())
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+				require.False(t, stepWitness.HasPreimage())
+
+				expected.Validate(t, state)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -141,37 +115,27 @@ func FuzzStateSyscallMmap(f *testing.F) {
 
 func FuzzStateSyscallExitGroup(f *testing.F) {
 	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, exitCode uint8, pc uint32, step uint64) {
+	f.Fuzz(func(t *testing.T, exitCode uint8, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				pc = pc & 0xFF_FF_FF_FC // align PC
-				nextPC := pc + 4
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step))
+					testutil.WithRandomization(seed))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysExitGroup
 				state.GetRegistersRef()[4] = uint32(exitCode)
-				state.GetMemory().SetMemory(pc, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+				step := state.GetStep()
 
-				preStateRoot := state.GetMemory().MerkleRoot()
-				preStateRegisters := testutil.CopyRegisters(state)
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.Exited = true
+				expected.ExitCode = exitCode
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				require.Equal(t, pc, state.GetCpu().PC)
-				require.Equal(t, nextPC, state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(exitCode), state.GetExitCode())
-				require.Equal(t, true, state.GetExited())
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, preStateRegisters, state.GetRegistersRef())
-				require.Equal(t, step+1, state.GetStep())
-				require.Equal(t, common.Hash{}, state.GetPreimageKey())
-				require.Equal(t, uint32(0), state.GetPreimageOffset())
+				expected.Validate(t, state)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -185,54 +149,44 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 
 func FuzzStateSyscallFcntl(f *testing.F) {
 	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, fd uint32, cmd uint32) {
+	f.Fuzz(func(t *testing.T, fd uint32, cmd uint32, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				step := uint64(0)
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithStep(step))
+					testutil.WithRandomization(seed))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysFcntl
 				state.GetRegistersRef()[4] = fd
 				state.GetRegistersRef()[5] = cmd
-				state.GetMemory().SetMemory(0, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+				step := state.GetStep()
 
-				preStateRoot := state.GetMemory().MerkleRoot()
-				preStateRegisters := testutil.CopyRegisters(state)
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
+				if cmd == 3 {
+					switch fd {
+					case exec.FdStdin, exec.FdPreimageRead, exec.FdHintRead:
+						expected.Registers[2] = 0
+						expected.Registers[7] = 0
+					case exec.FdStdout, exec.FdStderr, exec.FdPreimageWrite, exec.FdHintWrite:
+						expected.Registers[2] = 1
+						expected.Registers[7] = 0
+					default:
+						expected.Registers[2] = 0xFF_FF_FF_FF
+						expected.Registers[7] = exec.MipsEBADF
+					}
+				} else {
+					expected.Registers[2] = 0xFF_FF_FF_FF
+					expected.Registers[7] = exec.MipsEINVAL
+				}
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				require.Equal(t, uint32(4), state.GetCpu().PC)
-				require.Equal(t, uint32(8), state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, uint64(1), state.GetStep())
-				require.Equal(t, common.Hash{}, state.GetPreimageKey())
-				require.Equal(t, uint32(0), state.GetPreimageOffset())
-				if cmd == 3 {
-					expectedRegisters := preStateRegisters
-					switch fd {
-					case exec.FdStdin, exec.FdPreimageRead, exec.FdHintRead:
-						expectedRegisters[2] = 0
-					case exec.FdStdout, exec.FdStderr, exec.FdPreimageWrite, exec.FdHintWrite:
-						expectedRegisters[2] = 1
-					default:
-						expectedRegisters[2] = 0xFF_FF_FF_FF
-						expectedRegisters[7] = exec.MipsEBADF
-					}
-					require.Equal(t, expectedRegisters, state.GetRegistersRef())
-				} else {
-					expectedRegisters := preStateRegisters
-					expectedRegisters[2] = 0xFF_FF_FF_FF
-					expectedRegisters[7] = exec.MipsEINVAL
-					require.Equal(t, expectedRegisters, state.GetRegistersRef())
-				}
+				expected.Validate(t, state)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -246,43 +200,35 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 
 func FuzzStateHintRead(f *testing.F) {
 	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr uint32, count uint32) {
+	f.Fuzz(func(t *testing.T, addr uint32, count uint32, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				step := uint64(0)
 				preimageData := []byte("hello world")
 				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
 				oracle := testutil.StaticOracle(t, preimageData) // only used for hinting
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey))
+					testutil.WithRandomization(seed), testutil.WithPreimageKey(preimageKey))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysRead
 				state.GetRegistersRef()[4] = exec.FdHintRead
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
-				state.GetMemory().SetMemory(0, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+				step := state.GetStep()
 
-				preStatePreimageKey := state.GetPreimageKey()
-				preStateRoot := state.GetMemory().MerkleRoot()
-				expectedRegisters := testutil.CopyRegisters(state)
-				expectedRegisters[2] = count
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
+				expected.Registers[2] = count
+				expected.Registers[7] = 0 // no error
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				require.Equal(t, uint32(4), state.GetCpu().PC)
-				require.Equal(t, uint32(8), state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, uint64(1), state.GetStep())
-				require.Equal(t, preStatePreimageKey, state.GetPreimageKey())
-				require.Equal(t, expectedRegisters, state.GetRegistersRef())
+				expected.Validate(t, state)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -296,57 +242,55 @@ func FuzzStateHintRead(f *testing.F) {
 
 func FuzzStatePreimageRead(f *testing.F) {
 	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr uint32, count uint32, preimageOffset uint32) {
+	f.Fuzz(func(t *testing.T, addr uint32, count uint32, preimageOffset uint32, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				step := uint64(0)
-				preimageData := []byte("hello world")
-				if preimageOffset >= uint32(len(preimageData)) {
+				preimageValue := []byte("hello world")
+				if preimageOffset >= uint32(len(preimageValue)) {
 					t.SkipNow()
 				}
-				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
-				oracle := testutil.StaticOracle(t, preimageData)
+				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
+				oracle := testutil.StaticOracle(t, preimageValue)
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(preimageOffset))
+					testutil.WithRandomization(seed), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(preimageOffset))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysRead
 				state.GetRegistersRef()[4] = exec.FdPreimageRead
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
-				state.GetMemory().SetMemory(0, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+				step := state.GetStep()
 
-				preStatePreimageKey := state.GetPreimageKey()
-				preStateRoot := state.GetMemory().MerkleRoot()
-				writeLen := count
-				if writeLen > 4 {
-					writeLen = 4
+				alignment := addr & 3
+				writeLen := 4 - alignment
+				if count < writeLen {
+					writeLen = count
 				}
-				if preimageOffset+writeLen > uint32(8+len(preimageData)) {
-					writeLen = uint32(8+len(preimageData)) - preimageOffset
+				// Cap write length to remaining bytes of the preimage
+				preimageDataLen := uint32(len(preimageValue) + 8) // Data len includes a length prefix
+				if preimageOffset+writeLen > preimageDataLen {
+					writeLen = preimageDataLen - preimageOffset
 				}
+
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
+				expected.Registers[2] = writeLen
+				expected.Registers[7] = 0 // no error
+				expected.PreimageOffset += writeLen
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.True(t, stepWitness.HasPreimage())
 
-				require.Equal(t, uint32(4), state.GetCpu().PC)
-				require.Equal(t, uint32(8), state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				if writeLen > 0 {
-					// Memory may be unchanged if we're writing the first zero-valued 7 bytes of the pre-image.
-					//require.NotEqual(t, preStateRoot, state.GetMemory().MerkleRoot())
-					require.Greater(t, state.GetPreimageOffset(), preimageOffset)
-				} else {
-					require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-					require.Equal(t, state.GetPreimageOffset(), preimageOffset)
+				// TODO - Do stricter validation of expected memory
+				expected.Validate(t, state, testutil.SkipMemoryValidation)
+				if writeLen == 0 {
+					// With a non-zero writeLen, we may not modify memory because the length prefix is just writing zeroes
+					require.Equal(t, expected.MemoryRoot, common.Hash(state.GetMemory().MerkleRoot()))
 				}
-				require.Equal(t, uint64(1), state.GetStep())
-				require.Equal(t, preStatePreimageKey, state.GetPreimageKey())
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -363,47 +307,40 @@ func FuzzStateHintWrite(f *testing.F) {
 	f.Fuzz(func(t *testing.T, addr uint32, count uint32, randSeed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				step := uint64(0)
 				preimageData := []byte("hello world")
 				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
+				// TODO - use HintTrackingOracle
 				oracle := testutil.StaticOracle(t, preimageData) // only used for hinting
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey))
+					testutil.WithRandomization(randSeed), testutil.WithPreimageKey(preimageKey))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysWrite
 				state.GetRegistersRef()[4] = exec.FdHintWrite
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
+				step := state.GetStep()
 
 				// Set random data at the target memory range
-				randBytes, err := randomBytes(randSeed, count)
+				randBytes := testutil.RandomBytes(t, randSeed, count)
+				err := state.GetMemory().SetMemoryRange(addr, bytes.NewReader(randBytes))
 				require.NoError(t, err)
-				err = state.GetMemory().SetMemoryRange(addr, bytes.NewReader(randBytes))
-				require.NoError(t, err)
-				// Set syscall instruction
-				state.GetMemory().SetMemory(0, syscallInsn)
+				// Set instruction
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
 
-				preStatePreimageKey := state.GetPreimageKey()
-				preStateRoot := state.GetMemory().MerkleRoot()
-				expectedRegisters := testutil.CopyRegisters(state)
-				expectedRegisters[2] = count
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
+				expected.Registers[2] = count
+				expected.Registers[7] = 0 // no error
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				require.Equal(t, uint32(4), state.GetCpu().PC)
-				require.Equal(t, uint32(8), state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, uint64(1), state.GetStep())
-				require.Equal(t, preStatePreimageKey, state.GetPreimageKey())
-				require.Equal(t, expectedRegisters, state.GetRegistersRef())
+				// TODO - validate expected hints
+				expected.Validate(t, state, testutil.SkipHintValidation)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -417,46 +354,42 @@ func FuzzStateHintWrite(f *testing.F) {
 
 func FuzzStatePreimageWrite(f *testing.F) {
 	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr uint32, count uint32) {
+	f.Fuzz(func(t *testing.T, addr uint32, count uint32, seed int64) {
 		for _, v := range versions {
 			t.Run(v.Name, func(t *testing.T) {
-				step := uint64(0)
 				preimageData := []byte("hello world")
 				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
 				oracle := testutil.StaticOracle(t, preimageData)
 
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					testutil.WithStep(step), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(128))
+					testutil.WithRandomization(seed), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(128))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = exec.SysWrite
 				state.GetRegistersRef()[4] = exec.FdPreimageWrite
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
-				state.GetMemory().SetMemory(0, syscallInsn)
+				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+				step := state.GetStep()
 
-				preStateRoot := state.GetMemory().MerkleRoot()
-				expectedRegisters := testutil.CopyRegisters(state)
 				sz := 4 - (addr & 0x3)
 				if sz < count {
 					count = sz
 				}
-				expectedRegisters[2] = count
+
+				expected := testutil.CreateExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = state.GetCpu().NextPC + 4
+				expected.PreimageOffset = 0
+				expected.Registers[2] = count
+				expected.Registers[7] = 0 // No error
 
 				stepWitness, err := goVm.Step(true)
 				require.NoError(t, err)
 				require.False(t, stepWitness.HasPreimage())
 
-				require.Equal(t, uint32(4), state.GetCpu().PC)
-				require.Equal(t, uint32(8), state.GetCpu().NextPC)
-				require.Equal(t, uint32(0), state.GetCpu().LO)
-				require.Equal(t, uint32(0), state.GetCpu().HI)
-				require.Equal(t, uint32(0), state.GetHeap())
-				require.Equal(t, uint8(0), state.GetExitCode())
-				require.Equal(t, false, state.GetExited())
-				require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-				require.Equal(t, uint64(1), state.GetStep())
-				require.Equal(t, uint32(0), state.GetPreimageOffset())
-				require.Equal(t, expectedRegisters, state.GetRegistersRef())
+				// TODO - validate preimage key
+				expected.Validate(t, state, testutil.SkipPreimageKeyValidation)
 
 				evm := testutil.NewMIPSEVM(v.Contracts)
 				evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)
@@ -466,13 +399,4 @@ func FuzzStatePreimageWrite(f *testing.F) {
 			})
 		}
 	})
-}
-
-func randomBytes(seed int64, length uint32) ([]byte, error) {
-	r := rand.New(rand.NewSource(seed))
-	randBytes := make([]byte, length)
-	if _, err := r.Read(randBytes); err != nil {
-		return nil, err
-	}
-	return randBytes, nil
 }

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -288,7 +288,8 @@ func FuzzStatePreimageRead(f *testing.F) {
 				// TODO(cp-983) - Do stricter validation of expected memory
 				expected.Validate(t, state, testutil.SkipMemoryValidation)
 				if writeLen == 0 {
-					// With a non-zero writeLen, we may not modify memory because the length prefix is just writing zeroes
+					// Note: We are not asserting a memory root change when writeLen > 0 because we may not necessarily
+					// modify memory - it's possible we just write the leading zero bytes of the length prefix
 					require.Equal(t, expected.MemoryRoot, common.Hash(state.GetMemory().MerkleRoot()))
 				}
 

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 
@@ -17,37 +16,27 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 	v := GetMultiThreadedTestCase(f)
 	// t.Skip is causing linting check to fail, disable for now
 	//nolint:staticcheck
-	f.Fuzz(func(t *testing.T, pc uint32, step uint64, preimageOffset uint32) {
+	f.Fuzz(func(t *testing.T, seed int64) {
 		// TODO(cp-903) Customize test for multi-threaded vm
 		t.Skip("TODO - customize this test for MTCannon")
-		pc = pc & 0xFF_FF_FF_FC // align PC
-		nextPC := pc + 4
-		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-			testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step), testutil.WithPreimageOffset(preimageOffset))
+		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 		state := goVm.GetState()
 		state.GetRegistersRef()[2] = exec.SysClone
+		state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+		step := state.GetStep()
 
-		state.GetMemory().SetMemory(pc, syscallInsn)
-		preStateRoot := state.GetMemory().MerkleRoot()
-		expectedRegisters := testutil.CopyRegisters(state)
-		expectedRegisters[2] = 0x1
+		expected := testutil.CreateExpectedState(state)
+		expected.Step += 1
+		expected.PC = state.GetCpu().NextPC
+		expected.NextPC = state.GetCpu().NextPC + 4
+		expected.Registers[2] = 0x1
+		expected.Registers[7] = 0
 
 		stepWitness, err := goVm.Step(true)
 		require.NoError(t, err)
 		require.False(t, stepWitness.HasPreimage())
 
-		require.Equal(t, pc+4, state.GetCpu().PC)
-		require.Equal(t, nextPC+4, state.GetCpu().NextPC)
-		require.Equal(t, uint32(0), state.GetCpu().LO)
-		require.Equal(t, uint32(0), state.GetCpu().HI)
-		require.Equal(t, uint32(0), state.GetHeap())
-		require.Equal(t, uint8(0), state.GetExitCode())
-		require.Equal(t, false, state.GetExited())
-		require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-		require.Equal(t, expectedRegisters, state.GetRegistersRef())
-		require.Equal(t, step+1, state.GetStep())
-		require.Equal(t, common.Hash{}, state.GetPreimageKey())
-		require.Equal(t, preimageOffset, state.GetPreimageOffset())
+		expected.Validate(t, state)
 
 		evm := testutil.NewMIPSEVM(v.Contracts)
 		evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -23,7 +23,7 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 		pc = pc & 0xFF_FF_FF_FC // align PC
 		nextPC := pc + 4
 		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-			WithPC(pc), WithNextPC(nextPC), WithStep(step), WithPreimageOffset(preimageOffset))
+			testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step), testutil.WithPreimageOffset(preimageOffset))
 		state := goVm.GetState()
 		state.GetRegistersRef()[2] = exec.SysClone
 

--- a/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
@@ -18,7 +18,7 @@ func FuzzStateSyscallCloneST(f *testing.F) {
 		pc = pc & 0xFF_FF_FF_FC // align PC
 		nextPC := pc + 4
 		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-			WithPC(pc), WithNextPC(nextPC), WithStep(step), WithPreimageOffset(preimageOffset))
+			testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step), testutil.WithPreimageOffset(preimageOffset))
 		state := goVm.GetState()
 		state.GetRegistersRef()[2] = exec.SysClone
 

--- a/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 
@@ -14,35 +13,25 @@ import (
 
 func FuzzStateSyscallCloneST(f *testing.F) {
 	v := GetSingleThreadedTestCase(f)
-	f.Fuzz(func(t *testing.T, pc uint32, step uint64, preimageOffset uint32) {
-		pc = pc & 0xFF_FF_FF_FC // align PC
-		nextPC := pc + 4
-		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-			testutil.WithPC(pc), testutil.WithNextPC(nextPC), testutil.WithStep(step), testutil.WithPreimageOffset(preimageOffset))
+	f.Fuzz(func(t *testing.T, seed int64) {
+		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 		state := goVm.GetState()
 		state.GetRegistersRef()[2] = exec.SysClone
+		state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
+		step := state.GetStep()
 
-		state.GetMemory().SetMemory(pc, syscallInsn)
-		preStateRoot := state.GetMemory().MerkleRoot()
-		expectedRegisters := testutil.CopyRegisters(state)
-		expectedRegisters[2] = 0x1
+		expected := testutil.CreateExpectedState(state)
+		expected.Step += 1
+		expected.PC = state.GetCpu().NextPC
+		expected.NextPC = state.GetCpu().NextPC + 4
+		expected.Registers[2] = 0x1
+		expected.Registers[7] = 0
 
 		stepWitness, err := goVm.Step(true)
 		require.NoError(t, err)
 		require.False(t, stepWitness.HasPreimage())
 
-		require.Equal(t, pc+4, state.GetCpu().PC)
-		require.Equal(t, nextPC+4, state.GetCpu().NextPC)
-		require.Equal(t, uint32(0), state.GetCpu().LO)
-		require.Equal(t, uint32(0), state.GetCpu().HI)
-		require.Equal(t, uint32(0), state.GetHeap())
-		require.Equal(t, uint8(0), state.GetExitCode())
-		require.Equal(t, false, state.GetExited())
-		require.Equal(t, preStateRoot, state.GetMemory().MerkleRoot())
-		require.Equal(t, expectedRegisters, state.GetRegistersRef())
-		require.Equal(t, step+1, state.GetStep())
-		require.Equal(t, common.Hash{}, state.GetPreimageKey())
-		require.Equal(t, preimageOffset, state.GetPreimageOffset())
+		expected.Validate(t, state)
 
 		evm := testutil.NewMIPSEVM(v.Contracts)
 		evmPost := evm.Step(t, stepWitness, step, v.StateHashFn)

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -3,155 +3,31 @@ package tests
 import (
 	"io"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
+	testutil3 "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
+	testutil2 "github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
-type StateMutator interface {
-	SetPC(pc uint32)
-	SetNextPC(nextPC uint32)
-	SetHeap(addr uint32)
-	SetLastHint(lastHint hexutil.Bytes)
-	SetPreimageKey(key common.Hash)
-	SetPreimageOffset(offset uint32)
-	SetStep(step uint64)
-}
+type VMFactory func(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM
 
-type singlethreadedMutator struct {
-	state *singlethreaded.State
-}
-
-var _ StateMutator = (*singlethreadedMutator)(nil)
-
-func (m *singlethreadedMutator) SetPC(pc uint32) {
-	m.state.Cpu.PC = pc
-}
-
-func (m *singlethreadedMutator) SetNextPC(nextPC uint32) {
-	m.state.Cpu.NextPC = nextPC
-}
-
-func (m *singlethreadedMutator) SetHeap(addr uint32) {
-	m.state.Heap = addr
-}
-
-func (m *singlethreadedMutator) SetLastHint(lastHint hexutil.Bytes) {
-	m.state.LastHint = lastHint
-}
-
-func (m *singlethreadedMutator) SetPreimageKey(key common.Hash) {
-	m.state.PreimageKey = key
-}
-
-func (m *singlethreadedMutator) SetPreimageOffset(offset uint32) {
-	m.state.PreimageOffset = offset
-}
-
-func (m *singlethreadedMutator) SetStep(step uint64) {
-	m.state.Step = step
-}
-
-type multithreadedMutator struct {
-	state *multithreaded.State
-}
-
-var _ StateMutator = (*multithreadedMutator)(nil)
-
-func (m *multithreadedMutator) SetPC(pc uint32) {
-	thread := m.state.GetCurrentThread()
-	thread.Cpu.PC = pc
-}
-
-func (m *multithreadedMutator) SetHeap(addr uint32) {
-	m.state.Heap = addr
-}
-
-func (m *multithreadedMutator) SetNextPC(nextPC uint32) {
-	thread := m.state.GetCurrentThread()
-	thread.Cpu.NextPC = nextPC
-}
-
-func (m *multithreadedMutator) SetLastHint(lastHint hexutil.Bytes) {
-	m.state.LastHint = lastHint
-}
-
-func (m *multithreadedMutator) SetPreimageKey(key common.Hash) {
-	m.state.PreimageKey = key
-}
-
-func (m *multithreadedMutator) SetPreimageOffset(offset uint32) {
-	m.state.PreimageOffset = offset
-}
-
-func (m *multithreadedMutator) SetStep(step uint64) {
-	m.state.Step = step
-}
-
-type VMOption func(vm StateMutator)
-
-func WithPC(pc uint32) VMOption {
-	return func(state StateMutator) {
-		state.SetPC(pc)
-	}
-}
-
-func WithNextPC(nextPC uint32) VMOption {
-	return func(state StateMutator) {
-		state.SetNextPC(nextPC)
-	}
-}
-
-func WithHeap(addr uint32) VMOption {
-	return func(state StateMutator) {
-		state.SetHeap(addr)
-	}
-}
-
-func WithLastHint(lastHint hexutil.Bytes) VMOption {
-	return func(state StateMutator) {
-		state.SetLastHint(lastHint)
-	}
-}
-
-func WithPreimageKey(key common.Hash) VMOption {
-	return func(state StateMutator) {
-		state.SetPreimageKey(key)
-	}
-}
-
-func WithPreimageOffset(offset uint32) VMOption {
-	return func(state StateMutator) {
-		state.SetPreimageOffset(offset)
-	}
-}
-
-func WithStep(step uint64) VMOption {
-	return func(state StateMutator) {
-		state.SetStep(step)
-	}
-}
-
-type VMFactory func(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...VMOption) mipsevm.FPVM
-
-func singleThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...VMOption) mipsevm.FPVM {
+func singleThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM {
 	state := singlethreaded.CreateEmptyState()
-	mutator := &singlethreadedMutator{state: state}
+	mutator := testutil2.NewStateMutatorSingleThreaded(state)
 	for _, opt := range opts {
 		opt(mutator)
 	}
 	return singlethreaded.NewInstrumentedState(state, po, stdOut, stdErr, nil)
 }
 
-func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...VMOption) mipsevm.FPVM {
+func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM {
 	state := multithreaded.CreateEmptyState()
-	mutator := &multithreadedMutator{state: state}
+	mutator := testutil3.NewStateMutatorMultiThreaded(state)
 	for _, opt := range opts {
 		opt(mutator)
 	}

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
-	testutil3 "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
+	mttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
-	testutil2 "github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded/testutil"
+	sttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
@@ -18,7 +18,7 @@ type VMFactory func(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log
 
 func singleThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM {
 	state := singlethreaded.CreateEmptyState()
-	mutator := testutil2.NewStateMutatorSingleThreaded(state)
+	mutator := sttestutil.NewStateMutatorSingleThreaded(state)
 	for _, opt := range opts {
 		opt(mutator)
 	}
@@ -27,7 +27,7 @@ func singleThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer
 
 func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM {
 	state := multithreaded.CreateEmptyState()
-	mutator := testutil3.NewStateMutatorMultiThreaded(state)
+	mutator := mttestutil.NewStateMutatorMultiThreaded(state)
 	for _, opt := range opts {
 		opt(mutator)
 	}

--- a/cannon/mipsevm/testutil/oracle.go
+++ b/cannon/mipsevm/testutil/oracle.go
@@ -145,3 +145,19 @@ func SelectOracleFixture(t *testing.T, programName string) mipsevm.PreimageOracl
 		return nil
 	}
 }
+
+type HintTrackingOracle struct {
+	hints [][]byte
+}
+
+func (t *HintTrackingOracle) Hint(v []byte) {
+	t.hints = append(t.hints, v)
+}
+
+func (t *HintTrackingOracle) GetPreimage(k [32]byte) []byte {
+	return nil
+}
+
+func (t *HintTrackingOracle) Hints() [][]byte {
+	return t.hints
+}

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -1,11 +1,16 @@
 package testutil
 
 import (
+	"fmt"
 	"math/rand"
+	"slices"
+	"testing"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 )
 
 func RandomRegisters(seed int64) [32]uint32 {
@@ -35,6 +40,7 @@ type StateMutator interface {
 	SetExited(val bool)
 	SetStep(val uint64)
 	SetLastHint(val hexutil.Bytes)
+	GetRegistersRef() *[32]uint32
 }
 
 type StateOption func(state StateMutator)
@@ -79,4 +85,139 @@ func WithStep(step uint64) StateOption {
 	return func(state StateMutator) {
 		state.SetStep(step)
 	}
+}
+
+func WithRandomization(seed int64) StateOption {
+	return func(mut StateMutator) {
+		RandomizeState(seed, mut)
+	}
+}
+
+func RandomizeState(seed int64, mut StateMutator) {
+	r := rand.New(rand.NewSource(seed))
+
+	// Memory-align random pc and leave room for nextPC
+	pc := r.Uint32() & 0xFF_FF_FF_FC // Align address
+	if pc >= 0xFF_FF_FF_FC {
+		// Leave room to set and then increment nextPC
+		pc = 0xFF_FF_FF_FC - 8
+	}
+
+	// Set random step, but leave room to increment
+	step := r.Uint64()
+	if step == ^uint64(0) {
+		step -= 1
+	}
+
+	mut.SetPreimageKey(randHash(r))
+	mut.SetPreimageOffset(r.Uint32())
+	mut.SetPC(pc)
+	mut.SetNextPC(pc + 4)
+	mut.SetHI(r.Uint32())
+	mut.SetLO(r.Uint32())
+	mut.SetHeap(r.Uint32())
+	mut.SetStep(step)
+	mut.SetLastHint(randHint(r))
+	*mut.GetRegistersRef() = *randRegisters(r)
+}
+
+type ExpectedState struct {
+	PreimageKey    common.Hash
+	PreimageOffset uint32
+	PC             uint32
+	NextPC         uint32
+	HI             uint32
+	LO             uint32
+	Heap           uint32
+	ExitCode       uint8
+	Exited         bool
+	Step           uint64
+	LastHint       hexutil.Bytes
+	Registers      [32]uint32
+	MemoryRoot     common.Hash
+}
+
+func CreateExpectedState(fromState mipsevm.FPVMState) *ExpectedState {
+	return &ExpectedState{
+		PreimageKey:    fromState.GetPreimageKey(),
+		PreimageOffset: fromState.GetPreimageOffset(),
+		PC:             fromState.GetPC(),
+		NextPC:         fromState.GetCpu().NextPC,
+		HI:             fromState.GetCpu().HI,
+		LO:             fromState.GetCpu().LO,
+		Heap:           fromState.GetHeap(),
+		ExitCode:       fromState.GetExitCode(),
+		Exited:         fromState.GetExited(),
+		Step:           fromState.GetStep(),
+		LastHint:       fromState.GetLastHint(),
+		Registers:      *fromState.GetRegistersRef(),
+		MemoryRoot:     fromState.GetMemory().MerkleRoot(),
+	}
+}
+
+type StateValidationFlags int
+
+const (
+	SkipMemoryValidation StateValidationFlags = iota
+	SkipHintValidation
+	SkipPreimageKeyValidation
+)
+
+func (e *ExpectedState) Validate(t testing.TB, actualState mipsevm.FPVMState, flags ...StateValidationFlags) {
+	if !slices.Contains(flags, SkipPreimageKeyValidation) {
+		require.Equal(t, e.PreimageKey, actualState.GetPreimageKey(), fmt.Sprintf("Expect preimageKey = %v", e.PreimageKey))
+	}
+	require.Equal(t, e.PreimageOffset, actualState.GetPreimageOffset(), fmt.Sprintf("Expect preimageOffset = %v", e.PreimageOffset))
+	require.Equal(t, e.PC, actualState.GetCpu().PC, fmt.Sprintf("Expect PC = 0x%x", e.PC))
+	require.Equal(t, e.NextPC, actualState.GetCpu().NextPC, fmt.Sprintf("Expect nextPC = 0x%x", e.NextPC))
+	require.Equal(t, e.HI, actualState.GetCpu().HI, fmt.Sprintf("Expect HI = 0x%x", e.HI))
+	require.Equal(t, e.LO, actualState.GetCpu().LO, fmt.Sprintf("Expect LO = 0x%x", e.LO))
+	require.Equal(t, e.Heap, actualState.GetHeap(), fmt.Sprintf("Expect heap = 0x%x", e.Heap))
+	require.Equal(t, e.ExitCode, actualState.GetExitCode(), fmt.Sprintf("Expect exitCode = 0x%x", e.ExitCode))
+	require.Equal(t, e.Exited, actualState.GetExited(), fmt.Sprintf("Expect exited = %v", e.Exited))
+	require.Equal(t, e.Step, actualState.GetStep(), fmt.Sprintf("Expect step = %d", e.Step))
+	if !slices.Contains(flags, SkipHintValidation) {
+		require.Equal(t, e.LastHint, actualState.GetLastHint(), fmt.Sprintf("Expect lastHint = %v", e.LastHint))
+	}
+	require.Equal(t, e.Registers, *actualState.GetRegistersRef(), fmt.Sprintf("Expect registers = %v", e.Registers))
+	if !slices.Contains(flags, SkipMemoryValidation) {
+		require.Equal(t, e.MemoryRoot, common.Hash(actualState.GetMemory().MerkleRoot()), fmt.Sprintf("Expect memory root = %v", e.MemoryRoot))
+	}
+}
+
+func randHash(r *rand.Rand) common.Hash {
+	var bytes [32]byte
+	_, err := r.Read(bytes[:])
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}
+
+func randHint(r *rand.Rand) []byte {
+	count := r.Intn(10)
+
+	bytes := make([]byte, count)
+	_, err := r.Read(bytes[:])
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}
+
+func randRegisters(r *rand.Rand) *[32]uint32 {
+	registers := new([32]uint32)
+	for i := 0; i < 32; i++ {
+		registers[i] = r.Uint32()
+	}
+	return registers
+}
+
+func RandomBytes(t require.TestingT, seed int64, length uint32) []byte {
+	r := rand.New(rand.NewSource(seed))
+	randBytes := make([]byte, length)
+	if _, err := r.Read(randBytes); err != nil {
+		require.NoError(t, err)
+	}
+	return randBytes
 }

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func RandomRegisters(seed int64) [32]uint32 {
@@ -19,4 +21,62 @@ func CopyRegisters(state mipsevm.FPVMState) *[32]uint32 {
 	copy := new([32]uint32)
 	*copy = *state.GetRegistersRef()
 	return copy
+}
+
+type StateMutator interface {
+	SetPreimageKey(val common.Hash)
+	SetPreimageOffset(val uint32)
+	SetPC(val uint32)
+	SetNextPC(val uint32)
+	SetHI(val uint32)
+	SetLO(val uint32)
+	SetHeap(addr uint32)
+	SetExitCode(val uint8)
+	SetExited(val bool)
+	SetStep(val uint64)
+	SetLastHint(val hexutil.Bytes)
+}
+
+type StateOption func(state StateMutator)
+
+func WithPC(pc uint32) StateOption {
+	return func(state StateMutator) {
+		state.SetPC(pc)
+	}
+}
+
+func WithNextPC(nextPC uint32) StateOption {
+	return func(state StateMutator) {
+		state.SetNextPC(nextPC)
+	}
+}
+
+func WithHeap(addr uint32) StateOption {
+	return func(state StateMutator) {
+		state.SetHeap(addr)
+	}
+}
+
+func WithLastHint(lastHint hexutil.Bytes) StateOption {
+	return func(state StateMutator) {
+		state.SetLastHint(lastHint)
+	}
+}
+
+func WithPreimageKey(key common.Hash) StateOption {
+	return func(state StateMutator) {
+		state.SetPreimageKey(key)
+	}
+}
+
+func WithPreimageOffset(offset uint32) StateOption {
+	return func(state StateMutator) {
+		state.SetPreimageOffset(offset)
+	}
+}
+
+func WithStep(step uint64) StateOption {
+	return func(state StateMutator) {
+		state.SetStep(step)
+	}
 }

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -157,6 +157,7 @@ func CreateExpectedState(fromState mipsevm.FPVMState) *ExpectedState {
 
 type StateValidationFlags int
 
+// TODO(cp-983) - Remove these validation hacks
 const (
 	SkipMemoryValidation StateValidationFlags = iota
 	SkipHintValidation

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -13,15 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 )
 
-func RandomRegisters(seed int64) [32]uint32 {
-	r := rand.New(rand.NewSource(seed))
-	var registers [32]uint32
-	for i := 0; i < 32; i++ {
-		registers[i] = r.Uint32()
-	}
-	return registers
-}
-
 func CopyRegisters(state mipsevm.FPVMState) *[32]uint32 {
 	copy := new([32]uint32)
 	*copy = *state.GetRegistersRef()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR does a little bit of refactoring / cleanup and adds some new test utilities to make Cannon testing more robust and consistent.  

New utilities:
- Add an `ExpectedState` struct that:
  - Holds a set of expected values used to assert on a post-state
  - Is initialized with a pre-state, so that we need to explicitly modify any fields we expect to change
  - Provides a `Validate` method that will compare expectations with a provided post-state
- Add randomization utility:
  - Add a `WithRandomization(seed)` modifier that will randomize all fields on a state

Refactor:
- Move some utilities from `helpers.go` to `singlethreaded`, `multithreaded`, and `mipsevm` `testutil` packages to keep related code closer together / more reusable
- Move `HintTrackingOracle` logic to `testutil/oracle.go` for easier reuse

Remaining TODOs:
- https://github.com/ethereum-optimism/optimism/issues/11651
  - Created a follow-up ticket to address some remaining TODOs
  - Basically, implementing the new test utils revealed some tests that are not fully validating the post-state.  So need to do a bit more work on these tests to ensure we are fully validating expectations. 

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/11634
