### PR TITLE
OPSM: update bond defaults

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x08be0367ee031ee292b74aa9b6fc86c5d65cbbdadd455bb8120748eec79cf2d8",
-    "sourceCodeHash": "0x84fd2b583ddf44e900c58861ddda103f7bea793d71fb845f76ed28afd1e757bc"
+    "initCodeHash": "0x292d367322dc74744e8c98c463021e1abae77e57954eef8bac6e2081fcba5644",
+    "sourceCodeHash": "0xbfcc2032df842e50067d4b4a75ce66cc14cc34e67d35e37e2160215be57d8e2e"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -330,7 +330,6 @@ contract OPContractsManager is ISemver, Initializable {
         output.disputeGameFactoryProxy.setImplementation(
             GameTypes.PERMISSIONED_CANNON, IDisputeGame(address(output.permissionedDisputeGame))
         );
-        output.disputeGameFactoryProxy.setInitBond(GameTypes.PERMISSIONED_CANNON, 0.08 ether);
         output.disputeGameFactoryProxy.transferOwnership(address(output.opChainProxyAdmin));
 
         impl.logic = address(output.anchorStateRegistryImpl);

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -124,8 +124,8 @@ contract OPContractsManager is ISemver, Initializable {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.8
-    string public constant version = "1.0.0-beta.8";
+    /// @custom:semver 1.0.0-beta.9
+    string public constant version = "1.0.0-beta.9";
 
     /// @notice Represents the interface version so consumers know how to decode the DeployOutput struct
     /// that's emitted in the `Deployed` event. Whenever that struct changes, a new version should be used.

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -496,8 +496,12 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         assertEq(address(doo.permissionedDisputeGame().challenger()), challenger, "2600");
 
         // TODO once we deploy the Permissionless Dispute Game
-        // assertEq(address(doo.faultDisputeGame().proposer()), proposer, "2700");
-        // assertEq(address(doo.faultDisputeGame().challenger()), challenger, "2800");
+        // assertEq(address(doo.faultDisputeGame().proposer()), proposer, "2610");
+        // assertEq(address(doo.faultDisputeGame().challenger()), challenger, "2620");
+
+        // Verify that the initial bonds are zero.
+        assertEq(doo.disputeGameFactoryProxy().initBonds(GameTypes.CANNON), 0, "2700");
+        assertEq(doo.disputeGameFactoryProxy().initBonds(GameTypes.PERMISSIONED_CANNON), 0, "2800");
 
         // Most architecture assertions are handled within the OP Contracts Manager itself and therefore
         // we only assert on the things that are not visible onchain.


### PR DESCRIPTION
Sets the initial bond to 0, which is the default when `setInitBond` is not called