### PR TITLE
op-challenger: Release agent resources once game is complete

### DIFF
--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -64,6 +64,10 @@ type GameContract interface {
 	GetL1Head(ctx context.Context) (common.Hash, error)
 }
 
+var actNoop = func(ctx context.Context) error {
+	return nil
+}
+
 type resourceCreator func(ctx context.Context, logger log.Logger, gameDepth types.Depth, dir string) (types.TraceAccessor, error)
 
 func NewGamePlayer(
@@ -98,9 +102,7 @@ func NewGamePlayer(
 			prestateValidators: validators,
 			status:             status,
 			// Act function does nothing because the game is already complete
-			act: func(ctx context.Context) error {
-				return nil
-			},
+			act: actNoop,
 		}, nil
 	}
 
@@ -195,6 +197,10 @@ func (g *GamePlayer) ProgressGame(ctx context.Context) gameTypes.GameStatus {
 	}
 	g.logGameStatus(ctx, status)
 	g.status = status
+	if status != gameTypes.GameStatusInProgress {
+		// Release the agent as we will no longer need to act on this game.
+		g.act = actNoop
+	}
 	return status
 }
 

--- a/op-challenger/game/fault/player_test.go
+++ b/op-challenger/game/fault/player_test.go
@@ -90,6 +90,11 @@ func TestDoNotActOnCompleteGame(t *testing.T) {
 			fetched = game.ProgressGame(context.Background())
 			require.Equal(t, 1, gameState.callCount, "does not act after game is complete")
 			require.Equal(t, status, fetched)
+
+			// Should have replaced the act function with a noop so callCount doesn't update even when called directly
+			// This allows the agent resources to be GC'd
+			require.NoError(t, game.act(context.Background()))
+			require.Equal(t, 1, gameState.callCount)
 		})
 	}
 }


### PR DESCRIPTION
**Description**

When a player detects that a game is now complete, replace the `act` function with a no-op so that the agent resources (including the trace provider etc) can be GC'd.  We already use a no-op `act` function for games that are completed when the challenger first starts up.  Without this the agent resources are only released when the game drops out of the game window after 28 days which makes it look like the challenger has a memory leak as memory increases for the first 28 days of operation before levelling out.

**Tests**

Updated unit tests.

**Metadata**

- Fixes #10997 
