### PR TITLE
codeowners: Set proofs team as owners of faultproofs e2e tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,12 +19,13 @@
 
 /op-conductor   @ethereum-optimism/op-conductor @ethereum-optimism/go-reviewers
 
-/cannon         @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
-/op-challenger  @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
-/op-dispute-mon @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
-/op-preimage    @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
-/op-program     @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/cannon                @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-challenger         @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-dispute-mon        @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-preimage           @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-program            @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
 /op-e2e/actions/proofs @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
+/op-e2e/faultproofs    @ethereum-optimism/proofs @ethereum-optimism/go-reviewers
 
 # Ops
 /.circleci       @ethereum-optimism/monorepo-ops-reviewers


### PR DESCRIPTION
**Description**

Add `/op-e2e/faultproofs` to the list of directories that default to proofs team review.