### PR TITLE
Remove hardcoded entrypoint

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -70,8 +70,4 @@ COPY --from=base /opt/optimism/versions.json /opt/optimism/versions.json
 
 WORKDIR /opt/optimism/packages/contracts-bedrock
 
-# Set "just" as entrypoint, so the default args (the Dockerfile CMD)
-# are passed in to it. This was previously "pnpm run" + "deploy".
-ENTRYPOINT ["just"]
-
-CMD ["deploy"]
+CMD ["echo", "Override this command to use this image."]


### PR DESCRIPTION
Removes the `ENTRYPOINT` directive in the `contracts-bedrock` image. While convenient, using `ENTRYPOINT` makes building tooling on top of the image much harder since the entrypoint cannot be overridden without providing special flags to Docker. It is easier to use a dummy `CMD` instead that directs users to call specific tools when running the container. Functionally, this means users will run `docker run just <cmd>` instead of `docker run <cmd>` if they want to use the Justfile.
