### PR TITLE
op-batcher: prevent over-assessment of DA type

### DIFF
--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -588,6 +588,8 @@ func TestChannelManager_TxData(t *testing.T) {
 				if !errors.Is(err, io.EOF) {
 					require.NoError(t, err)
 				}
+				// We don't want this to be changed prematurely
+				require.Equal(t, tc.chooseBlobsWhenChannelCreated, m.defaultCfg.UseBlobs)
 			}
 
 			require.Equal(t, tc.chooseBlobsWhenChannelSubmitted, data.asBlob)


### PR DESCRIPTION
When rolling out #12002 I noticed a significant increase in logs, the batcher is reassessing DA type on every tick due to a bug.

This PR adds a test which fails under the current implementation, and then a fix for the above issue. 