### PR TITLE
Add entrypoint to deploy against existing Superchain

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -299,9 +299,6 @@ contract Deploy is Deployer {
         save("ProtocolVersions", pvProxy.implementation());
         save("ProtocolVersionsProxy", _protocolVersionsProxy);
 
-        // We still need to set up the address manager and proxy admin
-        // for this specific chain.
-        setupAdmin();
         _run(false);
 
         if (includeDump) {

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -273,6 +273,38 @@ contract Deploy is Deployer {
         _run();
     }
 
+    function runWithSuperchain(
+        address payable _superchainConfigProxy,
+        address payable _protocolVersionsProxy,
+        bool includeDump
+    )
+        public
+    {
+        require(_superchainConfigProxy != address(0), "must specify address for superchain config proxy");
+        require(_protocolVersionsProxy != address(0), "must specify address for protocol versions proxy");
+
+        vm.chainId(cfg.l1ChainID());
+
+        console.log("Deploying a fresh OP Stack with existing SuperchainConfig and ProtocolVersions");
+
+        Proxy scProxy = Proxy(_superchainConfigProxy);
+        save("SuperchainConfig", scProxy.implementation());
+        save("SuperchainConfigProxy", _superchainConfigProxy);
+
+        Proxy pvProxy = Proxy(_protocolVersionsProxy);
+        save("ProtocolVersions", pvProxy.implementation());
+        save("ProtocolVersionsProxy", _protocolVersionsProxy);
+
+        // We still need to set up the address manager and proxy admin
+        // for this specific chain.
+        setupAdmin();
+        _run(false);
+
+        if (includeDump) {
+            vm.dumpState(Config.stateDumpPath(""));
+        }
+    }
+
     function runWithStateDump() public {
         vm.chainId(cfg.l1ChainID());
         _run();
@@ -284,13 +316,27 @@ contract Deploy is Deployer {
         _run();
     }
 
-    /// @notice Internal function containing the deploy logic.
+    /// @notice Compatibility function for tests that override _run().
     function _run() internal virtual {
+        _run(true);
+    }
+
+    /// @notice Internal function containing the deploy logic.
+    function _run(bool _needsSuperchain) internal {
         console.log("start of L1 Deploy!");
         deploySafe("SystemOwnerSafe");
         console.log("deployed Safe!");
-        setupSuperchain();
-        console.log("set up superchain!");
+
+        // Deploy a new ProxyAdmin and AddressManager
+        // This proxy will be used on the SuperchainConfig and ProtocolVersions contracts, as well as the contracts
+        // in the OP Chain system.
+        setupAdmin();
+
+        if (_needsSuperchain) {
+            setupSuperchain();
+            console.log("set up superchain!");
+        }
+
         if (cfg.useAltDA()) {
             bytes32 typeHash = keccak256(bytes(cfg.daCommitmentType()));
             bytes32 keccakHash = keccak256(bytes("KeccakCommitment"));
@@ -306,19 +352,19 @@ contract Deploy is Deployer {
     //           High Level Deployment Functions                  //
     ////////////////////////////////////////////////////////////////
 
+    /// @notice Deploy the address manager and proxy admin contracts.
+    function setupAdmin() public {
+        deployAddressManager();
+        deployProxyAdmin();
+        transferProxyAdminOwnership();
+    }
+
     /// @notice Deploy a full system with a new SuperchainConfig
     ///         The Superchain system has 2 singleton contracts which lie outside of an OP Chain:
     ///         1. The SuperchainConfig contract
     ///         2. The ProtocolVersions contract
     function setupSuperchain() public {
         console.log("Setting up Superchain");
-
-        // Deploy a new ProxyAdmin and AddressManager
-        // This proxy will be used on the SuperchainConfig and ProtocolVersions contracts, as well as the contracts
-        // in the OP Chain system.
-        deployAddressManager();
-        deployProxyAdmin();
-        transferProxyAdminOwnership();
 
         // Deploy the SuperchainConfigProxy
         deployERC1967Proxy("SuperchainConfigProxy");

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -273,6 +273,10 @@ contract Deploy is Deployer {
         _run();
     }
 
+    /// @notice Deploy a new OP Chain using an existing SuperchainConfig and ProtocolVersions
+    /// @param _superchainConfigProxy Address of the existing SuperchainConfig proxy
+    /// @param _protocolVersionsProxy Address of the existing ProtocolVersions proxy
+    /// @param includeDump Whether to include a state dump after deployment
     function runWithSuperchain(
         address payable _superchainConfigProxy,
         address payable _protocolVersionsProxy,


### PR DESCRIPTION
Creates a separate entrypoint in the deploy script to allow an L2 to be deployed against an existing set of Superchain contracts. The deployment assumes that the Superchain contracts have been deployed correctly. The L2 still gets its own ProxyAdmin, AddressManager, and Safe. The API is additive and backwards-compatible.
