### PR TITLE
dockerignore: remove node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,8 @@
 .github
 .vscode
 
-node_modules
-**/node_modules
 .env
+.envrc
 **/.env
 
 test


### PR DESCRIPTION
**Description**

Cleans up the `.dockerignore` file to no longer ignore `node_modules`
since there is no more JS in the repo. Also ignore `.envrc` to prevent
touching secrets

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

