### PR TITLE
op-program: Make file preimage format the default again

### DIFF
--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -139,7 +139,7 @@ func NewConfig(
 		L2ClaimBlockNumber:  l2ClaimBlockNum,
 		L1RPCKind:           sources.RPCKindStandard,
 		IsCustomChainConfig: isCustomConfig,
-		DataFormat:          types.DataFormatDirectory,
+		DataFormat:          types.DataFormatFile,
 	}
 }
 

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -40,7 +40,7 @@ var (
 		Name:    "data.format",
 		Usage:   fmt.Sprintf("Format to use for preimage data storage. Available formats: %s", openum.EnumString(types.SupportedDataFormats)),
 		EnvVars: prefixEnvVars("DATA_FORMAT"),
-		Value:   string(types.DataFormatDirectory),
+		Value:   string(types.DataFormatFile),
 	}
 	L2NodeAddr = &cli.StringFlag{
 		Name:    "l2",


### PR DESCRIPTION
**Description**

The cannon tests are failing because op-challenger is still trying to read the preimage data using the flat file structure.  It's unclear which format asterisc would need to use so switch the default back to flat files to get things back to working ASAP.