### PR TITLE
op-chain-ops/interopgen: experimental interop genesis-state generation

### DIFF
--- a/op-chain-ops/devkeys/devkeys.go
+++ b/op-chain-ops/devkeys/devkeys.go
@@ -59,6 +59,10 @@ const (
 	SuperchainConfigGuardianKey SuperchainOperatorRole = 1
 	// DependencySetManagerKey is the key used to manage the dependency set of a superchain.
 	DependencySetManagerKey SuperchainOperatorRole = 2
+	// SuperchainProxyAdminOwner is the key that owns the superchain ProxyAdmin
+	SuperchainProxyAdminOwner SuperchainOperatorRole = 3
+	// SuperchainFinalSystemOwner is the key that ownership is transferred to after deployment.
+	SuperchainFinalSystemOwner SuperchainOperatorRole = 4
 )
 
 func (role SuperchainOperatorRole) String() string {

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -230,9 +230,9 @@ type GasPriceOracleDeployConfig struct {
 	// Deprecated: Since Ecotone, this field is superseded by GasPriceOracleBaseFeeScalar and GasPriceOracleBlobBaseFeeScalar.
 	GasPriceOracleScalar uint64 `json:"gasPriceOracleScalar"`
 	// GasPriceOracleBaseFeeScalar represents the value of the base fee scalar used for fee calculations.
-	GasPriceOracleBaseFeeScalar uint32 `json:"gasPriceOracleBaseFeeScalar"`
+	GasPriceOracleBaseFeeScalar uint32 `json:"gasPriceOracleBaseFeeScalar" evm:"basefeeScalar"`
 	// GasPriceOracleBlobBaseFeeScalar represents the value of the blob base fee scalar used for fee calculations.
-	GasPriceOracleBlobBaseFeeScalar uint32 `json:"gasPriceOracleBlobBaseFeeScalar"`
+	GasPriceOracleBlobBaseFeeScalar uint32 `json:"gasPriceOracleBlobBaseFeeScalar" evm:"blobbasefeeScalar"`
 }
 
 var _ ConfigChecker = (*GasPriceOracleDeployConfig)(nil)
@@ -282,7 +282,7 @@ func (d *GasTokenDeployConfig) Check(log log.Logger) error {
 // OperatorDeployConfig configures the hot-key addresses for operations such as sequencing and batch-submission.
 type OperatorDeployConfig struct {
 	// P2PSequencerAddress is the address of the key the sequencer uses to sign blocks on the P2P layer.
-	P2PSequencerAddress common.Address `json:"p2pSequencerAddress"`
+	P2PSequencerAddress common.Address `json:"p2pSequencerAddress" evm:"p2pSequencerAddress"`
 	// BatchSenderAddress represents the initial sequencer account that authorizes batches.
 	// Transactions sent from this account to the batch inbox address are considered valid.
 	BatchSenderAddress common.Address `json:"batchSenderAddress"`
@@ -627,7 +627,7 @@ type OutputOracleDeployConfig struct {
 	L2OutputOracleSubmissionInterval uint64 `json:"l2OutputOracleSubmissionInterval"`
 	// L2OutputOracleStartingTimestamp is the starting timestamp for the L2OutputOracle.
 	// MUST be the same as the timestamp of the L2OO start block.
-	L2OutputOracleStartingTimestamp int `json:"l2OutputOracleStartingTimestamp"`
+	L2OutputOracleStartingTimestamp int64 `json:"l2OutputOracleStartingTimestamp"`
 	// L2OutputOracleStartingBlockNumber is the starting block number for the L2OutputOracle.
 	// Must be greater than or equal to the first Bedrock block. The first L2 output will correspond
 	// to this value plus the submission interval.
@@ -808,7 +808,7 @@ type DeployConfig struct {
 	// The L2 genesis timestamp does not affect the initial L2 account state:
 	// the storage of the L1Block contract at genesis is zeroed, since the adoption of
 	// the L2-genesis allocs-generation through solidity script.
-	L1StartingBlockTag *MarshalableRPCBlockNumberOrHash `json:"l1StartingBlockTag"`
+	L1StartingBlockTag *MarshalableRPCBlockNumberOrHash `json:"l1StartingBlockTag" evm:"-"`
 
 	// L1 contracts configuration.
 	// The deployer of the contracts chooses which sub-systems to deploy.
@@ -820,7 +820,7 @@ type DeployConfig struct {
 	L1DependenciesConfig
 
 	// Legacy, ignored, here for strict-JSON decoding to be accepted.
-	LegacyDeployConfig
+	LegacyDeployConfig `evm:"-"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-chain-ops/genesis/withdrawal_network.go
+++ b/op-chain-ops/genesis/withdrawal_network.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/holiman/uint256"
 )
 
 // WithdrawalNetwork represents the network that withdrawals are sent to.
@@ -30,6 +32,11 @@ func (w *WithdrawalNetwork) ToUint8() uint8 {
 	default:
 		return 1
 	}
+}
+
+func (w WithdrawalNetwork) ToABI() []byte {
+	out := uint256.NewInt(uint64(w.ToUint8())).Bytes32()
+	return out[:]
 }
 
 // FromUint8 converts a uint8 to a WithdrawalNetwork.

--- a/op-chain-ops/interopgen/configs.go
+++ b/op-chain-ops/interopgen/configs.go
@@ -1,0 +1,92 @@
+package interopgen
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+)
+
+type L1Config struct {
+	ChainID *big.Int
+	genesis.DevL1DeployConfig
+	Prefund map[common.Address]*big.Int
+}
+
+func (c *L1Config) Check(log log.Logger) error {
+	if c.ChainID == nil {
+		return errors.New("missing L1 chain ID")
+	}
+	// nothing to check on c.DevL1DeployConfig
+	return nil
+}
+
+type SuperchainConfig struct {
+	Deployer common.Address
+
+	FinalSystemOwner common.Address
+	ProxyAdminOwner  common.Address
+
+	genesis.SuperchainL1DeployConfig
+}
+
+func (c *SuperchainConfig) Check(log log.Logger) error {
+	if c.Deployer == (common.Address{}) {
+		return errors.New("missing superchain deployer address")
+	}
+	if c.ProxyAdminOwner == (common.Address{}) {
+		return errors.New("missing superchain ProxyAdminOwner address")
+	}
+	if err := c.SuperchainL1DeployConfig.Check(log); err != nil {
+		return err
+	}
+	return nil
+}
+
+type L2Config struct {
+	Deployer common.Address // account used to deploy contracts to L2
+	genesis.L2InitializationConfig
+	genesis.FaultProofDeployConfig
+	Prefund map[common.Address]*big.Int
+}
+
+func (c *L2Config) Check(log log.Logger) error {
+	if c.Deployer == (common.Address{}) {
+		return errors.New("missing L2 deployer address")
+	}
+	if err := c.L2InitializationConfig.Check(log); err != nil {
+		return err
+	}
+	if !c.FaultProofDeployConfig.UseFaultProofs {
+		return errors.New("must set UseFaultProofs: legacy output oracle is not supported")
+	}
+	if err := c.FaultProofDeployConfig.Check(log); err != nil {
+		return err
+	}
+	return nil
+}
+
+type WorldConfig struct {
+	L1         *L1Config
+	Superchain *SuperchainConfig
+	L2s        map[string]*L2Config
+}
+
+func (c *WorldConfig) Check(log log.Logger) error {
+	if err := c.L1.Check(log); err != nil {
+		return fmt.Errorf("invalid L1 config: %w", err)
+	}
+	if err := c.Superchain.Check(log); err != nil {
+		return fmt.Errorf("invalid Superchain config: %w", err)
+	}
+	for l2ChainID, l2Cfg := range c.L2s {
+		if err := l2Cfg.Check(log.New("l2", &l2ChainID)); err != nil {
+			return fmt.Errorf("invalid L2 (chain ID %s) config: %w", l2ChainID, err)
+		}
+	}
+	return nil
+}

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -1,0 +1,472 @@
+package interopgen
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis/beacondeposit"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+)
+
+var (
+	// address(uint160(uint256(keccak256(abi.encode("optimism.deployconfig"))))) - not a simple hash, due to ABI encode
+	deployConfigAddr       = common.HexToAddress("0x9568d36E291c2C4c34fa5593fcE73715abEf6F9c")
+	deploymentRegistryAddr = common.Address(crypto.Keccak256([]byte("optimism.deploymentregistry"))[12:])
+
+	// sysGenesisDeployer is used as tx.origin/msg.sender on system genesis script calls.
+	// At the end we verify none of the deployed contracts persist (there may be temporary ones, to insert bytecode).
+	sysGenesisDeployer = common.Address(crypto.Keccak256([]byte("System genesis deployer"))[12:])
+)
+
+func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, cfg *WorldConfig) (*WorldDeployment, *WorldOutput, error) {
+	// Sanity check all L2s have consistent chain ID and attach to the same L1
+	for id, l2Cfg := range cfg.L2s {
+		if fmt.Sprintf("%d", l2Cfg.L2ChainID) != id {
+			return nil, nil, fmt.Errorf("chain L2 %s declared different L2 chain ID %d in config", id, l2Cfg.L2ChainID)
+		}
+		if !cfg.L1.ChainID.IsUint64() || cfg.L1.ChainID.Uint64() != l2Cfg.L1ChainID {
+			return nil, nil, fmt.Errorf("chain L2 %s declared different L1 chain ID %d in config than global %d", id, l2Cfg.L1ChainID, cfg.L1.ChainID)
+		}
+	}
+
+	deployments := &WorldDeployment{
+		L2s: make(map[string]*L2Deployment),
+	}
+
+	l1Host := createL1(logger, fa, srcFS, cfg.L1)
+	if err := l1Host.EnableCheats(); err != nil {
+		return nil, nil, fmt.Errorf("failed to enable cheats in L1 state: %w", err)
+	}
+
+	l1Deployment, err := initialL1(l1Host, cfg.L1)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to deploy initial L1 content: %w", err)
+	}
+	deployments.L1 = l1Deployment
+
+	superDeployment, err := deploySuperchainToL1(l1Host, cfg.Superchain)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to deploy superchain to L1: %w", err)
+	}
+	deployments.Superchain = superDeployment
+
+	for l2ChainID, l2Cfg := range cfg.L2s {
+		l2Deployment, err := deployL2ToL1(l1Host, cfg.Superchain, superDeployment, l2Cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to deploy L2 %d to L1: %w", &l2ChainID, err)
+		}
+		deployments.L2s[l2ChainID] = l2Deployment
+	}
+
+	out := &WorldOutput{
+		L2s: make(map[string]*L2Output),
+	}
+	l1Out, err := completeL1(l1Host, cfg.L1)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to complete L1: %w", err)
+	}
+	out.L1 = l1Out
+
+	l1GenesisBlock := l1Out.Genesis.ToBlock()
+	genesisTimestamp := l1Out.Genesis.Timestamp
+
+	for l2ChainID, l2Cfg := range cfg.L2s {
+		l2Host := createL2(logger, fa, srcFS, l2Cfg, genesisTimestamp)
+		if err := l2Host.EnableCheats(); err != nil {
+			return nil, nil, fmt.Errorf("failed to enable cheats in L2 state %s: %w", l2ChainID, err)
+		}
+		if err := genesisL2(l2Host, l2Cfg, deployments.L2s[l2ChainID]); err != nil {
+			return nil, nil, fmt.Errorf("failed to apply genesis data to L2 %s: %w", l2ChainID, err)
+		}
+		l2Out, err := completeL2(l2Host, l2Cfg, l1GenesisBlock, deployments.L2s[l2ChainID])
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to complete L2 %s: %w", l2ChainID, err)
+		}
+		out.L2s[l2ChainID] = l2Out
+	}
+	return deployments, out, nil
+}
+
+func createL1(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, cfg *L1Config) *script.Host {
+	l1Context := script.Context{
+		ChainID:      cfg.ChainID,
+		Sender:       sysGenesisDeployer,
+		Origin:       sysGenesisDeployer,
+		FeeRecipient: common.Address{},
+		GasLimit:     script.DefaultFoundryGasLimit,
+		BlockNum:     uint64(cfg.L1GenesisBlockNumber),
+		Timestamp:    uint64(cfg.L1GenesisBlockTimestamp),
+		PrevRandao:   cfg.L1GenesisBlockMixHash,
+		BlobHashes:   nil,
+	}
+	l1Host := script.NewHost(logger.New("role", "l1", "chain", cfg.ChainID), fa, srcFS, l1Context)
+	l1Host.SetEnvVar("DISABLE_DEPLOYMENT_REGISTRY", "true")           // we override it with a precompile
+	l1Host.SetEnvVar("SUPERCHAIN_IMPLEMENTATIONS_WORKAROUND", "true") // FP dependency issue workaround
+	l1Host.SetEnvVar("EXPERIMENTAL_SKIP_L2OUTPUTORACLE", "true")      // no more L2OutputOracle support
+	return l1Host
+}
+
+func createL2(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, l2Cfg *L2Config, genesisTimestamp uint64) *script.Host {
+	l2Context := script.Context{
+		ChainID:      new(big.Int).SetUint64(l2Cfg.L2ChainID),
+		Sender:       sysGenesisDeployer,
+		Origin:       sysGenesisDeployer,
+		FeeRecipient: common.Address{},
+		GasLimit:     script.DefaultFoundryGasLimit,
+		BlockNum:     uint64(l2Cfg.L2GenesisBlockNumber),
+		Timestamp:    genesisTimestamp,
+		PrevRandao:   l2Cfg.L2GenesisBlockMixHash,
+		BlobHashes:   nil,
+	}
+	l2Host := script.NewHost(logger.New("role", "l2", "chain", l2Cfg.L2ChainID), fa, srcFS, l2Context)
+	l2Host.SetEnvVar("DISABLE_DEPLOYMENT_REGISTRY", "true") // we override it with a precompile
+	l2Host.SetEnvVar("OUTPUT_MODE", "none")                 // we don't use the cheatcode, but capture the state outside of EVM execution
+	l2Host.SetEnvVar("FORK", "granite")                     // latest fork
+	return l2Host
+}
+
+// initialL1 deploys basics such as preinstalls to L1  (incl. EIP-4788)
+func initialL1(l1Host *script.Host, cfg *L1Config) (*L1Deployment, error) {
+	l1Host.SetTxOrigin(sysGenesisDeployer)
+	// Init L2Genesis script. Yes, this is L1. Hack to deploy all preinstalls.
+	l2GenesisScript, cleanupL2Genesis, err := script.WithScript[L2GenesisScript](l1Host, "L2Genesis.s.sol", "L2Genesis")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load L2Genesis script for L1 preinstalls work: %w", err)
+	}
+	defer cleanupL2Genesis()
+
+	// We need the Chain ID for the preinstalls setter to work
+	deployConfig := &genesis.DeployConfig{}
+	deployConfig.L2ChainID = cfg.ChainID.Uint64()
+	cleanupDeployConfig, err := script.WithPrecompileAtAddress[*genesis.DeployConfig](l1Host, deployConfigAddr, deployConfig, script.WithFieldsOnly[*genesis.DeployConfig])
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert DeployConfig precompile: %w", err)
+	}
+	defer cleanupDeployConfig()
+
+	if err := l2GenesisScript.SetPreinstalls(); err != nil {
+		return nil, fmt.Errorf("failed to set preinstalls in L1: %w", err)
+	}
+	return &L1Deployment{
+		// any contracts we need to register here?
+	}, nil
+}
+
+func deploySuperchainToL1(l1Host *script.Host, superCfg *SuperchainConfig) (*SuperchainDeployment, error) {
+	l1Host.SetTxOrigin(superCfg.Deployer)
+
+	deploymentRegistry := &DeploymentRegistryPrecompile{
+		Deployments: map[string]common.Address{},
+	}
+	cleanupDeploymentRegistry, err := script.WithPrecompileAtAddress[*DeploymentRegistryPrecompile](
+		l1Host, deploymentRegistryAddr, deploymentRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert DeploymentRegistry precompile: %w", err)
+	}
+	defer cleanupDeploymentRegistry()
+
+	l1DeployScript, cleanupL1Deploy, err := script.WithScript[DeployScript](l1Host, "Deploy.s.sol", "Deploy")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Deploy script: %w", err)
+	}
+	defer cleanupL1Deploy()
+
+	deployConfig := &genesis.DeployConfig{}
+	deployConfig.ProxyAdminOwner = superCfg.ProxyAdminOwner
+	deployConfig.SuperchainL1DeployConfig = superCfg.SuperchainL1DeployConfig
+	deployConfig.FinalSystemOwner = superCfg.FinalSystemOwner
+	cleanupDeployConfig, err := script.WithPrecompileAtAddress[*genesis.DeployConfig](l1Host, deployConfigAddr, deployConfig, script.WithFieldsOnly[*genesis.DeployConfig])
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert DeployConfig precompile: %w", err)
+	}
+	defer cleanupDeployConfig()
+
+	if err := l1DeployScript.DeploySafe("SystemOwnerSafe"); err != nil {
+		return nil, fmt.Errorf("failed to deploy superchain Safe: %w", err)
+	}
+	if err := l1DeployScript.SetupSuperchain(); err != nil {
+		return nil, fmt.Errorf("failed to deploy superchain core contracts: %w", err)
+	}
+
+	if err := l1DeployScript.DeployImplementations(); err != nil {
+		return nil, fmt.Errorf("failed to deploy superchain shared implementations: %w", err)
+	}
+
+	// TODO it still also deploys the legacy OptimismPortal implementation contract
+
+	// Collect deployment addresses
+	// This could all be automatic once we have better output-contract typing/scripting
+	return &SuperchainDeployment{
+		Implementations: Implementations{
+			L1CrossDomainMessenger:       deploymentRegistry.GetAddress("L1CrossDomainMessenger"),
+			L1ERC721Bridge:               deploymentRegistry.GetAddress("L1ERC721Bridge"),
+			L1StandardBridge:             deploymentRegistry.GetAddress("L1StandardBridge"),
+			L2OutputOracle:               deploymentRegistry.GetAddress("L2OutputOracle"),
+			OptimismMintableERC20Factory: deploymentRegistry.GetAddress("OptimismMintableERC20Factory"),
+			OptimismPortal2:              deploymentRegistry.GetAddress("OptimismPortal2"),
+			SystemConfig:                 deploymentRegistry.GetAddress("SystemConfig"),
+			DisputeGameFactory:           deploymentRegistry.GetAddress("DisputeGameFactory"),
+		},
+		SystemOwnerSafe:       deploymentRegistry.GetAddress("SystemOwnerSafe"),
+		AddressManager:        deploymentRegistry.GetAddress("AddressManager"),
+		ProxyAdmin:            deploymentRegistry.GetAddress("ProxyAdmin"),
+		ProtocolVersions:      deploymentRegistry.GetAddress("ProtocolVersions"),
+		ProtocolVersionsProxy: deploymentRegistry.GetAddress("ProtocolVersionsProxy"),
+		SuperchainConfig:      deploymentRegistry.GetAddress("SuperchainConfig"),
+		SuperchainConfigProxy: deploymentRegistry.GetAddress("SuperchainConfigProxy"),
+	}, nil
+}
+
+func deployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployment *SuperchainDeployment, cfg *L2Config) (*L2Deployment, error) {
+	if cfg.UseAltDA {
+		return nil, errors.New("alt-da mode not supported yet")
+	}
+
+	l1Host.SetTxOrigin(cfg.Deployer)
+
+	deploymentRegistry := &DeploymentRegistryPrecompile{
+		Deployments: map[string]common.Address{
+			"L1CrossDomainMessenger":       superDeployment.L1CrossDomainMessenger,
+			"L1ERC721Bridge":               superDeployment.L1ERC721Bridge,
+			"L1StandardBridge":             superDeployment.L1StandardBridge,
+			"L2OutputOracle":               superDeployment.L2OutputOracle,
+			"OptimismMintableERC20Factory": superDeployment.OptimismMintableERC20Factory,
+			"OptimismPortal2":              superDeployment.OptimismPortal2,
+			"SystemConfig":                 superDeployment.SystemConfig,
+			"DisputeGameFactory":           superDeployment.DisputeGameFactory,
+			// Deploy script shouldn't need these, but still loads the addresses
+			"SuperchainConfigProxy": superDeployment.SuperchainConfigProxy,
+			"ProtocolVersionsProxy": superDeployment.ProtocolVersionsProxy,
+			// Have to deal with unused address for global proxies struct
+			"L2OutputOracleProxy": {},
+		},
+	}
+	cleanupDeploymentRegistry, err := script.WithPrecompileAtAddress[*DeploymentRegistryPrecompile](
+		l1Host, deploymentRegistryAddr, deploymentRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert DeploymentRegistry precompile: %w", err)
+	}
+	defer cleanupDeploymentRegistry()
+
+	l1DeployScript, cleanupL1Deploy, err := script.WithScript[DeployScript](l1Host, "Deploy.s.sol", "Deploy")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Deploy script: %w", err)
+	}
+	defer cleanupL1Deploy()
+
+	deployConfig := &genesis.DeployConfig{
+		L2InitializationConfig: cfg.L2InitializationConfig,
+		FaultProofDeployConfig: cfg.FaultProofDeployConfig,
+	}
+	deployConfig.SuperchainConfigGuardian = superCfg.SuperchainConfigGuardian
+	cleanupDeployConfig, err := script.WithPrecompileAtAddress[*genesis.DeployConfig](l1Host, deployConfigAddr, deployConfig, script.WithFieldsOnly[*genesis.DeployConfig])
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert DeployConfig precompile: %w", err)
+	}
+	defer cleanupDeployConfig()
+
+	if err := l1DeployScript.DeploySafe("SystemOwnerSafe"); err != nil {
+		return nil, fmt.Errorf("failed to deploy L2 chain system owner Safe: %w", err)
+	}
+
+	if err := l1DeployScript.DeployAddressManager(); err != nil {
+		return nil, fmt.Errorf("failed to deploy L2 chain AddressManager: %w", err)
+	}
+	if err := l1DeployScript.DeployProxyAdmin(); err != nil {
+		return nil, fmt.Errorf("failed to deploy L2 chain ProxyAdmin: %w", err)
+	}
+	if err := l1DeployScript.TransferProxyAdminOwnership(); err != nil {
+		return nil, fmt.Errorf("failed to transfer L2 chain ownership of ProxyAdmin: %w", err)
+	}
+
+	// Make deployments
+	if err := l1DeployScript.DeployProxies(); err != nil {
+		return nil, fmt.Errorf("failed to deploy L2 chain proxies: %w", err)
+	}
+
+	// Work-around: contract uses an immutable var, that depends on deploy-config, breaking MCP.
+	if err := l1DeployScript.DeployDelayedWETH(); err != nil {
+		return nil, fmt.Errorf("failed to deploy DelayedWETH implementation: %w", err)
+	}
+
+	// Only now that we have the DisputeGameFactoryProxy can we deploy the AnchorStateRegistry implementation.
+	if err := l1DeployScript.DeployAnchorStateRegistry(); err != nil {
+		return nil, fmt.Errorf("failed to deploy AnchorStateRegistry registry: %w", err)
+	}
+
+	// OptimismPortalProxy2 is the same as the original OptimismPortalProxy
+	if err := l1DeployScript.InitializeImplementations(); err != nil {
+		return nil, fmt.Errorf("failed to initialize L2 implementations: %w", err)
+	}
+
+	// TODO we still need to attach the game-types to the dispute game factory
+	// TODO we still need to do final FP owner-address transfer calls
+
+	// TODO fund the operating accounts of this L2 (proposer, batcher, challenger, etc.)
+
+	// Collect deployment addresses
+	return &L2Deployment{
+		L2Proxies: L2Proxies{
+			L1CrossDomainMessengerProxy:       deploymentRegistry.GetAddress("L1CrossDomainMessengerProxy"),
+			L1ERC721BridgeProxy:               deploymentRegistry.GetAddress("L1ERC721BridgeProxy"),
+			L1StandardBridgeProxy:             deploymentRegistry.GetAddress("L1StandardBridgeProxy"),
+			OptimismMintableERC20FactoryProxy: deploymentRegistry.GetAddress("OptimismMintableERC20FactoryProxy"),
+			OptimismPortalProxy:               deploymentRegistry.GetAddress("OptimismPortalProxy"),
+			SystemConfigProxy:                 deploymentRegistry.GetAddress("SystemConfigProxy"),
+			AnchorStateRegistryProxy:          deploymentRegistry.GetAddress("AnchorStateRegistryProxy"),
+			DelayedWETHProxy:                  deploymentRegistry.GetAddress("DelayedWETHProxy"),
+			DisputeGameFactoryProxy:           deploymentRegistry.GetAddress("DisputeGameFactoryProxy"),
+			// special one: depends on DisputeGameFactoryProxy
+			AnchorStateRegistry: deploymentRegistry.GetAddress("DisputeGameFactoryProxy"),
+			// Another special one, depends on L2 deploy config
+			DelayedWETH: deploymentRegistry.GetAddress("DelayedWETH"),
+		},
+		ProxyAdmin:      deploymentRegistry.GetAddress("ProxyAdmin"),
+		SystemOwnerSafe: deploymentRegistry.GetAddress("SystemOwnerSafe"),
+	}, nil
+}
+
+func genesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) error {
+	deploymentRegistry := &DeploymentRegistryPrecompile{
+		Deployments: map[string]common.Address{
+			"L1CrossDomainMessengerProxy": deployment.L1CrossDomainMessengerProxy,
+			"L1StandardBridgeProxy":       deployment.L1StandardBridgeProxy,
+			"L1ERC721BridgeProxy":         deployment.L1ERC721BridgeProxy,
+		},
+	}
+	cleanupDeploymentRegistry, err := script.WithPrecompileAtAddress[*DeploymentRegistryPrecompile](
+		l2Host, deploymentRegistryAddr, deploymentRegistry)
+	if err != nil {
+		return fmt.Errorf("failed to insert DeploymentRegistry precompile: %w", err)
+	}
+	defer cleanupDeploymentRegistry()
+
+	deployConfig := &genesis.DeployConfig{
+		L2InitializationConfig: cfg.L2InitializationConfig,
+	}
+	cleanupDeployConfig, err := script.WithPrecompileAtAddress[*genesis.DeployConfig](l2Host, deployConfigAddr, deployConfig, script.WithFieldsOnly[*genesis.DeployConfig])
+	if err != nil {
+		return fmt.Errorf("failed to insert DeployConfig precompile: %w", err)
+	}
+	defer cleanupDeployConfig()
+
+	l2GenesisScript, cleanupL2Genesis, err := script.WithScript[L2GenesisScript](l2Host, "L2Genesis.s.sol", "L2Genesis")
+	if err != nil {
+		return fmt.Errorf("failed to load L2Genesis script: %w", err)
+	}
+	defer cleanupL2Genesis()
+
+	if err := l2GenesisScript.RunWithEnv(); err != nil {
+		return fmt.Errorf("failed to run through L2 genesis: %w", err)
+	}
+
+	return nil
+}
+
+func completeL1(l1Host *script.Host, cfg *L1Config) (*L1Output, error) {
+	l1Genesis, err := genesis.NewL1Genesis(&genesis.DeployConfig{
+		L2InitializationConfig: genesis.L2InitializationConfig{
+			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
+				L1ChainID: cfg.ChainID.Uint64(),
+			},
+		},
+		DevL1DeployConfig: cfg.DevL1DeployConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build L1 genesis template: %w", err)
+	}
+	allocs, err := l1Host.StateDump()
+	if err != nil {
+		return nil, fmt.Errorf("failed to dump L1 state: %w", err)
+	}
+
+	if err := noDeployed(allocs, sysGenesisDeployer); err != nil {
+		return nil, fmt.Errorf("unexpected deployed account content by L1 genesis deployer: %w", err)
+	}
+
+	for addr, amount := range cfg.Prefund {
+		acc := allocs.Accounts[addr]
+		acc.Balance = amount
+		allocs.Accounts[addr] = acc
+	}
+
+	l1Genesis.Alloc = allocs.Accounts
+
+	// Insert an empty beaconchain deposit contract with valid empty-tree prestate.
+	// This is part of dev-genesis, but not part of scripts yet.
+	beaconDepositAddr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	if err := beacondeposit.InsertEmptyBeaconDepositContract(l1Genesis, beaconDepositAddr); err != nil {
+		return nil, fmt.Errorf("failed to insert beacon deposit contract into L1 dev genesis: %w", err)
+	}
+
+	return &L1Output{
+		Genesis: l1Genesis,
+	}, nil
+}
+
+func completeL2(l2Host *script.Host, cfg *L2Config, l1Block *types.Block, deployment *L2Deployment) (*L2Output, error) {
+	deployCfg := &genesis.DeployConfig{
+		L2InitializationConfig: cfg.L2InitializationConfig,
+		L1DependenciesConfig: genesis.L1DependenciesConfig{
+			L1StandardBridgeProxy:       deployment.L1StandardBridgeProxy,
+			L1CrossDomainMessengerProxy: deployment.L1CrossDomainMessengerProxy,
+			L1ERC721BridgeProxy:         deployment.L1ERC721BridgeProxy,
+			SystemConfigProxy:           deployment.SystemConfigProxy,
+			OptimismPortalProxy:         deployment.OptimismPortalProxy,
+			DAChallengeProxy:            common.Address{}, // unsupported for now
+		},
+	}
+	// l1Block is used to determine genesis time.
+	l2Genesis, err := genesis.NewL2Genesis(deployCfg, l1Block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build L2 genesis config: %w", err)
+	}
+
+	allocs, err := l2Host.StateDump()
+	if err != nil {
+		return nil, fmt.Errorf("failed to dump L1 state: %w", err)
+	}
+
+	if err := noDeployed(allocs, sysGenesisDeployer); err != nil {
+		return nil, fmt.Errorf("unexpected deployed account content by L2 genesis deployer: %w", err)
+	}
+
+	for addr, amount := range cfg.Prefund {
+		acc := allocs.Accounts[addr]
+		acc.Balance = amount
+		allocs.Accounts[addr] = acc
+	}
+
+	l2Genesis.Alloc = allocs.Accounts
+	l2GenesisBlock := l2Genesis.ToBlock()
+
+	rollupCfg, err := deployCfg.RollupConfig(l1Block, l2GenesisBlock.Hash(), l2GenesisBlock.NumberU64())
+	if err != nil {
+		return nil, fmt.Errorf("failed to build L2 rollup config: %w", err)
+	}
+	return &L2Output{
+		Genesis:   l2Genesis,
+		RollupCfg: rollupCfg,
+	}, nil
+}
+
+func noDeployed(allocs *foundry.ForgeAllocs, deployer common.Address) error {
+	// Sanity check we have no deploy output that's not meant to be there.
+	for i := uint64(0); i <= allocs.Accounts[deployer].Nonce; i++ {
+		addr := crypto.CreateAddress(deployer, i)
+		if _, ok := allocs.Accounts[addr]; ok {
+			return fmt.Errorf("system deployer output %s (deployed with nonce %d) was not cleaned up", addr, i)
+		}
+	}
+	// Don't include the deployer account
+	delete(allocs.Accounts, deployer)
+	return nil
+}

--- a/op-chain-ops/interopgen/deployment_registry.go
+++ b/op-chain-ops/interopgen/deployment_registry.go
@@ -1,0 +1,48 @@
+package interopgen
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// DeploymentRegistryPrecompile is inserted as precompile,
+// substituting the regular DeploymentRegistry contract,
+// that the Artifacts contract uses to load/store contract deployments.
+//
+// The Deployments data can be overridden,
+// to sub in a context for a specific L2 deployment,
+// rather than monolithically assuming a single global instance of everything.
+type DeploymentRegistryPrecompile struct {
+	Deployments map[string]common.Address `evm:"-"`
+}
+
+// DeploymentRegistryPrecompile:
+// newDeployments() not supported, only used via CLI, not by scripts themselves.
+// get(string) not supported, does not seem to be used.
+// loadInitializedSlot(string) not supported. Only used by a test.
+
+func (dr *DeploymentRegistryPrecompile) Has(name string) bool {
+	_, ok := dr.Deployments[name]
+	return ok
+}
+
+func (dr *DeploymentRegistryPrecompile) GetAddress(name string) common.Address {
+	return dr.Deployments[name] // zero if not present
+}
+
+func (dr *DeploymentRegistryPrecompile) MustGetAddress(name string) (common.Address, error) {
+	addr, ok := dr.Deployments[name]
+	if !ok {
+		return common.Address{}, fmt.Errorf("unknown deployment %q", name)
+	}
+	return addr, nil
+}
+
+func (dr *DeploymentRegistryPrecompile) Save(name string, addr common.Address) {
+	dr.Deployments[name] = addr
+}
+
+func (dr *DeploymentRegistryPrecompile) PrankDeployment(name string, addr common.Address) {
+	dr.Deployments[name] = addr
+}

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -1,0 +1,72 @@
+package interopgen
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type L1Deployment struct {
+	// preinstalls maybe?
+}
+
+type Implementations struct {
+	L1CrossDomainMessenger       common.Address `json:"L1CrossDomainMessenger"`
+	L1ERC721Bridge               common.Address `json:"L1ERC721Bridge"`
+	L1StandardBridge             common.Address `json:"L1StandardBridge"`
+	L2OutputOracle               common.Address `json:"L2OutputOracle"`
+	OptimismMintableERC20Factory common.Address `json:"OptimismMintableERC20Factory"`
+	OptimismPortal2              common.Address `json:"OptimismPortal2"`
+	SystemConfig                 common.Address `json:"SystemConfig"`
+
+	DisputeGameFactory common.Address `json:"DisputeGameFactory"`
+}
+
+type SuperchainDeployment struct {
+	Implementations
+
+	// Safe that will own the Superchain contracts
+	SystemOwnerSafe common.Address `json:"SystemOwnerSafe"`
+
+	AddressManager common.Address `json:"AddressManager"`
+	ProxyAdmin     common.Address `json:"ProxyAdmin"`
+
+	ProtocolVersions      common.Address `json:"ProtocolVersions"`
+	ProtocolVersionsProxy common.Address `json:"ProtocolVersionsProxy"`
+
+	SuperchainConfig      common.Address `json:"SuperchainConfig"`
+	SuperchainConfigProxy common.Address `json:"SuperchainConfigProxy"`
+}
+
+type L2Proxies struct {
+	L1CrossDomainMessengerProxy common.Address `json:"L1CrossDomainMessengerProxy"`
+	L1ERC721BridgeProxy         common.Address `json:"L1ERC721BridgeProxy"`
+	L1StandardBridgeProxy       common.Address `json:"L1StandardBridgeProxy"`
+	// L2OutputOracleProxy is no longer used or deployed
+	OptimismMintableERC20FactoryProxy common.Address `json:"OptimismMintableERC20FactoryProxy"`
+	OptimismPortalProxy               common.Address `json:"OptimismPortalProxy"`
+	SystemConfigProxy                 common.Address `json:"SystemConfigProxy"`
+
+	// This implementation deployment depends on DisputeGameFactoryProxy
+	AnchorStateRegistry common.Address `json:"AnchorStateRegistry"`
+	// DelayedWETH bytecode is parameterized with deploy-config data
+	DelayedWETH common.Address `json:"DelayedWETH"`
+
+	// Fault proofs; some of these don't have to be deployed per chain
+	AnchorStateRegistryProxy common.Address `json:"AnchorStateRegistryProxy"`
+	DelayedWETHProxy         common.Address `json:"DelayedWETHProxy"`
+	DisputeGameFactoryProxy  common.Address `json:"DisputeGameFactoryProxy"`
+}
+
+type L2Deployment struct {
+	L2Proxies
+
+	ProxyAdmin common.Address `json:"ProxyAdmin"`
+
+	// Safe that will own the L2 chain contracts
+	SystemOwnerSafe common.Address `json:"SystemOwnerSafe"`
+}
+
+type WorldDeployment struct {
+	L1         *L1Deployment            `json:"L1"`
+	Superchain *SuperchainDeployment    `json:"Superchain"`
+	L2s        map[string]*L2Deployment `json:"L2s"`
+}

--- a/op-chain-ops/interopgen/outputs.go
+++ b/op-chain-ops/interopgen/outputs.go
@@ -1,0 +1,21 @@
+package interopgen
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+)
+
+type L1Output struct {
+	Genesis *core.Genesis
+}
+
+type L2Output struct {
+	Genesis   *core.Genesis
+	RollupCfg *rollup.Config
+}
+
+type WorldOutput struct {
+	L1  *L1Output
+	L2s map[string]*L2Output
+}

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -1,0 +1,261 @@
+package interopgen
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+)
+
+type InteropDevRecipe struct {
+	L1ChainID        uint64
+	L2ChainIDs       []uint64
+	GenesisTimestamp uint64
+}
+
+func (r *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, error) {
+	// L1 genesis
+	l1Cfg := &L1Config{
+		ChainID: new(big.Int).SetUint64(r.L1ChainID),
+		DevL1DeployConfig: genesis.DevL1DeployConfig{
+			L1BlockTime:             6,
+			L1GenesisBlockTimestamp: hexutil.Uint64(r.GenesisTimestamp),
+			L1GenesisBlockGasLimit:  30_000_000,
+		},
+		Prefund: make(map[common.Address]*big.Int),
+	}
+
+	l1Users := devkeys.ChainUserKeys(l1Cfg.ChainID)
+	for i := uint64(0); i < 20; i++ {
+		userAddr, err := addrs.Address(l1Users(i))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get L1 user addr %d: %w", i, err)
+		}
+		l1Cfg.Prefund[userAddr] = Ether(10_000_000)
+	}
+
+	superchainOps := devkeys.SuperchainOperatorKeys(l1Cfg.ChainID)
+
+	superchainDeployer, err := addrs.Address(superchainOps(devkeys.SuperchainDeployerKey))
+	if err != nil {
+		return nil, err
+	}
+	finalSystemOwner, err := addrs.Address(superchainOps(devkeys.SuperchainFinalSystemOwner))
+	if err != nil {
+		return nil, err
+	}
+	superchainProxyAdmin, err := addrs.Address(superchainOps(devkeys.SuperchainProxyAdminOwner))
+	if err != nil {
+		return nil, err
+	}
+	superchainConfigGuardian, err := addrs.Address(superchainOps(devkeys.SuperchainConfigGuardianKey))
+	if err != nil {
+		return nil, err
+	}
+	l1Cfg.Prefund[superchainDeployer] = Ether(10_000_000)
+	l1Cfg.Prefund[finalSystemOwner] = Ether(10_000_000)
+	l1Cfg.Prefund[superchainProxyAdmin] = Ether(10_000_000)
+	l1Cfg.Prefund[superchainConfigGuardian] = Ether(10_000_000)
+	superchainCfg := &SuperchainConfig{
+		FinalSystemOwner: finalSystemOwner,
+		ProxyAdminOwner:  superchainProxyAdmin,
+		Deployer:         superchainDeployer,
+		SuperchainL1DeployConfig: genesis.SuperchainL1DeployConfig{
+			RequiredProtocolVersion:    params.OPStackSupport,
+			RecommendedProtocolVersion: params.OPStackSupport,
+			SuperchainConfigGuardian:   superchainConfigGuardian,
+		},
+	}
+	world := &WorldConfig{
+		L1:         l1Cfg,
+		Superchain: superchainCfg,
+		L2s:        make(map[string]*L2Config),
+	}
+	for _, l2ChainID := range r.L2ChainIDs {
+		l2Cfg, err := InteropL2DevConfig(r.L1ChainID, l2ChainID, addrs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate L2 config for chain %d: %w", l2ChainID, err)
+		}
+		if err := prefundL2Accounts(l1Cfg, l2Cfg, addrs); err != nil {
+			return nil, fmt.Errorf("failed to prefund addresses on L1 for L2 chain %d: %w", l2ChainID, err)
+		}
+		world.L2s[fmt.Sprintf("%d", l2ChainID)] = l2Cfg
+	}
+	return world, nil
+}
+
+func prefundL2Accounts(l1Cfg *L1Config, l2Cfg *L2Config, addrs devkeys.Addresses) error {
+	l1Cfg.Prefund[l2Cfg.BatchSenderAddress] = Ether(10_000_000)
+	l1Cfg.Prefund[l2Cfg.Deployer] = Ether(10_000_000)
+	l1Cfg.Prefund[l2Cfg.FinalSystemOwner] = Ether(10_000_000)
+	proposer, err := addrs.Address(devkeys.ChainOperatorKey{
+		ChainID: new(big.Int).SetUint64(l2Cfg.L2ChainID),
+		Role:    devkeys.ProposerRole,
+	})
+	if err != nil {
+		return err
+	}
+	l1Cfg.Prefund[proposer] = Ether(10_000_000)
+	challenger, err := addrs.Address(devkeys.ChainOperatorKey{
+		ChainID: new(big.Int).SetUint64(l2Cfg.L2ChainID),
+		Role:    devkeys.ChallengerRole,
+	})
+	if err != nil {
+		return err
+	}
+	l1Cfg.Prefund[challenger] = Ether(10_000_000)
+	return nil
+}
+
+func InteropL2DevConfig(l1ChainID, l2ChainID uint64, addrs devkeys.Addresses) (*L2Config, error) {
+	// Padded chain ID, hex encoded, prefixed with 0xff like inboxes, then 0x02 to signify devnet.
+	batchInboxAddress := common.HexToAddress(fmt.Sprintf("0xff02%016x", l2ChainID))
+	chainOps := devkeys.ChainOperatorKeys(new(big.Int).SetUint64(l2ChainID))
+
+	deployer, err := addrs.Address(chainOps(devkeys.DeployerRole))
+	if err != nil {
+		return nil, err
+	}
+	l1ProxyAdminOwner, err := addrs.Address(chainOps(devkeys.L1ProxyAdminOwnerRole))
+	if err != nil {
+		return nil, err
+	}
+	l2ProxyAdminOwner, err := addrs.Address(chainOps(devkeys.L2ProxyAdminOwnerRole))
+	if err != nil {
+		return nil, err
+	}
+	baseFeeVaultRecipient, err := addrs.Address(chainOps(devkeys.BaseFeeVaultRecipientRole))
+	if err != nil {
+		return nil, err
+	}
+	l1FeeVaultRecipient, err := addrs.Address(chainOps(devkeys.L1FeeVaultRecipientRole))
+	if err != nil {
+		return nil, err
+	}
+	sequencerFeeVaultRecipient, err := addrs.Address(chainOps(devkeys.SequencerFeeVaultRecipientRole))
+	if err != nil {
+		return nil, err
+	}
+	sequencerP2P, err := addrs.Address(chainOps(devkeys.SequencerP2PRole))
+	if err != nil {
+		return nil, err
+	}
+	batcher, err := addrs.Address(chainOps(devkeys.BatcherRole))
+	if err != nil {
+		return nil, err
+	}
+
+	l2Cfg := &L2Config{
+		Deployer: deployer,
+		L2InitializationConfig: genesis.L2InitializationConfig{
+			DevDeployConfig: genesis.DevDeployConfig{
+				FundDevAccounts: true,
+			},
+			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
+				L2GenesisBlockGasLimit:      30_000_000,
+				L2GenesisBlockBaseFeePerGas: (*hexutil.Big)(big.NewInt(params.InitialBaseFee)),
+			},
+			OwnershipDeployConfig: genesis.OwnershipDeployConfig{
+				ProxyAdminOwner:  l2ProxyAdminOwner,
+				FinalSystemOwner: l1ProxyAdminOwner,
+			},
+			L2VaultsDeployConfig: genesis.L2VaultsDeployConfig{
+				BaseFeeVaultRecipient:                    baseFeeVaultRecipient,
+				L1FeeVaultRecipient:                      l1FeeVaultRecipient,
+				SequencerFeeVaultRecipient:               sequencerFeeVaultRecipient,
+				BaseFeeVaultMinimumWithdrawalAmount:      (*hexutil.Big)(Ether(10)),
+				L1FeeVaultMinimumWithdrawalAmount:        (*hexutil.Big)(Ether(10)),
+				SequencerFeeVaultMinimumWithdrawalAmount: (*hexutil.Big)(Ether(10)),
+				BaseFeeVaultWithdrawalNetwork:            "remote",
+				L1FeeVaultWithdrawalNetwork:              "remote",
+				SequencerFeeVaultWithdrawalNetwork:       "remote",
+			},
+			GovernanceDeployConfig: genesis.GovernanceDeployConfig{
+				EnableGovernance: false,
+			},
+			GasPriceOracleDeployConfig: genesis.GasPriceOracleDeployConfig{
+				GasPriceOracleBaseFeeScalar:     1368,
+				GasPriceOracleBlobBaseFeeScalar: 810949,
+			},
+			GasTokenDeployConfig: genesis.GasTokenDeployConfig{
+				UseCustomGasToken: false,
+			},
+			OperatorDeployConfig: genesis.OperatorDeployConfig{
+				P2PSequencerAddress: sequencerP2P,
+				BatchSenderAddress:  batcher,
+			},
+			EIP1559DeployConfig: genesis.EIP1559DeployConfig{
+				EIP1559Elasticity:        6,
+				EIP1559Denominator:       50,
+				EIP1559DenominatorCanyon: 250,
+			},
+			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
+				L2GenesisRegolithTimeOffset: new(hexutil.Uint64),
+				L2GenesisCanyonTimeOffset:   new(hexutil.Uint64),
+				L2GenesisDeltaTimeOffset:    new(hexutil.Uint64),
+				L2GenesisEcotoneTimeOffset:  new(hexutil.Uint64),
+				L2GenesisFjordTimeOffset:    new(hexutil.Uint64),
+				L2GenesisGraniteTimeOffset:  new(hexutil.Uint64),
+				L2GenesisInteropTimeOffset:  new(hexutil.Uint64),
+				L1CancunTimeOffset:          new(hexutil.Uint64),
+				UseInterop:                  true,
+			},
+			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
+				L1ChainID:                 l1ChainID,
+				L2ChainID:                 l2ChainID,
+				L2BlockTime:               2,
+				FinalizationPeriodSeconds: 2, // instant output finalization
+				MaxSequencerDrift:         300,
+				SequencerWindowSize:       200,
+				ChannelTimeoutBedrock:     120,
+				BatchInboxAddress:         batchInboxAddress,
+				SystemConfigStartBlock:    0,
+			},
+			AltDADeployConfig: genesis.AltDADeployConfig{
+				UseAltDA: false,
+			},
+		},
+		FaultProofDeployConfig: genesis.FaultProofDeployConfig{
+			UseFaultProofs:                  true,
+			FaultGameAbsolutePrestate:       common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
+			FaultGameMaxDepth:               50,
+			FaultGameClockExtension:         0,
+			FaultGameMaxClockDuration:       1200,
+			FaultGameGenesisBlock:           0,
+			FaultGameGenesisOutputRoot:      common.HexToHash("0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"),
+			FaultGameSplitDepth:             14,
+			FaultGameWithdrawalDelay:        604800,
+			PreimageOracleMinProposalSize:   10000,
+			PreimageOracleChallengePeriod:   120,
+			ProofMaturityDelaySeconds:       12,
+			DisputeGameFinalityDelaySeconds: 6,
+			RespectedGameType:               254, // "fast" game type
+		},
+		Prefund: make(map[common.Address]*big.Int),
+	}
+
+	l2Users := devkeys.ChainUserKeys(new(big.Int).SetUint64(l2ChainID))
+	for i := uint64(0); i < 20; i++ {
+		userAddr, err := addrs.Address(l2Users(i))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get L2 user addr %d: %w", i, err)
+		}
+		l2Cfg.Prefund[userAddr] = Ether(10_000_000)
+	}
+
+	l2Cfg.Prefund[l2ProxyAdminOwner] = Ether(10_000_000)
+
+	return l2Cfg, nil
+}
+
+var etherScalar = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+// Ether converts a uint64 Ether amount into a *big.Int amount in wei units, for allocating test balances.
+func Ether(v uint64) *big.Int {
+	return new(big.Int).Mul(new(big.Int).SetUint64(v), etherScalar)
+}

--- a/op-chain-ops/interopgen/recipe_test.go
+++ b/op-chain-ops/interopgen/recipe_test.go
@@ -1,0 +1,43 @@
+package interopgen
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestInteropDevRecipe(t *testing.T) {
+	rec := InteropDevRecipe{
+		L1ChainID:        900100,
+		L2ChainIDs:       []uint64{900200, 900201},
+		GenesisTimestamp: uint64(1234567),
+	}
+	hd, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+	worldCfg, err := rec.Build(hd)
+	require.NoError(t, err)
+
+	logger := testlog.Logger(t, log.LevelDebug)
+	require.NoError(t, worldCfg.Check(logger))
+
+	fa := foundry.OpenArtifactsDir("../../packages/contracts-bedrock/forge-artifacts")
+	srcFS := foundry.NewSourceMapFS(os.DirFS("../../packages/contracts-bedrock"))
+
+	worldDeployment, worldOutput, err := Deploy(logger, fa, srcFS, worldCfg)
+	require.NoError(t, err)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("  ", "  ")
+	require.NoError(t, enc.Encode(worldDeployment))
+	logger.Info("L1 output", "accounts", len(worldOutput.L1.Genesis.Alloc))
+	for id, l2Output := range worldOutput.L2s {
+		logger.Info("L2 output", "chain", &id, "accounts", len(l2Output.Genesis.Alloc))
+	}
+}

--- a/op-chain-ops/interopgen/scripts.go
+++ b/op-chain-ops/interopgen/scripts.go
@@ -1,0 +1,37 @@
+package interopgen
+
+type DeployScript struct {
+	DeploySafe func(name string) error
+
+	// setupSuperchain
+	SetupSuperchain func() error
+
+	// technically still part of setupOpChain, but we deploy them once, and share them, OPSM style.
+	// Run this with env "SUPERCHAIN_IMPLEMENTATIONS_WORKAROUND"
+	// to not run deployAnchorStateRegistry and deployDelayedWETH.
+	DeployImplementations func() error
+
+	// setupOpChain prep, not shared with superchain here, unique per L2
+	DeployAddressManager        func() error
+	DeployProxyAdmin            func() error
+	TransferProxyAdminOwnership func() error
+
+	// setupOpChain core
+	DeployProxies             func() error
+	DeployDelayedWETH         func() error // work around, address depends on config
+	DeployAnchorStateRegistry func() error // work around, depends on a proxy
+	InitializeImplementations func() error
+
+	// FP functions
+	SetAlphabetFaultGameImplementation           func(allowUpgrade bool) error
+	SetFastFaultGameImplementation               func(allowUpgrade bool) error
+	SetCannonFaultGameImplementation             func(allowUpgrade bool) error
+	SetPermissionedCannonFaultGameImplementation func(allowUpgrade bool) error
+	TransferDisputeGameFactoryOwnership          func() error
+	TransferDelayedWETHOwnership                 func() error
+}
+
+type L2GenesisScript struct {
+	RunWithEnv     func() error
+	SetPreinstalls func() error
+}

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -122,6 +122,11 @@ contract L2Genesis is Deployer {
         runWithOptions(OutputMode.ALL, LATEST_FORK, artifactDependencies());
     }
 
+    /// @notice This is used by new experimental interop deploy tooling.
+    function runWithEnv() public {
+        runWithOptions(OutputMode.NONE, Config.fork(), artifactDependencies());
+    }
+
     /// @notice This is used by foundry tests to enable the latest fork with the
     ///         given L1 dependencies.
     function runWithLatestLocal(L1Dependencies memory _l1Dependencies) public {
@@ -510,7 +515,7 @@ contract L2Genesis is Deployer {
     ///         When performing a regular user-initiated contract-creation of a preinstall,
     ///         the creation will fail (but nonce will be bumped and not blocked).
     ///         The preinstalls themselves are all inserted with a nonce of 1, reflecting regular user execution.
-    function setPreinstalls() internal {
+    function setPreinstalls() public {
         _setPreinstallCode(Preinstalls.MultiCall3);
         _setPreinstallCode(Preinstalls.Create2Deployer);
         _setPreinstallCode(Preinstalls.Safe_v130);

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -244,6 +244,9 @@ library ChainAssertions {
         internal
         view
     {
+        if(vm.envOr("EXPERIMENTAL_SKIP_L2OUTPUTORACLE", false)) {
+            return;
+        }
         console.log("Running chain assertions on the L2OutputOracle");
         L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
 


### PR DESCRIPTION
**Description**

Experimental draft of interop multi-L2 devnet genesis state generation code.

This can largely be cleaned up after the L2 chain deployment part of OPSM lands:
- Inputs will be statically typed, no need for partial deploy-config hack
- Outputs will be statically typed, no need for dynamic map of addresses (deploy-registry hack)
- FP deployment will be cleaner, no need for workarounds
- Deployment steps will be more succinct, no need to workaround legacy deployment step issues
- Diff with `Artifacts` can be dropped, as we don't use the legacy deployment anymore at that point

But for now, just need to get a working genesis deployment, so these temporary workarounds will have to do.

**Tests**

`recipe_test.go` turns a basic interop recipe into an expanded `WorldConfig`, which can then be deployed into a `WorldDeployment` (address data) and `WorldOutput` (genesis configs and state).

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/11493
