### PR TITLE
ci: fix config error in cannon tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2122,7 +2122,7 @@ workflows:
         - equal: [ true, << pipeline.parameters.cannon_full_test_dispatch >> ]
     jobs:
       - contracts-bedrock-build:
-          build_command: forge build --skip test --skip scripts
+          skip_pattern: test
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build


### PR DESCRIPTION
Fixes a configuration error in the scheduled-cannon-full-tests job.