### PR TITLE
Use DA /put path from spec

### DIFF
--- a/op-alt-da/daclient.go
+++ b/op-alt-da/daclient.go
@@ -119,7 +119,7 @@ func (c *DAClient) setInput(ctx context.Context, img []byte) (CommitmentData, er
 	}
 
 	body := bytes.NewReader(img)
-	url := fmt.Sprintf("%s/put/", c.url)
+	url := fmt.Sprintf("%s/put", c.url)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)

--- a/op-alt-da/damock.go
+++ b/op-alt-da/damock.go
@@ -141,7 +141,7 @@ func (s *FakeDAServer) Start() error {
 	// Override the HandleGet/Put method registrations
 	mux := http.NewServeMux()
 	mux.HandleFunc("/get/", s.HandleGet)
-	mux.HandleFunc("/put/", s.HandlePut)
+	mux.HandleFunc("/put", s.HandlePut)
 	s.httpServer.Handler = mux
 	return nil
 }

--- a/op-alt-da/daserver.go
+++ b/op-alt-da/daserver.go
@@ -54,6 +54,7 @@ func (d *DAServer) Start() error {
 
 	mux.HandleFunc("/get/", d.HandleGet)
 	mux.HandleFunc("/put/", d.HandlePut)
+	mux.HandleFunc("/put", d.HandlePut)
 
 	d.httpServer.Handler = mux
 
@@ -128,7 +129,7 @@ func (d *DAServer) HandlePut(w http.ResponseWriter, r *http.Request) {
 	d.log.Info("PUT", "url", r.URL)
 
 	route := path.Dir(r.URL.Path)
-	if route != "/put" {
+	if route != "/put" && r.URL.Path != "/put" {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
**Description**

The [OP alt-DA spec](https://specs.optimism.io/experimental/alt-da.html#da-server) mandates using `/put` and not `/put/`, so that is what we should do. To ease the migration, the DA server supports both paths for now.

**Warning**: The changed path in the DA client will break DA solutions that only accept `/put/` at the moment. It is recommended that DA solutions support both paths for a while, so that updating OP-stack can happen independently of the exact DA implementation version.

If we want to give other DAs a head start on supporting both paths, we can only merge the first commit now and delay the second commit (but should communicate the upcoming change).

**Tests**

The existing DA tests should cover this just as well as the previous version. I can modify the tests to run against both paths if desired, but I'm not sure if that isn't too much considering that having both paths active is a temporary measure.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/11499.