### PR TITLE
supervisor: APIs

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -140,10 +140,10 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	logIdx := identifier.LogIndex
 	ok, i, err := su.db.Check(chainID, blockNum, uint32(logIdx), backendTypes.TruncateHash(payloadHash))
 	if err != nil {
-		return types.CrossUnsafe, fmt.Errorf("failed to check log: %w", err)
+		return types.Invalid, fmt.Errorf("failed to check log: %w", err)
 	}
 	if !ok {
-		return types.CrossUnsafe, nil
+		return types.Invalid, nil
 	}
 	safest := types.CrossUnsafe
 	// at this point we have the log entry, and we can check if it is safe by various criteria
@@ -169,7 +169,7 @@ func (su *SupervisorBackend) CheckBlock(chainID *hexutil.U256, blockHash common.
 	// find the last log index in the block
 	i, err := su.db.LastLogInBlock(types.ChainID(*chainID), uint64(blockNumber))
 	if err != nil {
-		return types.CrossUnsafe, fmt.Errorf("failed to scan block: %w", err)
+		return types.Invalid, fmt.Errorf("failed to scan block: %w", err)
 	}
 	// at this point we have the extent of the block, and we can check if it is safe by various criteria
 	for _, checker := range []db.SafetyChecker{

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -148,9 +148,9 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	safest := types.CrossUnsafe
 	// at this point we have the log entry, and we can check if it is safe by various criteria
 	for _, checker := range []db.SafetyChecker{
-		db.NewSafetyChecker(types.Unsafe, *su.db),
-		db.NewSafetyChecker(types.Safe, *su.db),
-		db.NewSafetyChecker(types.Finalized, *su.db),
+		db.NewSafetyChecker(types.Unsafe, su.db),
+		db.NewSafetyChecker(types.Safe, su.db),
+		db.NewSafetyChecker(types.Finalized, su.db),
 	} {
 		if i <= checker.CrossHeadForChain(chainID) {
 			safest = checker.SafetyLevel()
@@ -173,9 +173,9 @@ func (su *SupervisorBackend) CheckBlock(chainID *hexutil.U256, blockHash common.
 	}
 	// at this point we have the extent of the block, and we can check if it is safe by various criteria
 	for _, checker := range []db.SafetyChecker{
-		db.NewSafetyChecker(types.Unsafe, *su.db),
-		db.NewSafetyChecker(types.Safe, *su.db),
-		db.NewSafetyChecker(types.Finalized, *su.db),
+		db.NewSafetyChecker(types.Unsafe, su.db),
+		db.NewSafetyChecker(types.Safe, su.db),
+		db.NewSafetyChecker(types.Finalized, su.db),
 	} {
 		if i <= checker.CrossHeadForChain(types.ChainID(*chainID)) {
 			safest = checker.SafetyLevel()

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -159,12 +159,15 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	return safest, nil
 }
 
-// TODO: this function ignores blockHash and assumes that the block in the db is the one we are looking for
+// CheckBlock checks if the block is safe according to the safety level
+// The block is considered safe if all logs in the block are safe
+// this is decided by finding the last log in the block and
 func (su *SupervisorBackend) CheckBlock(chainID *hexutil.U256, blockHash common.Hash, blockNumber hexutil.Uint64) (types.SafetyLevel, error) {
+	// TODO(#11612): this function ignores blockHash and assumes that the block in the db is the one we are looking for
+	// In order to check block hash, the database must *always* insert a block hash checkpoint, which is not currently done
 	safest := types.CrossUnsafe
-	// find the first first log entry beyond the block number
-	// TODO: off by one error?
-	i, err := su.db.ScanBlock(types.ChainID(*chainID), uint64(blockNumber))
+	// find the last log index in the block
+	i, err := su.db.LastLogInBlock(types.ChainID(*chainID), uint64(blockNumber))
 	if err != nil {
 		return types.CrossUnsafe, fmt.Errorf("failed to scan block: %w", err)
 	}

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -68,9 +68,9 @@ func (db *ChainsDB) Resume() error {
 func (db *ChainsDB) StartCrossHeadMaintenance(ctx context.Context) {
 	go func() {
 		// create three safety checkers, one for each safety level
-		unsafeChecker := NewSafetyChecker(Unsafe, *db)
-		safeChecker := NewSafetyChecker(Safe, *db)
-		finalizedChecker := NewSafetyChecker(Finalized, *db)
+		unsafeChecker := NewSafetyChecker(Unsafe, db)
+		safeChecker := NewSafetyChecker(Safe, db)
+		finalizedChecker := NewSafetyChecker(Finalized, db)
 		// run the maintenance loop every 10 seconds for now
 		ticker := time.NewTicker(time.Second * 10)
 		for {
@@ -104,7 +104,7 @@ func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, logIdx uint32, l
 // UpdateCrossSafeHeads updates the cross-heads of all chains
 // this is an example of how to use the SafetyChecker to update the cross-heads
 func (db *ChainsDB) UpdateCrossSafeHeads() error {
-	checker := NewSafetyChecker(Safe, *db)
+	checker := NewSafetyChecker(Safe, db)
 	return db.UpdateCrossHeads(checker)
 }
 

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -91,6 +91,15 @@ func (db *ChainsDB) StartCrossHeadMaintenance(ctx context.Context) {
 	}()
 }
 
+// Check calls the underlying logDB to determine if the given log entry is safe with respect to the checker's criteria.
+func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash backendTypes.TruncatedHash) (bool, entrydb.EntryIdx, error) {
+	logDB, ok := db.logDBs[chain]
+	if !ok {
+		return false, 0, fmt.Errorf("%w: %v", ErrUnknownChain, chain)
+	}
+	return logDB.Contains(blockNum, logIdx, logHash)
+}
+
 // UpdateCrossSafeHeads updates the cross-heads of all chains
 // this is an example of how to use the SafetyChecker to update the cross-heads
 func (db *ChainsDB) UpdateCrossSafeHeads() error {

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -286,6 +286,10 @@ func (s *stubLogDB) LastCheckpointBehind(entrydb.EntryIdx) (logs.Iterator, error
 	return s.lastCheckpointBehind, nil
 }
 
+func (s *stubLogDB) ClosestBlockIterator(blockNum uint64) (logs.Iterator, error) {
+	panic("not implemented")
+}
+
 func (s *stubLogDB) NextExecutingMessage(i logs.Iterator) (backendTypes.ExecutingMessage, error) {
 	// if error overload is set, return it to simulate a failure condition
 	if s.errOverload != nil && s.emIndex >= s.errAfter {

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -237,6 +237,10 @@ func (s *stubChecker) Update(chain types.ChainID, index entrydb.EntryIdx) heads.
 	}
 }
 
+func (s *stubChecker) SafetyLevel() types.SafetyLevel {
+	return types.CrossSafe
+}
+
 type stubHeadStorage struct {
 	heads *heads.Heads
 }

--- a/op-supervisor/supervisor/backend/db/init_test.go
+++ b/op-supervisor/supervisor/backend/db/init_test.go
@@ -54,6 +54,10 @@ func (s *stubLogStore) Contains(blockNum uint64, logIdx uint32, loghash types.Tr
 	panic("not supported")
 }
 
+func (s *stubLogStore) ClosestBlockIterator(blockNum uint64) (logs.Iterator, error) {
+	panic("not supported")
+}
+
 func (s *stubLogStore) LastCheckpointBehind(entrydb.EntryIdx) (logs.Iterator, error) {
 	panic("not supported")
 }

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -202,6 +202,18 @@ func (db *DB) ClosestBlockInfo(blockNum uint64) (uint64, types.TruncatedHash, er
 	return checkpoint.blockNum, entry.hash, nil
 }
 
+// ClosestBlockIterator returns an iterator for the block closest to the specified blockNum.
+// The iterator will start at the search checkpoint for the block, or the first checkpoint before it.
+func (db *DB) ClosestBlockIterator(blockNum uint64) (Iterator, error) {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	checkpointIdx, err := db.searchCheckpoint(blockNum, math.MaxUint32)
+	if err != nil {
+		return nil, fmt.Errorf("no checkpoint at or before block %v found: %w", blockNum, err)
+	}
+	return db.newIterator(checkpointIdx)
+}
+
 // Get returns the truncated hash of the log at the specified blockNum and logIdx,
 // or an error if the log is not found.
 func (db *DB) Get(blockNum uint64, logiIdx uint32) (types.TruncatedHash, error) {

--- a/op-supervisor/supervisor/backend/db/logs/iterator.go
+++ b/op-supervisor/supervisor/backend/db/logs/iterator.go
@@ -25,6 +25,8 @@ type iterator struct {
 	entriesRead int64
 }
 
+// NextLog returns the next log in the iterator.
+// It scans forward until it finds an initiating event, returning the block number, log index, and event hash.
 func (i *iterator) NextLog() (blockNum uint64, logIdx uint32, evtHash types.TruncatedHash, outErr error) {
 	for i.nextEntryIdx <= i.db.lastEntryIdx() {
 		entryIdx := i.nextEntryIdx

--- a/op-supervisor/supervisor/backend/db/safety_checkers.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers.go
@@ -26,21 +26,21 @@ type SafetyChecker interface {
 
 // unsafeChecker is a SafetyChecker that uses the unsafe head as the view into the database
 type unsafeChecker struct {
-	chainsDB ChainsDB
+	chainsDB *ChainsDB
 }
 
 // safeChecker is a SafetyChecker that uses the safe head as the view into the database
 type safeChecker struct {
-	chainsDB ChainsDB
+	chainsDB *ChainsDB
 }
 
 // finalizedChecker is a SafetyChecker that uses the finalized head as the view into the database
 type finalizedChecker struct {
-	chainsDB ChainsDB
+	chainsDB *ChainsDB
 }
 
 // NewSafetyChecker creates a new SafetyChecker of the given type
-func NewSafetyChecker(t types.SafetyLevel, chainsDB ChainsDB) SafetyChecker {
+func NewSafetyChecker(t types.SafetyLevel, chainsDB *ChainsDB) SafetyChecker {
 	switch t {
 	case Unsafe:
 		return &unsafeChecker{
@@ -121,7 +121,7 @@ func (c *finalizedChecker) SafetyLevel() types.SafetyLevel {
 // check checks if the log entry is safe, provided a local head for the chain
 // it is used by the individual SafetyCheckers to determine if a log entry is safe
 func check(
-	chainsDB ChainsDB,
+	chainsDB *ChainsDB,
 	localHead entrydb.EntryIdx,
 	chain types.ChainID,
 	blockNum uint64,

--- a/op-supervisor/supervisor/backend/db/safety_checkers_test.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers_test.go
@@ -29,7 +29,7 @@ func TestHeadsForChain(t *testing.T) {
 	tcases := []struct {
 		name          string
 		chainID       types.ChainID
-		checkerType   string
+		checkerType   types.SafetyLevel
 		expectedLocal entrydb.EntryIdx
 		expectedCross entrydb.EntryIdx
 	}{
@@ -96,7 +96,7 @@ func TestCheck(t *testing.T) {
 
 	tcases := []struct {
 		name             string
-		checkerType      string
+		checkerType      types.SafetyLevel
 		chainID          types.ChainID
 		blockNum         uint64
 		logIdx           uint32

--- a/op-supervisor/supervisor/backend/db/safety_checkers_test.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers_test.go
@@ -65,7 +65,7 @@ func TestHeadsForChain(t *testing.T) {
 
 	for _, c := range tcases {
 		t.Run(c.name, func(t *testing.T) {
-			checker := NewSafetyChecker(c.checkerType, *chainsDB)
+			checker := NewSafetyChecker(c.checkerType, chainsDB)
 			localHead := checker.LocalHeadForChain(c.chainID)
 			crossHead := checker.CrossHeadForChain(c.chainID)
 			require.Equal(t, c.expectedLocal, localHead)
@@ -199,7 +199,7 @@ func TestCheck(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			// rig the logStore to return the expected response
 			logDB.containsResponse = c.containsResponse
-			checker := NewSafetyChecker(c.checkerType, *chainsDB)
+			checker := NewSafetyChecker(c.checkerType, chainsDB)
 			r := checker.Check(c.chainID, c.blockNum, c.logIdx, c.loghash)
 			// confirm that the expected outcome is correct
 			require.Equal(t, c.expected, r)

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -84,10 +84,12 @@ func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
 }
 
 const (
-	Finalized   SafetyLevel = "finalized"
-	Safe        SafetyLevel = "safe"
-	CrossUnsafe SafetyLevel = "cross-unsafe"
-	Unsafe      SafetyLevel = "unsafe"
+	CrossFinalized SafetyLevel = "cross-finalized"
+	Finalized      SafetyLevel = "finalized"
+	CrossSafe      SafetyLevel = "cross-safe"
+	Safe           SafetyLevel = "safe"
+	CrossUnsafe    SafetyLevel = "cross-unsafe"
+	Unsafe         SafetyLevel = "unsafe"
 )
 
 type ChainID uint256.Int

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -90,6 +90,7 @@ const (
 	Safe           SafetyLevel = "safe"
 	CrossUnsafe    SafetyLevel = "cross-unsafe"
 	Unsafe         SafetyLevel = "unsafe"
+	Invalid        SafetyLevel = "invalid"
 )
 
 type ChainID uint256.Int


### PR DESCRIPTION
Implements APIs for `op-supervisor`

## APIs
### CheckMessage
Check Message gets the requested log event from the database, and then qualifies the safety level. It takes safety-checkers for three levels [Unsafe, Safe, Finalized], and uses their view of the Heads information to decide if a given message is within the safety range.

### CheckBlock
Check Block gets the first log index beyond the given Block Number using a new "Last Log In Block" function. It then does the same [Unsafe, Safe, Finalized] safety range checking as above.

## Testing
Test functionality for the new "Last Log In Block" function on the ChainsDB confirms:
* It scans forward and finds the last log in a block and returns the expected index
* It handles EOF and Not Found errors
* It handles bubbled-up errors

This PR *does not* include tests for the backend itself. This is because all components used in the backend are individually unit-tested, and this API would be much better served by integration testing. Adding unit testing to the backend would require turning the entire `ChainsDB` into a stubbed interface, which is a little redundant given how fully tested it already is. Willing to be challenged on this if people feel strongly.