### PR TITLE
proof-tools: Bump op-challenger version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -203,7 +203,7 @@ target "proofs-tools" {
   dockerfile = "./ops/docker/proofs-tools/Dockerfile"
   context = "."
   args = {
-    CHALLENGER_VERSION="v1.1.1"
+    CHALLENGER_VERSION="v1.1.2"
     KONA_VERSION="kona-client-v0.1.0-alpha.3"
     ASTERISC_VERSION="v1.0.2"
   }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -203,7 +203,7 @@ target "proofs-tools" {
   dockerfile = "./ops/docker/proofs-tools/Dockerfile"
   context = "."
   args = {
-    CHALLENGER_VERSION="v1.1.2"
+    CHALLENGER_VERSION="2fcbe4bab16a682bd51c2f0e6bd9be7f8d81c7a1"
     KONA_VERSION="kona-client-v0.1.0-alpha.3"
     ASTERISC_VERSION="v1.0.2"
   }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -203,7 +203,7 @@ target "proofs-tools" {
   dockerfile = "./ops/docker/proofs-tools/Dockerfile"
   context = "."
   args = {
-    CHALLENGER_VERSION="v1.1.0"
+    CHALLENGER_VERSION="v1.1.1"
     KONA_VERSION="kona-client-v0.1.0-alpha.3"
     ASTERISC_VERSION="v1.0.2"
   }


### PR DESCRIPTION
Depends on https://github.com/ethereum-optimism/optimism/pull/12016 and https://github.com/ethereum-optimism/optimism/pull/12018