### PR TITLE
vm-runner: User-provided mt-cannon absolute prestate URL

### DIFF
--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -52,7 +53,7 @@ func checkMTCannonFlags(ctx *cli.Context, cfg *config.Config) error {
 			return fmt.Errorf("both flag %v and %v must be set when running MT-Cannon traces", addMTCannonPrestateURLFlag.Name, addMTCannonPrestateFlag.Name)
 		}
 		if cfg.Cannon == (vm.Config{}) {
-			return fmt.Errorf("required Cannon vm configuration for mt-cannon traces is missing")
+			return errors.New("required Cannon vm configuration for mt-cannon traces is missing")
 		}
 	}
 	return nil

--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-challenger/runner"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -27,18 +30,36 @@ func RunTrace(ctx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, er
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
-	if ctx.IsSet(addMTCannonPrestate.Name) && cfg.CannonAbsolutePreStateBaseURL == nil {
-		return nil, fmt.Errorf("flag %v is required when using %v", flags.CannonPreStateFlag.Name, addMTCannonPrestate.Name)
+	if err := checkMTCannonFlags(ctx, cfg); err != nil {
+		return nil, err
 	}
+
 	var mtPrestate common.Hash
-	if ctx.IsSet(addMTCannonPrestate.Name) {
-		mtPrestate = common.HexToHash(ctx.String(addMTCannonPrestate.Name))
+	var mtPrestateURL *url.URL
+	if ctx.IsSet(addMTCannonPrestateFlag.Name) {
+		mtPrestate = common.HexToHash(ctx.String(addMTCannonPrestateFlag.Name))
+		mtPrestateURL, err = url.Parse(ctx.String(addMTCannonPrestateURLFlag.Name))
+		if err != nil {
+			return nil, fmt.Errorf("invalid mt-cannon prestate url (%v): %w", ctx.String(addMTCannonPrestateFlag.Name), err)
+		}
 	}
-	return runner.NewRunner(logger, cfg, mtPrestate), nil
+	return runner.NewRunner(logger, cfg, mtPrestate, mtPrestateURL), nil
+}
+
+func checkMTCannonFlags(ctx *cli.Context, cfg *config.Config) error {
+	if ctx.IsSet(addMTCannonPrestateFlag.Name) || ctx.IsSet(addMTCannonPrestateURLFlag.Name) {
+		if ctx.IsSet(addMTCannonPrestateFlag.Name) != ctx.IsSet(addMTCannonPrestateURLFlag.Name) {
+			return fmt.Errorf("both flag %v and %v must be set when running MT-Cannon traces", addMTCannonPrestateURLFlag.Name, addMTCannonPrestateFlag.Name)
+		}
+		if cfg.Cannon == (vm.Config{}) {
+			return fmt.Errorf("required Cannon vm configuration for mt-cannon traces is missing")
+		}
+	}
+	return nil
 }
 
 func runTraceFlags() []cli.Flag {
-	return append(flags.Flags, addMTCannonPrestate)
+	return append(flags.Flags, addMTCannonPrestateFlag, addMTCannonPrestateURLFlag)
 }
 
 var RunTraceCommand = &cli.Command{
@@ -49,8 +70,15 @@ var RunTraceCommand = &cli.Command{
 	Flags:       runTraceFlags(),
 }
 
-var addMTCannonPrestate = &cli.StringFlag{
-	Name:    "add-mt-cannon-prestate",
-	Usage:   "Use this prestate to run MT-Cannon compatibility tests",
-	EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "ADD_MT_CANNON_PRESTATE"),
-}
+var (
+	addMTCannonPrestateFlag = &cli.StringFlag{
+		Name:    "add-mt-cannon-prestate",
+		Usage:   "Use this prestate to run MT-Cannon compatibility tests",
+		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "ADD_MT_CANNON_PRESTATE"),
+	}
+	addMTCannonPrestateURLFlag = &cli.StringFlag{
+		Name:    "add-mt-cannon-prestate-url",
+		Usage:   "Use this prestate URL to run MT-Cannon compatibility tests",
+		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "ADD_MT_CANNON_PRESTATE_URL"),
+	}
+)


### PR DESCRIPTION
This change allows vm-runner load Cannon prestates from disk while also loading MT-Cannon prestates from a URL.

The `--cannon-prestates-url` flag cannot be used to configure the MT-Cannon prestate server URL because it is mutually exclusive with `--cannon-prestate`. As such, a new flag is introduced, `--add-mt-cannon-prestates-url`, to indicate the server used to fetch MT-Cannon prestates.