### PR TITLE
Implement CheckMessages API

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -171,32 +171,14 @@ func (su *SupervisorBackend) CheckMessages(
 		if err != nil {
 			return fmt.Errorf("failed to check message: %w", err)
 		}
-		if !atLeastAsSafe(safety, minSafety) {
-			return fmt.Errorf("message %v is not safe: %v", identifier, safety)
+		if !safety.AtLeastAsSafe(minSafety) {
+			return fmt.Errorf("message %v (safety level: %v) does not meet the minimum safety %v",
+				identifier,
+				safety,
+				minSafety)
 		}
 	}
 	return nil
-}
-
-// TODO: Really this should be a method on types.SafetyLevel
-// for now it's easy to do this calculation here
-func atLeastAsSafe(safety, minSafety types.SafetyLevel) bool {
-	switch minSafety {
-	// If for some reason the minimum safety level is invalid, then nothing is unsafe by comparison
-	case types.Invalid:
-		return true
-	// Unsafe is the lowest safety level, so it is safe so long as it isn't invalid
-	case types.Unsafe:
-		return safety != types.Invalid
-	// Safe is satisfied by Safe or Finalized
-	case types.Safe:
-		return safety == types.Safe || safety == types.Finalized
-	// Finalized is only satisfied by Finalized
-	case types.Finalized:
-		return safety == types.Finalized
-	default:
-		return false
-	}
 }
 
 // CheckBlock checks if the block is safe according to the safety level

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -160,20 +160,16 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 }
 
 func (su *SupervisorBackend) CheckMessages(
-	identifiers []types.Identifier,
-	payloadHashes []common.Hash,
+	messages []types.Message,
 	minSafety types.SafetyLevel) error {
-	if len(identifiers) != len(payloadHashes) {
-		return errors.New("identifiers and payload hashes must be the same length")
-	}
-	for i, identifier := range identifiers {
-		safety, err := su.CheckMessage(identifier, payloadHashes[i])
+	for _, msg := range messages {
+		safety, err := su.CheckMessage(msg.Identifier, msg.PayloadHash)
 		if err != nil {
 			return fmt.Errorf("failed to check message: %w", err)
 		}
 		if !safety.AtLeastAsSafe(minSafety) {
 			return fmt.Errorf("message %v (safety level: %v) does not meet the minimum safety %v",
-				identifier,
+				msg.Identifier,
 				safety,
 				minSafety)
 		}

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -43,6 +43,10 @@ func (m *MockBackend) CheckMessage(identifier types.Identifier, payloadHash comm
 	return types.CrossUnsafe, nil
 }
 
+func (m *MockBackend) CheckMessages(identifiers []types.Identifier, payloadHashes []common.Hash, minSafety types.SafetyLevel) error {
+	return nil
+}
+
 func (m *MockBackend) CheckBlock(chainID *hexutil.U256, blockHash common.Hash, blockNumber hexutil.Uint64) (types.SafetyLevel, error) {
 	return types.CrossUnsafe, nil
 }

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -43,7 +43,7 @@ func (m *MockBackend) CheckMessage(identifier types.Identifier, payloadHash comm
 	return types.CrossUnsafe, nil
 }
 
-func (m *MockBackend) CheckMessages(identifiers []types.Identifier, payloadHashes []common.Hash, minSafety types.SafetyLevel) error {
+func (m *MockBackend) CheckMessages(messages []types.Message, minSafety types.SafetyLevel) error {
 	return nil
 }
 

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -16,7 +16,7 @@ type AdminBackend interface {
 
 type QueryBackend interface {
 	CheckMessage(identifier types.Identifier, payloadHash common.Hash) (types.SafetyLevel, error)
-	CheckMessages(identifiers []types.Identifier, payloadHashes []common.Hash, minSafety types.SafetyLevel) error
+	CheckMessages(messages []types.Message, minSafety types.SafetyLevel) error
 	CheckBlock(chainID *hexutil.U256, blockHash common.Hash, blockNumber hexutil.Uint64) (types.SafetyLevel, error)
 }
 
@@ -38,10 +38,9 @@ func (q *QueryFrontend) CheckMessage(identifier types.Identifier, payloadHash co
 // CheckMessage checks the safety-level of a collection of messages,
 // and returns if the minimum safety-level is met for all messages.
 func (q *QueryFrontend) CheckMessages(
-	identifiers []types.Identifier,
-	payloadHashes []common.Hash,
+	messages []types.Message,
 	minSafety types.SafetyLevel) error {
-	return q.Supervisor.CheckMessages(identifiers, payloadHashes, minSafety)
+	return q.Supervisor.CheckMessages(messages, minSafety)
 }
 
 // CheckBlock checks the safety-level of an L2 block as a whole.

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -16,6 +16,7 @@ type AdminBackend interface {
 
 type QueryBackend interface {
 	CheckMessage(identifier types.Identifier, payloadHash common.Hash) (types.SafetyLevel, error)
+	CheckMessages(identifiers []types.Identifier, payloadHashes []common.Hash, minSafety types.SafetyLevel) error
 	CheckBlock(chainID *hexutil.U256, blockHash common.Hash, blockNumber hexutil.Uint64) (types.SafetyLevel, error)
 }
 
@@ -32,6 +33,15 @@ type QueryFrontend struct {
 // The payloadHash references the hash of the message-payload of the message.
 func (q *QueryFrontend) CheckMessage(identifier types.Identifier, payloadHash common.Hash) (types.SafetyLevel, error) {
 	return q.Supervisor.CheckMessage(identifier, payloadHash)
+}
+
+// CheckMessage checks the safety-level of a collection of messages,
+// and returns if the minimum safety-level is met for all messages.
+func (q *QueryFrontend) CheckMessages(
+	identifiers []types.Identifier,
+	payloadHashes []common.Hash,
+	minSafety types.SafetyLevel) error {
+	return q.Supervisor.CheckMessages(identifiers, payloadHashes, minSafety)
 }
 
 // CheckBlock checks the safety-level of an L2 block as a whole.

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+type Message struct {
+	Identifier  Identifier  `json:"identifier"`
+	PayloadHash common.Hash `json:"payloadHash"`
+}
+
 type Identifier struct {
 	Origin      common.Address
 	BlockNumber uint64

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -83,6 +83,22 @@ func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// AtLeastAsSafe returns true if the receiver is at least as safe as the other SafetyLevel.
+func (lvl *SafetyLevel) AtLeastAsSafe(min SafetyLevel) bool {
+	switch min {
+	case Invalid:
+		return true
+	case Unsafe:
+		return *lvl != Invalid
+	case Safe:
+		return *lvl == Safe || *lvl == Finalized
+	case Finalized:
+		return *lvl == Finalized
+	default:
+		return false
+	}
+}
+
 const (
 	CrossFinalized SafetyLevel = "cross-finalized"
 	Finalized      SafetyLevel = "finalized"


### PR DESCRIPTION
Building on the existing API PR: https://github.com/ethereum-optimism/optimism/pull/11586

### Check Messages
A batch version of CheckMessage which also accepts a minimum safety level. If any messages provided are not as safe as they need to be, the API returns in error.