### PR TITLE
maint: add interfaces for cannon contracts

### DIFF
--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { ISemver } from "src/universal/ISemver.sol";
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
+
+/// @title IMIPS
+/// @notice Interface for the MIPS contract.
+interface IMIPS is ISemver {
+    function oracle() external view returns (IPreimageOracle oracle_);
+    function step(bytes memory _stateData, bytes memory _proof, bytes32 _localContext) external returns (bytes32);
+}

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { ISemver } from "src/universal/ISemver.sol";
+
+/// @title IMIPS2
+/// @notice Interface for the MIPS2 contract.
+interface IMIPS2 is ISemver {
+    function step(bytes memory _stateData, bytes memory _proof, bytes32 _localContext) external returns (bytes32);
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Starting the long and slow road to improving our compile times and developer experience. First order of business is to add interfaces for the cannon contracts that don't already have interfaces.
