### PR TITLE
optimize e2e setup a bit

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -607,6 +607,9 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	}
 
 	for name := range cfg.Nodes {
+		if name == RoleL1 {
+			return nil, fmt.Errorf("node name %s is reserved for L1 node", RoleL1)
+		}
 		var ethClient services.EthInstance
 		if cfg.ExternalL2Shim == "" {
 			l2Geth, err := geth.InitL2(name, l2Genesis, cfg.JWTFilePath, cfg.GethOptions[name]...)
@@ -638,9 +641,6 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	for name, nodeCfg := range cfg.Nodes {
 		configureL1(nodeCfg, sys.EthInstances[RoleL1], sys.L1BeaconEndpoint())
 		configureL2(nodeCfg, sys.EthInstances[name], cfg.JWTSecret)
-		if sys.RollupConfig.EcotoneTime != nil {
-			nodeCfg.Beacon = &rollupNode.L1BeaconEndpointConfig{BeaconAddr: sys.L1BeaconAPIAddr.RestHTTP()}
-		}
 	}
 
 	l1Client := sys.NodeClient(RoleL1)


### PR DESCRIPTION
1. `RoleL1` should be reserved since it's separately initialized [here](https://github.com/ethereum-optimism/optimism/blob/2718b75628aa54245fd118ff2b60514ea151e271/op-e2e/setup.go#L641).
2. `configureL1` already assigns to `nodeCfg.Beacon` [here](https://github.com/ethereum-optimism/optimism/blob/2718b75628aa54245fd118ff2b60514ea151e271/op-e2e/setup.go#L1025), so [this](https://github.com/ethereum-optimism/optimism/blob/2718b75628aa54245fd118ff2b60514ea151e271/op-e2e/setup.go#L687) is redundant.