### PR TITLE
refactor: Rename OPSM to OPSMProxy for clarity

### DIFF
--- a/op-chain-ops/deployer/integration_test/apply_test.go
+++ b/op-chain-ops/deployer/integration_test/apply_test.go
@@ -147,7 +147,7 @@ func TestEndToEndApply(t *testing.T) {
 		{"SuperchainConfigImpl", st.SuperchainDeployment.SuperchainConfigImplAddress},
 		{"ProtocolVersionsProxy", st.SuperchainDeployment.ProtocolVersionsProxyAddress},
 		{"ProtocolVersionsImpl", st.SuperchainDeployment.ProtocolVersionsImplAddress},
-		{"Opsm", st.ImplementationsDeployment.OpsmAddress},
+		{"OpsmProxy", st.ImplementationsDeployment.OpsmProxyAddress},
 		{"DelayedWETHImpl", st.ImplementationsDeployment.DelayedWETHImplAddress},
 		{"OptimismPortalImpl", st.ImplementationsDeployment.OptimismPortalImplAddress},
 		{"PreimageOracleSingleton", st.ImplementationsDeployment.PreimageOracleSingletonAddress},

--- a/op-chain-ops/deployer/opsm/implementations.go
+++ b/op-chain-ops/deployer/opsm/implementations.go
@@ -30,7 +30,7 @@ func (input *DeployImplementationsInput) InputSet() bool {
 }
 
 type DeployImplementationsOutput struct {
-	Opsm                             common.Address
+	OpsmProxy                        common.Address
 	DelayedWETHImpl                  common.Address
 	OptimismPortalImpl               common.Address
 	PreimageOracleSingleton          common.Address

--- a/op-chain-ops/deployer/opsm/opchain.go
+++ b/op-chain-ops/deployer/opsm/opchain.go
@@ -20,7 +20,7 @@ type DeployOPChainInput struct {
 	BasefeeScalar     uint32
 	BlobBaseFeeScalar uint32
 	L2ChainId         *big.Int
-	Opsm              common.Address
+	OpsmProxy         common.Address
 }
 
 func (input *DeployOPChainInput) InputSet() bool {

--- a/op-chain-ops/deployer/pipeline/implementations.go
+++ b/op-chain-ops/deployer/pipeline/implementations.go
@@ -77,7 +77,7 @@ func DeployImplementations(ctx context.Context, env *Env, intent *state.Intent, 
 	}
 
 	st.ImplementationsDeployment = &state.ImplementationsDeployment{
-		OpsmAddress:                             dio.OpsmProxy,
+		OpsmProxyAddress:                        dio.OpsmProxy,
 		DelayedWETHImplAddress:                  dio.DelayedWETHImpl,
 		OptimismPortalImplAddress:               dio.OptimismPortalImpl,
 		PreimageOracleSingletonAddress:          dio.PreimageOracleSingleton,

--- a/op-chain-ops/deployer/pipeline/implementations.go
+++ b/op-chain-ops/deployer/pipeline/implementations.go
@@ -77,7 +77,7 @@ func DeployImplementations(ctx context.Context, env *Env, intent *state.Intent, 
 	}
 
 	st.ImplementationsDeployment = &state.ImplementationsDeployment{
-		OpsmAddress:                             dio.Opsm,
+		OpsmAddress:                             dio.OpsmProxy,
 		DelayedWETHImplAddress:                  dio.DelayedWETHImpl,
 		OptimismPortalImplAddress:               dio.OptimismPortalImpl,
 		PreimageOracleSingletonAddress:          dio.PreimageOracleSingleton,

--- a/op-chain-ops/deployer/pipeline/opchain.go
+++ b/op-chain-ops/deployer/pipeline/opchain.go
@@ -62,7 +62,7 @@ func DeployOPChain(ctx context.Context, env *Env, intent *state.Intent, st *stat
 						BasefeeScalar:          1368,
 						BlobBaseFeeScalar:      801949,
 						L2ChainId:              chainID.Big(),
-						Opsm:                   st.ImplementationsDeployment.OpsmAddress,
+						OpsmProxy:              st.ImplementationsDeployment.OpsmAddress,
 					},
 				)
 				return err

--- a/op-chain-ops/deployer/pipeline/opchain.go
+++ b/op-chain-ops/deployer/pipeline/opchain.go
@@ -62,7 +62,7 @@ func DeployOPChain(ctx context.Context, env *Env, intent *state.Intent, st *stat
 						BasefeeScalar:          1368,
 						BlobBaseFeeScalar:      801949,
 						L2ChainId:              chainID.Big(),
-						OpsmProxy:              st.ImplementationsDeployment.OpsmAddress,
+						OpsmProxy:              st.ImplementationsDeployment.OpsmProxyAddress,
 					},
 				)
 				return err

--- a/op-chain-ops/deployer/state/state.go
+++ b/op-chain-ops/deployer/state/state.go
@@ -60,7 +60,7 @@ type SuperchainDeployment struct {
 }
 
 type ImplementationsDeployment struct {
-	OpsmAddress                             common.Address       `json:"opsmAddress"`
+	OpsmProxyAddress                        common.Address       `json:"opsmProxyAddress"`
 	DelayedWETHImplAddress                  common.Address       `json:"delayedWETHImplAddress"`
 	OptimismPortalImplAddress               common.Address       `json:"optimismPortalImplAddress"`
 	PreimageOracleSingletonAddress          common.Address       `json:"preimageOracleSingletonAddress"`

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -206,7 +206,7 @@ func deployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 		BasefeeScalar:          cfg.GasPriceOracleBaseFeeScalar,
 		BlobBaseFeeScalar:      cfg.GasPriceOracleBlobBaseFeeScalar,
 		L2ChainId:              new(big.Int).SetUint64(cfg.L2ChainID),
-		Opsm:                   superDeployment.Opsm,
+		OpsmProxy:              superDeployment.OpsmProxy,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy L2 OP chain: %w", err)

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -9,7 +9,7 @@ type L1Deployment struct {
 }
 
 type Implementations struct {
-	Opsm                             common.Address `json:"OPSM"` // not proxied
+	OpsmProxy                        common.Address `json:"OPSMProxy"`
 	DelayedWETHImpl                  common.Address `json:"DelayedWETHImpl"`
 	OptimismPortalImpl               common.Address `json:"OptimismPortalImpl"`
 	PreimageOracleSingleton          common.Address `json:"PreimageOracleSingleton"`

--- a/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
@@ -155,7 +155,7 @@ contract DeployImplementationsInput is BaseDeployIO {
 }
 
 contract DeployImplementationsOutput is BaseDeployIO {
-    OPStackManager internal _opsm;
+    OPStackManager internal _opsmProxy;
     DelayedWETH internal _delayedWETHImpl;
     OptimismPortal2 internal _optimismPortalImpl;
     PreimageOracle internal _preimageOracleSingleton;
@@ -171,7 +171,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
         require(_addr != address(0), "DeployImplementationsOutput: cannot set zero address");
 
         // forgefmt: disable-start
-        if (sel == this.opsm.selector) _opsm = OPStackManager(payable(_addr));
+        if (sel == this.opsmProxy.selector) _opsmProxy = OPStackManager(payable(_addr));
         else if (sel == this.optimismPortalImpl.selector) _optimismPortalImpl = OptimismPortal2(payable(_addr));
         else if (sel == this.delayedWETHImpl.selector) _delayedWETHImpl = DelayedWETH(payable(_addr));
         else if (sel == this.preimageOracleSingleton.selector) _preimageOracleSingleton = PreimageOracle(_addr);
@@ -193,7 +193,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
 
     function checkOutput(DeployImplementationsInput) public {
         address[] memory addrs = Solarray.addresses(
-            address(this.opsm()),
+            address(this.opsmProxy()),
             address(this.optimismPortalImpl()),
             address(this.delayedWETHImpl()),
             address(this.preimageOracleSingleton()),
@@ -210,10 +210,10 @@ contract DeployImplementationsOutput is BaseDeployIO {
         // TODO Also add the assertions for the implementation contracts from ChainAssertions.sol
     }
 
-    function opsm() public returns (OPStackManager) {
-        DeployUtils.assertValidContractAddress(address(_opsm));
-        DeployUtils.assertImplementationSet(address(_opsm));
-        return _opsm;
+    function opsmProxy() public returns (OPStackManager) {
+        DeployUtils.assertValidContractAddress(address(_opsmProxy));
+        DeployUtils.assertImplementationSet(address(_opsmProxy));
+        return _opsmProxy;
     }
 
     function optimismPortalImpl() public view returns (OptimismPortal2) {
@@ -400,10 +400,10 @@ contract DeployImplementations is Script {
         });
 
         // This call contains a broadcast to deploy OPSM which is proxied.
-        OPStackManager opsm = createOPSMContract(_dii, _dio, blueprints, release, setters);
+        OPStackManager opsmProxy = createOPSMContract(_dii, _dio, blueprints, release, setters);
 
-        vm.label(address(opsm), "OPStackManager");
-        _dio.set(_dio.opsm.selector, address(opsm));
+        vm.label(address(opsmProxy), "OPStackManager");
+        _dio.set(_dio.opsmProxy.selector, address(opsmProxy));
     }
 
     // --- Core Contracts ---

--- a/packages/contracts-bedrock/test/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/DeployImplementations.t.sol
@@ -115,12 +115,12 @@ contract DeployImplementationsOutput_Test is Test {
     }
 
     function test_set_succeeds() public {
-        Proxy opsmProxy = new Proxy(address(0));
-        address opsmImpl = address(makeAddr("opsm"));
+        Proxy proxy = new Proxy(address(0));
+        address opsmImpl = address(makeAddr("opsmImpl"));
         vm.prank(address(0));
-        opsmProxy.upgradeTo(opsmImpl);
+        proxy.upgradeTo(opsmImpl);
 
-        OPStackManager opsm = OPStackManager(address(opsmProxy));
+        OPStackManager opsmProxy = OPStackManager(address(proxy));
         OptimismPortal2 optimismPortalImpl = OptimismPortal2(payable(makeAddr("optimismPortalImpl")));
         DelayedWETH delayedWETHImpl = DelayedWETH(payable(makeAddr("delayedWETHImpl")));
         PreimageOracle preimageOracleSingleton = PreimageOracle(makeAddr("preimageOracleSingleton"));
@@ -146,7 +146,7 @@ contract DeployImplementationsOutput_Test is Test {
         vm.etch(address(l1StandardBridgeImpl), hex"01");
         vm.etch(address(optimismMintableERC20FactoryImpl), hex"01");
         vm.etch(address(disputeGameFactoryImpl), hex"01");
-        dio.set(dio.opsm.selector, address(opsm));
+        dio.set(dio.opsmProxy.selector, address(opsmProxy));
         dio.set(dio.optimismPortalImpl.selector, address(optimismPortalImpl));
         dio.set(dio.delayedWETHImpl.selector, address(delayedWETHImpl));
         dio.set(dio.preimageOracleSingleton.selector, address(preimageOracleSingleton));
@@ -158,7 +158,7 @@ contract DeployImplementationsOutput_Test is Test {
         dio.set(dio.optimismMintableERC20FactoryImpl.selector, address(optimismMintableERC20FactoryImpl));
         dio.set(dio.disputeGameFactoryImpl.selector, address(disputeGameFactoryImpl));
 
-        assertEq(address(opsm), address(dio.opsm()), "50");
+        assertEq(address(opsmProxy), address(dio.opsmProxy()), "50");
         assertEq(address(optimismPortalImpl), address(dio.optimismPortalImpl()), "100");
         assertEq(address(delayedWETHImpl), address(dio.delayedWETHImpl()), "200");
         assertEq(address(preimageOracleSingleton), address(dio.preimageOracleSingleton()), "300");

--- a/packages/contracts-bedrock/test/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/DeployOPChain.t.sol
@@ -60,7 +60,7 @@ contract DeployOPChainInput_Test is Test {
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opsm.selector, address(opsm));
+        doi.set(doi.opsmProxy.selector, address(opsm));
         // Compare the default inputs to the getter methods.
         assertEq(opChainProxyAdminOwner, doi.opChainProxyAdminOwner(), "200");
         assertEq(systemConfigOwner, doi.systemConfigOwner(), "300");
@@ -71,7 +71,7 @@ contract DeployOPChainInput_Test is Test {
         assertEq(basefeeScalar, doi.basefeeScalar(), "800");
         assertEq(blobBaseFeeScalar, doi.blobBaseFeeScalar(), "900");
         assertEq(l2ChainId, doi.l2ChainId(), "1000");
-        assertEq(address(opsm), address(doi.opsm()), "1100");
+        assertEq(address(opsm), address(doi.opsmProxy()), "1100");
     }
 
     function test_getters_whenNotSet_revert() public {
@@ -374,7 +374,7 @@ contract DeployOPChain_TestBase is Test {
         deployImplementations.run(dii, dio);
 
         // Set the OPStackManager input for DeployOPChain.
-        opsm = dio.opsm();
+        opsm = dio.opsmProxy();
     }
 
     // See the function of the same name in the `DeployImplementations_Test` contract of
@@ -409,7 +409,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opsm.selector, address(opsm)); // Not fuzzed since it must be an actual instance.
+        doi.set(doi.opsmProxy.selector, address(opsm)); // Not fuzzed since it must be an actual instance.
 
         deployOPChain.run(doi, doo);
 

--- a/packages/contracts-bedrock/test/L1/OPStackManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPStackManager.t.sol
@@ -45,7 +45,7 @@ contract OPStackManager_Deploy_Test is DeployOPChain_TestBase {
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opsm.selector, address(opsm));
+        doi.set(doi.opsmProxy.selector, address(opsm));
     }
 
     // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol


### PR DESCRIPTION
This pull request renames the `opsm` variable to `opsmProxy` throughout the codebase to more accurately reflect its nature as a proxy contract. The change affects multiple files, including deployment scripts and test files. Key modifications include:

1. In `DeployImplementations.s.sol`:
   - Renamed `_opsm` to `_opsmProxy` in the `DeployImplementationsOutput` contract.
   - Updated related function names and references.

2. In `DeployOPChain.s.sol`:
   - Changed `_opsm` to `_opsmProxy` in the `DeployOPChainInput` contract.
   - Updated function names and references accordingly.

3. In test files:
   - Updated variable names and function calls in `DeployImplementations.t.sol`, `DeployOPChain.t.sol`, and `OPStackManager.t.sol` to reflect the new naming convention.

These changes improve code clarity by explicitly indicating that the OPStackManager instance is a proxy contract. The renaming ensures consistency across the codebase and helps prevent potential confusion about the nature of the OPStackManager implementation.