### PR TITLE
cannon: Clean up fuzz test todos

### DIFF
--- a/cannon/mipsevm/multithreaded/testutil/mutators.go
+++ b/cannon/mipsevm/multithreaded/testutil/mutators.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"math"
-	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -23,14 +22,14 @@ func NewStateMutatorMultiThreaded(state *multithreaded.State) testutil.StateMuta
 }
 
 func (m *StateMutatorMultiThreaded) Randomize(randSeed int64) {
-	r := rand.New(rand.NewSource(randSeed))
+	r := testutil.NewRandHelper(randSeed)
 
-	step := testutil.RandStep(r)
+	step := r.RandStep()
 
-	m.state.PreimageKey = testutil.RandHash(r)
+	m.state.PreimageKey = r.RandHash()
 	m.state.PreimageOffset = r.Uint32()
 	m.state.Step = step
-	m.state.LastHint = testutil.RandHint(r)
+	m.state.LastHint = r.RandHint()
 	m.state.StepsSinceLastContextSwitch = uint64(r.Intn(exec.SchedQuantum))
 
 	// Randomize memory-related fields

--- a/cannon/mipsevm/multithreaded/testutil/thread.go
+++ b/cannon/mipsevm/multithreaded/testutil/thread.go
@@ -1,19 +1,17 @@
 package testutil
 
 import (
-	"math/rand"
-
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
 func RandomThread(randSeed int64) *multithreaded.ThreadState {
-	r := rand.New(rand.NewSource(randSeed))
+	r := testutil.NewRandHelper(randSeed)
 	thread := multithreaded.CreateEmptyThread()
 
-	pc := testutil.RandPC(r)
+	pc := r.RandPC()
 
-	thread.Registers = *testutil.RandRegisters(r)
+	thread.Registers = *r.RandRegisters()
 	thread.Cpu.PC = pc
 	thread.Cpu.NextPC = pc + 4
 	thread.Cpu.HI = r.Uint32()

--- a/cannon/mipsevm/singlethreaded/testutil/state.go
+++ b/cannon/mipsevm/singlethreaded/testutil/state.go
@@ -1,8 +1,6 @@
 package testutil
 
 import (
-	"math/rand"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -15,12 +13,12 @@ type StateMutatorSingleThreaded struct {
 }
 
 func (m *StateMutatorSingleThreaded) Randomize(randSeed int64) {
-	r := rand.New(rand.NewSource(randSeed))
+	r := testutil.NewRandHelper(randSeed)
 
-	pc := testutil.RandPC(r)
-	step := testutil.RandStep(r)
+	pc := r.RandPC()
+	step := r.RandStep()
 
-	m.state.PreimageKey = testutil.RandHash(r)
+	m.state.PreimageKey = r.RandHash()
 	m.state.PreimageOffset = r.Uint32()
 	m.state.Cpu.PC = pc
 	m.state.Cpu.NextPC = pc + 4
@@ -28,8 +26,8 @@ func (m *StateMutatorSingleThreaded) Randomize(randSeed int64) {
 	m.state.Cpu.LO = r.Uint32()
 	m.state.Heap = r.Uint32()
 	m.state.Step = step
-	m.state.LastHint = testutil.RandHint(r)
-	m.state.Registers = *testutil.RandRegisters(r)
+	m.state.LastHint = r.RandHint()
+	m.state.Registers = *r.RandRegisters()
 }
 
 var _ testutil.StateMutator = (*StateMutatorSingleThreaded)(nil)

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -262,7 +262,7 @@ func FuzzStatePreimageRead(f *testing.F) {
 				expected.PreimageOffset += writeLen
 				if writeLen > 0 {
 					// Expect a memory write
-					expectedMemory := [4]byte{0xFF, 0xFF, 0xFF, 0xFF}
+					expectedMemory := preexistingMemoryVal
 					copy(expectedMemory[alignment:], preimageData[preimageOffset:preimageOffset+writeLen])
 					expected.ExpectMemoryWrite(effAddr, binary.BigEndian.Uint32(expectedMemory[:]))
 				}

--- a/cannon/mipsevm/testutil/rand.go
+++ b/cannon/mipsevm/testutil/rand.go
@@ -1,53 +1,82 @@
 package testutil
 
 import (
+	"encoding/binary"
 	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-func RandHash(r *rand.Rand) common.Hash {
+type RandHelper struct {
+	r *rand.Rand
+}
+
+func NewRandHelper(seed int64) *RandHelper {
+	r := rand.New(rand.NewSource(seed))
+	return &RandHelper{r: r}
+}
+
+func (h *RandHelper) Uint32() uint32 {
+	return h.r.Uint32()
+}
+
+func (h *RandHelper) Fraction() float64 {
+	return h.r.Float64()
+}
+
+func (h *RandHelper) Intn(n int) int {
+	return h.r.Intn(n)
+}
+
+func (h *RandHelper) RandHash() common.Hash {
 	var bytes [32]byte
-	_, err := r.Read(bytes[:])
+	_, err := h.r.Read(bytes[:])
 	if err != nil {
 		panic(err)
 	}
 	return bytes
 }
 
-func RandHint(r *rand.Rand) []byte {
-	count := r.Intn(10)
+func (h *RandHelper) RandHint() []byte {
 
-	bytes := make([]byte, count)
-	_, err := r.Read(bytes[:])
-	if err != nil {
-		panic(err)
+	bytesCount := h.r.Intn(24)
+	bytes := make([]byte, bytesCount)
+
+	if bytesCount >= 8 {
+		// Set up a reasonable length prefix
+		nextHintLen := uint64(h.r.Intn(30))
+		binary.BigEndian.PutUint64(bytes, nextHintLen)
+
+		_, err := h.r.Read(bytes[8:])
+		if err != nil {
+			panic(err)
+		}
 	}
+
 	return bytes
 }
 
-func RandRegisters(r *rand.Rand) *[32]uint32 {
+func (h *RandHelper) RandRegisters() *[32]uint32 {
 	registers := new([32]uint32)
 	for i := 0; i < 32; i++ {
-		registers[i] = r.Uint32()
+		registers[i] = h.r.Uint32()
 	}
 	return registers
 }
 
-func RandomBytes(t require.TestingT, seed int64, length uint32) []byte {
-	r := rand.New(rand.NewSource(seed))
+func (h *RandHelper) RandomBytes(t require.TestingT, length int) []byte {
 	randBytes := make([]byte, length)
-	if _, err := r.Read(randBytes); err != nil {
+	if _, err := h.r.Read(randBytes); err != nil {
 		require.NoError(t, err)
 	}
 	return randBytes
 }
 
-func RandPC(r *rand.Rand) uint32 {
-	return AlignPC(r.Uint32())
+func (h *RandHelper) RandPC() uint32 {
+	return AlignPC(h.r.Uint32())
 }
 
-func RandStep(r *rand.Rand) uint64 {
-	return BoundStep(r.Uint64())
+func (h *RandHelper) RandStep() uint64 {
+	return BoundStep(h.r.Uint64())
 }

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -48,6 +48,13 @@ func WithNextPC(nextPC uint32) StateOption {
 	}
 }
 
+func WithPCAndNextPC(pc uint32) StateOption {
+	return func(state StateMutator) {
+		state.SetPC(pc)
+		state.SetNextPC(pc + 4)
+	}
+}
+
 func WithHeap(addr uint32) StateOption {
 	return func(state StateMutator) {
 		state.SetHeap(addr)

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"encoding/binary"
 	"fmt"
-	"slices"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -161,19 +160,8 @@ func (e *ExpectedState) ExpectMemoryWrite(addr uint32, val uint32) {
 	e.MemoryRoot = e.expectedMemory.MerkleRoot()
 }
 
-type StateValidationFlags int
-
-// TODO(cp-983) - Remove these validation hacks
-const (
-	SkipMemoryValidation StateValidationFlags = iota
-	SkipHintValidation
-	SkipPreimageKeyValidation
-)
-
-func (e *ExpectedState) Validate(t testing.TB, actualState mipsevm.FPVMState, flags ...StateValidationFlags) {
-	if !slices.Contains(flags, SkipPreimageKeyValidation) {
-		require.Equal(t, e.PreimageKey, actualState.GetPreimageKey(), fmt.Sprintf("Expect preimageKey = %v", e.PreimageKey))
-	}
+func (e *ExpectedState) Validate(t testing.TB, actualState mipsevm.FPVMState) {
+	require.Equal(t, e.PreimageKey, actualState.GetPreimageKey(), fmt.Sprintf("Expect preimageKey = %v", e.PreimageKey))
 	require.Equal(t, e.PreimageOffset, actualState.GetPreimageOffset(), fmt.Sprintf("Expect preimageOffset = %v", e.PreimageOffset))
 	require.Equal(t, e.PC, actualState.GetCpu().PC, fmt.Sprintf("Expect PC = 0x%x", e.PC))
 	require.Equal(t, e.NextPC, actualState.GetCpu().NextPC, fmt.Sprintf("Expect nextPC = 0x%x", e.NextPC))
@@ -183,11 +171,7 @@ func (e *ExpectedState) Validate(t testing.TB, actualState mipsevm.FPVMState, fl
 	require.Equal(t, e.ExitCode, actualState.GetExitCode(), fmt.Sprintf("Expect exitCode = 0x%x", e.ExitCode))
 	require.Equal(t, e.Exited, actualState.GetExited(), fmt.Sprintf("Expect exited = %v", e.Exited))
 	require.Equal(t, e.Step, actualState.GetStep(), fmt.Sprintf("Expect step = %d", e.Step))
-	if !slices.Contains(flags, SkipHintValidation) {
-		require.Equal(t, e.LastHint, actualState.GetLastHint(), fmt.Sprintf("Expect lastHint = %v", e.LastHint))
-	}
+	require.Equal(t, e.LastHint, actualState.GetLastHint(), fmt.Sprintf("Expect lastHint = %v", e.LastHint))
 	require.Equal(t, e.Registers, *actualState.GetRegistersRef(), fmt.Sprintf("Expect registers = %v", e.Registers))
-	if !slices.Contains(flags, SkipMemoryValidation) {
-		require.Equal(t, e.MemoryRoot, common.Hash(actualState.GetMemory().MerkleRoot()), fmt.Sprintf("Expect memory root = %v", e.MemoryRoot))
-	}
+	require.Equal(t, e.MemoryRoot, common.Hash(actualState.GetMemory().MerkleRoot()), fmt.Sprintf("Expect memory root = %v", e.MemoryRoot))
 }

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"encoding/binary"
 	"fmt"
 	"slices"
 	"testing"
@@ -13,10 +14,13 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
 )
 
-func CopyRegisters(state mipsevm.FPVMState) *[32]uint32 {
-	copy := new([32]uint32)
-	*copy = *state.GetRegistersRef()
-	return copy
+func AddHintLengthPrefix(data []byte) []byte {
+	dataLen := len(data)
+	prefixed := make([]byte, 0, dataLen+4)
+	prefixed = binary.BigEndian.AppendUint32(prefixed, uint32(dataLen))
+	prefixed = append(prefixed, data...)
+
+	return prefixed
 }
 
 type StateMutator interface {

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -22,6 +22,15 @@ func AddHintLengthPrefix(data []byte) []byte {
 	return prefixed
 }
 
+func AddPreimageLengthPrefix(data []byte) []byte {
+	dataLen := len(data)
+	prefixed := make([]byte, 0, dataLen+8)
+	prefixed = binary.BigEndian.AppendUint64(prefixed, uint64(dataLen))
+	prefixed = append(prefixed, data...)
+
+	return prefixed
+}
+
 type StateMutator interface {
 	SetPreimageKey(val common.Hash)
 	SetPreimageOffset(val uint32)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Clean-up some deferred todos from `fuzz_evm_common_test.go`.  Remove special cases that skip a few types of validation and add assertions for all fields.  

Also includes some small changes to test helpers:
- Add some utils for adding length prefixes
- Rework random utils - wrap them in a struct so we can easily use the same generator for all random values

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/11651
