### PR TITLE
fix: justfile clean command

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -28,7 +28,6 @@ build-go-ffi:
   cd scripts/go-ffi && go build
 
 # Cleans build artifacts and deployments.
-# Removes everything inside of .testdata (except the .gitkeep file).
 clean:
   rm -rf ./artifacts ./forge-artifacts ./cache ./scripts/go-ffi/go-ffi ./deployments/hardhat/*
 

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -31,7 +31,6 @@ build-go-ffi:
 # Removes everything inside of .testdata (except the .gitkeep file).
 clean:
   rm -rf ./artifacts ./forge-artifacts ./cache ./scripts/go-ffi/go-ffi ./deployments/hardhat/*
-  find ./.testdata -mindepth 1 -not -name '.gitkeep' -delete
 
 
 ########################################################


### PR DESCRIPTION
Fixing a bug that was introduced when the `.testdata` file was removed in: https://github.com/ethereum-optimism/optimism/pull/12035/files#diff-bf8fe8a212b07c7b8d05a5e7f11b4f13c512e3688b45e6de16e4344895588e74 