### PR TITLE
Fix race condition in sequencer stopping logic

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -111,8 +111,9 @@ type Sequencer struct {
 	nextAction   time.Time
 	nextActionOK bool
 
-	latest     BuildingState
-	latestHead eth.L2BlockRef
+	latest       BuildingState
+	latestSealed eth.L2BlockRef
+	latestHead   eth.L2BlockRef
 
 	latestHeadSet chan struct{}
 
@@ -285,6 +286,7 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 		Ref:          x.Ref,
 	})
 	d.latest.Ref = x.Ref
+	d.latestSealed = x.Ref
 }
 
 func (d *Sequencer) onPayloadSealInvalid(x engine.PayloadSealInvalidEvent) {
@@ -667,7 +669,7 @@ func (d *Sequencer) Stop(ctx context.Context) (hash common.Hash, err error) {
 	}
 
 	// ensure latestHead has been updated to the latest sealed/gossiped block before stopping the sequencer
-	for d.latestHead.Hash != d.latest.Ref.Hash {
+	for d.latestHead.Hash != d.latestSealed.Hash {
 		latestHeadSet := make(chan struct{})
 		d.latestHeadSet = latestHeadSet
 		d.l.Unlock()

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -170,6 +170,12 @@ func TestSequencer_StartStop(t *testing.T) {
 	require.True(t, deps.asyncGossip.started, "async gossip is always started on initialization")
 	require.False(t, deps.seqState.active, "sequencer not active yet")
 
+	// latest refs should all be empty
+	require.Equal(t, common.Hash{}, seq.latest.Ref.Hash)
+	require.Equal(t, common.Hash{}, seq.latestSealed.Hash)
+	require.Equal(t, common.Hash{}, seq.latestHead.Hash)
+
+	// update the latestSealed
 	envelope := &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{},
 	}
@@ -181,12 +187,20 @@ func TestSequencer_StartStop(t *testing.T) {
 		Envelope: envelope,
 		Ref:      eth.L2BlockRef{Hash: common.Hash{0xaa}},
 	})
+	require.Equal(t, common.Hash{0xaa}, seq.latest.Ref.Hash)
+	require.Equal(t, common.Hash{0xaa}, seq.latestSealed.Hash)
+	require.Equal(t, common.Hash{}, seq.latestHead.Hash)
+
+	// update latestHead
 	emitter.AssertExpectations(t)
 	seq.OnEvent(engine.ForkchoiceUpdateEvent{
 		UnsafeL2Head:    eth.L2BlockRef{Hash: common.Hash{0xaa}},
 		SafeL2Head:      eth.L2BlockRef{},
 		FinalizedL2Head: eth.L2BlockRef{},
 	})
+	require.Equal(t, common.Hash{0xaa}, seq.latest.Ref.Hash)
+	require.Equal(t, common.Hash{0xaa}, seq.latestSealed.Hash)
+	require.Equal(t, common.Hash{0xaa}, seq.latestHead.Hash)
 
 	require.False(t, seq.Active())
 	// no action scheduled


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Introduce a loop in the sequencer `Stop()` method, waiting for the `latestHead` to be updated to the value of `latestSealed` (which is the latest ref passed to `onBuildSealed`), to ensure we stop the sequencer on the latest gossiped block.

**Tests**

Updated tests to be compatible with the change.

**Additional context**

I believe #10991 introduced a race condition where the latest sealed/gossiped block hash is not necessarily returned from the `admin_stopSequencer` call. This can result in 1-block reorgs, as we experienced on Base mainnet this morning:
```
parent block: 0x2c3e5368cc245462e30cdf172ab93cd2d36686812f8dd8f11cc28e1401c1474a
reorged block: 0x7376b44b298e605544559ea54056a362c90af21baaa22a9abecbcb1160b5e388
canonical block: 0x4be8861a14721c6f1236e24014dbd3f9fe71e824d0a9bdf1d406ad7c6449c064
```

Sequencer logs:
![Screenshot 2024-09-05 at 9 38 09 AM](https://github.com/user-attachments/assets/8c81ccf1-95d4-4e6a-b669-fd1981c0a655)

In this case, the block was built and gossiped, but `latestHead` was not updated until the `Sequencer is processing forkchoice update` log, _after_ the sequencer was stopped; therefore the stop command returned the previous block.

