### PR TITLE
contract-test: delete outdated structure explanation

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/README.md
+++ b/packages/contracts-bedrock/test/kontrol/README.md
@@ -37,7 +37,6 @@ The directory is structured as follows
 ├── <a href="./pausability-lemmas.md">pausability-lemmas.md</a>: File containing the necessary lemmas for this project
 ├── <a href="./deployment">deployment</a>: Custom deploy sequence for Kontrol proofs and tests for its <a href="https://github.com/runtimeverification/kontrol/pull/271">fast summarization</a>
 │   ├── <a href="./deployment/KontrolDeployment.sol">KontrolDeployment.sol</a>: Deployment sequence for Kontrol proofs
- deployment
 ├── <a href="./proofs">proofs</a>: Where the proofs (tests) themselves live
 │   ├── *.k.sol</a>: Symbolic property tests for contracts
 │   ├── <a href="./proofs/interfaces">interfaces</a>: Interface files for src contracts, to avoid unnecessary compilation of contracts

--- a/packages/contracts-bedrock/test/kontrol/README.md
+++ b/packages/contracts-bedrock/test/kontrol/README.md
@@ -37,8 +37,7 @@ The directory is structured as follows
 ├── <a href="./pausability-lemmas.md">pausability-lemmas.md</a>: File containing the necessary lemmas for this project
 ├── <a href="./deployment">deployment</a>: Custom deploy sequence for Kontrol proofs and tests for its <a href="https://github.com/runtimeverification/kontrol/pull/271">fast summarization</a>
 │   ├── <a href="./deployment/KontrolDeployment.sol">KontrolDeployment.sol</a>: Deployment sequence for Kontrol proofs
-│   ├── <a href="./deployment/DeploymentSummary.t.sol">DeploymentSummary.t.sol</a>: Tests for the summarization of classic deployment
-│   └── <a href="./deployment/DeploymentSummaryFaultProofs.t.sol">DeploymentSummaryFaultProofs.t.sol</a>: Tests for the summarization of fault proofs deployment
+ deployment
 ├── <a href="./proofs">proofs</a>: Where the proofs (tests) themselves live
 │   ├── *.k.sol</a>: Symbolic property tests for contracts
 │   ├── <a href="./proofs/interfaces">interfaces</a>: Interface files for src contracts, to avoid unnecessary compilation of contracts


### PR DESCRIPTION
The file structure has been changed in https://github.com/ethereum-optimism/optimism/pull/11725
And all these two files was removed.