### PR TITLE
op-supervisor: cleanup cross-L2 safety types

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -42,7 +42,7 @@ func TestInteropVerifier(gt *testing.T) {
 	ver.ActL2PipelineFull(t)
 
 	l2ChainID := types.ChainIDFromBig(sd.RollupCfg.L2ChainID)
-	seqMockBackend.ExpectCheckBlock(l2ChainID, 1, types.Unsafe, nil)
+	seqMockBackend.ExpectCheckBlock(l2ChainID, 1, types.LocalUnsafe, nil)
 	// create an unsafe L2 block
 	seq.ActL2StartBlock(t)
 	seq.ActL2EndBlock(t)
@@ -99,8 +99,8 @@ func TestInteropVerifier(gt *testing.T) {
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
 
 	// The verifier might not see the L2 block that was just derived from L1 as cross-verified yet.
-	verMockBackend.ExpectCheckBlock(l2ChainID, 1, types.Unsafe, nil) // for the local unsafe check
-	verMockBackend.ExpectCheckBlock(l2ChainID, 1, types.Unsafe, nil) // for the local safe check
+	verMockBackend.ExpectCheckBlock(l2ChainID, 1, types.LocalUnsafe, nil) // for the local unsafe check
+	verMockBackend.ExpectCheckBlock(l2ChainID, 1, types.LocalUnsafe, nil) // for the local safe check
 	ver.ActL1HeadSignal(t)
 	ver.ActL2PipelineFull(t)
 	verMockBackend.AssertExpectations(t)

--- a/op-node/rollup/interop/interop.go
+++ b/op-node/rollup/interop/interop.go
@@ -101,7 +101,7 @@ func (d *InteropDeriver) OnEvent(ev event.Event) bool {
 			break
 		}
 		switch blockSafety {
-		case types.CrossUnsafe, types.CrossSafe, types.CrossFinalized:
+		case types.CrossUnsafe, types.CrossSafe, types.Finalized:
 			// Hold off on promoting higher than cross-unsafe,
 			// this will happen once we verify it to be local-safe first.
 			d.emitter.Emit(engine.PromoteCrossUnsafeEvent{Ref: candidate})

--- a/op-node/rollup/interop/interop_test.go
+++ b/op-node/rollup/interop/interop_test.go
@@ -61,7 +61,7 @@ func TestInteropDeriver(t *testing.T) {
 		firstLocalUnsafe := testutils.NextRandomL2Ref(rng, 2, crossUnsafe, crossUnsafe.L1Origin)
 		lastLocalUnsafe := testutils.NextRandomL2Ref(rng, 2, firstLocalUnsafe, firstLocalUnsafe.L1Origin)
 		interopBackend.ExpectCheckBlock(
-			chainID, firstLocalUnsafe.Number, supervisortypes.Unsafe, nil)
+			chainID, firstLocalUnsafe.Number, supervisortypes.LocalUnsafe, nil)
 		l2Source.ExpectL2BlockRefByNumber(firstLocalUnsafe.Number, firstLocalUnsafe, nil)
 		interopDeriver.OnEvent(engine.CrossUnsafeUpdateEvent{
 			CrossUnsafe: crossUnsafe,
@@ -122,7 +122,7 @@ func TestInteropDeriver(t *testing.T) {
 			DerivedFrom: derivedFrom,
 		})
 		interopBackend.ExpectCheckBlock(
-			chainID, firstLocalSafe.Number, supervisortypes.Safe, nil)
+			chainID, firstLocalSafe.Number, supervisortypes.CrossSafe, nil)
 		l2Source.ExpectL2BlockRefByNumber(firstLocalSafe.Number, firstLocalSafe, nil)
 		interopDeriver.OnEvent(engine.CrossSafeUpdateEvent{
 			CrossSafe: crossSafe,

--- a/op-node/rollup/interop/interop_test.go
+++ b/op-node/rollup/interop/interop_test.go
@@ -122,7 +122,7 @@ func TestInteropDeriver(t *testing.T) {
 			DerivedFrom: derivedFrom,
 		})
 		interopBackend.ExpectCheckBlock(
-			chainID, firstLocalSafe.Number, supervisortypes.CrossSafe, nil)
+			chainID, firstLocalSafe.Number, supervisortypes.LocalSafe, nil)
 		l2Source.ExpectL2BlockRefByNumber(firstLocalSafe.Number, firstLocalSafe, nil)
 		interopDeriver.OnEvent(engine.CrossSafeUpdateEvent{
 			CrossSafe: crossSafe,

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -74,7 +74,7 @@ func (cl *SupervisorClient) CheckBlock(ctx context.Context,
 		"supervisor_checkBlock",
 		(*hexutil.U256)(&chainID), blockHash, hexutil.Uint64(blockNumber))
 	if err != nil {
-		return types.Unsafe, fmt.Errorf("failed to check Block %s:%d (chain %s): %w", blockHash, blockNumber, chainID, err)
+		return types.LocalUnsafe, fmt.Errorf("failed to check Block %s:%d (chain %s): %w", blockHash, blockNumber, chainID, err)
 	}
 	return result, nil
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -192,7 +192,7 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	logIdx := identifier.LogIndex
 	_, err := su.db.Check(chainID, blockNum, uint32(logIdx), payloadHash)
 	if errors.Is(err, logs.ErrFuture) {
-		return types.Unsafe, nil
+		return types.LocalUnsafe, nil
 	}
 	if errors.Is(err, logs.ErrConflict) {
 		return types.Invalid, nil
@@ -203,9 +203,9 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	safest := types.CrossUnsafe
 	// at this point we have the log entry, and we can check if it is safe by various criteria
 	for _, checker := range []db.SafetyChecker{
-		db.NewSafetyChecker(types.Unsafe, su.db),
-		db.NewSafetyChecker(types.Safe, su.db),
-		db.NewSafetyChecker(types.Finalized, su.db),
+		db.NewSafetyChecker(db.Unsafe, su.db),
+		db.NewSafetyChecker(db.Safe, su.db),
+		db.NewSafetyChecker(db.Finalized, su.db),
 	} {
 		// check local safety limit first as it's more permissive
 		localPtr := checker.LocalHead(chainID)
@@ -248,7 +248,7 @@ func (su *SupervisorBackend) CheckBlock(chainID *hexutil.U256, blockHash common.
 	id := eth.BlockID{Hash: blockHash, Number: uint64(blockNumber)}
 	_, err := su.db.FindSealedBlock(types.ChainID(*chainID), id)
 	if errors.Is(err, logs.ErrFuture) {
-		return types.Unsafe, nil
+		return types.LocalUnsafe, nil
 	}
 	if errors.Is(err, logs.ErrConflict) {
 		return types.Invalid, nil
@@ -259,9 +259,9 @@ func (su *SupervisorBackend) CheckBlock(chainID *hexutil.U256, blockHash common.
 	}
 	// at this point we have the extent of the block, and we can check if it is safe by various criteria
 	for _, checker := range []db.SafetyChecker{
-		db.NewSafetyChecker(types.Unsafe, su.db),
-		db.NewSafetyChecker(types.Safe, su.db),
-		db.NewSafetyChecker(types.Finalized, su.db),
+		db.NewSafetyChecker(db.Unsafe, su.db),
+		db.NewSafetyChecker(db.Safe, su.db),
+		db.NewSafetyChecker(db.Finalized, su.db),
 	} {
 		// check local safety limit first as it's more permissive
 		localPtr := checker.LocalHead(types.ChainID(*chainID))

--- a/op-supervisor/supervisor/backend/db/safety_checkers.go
+++ b/op-supervisor/supervisor/backend/db/safety_checkers.go
@@ -115,7 +115,7 @@ func NewChecker(t types.SafetyLevel, c *ChainsDB) SafetyChecker {
 	case Unsafe:
 		return &checker{
 			chains:      c,
-			localSafety: types.Unsafe,
+			localSafety: types.LocalUnsafe,
 			crossSafety: types.CrossUnsafe,
 			updateCross: c.heads.UpdateCrossUnsafe,
 			updateLocal: c.heads.UpdateLocalUnsafe,
@@ -127,7 +127,7 @@ func NewChecker(t types.SafetyLevel, c *ChainsDB) SafetyChecker {
 	case Safe:
 		return &checker{
 			chains:      c,
-			localSafety: types.Safe,
+			localSafety: types.LocalSafe,
 			crossSafety: types.CrossSafe,
 			updateCross: c.heads.UpdateCrossSafe,
 			updateLocal: c.heads.UpdateLocalSafe,
@@ -140,7 +140,7 @@ func NewChecker(t types.SafetyLevel, c *ChainsDB) SafetyChecker {
 		return &checker{
 			chains:      c,
 			localSafety: types.Finalized,
-			crossSafety: types.CrossFinalized,
+			crossSafety: types.Finalized,
 			updateCross: c.heads.UpdateCrossFinalized,
 			updateLocal: c.heads.UpdateLocalFinalized,
 			crossHead:   c.heads.CrossFinalized,

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -73,7 +73,7 @@ func (lvl SafetyLevel) String() string {
 
 func (lvl SafetyLevel) Valid() bool {
 	switch lvl {
-	case CrossFinalized, Finalized, Safe, CrossUnsafe, Unsafe:
+	case Finalized, CrossSafe, LocalSafe, CrossUnsafe, LocalUnsafe:
 		return true
 	default:
 		return false
@@ -101,10 +101,10 @@ func (lvl *SafetyLevel) AtLeastAsSafe(min SafetyLevel) bool {
 	switch min {
 	case Invalid:
 		return true
-	case Unsafe:
+	case CrossUnsafe:
 		return *lvl != Invalid
-	case Safe:
-		return *lvl == Safe || *lvl == Finalized
+	case CrossSafe:
+		return *lvl == CrossSafe || *lvl == Finalized
 	case Finalized:
 		return *lvl == Finalized
 	default:
@@ -113,13 +113,26 @@ func (lvl *SafetyLevel) AtLeastAsSafe(min SafetyLevel) bool {
 }
 
 const (
-	CrossFinalized SafetyLevel = "cross-finalized"
-	Finalized      SafetyLevel = "finalized"
-	CrossSafe      SafetyLevel = "cross-safe"
-	Safe           SafetyLevel = "safe"
-	CrossUnsafe    SafetyLevel = "cross-unsafe"
-	Unsafe         SafetyLevel = "unsafe"
-	Invalid        SafetyLevel = "invalid"
+	// Finalized is CrossSafe, with the additional constraint that every
+	// dependency is derived only from finalized L1 input data.
+	// This matches RPC label "finalized".
+	Finalized SafetyLevel = "finalized"
+	// CrossSafe is as safe as LocalSafe, with all its dependencies
+	// also fully verified to be reproducible from L1.
+	// This matches RPC label "safe".
+	CrossSafe SafetyLevel = "safe"
+	// LocalSafe is verified to be reproducible from L1,
+	// without any verified cross-L2 dependencies.
+	// This does not have an RPC label.
+	LocalSafe SafetyLevel = "local-safe"
+	// CrossUnsafe is as safe as LocalUnsafe,
+	// but with verified cross-L2 dependencies that are at least CrossUnsafe.
+	// This does not have an RPC label.
+	CrossUnsafe SafetyLevel = "cross-unsafe"
+	// LocalUnsafe is the safety of the tip of the chain. This matches RPC label "unsafe".
+	LocalUnsafe SafetyLevel = "unsafe"
+	// Invalid is the safety of when the message or block is not matching the expected data.
+	Invalid SafetyLevel = "invalid"
 )
 
 type ChainID uint256.Int


### PR DESCRIPTION
**Description**

This:
- removes `cross-finalized`/`local-finalized` difference. Finality depends on cross-safe limited to a view of irreversible L1 blocks. Taking a combination of local-finalized chains is not the same. And having two levels of finality is confusing.
- make RPC string constants consistent with RPC
- be explicit about local/cross difference in the Go type naming.
