### PR TITLE
fix: Remove `--l2-chain-id` default

### DIFF
--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -46,7 +46,6 @@ func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.Lo
 
 	if cfg.RollupConfigPath != "" {
 		args = append(args, "--rollup-config-path", cfg.RollupConfigPath)
-		args = append(args, "--l2-chain-id", "0")
 	} else {
 		if cfg.Network == "" {
 			return nil, errors.New("network is not defined")


### PR DESCRIPTION
## Overview

Removes the default `--l2-chain-id` flag for the kona host binary when executing with a custom rollup config. Needed previously due to a smell in the CLI flags of `kona`, has been patched.
