### PR TITLE
ci: correct perms for tag-service.yml

### DIFF
--- a/.github/workflows/tag-service.yml
+++ b/.github/workflows/tag-service.yml
@@ -36,6 +36,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GITHUB_TOKEN no longer gets write access by default so it needs to be provided with write access explicitly.