### PR TITLE
cannon: Support the --version argument for multicannon

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -4,8 +4,8 @@ VERSION ?= v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
-LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Version=$(VERSION)
-LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta=$(VERSION_META)
+LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/cannon/multicannon/version.Version=$(VERSION)
+LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/cannon/multicannon/version.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 # Use the old Apple linker to workaround broken xcode - https://github.com/golang/go/issues/65169

--- a/cannon/multicannon/main.go
+++ b/cannon/multicannon/main.go
@@ -6,15 +6,26 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ethereum-optimism/optimism/cannon/multicannon/version"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	"github.com/urfave/cli/v2"
 )
+
+var (
+	GitCommit = ""
+	GitDate   = ""
+)
+
+// VersionWithMeta holds the textual version string including the metadata.
+var VersionWithMeta = opservice.FormatVersion(version.Version, GitCommit, GitDate, version.Meta)
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "multicannon"
 	app.Usage = "MIPS Fault Proof tool"
 	app.Description = "MIPS Fault Proof tool"
+	app.Version = VersionWithMeta
 	app.Commands = []*cli.Command{
 		LoadELFCommand,
 		WitnessCommand,

--- a/cannon/multicannon/version/version.go
+++ b/cannon/multicannon/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	Version = "v0.0.0"
+	Meta    = "dev"
+)

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -51,8 +51,7 @@ ARG TARGETARCH
 #FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:v1.1.0 AS cannon-builder-0
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-builder
-# note: bump this CANNON_VERSION when the VM behavior changes
-ARG CANNON_VERSION=v1.0.0
+ARG CANNON_VERSION=v0.0.0
 # uncomment these lines once there's a new Cannon version available
 #COPY --from=cannon-builder-0 /usr/local/bin/cannon ./cannon/multicannon/embeds/cannon-0
 #COPY --from=cannon-builder-0 /usr/local/bin/cannon ./cannon/multicannon/embeds/cannon-1


### PR DESCRIPTION
**Description**

Support the `--version` argument for multicannon so that the cross-platform test works.  It also now picks up the version from the git tag like all our other executables.
