### PR TITLE
fix(challenger): `asterisc-kona` trace type

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -264,8 +264,104 @@ func TestPollInterval(t *testing.T) {
 	})
 }
 
-func TestAsteriscRequiredArgs(t *testing.T) {
-	for _, traceType := range []types.TraceType{types.TraceTypeAsterisc} {
+func TestAsteriscOpProgramRequiredArgs(t *testing.T) {
+	traceType := types.TraceTypeAsterisc
+	t.Run(fmt.Sprintf("TestAsteriscServer-%v", traceType), func(t *testing.T) {
+		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+			configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-server"))
+		})
+
+		t.Run("Required", func(t *testing.T) {
+			verifyArgsInvalid(t, "flag asterisc-server is required", addRequiredArgsExcept(traceType, "--asterisc-server"))
+		})
+
+		t.Run("Valid", func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-server", "--asterisc-server=./op-program"))
+			require.Equal(t, "./op-program", cfg.Asterisc.Server)
+		})
+	})
+
+	t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestate-%v", traceType), func(t *testing.T) {
+		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+			configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-prestate"))
+		})
+
+		t.Run("Required", func(t *testing.T) {
+			verifyArgsInvalid(t, "flag asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
+		})
+
+		t.Run("Valid", func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-prestate", "--asterisc-prestate=./pre.json"))
+			require.Equal(t, "./pre.json", cfg.AsteriscAbsolutePreState)
+		})
+	})
+
+	t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestateBaseURL-%v", traceType), func(t *testing.T) {
+		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+			configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-prestates-url"))
+		})
+
+		t.Run("Required", func(t *testing.T) {
+			verifyArgsInvalid(t, "flag asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
+		})
+
+		t.Run("Valid", func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-prestates-url", "--asterisc-prestates-url=http://localhost/bar"))
+			require.Equal(t, "http://localhost/bar", cfg.AsteriscAbsolutePreStateBaseURL.String())
+		})
+	})
+}
+
+func TestAsteriscKonaRequiredArgs(t *testing.T) {
+	traceType := types.TraceTypeAsteriscKona
+	t.Run(fmt.Sprintf("TestAsteriscServer-%v", traceType), func(t *testing.T) {
+		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+			configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-kona-server"))
+		})
+
+		t.Run("Required", func(t *testing.T) {
+			verifyArgsInvalid(t, "flag asterisc-kona-server is required", addRequiredArgsExcept(traceType, "--asterisc-kona-server"))
+		})
+
+		t.Run("Valid", func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-kona-server", "--asterisc-kona-server=./kona-host"))
+			require.Equal(t, "./kona-host", cfg.AsteriscKona.Server)
+		})
+	})
+
+	t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestate-%v", traceType), func(t *testing.T) {
+		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+			configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-kona-prestate"))
+		})
+
+		t.Run("Required", func(t *testing.T) {
+			verifyArgsInvalid(t, "flag asterisc-kona-prestates-url or asterisc-kona-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-kona-prestate"))
+		})
+
+		t.Run("Valid", func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-kona-prestate", "--asterisc-kona-prestate=./pre.json"))
+			require.Equal(t, "./pre.json", cfg.AsteriscKonaAbsolutePreState)
+		})
+	})
+
+	t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestateBaseURL-%v", traceType), func(t *testing.T) {
+		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+			configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-kona-prestates-url"))
+		})
+
+		t.Run("Required", func(t *testing.T) {
+			verifyArgsInvalid(t, "flag asterisc-kona-prestates-url or asterisc-kona-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-kona-prestate"))
+		})
+
+		t.Run("Valid", func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-kona-prestates-url", "--asterisc-kona-prestates-url=http://localhost/bar"))
+			require.Equal(t, "http://localhost/bar", cfg.AsteriscKonaAbsolutePreStateBaseURL.String())
+		})
+	})
+}
+
+func TestAsteriscBaseRequiredArgs(t *testing.T) {
+	for _, traceType := range []types.TraceType{types.TraceTypeAsterisc, types.TraceTypeAsteriscKona} {
 		traceType := traceType
 		t.Run(fmt.Sprintf("TestAsteriscBin-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
@@ -279,51 +375,6 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-bin", "--asterisc-bin=./asterisc"))
 				require.Equal(t, "./asterisc", cfg.Asterisc.VmBin)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestAsteriscServer-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-server"))
-			})
-
-			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag asterisc-server is required", addRequiredArgsExcept(traceType, "--asterisc-server"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-server", "--asterisc-server=./op-program"))
-				require.Equal(t, "./op-program", cfg.Asterisc.Server)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestate-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-prestate"))
-			})
-
-			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-prestate", "--asterisc-prestate=./pre.json"))
-				require.Equal(t, "./pre.json", cfg.AsteriscAbsolutePreState)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestAsteriscAbsolutePrestateBaseURL-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-prestates-url"))
-			})
-
-			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-prestates-url", "--asterisc-prestates-url=http://localhost/bar"))
-				require.Equal(t, "http://localhost/bar", cfg.AsteriscAbsolutePreStateBaseURL.String())
 			})
 		})
 
@@ -853,6 +904,8 @@ func requiredArgs(traceType types.TraceType) map[string]string {
 		addRequiredCannonArgs(args)
 	case types.TraceTypeAsterisc:
 		addRequiredAsteriscArgs(args)
+	case types.TraceTypeAsteriscKona:
+		addRequiredAsteriscKonaArgs(args)
 	}
 	return args
 }
@@ -870,6 +923,14 @@ func addRequiredAsteriscArgs(args map[string]string) {
 	args["--asterisc-bin"] = asteriscBin
 	args["--asterisc-server"] = asteriscServer
 	args["--asterisc-prestate"] = asteriscPreState
+	args["--l2-eth-rpc"] = l2EthRpc
+}
+
+func addRequiredAsteriscKonaArgs(args map[string]string) {
+	args["--asterisc-network"] = asteriscNetwork
+	args["--asterisc-bin"] = asteriscBin
+	args["--asterisc-kona-server"] = asteriscServer
+	args["--asterisc-kona-prestate"] = asteriscPreState
 	args["--l2-eth-rpc"] = l2EthRpc
 }
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -327,7 +327,7 @@ func CheckCannonFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckAsteriscFlags(ctx *cli.Context) error {
+func CheckAsteriscBaseFlags(ctx *cli.Context) error {
 	if ctx.IsSet(AsteriscNetworkFlag.Name) && ctx.IsSet(flags.NetworkFlagName) {
 		return fmt.Errorf("flag %v can not be used with %v", AsteriscNetworkFlag.Name, flags.NetworkFlagName)
 	}
@@ -350,11 +350,31 @@ func CheckAsteriscFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(AsteriscBinFlag.Name) {
 		return fmt.Errorf("flag %s is required", AsteriscBinFlag.Name)
 	}
+	return nil
+}
+
+func CheckAsteriscFlags(ctx *cli.Context) error {
+	if err := CheckAsteriscBaseFlags(ctx); err != nil {
+		return err
+	}
 	if !ctx.IsSet(AsteriscServerFlag.Name) {
 		return fmt.Errorf("flag %s is required", AsteriscServerFlag.Name)
 	}
 	if !ctx.IsSet(AsteriscPreStateFlag.Name) && !ctx.IsSet(AsteriscPreStatesURLFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", AsteriscPreStatesURLFlag.Name, AsteriscPreStateFlag.Name)
+	}
+	return nil
+}
+
+func CheckAsteriscKonaFlags(ctx *cli.Context) error {
+	if err := CheckAsteriscBaseFlags(ctx); err != nil {
+		return err
+	}
+	if !ctx.IsSet(AsteriscKonaServerFlag.Name) {
+		return fmt.Errorf("flag %s is required", AsteriscKonaServerFlag.Name)
+	}
+	if !ctx.IsSet(AsteriscKonaPreStateFlag.Name) && !ctx.IsSet(AsteriscKonaPreStatesURLFlag.Name) {
+		return fmt.Errorf("flag %s or %s is required", AsteriscKonaPreStatesURLFlag.Name, AsteriscKonaPreStateFlag.Name)
 	}
 	return nil
 }
@@ -377,6 +397,10 @@ func CheckRequired(ctx *cli.Context, traceTypes []types.TraceType) error {
 			}
 		case types.TraceTypeAsterisc:
 			if err := CheckAsteriscFlags(ctx); err != nil {
+				return err
+			}
+		case types.TraceTypeAsteriscKona:
+			if err := CheckAsteriscKonaFlags(ctx); err != nil {
 				return err
 			}
 		case types.TraceTypeAlphabet, types.TraceTypeFast:

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -77,7 +77,7 @@ func RegisterGameTypes(
 		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor()))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsteriscKona) {
-		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaServerExecutor()))
+		registerTasks = append(registerTasks, NewAsteriscKonaRegisterTask(faultTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaServerExecutor()))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeFast) {
 		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.FastGameType))

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -107,6 +107,36 @@ func NewAsteriscRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m
 	}
 }
 
+func NewAsteriscKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor) *RegisterTask {
+	return &RegisterTask{
+		gameType: gameType,
+		getPrestateProvider: cachePrestates(
+			gameType,
+			m,
+			cfg.AsteriscKonaAbsolutePreStateBaseURL,
+			cfg.AsteriscKonaAbsolutePreState,
+			filepath.Join(cfg.Datadir, "asterisc-kona-prestates"),
+			func(path string) faultTypes.PrestateProvider {
+				return vm.NewPrestateProvider(path, asterisc.NewStateConverter())
+			}),
+		newTraceAccessor: func(
+			logger log.Logger,
+			m metrics.Metricer,
+			l2Client utils.L2HeaderSource,
+			prestateProvider faultTypes.PrestateProvider,
+			vmPrestateProvider faultTypes.PrestateProvider,
+			rollupClient outputs.OutputRollupClient,
+			dir string,
+			l1Head eth.BlockID,
+			splitDepth faultTypes.Depth,
+			prestateBlock uint64,
+			poststateBlock uint64) (*trace.Accessor, error) {
+			provider := vmPrestateProvider.(*vm.PrestateProvider)
+			return outputs.NewOutputAsteriscTraceAccessor(logger, m, cfg.AsteriscKona, serverExecutor, l2Client, prestateProvider, provider.PrestatePath(), rollupClient, dir, l1Head, splitDepth, prestateBlock, poststateBlock)
+		},
+	}
+}
+
 func NewAlphabetRegisterTask(gameType faultTypes.GameType) *RegisterTask {
 	return &RegisterTask{
 		gameType: gameType,

--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -8,8 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 )
 
-type KonaServerExecutor struct {
-}
+type KonaServerExecutor struct{}
 
 var _ OracleServerExecutor = (*KonaServerExecutor)(nil)
 
@@ -23,7 +22,7 @@ func (s *KonaServerExecutor) OracleCommand(cfg Config, dataDir string, inputs ut
 	}
 
 	chainCfg := chaincfg.ChainByName(cfg.Network)
-	return []string{
+	args := []string{
 		cfg.Server, "--server",
 		"--l1-node-address", cfg.L1,
 		"--l1-beacon-address", cfg.L1Beacon,
@@ -35,5 +34,10 @@ func (s *KonaServerExecutor) OracleCommand(cfg Config, dataDir string, inputs ut
 		"--l2-output-root", inputs.L2OutputRoot.Hex(),
 		"--l2-claim", inputs.L2Claim.Hex(),
 		"--l2-block-number", inputs.L2BlockNumber.Text(10),
-	}, nil
+	}
+	if cfg.RollupConfigPath != "" {
+		args = append(args, "--rollup-config-path", cfg.RollupConfigPath)
+	}
+
+	return args, nil
 }

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -67,7 +67,7 @@ const (
 	TraceTypePermissioned TraceType = "permissioned"
 )
 
-var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned, TraceTypeAsterisc, TraceTypeFast}
+var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned, TraceTypeAsterisc, TraceTypeAsteriscKona, TraceTypeFast}
 
 func (t TraceType) String() string {
 	return string(t)
@@ -104,6 +104,8 @@ func (t TraceType) GameType() GameType {
 		return PermissionedGameType
 	case TraceTypeAsterisc:
 		return AsteriscGameType
+	case TraceTypeAsteriscKona:
+		return AsteriscKonaGameType
 	case TraceTypeFast:
 		return FastGameType
 	case TraceTypeAlphabet:

--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -45,12 +45,12 @@ func createTraceProvider(
 		return asterisc.NewTraceProvider(logger, m, cfg.Asterisc, vmConfig, prestateProvider, prestate, localInputs, dir, 42), nil
 	case types.TraceTypeAsteriscKona:
 		vmConfig := vm.NewKonaServerExecutor()
-		prestate, err := getPrestate(prestateHash, cfg.AsteriscAbsolutePreStateBaseURL, cfg.AsteriscAbsolutePreState, dir)
+		prestate, err := getPrestate(prestateHash, cfg.AsteriscKonaAbsolutePreStateBaseURL, cfg.AsteriscKonaAbsolutePreState, dir)
 		if err != nil {
 			return nil, err
 		}
 		prestateProvider := vm.NewPrestateProvider(prestate, asterisc.NewStateConverter())
-		return asterisc.NewTraceProvider(logger, m, cfg.Asterisc, vmConfig, prestateProvider, prestate, localInputs, dir, 42), nil
+		return asterisc.NewTraceProvider(logger, m, cfg.AsteriscKona, vmConfig, prestateProvider, prestate, localInputs, dir, 42), nil
 	}
 	return nil, errors.New("invalid trace type")
 }


### PR DESCRIPTION
## Overview

Fixes the integration of the `asterisc-kona` trace type and adds tests for the CLI flags, following up on https://github.com/ethereum-optimism/optimism/pull/11140.

### `run-trace` example

```sh
#!/bin/sh

NETWORK="op-sepolia"
ASTERISC_BIN_PATH="..."
KONA_HOST_PATH="..."
KONA_PRESTATE_PATH="..."
L1_SEPOLIA_RPC="..."
L1_BEACON_HTTP="..."
L2_ETH_RPC="..."
L2_CL_RPC="..."

# Build challenger
make

# Run challenger
./bin/op-challenger \
  run-trace \
  --l1-eth-rpc "$L1_ETH_RPC" \
  --l2-eth-rpc "$L2_ETH_RPC" \
  --rollup-rpc "$L2_CL_RPC" \
  --l1-beacon "$L1_BEACON_HTTP" \
  --datadir ./data \
  --trace-type asterisc-kona \
  --network "$NETWORK" \
  --asterisc-bin "$ASTERISC_BIN_PATH" \
  --asterisc-kona-server "$KONA_HOST_PATH" \
  --asterisc-kona-prestate "$KONA_PRESTATE_PATH"
```

<img width="3162" alt="Screenshot 2024-09-06 at 2 24 32 PM" src="https://github.com/user-attachments/assets/6fc4cee7-1dca-41cb-b46a-28ac551a3829">
