### PR TITLE
codeowners: own op-e2e/actions/proofs by proofs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,10 +20,11 @@
 /op-conductor   @ethereum-optimism/op-conductor @ethereum-optimism/go-reviewers
 
 /cannon         @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
-/op-dispute-mon @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
 /op-challenger  @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-dispute-mon @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
 /op-preimage    @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
 /op-program     @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-e2e/actions/proofs @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
 
 # Ops
 /.circleci       @ethereum-optimism/monorepo-ops-reviewers


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Lets the newly created action test sub-dir for proofs tests be owned by the proofs team.
