### PR TITLE
feat: Sepolia Standard Versions OPCM

### DIFF
--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -46,6 +46,7 @@ fuzz:
 
 
 sync-standard-version:
-	curl -Lo ./deployer/opcm/standard-versions.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions.toml
+	curl -Lo ./deployer/opcm/standard-versions-mainnet.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-mainnet.toml
+	curl -Lo ./deployer/opcm/standard-versions-sepolia.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-sepolia.toml
 
 .PHONY: test fuzz op-deployer sync-standard-version

--- a/op-chain-ops/deployer/opcm/implementations.go
+++ b/op-chain-ops/deployer/opcm/implementations.go
@@ -23,7 +23,7 @@ type DeployImplementationsInput struct {
 	UseInterop            bool // if true, deploy Interop implementations
 
 	SuperchainProxyAdmin common.Address
-	StandardVersionsToml string // contents of 'standard-versions.toml' file
+	StandardVersionsToml string // contents of 'standard-versions-mainnet.toml' file
 }
 
 func (input *DeployImplementationsInput) InputSet() bool {

--- a/op-chain-ops/deployer/opcm/implementations.go
+++ b/op-chain-ops/deployer/opcm/implementations.go
@@ -23,7 +23,7 @@ type DeployImplementationsInput struct {
 	UseInterop            bool // if true, deploy Interop implementations
 
 	SuperchainProxyAdmin common.Address
-	StandardVersionsToml string // contents of 'standard-versions-mainnet.toml' file
+	StandardVersionsToml string // contents of 'standard-versions-mainnet.toml' or 'standard-versions-sepolia.toml' file
 }
 
 func (input *DeployImplementationsInput) InputSet() bool {

--- a/op-chain-ops/deployer/opcm/standard-versions-mainnet.toml
+++ b/op-chain-ops/deployer/opcm/standard-versions-mainnet.toml
@@ -1,0 +1,45 @@
+[releases]
+
+# Contracts which are
+#   * unproxied singletons: specify a standard "address"
+#   * proxied             : specify a standard "implementation_address"
+#   * neither             : specify neither a standard "address" nor "implementation_address"
+
+# Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
+[releases."op-contracts/v1.6.0"]
+optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
+system_config = { version = "2.2.0", implementation_address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
+anchor_state_registry = { version = "2.0.0" }
+delayed_weth = { version = "1.1.0", implementation_address = "0x71e966Ae981d1ce531a7b6d23DC0f27B38409087" }
+dispute_game_factory = { version = "1.0.0", implementation_address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
+fault_dispute_game = { version = "1.3.0" }
+permissioned_dispute_game = { version = "1.3.0" }
+mips = { version = "1.1.0", address = "0x16e83cE5Ce29BF90AD9Da06D2fE6a15d5f344ce4" }
+preimage_oracle = { version = "1.1.2", address = "0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277" }
+l1_cross_domain_messenger = { version = "2.3.0", implementation_address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
+l1_erc721_bridge = { version = "2.1.0", implementation_address = "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d" }
+l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF" }
+# l2_output_oracle -- This contract not used in fault proofs
+optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846" }
+
+# Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.4.0
+[releases."op-contracts/v1.4.0"]
+optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
+system_config = { version = "2.2.0", implementation_address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
+anchor_state_registry = { version = "1.0.0" }
+delayed_weth = { version = "1.0.0", implementation_address = "0x97988d5624F1ba266E1da305117BCf20713bee08" }
+dispute_game_factory = { version = "1.0.0", implementation_address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
+fault_dispute_game = { version = "1.2.0" }
+permissioned_dispute_game = { version = "1.2.0" }
+mips = { version = "1.0.1", address = "0x0f8EdFbDdD3c0256A80AD8C0F2560B1807873C9c" }
+preimage_oracle = { version = "1.0.0", address = "0xD326E10B8186e90F4E2adc5c13a2d0C137ee8b34" }
+
+# MCP https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.3.0
+[releases."op-contracts/v1.3.0"]
+l1_cross_domain_messenger = { version = "2.3.0", implementation_address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
+l1_erc721_bridge = { version = "2.1.0", implementation_address = "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d" }
+l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF" }
+l2_output_oracle = { version = "1.8.0", implementation_address = "0xF243BEd163251380e78068d317ae10f26042B292" }
+optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846" }
+optimism_portal = { version = "2.5.0", implementation_address = "0x2D778797049FE9259d947D1ED8e5442226dFB589" }
+system_config = { version = "1.12.0", implementation_address = "0xba2492e52F45651B60B8B38d4Ea5E2390C64Ffb1" }

--- a/op-chain-ops/deployer/opcm/standard-versions-sepolia.toml
+++ b/op-chain-ops/deployer/opcm/standard-versions-sepolia.toml
@@ -1,0 +1,23 @@
+[releases]
+
+# Contracts which are
+#   * unproxied singletons: specify a standard "address"
+#   * proxied             : specify a standard "implementation_address"
+#   * neither             : specify neither a standard "address" nor "implementation_address"
+
+# Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
+[releases."op-contracts/v1.6.0"]
+optimism_portal = { version = "3.10.0", implementation_address = "0x35028bae87d71cbc192d545d38f960ba30b4b233" }
+system_config = { version = "2.2.0", implementation_address = "0xCcdd86d581e40fb5a1C77582247BC493b6c8B169" }
+anchor_state_registry = { version = "2.0.0" }
+delayed_weth = { version = "1.1.0", implementation_address = "0x07f69b19532476c6cd03056d6bc3f1b110ab7538" }
+dispute_game_factory = { version = "1.0.0", implementation_address = "0xa51bea7e4d34206c0bcb04a776292f2f19f0beec" }
+fault_dispute_game = { version = "1.3.0" }
+permissioned_dispute_game = { version = "1.3.0" }
+mips = { version = "1.1.0", address = "0x47B0E34C1054009e696BaBAAd56165e1e994144d" }
+preimage_oracle = { version = "1.1.2", address = "0x92240135b46fc1142dA181f550aE8f595B858854" }
+l1_cross_domain_messenger = { version = "2.3.0", implementation_address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
+l1_erc721_bridge = { version = "2.1.0", implementation_address = "0xae2af01232a6c4a4d3012c5ec5b1b35059caf10d" }
+l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64b5a5ed26dcb17370ff4d33a8d503f0fbd06cff" }
+# l2_output_oracle -- This contract not used in fault proofs
+optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xe01efbeb1089d1d1db9c6c8b135c934c0734c846" }

--- a/op-chain-ops/deployer/opcm/standard.go
+++ b/op-chain-ops/deployer/opcm/standard.go
@@ -2,7 +2,10 @@ package opcm
 
 import "embed"
 
-//go:embed standard-versions.toml
-var StandardVersionsData string
+//go:embed standard-versions-mainnet.toml
+var StandardVersionsMainnetData string
+
+//go:embed standard-versions-sepolia.toml
+var StandardVersionsSepoliaData string
 
 var _ embed.FS

--- a/op-chain-ops/deployer/pipeline/implementations.go
+++ b/op-chain-ops/deployer/pipeline/implementations.go
@@ -50,7 +50,7 @@ func DeployImplementations(ctx context.Context, env *Env, artifactsFS foundry.St
 						SuperchainConfigProxy:           st.SuperchainDeployment.SuperchainConfigProxyAddress,
 						ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxyAddress,
 						SuperchainProxyAdmin:            st.SuperchainDeployment.ProxyAdminAddress,
-						StandardVersionsToml:            opcm.StandardVersionsData,
+						StandardVersionsToml:            opcm.StandardVersionsMainnetData,
 						UseInterop:                      false,
 					},
 				)

--- a/op-chain-ops/interopgen/configs.go
+++ b/op-chain-ops/interopgen/configs.go
@@ -40,7 +40,7 @@ type OPCMImplementationsConfig struct {
 
 	UseInterop bool // to deploy Interop implementation contracts, instead of the regular ones.
 
-	StandardVersionsToml string // serialized string of superchain-registry 'standard-versions.toml' file
+	StandardVersionsToml string // serialized string of superchain-registry 'standard-versions-mainnet.toml' file
 }
 
 type SuperchainConfig struct {

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -171,7 +171,7 @@ func deploySuperchainToL1(l1Host *script.Host, superCfg *SuperchainConfig) (*Sup
 		ProtocolVersionsProxy:           superDeployment.ProtocolVersionsProxy,
 		SuperchainProxyAdmin:            superDeployment.SuperchainProxyAdmin,
 		UseInterop:                      superCfg.Implementations.UseInterop,
-		StandardVersionsToml:            opcm.StandardVersionsData,
+		StandardVersionsToml:            opcm.StandardVersionsMainnetData,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy Implementations contracts: %w", err)

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -77,7 +77,7 @@ func (r *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, error) 
 				DisputeGameFinalityDelaySeconds: big.NewInt(6),
 			},
 			UseInterop:           true,
-			StandardVersionsToml: opcm.StandardVersionsData,
+			StandardVersionsToml: opcm.StandardVersionsMainnetData,
 		},
 		SuperchainL1DeployConfig: genesis.SuperchainL1DeployConfig{
 			RequiredProtocolVersion:    params.OPStackSupport,


### PR DESCRIPTION
Adding Sepolia standard versions toml file. This will be used for when we're using `op-deployer` to deploy to Sepolia (if we use a release string of the pattern `op-contracts/v*`.