### PR TITLE
Add Logging ; Fix Broken Maintenance Context

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -53,6 +53,9 @@ func TestInteropTrivial(t *testing.T) {
 	expectedBalance, _ := big.NewInt(0).SetString("10000000000000000000000000", 10)
 	require.Equal(t, expectedBalance, bobBalance)
 
+	// sleep for a bit to allow the chain to start
+	time.Sleep(30 * time.Second)
+
 	// send a tx from Alice to Bob
 	s2.SendL2Tx(
 		chainA,

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -471,9 +471,6 @@ func (s *interopE2ESystem) prepare(t *testing.T, w worldResourcePaths) {
 	// add the L2 RPCs to the supervisor now that the L2s are created
 	ctx := context.Background()
 	for _, l2 := range s.l2s {
-		// hack: wait for previous L2 additions to stop and start the supervisor again
-		// better would be to wait for the supervisor to be ready to accept new L2s
-		time.Sleep(10 * time.Second)
 		err := s.SupervisorClient().AddL2RPC(ctx, l2.l2Geth.UserRPC().RPC())
 		require.NoError(s.t, err, "failed to add L2 RPC to supervisor", "error", err)
 	}

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -413,7 +413,7 @@ func (s *interopE2ESystem) prepareSupervisor() *supervisor.SupervisorService {
 			ListenEnabled: false,
 		},
 		LogConfig: oplog.CLIConfig{
-			Level:  log.LevelTrace,
+			Level:  log.LevelDebug,
 			Format: oplog.FormatText,
 		},
 		RPC: oprpc.CLIConfig{
@@ -469,9 +469,13 @@ func (s *interopE2ESystem) prepare(t *testing.T, w worldResourcePaths) {
 	s.l2s = s.prepareL2s()
 
 	// add the L2 RPCs to the supervisor now that the L2s are created
+	ctx := context.Background()
 	for _, l2 := range s.l2s {
-		err := s.SupervisorClient().AddL2RPC(context.Background(), l2.l2Geth.UserRPC().RPC())
-		require.NoError(s.t, err, "failed to add L2 RPC to supervisor")
+		// hack: wait for previous L2 additions to stop and start the supervisor again
+		// better would be to wait for the supervisor to be ready to accept new L2s
+		time.Sleep(10 * time.Second)
+		err := s.SupervisorClient().AddL2RPC(ctx, l2.l2Geth.UserRPC().RPC())
+		require.NoError(s.t, err, "failed to add L2 RPC to supervisor", "error", err)
 	}
 }
 

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -44,7 +44,7 @@ func (cl *SupervisorClient) Start(
 		&result,
 		"admin_start")
 	if err != nil {
-		return fmt.Errorf("failed to start Supervisor: %s): %w", err)
+		return fmt.Errorf("failed to start Supervisor: %w", err)
 	}
 	return result
 }

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -21,6 +21,34 @@ func NewSupervisorClient(client client.RPC) *SupervisorClient {
 	}
 }
 
+func (cl *SupervisorClient) Stop(
+	ctx context.Context,
+) error {
+	var result error
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"admin_stop")
+	if err != nil {
+		return fmt.Errorf("failed to stop Supervisor: %w", err)
+	}
+	return result
+}
+
+func (cl *SupervisorClient) Start(
+	ctx context.Context,
+) error {
+	var result error
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"admin_start")
+	if err != nil {
+		return fmt.Errorf("failed to start Supervisor: %s): %w", err)
+	}
+	return result
+}
+
 func (cl *SupervisorClient) AddL2RPC(
 	ctx context.Context,
 	rpc string,

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -142,7 +142,7 @@ func (su *SupervisorBackend) Start(ctx context.Context) error {
 	return nil
 }
 
-var errAlreadyStopped = fmt.Errorf("already stopped")
+var errAlreadyStopped = errors.New("already stopped")
 
 func (su *SupervisorBackend) Stop(ctx context.Context) error {
 	if !su.started.CompareAndSwap(true, false) {

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -53,7 +53,7 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger, m Metrics, cfg
 	}
 
 	// create the chains db
-	db := db.NewChainsDB(map[types.ChainID]db.LogStorage{}, headTracker)
+	db := db.NewChainsDB(map[types.ChainID]db.LogStorage{}, headTracker, logger)
 
 	// create an empty map of chain monitors
 	chainMonitors := make(map[types.ChainID]*source.ChainMonitor, len(cfg.L2RPCs))
@@ -85,6 +85,7 @@ func (su *SupervisorBackend) addFromRPC(ctx context.Context, logger log.Logger, 
 	if err != nil {
 		return err
 	}
+	su.logger.Info("adding from rpc connection", "rpc", rpc, "chainID", chainID)
 	// create metrics and a logdb for the chain
 	cm := newChainMetrics(chainID, su.m)
 	path, err := prepLogDBPath(chainID, su.dataDir)
@@ -135,15 +136,17 @@ func (su *SupervisorBackend) Start(ctx context.Context) error {
 		}
 	}
 	// start db maintenance loop
-	maintinenceCtx, cancel := context.WithCancel(ctx)
+	maintinenceCtx, cancel := context.WithCancel(context.Background())
 	su.db.StartCrossHeadMaintenance(maintinenceCtx)
 	su.maintenanceCancel = cancel
 	return nil
 }
 
+var errAlreadyStopped = fmt.Errorf("already stopped")
+
 func (su *SupervisorBackend) Stop(ctx context.Context) error {
 	if !su.started.CompareAndSwap(true, false) {
-		return errors.New("already stopped")
+		return errAlreadyStopped
 	}
 	// signal the maintenance loop to stop
 	su.maintenanceCancel()

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/heads"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
@@ -17,7 +18,7 @@ import (
 
 func TestChainsDB_AddLog(t *testing.T) {
 	t.Run("UnknownChain", func(t *testing.T) {
-		db := NewChainsDB(nil, &stubHeadStorage{}, log.New())
+		db := NewChainsDB(nil, &stubHeadStorage{}, testlog.Logger(t, log.LevelDebug))
 		err := db.AddLog(types.ChainIDFromUInt64(2), backendTypes.TruncatedHash{}, eth.BlockID{}, 1234, 33, nil)
 		require.ErrorIs(t, err, ErrUnknownChain)
 	})
@@ -28,7 +29,7 @@ func TestChainsDB_AddLog(t *testing.T) {
 		db := NewChainsDB(map[types.ChainID]LogStorage{
 			chainID: logDB,
 		}, &stubHeadStorage{},
-			log.New())
+			testlog.Logger(t, log.LevelDebug))
 		err := db.AddLog(chainID, backendTypes.TruncatedHash{}, eth.BlockID{}, 1234, 33, nil)
 		require.NoError(t, err, err)
 		require.Equal(t, 1, logDB.addLogCalls)
@@ -37,7 +38,7 @@ func TestChainsDB_AddLog(t *testing.T) {
 
 func TestChainsDB_Rewind(t *testing.T) {
 	t.Run("UnknownChain", func(t *testing.T) {
-		db := NewChainsDB(nil, &stubHeadStorage{}, log.New())
+		db := NewChainsDB(nil, &stubHeadStorage{}, testlog.Logger(t, log.LevelDebug))
 		err := db.Rewind(types.ChainIDFromUInt64(2), 42)
 		require.ErrorIs(t, err, ErrUnknownChain)
 	})
@@ -48,7 +49,7 @@ func TestChainsDB_Rewind(t *testing.T) {
 		db := NewChainsDB(map[types.ChainID]LogStorage{
 			chainID: logDB,
 		}, &stubHeadStorage{},
-			log.New())
+			testlog.Logger(t, log.LevelDebug))
 		err := db.Rewind(chainID, 23)
 		require.NoError(t, err, err)
 		require.EqualValues(t, 23, logDB.headBlockNum)
@@ -73,7 +74,7 @@ func TestChainsDB_LastLogInBlock(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -103,7 +104,7 @@ func TestChainsDB_LastLogInBlockEOF(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -133,7 +134,7 @@ func TestChainsDB_LastLogInBlockNotFound(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -161,7 +162,7 @@ func TestChainsDB_LastLogInBlockError(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -182,7 +183,7 @@ func TestChainsDB_UpdateCrossHeads(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 15)
@@ -207,7 +208,7 @@ func TestChainsDB_UpdateCrossHeadsBeyondLocal(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 15)
@@ -234,7 +235,7 @@ func TestChainsDB_UpdateCrossHeadsEOF(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 15)
@@ -261,7 +262,7 @@ func TestChainsDB_UpdateCrossHeadsError(t *testing.T) {
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
 		&stubHeadStorage{h},
-		log.New())
+		testlog.Logger(t, log.LevelDebug))
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 10)

--- a/op-supervisor/supervisor/backend/db/db_test.go
+++ b/op-supervisor/supervisor/backend/db/db_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
 	backendTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChainsDB_AddLog(t *testing.T) {
 	t.Run("UnknownChain", func(t *testing.T) {
-		db := NewChainsDB(nil, &stubHeadStorage{})
+		db := NewChainsDB(nil, &stubHeadStorage{}, log.New())
 		err := db.AddLog(types.ChainIDFromUInt64(2), backendTypes.TruncatedHash{}, eth.BlockID{}, 1234, 33, nil)
 		require.ErrorIs(t, err, ErrUnknownChain)
 	})
@@ -26,7 +27,8 @@ func TestChainsDB_AddLog(t *testing.T) {
 		logDB := &stubLogDB{}
 		db := NewChainsDB(map[types.ChainID]LogStorage{
 			chainID: logDB,
-		}, &stubHeadStorage{})
+		}, &stubHeadStorage{},
+			log.New())
 		err := db.AddLog(chainID, backendTypes.TruncatedHash{}, eth.BlockID{}, 1234, 33, nil)
 		require.NoError(t, err, err)
 		require.Equal(t, 1, logDB.addLogCalls)
@@ -35,7 +37,7 @@ func TestChainsDB_AddLog(t *testing.T) {
 
 func TestChainsDB_Rewind(t *testing.T) {
 	t.Run("UnknownChain", func(t *testing.T) {
-		db := NewChainsDB(nil, &stubHeadStorage{})
+		db := NewChainsDB(nil, &stubHeadStorage{}, log.New())
 		err := db.Rewind(types.ChainIDFromUInt64(2), 42)
 		require.ErrorIs(t, err, ErrUnknownChain)
 	})
@@ -45,7 +47,8 @@ func TestChainsDB_Rewind(t *testing.T) {
 		logDB := &stubLogDB{}
 		db := NewChainsDB(map[types.ChainID]LogStorage{
 			chainID: logDB,
-		}, &stubHeadStorage{})
+		}, &stubHeadStorage{},
+			log.New())
 		err := db.Rewind(chainID, 23)
 		require.NoError(t, err, err)
 		require.EqualValues(t, 23, logDB.headBlockNum)
@@ -69,7 +72,8 @@ func TestChainsDB_LastLogInBlock(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -98,7 +102,8 @@ func TestChainsDB_LastLogInBlockEOF(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -127,7 +132,8 @@ func TestChainsDB_LastLogInBlockNotFound(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -154,7 +160,8 @@ func TestChainsDB_LastLogInBlockError(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// LastLogInBlock is expected to:
 	// 1. get a block iterator for block 10 (stubbed)
@@ -174,7 +181,8 @@ func TestChainsDB_UpdateCrossHeads(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 15)
@@ -198,7 +206,8 @@ func TestChainsDB_UpdateCrossHeadsBeyondLocal(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 15)
@@ -224,7 +233,8 @@ func TestChainsDB_UpdateCrossHeadsEOF(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 15)
@@ -250,7 +260,8 @@ func TestChainsDB_UpdateCrossHeadsError(t *testing.T) {
 	db := NewChainsDB(
 		map[types.ChainID]LogStorage{
 			chainID: logDB},
-		&stubHeadStorage{h})
+		&stubHeadStorage{h},
+		log.New())
 
 	// Update cross-heads is expected to:
 	// 1. get a last checkpoint iterator from the logDB (stubbed to be at 10)

--- a/op-supervisor/supervisor/backend/db/safety_checkers_test.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/heads"
 	backendTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
@@ -26,7 +27,7 @@ func TestHeadsForChain(t *testing.T) {
 		CrossFinalized: entrydb.EntryIdx(6),
 	}
 	h.Put(types.ChainIDFromUInt64(1), chainHeads)
-	chainsDB := NewChainsDB(nil, &stubHeadStorage{h}, log.New())
+	chainsDB := NewChainsDB(nil, &stubHeadStorage{h}, testlog.Logger(t, log.LevelDebug))
 	tcases := []struct {
 		name          string
 		chainID       types.ChainID
@@ -93,7 +94,7 @@ func TestCheck(t *testing.T) {
 		types.ChainIDFromUInt64(1): logDB,
 	}
 
-	chainsDB := NewChainsDB(logsStore, &stubHeadStorage{h}, log.New())
+	chainsDB := NewChainsDB(logsStore, &stubHeadStorage{h}, testlog.Logger(t, log.LevelDebug))
 
 	tcases := []struct {
 		name             string

--- a/op-supervisor/supervisor/backend/db/safety_checkers_test.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/heads"
 	backendTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/types"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +26,7 @@ func TestHeadsForChain(t *testing.T) {
 		CrossFinalized: entrydb.EntryIdx(6),
 	}
 	h.Put(types.ChainIDFromUInt64(1), chainHeads)
-	chainsDB := NewChainsDB(nil, &stubHeadStorage{h})
+	chainsDB := NewChainsDB(nil, &stubHeadStorage{h}, log.New())
 	tcases := []struct {
 		name          string
 		chainID       types.ChainID
@@ -92,7 +93,7 @@ func TestCheck(t *testing.T) {
 		types.ChainIDFromUInt64(1): logDB,
 	}
 
-	chainsDB := NewChainsDB(logsStore, &stubHeadStorage{h})
+	chainsDB := NewChainsDB(logsStore, &stubHeadStorage{h}, log.New())
 
 	tcases := []struct {
 		name             string


### PR DESCRIPTION
* Fixes the maintenance routine to use a context that doesn't have a cancelled parent
* Adds a Logger to ChainsDB
* Uses the Logger to describe maintenance behaviors
* Tweaks the Trivial Test a bit (adds a 30s period where the network runs)
* ~~Adds a delay between `AddL2` calls on the Supervisor, as that API is not very stable~~
* Adds client code for Supervisor Start and Stop

I wanted to add some logging to witness Maintenance loops doing things when working on event-log emissions in SuperSystem. In doing so I found that the maintenance loop was using a context with a closing parent.