### PR TITLE
fix: Temporarily stop deploying DelayedWETHPermissionlessGameProxy

### DIFF
--- a/op-chain-ops/deployer/integration_test/apply_test.go
+++ b/op-chain-ops/deployer/integration_test/apply_test.go
@@ -243,7 +243,7 @@ func validateOPChainDeployment(t *testing.T, ctx context.Context, l1Client *ethc
 			{"FaultDisputeGameAddress", chainState.FaultDisputeGameAddress},
 			{"PermissionedDisputeGameAddress", chainState.PermissionedDisputeGameAddress},
 			{"DelayedWETHPermissionedGameProxyAddress", chainState.DelayedWETHPermissionedGameProxyAddress},
-			{"DelayedWETHPermissionlessGameProxyAddress", chainState.DelayedWETHPermissionlessGameProxyAddress},
+			// {"DelayedWETHPermissionlessGameProxyAddress", chainState.DelayedWETHPermissionlessGameProxyAddress},
 		}
 		for _, addr := range chainAddrs {
 			// TODO Delete this `if`` block once FaultDisputeGameAddress is deployed.

--- a/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployOPChain.s.sol
@@ -216,9 +216,11 @@ contract DeployOPChainOutput is BaseDeployIO {
             address(_anchorStateRegistryImpl),
             // address(_faultDisputeGame),
             address(_permissionedDisputeGame),
-            address(_delayedWETHPermissionedGameProxy),
-            address(_delayedWETHPermissionlessGameProxy)
+            address(_delayedWETHPermissionedGameProxy)
         );
+        // TODO: Eventually switch from Permissioned to Permissionless. Add this address back in.
+        // address(_delayedWETHPermissionlessGameProxy)
+
         DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
 
         assertValidDeploy(_doi);
@@ -295,7 +297,8 @@ contract DeployOPChainOutput is BaseDeployIO {
     }
 
     function delayedWETHPermissionlessGameProxy() public view returns (DelayedWETH) {
-        DeployUtils.assertValidContractAddress(address(_delayedWETHPermissionlessGameProxy));
+        // TODO: Eventually switch from Permissioned to Permissionless. Add this check back in.
+        // DeployUtils.assertValidContractAddress(address(_delayedWETHPermissionlessGameProxy));
         return _delayedWETHPermissionlessGameProxy;
     }
 
@@ -518,7 +521,8 @@ contract DeployOPChain is Script {
         // vm.label(address(deployOutput.faultDisputeGame), "faultDisputeGame");
         vm.label(address(deployOutput.permissionedDisputeGame), "permissionedDisputeGame");
         vm.label(address(deployOutput.delayedWETHPermissionedGameProxy), "delayedWETHPermissionedGameProxy");
-        vm.label(address(deployOutput.delayedWETHPermissionlessGameProxy), "delayedWETHPermissionlessGameProxy");
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // vm.label(address(deployOutput.delayedWETHPermissionlessGameProxy), "delayedWETHPermissionlessGameProxy");
 
         _doo.set(_doo.opChainProxyAdmin.selector, address(deployOutput.opChainProxyAdmin));
         _doo.set(_doo.addressManager.selector, address(deployOutput.addressManager));
@@ -536,9 +540,11 @@ contract DeployOPChain is Script {
         // _doo.set(_doo.faultDisputeGame.selector, address(deployOutput.faultDisputeGame));
         _doo.set(_doo.permissionedDisputeGame.selector, address(deployOutput.permissionedDisputeGame));
         _doo.set(_doo.delayedWETHPermissionedGameProxy.selector, address(deployOutput.delayedWETHPermissionedGameProxy));
-        _doo.set(
-            _doo.delayedWETHPermissionlessGameProxy.selector, address(deployOutput.delayedWETHPermissionlessGameProxy)
-        );
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // _doo.set(
+        //     _doo.delayedWETHPermissionlessGameProxy.selector,
+        // address(deployOutput.delayedWETHPermissionlessGameProxy)
+        // );
 
         _doo.checkOutput(_doi);
     }

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -33,7 +33,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0x43a2c579efd70775daa01a374e54ff1d45138f0a0dc3fcedfc9cbcd69e3747d5",
-    "sourceCodeHash": "0xb3e8744fa592e58482dedebee511a0ec7cb7ecb09faa9670fc7b452a8962a9bc"
+    "sourceCodeHash": "0xe9537f6c10fbc21cdac82fbe81770853c93ac1fa19b31505f4e4bcbdb69026e8"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x43a2c579efd70775daa01a374e54ff1d45138f0a0dc3fcedfc9cbcd69e3747d5",
-    "sourceCodeHash": "0xe9537f6c10fbc21cdac82fbe81770853c93ac1fa19b31505f4e4bcbdb69026e8"
+    "initCodeHash": "0x10d782d052937585b039a500c605d118947cca35fd0a09edfb8130534909b4be",
+    "sourceCodeHash": "0xce81774ba53cc358545ac92d302adff315e5f3a8354b449e960f6e16aa77b782"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x8f00d4415fe9bef59c1aec5b6729105c686e0238ce947432b2b5a035589cff19",
-    "sourceCodeHash": "0x4b1cb591b22821ae7246fe47260e1ece74f2cb0463fb949de66fe2b6a986a32c"
+    "initCodeHash": "0x43a2c579efd70775daa01a374e54ff1d45138f0a0dc3fcedfc9cbcd69e3747d5",
+    "sourceCodeHash": "0xb3e8744fa592e58482dedebee511a0ec7cb7ecb09faa9670fc7b452a8962a9bc"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x10d782d052937585b039a500c605d118947cca35fd0a09edfb8130534909b4be",
-    "sourceCodeHash": "0xce81774ba53cc358545ac92d302adff315e5f3a8354b449e960f6e16aa77b782"
+    "initCodeHash": "0xfc35bbfe19cb5345288d314ade85538a65ad213a7163133c0044b5556b180836",
+    "sourceCodeHash": "0x597bb234e83560d0e120b83334e152269d5fcdba2f8743bdd7594cc79098c15f"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -84,8 +84,6 @@ contract OPContractsManager is ISemver, Initializable {
         PermissionedDisputeGame permissionedDisputeGame;
         DelayedWETH delayedWETHPermissionedGameProxy;
     }
-    // TODO: Eventually switch from Permissioned to Permissionless
-    // DelayedWETH delayedWETHPermissionlessGameProxy;
 
     /// @notice The logic address and initializer selector for an implementation contract.
     struct Implementation {
@@ -283,11 +281,7 @@ contract OPContractsManager is ISemver, Initializable {
             Blueprint.deployFrom(blueprint.anchorStateRegistry, salt, abi.encode(output.disputeGameFactoryProxy))
         );
 
-        // We have two delayed WETH contracts per chain, one for each of the permissioned and permissionless games.
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // output.delayedWETHPermissionlessGameProxy = DelayedWETH(
-        //     payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "DelayedWETHPermissionlessGame"))
-        // );
+        // Eventually we will switch from DelayedWETHPermissionedGameProxy to DelayedWETHPermissionlessGameProxy.
         output.delayedWETHPermissionedGameProxy = DelayedWETH(
             payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "DelayedWETHPermissionedGame"))
         );
@@ -332,10 +326,8 @@ contract OPContractsManager is ISemver, Initializable {
 
         impl = getLatestImplementation("DelayedWETH");
         data = encodeDelayedWETHInitializer(impl.initializer, _input);
+        // Eventually we will switch from DelayedWETHPermissionedGameProxy to DelayedWETHPermissionlessGameProxy.
         upgradeAndCall(output.opChainProxyAdmin, address(output.delayedWETHPermissionedGameProxy), impl.logic, data);
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        //upgradeAndCall(output.opChainProxyAdmin, address(output.delayedWETHPermissionlessGameProxy), impl.logic,
-        // data);
 
         // We set the initial owner to this contract, set game implementations, then transfer ownership.
         impl = getLatestImplementation("DisputeGameFactory");

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -83,6 +83,7 @@ contract OPContractsManager is ISemver, Initializable {
         FaultDisputeGame faultDisputeGame;
         PermissionedDisputeGame permissionedDisputeGame;
         DelayedWETH delayedWETHPermissionedGameProxy;
+        DelayedWETH delayedWETHPermissionlessGameProxy;
     }
 
     /// @notice The logic address and initializer selector for an implementation contract.

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -125,8 +125,8 @@ contract OPContractsManager is ISemver, Initializable {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.10
-    string public constant version = "1.0.0-beta.10";
+    /// @custom:semver 1.0.0-beta.11
+    string public constant version = "1.0.0-beta.11";
 
     /// @notice Represents the interface version so consumers know how to decode the DeployOutput struct
     /// that's emitted in the `Deployed` event. Whenever that struct changes, a new version should be used.

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -83,8 +83,9 @@ contract OPContractsManager is ISemver, Initializable {
         FaultDisputeGame faultDisputeGame;
         PermissionedDisputeGame permissionedDisputeGame;
         DelayedWETH delayedWETHPermissionedGameProxy;
-        DelayedWETH delayedWETHPermissionlessGameProxy;
     }
+    // TODO: Eventually switch from Permissioned to Permissionless
+    // DelayedWETH delayedWETHPermissionlessGameProxy;
 
     /// @notice The logic address and initializer selector for an implementation contract.
     struct Implementation {
@@ -283,9 +284,10 @@ contract OPContractsManager is ISemver, Initializable {
         );
 
         // We have two delayed WETH contracts per chain, one for each of the permissioned and permissionless games.
-        output.delayedWETHPermissionlessGameProxy = DelayedWETH(
-            payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "DelayedWETHPermissionlessGame"))
-        );
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // output.delayedWETHPermissionlessGameProxy = DelayedWETH(
+        //     payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "DelayedWETHPermissionlessGame"))
+        // );
         output.delayedWETHPermissionedGameProxy = DelayedWETH(
             payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "DelayedWETHPermissionedGame"))
         );
@@ -331,7 +333,9 @@ contract OPContractsManager is ISemver, Initializable {
         impl = getLatestImplementation("DelayedWETH");
         data = encodeDelayedWETHInitializer(impl.initializer, _input);
         upgradeAndCall(output.opChainProxyAdmin, address(output.delayedWETHPermissionedGameProxy), impl.logic, data);
-        upgradeAndCall(output.opChainProxyAdmin, address(output.delayedWETHPermissionlessGameProxy), impl.logic, data);
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        //upgradeAndCall(output.opChainProxyAdmin, address(output.delayedWETHPermissionlessGameProxy), impl.logic,
+        // data);
 
         // We set the initial owner to this contract, set game implementations, then transfer ownership.
         impl = getLatestImplementation("DisputeGameFactory");

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -142,8 +142,9 @@ contract DeployOPChainOutput_Test is Test {
     FaultDisputeGame faultDisputeGame = FaultDisputeGame(makeAddr("faultDisputeGame"));
     PermissionedDisputeGame permissionedDisputeGame = PermissionedDisputeGame(makeAddr("permissionedDisputeGame"));
     DelayedWETH delayedWETHPermissionedGameProxy = DelayedWETH(payable(makeAddr("delayedWETHPermissionedGameProxy")));
-    DelayedWETH delayedWETHPermissionlessGameProxy =
-        DelayedWETH(payable(makeAddr("delayedWETHPermissionlessGameProxy")));
+    // TODO: Eventually switch from Permissioned to Permissionless.
+    // DelayedWETH delayedWETHPermissionlessGameProxy =
+    //     DelayedWETH(payable(makeAddr("delayedWETHPermissionlessGameProxy")));
 
     function setUp() public {
         doo = new DeployOPChainOutput();
@@ -164,7 +165,8 @@ contract DeployOPChainOutput_Test is Test {
         vm.etch(address(faultDisputeGame), hex"01");
         vm.etch(address(permissionedDisputeGame), hex"01");
         vm.etch(address(delayedWETHPermissionedGameProxy), hex"01");
-        vm.etch(address(delayedWETHPermissionlessGameProxy), hex"01");
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // vm.etch(address(delayedWETHPermissionlessGameProxy), hex"01");
 
         doo.set(doo.opChainProxyAdmin.selector, address(opChainProxyAdmin));
         doo.set(doo.addressManager.selector, address(addressManager));
@@ -180,7 +182,8 @@ contract DeployOPChainOutput_Test is Test {
         doo.set(doo.faultDisputeGame.selector, address(faultDisputeGame));
         doo.set(doo.permissionedDisputeGame.selector, address(permissionedDisputeGame));
         doo.set(doo.delayedWETHPermissionedGameProxy.selector, address(delayedWETHPermissionedGameProxy));
-        doo.set(doo.delayedWETHPermissionlessGameProxy.selector, address(delayedWETHPermissionlessGameProxy));
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // doo.set(doo.delayedWETHPermissionlessGameProxy.selector, address(delayedWETHPermissionlessGameProxy));
 
         assertEq(address(opChainProxyAdmin), address(doo.opChainProxyAdmin()), "100");
         assertEq(address(addressManager), address(doo.addressManager()), "200");
@@ -196,7 +199,9 @@ contract DeployOPChainOutput_Test is Test {
         assertEq(address(faultDisputeGame), address(doo.faultDisputeGame()), "1300");
         assertEq(address(permissionedDisputeGame), address(doo.permissionedDisputeGame()), "1400");
         assertEq(address(delayedWETHPermissionedGameProxy), address(doo.delayedWETHPermissionedGameProxy()), "1500");
-        assertEq(address(delayedWETHPermissionlessGameProxy), address(doo.delayedWETHPermissionlessGameProxy()), "1600");
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // assertEq(address(delayedWETHPermissionlessGameProxy), address(doo.delayedWETHPermissionlessGameProxy()),
+        // "1600");
     }
 
     function test_getters_whenNotSet_revert() public {
@@ -244,8 +249,9 @@ contract DeployOPChainOutput_Test is Test {
         vm.expectRevert(expectedErr);
         doo.delayedWETHPermissionedGameProxy();
 
-        vm.expectRevert(expectedErr);
-        doo.delayedWETHPermissionlessGameProxy();
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // vm.expectRevert(expectedErr);
+        // doo.delayedWETHPermissionlessGameProxy();
     }
 
     function test_getters_whenAddrHasNoCode_reverts() public {
@@ -308,9 +314,10 @@ contract DeployOPChainOutput_Test is Test {
         vm.expectRevert(expectedErr);
         doo.delayedWETHPermissionedGameProxy();
 
-        doo.set(doo.delayedWETHPermissionlessGameProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.delayedWETHPermissionlessGameProxy();
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // doo.set(doo.delayedWETHPermissionlessGameProxy.selector, emptyAddr);
+        // vm.expectRevert(expectedErr);
+        // doo.delayedWETHPermissionlessGameProxy();
     }
 }
 


### PR DESCRIPTION
We will eventually deploy `DelayedWETHPermissionlessGameProxy` instead of `DelayedWETHPermissionedGameProxy`. Not for this release of OPCM.