### PR TITLE
Update and cleanup CODEOWNERS with expert teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,29 @@
-# Packages
-/packages/contracts-bedrock     @ethereum-optimism/contract-reviewers
-/packages/sdk                   @ethereum-optimism/devxpod
+# Monorepo - default to go-reviewers
+* @ethereum-optimism/go-reviewers
 
-# Bedrock codebases
-/bedrock-devnet @ethereum-optimism/go-reviewers
-/cannon         @ethereum-optimism/go-reviewers
-/op-batcher     @ethereum-optimism/go-reviewers
-/op-bootnode    @ethereum-optimism/go-reviewers
-/op-chain-ops   @ethereum-optimism/go-reviewers
-/op-challenger  @ethereum-optimism/go-reviewers
-/op-dispute-mon  @ethereum-optimism/go-reviewers
-/op-e2e         @ethereum-optimism/go-reviewers
-/op-node        @ethereum-optimism/go-reviewers
-/op-node/rollup @protolambda @ajsutton
-/op-alt-da      @ethereum-optimism/go-reviewers
-/op-preimage    @ethereum-optimism/go-reviewers
-/op-program     @ethereum-optimism/go-reviewers
-/op-proposer    @ethereum-optimism/go-reviewers
-/op-service     @ethereum-optimism/go-reviewers
-/op-supervisor  @ethereum-optimism/go-reviewers
-/op-wheel       @ethereum-optimism/go-reviewers
-/ops-bedrock    @ethereum-optimism/go-reviewers
-/op-conductor   @0x00101010 @zhwrd @mslipper
+# OP Stack general
+/bedrock-devnet @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-alt-da      @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-batcher     @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-chain-ops   @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-e2e         @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-node        @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-proposer    @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/op-wheel       @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+/ops-bedrock    @ethereum-optimism/go-reviewers @ethereum-optimism/op-stack
+
+# Expert areas
+/op-node/rollup @ethereum-optimism/go-reviewers @ethereum-optimism/consensus
+
+/op-supervisor  @ethereum-optimism/go-reviewers @ethereum-optimism/interop
+
+/op-conductor   @ethereum-optimism/go-reviewers @ethereum-optimism/op-conductor
+
+/cannon         @ethereum-optimism/go-reviewers @ethereum-optimism/proofs
+/op-dispute-mon @ethereum-optimism/go-reviewers @ethereum-optimism/proofs
+/op-challenger  @ethereum-optimism/go-reviewers @ethereum-optimism/proofs
+/op-preimage    @ethereum-optimism/go-reviewers @ethereum-optimism/proofs
+/op-program     @ethereum-optimism/go-reviewers @ethereum-optimism/proofs
 
 # Ops
 /.circleci       @ethereum-optimism/monorepo-ops-reviewers
@@ -29,15 +31,5 @@
 /ops             @ethereum-optimism/monorepo-ops-reviewers
 /docker-bake.hcl @ethereum-optimism/monorepo-ops-reviewers
 
-# Misc
-/proxyd           @ethereum-optimism/infra-reviewers
-/infra            @ethereum-optimism/infra-reviewers
-/specs            @ethereum-optimism/contract-reviewers @ethereum-optimism/go-reviewers
-
-# Don't add owners if only package.json is updated
-/packages/*/package.json
-/*/package.json
-
-# JavaScript Releases
-/packages/*/CHANGELOG.md @ethereum-optimism/release-managers
-/*/CHANGELOG.md          @ethereum-optimism/release-managers
+# Contracts
+/packages/contracts-bedrock     @ethereum-optimism/contract-reviewers


### PR DESCRIPTION
**Description**

This is the CODEOWNERS update to execute the following plan ([internal source](https://www.notion.so/oplabs/Proposal-changes-to-CODEOWNERS-and-reviewer-assignment-behaviour-91cd76268d2a402aa3574251f4dca857?pvs=4#ee4d6b8b085644eabe417acd773585b1))


- keep `go-reviewers`
    - but remove auto-assignment for that team
    - this allows approving, so remove blocks
- add domain-expert sub-teams
    - `proofs` (`cannon` , `op-challenger`, …)
    - `protocol` (`op-node/rollup`)
        - maybe we keep this as a separate group to *require* an approval from a protocol engineer, and not let any `go-reviewers` approve, unsure
    - `op-stack` (`op-node`, `op-batcher` , `op-proposer`, …)
    - `op-conductor`
    - `interop`
- randomly assign from those sub teams
- all directories in the CODEOWNERS file would have `go-reviewers` as well as a special team as owner
    - this lets all `go-reviewers` *approve* PRs
    - but *requests* reviews *only* from special teams

The `go-reviewers` super-team is also set as the default owner of all files. Previously, we had unowned files and directories. Since the monorepo is primarily a go module, besides the contracts, it seems to make sense to have go-reviewers be the default owners.