### PR TITLE
proofs-tools: Update challenger to v1.1.2-rc.1

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -206,7 +206,7 @@ target "proofs-tools" {
   dockerfile = "./ops/docker/proofs-tools/Dockerfile"
   context = "."
   args = {
-    CHALLENGER_VERSION="90700b9bb37080961747420882b14578577d47cc"
+    CHALLENGER_VERSION="v1.1.2-rc.1"
     KONA_VERSION="kona-client-v0.1.0-alpha.3"
     ASTERISC_VERSION="v1.0.2"
   }


### PR DESCRIPTION
**Description**

Update proofs-tools to use op-challenger v1.1.2-rc.1 so we can test it in vm runner.
