### PR TITLE
feat(deploy): deploy implementations before proxies

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -398,9 +398,10 @@ contract Deploy is Deployer {
         mustGetAddress("AddressManager");
         mustGetAddress("ProxyAdmin");
 
-        deployProxies();
         deployImplementations();
-        initializeImplementations();
+
+        deployProxies();
+        initializeProxies();
 
         setAlphabetFaultGameImplementation({ _allowUpgrade: false });
         setFastFaultGameImplementation({ _allowUpgrade: false });
@@ -453,9 +454,9 @@ contract Deploy is Deployer {
         deployAnchorStateRegistry();
     }
 
-    /// @notice Initialize all of the implementations
-    function initializeImplementations() public {
-        console.log("Initializing implementations");
+    /// @notice Initialize all of the proxies by upgrading to the correct proxy and calling the initialize function
+    function initializeProxies() public {
+        console.log("Initializing proxies");
         // Selectively initialize either the original OptimismPortal or the new OptimismPortal2. Since this will upgrade
         // the proxy, we cannot initialize both.
         if (cfg.useFaultProofs()) {

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -432,6 +432,8 @@ contract Deploy is Deployer {
         deployERC1967Proxy("PermissionedDelayedWETHProxy");
         deployERC1967Proxy("AnchorStateRegistryProxy");
 
+        deployAnchorStateRegistry();
+
         transferAddressManagerOwnership(); // to the ProxyAdmin
     }
 
@@ -451,7 +453,6 @@ contract Deploy is Deployer {
         deployDelayedWETH();
         deployPreimageOracle();
         deployMips();
-        deployAnchorStateRegistry();
     }
 
     /// @notice Initialize all of the proxies by upgrading to the correct proxy and calling the initialize function

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -400,8 +400,8 @@ contract Deploy is Deployer {
 
         deployImplementations();
 
-        deployProxies();
-        initializeProxies();
+        deployOpChain();
+        initializeOpChain();
 
         setAlphabetFaultGameImplementation({ _allowUpgrade: false });
         setFastFaultGameImplementation({ _allowUpgrade: false });
@@ -412,9 +412,9 @@ contract Deploy is Deployer {
         transferDelayedWETHOwnership();
     }
 
-    /// @notice Deploy all of the proxies
-    function deployProxies() public {
-        console.log("Deploying proxies");
+    /// @notice Deploy all of the OP Chain specific contracts
+    function deployOpChain() public {
+        console.log("Deploying OP Chain contracts");
 
         deployERC1967Proxy("OptimismPortalProxy");
         deployERC1967Proxy("SystemConfigProxy");
@@ -455,9 +455,10 @@ contract Deploy is Deployer {
         deployMips();
     }
 
-    /// @notice Initialize all of the proxies by upgrading to the correct proxy and calling the initialize function
-    function initializeProxies() public {
-        console.log("Initializing proxies");
+    /// @notice Initialize all of the proxies in an OP Chain by upgrading to the correct proxy and calling the
+    /// initialize function
+    function initializeOpChain() public {
+        console.log("Initializing Op Chain proxies");
         // Selectively initialize either the original OptimismPortal or the new OptimismPortal2. Since this will upgrade
         // the proxy, we cannot initialize both.
         if (cfg.useFaultProofs()) {


### PR DESCRIPTION
This change prepares for the OPCM integration by deploying the implementations before the proxies.
`intializeImplementations()` was renamed to `initializeProxies()` which is more accurate.

Also the ASR's implementation was unnecessarily initialized with a proxy address for a constructor
argument.