### PR TITLE
cannon: Fix path used when verifying a downloaded state

### DIFF
--- a/op-challenger/game/fault/trace/prestates/multi.go
+++ b/op-challenger/game/fault/trace/prestates/multi.go
@@ -91,7 +91,7 @@ func (m *MultiPrestateProvider) fetchPrestate(hash common.Hash, fileType string,
 		return fmt.Errorf("failed to close file %v: %w", dest, err)
 	}
 	// Verify the prestate actually matches the expected hash before moving it into the final destination
-	proof, _, _, err := m.stateConverter.ConvertStateToProof(dest)
+	proof, _, _, err := m.stateConverter.ConvertStateToProof(tmpFile)
 	if err != nil || proof.ClaimValue != hash {
 		// Treat invalid prestates as unavailable. Often servers return a 404 page with 200 status code
 		_ = os.Remove(tmpFile) // Best effort attempt to clean up the temporary file

--- a/op-challenger/game/fault/trace/prestates/multi_test.go
+++ b/op-challenger/game/fault/trace/prestates/multi_test.go
@@ -167,5 +167,9 @@ type stubStateConverter struct {
 }
 
 func (s *stubStateConverter) ConvertStateToProof(path string) (*utils.ProofData, uint64, bool, error) {
+	// Return an error if we're given the wrong path
+	if _, err := os.Stat(path); err != nil {
+		return nil, 0, false, err
+	}
 	return &utils.ProofData{ClaimValue: s.hash}, 0, false, s.err
 }


### PR DESCRIPTION
**Description**

Fix verification of downloaded prestates in cannon - it was previously being given the final path, not the temp one used prior to validation happening. 

**Tests**

Updated the unit tests to cover this properly.

