### PR TITLE
ci: bump semgrep-scan to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1371,7 +1371,7 @@ jobs:
       SEMGREP_COMMIT: << pipeline.git.revision >>
     docker:
       - image: returntocorp/semgrep
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - unless:


### PR DESCRIPTION
We're still having resource issues with a large image. Going to bump this to xlarge to see if that will fix it. It seems to work mostly with large but fails sometimes.