### PR TITLE
ci: run slow Cannon test every 4 hours

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ parameters:
   kontrol_dispatch:
     type: boolean
     default: false
+  cannon_full_test_dispatch:
+    type: boolean
+    default: false
   sdk_dispatch:
     type: boolean
     default: false
@@ -134,6 +137,14 @@ jobs:
   cannon-go-lint-and-test:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
+    parameters:
+      skip_slow_tests:
+        type: boolean
+        default: false
+      notify:
+        description: Whether to notify on failure
+        type: boolean
+        default: false
     resource_class: xlarge
     steps:
       - checkout
@@ -141,6 +152,9 @@ jobs:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
       - attach_workspace:
           at: "."
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
       - run:
           name: prep Cannon results dir
           command: mkdir -p /tmp/test-results
@@ -156,6 +170,7 @@ jobs:
       - run:
           name: Cannon Go tests
           command: |
+            export SKIP_SLOW_TESTS=<<parameters.skip_slow_tests>>
             mkdir -p /testlogs
             gotestsum --format=testname --junitfile=/tmp/test-results/cannon.xml --jsonfile=/testlogs/log.json \
             -- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage.out ./...
@@ -168,6 +183,11 @@ jobs:
       - store_artifacts:
           path: /testlogs
           when: always
+      - when:
+          condition: <<parameters.notify>>
+          steps:
+            - notify-failures-on-develop:
+                mentions: "@proofs-squad"
 
   cannon-build-test-vectors:
     docker:
@@ -1836,6 +1856,8 @@ workflows:
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build
+          skip_slow_tests: true
+          notify: true
       - cannon-build-test-vectors
       - shellcheck/check:
           name: shell-check
@@ -2149,6 +2171,20 @@ workflows:
           context:
             - slack
             - runtimeverification
+
+  scheduled-cannon-full-tests:
+    when:
+      or:
+        - equal: [ build_four_hours, <<pipeline.schedule.name>> ]
+        - equal: [ true, << pipeline.parameters.cannon_full_test_dispatch >> ]
+    jobs:
+      - contracts-bedrock-build:
+          build_command: forge build --skip test --skip scripts
+      - cannon-go-lint-and-test:
+          requires:
+            - contracts-bedrock-build
+          context:
+            - slack
 
   scheduled-docker-publish:
     when:

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -58,6 +58,10 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 }
 
 func TestInstrumentedState_Alloc(t *testing.T) {
+	if os.Getenv("SKIP_SLOW_TESTS") == "true" {
+		t.Skip("Skipping slow test because SKIP_SLOW_TESTS is enabled")
+	}
+
 	const MiB = 1024 * 1024
 
 	cases := []struct {


### PR DESCRIPTION
Updates CI to run the (very) slow Cannon go-lint-and-test suite every 4 hours instead of running it on merge since it adds at least 5 minutes to CI.