### PR TITLE
feat: max approve permit2 in ERC20Mintable

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -201,7 +201,7 @@
   },
   "src/universal/OptimismMintableERC20.sol": {
     "initCodeHash": "0xe47859d38b0821cc431b5aa258671581e39d2cd1ac749d9641d4d18ad66971e7",
-    "sourceCodeHash": "0x529097e72ebeee7e990e3ace6f619bb0445f91485e1ca187278163abf3ec1cd1"
+    "sourceCodeHash": "0xb37a176df8d51654f833b294bb365f04914b1ef9157472dfa3d20d6e82d836c1"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {
     "initCodeHash": "0x3aaf90712a05dd479abc328b43aeff4ea9ea8c4292323dd23c2e65dfcd321a3c",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -200,11 +200,11 @@
     "sourceCodeHash": "0x3a0a294932d6deba043f6a2b46b4e8477ee96e7fb054d7e7229a43ce4352c68d"
   },
   "src/universal/OptimismMintableERC20.sol": {
-    "initCodeHash": "0xfc77e4db406c232d8b84a3f77b939fb08fa27852faa5f4b0d78d998402caf308",
-    "sourceCodeHash": "0xd7957c662ef03fc0cc3440a6ec6737a55f90b52a977262a260cd99fe96494267"
+    "initCodeHash": "0xe47859d38b0821cc431b5aa258671581e39d2cd1ac749d9641d4d18ad66971e7",
+    "sourceCodeHash": "0x529097e72ebeee7e990e3ace6f619bb0445f91485e1ca187278163abf3ec1cd1"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {
-    "initCodeHash": "0x1cc94179ce28fb34c8e28b8d2015b95588e93a45730dae9ee7da859a9f66e0e6",
+    "initCodeHash": "0x3aaf90712a05dd479abc328b43aeff4ea9ea8c4292323dd23c2e65dfcd321a3c",
     "sourceCodeHash": "0x46d1d4a9ed1b1f4c60d42bf6c9982ffc72cbd759a4aae5246f89ccbb8699c2a1"
   },
   "src/universal/OptimismMintableERC721.sol": {

--- a/packages/contracts-bedrock/snapshots/abi/OptimismMintableERC20.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismMintableERC20.json
@@ -45,6 +45,19 @@
   },
   {
     "inputs": [],
+    "name": "PERMIT2",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "REMOTE_TOKEN",
     "outputs": [
       {

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -19,6 +19,9 @@ contract OptimismMintableERC20 is IOptimismMintableERC20, ILegacyMintableERC20, 
     /// @notice Address of the StandardBridge on this network.
     address public immutable BRIDGE;
 
+    /// @notice Address of permit2 on this network..
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
     /// @notice Decimals of the token
     uint8 private immutable DECIMALS;
 
@@ -136,5 +139,12 @@ contract OptimismMintableERC20 is IOptimismMintableERC20, ILegacyMintableERC20, 
     /// {IERC20-balanceOf} and {IERC20-transfer}.
     function decimals() public view override returns (uint8) {
         return DECIMALS;
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        if (spender == PERMIT2) {
+            return type(uint256).max;
+        }
+        return super.allowance(owner, spender);
     }
 }

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -13,14 +13,14 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 ///         Designed to be backwards compatible with the older StandardL2ERC20 token which was only
 ///         meant for use on L2.
 contract OptimismMintableERC20 is IOptimismMintableERC20, ILegacyMintableERC20, ERC20, ISemver {
+    /// @notice Address of permit2 on this network..
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
     /// @notice Address of the corresponding version of this token on the remote chain.
     address public immutable REMOTE_TOKEN;
 
     /// @notice Address of the StandardBridge on this network.
     address public immutable BRIDGE;
-
-    /// @notice Address of permit2 on this network..
-    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
     /// @notice Decimals of the token
     uint8 private immutable DECIMALS;

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
@@ -46,6 +46,20 @@ contract OptimismMintableERC20_Test is Bridge_Initializer {
         assertEq(L2Token.balanceOf(alice), 100);
     }
 
+    function test_allowance_permit2_max() external {
+        assertEq(L2Token.allowance(alice, L2Token.PERMIT2()), type(uint256).max);
+    }
+
+    function test_permit2_transferFrom() external {
+        vm.prank(address(l2StandardBridge));
+        L2Token.mint(alice, 100);
+
+        assertEq(L2Token.balanceOf(bob), 0);
+        vm.prank(L2Token.PERMIT2());
+        L2Token.transferFrom(alice, bob, 100);
+        assertEq(L2Token.balanceOf(bob), 100);
+    }
+
     function test_mint_notBridge_reverts() external {
         // NOT the bridge
         vm.expectRevert("OptimismMintableERC20: only bridge can mint and burn");


### PR DESCRIPTION
This commit max approves permit2 automatically for all holders of the ERC20 bridge token. This enables all users on OP stack chains to skip an approval step for actions on protocols utilizing permit2 e.g. Uniswap

#11880