### PR TITLE
cannon: Port audit fixes

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0xb6e219e8c2d81d75c48a1459907609e9096fe032a7447c88cd3e0d134752ac8e"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x0045a97c01bc9c7c9e38d832e218594472e945f035bee81e92e105b3df20a469",
-    "sourceCodeHash": "0xc5b323d995d3bcb3d2da39c4c1037047169e25107bf4c043fb98d27e35425087"
+    "initCodeHash": "0xf5e2bca4ba0c504ffa68f1ce5fbf4349b1fa892034777d77803d9111aed279fa",
+    "sourceCodeHash": "0xe8d06d4e2c3cf6e0682e4c152429cd61f0fd963acb1190df1bba1727d90ef6b7"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xce7a1c3265e457a05d17b6d1a2ef93c4639caac3733c9cf88bfd192eae2c5788",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0xb6e219e8c2d81d75c48a1459907609e9096fe032a7447c88cd3e0d134752ac8e"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x36b7c32cf9eba05e6db44910a25c800b801c075f8e053eca9515c6e0e4d8a902",
-    "sourceCodeHash": "0xa307c44a2d67bc84e75f4b7341345ed236da2e63c1f3f442416f14cd262126bf"
+    "initCodeHash": "0x0045a97c01bc9c7c9e38d832e218594472e945f035bee81e92e105b3df20a469",
+    "sourceCodeHash": "0xc5b323d995d3bcb3d2da39c4c1037047169e25107bf4c043fb98d27e35425087"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xce7a1c3265e457a05d17b6d1a2ef93c4639caac3733c9cf88bfd192eae2c5788",

--- a/packages/contracts-bedrock/snapshots/abi/MIPS2.json
+++ b/packages/contracts-bedrock/snapshots/abi/MIPS2.json
@@ -51,5 +51,10 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidExitedValue",
+    "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
@@ -6,5 +6,7 @@ import { ISemver } from "src/universal/ISemver.sol";
 /// @title IMIPS2
 /// @notice Interface for the MIPS2 contract.
 interface IMIPS2 is ISemver {
+    error InvalidExitedValue();
+
     function step(bytes memory _stateData, bytes memory _proof, bytes32 _localContext) external returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";
+
 library MIPSState {
     struct CpuScalars {
         uint32 pc;
         uint32 nextPC;
         uint32 lo;
         uint32 hi;
+    }
+
+    function assertExitedIsValid(uint32 exited) internal pure {
+        if (exited > 1) {
+            revert InvalidExitedValue();
+        }
     }
 }

--- a/packages/contracts-bedrock/test/cannon/MIPS.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS.t.sol
@@ -65,7 +65,6 @@ contract MIPS_Test is CommonTest {
     ///         invalid (anything greater than 1).
     /// @param _exited Value to set the exited field to.
     function testFuzz_step_invalidExitedValue_fails(uint8 _exited) external {
-        // Assume
         // Make sure the value of _exited is invalid.
         _exited = uint8(bound(uint256(_exited), 2, type(uint8).max));
 
@@ -77,6 +76,7 @@ contract MIPS_Test is CommonTest {
         // Compute the encoded state and manipulate it.
         bytes memory enc = encodeState(state);
         assembly {
+            // Push offset by an additional 32 bytes (0x20) to account for length prefix
             mstore8(add(add(enc, 0x20), 89), _exited)
         }
 

--- a/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
@@ -6,6 +6,7 @@ import { MIPS2 } from "src/cannon/MIPS2.sol";
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import "src/dispute/lib/Types.sol";
+import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";
 
 contract ThreadStack {
     bytes32 internal constant EMPTY_THREAD_ROOT = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
@@ -189,6 +190,64 @@ contract MIPS2_Test is CommonTest {
             hex"3c10bfff3610fff0341100013c08ffff3508fffd34090003010950202d420001ae020008ae11000403e000080000000000000000000000000000000000000000ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5b4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d3021ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85e58769b32a1beaf1ea27375a44095a0d1fb664ce2dd358e7fcbfb78c26a193440eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968ffd70157e48063fc33c97a050f7f640233bf646cc98d9524c6b92bcf3ab56f839867cc5f7f196b93bae1e27e6320742445d290f2263827498b54fec539f756afcefad4e508c098b9a7e1d8feb19955fb02ba9675585078710969d3440f5054e0f9dc3e7fe016e050eff260334f18a5d4fe391d82092319f5964f2e2eb7c1c3a5f8b13a49e282f609c317a833fb8d976d11517c571d1221a265d25af778ecf8923490c6ceeb450aecdc82e28293031d10c7d73bf85e57bf041a97360aa2c5d99cc1df82d9c4b87413eae2ef048f94b4d3554cea73d92b0f7af96e0271c691e2bb5c67add7c6caf302256adedf7ab114da0acfe870d449a3a489f781d659e8beccda7bce9f4e8618b6bd2f4132ce798cdc7a60e7e1460a7299e3c6342a579626d22733e50f526ec2fa19a22b31e8ed50f23cd1fdf94c9154ed3a7609a2f1ff981fe1d3b5c807b281e4683cc6d6315cf95b9ade8641defcb32372f1c126e398ef7a5a2dce0a8a7f68bb74560f8f71837c2c2ebbcbf7fffb42ae1896f13f7c7479a0b46a28b6f55540f89444f63de0378e3d121be09e06cc9ded1c20e65876d36aa0c65e9645644786b620e2dd2ad648ddfcbf4a7e5b1a3a4ecfe7f64667a3f0b7e2f4418588ed35a2458cffeb39b93d26f18d2ab13bdce6aee58e7b99359ec2dfd95a9c16dc00d6ef18b7933a6f8dc65ccb55667138776f7dea101070dc8796e3774df84f40ae0c8229d0d6069e5c8f39a7c299677a09d367fc7b05e3bc380ee652cdc72595f74c7b1043d0e1ffbab734648c838dfb0527d971b602bc216c9619ef0abf5ac974a1ed57f4050aa510dd9c74f508277b39d7973bb2dfccc5eeb0618db8cd74046ff337f0a7bf2c8e03e10f642c1886798d71806ab1e888d9e5ee87d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
         bytes32 post = mips.step(encodeState(state), bytes.concat(threadWitness, memProof), 0);
         assertNotEq(post, bytes32(0));
+    }
+
+    /// @notice Tests that the mips step function fails when the value of the exited field is
+    ///         invalid (anything greater than 1).
+    /// @param _exited Value to set the exited field to.
+    function testFuzz_step_invalidExitedValueInState_fails(uint8 _exited) external {
+        // Make sure the value of _exited is invalid.
+        _exited = uint8(bound(uint256(_exited), 2, type(uint8).max));
+
+        // Setup state
+        uint32 insn = encodespec(17, 18, 8, 0x20); // Arbitrary instruction: add t0, s1, s2
+        (MIPS2.State memory state, MIPS2.ThreadState memory thread, bytes memory memProof) =
+            constructMIPSState(0, insn, 0x4, 0);
+
+        // Set up step data
+        bytes memory encodedThread = encodeThread(thread);
+        bytes memory threadWitness = abi.encodePacked(encodedThread, EMPTY_THREAD_ROOT);
+        bytes memory proofData = bytes.concat(threadWitness, memProof);
+        bytes memory stateData = encodeState(state);
+        assembly {
+            // Manipulate state data
+            // Push offset by an additional 32 bytes (0x20) to account for length prefix
+            mstore8(add(add(stateData, 0x20), 73), _exited)
+        }
+
+        // Call the step function and expect a revert.
+        vm.expectRevert(InvalidExitedValue.selector);
+        mips.step(stateData, proofData, 0);
+    }
+
+    /// @notice Tests that the mips step function fails when the value of the exited field on the thread witness is
+    ///         invalid (anything greater than 1).
+    /// @param _exited Value to set the exited field to.
+    function testFuzz_step_invalidExitedValueInThread_fails(uint8 _exited) external {
+        // Make sure the value of _exited is invalid.
+        _exited = uint8(bound(uint256(_exited), 2, type(uint8).max));
+
+        // Set up state with exited thread
+        uint32 insn = encodespec(17, 18, 8, 0x20); // Arbitrary instruction: add t0, s1, s2
+        (MIPS2.State memory state, MIPS2.ThreadState memory thread, bytes memory memProof) =
+            constructMIPSState(0, insn, 0x4, 0);
+        thread.exited = true;
+        thread.exitCode = uint8(1);
+        updateThreadStacks(state, thread);
+
+        // Set up step data
+        bytes memory stateData = encodeState(state);
+        bytes memory threadWitness = abi.encodePacked(encodeThread(thread), EMPTY_THREAD_ROOT);
+        bytes memory proofData = bytes.concat(threadWitness, memProof);
+        assembly {
+            // Manipulate threadWitness to contain invalid exited value
+            // Push offset by an additional 32 bytes (0x20) to account for length prefix
+            mstore8(add(add(proofData, 0x20), 5), _exited)
+        }
+
+        // Call the step function and expect a revert.
+        vm.expectRevert(InvalidExitedValue.selector);
+        mips.step(stateData, proofData, 0);
     }
 
     function test_invalidThreadWitness_reverts() public {

--- a/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
@@ -221,36 +221,6 @@ contract MIPS2_Test is CommonTest {
         mips.step(stateData, proofData, 0);
     }
 
-    /// @notice Tests that the mips step function fails when the value of the exited field on the thread witness is
-    ///         invalid (anything greater than 1).
-    /// @param _exited Value to set the exited field to.
-    function testFuzz_step_invalidExitedValueInThread_fails(uint8 _exited) external {
-        // Make sure the value of _exited is invalid.
-        _exited = uint8(bound(uint256(_exited), 2, type(uint8).max));
-
-        // Set up state with exited thread
-        uint32 insn = encodespec(17, 18, 8, 0x20); // Arbitrary instruction: add t0, s1, s2
-        (MIPS2.State memory state, MIPS2.ThreadState memory thread, bytes memory memProof) =
-            constructMIPSState(0, insn, 0x4, 0);
-        thread.exited = true;
-        thread.exitCode = uint8(1);
-        updateThreadStacks(state, thread);
-
-        // Set up step data
-        bytes memory stateData = encodeState(state);
-        bytes memory threadWitness = abi.encodePacked(encodeThread(thread), EMPTY_THREAD_ROOT);
-        bytes memory proofData = bytes.concat(threadWitness, memProof);
-        assembly {
-            // Manipulate threadWitness to contain invalid exited value
-            // Push offset by an additional 32 bytes (0x20) to account for length prefix
-            mstore8(add(add(proofData, 0x20), 5), _exited)
-        }
-
-        // Call the step function and expect a revert.
-        vm.expectRevert(InvalidExitedValue.selector);
-        mips.step(stateData, proofData, 0);
-    }
-
     function test_invalidThreadWitness_reverts() public {
         MIPS2.State memory state;
         MIPS2.ThreadState memory thread;


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Port [audit fixes](https://github.com/ethereum-optimism/optimism/pull/11503) applied to `MIPS.sol` to `MIPS2.sol`:
- Enforce state.exited must be either 0 or 1 ([from this commit](https://github.com/ethereum-optimism/optimism/pull/11503/commits/4348c663d308397f81de9cc9e5f038330254b7ec))
- Add additional tests to MIPS2.t.sol:
  - Add mmap tests ([from this commit](https://github.com/ethereum-optimism/optimism/pull/11503/commits/9750b3b0a434d5a72baeca7088cd3abf1f886294#diff-8a309985f18adabf8c792660e4a3e751256bf3fdea4045abed2248b2a2fa5c16))
  - Add srav tests ([from this commit](https://github.com/ethereum-optimism/optimism/pull/11503/commits/c303b2180a9bc043b5dfe177124e7bc5d8667b2d#diff-8a309985f18adabf8c792660e4a3e751256bf3fdea4045abed2248b2a2fa5c16))

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/11652
