### PR TITLE
MTCannon: Add add/addi/addu/addiu opcodes tests

### DIFF
--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -115,7 +115,7 @@ func TestEVM(t *testing.T) {
 	}
 }
 
-func TestEVMSingleStep(t *testing.T) {
+func TestEVMSingleStep_Jump(t *testing.T) {
 	var tracer *tracing.Hooks
 
 	versions := GetMipsVersionTestCases(t)
@@ -126,7 +126,11 @@ func TestEVMSingleStep(t *testing.T) {
 		insn         uint32
 		expectNextPC uint32
 		expectLink   bool
+		expectRS     uint32
+		expectRT     uint32
+		expectRD     uint32
 	}{
+		{name: "add", pc: 0, nextPC: 4, insn: 0x02_32_40_20, expectNextPC: 8, expectRS: uint32(17), expectRT: uint32(18), expectRD: uint32(8)},   // add $t0, $s1, $s2
 		{name: "j MSB set target", pc: 0, nextPC: 4, insn: 0x0A_00_00_02, expectNextPC: 0x08_00_00_08},                                           // j 0x02_00_00_02
 		{name: "j non-zero PC region", pc: 0x10000000, nextPC: 0x10000004, insn: 0x08_00_00_02, expectNextPC: 0x10_00_00_08},                     // j 0x2
 		{name: "jal MSB set target", pc: 0, nextPC: 4, insn: 0x0E_00_00_02, expectNextPC: 0x08_00_00_08, expectLink: true},                       // jal 0x02_00_00_02
@@ -149,6 +153,81 @@ func TestEVMSingleStep(t *testing.T) {
 				expected.NextPC = tt.expectNextPC
 				if tt.expectLink {
 					expected.Registers[31] = state.GetPC() + 8
+				}
+				if tt.expectRS != 0 {
+					expected.Registers[tt.expectRD] = state.GetRegistersRef()[tt.expectRS]
+				}
+				if tt.expectRT != 0 {
+					expected.Registers[tt.expectRD] = state.GetRegistersRef()[tt.expectRT]
+				}
+				if tt.expectRD != 0 {
+					expected.Registers[tt.expectRD] = state.GetRegistersRef()[tt.expectRS] + state.GetRegistersRef()[tt.expectRT]
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts, tracer)
+			})
+		}
+	}
+}
+
+func TestEVMSingleStep_Add(t *testing.T) {
+	var tracer *tracing.Hooks
+
+	versions := GetMipsVersionTestCases(t)
+	cases := []struct {
+		name         string
+		pc           uint32
+		nextPC       uint32
+		insn         uint32
+		ifImm        bool
+		rs           uint32
+		rt           uint32
+		imm          uint16
+		expectNextPC uint32
+		expectRD     uint32
+		expectImm    uint32
+	}{
+		{name: "add", pc: 0, nextPC: 4, insn: 0x02_32_40_20, ifImm: false, rs: uint32(12), rt: uint32(20), expectNextPC: 8, expectRD: uint32(32)},                         // add t0, s1, s2
+		{name: "addu", pc: 0, nextPC: 4, insn: 0x02_32_40_21, ifImm: false, rs: uint32(12), rt: uint32(20), expectNextPC: 8, expectRD: uint32(32)},                        // addu t0, s1, s2
+		{name: "addi", pc: 0, nextPC: 4, insn: 0x22_28_00_28, ifImm: true, rs: uint32(4), rt: uint32(1), imm: uint16(40), expectNextPC: 8, expectImm: uint32(44)},         // addi t0, s1, 40
+		{name: "addi sign", pc: 0, nextPC: 4, insn: 0x22_28_ff_fe, ifImm: true, rs: uint32(2), rt: uint32(1), imm: uint16(0xfffe), expectNextPC: 8, expectImm: uint32(0)}, // addi t0, s1, -2
+		{name: "addui", pc: 0, nextPC: 4, insn: 0x26_28_00_28, ifImm: true, rs: uint32(4), rt: uint32(1), imm: uint16(40), expectNextPC: 8, expectImm: uint32(44)},        // addiu t0, s1, 40
+	}
+
+	for _, v := range versions {
+		for i, tt := range cases {
+			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
+			t.Run(testName, func(t *testing.T) {
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithPC(tt.pc), testutil.WithNextPC(tt.nextPC))
+				state := goVm.GetState()
+				if tt.ifImm {
+					state.GetRegistersRef()[8] = tt.rt
+					state.GetRegistersRef()[17] = tt.rs
+				} else {
+					state.GetRegistersRef()[17] = tt.rs
+					state.GetRegistersRef()[18] = tt.rt
+				}
+				state.GetMemory().SetMemory(tt.pc, tt.insn)
+				step := state.GetStep()
+
+				// Setup expectations
+				expected := testutil.NewExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = tt.expectNextPC
+
+				if tt.ifImm {
+					expected.Registers[8] = tt.expectImm
+					expected.Registers[17] = tt.rs
+				} else {
+					expected.Registers[8] = tt.expectRD
+					expected.Registers[17] = tt.rs
+					expected.Registers[18] = tt.rt
 				}
 
 				stepWitness, err := goVm.Step(true)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR Add add/addi/addu/addiu opcodes tests.

**Tests**



**Additional context**



**Metadata**

- Fixes #12084
