### PR TITLE
chore(op-service): use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/op-service/dial/active_l2_provider_test.go
+++ b/op-service/dial/active_l2_provider_test.go
@@ -2,6 +2,7 @@ package dial
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -204,7 +205,7 @@ func TestRollupProvider_FailoverOnErroredSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, primarySequencer, firstSequencerUsed)
 
-	primarySequencer.ExpectSequencerActive(true, fmt.Errorf("a test error")) // error-out after that
+	primarySequencer.ExpectSequencerActive(true, errors.New("a test error")) // error-out after that
 	primarySequencer.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 	secondSequencerUsed, err := rollupProvider.RollupClient(context.Background())
@@ -231,7 +232,7 @@ func TestEndpointProvider_FailoverOnErroredSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, primaryEthClient, firstSequencerUsed)
 
-	primarySequencer.ExpectSequencerActive(true, fmt.Errorf("a test error")) // error out after that
+	primarySequencer.ExpectSequencerActive(true, errors.New("a test error")) // error out after that
 	primarySequencer.MaybeClose()
 	primaryEthClient.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
@@ -465,7 +466,7 @@ func TestRollupProvider_ConstructorErrorOnFirstSequencerOffline(t *testing.T) {
 	ept := setupEndpointProviderTest(t, 2)
 
 	// First sequencer is dead, second sequencer is active
-	ept.rollupClients[0].ExpectSequencerActive(false, fmt.Errorf("I am offline"))
+	ept.rollupClients[0].ExpectSequencerActive(false, errors.New("I am offline"))
 	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 
@@ -482,7 +483,7 @@ func TestEndpointProvider_ConstructorErrorOnFirstSequencerOffline(t *testing.T) 
 	ept := setupEndpointProviderTest(t, 2)
 
 	// First sequencer is dead, second sequencer is active
-	ept.rollupClients[0].ExpectSequencerActive(false, fmt.Errorf("I am offline"))
+	ept.rollupClients[0].ExpectSequencerActive(false, errors.New("I am offline"))
 	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 	ept.rollupClients[1].ExpectSequencerActive(true, nil) // see comment in other tests about why we expect this twice
@@ -533,7 +534,7 @@ func TestRollupProvider_FailOnAllErroredSequencers(t *testing.T) {
 
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
-		sequencer.ExpectSequencerActive(true, fmt.Errorf("a test error"))
+		sequencer.ExpectSequencerActive(true, errors.New("a test error"))
 		sequencer.MaybeClose()
 	}
 
@@ -549,7 +550,7 @@ func TestEndpointProvider_FailOnAllErroredSequencers(t *testing.T) {
 
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
-		sequencer.ExpectSequencerActive(true, fmt.Errorf("a test error"))
+		sequencer.ExpectSequencerActive(true, errors.New("a test error"))
 		sequencer.MaybeClose()
 	}
 
@@ -711,7 +712,7 @@ func TestRollupProvider_HandlesManyIndexClientMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// primarySequencer goes down
-	seq0.ExpectSequencerActive(false, fmt.Errorf("I'm offline now"))
+	seq0.ExpectSequencerActive(false, errors.New("I'm offline now"))
 	seq0.MaybeClose()
 	ept.setRollupDialOutcome(0, false) // primarySequencer fails to dial
 	// secondarySequencer is inactive, but online

--- a/op-service/eth/status.go
+++ b/op-service/eth/status.go
@@ -1,18 +1,19 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
 )
 
 func ForkchoiceUpdateErr(payloadStatus PayloadStatusV1) error {
 	switch payloadStatus.Status {
 	case ExecutionSyncing:
-		return fmt.Errorf("updated forkchoice, but node is syncing")
+		return errors.New("updated forkchoice, but node is syncing")
 	case ExecutionAccepted, ExecutionInvalidTerminalBlock, ExecutionInvalidBlockHash:
 		// ACCEPTED, INVALID_TERMINAL_BLOCK, INVALID_BLOCK_HASH are only for execution
 		return fmt.Errorf("unexpected %s status, could not update forkchoice", payloadStatus.Status)
 	case ExecutionInvalid:
-		return fmt.Errorf("cannot update forkchoice, block is invalid")
+		return errors.New("cannot update forkchoice, block is invalid")
 	case ExecutionValid:
 		return nil
 	default:

--- a/op-service/solabi/util.go
+++ b/op-service/solabi/util.go
@@ -69,7 +69,7 @@ func ReadUint64(r io.Reader) (uint64, error) {
 		return n, fmt.Errorf("number padding was not empty: %x", readPadding[:])
 	}
 	if err := binary.Read(r, binary.BigEndian, &n); err != nil {
-		return 0, fmt.Errorf("expected number length to be 8 bytes")
+		return 0, errors.New("expected number length to be 8 bytes")
 	}
 	return n, nil
 }

--- a/op-service/sources/batching/batching.go
+++ b/op-service/sources/batching/batching.go
@@ -2,6 +2,7 @@ package batching
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -176,7 +177,7 @@ func (ibc *IterativeBatchCall[K, V]) Result() ([]V, error) {
 	ibc.resetLock.RLock()
 	if atomic.LoadUint32(&ibc.completed) < uint32(len(ibc.requestsKeys)) {
 		ibc.resetLock.RUnlock()
-		return nil, fmt.Errorf("results not available yet, Fetch more first")
+		return nil, errors.New("results not available yet, Fetch more first")
 	}
 	ibc.resetLock.RUnlock()
 	return ibc.requestsValues, nil

--- a/op-service/sources/batching/test/abi_stub.go
+++ b/op-service/sources/batching/test/abi_stub.go
@@ -35,7 +35,7 @@ func (c *expectedCall) Matches(rpcMethod string, args ...interface{}) error {
 	}
 	callOpts, ok := args[0].(map[string]any)
 	if !ok {
-		return fmt.Errorf("arg 0 is not a map[string]any")
+		return errors.New("arg 0 is not a map[string]any")
 	}
 	actualBlockRef := args[1]
 	to, ok := callOpts["to"].(*common.Address)

--- a/op-service/sources/limit_test.go
+++ b/op-service/sources/limit_test.go
@@ -2,7 +2,7 @@ package sources
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -97,10 +97,10 @@ func TestLimitClient(t *testing.T) {
 		// None of the clients should return yet
 	}
 
-	m.errC <- fmt.Errorf("fake-error")
-	m.errC <- fmt.Errorf("fake-error")
+	m.errC <- errors.New("fake-error")
+	m.errC <- errors.New("fake-error")
 	require.Eventually(t, func() bool { return m.blockedCallers.Load() == 1 }, time.Second, 10*time.Millisecond)
-	m.errC <- fmt.Errorf("fake-error")
+	m.errC <- errors.New("fake-error")
 
 	require.ErrorContains(t, <-errC1, "fake-error")
 	require.ErrorContains(t, <-errC2, "fake-error")

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -229,7 +230,7 @@ func (block *RPCBlock) verify() error {
 	}
 	if block.WithdrawalsRoot != nil {
 		if block.Withdrawals == nil {
-			return fmt.Errorf("expected withdrawals")
+			return errors.New("expected withdrawals")
 		}
 		for i, w := range *block.Withdrawals {
 			if w == nil {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -376,7 +376,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 	var txMessage types.TxData
 	if sidecar != nil {
 		if blobBaseFee == nil {
-			return nil, fmt.Errorf("expected non-nil blobBaseFee")
+			return nil, errors.New("expected non-nil blobBaseFee")
 		}
 		blobFeeCap := m.calcBlobFeeCap(blobBaseFee)
 		message := &types.BlobTx{
@@ -1036,19 +1036,19 @@ func errStringMatch(err, target error) bool {
 func finishBlobTx(message *types.BlobTx, chainID, tip, fee, blobFee, value *big.Int) error {
 	var o bool
 	if message.ChainID, o = uint256.FromBig(chainID); o {
-		return fmt.Errorf("ChainID overflow")
+		return errors.New("ChainID overflow")
 	}
 	if message.GasTipCap, o = uint256.FromBig(tip); o {
-		return fmt.Errorf("GasTipCap overflow")
+		return errors.New("GasTipCap overflow")
 	}
 	if message.GasFeeCap, o = uint256.FromBig(fee); o {
-		return fmt.Errorf("GasFeeCap overflow")
+		return errors.New("GasFeeCap overflow")
 	}
 	if message.BlobFeeCap, o = uint256.FromBig(blobFee); o {
-		return fmt.Errorf("BlobFeeCap overflow")
+		return errors.New("BlobFeeCap overflow")
 	}
 	if message.Value, o = uint256.FromBig(value); o {
-		return fmt.Errorf("Value overflow")
+		return errors.New("Value overflow")
 	}
 	return nil
 }

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -669,7 +669,7 @@ func TestTxMgr_EstimateGasFails(t *testing.T) {
 	lastNonce := tx.Nonce()
 
 	// Mock gas estimation failure.
-	h.gasPricer.err = fmt.Errorf("execution error")
+	h.gasPricer.err = errors.New("execution error")
 	_, err = h.mgr.craftTx(context.Background(), candidate)
 	require.ErrorContains(t, err, "failed to estimate gas")
 
@@ -686,7 +686,7 @@ func TestTxMgr_SigningFails(t *testing.T) {
 	cfg := configWithNumConfs(1)
 	cfg.Signer = func(ctx context.Context, from common.Address, tx *types.Transaction) (*types.Transaction, error) {
 		if errorSigning {
-			return nil, fmt.Errorf("signer error")
+			return nil, errors.New("signer error")
 		} else {
 			return tx, nil
 		}

--- a/op-service/util.go
+++ b/op-service/util.go
@@ -130,5 +130,5 @@ func FindMonorepoRoot(startDir string) (string, error) {
 		}
 		dir = parentDir
 	}
-	return "", fmt.Errorf("monorepo root not found")
+	return "", errors.New("monorepo root not found")
 }


### PR DESCRIPTION
**Description**

Open a new pr for #11176 ,  since the auto merge queue of old pr is not working correctly and has been closed by bot.

This PR replaces fmt.Errorf without parameters with errors.New

**Tests**
No new test case need add
