### PR TITLE
ci: Add Cannon STF verify recurring job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1165,7 +1165,7 @@ jobs:
           command: make cannon
       - run:
           name: Verify the Cannon STF
-          command: make -f cannon/Makefile cannon-stf-verify
+          command: make -f cannon/Makefile -C ./cannon cannon-stf-verify
       - save_cache:
           name: Save Go build cache
           key: golang-build-cache-cannon-stf-verify-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1165,7 +1165,7 @@ jobs:
           command: make cannon
       - run:
           name: Verify the Cannon STF
-          command: make -f cannon/Makefile -C ./cannon cannon-stf-verify
+          command: make -C ./cannon cannon-stf-verify
       - save_cache:
           name: Save Go build cache
           key: golang-build-cache-cannon-stf-verify-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,6 +1151,7 @@ jobs:
       - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
+      - setup_remote_docker
       - restore_cache:
           name: Restore Go modules cache
           key: gomod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1146,6 +1146,31 @@ jobs:
       - notify-failures-on-develop:
           mentions: "@proofs-squad"
 
+  cannon-stf-verify:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          name: Restore Go build cache
+          keys:
+            - golang-build-cache-cannon-stf-verify-{{ checksum "go.sum" }}
+            - golang-build-cache-cannon-stf-verify-
+      - run:
+          name: Build cannon
+          command: make cannon
+      - run:
+          name: Verify the Cannon STF
+          command: make -f cannon/Makefile cannon-stf-verify
+      - save_cache:
+          name: Save Go build cache
+          key: golang-build-cache-cannon-stf-verify-{{ checksum "go.sum" }}
+          paths:
+            - "/root/.cache/go-build"
+
   devnet:
     machine:
       image: <<pipeline.parameters.base_image>>
@@ -1867,6 +1892,9 @@ workflows:
       - cannon-prestate:
           requires:
             - go-mod-download
+      - cannon-stf-verify:
+          requires:
+            - go-mod-download
       - contracts-bedrock-build:
           skip_pattern: test
           context:
@@ -1884,6 +1912,7 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
+            - cannon-stf-verify
           context:
             - slack
 

--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,0 +1,34 @@
+FROM golang:1.21.3-alpine3.18 as builder
+
+RUN apk add --no-cache make bash
+
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN echo "go mod cache: $(go env GOMODCACHE)"
+RUN echo "go build cache: $(go env GOCACHE)"
+
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go mod download
+
+COPY . /app
+
+# We avoid copying the full .git dir into the build for just some metadata.
+# Instead, specify:
+# --build-arg GIT_COMMIT=$(git rev-parse HEAD)
+# --build-arg GIT_DATE=$(git show -s --format='%ct')
+ARG GIT_COMMIT
+ARG GIT_DATE
+
+ARG TARGETOS TARGETARCH
+
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.0.0-alpha.2 AS cannon-v1
+
+FROM --platform=$BUILDPLATFORM builder as cannon-verify
+COPY --from=cannon-v1 /usr/local/bin/cannon /usr/local/bin/cannon-v1
+# verify the latest singlethreaded VM behavior against cannon-v1
+RUN cd cannon && make diff-singlethreaded-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v1
+RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && \
+    make diff-singlethreaded-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v1 \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -65,6 +65,9 @@ diff-%-cannon: cannon elf
 		exit 1; \
 	fi
 
+cannon-stf-verify:
+	@docker build --progress plain -f Dockerfile.diff ../
+
 fuzz:
   # Common vm tests
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallBrk ./mipsevm/tests
@@ -88,4 +91,5 @@ fuzz:
 	test \
 	lint \
 	fuzz \
-	diff-%-cannon
+	diff-%-cannon \
+	cannon-stf-verify


### PR DESCRIPTION
This patch adds a recurring CI job that compares the generated states and execution of cannon against an older cannon release. It's an sanity check, over the existing VM tests, asserting that the Cannon STF isn't altered. This can be more robust than existing tests in the VM as it avoids bugs introduced to the test themselves.

For now, the job asserts that changes to Cannon does not alter the state transition function of the singlethreaded V1 state version (i.e. the version used for the Granite upgrade). In the future, the new job will be extended to verify multithreaded cannon and the upcoming cannon STF changes for holocene.