### PR TITLE
e2e-test: correct the comment

### DIFF
--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -44,7 +44,7 @@ type FixtureInputs struct {
 	L1Head        common.Hash `toml:"l1-head"`
 }
 
-// Dumps a `fp-tests` test fixture to disk if the `OP_E2E_DUMP_FIXTURES` environment variable is set.
+// Dumps a `fp-tests` test fixture to disk if the `OP_E2E_FPP_FIXTURE_DIR` environment variable is set.
 //
 // [fp-tests]: https://github.com/ethereum-optimism/fp-tests
 func tryDumpTestFixture(


### PR DESCRIPTION
`OP_E2E_DUMP_FIXTURES`  was replaced by `OP_E2E_FPP_FIXTURE_DIR`