### PR TITLE
cannon: Drop unnecessary wakeup field reset

### DIFF
--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -363,6 +363,7 @@ func (m *InstrumentedState) handleRMWOps(insn, opcode uint32) error {
 }
 
 func (m *InstrumentedState) onWaitComplete(thread *ThreadState, isTimedOut bool) {
+	// Note: no need to reset m.state.Wakeup.  If we're here, the Wakeup field has already been reset
 	// Clear the futex state
 	thread.FutexAddr = exec.FutexEmptyAddr
 	thread.FutexVal = 0
@@ -376,9 +377,6 @@ func (m *InstrumentedState) onWaitComplete(thread *ThreadState, isTimedOut bool)
 		v1 = exec.MipsETIMEDOUT
 	}
 	exec.HandleSyscallUpdates(&thread.Cpu, &thread.Registers, v0, v1)
-
-	// Clear wakeup signal
-	m.state.Wakeup = exec.FutexEmptyAddr
 }
 
 func (m *InstrumentedState) preemptThread(thread *ThreadState) bool {

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -144,8 +144,8 @@
     "sourceCodeHash": "0xba4674e1846afbbc708877332a38dfabd4b8d1e48ce07d8ebf0a45c9f27f16b0"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0xd9da47f735b7a655a25ae0e867b467620a2cb537eb65d184a361f5ea4174d384",
-    "sourceCodeHash": "0x3a6d83a7d46eb267f6778f8ae116383fe3c14ad553d90b6c761fafeef22ae29c"
+    "initCodeHash": "0x67fb4107e25561ffcb3a9b6653f695e125773408d626a92036ea4b0814797021",
+    "sourceCodeHash": "0x5f4851e04dc9369552c94fb23aee8e8ca4ea9a9602917f0abb3b5f1347460bd5"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x801e52f9c8439fcf7089575fa93272dfb874641dbfc7d82f36d979c987271c0b",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -202,7 +202,7 @@ contract MIPS2 is ISemver {
                 // check timeout first
                 if (state.step > thread.futexTimeoutStep) {
                     // timeout! Allow execution
-                    return onWaitComplete(state, thread, true);
+                    return onWaitComplete(thread, true);
                 } else {
                     uint32 mem = MIPSMemory.readMem(
                         state.memRoot, thread.futexAddr & 0xFFffFFfc, MIPSMemory.memoryProofOffset(MEM_PROOF_OFFSET, 1)
@@ -214,7 +214,7 @@ contract MIPS2 is ISemver {
                     } else {
                         // wake thread up, the value at its address changed!
                         // Userspace can turn thread back to sleep if it was too sporadic.
-                        return onWaitComplete(state, thread, false);
+                        return onWaitComplete(thread, false);
                     }
                 }
             }
@@ -690,15 +690,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice Completes the FUTEX_WAIT syscall.
-    function onWaitComplete(
-        State memory _state,
-        ThreadState memory _thread,
-        bool _isTimedOut
-    )
-        internal
-        returns (bytes32 out_)
-    {
-        // Note: no need to reset _state.wakeup.  If we're here, the wakeup field has already been reset
+    function onWaitComplete(ThreadState memory _thread, bool _isTimedOut) internal returns (bytes32 out_) {
+        // Note: no need to reset State.wakeup.  If we're here, the wakeup field has already been reset
         // Clear the futex state
         _thread.futexAddr = sys.FUTEX_EMPTY_ADDR;
         _thread.futexVal = 0;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -57,8 +57,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.10
-    string public constant version = "1.0.0-beta.10";
+    /// @custom:semver 1.0.0-beta.11
+    string public constant version = "1.0.0-beta.11";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -698,6 +698,7 @@ contract MIPS2 is ISemver {
         internal
         returns (bytes32 out_)
     {
+        // Note: no need to reset _state.wakeup.  If we're here, the wakeup field has already been reset
         // Clear the futex state
         _thread.futexAddr = sys.FUTEX_EMPTY_ADDR;
         _thread.futexVal = 0;
@@ -711,7 +712,6 @@ contract MIPS2 is ISemver {
         sys.handleSyscallUpdates(cpu, _thread.registers, v0, v1);
         setStateCpuScalars(_thread, cpu);
 
-        _state.wakeup = sys.FUTEX_EMPTY_ADDR;
         updateCurrentThreadRoot();
         out_ = outputState();
     }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Cut unnecessary wakeup reset logic.

**Tests**

Existing tests should provide coverage. 

