### PR TITLE
ci: selectively build contract tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,10 +189,22 @@ jobs:
     parameters:
       build_command:
         type: string
-        default: just prebuild && forge build --deny-warnings
+        default: |
+          just prebuild
+          forge build --deny-warnings
     steps:
       - checkout
       - install-contracts-dependencies
+      - restore_cache:
+          name: Restore Go modules cache
+          keys:
+            - gomod-contracts-build-{{ checksum "go.sum" }}
+            - gomod-contracts-build-
+      - restore_cache:
+          name: Restore Go build cache
+          keys:
+            - golang-build-cache-contracts-build-{{ checksum "go.sum" }}
+            - golang-build-cache-contracts-build-
       - run:
           name: Print forge version
           command: forge --version
@@ -206,35 +218,6 @@ jobs:
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - ".git"
-            - "packages/contracts-bedrock/lib"
-            - "packages/contracts-bedrock/cache"
-            - "packages/contracts-bedrock/artifacts"
-            - "packages/contracts-bedrock/forge-artifacts"
-      - notify-failures-on-develop
-
-  build-devnet-allocs:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: xlarge
-    steps:
-      - checkout
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
-#      - run:  # temporarily disabled, to update ci-builder.
-#          name: "Check L1 geth version"
-#          command: ./ops/scripts/geth-version-checker.sh || (echo "geth version is wrong, update ci-builder"; false)
-      - restore_cache:
-          name: Restore Go modules cache
-          key: gomod-allocs-{{ checksum "go.sum" }}
-      - restore_cache:
-          name: Restore Go build cache
-          keys:
-            - golang-build-cache-allocs-{{ checksum "go.sum" }}
-            - golang-build-cache-allocs-
       - run:
           name: Generate L2OO allocs
           command: DEVNET_L2OO="true" make devnet-allocs
@@ -258,17 +241,20 @@ jobs:
           command: make devnet-allocs
       - save_cache:
           name: Save Go modules cache
-          key: gomod-allocs-{{ checksum "go.sum" }}
+          key: gomod-contracts-build-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
       - save_cache:
           name: Save Go build cache
-          key: golang-build-cache-allocs-{{ checksum "go.sum" }}
+          key: golang-build-cache-contracts-build-{{ checksum "go.sum" }}
           paths:
             - "/root/.cache/go-build"
       - persist_to_workspace:
           root: "."
           paths:
+            - "packages/contracts-bedrock/cache"
+            - "packages/contracts-bedrock/artifacts"
+            - "packages/contracts-bedrock/forge-artifacts"
             - ".devnet/allocs-l1.json"
             - ".devnet/allocs-l2-delta.json"
             - ".devnet/allocs-l2-ecotone.json"
@@ -565,7 +551,16 @@ jobs:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
     resource_class: xlarge
-    parallelism: 4
+    parameters:
+      test_parallelism:
+        description: Number of test jobs to run in parallel
+        type: integer
+        default: 4
+      test_filter:
+        description: List of test files to run
+        type: string
+        default: find ./test -name "*.t.sol"
+    parallelism: <<parameters.test_parallelism>>
     steps:
       - checkout
       - attach_workspace: { at: "." }
@@ -589,6 +584,10 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
+          name: Pull artifacts
+          command: bash scripts/ops/pull-artifacts.sh
+          working_directory: packages/contracts-bedrock
+      - run:
           name: build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
@@ -596,7 +595,7 @@ jobs:
           name: run tests
           command: |
             # Find all test files
-            TEST_FILES=$(find ./test -name "*.t.sol")
+            TEST_FILES=$(<<parameters.test_filter>>)
             # Split the tests by timings
             TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
             # Strip the leading "./test/" from each file path
@@ -621,6 +620,7 @@ jobs:
           key: golang-build-cache-contracts-bedrock-tests-{{ checksum "go.sum" }}
           paths:
             - "/root/.cache/go-build"
+      - notify-failures-on-develop
 
   contracts-bedrock-checks:
     docker:
@@ -1568,25 +1568,26 @@ workflows:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - go-mod-download
-      - contracts-bedrock-build
       - contracts-bedrock-build:
-          name: contracts-bedrock-build-skip-tests
-          build_command: forge build --skip test
+          name: contracts-bedrock-build
+          build_command: |
+            forge build --skip test --skip scripts
+            forge build ./scripts/deploy/Deploy.s.sol
       - contracts-bedrock-tests:
-          requires:
-            - contracts-bedrock-build
-            - go-mod-download
+          test_filter: find . -name "*.t.sol" -not -name "PreimageOracle.t.sol"
+          test_parallelism: 4
+      - contracts-bedrock-tests:
+          # PreimageOracle test is slow, run it separately to unblock CI
+          name: contracts-bedrock-tests-preimage-oracle
+          test_filter: find . -name "PreimageOracle.t.sol"
+          test_parallelism: 1
       - contracts-bedrock-coverage
       - contracts-bedrock-checks:
           requires:
-            - contracts-bedrock-build-skip-tests
+            - contracts-bedrock-build
       - contracts-bedrock-validate-spacers:
           requires:
-            - contracts-bedrock-build-skip-tests
-      - build-devnet-allocs:
-          requires:
-            - contracts-bedrock-build-skip-tests
-            - go-mod-download
+            - contracts-bedrock-build
       - semgrep-scan
       - go-lint:
           requires:
@@ -1616,13 +1617,13 @@ workflows:
           package_name: cannon
           on_changes: cannon,packages/contracts-bedrock/src/cannon
           uses_artifacts: true
-          requires: ["go-mod-download", "build-devnet-allocs"]
+          requires: ["go-mod-download", "contracts-bedrock-build"]
       - fuzz-golang:
           name: op-e2e-fuzz
           package_name: op-e2e
           on_changes: op-e2e,packages/contracts-bedrock/src
           uses_artifacts: true
-          requires: ["go-mod-download", "build-devnet-allocs"]
+          requires: ["go-mod-download", "contracts-bedrock-build"]
       - go-test:
           name: op-batcher-tests
           module: op-batcher
@@ -1673,7 +1674,7 @@ workflows:
           parallelism: 4
           requires:
             - go-mod-download
-            - build-devnet-allocs
+            - contracts-bedrock-build
       - go-e2e-test:
           name: op-e2e-action-tests<< matrix.variant >>
           matrix:
@@ -1684,14 +1685,14 @@ workflows:
           parallelism: 1
           requires:
             - go-mod-download
-            - build-devnet-allocs
+            - contracts-bedrock-build
       - go-e2e-test:
           name: op-e2e-fault-proof-tests
           module: op-e2e
           target: test-fault-proofs
           parallelism: 4
           requires:
-            - build-devnet-allocs
+            - contracts-bedrock-build
             - cannon-prestate
       - op-program-compat:
           requires:
@@ -1772,7 +1773,7 @@ workflows:
             parameters:
               variant: ["default", "altda", "altda-generic"]
           requires:
-            - build-devnet-allocs
+            - contracts-bedrock-build
             - op-batcher-docker-build
             - op-proposer-docker-build
             - op-node-docker-build
@@ -1783,7 +1784,7 @@ workflows:
       - check-generated-mocks-op-service
       - cannon-go-lint-and-test:
           requires:
-            - build-devnet-allocs
+            - contracts-bedrock-build
       - cannon-build-test-vectors
       - shellcheck/check:
           name: shell-check
@@ -2051,13 +2052,7 @@ workflows:
       - cannon-prestate:
           requires:
             - go-mod-download
-      - contracts-bedrock-build:
-          requires:
-            - go-mod-download
-      - build-devnet-allocs:
-          name: build-devnet-allocs
-          requires:
-            - contracts-bedrock-build
+      - contracts-bedrock-build
       - go-e2e-test:
           name: op-e2e-cannon-tests
           module: op-e2e
@@ -2066,7 +2061,7 @@ workflows:
           notify: true
           mentions: "@proofs-squad"
           requires:
-            - build-devnet-allocs
+            - contracts-bedrock-build
             - cannon-prestate
           context:
             - slack


### PR DESCRIPTION
Updates the contracts-bedrock-tests job to only build the specific
tests that are being tested as part of the test split for that
job. Also merges the other contracts-bedrock-build with
build-devnet-allocs since this is a bottleneck now. Overall impact
is that CI time is now 7-10 minutes.