### PR TITLE
ci: parallelize Cannon go tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
     resource_class: xlarge
+    parallelism: 4
     steps:
       - checkout
       - check-changed:
@@ -157,8 +158,15 @@ jobs:
           name: Cannon Go tests
           command: |
             mkdir -p /testlogs
-            gotestsum --format=testname --junitfile=/tmp/test-results/cannon.xml --jsonfile=/testlogs/log.json \
-            -- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./...
+            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            gotestsum --format=testname --junitfile=/tmp/test-results/cannon_${CIRCLE_NODE_INDEX}.xml --jsonfile=/testlogs/log_${CIRCLE_NODE_INDEX}.json \
+            -- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage_${CIRCLE_NODE_INDEX}.out ${PACKAGE_NAMES}
+          working_directory: cannon
+      - run:
+          name: Merge coverage files
+          command: |
+            echo "mode: set" > coverage.out
+            tail -n +2 -q coverage_*.out >> coverage.out
           working_directory: cannon
       - run:
           name: upload Cannon coverage


### PR DESCRIPTION
Cannon go tests now take close to 10 minutes. This PR uses Circle CI's test splitting functionality to parallelize test runners to cut Cannon test time down.
