### PR TITLE
maint: fix up cannon interfaces

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -86,6 +86,9 @@ snapshots-check:
 interfaces-check-no-build:
   ./scripts/checks/check-interfaces.sh
 
+# Checks interface correctness without cleaning before building.
+interfaces-check-no-clean: build interfaces-check-no-build
+
 # Checks that all interfaces are appropriately named and accurately reflect the corresponding
 # contract that they're meant to represent. We run "clean" before building because leftover
 # artifacts can cause the script to detect issues incorrectly.2

--- a/packages/contracts-bedrock/scripts/checks/check-interfaces.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-interfaces.sh
@@ -48,7 +48,6 @@ EXCLUDE_CONTRACTS=(
     "KontrolCheatsBase"
 
     # TODO: Interfaces that need to be fixed
-    "IPreimageOracle"
     "IOptimismMintableERC721"
     "IFaultDisputeGame"
     "IOptimismSuperchainERC20"

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xa307c44a2d67bc84e75f4b7341345ed236da2e63c1f3f442416f14cd262126bf"
   },
   "src/cannon/PreimageOracle.sol": {
-    "initCodeHash": "0xce7a1c3265e457a05d17b6d1a2ef93c4639caac3733c9cf88bfd192eae2c5788",
-    "sourceCodeHash": "0x0a3cd959b361f1da998365da8b3c14362007d73b36196cced0606a9f082e63a8"
+    "initCodeHash": "0xfb7b3221c2501448e451d053ec78c8fe8b669b97eecd06c85ab9deffe93f78d0",
+    "sourceCodeHash": "0xa664d3bf84dde60c6657e1f7be747229dd9a4f91a79a9c98d4b20b718c025dba"
   },
   "src/dispute/AnchorStateRegistry.sol": {
     "initCodeHash": "0x544f0398155e958b0de59f9448801e75c66042c95a7892e2264c015973be8bec",

--- a/packages/contracts-bedrock/snapshots/abi/PreimageOracle.json
+++ b/packages/contracts-bedrock/snapshots/abi/PreimageOracle.json
@@ -130,7 +130,7 @@
             "type": "bytes32"
           }
         ],
-        "internalType": "struct PreimageOracle.Leaf",
+        "internalType": "struct IPreimageOracle.Leaf",
         "name": "_postState",
         "type": "tuple"
       },
@@ -187,7 +187,7 @@
             "type": "bytes32"
           }
         ],
-        "internalType": "struct PreimageOracle.Leaf",
+        "internalType": "struct IPreimageOracle.Leaf",
         "name": "_preState",
         "type": "tuple"
       },
@@ -214,7 +214,7 @@
             "type": "bytes32"
           }
         ],
-        "internalType": "struct PreimageOracle.Leaf",
+        "internalType": "struct IPreimageOracle.Leaf",
         "name": "_postState",
         "type": "tuple"
       },
@@ -767,7 +767,7 @@
             "type": "bytes32"
           }
         ],
-        "internalType": "struct PreimageOracle.Leaf",
+        "internalType": "struct IPreimageOracle.Leaf",
         "name": "_preState",
         "type": "tuple"
       },
@@ -794,7 +794,7 @@
             "type": "bytes32"
           }
         ],
-        "internalType": "struct PreimageOracle.Leaf",
+        "internalType": "struct IPreimageOracle.Leaf",
         "name": "_postState",
         "type": "tuple"
       },

--- a/packages/contracts-bedrock/snapshots/storageLayout/PreimageOracle.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PreimageOracle.json
@@ -32,7 +32,7 @@
     "label": "proposals",
     "offset": 0,
     "slot": "19",
-    "type": "struct PreimageOracle.LargePreimageProposalKeys[]"
+    "type": "struct IPreimageOracle.LargePreimageProposalKeys[]"
   },
   {
     "bytes": "32",

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
-import { ISemver } from "src/universal/ISemver.sol";
 import { PreimageKeyLib } from "./PreimageKeyLib.sol";
 import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
 import "src/cannon/libraries/CannonErrors.sol";
@@ -12,7 +11,7 @@ import "src/cannon/libraries/CannonTypes.sol";
 /// @notice A contract for storing permissioned pre-images.
 /// @custom:attribution Solady <https://github.com/Vectorized/solady/blob/main/src/utils/MerkleProofLib.sol#L13-L43>
 /// @custom:attribution Beacon Deposit Contract <0x00000000219ab540356cbb839cbe05303d7705fa>
-contract PreimageOracle is IPreimageOracle, ISemver {
+contract PreimageOracle is IPreimageOracle {
     ////////////////////////////////////////////////////////////////
     //                   Constants & Immutables                   //
     ////////////////////////////////////////////////////////////////
@@ -31,8 +30,8 @@ contract PreimageOracle is IPreimageOracle, ISemver {
     uint256 public constant PRECOMPILE_CALL_RESERVED_GAS = 100_000;
 
     /// @notice The semantic version of the Preimage Oracle contract.
-    /// @custom:semver 1.1.2-rc.1
-    string public constant version = "1.1.2-rc.1";
+    /// @custom:semver 1.2.0-beta.1
+    string public constant version = "1.2.0-beta.1";
 
     ////////////////////////////////////////////////////////////////
     //                 Authorized Preimage Parts                  //
@@ -48,24 +47,6 @@ contract PreimageOracle is IPreimageOracle, ISemver {
     ////////////////////////////////////////////////////////////////
     //                  Large Preimage Proposals                  //
     ////////////////////////////////////////////////////////////////
-
-    /// @notice A raw leaf of the large preimage proposal merkle tree.
-    struct Leaf {
-        /// @notice The input absorbed for the block, exactly 136 bytes.
-        bytes input;
-        /// @notice The index of the block in the absorption process.
-        uint256 index;
-        /// @notice The hash of the internal state after absorbing the input.
-        bytes32 stateCommitment;
-    }
-
-    /// @notice Unpacked keys for large preimage proposals.
-    struct LargePreimageProposalKeys {
-        /// @notice The claimant of the large preimage proposal.
-        address claimant;
-        /// @notice The UUID of the large preimage proposal.
-        uint256 uuid;
-    }
 
     /// @notice Static padding hashes. These values are persisted in storage, but are entirely immutable
     ///         after the constructor's execution.
@@ -107,7 +88,11 @@ contract PreimageOracle is IPreimageOracle, ISemver {
     //             Standard Preimage Route (External)             //
     ////////////////////////////////////////////////////////////////
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Reads a preimage from the oracle.
+    /// @param _key The key of the preimage to read.
+    /// @param _offset The offset of the preimage to read.
+    /// @return dat_ The preimage data.
+    /// @return datLen_ The length of the preimage data.
     function readPreimage(bytes32 _key, uint256 _offset) external view returns (bytes32 dat_, uint256 datLen_) {
         require(preimagePartOk[_key][_offset], "pre-image must exist");
 
@@ -123,7 +108,27 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         dat_ = preimageParts[_key][_offset];
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Loads of local data part into the preimage oracle.
+    /// @param _ident The identifier of the local data.
+    /// @param _localContext The local key context for the preimage oracle. Optionally, can be set as a constant
+    ///                      if the caller only requires one set of local keys.
+    /// @param _word The local data word.
+    /// @param _size The number of bytes in `_word` to load.
+    /// @param _partOffset The offset of the local data part to write to the oracle.
+    /// @dev The local data parts are loaded into the preimage oracle under the context
+    ///      of the caller - no other account can write to the caller's context
+    ///      specific data.
+    ///
+    ///      There are 5 local data identifiers:
+    ///      ┌────────────┬────────────────────────┐
+    ///      │ Identifier │      Data              │
+    ///      ├────────────┼────────────────────────┤
+    ///      │          1 │ L1 Head Hash (bytes32) │
+    ///      │          2 │ Output Root (bytes32)  │
+    ///      │          3 │ Root Claim (bytes32)   │
+    ///      │          4 │ L2 Block Number (u64)  │
+    ///      │          5 │ Chain ID (u64)         │
+    ///      └────────────┴────────────────────────┘
     function loadLocalData(
         uint256 _ident,
         bytes32 _localContext,
@@ -163,7 +168,10 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key_] = _size;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Prepares a preimage to be read by keccak256 key, starting at the given offset and up to 32 bytes
+    ///         (clipped at preimage length, if out of data).
+    /// @param _partOffset The offset of the preimage to read.
+    /// @param _preimage The preimage data.
     function loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external {
         uint256 size;
         bytes32 key;
@@ -198,7 +206,10 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key] = size;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Prepares a preimage to be read by sha256 key, starting at the given offset and up to 32 bytes
+    ///         (clipped at preimage length, if out of data).
+    /// @param _partOffset The offset of the preimage to read.
+    /// @param _preimage The preimage data.
     function loadSha256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external {
         uint256 size;
         bytes32 key;
@@ -247,7 +258,13 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key] = size;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Verifies that `p(_z) = _y` given `_commitment` that corresponds to the polynomial `p(x)` and a KZG
+    //          proof. The value `y` is the pre-image, and the preimage key is `5 ++ keccak256(_commitment ++ z)[1:]`.
+    /// @param _z Big endian point value. Part of the preimage key.
+    /// @param _y Big endian point value. The preimage for the key.
+    /// @param _commitment The commitment to the polynomial. 48 bytes, part of the preimage key.
+    /// @param _proof The KZG proof, part of the preimage key.
+    /// @param _partOffset The offset of the preimage to store.
     function loadBlobPreimagePart(
         uint256 _z,
         uint256 _y,
@@ -338,7 +355,13 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key] = 32;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Prepares a precompile result to be read by a precompile key for the specified offset.
+    ///         The precompile result data is a concatenation of the precompile call status byte and its return data.
+    ///         The preimage key is `6 ++ keccak256(precompile ++ input)[1:]`.
+    /// @param _partOffset The offset of the precompile result being loaded.
+    /// @param _precompile The precompile address
+    /// @param _requiredGas The gas required to fully execute an L1 precompile.
+    /// @param _input The input to the precompile call.
     function loadPrecompilePreimagePart(
         uint256 _partOffset,
         address _precompile,

--- a/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
@@ -1,41 +1,89 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { ISemver } from "src/universal/ISemver.sol";
+import { LPPMetaData } from "src/cannon/libraries/CannonTypes.sol";
+import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
+
 /// @title IPreimageOracle
-/// @notice Interface for a preimage oracle.
-interface IPreimageOracle {
-    /// @notice Returns the length of the large preimage proposal challenge period.
-    /// @return challengePeriod_ The length of the challenge period in seconds.
+/// @notice Interface for the PreimageOracle contract.
+interface IPreimageOracle is ISemver {
+    /// @notice A raw leaf of the large preimage proposal merkle tree.
+    struct Leaf {
+        /// @notice The input absorbed for the block, exactly 136 bytes.
+        bytes input;
+        /// @notice The index of the block in the absorption process.
+        uint256 index;
+        /// @notice The hash of the internal state after absorbing the input.
+        bytes32 stateCommitment;
+    }
+
+    /// @notice Unpacked keys for large preimage proposals.
+    struct LargePreimageProposalKeys {
+        /// @notice The claimant of the large preimage proposal.
+        address claimant;
+        /// @notice The UUID of the large preimage proposal.
+        uint256 uuid;
+    }
+
+    error ActiveProposal();
+    error AlreadyFinalized();
+    error AlreadyInitialized();
+    error BadProposal();
+    error BondTransferFailed();
+    error InsufficientBond();
+    error InvalidInputSize();
+    error InvalidPreimage();
+    error InvalidProof();
+    error NotEOA();
+    error NotInitialized();
+    error PartOffsetOOB();
+    error PostStateMatches();
+    error StatesNotContiguous();
+    error TreeSizeOverflow();
+    error WrongStartingBlock();
+
+    function KECCAK_TREE_DEPTH() external view returns (uint256);
+    function MAX_LEAF_COUNT() external view returns (uint256);
+    function MIN_BOND_SIZE() external view returns (uint256);
+    function PRECOMPILE_CALL_RESERVED_GAS() external view returns (uint256);
+    function addLeavesLPP(
+        uint256 _uuid,
+        uint256 _inputStartBlock,
+        bytes memory _input,
+        bytes32[] memory _stateCommitments,
+        bool _finalize
+    )
+        external;
+    function challengeFirstLPP(
+        address _claimant,
+        uint256 _uuid,
+        Leaf memory _postState,
+        bytes32[] memory _postStateProof
+    )
+        external;
+    function challengeLPP(
+        address _claimant,
+        uint256 _uuid,
+        LibKeccak.StateMatrix memory _stateMatrix,
+        Leaf memory _preState,
+        bytes32[] memory _preStateProof,
+        Leaf memory _postState,
+        bytes32[] memory _postStateProof
+    )
+        external;
     function challengePeriod() external view returns (uint256 challengePeriod_);
-
-    /// @notice Reads a preimage from the oracle.
-    /// @param _key The key of the preimage to read.
-    /// @param _offset The offset of the preimage to read.
-    /// @return dat_ The preimage data.
-    /// @return datLen_ The length of the preimage data.
-    function readPreimage(bytes32 _key, uint256 _offset) external view returns (bytes32 dat_, uint256 datLen_);
-
-    /// @notice Loads of local data part into the preimage oracle.
-    /// @param _ident The identifier of the local data.
-    /// @param _localContext The local key context for the preimage oracle. Optionally, can be set as a constant
-    ///                      if the caller only requires one set of local keys.
-    /// @param _word The local data word.
-    /// @param _size The number of bytes in `_word` to load.
-    /// @param _partOffset The offset of the local data part to write to the oracle.
-    /// @dev The local data parts are loaded into the preimage oracle under the context
-    ///      of the caller - no other account can write to the caller's context
-    ///      specific data.
-    ///
-    ///      There are 5 local data identifiers:
-    ///      ┌────────────┬────────────────────────┐
-    ///      │ Identifier │      Data              │
-    ///      ├────────────┼────────────────────────┤
-    ///      │          1 │ L1 Head Hash (bytes32) │
-    ///      │          2 │ Output Root (bytes32)  │
-    ///      │          3 │ Root Claim (bytes32)   │
-    ///      │          4 │ L2 Block Number (u64)  │
-    ///      │          5 │ Chain ID (u64)         │
-    ///      └────────────┴────────────────────────┘
+    function getTreeRootLPP(address _owner, uint256 _uuid) external view returns (bytes32 treeRoot_);
+    function initLPP(uint256 _uuid, uint32 _partOffset, uint32 _claimedSize) external payable;
+    function loadBlobPreimagePart(
+        uint256 _z,
+        uint256 _y,
+        bytes memory _commitment,
+        bytes memory _proof,
+        uint256 _partOffset
+    )
+        external;
+    function loadKeccak256PreimagePart(uint256 _partOffset, bytes memory _preimage) external;
     function loadLocalData(
         uint256 _ident,
         bytes32 _localContext,
@@ -45,47 +93,36 @@ interface IPreimageOracle {
     )
         external
         returns (bytes32 key_);
-
-    /// @notice Prepares a preimage to be read by keccak256 key, starting at the given offset and up to 32 bytes
-    ///         (clipped at preimage length, if out of data).
-    /// @param _partOffset The offset of the preimage to read.
-    /// @param _preimage The preimage data.
-    function loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external;
-
-    /// @notice Prepares a preimage to be read by sha256 key, starting at the given offset and up to 32 bytes
-    ///         (clipped at preimage length, if out of data).
-    /// @param _partOffset The offset of the preimage to read.
-    /// @param _preimage The preimage data.
-    function loadSha256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external;
-
-    /// @notice Verifies that `p(_z) = _y` given `_commitment` that corresponds to the polynomial `p(x)` and a KZG
-    //          proof. The value `y` is the pre-image, and the preimage key is `5 ++ keccak256(_commitment ++ z)[1:]`.
-    /// @param _z Big endian point value. Part of the preimage key.
-    /// @param _y Big endian point value. The preimage for the key.
-    /// @param _commitment The commitment to the polynomial. 48 bytes, part of the preimage key.
-    /// @param _proof The KZG proof, part of the preimage key.
-    /// @param _partOffset The offset of the preimage to store.
-    function loadBlobPreimagePart(
-        uint256 _z,
-        uint256 _y,
-        bytes calldata _commitment,
-        bytes calldata _proof,
-        uint256 _partOffset
-    )
-        external;
-
-    /// @notice Prepares a precompile result to be read by a precompile key for the specified offset.
-    ///         The precompile result data is a concatenation of the precompile call status byte and its return data.
-    ///         The preimage key is `6 ++ keccak256(precompile ++ input)[1:]`.
-    /// @param _partOffset The offset of the precompile result being loaded.
-    /// @param _precompile The precompile address
-    /// @param _requiredGas The gas required to fully execute an L1 precompile.
-    /// @param _input The input to the precompile call.
     function loadPrecompilePreimagePart(
         uint256 _partOffset,
         address _precompile,
         uint64 _requiredGas,
-        bytes calldata _input
+        bytes memory _input
     )
         external;
+    function loadSha256PreimagePart(uint256 _partOffset, bytes memory _preimage) external;
+    function minProposalSize() external view returns (uint256 minProposalSize_);
+    function preimageLengths(bytes32) external view returns (uint256);
+    function preimagePartOk(bytes32, uint256) external view returns (bool);
+    function preimageParts(bytes32, uint256) external view returns (bytes32);
+    function proposalBlocks(address, uint256, uint256) external view returns (uint64);
+    function proposalBlocksLen(address _claimant, uint256 _uuid) external view returns (uint256 len_);
+    function proposalBonds(address, uint256) external view returns (uint256);
+    function proposalBranches(address, uint256, uint256) external view returns (bytes32);
+    function proposalCount() external view returns (uint256 count_);
+    function proposalMetadata(address, uint256) external view returns (LPPMetaData);
+    function proposalParts(address, uint256) external view returns (bytes32);
+    function proposals(uint256) external view returns (address claimant, uint256 uuid); // nosemgrep
+    function readPreimage(bytes32 _key, uint256 _offset) external view returns (bytes32 dat_, uint256 datLen_);
+    function squeezeLPP(
+        address _claimant,
+        uint256 _uuid,
+        LibKeccak.StateMatrix memory _stateMatrix,
+        Leaf memory _preState,
+        bytes32[] memory _preStateProof,
+        Leaf memory _postState,
+        bytes32[] memory _postStateProof
+    )
+        external;
+    function zeroHashes(uint256) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test, Vm, console2 as console } from "forge-std/Test.sol";
 
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
 import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
@@ -552,7 +553,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -607,7 +608,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
 
@@ -676,7 +677,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -723,7 +724,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Finalize the proposal.
         vm.expectRevert(ActiveProposal.selector);
@@ -751,7 +752,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Finalize the proposal.
         vm.expectRevert(ActiveProposal.selector);
@@ -784,7 +785,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -830,7 +831,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -882,7 +883,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
             // Construct the leaf preimage data for the blocks added.
             LibKeccak.StateMatrix memory matrixB;
-            PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
+            IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
 
             // Fetch the merkle proofs for the pre/post state leaves in the proposal tree.
             bytes32 canonicalRoot = oracle.getTreeRootLPP(address(this), TEST_UUID);
@@ -949,7 +950,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory p = new bytes32[](16);
@@ -989,7 +990,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
 
@@ -1029,7 +1030,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
 
@@ -1077,7 +1078,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added and corrupt the state commitments.
         LibKeccak.StateMatrix memory matrixB;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
         for (uint256 i = _lastCorrectLeafIdx + 1; i < leaves.length; i++) {
             leaves[i].stateCommitment = 0;
         }
@@ -1127,7 +1128,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added and corrupt the state commitments.
         LibKeccak.StateMatrix memory matrixB;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
         for (uint256 i = 0; i < leaves.length; i++) {
             leaves[i].stateCommitment = 0;
         }
@@ -1166,7 +1167,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -1218,7 +1219,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
         leaves[2].stateCommitment = stateCommitments[2];
@@ -1272,7 +1273,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
         leaves[2].stateCommitment = stateCommitments[2];
@@ -1326,7 +1327,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
         leaves[2].stateCommitment = stateCommitments[2];
@@ -1363,7 +1364,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     }
 
     /// @notice Hashes leaf data for the preimage proposals tree
-    function _hashLeaf(PreimageOracle.Leaf memory _leaf) internal pure returns (bytes32 leaf_) {
+    function _hashLeaf(IPreimageOracle.Leaf memory _leaf) internal pure returns (bytes32 leaf_) {
         leaf_ = keccak256(abi.encodePacked(_leaf.input, _leaf.index, _leaf.stateCommitment));
     }
 
@@ -1374,18 +1375,18 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     )
         internal
         pure
-        returns (PreimageOracle.Leaf[] memory leaves_)
+        returns (IPreimageOracle.Leaf[] memory leaves_)
     {
         bytes memory data = LibKeccak.padMemory(_data);
         uint256 numCommitments = data.length / LibKeccak.BLOCK_SIZE_BYTES;
 
-        leaves_ = new PreimageOracle.Leaf[](numCommitments);
+        leaves_ = new IPreimageOracle.Leaf[](numCommitments);
         for (uint256 i = 0; i < numCommitments; i++) {
             bytes memory blockSlice = Bytes.slice(data, i * LibKeccak.BLOCK_SIZE_BYTES, LibKeccak.BLOCK_SIZE_BYTES);
             LibKeccak.absorb(_stateMatrix, blockSlice);
             LibKeccak.permutation(_stateMatrix);
 
-            leaves_[i] = PreimageOracle.Leaf({
+            leaves_[i] = IPreimageOracle.Leaf({
                 input: blockSlice,
                 index: uint32(i),
                 stateCommitment: keccak256(abi.encode(_stateMatrix))
@@ -1437,7 +1438,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     ///         constructed with `_leaves`.
     function _generateProof(
         uint256 _leafIdx,
-        PreimageOracle.Leaf[] memory _leaves
+        IPreimageOracle.Leaf[] memory _leaves
     )
         internal
         returns (bytes32 root_, bytes32[] memory proof_)


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Fixes up the cannon interfaces, primarily updates the interface for the PreimageOracle so that it passes the interface check.