### PR TITLE
test: fix test and variable naming conventions

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
@@ -292,39 +292,39 @@ contract DeployOPChainOutput {
 contract DeployOPChain is Script {
     // -------- Core Deployment Methods --------
     function run(string memory _infile) public {
-        (DeployOPChainInput dsi, DeployOPChainOutput dso) = etchIOContracts();
-        dsi.loadInputFile(_infile);
-        run(dsi, dso);
+        (DeployOPChainInput doi, DeployOPChainOutput doo) = etchIOContracts();
+        doi.loadInputFile(_infile);
+        run(doi, doo);
         string memory outfile = ""; // This will be derived from input file name, e.g. `foo.in.toml` -> `foo.out.toml`
-        dso.writeOutputFile(outfile);
+        doo.writeOutputFile(outfile);
         require(false, "DeployOPChain: run is not implemented");
     }
 
     function run(DeployOPChainInput.Input memory _input) public returns (DeployOPChainOutput.Output memory) {
-        (DeployOPChainInput dsi, DeployOPChainOutput dso) = etchIOContracts();
-        dsi.loadInput(_input);
-        run(dsi, dso);
-        return dso.output();
+        (DeployOPChainInput doi, DeployOPChainOutput doo) = etchIOContracts();
+        doi.loadInput(_input);
+        run(doi, doo);
+        return doo.output();
     }
 
-    function run(DeployOPChainInput _dsi, DeployOPChainOutput _dso) public {
-        require(_dsi.inputSet(), "DeployOPChain: input not set");
+    function run(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
+        require(_doi.inputSet(), "DeployOPChain: input not set");
 
-        OPStackManager opsm = _dsi.opsm();
+        OPStackManager opsm = _doi.opsm();
 
         OPStackManager.Roles memory roles = OPStackManager.Roles({
-            opChainProxyAdminOwner: _dsi.opChainProxyAdminOwner(),
-            systemConfigOwner: _dsi.systemConfigOwner(),
-            batcher: _dsi.batcher(),
-            unsafeBlockSigner: _dsi.unsafeBlockSigner(),
-            proposer: _dsi.proposer(),
-            challenger: _dsi.challenger()
+            opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
+            systemConfigOwner: _doi.systemConfigOwner(),
+            batcher: _doi.batcher(),
+            unsafeBlockSigner: _doi.unsafeBlockSigner(),
+            proposer: _doi.proposer(),
+            challenger: _doi.challenger()
         });
         OPStackManager.DeployInput memory deployInput = OPStackManager.DeployInput({
             roles: roles,
-            basefeeScalar: _dsi.basefeeScalar(),
-            blobBasefeeScalar: _dsi.blobBaseFeeScalar(),
-            l2ChainId: _dsi.l2ChainId()
+            basefeeScalar: _doi.basefeeScalar(),
+            blobBasefeeScalar: _doi.blobBaseFeeScalar(),
+            l2ChainId: _doi.l2ChainId()
         });
 
         vm.broadcast(msg.sender);
@@ -347,40 +347,40 @@ contract DeployOPChain is Script {
         vm.label(address(deployOutput.delayedWETHPermissionedGameProxy), "delayedWETHPermissionedGameProxy");
         vm.label(address(deployOutput.delayedWETHPermissionlessGameProxy), "delayedWETHPermissionlessGameProxy");
 
-        _dso.set(_dso.opChainProxyAdmin.selector, address(deployOutput.opChainProxyAdmin));
-        _dso.set(_dso.addressManager.selector, address(deployOutput.addressManager));
-        _dso.set(_dso.l1ERC721BridgeProxy.selector, address(deployOutput.l1ERC721BridgeProxy));
-        _dso.set(_dso.systemConfigProxy.selector, address(deployOutput.systemConfigProxy));
-        _dso.set(
-            _dso.optimismMintableERC20FactoryProxy.selector, address(deployOutput.optimismMintableERC20FactoryProxy)
+        _doo.set(_doo.opChainProxyAdmin.selector, address(deployOutput.opChainProxyAdmin));
+        _doo.set(_doo.addressManager.selector, address(deployOutput.addressManager));
+        _doo.set(_doo.l1ERC721BridgeProxy.selector, address(deployOutput.l1ERC721BridgeProxy));
+        _doo.set(_doo.systemConfigProxy.selector, address(deployOutput.systemConfigProxy));
+        _doo.set(
+            _doo.optimismMintableERC20FactoryProxy.selector, address(deployOutput.optimismMintableERC20FactoryProxy)
         );
-        _dso.set(_dso.l1StandardBridgeProxy.selector, address(deployOutput.l1StandardBridgeProxy));
-        _dso.set(_dso.l1CrossDomainMessengerProxy.selector, address(deployOutput.l1CrossDomainMessengerProxy));
-        _dso.set(_dso.optimismPortalProxy.selector, address(deployOutput.optimismPortalProxy));
-        _dso.set(_dso.disputeGameFactoryProxy.selector, address(deployOutput.disputeGameFactoryProxy));
-        _dso.set(_dso.disputeGameFactoryImpl.selector, address(deployOutput.disputeGameFactoryImpl));
-        _dso.set(_dso.anchorStateRegistryProxy.selector, address(deployOutput.anchorStateRegistryProxy));
-        _dso.set(_dso.anchorStateRegistryImpl.selector, address(deployOutput.anchorStateRegistryImpl));
-        _dso.set(_dso.faultDisputeGame.selector, address(deployOutput.faultDisputeGame));
-        _dso.set(_dso.permissionedDisputeGame.selector, address(deployOutput.permissionedDisputeGame));
-        _dso.set(_dso.delayedWETHPermissionedGameProxy.selector, address(deployOutput.delayedWETHPermissionedGameProxy));
-        _dso.set(
-            _dso.delayedWETHPermissionlessGameProxy.selector, address(deployOutput.delayedWETHPermissionlessGameProxy)
+        _doo.set(_doo.l1StandardBridgeProxy.selector, address(deployOutput.l1StandardBridgeProxy));
+        _doo.set(_doo.l1CrossDomainMessengerProxy.selector, address(deployOutput.l1CrossDomainMessengerProxy));
+        _doo.set(_doo.optimismPortalProxy.selector, address(deployOutput.optimismPortalProxy));
+        _doo.set(_doo.disputeGameFactoryProxy.selector, address(deployOutput.disputeGameFactoryProxy));
+        _doo.set(_doo.disputeGameFactoryImpl.selector, address(deployOutput.disputeGameFactoryImpl));
+        _doo.set(_doo.anchorStateRegistryProxy.selector, address(deployOutput.anchorStateRegistryProxy));
+        _doo.set(_doo.anchorStateRegistryImpl.selector, address(deployOutput.anchorStateRegistryImpl));
+        _doo.set(_doo.faultDisputeGame.selector, address(deployOutput.faultDisputeGame));
+        _doo.set(_doo.permissionedDisputeGame.selector, address(deployOutput.permissionedDisputeGame));
+        _doo.set(_doo.delayedWETHPermissionedGameProxy.selector, address(deployOutput.delayedWETHPermissionedGameProxy));
+        _doo.set(
+            _doo.delayedWETHPermissionlessGameProxy.selector, address(deployOutput.delayedWETHPermissionlessGameProxy)
         );
 
-        _dso.checkOutput();
+        _doo.checkOutput();
     }
 
     // -------- Utilities --------
 
-    function etchIOContracts() internal returns (DeployOPChainInput dsi_, DeployOPChainOutput dso_) {
-        (dsi_, dso_) = getIOContracts();
-        vm.etch(address(dsi_), type(DeployOPChainInput).runtimeCode);
-        vm.etch(address(dso_), type(DeployOPChainOutput).runtimeCode);
+    function etchIOContracts() internal returns (DeployOPChainInput doi_, DeployOPChainOutput doo_) {
+        (doi_, doo_) = getIOContracts();
+        vm.etch(address(doi_), type(DeployOPChainInput).runtimeCode);
+        vm.etch(address(doo_), type(DeployOPChainOutput).runtimeCode);
     }
 
-    function getIOContracts() public view returns (DeployOPChainInput dsi_, DeployOPChainOutput dso_) {
-        dsi_ = DeployOPChainInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainInput"));
-        dso_ = DeployOPChainOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainOutput"));
+    function getIOContracts() public view returns (DeployOPChainInput doi_, DeployOPChainOutput doo_) {
+        doi_ = DeployOPChainInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainInput"));
+        doo_ = DeployOPChainOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainOutput"));
     }
 }

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -56,7 +56,15 @@ import { Solarray } from "scripts/libraries/Solarray.sol";
 // documentation.
 //
 // Additionally, we intentionally use "Input" and "Output" terminology to clearly distinguish these
-// scripts from the existing ones that use the "Config" and "Artifacts" terminology.
+// scripts from the existing ones that use the "Config" and "Artifacts" terminology. Within scripts
+// we use variable names that are shorthand for the full contract names, for example:
+//   - `dsi` for DeploySuperchainInput
+//   - `dso` for DeploySuperchainOutput
+//   - `dio` for DeployImplementationsInput
+//   - `dio` for DeployImplementationsOutput
+//   - `doo` for DeployOPChainInput
+//   - `doo` for DeployOPChainOutput
+//   - etc.
 contract DeploySuperchainInput is CommonBase {
     using stdToml for string;
 

--- a/packages/contracts-bedrock/test/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/DeployImplementations.t.sol
@@ -26,7 +26,7 @@ import {
 } from "scripts/DeployImplementations.s.sol";
 
 contract DeployImplementationsInput_Test is Test {
-    DeployImplementationsInput dsi;
+    DeployImplementationsInput dii;
 
     DeployImplementationsInput.Input input = DeployImplementationsInput.Input({
         withdrawalDelaySeconds: 100,
@@ -40,50 +40,50 @@ contract DeployImplementationsInput_Test is Test {
     });
 
     function setUp() public {
-        dsi = new DeployImplementationsInput();
+        dii = new DeployImplementationsInput();
     }
 
     function test_loadInput_succeeds() public {
-        dsi.loadInput(input);
+        dii.loadInput(input);
 
-        assertTrue(dsi.inputSet(), "100");
+        assertTrue(dii.inputSet(), "100");
 
         // Compare the test input struct to the getter methods.
-        assertEq(input.withdrawalDelaySeconds, dsi.withdrawalDelaySeconds(), "200");
-        assertEq(input.minProposalSizeBytes, dsi.minProposalSizeBytes(), "300");
-        assertEq(input.challengePeriodSeconds, dsi.challengePeriodSeconds(), "400");
-        assertEq(input.proofMaturityDelaySeconds, dsi.proofMaturityDelaySeconds(), "500");
-        assertEq(input.disputeGameFinalityDelaySeconds, dsi.disputeGameFinalityDelaySeconds(), "600");
+        assertEq(input.withdrawalDelaySeconds, dii.withdrawalDelaySeconds(), "200");
+        assertEq(input.minProposalSizeBytes, dii.minProposalSizeBytes(), "300");
+        assertEq(input.challengePeriodSeconds, dii.challengePeriodSeconds(), "400");
+        assertEq(input.proofMaturityDelaySeconds, dii.proofMaturityDelaySeconds(), "500");
+        assertEq(input.disputeGameFinalityDelaySeconds, dii.disputeGameFinalityDelaySeconds(), "600");
 
         // Compare the test input struct to the `input` getter method.
-        assertEq(keccak256(abi.encode(input)), keccak256(abi.encode(dsi.input())), "800");
+        assertEq(keccak256(abi.encode(input)), keccak256(abi.encode(dii.input())), "800");
     }
 
     function test_getters_whenNotSet_revert() public {
         bytes memory expectedErr = "DeployImplementationsInput: input not set";
 
         vm.expectRevert(expectedErr);
-        dsi.withdrawalDelaySeconds();
+        dii.withdrawalDelaySeconds();
 
         vm.expectRevert(expectedErr);
-        dsi.minProposalSizeBytes();
+        dii.minProposalSizeBytes();
 
         vm.expectRevert(expectedErr);
-        dsi.challengePeriodSeconds();
+        dii.challengePeriodSeconds();
 
         vm.expectRevert(expectedErr);
-        dsi.proofMaturityDelaySeconds();
+        dii.proofMaturityDelaySeconds();
 
         vm.expectRevert(expectedErr);
-        dsi.disputeGameFinalityDelaySeconds();
+        dii.disputeGameFinalityDelaySeconds();
     }
 }
 
 contract DeployImplementationsOutput_Test is Test {
-    DeployImplementationsOutput dso;
+    DeployImplementationsOutput dio;
 
     function setUp() public {
-        dso = new DeployImplementationsOutput();
+        dio = new DeployImplementationsOutput();
     }
 
     function test_set_succeeds() public {
@@ -112,115 +112,115 @@ contract DeployImplementationsOutput_Test is Test {
         vm.etch(address(output.l1StandardBridgeImpl), hex"01");
         vm.etch(address(output.optimismMintableERC20FactoryImpl), hex"01");
         vm.etch(address(output.disputeGameFactoryImpl), hex"01");
-        dso.set(dso.opsm.selector, address(output.opsm));
-        dso.set(dso.optimismPortalImpl.selector, address(output.optimismPortalImpl));
-        dso.set(dso.delayedWETHImpl.selector, address(output.delayedWETHImpl));
-        dso.set(dso.preimageOracleSingleton.selector, address(output.preimageOracleSingleton));
-        dso.set(dso.mipsSingleton.selector, address(output.mipsSingleton));
-        dso.set(dso.systemConfigImpl.selector, address(output.systemConfigImpl));
-        dso.set(dso.l1CrossDomainMessengerImpl.selector, address(output.l1CrossDomainMessengerImpl));
-        dso.set(dso.l1ERC721BridgeImpl.selector, address(output.l1ERC721BridgeImpl));
-        dso.set(dso.l1StandardBridgeImpl.selector, address(output.l1StandardBridgeImpl));
-        dso.set(dso.optimismMintableERC20FactoryImpl.selector, address(output.optimismMintableERC20FactoryImpl));
-        dso.set(dso.disputeGameFactoryImpl.selector, address(output.disputeGameFactoryImpl));
+        dio.set(dio.opsm.selector, address(output.opsm));
+        dio.set(dio.optimismPortalImpl.selector, address(output.optimismPortalImpl));
+        dio.set(dio.delayedWETHImpl.selector, address(output.delayedWETHImpl));
+        dio.set(dio.preimageOracleSingleton.selector, address(output.preimageOracleSingleton));
+        dio.set(dio.mipsSingleton.selector, address(output.mipsSingleton));
+        dio.set(dio.systemConfigImpl.selector, address(output.systemConfigImpl));
+        dio.set(dio.l1CrossDomainMessengerImpl.selector, address(output.l1CrossDomainMessengerImpl));
+        dio.set(dio.l1ERC721BridgeImpl.selector, address(output.l1ERC721BridgeImpl));
+        dio.set(dio.l1StandardBridgeImpl.selector, address(output.l1StandardBridgeImpl));
+        dio.set(dio.optimismMintableERC20FactoryImpl.selector, address(output.optimismMintableERC20FactoryImpl));
+        dio.set(dio.disputeGameFactoryImpl.selector, address(output.disputeGameFactoryImpl));
 
-        assertEq(address(output.opsm), address(dso.opsm()), "50");
-        assertEq(address(output.optimismPortalImpl), address(dso.optimismPortalImpl()), "100");
-        assertEq(address(output.delayedWETHImpl), address(dso.delayedWETHImpl()), "200");
-        assertEq(address(output.preimageOracleSingleton), address(dso.preimageOracleSingleton()), "300");
-        assertEq(address(output.mipsSingleton), address(dso.mipsSingleton()), "400");
-        assertEq(address(output.systemConfigImpl), address(dso.systemConfigImpl()), "500");
-        assertEq(address(output.l1CrossDomainMessengerImpl), address(dso.l1CrossDomainMessengerImpl()), "600");
-        assertEq(address(output.l1ERC721BridgeImpl), address(dso.l1ERC721BridgeImpl()), "700");
-        assertEq(address(output.l1StandardBridgeImpl), address(dso.l1StandardBridgeImpl()), "800");
+        assertEq(address(output.opsm), address(dio.opsm()), "50");
+        assertEq(address(output.optimismPortalImpl), address(dio.optimismPortalImpl()), "100");
+        assertEq(address(output.delayedWETHImpl), address(dio.delayedWETHImpl()), "200");
+        assertEq(address(output.preimageOracleSingleton), address(dio.preimageOracleSingleton()), "300");
+        assertEq(address(output.mipsSingleton), address(dio.mipsSingleton()), "400");
+        assertEq(address(output.systemConfigImpl), address(dio.systemConfigImpl()), "500");
+        assertEq(address(output.l1CrossDomainMessengerImpl), address(dio.l1CrossDomainMessengerImpl()), "600");
+        assertEq(address(output.l1ERC721BridgeImpl), address(dio.l1ERC721BridgeImpl()), "700");
+        assertEq(address(output.l1StandardBridgeImpl), address(dio.l1StandardBridgeImpl()), "800");
         assertEq(
-            address(output.optimismMintableERC20FactoryImpl), address(dso.optimismMintableERC20FactoryImpl()), "900"
+            address(output.optimismMintableERC20FactoryImpl), address(dio.optimismMintableERC20FactoryImpl()), "900"
         );
-        assertEq(address(output.disputeGameFactoryImpl), address(dso.disputeGameFactoryImpl()), "950");
+        assertEq(address(output.disputeGameFactoryImpl), address(dio.disputeGameFactoryImpl()), "950");
 
-        assertEq(keccak256(abi.encode(output)), keccak256(abi.encode(dso.output())), "1000");
+        assertEq(keccak256(abi.encode(output)), keccak256(abi.encode(dio.output())), "1000");
     }
 
     function test_getters_whenNotSet_revert() public {
         bytes memory expectedErr = "DeployUtils: zero address";
 
         vm.expectRevert(expectedErr);
-        dso.optimismPortalImpl();
+        dio.optimismPortalImpl();
 
         vm.expectRevert(expectedErr);
-        dso.delayedWETHImpl();
+        dio.delayedWETHImpl();
 
         vm.expectRevert(expectedErr);
-        dso.preimageOracleSingleton();
+        dio.preimageOracleSingleton();
 
         vm.expectRevert(expectedErr);
-        dso.mipsSingleton();
+        dio.mipsSingleton();
 
         vm.expectRevert(expectedErr);
-        dso.systemConfigImpl();
+        dio.systemConfigImpl();
 
         vm.expectRevert(expectedErr);
-        dso.l1CrossDomainMessengerImpl();
+        dio.l1CrossDomainMessengerImpl();
 
         vm.expectRevert(expectedErr);
-        dso.l1ERC721BridgeImpl();
+        dio.l1ERC721BridgeImpl();
 
         vm.expectRevert(expectedErr);
-        dso.l1StandardBridgeImpl();
+        dio.l1StandardBridgeImpl();
 
         vm.expectRevert(expectedErr);
-        dso.optimismMintableERC20FactoryImpl();
+        dio.optimismMintableERC20FactoryImpl();
 
         vm.expectRevert(expectedErr);
-        dso.disputeGameFactoryImpl();
+        dio.disputeGameFactoryImpl();
     }
 
     function test_getters_whenAddrHasNoCode_reverts() public {
         address emptyAddr = makeAddr("emptyAddr");
         bytes memory expectedErr = bytes(string.concat("DeployUtils: no code at ", vm.toString(emptyAddr)));
 
-        dso.set(dso.optimismPortalImpl.selector, emptyAddr);
+        dio.set(dio.optimismPortalImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.optimismPortalImpl();
+        dio.optimismPortalImpl();
 
-        dso.set(dso.delayedWETHImpl.selector, emptyAddr);
+        dio.set(dio.delayedWETHImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.delayedWETHImpl();
+        dio.delayedWETHImpl();
 
-        dso.set(dso.preimageOracleSingleton.selector, emptyAddr);
+        dio.set(dio.preimageOracleSingleton.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.preimageOracleSingleton();
+        dio.preimageOracleSingleton();
 
-        dso.set(dso.mipsSingleton.selector, emptyAddr);
+        dio.set(dio.mipsSingleton.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.mipsSingleton();
+        dio.mipsSingleton();
 
-        dso.set(dso.systemConfigImpl.selector, emptyAddr);
+        dio.set(dio.systemConfigImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.systemConfigImpl();
+        dio.systemConfigImpl();
 
-        dso.set(dso.l1CrossDomainMessengerImpl.selector, emptyAddr);
+        dio.set(dio.l1CrossDomainMessengerImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.l1CrossDomainMessengerImpl();
+        dio.l1CrossDomainMessengerImpl();
 
-        dso.set(dso.l1ERC721BridgeImpl.selector, emptyAddr);
+        dio.set(dio.l1ERC721BridgeImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.l1ERC721BridgeImpl();
+        dio.l1ERC721BridgeImpl();
 
-        dso.set(dso.l1StandardBridgeImpl.selector, emptyAddr);
+        dio.set(dio.l1StandardBridgeImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.l1StandardBridgeImpl();
+        dio.l1StandardBridgeImpl();
 
-        dso.set(dso.optimismMintableERC20FactoryImpl.selector, emptyAddr);
+        dio.set(dio.optimismMintableERC20FactoryImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.optimismMintableERC20FactoryImpl();
+        dio.optimismMintableERC20FactoryImpl();
     }
 }
 
 contract DeployImplementations_Test is Test {
     DeployImplementations deployImplementations;
-    DeployImplementationsInput dsi;
-    DeployImplementationsOutput dso;
+    DeployImplementationsInput dii;
+    DeployImplementationsOutput dio;
 
     // Define a default input struct for testing.
     DeployImplementationsInput.Input input = DeployImplementationsInput.Input({
@@ -236,7 +236,7 @@ contract DeployImplementations_Test is Test {
 
     function setUp() public virtual {
         deployImplementations = new DeployImplementations();
-        (dsi, dso) = deployImplementations.getIOContracts();
+        (dii, dio) = deployImplementations.getIOContracts();
     }
 
     // By deploying the `DeployImplementations` contract with this virtual function, we provide a
@@ -246,37 +246,37 @@ contract DeployImplementations_Test is Test {
         return new DeployImplementations();
     }
 
-    function test_run_succeeds(DeployImplementationsInput.Input memory _input) public {
+    function testFuzz_run_succeeds(DeployImplementationsInput.Input memory _input) public {
         // This is a requirement in the PreimageOracle contract.
         _input.challengePeriodSeconds = bound(_input.challengePeriodSeconds, 0, type(uint64).max);
 
         DeployImplementationsOutput.Output memory output = deployImplementations.run(_input);
 
         // Assert that individual input fields were properly set based on the input struct.
-        assertEq(_input.withdrawalDelaySeconds, dsi.withdrawalDelaySeconds(), "100");
-        assertEq(_input.minProposalSizeBytes, dsi.minProposalSizeBytes(), "200");
-        assertEq(_input.challengePeriodSeconds, dsi.challengePeriodSeconds(), "300");
-        assertEq(_input.proofMaturityDelaySeconds, dsi.proofMaturityDelaySeconds(), "400");
-        assertEq(_input.disputeGameFinalityDelaySeconds, dsi.disputeGameFinalityDelaySeconds(), "500");
+        assertEq(_input.withdrawalDelaySeconds, dii.withdrawalDelaySeconds(), "100");
+        assertEq(_input.minProposalSizeBytes, dii.minProposalSizeBytes(), "200");
+        assertEq(_input.challengePeriodSeconds, dii.challengePeriodSeconds(), "300");
+        assertEq(_input.proofMaturityDelaySeconds, dii.proofMaturityDelaySeconds(), "400");
+        assertEq(_input.disputeGameFinalityDelaySeconds, dii.disputeGameFinalityDelaySeconds(), "500");
 
         // Assert that individual output fields were properly set based on the output struct.
-        assertEq(address(output.optimismPortalImpl), address(dso.optimismPortalImpl()), "600");
-        assertEq(address(output.delayedWETHImpl), address(dso.delayedWETHImpl()), "700");
-        assertEq(address(output.preimageOracleSingleton), address(dso.preimageOracleSingleton()), "800");
-        assertEq(address(output.mipsSingleton), address(dso.mipsSingleton()), "900");
-        assertEq(address(output.systemConfigImpl), address(dso.systemConfigImpl()), "1000");
-        assertEq(address(output.l1CrossDomainMessengerImpl), address(dso.l1CrossDomainMessengerImpl()), "1100");
-        assertEq(address(output.l1ERC721BridgeImpl), address(dso.l1ERC721BridgeImpl()), "1200");
-        assertEq(address(output.l1StandardBridgeImpl), address(dso.l1StandardBridgeImpl()), "1300");
+        assertEq(address(output.optimismPortalImpl), address(dio.optimismPortalImpl()), "600");
+        assertEq(address(output.delayedWETHImpl), address(dio.delayedWETHImpl()), "700");
+        assertEq(address(output.preimageOracleSingleton), address(dio.preimageOracleSingleton()), "800");
+        assertEq(address(output.mipsSingleton), address(dio.mipsSingleton()), "900");
+        assertEq(address(output.systemConfigImpl), address(dio.systemConfigImpl()), "1000");
+        assertEq(address(output.l1CrossDomainMessengerImpl), address(dio.l1CrossDomainMessengerImpl()), "1100");
+        assertEq(address(output.l1ERC721BridgeImpl), address(dio.l1ERC721BridgeImpl()), "1200");
+        assertEq(address(output.l1StandardBridgeImpl), address(dio.l1StandardBridgeImpl()), "1300");
         assertEq(
-            address(output.optimismMintableERC20FactoryImpl), address(dso.optimismMintableERC20FactoryImpl()), "1400"
+            address(output.optimismMintableERC20FactoryImpl), address(dio.optimismMintableERC20FactoryImpl()), "1400"
         );
-        assertEq(address(output.disputeGameFactoryImpl), address(dso.disputeGameFactoryImpl()), "1450");
+        assertEq(address(output.disputeGameFactoryImpl), address(dio.disputeGameFactoryImpl()), "1450");
 
         // Assert that the full input and output structs were properly set.
-        assertEq(keccak256(abi.encode(_input)), keccak256(abi.encode(DeployImplementationsInput(dsi).input())), "1500");
+        assertEq(keccak256(abi.encode(_input)), keccak256(abi.encode(DeployImplementationsInput(dii).input())), "1500");
         assertEq(
-            keccak256(abi.encode(output)), keccak256(abi.encode(DeployImplementationsOutput(dso).output())), "1600"
+            keccak256(abi.encode(output)), keccak256(abi.encode(DeployImplementationsOutput(dio).output())), "1600"
         );
 
         // Assert inputs were properly passed through to the contract initializers.
@@ -293,10 +293,10 @@ contract DeployImplementations_Test is Test {
 
         // Ensure that `checkOutput` passes. This is called by the `run` function during execution,
         // so this just acts as a sanity check. It reverts on failure.
-        dso.checkOutput();
+        dio.checkOutput();
     }
 
-    function test_run_largeChallengePeriodSeconds_reverts(uint256 _challengePeriodSeconds) public {
+    function testFuzz_run_largeChallengePeriodSeconds_reverts(uint256 _challengePeriodSeconds) public {
         input.challengePeriodSeconds = bound(_challengePeriodSeconds, uint256(type(uint64).max) + 1, type(uint256).max);
         vm.expectRevert("DeployImplementationsInput: challenge period too large");
         deployImplementations.run(input);

--- a/packages/contracts-bedrock/test/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/DeployOPChain.t.sol
@@ -32,7 +32,7 @@ import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
 import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
 
 contract DeployOPChainInput_Test is Test {
-    DeployOPChainInput dsi;
+    DeployOPChainInput doi;
 
     DeployOPChainInput.Input input = DeployOPChainInput.Input({
         roles: DeployOPChainInput.Roles({
@@ -50,67 +50,67 @@ contract DeployOPChainInput_Test is Test {
     });
 
     function setUp() public {
-        dsi = new DeployOPChainInput();
+        doi = new DeployOPChainInput();
     }
 
     function test_loadInput_succeeds() public {
-        dsi.loadInput(input);
+        doi.loadInput(input);
 
-        assertTrue(dsi.inputSet(), "100");
+        assertTrue(doi.inputSet(), "100");
 
         // Compare the test input struct to the getter methods.
-        assertEq(input.roles.opChainProxyAdminOwner, dsi.opChainProxyAdminOwner(), "200");
-        assertEq(input.roles.systemConfigOwner, dsi.systemConfigOwner(), "300");
-        assertEq(input.roles.batcher, dsi.batcher(), "400");
-        assertEq(input.roles.unsafeBlockSigner, dsi.unsafeBlockSigner(), "500");
-        assertEq(input.roles.proposer, dsi.proposer(), "600");
-        assertEq(input.roles.challenger, dsi.challenger(), "700");
-        assertEq(input.basefeeScalar, dsi.basefeeScalar(), "800");
-        assertEq(input.blobBaseFeeScalar, dsi.blobBaseFeeScalar(), "900");
-        assertEq(input.l2ChainId, dsi.l2ChainId(), "1000");
-        assertEq(address(input.opsm), address(dsi.opsm()), "1100");
+        assertEq(input.roles.opChainProxyAdminOwner, doi.opChainProxyAdminOwner(), "200");
+        assertEq(input.roles.systemConfigOwner, doi.systemConfigOwner(), "300");
+        assertEq(input.roles.batcher, doi.batcher(), "400");
+        assertEq(input.roles.unsafeBlockSigner, doi.unsafeBlockSigner(), "500");
+        assertEq(input.roles.proposer, doi.proposer(), "600");
+        assertEq(input.roles.challenger, doi.challenger(), "700");
+        assertEq(input.basefeeScalar, doi.basefeeScalar(), "800");
+        assertEq(input.blobBaseFeeScalar, doi.blobBaseFeeScalar(), "900");
+        assertEq(input.l2ChainId, doi.l2ChainId(), "1000");
+        assertEq(address(input.opsm), address(doi.opsm()), "1100");
 
         // Compare the test input struct to the `input` getter method.
-        assertEq(keccak256(abi.encode(input)), keccak256(abi.encode(dsi.input())), "1200");
+        assertEq(keccak256(abi.encode(input)), keccak256(abi.encode(doi.input())), "1200");
     }
 
     function test_getters_whenNotSet_revert() public {
         bytes memory expectedErr = "DeployOPChainInput: input not set";
 
         vm.expectRevert(expectedErr);
-        dsi.opChainProxyAdminOwner();
+        doi.opChainProxyAdminOwner();
 
         vm.expectRevert(expectedErr);
-        dsi.systemConfigOwner();
+        doi.systemConfigOwner();
 
         vm.expectRevert(expectedErr);
-        dsi.batcher();
+        doi.batcher();
 
         vm.expectRevert(expectedErr);
-        dsi.unsafeBlockSigner();
+        doi.unsafeBlockSigner();
 
         vm.expectRevert(expectedErr);
-        dsi.proposer();
+        doi.proposer();
 
         vm.expectRevert(expectedErr);
-        dsi.challenger();
+        doi.challenger();
 
         vm.expectRevert(expectedErr);
-        dsi.basefeeScalar();
+        doi.basefeeScalar();
 
         vm.expectRevert(expectedErr);
-        dsi.blobBaseFeeScalar();
+        doi.blobBaseFeeScalar();
 
         vm.expectRevert(expectedErr);
-        dsi.l2ChainId();
+        doi.l2ChainId();
     }
 }
 
 contract DeployOPChainOutput_Test is Test {
-    DeployOPChainOutput dso;
+    DeployOPChainOutput doo;
 
     function setUp() public {
-        dso = new DeployOPChainOutput();
+        doo = new DeployOPChainOutput();
     }
 
     function test_set_succeeds() public {
@@ -150,170 +150,170 @@ contract DeployOPChainOutput_Test is Test {
         vm.etch(address(output.delayedWETHPermissionedGameProxy), hex"01");
         vm.etch(address(output.delayedWETHPermissionlessGameProxy), hex"01");
 
-        dso.set(dso.opChainProxyAdmin.selector, address(output.opChainProxyAdmin));
-        dso.set(dso.addressManager.selector, address(output.addressManager));
-        dso.set(dso.l1ERC721BridgeProxy.selector, address(output.l1ERC721BridgeProxy));
-        dso.set(dso.systemConfigProxy.selector, address(output.systemConfigProxy));
-        dso.set(dso.optimismMintableERC20FactoryProxy.selector, address(output.optimismMintableERC20FactoryProxy));
-        dso.set(dso.l1StandardBridgeProxy.selector, address(output.l1StandardBridgeProxy));
-        dso.set(dso.l1CrossDomainMessengerProxy.selector, address(output.l1CrossDomainMessengerProxy));
-        dso.set(dso.optimismPortalProxy.selector, address(output.optimismPortalProxy));
-        dso.set(dso.disputeGameFactoryProxy.selector, address(output.disputeGameFactoryProxy));
-        dso.set(dso.disputeGameFactoryImpl.selector, address(output.disputeGameFactoryImpl));
-        dso.set(dso.anchorStateRegistryProxy.selector, address(output.anchorStateRegistryProxy));
-        dso.set(dso.anchorStateRegistryImpl.selector, address(output.anchorStateRegistryImpl));
-        dso.set(dso.faultDisputeGame.selector, address(output.faultDisputeGame));
-        dso.set(dso.permissionedDisputeGame.selector, address(output.permissionedDisputeGame));
-        dso.set(dso.delayedWETHPermissionedGameProxy.selector, address(output.delayedWETHPermissionedGameProxy));
-        dso.set(dso.delayedWETHPermissionlessGameProxy.selector, address(output.delayedWETHPermissionlessGameProxy));
+        doo.set(doo.opChainProxyAdmin.selector, address(output.opChainProxyAdmin));
+        doo.set(doo.addressManager.selector, address(output.addressManager));
+        doo.set(doo.l1ERC721BridgeProxy.selector, address(output.l1ERC721BridgeProxy));
+        doo.set(doo.systemConfigProxy.selector, address(output.systemConfigProxy));
+        doo.set(doo.optimismMintableERC20FactoryProxy.selector, address(output.optimismMintableERC20FactoryProxy));
+        doo.set(doo.l1StandardBridgeProxy.selector, address(output.l1StandardBridgeProxy));
+        doo.set(doo.l1CrossDomainMessengerProxy.selector, address(output.l1CrossDomainMessengerProxy));
+        doo.set(doo.optimismPortalProxy.selector, address(output.optimismPortalProxy));
+        doo.set(doo.disputeGameFactoryProxy.selector, address(output.disputeGameFactoryProxy));
+        doo.set(doo.disputeGameFactoryImpl.selector, address(output.disputeGameFactoryImpl));
+        doo.set(doo.anchorStateRegistryProxy.selector, address(output.anchorStateRegistryProxy));
+        doo.set(doo.anchorStateRegistryImpl.selector, address(output.anchorStateRegistryImpl));
+        doo.set(doo.faultDisputeGame.selector, address(output.faultDisputeGame));
+        doo.set(doo.permissionedDisputeGame.selector, address(output.permissionedDisputeGame));
+        doo.set(doo.delayedWETHPermissionedGameProxy.selector, address(output.delayedWETHPermissionedGameProxy));
+        doo.set(doo.delayedWETHPermissionlessGameProxy.selector, address(output.delayedWETHPermissionlessGameProxy));
 
-        assertEq(address(output.opChainProxyAdmin), address(dso.opChainProxyAdmin()), "100");
-        assertEq(address(output.addressManager), address(dso.addressManager()), "200");
-        assertEq(address(output.l1ERC721BridgeProxy), address(dso.l1ERC721BridgeProxy()), "300");
-        assertEq(address(output.systemConfigProxy), address(dso.systemConfigProxy()), "400");
+        assertEq(address(output.opChainProxyAdmin), address(doo.opChainProxyAdmin()), "100");
+        assertEq(address(output.addressManager), address(doo.addressManager()), "200");
+        assertEq(address(output.l1ERC721BridgeProxy), address(doo.l1ERC721BridgeProxy()), "300");
+        assertEq(address(output.systemConfigProxy), address(doo.systemConfigProxy()), "400");
         assertEq(
-            address(output.optimismMintableERC20FactoryProxy), address(dso.optimismMintableERC20FactoryProxy()), "500"
+            address(output.optimismMintableERC20FactoryProxy), address(doo.optimismMintableERC20FactoryProxy()), "500"
         );
-        assertEq(address(output.l1StandardBridgeProxy), address(dso.l1StandardBridgeProxy()), "600");
-        assertEq(address(output.l1CrossDomainMessengerProxy), address(dso.l1CrossDomainMessengerProxy()), "700");
-        assertEq(address(output.optimismPortalProxy), address(dso.optimismPortalProxy()), "800");
-        assertEq(address(output.disputeGameFactoryProxy), address(dso.disputeGameFactoryProxy()), "900");
-        assertEq(address(output.disputeGameFactoryImpl), address(dso.disputeGameFactoryImpl()), "1000");
-        assertEq(address(output.anchorStateRegistryProxy), address(dso.anchorStateRegistryProxy()), "1100");
-        assertEq(address(output.anchorStateRegistryImpl), address(dso.anchorStateRegistryImpl()), "1200");
-        assertEq(address(output.faultDisputeGame), address(dso.faultDisputeGame()), "1300");
-        assertEq(address(output.permissionedDisputeGame), address(dso.permissionedDisputeGame()), "1400");
+        assertEq(address(output.l1StandardBridgeProxy), address(doo.l1StandardBridgeProxy()), "600");
+        assertEq(address(output.l1CrossDomainMessengerProxy), address(doo.l1CrossDomainMessengerProxy()), "700");
+        assertEq(address(output.optimismPortalProxy), address(doo.optimismPortalProxy()), "800");
+        assertEq(address(output.disputeGameFactoryProxy), address(doo.disputeGameFactoryProxy()), "900");
+        assertEq(address(output.disputeGameFactoryImpl), address(doo.disputeGameFactoryImpl()), "1000");
+        assertEq(address(output.anchorStateRegistryProxy), address(doo.anchorStateRegistryProxy()), "1100");
+        assertEq(address(output.anchorStateRegistryImpl), address(doo.anchorStateRegistryImpl()), "1200");
+        assertEq(address(output.faultDisputeGame), address(doo.faultDisputeGame()), "1300");
+        assertEq(address(output.permissionedDisputeGame), address(doo.permissionedDisputeGame()), "1400");
         assertEq(
-            address(output.delayedWETHPermissionedGameProxy), address(dso.delayedWETHPermissionedGameProxy()), "1500"
+            address(output.delayedWETHPermissionedGameProxy), address(doo.delayedWETHPermissionedGameProxy()), "1500"
         );
         assertEq(
             address(output.delayedWETHPermissionlessGameProxy),
-            address(dso.delayedWETHPermissionlessGameProxy()),
+            address(doo.delayedWETHPermissionlessGameProxy()),
             "1600"
         );
 
-        assertEq(keccak256(abi.encode(output)), keccak256(abi.encode(dso.output())), "1700");
+        assertEq(keccak256(abi.encode(output)), keccak256(abi.encode(doo.output())), "1700");
     }
 
     function test_getters_whenNotSet_revert() public {
         bytes memory expectedErr = "DeployUtils: zero address";
 
         vm.expectRevert(expectedErr);
-        dso.opChainProxyAdmin();
+        doo.opChainProxyAdmin();
 
         vm.expectRevert(expectedErr);
-        dso.addressManager();
+        doo.addressManager();
 
         vm.expectRevert(expectedErr);
-        dso.l1ERC721BridgeProxy();
+        doo.l1ERC721BridgeProxy();
 
         vm.expectRevert(expectedErr);
-        dso.systemConfigProxy();
+        doo.systemConfigProxy();
 
         vm.expectRevert(expectedErr);
-        dso.optimismMintableERC20FactoryProxy();
+        doo.optimismMintableERC20FactoryProxy();
 
         vm.expectRevert(expectedErr);
-        dso.l1StandardBridgeProxy();
+        doo.l1StandardBridgeProxy();
 
         vm.expectRevert(expectedErr);
-        dso.l1CrossDomainMessengerProxy();
+        doo.l1CrossDomainMessengerProxy();
 
         vm.expectRevert(expectedErr);
-        dso.optimismPortalProxy();
+        doo.optimismPortalProxy();
 
         vm.expectRevert(expectedErr);
-        dso.disputeGameFactoryProxy();
+        doo.disputeGameFactoryProxy();
 
         vm.expectRevert(expectedErr);
-        dso.disputeGameFactoryImpl();
+        doo.disputeGameFactoryImpl();
 
         vm.expectRevert(expectedErr);
-        dso.anchorStateRegistryProxy();
+        doo.anchorStateRegistryProxy();
 
         vm.expectRevert(expectedErr);
-        dso.anchorStateRegistryImpl();
+        doo.anchorStateRegistryImpl();
 
         vm.expectRevert(expectedErr);
-        dso.faultDisputeGame();
+        doo.faultDisputeGame();
 
         vm.expectRevert(expectedErr);
-        dso.permissionedDisputeGame();
+        doo.permissionedDisputeGame();
 
         vm.expectRevert(expectedErr);
-        dso.delayedWETHPermissionedGameProxy();
+        doo.delayedWETHPermissionedGameProxy();
 
         vm.expectRevert(expectedErr);
-        dso.delayedWETHPermissionlessGameProxy();
+        doo.delayedWETHPermissionlessGameProxy();
     }
 
     function test_getters_whenAddrHasNoCode_reverts() public {
         address emptyAddr = makeAddr("emptyAddr");
         bytes memory expectedErr = bytes(string.concat("DeployUtils: no code at ", vm.toString(emptyAddr)));
 
-        dso.set(dso.opChainProxyAdmin.selector, emptyAddr);
+        doo.set(doo.opChainProxyAdmin.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.opChainProxyAdmin();
+        doo.opChainProxyAdmin();
 
-        dso.set(dso.addressManager.selector, emptyAddr);
+        doo.set(doo.addressManager.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.addressManager();
+        doo.addressManager();
 
-        dso.set(dso.l1ERC721BridgeProxy.selector, emptyAddr);
+        doo.set(doo.l1ERC721BridgeProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.l1ERC721BridgeProxy();
+        doo.l1ERC721BridgeProxy();
 
-        dso.set(dso.systemConfigProxy.selector, emptyAddr);
+        doo.set(doo.systemConfigProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.systemConfigProxy();
+        doo.systemConfigProxy();
 
-        dso.set(dso.optimismMintableERC20FactoryProxy.selector, emptyAddr);
+        doo.set(doo.optimismMintableERC20FactoryProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.optimismMintableERC20FactoryProxy();
+        doo.optimismMintableERC20FactoryProxy();
 
-        dso.set(dso.l1StandardBridgeProxy.selector, emptyAddr);
+        doo.set(doo.l1StandardBridgeProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.l1StandardBridgeProxy();
+        doo.l1StandardBridgeProxy();
 
-        dso.set(dso.l1CrossDomainMessengerProxy.selector, emptyAddr);
+        doo.set(doo.l1CrossDomainMessengerProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.l1CrossDomainMessengerProxy();
+        doo.l1CrossDomainMessengerProxy();
 
-        dso.set(dso.optimismPortalProxy.selector, emptyAddr);
+        doo.set(doo.optimismPortalProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.optimismPortalProxy();
+        doo.optimismPortalProxy();
 
-        dso.set(dso.disputeGameFactoryProxy.selector, emptyAddr);
+        doo.set(doo.disputeGameFactoryProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.disputeGameFactoryProxy();
+        doo.disputeGameFactoryProxy();
 
-        dso.set(dso.disputeGameFactoryImpl.selector, emptyAddr);
+        doo.set(doo.disputeGameFactoryImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.disputeGameFactoryImpl();
+        doo.disputeGameFactoryImpl();
 
-        dso.set(dso.anchorStateRegistryProxy.selector, emptyAddr);
+        doo.set(doo.anchorStateRegistryProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.anchorStateRegistryProxy();
+        doo.anchorStateRegistryProxy();
 
-        dso.set(dso.anchorStateRegistryImpl.selector, emptyAddr);
+        doo.set(doo.anchorStateRegistryImpl.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.anchorStateRegistryImpl();
+        doo.anchorStateRegistryImpl();
 
-        dso.set(dso.faultDisputeGame.selector, emptyAddr);
+        doo.set(doo.faultDisputeGame.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.faultDisputeGame();
+        doo.faultDisputeGame();
 
-        dso.set(dso.permissionedDisputeGame.selector, emptyAddr);
+        doo.set(doo.permissionedDisputeGame.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.permissionedDisputeGame();
+        doo.permissionedDisputeGame();
 
-        dso.set(dso.delayedWETHPermissionedGameProxy.selector, emptyAddr);
+        doo.set(doo.delayedWETHPermissionedGameProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.delayedWETHPermissionedGameProxy();
+        doo.delayedWETHPermissionedGameProxy();
 
-        dso.set(dso.delayedWETHPermissionlessGameProxy.selector, emptyAddr);
+        doo.set(doo.delayedWETHPermissionlessGameProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
-        dso.delayedWETHPermissionlessGameProxy();
+        doo.delayedWETHPermissionlessGameProxy();
     }
 }
 
@@ -401,7 +401,7 @@ contract DeployOPChain_TestBase is Test {
 }
 
 contract DeployOPChain_Test is DeployOPChain_TestBase {
-    function test_run_succeeds(DeployOPChainInput.Input memory _input) public {
+    function testFuzz_run_succeeds(DeployOPChainInput.Input memory _input) public {
         vm.assume(_input.roles.opChainProxyAdminOwner != address(0));
         vm.assume(_input.roles.systemConfigOwner != address(0));
         vm.assume(_input.roles.batcher != address(0));

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -206,7 +206,7 @@ contract DeploySuperchain_Test is Test {
         return keccak256(abi.encode(_seed, _i));
     }
 
-    function test_run_memory_succeeds(bytes32 _seed) public {
+    function testFuzz_run_memory_succeeds(bytes32 _seed) public {
         // Generate random input values from the seed. This doesn't give us the benefit of the forge
         // fuzzer's dictionary, but that's ok because we are just testing that values are set and
         // passed correctly.


### PR DESCRIPTION
Small fixes:
- Ensures fuzz tests are prefixed with `testFuzz`, per the style guide
- We accidentally used `dsi` and `dso`, which are shorthand for DeploySuperchainInput and DeploySuperchainOutput, for many var names. This is corrected and explained in code comments of `DeploySuperchain.s.sol`