### PR TITLE
cannon: Fix stack patching

### DIFF
--- a/cannon/mipsevm/program/patch.go
+++ b/cannon/mipsevm/program/patch.go
@@ -89,6 +89,7 @@ func PatchStack(st mipsevm.FPVMState) error {
 	envar := append([]byte("memprofilerate=0"), 0x0, 0x0, 0x0, 0x0)
 	_ = st.GetMemory().SetMemoryRange(sp+4*14, bytes.NewReader(envar))
 
+	// 16 bytes for memprofilerate=0 + 4 null bytes
 	programName := append([]byte("op-program"), 0x0)
 	_ = st.GetMemory().SetMemoryRange(sp+4*19, bytes.NewReader(programName))
 

--- a/cannon/mipsevm/program/patch.go
+++ b/cannon/mipsevm/program/patch.go
@@ -86,7 +86,8 @@ func PatchStack(st mipsevm.FPVMState) error {
 	_ = st.GetMemory().SetMemoryRange(sp+4*14, bytes.NewReader(envar))
 
 	// 24 bytes for GODEBUG=memprofilerate=0 + 4 null bytes
-	programName := append([]byte("op-program"), 0x0)
+	// Then append program name + 2 null bytes for 4-byte alignment
+	programName := append([]byte("op-program"), 0x0, 0x0)
 	_ = st.GetMemory().SetMemoryRange(sp+4*21, bytes.NewReader(programName))
 
 	return nil

--- a/cannon/mipsevm/program/patch.go
+++ b/cannon/mipsevm/program/patch.go
@@ -81,7 +81,7 @@ func PatchStack(st mipsevm.FPVMState) error {
 
 	_ = st.GetMemory().SetMemoryRange(sp+4*10, bytes.NewReader([]byte("4;byfairdiceroll"))) // 16 bytes of "randomness"
 
-	// append 3 extra zero bytes to end at 4-byte alignment
+	// append 4 extra zero bytes to end at 4-byte alignment
 	envar := append([]byte("GODEBUG=memprofilerate=0"), 0x0, 0x0, 0x0, 0x0)
 	_ = st.GetMemory().SetMemoryRange(sp+4*14, bytes.NewReader(envar))
 

--- a/cannon/mipsevm/program/patch.go
+++ b/cannon/mipsevm/program/patch.go
@@ -73,9 +73,9 @@ func PatchStack(st mipsevm.FPVMState) error {
 
 	// init argc, argv, aux on stack
 	storeMem(sp+4*0, 1)       // argc = 1 (argument count)
-	storeMem(sp+4*1, sp+4*20) // argv[0]
+	storeMem(sp+4*1, sp+4*19) // argv[0]
 	storeMem(sp+4*2, 0)       // argv[1] = terminating
-	storeMem(sp+4*3, sp+4*15) // envp[0] = x (offset to first env var)
+	storeMem(sp+4*3, sp+4*14) // envp[0] = x (offset to first env var)
 	storeMem(sp+4*4, 0)       // envp[1] = terminating
 	storeMem(sp+4*5, 6)       // auxv[0] = _AT_PAGESZ = 6 (key)
 	storeMem(sp+4*6, 4096)    // auxv[1] = page size of 4 KiB (value) - (== minPhysPageSize)
@@ -85,11 +85,12 @@ func PatchStack(st mipsevm.FPVMState) error {
 
 	_ = st.GetMemory().SetMemoryRange(sp+4*10, bytes.NewReader([]byte("4;byfairdiceroll"))) // 16 bytes of "randomness"
 
-	envar := append([]byte("memprofilerate=0"), 0x0)
-	_ = st.GetMemory().SetMemoryRange(sp+4*15, bytes.NewReader(envar))
+	// append 3 extra zero bytes to end at 4-byte alignment
+	envar := append([]byte("memprofilerate=0"), 0x0, 0x0, 0x0, 0x0)
+	_ = st.GetMemory().SetMemoryRange(sp+4*14, bytes.NewReader(envar))
 
 	programName := append([]byte("op-program"), 0x0)
-	_ = st.GetMemory().SetMemoryRange(sp+4*20, bytes.NewReader(programName))
+	_ = st.GetMemory().SetMemoryRange(sp+4*19, bytes.NewReader(programName))
 
 	return nil
 }

--- a/cannon/mipsevm/program/patch.go
+++ b/cannon/mipsevm/program/patch.go
@@ -75,7 +75,7 @@ func PatchStack(st mipsevm.FPVMState) error {
 	storeMem(sp+4*0, 1)       // argc = 1 (argument count)
 	storeMem(sp+4*1, sp+4*20) // argv[0]
 	storeMem(sp+4*2, 0)       // argv[1] = terminating
-	storeMem(sp+4*3, sp+4*15) // envp[0] = 0 (no env vars)
+	storeMem(sp+4*3, sp+4*15) // envp[0] = x (offset to first env var)
 	storeMem(sp+4*4, 0)       // envp[1] = terminating
 	storeMem(sp+4*5, 6)       // auxv[0] = _AT_PAGESZ = 6 (key)
 	storeMem(sp+4*6, 4096)    // auxv[1] = page size of 4 KiB (value) - (== minPhysPageSize)

--- a/cannon/testdata/example/entry/go.mod
+++ b/cannon/testdata/example/entry/go.mod
@@ -1,0 +1,3 @@
+module entry
+
+go 1.21

--- a/cannon/testdata/example/entry/main.go
+++ b/cannon/testdata/example/entry/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"runtime"
-	"strings"
 )
 
 func main() {
@@ -17,13 +16,10 @@ func main() {
 	var memProfileRate bool
 	env := os.Environ()
 	for _, env := range env {
-		toks := strings.Split(env, "=")
-		if len(toks) != 2 {
+		if env != "GODEBUG=memprofilerate=0" {
 			panic("invalid envar")
 		}
-		if toks[0] == "memprofilerate" && toks[1] == "0" {
-			memProfileRate = true
-		}
+		memProfileRate = true
 	}
 	if !memProfileRate {
 		panic("memProfileRate env is not set")

--- a/cannon/testdata/example/entry/main.go
+++ b/cannon/testdata/example/entry/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) != 1 {
+		panic("expected 1 arg")
+	}
+	if os.Args[0] != "op-program" {
+		panic("unexpected arg0")
+	}
+
+	var memProfileRate bool
+	env := os.Environ()
+	for _, env := range env {
+		toks := strings.Split(env, "=")
+		if len(toks) != 2 {
+			panic("invalid envar")
+		}
+		if toks[0] == "memprofilerate" && toks[1] == "0" {
+			memProfileRate = true
+		}
+	}
+	if !memProfileRate {
+		panic("memProfileRate env is not set")
+	}
+	if runtime.MemProfileRate != 0 {
+		panic("runtime.MemProfileRate is non-zero")
+	}
+}


### PR DESCRIPTION
Fixes the base stack pointer of the op-program.
Also adds the `memprofilerate=0` environment variable to all patched programs.

Setting `memprofilerate` avoids floating point operations within the Go runtime. We should be able to disable Go specific patches with this change, but this will be done on a later PR.

fixes: https://github.com/ethereum-optimism/optimism/issues/11660