### PR TITLE
 Add DisputeGameFactory to OPStackManager 

### DIFF
--- a/op-chain-ops/deployer/integration_test/apply_test.go
+++ b/op-chain-ops/deployer/integration_test/apply_test.go
@@ -181,7 +181,6 @@ func TestEndToEndApply(t *testing.T) {
 			{"L1CrossDomainMessengerProxyAddress", chainState.L1CrossDomainMessengerProxyAddress},
 			{"OptimismPortalProxyAddress", chainState.OptimismPortalProxyAddress},
 			{"DisputeGameFactoryProxyAddress", chainState.DisputeGameFactoryProxyAddress},
-			{"DisputeGameFactoryImplAddress", chainState.DisputeGameFactoryImplAddress},
 			{"AnchorStateRegistryProxyAddress", chainState.AnchorStateRegistryProxyAddress},
 			{"AnchorStateRegistryImplAddress", chainState.AnchorStateRegistryImplAddress},
 			{"FaultDisputeGameAddress", chainState.FaultDisputeGameAddress},

--- a/op-chain-ops/deployer/opsm/opchain.go
+++ b/op-chain-ops/deployer/opsm/opchain.go
@@ -39,7 +39,6 @@ type DeployOPChainOutput struct {
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address
 	DisputeGameFactoryProxy            common.Address
-	DisputeGameFactoryImpl             common.Address
 	AnchorStateRegistryProxy           common.Address
 	AnchorStateRegistryImpl            common.Address
 	FaultDisputeGame                   common.Address

--- a/op-chain-ops/deployer/pipeline/opchain.go
+++ b/op-chain-ops/deployer/pipeline/opchain.go
@@ -84,7 +84,6 @@ func DeployOPChain(ctx context.Context, env *Env, intent *state.Intent, st *stat
 		L1CrossDomainMessengerProxyAddress:        dco.L1CrossDomainMessengerProxy,
 		OptimismPortalProxyAddress:                dco.OptimismPortalProxy,
 		DisputeGameFactoryProxyAddress:            dco.DisputeGameFactoryProxy,
-		DisputeGameFactoryImplAddress:             dco.DisputeGameFactoryImpl,
 		AnchorStateRegistryProxyAddress:           dco.AnchorStateRegistryProxy,
 		AnchorStateRegistryImplAddress:            dco.AnchorStateRegistryImpl,
 		FaultDisputeGameAddress:                   dco.FaultDisputeGame,

--- a/op-chain-ops/deployer/state/state.go
+++ b/op-chain-ops/deployer/state/state.go
@@ -75,7 +75,6 @@ type ChainState struct {
 	L1CrossDomainMessengerProxyAddress        common.Address `json:"l1CrossDomainMessengerProxyAddress"`
 	OptimismPortalProxyAddress                common.Address `json:"optimismPortalProxyAddress"`
 	DisputeGameFactoryProxyAddress            common.Address `json:"disputeGameFactoryProxyAddress"`
-	DisputeGameFactoryImplAddress             common.Address `json:"disputeGameFactoryImplAddress"`
 	AnchorStateRegistryProxyAddress           common.Address `json:"anchorStateRegistryProxyAddress"`
 	AnchorStateRegistryImplAddress            common.Address `json:"anchorStateRegistryImplAddress"`
 	FaultDisputeGameAddress                   common.Address `json:"faultDisputeGameAddress"`

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -45,7 +45,6 @@ type L2OpchainDeployment struct {
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address `json:"OptimismPortalProxy"`
 	DisputeGameFactoryProxy            common.Address `json:"DisputeGameFactoryProxy"`
-	DisputeGameFactoryImpl             common.Address `json:"DisputeGameFactoryImpl"`
 	AnchorStateRegistryProxy           common.Address `json:"AnchorStateRegistryProxy"`
 	AnchorStateRegistryImpl            common.Address `json:"AnchorStateRegistryImpl"`
 	FaultDisputeGame                   common.Address `json:"FaultDisputeGame"`

--- a/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
@@ -361,7 +361,7 @@ contract DeployImplementations is Script {
         vm.stopBroadcast();
         // forgefmt: disable-end
 
-        OPStackManager.ImplementationSetter[] memory setters = new OPStackManager.ImplementationSetter[](6);
+        OPStackManager.ImplementationSetter[] memory setters = new OPStackManager.ImplementationSetter[](7);
         setters[0] = OPStackManager.ImplementationSetter({
             name: "L1ERC721Bridge",
             info: OPStackManager.Implementation(address(_dio.l1ERC721BridgeImpl()), L1ERC721Bridge.initialize.selector)
@@ -386,6 +386,13 @@ contract DeployImplementations is Script {
         setters[5] = OPStackManager.ImplementationSetter({
             name: "L1StandardBridge",
             info: OPStackManager.Implementation(address(_dio.l1StandardBridgeImpl()), L1StandardBridge.initialize.selector)
+        });
+
+        setters[6] = OPStackManager.ImplementationSetter({
+            name: "DisputeGameFactory",
+            info: OPStackManager.Implementation(
+                address(_dio.disputeGameFactoryImpl()), DisputeGameFactory.initialize.selector
+            )
         });
 
         // This call contains a broadcast to deploy OPSM which is proxied.

--- a/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
@@ -135,7 +135,6 @@ contract DeployOPChainOutput {
     L1CrossDomainMessenger internal _l1CrossDomainMessengerProxy;
     OptimismPortal2 internal _optimismPortalProxy;
     DisputeGameFactory internal _disputeGameFactoryProxy;
-    DisputeGameFactory internal _disputeGameFactoryImpl;
     AnchorStateRegistry internal _anchorStateRegistryProxy;
     AnchorStateRegistry internal _anchorStateRegistryImpl;
     FaultDisputeGame internal _faultDisputeGame;
@@ -155,7 +154,6 @@ contract DeployOPChainOutput {
         else if (sel == this.l1CrossDomainMessengerProxy.selector) _l1CrossDomainMessengerProxy = L1CrossDomainMessenger(_addr) ;
         else if (sel == this.optimismPortalProxy.selector) _optimismPortalProxy = OptimismPortal2(payable(_addr)) ;
         else if (sel == this.disputeGameFactoryProxy.selector) _disputeGameFactoryProxy = DisputeGameFactory(_addr) ;
-        else if (sel == this.disputeGameFactoryImpl.selector) _disputeGameFactoryImpl = DisputeGameFactory(_addr) ;
         else if (sel == this.anchorStateRegistryProxy.selector) _anchorStateRegistryProxy = AnchorStateRegistry(_addr) ;
         else if (sel == this.anchorStateRegistryImpl.selector) _anchorStateRegistryImpl = AnchorStateRegistry(_addr) ;
         else if (sel == this.faultDisputeGame.selector) _faultDisputeGame = FaultDisputeGame(_addr) ;
@@ -186,7 +184,6 @@ contract DeployOPChainOutput {
         address[] memory addrs2 = Solarray.addresses(
             address(_optimismPortalProxy),
             address(_disputeGameFactoryProxy),
-            address(_disputeGameFactoryImpl),
             address(_anchorStateRegistryProxy),
             address(_anchorStateRegistryImpl),
             address(_faultDisputeGame),
@@ -242,11 +239,6 @@ contract DeployOPChainOutput {
     function disputeGameFactoryProxy() public view returns (DisputeGameFactory) {
         DeployUtils.assertValidContractAddress(address(_disputeGameFactoryProxy));
         return _disputeGameFactoryProxy;
-    }
-
-    function disputeGameFactoryImpl() public view returns (DisputeGameFactory) {
-        DeployUtils.assertValidContractAddress(address(_disputeGameFactoryImpl));
-        return _disputeGameFactoryImpl;
     }
 
     function anchorStateRegistryProxy() public view returns (AnchorStateRegistry) {
@@ -361,7 +353,6 @@ contract DeployOPChain is Script {
         vm.label(address(deployOutput.l1CrossDomainMessengerProxy), "l1CrossDomainMessengerProxy");
         vm.label(address(deployOutput.optimismPortalProxy), "optimismPortalProxy");
         vm.label(address(deployOutput.disputeGameFactoryProxy), "disputeGameFactoryProxy");
-        vm.label(address(deployOutput.disputeGameFactoryImpl), "disputeGameFactoryImpl");
         vm.label(address(deployOutput.anchorStateRegistryProxy), "anchorStateRegistryProxy");
         vm.label(address(deployOutput.anchorStateRegistryImpl), "anchorStateRegistryImpl");
         vm.label(address(deployOutput.faultDisputeGame), "faultDisputeGame");
@@ -380,7 +371,6 @@ contract DeployOPChain is Script {
         _doo.set(_doo.l1CrossDomainMessengerProxy.selector, address(deployOutput.l1CrossDomainMessengerProxy));
         _doo.set(_doo.optimismPortalProxy.selector, address(deployOutput.optimismPortalProxy));
         _doo.set(_doo.disputeGameFactoryProxy.selector, address(deployOutput.disputeGameFactoryProxy));
-        _doo.set(_doo.disputeGameFactoryImpl.selector, address(deployOutput.disputeGameFactoryImpl));
         _doo.set(_doo.anchorStateRegistryProxy.selector, address(deployOutput.anchorStateRegistryProxy));
         _doo.set(_doo.anchorStateRegistryImpl.selector, address(deployOutput.anchorStateRegistryImpl));
         _doo.set(_doo.faultDisputeGame.selector, address(deployOutput.faultDisputeGame));

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPStackManager.sol": {
-    "initCodeHash": "0x31378d0ea88a358f517927f5bc530a5b958f43c5462e4a822388ec70bd45e8d4",
-    "sourceCodeHash": "0x9ed271fbb40f25528652bfecc10d2010a588629047b3aaed2b14247d2fa7b45e"
+    "initCodeHash": "0xfcb568c59e2b4fd927b27b3434db657b53571bf64f70bc8453aaf696eda9c3f9",
+    "sourceCodeHash": "0xfc9069d6967b9b90413fe391805509b178dd134b008a582e4dc64afe14cc1b2a"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xb7a7a28d5b3b88334e7cb4bc1c5fbbf9f691d934e907a2fed6a30e461eb1c0f6",

--- a/packages/contracts-bedrock/snapshots/abi/OPStackManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPStackManager.json
@@ -186,11 +186,6 @@
             "type": "address"
           },
           {
-            "internalType": "contract DisputeGameFactory",
-            "name": "disputeGameFactoryImpl",
-            "type": "address"
-          },
-          {
             "internalType": "contract AnchorStateRegistry",
             "name": "anchorStateRegistryProxy",
             "type": "address"

--- a/packages/contracts-bedrock/snapshots/abi/OPStackManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPStackManagerInterop.json
@@ -186,11 +186,6 @@
             "type": "address"
           },
           {
-            "internalType": "contract DisputeGameFactory",
-            "name": "disputeGameFactoryImpl",
-            "type": "address"
-          },
-          {
             "internalType": "contract AnchorStateRegistry",
             "name": "anchorStateRegistryProxy",
             "type": "address"

--- a/packages/contracts-bedrock/src/L1/OPStackManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPStackManager.sol
@@ -69,7 +69,6 @@ contract OPStackManager is ISemver, Initializable {
         // Fault proof contracts below.
         OptimismPortal2 optimismPortalProxy;
         DisputeGameFactory disputeGameFactoryProxy;
-        DisputeGameFactory disputeGameFactoryImpl;
         AnchorStateRegistry anchorStateRegistryProxy;
         AnchorStateRegistry anchorStateRegistryImpl;
         FaultDisputeGame faultDisputeGame;
@@ -206,8 +205,6 @@ contract OPStackManager is ISemver, Initializable {
         // -------- TODO: Placeholders --------
         // For contracts we don't yet deploy, we set the outputs to  dummy proxies so they have code to pass assertions.
         // We do these first, that way the disputeGameFactoryProxy is set when passed to the SystemConfig input.
-        output.disputeGameFactoryProxy = DisputeGameFactory(deployProxy(l2ChainId, output.opChainProxyAdmin, "1"));
-        output.disputeGameFactoryImpl = DisputeGameFactory(deployProxy(l2ChainId, output.opChainProxyAdmin, "2"));
         output.anchorStateRegistryProxy = AnchorStateRegistry(deployProxy(l2ChainId, output.opChainProxyAdmin, "3"));
         output.anchorStateRegistryImpl = AnchorStateRegistry(deployProxy(l2ChainId, output.opChainProxyAdmin, "4"));
         output.faultDisputeGame = FaultDisputeGame(deployProxy(l2ChainId, output.opChainProxyAdmin, "5"));
@@ -238,6 +235,8 @@ contract OPStackManager is ISemver, Initializable {
         output.optimismMintableERC20FactoryProxy = OptimismMintableERC20Factory(
             deployProxy(l2ChainId, output.opChainProxyAdmin, "OptimismMintableERC20Factory")
         );
+        output.disputeGameFactoryProxy =
+            DisputeGameFactory(deployProxy(l2ChainId, output.opChainProxyAdmin, "DisputeGameFactory"));
 
         // Deploy legacy proxied contracts.
         output.l1StandardBridgeProxy = L1StandardBridge(
@@ -284,6 +283,10 @@ contract OPStackManager is ISemver, Initializable {
         impl = getLatestImplementation("L1StandardBridge");
         data = encodeL1StandardBridgeInitializer(impl.initializer, output);
         upgradeAndCall(output.opChainProxyAdmin, address(output.l1StandardBridgeProxy), impl.logic, data);
+
+        impl = getLatestImplementation("DisputeGameFactory");
+        data = encodeDisputeGameFactoryInitializer(impl.initializer, _input);
+        upgradeAndCall(output.opChainProxyAdmin, address(output.disputeGameFactoryProxy), impl.logic, data);
 
         // -------- Finalize Deployment --------
         // Transfer ownership of the ProxyAdmin from this contract to the specified owner.
@@ -438,6 +441,18 @@ contract OPStackManager is ISemver, Initializable {
         return abi.encodeWithSelector(
             _selector, _output.l1CrossDomainMessengerProxy, superchainConfig, _output.systemConfigProxy
         );
+    }
+
+    function encodeDisputeGameFactoryInitializer(
+        bytes4 _selector,
+        DeployInput memory _input
+    )
+        internal
+        view
+        virtual
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(_selector, _input.roles.opChainProxyAdminOwner);
     }
 
     /// @notice Returns default, standard config arguments for the SystemConfig initializer.

--- a/packages/contracts-bedrock/test/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/DeployOPChain.t.sol
@@ -121,7 +121,6 @@ contract DeployOPChainOutput_Test is Test {
     L1CrossDomainMessenger l1CrossDomainMessengerProxy = L1CrossDomainMessenger(makeAddr("l1CrossDomainMessengerProxy"));
     OptimismPortal2 optimismPortalProxy = OptimismPortal2(payable(makeAddr("optimismPortalProxy")));
     DisputeGameFactory disputeGameFactoryProxy = DisputeGameFactory(makeAddr("disputeGameFactoryProxy"));
-    DisputeGameFactory disputeGameFactoryImpl = DisputeGameFactory(makeAddr("disputeGameFactoryImpl"));
     AnchorStateRegistry anchorStateRegistryProxy = AnchorStateRegistry(makeAddr("anchorStateRegistryProxy"));
     AnchorStateRegistry anchorStateRegistryImpl = AnchorStateRegistry(makeAddr("anchorStateRegistryImpl"));
     FaultDisputeGame faultDisputeGame = FaultDisputeGame(makeAddr("faultDisputeGame"));
@@ -144,7 +143,6 @@ contract DeployOPChainOutput_Test is Test {
         vm.etch(address(l1CrossDomainMessengerProxy), hex"01");
         vm.etch(address(optimismPortalProxy), hex"01");
         vm.etch(address(disputeGameFactoryProxy), hex"01");
-        vm.etch(address(disputeGameFactoryImpl), hex"01");
         vm.etch(address(anchorStateRegistryProxy), hex"01");
         vm.etch(address(anchorStateRegistryImpl), hex"01");
         vm.etch(address(faultDisputeGame), hex"01");
@@ -161,7 +159,6 @@ contract DeployOPChainOutput_Test is Test {
         doo.set(doo.l1CrossDomainMessengerProxy.selector, address(l1CrossDomainMessengerProxy));
         doo.set(doo.optimismPortalProxy.selector, address(optimismPortalProxy));
         doo.set(doo.disputeGameFactoryProxy.selector, address(disputeGameFactoryProxy));
-        doo.set(doo.disputeGameFactoryImpl.selector, address(disputeGameFactoryImpl));
         doo.set(doo.anchorStateRegistryProxy.selector, address(anchorStateRegistryProxy));
         doo.set(doo.anchorStateRegistryImpl.selector, address(anchorStateRegistryImpl));
         doo.set(doo.faultDisputeGame.selector, address(faultDisputeGame));
@@ -178,7 +175,6 @@ contract DeployOPChainOutput_Test is Test {
         assertEq(address(l1CrossDomainMessengerProxy), address(doo.l1CrossDomainMessengerProxy()), "700");
         assertEq(address(optimismPortalProxy), address(doo.optimismPortalProxy()), "800");
         assertEq(address(disputeGameFactoryProxy), address(doo.disputeGameFactoryProxy()), "900");
-        assertEq(address(disputeGameFactoryImpl), address(doo.disputeGameFactoryImpl()), "1000");
         assertEq(address(anchorStateRegistryProxy), address(doo.anchorStateRegistryProxy()), "1100");
         assertEq(address(anchorStateRegistryImpl), address(doo.anchorStateRegistryImpl()), "1200");
         assertEq(address(faultDisputeGame), address(doo.faultDisputeGame()), "1300");
@@ -216,9 +212,6 @@ contract DeployOPChainOutput_Test is Test {
 
         vm.expectRevert(expectedErr);
         doo.disputeGameFactoryProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.disputeGameFactoryImpl();
 
         vm.expectRevert(expectedErr);
         doo.anchorStateRegistryProxy();
@@ -278,10 +271,6 @@ contract DeployOPChainOutput_Test is Test {
         doo.set(doo.disputeGameFactoryProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);
         doo.disputeGameFactoryProxy();
-
-        doo.set(doo.disputeGameFactoryImpl.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.disputeGameFactoryImpl();
 
         doo.set(doo.anchorStateRegistryProxy.selector, emptyAddr);
         vm.expectRevert(expectedErr);


### PR DESCRIPTION
Replaces the dummy deployment of the DisputeGameFactory with a proper one.