### PR TITLE
feat: update interface validation script to check semver

### DIFF
--- a/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 /// @title Enum - Collection of enums used in Safe contracts.
 /// @author Richard Meissner - @rmeissner

--- a/packages/contracts-bedrock/scripts/interfaces/ISystemConfigV0.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/ISystemConfigV0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -69,7 +69,7 @@
   },
   "src/L2/CrossL2Inbox.sol": {
     "initCodeHash": "0x071b53cd8cf0503af856c4ee0ee34643e85059d53c096453891225472e02abfa",
-    "sourceCodeHash": "0x3c78129b91d9f06afa4787d4b3039f45a3b22b3edf5155ed73d4f0c3ab33c6c8"
+    "sourceCodeHash": "0xc3478a7036b8c58ed1a90ad90556a62c99a4abb124b0fa47f2edfca31eec680f"
   },
   "src/L2/ETHLiquidity.sol": {
     "initCodeHash": "0x98177562fca0de0dfea5313c9acefe2fdbd73dee5ce6c1232055601f208f0177",

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -6,16 +6,7 @@ import { TransientContext, TransientReentrancyAware } from "src/libraries/Transi
 import { ISemver } from "src/universal/ISemver.sol";
 import { ICrossL2Inbox } from "src/L2/ICrossL2Inbox.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
-
-/// @title IDependencySet
-/// @notice Interface for L1Block with only `isInDependencySet(uint256)` method.
-interface IDependencySet {
-    /// @notice Returns true if the chain associated with input chain ID is in the interop dependency set.
-    ///         Every chain is in the interop dependency set of itself.
-    /// @param _chainId Input chain ID.
-    /// @return True if the input chain ID corresponds to a chain in the interop dependency set, and false otherwise.
-    function isInDependencySet(uint256 _chainId) external view returns (bool);
-}
+import { IDependencySet } from "src/L2/interfaces/IDependencySet.sol";
 
 /// @notice Thrown when the caller is not DEPOSITOR_ACCOUNT when calling `setInteropStart()`
 error NotDepositor();

--- a/packages/contracts-bedrock/src/L2/interfaces/IDependencySet.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IDependencySet.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IDependencySet
+/// @notice Interface for L1Block with only `isInDependencySet(uint256)` method.
+interface IDependencySet {
+    /// @notice Returns true if the chain associated with input chain ID is in the interop dependency set.
+    ///         Every chain is in the interop dependency set of itself.
+    /// @param _chainId Input chain ID.
+    /// @return True if the input chain ID corresponds to a chain in the interop dependency set, and false otherwise.
+    function isInDependencySet(uint256 _chainId) external view returns (bool);
+}

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { ISemver } from "src/universal/ISemver.sol";
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { ISemver } from "src/universal/ISemver.sol";
 

--- a/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 /// @title IPreimageOracle
 /// @notice Interface for a preimage oracle.

--- a/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
@@ -2,11 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Constants } from "src/libraries/Constants.sol";
-
-/// @title IL1ChugSplashDeployer
-interface IL1ChugSplashDeployer {
-    function isUpgrading() external view returns (bool);
-}
+import { IL1ChugSplashDeployer } from "src/legacy/interfaces/IL1ChugSplashProxy.sol";
 
 /// @custom:legacy
 /// @title L1ChugSplashProxy

--- a/packages/contracts-bedrock/src/legacy/interfaces/IL1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/interfaces/IL1ChugSplashProxy.sol
@@ -14,3 +14,15 @@ interface IL1ChugSplashProxy {
     function setOwner(address _owner) external;
     function setStorage(bytes32 _key, bytes32 _value) external;
 }
+
+/// @title IStaticL1ChugSplashProxy
+/// @notice IStaticL1ChugSplashProxy is a static version of the ChugSplash proxy interface.
+interface IStaticL1ChugSplashProxy {
+    function getImplementation() external view returns (address);
+    function getOwner() external view returns (address);
+}
+
+/// @title IL1ChugSplashDeployer
+interface IL1ChugSplashDeployer {
+    function isUpgrading() external view returns (bool);
+}

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
@@ -2,11 +2,7 @@
 pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";
-
-interface IGelatoTreasury {
-    function totalDepositedAmount(address _user, address _token) external view returns (uint256);
-    function totalWithdrawnAmount(address _user, address _token) external view returns (uint256);
-}
+import { IGelatoTreasury } from "src/vendor/interfaces/IGelatoTreasury.sol";
 
 /// @title CheckGelatoLow
 /// @notice DripCheck for checking if an account's Gelato ETH balance is below some threshold.

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { Faucet } from "../Faucet.sol";
 

--- a/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
+++ b/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
@@ -6,22 +6,8 @@ import { Proxy } from "src/universal/Proxy.sol";
 import { AddressManager } from "src/legacy/AddressManager.sol";
 import { L1ChugSplashProxy } from "src/legacy/L1ChugSplashProxy.sol";
 import { Constants } from "src/libraries/Constants.sol";
-
-/// @title IStaticERC1967Proxy
-/// @notice IStaticERC1967Proxy is a static version of the ERC1967 proxy interface.
-interface IStaticERC1967Proxy {
-    function implementation() external view returns (address);
-
-    function admin() external view returns (address);
-}
-
-/// @title IStaticL1ChugSplashProxy
-/// @notice IStaticL1ChugSplashProxy is a static version of the ChugSplash proxy interface.
-interface IStaticL1ChugSplashProxy {
-    function getImplementation() external view returns (address);
-
-    function getOwner() external view returns (address);
-}
+import { IStaticERC1967Proxy } from "src/universal/interfaces/IStaticERC1967Proxy.sol";
+import { IStaticL1ChugSplashProxy } from "src/legacy/interfaces/IL1ChugSplashProxy.sol";
 
 /// @title ProxyAdmin
 /// @notice This is an auxiliary contract meant to be assigned as the admin of an ERC1967 Proxy,

--- a/packages/contracts-bedrock/src/universal/interfaces/IEIP712.sol
+++ b/packages/contracts-bedrock/src/universal/interfaces/IEIP712.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IEIP712
+interface IEIP712 {
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/packages/contracts-bedrock/src/universal/interfaces/IStaticERC1967Proxy.sol
+++ b/packages/contracts-bedrock/src/universal/interfaces/IStaticERC1967Proxy.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IStaticERC1967Proxy
+/// @notice IStaticERC1967Proxy is a static version of the ERC1967 proxy interface.
+interface IStaticERC1967Proxy {
+    function implementation() external view returns (address);
+    function admin() external view returns (address);
+}

--- a/packages/contracts-bedrock/src/vendor/interfaces/IGelatoTreasury.sol
+++ b/packages/contracts-bedrock/src/vendor/interfaces/IGelatoTreasury.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IGelatoTreasury
+/// @notice Interface for the GelatoTreasury contract.
+interface IGelatoTreasury {
+    function totalDepositedAmount(address _user, address _token) external view returns (uint256);
+    function totalWithdrawnAmount(address _user, address _token) external view returns (uint256);
+}

--- a/packages/contracts-bedrock/test/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/Preinstalls.t.sol
@@ -5,10 +5,7 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { Bytes } from "src/libraries/Bytes.sol";
 import { console2 as console } from "forge-std/console2.sol";
-
-interface IEIP712 {
-    function DOMAIN_SEPARATOR() external view returns (bytes32);
-}
+import { IEIP712 } from "src/universal/interfaces/IEIP712.sol";
 
 /// @title PreinstallsTest
 contract PreinstallsTest is CommonTest {

--- a/packages/contracts-bedrock/test/periphery/op-nft/Optimist.t.sol
+++ b/packages/contracts-bedrock/test/periphery/op-nft/Optimist.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.6.2 <0.9.0;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
+import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
 import { Optimist } from "src/periphery/op-nft/Optimist.sol";
 import { OptimistAllowlist } from "src/periphery/op-nft/OptimistAllowlist.sol";
@@ -10,21 +11,6 @@ import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
 import { OptimistInviterHelper } from "test/mocks/OptimistInviterHelper.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-
-interface IMulticall3 {
-    struct Call3 {
-        address target;
-        bool allowFailure;
-        bytes callData;
-    }
-
-    struct Result {
-        bool success;
-        bytes returnData;
-    }
-
-    function aggregate3(Call3[] calldata calls) external payable returns (Result[] memory returnData);
-}
 
 library Multicall {
     bytes internal constant code =


### PR DESCRIPTION
Updates the interface validation script to verify that all interface contracts are using Solidity ^0.8.0 exactly.

Closes #11741