### PR TITLE
fix(ci): tweak heavy fuzz run parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,6 +559,10 @@ jobs:
       test_command:
         description: List of test files to run
         type: string
+      test_timeout:
+        description: Timeout for running tests
+        type: string
+        default: 15m
     parallelism: <<parameters.test_parallelism>>
     steps:
       - checkout
@@ -596,7 +600,7 @@ jobs:
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
-          no_output_timeout: 15m
+          no_output_timeout: <<parameters.test_timeout>>
       - run:
           name: print failed test traces
           command: just test-rerun
@@ -1579,6 +1583,7 @@ workflows:
           # Heavily fuzz any fuzz tests that have been added or modified.
           name: contracts-bedrock-tests-heavy-fuzz-modified
           test_parallelism: 1
+          test_timeout: 1h
           test_command: just test-heavy-fuzz-modified-tests
       - contracts-bedrock-coverage
       - contracts-bedrock-checks:

--- a/packages/contracts-bedrock/scripts/testing/test-heavy-fuzz-modified-tests.sh
+++ b/packages/contracts-bedrock/scripts/testing/test-heavy-fuzz-modified-tests.sh
@@ -12,10 +12,10 @@ set -euo pipefail
 # modified.
 
 # Set the number of fuzz runs to run.
-# 350000 fuzz runs will guarantee that any test that fails 1% of the time with
-# the default 512 fuzz runs will fail 99.9% of the time (on average) inside of
+# 75000 fuzz runs will guarantee that any test that fails 5% of the time with
+# the default 512 fuzz runs will fail >99.9% of the time (on average) inside of
 # this script.
-FUZZ_RUNS=${1:-350000}
+FUZZ_RUNS=${1:-75000}
 
 # Set the number of invariant runs to run.
 # Invariant runs are generally slower than fuzz runs so we can't afford to run


### PR DESCRIPTION
Tweaks various parameters for the heavy fuzz run tests to prevent the test from taking too long. We can run a daily super heavy fuzz run instead to catch any rare flakes.