### PR TITLE
Fix contracts-bedrock-docker-publish build

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -34,7 +34,7 @@ RUN git submodule update --init --recursive \
     && just build \
     && echo $(git rev-parse HEAD) > .gitcommit
 
-FROM --platform=linux/amd64 debian:bookworm-20240812-slim
+FROM --platform=linux/amd64 debian:bookworm-20240812-slim as contracts-bedrock
 
 RUN apt-get update && apt-get install -y \
   curl \


### PR DESCRIPTION
The build stage name was accidentally removed, which [broke](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/63237/workflows/e6a2d738-132f-4e10-9da2-c265b364c771/jobs/2627291) the job.
