### PR TITLE
repo: bump foundry

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "go": "1.22.6",
   "abigen": "v1.10.25",
-  "foundry": "d28a3377e52e6a4114a8cea2903c115b023279e8",
+  "foundry": "143abd6a768eeb52a5785240b763d72a56987b4a",
   "geth": "v1.14.7",
   "geth_release": "1.14.7-aa55f5ea",
   "eth2_testnet_genesis": "v0.10.0",


### PR DESCRIPTION
**Description**

Bumps foundry to the following commit: https://github.com/foundry-rs/foundry/commit/143abd6a768eeb52a5785240b763d72a56987b4a

Release: https://github.com/foundry-rs/foundry/releases/tag/nightly

This needs to be followed up with a rebuild of `ci-builder`

Closes https://github.com/ethereum-optimism/optimism/issues/11692

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

