### PR TITLE
fix: op-challenger move.go cli command wasn't cancellable

### DIFF
--- a/op-challenger/cmd/move.go
+++ b/op-challenger/cmd/move.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
@@ -70,7 +69,7 @@ func Move(ctx *cli.Context) error {
 		return fmt.Errorf("either attack or defense flag must be set")
 	}
 
-	rct, err := txMgr.Send(context.Background(), tx)
+	rct, err := txMgr.Send(ctx.Context, tx)
 	if err != nil {
 		return fmt.Errorf("failed to send tx: %w", err)
 	}


### PR DESCRIPTION
The txmgr is started with context.Background instead of the actual cancellable cli context, which traps ctrl-c interrupts. Hence it was not interruptable.
```
$ ./op-challenger/bin/op-challenger move --attack --parent-index latest --claim 0x0 --private-key $ATTACKER_SK
INFO [09-02|22:13:33.927] Configured transaction manager           sender=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
WARN [09-02|22:13:33.937] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:13:35.948] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:13:37.971] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:13:39.979] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:13:41.987] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:13:43.994] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:13:46.002] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
```

This simple fix makes it cancellable:
```
$ ./op-challenger/bin/op-challenger move --attack --parent-index latest --claim 0x0 --private-key $ATTACKER_SK
INFO [09-02|22:20:31.850] Configured transaction manager           sender=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
WARN [09-02|22:20:31.857] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
WARN [09-02|22:20:33.869] Failed to create a transaction, will retry service=challenger err="failed to estimate gas: execution reverted, reason: 0x3381d114"
^CCRIT [09-02|22:20:35.869] Application failed                       err="failed to send tx: failed to create the tx: context canceled"
```