### PR TITLE
chore: make interopgen deploy step fns public

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -39,18 +39,18 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 		L2s: make(map[string]*L2Deployment),
 	}
 
-	l1Host := createL1(logger, fa, srcFS, cfg.L1)
+	l1Host := CreateL1(logger, fa, srcFS, cfg.L1)
 	if err := l1Host.EnableCheats(); err != nil {
 		return nil, nil, fmt.Errorf("failed to enable cheats in L1 state: %w", err)
 	}
 
-	l1Deployment, err := prepareInitialL1(l1Host, cfg.L1)
+	l1Deployment, err := PrepareInitialL1(l1Host, cfg.L1)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to deploy initial L1 content: %w", err)
 	}
 	deployments.L1 = l1Deployment
 
-	superDeployment, err := deploySuperchainToL1(l1Host, cfg.Superchain)
+	superDeployment, err := DeploySuperchainToL1(l1Host, cfg.Superchain)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to deploy superchain to L1: %w", err)
 	}
@@ -62,7 +62,7 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 	// after creating the final config for any particular L2. Will add comments.
 
 	for l2ChainID, l2Cfg := range cfg.L2s {
-		l2Deployment, err := deployL2ToL1(l1Host, cfg.Superchain, superDeployment, l2Cfg)
+		l2Deployment, err := DeployL2ToL1(l1Host, cfg.Superchain, superDeployment, l2Cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to deploy L2 %d to L1: %w", &l2ChainID, err)
 		}
@@ -72,7 +72,7 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 	out := &WorldOutput{
 		L2s: make(map[string]*L2Output),
 	}
-	l1Out, err := completeL1(l1Host, cfg.L1)
+	l1Out, err := CompleteL1(l1Host, cfg.L1)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to complete L1: %w", err)
 	}
@@ -83,14 +83,14 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 	genesisTimestamp := l1Out.Genesis.Timestamp
 
 	for l2ChainID, l2Cfg := range cfg.L2s {
-		l2Host := createL2(logger, fa, srcFS, l2Cfg, genesisTimestamp)
+		l2Host := CreateL2(logger, fa, srcFS, l2Cfg, genesisTimestamp)
 		if err := l2Host.EnableCheats(); err != nil {
 			return nil, nil, fmt.Errorf("failed to enable cheats in L2 state %s: %w", l2ChainID, err)
 		}
-		if err := genesisL2(l2Host, l2Cfg, deployments.L2s[l2ChainID]); err != nil {
+		if err := GenesisL2(l2Host, l2Cfg, deployments.L2s[l2ChainID]); err != nil {
 			return nil, nil, fmt.Errorf("failed to apply genesis data to L2 %s: %w", l2ChainID, err)
 		}
-		l2Out, err := completeL2(l2Host, l2Cfg, l1GenesisBlock, deployments.L2s[l2ChainID])
+		l2Out, err := CompleteL2(l2Host, l2Cfg, l1GenesisBlock, deployments.L2s[l2ChainID])
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to complete L2 %s: %w", l2ChainID, err)
 		}
@@ -99,7 +99,7 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 	return deployments, out, nil
 }
 
-func createL1(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, cfg *L1Config) *script.Host {
+func CreateL1(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, cfg *L1Config) *script.Host {
 	l1Context := script.Context{
 		ChainID:      cfg.ChainID,
 		Sender:       sysGenesisDeployer,
@@ -115,7 +115,7 @@ func createL1(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceM
 	return l1Host
 }
 
-func createL2(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, l2Cfg *L2Config, genesisTimestamp uint64) *script.Host {
+func CreateL2(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMapFS, l2Cfg *L2Config, genesisTimestamp uint64) *script.Host {
 	l2Context := script.Context{
 		ChainID:      new(big.Int).SetUint64(l2Cfg.L2ChainID),
 		Sender:       sysGenesisDeployer,
@@ -134,7 +134,7 @@ func createL2(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceM
 }
 
 // prepareInitialL1 deploys basics such as preinstalls to L1  (incl. EIP-4788)
-func prepareInitialL1(l1Host *script.Host, cfg *L1Config) (*L1Deployment, error) {
+func PrepareInitialL1(l1Host *script.Host, cfg *L1Config) (*L1Deployment, error) {
 	l1Host.SetTxOrigin(sysGenesisDeployer)
 
 	if err := deployers.InsertPreinstalls(l1Host); err != nil {
@@ -145,7 +145,7 @@ func prepareInitialL1(l1Host *script.Host, cfg *L1Config) (*L1Deployment, error)
 	return &L1Deployment{}, nil
 }
 
-func deploySuperchainToL1(l1Host *script.Host, superCfg *SuperchainConfig) (*SuperchainDeployment, error) {
+func DeploySuperchainToL1(l1Host *script.Host, superCfg *SuperchainConfig) (*SuperchainDeployment, error) {
 	l1Host.SetTxOrigin(superCfg.Deployer)
 
 	superDeployment, err := opcm.DeploySuperchain(l1Host, opcm.DeploySuperchainInput{
@@ -189,7 +189,7 @@ func deploySuperchainToL1(l1Host *script.Host, superCfg *SuperchainConfig) (*Sup
 	}, nil
 }
 
-func deployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployment *SuperchainDeployment, cfg *L2Config) (*L2Deployment, error) {
+func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployment *SuperchainDeployment, cfg *L2Config) (*L2Deployment, error) {
 	if cfg.UseAltDA {
 		return nil, errors.New("alt-da mode not supported yet")
 	}
@@ -218,7 +218,7 @@ func deployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 	}, nil
 }
 
-func genesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) error {
+func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) error {
 	if err := opcm.L2Genesis(l2Host, &opcm.L2GenesisInput{
 		L1Deployments: opcm.L1Deployments{
 			L1CrossDomainMessengerProxy: deployment.L1CrossDomainMessengerProxy,
@@ -233,7 +233,7 @@ func genesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) err
 	return nil
 }
 
-func completeL1(l1Host *script.Host, cfg *L1Config) (*L1Output, error) {
+func CompleteL1(l1Host *script.Host, cfg *L1Config) (*L1Output, error) {
 	l1Genesis, err := genesis.NewL1Genesis(&genesis.DeployConfig{
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
@@ -276,7 +276,7 @@ func completeL1(l1Host *script.Host, cfg *L1Config) (*L1Output, error) {
 	}, nil
 }
 
-func completeL2(l2Host *script.Host, cfg *L2Config, l1Block *types.Block, deployment *L2Deployment) (*L2Output, error) {
+func CompleteL2(l2Host *script.Host, cfg *L2Config, l1Block *types.Block, deployment *L2Deployment) (*L2Output, error) {
 	deployCfg := &genesis.DeployConfig{
 		L2InitializationConfig: cfg.L2InitializationConfig,
 		L1DependenciesConfig: genesis.L1DependenciesConfig{


### PR DESCRIPTION
makes each step public so they can be used separately 

cc. @protolambda 

This is useful for generating genesis files for supersim so that we can deploy periphery contracts before generating the L2 genesis block