### PR TITLE
op-chain-ops: prep / utils for interop genesis work

### DIFF
--- a/op-chain-ops/devkeys/devkeys.go
+++ b/op-chain-ops/devkeys/devkeys.go
@@ -55,18 +55,26 @@ type SuperchainOperatorRole uint64
 const (
 	// SuperchainDeployerKey is the deployer of the superchain contracts.
 	SuperchainDeployerKey SuperchainOperatorRole = 0
+	// SuperchainProxyAdminOwner is the key that owns the superchain ProxyAdmin
+	SuperchainProxyAdminOwner SuperchainOperatorRole = 1
 	// SuperchainConfigGuardianKey is the Guardian of the SuperchainConfig.
-	SuperchainConfigGuardianKey SuperchainOperatorRole = 1
+	SuperchainConfigGuardianKey SuperchainOperatorRole = 2
+	// SuperchainProtocolVersionsOwner is the key that can make ProtocolVersions changes.
+	SuperchainProtocolVersionsOwner SuperchainOperatorRole = 3
 	// DependencySetManagerKey is the key used to manage the dependency set of a superchain.
-	DependencySetManagerKey SuperchainOperatorRole = 2
+	DependencySetManagerKey SuperchainOperatorRole = 4
 )
 
 func (role SuperchainOperatorRole) String() string {
 	switch role {
 	case SuperchainDeployerKey:
 		return "superchain-deployer"
+	case SuperchainProxyAdminOwner:
+		return "superchain-proxy-admin-owner"
 	case SuperchainConfigGuardianKey:
 		return "superchain-config-guardian"
+	case SuperchainProtocolVersionsOwner:
+		return "superchain-protocol-versions-owner"
 	case DependencySetManagerKey:
 		return "dependency-set-manager"
 	default:
@@ -122,6 +130,8 @@ const (
 	L1FeeVaultRecipientRole ChainOperatorRole = 8
 	// SequencerFeeVaultRecipientRole is the key that receives form the SequencerFeeVault predeploy
 	SequencerFeeVaultRecipientRole ChainOperatorRole = 9
+	// SystemConfigOwner is the key that can make SystemConfig changes.
+	SystemConfigOwner ChainOperatorRole = 10
 )
 
 func (role ChainOperatorRole) String() string {
@@ -146,6 +156,8 @@ func (role ChainOperatorRole) String() string {
 		return "l1-fee-vault-recipient"
 	case SequencerFeeVaultRecipientRole:
 		return "sequencer-fee-vault-recipient"
+	case SystemConfigOwner:
+		return "system-config-owner"
 	default:
 		return fmt.Sprintf("unknown-operator-%d", uint64(role))
 	}

--- a/op-chain-ops/srcmap/solutil.go
+++ b/op-chain-ops/srcmap/solutil.go
@@ -120,6 +120,10 @@ type SourceMap struct {
 // This location is the source file-path, the line number, and column number.
 // This may return an error, as the source-file is lazy-loaded to calculate the position data.
 func (s *SourceMap) Info(pc uint64) (source string, line uint32, col uint32, err error) {
+	if pc >= uint64(len(s.Instr)) {
+		source = "invalid"
+		return
+	}
 	instr := s.Instr[pc]
 	if instr.F < 0 || instr == (InstrMapping{}) {
 		return "generated", 0, 0, nil


### PR DESCRIPTION
**Description**

To support `interopgen2` (see #11702 ):
- Fix `devkeys`: fix string method, add missing key roles
- Add auto-generated `set(bytes4,address)` support to `Precompile`, so we can collect deployment addresses easily.
- Track more recent jump history in `script.Host`, to make debugging of reverts easy.
- Add `NewScriptAddress` to `script.Host` to easily make temporary addresses with (used for inputs/outputs during OPSM deployments)
- Add `RememberOnLabel` to `script.Host` so we can register a contract to be source-mapped upon labeling. The OPSM flow separates and bundles a lot of contract deployment work, making it difficult to source-map contracts otherwise.
- Catch a call to a source-map with out-of-bound program-counter. No error, just "invalid", as it's not a source-map reading problem, but more just an invalid program-counter (happens when misconfiguring source maps).

**Tests**

Added a test to cover the new `Precompile` address-setter functionality. The other functionality will either be covered by the interop deploy-script tests (e.g. temporary addresses), or is already covered by running through script tests.
