### PR TITLE
ci: update contracts tests to split by file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,8 +595,16 @@ jobs:
       - run:
           name: run tests
           command: |
-            TESTS=$(forge test --list | grep -E '^\s{4}' | awk '{print $1}' | circleci tests split --split-by=timings | paste -sd "|" -)
-            forge test --match-test "$TESTS"
+            # Find all test files
+            TEST_FILES=$(find ./test -name "*.t.sol")
+            # Split the tests by timings
+            TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
+            # Strip the leading "./test/" from each file path
+            TEST_FILES=$(echo "$TEST_FILES" | sed 's|./test/||')
+            # Generate the match path
+            MATCH_PATH="./test/{$(echo "$TEST_FILES" | paste -sd "," -)}"
+            # Run the tests
+            forge test --match-path "$MATCH_PATH"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock


### PR DESCRIPTION
Contracts tests were being split by test name which meant that Circle CI wouldn't be able to (eventually) be able to properly split these files by timings. Updates the CI job to split by file instead.