### PR TITLE
cannon, op-program: Avoid logging errors during normal shutdown.

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -248,7 +248,8 @@ func (p *ProcessPreimageOracle) Close() error {
 func (p *ProcessPreimageOracle) wait() {
 	err := p.cmd.Wait()
 	var waitErr error
-	if err, ok := err.(*exec.ExitError); !ok || !err.Success() {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && !exitErr.Success() {
 		waitErr = err
 	}
 	p.cancelIO(fmt.Errorf("%w: pre-image server has exited", waitErr))

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -217,6 +217,10 @@ func PreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, 
 		return err
 	case <-ctx.Done():
 		logger.Info("Shutting down")
+		if errors.Is(ctx.Err(), context.Canceled) {
+			// We were asked to shutdown by the context being cancelled so don't treat it as an error condition.
+			return nil
+		}
 		return ctx.Err()
 	}
 }


### PR DESCRIPTION
**Description**

Previously op-program host and cannon both logged an error message that the pre-image server couldn't be stopped after it stopped successfully. This keeps the logs clean to avoid confusion.
