### PR TITLE
remove unused function `_isInterop`

### DIFF
--- a/packages/contracts-bedrock/test/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/Predeploys.t.sol
@@ -12,13 +12,6 @@ contract PredeploysBaseTest is CommonTest {
     /// Internal helpers
     //////////////////////////////////////////////////////
 
-    /// @dev Returns true if the address is an interop predeploy.
-    function _isInterop(address _addr) internal pure returns (bool) {
-        return _addr == Predeploys.CROSS_L2_INBOX || _addr == Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
-            || _addr == Predeploys.SUPERCHAIN_WETH || _addr == Predeploys.ETH_LIQUIDITY
-            || _addr == Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY || _addr == Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON;
-    }
-
     /// @dev Returns true if the address is a predeploy that has a different code in the interop mode.
     function _interopCodeDiffer(address _addr) internal pure returns (bool) {
         return _addr == Predeploys.L1_BLOCK_ATTRIBUTES || _addr == Predeploys.L2_STANDARD_BRIDGE;


### PR DESCRIPTION
The `_isInterop` function is the only one in `PredeploysBaseTest` that's never used in the codebase, so I guess it's a leftover.