### PR TITLE
op-challenger: Support MT-Cannon in run-trace

### DIFF
--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
 	"github.com/ethereum-optimism/optimism/op-challenger/runner"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"
 )
 
@@ -24,11 +27,18 @@ func RunTrace(ctx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, er
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
-	return runner.NewRunner(logger, cfg), nil
+	if ctx.IsSet(addMTCannonPrestate.Name) && cfg.CannonAbsolutePreStateBaseURL == nil {
+		return nil, fmt.Errorf("flag %v is required when using %v", flags.CannonPreStateFlag.Name, addMTCannonPrestate.Name)
+	}
+	var mtPrestate common.Hash
+	if ctx.IsSet(addMTCannonPrestate.Name) {
+		mtPrestate = common.HexToHash(ctx.String(addMTCannonPrestate.Name))
+	}
+	return runner.NewRunner(logger, cfg, mtPrestate), nil
 }
 
 func runTraceFlags() []cli.Flag {
-	return flags.Flags
+	return append(flags.Flags, addMTCannonPrestate)
 }
 
 var RunTraceCommand = &cli.Command{
@@ -37,4 +47,10 @@ var RunTraceCommand = &cli.Command{
 	Description: "Runs trace providers against real chain data to confirm compatibility",
 	Action:      cliapp.LifecycleCmd(RunTrace),
 	Flags:       runTraceFlags(),
+}
+
+var addMTCannonPrestate = &cli.StringFlag{
+	Name:    "add-mt-cannon-prestate",
+	Usage:   "After running Cannon traces, additionally use this prestate to run MT-Cannon",
+	EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "ADD_MT_CANNON_PRESTATE"),
 }

--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -51,6 +51,6 @@ var RunTraceCommand = &cli.Command{
 
 var addMTCannonPrestate = &cli.StringFlag{
 	Name:    "add-mt-cannon-prestate",
-	Usage:   "After running Cannon traces, additionally use this prestate to run MT-Cannon",
+	Usage:   "Use this prestate to run MT-Cannon compatibility tests",
 	EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "ADD_MT_CANNON_PRESTATE"),
 }

--- a/op-challenger/game/fault/trace/prestates/multi.go
+++ b/op-challenger/game/fault/trace/prestates/multi.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -75,8 +76,13 @@ func (m *MultiPrestateProvider) fetchPrestate(hash common.Hash, fileType string,
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w from url %v: status %v", ErrPrestateUnavailable, prestateUrl, resp.StatusCode)
 	}
-	tmpFile := dest + ".tmp" + fileType // Preserve the file type extension so compression is applied correctly
-	out, err := ioutil.NewAtomicWriterCompressed(tmpFile, 0o644)
+	tmpFile := dest + ".tmp" + fileType // Preserve the file type extension so state decoding is applied correctly
+	var out *ioutil.AtomicWriter
+	if strings.HasSuffix(fileType, ".gz") {
+		out, err = ioutil.NewAtomicWriter(tmpFile, 0o644)
+	} else {
+		out, err = ioutil.NewAtomicWriterCompressed(tmpFile, 0o644)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to open atomic writer for %v: %w", dest, err)
 	}

--- a/op-challenger/game/fault/trace/prestates/multi.go
+++ b/op-challenger/game/fault/trace/prestates/multi.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -77,12 +76,7 @@ func (m *MultiPrestateProvider) fetchPrestate(hash common.Hash, fileType string,
 		return fmt.Errorf("%w from url %v: status %v", ErrPrestateUnavailable, prestateUrl, resp.StatusCode)
 	}
 	tmpFile := dest + ".tmp" + fileType // Preserve the file type extension so state decoding is applied correctly
-	var out *ioutil.AtomicWriter
-	if strings.HasSuffix(fileType, ".gz") {
-		out, err = ioutil.NewAtomicWriter(tmpFile, 0o644)
-	} else {
-		out, err = ioutil.NewAtomicWriterCompressed(tmpFile, 0o644)
-	}
+	out, err := ioutil.NewAtomicWriter(tmpFile, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open atomic writer for %v: %w", dest, err)
 	}

--- a/op-challenger/game/fault/trace/prestates/multi_test.go
+++ b/op-challenger/game/fault/trace/prestates/multi_test.go
@@ -27,7 +27,7 @@ func TestDownloadPrestate(t *testing.T) {
 			provider := NewMultiPrestateProvider(parseURL(t, server.URL), dir, &stubStateConverter{hash: hash})
 			path, err := provider.PrestatePath(hash)
 			require.NoError(t, err)
-			in, err := makePrestateReader(path)
+			in, err := os.Open(path)
 			require.NoError(t, err)
 			defer in.Close()
 			content, err := io.ReadAll(in)
@@ -48,7 +48,7 @@ func TestCreateDirectory(t *testing.T) {
 			provider := NewMultiPrestateProvider(parseURL(t, server.URL), dir, &stubStateConverter{hash: hash})
 			path, err := provider.PrestatePath(hash)
 			require.NoError(t, err)
-			in, err := makePrestateReader(path)
+			in, err := os.Open(path)
 			require.NoError(t, err)
 			defer in.Close()
 			content, err := io.ReadAll(in)
@@ -118,7 +118,7 @@ func TestStorePrestateWithCorrectExtension(t *testing.T) {
 			path, err := provider.PrestatePath(hash)
 			require.NoError(t, err)
 			require.Truef(t, strings.HasSuffix(path, ext), "Expected path %v to have extension %v", path, ext)
-			in, err := makePrestateReader(path)
+			in, err := os.Open(path)
 			require.NoError(t, err)
 			defer in.Close()
 			content, err := io.ReadAll(in)
@@ -173,14 +173,6 @@ func prestateHTTPServer(ext string) *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-}
-
-func makePrestateReader(path string) (io.ReadCloser, error) {
-	if strings.HasSuffix(path, ".gz") {
-		return os.Open(path)
-	} else {
-		return ioutil.OpenDecompressed(path)
-	}
 }
 
 type stubStateConverter struct {

--- a/op-challenger/runner/metrics.go
+++ b/op-challenger/runner/metrics.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -100,14 +99,14 @@ func (m *Metrics) RecordVmMemoryUsed(vmType string, memoryUsed uint64) {
 	m.vmLastMemoryUsed.WithLabelValues(vmType).Set(float64(memoryUsed))
 }
 
-func (m *Metrics) RecordSuccess(vmType types.TraceType) {
-	m.successTotal.WithLabelValues(vmType.String()).Inc()
+func (m *Metrics) RecordSuccess(vmType string) {
+	m.successTotal.WithLabelValues(vmType).Inc()
 }
 
-func (m *Metrics) RecordFailure(vmType types.TraceType) {
-	m.failuresTotal.WithLabelValues(vmType.String()).Inc()
+func (m *Metrics) RecordFailure(vmType string) {
+	m.failuresTotal.WithLabelValues(vmType).Inc()
 }
 
-func (m *Metrics) RecordInvalid(vmType types.TraceType) {
-	m.invalidTotal.WithLabelValues(vmType.String()).Inc()
+func (m *Metrics) RecordInvalid(vmType string) {
+	m.invalidTotal.WithLabelValues(vmType).Inc()
 }


### PR DESCRIPTION
Add an option to the op-challenger `run-trace` subcommand that runs MT-Cannon right after generating a cannon trace.

The MT-Cannon run uses the same inputs as Cannon so we can easily compare the two runs.