### PR TITLE
chore: export `ProcessFrames`

### DIFF
--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -72,7 +72,7 @@ func Channels(config Config, rollupCfg *rollup.Config) {
 		framesByChannel[frame.Frame.ID] = append(framesByChannel[frame.Frame.ID], frame)
 	}
 	for id, frames := range framesByChannel {
-		ch := processFrames(config, rollupCfg, id, frames)
+		ch := ProcessFrames(config, rollupCfg, id, frames)
 		filename := path.Join(config.OutDirectory, fmt.Sprintf("%s.json", id.String()))
 		if err := writeChannel(ch, filename); err != nil {
 			log.Fatal(err)
@@ -90,7 +90,9 @@ func writeChannel(ch ChannelWithMetadata, filename string) error {
 	return enc.Encode(ch)
 }
 
-func processFrames(cfg Config, rollupCfg *rollup.Config, id derive.ChannelID, frames []FrameWithMetadata) ChannelWithMetadata {
+// ProcessFrames processes the frames for a given channel and reads batches and other relevant metadata
+// from the channel. Returns a ChannelWithMetadata struct containing all the relevant data.
+func ProcessFrames(cfg Config, rollupCfg *rollup.Config, id derive.ChannelID, frames []FrameWithMetadata) ChannelWithMetadata {
 	spec := rollup.NewChainSpec(rollupCfg)
 	ch := derive.NewChannel(id, eth.L1BlockRef{Number: frames[0].InclusionBlock})
 	invalidFrame := false


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Exports `ProcessFrames` for external usage. In `op-succinct` we use `processFrames` to parse span batches in a custom way, and we currently have a copy of the implementation.

**Additional context**

Relevant usage in `op-succinct`: https://github.com/succinctlabs/op-succinct/blob/main/proposer/op/proposer/utils/utils.go#L111-L145
