### PR TITLE
op-e2e: Run the op-program in a vm

### DIFF
--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -160,7 +160,7 @@ func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer,
 
 type ElfVMFactory func(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM
 
-func singleThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
+func SingleThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
 	state := testutil.LoadELFProgram(t, elfFile, singlethreaded.CreateInitialState, true)
 	return singlethreaded.NewInstrumentedState(state, po, stdOut, stdErr, nil)
 }
@@ -184,7 +184,7 @@ func GetSingleThreadedTestCase(t require.TestingT) VersionedVMTestCase {
 		Contracts:    testutil.TestContractsSetup(t, testutil.MipsSingleThreaded),
 		StateHashFn:  singlethreaded.GetStateHashFn(),
 		VMFactory:    singleThreadedVmFactory,
-		ElfVMFactory: singleThreadElfVmFactory,
+		ElfVMFactory: SingleThreadElfVmFactory,
 	}
 }
 

--- a/op-e2e/build_helper.go
+++ b/op-e2e/build_helper.go
@@ -24,3 +24,18 @@ func BuildOpProgramClient(t *testing.T) string {
 	t.Log("Built op-program-client successfully")
 	return "../op-program/bin/op-program-client"
 }
+
+// BuildOpProgramClientMips builds the `op-program` client executable that targets mips32 and returns the path to the resulting executable
+func BuildOpProgramClientMips(t *testing.T) string {
+	t.Log("Building op-program-client-mips")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "make", "op-program-client-mips")
+	cmd.Dir = "../op-program"
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	require.NoErrorf(t, cmd.Run(), "Failed to build op-program-client-mips: %v", &out)
+	t.Log("Built op-program-client-mips successfully")
+	return "../op-program/bin/op-program-client.elf"
+}

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -49,6 +49,15 @@ func Main(logger log.Logger, cfg *config.Config) error {
 	return nil
 }
 
+func ChanneledServer(ctx context.Context, logger log.Logger, cfg *config.Config, preimageChan preimage.FileChannel, hinterChan preimage.FileChannel) error {
+	if err := cfg.Check(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+	opservice.ValidateEnvVars(flags.EnvVarPrefix, flags.Flags, logger)
+	cfg.Rollup.LogDescription(logger, chaincfg.L2ChainIDToNetworkDisplayName)
+	return PreimageServer(ctx, logger, cfg, preimageChan, hinterChan)
+}
+
 // FaultProofProgram is the programmatic entry-point for the fault proof program
 func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Config) error {
 	var (


### PR DESCRIPTION
Add Cannon execution of the op-program to fault proof tests.

Fixes https://github.com/ethereum-optimism/optimism/issues/11653