### PR TITLE
chore(op-e2e): assert that the channel actually timed out

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -49,9 +49,9 @@ type L2Verifier struct {
 	drainer event.Drainer
 
 	// L2 rollup
-	engine     *engine.EngineController
+	engine            *engine.EngineController
 	derivationMetrics *testutils.TestDerivationMetrics
-	derivation *derive.DerivationPipeline
+	derivation        *derive.DerivationPipeline
 
 	safeHeadListener rollup.SafeHeadListener
 	syncCfg          *sync.Config
@@ -89,7 +89,8 @@ type safeDB interface {
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	blobsSrc derive.L1BlobsFetcher, altDASrc driver.AltDAIface,
 	eng L2API, cfg *rollup.Config, syncCfg *sync.Config, safeHeadListener safeDB,
-	interopBackend interop.InteropBackend) *L2Verifier {
+	interopBackend interop.InteropBackend,
+) *L2Verifier {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -50,6 +50,7 @@ type L2Verifier struct {
 
 	// L2 rollup
 	engine     *engine.EngineController
+	derivationMetrics *testutils.TestDerivationMetrics
 	derivation *derive.DerivationPipeline
 
 	safeHeadListener rollup.SafeHeadListener
@@ -162,6 +163,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		log:               log,
 		Eng:               eng,
 		engine:            ec,
+		derivationMetrics: metrics,
 		derivation:        pipeline,
 		safeHeadListener:  safeHeadListener,
 		syncCfg:           syncCfg,
@@ -236,6 +238,10 @@ func (s *l2VerifierBackend) OverrideLeader(ctx context.Context) error {
 
 func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
 	return nil
+}
+
+func (s *L2Verifier) DerivationMetricsTracer() *testutils.TestDerivationMetrics {
+	return s.derivationMetrics
 }
 
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {

--- a/op-service/testutils/metrics.go
+++ b/op-service/testutils/metrics.go
@@ -14,6 +14,7 @@ type TestDerivationMetrics struct {
 	FnRecordL2Ref             func(name string, ref eth.L2BlockRef)
 	FnRecordUnsafePayloads    func(length uint64, memSize uint64, next eth.BlockID)
 	FnRecordChannelInputBytes func(inputCompressedBytes int)
+	FnRecordChannelTimedOut   func()
 }
 
 func (t *TestDerivationMetrics) CountSequencedTxs(count int) {
@@ -59,6 +60,9 @@ func (t *TestDerivationMetrics) RecordHeadChannelOpened() {
 }
 
 func (t *TestDerivationMetrics) RecordChannelTimedOut() {
+	if t.FnRecordChannelTimedOut != nil {
+		t.FnRecordChannelTimedOut()
+	}
 }
 
 func (t *TestDerivationMetrics) RecordFrame() {


### PR DESCRIPTION
## Overview

Adds an assertion that the pipeline encountered a channel timeout to the channel timeout action tests using the `TestDerivationMetrics`.