### PR TITLE
op-chain-ops/script: cleanup and improve console logging

### DIFF
--- a/op-chain-ops/script/cheatcodes_environment.go
+++ b/op-chain-ops/script/cheatcodes_environment.go
@@ -183,31 +183,26 @@ func (c *CheatCodesPrecompile) Coinbase(addr common.Address) {
 
 // Broadcast_afc98040 implements https://book.getfoundry.sh/cheatcodes/broadcast
 func (c *CheatCodesPrecompile) Broadcast_afc98040() error {
-	c.h.log.Info("broadcasting next call")
 	return c.h.Prank(nil, nil, false, true)
 }
 
 // Broadcast_e6962cdb implements https://book.getfoundry.sh/cheatcodes/broadcast
 func (c *CheatCodesPrecompile) Broadcast_e6962cdb(who common.Address) error {
-	c.h.log.Info("broadcasting next call", "who", who)
 	return c.h.Prank(&who, nil, false, true)
 }
 
 // StartBroadcast_7fb5297f implements https://book.getfoundry.sh/cheatcodes/start-broadcast
 func (c *CheatCodesPrecompile) StartBroadcast_7fb5297f() error {
-	c.h.log.Info("starting repeat-broadcast")
 	return c.h.Prank(nil, nil, true, true)
 }
 
 // StartBroadcast_7fec2a8d implements https://book.getfoundry.sh/cheatcodes/start-broadcast
 func (c *CheatCodesPrecompile) StartBroadcast_7fec2a8d(who common.Address) error {
-	c.h.log.Info("starting repeat-broadcast", "who", who)
 	return c.h.Prank(&who, nil, true, true)
 }
 
 // StopBroadcast implements https://book.getfoundry.sh/cheatcodes/stop-broadcast
 func (c *CheatCodesPrecompile) StopBroadcast() error {
-	c.h.log.Info("stopping repeat-broadcast")
 	return c.h.StopPrank(true)
 }
 

--- a/op-chain-ops/script/console.go
+++ b/op-chain-ops/script/console.go
@@ -1,20 +1,247 @@
 package script
 
 import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/scanner"
+
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+//go:generate go run ./consolegen --abi-txt=console2.txt --out=console2_gen.go
 
 type ConsolePrecompile struct {
 	logger log.Logger
 	sender func() common.Address
 }
 
-func (c *ConsolePrecompile) log(ctx ...any) {
+func (c *ConsolePrecompile) log(args ...any) {
 	sender := c.sender()
-
-	// Log the sender, since the self-address is always equal to the ConsoleAddr
-	c.logger.With("sender", sender).Info("console", ctx...)
+	logger := c.logger.With("sender", sender)
+	if len(args) == 0 {
+		logger.Info("")
+		return
+	}
+	if msg, ok := args[0].(string); ok { // if starting with a string, use it as message. And format with args if needed.
+		logger.Info(consoleFormat(msg, args[1:]...))
+		return
+	} else {
+		logger.Info(consoleFormat("", args...))
+	}
 }
 
-//go:generate go run ./consolegen --abi-txt=console2.txt --out=console2_gen.go
+type stringFormat struct{}
+type numberFormat struct{}
+type objectFormat struct{}
+type integerFormat struct{}
+type exponentialFormat struct {
+	precision int
+}
+type hexadecimalFormat struct{}
+
+func formatBigInt(x *big.Int, precision int) string {
+	if precision < 0 {
+		precision = len(new(big.Int).Abs(x).String()) - 1
+		return formatBigIntFixedPrecision(x, uint(precision)) + fmt.Sprintf("e%d", precision)
+	}
+	return formatBigIntFixedPrecision(x, uint(precision))
+}
+
+func formatBigIntFixedPrecision(x *big.Int, precision uint) string {
+	prec := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+	integer, remainder := new(big.Int).QuoRem(x, prec, new(big.Int))
+	if remainder.Sign() != 0 {
+		decimal := fmt.Sprintf("%0"+fmt.Sprintf("%d", precision)+"d",
+			new(big.Int).Abs(remainder))
+		decimal = strings.TrimRight(decimal, "0")
+		return fmt.Sprintf("%d.%s", integer, decimal)
+	} else {
+		return fmt.Sprintf("%d", integer)
+	}
+}
+
+// formatValue formats a value v following the given format-spec.
+func formatValue(v any, spec any) string {
+	switch x := v.(type) {
+	case string:
+		switch spec.(type) {
+		case stringFormat:
+			return x
+		case objectFormat:
+			return fmt.Sprintf("'%s'", v)
+		default:
+			return "NaN"
+		}
+	case bool:
+		switch spec.(type) {
+		case stringFormat:
+			return fmt.Sprintf("%v", x)
+		case objectFormat:
+			return fmt.Sprintf("'%v'", x)
+		case numberFormat:
+			if x {
+				return "1"
+			}
+			return "0"
+		default:
+			return "NaN"
+		}
+	case *big.Int:
+		switch s := spec.(type) {
+		case stringFormat, objectFormat, numberFormat, integerFormat:
+			return fmt.Sprintf("%d", x)
+		case exponentialFormat:
+			return formatBigInt(x, s.precision)
+		case hexadecimalFormat:
+			return (*hexutil.Big)(x).String()
+		default:
+			return fmt.Sprintf("%d", x)
+		}
+	case *ABIInt256:
+		switch s := spec.(type) {
+		case stringFormat, objectFormat, numberFormat, integerFormat:
+			return fmt.Sprintf("%d", (*big.Int)(x))
+		case exponentialFormat:
+			return formatBigInt((*big.Int)(x), s.precision)
+		case hexadecimalFormat:
+			return (*hexutil.Big)(x).String()
+		default:
+			return fmt.Sprintf("%d", (*big.Int)(x))
+		}
+	case common.Address:
+		switch spec.(type) {
+		case stringFormat, hexadecimalFormat:
+			return x.String()
+		case objectFormat:
+			return fmt.Sprintf("'%s'", x)
+		default:
+			return "NaN"
+		}
+	default:
+		if typ := reflect.TypeOf(v); (typ.Kind() == reflect.Array || typ.Kind() == reflect.Slice) &&
+			typ.Elem().Kind() == reflect.Uint8 {
+			switch spec.(type) {
+			case stringFormat, hexadecimalFormat:
+				return fmt.Sprintf("0x%x", v)
+			case objectFormat:
+				return fmt.Sprintf("'0x%x'", v)
+			default:
+				return "NaN"
+			}
+		}
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// consoleFormat emulates the foundry-flavor of printf, to format console.log data.
+func consoleFormat(fmtMsg string, values ...any) string {
+	var sc scanner.Scanner
+	sc.Init(bytes.NewReader([]byte(fmtMsg)))
+	// default scanner settings are for Go source code parsing. Reset all of that.
+	sc.Whitespace = 0
+	sc.Mode = 0
+	sc.IsIdentRune = func(ch rune, i int) bool {
+		return false
+	}
+
+	nextValue := func() (v any, ok bool) {
+		if len(values) > 0 {
+			v = values[0]
+			values = values[1:]
+			return v, true
+		}
+		return nil, false
+	}
+
+	// Parses a format-spec from a string sequence (excl. the % prefix)
+	// Returns the spec (if any), and the consumed characters (to abort with / fall back to)
+	formatSpecFromChars := func() (spec any, consumed string) {
+		fmtChar := sc.Scan()
+		switch fmtChar {
+		case 's':
+			return stringFormat{}, "s"
+		case 'd':
+			return numberFormat{}, "d"
+		case 'i':
+			return integerFormat{}, "i"
+		case 'o':
+			return objectFormat{}, "o"
+		case 'e':
+			return exponentialFormat{precision: -1}, "e"
+		case 'x':
+			return hexadecimalFormat{}, "x"
+		case scanner.EOF:
+			return nil, ""
+		default:
+			for ; fmtChar != scanner.EOF; fmtChar = sc.Scan() {
+				if fmtChar == 'e' {
+					precision, err := strconv.ParseUint(consumed, 10, 16)
+					consumed += "e"
+					if err != nil {
+						return nil, consumed
+					}
+					return exponentialFormat{precision: int(precision)}, consumed
+				}
+				consumed += string(fmtChar)
+				if !strings.ContainsRune("0123456789", fmtChar) {
+					return nil, consumed
+				}
+			}
+			return nil, consumed
+		}
+	}
+
+	expectFmt := false
+	var out strings.Builder
+	for sc.Peek() != scanner.EOF {
+		if expectFmt {
+			expectFmt = false
+			spec, consumed := formatSpecFromChars()
+			if spec != nil {
+				value, ok := nextValue()
+				if ok {
+					out.WriteString(formatValue(value, spec))
+				} else {
+					// rather than panic with an .expect() like foundry,
+					// just log the original format string
+					out.WriteRune('%')
+					out.WriteString(consumed)
+				}
+			} else {
+				// on parser failure, write '%' and consumed characters
+				out.WriteRune('%')
+				out.WriteString(consumed)
+			}
+		} else {
+			tok := sc.Scan()
+			if tok == '%' {
+				next := sc.Peek()
+				switch next {
+				case '%': // %% formats as "%"
+					out.WriteRune('%')
+				case scanner.EOF:
+					out.WriteRune(tok)
+				default:
+					expectFmt = true
+				}
+			} else {
+				out.WriteRune(tok)
+			}
+		}
+	}
+
+	// for all remaining values, append them to the output
+	for _, v := range values {
+		if out.Len() > 0 {
+			out.WriteRune(' ')
+		}
+		out.WriteString(formatValue(v, stringFormat{}))
+	}
+	return out.String()
+}

--- a/op-chain-ops/script/console2_gen.go
+++ b/op-chain-ops/script/console2_gen.go
@@ -13,1502 +13,1502 @@ func (c *ConsolePrecompile) Log_51973ec9() {
 }
 
 func (c *ConsolePrecompile) Log_665bf134(p0 common.Address, p1 common.Address, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0e378994(p0 common.Address, p1 common.Address, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_018c84c2(p0 common.Address, p1 common.Address, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_f808da20(p0 common.Address, p1 common.Address, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_94250d77(p0 common.Address, p1 common.Address, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9f1bc36e(p0 common.Address, p1 common.Address, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2cd4134a(p0 common.Address, p1 common.Address, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f2a66286(p0 common.Address, p1 common.Address, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_aa6540c8(p0 common.Address, p1 common.Address, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3971e78c(p0 common.Address, p1 common.Address, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_daf0d4aa(p0 common.Address, p1 common.Address) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_8f736d16(p0 common.Address, p1 common.Address, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_6f1a594e(p0 common.Address, p1 common.Address, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_007150be(p0 common.Address, p1 common.Address, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_21bdaf25(p0 common.Address, p1 common.Address, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ef1cefe7(p0 common.Address, p1 common.Address, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8da6def5(p0 common.Address, p1 common.Address, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9b4254e2(p0 common.Address, p1 common.Address, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_17fe6185(p0 common.Address, p1 common.Address, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_fdb4f990(p0 common.Address, p1 common.Address, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_be553481(p0 common.Address, p1 common.Address, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_660375dd(p0 common.Address, p1 bool, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a6f50b0f(p0 common.Address, p1 bool, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f11699ed(p0 common.Address, p1 bool, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_2dd778e6(p0 common.Address, p1 bool, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a75c59de(p0 common.Address, p1 bool, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_cf394485(p0 common.Address, p1 bool, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_cac43479(p0 common.Address, p1 bool, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_eb830c92(p0 common.Address, p1 bool, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_dfc4a2e8(p0 common.Address, p1 bool, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8c4e5de6(p0 common.Address, p1 bool, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_75b605d3(p0 common.Address, p1 bool) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_19fd4956(p0 common.Address, p1 bool, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_50ad461d(p0 common.Address, p1 bool, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_212255cc(p0 common.Address, p1 bool, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_475c5c33(p0 common.Address, p1 bool, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_80e6a20b(p0 common.Address, p1 bool, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ccf790a1(p0 common.Address, p1 bool, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c4643e20(p0 common.Address, p1 bool, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9c4f99fb(p0 common.Address, p1 bool, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_0aa6cfad(p0 common.Address, p1 bool, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_386ff5f4(p0 common.Address, p1 bool, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2c2ecbc2(p0 common.Address) {
-	c.log("p0", p0)
+	c.log(p0)
 }
 
 func (c *ConsolePrecompile) Log_0d36fa20(p0 common.Address, p1 string, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0df12b76(p0 common.Address, p1 string, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f08744e8(p0 common.Address, p1 string, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_f7e36245(p0 common.Address, p1 string, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_457fe3cf(p0 common.Address, p1 string, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_205871c2(p0 common.Address, p1 string, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5f1d5c9f(p0 common.Address, p1 string, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_cf020fb1(p0 common.Address, p1 string, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_bc0b61fe(p0 common.Address, p1 string, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_515e38b6(p0 common.Address, p1 string, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_759f86bb(p0 common.Address, p1 string) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_a04e2f87(p0 common.Address, p1 string, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_35a5071f(p0 common.Address, p1 string, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_fb772265(p0 common.Address, p1 string, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_5d02c50b(p0 common.Address, p1 string, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_159f8927(p0 common.Address, p1 string, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_63183678(p0 common.Address, p1 string, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0ef7e050(p0 common.Address, p1 string, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_67dd6ff1(p0 common.Address, p1 string, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_448830a8(p0 common.Address, p1 string, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1dc8e1b8(p0 common.Address, p1 string, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_478d1c62(p0 common.Address, p1 *big.Int, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a1bcc9b3(p0 common.Address, p1 *big.Int, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7bc0d848(p0 common.Address, p1 *big.Int, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_1da986ea(p0 common.Address, p1 *big.Int, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_100f650e(p0 common.Address, p1 *big.Int, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a31bfdcc(p0 common.Address, p1 *big.Int, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3bf5e537(p0 common.Address, p1 *big.Int, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_678209a8(p0 common.Address, p1 *big.Int, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_c5ad85f9(p0 common.Address, p1 *big.Int, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_22f6b999(p0 common.Address, p1 *big.Int, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8309e8a8(p0 common.Address, p1 *big.Int) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_5c430d47(p0 common.Address, p1 *big.Int, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_cf18105c(p0 common.Address, p1 *big.Int, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a1f2e8aa(p0 common.Address, p1 *big.Int, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_88a8c406(p0 common.Address, p1 *big.Int, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_bf01f891(p0 common.Address, p1 *big.Int, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_20e3984d(p0 common.Address, p1 *big.Int, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_66f1bc67(p0 common.Address, p1 *big.Int, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b69bcaf6(p0 common.Address, p1 *big.Int, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_4a28c017(p0 common.Address, p1 *big.Int, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_34f0e636(p0 common.Address, p1 *big.Int, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1d14d001(p0 bool, p1 common.Address, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_46600be0(p0 bool, p1 common.Address, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_d2763667(p0 bool, p1 common.Address, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_d812a167(p0 bool, p1 common.Address, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0c66d1be(p0 bool, p1 common.Address, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1c41a336(p0 bool, p1 common.Address, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_6a9c478b(p0 bool, p1 common.Address, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_18c9c746(p0 bool, p1 common.Address, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_4a66cb34(p0 bool, p1 common.Address, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_07831502(p0 bool, p1 common.Address, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_853c4849(p0 bool, p1 common.Address) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_6f7c603e(p0 bool, p1 common.Address, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e2bfd60b(p0 bool, p1 common.Address, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_de9a9270(p0 bool, p1 common.Address, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_a73c1db6(p0 bool, p1 common.Address, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c21f64c7(p0 bool, p1 common.Address, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_136b05dd(p0 bool, p1 common.Address, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_d6019f1c(p0 bool, p1 common.Address, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5f7b9afb(p0 bool, p1 common.Address, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_51f09ff8(p0 bool, p1 common.Address, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7bf181a1(p0 bool, p1 common.Address, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f4880ea4(p0 bool, p1 bool, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c0a302d8(p0 bool, p1 bool, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1078f68d(p0 bool, p1 bool, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_a0a47963(p0 bool, p1 bool, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_4c123d57(p0 bool, p1 bool, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8c329b1a(p0 bool, p1 bool, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3b2a5ce0(p0 bool, p1 bool, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_50709698(p0 bool, p1 bool, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_2ae408d4(p0 bool, p1 bool, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_6d7045c1(p0 bool, p1 bool, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2a110e83(p0 bool, p1 bool) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_f9ad2b89(p0 bool, p1 bool, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b857163a(p0 bool, p1 bool, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2555fa46(p0 bool, p1 bool, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_6d1e8751(p0 bool, p1 bool, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e3a9ca2f(p0 bool, p1 bool, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_54a7a9a0(p0 bool, p1 bool, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_619e4d0e(p0 bool, p1 bool, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_12f21602(p0 bool, p1 bool, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_7dd4d0e0(p0 bool, p1 bool, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0bb00eab(p0 bool, p1 bool, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_32458eed(p0 bool) {
-	c.log("p0", p0)
+	c.log(p0)
 }
 
 func (c *ConsolePrecompile) Log_2b2b18dc(p0 bool, p1 string, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_6dd434ca(p0 bool, p1 string, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9591b953(p0 bool, p1 string, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_12d6c788(p0 bool, p1 string, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a5cada94(p0 bool, p1 string, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_538e06ab(p0 bool, p1 string, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_dc5e935b(p0 bool, p1 string, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_dbb4c247(p0 bool, p1 string, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_483d0416(p0 bool, p1 string, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1606a393(p0 bool, p1 string, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8feac525(p0 bool, p1 string) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_97d394d8(p0 bool, p1 string, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1e4b87e5(p0 bool, p1 string, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b076847f(p0 bool, p1 string, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_1762e32a(p0 bool, p1 string, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7be0c3eb(p0 bool, p1 string, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1596a1ce(p0 bool, p1 string, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_6b0e5d53(p0 bool, p1 string, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1093ee11(p0 bool, p1 string, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_1ad96de6(p0 bool, p1 string, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_28863fcb(p0 bool, p1 string, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_26f560a8(p0 bool, p1 *big.Int, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b4c314ff(p0 bool, p1 *big.Int, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_088ef9d2(p0 bool, p1 *big.Int, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_1bb3b09a(p0 bool, p1 *big.Int, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1537dc87(p0 bool, p1 *big.Int, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9acd3616(p0 bool, p1 *big.Int, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ceb5f4d7(p0 bool, p1 *big.Int, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e8defba9(p0 bool, p1 *big.Int, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_9143dbb1(p0 bool, p1 *big.Int, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7f9bbca2(p0 bool, p1 *big.Int, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_399174d3(p0 bool, p1 *big.Int) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_fedd1fff(p0 bool, p1 *big.Int, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e5e70b2b(p0 bool, p1 *big.Int, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c3fc3970(p0 bool, p1 *big.Int, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_f5bc2249(p0 bool, p1 *big.Int, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_6a1199e2(p0 bool, p1 *big.Int, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_00dd87b9(p0 bool, p1 *big.Int, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_be984353(p0 bool, p1 *big.Int, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_37103367(p0 bool, p1 *big.Int, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_8e69fb5d(p0 bool, p1 *big.Int, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_374bb4b2(p0 bool, p1 *big.Int, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_013d178b(p0 [10]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_04004a2e(p0 [11]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_86a06abd(p0 [12]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_94529e34(p0 [13]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_9266f07f(p0 [14]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_da9574e0(p0 [15]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_665c6104(p0 [16]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_339f673a(p0 [17]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_c4d23d9a(p0 [18]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_5e6b5a33(p0 [19]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_6e18a128(p0 [1]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_5188e3e9(p0 [20]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_e9da3560(p0 [21]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_d5fae89c(p0 [22]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_aba1cf0d(p0 [23]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_f1b35b34(p0 [24]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_0b84bc58(p0 [25]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_f8b149f1(p0 [26]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_3a3757dd(p0 [27]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_c82aeaee(p0 [28]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_4b69c3d5(p0 [29]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_e9b62296(p0 [2]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_ee12c4ed(p0 [30]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_c2854d92(p0 [31]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_27b7cf85(p0 [32]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_2d834926(p0 [3]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_e05f48d1(p0 [4]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_a684808d(p0 [5]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_ae84a591(p0 [6]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_4ed57e28(p0 [7]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_4f84252e(p0 [8]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_90bd8cd0(p0 [9]byte) {
-	c.log("p0", hexutil.Bytes(p0[:]))
+	c.log(hexutil.Bytes(p0[:]))
 }
 
 func (c *ConsolePrecompile) Log_0be77f56(p0 hexutil.Bytes) {
-	c.log("p0", p0)
+	c.log(p0)
 }
 
 func (c *ConsolePrecompile) Log_2d5b6cb9(p0 *ABIInt256) {
-	c.log("p0", (*big.Int)(p0))
+	c.log((*big.Int)(p0))
 }
 
 func (c *ConsolePrecompile) Log_ed8f28f6(p0 string, p1 common.Address, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b59dbd60(p0 string, p1 common.Address, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_fcec75e0(p0 string, p1 common.Address, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_800a1c67(p0 string, p1 common.Address, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8ef3f399(p0 string, p1 common.Address, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_223603bd(p0 string, p1 common.Address, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_79884c2b(p0 string, p1 common.Address, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c91d5ed4(p0 string, p1 common.Address, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_0454c079(p0 string, p1 common.Address, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3e9f866a(p0 string, p1 common.Address, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_319af333(p0 string, p1 common.Address) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_aabc9a31(p0 string, p1 common.Address, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5f15d28c(p0 string, p1 common.Address, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e0e9ad4f(p0 string, p1 common.Address, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_245986f2(p0 string, p1 common.Address, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_91d1112e(p0 string, p1 common.Address, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_63fb8bc5(p0 string, p1 common.Address, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_fc4845f0(p0 string, p1 common.Address, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0d26b925(p0 string, p1 common.Address, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_5a477632(p0 string, p1 common.Address, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f8f51b1e(p0 string, p1 common.Address, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_33e9dd1d(p0 string, p1 bool, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_958c28c6(p0 string, p1 bool, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_932bbb38(p0 string, p1 bool, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_2d8e33a4(p0 string, p1 bool, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5d08bb05(p0 string, p1 bool, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7190a529(p0 string, p1 bool, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_895af8c5(p0 string, p1 bool, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_850b7ad6(p0 string, p1 bool, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_9d22d5dd(p0 string, p1 bool, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8e3f78a9(p0 string, p1 bool, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c3b55635(p0 string, p1 bool) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_e0625b29(p0 string, p1 bool, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3f8a701d(p0 string, p1 bool, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e298f47d(p0 string, p1 bool, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_a826caeb(p0 string, p1 bool, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_24f91465(p0 string, p1 bool, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_935e09bf(p0 string, p1 bool, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8af7cf8a(p0 string, p1 bool, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c95958d6(p0 string, p1 bool, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_742d6ee7(p0 string, p1 bool, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_64b5bb67(p0 string, p1 bool, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3ca6268e(p0 string, p1 *ABIInt256) {
-	c.log("p0", p0, "p1", (*big.Int)(p1))
+	c.log(p0, (*big.Int)(p1))
 }
 
 func (c *ConsolePrecompile) Log_41304fac(p0 string) {
-	c.log("p0", p0)
+	c.log(p0)
 }
 
 func (c *ConsolePrecompile) Log_439c7bef(p0 string, p1 string, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5ccd4e37(p0 string, p1 string, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_95ed0195(p0 string, p1 string, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_eb1bff80(p0 string, p1 string, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7cc3c607(p0 string, p1 string, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c371c7db(p0 string, p1 string, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_40785869(p0 string, p1 string, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b0e0f9b5(p0 string, p1 string, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_5e84b0ea(p0 string, p1 string, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_d6aefad2(p0 string, p1 string, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_4b5c4277(p0 string, p1 string) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_6d572f44(p0 string, p1 string, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2c1754ed(p0 string, p1 string, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2ced7cef(p0 string, p1 string, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_de68f20a(p0 string, p1 string, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_8eafb02b(p0 string, p1 string, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1023f7b2(p0 string, p1 string, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c3a8a654(p0 string, p1 string, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5821efa1(p0 string, p1 string, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_5d1a971a(p0 string, p1 string, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f45d7d2c(p0 string, p1 string, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5ea2b7ae(p0 string, p1 *big.Int, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_82112a42(p0 string, p1 *big.Int, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1c7ec448(p0 string, p1 *big.Int, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_9ffb2f93(p0 string, p1 *big.Int, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_4f04fdc6(p0 string, p1 *big.Int, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e0e95b98(p0 string, p1 *big.Int, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_354c36d6(p0 string, p1 *big.Int, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ca7733b1(p0 string, p1 *big.Int, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_abf73a98(p0 string, p1 *big.Int, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e41b6f6f(p0 string, p1 *big.Int, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b60e72cc(p0 string, p1 *big.Int) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_7c4632a4(p0 string, p1 *big.Int, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7d24491d(p0 string, p1 *big.Int, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5970e089(p0 string, p1 *big.Int, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_5ab84e1f(p0 string, p1 *big.Int, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c67ea9d1(p0 string, p1 *big.Int, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e21de278(p0 string, p1 *big.Int, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7626db92(p0 string, p1 *big.Int, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ca47c4eb(p0 string, p1 *big.Int, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_854b3496(p0 string, p1 *big.Int, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a7a87853(p0 string, p1 *big.Int, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2488b414(p0 *big.Int, p1 common.Address, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_091ffaf5(p0 *big.Int, p1 common.Address, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_bcfd9be0(p0 *big.Int, p1 common.Address, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_031c6f73(p0 *big.Int, p1 common.Address, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_736efbb6(p0 *big.Int, p1 common.Address, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ef72c513(p0 *big.Int, p1 common.Address, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e351140f(p0 *big.Int, p1 common.Address, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9b6ec042(p0 *big.Int, p1 common.Address, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_90fb06aa(p0 *big.Int, p1 common.Address, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5abd992a(p0 *big.Int, p1 common.Address, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_69276c86(p0 *big.Int, p1 common.Address) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_9cba8fff(p0 *big.Int, p1 common.Address, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_cc32ab07(p0 *big.Int, p1 common.Address, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_63cb41f9(p0 *big.Int, p1 common.Address, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_3e128ca3(p0 *big.Int, p1 common.Address, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_46826b5d(p0 *big.Int, p1 common.Address, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_15c127b5(p0 *big.Int, p1 common.Address, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5f743a7c(p0 *big.Int, p1 common.Address, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5a9b5ed5(p0 *big.Int, p1 common.Address, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_ddb06521(p0 *big.Int, p1 common.Address, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_0c9cd9c1(p0 *big.Int, p1 common.Address, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_a1ef4cbb(p0 *big.Int, p1 bool, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_454d54a5(p0 *big.Int, p1 bool, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_35085f7b(p0 *big.Int, p1 bool, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_ade052c7(p0 *big.Int, p1 bool, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_078287f5(p0 *big.Int, p1 bool, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_69640b59(p0 *big.Int, p1 bool, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b6f577a1(p0 *big.Int, p1 bool, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_20718650(p0 *big.Int, p1 bool, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_dddb9561(p0 *big.Int, p1 bool, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7464ce23(p0 *big.Int, p1 bool, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_1c9d7eb3(p0 *big.Int, p1 bool) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_ef529018(p0 *big.Int, p1 bool, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_eb928d7f(p0 *big.Int, p1 bool, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_85775021(p0 *big.Int, p1 bool, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_68c8b8bd(p0 *big.Int, p1 bool, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_2c1d0746(p0 *big.Int, p1 bool, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_88cb6041(p0 *big.Int, p1 bool, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_91a02e2a(p0 *big.Int, p1 bool, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_20098014(p0 *big.Int, p1 bool, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_de03e774(p0 *big.Int, p1 bool, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c6acc7a8(p0 *big.Int, p1 bool, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f82c50f1(p0 *big.Int) {
-	c.log("p0", p0)
+	c.log(p0)
 }
 
 func (c *ConsolePrecompile) Log_6168ed61(p0 *big.Int, p1 string, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_90c30a56(p0 *big.Int, p1 string, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7afac959(p0 *big.Int, p1 string, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_9c3adfa1(p0 *big.Int, p1 string, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_e8d3018d(p0 *big.Int, p1 string, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ae2ec581(p0 *big.Int, p1 string, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ba535d9c(p0 *big.Int, p1 string, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_4ceda75a(p0 *big.Int, p1 string, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_d2d423cd(p0 *big.Int, p1 string, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_cf009880(p0 *big.Int, p1 string, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_643fd0df(p0 *big.Int, p1 string) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_d583c602(p0 *big.Int, p1 string, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b3a6b6bd(p0 *big.Int, p1 string, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b115611f(p0 *big.Int, p1 string, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_21ad0683(p0 *big.Int, p1 string, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_b028c9bd(p0 *big.Int, p1 string, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_3b2279b4(p0 *big.Int, p1 string, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_691a8f74(p0 *big.Int, p1 string, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_37aa7d4c(p0 *big.Int, p1 string, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_b7b914ca(p0 *big.Int, p1 string, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_82c25b74(p0 *big.Int, p1 string, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_56a5d1b1(p0 *big.Int, p1 *big.Int, p2 common.Address, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_15cac476(p0 *big.Int, p1 *big.Int, p2 common.Address, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5c96b331(p0 *big.Int, p1 *big.Int, p2 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_6cde40b8(p0 *big.Int, p1 *big.Int, p2 common.Address, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_88f6e4b2(p0 *big.Int, p1 *big.Int, p2 common.Address, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_9a816a83(p0 *big.Int, p1 *big.Int, p2 bool, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_ab085ae6(p0 *big.Int, p1 *big.Int, p2 bool, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_4766da72(p0 *big.Int, p1 *big.Int, p2 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_a5b4fc99(p0 *big.Int, p1 *big.Int, p2 bool, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_eb7f6fd2(p0 *big.Int, p1 *big.Int, p2 bool, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_f666715a(p0 *big.Int, p1 *big.Int) {
-	c.log("p0", p0, "p1", p1)
+	c.log(p0, p1)
 }
 
 func (c *ConsolePrecompile) Log_42d21db7(p0 *big.Int, p1 *big.Int, p2 string, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_7af6ab25(p0 *big.Int, p1 *big.Int, p2 string, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_71d04af2(p0 *big.Int, p1 *big.Int, p2 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_27d8afd2(p0 *big.Int, p1 *big.Int, p2 string, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_5da297eb(p0 *big.Int, p1 *big.Int, p2 string, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_fa8185af(p0 *big.Int, p1 *big.Int, p2 *big.Int, p3 common.Address) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_c598d185(p0 *big.Int, p1 *big.Int, p2 *big.Int, p3 bool) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_d1ed7a3c(p0 *big.Int, p1 *big.Int, p2 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2)
+	c.log(p0, p1, p2)
 }
 
 func (c *ConsolePrecompile) Log_59cfcbe3(p0 *big.Int, p1 *big.Int, p2 *big.Int, p3 string) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 
 func (c *ConsolePrecompile) Log_193fb800(p0 *big.Int, p1 *big.Int, p2 *big.Int, p3 *big.Int) {
-	c.log("p0", p0, "p1", p1, "p2", p2, "p3", p3)
+	c.log(p0, p1, p2, p3)
 }
 

--- a/op-chain-ops/script/console_test.go
+++ b/op-chain-ops/script/console_test.go
@@ -1,15 +1,16 @@
 package script
 
 import (
+	"fmt"
 	"log/slog"
+	"math/big"
 	"math/rand" // nosemgrep
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -50,8 +51,25 @@ func TestConsole(t *testing.T) {
 		})
 	}
 
-	require.NotNil(t, captLog.FindLog(testlog.NewMessageFilter("console")))
-	require.NotNil(t, captLog.FindLog(testlog.NewAttributesFilter("p0", alice.String())))
-	require.NotNil(t, captLog.FindLog(testlog.NewAttributesFilter("p1", bob.String())))
+	require.NotNil(t, captLog.FindLog(testlog.NewMessageFilter(fmt.Sprintf("%s %s", alice, bob))))
 	require.NotNil(t, captLog.FindLog(testlog.NewAttributesFilter("sender", sender.String())))
+}
+
+func TestFormatter(t *testing.T) {
+	got := consoleFormat("hello %d world %x example %3e",
+		big.NewInt(3), big.NewInt(0xc0ffee), big.NewInt(42), big.NewInt(123))
+	require.Equal(t, "hello 3 world 0xc0ffee example 0.042 123", got)
+	require.Equal(t, "4.2", consoleFormat("%8e", big.NewInt(420000000)))
+	require.Equal(t, "foo true bar false", consoleFormat("foo %s bar %s", true, false))
+	require.Equal(t, "foo 1 bar 0", consoleFormat("foo %d bar %d", true, false))
+	require.Equal(t, "sender: "+DefaultSenderAddr.String(),
+		consoleFormat("sender: %s", DefaultSenderAddr))
+	require.Equal(t, "long 0.000000000000000042 number", consoleFormat("long %18e number", big.NewInt(42)))
+	require.Equal(t, "long 4200.000000000000000003 number", consoleFormat("long %18e number",
+		new(big.Int).Add(new(big.Int).Mul(
+			big.NewInt(42),
+			new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil),
+		), big.NewInt(3))))
+	require.Equal(t, "1.23456e5", consoleFormat("%e", big.NewInt(123456)))
+	require.Equal(t, "-1.23456e5", consoleFormat("%e", (*ABIInt256)(big.NewInt(-123456))))
 }

--- a/op-chain-ops/script/consolegen/main.go
+++ b/op-chain-ops/script/consolegen/main.go
@@ -71,7 +71,6 @@ import (
 			if p == "" {
 				continue
 			}
-			out.WriteString(fmt.Sprintf(`"p%d", `, i))
 			out.WriteString(prettyArg(fmt.Sprintf("p%d", i), p))
 			if i != len(params)-1 {
 				out.WriteString(", ")

--- a/op-chain-ops/script/prank.go
+++ b/op-chain-ops/script/prank.go
@@ -78,7 +78,11 @@ func (h *Host) Prank(msgSender *common.Address, txOrigin *common.Address, repeat
 			return errors.New("you have an active prank; broadcasting and pranks are not compatible")
 		}
 	}
-	h.log.Warn("prank", "sender", msgSender)
+	if broadcast {
+		h.log.Debug("starting broadcast", "sender", msgSender, "repeat", repeat)
+	} else {
+		h.log.Debug("starting prank", "sender", msgSender, "repeat", repeat)
+	}
 	cf.Prank = &Prank{
 		Sender:     msgSender,
 		Origin:     txOrigin,
@@ -107,6 +111,11 @@ func (h *Host) StopPrank(broadcast bool) error {
 	}
 	if !cf.Prank.Broadcast && broadcast {
 		return errors.New("no broadcast in progress to stop")
+	}
+	if broadcast {
+		h.log.Debug("stopping broadcast")
+	} else {
+		h.log.Debug("stopping prank")
 	}
 	cf.Prank = nil
 	return nil

--- a/op-chain-ops/script/script_test.go
+++ b/op-chain-ops/script/script_test.go
@@ -29,9 +29,7 @@ func TestScript(t *testing.T) {
 	input := bytes4("run()")
 	returnData, _, err := h.Call(scriptContext.Sender, addr, input[:], DefaultFoundryGasLimit, uint256.NewInt(0))
 	require.NoError(t, err, "call failed: %x", string(returnData))
-	require.NotNil(t, captLog.FindLog(
-		testlog.NewAttributesFilter("p0", "sender nonce"),
-		testlog.NewAttributesFilter("p1", "1")))
+	require.NotNil(t, captLog.FindLog(testlog.NewMessageFilter("sender nonce 1")))
 
 	require.NoError(t, h.cheatcodes.Precompile.DumpState("noop"))
 	// and a second time, to see if we can revisit the host state.


### PR DESCRIPTION
**Description**

Quality-of-life improvement on Go forge script logging:
- format console logs, like how forge does it, to make logs more readable. (required re-generating the console Go file)
- cleanup verbose logs

**Tests**

Updated existing tests + added a test to cover the console formatting.
