### PR TITLE
contracts-bedrock: better error message

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-foundry-install.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-foundry-install.sh
@@ -5,6 +5,13 @@ CONTRACTS_BASE=$(dirname "$(dirname "$SCRIPT_DIR")")
 MONOREPO_BASE=$(dirname "$(dirname "$CONTRACTS_BASE")")
 VERSIONS_FILE="${MONOREPO_BASE}/versions.json"
 
+if ! command -v jq &> /dev/null
+then
+  # shellcheck disable=SC2006
+  echo "Please install jq" >&2
+  exit 1
+fi
+
 if ! command -v forge &> /dev/null
 then
   # shellcheck disable=SC2006


### PR DESCRIPTION
**Description**

The build fails when jq is not installed with
a mysterious error message, so improve the error message.
This will help debugging for new contributors.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
