### PR TITLE
cannon: Consistent state serialization

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -43,6 +43,26 @@ contract:
 test: elf contract
 	go test -v ./...
 
+diff-%-cannon: cannon
+	$$OTHER_CANNON load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate-other.bin.gz --meta ""
+	./bin/cannon   load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate.bin.gz --meta ""
+	@cmp -s ./bin/prestate-other.bin.gz ./bin/prestate.bin.gz
+	@if [ $$? -eq 0 ]; then \
+		echo "Generated identical prestates"; \
+	else \
+		echo "Generated different prestates"; \
+		exit 1; \
+	fi
+	$$OTHER_CANNON run --proof-at '=0' --stop-at '=100000000' --input=/tmp/out32.bin.gz  --output ./bin/out-other.bin.gz --meta ""
+	./bin/cannon    run --proof-at '=0' --stop-at '=100000000' --input=/tmp/out32.bin.gz  --output ./bin/out.bin.gz --meta ""
+	@cmp -s ./bin/out-other.bin.gz ./bin/out.bin.gz
+	@if [ $$? -eq 0 ]; then \
+		echo "Generated identical states"; \
+	else \
+		echo "Generated different prestates"; \
+		exit 1; \
+	fi
+
 fuzz:
   # Common vm tests
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallBrk ./mipsevm/tests
@@ -65,4 +85,5 @@ fuzz:
 	clean \
 	test \
 	lint \
-	fuzz
+	fuzz \
+	diff-%-cannon

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -43,7 +43,7 @@ contract:
 test: elf contract
 	go test -v ./...
 
-diff-%-cannon: cannon
+diff-%-cannon: cannon elf
 	$$OTHER_CANNON load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate-other.bin.gz --meta ""
 	./bin/cannon   load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate.bin.gz --meta ""
 	@cmp ./bin/prestate-other.bin.gz ./bin/prestate.bin.gz

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -46,7 +46,7 @@ test: elf contract
 diff-%-cannon: cannon
 	$$OTHER_CANNON load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate-other.bin.gz --meta ""
 	./bin/cannon   load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate.bin.gz --meta ""
-	@cmp -s ./bin/prestate-other.bin.gz ./bin/prestate.bin.gz
+	@cmp ./bin/prestate-other.bin.gz ./bin/prestate.bin.gz
 	@if [ $$? -eq 0 ]; then \
 		echo "Generated identical prestates"; \
 	else \
@@ -55,7 +55,7 @@ diff-%-cannon: cannon
 	fi
 	$$OTHER_CANNON run --proof-at '=0' --stop-at '=100000000' --input=/tmp/out32.bin.gz  --output ./bin/out-other.bin.gz --meta ""
 	./bin/cannon    run --proof-at '=0' --stop-at '=100000000' --input=/tmp/out32.bin.gz  --output ./bin/out.bin.gz --meta ""
-	@cmp -s ./bin/out-other.bin.gz ./bin/out.bin.gz
+	@cmp ./bin/out-other.bin.gz ./bin/out.bin.gz
 	@if [ $$? -eq 0 ]; then \
 		echo "Generated identical states"; \
 	else \

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -53,8 +53,8 @@ diff-%-cannon: cannon
 		echo "Generated different prestates"; \
 		exit 1; \
 	fi
-	$$OTHER_CANNON run --proof-at '=0' --stop-at '=100000000' --input=/tmp/out32.bin.gz  --output ./bin/out-other.bin.gz --meta ""
-	./bin/cannon    run --proof-at '=0' --stop-at '=100000000' --input=/tmp/out32.bin.gz  --output ./bin/out.bin.gz --meta ""
+	$$OTHER_CANNON run --proof-at '=0' --stop-at '=100000000' --input=./bin/prestate.bin.gz  --output ./bin/out-other.bin.gz --meta ""
+	./bin/cannon   run --proof-at '=0' --stop-at '=100000000' --input=./bin/prestate.bin.gz  --output ./bin/out.bin.gz --meta ""
 	@cmp ./bin/out-other.bin.gz ./bin/out.bin.gz
 	@if [ $$? -eq 0 ]; then \
 		echo "Generated identical states"; \

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	"slices"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/exp/maps"
 )
 
 // Note: 2**12 = 4 KiB, the min phys page size in the Go runtime.
@@ -299,7 +301,11 @@ func (m *Memory) Serialize(out io.Writer) error {
 	if err := binary.Write(out, binary.BigEndian, uint32(m.PageCount())); err != nil {
 		return err
 	}
-	for pageIndex, page := range m.pages {
+	indexes := maps.Keys(m.pages)
+	// iterate sorted map keys for consistent serialization
+	slices.Sort(indexes)
+	for _, pageIndex := range indexes {
+		page := m.pages[pageIndex]
 		if err := binary.Write(out, binary.BigEndian, pageIndex); err != nil {
 			return err
 		}


### PR DESCRIPTION
Ensure that a given version of cannon can generate prestates consistently.

Also added a make file target to let us easily assert that the prestate is generated consistently and assert that the cannon behavior doesn't change.
After this change, we can utilize the `diff-singlethreaded-cannon` makefiel target to flag changes to cannon in CI.