### PR TITLE
Batcher: support the txmgr.TxManager interface rather than SimpleTxManager implementation

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -80,7 +80,7 @@ type DriverSetup struct {
 	Metr             metrics.Metricer
 	RollupConfig     *rollup.Config
 	Config           BatcherConfig
-	Txmgr            *txmgr.SimpleTxManager
+	Txmgr            txmgr.TxManager
 	L1Client         L1Client
 	EndpointProvider dial.L2EndpointProvider
 	ChannelConfig    ChannelConfigProvider

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -53,7 +53,7 @@ type BatcherService struct {
 	Metrics          metrics.Metricer
 	L1Client         *ethclient.Client
 	EndpointProvider dial.L2EndpointProvider
-	TxManager        *txmgr.SimpleTxManager
+	TxManager        txmgr.TxManager
 	AltDA            *altda.DAClient
 
 	BatcherConfig

--- a/op-batcher/batcher/test_batch_submitter.go
+++ b/op-batcher/batcher/test_batch_submitter.go
@@ -37,8 +37,12 @@ func (l *TestBatchSubmitter) JamTxPool(ctx context.Context) error {
 		return err
 	}
 
+	simpleTxMgr, ok := l.Txmgr.(*txmgr.SimpleTxManager)
+	if !ok {
+		return errors.New("txmgr is not a SimpleTxManager")
+	}
 	l.ttm = &txmgr.TestTxManager{
-		SimpleTxManager: l.Txmgr,
+		SimpleTxManager: simpleTxMgr,
 	}
 	l.Log.Info("sending txpool blocking test tx")
 	if err := l.ttm.JamTxPool(ctx, *candidate); err != nil {

--- a/op-challenger/sender/sender_test.go
+++ b/op-challenger/sender/sender_test.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -180,4 +181,8 @@ func (s *stubTxMgr) API() rpc.API {
 }
 
 func (s *stubTxMgr) Close() {
+}
+
+func (s *stubTxMgr) SuggestGasPriceCaps(context.Context) (*big.Int, *big.Int, *big.Int, error) {
+	panic("unimplemented")
 }

--- a/op-e2e/actions/helpers/l2_proposer.go
+++ b/op-e2e/actions/helpers/l2_proposer.go
@@ -84,6 +84,10 @@ func (f fakeTxMgr) API() rpc.API {
 	panic("unimplemented")
 }
 
+func (f fakeTxMgr) SuggestGasPriceCaps(context.Context) (*big.Int, *big.Int, *big.Int, error) {
+	panic("unimplemented")
+}
+
 func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {
 	proposerConfig := proposer.ProposerConfig{
 		PollInterval:           time.Second,

--- a/op-service/txmgr/mocks/TxManager.go
+++ b/op-service/txmgr/mocks/TxManager.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 
 	common "github.com/ethereum/go-ethereum/common"
 
@@ -123,6 +124,50 @@ func (_m *TxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*ty
 // SendAsync provides a mock function with given fields: ctx, candidate, ch
 func (_m *TxManager) SendAsync(ctx context.Context, candidate txmgr.TxCandidate, ch chan txmgr.SendResponse) {
 	_m.Called(ctx, candidate, ch)
+}
+
+// SuggestGasPriceCaps provides a mock function with given fields: ctx
+func (_m *TxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *big.Int, *big.Int, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *big.Int
+	var r1 *big.Int
+	var r2 *big.Int
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*big.Int, *big.Int, *big.Int, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *big.Int); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) *big.Int); ok {
+		r1 = rf(ctx)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*big.Int)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context) *big.Int); ok {
+		r2 = rf(ctx)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*big.Int)
+		}
+	}
+
+	if rf, ok := ret.Get(3).(func(context.Context) error); ok {
+		r3 = rf(ctx)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 type mockConstructorTestingTNewTxManager interface {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -90,6 +90,10 @@ type TxManager interface {
 	// Close the underlying connection
 	Close()
 	IsClosed() bool
+
+	// SuggestGasPriceCaps suggests what the new tip, base fee, and blob base fee should be based on
+	// the current L1 conditions. `blobBaseFee` will be nil if 4844 is not yet active.
+	SuggestGasPriceCaps(ctx context.Context) (tipCap *big.Int, baseFee *big.Int, blobBaseFee *big.Int, err error)
 }
 
 // ETHBackend is the set of methods that the transaction manager uses to resubmit gas & determine
@@ -857,7 +861,7 @@ func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transa
 }
 
 // SuggestGasPriceCaps suggests what the new tip, base fee, and blob base fee should be based on
-// the current L1 conditions. blobfee will be nil if 4844 is not yet active.
+// the current L1 conditions. `blobBaseFee` will be nil if 4844 is not yet active.
 func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *big.Int, *big.Int, error) {
 	cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
 	defer cancel()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Replace the `*txmgr.SimpleTxManager` in the batcher driver setup with the `txmgr.TxManager` interface. This allows more flexibility in the TxManager implementation.

This was changed in #10941 for testing purposes; there's no particular reason the batcher needs the `SimpleTxManager` implementation.

**Tests**

Updated tests.

**Additional context**

I'm working on a separate batcher implementation for L3s that uses a different TxManager.
