### PR TITLE
op-challenger: Skip prestate verifications for the permissioned game.

### DIFF
--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -58,7 +58,7 @@ func NewHelper(log log.Logger, t *testing.T, require *require.Assertions, dir st
 	}
 }
 
-type Option func(config2 *config.Config)
+type Option func(c *config.Config)
 
 func WithFactoryAddress(addr common.Address) Option {
 	return func(c *config.Config) {
@@ -81,6 +81,18 @@ func WithPrivKey(key *ecdsa.PrivateKey) Option {
 func WithPollInterval(pollInterval time.Duration) Option {
 	return func(c *config.Config) {
 		c.PollInterval = pollInterval
+	}
+}
+
+func WithValidPrestateRequired() Option {
+	return func(c *config.Config) {
+		c.AllowInvalidPrestate = false
+	}
+}
+
+func WithInvalidCannonPrestate() Option {
+	return func(c *config.Config) {
+		c.CannonAbsolutePreState = "/tmp/not-a-real-prestate.foo"
 	}
 }
 
@@ -132,6 +144,13 @@ func applyCannonConfig(c *config.Config, t *testing.T, rollupCfg *rollup.Config,
 func WithCannon(t *testing.T, rollupCfg *rollup.Config, l2Genesis *core.Genesis) Option {
 	return func(c *config.Config) {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypeCannon)
+		applyCannonConfig(c, t, rollupCfg, l2Genesis)
+	}
+}
+
+func WithPermissioned(t *testing.T, rollupCfg *rollup.Config, l2Genesis *core.Genesis) Option {
+	return func(c *config.Config) {
+		c.TraceTypes = append(c.TraceTypes, types.TraceTypePermissioned)
 		applyCannonConfig(c, t, rollupCfg, l2Genesis)
 	}
 }

--- a/op-e2e/faultproofs/permissioned_test.go
+++ b/op-e2e/faultproofs/permissioned_test.go
@@ -1,0 +1,35 @@
+package faultproofs
+
+import (
+	"context"
+	"testing"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestPermissionedGameType(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+
+	ctx := context.Background()
+	sys, _ := StartFaultDisputeSystem(t)
+	t.Cleanup(sys.Close)
+
+	gameFactory := disputegame.NewFactoryHelper(t, ctx, sys, disputegame.WithFactoryPrivKey(sys.Cfg.Secrets.Proposer))
+
+	game := gameFactory.StartPermissionedGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
+
+	// Start a challenger with both cannon and alphabet support
+	gameFactory.StartChallenger(ctx, "TowerDefense",
+		challenger.WithValidPrestateRequired(),
+		challenger.WithInvalidCannonPrestate(),
+		challenger.WithPermissioned(t, sys.RollupConfig, sys.L2GenesisCfg),
+		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
+	)
+
+	// Wait for the challenger to respond
+	game.RootClaim(ctx).WaitForCounterClaim(ctx)
+}


### PR DESCRIPTION
**Description**

Skip prestate verifications for the permissioned game.

Simplifies deployment with minimal risk given that only permissioned actors are involved in the game and typically the challenger is only resolving games.

**Tests**

Added e2e test to ensure the challenger will interact with games even when the prestate doesn't match.
