### PR TITLE
Use env not context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ parameters:
   docker_publish_dispatch:
     type: boolean
     default: false
+  publish_contract_artifacts_dispatch:
+    type: boolean
+    default: false
 
 orbs:
   go: circleci/go@1.8.0
@@ -1474,10 +1477,20 @@ jobs:
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /root/gcp_cred_config.json
           oidc_token_file_path: /root/oidc_token.json
-          service_account_email: GCP_SERVICE_CONTRACTS_ACCOUNT_EMAIL
+          project_id: GCP_TOOLS_ARTIFACTS_PROJECT_ID
+          service_account_email: GCP_CONTRACTS_PUBLISHER_SERVICE_ACCOUNT_EMAIL
       - checkout
-      - attach_workspace: { at: "." }
       - install-contracts-dependencies
+      - run:
+          name: Pull artifacts
+          command: bash scripts/ops/pull-artifacts.sh
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Build contracts
+          environment:
+            FOUNDRY_PROFILE: ci
+          command: just build
+          working_directory: packages/contracts-bedrock
       - run:
           name: Publish artifacts
           command: bash scripts/ops/publish-artifacts.sh
@@ -1497,11 +1510,6 @@ workflows:
     jobs:
       - pnpm-monorepo:
           name: pnpm-monorepo
-      - publish-contract-artifacts:
-          requires:
-            - pnpm-monorepo
-          context:
-            - oplabs-gcr-release
       - contracts-bedrock-tests
       - contracts-bedrock-coverage
       - contracts-bedrock-checks:
@@ -1954,6 +1962,14 @@ workflows:
           context:
             - slack
             - oplabs-fpp-nodes
+
+  develop-publish-contract-artifacts:
+    when:
+      or:
+        - equal: [ "develop", <<pipeline.git.branch>> ]
+        - equal: [ true, <<pipeline.parameters.publish_contract_artifacts_dispatch>> ]
+    jobs:
+      - publish-contract-artifacts
 
   develop-fault-proofs:
     when:


### PR DESCRIPTION
Contexts are scoped to a specific GitHub user group, which doesn't work with the GitHub merge queue or OSS contributors. This PR updates the packaging job to use raw project-level env vars instead (which are not user-scoped), and to only run on commits to `develop`.