### PR TITLE
feat(op-conductor): implement startup handshake

### DIFF
--- a/op-conductor/client/mocks/SequencerControl.go
+++ b/op-conductor/client/mocks/SequencerControl.go
@@ -25,6 +25,62 @@ func (_m *SequencerControl) EXPECT() *SequencerControl_Expecter {
 	return &SequencerControl_Expecter{mock: &_m.Mock}
 }
 
+// ConductorEnabled provides a mock function with given fields: ctx
+func (_m *SequencerControl) ConductorEnabled(ctx context.Context) (bool, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConductorEnabled")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SequencerControl_ConductorEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConductorEnabled'
+type SequencerControl_ConductorEnabled_Call struct {
+	*mock.Call
+}
+
+// ConductorEnabled is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *SequencerControl_Expecter) ConductorEnabled(ctx interface{}) *SequencerControl_ConductorEnabled_Call {
+	return &SequencerControl_ConductorEnabled_Call{Call: _e.mock.On("ConductorEnabled", ctx)}
+}
+
+func (_c *SequencerControl_ConductorEnabled_Call) Run(run func(ctx context.Context)) *SequencerControl_ConductorEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *SequencerControl_ConductorEnabled_Call) Return(_a0 bool, _a1 error) *SequencerControl_ConductorEnabled_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SequencerControl_ConductorEnabled_Call) RunAndReturn(run func(context.Context) (bool, error)) *SequencerControl_ConductorEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LatestUnsafeBlock provides a mock function with given fields: ctx
 func (_m *SequencerControl) LatestUnsafeBlock(ctx context.Context) (eth.BlockInfo, error) {
 	ret := _m.Called(ctx)

--- a/op-conductor/client/sequencer.go
+++ b/op-conductor/client/sequencer.go
@@ -18,6 +18,7 @@ type SequencerControl interface {
 	SequencerActive(ctx context.Context) (bool, error)
 	LatestUnsafeBlock(ctx context.Context) (eth.BlockInfo, error)
 	PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	ConductorEnabled(ctx context.Context) (bool, error)
 }
 
 // NewSequencerControl creates a new SequencerControl instance.
@@ -58,4 +59,9 @@ func (s *sequencerController) SequencerActive(ctx context.Context) (bool, error)
 // PostUnsafePayload implements SequencerControl.
 func (s *sequencerController) PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
 	return s.node.PostUnsafePayload(ctx, payload)
+}
+
+// ConductorEnabled implements SequencerControl.
+func (s *sequencerController) ConductorEnabled(ctx context.Context) (bool, error) {
+	return s.node.ConductorEnabled(ctx)
 }

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -241,6 +241,10 @@ func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, envelope *eth
 	return nil
 }
 
+func (s *l2VerifierBackend) ConductorEnabled(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func (s *L2Verifier) DerivationMetricsTracer() *testutils.TestDerivationMetrics {
 	return s.derivationMetrics
 }

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -34,6 +34,7 @@ type driverClient interface {
 	SequencerActive(context.Context) (bool, error)
 	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
 	OverrideLeader(ctx context.Context) error
+	ConductorEnabled(ctx context.Context) (bool, error)
 }
 
 type SafeDBReader interface {
@@ -96,6 +97,13 @@ func (n *adminAPI) OverrideLeader(ctx context.Context) error {
 	recordDur := n.M.RecordRPCServerRequest("admin_overrideLeader")
 	defer recordDur()
 	return n.dr.OverrideLeader(ctx)
+}
+
+// ConductorEnabled returns true if the sequencer conductor is enabled.
+func (n *adminAPI) ConductorEnabled(ctx context.Context) (bool, error) {
+	recordDur := n.M.RecordRPCServerRequest("admin_conductorEnabled")
+	defer recordDur()
+	return n.dr.ConductorEnabled(ctx)
 }
 
 type nodeAPI struct {

--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -53,7 +53,7 @@ func (c *ConductorClient) initialize() error {
 	return nil
 }
 
-// Enabled returns true if the conductor is enabled.
+// Enabled returns true if the conductor is enabled, and since the conductor client is initialized, the conductor is always enabled.
 func (c *ConductorClient) Enabled(ctx context.Context) bool {
 	return true
 }

--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -40,7 +40,7 @@ func NewConductorClient(cfg *Config, log log.Logger, metrics *metrics.Metrics) c
 	}
 }
 
-// Initialize implements conductor.SequencerConductor.
+// Initialize initializes the conductor client, make sure the remote service is reachable.
 func (c *ConductorClient) Initialize(ctx context.Context) error {
 	apiClient, err := retry.Do(ctx, 60, retry.Fixed(5*time.Second), func() (*conductorRpc.APIClient, error) {
 		conductorRpcClient, err := dial.DialRPCClientWithTimeout(ctx, c.cfg.ConductorRpcTimeout, c.log, c.cfg.ConductorRpc)
@@ -58,6 +58,11 @@ func (c *ConductorClient) Initialize(ctx context.Context) error {
 
 	c.apiClient = apiClient
 	return nil
+}
+
+// Enabled returns true if conductor is enabled.
+func (c *ConductorClient) Enabled(ctx context.Context) bool {
+	return true
 }
 
 // Leader returns true if this node is the leader sequencer.

--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -45,11 +45,11 @@ func (c *ConductorClient) Initialize(ctx context.Context) error {
 	apiClient, err := retry.Do(ctx, 60, retry.Fixed(5*time.Second), func() (*conductorRpc.APIClient, error) {
 		conductorRpcClient, err := dial.DialRPCClientWithTimeout(ctx, c.cfg.ConductorRpcTimeout, c.log, c.cfg.ConductorRpc)
 		if err != nil {
-			log.Warn("failed to dial conductor RPC", "err", err)
+			c.log.Warn("failed to dial conductor RPC", "err", err)
 			return nil, fmt.Errorf("failed to dial conductor RPC: %w", err)
 		}
 
-		log.Info("conductor connected")
+		c.log.Info("conductor connected")
 		return conductorRpc.NewAPIClient(conductorRpcClient), nil
 	})
 	if err != nil {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -287,6 +287,10 @@ func (c *mockDriverClient) OverrideLeader(ctx context.Context) error {
 	return c.Mock.MethodCalled("OverrideLeader").Get(0).(error)
 }
 
+func (c *mockDriverClient) ConductorEnabled(ctx context.Context) (bool, error) {
+	return c.Mock.MethodCalled("ConductorEnabled").Get(0).(bool), nil
+}
+
 type mockSafeDBReader struct {
 	mock.Mock
 }

--- a/op-node/rollup/conductor/conductor.go
+++ b/op-node/rollup/conductor/conductor.go
@@ -11,6 +11,8 @@ import (
 type SequencerConductor interface {
 	// Initialize initializes the conductor client, make sure the remote service is reachable.
 	Initialize(ctx context.Context) error
+	// Enabled returns true if the conductor is enabled.
+	Enabled(ctx context.Context) bool
 	// Leader returns true if this node is the leader sequencer.
 	Leader(ctx context.Context) (bool, error)
 	// CommitUnsafePayload commits an unsafe payload to the conductor FSM.
@@ -29,6 +31,11 @@ var _ SequencerConductor = &NoOpConductor{}
 // Initialize returns nil if remote is reachable. NoOpConductor always returns nil.
 func (c *NoOpConductor) Initialize(ctx context.Context) error {
 	return nil
+}
+
+// Enabled implements SequencerConductor.
+func (c *NoOpConductor) Enabled(ctx context.Context) bool {
+	return false
 }
 
 // Leader returns true if this node is the leader sequencer. NoOpConductor always returns true.

--- a/op-node/rollup/conductor/conductor.go
+++ b/op-node/rollup/conductor/conductor.go
@@ -9,8 +9,6 @@ import (
 // SequencerConductor is an interface for the driver to communicate with the sequencer conductor.
 // It is used to determine if the current node is the active sequencer, and to commit unsafe payloads to the conductor log.
 type SequencerConductor interface {
-	// Initialize initializes the conductor client, make sure the remote service is reachable.
-	Initialize(ctx context.Context) error
 	// Enabled returns true if the conductor is enabled.
 	Enabled(ctx context.Context) bool
 	// Leader returns true if this node is the leader sequencer.
@@ -27,11 +25,6 @@ type SequencerConductor interface {
 type NoOpConductor struct{}
 
 var _ SequencerConductor = &NoOpConductor{}
-
-// Initialize returns nil if remote is reachable. NoOpConductor always returns nil.
-func (c *NoOpConductor) Initialize(ctx context.Context) error {
-	return nil
-}
 
 // Enabled implements SequencerConductor.
 func (c *NoOpConductor) Enabled(ctx context.Context) bool {

--- a/op-node/rollup/conductor/conductor.go
+++ b/op-node/rollup/conductor/conductor.go
@@ -9,6 +9,8 @@ import (
 // SequencerConductor is an interface for the driver to communicate with the sequencer conductor.
 // It is used to determine if the current node is the active sequencer, and to commit unsafe payloads to the conductor log.
 type SequencerConductor interface {
+	// Initialize initializes the conductor client, make sure the remote service is reachable.
+	Initialize(ctx context.Context) error
 	// Leader returns true if this node is the leader sequencer.
 	Leader(ctx context.Context) (bool, error)
 	// CommitUnsafePayload commits an unsafe payload to the conductor FSM.
@@ -23,6 +25,11 @@ type SequencerConductor interface {
 type NoOpConductor struct{}
 
 var _ SequencerConductor = &NoOpConductor{}
+
+// Initialize returns nil if remote is reachable. NoOpConductor always returns nil.
+func (c *NoOpConductor) Initialize(ctx context.Context) error {
+	return nil
+}
 
 // Leader returns true if this node is the leader sequencer. NoOpConductor always returns true.
 func (c *NoOpConductor) Leader(ctx context.Context) (bool, error) {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -483,6 +483,10 @@ func (s *Driver) OverrideLeader(ctx context.Context) error {
 	return s.sequencer.OverrideLeader(ctx)
 }
 
+func (s *Driver) ConductorEnabled(ctx context.Context) (bool, error) {
+	return s.sequencer.ConductorEnabled(ctx), nil
+}
+
 // SyncStatus blocks the driver event loop and captures the syncing status.
 func (s *Driver) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	return s.statusTracker.SyncStatus(), nil

--- a/op-node/rollup/sequencing/disabled.go
+++ b/op-node/rollup/sequencing/disabled.go
@@ -48,4 +48,8 @@ func (ds DisabledSequencer) OverrideLeader(ctx context.Context) error {
 	return ErrSequencerNotEnabled
 }
 
+func (ds DisabledSequencer) ConductorEnabled(ctx context.Context) bool {
+	return false
+}
+
 func (ds DisabledSequencer) Close() {}

--- a/op-node/rollup/sequencing/iface.go
+++ b/op-node/rollup/sequencing/iface.go
@@ -19,5 +19,6 @@ type SequencerIface interface {
 	Stop(ctx context.Context) (hash common.Hash, err error)
 	SetMaxSafeLag(ctx context.Context, v uint64) error
 	OverrideLeader(ctx context.Context) error
+	ConductorEnabled(ctx context.Context) bool
 	Close()
 }

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -617,9 +617,6 @@ func (d *Sequencer) Init(ctx context.Context, active bool) error {
 	d.emitter.Emit(engine.ForkchoiceRequestEvent{})
 
 	if active {
-		if err := d.conductor.Initialize(ctx); err != nil {
-			return fmt.Errorf("failed to initialize sequencer conductor: %w", err)
-		}
 		return d.forceStart()
 	} else {
 		if err := d.listener.SequencerStopped(); err != nil {

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -713,6 +713,10 @@ func (d *Sequencer) OverrideLeader(ctx context.Context) error {
 	return d.conductor.OverrideLeader(ctx)
 }
 
+func (d *Sequencer) ConductorEnabled(ctx context.Context) bool {
+	return d.conductor.Enabled(ctx)
+}
+
 func (d *Sequencer) Close() {
 	d.conductor.Close()
 	d.asyncGossip.Stop()

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -617,8 +617,9 @@ func (d *Sequencer) Init(ctx context.Context, active bool) error {
 	d.emitter.Emit(engine.ForkchoiceRequestEvent{})
 
 	if active {
-		// TODO(#11121): should the conductor be checked on startup?
-		// The conductor was previously not being checked in this case, but that may be a bug.
+		if err := d.conductor.Initialize(ctx); err != nil {
+			return fmt.Errorf("failed to initialize sequencer conductor: %w", err)
+		}
 		return d.forceStart()
 	} else {
 		if err := d.listener.SequencerStopped(); err != nil {

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -109,10 +109,6 @@ func (c *FakeConductor) Enabled(ctx context.Context) bool {
 	return true
 }
 
-func (c *FakeConductor) Initialize(ctx context.Context) error {
-	return nil
-}
-
 func (c *FakeConductor) Leader(ctx context.Context) (bool, error) {
 	return c.leader, nil
 }

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -105,6 +105,14 @@ type FakeConductor struct {
 
 var _ conductor.SequencerConductor = &FakeConductor{}
 
+func (c *FakeConductor) Enabled(ctx context.Context) bool {
+	return true
+}
+
+func (c *FakeConductor) Initialize(ctx context.Context) error {
+	return nil
+}
+
 func (c *FakeConductor) Leader(ctx context.Context) (bool, error) {
 	return c.leader, nil
 }

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -74,6 +74,12 @@ func (r *RollupClient) OverrideLeader(ctx context.Context) error {
 	return r.rpc.CallContext(ctx, nil, "admin_overrideLeader")
 }
 
+func (r *RollupClient) ConductorEnabled(ctx context.Context) (bool, error) {
+	var result bool
+	err := r.rpc.CallContext(ctx, &result, "admin_conductorEnabled")
+	return result, err
+}
+
 func (r *RollupClient) SetLogLevel(ctx context.Context, lvl slog.Level) error {
 	return r.rpc.CallContext(ctx, nil, "admin_setLogLevel", lvl.String())
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Implement startup handshake, this is used to make sure that both conductor and sequencer are configured properly in HA setup.

This PR prevents the situation that conductor is configured and running, but op-node did not enable conductor, this situation allows conductor to control (start / stop) sequencer, but not with sequencer committing unsafe payload into conductor, which is dangerous in faulty situations.

For op-conductor:
1. Waits for op-node to start
2. if cannot reach op-node, exit
3. check if conductor is enabled on op-node, if not, exit

**Tests**

1. Covered by existing e2e tests.
2. Tested in testnet

**Metadata**

- Unrelated, but resolves one todo: https://github.com/ethereum-optimism/optimism/issues/11121
