### PR TITLE
docs: fix invalid link to github issue

### DIFF
--- a/packages/contracts-bedrock/CONTRIBUTING.md
+++ b/packages/contracts-bedrock/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you have any questions about the smart contracts, please feel free to ask the
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/ethereum-optimism/optimism/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step** description of the suggested enhancement in as many details as possible.


### PR DESCRIPTION
**Description**

I've found that the link to github issue is invalid while checking the contributing document.
The link is modified and should work now.

**Tests**

no test is required