### PR TITLE
fix(ci): semgrep cli breaking change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1397,11 +1397,10 @@ jobs:
             echo 'export SEMGREP_REPO_NAME=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
       - run:
           name: "Semgrep scan"
-          # --time shows which rules take the most time
           # --timeout (in seconds) limits the time per rule and file.
           #   SEMGREP_TIMEOUT is the same, but docs have conflicting defaults (5s in CLI flag, 1800 in some places)
           #    https://semgrep.dev/docs/troubleshooting/semgrep-app#if-the-job-is-aborted-due-to-taking-too-long
-          command: semgrep ci --time --timeout=100
+          command: semgrep ci --timeout=100
           # If semgrep hangs, stop the scan after 20m, to prevent a useless 5h job
           no_output_timeout: 20m
       - notify-failures-on-develop


### PR DESCRIPTION
Semgrep CLI tool recently removed the --time option which caused CI to suddenly break.