### PR TITLE
maint: add interface for L2OutputOracle

### DIFF
--- a/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
+++ b/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
@@ -1,21 +1,21 @@
 # `OptimismPortal` Invariants
 
 ## Deposits of any value should always succeed unless `_to` = `address(0)` or `_isCreation` = `true`.
-**Test:** [`OptimismPortal.t.sol#L149`](../test/invariants/OptimismPortal.t.sol#L149)
+**Test:** [`OptimismPortal.t.sol#L148`](../test/invariants/OptimismPortal.t.sol#L148)
 
 All deposits, barring creation transactions and transactions sent to `address(0)`, should always succeed. 
 
 ## `finalizeWithdrawalTransaction` should revert if the finalization period has not elapsed.
-**Test:** [`OptimismPortal.t.sol#L172`](../test/invariants/OptimismPortal.t.sol#L172)
+**Test:** [`OptimismPortal.t.sol#L171`](../test/invariants/OptimismPortal.t.sol#L171)
 
 A withdrawal that has been proven should not be able to be finalized until after the finalization period has elapsed. 
 
 ## `finalizeWithdrawalTransaction` should revert if the withdrawal has already been finalized.
-**Test:** [`OptimismPortal.t.sol#L202`](../test/invariants/OptimismPortal.t.sol#L202)
+**Test:** [`OptimismPortal.t.sol#L201`](../test/invariants/OptimismPortal.t.sol#L201)
 
 Ensures that there is no chain of calls that can be made that allows a withdrawal to be finalized twice. 
 
 ## A withdrawal should **always** be able to be finalized `FINALIZATION_PERIOD_SECONDS` after it was successfully proven.
-**Test:** [`OptimismPortal.t.sol#L231`](../test/invariants/OptimismPortal.t.sol#L231)
+**Test:** [`OptimismPortal.t.sol#L230`](../test/invariants/OptimismPortal.t.sol#L230)
 
 This invariant asserts that there is no chain of calls that can be made that will prevent a withdrawal from being finalized exactly `FINALIZATION_PERIOD_SECONDS` after it was successfully proven. 

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -8,7 +8,7 @@ import { Deployer } from "scripts/deploy/Deployer.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
 import { DelayedWETH } from "src/dispute/weth/DelayedWETH.sol";
 import { ProtocolVersion, ProtocolVersions } from "src/L1/ProtocolVersions.sol";
@@ -245,7 +245,7 @@ library ChainAssertions {
         view
     {
         console.log("Running chain assertions on the L2OutputOracle");
-        L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
+        IL2OutputOracle oracle = IL2OutputOracle(_contracts.L2OutputOracle);
 
         // Check that the contract is initialized
         assertSlotValueIsOne({ _contractAddress: address(oracle), _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -29,7 +29,7 @@
   },
   "src/L1/L2OutputOracle.sol": {
     "initCodeHash": "0x433fac9de52d8ce8fc3471b78ef6cc9cff1019f480c9ad91b6e09ab8738a8edb",
-    "sourceCodeHash": "0xc11a2a514a051bdc82b21ec39c7b923145d384629adb1efc52b534f3c686f6a0"
+    "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPStackManager.sol": {
     "initCodeHash": "0x67bf02405bf1ca7d78c4215c350ad9c5c7b4cece35d9fab837f279d65f995c5d",
@@ -37,7 +37,7 @@
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0x6bf59539298b20221de6c51db21016be8d3278bdbe0be1cdd49638dc828e003e",
-    "sourceCodeHash": "0xad97b31e3855ad0af82a0fc80db9773b7eacc85215611854dcc54f60f97f06bf"
+    "sourceCodeHash": "0x07f6f4c0cc14be4aeb9a29ec4a238ea3748d5cb6b244e0054845a18308c16ab5"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x414ad1fdb6296ac32fc67ce01288b6e67bedd2ed239d7eb8ed40c7f55f9021f2",

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal.json
@@ -179,7 +179,7 @@
   {
     "inputs": [
       {
-        "internalType": "contract L2OutputOracle",
+        "internalType": "contract IL2OutputOracle",
         "name": "_l2Oracle",
         "type": "address"
       },
@@ -223,7 +223,7 @@
     "name": "l2Oracle",
     "outputs": [
       {
-        "internalType": "contract L2OutputOracle",
+        "internalType": "contract IL2OutputOracle",
         "name": "",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal.json
@@ -67,7 +67,7 @@
     "label": "l2Oracle",
     "offset": 0,
     "slot": "54",
-    "type": "contract L2OutputOracle"
+    "type": "contract IL2OutputOracle"
   },
   {
     "bytes": "20",

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @title L2OutputOracle

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { Constants } from "src/libraries/Constants.sol";
@@ -68,7 +68,7 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
 
     /// @notice Contract of the L2OutputOracle.
     /// @custom:network-specific
-    L2OutputOracle public l2Oracle;
+    IL2OutputOracle public l2Oracle;
 
     /// @notice Contract of the SystemConfig.
     /// @custom:network-specific
@@ -136,7 +136,7 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     /// @notice Constructs the OptimismPortal contract.
     constructor() {
         initialize({
-            _l2Oracle: L2OutputOracle(address(0)),
+            _l2Oracle: IL2OutputOracle(address(0)),
             _systemConfig: SystemConfig(address(0)),
             _superchainConfig: SuperchainConfig(address(0))
         });
@@ -147,7 +147,7 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     /// @param _systemConfig Contract of the SystemConfig.
     /// @param _superchainConfig Contract of the SuperchainConfig.
     function initialize(
-        L2OutputOracle _l2Oracle,
+        IL2OutputOracle _l2Oracle,
         SystemConfig _systemConfig,
         SuperchainConfig _superchainConfig
     )

--- a/packages/contracts-bedrock/src/L1/interfaces/IL2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/interfaces/IL2OutputOracle.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Types } from "src/libraries/Types.sol";
+
+interface IL2OutputOracle {
+    event Initialized(uint8 version);
+    event OutputProposed(
+        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
+    );
+    event OutputsDeleted(uint256 indexed prevNextOutputIndex, uint256 indexed newNextOutputIndex);
+
+    function CHALLENGER() external view returns (address);
+    function FINALIZATION_PERIOD_SECONDS() external view returns (uint256);
+    function L2_BLOCK_TIME() external view returns (uint256);
+    function PROPOSER() external view returns (address);
+    function SUBMISSION_INTERVAL() external view returns (uint256);
+    function challenger() external view returns (address);
+    function computeL2Timestamp(uint256 _l2BlockNumber) external view returns (uint256);
+    function deleteL2Outputs(uint256 _l2OutputIndex) external;
+    function finalizationPeriodSeconds() external view returns (uint256);
+    function getL2Output(uint256 _l2OutputIndex) external view returns (Types.OutputProposal memory);
+    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (Types.OutputProposal memory);
+    function getL2OutputIndexAfter(uint256 _l2BlockNumber) external view returns (uint256);
+    function initialize(
+        uint256 _submissionInterval,
+        uint256 _l2BlockTime,
+        uint256 _startingBlockNumber,
+        uint256 _startingTimestamp,
+        address _proposer,
+        address _challenger,
+        uint256 _finalizationPeriodSeconds
+    )
+        external;
+    function l2BlockTime() external view returns (uint256);
+    function latestBlockNumber() external view returns (uint256);
+    function latestOutputIndex() external view returns (uint256);
+    function nextBlockNumber() external view returns (uint256);
+    function nextOutputIndex() external view returns (uint256);
+    function proposeL2Output(
+        bytes32 _outputRoot,
+        uint256 _l2BlockNumber,
+        bytes32 _l1BlockHash,
+        uint256 _l1BlockNumber
+    )
+        external
+        payable;
+    function proposer() external view returns (address);
+    function startingBlockNumber() external view returns (uint256);
+    function startingTimestamp() external view returns (uint256);
+    function submissionInterval() external view returns (uint256);
+    function version() external view returns (string memory);
+}

--- a/packages/contracts-bedrock/test/L1/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/L1/L2OutputOracle.t.sol
@@ -16,11 +16,12 @@ import { Proxy } from "src/universal/Proxy.sol";
 
 // Target contract
 import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 
 contract L2OutputOracle_constructor_Test is CommonTest {
     /// @dev Tests that constructor sets the initial values correctly.
     function test_constructor_succeeds() external {
-        L2OutputOracle oracleImpl = new L2OutputOracle();
+        IL2OutputOracle oracleImpl = IL2OutputOracle(address(new L2OutputOracle()));
 
         assertEq(oracleImpl.SUBMISSION_INTERVAL(), 1);
         assertEq(oracleImpl.submissionInterval(), 1);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -18,7 +18,7 @@ import { Constants } from "src/libraries/Constants.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { L1Block } from "src/L2/L1Block.sol";
@@ -403,7 +403,7 @@ contract OptimismPortal_Test is CommonTest {
         uint256 ts = block.timestamp;
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(Types.OutputProposal(bytes32(uint256(1)), uint128(ts), uint128(startingBlockNumber)))
         );
 
@@ -831,7 +831,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
         // this case we just use bytes32(uint256(1)).
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(bytes32(uint256(1)), _proposedBlockNumber)
         );
 
@@ -886,7 +886,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
         // to finalize the withdrawal.
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(
                 Types.OutputProposal(bytes32(uint256(0)), uint128(block.timestamp), uint128(_proposedBlockNumber))
             )
@@ -917,7 +917,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
         // finalization period.
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(Types.OutputProposal(_outputRoot, uint128(block.timestamp + 1), uint128(_proposedBlockNumber)))
         );
 
@@ -953,7 +953,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
         uint256 recentTimestamp = block.timestamp - 1;
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(Types.OutputProposal(_outputRoot, uint128(recentTimestamp), uint128(_proposedBlockNumber)))
         );
 
@@ -1005,7 +1005,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
 
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(
                 Types.OutputProposal(
                     Hashing.hashOutputRootProof(outputRootProof),
@@ -1054,7 +1054,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
         uint256 finalizedTimestamp = block.timestamp - l2OutputOracle.FINALIZATION_PERIOD_SECONDS() - 1;
         vm.mockCall(
             address(optimismPortal.l2Oracle()),
-            abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
+            abi.encodeWithSelector(IL2OutputOracle.getL2Output.selector),
             abi.encode(Types.OutputProposal(outputRoot, uint128(finalizedTimestamp), uint128(_proposedBlockNumber)))
         );
 

--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -907,10 +907,11 @@ contract Specification_Test is CommonTest {
 
     /// @notice Ensures that there's an auth spec for every L1 contract function.
     function testContractAuth() public {
-        string[] memory pathExcludes = new string[](3);
+        string[] memory pathExcludes = new string[](4);
         pathExcludes[0] = "src/dispute/interfaces/*";
         pathExcludes[1] = "src/dispute/lib/*";
         pathExcludes[2] = "src/Safe/SafeSigners.sol";
+        pathExcludes[3] = "src/L1/interfaces/*";
         Abi[] memory abis = ForgeArtifacts.getContractFunctionAbis(
             "src/{L1,dispute,governance,Safe,universal/ProxyAdmin.sol}", pathExcludes
         );

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -7,7 +7,6 @@ import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
 import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
 import { PermissionedDisputeGame } from "src/dispute/PermissionedDisputeGame.sol";
 import { DelayedWETH } from "src/dispute/weth/DelayedWETH.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
 

--- a/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.15;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 contract L2OutputOracle_Proposer {
-    L2OutputOracle internal oracle;
+    IL2OutputOracle internal oracle;
     Vm internal vm;
 
-    constructor(L2OutputOracle _oracle, Vm _vm) {
+    constructor(IL2OutputOracle _oracle, Vm _vm) {
         oracle = _oracle;
         vm = _vm;
     }
@@ -36,7 +36,7 @@ contract L2OutputOracle_MonotonicBlockNumIncrease_Invariant is CommonTest {
         super.setUp();
 
         // Create a proposer actor.
-        actor = new L2OutputOracle_Proposer(l2OutputOracle, vm);
+        actor = new L2OutputOracle_Proposer(IL2OutputOracle(address(l2OutputOracle)), vm);
 
         // Set the target contract to the proposer actor.
         targetContract(address(actor));

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
@@ -5,7 +5,6 @@ import { StdUtils } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 import { Constants } from "src/libraries/Constants.sol";
 

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -29,7 +29,7 @@ import { Deploy } from "scripts/deploy/Deploy.s.sol";
 import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
 import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
 import { OutputMode, Fork, ForkUtils } from "scripts/libraries/Config.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 import { ProtocolVersions } from "src/L1/ProtocolVersions.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
@@ -69,7 +69,7 @@ contract Setup {
     OptimismPortal2 optimismPortal2;
     DisputeGameFactory disputeGameFactory;
     DelayedWETH delayedWeth;
-    L2OutputOracle l2OutputOracle;
+    IL2OutputOracle l2OutputOracle;
     SystemConfig systemConfig;
     L1StandardBridge l1StandardBridge;
     L1CrossDomainMessenger l1CrossDomainMessenger;
@@ -135,7 +135,7 @@ contract Setup {
         optimismPortal2 = OptimismPortal2(deploy.mustGetAddress("OptimismPortalProxy"));
         disputeGameFactory = DisputeGameFactory(deploy.mustGetAddress("DisputeGameFactoryProxy"));
         delayedWeth = DelayedWETH(deploy.mustGetAddress("DelayedWETHProxy"));
-        l2OutputOracle = L2OutputOracle(deploy.mustGetAddress("L2OutputOracleProxy"));
+        l2OutputOracle = IL2OutputOracle(deploy.mustGetAddress("L2OutputOracleProxy"));
         systemConfig = SystemConfig(deploy.mustGetAddress("SystemConfigProxy"));
         l1StandardBridge = L1StandardBridge(deploy.mustGetAddress("L1StandardBridgeProxy"));
         l1CrossDomainMessenger = L1CrossDomainMessenger(deploy.mustGetAddress("L1CrossDomainMessengerProxy"));

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -6,7 +6,6 @@ import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";
 import { Executables } from "scripts/libraries/Executables.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { SystemConfigInterop } from "src/L1/SystemConfigInterop.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";


### PR DESCRIPTION
First in a series of PRs adding interfaces for L2 contracts. Since each of these changes involves touching a lot of other contracts it seemed easier to split this up into several PRs for legibility.

IMPORTANT: This is the first PR where we're introducing the principle that `interface` files will be automatically generated and that all contracts MUST use the interface file except the base contract which MUST NOT use the interface file. We will add a document explaining this principle once this migration is completed.

For now we're using `cast interface` and then manually tweaking the interface where necessary. Eventually we will hopefully get foundry to fix their interface generation to properly include imported components.