### PR TITLE
op-node: find sync-start, discard candidate when ahead

### DIFF
--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -214,6 +214,8 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 		}
 
 		if ahead {
+			// discard previous candidate
+			highestL2WithCanonicalL1Origin = eth.L2BlockRef{}
 			// keep the unsafe head if we can't tell if its L1 origin is canonical or not yet.
 		} else if l1Block.Hash == n.L1Origin.Hash {
 			// if L2 matches canonical chain, even if unsafe,

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -215,8 +215,8 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 
 		if ahead {
 			// discard previous candidate
-			result.Unsafe = eth.L2BlockRef{}
 			highestL2WithCanonicalL1Origin = eth.L2BlockRef{}
+			// keep the unsafe head if we can't tell if its L1 origin is canonical or not yet.
 		} else if l1Block.Hash == n.L1Origin.Hash {
 			// if L2 matches canonical chain, even if unsafe,
 			// then we can start finding a span of L1 blocks to cover the sequence window,

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -215,8 +215,8 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 
 		if ahead {
 			// discard previous candidate
+			result.Unsafe = eth.L2BlockRef{}
 			highestL2WithCanonicalL1Origin = eth.L2BlockRef{}
-			// keep the unsafe head if we can't tell if its L1 origin is canonical or not yet.
 		} else if l1Block.Hash == n.L1Origin.Hash {
 			// if L2 matches canonical chain, even if unsafe,
 			// then we can start finding a span of L1 blocks to cover the sequence window,

--- a/op-node/rollup/sync/start_test.go
+++ b/op-node/rollup/sync/start_test.go
@@ -26,7 +26,7 @@ func (c *syncStartTestCase) generateFakeL2(t *testing.T) (*testutils.FakeChainSo
 	log := testlog.Logger(t, log.LevelError)
 	chain := testutils.NewFakeChainSource([]string{c.L1, c.NewL1}, []string{c.L2}, int(c.GenesisL1Num), log)
 	chain.SetL2Head(len(c.L2) - 1)
-	genesis := testutils.FakeGenesis(c.GenesisL1, c.GenesisL2, int(c.GenesisL1Num))
+	genesis := testutils.FakeGenesis(c.GenesisL1, c.GenesisL2, c.GenesisL1Num)
 	chain.ReorgL1()
 	for i := 0; i < len(c.NewL1)-1; i++ {
 		chain.AdvanceL1()

--- a/op-service/testutils/fake_chain.go
+++ b/op-service/testutils/fake_chain.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber int) rollup.Genesis {
+func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber uint64) rollup.Genesis {
 	return rollup.Genesis{
 		L1: fakeID(l1, uint64(l1GenesisNumber)),
 		L2: fakeID(l2, 0),

--- a/op-service/testutils/fake_chain.go
+++ b/op-service/testutils/fake_chain.go
@@ -16,7 +16,7 @@ import (
 
 func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber uint64) rollup.Genesis {
 	return rollup.Genesis{
-		L1: fakeID(l1, uint64(l1GenesisNumber)),
+		L1: fakeID(l1, l1GenesisNumber),
 		L2: fakeID(l2, 0),
 	}
 }


### PR DESCRIPTION
When `ahead` is true, we want to discard previous candidate, otherwise `ready` may become true [unexpectedly](https://github.com/ethereum-optimism/optimism/blob/d887cfa990a39b30bb102e480661a1f09e0add67/op-node/rollup/sync/start.go#L233).