### PR TITLE
npmrc: delete

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-# run prefoo scripts
-# npm and yarn support this as a default pnpm defaults to false
-enable-pre-post-scripts=true
-lockfile=true


### PR DESCRIPTION
**Description**

There is no longer any JS in the monorepo, we can remove
the `.npmrc` as its no longer used

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

