### PR TITLE
ci: fix broken build in develop-fault-proofs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2119,7 +2119,12 @@ workflows:
       - cannon-prestate:
           requires:
             - go-mod-download
-      - contracts-bedrock-build
+      - contracts-bedrock-build:
+          build_command: |
+            # Note: scripts are included, to be available to op-e2e
+            forge build --skip test --deny-warnings
+          context:
+            - slack
       - go-e2e-test:
           name: op-e2e-cannon-tests<< matrix.variant >>
           matrix:


### PR DESCRIPTION
Contracts build was failing in develop-fault-proofs because there is a bug in foundry where --deny-warnings will throw for code size warnings even if those warnings are from test or script files. This PR addresses that by skipping test files when checking for warnings. Additionally, this PR fixes an issue that meant that the build was not properly reporting issues to slack on fail.