### PR TITLE
maint: add comment to OptimismPortal2 proof submitters mapping

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -40,11 +40,11 @@
     "sourceCodeHash": "0x17404b6cc3f62f66786c314e2abdf021a19c00845e2cbb2ec7796f2fa469991c"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x6c1168834a0d2a23d9bfb995dd458ef5c2fd059c874d453988ef648de8300730",
-    "sourceCodeHash": "0xa8053edf2ddd421615c7570e5dbb435980b88e0f08e3189e2fc69b7a476e80a2"
+    "initCodeHash": "0xa5e9f45888a4a7cd6bf50c63bd6414181dd6ffdfc2afbcbe31046c0abc199a28",
+    "sourceCodeHash": "0xdcecbbd01e867f6b93b3d57f22de946237d56341606bdabb53257e017117f10a"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0xc95dd89962e301ce1fe773337463ea6e3b32b362971e5ad4f69e0881af7f4b7d",
+    "initCodeHash": "0x8bac6679aaf2c593d22fbe6b558509eef004959846e842181e5cc55e14b36ada",
     "sourceCodeHash": "0xe6a7794799915f408cb57c73af266670de8a3f02408d3dbc2c97db25d3e42635"
   },
   "src/L1/ProtocolVersions.sol": {

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -106,7 +106,13 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     /// @notice The timestamp at which the respected game type was last updated.
     uint64 public respectedGameTypeUpdatedAt;
 
-    /// @notice Mapping of withdrawal hashes to addresses that have submitted a proof for the withdrawal.
+    /// @notice Mapping of withdrawal hashes to addresses that have submitted a proof for the
+    ///         withdrawal. Original OptimismPortal contract only allowed one proof to be submitted
+    ///         for any given withdrawal hash. Fault Proofs version of this contract must allow
+    ///         multiple proofs for the same withdrawal hash to prevent a malicious user from
+    ///         blocking other withdrawals by proving them against invalid proposals. Submitters
+    ///         are tracked in an array to simplify the off-chain process of determining which
+    ///         proof submission should be used when finalizing a withdrawal.
     mapping(bytes32 => address[]) public proofSubmitters;
 
     /// @notice Represents the amount of native asset minted in L2. This may not
@@ -158,9 +164,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.11.0-beta.3
+    /// @custom:semver 3.11.0-beta.4
     function version() public pure virtual returns (string memory) {
-        return "3.11.0-beta.3";
+        return "3.11.0-beta.4";
     }
 
     /// @notice Constructs the OptimismPortal contract.


### PR DESCRIPTION
Adds a comment to OptimismPortal2 that further explains the proofSubmitters mapping.