### PR TITLE
chore: Fix lint error

### DIFF
--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -31,7 +31,7 @@ func BuildL1DeveloperGenesis(config *DeployConfig, dump *foundry.ForgeAllocs, l1
 		return nil, fmt.Errorf("cannot create L1 developer genesis: %w", err)
 	}
 
-	if genesis.Alloc != nil && len(genesis.Alloc) != 0 {
+	if len(genesis.Alloc) != 0 {
 		panic("Did not expect NewL1Genesis to generate non-empty state") // sanity check for dev purposes.
 	}
 	// copy, for safety when the dump is reused (like in e2e testing)


### PR DESCRIPTION
**Description**

golangci-lint v1.60.2 seems to report a new error when performing a nil check and length != 0 on maps. We're not using this version in CI yet but fix the error to simplify the code and provide for a future upgrade.

