### PR TITLE
cannon: Fix custom --help for multicannon subcommands

### DIFF
--- a/cannon/multicannon/load_elf.go
+++ b/cannon/multicannon/load_elf.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ethereum-optimism/optimism/cannon/cmd"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/urfave/cli/v2"
 )
 
 func LoadELF(ctx *cli.Context) error {
-	if len(os.Args) == 2 && os.Args[2] == "--help" {
+	if len(os.Args) == 3 && os.Args[2] == "--help" {
 		if err := list(); err != nil {
 			return err
 		}
 		fmt.Println("use `--type <vm type> --help` to get more detailed help")
+		return nil
 	}
 
 	typ, err := parseFlag(os.Args[1:], "--type")
@@ -28,4 +28,10 @@ func LoadELF(ctx *cli.Context) error {
 	return ExecuteCannon(ctx.Context, os.Args[1:], ver)
 }
 
-var LoadELFCommand = cmd.CreateLoadELFCommand(LoadELF)
+var LoadELFCommand = &cli.Command{
+	Name:            "load-elf",
+	Usage:           "Load ELF file into Cannon state",
+	Description:     "Load ELF file into Cannon state",
+	Action:          LoadELF,
+	SkipFlagParsing: true,
+}

--- a/cannon/multicannon/run.go
+++ b/cannon/multicannon/run.go
@@ -16,6 +16,7 @@ func Run(ctx *cli.Context) error {
 			return err
 		}
 		fmt.Println("use `--input <valid input file> --help` to get more detailed help")
+		return nil
 	}
 
 	inputPath, err := parsePathFlag(os.Args[1:], "--input")

--- a/cannon/multicannon/run.go
+++ b/cannon/multicannon/run.go
@@ -30,7 +30,6 @@ func Run(ctx *cli.Context) error {
 	return ExecuteCannon(ctx.Context, os.Args[1:], version)
 }
 
-// var RunCommand = cmd.CreateRunCommand(Run)
 var RunCommand = &cli.Command{
 	Name:            "run",
 	Usage:           "Run VM step(s) and generate proof data to replicate onchain.",

--- a/cannon/multicannon/witness.go
+++ b/cannon/multicannon/witness.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/ethereum-optimism/optimism/cannon/cmd"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 )
 
@@ -16,6 +15,7 @@ func Witness(ctx *cli.Context) error {
 			return err
 		}
 		fmt.Println("use `--input <valid input file> --help` to get more detailed help")
+		return nil
 	}
 
 	inputPath, err := parsePathFlag(os.Args[1:], "--input")
@@ -29,4 +29,10 @@ func Witness(ctx *cli.Context) error {
 	return ExecuteCannon(ctx.Context, os.Args[1:], version)
 }
 
-var WitnessCommand = cmd.CreateWitnessCommand(Witness)
+var WitnessCommand = &cli.Command{
+	Name:            "witness",
+	Usage:           "Convert a Cannon JSON state into a binary witness",
+	Description:     "Convert a Cannon JSON state into a binary witness. The hash of the witness is written to stdout",
+	Action:          Witness,
+	SkipFlagParsing: true,
+}


### PR DESCRIPTION
The multicannon CLI interface needs to be backwards and forwards compatible with all cannon implementations. However, all commands currently require either a `--input` or `--type` to select the VM implementation. This means the user cannot get `--help` on a vm implementation without specifying either `--input` or `--type`. The workaround previously implemented was to have multicannon list the available VM implementations whenever the user invokes `multicannon --help`. This way the user can at least know what options are available when specifying `--input`/`--type` args. This patch fixes a bugs in `--help` handling.