### PR TITLE
proofs-tools: Fix circleci config to run hold job on proofs-tools release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1805,7 +1805,7 @@ workflows:
           type: approval
           filters:
             tags:
-              only: /^(da-server|ci-builder(-rust)?|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
+              only: /^(da-server|ci-builder(-rust)?|proofs-tools|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
             branches:
               ignore: /.*/
       - docker-build:


### PR DESCRIPTION
**Description**

The hold job was restricted in a way that prevented it running for proofs-tools. Since it was set as a dependency that prevented the workflow running at all.
