### PR TITLE
feat: avoid some anchor state poisoning

### DIFF
--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -592,8 +592,11 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         // Update the status and emit the resolved event, note that we're performing an assignment here.
         emit Resolved(status = status_);
 
-        // Try to update the anchor state, this should not revert.
-        ANCHOR_STATE_REGISTRY.tryUpdateAnchorState();
+        // Try to update the anchor state.
+        // Can fail if this game is older than the current anchor state, if the game is
+        // blacklisted, or if the game did not resolve in favor of the defender. We don't care if
+        // this fails for one of those reasons, so simply empty try/catch and move on.
+        try ANCHOR_STATE_REGISTRY.tryUpdateAnchorState() { } catch { }
     }
 
     /// @inheritdoc IFaultDisputeGame

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -20,6 +20,12 @@ error GameAlreadyExists(Hash uuid);
 /// @param rootClaim is the claim that was unexpected.
 error UnexpectedRootClaim(Claim rootClaim);
 
+/// @notice Thrown when attempting to update an anchor state with an older game.
+error OldGame();
+
+/// @notice Thrown when attempting to update an anchor state with a blacklisted game.
+error BlacklistedGame();
+
 ////////////////////////////////////////////////////////////////
 //                 `FaultDisputeGame` Errors                  //
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Updates the AnchorStateRegistry to use the OptimismPortal contract to check for blacklisted games. Blacklisted games cannot be used to update the anchor state registry.