### PR TITLE
op-chain-ops/devkeys: util for organizing and deriving development keys

### DIFF
--- a/op-chain-ops/devkeys/devkeys.go
+++ b/op-chain-ops/devkeys/devkeys.go
@@ -1,0 +1,116 @@
+package devkeys
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Domain separates the usage of development keys by broad kind of usage.
+// E.g. a general user account, a L1 thing, a superchain thing, a L2 thing, etc.
+type Domain uint64
+
+const (
+	// DefaultKeyDomain is the domain for keys that get pre-funded in every chain.
+	// A 0 chain ID should be used for this domain.
+	DefaultKeyDomain Domain = 0
+	// L1OperatorKeyDomain is the domain for keys used in L1 ops
+	L1OperatorKeyDomain Domain = 1
+	// L1UserKeyDomain is the domain for pre-funded user accounts specific to L1
+	L1UserKeyDomain Domain = 2
+	// SuperchainKeyDomain is the domain for superchain contracts.
+	// The L1 chain ID should be used as chain ID for this domain.
+	SuperchainKeyDomain Domain = 3
+	// L2OperatorKeyDomain is the domain for L2 operator keys
+	L2OperatorKeyDomain Domain = 4
+	// L2UserKeyDomain is the domain for pre-funded L2 user accounts specific to a single L2
+	L2UserKeyDomain Domain = 5
+)
+
+func (d Domain) String() string {
+	switch d {
+	case DefaultKeyDomain:
+		return "default"
+	case L1OperatorKeyDomain:
+		return "l1-operator"
+	case L1UserKeyDomain:
+		return "l1-user"
+	case SuperchainKeyDomain:
+		return "superchain"
+	case L2OperatorKeyDomain:
+		return "l2-operator"
+	case L2UserKeyDomain:
+		return "l2-user"
+	default:
+		return fmt.Sprintf("unknown-domain-%d", uint64(d))
+	}
+}
+
+// Role separates the usage of development keys by exact role, within a Domain.
+// Some roles may not be applicable to every Domain, those can be ignored.
+type Role uint64
+
+const (
+	DeployerRole                   Role = 0
+	ProposerRole                   Role = 1
+	BatcherRole                    Role = 2
+	SequencerP2PRole               Role = 3
+	ChallengerRole                 Role = 4
+	ProxyAdminOwnerRole            Role = 5
+	SuperchainConfigGuardianRole   Role = 6
+	FinalSystemOwnerRole           Role = 7
+	BaseFeeVaultRecipientRole      Role = 8
+	L1FeeVaultRecipientRole        Role = 9
+	SequencerFeeVaultRecipientRole Role = 10
+)
+
+func (d Role) String() string {
+	switch d {
+	case DeployerRole:
+		return "deployer"
+	case ProposerRole:
+		return "proposer"
+	case BatcherRole:
+		return "batcher"
+	case SequencerP2PRole:
+		return "sequencer-p2p"
+	case ChallengerRole:
+		return "challenger"
+	case ProxyAdminOwnerRole:
+		return "proxy-admin-owner"
+	case SuperchainConfigGuardianRole:
+		return "superchain-config-guardian"
+	case FinalSystemOwnerRole:
+		return "final-system-owner"
+	case BaseFeeVaultRecipientRole:
+		return "base-fee-vault-recipient"
+	case L1FeeVaultRecipientRole:
+		return "l1-fee-vault-recipient"
+	case SequencerFeeVaultRecipientRole:
+		return "sequencer-fee-vault-recipient"
+	default:
+		return fmt.Sprintf("unknown-role-%d", uint64(d))
+	}
+}
+
+// DevSecrets selects a secret-key based on domain, chain and role.
+// This is meant for dev-purposes only.
+// Secret keys should not directly be exposed to live production services.
+type DevSecrets interface {
+	Secret(domain Domain, chain *big.Int, role Role) (*ecdsa.PrivateKey, error)
+}
+
+// DevAddresses selects an address based on domain, chain and role.
+// This interface is preferred in tools that do not directly rely on secret-key material.
+type DevAddresses interface {
+	// Address produces an address for the given domain/role.
+	Address(domain Domain, chain *big.Int, role Role) (common.Address, error)
+}
+
+// DevKeys is a joint interface of DevSecrets and DevAddresses
+type DevKeys interface {
+	DevSecrets
+	DevAddresses
+}

--- a/op-chain-ops/devkeys/devkeys.go
+++ b/op-chain-ops/devkeys/devkeys.go
@@ -16,33 +16,26 @@ const (
 	// DefaultKeyDomain is the domain for keys that get pre-funded in every chain.
 	// A 0 chain ID should be used for this domain.
 	DefaultKeyDomain Domain = 0
-	// L1OperatorKeyDomain is the domain for keys used in L1 ops
-	L1OperatorKeyDomain Domain = 1
-	// L1UserKeyDomain is the domain for pre-funded user accounts specific to L1
-	L1UserKeyDomain Domain = 2
+	// OperatorKeyDomain is the domain for keys used in operation of a chain.
+	// The key may be used on any chain, the chain ID represents the chain that operations are for.
+	OperatorKeyDomain Domain = 1
+	// UserKeyDomain is the domain for pre-funded user accounts specific to a single chain, not initially funded in other chains.
+	UserKeyDomain Domain = 2
 	// SuperchainKeyDomain is the domain for superchain contracts.
-	// The L1 chain ID should be used as chain ID for this domain.
+	// The chain ID that the SuperchainConfig is deployed on should be used as chain ID for this domain.
 	SuperchainKeyDomain Domain = 3
-	// L2OperatorKeyDomain is the domain for L2 operator keys
-	L2OperatorKeyDomain Domain = 4
-	// L2UserKeyDomain is the domain for pre-funded L2 user accounts specific to a single L2
-	L2UserKeyDomain Domain = 5
 )
 
 func (d Domain) String() string {
 	switch d {
 	case DefaultKeyDomain:
 		return "default"
-	case L1OperatorKeyDomain:
-		return "l1-operator"
-	case L1UserKeyDomain:
-		return "l1-user"
+	case OperatorKeyDomain:
+		return "operator"
+	case UserKeyDomain:
+		return "user"
 	case SuperchainKeyDomain:
 		return "superchain"
-	case L2OperatorKeyDomain:
-		return "l2-operator"
-	case L2UserKeyDomain:
-		return "l2-user"
 	default:
 		return fmt.Sprintf("unknown-domain-%d", uint64(d))
 	}
@@ -53,17 +46,31 @@ func (d Domain) String() string {
 type Role uint64
 
 const (
-	DeployerRole                   Role = 0
-	ProposerRole                   Role = 1
-	BatcherRole                    Role = 2
-	SequencerP2PRole               Role = 3
-	ChallengerRole                 Role = 4
-	ProxyAdminOwnerRole            Role = 5
-	SuperchainConfigGuardianRole   Role = 6
-	FinalSystemOwnerRole           Role = 7
-	BaseFeeVaultRecipientRole      Role = 8
-	L1FeeVaultRecipientRole        Role = 9
+	// DeployerRole is the deployer of contracts
+	DeployerRole Role = 0
+	// ProposerRole is the key used by op-proposer
+	ProposerRole Role = 1
+	// BatcherRole is the key used by op-batcher
+	BatcherRole Role = 2
+	// SequencerP2PRole is the key used to publish sequenced L2 blocks
+	SequencerP2PRole Role = 3
+	// ChallengerRole is the key used by op-challenger
+	ChallengerRole Role = 4
+	// L2ProxyAdminOwnerRole is the key that controls the ProxyAdmin predeploy in L2
+	L2ProxyAdminOwnerRole Role = 5
+	// SuperchainConfigGuardianRole is the Guardian of the SuperchainConfig
+	SuperchainConfigGuardianRole Role = 6
+	// L1ProxyAdminOwnerRole is the key that owns the ProxyAdmin on the L1 side of the deployment.
+	// This can be the ProxyAdmin of a L2 chain deployment, or a superchain deployment, depending on the domain.
+	L1ProxyAdminOwnerRole Role = 7
+	// BaseFeeVaultRecipientRole is the key that receives from the BaseFeeVault predeploy
+	BaseFeeVaultRecipientRole Role = 8
+	// L1FeeVaultRecipientRole is the key that receives from the L1FeeVault predeploy
+	L1FeeVaultRecipientRole Role = 9
+	// SequencerFeeVaultRecipientRole is the key that receives form the SequencerFeeVault predeploy
 	SequencerFeeVaultRecipientRole Role = 10
+	// DependencySetManagerRole is the key used to manage the dependency set of a superchain.
+	DependencySetManagerRole Role = 11
 )
 
 func (d Role) String() string {
@@ -78,18 +85,20 @@ func (d Role) String() string {
 		return "sequencer-p2p"
 	case ChallengerRole:
 		return "challenger"
-	case ProxyAdminOwnerRole:
-		return "proxy-admin-owner"
+	case L2ProxyAdminOwnerRole:
+		return "l2-proxy-admin-owner"
 	case SuperchainConfigGuardianRole:
 		return "superchain-config-guardian"
-	case FinalSystemOwnerRole:
-		return "final-system-owner"
+	case L1ProxyAdminOwnerRole:
+		return "l1-proxy-admin-owner"
 	case BaseFeeVaultRecipientRole:
 		return "base-fee-vault-recipient"
 	case L1FeeVaultRecipientRole:
 		return "l1-fee-vault-recipient"
 	case SequencerFeeVaultRecipientRole:
 		return "sequencer-fee-vault-recipient"
+	case DependencySetManagerRole:
+		return "dependency-set-manager"
 	default:
 		return fmt.Sprintf("unknown-role-%d", uint64(d))
 	}

--- a/op-chain-ops/devkeys/hd.go
+++ b/op-chain-ops/devkeys/hd.go
@@ -3,7 +3,6 @@ package devkeys
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"math/big"
 
 	hdwallet "github.com/ethereum-optimism/go-ethereum-hdwallet"
 
@@ -14,24 +13,11 @@ import (
 
 const TestMnemonic = "test test test test test test test test test test test junk"
 
-// MnemonicDevKeys derives dev keys from a mnemonic key-path structure as following:
-// BIP-44: `m / purpose' / coin_type' / account' / change / address_index`
-// purpose = standard secp256k1 usage (Eth2 BLS keys use different purpose data).
-// coin_type = chain type, set to 60' for ETH. See SLIP-0044.
-// account = for different identities, used here to separate domains.
-// change = to separate external and internal addresses. Used here for chain ID, 0 if the domain is not a chain.
-// address_index = used here to separate roles.
-// The `'` char signifies BIP-32 hardened derivation.
-//
-// See:
-// https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
-// https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 type MnemonicDevKeys struct {
 	w *hdwallet.Wallet
 }
 
-var _ DevKeys = (*MnemonicDevKeys)(nil)
+var _ Keys = (*MnemonicDevKeys)(nil)
 
 func NewMnemonicDevKeys(mnemonic string) (*MnemonicDevKeys, error) {
 	w, err := hdwallet.NewFromMnemonic(mnemonic)
@@ -41,28 +27,21 @@ func NewMnemonicDevKeys(mnemonic string) (*MnemonicDevKeys, error) {
 	return &MnemonicDevKeys{w: w}, nil
 }
 
-func (d *MnemonicDevKeys) Secret(domain Domain, chainID *big.Int, role Role) (*ecdsa.PrivateKey, error) {
+func (d *MnemonicDevKeys) Secret(key Key) (*ecdsa.PrivateKey, error) {
 	account := accounts.Account{URL: accounts.URL{
-		Path: fmt.Sprintf("m/44'/60'/%d'/%d/%d", uint64(domain), chainID, uint64(role)),
+		Path: key.HDPath(),
 	}}
 	priv, err := d.w.PrivateKey(account)
 	if err != nil {
-		return nil, fmt.Errorf("failed to derive key of path %s (domain: %s, chain: %d, role: %s): %w", account.URL.Path, domain, chainID, role, err)
+		return nil, fmt.Errorf("failed to derive key of path %s (key description: %s): %w", account.URL.Path, key.String(), err)
 	}
 	return priv, nil
 }
 
-func (d *MnemonicDevKeys) Address(domain Domain, chainID *big.Int, role Role) (common.Address, error) {
-	secret, err := d.Secret(domain, chainID, role)
+func (d *MnemonicDevKeys) Address(key Key) (common.Address, error) {
+	secret, err := d.Secret(key)
 	if err != nil {
 		return common.Address{}, err
 	}
 	return crypto.PubkeyToAddress(secret.PublicKey), nil
-}
-
-// Scope is a helper method to not repeat domain and chainID on every address-getter call.
-func Scope(addrs DevAddresses, domain Domain, chainID *big.Int) func(Role) (common.Address, error) {
-	return func(role Role) (common.Address, error) {
-		return addrs.Address(domain, chainID, role)
-	}
 }

--- a/op-chain-ops/devkeys/hd.go
+++ b/op-chain-ops/devkeys/hd.go
@@ -1,0 +1,68 @@
+package devkeys
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+
+	hdwallet "github.com/ethereum-optimism/go-ethereum-hdwallet"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+const TestMnemonic = "test test test test test test test test test test test junk"
+
+// MnemonicDevKeys derives dev keys from a mnemonic key-path structure as following:
+// BIP-44: `m / purpose' / coin_type' / account' / change / address_index`
+// purpose = standard secp256k1 usage (Eth2 BLS keys use different purpose data).
+// coin_type = chain type, set to 60' for ETH. See SLIP-0044.
+// account = for different identities, used here to separate domains.
+// change = to separate external and internal addresses. Used here for chain ID, 0 if the domain is not a chain.
+// address_index = used here to separate roles.
+// The `'` char signifies BIP-32 hardened derivation.
+//
+// See:
+// https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+// https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+type MnemonicDevKeys struct {
+	w *hdwallet.Wallet
+}
+
+var _ DevKeys = (*MnemonicDevKeys)(nil)
+
+func NewMnemonicDevKeys(mnemonic string) (*MnemonicDevKeys, error) {
+	w, err := hdwallet.NewFromMnemonic(mnemonic)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mnemonic: %w", err)
+	}
+	return &MnemonicDevKeys{w: w}, nil
+}
+
+func (d *MnemonicDevKeys) Secret(domain Domain, chainID *big.Int, role Role) (*ecdsa.PrivateKey, error) {
+	account := accounts.Account{URL: accounts.URL{
+		Path: fmt.Sprintf("m/44'/60'/%d'/%d/%d", uint64(domain), chainID, uint64(role)),
+	}}
+	priv, err := d.w.PrivateKey(account)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive key of path %s (domain: %s, chain: %d, role: %s): %w", account.URL.Path, domain, chainID, role, err)
+	}
+	return priv, nil
+}
+
+func (d *MnemonicDevKeys) Address(domain Domain, chainID *big.Int, role Role) (common.Address, error) {
+	secret, err := d.Secret(domain, chainID, role)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return crypto.PubkeyToAddress(secret.PublicKey), nil
+}
+
+// Scope is a helper method to not repeat domain and chainID on every address-getter call.
+func Scope(addrs DevAddresses, domain Domain, chainID *big.Int) func(Role) (common.Address, error) {
+	return func(role Role) (common.Address, error) {
+		return addrs.Address(domain, chainID, role)
+	}
+}

--- a/op-chain-ops/devkeys/hd_test.go
+++ b/op-chain-ops/devkeys/hd_test.go
@@ -1,0 +1,49 @@
+package devkeys
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestMnemonicDevKeys(t *testing.T) {
+	m, err := NewMnemonicDevKeys(TestMnemonic)
+	require.NoError(t, err)
+
+	t.Run("default", func(t *testing.T) {
+		defaultAccount, err := m.Address(DefaultKeyDomain, big.NewInt(0), 0)
+		require.NoError(t, err)
+		// Sanity check against a well-known dev account address,
+		// to ensure the mnemonic path is formatted with the right hardening at each path segment.
+		require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), defaultAccount)
+	})
+
+	// Check that we have unique accounts for all possible dev combinations.
+	// And domain/role toString will be exercised as part of sub-test names.
+	addrs := make(map[common.Address]struct{})
+	for domain := Domain(0); domain < 20; domain++ {
+		t.Run("domain_"+domain.String(), func(t *testing.T) {
+			for chID := 0; chID < 4; chID++ {
+				chainID := big.NewInt(int64(chID))
+				t.Run("chain_"+fmt.Sprintf("%d", chID), func(t *testing.T) {
+					for role := Role(0); role < 20; role++ {
+						t.Run("role_"+role.String(), func(t *testing.T) {
+							secret, err := m.Secret(domain, chainID, role)
+							require.NoError(t, err)
+							addr, err := m.Address(domain, chainID, role)
+							require.NoError(t, err)
+							require.Equal(t, crypto.PubkeyToAddress(secret.PublicKey), addr)
+							addrs[addr] = struct{}{}
+						})
+					}
+				})
+			}
+		})
+	}
+	require.Len(t, addrs, 20*4*20, "unique address for each account")
+}

--- a/op-chain-ops/devkeys/hd_test.go
+++ b/op-chain-ops/devkeys/hd_test.go
@@ -1,7 +1,6 @@
 package devkeys
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -16,34 +15,54 @@ func TestMnemonicDevKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("default", func(t *testing.T) {
-		defaultAccount, err := m.Address(DefaultKeyDomain, big.NewInt(0), 0)
+		defaultAccount, err := m.Address(DefaultKey)
 		require.NoError(t, err)
 		// Sanity check against a well-known dev account address,
 		// to ensure the mnemonic path is formatted with the right hardening at each path segment.
 		require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), defaultAccount)
+
+		// Check that we can localize users to a chain
+		chain1UserKey0, err := m.Address(ChainUserKeys(big.NewInt(1))(0))
+		require.NoError(t, err)
+		require.NotEqual(t, defaultAccount, chain1UserKey0)
 	})
 
-	// Check that we have unique accounts for all possible dev combinations.
-	// And domain/role toString will be exercised as part of sub-test names.
-	addrs := make(map[common.Address]struct{})
-	for domain := Domain(0); domain < 20; domain++ {
-		t.Run("domain_"+domain.String(), func(t *testing.T) {
-			for chID := 0; chID < 4; chID++ {
-				chainID := big.NewInt(int64(chID))
-				t.Run("chain_"+fmt.Sprintf("%d", chID), func(t *testing.T) {
-					for role := Role(0); role < 20; role++ {
-						t.Run("role_"+role.String(), func(t *testing.T) {
-							secret, err := m.Secret(domain, chainID, role)
-							require.NoError(t, err)
-							addr, err := m.Address(domain, chainID, role)
-							require.NoError(t, err)
-							require.Equal(t, crypto.PubkeyToAddress(secret.PublicKey), addr)
-							addrs[addr] = struct{}{}
-						})
-					}
-				})
-			}
-		})
-	}
-	require.Len(t, addrs, 20*4*20, "unique address for each account")
+	t.Run("superchain-operator", func(t *testing.T) {
+		keys := SuperchainOperatorKeys(big.NewInt(1))
+		// Check that each key address and name is unique
+		addrs := make(map[common.Address]struct{})
+		names := make(map[string]struct{})
+		for i := SuperchainOperatorRole(0); i < 20; i++ {
+			key := keys(i)
+			secret, err := m.Secret(key)
+			require.NoError(t, err)
+			addr, err := m.Address(key)
+			require.NoError(t, err)
+			require.Equal(t, crypto.PubkeyToAddress(secret.PublicKey), addr)
+			addrs[addr] = struct{}{}
+			names[key.String()] = struct{}{}
+		}
+		require.Len(t, addrs, 20, "unique address for each account")
+		require.Len(t, names, 20, "unique name for each account")
+	})
+
+	t.Run("chain-operator", func(t *testing.T) {
+		keys := ChainOperatorKeys(big.NewInt(1))
+		// Check that each key address and name is unique
+		addrs := make(map[common.Address]struct{})
+		names := make(map[string]struct{})
+		for i := ChainOperatorRole(0); i < 20; i++ {
+			key := keys(i)
+			secret, err := m.Secret(key)
+			require.NoError(t, err)
+			addr, err := m.Address(key)
+			require.NoError(t, err)
+			require.Equal(t, crypto.PubkeyToAddress(secret.PublicKey), addr)
+			addrs[addr] = struct{}{}
+			names[key.String()] = struct{}{}
+		}
+		require.Len(t, addrs, 20, "unique address for each account")
+		require.Len(t, names, 20, "unique name for each account")
+	})
+
 }


### PR DESCRIPTION
**Description**

Utils for easily deriving op-stack keys for development / testing purposes.

There is a layer of abstraction to define domains and roles, and interfaces to get secrets/addresses for those.
And then a Hierarchical Key derivation util to turn a `(domain, chainID, role)` into a key and address.

For ephemeral devnets we can swap the test mnemonic for a shared test development mnemonic.

**Tests**

Sanity-check a key, and generate the rest.

