### PR TITLE
op-batcher: Move decision about data availability type to channel submission time

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -171,6 +171,7 @@ func (s *channel) NextTxData() txData {
 
 	id := txdata.ID().String()
 	s.log.Debug("returning next tx data", "id", id, "num_frames", len(txdata.frames), "as_blob", txdata.asBlob)
+	s.pendingTransactions[id] = txdata
 
 	return txdata
 }

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -155,9 +155,9 @@ func (s *channel) ID() derive.ChannelID {
 	return s.channelBuilder.ID()
 }
 
-// NextTxData returns the next tx data packet.
-// If cfg.MultiFrameTxs is false, it returns txData with a single frame.
-// If cfg.MultiFrameTxs is true, it will read frames from its channel builder
+// NextTxData dequeues the next frames from the channel and returns them encoded in a tx data packet.
+// If cfg.UseBlobs is false, it returns txData with a single frame.
+// If cfg.UseBlobs is true, it will read frames from its channel builder
 // until it either doesn't have more frames or the target number of frames is reached.
 //
 // NextTxData should only be called after HasTxData returned true.
@@ -177,10 +177,11 @@ func (s *channel) NextTxData() txData {
 }
 
 func (s *channel) HasTxData() bool {
-	if s.IsFull() || !s.cfg.UseBlobs {
+	if s.IsFull() || // If the channel is full, we should start to submit it
+		!s.cfg.UseBlobs { // If using calldata, we only send one frame per tx
 		return s.channelBuilder.HasFrame()
 	}
-	// collect enough frames if channel is not full yet
+	// Collect enough frames if channel is not full yet
 	return s.channelBuilder.PendingFrames() >= int(s.cfg.MaxFramesPerTx())
 }
 

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -171,7 +171,6 @@ func (s *channel) NextTxData() txData {
 
 	id := txdata.ID().String()
 	s.log.Debug("returning next tx data", "id", id, "num_frames", len(txdata.frames), "as_blob", txdata.asBlob)
-	s.pendingTransactions[id] = txdata
 
 	return txdata
 }

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -417,12 +417,12 @@ func (c *ChannelBuilder) HasFrame() bool {
 }
 
 // PendingFrames returns the number of pending frames in the frames queue.
-// It is larger zero iff HasFrames() returns true.
+// It is larger zero iff HasFrame() returns true.
 func (c *ChannelBuilder) PendingFrames() int {
 	return len(c.frames)
 }
 
-// NextFrame returns the next available frame.
+// NextFrame dequeues the next available frame.
 // HasFrame must be called prior to check if there's a next frame available.
 // Panics if called when there's no next frame.
 func (c *ChannelBuilder) NextFrame() frameData {

--- a/op-batcher/batcher/channel_config.go
+++ b/op-batcher/batcher/channel_config.go
@@ -51,8 +51,8 @@ type ChannelConfig struct {
 	UseBlobs bool
 }
 
-// ChannelConfig returns a copy of itself. This makes a ChannelConfig a static
-// ChannelConfigProvider of itself.
+// ChannelConfig returns a copy of the receiver.
+// This allows the receiver to be a static ChannelConfigProvider of itself.
 func (cc ChannelConfig) ChannelConfig() ChannelConfig {
 	return cc
 }

--- a/op-batcher/batcher/channel_config_provider.go
+++ b/op-batcher/batcher/channel_config_provider.go
@@ -93,7 +93,7 @@ func (dec *DynamicEthChannelConfig) ChannelConfig() ChannelConfig {
 		"blob_data_bytes", blobDataBytes, "blob_cost", blobCost,
 		"cost_ratio", costRatio)
 
-	if ay.Cmp(bx) > 0 {
+	if ay.Cmp(bx) == 1 {
 		lgr.Info("Using calldata channel config")
 		dec.lastConfig = &dec.calldataConfig
 		return dec.calldataConfig

--- a/op-batcher/batcher/channel_config_provider.go
+++ b/op-batcher/batcher/channel_config_provider.go
@@ -48,6 +48,10 @@ func NewDynamicEthChannelConfig(lgr log.Logger,
 	return dec
 }
 
+// ChannelConfig will perform an estimate of the cost per byte for
+// calldata and for blobs, given current market conditions: it will return
+// the appropriate ChannelConfig depending on which is cheaper. It makes
+// assumptions about the typical makeup of channel data.
 func (dec *DynamicEthChannelConfig) ChannelConfig() ChannelConfig {
 	ctx, cancel := context.WithTimeout(context.Background(), dec.timeout)
 	defer cancel()
@@ -89,7 +93,7 @@ func (dec *DynamicEthChannelConfig) ChannelConfig() ChannelConfig {
 		"blob_data_bytes", blobDataBytes, "blob_cost", blobCost,
 		"cost_ratio", costRatio)
 
-	if ay.Cmp(bx) == 1 {
+	if ay.Cmp(bx) > 0 {
 		lgr.Info("Using calldata channel config")
 		dec.lastConfig = &dec.calldataConfig
 		return dec.calldataConfig

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -16,8 +16,7 @@ import (
 )
 
 var (
-	ErrReorg            = errors.New("block does not extend existing chain")
-	ErrInsufficientData = errors.New("insufficient data")
+	ErrReorg = errors.New("block does not extend existing chain")
 )
 
 // channelManager stores a contiguous set of blocks & turns them into channels.
@@ -142,13 +141,9 @@ func (s *channelManager) removePendingChannel(channel *channel) {
 // nextTxData dequeues frames from the channel and returns them encoded in a transaction.
 // It also updates the internal tx -> channels mapping
 func (s *channelManager) nextTxData(channel *channel) (txData, error) {
-	if channel == nil {
-		s.log.Trace("no channel")
-		return txData{}, io.EOF
-	}
-	if !channel.HasTxData() {
+	if channel == nil || !channel.HasTxData() {
 		s.log.Trace("no next tx data")
-		return txData{}, ErrInsufficientData
+		return txData{}, io.EOF
 	}
 	tx := channel.NextTxData()
 	s.txChannels[tx.ID().String()] = channel

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -15,7 +15,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var ErrReorg = errors.New("block does not extend existing chain")
+var (
+	ErrReorg            = errors.New("block does not extend existing chain")
+	ErrInsufficientData = errors.New("insufficient data")
+)
 
 // channelManager stores a contiguous set of blocks & turns them into channels.
 // Upon receiving tx confirmation (or a tx failure), it does channel error handling.
@@ -135,8 +138,6 @@ func (s *channelManager) removePendingChannel(channel *channel) {
 	}
 	s.channelQueue = append(s.channelQueue[:index], s.channelQueue[index+1:]...)
 }
-
-var ErrInsufficientData = errors.New("insufficient data")
 
 // nextTxData dequeues frames from the channel and returns them encoded in a transaction.
 // It also updates the internal tx -> channels mapping

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -15,9 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var (
-	ErrReorg = errors.New("block does not extend existing chain")
-)
+var ErrReorg = errors.New("block does not extend existing chain")
 
 // channelManager stores a contiguous set of blocks & turns them into channels.
 // Upon receiving tx confirmation (or a tx failure), it does channel error handling.
@@ -143,7 +141,7 @@ func (s *channelManager) removePendingChannel(channel *channel) {
 func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 	if channel == nil || !channel.HasTxData() {
 		s.log.Trace("no next tx data")
-		return txData{}, io.EOF
+		return txData{}, io.EOF // TODO: not enough data error instead
 	}
 	tx := channel.NextTxData()
 	s.txChannels[tx.ID().String()] = channel

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -200,6 +200,7 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 }
 
 // getReadyChannel returns the next channel ready to submit data, or an error.
+// It adds blocks from the block queue to the current channel and generates frames for it.
 func (s *channelManager) getReadyChannel(l1Head eth.BlockID) (*channel, error) {
 	var firstWithTxData *channel
 	for _, ch := range s.channelQueue {

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -166,10 +166,13 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 	assumedBlobs := s.currentChannel.cfg.UseBlobs
 	newCfg := s.cfgProvider.ChannelConfig()
 	if newCfg.UseBlobs == assumedBlobs {
-		s.log.Info("Recomputing optimal ChannelConfig: no need to switch DA type", "useBlobs", assumedBlobs)
+		s.log.Info("Recomputing optimal ChannelConfig: no need to switch DA type",
+			"useBlobs", assumedBlobs)
 		return data, err
 	}
-	s.log.Info("Recomputing optimal ChannelConfig: changing DA type...", "useBlobsBefore", assumedBlobs, "useBlobsAfter", newCfg.UseBlobs)
+	s.log.Info("Recomputing optimal ChannelConfig: changing DA type...",
+		"useBlobsBefore", assumedBlobs,
+		"useBlobsAfter", newCfg.UseBlobs)
 	// We have detected that our assumptions on DA
 	// type were wrong and we need to rebuild
 	// the channel manager state
@@ -202,7 +205,6 @@ func (s *channelManager) txData(l1Head eth.BlockID) (txData, error) {
 	s.log.Debug("Requested tx data", "l1Head", l1Head, "txdata_pending", dataPending, "blocks_pending", len(s.blocks))
 
 	// Short circuit if there is pending tx data or the channel manager is closed.
-
 	if dataPending || s.closed {
 		return s.nextTxData(firstWithTxData)
 	}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -480,17 +480,17 @@ func (s *channelManager) Close() error {
 // rewinding blocks back from the channel queue, and setting the defaultCfg.
 func (s *channelManager) Requeue(newCfg ChannelConfig) {
 	newChannelQueue := []*channel{}
-	blocksToRequeueInChannelManager := []*types.Block{}
+	blocksToRequeue := []*types.Block{}
 	for _, channel := range s.channelQueue {
 		if !channel.NoneSubmitted() {
 			newChannelQueue = append(newChannelQueue, channel)
 			continue
 		}
-		blocksToRequeueInChannelManager = append(blocksToRequeueInChannelManager, channel.channelBuilder.Blocks()...)
+		blocksToRequeue = append(blocksToRequeue, channel.channelBuilder.Blocks()...)
 	}
 
 	// We put the blocks back at the front of the queue:
-	s.blocks = append(blocksToRequeueInChannelManager, s.blocks...)
+	s.blocks = append(blocksToRequeue, s.blocks...)
 	// Channels which where already being submitted are put back
 	s.channelQueue = newChannelQueue
 	s.currentChannel = nil

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -35,6 +35,8 @@ type channelManager struct {
 	blocks []*types.Block
 	// The latest L1 block from all the L2 blocks in the most recently closed channel
 	l1OriginLastClosedChannel eth.BlockID
+	// The default ChannelConfig to use for the next channel
+	defaultCfg ChannelConfig
 	// last block hash - for reorg detection
 	tip common.Hash
 
@@ -54,6 +56,7 @@ func NewChannelManager(log log.Logger, metr metrics.Metricer, cfgProvider Channe
 		log:         log,
 		metr:        metr,
 		cfgProvider: cfgProvider,
+		defaultCfg:  cfgProvider.ChannelConfig(),
 		rollupCfg:   rollupCfg,
 		txChannels:  make(map[string]*channel),
 	}
@@ -133,7 +136,8 @@ func (s *channelManager) removePendingChannel(channel *channel) {
 	s.channelQueue = append(s.channelQueue[:index], s.channelQueue[index+1:]...)
 }
 
-// nextTxData pops off s.datas & handles updating the internal state
+// nextTxData dequeues frames from the channel and returns them encoded in a transaction.
+// It also handles updating the internal state of the receiver.
 func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 	if channel == nil || !channel.HasTxData() {
 		s.log.Trace("no next tx data")
@@ -146,10 +150,44 @@ func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 
 // TxData returns the next tx data that should be submitted to L1.
 //
-// If the pending channel is
+// If the current channel is
 // full, it only returns the remaining frames of this channel until it got
 // successfully fully sent to L1. It returns io.EOF if there's no pending tx data.
+//
+// It will generate the tx data internally, and decide whether to switch DA type
+// automatically. When switching DA type, the channelManager state will be rebuilt
+// with a new ChannelConfig.
 func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
+	data, err := s.txData(l1Head)
+	if s.currentChannel == nil {
+		s.log.Trace("no current channel")
+		return data, err
+	}
+	assumedBlobs := s.currentChannel.cfg.UseBlobs
+	newCfg := s.cfgProvider.ChannelConfig()
+	if newCfg.UseBlobs == assumedBlobs {
+		s.log.Info("Recomputing optimal ChannelConfig: no need to switch DA type", "useBlobs", assumedBlobs)
+		return data, err
+	}
+	s.log.Info("Recomputing optimal ChannelConfig: changing DA type...", "useBlobsBefore", assumedBlobs, "useBlobsAfter", newCfg.UseBlobs)
+	// We have detected that our assumptions on DA
+	// type were wrong and we need to rebuild
+	// the channel manager state
+	err = s.Rebuild(newCfg)
+	if err != nil {
+		return data, err
+	}
+	// Finally, call the inner function to get txData
+	// with the new config
+	return s.txData(l1Head)
+}
+
+// txData returns the next tx data that should be submitted to L1.
+//
+// If the current channel is
+// full, it only returns the remaining frames of this channel until it got
+// successfully fully sent to L1. It returns io.EOF if there's no pending tx data.
+func (s *channelManager) txData(l1Head eth.BlockID) (txData, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var firstWithTxData *channel
@@ -160,10 +198,11 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 		}
 	}
 
-	dataPending := firstWithTxData != nil && firstWithTxData.HasTxData()
+	dataPending := firstWithTxData != nil
 	s.log.Debug("Requested tx data", "l1Head", l1Head, "txdata_pending", dataPending, "blocks_pending", len(s.blocks))
 
 	// Short circuit if there is pending tx data or the channel manager is closed.
+
 	if dataPending || s.closed {
 		return s.nextTxData(firstWithTxData)
 	}
@@ -203,7 +242,10 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		return nil
 	}
 
-	cfg := s.cfgProvider.ChannelConfig()
+	// We reuse the ChannelConfig from the last channel.
+	// This will be reassessed at channel submission-time,
+	// but this is our best guess at the appropriate values for now.
+	cfg := s.defaultCfg
 	pc, err := newChannel(s.log, s.metr, cfg, s.rollupCfg, s.l1OriginLastClosedChannel.Number)
 	if err != nil {
 		return fmt.Errorf("creating new channel: %w", err)
@@ -228,7 +270,7 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 	return nil
 }
 
-// registerL1Block registers the given block at the pending channel.
+// registerL1Block registers the given block at the current channel.
 func (s *channelManager) registerL1Block(l1Head eth.BlockID) {
 	s.currentChannel.CheckTimeout(l1Head.Number)
 	s.log.Debug("new L1-block registered at channel builder",
@@ -238,7 +280,7 @@ func (s *channelManager) registerL1Block(l1Head eth.BlockID) {
 	)
 }
 
-// processBlocks adds blocks from the blocks queue to the pending channel until
+// processBlocks adds blocks from the blocks queue to the current channel until
 // either the queue got exhausted or the channel is full.
 func (s *channelManager) processBlocks() error {
 	var (
@@ -288,6 +330,7 @@ func (s *channelManager) processBlocks() error {
 	return nil
 }
 
+// outputFrames generates frames for the current channel, and computes and logs the compression ratio
 func (s *channelManager) outputFrames() error {
 	if err := s.currentChannel.OutputFrames(); err != nil {
 		return fmt.Errorf("creating frames with channel builder: %w", err)
@@ -339,6 +382,7 @@ func (s *channelManager) outputFrames() error {
 func (s *channelManager) AddL2Block(block *types.Block) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	if s.tip != (common.Hash{}) && s.tip != block.ParentHash() {
 		return ErrReorg
 	}
@@ -412,5 +456,30 @@ func (s *channelManager) Close() error {
 		// Make it clear to the caller that there is remaining pending work.
 		return ErrPendingAfterClose
 	}
+	return nil
+}
+
+// Rebuild rebuilds the channel manager state by
+// rewinding blocks back from the channel queue, and setting the defaultCfg.
+func (s *channelManager) Rebuild(newCfg ChannelConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.log.Info("Rebuilding channelManager state", "UseBlobs", newCfg.UseBlobs)
+	newChannelQueue := []*channel{}
+	blocksToRequeueInChannelManager := []*types.Block{}
+	for _, channel := range s.channelQueue {
+		if len(channel.pendingTransactions) > 0 {
+			newChannelQueue = append(newChannelQueue, channel)
+			continue
+		}
+		blocksToRequeueInChannelManager = append(blocksToRequeueInChannelManager, channel.channelBuilder.Blocks()...)
+	}
+	// We put the blocks back at the front of the queue:
+	s.blocks = append(blocksToRequeueInChannelManager, s.blocks...)
+	s.channelQueue = newChannelQueue
+	s.currentChannel = nil
+	// Setting the defaultCfg will cause new channels
+	// to pick up the new ChannelConfig
+	s.defaultCfg = newCfg
 	return nil
 }

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -171,9 +171,6 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 	if channel == nil {
 		panic("nil channel and nil err returned from getReadyChannel")
 	}
-	if !channel.HasTxData() {
-		return emptyTxData, ErrInsufficientData
-	}
 	if !channel.NoneSubmitted() {
 		return s.nextTxData(channel)
 	}
@@ -193,9 +190,6 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 	channel, err = s.getReadyChannel(l1Head)
 	if err != nil {
 		return emptyTxData, err
-	}
-	if !channel.HasTxData() {
-		return emptyTxData, ErrInsufficientData
 	}
 	return s.nextTxData(channel)
 }

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -165,6 +165,8 @@ func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 // When switching DA type, the channelManager state will be rebuilt
 // with a new ChannelConfig.
 func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	channel, err := s.getReadyChannel(l1Head)
 	if err != nil {
 		return emptyTxData, err
@@ -202,9 +204,6 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 
 // getReadyChannel returns the next channel ready to submit data, or an error.
 func (s *channelManager) getReadyChannel(l1Head eth.BlockID) (*channel, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	var firstWithTxData *channel
 	for _, ch := range s.channelQueue {
 		if ch.HasTxData() {
@@ -480,9 +479,6 @@ func (s *channelManager) Close() error {
 // Requeue rebuilds the channel manager state by
 // rewinding blocks back from the channel queue, and setting the defaultCfg.
 func (s *channelManager) Requeue(newCfg ChannelConfig) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	newChannelQueue := []*channel{}
 	blocksToRequeueInChannelManager := []*types.Block{}
 	for _, channel := range s.channelQueue {

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -171,9 +171,6 @@ func (s *channelManager) TxData(l1Head eth.BlockID) (txData, error) {
 	if err != nil {
 		return emptyTxData, err
 	}
-	if channel == nil {
-		panic("nil channel and nil err returned from getReadyChannel")
-	}
 	// If the channel has already started being submitted,
 	// return now and ensure no requeueing happens
 	if !channel.NoneSubmitted() {

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -491,7 +491,7 @@ func TestChannelManager_Requeue(t *testing.T) {
 
 	// Seed channel manager with a single block
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	blockA := derivetest.RandomL2BlockWithChainId(rng, 1000, defaultTestRollupConfig.L2ChainID)
+	blockA := derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID)
 	require.NoError(t, m.AddL2Block(blockA))
 
 	// This is the snapshot of channel manager state we want to reinstate

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -558,7 +558,7 @@ func TestChannelManager_TxData(t *testing.T) {
 
 			// Seed channel manager with a block
 			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-			blockA := derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID)
+			blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
 			m.blocks = []*types.Block{blockA}
 
 			// Call TxData a first time to trigger blocks->channels pipeline

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -563,7 +563,7 @@ func TestChannelManager_TxData(t *testing.T) {
 
 			// Call TxData a first time to trigger blocks->channels pipeline
 			_, err := m.TxData(eth.BlockID{})
-			require.ErrorIs(t, err, ErrInsufficientData)
+			require.ErrorIs(t, err, io.EOF)
 
 			// The test requires us to have something in the channel queue
 			// at this point, but not yet ready to send and not full
@@ -585,7 +585,7 @@ func TestChannelManager_TxData(t *testing.T) {
 				if err == nil && data.Len() > 0 {
 					break
 				}
-				if !errors.Is(err, ErrInsufficientData) {
+				if !errors.Is(err, io.EOF) {
 					require.NoError(t, err)
 				}
 			}

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -483,3 +483,50 @@ func TestChannelManager_ChannelCreation(t *testing.T) {
 		})
 	}
 }
+
+func TestChannelManager_Requeue(t *testing.T) {
+	l := testlog.Logger(t, log.LevelCrit)
+	cfg := channelManagerTestConfig(1000, derive.SpanBatchType)
+	m := NewChannelManager(l, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+
+	// Seed channel manager with a single block
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	blockA := derivetest.RandomL2BlockWithChainId(rng, 1000, defaultTestRollupConfig.L2ChainID)
+	require.NoError(t, m.AddL2Block(blockA))
+
+	// This is the snapshot of channel manager state we want to reinstate
+	require.Equal(t, m.blocks, []*types.Block{blockA})
+	require.Empty(t, m.channelQueue)
+
+	// Trigger the blocks -> channelQueue data pipelining
+	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
+	require.NotEmpty(t, m.channelQueue)
+	require.NoError(t, m.processBlocks())
+	require.Empty(t, m.blocks)
+
+	// Call the function we are testing
+	require.NoError(t, m.Requeue(m.defaultCfg))
+
+	// Ensure we got back to the state above
+	require.Equal(t, m.blocks, []*types.Block{blockA})
+	require.Empty(t, m.channelQueue)
+
+	// Trigger the blocks -> channelQueue data pipelining again
+	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
+	require.NotEmpty(t, m.channelQueue)
+	require.NoError(t, m.processBlocks())
+	require.Empty(t, m.blocks)
+
+	// Now mark the 0th channel in the queue as already
+	// starting to send on chain
+	channel0 := m.channelQueue[0]
+	channel0.pendingTransactions["foo"] = txData{}
+	require.False(t, channel0.NoneSubmitted())
+
+	// Call the function we are testing
+	require.NoError(t, m.Requeue(m.defaultCfg))
+
+	// The rewind shouldn't affect the pending channel
+	require.Contains(t, m.channelQueue, channel0)
+	require.Empty(t, m.blocks)
+}

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -540,7 +540,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			cfg := newFakeDynamicEthChannelConfig(l, 1000)
 
 			cfg.chooseBlobs = tc.chooseBlobsWhenChannelCreated
-			m := NewChannelManager(l, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+			m := NewChannelManager(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 			require.Equal(t, tc.chooseBlobsWhenChannelCreated, m.defaultCfg.UseBlobs)
 
 			// Seed channel manager with blocks
@@ -591,7 +591,7 @@ func TestChannelManager_TxData(t *testing.T) {
 func TestChannelManager_Requeue(t *testing.T) {
 	l := testlog.Logger(t, log.LevelCrit)
 	cfg := channelManagerTestConfig(100, derive.SingularBatchType)
-	m := NewChannelManager(l, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 
 	// Seed channel manager with blocks
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -597,7 +597,7 @@ func TestChannelManager_TxData(t *testing.T) {
 
 }
 
-// TestChannelManager_Requeue sees the channel manager with blocks,
+// TestChannelManager_Requeue seeds the channel manager with blocks,
 // takes a state snapshot, triggers the blocks->channels pipeline,
 // and then calls Requeue. Finally, it asserts the channel manager's
 // state is equal to the snapshot. It repeats this for a channel

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -491,8 +491,8 @@ type MockChannelManager struct {
 	*channelManager
 }
 
-func (m *MockChannelManager) Requeue(cfg ChannelConfig) error {
-	args := m.Called(cfg)
+func (m *MockChannelManager) Requeue(newCfg ChannelConfig) error {
+	args := m.Called(newCfg)
 	return args.Error(0)
 }
 
@@ -600,11 +600,11 @@ func TestChannelManager_TxData(t *testing.T) {
 			require.True(t, m.channelQueue[0].IsFull())
 
 			if tc.chooseBlobsWhenChannelCreated != tc.chooseBlobsWhenChannelSubmitted {
-				m.AssertCalled(t, "Requeue", cfg)
+				m.AssertCalled(t, "Requeue", mock.Anything)
 			} else {
-				m.AssertNotCalled(t, "Requeue", cfg)
+				m.AssertNotCalled(t, "Requeue", mock.Anything)
 			}
-			// TODO assert defaultCfg updated correctly
+			require.True(t, tc.chooseBlobsWhenChannelSubmitted, m.defaultCfg.UseBlobs)
 		})
 	}
 

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -609,7 +609,7 @@ func TestChannelManager_Requeue(t *testing.T) {
 	require.NotContains(t, m.blocks, blockA)
 
 	// Call the function we are testing
-	require.NoError(t, m.Requeue(m.defaultCfg))
+	m.Requeue(m.defaultCfg)
 
 	// Ensure we got back to the state above
 	require.Equal(t, m.blocks, stateSnapshot)
@@ -630,7 +630,7 @@ func TestChannelManager_Requeue(t *testing.T) {
 	require.False(t, channel0.NoneSubmitted())
 
 	// Call the function we are testing
-	require.NoError(t, m.Requeue(m.defaultCfg))
+	m.Requeue(m.defaultCfg)
 
 	// The requeue shouldn't affect the pending channel
 	require.Contains(t, m.channelQueue, channel0)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -581,6 +581,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			}
 
 			require.True(t, m.channelQueue[0].IsFull())
+			require.Equal(t, tc.chooseBlobsWhenChannelSubmitted, m.channelQueue[0].cfg.UseBlobs)
 			require.Equal(t, tc.chooseBlobsWhenChannelSubmitted, data.asBlob)
 			require.Equal(t, tc.chooseBlobsWhenChannelSubmitted, m.defaultCfg.UseBlobs)
 		})

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -512,8 +512,8 @@ func newFakeDynamicEthChannelConfig(lgr log.Logger,
 		TargetNumFrames: 3, // gets closest to amortized fixed tx costs
 		UseBlobs:        true,
 	}
-	calldataCfg.InitRatioCompressor(1, derive.Brotli)
-	blobCfg.InitRatioCompressor(1, derive.Brotli)
+	calldataCfg.InitNoneCompressor()
+	blobCfg.InitNoneCompressor()
 
 	return &FakeDynamicEthChannelConfig{
 		chooseBlobs: false,
@@ -609,7 +609,7 @@ func TestChannelManager_Requeue(t *testing.T) {
 	m := NewChannelManager(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 
 	// Seed channel manager with blocks
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rng := rand.New(rand.NewSource(99))
 	blockA := derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID)
 	blockB := derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID)
 

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -86,13 +86,13 @@ func TestChannelManager_NextTxData(t *testing.T) {
 	require.Equal(t, txData{}, returnedTxData)
 
 	// Set the pending channel
-	// The nextTxData function should still return EOF
-	// since the pending channel has no frames
+	// The nextTxData function should still return ErrInsufficientData
+	// since the current channel has no frames
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 	channel := m.currentChannel
 	require.NotNil(t, channel)
 	returnedTxData, err = m.nextTxData(channel)
-	require.ErrorIs(t, err, io.EOF)
+	require.ErrorIs(t, err, ErrInsufficientData)
 	require.Equal(t, txData{}, returnedTxData)
 
 	// Manually push a frame into the pending channel

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -86,13 +86,13 @@ func TestChannelManager_NextTxData(t *testing.T) {
 	require.Equal(t, txData{}, returnedTxData)
 
 	// Set the pending channel
-	// The nextTxData function should still return ErrInsufficientData
+	// The nextTxData function should still return io.EOF
 	// since the current channel has no frames
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 	channel := m.currentChannel
 	require.NotNil(t, channel)
 	returnedTxData, err = m.nextTxData(channel)
-	require.ErrorIs(t, err, ErrInsufficientData)
+	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, txData{}, returnedTxData)
 
 	// Manually push a frame into the pending channel

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -190,10 +190,11 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 
 // loadBlocksIntoState loads all blocks since the previous stored block
 // It does the following:
-// 1. Fetch the sync status of the sequencer
-// 2. Check if the sync status is valid or if we are all the way up to date
-// 3. Check if it needs to initialize state OR it is lagging (todo: lagging just means race condition?)
-// 4. Load all new blocks into the local state.
+//  1. Fetch the sync status of the sequencer
+//  2. Check if the sync status is valid or if we are all the way up to date
+//  3. Check if it needs to initialize state OR it is lagging (todo: lagging just means race condition?)
+//  4. Load all new blocks into the local state.
+//
 // If there is a reorg, it will reset the last stored block but not clear the internal state so
 // the state can be flushed to L1.
 func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context) error {

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -50,6 +50,7 @@ func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 		Log:              testlog.Logger(t, log.LevelDebug),
 		Metr:             metrics.NoopMetrics,
 		RollupConfig:     cfg,
+		ChannelConfig:    defaultTestChannelConfig(),
 		EndpointProvider: ep,
 	}), ep
 }


### PR DESCRIPTION
Closes #11609 

For now, I decided to not make any changes to the decision logic itself (only to when it is triggered and what happens when a change is necessary). 

Changing the trigger for the decision opens the opportunity to make a more accurate decision about which DA type to choose, since some transaction data is now in scope. However, this would not address the larger assumption in the current logic, which is about how many blobs are typically included in a tx. This can be lower than the target number on chains with low throughput as channels must be closed before they time out. To address this assumption, we could store the previous number of blobs per tx to make a better estimate than the current one (which assumes we always include the target number). This is saved for future work. 

Tests: the modified implementation passes existing tests, including an end to end test for switching DA type. 

