### PR TITLE
op-node: read DACommitmentType from scr in LoadOPStackRollupConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240821192748-42bd03ba8313
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240827042333-110c433a2469 h1:sGqlBjx0+z/ExU6VNo5OHSXS/5nc6BfkEQJvSdVbWp0=
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240827042333-110c433a2469/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240821192748-42bd03ba8313 h1:SVSFg8ccdRBJxOdRS1pK8oIHvMufiPAQz1gkQsEPnZc=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240821192748-42bd03ba8313/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.1.1-0.20240306133620-7d920df305f0 h1:KrE8I4reeVvf7C1tm8elRjj4BdscTYzz/WAbYyf/JI4=

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -44,13 +44,19 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		return nil, fmt.Errorf("unable to retrieve deposit contract address")
 	}
 
-	var altDA *AltDAConfig
+	var altDA AltDAConfig
 	if chConfig.AltDA != nil {
-		altDA = &AltDAConfig{
-			DAChallengeAddress: common.Address(*chConfig.AltDA.DAChallengeAddress),
-			DAChallengeWindow:  *chConfig.AltDA.DAChallengeWindow,
-			DAResolveWindow:    *chConfig.AltDA.DAResolveWindow,
-			CommitmentType:     *chConfig.AltDA.DACommitmentType,
+		if chConfig.AltDA.DAChallengeAddress != nil {
+			altDA.DAChallengeAddress = common.Address(*chConfig.AltDA.DAChallengeAddress)
+		}
+		if chConfig.AltDA.DAChallengeWindow != nil {
+			altDA.DAChallengeWindow = *chConfig.AltDA.DAChallengeWindow
+		}
+		if chConfig.AltDA.DAResolveWindow != nil {
+			altDA.DAResolveWindow = *chConfig.AltDA.DAResolveWindow
+		}
+		if chConfig.AltDA.DACommitmentType != nil {
+			altDA.CommitmentType = *chConfig.AltDA.DACommitmentType
 		}
 	}
 
@@ -87,7 +93,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		BatchInboxAddress:      common.Address(chConfig.BatchInboxAddr),
 		DepositContractAddress: common.Address(addrs.OptimismPortalProxy),
 		L1SystemConfigAddress:  common.Address(addrs.SystemConfigProxy),
-		AltDAConfig:            altDA,
+		AltDAConfig:            &altDA,
 	}
 
 	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -44,8 +44,9 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		return nil, fmt.Errorf("unable to retrieve deposit contract address")
 	}
 
-	var altDA AltDAConfig
+	var altDA *AltDAConfig
 	if chConfig.AltDA != nil {
+		altDA = &AltDAConfig{}
 		if chConfig.AltDA.DAChallengeAddress != nil {
 			altDA.DAChallengeAddress = common.Address(*chConfig.AltDA.DAChallengeAddress)
 		}
@@ -93,7 +94,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		BatchInboxAddress:      common.Address(chConfig.BatchInboxAddr),
 		DepositContractAddress: common.Address(addrs.OptimismPortalProxy),
 		L1SystemConfigAddress:  common.Address(addrs.SystemConfigProxy),
-		AltDAConfig:            &altDA,
+		AltDAConfig:            altDA,
 	}
 
 	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -50,6 +50,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 			DAChallengeAddress: common.Address(*chConfig.AltDA.DAChallengeAddress),
 			DAChallengeWindow:  *chConfig.AltDA.DAChallengeWindow,
 			DAResolveWindow:    *chConfig.AltDA.DAResolveWindow,
+			CommitmentType:     *chConfig.AltDA.DACommitmentType,
 		}
 	}
 


### PR DESCRIPTION
Follow-up to superchain-registry pr: https://github.com/ethereum-optimism/superchain-registry/pull/559

Read `DACommitmentType` from superchain-registry config during `LoadOPStackRollupConfig`