### PR TITLE
vm-runner: Fix mt-cannon VM metric labels

### DIFF
--- a/op-challenger/runner/metrics.go
+++ b/op-challenger/runner/metrics.go
@@ -27,6 +27,12 @@ type Metrics struct {
 
 var _ Metricer = (*Metrics)(nil)
 
+type MTCannonMetrics struct {
+	*Metrics
+}
+
+var _ Metricer = (*MTCannonMetrics)(nil)
+
 // Metrics implementation must implement RegistryMetricer to allow the metrics server to work.
 var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
 
@@ -48,40 +54,44 @@ func NewMetrics() *Metrics {
 			Buckets: append(
 				[]float64{1.0, 10.0},
 				prometheus.ExponentialBuckets(30.0, 2.0, 14)...),
-		}, []string{"vm"}),
+		}, []string{"vm", "mt"}),
 		vmLastExecutionTime: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "vm_last_execution_time",
 			Help:      "Time (in seconds) taken for the last execution of the fault proof VM",
-		}, []string{"vm"}),
+		}, []string{"vm", "mt"}),
 		vmMemoryUsed: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: Namespace,
 			Name:      "vm_memory_used",
 			Help:      "Memory used (in bytes) to execute the fault proof VM",
 			// 100MiB increments from 0 to 1.5GiB
 			Buckets: prometheus.LinearBuckets(0, 1024*1024*100, 15),
-		}, []string{"vm"}),
+		}, []string{"vm", "mt"}),
 		vmLastMemoryUsed: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "vm_last_memory_used",
 			Help:      "Memory used (in bytes) for the last execution of the fault proof VM",
-		}, []string{"vm"}),
+		}, []string{"vm", "mt"}),
 		successTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: Namespace,
 			Name:      "success_total",
 			Help:      "Number of VM executions that successfully verified the output root",
-		}, []string{"type"}),
+		}, []string{"type", "mt"}),
 		failuresTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: Namespace,
 			Name:      "failures_total",
 			Help:      "Number of failures to execute a VM",
-		}, []string{"type"}),
+		}, []string{"type", "mt"}),
 		invalidTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: Namespace,
 			Name:      "invalid_total",
 			Help:      "Number of runs that determined the output root was invalid",
-		}, []string{"type"}),
+		}, []string{"type", "mt"}),
 	}
+}
+
+func NewMTCannonMetrics(m *Metrics) *MTCannonMetrics {
+	return &MTCannonMetrics{Metrics: m}
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -90,23 +100,46 @@ func (m *Metrics) Registry() *prometheus.Registry {
 
 func (m *Metrics) RecordVmExecutionTime(vmType string, dur time.Duration) {
 	val := dur.Seconds()
-	m.vmExecutionTime.WithLabelValues(vmType).Observe(val)
-	m.vmLastExecutionTime.WithLabelValues(vmType).Set(val)
+	m.vmExecutionTime.WithLabelValues(vmType, "false").Observe(val)
+	m.vmLastExecutionTime.WithLabelValues(vmType, "false").Set(val)
 }
 
 func (m *Metrics) RecordVmMemoryUsed(vmType string, memoryUsed uint64) {
-	m.vmMemoryUsed.WithLabelValues(vmType).Observe(float64(memoryUsed))
-	m.vmLastMemoryUsed.WithLabelValues(vmType).Set(float64(memoryUsed))
+	m.vmMemoryUsed.WithLabelValues(vmType, "false").Observe(float64(memoryUsed))
+	m.vmLastMemoryUsed.WithLabelValues(vmType, "false").Set(float64(memoryUsed))
 }
 
 func (m *Metrics) RecordSuccess(vmType string) {
-	m.successTotal.WithLabelValues(vmType).Inc()
+	m.successTotal.WithLabelValues(vmType, "false").Inc()
 }
 
 func (m *Metrics) RecordFailure(vmType string) {
-	m.failuresTotal.WithLabelValues(vmType).Inc()
+	m.failuresTotal.WithLabelValues(vmType, "false").Inc()
 }
 
 func (m *Metrics) RecordInvalid(vmType string) {
-	m.invalidTotal.WithLabelValues(vmType).Inc()
+	m.invalidTotal.WithLabelValues(vmType, "false").Inc()
+}
+
+func (m *MTCannonMetrics) RecordVmExecutionTime(vmType string, dur time.Duration) {
+	val := dur.Seconds()
+	m.vmExecutionTime.WithLabelValues(vmType, "true").Observe(val)
+	m.vmLastExecutionTime.WithLabelValues(vmType, "true").Set(val)
+}
+
+func (m *MTCannonMetrics) RecordVmMemoryUsed(vmType string, memoryUsed uint64) {
+	m.vmMemoryUsed.WithLabelValues(vmType, "true").Observe(float64(memoryUsed))
+	m.vmLastMemoryUsed.WithLabelValues(vmType, "true").Set(float64(memoryUsed))
+}
+
+func (m *MTCannonMetrics) RecordSuccess(vmType string) {
+	m.successTotal.WithLabelValues(vmType, "true").Inc()
+}
+
+func (m *MTCannonMetrics) RecordFailure(vmType string) {
+	m.failuresTotal.WithLabelValues(vmType, "true").Inc()
+}
+
+func (m *MTCannonMetrics) RecordInvalid(vmType string) {
+	m.invalidTotal.WithLabelValues(vmType, "true").Inc()
 }


### PR DESCRIPTION
Ideally, the appropriate VM type labels should flow from configuration. But with MT-Cannon, we need to disambiguate between vanilla cannon and multithreaded cannon executions. To do this, this patch adds a `mt` label to the existing metrics.

This workaround is temporary and will be cleaned up once MT-Cannon is the default VM.