### PR TITLE
op-challenger: Fix run-trace to only run mt-cannon in parallel with cannon traces

### DIFF
--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -154,7 +154,7 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, traceType types.TraceType
 		recordError(err, traceType.String(), r.m, r.log)
 	}()
 
-	if r.addMTCannonPrestate != (common.Hash{}) && r.addMTCannonPrestateURL != nil {
+	if traceType == types.TraceTypeCannon && r.addMTCannonPrestate != (common.Hash{}) && r.addMTCannonPrestateURL != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
**Description**

Fix run-trace to only run mt-cannon in parallel with cannon traces

Previously it was also running it in parallel with kona-asterisc traces, resulting in errors because there were two mt-cannon traces sharing a preimages directory.