### PR TITLE
chore: rename isthmus to interop on golang files

### DIFF
--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -195,7 +195,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.Equal(t, l1InfoTx, []byte(attrs.Transactions[0]))
 		require.True(t, attrs.NoTxPool)
 	})
-	t.Run("new origin with deposits on post-Isthmus", func(t *testing.T) {
+	t.Run("new origin with deposits on post-Interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
@@ -247,7 +247,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.True(t, attrs.NoTxPool)
 	})
 
-	t.Run("same origin without deposits on post-Isthmus", func(t *testing.T) {
+	t.Run("same origin without deposits on post-Interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)

--- a/op-node/rollup/derive/fuzz_parsers_test.go
+++ b/op-node/rollup/derive/fuzz_parsers_test.go
@@ -93,16 +93,16 @@ func FuzzL1InfoEcotoneRoundTrip(f *testing.F) {
 		if !cmp.Equal(in, out, cmp.Comparer(testutils.BigEqual)) {
 			t.Fatalf("The Ecotone data did not round trip correctly. in: %v. out: %v", in, out)
 		}
-		enc, err = in.marshalBinaryIsthmus()
+		enc, err = in.marshalBinaryInterop()
 		if err != nil {
-			t.Fatalf("Failed to marshal Isthmus binary: %v", err)
+			t.Fatalf("Failed to marshal Interop binary: %v", err)
 		}
-		err = out.unmarshalBinaryIsthmus(enc)
+		err = out.unmarshalBinaryInterop(enc)
 		if err != nil {
-			t.Fatalf("Failed to unmarshal Isthmus binary: %v", err)
+			t.Fatalf("Failed to unmarshal Interop binary: %v", err)
 		}
 		if !cmp.Equal(in, out, cmp.Comparer(testutils.BigEqual)) {
-			t.Fatalf("The Isthmus data did not round trip correctly. in: %v. out: %v", in, out)
+			t.Fatalf("The Interop data did not round trip correctly. in: %v. out: %v", in, out)
 		}
 
 	})

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -154,7 +154,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		require.Equal(t, depTx.Gas, uint64(RegolithSystemTxGas))
 		require.Equal(t, L1InfoEcotoneLen, len(depTx.Data))
 	})
-	t.Run("isthmus", func(t *testing.T) {
+	t.Run("interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
@@ -165,25 +165,25 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)
 		require.Equal(t, depTx.Gas, uint64(RegolithSystemTxGas))
-		require.Equal(t, L1InfoEcotoneLen, len(depTx.Data), "the length is same in isthmus")
-		require.Equal(t, L1InfoFuncIsthmusBytes4, depTx.Data[:4], "upgrade is active, need isthmus signature")
+		require.Equal(t, L1InfoEcotoneLen, len(depTx.Data), "the length is same in interop")
+		require.Equal(t, L1InfoFuncInteropBytes4, depTx.Data[:4], "upgrade is active, need interop signature")
 	})
-	t.Run("activation-block isthmus", func(t *testing.T) {
+	t.Run("activation-block interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
 		rollupCfg.ActivateAtGenesis(rollup.Fjord)
-		isthmusTime := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime // activate isthmus just after genesis
-		rollupCfg.InteropTime = &isthmusTime
-		depTx, err := L1InfoDeposit(&rollupCfg, randomL1Cfg(rng, info), randomSeqNr(rng), info, isthmusTime)
+		interopTime := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime // activate interop just after genesis
+		rollupCfg.InteropTime = &interopTime
+		depTx, err := L1InfoDeposit(&rollupCfg, randomL1Cfg(rng, info), randomSeqNr(rng), info, interopTime)
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)
 		require.Equal(t, depTx.Gas, uint64(RegolithSystemTxGas))
-		// Isthmus activates, but ecotone L1 info is still used at this upgrade block
+		// Interop activates, but ecotone L1 info is still used at this upgrade block
 		require.Equal(t, L1InfoEcotoneLen, len(depTx.Data))
 		require.Equal(t, L1InfoFuncEcotoneBytes4, depTx.Data[:4])
 	})
-	t.Run("genesis-block isthmus", func(t *testing.T) {
+	t.Run("genesis-block interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}


### PR DESCRIPTION
**Description**

Rename L1BlockIsthmus to L1BlockInterop for consistency with the upgrade naming.
The scope of it is only the Golang files, there will be another one with the changes on the Solidity files because that's how it was asked from reviewers.

**Tests**

I added no tests, but only modified the contracts name so they don' break

**Additional context**

PR for the renaming on Soldity files: https://github.com/ethereum-optimism/optimism/pull/12132