### PR TITLE
op-program: Reproducible MT-Cannon prestate

### DIFF
--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -36,6 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-pro
 
 # Run the op-program-client.elf binary directly through cannon's load-elf subcommand.
 RUN /app/cannon/bin/cannon load-elf --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate.json --meta ""
+RUN /app/cannon/bin/cannon load-elf --type cannon-mt --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate-mt.bin.gz --meta ""
 
 # Generate the prestate proof containing the absolute pre-state hash.
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate.json --meta "" --proof-fmt '/app/op-program/bin/%d.json' --output ""

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -41,6 +41,9 @@ RUN /app/cannon/bin/cannon load-elf --path /app/op-program/bin/op-program-client
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate.json --meta "" --proof-fmt '/app/op-program/bin/%d.json' --output ""
 RUN mv /app/op-program/bin/0.json /app/op-program/bin/prestate-proof.json
 
+RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt.json' --output ""
+RUN mv /app/op-program/bin/0-mt.json /app/op-program/bin/prestate-proof-mt.json
+
 # Exports files to the specified output location.
 # Writing files to host requires buildkit to be enabled.
 # e.g. `BUILDKIT=1 docker build ...`
@@ -49,3 +52,5 @@ COPY --from=builder /app/op-program/bin/op-program .
 COPY --from=builder /app/op-program/bin/op-program-client.elf .
 COPY --from=builder /app/op-program/bin/prestate.json .
 COPY --from=builder /app/op-program/bin/prestate-proof.json .
+COPY --from=builder /app/op-program/bin/prestate-mt.bin.gz .
+COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -36,8 +36,10 @@ op-program-client-riscv:
 
 reproducible-prestate:
 	@docker build --output ./bin/ --progress plain -f Dockerfile.repro ../
-	@echo "Absolute prestate hash:"
+	@echo "Cannon Absolute prestate hash: "
 	@cat ./bin/prestate-proof.json | jq -r .pre
+	@echo "MT-Cannon Absolute prestate hash: "
+	@cat ./bin/prestate-proof-mt.json | jq -r .pre
 .PHONY: reproducible-prestate
 
 clean:


### PR DESCRIPTION
Updates the `make reproducible-prestate` script to emit MT-Cannon prestates.

The preimage-reproducibility job isn't yet updated until MT-Cannon is ported to MIPS64.