### PR TITLE
cannon: Output information about the state in JSON format from the witness command

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -13,6 +13,8 @@ ifeq ($(shell uname),Darwin)
 	FUZZLDFLAGS := -ldflags=-extldflags=-Wl,-ld_classic
 endif
 
+.DEFAULT_GOAL := cannon
+
 cannon-impl:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/cannon-impl .
 

--- a/cannon/cmd/witness.go
+++ b/cannon/cmd/witness.go
@@ -5,6 +5,9 @@ import (
 	"os"
 
 	factory "github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"
 )
 
@@ -22,20 +25,35 @@ var (
 	}
 )
 
+type response struct {
+	WitnessHash common.Hash `json:"witnessHash"`
+	Step        uint64      `json:"step"`
+	Exited      bool        `json:"exited"`
+	ExitCode    uint8       `json:"exitCode"`
+}
+
 func Witness(ctx *cli.Context) error {
 	input := ctx.Path(WitnessInputFlag.Name)
-	output := ctx.Path(WitnessOutputFlag.Name)
+	witnessOutput := ctx.Path(WitnessOutputFlag.Name)
 	state, err := factory.LoadStateFromFile(input)
 	if err != nil {
 		return fmt.Errorf("invalid input state (%v): %w", input, err)
 	}
 	witness, h := state.EncodeWitness()
-	if output != "" {
-		if err := os.WriteFile(output, witness, 0755); err != nil {
-			return fmt.Errorf("writing output to %v: %w", output, err)
+	if witnessOutput != "" {
+		if err := os.WriteFile(witnessOutput, witness, 0755); err != nil {
+			return fmt.Errorf("writing output to %v: %w", witnessOutput, err)
 		}
 	}
-	fmt.Println(h.Hex())
+	output := response{
+		WitnessHash: h,
+		Step:        state.GetStep(),
+		Exited:      state.GetExited(),
+		ExitCode:    state.GetExitCode(),
+	}
+	if err := jsonutil.WriteJSON(output, ioutil.ToStdOut()); err != nil {
+		return fmt.Errorf("failed to write response: %w", err)
+	}
 	return nil
 }
 
@@ -43,7 +61,7 @@ func CreateWitnessCommand(action cli.ActionFunc) *cli.Command {
 	return &cli.Command{
 		Name:        "witness",
 		Usage:       "Convert a Cannon JSON state into a binary witness",
-		Description: "Convert a Cannon JSON state into a binary witness. The hash of the witness is written to stdout",
+		Description: "Convert a Cannon JSON state into a binary witness. Basic data about the state is printed to stdout in JSON format.",
 		Action:      action,
 		Flags: []cli.Flag{
 			WitnessInputFlag,

--- a/cannon/multicannon/witness.go
+++ b/cannon/multicannon/witness.go
@@ -32,7 +32,7 @@ func Witness(ctx *cli.Context) error {
 var WitnessCommand = &cli.Command{
 	Name:            "witness",
 	Usage:           "Convert a Cannon JSON state into a binary witness",
-	Description:     "Convert a Cannon JSON state into a binary witness. The hash of the witness is written to stdout",
+	Description:     "Convert a Cannon JSON state into a binary witness. Basic data about the state is printed to stdout in JSON format.",
 	Action:          Witness,
 	SkipFlagParsing: true,
 }


### PR DESCRIPTION
**Description**

Will provide all the information about a state that the challenger needs so it doesn't have to depend on the parsing code directly.

Also set the default target for make to `cannon` - previously it was just building `cannon-impl` so the `bin/cannon` command didn't get updated.
