### PR TITLE
Makefile: Fix executable command detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,10 +173,10 @@ nuke: clean devnet-clean ## Completely clean the project directory
 
 ## Prepares for running a local devnet
 pre-devnet: submodules $(DEVNET_CANNON_PRESTATE_FILES)
-	@if ! [ -x "$(command -v geth)" ]; then \
+	@if ! [ -x "$$(command -v geth)" ]; then \
 		make install-geth; \
 	fi
-	@if ! [ -x "$(command -v eth2-testnet-genesis)" ]; then \
+	@if ! [ -x "$$(command -v eth2-testnet-genesis)" ]; then \
 		make install-eth2-testnet-genesis; \
 	fi
 .PHONY: pre-devnet


### PR DESCRIPTION
`$(command -v geth)` is valid shell syntax, but it gets processed by make first, so that this never gets correctly executed by the shell. As a result, `make install-geth` and `make install-eth2-testnet-genesis` are always executed and not, as intended, just when the commands are not present.

The fix is easy: escape the dollar by duplicating it, so that make won't do anything and the correct command reaches the shell.
