### PR TITLE
fix(ci): do not check closed issues in main job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,6 +714,10 @@ jobs:
           working_directory: packages/contracts-bedrock
 
   todo-issues:
+    parameters:
+      check_closed:
+        type: boolean
+        default: true
     machine:
       image: <<pipeline.parameters.base_image>>
     steps:
@@ -723,7 +727,7 @@ jobs:
           command: sudo apt-get install -y ripgrep
       - run:
           name: Check TODO issues
-          command: ./ops/scripts/todo-checker.sh --verbose
+          command: ./ops/scripts/todo-checker.sh --verbose <<#parameters.check_closed>> --check-closed <</parameters.check_closed>>
       - notify-failures-on-develop
 
   fuzz-golang:
@@ -1709,6 +1713,7 @@ workflows:
       - cannon-build-test-vectors
       - todo-issues:
           name: todo-issues-check
+          check_closed: false
       - shellcheck/check:
           name: shell-check
           # We don't need the `exclude` key as the orb detects the `.shellcheckrc`


### PR DESCRIPTION
Updates the todo-checker to not check for closed issues in the main job. Will still check for closed issues in the scheduled job. Prevents CI from randomly failing when stuff gets closed.