### PR TITLE
Fix deploy-config absolute prestate

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -42,7 +42,7 @@
   "systemConfigStartBlock": 17422444,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000000",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000000",
-  "faultGameAbsolutePrestate": "0x03e806a2859a875267a563462a06d4d1d1b455a9efee959a46e21e54b6caf69a",
+  "faultGameAbsolutePrestate": "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c",
   "faultGameMaxDepth": 73,
   "faultGameClockExtension": 10800,
   "faultGameMaxClockDuration": 302400,


### PR DESCRIPTION
Optimistically update the Fault Dispute Game absolute prestate for the granite HF.
To verify:
```
git checkout op-program/v1.3.1-rc.2
make reproducible-prestate && cat ./op-program/bin/prestate-proof.json | jq .pre
```

This is the final step of a series of PR to fix the op-program prestate.

Previous step is the `op-program/v1.3.1-rc.2` tagged on the `inphi/v1.9.0-mainnet` branch. You can verify the `op-program/v1.3.1-rc.2` contains the features we want by checking out this [PR](https://github.com/ethereum-optimism/optimism/pull/11579).