### PR TITLE
show log for `devnet`

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -11,6 +11,7 @@ import http.client
 from multiprocessing import Process, Queue
 import concurrent.futures
 from collections import namedtuple
+# This import is necessary for devnet logs to be shown.
 from . import log_setup
 
 

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -11,6 +11,7 @@ import http.client
 from multiprocessing import Process, Queue
 import concurrent.futures
 from collections import namedtuple
+from . import log_setup
 
 
 pjoin = os.path.join


### PR DESCRIPTION
It seems devnet logs are gone ever since [this](https://github.com/ethereum-optimism/optimism/pull/11045) PR.

This PR makes devnet logs show again.