### PR TITLE
fix(op-challenger): Don't hold onto DB lock

### DIFF
--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -26,7 +26,6 @@ type AsteriscTraceProvider struct {
 	prestate       string
 	generator      utils.ProofGenerator
 	gameDepth      types.Depth
-	preimageLoader *utils.PreimageLoader
 
 	types.PrestateProvider
 
@@ -42,7 +41,6 @@ func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.
 		prestate:         asteriscPrestate,
 		generator:        vm.NewExecutor(logger, m, cfg, vmCfg, asteriscPrestate, localInputs),
 		gameDepth:        gameDepth,
-		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 		PrestateProvider: prestateProvider,
 	}
 }
@@ -81,7 +79,8 @@ func (p *AsteriscTraceProvider) GetStepData(ctx context.Context, pos types.Posit
 	if data == nil {
 		return nil, nil, nil, errors.New("proof missing proof data")
 	}
-	oracleData, err := p.preimageLoader.LoadPreimage(proof)
+	preimageLoader := utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(p.dir)).Get)
+	oracleData, err := preimageLoader.LoadPreimage(proof)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to load preimage: %w", err)
 	}
@@ -179,7 +178,6 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		prestate:       cfg.AsteriscAbsolutePreState,
 		generator:      vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramServerExecutor(), cfg.AsteriscAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
-		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 	}
 	return &AsteriscTraceProviderForTest{p}
 }

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -24,12 +24,11 @@ import (
 )
 
 type CannonTraceProvider struct {
-	logger         log.Logger
-	dir            string
-	prestate       string
-	generator      utils.ProofGenerator
-	gameDepth      types.Depth
-	preimageLoader *utils.PreimageLoader
+	logger    log.Logger
+	dir       string
+	prestate  string
+	generator utils.ProofGenerator
+	gameDepth types.Depth
 
 	types.PrestateProvider
 
@@ -45,7 +44,6 @@ func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.
 		prestate:         prestate,
 		generator:        vm.NewExecutor(logger, m, cfg, vmCfg, prestate, localInputs),
 		gameDepth:        gameDepth,
-		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
 		PrestateProvider: prestateProvider,
 	}
 }
@@ -84,7 +82,8 @@ func (p *CannonTraceProvider) GetStepData(ctx context.Context, pos types.Positio
 	if data == nil {
 		return nil, nil, nil, errors.New("proof missing proof data")
 	}
-	oracleData, err := p.preimageLoader.LoadPreimage(proof)
+	preimageLoader := utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(p.dir)).Get)
+	oracleData, err := preimageLoader.LoadPreimage(proof)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to load preimage: %w", err)
 	}
@@ -178,12 +177,11 @@ type CannonTraceProviderForTest struct {
 
 func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Config, localInputs utils.LocalGameInputs, dir string, gameDepth types.Depth) *CannonTraceProviderForTest {
 	p := &CannonTraceProvider{
-		logger:         logger,
-		dir:            dir,
-		prestate:       cfg.CannonAbsolutePreState,
-		generator:      vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramServerExecutor(), cfg.CannonAbsolutePreState, localInputs),
-		gameDepth:      gameDepth,
-		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
+		logger:    logger,
+		dir:       dir,
+		prestate:  cfg.CannonAbsolutePreState,
+		generator: vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramServerExecutor(), cfg.CannonAbsolutePreState, localInputs),
+		gameDepth: gameDepth,
 	}
 	return &CannonTraceProviderForTest{p}
 }


### PR DESCRIPTION
## Overview

Opens the handle to the pebble database on the fly as to not hold onto the directory lock within the cannon or asterisc trace provider.