### PR TITLE
contracts-bedrock: fix snapshots build

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -59,7 +59,7 @@ snapshots-abi-storage:
 
 snapshots: build snapshots-no-build
 
-snapshots-no-build: snapshots-abi-storage kontrol-summary-fp kontrol-summary
+snapshots-no-build: semver-lock snapshots-abi-storage kontrol-summary-fp kontrol-summary
 
 snapshots-check:
   ./scripts/checks/check-snapshots.sh


### PR DESCRIPTION
**Description**

Adds the semver lock task to `snapshots` to ensure there
is just 1 command that needs to be ran to generate all snapshots.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

