### PR TITLE
Catch `'header not found'` string in `L2BlockRefByLabel`

### DIFF
--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -102,7 +102,7 @@ func (s *L2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) 
 	if err != nil {
 		// Both geth and erigon like to serve non-standard errors for the safe and finalized heads, correct that.
 		// This happens when the chain just started and nothing is marked as safe/finalized yet.
-		if strings.Contains(err.Error(), "block not found") || strings.Contains(err.Error(), "Unknown block") || strings.Contains(err.Error(), "unknown block") {
+		if strings.Contains(err.Error(), "block not found") || strings.Contains(err.Error(), "Unknown block") || strings.Contains(err.Error(), "unknown block") || strings.Contains(err.Error(), "header not found") {
 			err = ethereum.NotFound
 		}
 		// w%: wrap to preserve ethereum.NotFound case


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds `'header not found'` to list of EL RPC errors caught by `L2BlockRefByLabel`.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Geth sometimes returns `'header not found'` and sometimes `'block not found'`. The distinction isn't apparent. Reth has defaulted to returning `'header not found'`, which better describes the root of the error in the reth code.

**Metadata**

- geth `'header not found'`
`https://github.com/ethereum/go-ethereum/blob/623b17ba20daea8cfd2530dd906fda0193b79579/eth/api_backend.go#L204
- geth `'block not found'`
https://github.com/ethereum/go-ethereum/blob/623b17ba20daea8cfd2530dd906fda0193b79579/eth/api_backend.go#L134-L136
- https://github.com/paradigmxyz/reth/pull/7416
