### PR TITLE
fix: incorrect import in ManageDrippie.s.sol

### DIFF
--- a/packages/contracts-bedrock/scripts/periphery/drippie/ManageDrippie.s.sol
+++ b/packages/contracts-bedrock/scripts/periphery/drippie/ManageDrippie.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import { console2 as console } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";
 
-import { LibString } from "solady/src/utils/LibString.sol";
+import { LibString } from "@solady/utils/LibString.sol";
 
 import { IAutomate as IGelato } from "gelato/interfaces/IAutomate.sol";
 import { LibDataTypes as GelatoDataTypes } from "gelato/libraries/LibDataTypes.sol";


### PR DESCRIPTION
Fixes an incorrect import inside of ManageDrippie.s.sol. Seems to work just fine when forge install is executed but not otherwise.