### PR TITLE
Remove AddSingularBatch from ChannelOut interface (prefer AddBlock)

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -178,12 +178,8 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 		return nil, c.FullErr()
 	}
 
-	batch, l1info, err := derive.BlockToSingularBatch(c.rollupCfg, block)
-	if err != nil {
-		return l1info, fmt.Errorf("converting block to batch: %w", err)
-	}
-
-	if err = c.co.AddSingularBatch(batch, l1info.SequenceNumber); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.ErrCompressorFull) {
+	l1info, err := c.co.AddBlock(c.rollupCfg, block)
+	if errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.ErrCompressorFull) {
 		c.setFullErr(err)
 		return l1info, c.FullErr()
 	} else if err != nil {
@@ -191,7 +187,7 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 	}
 
 	c.blocks = append(c.blocks, block)
-	c.updateSwTimeout(batch)
+	c.updateSwTimeout(l1info.Number)
 
 	if l1info.Number > c.latestL1Origin.Number {
 		c.latestL1Origin = eth.BlockID{
@@ -252,8 +248,8 @@ func (c *ChannelBuilder) updateDurationTimeout(l1BlockNum uint64) {
 // derived from the batch's origin L1 block. The timeout is only moved forward
 // if the derived sequencer window timeout is earlier than the currently set
 // timeout.
-func (c *ChannelBuilder) updateSwTimeout(batch *derive.SingularBatch) {
-	timeout := uint64(batch.EpochNum) + c.cfg.SeqWindowSize - c.cfg.SubSafetyMargin
+func (c *ChannelBuilder) updateSwTimeout(l1InfoNumber uint64) {
+	timeout := l1InfoNumber + c.cfg.SeqWindowSize - c.cfg.SubSafetyMargin
 	c.updateTimeout(timeout, ErrSeqWindowClose)
 }
 

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -250,7 +250,7 @@ func FuzzSeqWindowClose(f *testing.F) {
 
 		// Check the timeout
 		cb.timeout = timeout
-		cb.updateSwTimeout(&derive.SingularBatch{EpochNum: rollup.Epoch(epochNum)})
+		cb.updateSwTimeout(epochNum)
 		calculatedTimeout := epochNum + seqWindowSize - subSafetyMargin
 		if timeout > calculatedTimeout && calculatedTimeout != 0 {
 			cb.CheckTimeout(calculatedTimeout)
@@ -278,7 +278,7 @@ func FuzzSeqWindowZeroTimeoutClose(f *testing.F) {
 
 		// Check the timeout
 		cb.timeout = 0
-		cb.updateSwTimeout(&derive.SingularBatch{EpochNum: rollup.Epoch(epochNum)})
+		cb.updateSwTimeout(epochNum)
 		calculatedTimeout := epochNum + seqWindowSize - subSafetyMargin
 		cb.CheckTimeout(calculatedTimeout)
 		if cb.timeout != 0 {

--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -229,7 +229,7 @@ func (s *L2Batcher) Buffer(t Testing, opts ...BlockModifier) error {
 		require.NoError(t, err, "failed to create channel")
 		s.L2ChannelOut = ch
 	}
-	if err := s.L2ChannelOut.AddBlock(s.rollupCfg, block); err != nil {
+	if _, err := s.L2ChannelOut.AddBlock(s.rollupCfg, block); err != nil {
 		return err
 	}
 	ref, err := s.engCl.L2BlockRefByHash(t.Ctx(), block.Hash())

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -253,7 +253,7 @@ func TestBackupUnsafe(gt *testing.T) {
 			block = block.WithBody(types.Body{Transactions: []*types.Transaction{block.Transactions()[0], invalidTx}})
 		}
 		// Add A1, B2, B3, B4, B5 into the channel
-		err = channelOut.AddBlock(sd.RollupCfg, block)
+		_, err = channelOut.AddBlock(sd.RollupCfg, block)
 		require.NoError(t, err)
 	}
 
@@ -414,7 +414,7 @@ func TestBackupUnsafeReorgForkChoiceInputError(gt *testing.T) {
 			block = block.WithBody(types.Body{Transactions: []*types.Transaction{block.Transactions()[0], invalidTx}})
 		}
 		// Add A1, B2, B3, B4, B5 into the channel
-		err = channelOut.AddBlock(sd.RollupCfg, block)
+		_, err = channelOut.AddBlock(sd.RollupCfg, block)
 		require.NoError(t, err)
 	}
 
@@ -547,7 +547,7 @@ func TestBackupUnsafeReorgForkChoiceNotInputError(gt *testing.T) {
 			block = block.WithBody(types.Body{Transactions: []*types.Transaction{block.Transactions()[0], invalidTx}})
 		}
 		// Add A1, B2, B3, B4, B5 into the channel
-		err = channelOut.AddBlock(sd.RollupCfg, block)
+		_, err = channelOut.AddBlock(sd.RollupCfg, block)
 		require.NoError(t, err)
 	}
 
@@ -924,7 +924,7 @@ func TestInvalidPayloadInSpanBatch(gt *testing.T) {
 			block = block.WithBody(types.Body{Transactions: []*types.Transaction{block.Transactions()[0], invalidTx}})
 		}
 		// Add A1 ~ A12 into the channel
-		err = channelOut.AddBlock(sd.RollupCfg, block)
+		_, err = channelOut.AddBlock(sd.RollupCfg, block)
 		require.NoError(t, err)
 	}
 
@@ -973,7 +973,7 @@ func TestInvalidPayloadInSpanBatch(gt *testing.T) {
 			block = block.WithBody(types.Body{Transactions: []*types.Transaction{block.Transactions()[0], tx}})
 		}
 		// Add B1, A2 ~ A12 into the channel
-		err = channelOut.AddBlock(sd.RollupCfg, block)
+		_, err = channelOut.AddBlock(sd.RollupCfg, block)
 		require.NoError(t, err)
 	}
 	// Submit span batch(B1, A2, ... A12)

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,6 +104,40 @@ func channelOutByType(b *testing.B, batchType uint, cd compressorDetails) (deriv
 	return nil, fmt.Errorf("unsupported batch type: %d", batchType)
 }
 
+func randomBlock(cfg *rollup.Config, rng *rand.Rand, txCount int, timestamp uint64) (*types.Block, error) {
+	batch := derive.RandomSingularBatch(rng, txCount, cfg.L2ChainID)
+	batch.Timestamp = timestamp
+	return singularBatchToBlock(cfg, batch)
+}
+
+// singularBatchToBlock converts a singular batch to a block for use in the benchmarks. This function
+// should only be used for testing purposes, as the batch input doesn't contain the necessary information
+// to build the full block (only non-deposit transactions and a subset of header fields are populated).
+func singularBatchToBlock(rollupCfg *rollup.Config, batch *derive.SingularBatch) (*types.Block, error) {
+	l1InfoTx, err := derive.L1InfoDeposit(rollupCfg, eth.SystemConfig{}, 0, &testutils.MockBlockInfo{
+		InfoNum:  uint64(batch.EpochNum),
+		InfoHash: batch.EpochHash,
+	}, batch.Timestamp)
+	if err != nil {
+		return nil, fmt.Errorf("could not build L1 Info transaction: %w", err)
+	}
+	txs := []*types.Transaction{types.NewTx(l1InfoTx)}
+	for i, opaqueTx := range batch.Transactions {
+		var tx types.Transaction
+		err = tx.UnmarshalBinary(opaqueTx)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode tx %d: %w", i, err)
+		}
+		txs = append(txs, &tx)
+	}
+	return types.NewBlockWithHeader(&types.Header{
+		ParentHash: batch.ParentHash,
+		Time:       batch.Timestamp,
+	}).WithBody(types.Body{
+		Transactions: txs,
+	}), nil
+}
+
 // a test case for the benchmark controls the number of batches and transactions per batch,
 // as well as the batch type and compressor used
 type BatchingBenchmarkTC struct {
@@ -155,16 +192,17 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 	}
 
 	for _, tc := range tests {
-		chainID := big.NewInt(333)
+		cfg := &rollup.Config{L2ChainID: big.NewInt(333)}
 		rng := rand.New(rand.NewSource(0x543331))
 		// pre-generate batches to keep the benchmark from including the random generation
-		batches := make([]*derive.SingularBatch, tc.BatchCount)
+		blocks := make([]*types.Block, tc.BatchCount)
 		t := time.Now()
 		for i := 0; i < tc.BatchCount; i++ {
-			batches[i] = derive.RandomSingularBatch(rng, tc.txPerBatch, chainID)
 			// set the timestamp to increase with each batch
 			// to leverage optimizations in the Batch Linked List
-			batches[i].Timestamp = uint64(t.Add(time.Duration(i) * time.Second).Unix())
+			var err error
+			blocks[i], err = randomBlock(cfg, rng, tc.txPerBatch, uint64(t.Add(time.Duration(i)*time.Second).Unix()))
+			require.NoError(b, err)
 		}
 		b.Run(tc.String(), func(b *testing.B) {
 			// reset the compressor used in the test case
@@ -174,13 +212,13 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 				cout, _ := channelOutByType(b, tc.BatchType, tc.cd)
 				// add all but the final batch to the channel out
 				for i := 0; i < tc.BatchCount-1; i++ {
-					err := cout.AddSingularBatch(batches[i], 0)
+					_, err := cout.AddBlock(cfg, blocks[i])
 					require.NoError(b, err)
 				}
 				// measure the time to add the final batch
 				b.StartTimer()
 				// add the final batch to the channel out
-				err := cout.AddSingularBatch(batches[tc.BatchCount-1], 0)
+				_, err := cout.AddBlock(cfg, blocks[tc.BatchCount-1])
 				require.NoError(b, err)
 			}
 		})
@@ -193,7 +231,7 @@ func BenchmarkFinalBatchChannelOut(b *testing.B) {
 // Hint: use -benchtime=1x to run the benchmarks for a single iteration
 // it is not currently designed to use b.N
 func BenchmarkIncremental(b *testing.B) {
-	chainID := big.NewInt(333)
+	cfg := &rollup.Config{L2ChainID: big.NewInt(333)}
 	rng := rand.New(rand.NewSource(0x543331))
 	// use the real compressor for this benchmark
 	// use batchCount as the number of batches to add in each benchmark iteration
@@ -226,17 +264,20 @@ func BenchmarkIncremental(b *testing.B) {
 				b.StopTimer()
 				// prepare the batches
 				t := time.Now()
-				batches := make([]*derive.SingularBatch, tc.BatchCount)
+				blocks := make([]*types.Block, tc.BatchCount)
 				for i := 0; i < tc.BatchCount; i++ {
-					t := t.Add(time.Second)
-					batches[i] = derive.RandomSingularBatch(rng, tc.txPerBatch, chainID)
 					// set the timestamp to increase with each batch
 					// to leverage optimizations in the Batch Linked List
-					batches[i].Timestamp = uint64(t.Unix())
+					t = t.Add(time.Second)
+					blocks[i], err = randomBlock(cfg, rng, tc.txPerBatch, uint64(t.Unix()))
+					if err != nil {
+						done = true
+						return
+					}
 				}
 				b.StartTimer()
 				for i := 0; i < tc.BatchCount; i++ {
-					err := cout.AddSingularBatch(batches[i], 0)
+					_, err := cout.AddBlock(cfg, blocks[i])
 					if err != nil {
 						done = true
 						return
@@ -280,16 +321,17 @@ func BenchmarkAllBatchesChannelOut(b *testing.B) {
 	}
 
 	for _, tc := range tests {
-		chainID := big.NewInt(333)
+		cfg := &rollup.Config{L2ChainID: big.NewInt(333)}
 		rng := rand.New(rand.NewSource(0x543331))
 		// pre-generate batches to keep the benchmark from including the random generation
-		batches := make([]*derive.SingularBatch, tc.BatchCount)
+		blocks := make([]*types.Block, tc.BatchCount)
 		t := time.Now()
 		for i := 0; i < tc.BatchCount; i++ {
-			batches[i] = derive.RandomSingularBatch(rng, tc.txPerBatch, chainID)
 			// set the timestamp to increase with each batch
 			// to leverage optimizations in the Batch Linked List
-			batches[i].Timestamp = uint64(t.Add(time.Duration(i) * time.Second).Unix())
+			var err error
+			blocks[i], err = randomBlock(cfg, rng, tc.txPerBatch, uint64(t.Add(time.Duration(i)*time.Second).Unix()))
+			require.NoError(b, err)
 		}
 		b.Run(tc.String(), func(b *testing.B) {
 			// reset the compressor used in the test case
@@ -300,7 +342,7 @@ func BenchmarkAllBatchesChannelOut(b *testing.B) {
 				b.StartTimer()
 				// add all batches to the channel out
 				for i := 0; i < tc.BatchCount; i++ {
-					err := cout.AddSingularBatch(batches[i], 0)
+					_, err := cout.AddBlock(cfg, blocks[i])
 					require.NoError(b, err)
 				}
 			}

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -45,14 +45,19 @@ func (s *nonCompressor) FullErr() error {
 	return nil
 }
 
+type channelOut interface {
+	ChannelOut
+	addSingularBatch(batch *SingularBatch, seqNum uint64) error
+}
+
 // channelTypes allows tests to run against different channel types
 var channelTypes = []struct {
-	ChannelOut func(t *testing.T, rcfg *rollup.Config) ChannelOut
+	ChannelOut func(t *testing.T, rcfg *rollup.Config) channelOut
 	Name       string
 }{
 	{
 		Name: "Singular",
-		ChannelOut: func(t *testing.T, rcfg *rollup.Config) ChannelOut {
+		ChannelOut: func(t *testing.T, rcfg *rollup.Config) channelOut {
 			cout, err := NewSingularChannelOut(&nonCompressor{}, rollup.NewChainSpec(rcfg))
 			require.NoError(t, err)
 			return cout
@@ -60,7 +65,7 @@ var channelTypes = []struct {
 	},
 	{
 		Name: "Span",
-		ChannelOut: func(t *testing.T, rcfg *rollup.Config) ChannelOut {
+		ChannelOut: func(t *testing.T, rcfg *rollup.Config) channelOut {
 			cout, err := NewSpanChannelOut(128_000, Zlib, rollup.NewChainSpec(rcfg))
 			require.NoError(t, err)
 			return cout
@@ -80,9 +85,9 @@ func TestChannelOutAddBlock(t *testing.T) {
 					},
 				},
 			)
-			err := cout.AddBlock(&rollupCfg, block)
+			_, err := cout.AddBlock(&rollupCfg, block)
 			require.Error(t, err)
-			require.Equal(t, ErrNotDepositTx, err)
+			require.ErrorIs(t, err, ErrNotDepositTx)
 		})
 	}
 }
@@ -114,7 +119,7 @@ func TestOutputFrameNoEmptyLastFrame(t *testing.T) {
 			txCount := 1
 			singularBatch := RandomSingularBatch(rng, txCount, rollupCfg.L2ChainID)
 
-			err := cout.AddSingularBatch(singularBatch, 0)
+			err := cout.addSingularBatch(singularBatch, 0)
 			var written uint64
 			require.NoError(t, err)
 
@@ -274,7 +279,7 @@ func funcName(fn any) string {
 func SpanChannelOutCompressionOnlyOneBatch(t *testing.T, algo CompressionAlgo) {
 	cout, singularBatches := SpanChannelAndBatches(t, 300, 2, algo)
 
-	err := cout.AddSingularBatch(singularBatches[0], 0)
+	err := cout.addSingularBatch(singularBatches[0], 0)
 	// confirm compression was not skipped
 	require.Greater(t, cout.compressor.Len(), 0)
 	require.NoError(t, err)
@@ -283,7 +288,7 @@ func SpanChannelOutCompressionOnlyOneBatch(t *testing.T, algo CompressionAlgo) {
 	require.ErrorIs(t, cout.FullErr(), ErrCompressorFull)
 
 	// confirm adding another batch would cause the same full error
-	err = cout.AddSingularBatch(singularBatches[1], 0)
+	err = cout.addSingularBatch(singularBatches[1], 0)
 	require.ErrorIs(t, err, ErrCompressorFull)
 }
 
@@ -292,7 +297,7 @@ func SpanChannelOutCompressionUndo(t *testing.T, algo CompressionAlgo) {
 	// target is larger than one batch, but smaller than two batches
 	cout, singularBatches := SpanChannelAndBatches(t, 1100, 2, algo)
 
-	err := cout.AddSingularBatch(singularBatches[0], 0)
+	err := cout.addSingularBatch(singularBatches[0], 0)
 	require.NoError(t, err)
 	// confirm that the first compression was skipped
 	if algo == Zlib {
@@ -303,7 +308,7 @@ func SpanChannelOutCompressionUndo(t *testing.T, algo CompressionAlgo) {
 	// record the RLP length to confirm it doesn't change when adding a rejected batch
 	rlp1 := cout.activeRLP().Len()
 
-	err = cout.AddSingularBatch(singularBatches[1], 0)
+	err = cout.addSingularBatch(singularBatches[1], 0)
 	require.ErrorIs(t, err, ErrCompressorFull)
 	// confirm that the second compression was not skipped
 	require.Greater(t, cout.compressor.Len(), 0)
@@ -318,7 +323,7 @@ func SpanChannelOutClose(t *testing.T, algo CompressionAlgo) {
 	target := uint64(1100)
 	cout, singularBatches := SpanChannelAndBatches(t, target, 1, algo)
 
-	err := cout.AddSingularBatch(singularBatches[0], 0)
+	err := cout.addSingularBatch(singularBatches[0], 0)
 	require.NoError(t, err)
 	// confirm no compression has happened yet
 
@@ -413,7 +418,7 @@ func testSpanChannelOut_MaxBlocksPerSpanBatch(t *testing.T, tt maxBlocksTest) {
 	for i, b := range bs {
 		b.EpochNum = rollup.Epoch(l1Origin.Number)
 		b.EpochHash = l1Origin.Hash
-		err := cout.AddSingularBatch(b, uint64(i))
+		err := cout.addSingularBatch(b, uint64(i))
 		if i != tt.numBatches-1 || tt.exactFull {
 			require.NoErrorf(t, err, "iteration %d", i)
 		} else {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Removes the `AddSingularBatch` function from the `ChannelOut` interface. This was duplicative of the `AddBlock` method.

There wasn't a case where `AddSingularBatch` was called without calling `BlockToSingularBatch` beforehand (apart from in tests), so this PR is a simplification of the exposed interface. It also lets future ChannelOut implementations access the `Block` if needed, as only exposing `AddBlock` forces callers to always pass a block.

**Tests**

Existing tests have been updated to the newly exposed interface. There were some tests that were specifically testing `AddSingularBatch`, so a new test-only interface has been added to expose this as an internal method `addSingularBatch`. Also one of the benchmark tests was updated to call `AddBlock` rather than `AddSingularBatch` which required a small helper function to convert from a `SinglularBatch` to a `Block`.

**Additional context**

I'd like to access the block (to check for withdrawal logs in the Bloom) in a `ChannelOut` for L3 batch submission. Exposing the alternate `AddSingularBatch` was preventing this.