### PR TITLE
feat(op-program): Use `PebbleDB` for `DiskKV`

### DIFF
--- a/op-e2e/system_fpp_test.go
+++ b/op-e2e/system_fpp_test.go
@@ -3,7 +3,6 @@ package op_e2e
 import (
 	"context"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -87,6 +86,7 @@ func applySpanBatchActivation(active bool, dp *genesis.DeployConfig) {
 // - update the state root via a tx
 // - run program
 func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActivated bool) {
+	t.Helper()
 	InitParallel(t)
 	ctx := context.Background()
 
@@ -187,6 +187,7 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActi
 }
 
 func testVerifyL2OutputRoot(t *testing.T, detached bool, spanBatchActivated bool) {
+	t.Helper()
 	InitParallel(t)
 	ctx := context.Background()
 
@@ -278,10 +279,7 @@ type FaultProofProgramTestScenario struct {
 
 // testFaultProofProgramScenario runs the fault proof program in several contexts, given a test scenario.
 func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *System, s *FaultProofProgramTestScenario) {
-	// Use `os.MkdirTemp` to apply extra randomness over `t.TempDir`. This prevents the same directory from being reused
-	// across multiple test runs, which can cause issues when running tests in parallel.
-	preimageDir, err := os.MkdirTemp("", "witness-db-*")
-	require.NoError(t, err)
+	preimageDir := t.TempDir()
 
 	fppConfig := oppconf.NewConfig(sys.RollupConfig, sys.L2GenesisCfg.Config, s.L1Head, s.L2Head, s.L2OutputRoot, common.Hash(s.L2Claim), s.L2ClaimBlockNumber)
 	fppConfig.L1URL = sys.NodeEndpoint("l1").RPC()
@@ -295,7 +293,7 @@ func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *Syste
 	// Check the FPP confirms the expected output
 	t.Log("Running fault proof in fetching mode")
 	log := testlog.Logger(t, log.LevelInfo)
-	err = opp.FaultProofProgram(ctx, log, fppConfig)
+	err := opp.FaultProofProgram(ctx, log, fppConfig)
 	require.NoError(t, err)
 
 	t.Log("Shutting down network")

--- a/op-e2e/system_fpp_test.go
+++ b/op-e2e/system_fpp_test.go
@@ -280,7 +280,7 @@ type FaultProofProgramTestScenario struct {
 func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *System, s *FaultProofProgramTestScenario) {
 	// Use `os.MkdirTemp` to apply extra randomness over `t.TempDir`. This prevents the same directory from being reused
 	// across multiple test runs, which can cause issues when running tests in parallel.
-	preimageDir, err := os.MkdirTemp("", "witness-db")
+	preimageDir, err := os.MkdirTemp("", "witness-db-*")
 	require.NoError(t, err)
 
 	fppConfig := oppconf.NewConfig(sys.RollupConfig, sys.L2GenesisCfg.Config, s.L1Head, s.L2Head, s.L2OutputRoot, common.Hash(s.L2Claim), s.L2ClaimBlockNumber)

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -175,8 +175,14 @@ func PreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, 
 	hinterDone = routeHints(logger, hintChannel, hinter)
 	select {
 	case err := <-serverDone:
+		if err := kv.Close(); err != nil {
+			return err
+		}
 		return err
 	case err := <-hinterDone:
+		if err := kv.Close(); err != nil {
+			return err
+		}
 		return err
 	}
 }

--- a/op-program/host/kvstore/disk.go
+++ b/op-program/host/kvstore/disk.go
@@ -1,93 +1,64 @@
 package kvstore
 
 import (
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"io"
-	"os"
-	"path"
+	"runtime"
 	"sync"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// read/write mode for user/group/other, not executable.
-const diskPermission = 0666
-
-// DiskKV is a disk-backed key-value store, every key-value pair is a hex-encoded .txt file, with the value as content.
+// DiskKV is a disk-backed key-value store, with PebbleDB as the underlying DBMS.
 // DiskKV is safe for concurrent use with a single DiskKV instance.
 // DiskKV is safe for concurrent use between different DiskKV instances of the same disk directory as long as the
 // file system supports atomic renames.
 type DiskKV struct {
 	sync.RWMutex
-	path string
+	db *pebble.DB
 }
 
 // NewDiskKV creates a DiskKV that puts/gets pre-images as files in the given directory path.
 // The path must exist, or subsequent Put/Get calls will error when it does not.
 func NewDiskKV(path string) *DiskKV {
-	return &DiskKV{path: path}
-}
+	levels := make([]pebble.LevelOptions, 1)
+	levels[0].Compression = pebble.ZstdCompression
+	opts := &pebble.Options{
+		Cache:                    pebble.NewCache(int64(32 * 1024 * 1024)),
+		MaxConcurrentCompactions: runtime.NumCPU,
+		Levels: []pebble.LevelOptions{
+			{Compression: pebble.ZstdCompression},
+		},
+	}
+	db, err := pebble.Open(path, opts)
+	if err != nil {
+		panic(fmt.Errorf("failed to open pebbledb at %s: %w", path, err))
+	}
 
-func (d *DiskKV) pathKey(k common.Hash) string {
-	return path.Join(d.path, k.String()+".txt")
+	return &DiskKV{db: db}
 }
 
 func (d *DiskKV) Put(k common.Hash, v []byte) error {
 	d.Lock()
 	defer d.Unlock()
-	f, err := openTempFile(d.path, k.String()+".txt.*")
-	if err != nil {
-		return fmt.Errorf("failed to open temp file for pre-image %s: %w", k, err)
-	}
-	defer os.Remove(f.Name()) // Clean up the temp file if it doesn't actually get moved into place
-	if _, err := f.Write([]byte(hex.EncodeToString(v))); err != nil {
-		_ = f.Close()
-		return fmt.Errorf("failed to write pre-image %s to disk: %w", k, err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("failed to close temp pre-image %s file: %w", k, err)
-	}
-
-	targetFile := d.pathKey(k)
-	if err := os.Rename(f.Name(), targetFile); err != nil {
-		return fmt.Errorf("failed to move temp dir %v to final destination %v: %w", f.Name(), targetFile, err)
-	}
-	return nil
-}
-
-func openTempFile(dir string, nameTemplate string) (*os.File, error) {
-	f, err := os.CreateTemp(dir, nameTemplate)
-	// Directory has been deleted out from underneath us. Recreate it.
-	if errors.Is(err, os.ErrNotExist) {
-		if mkdirErr := os.MkdirAll(dir, 0777); mkdirErr != nil {
-			return nil, errors.Join(fmt.Errorf("failed to create directory %v: %w", dir, mkdirErr), err)
-		}
-		f, err = os.CreateTemp(dir, nameTemplate)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return f, nil
+	return d.db.Set(k.Bytes(), v, pebble.NoSync)
 }
 
 func (d *DiskKV) Get(k common.Hash) ([]byte, error) {
 	d.RLock()
 	defer d.RUnlock()
-	f, err := os.OpenFile(d.pathKey(k), os.O_RDONLY, diskPermission)
+
+	dat, closer, err := d.db.Get(k.Bytes())
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if err == pebble.ErrNotFound {
 			return nil, ErrNotFound
 		}
-		return nil, fmt.Errorf("failed to open pre-image file %s: %w", k, err)
+		return nil, err
 	}
-	defer f.Close() // fine to ignore closing error here
-	dat, err := io.ReadAll(f)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read pre-image from file %s: %w", k, err)
-	}
-	return hex.DecodeString(string(dat))
+	ret := make([]byte, len(dat))
+	copy(ret, dat)
+	closer.Close()
+	return ret, nil
 }
 
 var _ KV = (*DiskKV)(nil)

--- a/op-program/host/kvstore/disk.go
+++ b/op-program/host/kvstore/disk.go
@@ -1,6 +1,7 @@
 package kvstore
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -11,8 +12,6 @@ import (
 
 // DiskKV is a disk-backed key-value store, with PebbleDB as the underlying DBMS.
 // DiskKV is safe for concurrent use with a single DiskKV instance.
-// DiskKV is safe for concurrent use between different DiskKV instances of the same disk directory as long as the
-// file system supports atomic renames.
 type DiskKV struct {
 	sync.RWMutex
 	db *pebble.DB
@@ -21,8 +20,6 @@ type DiskKV struct {
 // NewDiskKV creates a DiskKV that puts/gets pre-images as files in the given directory path.
 // The path must exist, or subsequent Put/Get calls will error when it does not.
 func NewDiskKV(path string) *DiskKV {
-	levels := make([]pebble.LevelOptions, 1)
-	levels[0].Compression = pebble.ZstdCompression
 	opts := &pebble.Options{
 		Cache:                    pebble.NewCache(int64(32 * 1024 * 1024)),
 		MaxConcurrentCompactions: runtime.NumCPU,
@@ -50,7 +47,7 @@ func (d *DiskKV) Get(k common.Hash) ([]byte, error) {
 
 	dat, closer, err := d.db.Get(k.Bytes())
 	if err != nil {
-		if err == pebble.ErrNotFound {
+		if errors.Is(err, pebble.ErrNotFound) {
 			return nil, ErrNotFound
 		}
 		return nil, err
@@ -59,6 +56,13 @@ func (d *DiskKV) Get(k common.Hash) ([]byte, error) {
 	copy(ret, dat)
 	closer.Close()
 	return ret, nil
+}
+
+func (d *DiskKV) Close() error {
+	d.Lock()
+	defer d.Unlock()
+
+	return d.db.Close()
 }
 
 var _ KV = (*DiskKV)(nil)

--- a/op-program/host/kvstore/disk.go
+++ b/op-program/host/kvstore/disk.go
@@ -24,7 +24,7 @@ func NewDiskKV(path string) *DiskKV {
 		Cache:                    pebble.NewCache(int64(32 * 1024 * 1024)),
 		MaxConcurrentCompactions: runtime.NumCPU,
 		Levels: []pebble.LevelOptions{
-			{Compression: pebble.ZstdCompression},
+			{Compression: pebble.SnappyCompression},
 		},
 	}
 	db, err := pebble.Open(path, opts)

--- a/op-program/host/kvstore/kv.go
+++ b/op-program/host/kvstore/kv.go
@@ -19,4 +19,7 @@ type KV interface {
 	// It returns ErrNotFound when the pre-image cannot be found.
 	// KV store implementations may return additional errors specific to the KV storage.
 	Get(k common.Hash) ([]byte, error)
+
+	// Closes the KV store.
+	Close() error
 }

--- a/op-program/host/kvstore/mem.go
+++ b/op-program/host/kvstore/mem.go
@@ -37,3 +37,7 @@ func (m *MemKV) Get(k common.Hash) ([]byte, error) {
 	}
 	return slices.Clone(v), nil
 }
+
+func (m *MemKV) Close() error {
+	return nil
+}

--- a/op-program/scripts/run-compat.sh
+++ b/op-program/scripts/run-compat.sh
@@ -5,7 +5,7 @@ SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 COMPAT_DIR="${SCRIPTS_DIR}/../temp/compat"
 
 TESTNAME="${1?Must specify compat file to run}"
-BASEURL="${2:-https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-08-02}"
+BASEURL="${2:-https://github.com/ethereum-optimism/chain-test-data/releases/download/2024-09-01}"
 
 URL="${BASEURL}/${TESTNAME}.tar.bz"
 


### PR DESCRIPTION
## Overview

Uses `PebbleDB` as the persistent key-value store for the `op-program` host. Previously, the format used was very unfriendly for compression, which is a nice property to have for the test suite.

### Why change the `DiskKV` format?

Performance doesn't really matter a ton in this path, but while putting together [`fp-tests`](https://github.com/ethereum-optimism/fp-tests), I ran into two things:
1. The current format is awful for compression, hindering our ability to check in, upload, or download compressed witness databases.
2. `kona` and `op-program` used different file formats for their disk k/v store, which prevented them from running on the same witness DB. Other options included further transformation of the data, handled by the test runner tool, or a new `DiskKV` implementation solely for the `fp-tests` suite in each implementation.

### Why Pebble?

Pebble is a fast K/V store that is based off of the RocksDB format, used in geth. I would have used [`grocksdb`](https://github.com/linxGnu/grocksdb) over pebble, but getting CGO near the `op-program` seems like a bad idea.

`kona` is switching over to RocksDB in https://github.com/ethereum-optimism/kona/pull/471 - fortunately, `rocksdb` is compatible with Pebble databases, given the options set in this PR. With these two changes, `kona` will be able to run off of the same witness databases generated by `op-program` in the `fp-tests` suite.

### Dependencies

- [x] Updates to https://github.com/ethereum-optimism/chain-test-data 
- [x] Disallow concurrent creation of database instances for the same directory in `op-e2e`, cc @ajsutton.