### PR TITLE
Allow cheatcodes on DeploySuperchain.s.sol

### DIFF
--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -381,6 +381,8 @@ contract DeploySuperchain is Script {
         (dsi_, dso_) = getIOContracts();
         vm.etch(address(dsi_), type(DeploySuperchainInput).runtimeCode);
         vm.etch(address(dso_), type(DeploySuperchainOutput).runtimeCode);
+        vm.allowCheatcodes(address(dsi_));
+        vm.allowCheatcodes(address(dso_));
     }
 
     function getIOContracts() public view returns (DeploySuperchainInput dsi_, DeploySuperchainOutput dso_) {


### PR DESCRIPTION
We need to add these calls otherwise calling `DeploySuperchain.s.sol` as a script with input/output files fails.
