### PR TITLE
.vscode: simplify configs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,7 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-  // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
     "juanblanco.solidity",
-    "golang.go",
-  ],
+    "golang.go"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,4 @@
 {
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-    "editor.formatOnSave": true
-  },
-  "eslint.workingDirectories": [
-    {
-      "directory": "packages/chain-mon",
-      "changeProcessCWD": true
-    }
-  ],
-  "eslint.nodePath": "./node_modules/eslint/bin/",
-  "eslint.format.enable": true,
   "editorconfig.generateAuto": false,
   "files.trimTrailingWhitespace": true
 }


### PR DESCRIPTION
**Description**

Small PR to remove vscode config parts that appear to be stale; typescript/eslint is not used.
