### PR TITLE
docs: remove fault proof alpha from readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,3 @@ The directory layout is divided into the following sub-directories.
 
 - [`postmortems/`](./postmortems/): Timestamped post-mortem documents.
 - [`security-reviews`](./security-reviews/): Audit summaries and other security review documents.
-- [`fault-proof-alpha`](./fault-proof-alpha): Information on the alpha version of the fault proof system.


### PR DESCRIPTION
**Description**

I found out that the Fault Proof Alpha folder is not existing any more in the docs (  [11200](https://github.com/ethereum-optimism/optimism/pull/11200) ) , but in README.md still refers to it which creates confusion. Therefore it needs to be removed.


**Tests**

No test is needed as it is only a doc modification
