### PR TITLE
add `AltDAConfig.DAWindow`

### DIFF
--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -37,7 +37,7 @@ const finalityDelay = 64
 // calcFinalityLookback calculates the default finality lookback based on DA challenge window if altDA
 // mode is activated or L1 finality lookback.
 func calcFinalityLookback(cfg *rollup.Config) uint64 {
-	// in alt-da mode the longest finality lookback is a commitment is challenged on the last block of
+	// in alt-da mode the longest finality lookback happens when a commitment is challenged on the last block of
 	// the challenge window in which case it will be both challenge + resolve window.
 	if cfg.AltDAEnabled() {
 		lkb := cfg.AltDAConfig.DAWindow()

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -40,7 +40,7 @@ func calcFinalityLookback(cfg *rollup.Config) uint64 {
 	// in alt-da mode the longest finality lookback is a commitment is challenged on the last block of
 	// the challenge window in which case it will be both challenge + resolve window.
 	if cfg.AltDAEnabled() {
-		lkb := cfg.AltDAConfig.DAChallengeWindow + cfg.AltDAConfig.DAResolveWindow + 1
+		lkb := cfg.AltDAConfig.DAWindow()
 		// in the case only if the altDA windows are longer than the default finality lookback
 		if lkb > defaultFinalityLookback {
 			return lkb

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -63,6 +63,11 @@ type AltDAConfig struct {
 	DAResolveWindow uint64 `json:"da_resolve_window"`
 }
 
+// DAWindow is number of L1 blocks to wait for challenge and resolve in the worst case, including the challenged L1 origin block itself
+func (a *AltDAConfig) DAWindow() uint64 {
+	return a.DAChallengeWindow + a.DAResolveWindow + 1
+}
+
 type Config struct {
 	// Genesis anchor point of the rollup
 	Genesis Genesis `json:"genesis"`
@@ -565,10 +570,10 @@ func (c *Config) AltDAEnabled() bool {
 }
 
 // SyncLookback computes the number of blocks to walk back in order to find the correct L1 origin.
-// In alt-da mode longest possible window is challenge + resolve windows.
+// In alt-da mode longest possible window is challenge + resolve windows + 1.
 func (c *Config) SyncLookback() uint64 {
 	if c.AltDAEnabled() {
-		if win := (c.AltDAConfig.DAChallengeWindow + c.AltDAConfig.DAResolveWindow); win > c.SeqWindowSize {
+		if win := c.AltDAConfig.DAWindow(); win > c.SeqWindowSize {
 			return win
 		}
 	}


### PR DESCRIPTION
This PR adds a `AltDAConfig.DAWindow` method, which is also including the initial L1 block that is being challenged.

This definition aligns with that of `SeqWindowSize`:

```
// Number of epochs (L1 blocks) per sequencing window, including the epoch L1 origin block itself
```

So when we think about window, it's always inclusive.

This change may make `SyncLookback` greater by `1`, but should be fine.