### PR TITLE
semgrep: try to fix CI timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1322,10 +1322,6 @@ jobs:
       SEMGREP_REPO_URL: << pipeline.project.git_url >>
       SEMGREP_BRANCH: << pipeline.git.branch >>
       SEMGREP_COMMIT: << pipeline.git.revision >>
-
-      # Change job timeout (default is 1800 seconds; set to 0 to disable)
-      SEMGREP_TIMEOUT: 3000
-
     docker:
       - image: returntocorp/semgrep
     resource_class: medium
@@ -1349,7 +1345,15 @@ jobs:
             echo 'export SEMGREP_REPO_NAME=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
       - run:
           name: "Semgrep scan"
-          command: semgrep ci
+          # --time shows which rules take the most time
+          # --max-memory (in MiB) limits memory usage
+          #   (defaults to 5GB, but medium runner only has 4GB, so we conservatively limit it to 3GB)
+          # --timeout (in seconds) limits the time per rule and file.
+          #   SEMGREP_TIMEOUT is the same, but docs have conflicting defaults (5s in CLI flag, 1800 in some places)
+          #    https://semgrep.dev/docs/troubleshooting/semgrep-app#if-the-job-is-aborted-due-to-taking-too-long
+          command: semgrep ci --time --timeout=100 --max-memory=3000
+          # If semgrep hangs, stop the scan after 20m, to prevent a useless 5h job
+          no_output_timeout: 20m
       - notify-failures-on-develop
 
   go-mod-download:


### PR DESCRIPTION
**Description**

- Apply timeout via CLI flag. Env var might be misapplied and is inconsistent in semgrep docs. A 100s per rule and file ought to be enough.
- List time of semver rules, so we can tell what is slow and causing problems
- Limit memory, to stay under the circle CI resource class memory. It might have been using swap memory.
- Apply timeout to semgrep as a whole. If it takes longer than 20m without output, something is very wrong, and it should just stop, instead of running for 5 hours.
