### PR TITLE
ci: Sanitize op-program for unsupported instructions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1102,6 +1102,9 @@ jobs:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
       - run:
+          name: Sanitize op-program guest
+          command: make -f cannon/Makefile sanitize-program GUEST_PROGRAM=op-program/bin/op-program-client.elf
+      - run:
           name: generate cannon prestate
           command: make cannon-prestate
       - save_cache:

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -22,6 +22,14 @@ clean:
 elf:
 	make -C ./testdata/example elf
 
+sanitize-program:
+	@if ! { mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM | awk '{print $3}' | grep -Ew -m1 '(bgezal|bltzal)'; }; then \
+		echo "guest program is sanitized for unsupported instructions"; \
+	else \
+		echo "found unsupported instructions in the guest program"; \
+		exit 1; \
+	fi
+
 contract:
 	cd ../packages/contracts-bedrock && forge build
 


### PR DESCRIPTION
Cannon doesn't support `bgezal` and `bltzal` instructions as they're not emitted by Go. This CI check asserts that this is always the case for the MIPS32 op-program.