### PR TITLE
fix: add IBeacon to interface check ignore

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-interfaces.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-interfaces.sh
@@ -37,6 +37,7 @@ EXCLUDE_CONTRACTS=(
     "IMulticall3"
     "IERC721TokenReceiver"
     "IProxyCreationCallback"
+    "IBeacon"
 
     # EAS
     "IEAS"


### PR DESCRIPTION
IBeacon should've thrown an error but didn't, need to investigate why that was the case. For now I've added it to the ignore list.