### PR TITLE
refactor: Update DeploySuperchain input structure

### DIFF
--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -14,6 +14,7 @@ coverage.out
 # Testing State
 .testdata
 kontrol_prove_report.xml
+.tempdata
 
 # Scripts
 scripts/go-ffi/go-ffi

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -49,6 +49,7 @@ fs_permissions = [
   { access='read', path = './forge-artifacts/' },
   { access='write', path='./semver-lock.json' },
   { access='read-write', path='./.testdata/' },
+  { access='read-write', path='./.tempdata/' },
   { access='read', path='./kout-deployment' },
   { access='read', path='./test/fixtures' },
 ]

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -112,6 +112,7 @@ validate-spacers: build validate-spacers-no-build
 clean:
   rm -rf ./artifacts ./forge-artifacts ./cache ./scripts/go-ffi/go-ffi ./deployments/hardhat/*
   find ./.testdata -mindepth 1 -not -name '.gitkeep' -delete
+  find ./.tempdata -mindepth 1 -not -name '.gitkeep' -delete
 
 pre-pr-no-build: gas-snapshot-no-build snapshots-no-build semver-lock autogen-invariant-docs lint
 

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -117,17 +117,17 @@ contract DeploySuperchainInput is BaseDeployIO {
         string memory toml = vm.readFile(_infile);
 
         // Parse and set role inputs.
-        set(this.guardian.selector, toml.readAddress(".roles.guardian"));
-        set(this.protocolVersionsOwner.selector, toml.readAddress(".roles.protocolVersionsOwner"));
-        set(this.proxyAdminOwner.selector, toml.readAddress(".roles.proxyAdminOwner"));
+        set(this.guardian.selector, toml.readAddress(".dsi.roles.guardian"));
+        set(this.protocolVersionsOwner.selector, toml.readAddress(".dsi.roles.protocolVersionsOwner"));
+        set(this.proxyAdminOwner.selector, toml.readAddress(".dsi.roles.proxyAdminOwner"));
 
         // Parse and set other inputs.
-        set(this.paused.selector, toml.readBool(".paused"));
+        set(this.paused.selector, toml.readBool(".dsi.paused"));
 
-        uint256 recVersion = toml.readUint(".recommendedProtocolVersion");
+        uint256 recVersion = toml.readUint(".dsi.protocolVersions.recommendedProtocolVersion");
         set(this.recommendedProtocolVersion.selector, ProtocolVersion.wrap(recVersion));
 
-        uint256 reqVersion = toml.readUint(".requiredProtocolVersion");
+        uint256 reqVersion = toml.readUint(".dsi.protocolVersions.requiredProtocolVersion");
         set(this.requiredProtocolVersion.selector, ProtocolVersion.wrap(reqVersion));
     }
 

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -13,7 +13,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { BaseDeployIO } from "scripts/utils/BaseDeployIO.sol";
 import { Executables } from "scripts/libraries/Executables.sol";
-import { Process } from "scripts/libraries/Process.sol";
 
 // This comment block defines the requirements and rationale for the architecture used in this forge
 // script, along with other scripts that are being written as new Superchain-first deploy scripts to

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -200,16 +200,16 @@ contract DeploySuperchainOutput is BaseDeployIO {
     // alphabetical ordering when generating TOML files. To preserve the desired order of the outputs,
     // we first write them to a temporary file, then prepend the contents of the temporary file
     // to the final output file.
-    function writeOutputFile(DeploySuperchainInput dsi, string memory _outfile) public {
+    function writeOutputFile(DeploySuperchainInput _dsi, string memory _outfile) public {
         string memory root = vm.projectRoot();
         string memory tempOutFile = string.concat(root, "/.tempdata/temp-deploy-superchain-out.toml");
 
         // Serialize input values
         string memory inputRootKey = "inputRoot";
-        serializeInput(dsi, inputRootKey);
+        serializeInput(_dsi, inputRootKey);
         // Serialize roles section
         string memory inputRolesKey = "roles";
-        string memory rolesJson = serializeInputRoles(dsi, inputRolesKey);
+        string memory rolesJson = serializeInputRoles(_dsi, inputRolesKey);
         // Write serialized inputs to the temp file
         string memory inputsJson = vm.serializeString(inputRootKey, inputRolesKey, rolesJson);
         vm.writeToml(inputsJson, tempOutFile);

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -206,30 +206,28 @@ contract DeploySuperchainOutput is BaseDeployIO {
         string memory tempOutFile = string.concat(root, "/.tempdata/temp-deploy-superchain-out.toml");
 
         string memory inputRootKey = "inputRoot";
-        string memory inputsJson = vm.serializeBool(inputRootKey, "paused", dsi.paused());
-        string memory protocolVersionsJson = vm.serializeUint(
-            inputRootKey, "requiredProtocolVersion", ProtocolVersion.unwrap(dsi.requiredProtocolVersion())
-        );
-        protocolVersionsJson = vm.serializeUint(
+        vm.serializeBool(inputRootKey, "paused", dsi.paused());
+        vm.serializeUint(inputRootKey, "requiredProtocolVersion", ProtocolVersion.unwrap(dsi.requiredProtocolVersion()));
+        vm.serializeUint(
             inputRootKey, "recommendedProtocolVersion", ProtocolVersion.unwrap(dsi.recommendedProtocolVersion())
         );
 
         string memory inputRolesKey = "roles";
-        string memory rolesJson = vm.serializeAddress(inputRolesKey, "proxyAdminOwner", dsi.proxyAdminOwner());
+        vm.serializeAddress(inputRolesKey, "proxyAdminOwner", dsi.proxyAdminOwner());
         vm.serializeAddress(inputRolesKey, "protocolVersionsOwner", dsi.protocolVersionsOwner());
-        rolesJson = vm.serializeAddress(inputRolesKey, "guardian", dsi.guardian());
+        string memory rolesJson = vm.serializeAddress(inputRolesKey, "guardian", dsi.guardian());
 
-        inputsJson = vm.serializeString(inputRootKey, inputRolesKey, rolesJson);
+        string memory inputsJson = vm.serializeString(inputRootKey, inputRolesKey, rolesJson);
         vm.writeToml(inputsJson, tempOutFile);
 
         // Creating outputs toml file
         string memory outputsKey = "outputs";
-        string memory outputsJson =
-            vm.serializeAddress(outputsKey, "superchainProxyAdmin", address(this.superchainProxyAdmin()));
+        vm.serializeAddress(outputsKey, "superchainProxyAdmin", address(this.superchainProxyAdmin()));
         vm.serializeAddress(outputsKey, "superchainConfigImpl", address(this.superchainConfigImpl()));
         vm.serializeAddress(outputsKey, "superchainConfigProxy", address(this.superchainConfigProxy()));
         vm.serializeAddress(outputsKey, "protocolVersionsImpl", address(this.protocolVersionsImpl()));
-        outputsJson = vm.serializeAddress(outputsKey, "protocolVersionsProxy", address(this.protocolVersionsProxy()));
+        string memory outputsJson =
+            vm.serializeAddress(outputsKey, "protocolVersionsProxy", address(this.protocolVersionsProxy()));
 
         outputsJson = vm.serializeString("outputRootKey", outputsKey, outputsJson);
         vm.writeToml(outputsJson, _outfile);

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -228,32 +228,34 @@ contract DeploySuperchainOutput is BaseDeployIO {
         if (vm.exists(tempOutFile)) vm.removeFile(tempOutFile);
     }
 
-    function serializeInput(DeploySuperchainInput dsi, string memory inputRootKey) internal {
-        vm.serializeBool(inputRootKey, "paused", dsi.paused());
-        vm.serializeUint(inputRootKey, "requiredProtocolVersion", ProtocolVersion.unwrap(dsi.requiredProtocolVersion()));
+    function serializeInput(DeploySuperchainInput _dsi, string memory _inputRootKey) internal {
+        vm.serializeBool(_inputRootKey, "paused", _dsi.paused());
         vm.serializeUint(
-            inputRootKey, "recommendedProtocolVersion", ProtocolVersion.unwrap(dsi.recommendedProtocolVersion())
+            _inputRootKey, "requiredProtocolVersion", ProtocolVersion.unwrap(_dsi.requiredProtocolVersion())
+        );
+        vm.serializeUint(
+            _inputRootKey, "recommendedProtocolVersion", ProtocolVersion.unwrap(_dsi.recommendedProtocolVersion())
         );
     }
 
     function serializeInputRoles(
-        DeploySuperchainInput dsi,
-        string memory inputRolesKey
+        DeploySuperchainInput _dsi,
+        string memory _inputRolesKey
     )
         internal
         returns (string memory)
     {
-        vm.serializeAddress(inputRolesKey, "proxyAdminOwner", dsi.proxyAdminOwner());
-        vm.serializeAddress(inputRolesKey, "protocolVersionsOwner", dsi.protocolVersionsOwner());
-        return vm.serializeAddress(inputRolesKey, "guardian", dsi.guardian());
+        vm.serializeAddress(_inputRolesKey, "proxyAdminOwner", _dsi.proxyAdminOwner());
+        vm.serializeAddress(_inputRolesKey, "protocolVersionsOwner", _dsi.protocolVersionsOwner());
+        return vm.serializeAddress(_inputRolesKey, "guardian", _dsi.guardian());
     }
 
-    function serializeOutputs(string memory outputsKey) internal returns (string memory) {
-        vm.serializeAddress(outputsKey, "superchainProxyAdmin", address(this.superchainProxyAdmin()));
-        vm.serializeAddress(outputsKey, "superchainConfigImpl", address(this.superchainConfigImpl()));
-        vm.serializeAddress(outputsKey, "superchainConfigProxy", address(this.superchainConfigProxy()));
-        vm.serializeAddress(outputsKey, "protocolVersionsImpl", address(this.protocolVersionsImpl()));
-        return vm.serializeAddress(outputsKey, "protocolVersionsProxy", address(this.protocolVersionsProxy()));
+    function serializeOutputs(string memory _outputsKey) internal returns (string memory) {
+        vm.serializeAddress(_outputsKey, "superchainProxyAdmin", address(this.superchainProxyAdmin()));
+        vm.serializeAddress(_outputsKey, "superchainConfigImpl", address(this.superchainConfigImpl()));
+        vm.serializeAddress(_outputsKey, "superchainConfigProxy", address(this.superchainConfigProxy()));
+        vm.serializeAddress(_outputsKey, "protocolVersionsImpl", address(this.protocolVersionsImpl()));
+        return vm.serializeAddress(_outputsKey, "protocolVersionsProxy", address(this.protocolVersionsProxy()));
     }
 
     // This function can be called to ensure all outputs are correct. Similar to `writeOutputFile`,

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -228,7 +228,6 @@ contract DeploySuperchainOutput is BaseDeployIO {
         vm.serializeAddress(outputsKey, "protocolVersionsImpl", address(this.protocolVersionsImpl()));
         string memory outputsJson =
             vm.serializeAddress(outputsKey, "protocolVersionsProxy", address(this.protocolVersionsProxy()));
-
         outputsJson = vm.serializeString("outputRootKey", outputsKey, outputsJson);
         vm.writeToml(outputsJson, _outfile);
 

--- a/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeploySuperchain.s.sol
@@ -236,7 +236,13 @@ contract DeploySuperchainOutput is BaseDeployIO {
         );
     }
 
-    function serializeInputRoles(DeploySuperchainInput dsi, string memory inputRolesKey) internal returns (string memory) {
+    function serializeInputRoles(
+        DeploySuperchainInput dsi,
+        string memory inputRolesKey
+    )
+        internal
+        returns (string memory)
+    {
         vm.serializeAddress(inputRolesKey, "proxyAdminOwner", dsi.proxyAdminOwner());
         vm.serializeAddress(inputRolesKey, "protocolVersionsOwner", dsi.protocolVersionsOwner());
         return vm.serializeAddress(inputRolesKey, "guardian", dsi.guardian());

--- a/packages/contracts-bedrock/scripts/libraries/Executables.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Executables.sol
@@ -32,7 +32,7 @@ library Executables {
         return abi.decode(Process.run(commands), (string));
     }
 
-    function prependContentToFile(string memory _contentToPrepend, string memory _outfile) public {
+    function prependContentToFile(string memory _contentToPrepend, string memory _outfile) internal {
         string[] memory command = new string[](3);
         command[0] = Executables.bash;
         command[1] = "-c";

--- a/packages/contracts-bedrock/scripts/libraries/Executables.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Executables.sol
@@ -31,4 +31,20 @@ library Executables {
         commands[2] = "cast abi-encode 'f(string)' $(git rev-parse HEAD || cat .gitcommit)";
         return abi.decode(Process.run(commands), (string));
     }
+
+    function prependContentToFile(string memory _contentToPrepend, string memory _outfile) public {
+        string[] memory command = new string[](3);
+        command[0] = Executables.bash;
+        command[1] = "-c";
+        command[2] = string.concat(
+            "temp_file=${RANDOM}${RANDOM}_temp_file.toml && " // can't use timestamp because testsuite runs in parallel
+            "printf '",
+            _contentToPrepend,
+            "' | cat - ",
+            _outfile,
+            " > $temp_file && mv $temp_file ",
+            _outfile
+        );
+        Process.run(command);
+    }
 }

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -154,27 +154,26 @@ contract DeploySuperchainOutput_Test is Test {
         dsi.loadInputFile(expInPath);
 
         // Parse each dsi field of expOutToml
-        bool paused = expOutToml.readBool(".dsi.paused");
+        bool paused = expOutToml.readBool(".paused");
         assertEq(paused, dsi.paused(), "100");
-        ProtocolVersion requiredProtocolVersion =
-            ProtocolVersion.wrap(expOutToml.readUint(".dsi.protocolVersions.requiredProtocolVersion"));
+        ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(expOutToml.readUint(".requiredProtocolVersion"));
         assertEq(
             ProtocolVersion.unwrap(requiredProtocolVersion),
             ProtocolVersion.unwrap(dsi.requiredProtocolVersion()),
             "200"
         );
         ProtocolVersion recommendedProtocolVersion =
-            ProtocolVersion.wrap(expOutToml.readUint(".dsi.protocolVersions.recommendedProtocolVersion"));
+            ProtocolVersion.wrap(expOutToml.readUint(".recommendedProtocolVersion"));
         assertEq(
             ProtocolVersion.unwrap(recommendedProtocolVersion),
             ProtocolVersion.unwrap(dsi.recommendedProtocolVersion()),
             "300"
         );
-        address guardian = expOutToml.readAddress(".dsi.roles.guardian");
+        address guardian = expOutToml.readAddress(".roles.guardian");
         assertEq(guardian, dsi.guardian(), "400");
-        address protocolVersionsOwner = expOutToml.readAddress(".dsi.roles.protocolVersionsOwner");
+        address protocolVersionsOwner = expOutToml.readAddress(".roles.protocolVersionsOwner");
         assertEq(protocolVersionsOwner, dsi.protocolVersionsOwner(), "500");
-        address proxyAdminOwner = expOutToml.readAddress(".dsi.roles.proxyAdminOwner");
+        address proxyAdminOwner = expOutToml.readAddress(".roles.proxyAdminOwner");
         assertEq(proxyAdminOwner, dsi.proxyAdminOwner(), "600");
     }
 
@@ -190,13 +189,15 @@ contract DeploySuperchainOutput_Test is Test {
         dsi.loadInputFile(expInPath);
 
         // Parse outputs
-        ProxyAdmin expSuperchainProxyAdmin = ProxyAdmin(expOutToml.readAddress(".dso.superchainProxyAdmin"));
-        SuperchainConfig expSuperchainConfigImpl = SuperchainConfig(expOutToml.readAddress(".dso.superchainConfigImpl"));
+        ProxyAdmin expSuperchainProxyAdmin = ProxyAdmin(expOutToml.readAddress(".outputs.superchainProxyAdmin"));
+        SuperchainConfig expSuperchainConfigImpl =
+            SuperchainConfig(expOutToml.readAddress(".outputs.superchainConfigImpl"));
         SuperchainConfig expSuperchainConfigProxy =
-            SuperchainConfig(expOutToml.readAddress(".dso.superchainConfigProxy"));
-        ProtocolVersions expProtocolVersionsImpl = ProtocolVersions(expOutToml.readAddress(".dso.protocolVersionsImpl"));
+            SuperchainConfig(expOutToml.readAddress(".outputs.superchainConfigProxy"));
+        ProtocolVersions expProtocolVersionsImpl =
+            ProtocolVersions(expOutToml.readAddress(".outputs.protocolVersionsImpl"));
         ProtocolVersions expProtocolVersionsProxy =
-            ProtocolVersions(expOutToml.readAddress(".dso.protocolVersionsProxy"));
+            ProtocolVersions(expOutToml.readAddress(".outputs.protocolVersionsProxy"));
 
         // Etch code at each address so the code checks pass when settings values.
         vm.etch(address(expSuperchainConfigImpl), hex"01");

--- a/packages/contracts-bedrock/test/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/DeploySuperchain.t.sol
@@ -142,7 +142,7 @@ contract DeploySuperchainOutput_Test is Test {
         dso.protocolVersionsProxy();
     }
 
-    function test_writeOutputFile_succeeds() public {
+    function test_outputFileInputDataPrepended_succeeds() public {
         string memory root = vm.projectRoot();
 
         // Use the expected data from the test fixture.
@@ -153,7 +153,7 @@ contract DeploySuperchainOutput_Test is Test {
         // Load the input file to use later when writing new output file.
         dsi.loadInputFile(expInPath);
 
-        // Parse each field of expOutToml individually starting with inputs
+        // Parse each dsi field of expOutToml
         bool paused = expOutToml.readBool(".dsi.paused");
         assertEq(paused, dsi.paused(), "100");
         ProtocolVersion requiredProtocolVersion =
@@ -176,6 +176,19 @@ contract DeploySuperchainOutput_Test is Test {
         assertEq(protocolVersionsOwner, dsi.protocolVersionsOwner(), "500");
         address proxyAdminOwner = expOutToml.readAddress(".dsi.roles.proxyAdminOwner");
         assertEq(proxyAdminOwner, dsi.proxyAdminOwner(), "600");
+    }
+
+    function test_writeOutputFile_succeeds() public {
+        string memory root = vm.projectRoot();
+
+        // Use the expected data from the test fixture.
+        string memory expInPath = string.concat(root, "/test/fixtures/test-deploy-superchain-in.toml");
+        string memory expOutPath = string.concat(root, "/test/fixtures/test-deploy-superchain-out.toml");
+        string memory expOutToml = vm.readFile(expOutPath);
+
+        // Load the input file to use later when writing new output file.
+        dsi.loadInputFile(expInPath);
+
         // Parse outputs
         ProxyAdmin expSuperchainProxyAdmin = ProxyAdmin(expOutToml.readAddress(".dso.superchainProxyAdmin"));
         SuperchainConfig expSuperchainConfigImpl = SuperchainConfig(expOutToml.readAddress(".dso.superchainConfigImpl"));

--- a/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-in.toml
+++ b/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-in.toml
@@ -1,11 +1,8 @@
-[dsi]
 paused = false
-
-[dsi.protocolVersions]
-requiredProtocolVersion = 1
 recommendedProtocolVersion = 2
+requiredProtocolVersion = 1
 
-[dsi.roles]
-proxyAdminOwner = "0x51f0348a9fA2aAbaB45E82825Fbd13d406e04497"
-protocolVersionsOwner = "0xeEB4cc05dC0dE43c465f97cfc703D165418CA93A"
+[roles]
 guardian = "0xE5DbA98c65F4B9EB0aeEBb3674fE64f88509a1eC"
+protocolVersionsOwner = "0xeEB4cc05dC0dE43c465f97cfc703D165418CA93A"
+proxyAdminOwner = "0x51f0348a9fA2aAbaB45E82825Fbd13d406e04497"

--- a/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-in.toml
+++ b/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-in.toml
@@ -1,8 +1,11 @@
+[dsi]
 paused = false
+
+[dsi.protocolVersions]
 requiredProtocolVersion = 1
 recommendedProtocolVersion = 2
 
-[roles]
+[dsi.roles]
 proxyAdminOwner = "0x51f0348a9fA2aAbaB45E82825Fbd13d406e04497"
 protocolVersionsOwner = "0xeEB4cc05dC0dE43c465f97cfc703D165418CA93A"
 guardian = "0xE5DbA98c65F4B9EB0aeEBb3674fE64f88509a1eC"

--- a/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-out.toml
+++ b/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-out.toml
@@ -1,3 +1,16 @@
+[dsi]
+paused = false
+
+[dsi.protocolVersions]
+recommendedProtocolVersion = 2
+requiredProtocolVersion = 1
+
+[dsi.roles]
+guardian = "0xE5DbA98c65F4B9EB0aeEBb3674fE64f88509a1eC"
+protocolVersionsOwner = "0xeEB4cc05dC0dE43c465f97cfc703D165418CA93A"
+proxyAdminOwner = "0x51f0348a9fA2aAbaB45E82825Fbd13d406e04497"
+
+[dso]
 protocolVersionsImpl = "0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9"
 protocolVersionsProxy = "0x1d1499e622D69689cdf9004d05Ec547d650Ff211"
 superchainConfigImpl = "0xF62849F9A0B5Bf2913b396098F7c7019b51A820a"

--- a/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-out.toml
+++ b/packages/contracts-bedrock/test/fixtures/test-deploy-superchain-out.toml
@@ -1,16 +1,13 @@
-[dsi]
 paused = false
-
-[dsi.protocolVersions]
 recommendedProtocolVersion = 2
 requiredProtocolVersion = 1
 
-[dsi.roles]
+[roles]
 guardian = "0xE5DbA98c65F4B9EB0aeEBb3674fE64f88509a1eC"
 protocolVersionsOwner = "0xeEB4cc05dC0dE43c465f97cfc703D165418CA93A"
 proxyAdminOwner = "0x51f0348a9fA2aAbaB45E82825Fbd13d406e04497"
 
-[dso]
+[outputs]
 protocolVersionsImpl = "0x5991A2dF15A8F6A256D3Ec51E99254Cd3fb576A9"
 protocolVersionsProxy = "0x1d1499e622D69689cdf9004d05Ec547d650Ff211"
 superchainConfigImpl = "0xF62849F9A0B5Bf2913b396098F7c7019b51A820a"


### PR DESCRIPTION
This pull request updates the DeploySuperchain script and its corresponding test fixture to use a more structured TOML format. The changes include:

1. Modifying the TOML parsing in `DeploySuperchainInput.sol` to read from a new `dsi` (Deploy Superchain Input) namespace.

2. Updating the TOML structure in the test fixture file `test-deploy-superchain-in.toml` to include the new `dsi` namespace.

3. Reorganizing the TOML structure to group related settings under appropriate subsections (e.g., `dsi.protocolVersions` and `dsi.roles`).

These changes improve the organization and readability of the deployment configuration, making it easier to manage and maintain the superchain deployment process.