### PR TITLE
fix: fix potential error when running without any argument in check-snapshots.sh

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-snapshots.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-snapshots.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Check for the --no-build flag
 # Generate snapshots
-if [ "$1" == "--no-build" ]; then
+if [ "${1:-}" == "--no-build" ]; then
     just snapshots-no-build
 else
     just snapshots


### PR DESCRIPTION
**Description**

The fix improves robustness of the script.
The orginal script assumes that $1 will always be set. If the script is run without any arguments, this will produce an error due to set -u (which treats unset variables as an error).  

To fix this, before comparing it, whether $1 is set is checked 

**Tests**

Local test has been performed, no issue found