### PR TITLE
op-batcher: use deterministic seed for test data

### DIFF
--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -567,7 +567,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			require.Equal(t, tc.chooseBlobsWhenChannelCreated, m.defaultCfg.UseBlobs)
 
 			// Seed channel manager with a block
-			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+			rng := rand.New(rand.NewSource(99))
 			blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
 			m.blocks = []*types.Block{blockA}
 


### PR DESCRIPTION
The random test data was causing the `TestChannelManager_TxData` test to fail in approx 5% of cases.

With this change:
```
go run gotest.tools/gotestsum@latest ./... -run=TestChannelManager_TxData -count=1000 -v
∅  op-batcher/cmd
∅  op-batcher/metrics
∅  op-batcher/rpc
∅  op-batcher/compressor (816ms)
∅  op-batcher/flags (1.094s)
✓  op-batcher/batcher (59s)

DONE 5000 tests in 60.330s
```

