### PR TITLE
op-node: sanity-check the forkchoice updates

### DIFF
--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -34,6 +34,11 @@ func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
 		SafeL2Head:      eq.ec.safeHead,
 		FinalizedL2Head: eq.ec.finalizedHead,
 	}
+	if fcEvent.UnsafeL2Head.Number < fcEvent.FinalizedL2Head.Number {
+		err := fmt.Errorf("invalid block-building pre-state, unsafe head %s is behind finalized head %s", fcEvent.UnsafeL2Head, fcEvent.FinalizedL2Head)
+		eq.emitter.Emit(rollup.CriticalErrorEvent{Err: err}) // make the node exit, things are very wrong.
+		return
+	}
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      fcEvent.UnsafeL2Head.Hash,
 		SafeBlockHash:      fcEvent.SafeL2Head.Hash,

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -269,6 +269,11 @@ func (e *EngineController) TryUpdateEngine(ctx context.Context) error {
 	if e.IsEngineSyncing() {
 		e.log.Warn("Attempting to update forkchoice state while EL syncing")
 	}
+	if e.unsafeHead.Number < e.finalizedHead.Number {
+		err := fmt.Errorf("invalid forkchoice state, unsafe head %s is behind finalized head %s", e.unsafeHead, e.finalizedHead)
+		e.emitter.Emit(rollup.CriticalErrorEvent{Err: err}) // make the node exit, things are very wrong.
+		return err
+	}
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      e.unsafeHead.Hash,
 		SafeBlockHash:      e.safeHead.Hash,


### PR DESCRIPTION
Defensive sanity checks, so if something is corrupted in the op-node (e.g. stale buffer content), we don't apply it to the execution engine.
