### PR TITLE
Batcher: simplify ChannelOut initialization

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -35,7 +35,7 @@ type channel struct {
 }
 
 func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64) (*channel, error) {
-	cb, err := NewChannelBuilder(cfg, *rollupCfg, latestL1OriginBlockNum)
+	cb, err := NewChannelBuilder(cfg, rollupCfg, latestL1OriginBlockNum)
 	if err != nil {
 		return nil, fmt.Errorf("creating new channel: %w", err)
 	}

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -48,7 +48,7 @@ type frameData struct {
 // size approximation.
 type ChannelBuilder struct {
 	cfg       ChannelConfig
-	rollupCfg rollup.Config
+	rollupCfg *rollup.Config
 
 	// L1 block number timeout of combined
 	// - channel duration timeout,
@@ -85,22 +85,8 @@ type ChannelBuilder struct {
 // NewChannelBuilder creates a new channel builder or returns an error if the
 // channel out could not be created.
 // it acts as a factory for either a span or singular channel out
-func NewChannelBuilder(cfg ChannelConfig, rollupCfg rollup.Config, latestL1OriginBlockNum uint64) (*ChannelBuilder, error) {
-	c, err := cfg.CompressorConfig.NewCompressor()
-	if err != nil {
-		return nil, err
-	}
-
-	chainSpec := rollup.NewChainSpec(&rollupCfg)
-	var co derive.ChannelOut
-	if cfg.BatchType == derive.SpanBatchType {
-		co, err = derive.NewSpanChannelOut(
-			rollupCfg.Genesis.L2Time, rollupCfg.L2ChainID,
-			cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo,
-			chainSpec, derive.WithMaxBlocksPerSpanBatch(cfg.MaxBlocksPerSpanBatch))
-	} else {
-		co, err = derive.NewSingularChannelOut(c, chainSpec)
-	}
+func NewChannelBuilder(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64) (*ChannelBuilder, error) {
+	co, err := newChannelOut(cfg, rollupCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating channel out: %w", err)
 	}
@@ -114,6 +100,21 @@ func NewChannelBuilder(cfg ChannelConfig, rollupCfg rollup.Config, latestL1Origi
 	cb.updateDurationTimeout(latestL1OriginBlockNum)
 
 	return cb, nil
+}
+
+// newChannelOut creates a new channel out based on the given configuration.
+func newChannelOut(cfg ChannelConfig, rollupCfg *rollup.Config) (derive.ChannelOut, error) {
+	spec := rollup.NewChainSpec(rollupCfg)
+	if cfg.BatchType == derive.SpanBatchType {
+		return derive.NewSpanChannelOut(
+			cfg.CompressorConfig.TargetOutputSize, cfg.CompressorConfig.CompressionAlgo,
+			spec, derive.WithMaxBlocksPerSpanBatch(cfg.MaxBlocksPerSpanBatch))
+	}
+	comp, err := cfg.CompressorConfig.NewCompressor()
+	if err != nil {
+		return nil, err
+	}
+	return derive.NewSingularChannelOut(comp, spec)
 }
 
 func (c *ChannelBuilder) ID() derive.ChannelID {
@@ -177,7 +178,7 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 		return nil, c.FullErr()
 	}
 
-	batch, l1info, err := derive.BlockToSingularBatch(&c.rollupCfg, block)
+	batch, l1info, err := derive.BlockToSingularBatch(c.rollupCfg, block)
 	if err != nil {
 		return l1info, fmt.Errorf("converting block to batch: %w", err)
 	}

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -22,7 +22,7 @@ import (
 
 const latestL1BlockOrigin = 10
 
-var defaultTestRollupConfig = rollup.Config{
+var defaultTestRollupConfig = &rollup.Config{
 	Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}},
 	L2ChainID: big.NewInt(1234),
 }
@@ -63,7 +63,7 @@ func newMiniL2BlockWithNumberParentAndL1Information(numTx int, l2Number *big.Int
 		Number:     big.NewInt(l1Number),
 		Time:       blockTime,
 	}, nil, nil, trie.NewStackTrie(nil))
-	l1InfoTx, err := derive.L1InfoDeposit(&defaultTestRollupConfig, eth.SystemConfig{}, 0, eth.BlockToInfo(l1Block), blockTime)
+	l1InfoTx, err := derive.L1InfoDeposit(defaultTestRollupConfig, eth.SystemConfig{}, 0, eth.BlockToInfo(l1Block), blockTime)
 	if err != nil {
 		panic(err)
 	}
@@ -369,7 +369,7 @@ func ChannelBuilder_OutputWrongFramePanic(t *testing.T, batchType uint) {
 	// the type of batch does not matter here because we are using it to construct a broken frame
 	c, err := channelConfig.CompressorConfig.NewCompressor()
 	require.NoError(t, err)
-	co, err := derive.NewSingularChannelOut(c, rollup.NewChainSpec(&defaultTestRollupConfig))
+	co, err := derive.NewSingularChannelOut(c, rollup.NewChainSpec(defaultTestRollupConfig))
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	fn, err := co.OutputFrame(&buf, channelConfig.MaxFrameSize)
@@ -503,7 +503,7 @@ func ChannelBuilder_OutputFrames_SpanBatch(t *testing.T, algo derive.Compression
 func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	t.Parallel()
 	channelConfig := defaultTestChannelConfig()
-	chainSpec := rollup.NewChainSpec(&defaultTestRollupConfig)
+	chainSpec := rollup.NewChainSpec(defaultTestRollupConfig)
 	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
 	channelConfig.InitNoneCompressor()
 	channelConfig.BatchType = batchType
@@ -525,7 +525,7 @@ func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
 	t.Parallel()
 	channelConfig := defaultTestChannelConfig()
-	chainSpec := rollup.NewChainSpec(&defaultTestRollupConfig)
+	chainSpec := rollup.NewChainSpec(defaultTestRollupConfig)
 	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
 	channelConfig.InitNoneCompressor()
 	channelConfig.BatchType = batchType
@@ -541,13 +541,13 @@ func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
 	// Create a new channel builder with fjord fork
 	now := time.Now()
 	fjordTime := uint64(now.Add(-1 * time.Second).Unix())
-	rollupConfig := rollup.Config{
+	rollupConfig := &rollup.Config{
 		Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}},
 		L2ChainID: big.NewInt(1234),
 		FjordTime: &fjordTime,
 	}
 
-	chainSpec = rollup.NewChainSpec(&rollupConfig)
+	chainSpec = rollup.NewChainSpec(rollupConfig)
 	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(uint64(now.Unix())) * 2
 	channelConfig.InitNoneCompressor()
 	channelConfig.BatchType = batchType
@@ -887,7 +887,7 @@ func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 		if batchType == derive.SingularBatchType {
 			l += blockBatchRlpSize(t, block)
 		} else {
-			singularBatch, l1Info, err := derive.BlockToSingularBatch(&defaultTestRollupConfig, block)
+			singularBatch, l1Info, err := derive.BlockToSingularBatch(defaultTestRollupConfig, block)
 			require.NoError(err)
 			err = spanBatch.AppendSingularBatch(singularBatch, l1Info.SequenceNumber)
 			require.NoError(err)
@@ -942,7 +942,7 @@ func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 
 func blockBatchRlpSize(t *testing.T, b *types.Block) int {
 	t.Helper()
-	singularBatch, _, err := derive.BlockToSingularBatch(&defaultTestRollupConfig, b)
+	singularBatch, _, err := derive.BlockToSingularBatch(defaultTestRollupConfig, b)
 	batch := derive.NewBatchData(singularBatch)
 	require.NoError(t, err)
 	var buf bytes.Buffer

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -124,7 +124,7 @@ func ChannelManager_Clear(t *testing.T, batchType uint) {
 	// clearing confirmed transactions, and resetting the pendingChannels map
 	cfg.ChannelTimeout = 10
 	cfg.InitRatioCompressor(1, derive.Zlib)
-	m := NewChannelManager(log, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 
 	// Channel Manager state should be empty by default
 	require.Empty(m.blocks)
@@ -195,7 +195,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 	log := testlog.Logger(t, log.LevelError)
 	cfg := channelManagerTestConfig(120_000, batchType)
 	cfg.CompressorConfig.TargetOutputSize = 1 // full on first block
-	m := NewChannelManager(log, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
 	a := derivetest.RandomL2BlockWithChainId(rng, 4, defaultTestRollupConfig.L2ChainID)
@@ -234,7 +234,7 @@ func ChannelManagerCloseBeforeFirstUse(t *testing.T, batchType uint) {
 	log := testlog.Logger(t, log.LevelCrit)
 	m := NewChannelManager(log, metrics.NoopMetrics,
 		channelManagerTestConfig(10000, batchType),
-		&defaultTestRollupConfig,
+		defaultTestRollupConfig,
 	)
 	m.Clear(eth.BlockID{})
 
@@ -258,7 +258,7 @@ func ChannelManagerCloseNoPendingChannel(t *testing.T, batchType uint) {
 	cfg := channelManagerTestConfig(10000, batchType)
 	cfg.CompressorConfig.TargetOutputSize = 1 // full on first block
 	cfg.ChannelTimeout = 1000
-	m := NewChannelManager(log, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 	a := newMiniL2Block(0)
 	b := newMiniL2BlockWithNumberParent(0, big.NewInt(1), a.Hash())
@@ -294,7 +294,7 @@ func ChannelManagerClosePendingChannel(t *testing.T, batchType uint) {
 	log := testlog.Logger(t, log.LevelError)
 	cfg := channelManagerTestConfig(10_000, batchType)
 	cfg.ChannelTimeout = 1000
-	m := NewChannelManager(log, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
 	numTx := 20 // Adjust number of txs to make 2 frames
@@ -346,7 +346,7 @@ func TestChannelManager_Close_PartiallyPendingChannel(t *testing.T) {
 		TargetNumFrames: 100,
 	}
 	cfg.InitNoneCompressor()
-	m := NewChannelManager(log, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
 	numTx := 3 // Adjust number of txs to make 2 frames
@@ -398,7 +398,7 @@ func ChannelManagerCloseAllTxsFailed(t *testing.T, batchType uint) {
 	cfg := channelManagerTestConfig(100, batchType)
 	cfg.TargetNumFrames = 1000
 	cfg.InitNoneCompressor()
-	m := NewChannelManager(log, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
 	a := derivetest.RandomL2BlockWithChainId(rng, 1000, defaultTestRollupConfig.L2ChainID)
@@ -471,7 +471,7 @@ func TestChannelManager_ChannelCreation(t *testing.T) {
 	} {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			m := NewChannelManager(l, metrics.NoopMetrics, cfg, &defaultTestRollupConfig)
+			m := NewChannelManager(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 
 			m.l1OriginLastClosedChannel = test.safeL1Block
 			require.Nil(t, m.currentChannel)

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -49,7 +49,7 @@ func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 	return NewBatchSubmitter(DriverSetup{
 		Log:              testlog.Logger(t, log.LevelDebug),
 		Metr:             metrics.NoopMetrics,
-		RollupConfig:     &cfg,
+		RollupConfig:     cfg,
 		EndpointProvider: ep,
 	}), ep
 }

--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -202,7 +202,7 @@ func (s *L2Batcher) Buffer(t Testing) error {
 				chainSpec := rollup.NewChainSpec(s.rollupCfg)
 				// use span batch if we're forcing it or if we're at/beyond delta
 				if s.l2BatcherCfg.ForceSubmitSpanBatch || s.rollupCfg.IsDelta(block.Time()) {
-					ch, err = derive.NewSpanChannelOut(s.rollupCfg.Genesis.L2Time, s.rollupCfg.L2ChainID, target, derive.Zlib, chainSpec)
+					ch, err = derive.NewSpanChannelOut(target, derive.Zlib, chainSpec)
 					// use singular batches in all other cases
 				} else {
 					ch, err = derive.NewSingularChannelOut(c, chainSpec)

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func newSpanChannelOut(t actionsHelpers.StatefulTesting, e e2eutils.SetupData) derive.ChannelOut {
-	channelOut, err := derive.NewSpanChannelOut(e.RollupCfg.Genesis.L2Time, e.RollupCfg.L2ChainID, 128_000, derive.Zlib, rollup.NewChainSpec(e.RollupCfg))
+	channelOut, err := derive.NewSpanChannelOut(128_000, derive.Zlib, rollup.NewChainSpec(e.RollupCfg))
 	require.NoError(t, err)
 	return channelOut
 }

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -87,15 +87,16 @@ var (
 
 // channelOutByType returns a channel out of the given type as a helper for the benchmarks
 func channelOutByType(b *testing.B, batchType uint, cd compressorDetails) (derive.ChannelOut, error) {
-	chainID := big.NewInt(333)
-	rollupConfig := new(rollup.Config)
+	rollupConfig := &rollup.Config{
+		L2ChainID: big.NewInt(333),
+	}
 	if batchType == derive.SingularBatchType {
 		compressor, err := cd.Compressor()
 		require.NoError(b, err)
 		return derive.NewSingularChannelOut(compressor, rollup.NewChainSpec(rollupConfig))
 	}
 	if batchType == derive.SpanBatchType {
-		return derive.NewSpanChannelOut(0, chainID, cd.config.TargetOutputSize, cd.config.CompressionAlgo, rollup.NewChainSpec(rollupConfig))
+		return derive.NewSpanChannelOut(cd.config.TargetOutputSize, cd.config.CompressionAlgo, rollup.NewChainSpec(rollupConfig))
 	}
 	return nil, fmt.Errorf("unsupported batch type: %d", batchType)
 }

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -1,6 +1,8 @@
 package rollup
 
 import (
+	"math/big"
+
 	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
@@ -61,6 +63,16 @@ type ChainSpec struct {
 
 func NewChainSpec(config *Config) *ChainSpec {
 	return &ChainSpec{config: config}
+}
+
+// L2ChainID returns the chain ID of the L2 chain.
+func (s *ChainSpec) L2ChainID() *big.Int {
+	return s.config.L2ChainID
+}
+
+// L2GenesisTime returns the genesis time of the L2 chain.
+func (s *ChainSpec) L2GenesisTime() uint64 {
+	return s.config.Genesis.L2Time
 }
 
 // IsCanyon returns true if t >= canyon_time

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -61,7 +61,7 @@ var channelTypes = []struct {
 	{
 		Name: "Span",
 		ChannelOut: func(t *testing.T, rcfg *rollup.Config) ChannelOut {
-			cout, err := NewSpanChannelOut(0, big.NewInt(0), 128_000, Zlib, rollup.NewChainSpec(rcfg))
+			cout, err := NewSpanChannelOut(128_000, Zlib, rollup.NewChainSpec(rcfg))
 			require.NoError(t, err)
 			return cout
 		},
@@ -111,9 +111,8 @@ func TestOutputFrameNoEmptyLastFrame(t *testing.T) {
 			cout := tcase.ChannelOut(t, &rollupCfg)
 
 			rng := rand.New(rand.NewSource(0x543331))
-			chainID := big.NewInt(0)
 			txCount := 1
-			singularBatch := RandomSingularBatch(rng, txCount, chainID)
+			singularBatch := RandomSingularBatch(rng, txCount, rollupCfg.L2ChainID)
 
 			err := cout.AddSingularBatch(singularBatch, 0)
 			var written uint64
@@ -236,7 +235,7 @@ func SpanChannelAndBatches(t *testing.T, targetOutputSize uint64, numBatches int
 	chainID := rollupCfg.L2ChainID
 	txCount := 1
 	genesisTime := rollupCfg.Genesis.L2Time
-	cout, err := NewSpanChannelOut(genesisTime, chainID, targetOutputSize, algo, rollup.NewChainSpec(&rollupCfg), opts...)
+	cout, err := NewSpanChannelOut(targetOutputSize, algo, rollup.NewChainSpec(&rollupCfg), opts...)
 	require.NoError(t, err)
 	batches := make([]*SingularBatch, 0, numBatches)
 	// adding the first batch should not cause an error

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -65,11 +64,11 @@ func WithMaxBlocksPerSpanBatch(maxBlock int) SpanChannelOutOption {
 	}
 }
 
-func NewSpanChannelOut(genesisTimestamp uint64, chainID *big.Int, targetOutputSize uint64, compressionAlgo CompressionAlgo, chainSpec *rollup.ChainSpec, opts ...SpanChannelOutOption) (*SpanChannelOut, error) {
+func NewSpanChannelOut(targetOutputSize uint64, compressionAlgo CompressionAlgo, chainSpec *rollup.ChainSpec, opts ...SpanChannelOutOption) (*SpanChannelOut, error) {
 	c := &SpanChannelOut{
 		id:        ChannelID{},
 		frame:     0,
-		spanBatch: NewSpanBatch(genesisTimestamp, chainID),
+		spanBatch: NewSpanBatch(chainSpec.L2GenesisTime(), chainSpec.L2ChainID()),
 		rlp:       [2]*bytes.Buffer{{}, {}},
 		target:    targetOutputSize,
 		chainSpec: chainSpec,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Simplify the initialization of new `derive.ChannelOut` instances in the batcher. Includes:
 - Removing `genesisTimestamp` and `chainID` from `NewSpanChannelOut` (they are instead exposed from the `rollup.ChainSpec` struct
 - Move ChannelOut selection to a separate function for clarity
 - Changed the `rollup.Config` variable to a reference in `ChannelBuilder`, to avoid the unnecessary referencing/dereferencing.

**Tests**

There are no logic changes, apart from the `ChannelBuilder.rollupCfg`, which should be covered by existing tests.

**Additional context**

Paving the way for customization of the derive.ChannelOut, which will come in a follow up.