### PR TITLE
fix(op-challenger): Optionally open Pebble in RO mode

### DIFF
--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -42,7 +42,7 @@ func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.
 		prestate:         asteriscPrestate,
 		generator:        vm.NewExecutor(logger, m, cfg, vmCfg, asteriscPrestate, localInputs),
 		gameDepth:        gameDepth,
-		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
+		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir), true).Get),
 		PrestateProvider: prestateProvider,
 	}
 }
@@ -179,7 +179,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		prestate:       cfg.AsteriscAbsolutePreState,
 		generator:      vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramServerExecutor(), cfg.AsteriscAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
-		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
+		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir), true).Get),
 	}
 	return &AsteriscTraceProviderForTest{p}
 }

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -45,7 +45,7 @@ func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.
 		prestate:         prestate,
 		generator:        vm.NewExecutor(logger, m, cfg, vmCfg, prestate, localInputs),
 		gameDepth:        gameDepth,
-		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
+		preimageLoader:   utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir), true).Get),
 		PrestateProvider: prestateProvider,
 	}
 }
@@ -183,7 +183,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		prestate:       cfg.CannonAbsolutePreState,
 		generator:      vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramServerExecutor(), cfg.CannonAbsolutePreState, localInputs),
 		gameDepth:      gameDepth,
-		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir)).Get),
+		preimageLoader: utils.NewPreimageLoader(kvstore.NewDiskKV(vm.PreimageDir(dir), true).Get),
 	}
 	return &CannonTraceProviderForTest{p}
 }

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -151,7 +151,7 @@ func PreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, 
 		if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
 			return fmt.Errorf("creating datadir: %w", err)
 		}
-		kv = kvstore.NewDiskKV(cfg.DataDir)
+		kv = kvstore.NewDiskKV(cfg.DataDir, !cfg.FetchingEnabled())
 	}
 
 	var (

--- a/op-program/host/kvstore/disk.go
+++ b/op-program/host/kvstore/disk.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -19,7 +20,7 @@ type DiskKV struct {
 
 // NewDiskKV creates a DiskKV that puts/gets pre-images as files in the given directory path.
 // The path must exist, or subsequent Put/Get calls will error when it does not.
-func NewDiskKV(path string) *DiskKV {
+func NewDiskKV(path string, readOnly bool) *DiskKV {
 	opts := &pebble.Options{
 		Cache:                    pebble.NewCache(int64(32 * 1024 * 1024)),
 		MaxConcurrentCompactions: runtime.NumCPU,
@@ -27,6 +28,17 @@ func NewDiskKV(path string) *DiskKV {
 			{Compression: pebble.SnappyCompression},
 		},
 	}
+
+	// Check if the database exists. If it does not, create it.
+	desc, err := pebble.Peek(path, vfs.Default)
+	if err != nil || !desc.Exists {
+		// Attempt to create the database if it does not exist.
+		// We ignore the error; if the database cannot be created, the subsequent Open will fail.
+		db, _ := pebble.Open(path, opts)
+		db.Close()
+	}
+
+	opts.ReadOnly = readOnly
 	db, err := pebble.Open(path, opts)
 	if err != nil {
 		panic(fmt.Errorf("failed to open pebbledb at %s: %w", path, err))

--- a/op-program/host/kvstore/disk_test.go
+++ b/op-program/host/kvstore/disk_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestDiskKV(t *testing.T) {
 	tmp := t.TempDir() // automatically removed by testing cleanup
-	kv := NewDiskKV(tmp)
+	kv := NewDiskKV(tmp, false)
 	kvTest(t, kv)
 }
 
 func TestCreateMissingDirectory(t *testing.T) {
 	tmp := t.TempDir()
 	dir := filepath.Join(tmp, "data")
-	kv := NewDiskKV(dir)
+	kv := NewDiskKV(dir, false)
 	val := []byte{1, 2, 3, 4}
 	key := crypto.Keccak256Hash(val)
 	require.NoError(t, kv.Put(key, val))


### PR DESCRIPTION
## Overview

Adds an option to open pebble in read-only mode for concurrent read access.

Not 100% if this works; just experimenting. Will be nice to allow for concurrent read access if we can.

refs: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances, yet to determine if pebble's "read only" mode acts similarly to rocks' secondary instance mode.