### PR TITLE
ci: Restore ci-builder docker release and remove invalid op-challenger-big-docker-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1947,13 +1947,13 @@ workflows:
           requires:
             - op-supervisor-docker-release
       - docker-build:
-          name: op-challenger-big-docker-release
+          name: proofs-tools-docker-release
           filters:
             tags:
-              only: /^op-challenger\/v.*/
+              only: /^proofs-tools\/v.*/
             branches:
               ignore: /.*/
-          docker_name: ci-builder
+          docker_name: proofs-tools
           docker_tags: <<pipeline.git.revision>>,latest
           publish: true
           release: true
@@ -1963,13 +1963,13 @@ workflows:
           requires:
             - hold
       - docker-build:
-          name: proofs-tools-docker-release
+          name: ci-builder-docker-release
           filters:
             tags:
-              only: /^proofs-tools\/v.*/
+              only: /^ci-builder\/v.*/
             branches:
               ignore: /.*/
-          docker_name: proofs-tools
+          docker_name: ci-builder
           docker_tags: <<pipeline.git.revision>>,latest
           publish: true
           release: true


### PR DESCRIPTION
**Description**

Somewhere in the process of adding proofs-tools docker image the ci-builder release got replaced by an early attempt at building a precursor to the proofs-tools image `op-challenger-big-docker-release`.  Remove the `op-challenger-big-docker-release` and restore ci-builder.