### PR TITLE
OPSM: scaffold the `DeployOPChain` script

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
@@ -273,14 +273,15 @@ contract DeployImplementations is Script {
     //   - AnchorStateRegistry: Proxied, bespoke per chain.
     //   - FaultDisputeGame: Not proxied, bespoke per chain.
     //   - PermissionedDisputeGame: Not proxied, bespoke per chain.
-    //   - DelayedWETH: Proxied, shared by all standard chains.
+    //   - DelayedWETH: Proxied, and two bespoke ones per chain (one for each DisputeGame).
     //   - PreimageOracle: Not proxied, shared by all standard chains.
     //   - MIPS: Not proxied, shared by all standard chains.
     //   - OptimismPortal2: Proxied, shared by all standard chains.
     //
     // This script only deploys the shared contracts. The bespoke contracts are deployed by
-    // `DeployOPChain.s.sol`. When the shared contracts are proxied, we call the "implementations",
-    // and when they are not proxied, we call them "singletons". So here we deploy:
+    // `DeployOPChain.s.sol`. When the shared contracts are proxied, the contracts deployed here are
+    // "implementations", and when shared contracts are not proxied, they are "singletons". So
+    // here we deploy:
     //
     //   - OptimismPortal2 (implementation)
     //   - DelayedWETH (implementation)

--- a/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
@@ -32,7 +32,7 @@ contract DeployOPChainInput {
         address challenger;
     }
 
-    // TODO fault proofs inputs
+    // TODO Add fault proofs inputs in a future PR.
     struct Input {
         Roles roles;
         uint32 basefeeScalar;
@@ -111,6 +111,11 @@ contract DeployOPChainInput {
     function blobBaseFeeScalar() public view returns (uint32) {
         assertInputSet();
         return inputs.blobBaseFeeScalar;
+    }
+
+    function l2ChainId() public view returns (uint256) {
+        assertInputSet();
+        return inputs.l2ChainId;
     }
 }
 
@@ -293,7 +298,7 @@ contract DeployOPChain is Script {
         return dso.output();
     }
 
-    function run(DeployOPChainInput _dsi, DeployOPChainOutput _dso) public {
+    function run(DeployOPChainInput _dsi, DeployOPChainOutput _dso) public view {
         require(_dsi.inputSet(), "DeployOPChain: input not set");
 
         // TODO call OP Stack Manager deploy method

--- a/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+
+import { AddressManager } from "src/legacy/AddressManager.sol";
+import { DelayedWETH } from "src/dispute/weth/DelayedWETH.sol";
+import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
+import { AnchorStateRegistry } from "src/dispute/AnchorStateRegistry.sol";
+import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
+import { PermissionedDisputeGame } from "src/dispute/PermissionedDisputeGame.sol";
+
+import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
+import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
+import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
+import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
+
+contract DeployOPChainInput {
+    struct Roles {
+        address opChainProxyAdminOwner;
+        address systemConfigOwner;
+        address batcher;
+        address unsafeBlockSigner;
+        address proposer;
+        address challenger;
+    }
+
+    // TODO fault proofs inputs
+    struct Input {
+        Roles roles;
+        uint32 basefeeScalar;
+        uint32 blobBaseFeeScalar;
+        uint256 l2ChainId;
+    }
+
+    bool public inputSet = false;
+    Input internal inputs;
+
+    function loadInputFile(string memory _infile) public {
+        _infile;
+        Input memory parsedInput;
+        loadInput(parsedInput);
+        require(false, "DeployOPChainInput: not implemented");
+    }
+
+    function loadInput(Input memory _input) public {
+        require(!inputSet, "DeployOPChainInput: input already set");
+
+        require(_input.roles.opChainProxyAdminOwner != address(0), "DeployOPChainInput: null opChainProxyAdminOwner");
+        require(_input.roles.systemConfigOwner != address(0), "DeployOPChainInput: null systemConfigOwner");
+        require(_input.roles.batcher != address(0), "DeployOPChainInput: null batcher");
+        require(_input.roles.unsafeBlockSigner != address(0), "DeployOPChainInput: null unsafeBlockSigner");
+        require(_input.roles.proposer != address(0), "DeployOPChainInput: null proposer");
+        require(_input.roles.challenger != address(0), "DeployOPChainInput: null challenger");
+
+        inputSet = true;
+        inputs = _input;
+    }
+
+    function assertInputSet() internal view {
+        require(inputSet, "DeployOPChainInput: input not set");
+    }
+
+    function input() public view returns (Input memory) {
+        assertInputSet();
+        return inputs;
+    }
+
+    function opChainProxyAdminOwner() public view returns (address) {
+        assertInputSet();
+        return inputs.roles.opChainProxyAdminOwner;
+    }
+
+    function systemConfigOwner() public view returns (address) {
+        assertInputSet();
+        return inputs.roles.systemConfigOwner;
+    }
+
+    function batcher() public view returns (address) {
+        assertInputSet();
+        return inputs.roles.batcher;
+    }
+
+    function unsafeBlockSigner() public view returns (address) {
+        assertInputSet();
+        return inputs.roles.unsafeBlockSigner;
+    }
+
+    function proposer() public view returns (address) {
+        assertInputSet();
+        return inputs.roles.proposer;
+    }
+
+    function challenger() public view returns (address) {
+        assertInputSet();
+        return inputs.roles.challenger;
+    }
+
+    function basefeeScalar() public view returns (uint32) {
+        assertInputSet();
+        return inputs.basefeeScalar;
+    }
+
+    function blobBaseFeeScalar() public view returns (uint32) {
+        assertInputSet();
+        return inputs.blobBaseFeeScalar;
+    }
+}
+
+contract DeployOPChainOutput {
+    struct Output {
+        ProxyAdmin opChainProxyAdmin;
+        AddressManager addressManager;
+        L1ERC721Bridge l1ERC721BridgeProxy;
+        SystemConfig systemConfigProxy;
+        OptimismMintableERC20Factory optimismMintableERC20FactoryProxy;
+        L1StandardBridge l1StandardBridgeProxy;
+        L1CrossDomainMessenger l1CrossDomainMessengerProxy;
+        // Fault proof contracts below.
+        OptimismPortal2 optimismPortalProxy;
+        DisputeGameFactory disputeGameFactoryProxy;
+        DisputeGameFactory disputeGameFactoryImpl;
+        AnchorStateRegistry anchorStateRegistryProxy;
+        AnchorStateRegistry anchorStateRegistryImpl;
+        FaultDisputeGame faultDisputeGame;
+        PermissionedDisputeGame permissionedDisputeGame;
+        DelayedWETH delayedWETHPermissionedGameProxy;
+        DelayedWETH delayedWETHPermissionlessGameProxy;
+    }
+
+    Output internal outputs;
+
+    function set(bytes4 sel, address _addr) public {
+        // forgefmt: disable-start
+        if (sel == this.opChainProxyAdmin.selector) outputs.opChainProxyAdmin = ProxyAdmin(_addr) ;
+        else if (sel == this.addressManager.selector) outputs.addressManager = AddressManager(_addr) ;
+        else if (sel == this.l1ERC721BridgeProxy.selector) outputs.l1ERC721BridgeProxy = L1ERC721Bridge(_addr) ;
+        else if (sel == this.systemConfigProxy.selector) outputs.systemConfigProxy = SystemConfig(_addr) ;
+        else if (sel == this.optimismMintableERC20FactoryProxy.selector) outputs.optimismMintableERC20FactoryProxy = OptimismMintableERC20Factory(_addr) ;
+        else if (sel == this.l1StandardBridgeProxy.selector) outputs.l1StandardBridgeProxy = L1StandardBridge(payable(_addr)) ;
+        else if (sel == this.l1CrossDomainMessengerProxy.selector) outputs.l1CrossDomainMessengerProxy = L1CrossDomainMessenger(_addr) ;
+        else if (sel == this.optimismPortalProxy.selector) outputs.optimismPortalProxy = OptimismPortal2(payable(_addr)) ;
+        else if (sel == this.disputeGameFactoryProxy.selector) outputs.disputeGameFactoryProxy = DisputeGameFactory(_addr) ;
+        else if (sel == this.disputeGameFactoryImpl.selector) outputs.disputeGameFactoryImpl = DisputeGameFactory(_addr) ;
+        else if (sel == this.anchorStateRegistryProxy.selector) outputs.anchorStateRegistryProxy = AnchorStateRegistry(_addr) ;
+        else if (sel == this.anchorStateRegistryImpl.selector) outputs.anchorStateRegistryImpl = AnchorStateRegistry(_addr) ;
+        else if (sel == this.faultDisputeGame.selector) outputs.faultDisputeGame = FaultDisputeGame(_addr) ;
+        else if (sel == this.permissionedDisputeGame.selector) outputs.permissionedDisputeGame = PermissionedDisputeGame(_addr) ;
+        else if (sel == this.delayedWETHPermissionedGameProxy.selector) outputs.delayedWETHPermissionedGameProxy = DelayedWETH(payable(_addr)) ;
+        else if (sel == this.delayedWETHPermissionlessGameProxy.selector) outputs.delayedWETHPermissionlessGameProxy = DelayedWETH(payable(_addr)) ;
+        else revert("DeployOPChainOutput: unknown selector");
+        // forgefmt: disable-end
+    }
+
+    function writeOutputFile(string memory _outfile) public pure {
+        _outfile;
+        require(false, "DeployOPChainOutput: not implemented");
+    }
+
+    function output() public view returns (Output memory) {
+        return outputs;
+    }
+
+    function checkOutput() public view {
+        // With 16 addresses, we'd get a stack too deep error if we tried to do this inline as a
+        // single call to `Solarray.addresses`. So we split it into two calls.
+        address[] memory addrs1 = Solarray.addresses(
+            address(outputs.opChainProxyAdmin),
+            address(outputs.addressManager),
+            address(outputs.l1ERC721BridgeProxy),
+            address(outputs.systemConfigProxy),
+            address(outputs.optimismMintableERC20FactoryProxy),
+            address(outputs.l1StandardBridgeProxy),
+            address(outputs.l1CrossDomainMessengerProxy)
+        );
+        address[] memory addrs2 = Solarray.addresses(
+            address(outputs.optimismPortalProxy),
+            address(outputs.disputeGameFactoryProxy),
+            address(outputs.disputeGameFactoryImpl),
+            address(outputs.anchorStateRegistryProxy),
+            address(outputs.anchorStateRegistryImpl),
+            address(outputs.faultDisputeGame),
+            address(outputs.permissionedDisputeGame),
+            address(outputs.delayedWETHPermissionedGameProxy),
+            address(outputs.delayedWETHPermissionlessGameProxy)
+        );
+        DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
+    }
+
+    function opChainProxyAdmin() public view returns (ProxyAdmin) {
+        DeployUtils.assertValidContractAddress(address(outputs.opChainProxyAdmin));
+        return outputs.opChainProxyAdmin;
+    }
+
+    function addressManager() public view returns (AddressManager) {
+        DeployUtils.assertValidContractAddress(address(outputs.addressManager));
+        return outputs.addressManager;
+    }
+
+    function l1ERC721BridgeProxy() public view returns (L1ERC721Bridge) {
+        DeployUtils.assertValidContractAddress(address(outputs.l1ERC721BridgeProxy));
+        return outputs.l1ERC721BridgeProxy;
+    }
+
+    function systemConfigProxy() public view returns (SystemConfig) {
+        DeployUtils.assertValidContractAddress(address(outputs.systemConfigProxy));
+        return outputs.systemConfigProxy;
+    }
+
+    function optimismMintableERC20FactoryProxy() public view returns (OptimismMintableERC20Factory) {
+        DeployUtils.assertValidContractAddress(address(outputs.optimismMintableERC20FactoryProxy));
+        return outputs.optimismMintableERC20FactoryProxy;
+    }
+
+    function l1StandardBridgeProxy() public view returns (L1StandardBridge) {
+        DeployUtils.assertValidContractAddress(address(outputs.l1StandardBridgeProxy));
+        return outputs.l1StandardBridgeProxy;
+    }
+
+    function l1CrossDomainMessengerProxy() public view returns (L1CrossDomainMessenger) {
+        DeployUtils.assertValidContractAddress(address(outputs.l1CrossDomainMessengerProxy));
+        return outputs.l1CrossDomainMessengerProxy;
+    }
+
+    function optimismPortalProxy() public view returns (OptimismPortal2) {
+        DeployUtils.assertValidContractAddress(address(outputs.optimismPortalProxy));
+        return outputs.optimismPortalProxy;
+    }
+
+    function disputeGameFactoryProxy() public view returns (DisputeGameFactory) {
+        DeployUtils.assertValidContractAddress(address(outputs.disputeGameFactoryProxy));
+        return outputs.disputeGameFactoryProxy;
+    }
+
+    function disputeGameFactoryImpl() public view returns (DisputeGameFactory) {
+        DeployUtils.assertValidContractAddress(address(outputs.disputeGameFactoryImpl));
+        return outputs.disputeGameFactoryImpl;
+    }
+
+    function anchorStateRegistryProxy() public view returns (AnchorStateRegistry) {
+        DeployUtils.assertValidContractAddress(address(outputs.anchorStateRegistryProxy));
+        return outputs.anchorStateRegistryProxy;
+    }
+
+    function anchorStateRegistryImpl() public view returns (AnchorStateRegistry) {
+        DeployUtils.assertValidContractAddress(address(outputs.anchorStateRegistryImpl));
+        return outputs.anchorStateRegistryImpl;
+    }
+
+    function faultDisputeGame() public view returns (FaultDisputeGame) {
+        DeployUtils.assertValidContractAddress(address(outputs.faultDisputeGame));
+        return outputs.faultDisputeGame;
+    }
+
+    function permissionedDisputeGame() public view returns (PermissionedDisputeGame) {
+        DeployUtils.assertValidContractAddress(address(outputs.permissionedDisputeGame));
+        return outputs.permissionedDisputeGame;
+    }
+
+    function delayedWETHPermissionedGameProxy() public view returns (DelayedWETH) {
+        DeployUtils.assertValidContractAddress(address(outputs.delayedWETHPermissionedGameProxy));
+        return outputs.delayedWETHPermissionedGameProxy;
+    }
+
+    function delayedWETHPermissionlessGameProxy() public view returns (DelayedWETH) {
+        DeployUtils.assertValidContractAddress(address(outputs.delayedWETHPermissionlessGameProxy));
+        return outputs.delayedWETHPermissionlessGameProxy;
+    }
+}
+
+contract DeployOPChain is Script {
+    // -------- Core Deployment Methods --------
+    function run(string memory _infile) public {
+        (DeployOPChainInput dsi, DeployOPChainOutput dso) = etchIOContracts();
+        dsi.loadInputFile(_infile);
+        run(dsi, dso);
+        string memory outfile = ""; // This will be derived from input file name, e.g. `foo.in.toml` -> `foo.out.toml`
+        dso.writeOutputFile(outfile);
+        require(false, "DeployOPChain: run is not implemented");
+    }
+
+    function run(DeployOPChainInput.Input memory _input) public returns (DeployOPChainOutput.Output memory) {
+        (DeployOPChainInput dsi, DeployOPChainOutput dso) = etchIOContracts();
+        dsi.loadInput(_input);
+        run(dsi, dso);
+        return dso.output();
+    }
+
+    function run(DeployOPChainInput _dsi, DeployOPChainOutput _dso) public {
+        require(_dsi.inputSet(), "DeployOPChain: input not set");
+
+        // TODO call OP Stack Manager deploy method
+
+        _dso.checkOutput();
+    }
+
+    // -------- Utilities --------
+
+    function etchIOContracts() internal returns (DeployOPChainInput dsi_, DeployOPChainOutput dso_) {
+        (dsi_, dso_) = getIOContracts();
+        vm.etch(address(dsi_), type(DeployOPChainInput).runtimeCode);
+        vm.etch(address(dso_), type(DeployOPChainOutput).runtimeCode);
+    }
+
+    function getIOContracts() public view returns (DeployOPChainInput dsi_, DeployOPChainOutput dso_) {
+        dsi_ = DeployOPChainInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainInput"));
+        dso_ = DeployOPChainOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainOutput"));
+    }
+}

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -96,7 +96,8 @@ contract DeploySuperchainInput {
         require(!inputSet, "DeploySuperchainInput: input already set");
 
         // All assertions on inputs happen here. You cannot set any inputs in Solidity unless
-        // they're all valid. For Go testing, the input and outputs
+        // they're all valid. For Go testing, the input and outputs are set individually by
+        // treating the input and output contracts as precompiles and intercepting calls to them.
         require(_input.roles.proxyAdminOwner != address(0), "DeploySuperchainInput: null proxyAdminOwner");
         require(_input.roles.protocolVersionsOwner != address(0), "DeploySuperchainInput: null protocolVersionsOwner");
         require(_input.roles.guardian != address(0), "DeploySuperchainInput: null guardian");

--- a/packages/contracts-bedrock/scripts/libraries/Solarray.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Solarray.sol
@@ -188,4 +188,26 @@ library Solarray {
         arr[9] = j;
         return arr;
     }
+
+    function extend(address[] memory arr1, address[] memory arr2) internal pure returns (address[] memory newArr) {
+        uint256 length1 = arr1.length;
+        uint256 length2 = arr2.length;
+        newArr = new address[](length1 + length2);
+        for (uint256 i = 0; i < length1;) {
+            newArr[i] = arr1[i];
+            unchecked {
+                ++i;
+            }
+        }
+        for (uint256 i = 0; i < arr2.length;) {
+            uint256 j;
+            unchecked {
+                j = i + length1;
+            }
+            newArr[j] = arr2[i];
+            unchecked {
+                ++i;
+            }
+        }
+    }
 }

--- a/packages/contracts-bedrock/test/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/DeployOPChain.t.sol
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+
+import { AddressManager } from "src/legacy/AddressManager.sol";
+import { DelayedWETH } from "src/dispute/weth/DelayedWETH.sol";
+import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
+import { AnchorStateRegistry } from "src/dispute/AnchorStateRegistry.sol";
+import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
+import { PermissionedDisputeGame } from "src/dispute/PermissionedDisputeGame.sol";
+
+import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
+import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
+import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
+import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
+
+import { DeployOPChainInput, DeployOPChain, DeployOPChainOutput } from "scripts/DeployOPChain.s.sol";
+
+contract DeployOPChainInput_Test is Test {
+    DeployOPChainInput dsi;
+
+    DeployOPChainInput.Input input = DeployOPChainInput.Input({
+        roles: DeployOPChainInput.Roles({
+            opChainProxyAdminOwner: makeAddr("opChainProxyAdminOwner"),
+            systemConfigOwner: makeAddr("systemConfigOwner"),
+            batcher: makeAddr("batcher"),
+            unsafeBlockSigner: makeAddr("unsafeBlockSigner"),
+            proposer: makeAddr("proposer"),
+            challenger: makeAddr("challenger")
+        }),
+        basefeeScalar: 100,
+        blobBaseFeeScalar: 200,
+        l2ChainId: 300
+    });
+
+    function setUp() public {
+        dsi = new DeployOPChainInput();
+    }
+
+    function test_loadInput_succeeds() public {
+        dsi.loadInput(input);
+
+        assertTrue(dsi.inputSet(), "100");
+
+        // Compare the test input struct to the getter methods.
+        assertEq(input.roles.opChainProxyAdminOwner, dsi.opChainProxyAdminOwner(), "200");
+        assertEq(input.roles.systemConfigOwner, dsi.systemConfigOwner(), "300");
+        assertEq(input.roles.batcher, dsi.batcher(), "400");
+        assertEq(input.roles.unsafeBlockSigner, dsi.unsafeBlockSigner(), "500");
+        assertEq(input.roles.proposer, dsi.proposer(), "600");
+        assertEq(input.roles.challenger, dsi.challenger(), "700");
+        assertEq(input.basefeeScalar, dsi.basefeeScalar(), "800");
+        assertEq(input.blobBaseFeeScalar, dsi.blobBaseFeeScalar(), "900");
+        assertEq(input.l2ChainId, dsi.l2ChainId(), "1000");
+
+        // Compare the test input struct to the `input` getter method.
+        assertEq(keccak256(abi.encode(input)), keccak256(abi.encode(dsi.input())), "1100");
+    }
+
+    function test_getters_whenNotSet_revert() public {
+        bytes memory expectedErr = "DeployOPChainInput: input not set";
+
+        vm.expectRevert(expectedErr);
+        dsi.opChainProxyAdminOwner();
+
+        vm.expectRevert(expectedErr);
+        dsi.systemConfigOwner();
+
+        vm.expectRevert(expectedErr);
+        dsi.batcher();
+
+        vm.expectRevert(expectedErr);
+        dsi.unsafeBlockSigner();
+
+        vm.expectRevert(expectedErr);
+        dsi.proposer();
+
+        vm.expectRevert(expectedErr);
+        dsi.challenger();
+
+        vm.expectRevert(expectedErr);
+        dsi.basefeeScalar();
+
+        vm.expectRevert(expectedErr);
+        dsi.blobBaseFeeScalar();
+
+        vm.expectRevert(expectedErr);
+        dsi.l2ChainId();
+    }
+}
+
+contract DeployOPChainOutput_Test is Test {
+    DeployOPChainOutput dso;
+
+    function setUp() public {
+        dso = new DeployOPChainOutput();
+    }
+
+    function test_set_succeeds() public {
+        DeployOPChainOutput.Output memory output = DeployOPChainOutput.Output({
+            opChainProxyAdmin: ProxyAdmin(makeAddr("optimismPortal2Impl")),
+            addressManager: AddressManager(makeAddr("delayedWETHImpl")),
+            l1ERC721BridgeProxy: L1ERC721Bridge(makeAddr("l1ERC721BridgeProxy")),
+            systemConfigProxy: SystemConfig(makeAddr("systemConfigProxy")),
+            optimismMintableERC20FactoryProxy: OptimismMintableERC20Factory(makeAddr("optimismMintableERC20FactoryProxy")),
+            l1StandardBridgeProxy: L1StandardBridge(payable(makeAddr("l1StandardBridgeProxy"))),
+            l1CrossDomainMessengerProxy: L1CrossDomainMessenger(makeAddr("l1CrossDomainMessengerProxy")),
+            optimismPortalProxy: OptimismPortal2(payable(makeAddr("optimismPortalProxy"))),
+            disputeGameFactoryProxy: DisputeGameFactory(makeAddr("disputeGameFactoryProxy")),
+            disputeGameFactoryImpl: DisputeGameFactory(makeAddr("disputeGameFactoryImpl")),
+            anchorStateRegistryProxy: AnchorStateRegistry(makeAddr("anchorStateRegistryProxy")),
+            anchorStateRegistryImpl: AnchorStateRegistry(makeAddr("anchorStateRegistryImpl")),
+            faultDisputeGame: FaultDisputeGame(makeAddr("faultDisputeGame")),
+            permissionedDisputeGame: PermissionedDisputeGame(makeAddr("permissionedDisputeGame")),
+            delayedWETHPermissionedGameProxy: DelayedWETH(payable(makeAddr("delayedWETHPermissionedGameProxy"))),
+            delayedWETHPermissionlessGameProxy: DelayedWETH(payable(makeAddr("delayedWETHPermissionlessGameProxy")))
+        });
+
+        vm.etch(address(output.opChainProxyAdmin), hex"01");
+        vm.etch(address(output.addressManager), hex"01");
+        vm.etch(address(output.l1ERC721BridgeProxy), hex"01");
+        vm.etch(address(output.systemConfigProxy), hex"01");
+        vm.etch(address(output.optimismMintableERC20FactoryProxy), hex"01");
+        vm.etch(address(output.l1StandardBridgeProxy), hex"01");
+        vm.etch(address(output.l1CrossDomainMessengerProxy), hex"01");
+        vm.etch(address(output.optimismPortalProxy), hex"01");
+        vm.etch(address(output.disputeGameFactoryProxy), hex"01");
+        vm.etch(address(output.disputeGameFactoryImpl), hex"01");
+        vm.etch(address(output.anchorStateRegistryProxy), hex"01");
+        vm.etch(address(output.anchorStateRegistryImpl), hex"01");
+        vm.etch(address(output.faultDisputeGame), hex"01");
+        vm.etch(address(output.permissionedDisputeGame), hex"01");
+        vm.etch(address(output.delayedWETHPermissionedGameProxy), hex"01");
+        vm.etch(address(output.delayedWETHPermissionlessGameProxy), hex"01");
+
+        dso.set(dso.opChainProxyAdmin.selector, address(output.opChainProxyAdmin));
+        dso.set(dso.addressManager.selector, address(output.addressManager));
+        dso.set(dso.l1ERC721BridgeProxy.selector, address(output.l1ERC721BridgeProxy));
+        dso.set(dso.systemConfigProxy.selector, address(output.systemConfigProxy));
+        dso.set(dso.optimismMintableERC20FactoryProxy.selector, address(output.optimismMintableERC20FactoryProxy));
+        dso.set(dso.l1StandardBridgeProxy.selector, address(output.l1StandardBridgeProxy));
+        dso.set(dso.l1CrossDomainMessengerProxy.selector, address(output.l1CrossDomainMessengerProxy));
+        dso.set(dso.optimismPortalProxy.selector, address(output.optimismPortalProxy));
+        dso.set(dso.disputeGameFactoryProxy.selector, address(output.disputeGameFactoryProxy));
+        dso.set(dso.disputeGameFactoryImpl.selector, address(output.disputeGameFactoryImpl));
+        dso.set(dso.anchorStateRegistryProxy.selector, address(output.anchorStateRegistryProxy));
+        dso.set(dso.anchorStateRegistryImpl.selector, address(output.anchorStateRegistryImpl));
+        dso.set(dso.faultDisputeGame.selector, address(output.faultDisputeGame));
+        dso.set(dso.permissionedDisputeGame.selector, address(output.permissionedDisputeGame));
+        dso.set(dso.delayedWETHPermissionedGameProxy.selector, address(output.delayedWETHPermissionedGameProxy));
+        dso.set(dso.delayedWETHPermissionlessGameProxy.selector, address(output.delayedWETHPermissionlessGameProxy));
+
+        assertEq(address(output.opChainProxyAdmin), address(dso.opChainProxyAdmin()), "100");
+        assertEq(address(output.addressManager), address(dso.addressManager()), "200");
+        assertEq(address(output.l1ERC721BridgeProxy), address(dso.l1ERC721BridgeProxy()), "300");
+        assertEq(address(output.systemConfigProxy), address(dso.systemConfigProxy()), "400");
+        assertEq(
+            address(output.optimismMintableERC20FactoryProxy), address(dso.optimismMintableERC20FactoryProxy()), "500"
+        );
+        assertEq(address(output.l1StandardBridgeProxy), address(dso.l1StandardBridgeProxy()), "600");
+        assertEq(address(output.l1CrossDomainMessengerProxy), address(dso.l1CrossDomainMessengerProxy()), "700");
+        assertEq(address(output.optimismPortalProxy), address(dso.optimismPortalProxy()), "800");
+        assertEq(address(output.disputeGameFactoryProxy), address(dso.disputeGameFactoryProxy()), "900");
+        assertEq(address(output.disputeGameFactoryImpl), address(dso.disputeGameFactoryImpl()), "1000");
+        assertEq(address(output.anchorStateRegistryProxy), address(dso.anchorStateRegistryProxy()), "1100");
+        assertEq(address(output.anchorStateRegistryImpl), address(dso.anchorStateRegistryImpl()), "1200");
+        assertEq(address(output.faultDisputeGame), address(dso.faultDisputeGame()), "1300");
+        assertEq(address(output.permissionedDisputeGame), address(dso.permissionedDisputeGame()), "1400");
+        assertEq(
+            address(output.delayedWETHPermissionedGameProxy), address(dso.delayedWETHPermissionedGameProxy()), "1500"
+        );
+        assertEq(
+            address(output.delayedWETHPermissionlessGameProxy),
+            address(dso.delayedWETHPermissionlessGameProxy()),
+            "1600"
+        );
+
+        assertEq(keccak256(abi.encode(output)), keccak256(abi.encode(dso.output())), "1700");
+    }
+
+    function test_getters_whenNotSet_revert() public {
+        bytes memory expectedErr = "DeployUtils: zero address";
+
+        vm.expectRevert(expectedErr);
+        dso.opChainProxyAdmin();
+
+        vm.expectRevert(expectedErr);
+        dso.addressManager();
+
+        vm.expectRevert(expectedErr);
+        dso.l1ERC721BridgeProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.systemConfigProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.optimismMintableERC20FactoryProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.l1StandardBridgeProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.l1CrossDomainMessengerProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.optimismPortalProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.disputeGameFactoryProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.disputeGameFactoryImpl();
+
+        vm.expectRevert(expectedErr);
+        dso.anchorStateRegistryProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.anchorStateRegistryImpl();
+
+        vm.expectRevert(expectedErr);
+        dso.faultDisputeGame();
+
+        vm.expectRevert(expectedErr);
+        dso.permissionedDisputeGame();
+
+        vm.expectRevert(expectedErr);
+        dso.delayedWETHPermissionedGameProxy();
+
+        vm.expectRevert(expectedErr);
+        dso.delayedWETHPermissionlessGameProxy();
+    }
+
+    function test_getters_whenAddrHasNoCode_reverts() public {
+        address emptyAddr = makeAddr("emptyAddr");
+        bytes memory expectedErr = bytes(string.concat("DeployUtils: no code at ", vm.toString(emptyAddr)));
+
+        dso.set(dso.opChainProxyAdmin.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.opChainProxyAdmin();
+
+        dso.set(dso.addressManager.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.addressManager();
+
+        dso.set(dso.l1ERC721BridgeProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.l1ERC721BridgeProxy();
+
+        dso.set(dso.systemConfigProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.systemConfigProxy();
+
+        dso.set(dso.optimismMintableERC20FactoryProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.optimismMintableERC20FactoryProxy();
+
+        dso.set(dso.l1StandardBridgeProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.l1StandardBridgeProxy();
+
+        dso.set(dso.l1CrossDomainMessengerProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.l1CrossDomainMessengerProxy();
+
+        dso.set(dso.optimismPortalProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.optimismPortalProxy();
+
+        dso.set(dso.disputeGameFactoryProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.disputeGameFactoryProxy();
+
+        dso.set(dso.disputeGameFactoryImpl.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.disputeGameFactoryImpl();
+
+        dso.set(dso.anchorStateRegistryProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.anchorStateRegistryProxy();
+
+        dso.set(dso.anchorStateRegistryImpl.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.anchorStateRegistryImpl();
+
+        dso.set(dso.faultDisputeGame.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.faultDisputeGame();
+
+        dso.set(dso.permissionedDisputeGame.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.permissionedDisputeGame();
+
+        dso.set(dso.delayedWETHPermissionedGameProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.delayedWETHPermissionedGameProxy();
+
+        dso.set(dso.delayedWETHPermissionlessGameProxy.selector, emptyAddr);
+        vm.expectRevert(expectedErr);
+        dso.delayedWETHPermissionlessGameProxy();
+    }
+}


### PR DESCRIPTION
Next PR in the OP Stack Manager (OPSM) sequence, which sets up the third and final script `DeployOPChain.s.sol`. It only adds this script's input and output contracts and corresponding tests. It does not fully implement it, because it will get pretty big, so I'm splitting this up into smaller PRs will make reviews easier.

In the prior `DeploySuperchain.s.sol` and `DeployImplementations.s.sol` scripts, the deployment logic happened directly in those scripts.

However, for `DeployOPChain.s.sol`, we ultimately want the deployment logic to occur onchain, making it easy for users to deploy new OP chains. As a result the deployment logic will happen in `OPStackManager.sol`, and `DeployOPChain.s.sol` will call that contract to deploy a new OP chain in a single, atomic step. 

The deployment steps within `OPStackManager` will be similarly atomic and composable, this way other non-standard features can be developed by inheriting from `OPStackManager`.

