### PR TITLE
ci: pull cached artifacts for contracts tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,6 +544,10 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
+          name: pull cached artifacts
+          command: bash scripts/ops/pull-artifacts.sh
+          working_directory: packages/contracts-bedrock
+      - run:
           name: run tests
           command: just test
           environment:


### PR DESCRIPTION
Contracts tests don't need to recompile if we can just use the artifacts instead. Reduces test time in cases where the contracts aren't changed by up to 5 minutes.