### PR TITLE
maint(ct): add leftover interfaces

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
@@ -885,7 +885,7 @@ contract DeployImplementations is Script {
         if (existingImplementation != address(0)) {
             singleton = MIPS(payable(existingImplementation));
         } else if (isDevelopRelease(release)) {
-            IPreimageOracle preimageOracle = IPreimageOracle(_dio.preimageOracleSingleton());
+            IPreimageOracle preimageOracle = IPreimageOracle(address(_dio.preimageOracleSingleton()));
             vm.broadcast(msg.sender);
             singleton = new MIPS(preimageOracle);
         } else {

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -10,9 +10,6 @@ import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
 import { Deployer } from "scripts/deploy/Deployer.sol";
 import { ISystemConfigV0 } from "scripts/interfaces/ISystemConfigV0.sol";
 
-// Contracts
-import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
-
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/scripts/fpac/FPACOPS.s.sol
+++ b/packages/contracts-bedrock/scripts/fpac/FPACOPS.s.sol
@@ -5,13 +5,11 @@ pragma solidity 0.8.15;
 import { StdAssertions } from "forge-std/StdAssertions.sol";
 import "scripts/deploy/Deploy.s.sol";
 
-// Contracts
-import { Proxy } from "src/universal/Proxy.sol";
-
 // Libraries
 import "src/dispute/lib/Types.sol";
 
 // Interfaces
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
@@ -78,7 +76,7 @@ contract FPACOPS is Deploy, StdAssertions {
         console.log("Initializing DisputeGameFactoryProxy with DisputeGameFactory.");
 
         address dgfProxy = mustGetAddress("DisputeGameFactoryProxy");
-        Proxy(payable(dgfProxy)).upgradeToAndCall(
+        IProxy(payable(dgfProxy)).upgradeToAndCall(
             mustGetAddress("DisputeGameFactory"), abi.encodeCall(IDisputeGameFactory.initialize, msg.sender)
         );
 
@@ -93,7 +91,7 @@ contract FPACOPS is Deploy, StdAssertions {
 
         address wethProxy = mustGetAddress("DelayedWETHProxy");
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
-        Proxy(payable(wethProxy)).upgradeToAndCall(
+        IProxy(payable(wethProxy)).upgradeToAndCall(
             mustGetAddress("DelayedWETH"),
             abi.encodeCall(IDelayedWETH.initialize, (msg.sender, ISuperchainConfig(superchainConfigProxy)))
         );
@@ -121,7 +119,7 @@ contract FPACOPS is Deploy, StdAssertions {
         });
 
         address asrProxy = mustGetAddress("AnchorStateRegistryProxy");
-        Proxy(payable(asrProxy)).upgradeToAndCall(
+        IProxy(payable(asrProxy)).upgradeToAndCall(
             mustGetAddress("AnchorStateRegistry"),
             abi.encodeCall(IAnchorStateRegistry.initialize, (roots, superchainConfig))
         );
@@ -136,7 +134,7 @@ contract FPACOPS is Deploy, StdAssertions {
         dgf.transferOwnership(_systemOwnerSafe);
 
         // Transfer the admin rights of the DisputeGameFactoryProxy to the ProxyAdmin.
-        Proxy prox = Proxy(payable(address(dgf)));
+        IProxy prox = IProxy(payable(address(dgf)));
         prox.changeAdmin(_proxyAdmin);
     }
 
@@ -149,7 +147,7 @@ contract FPACOPS is Deploy, StdAssertions {
         weth.transferOwnership(_systemOwnerSafe);
 
         // Transfer the admin rights of the DelayedWETHProxy to the ProxyAdmin.
-        Proxy prox = Proxy(payable(address(weth)));
+        IProxy prox = IProxy(payable(address(weth)));
         prox.changeAdmin(_proxyAdmin);
     }
 
@@ -158,7 +156,7 @@ contract FPACOPS is Deploy, StdAssertions {
         IAnchorStateRegistry asr = IAnchorStateRegistry(mustGetAddress("AnchorStateRegistryProxy"));
 
         // Transfer the admin rights of the AnchorStateRegistryProxy to the ProxyAdmin.
-        Proxy prox = Proxy(payable(address(asr)));
+        IProxy prox = IProxy(payable(address(asr)));
         prox.changeAdmin(_proxyAdmin);
     }
 
@@ -182,11 +180,11 @@ contract FPACOPS is Deploy, StdAssertions {
         // Check the config elements in the deployed contracts.
         ChainAssertions.checkOptimismPortal2(contracts, cfg, false);
 
-        PreimageOracle oracle = PreimageOracle(mustGetAddress("PreimageOracle"));
+        IPreimageOracle oracle = IPreimageOracle(mustGetAddress("PreimageOracle"));
         assertEq(oracle.minProposalSize(), cfg.preimageOracleMinProposalSize());
         assertEq(oracle.challengePeriod(), cfg.preimageOracleChallengePeriod());
 
-        MIPS mips = MIPS(mustGetAddress("Mips"));
+        IMIPS mips = IMIPS(mustGetAddress("Mips"));
         assertEq(address(mips.oracle()), address(oracle));
 
         // Check the AnchorStateRegistry configuration.

--- a/packages/contracts-bedrock/scripts/fpac/FPACOPS2.s.sol
+++ b/packages/contracts-bedrock/scripts/fpac/FPACOPS2.s.sol
@@ -5,13 +5,11 @@ pragma solidity 0.8.15;
 import { StdAssertions } from "forge-std/StdAssertions.sol";
 import "scripts/deploy/Deploy.s.sol";
 
-// Contracts
-import { Proxy } from "src/universal/Proxy.sol";
-
 // Libraries
 import "src/dispute/lib/Types.sol";
 
 // Interfaces
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
@@ -152,7 +150,7 @@ contract FPACOPS2 is Deploy, StdAssertions {
 
         address wethProxy = mustGetAddress("DelayedWETHProxy");
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
-        Proxy(payable(wethProxy)).upgradeToAndCall(
+        IProxy(payable(wethProxy)).upgradeToAndCall(
             mustGetAddress("DelayedWETH"),
             abi.encodeCall(IDelayedWETH.initialize, (msg.sender, ISuperchainConfig(superchainConfigProxy)))
         );
@@ -164,7 +162,7 @@ contract FPACOPS2 is Deploy, StdAssertions {
 
         address wethProxy = mustGetAddress("PermissionedDelayedWETHProxy");
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
-        Proxy(payable(wethProxy)).upgradeToAndCall(
+        IProxy(payable(wethProxy)).upgradeToAndCall(
             mustGetAddress("DelayedWETH"),
             abi.encodeCall(IDelayedWETH.initialize, (msg.sender, ISuperchainConfig(superchainConfigProxy)))
         );
@@ -181,7 +179,7 @@ contract FPACOPS2 is Deploy, StdAssertions {
         weth.transferOwnership(_systemOwnerSafe);
 
         // Transfer the admin rights of the DelayedWETHProxy to the ProxyAdmin.
-        Proxy prox = Proxy(payable(address(weth)));
+        IProxy prox = IProxy(payable(address(weth)));
         prox.changeAdmin(_proxyAdmin);
     }
 
@@ -196,7 +194,7 @@ contract FPACOPS2 is Deploy, StdAssertions {
         weth.transferOwnership(_systemOwnerSafe);
 
         // Transfer the admin rights of the DelayedWETHProxy to the ProxyAdmin.
-        Proxy prox = Proxy(payable(address(weth)));
+        IProxy prox = IProxy(payable(address(weth)));
         prox.changeAdmin(_proxyAdmin);
     }
 
@@ -225,12 +223,12 @@ contract FPACOPS2 is Deploy, StdAssertions {
         ChainAssertions.checkPermissionedDelayedWETH(contracts, cfg, true, _systemOwnerSafe);
 
         // Verify PreimageOracle configuration.
-        PreimageOracle oracle = PreimageOracle(mustGetAddress("PreimageOracle"));
+        IPreimageOracle oracle = IPreimageOracle(mustGetAddress("PreimageOracle"));
         assertEq(oracle.minProposalSize(), cfg.preimageOracleMinProposalSize());
         assertEq(oracle.challengePeriod(), cfg.preimageOracleChallengePeriod());
 
         // Verify MIPS configuration.
-        MIPS mips = MIPS(mustGetAddress("Mips"));
+        IMIPS mips = IMIPS(mustGetAddress("Mips"));
         assertEq(address(mips.oracle()), address(oracle));
 
         // Grab ASR

--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -10,8 +10,8 @@ import { Artifacts } from "scripts/Artifacts.s.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { Bytes } from "src/libraries/Bytes.sol";
 
-// Contracts
-import { Proxy } from "src/universal/Proxy.sol";
+// Interfaces
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 
 library DeployUtils {
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
@@ -221,7 +221,7 @@ library DeployUtils {
         // We prank as the zero address due to the Proxy's `proxyCallIfNotAdmin` modifier.
         // Pranking inside this function also means it can no longer be considered `view`.
         vm.prank(address(0));
-        address implementation = Proxy(payable(_proxy)).implementation();
+        address implementation = IProxy(payable(_proxy)).implementation();
         assertValidContractAddress(implementation);
     }
 

--- a/packages/contracts-bedrock/scripts/periphery/deploy/DeployPeriphery.s.sol
+++ b/packages/contracts-bedrock/scripts/periphery/deploy/DeployPeriphery.s.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
+// TODO: Migrate this script to use DeployUtils
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xde4df0f9633dc0cdb1c9f634003ea5b0f7c5c1aebc407bc1b2f44c0ecf938649"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x620481066bd0979c409ed9c089d32a1b7a05c610509222901ee3e73b0dc5565d",
-    "sourceCodeHash": "0x1bd201aef876cd32a34f8b100362df87ffaa0c1ddfbf5a19a5c43ced4c26d791"
+    "initCodeHash": "0x944deadee322fdbae8a8fffd16deceb3766509cfb54da06adb8aa84473f79f53",
+    "sourceCodeHash": "0x1a48119cbc0b778a4dd3454179060b71361ba44b61af1ac6398cc9274bb5e89f"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0x50ed780b621521047ed36ffb260032f2e5ec287f3e1ab3d742c7de45febb280d"
   },
   "src/cannon/PreimageOracle.sol": {
-    "initCodeHash": "0x801e52f9c8439fcf7089575fa93272dfb874641dbfc7d82f36d979c987271c0b",
-    "sourceCodeHash": "0xdb9421a552e6d7581b3db9e4c2a02d8210ad6ca66ba0f8703d77f7cd4b8e132b"
+    "initCodeHash": "0x3690e6dafe588c29de74790123bf6de5b0f741869bf5dbd8a122fdef96cab733",
+    "sourceCodeHash": "0x19b48b7d5fcb296cacf0cb15326b2e12a9556d6d811a16cbe2344792afa30427"
   },
   "src/dispute/AnchorStateRegistry.sol": {
     "initCodeHash": "0x13d00eef8c3f769863fc766180acc8586f5da309ca0a098e67d4d90bd3243341",

--- a/packages/contracts-bedrock/snapshots/abi/ProxyAdmin.json
+++ b/packages/contracts-bedrock/snapshots/abi/ProxyAdmin.json
@@ -15,7 +15,7 @@
     "name": "addressManager",
     "outputs": [
       {
-        "internalType": "contract AddressManager",
+        "internalType": "contract IAddressManager",
         "name": "",
         "type": "address"
       }
@@ -171,7 +171,7 @@
   {
     "inputs": [
       {
-        "internalType": "contract AddressManager",
+        "internalType": "contract IAddressManager",
         "name": "_address",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/storageLayout/ProxyAdmin.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ProxyAdmin.json
@@ -25,7 +25,7 @@
     "label": "addressManager",
     "offset": 0,
     "slot": "3",
-    "type": "contract AddressManager"
+    "type": "contract IAddressManager"
   },
   {
     "bytes": "1",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -13,6 +13,7 @@ import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { ISystemConfigV160 } from "src/L1/interfaces/ISystemConfigV160.sol";
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
 
 import { Proxy } from "src/universal/Proxy.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
@@ -127,8 +128,8 @@ contract OPContractsManager is ISemver, Initializable {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.13
-    string public constant version = "1.0.0-beta.13";
+    /// @custom:semver 1.0.0-beta.14
+    string public constant version = "1.0.0-beta.14";
 
     /// @notice Represents the interface version so consumers know how to decode the DeployOutput struct
     /// that's emitted in the `Deployed` event. Whenever that struct changes, a new version should be used.
@@ -240,7 +241,7 @@ contract OPContractsManager is ISemver, Initializable {
         output.addressManager = AddressManager(Blueprint.deployFrom(blueprint.addressManager, salt));
         output.opChainProxyAdmin =
             ProxyAdmin(Blueprint.deployFrom(blueprint.proxyAdmin, salt, abi.encode(address(this))));
-        output.opChainProxyAdmin.setAddressManager(output.addressManager);
+        output.opChainProxyAdmin.setAddressManager(IAddressManager(address(output.addressManager)));
 
         // -------- Deploy Proxy Contracts --------
 

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { PreimageKeyLib } from "./PreimageKeyLib.sol";
+// Libraries
 import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
+import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
 import "src/cannon/libraries/CannonErrors.sol";
 import "src/cannon/libraries/CannonTypes.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title PreimageOracle
 /// @notice A contract for storing permissioned pre-images.
 /// @custom:attribution Solady <https://github.com/Vectorized/solady/blob/main/src/utils/MerkleProofLib.sol#L13-L43>
 /// @custom:attribution Beacon Deposit Contract <0x00000000219ab540356cbb839cbe05303d7705fa>
-contract PreimageOracle is IPreimageOracle, ISemver {
+contract PreimageOracle is ISemver {
     ////////////////////////////////////////////////////////////////
     //                   Constants & Immutables                   //
     ////////////////////////////////////////////////////////////////
@@ -31,8 +33,8 @@ contract PreimageOracle is IPreimageOracle, ISemver {
     uint256 public constant PRECOMPILE_CALL_RESERVED_GAS = 100_000;
 
     /// @notice The semantic version of the Preimage Oracle contract.
-    /// @custom:semver 1.1.3-beta.2
-    string public constant version = "1.1.3-beta.2";
+    /// @custom:semver 1.1.3-beta.3
+    string public constant version = "1.1.3-beta.3";
 
     ////////////////////////////////////////////////////////////////
     //                 Authorized Preimage Parts                  //
@@ -107,7 +109,11 @@ contract PreimageOracle is IPreimageOracle, ISemver {
     //             Standard Preimage Route (External)             //
     ////////////////////////////////////////////////////////////////
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Reads a preimage from the oracle.
+    /// @param _key The key of the preimage to read.
+    /// @param _offset The offset of the preimage to read.
+    /// @return dat_ The preimage data.
+    /// @return datLen_ The length of the preimage data.
     function readPreimage(bytes32 _key, uint256 _offset) external view returns (bytes32 dat_, uint256 datLen_) {
         require(preimagePartOk[_key][_offset], "pre-image must exist");
 
@@ -123,7 +129,27 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         dat_ = preimageParts[_key][_offset];
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Loads of local data part into the preimage oracle.
+    /// @param _ident The identifier of the local data.
+    /// @param _localContext The local key context for the preimage oracle. Optionally, can be set as a constant
+    ///                      if the caller only requires one set of local keys.
+    /// @param _word The local data word.
+    /// @param _size The number of bytes in `_word` to load.
+    /// @param _partOffset The offset of the local data part to write to the oracle.
+    /// @dev The local data parts are loaded into the preimage oracle under the context
+    ///      of the caller - no other account can write to the caller's context
+    ///      specific data.
+    ///
+    ///      There are 5 local data identifiers:
+    ///      ┌────────────┬────────────────────────┐
+    ///      │ Identifier │      Data              │
+    ///      ├────────────┼────────────────────────┤
+    ///      │          1 │ L1 Head Hash (bytes32) │
+    ///      │          2 │ Output Root (bytes32)  │
+    ///      │          3 │ Root Claim (bytes32)   │
+    ///      │          4 │ L2 Block Number (u64)  │
+    ///      │          5 │ Chain ID (u64)         │
+    ///      └────────────┴────────────────────────┘
     function loadLocalData(
         uint256 _ident,
         bytes32 _localContext,
@@ -163,7 +189,10 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key_] = _size;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Prepares a preimage to be read by keccak256 key, starting at the given offset and up to 32 bytes
+    ///         (clipped at preimage length, if out of data).
+    /// @param _partOffset The offset of the preimage to read.
+    /// @param _preimage The preimage data.
     function loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external {
         uint256 size;
         bytes32 key;
@@ -198,7 +227,10 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key] = size;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Prepares a preimage to be read by sha256 key, starting at the given offset and up to 32 bytes
+    ///         (clipped at preimage length, if out of data).
+    /// @param _partOffset The offset of the preimage to read.
+    /// @param _preimage The preimage data.
     function loadSha256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external {
         uint256 size;
         bytes32 key;
@@ -247,7 +279,13 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key] = size;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Verifies that `p(_z) = _y` given `_commitment` that corresponds to the polynomial `p(x)` and a KZG
+    //          proof. The value `y` is the pre-image, and the preimage key is `5 ++ keccak256(_commitment ++ z)[1:]`.
+    /// @param _z Big endian point value. Part of the preimage key.
+    /// @param _y Big endian point value. The preimage for the key.
+    /// @param _commitment The commitment to the polynomial. 48 bytes, part of the preimage key.
+    /// @param _proof The KZG proof, part of the preimage key.
+    /// @param _partOffset The offset of the preimage to store.
     function loadBlobPreimagePart(
         uint256 _z,
         uint256 _y,
@@ -338,7 +376,13 @@ contract PreimageOracle is IPreimageOracle, ISemver {
         preimageLengths[key] = 32;
     }
 
-    /// @inheritdoc IPreimageOracle
+    /// @notice Prepares a precompile result to be read by a precompile key for the specified offset.
+    ///         The precompile result data is a concatenation of the precompile call status byte and its return data.
+    ///         The preimage key is `6 ++ keccak256(precompile ++ input)[1:]`.
+    /// @param _partOffset The offset of the precompile result being loaded.
+    /// @param _precompile The precompile address
+    /// @param _requiredGas The gas required to fully execute an L1 precompile.
+    /// @param _input The input to the precompile call.
     function loadPrecompilePreimagePart(
         uint256 _partOffset,
         address _precompile,

--- a/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
@@ -88,4 +88,9 @@ interface IPreimageOracle {
         bytes calldata _input
     )
         external;
+
+    /// @notice Returns the minimum size (in bytes) of a large preimage proposal.
+    function minProposalSize() external view returns (uint256);
+
+    function __constructor__(uint256 _minProposalSize, uint256 _challengePeriod) external;
 }

--- a/packages/contracts-bedrock/src/legacy/interfaces/IResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/interfaces/IResolvedDelegateProxy.sol
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
+
 /// @title IResolvedDelegateProxy
 /// @notice Interface for the ResolvedDelegateProxy contract.
 interface IResolvedDelegateProxy {
     fallback() external payable;
+
+    receive() external payable;
+
+    function __constructor__(IAddressManager _addressManager, string memory _implementationName) external;
 }

--- a/packages/contracts-bedrock/src/universal/interfaces/IOptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/universal/interfaces/IOptimismMintableERC721Factory.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOptimismMintableERC721Factory {
+    event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
+
+    function BRIDGE() external view returns (address);
+    function REMOTE_CHAIN_ID() external view returns (uint256);
+    function createOptimismMintableERC721(
+        address _remoteToken,
+        string memory _name,
+        string memory _symbol
+    )
+        external
+        returns (address);
+    function isOptimismMintableERC721(address) external view returns (bool);
+    function version() external view returns (string memory);
+
+    function __constructor__(address _bridge, uint256 _remoteChainId) external;
+}

--- a/packages/contracts-bedrock/src/universal/interfaces/IProxy.sol
+++ b/packages/contracts-bedrock/src/universal/interfaces/IProxy.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IProxy {
+    event AdminChanged(address previousAdmin, address newAdmin);
+    event Upgraded(address indexed implementation);
+
+    fallback() external payable;
+
+    receive() external payable;
+
+    function admin() external returns (address);
+    function changeAdmin(address _admin) external;
+    function implementation() external returns (address);
+    function upgradeTo(address _implementation) external;
+    function upgradeToAndCall(address _implementation, bytes memory _data) external payable returns (bytes memory);
+
+    function __constructor__(address _admin) external;
+}

--- a/packages/contracts-bedrock/src/universal/interfaces/IProxyAdmin.sol
+++ b/packages/contracts-bedrock/src/universal/interfaces/IProxyAdmin.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
+
+interface IProxyAdmin {
+    enum ProxyType {
+        ERC1967,
+        CHUGSPLASH,
+        RESOLVED
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    function addressManager() external view returns (IAddressManager);
+    function changeProxyAdmin(address payable _proxy, address _newAdmin) external;
+    function getProxyAdmin(address payable _proxy) external view returns (address);
+    function getProxyImplementation(address _proxy) external view returns (address);
+    function implementationName(address) external view returns (string memory);
+    function isUpgrading() external view returns (bool);
+    function owner() external view returns (address);
+    function proxyType(address) external view returns (ProxyType);
+    function renounceOwnership() external;
+    function setAddress(string memory _name, address _address) external;
+    function setAddressManager(IAddressManager _address) external;
+    function setImplementationName(address _address, string memory _name) external;
+    function setProxyType(address _address, ProxyType _type) external;
+    function setUpgrading(bool _upgrading) external;
+    function transferOwnership(address newOwner) external; // nosemgrep
+    function upgrade(address payable _proxy, address _implementation) external;
+    function upgradeAndCall(address payable _proxy, address _implementation, bytes memory _data) external payable;
+
+    function __constructor__(address _owner) external;
+}

--- a/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
+++ b/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
@@ -8,7 +8,6 @@ import {
     CommitmentType
 } from "src/L1/interfaces/IDataAvailabilityChallenge.sol";
 import { computeCommitmentKeccak256 } from "src/L1/DataAvailabilityChallenge.sol";
-import { Proxy } from "src/universal/Proxy.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -10,7 +10,6 @@ import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Contracts
-import { Proxy } from "src/universal/Proxy.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 
 // Libraries
@@ -27,6 +26,7 @@ import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
 import { IL2OutputOracle } from "src/L1/interfaces/IL2OutputOracle.sol";
 import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
 import { IOptimismPortal } from "src/L1/interfaces/IOptimismPortal.sol";
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 
 contract OptimismPortal_Test is CommonTest {
     address depositor;
@@ -1173,10 +1173,10 @@ contract OptimismPortalUpgradeable_Test is CommonTest {
         vm.startPrank(EIP1967Helper.getAdmin(address(optimismPortal)));
         // The value passed to the initialize must be larger than the last value
         // that initialize was called with.
-        Proxy(payable(address(optimismPortal))).upgradeToAndCall(
+        IProxy(payable(address(optimismPortal))).upgradeToAndCall(
             address(nextImpl), abi.encodeWithSelector(NextImpl.initialize.selector, 2)
         );
-        assertEq(Proxy(payable(address(optimismPortal))).implementation(), address(nextImpl));
+        assertEq(IProxy(payable(address(optimismPortal))).implementation(), address(nextImpl));
 
         // Verify that the NextImpl contract initialized its values according as expected
         bytes32 slot21After = vm.load(address(optimismPortal), bytes32(uint256(21)));

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -10,7 +10,6 @@ import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Contracts
-import { Proxy } from "src/universal/Proxy.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 
 // Libraries
@@ -29,6 +28,7 @@ import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
 import { IOptimismPortal2 } from "src/L1/interfaces/IOptimismPortal2.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 
 contract OptimismPortal2_Test is CommonTest {
     address depositor;
@@ -1422,10 +1422,10 @@ contract OptimismPortal2_Upgradeable_Test is CommonTest {
         vm.startPrank(EIP1967Helper.getAdmin(address(optimismPortal2)));
         // The value passed to the initialize must be larger than the last value
         // that initialize was called with.
-        Proxy(payable(address(optimismPortal2))).upgradeToAndCall(
+        IProxy(payable(address(optimismPortal2))).upgradeToAndCall(
             address(nextImpl), abi.encodeWithSelector(NextImpl.initialize.selector, 2)
         );
-        assertEq(Proxy(payable(address(optimismPortal2))).implementation(), address(nextImpl));
+        assertEq(IProxy(payable(address(optimismPortal2))).implementation(), address(nextImpl));
 
         // Verify that the NextImpl contract initialized its values according as expected
         bytes32 slot21After = vm.load(address(optimismPortal2), bytes32(uint256(21)));

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 
-// Target contract dependencies
-import { Proxy } from "src/universal/Proxy.sol";
-
-// Target contract
+// Interfaces
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 import { IProtocolVersions, ProtocolVersion } from "src/L1/interfaces/IProtocolVersions.sol";
 
 contract ProtocolVersions_Init is CommonTest {
@@ -57,7 +55,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_Init {
         emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(recommended));
 
         vm.prank(EIP1967Helper.getAdmin(address(protocolVersions)));
-        Proxy(payable(address(protocolVersions))).upgradeToAndCall(
+        IProxy(payable(address(protocolVersions))).upgradeToAndCall(
             address(protocolVersionsImpl),
             abi.encodeCall(
                 IProtocolVersions.initialize,

--- a/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { Test } from "forge-std/Test.sol";
+
+// Contracts
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 
-// Target contract dependencies
-import { Proxy } from "src/universal/Proxy.sol";
-
-// Target contract
-import { ResourceMetering } from "src/L1/ResourceMetering.sol";
+// Interfaces
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
 
 contract MeterUser is ResourceMetering {

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -7,7 +7,6 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { Proxy } from "src/universal/Proxy.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/test/cannon/MIPS.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS.t.sol
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
+
+// Contracts
 import { MIPS } from "src/cannon/MIPS.sol";
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
+
+// Libraries
 import { MIPSInstructions } from "src/cannon/libraries/MIPSInstructions.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { InvalidExitedValue, InvalidMemoryProof } from "src/cannon/libraries/CannonErrors.sol";
 import "src/dispute/lib/Types.sol";
+
+// Interfaces
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 contract MIPS_Test is CommonTest {
     MIPS internal mips;
@@ -16,7 +24,7 @@ contract MIPS_Test is CommonTest {
     function setUp() public virtual override {
         super.setUp();
         oracle = new PreimageOracle(0, 0);
-        mips = new MIPS(oracle);
+        mips = new MIPS(IPreimageOracle(address(oracle)));
         vm.store(address(mips), 0x0, bytes32(abi.encode(address(oracle))));
         vm.label(address(oracle), "PreimageOracle");
         vm.label(address(mips), "MIPS");

--- a/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
+
+// Contracts
 import { MIPS2 } from "src/cannon/MIPS2.sol";
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
+
+// Libraries
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { MIPSInstructions as ins } from "src/cannon/libraries/MIPSInstructions.sol";
-import "src/dispute/lib/Types.sol";
 import { InvalidExitedValue, InvalidMemoryProof, InvalidSecondMemoryProof } from "src/cannon/libraries/CannonErrors.sol";
+import "src/dispute/lib/Types.sol";
+
+// Interfaces
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 contract ThreadStack {
     bytes32 internal constant EMPTY_THREAD_ROOT = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
@@ -127,7 +135,7 @@ contract MIPS2_Test is CommonTest {
     function setUp() public virtual override {
         super.setUp();
         oracle = new PreimageOracle(0, 0);
-        mips = new MIPS2(oracle);
+        mips = new MIPS2(IPreimageOracle(address(oracle)));
         threading = new Threading();
         vm.store(address(mips), 0x0, bytes32(abi.encode(address(oracle))));
         vm.label(address(oracle), "PreimageOracle");

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -54,7 +54,7 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
         // Set preimage oracle challenge period to something arbitrary (4 seconds) just so we can
         // actually test the clock extensions later on. This is not a realistic value.
         PreimageOracle oracle = new PreimageOracle(0, 4);
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, oracle);
+        AlphabetVM _vm = new AlphabetVM(absolutePrestate, IPreimageOracle(address(oracle)));
 
         // Deploy an implementation of the fault game
         gameImpl = IFaultDisputeGame(
@@ -123,7 +123,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
     ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, IPreimageOracle(address(new PreimageOracle(0, 0))));
 
         _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
         vm.expectRevert(MaxDepthTooLarge.selector);
@@ -148,7 +148,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         _challengePeriod = bound(_challengePeriod, uint256(type(uint64).max) + 1, type(uint256).max);
 
         PreimageOracle oracle = new PreimageOracle(0, 0);
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, oracle);
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, IPreimageOracle(address(oracle)));
 
         // PreimageOracle constructor will revert if the challenge period is too large, so we need
         // to mock the call to pretend this is a bugged implementation where the challenge period
@@ -175,7 +175,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, IPreimageOracle(address(new PreimageOracle(0, 0))));
 
         uint256 maxGameDepth = 2 ** 3;
         _splitDepth = bound(_splitDepth, maxGameDepth - 1, type(uint256).max);
@@ -197,7 +197,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///      parameter is less than the minimum split depth (currently 2).
     function testFuzz_constructor_lowSplitDepth_reverts(uint256 _splitDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, IPreimageOracle(address(new PreimageOracle(0, 0))));
 
         uint256 minSplitDepth = 2;
         _splitDepth = bound(_splitDepth, 0, minSplitDepth - 1);
@@ -224,7 +224,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     )
         public
     {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, IPreimageOracle(address(new PreimageOracle(0, 0))));
 
         // Force the clock extension * 2 to be greater than the max clock duration, but keep things within
         // bounds of the uint64 type.

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -47,7 +47,7 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         // Set the extra data for the game creation
         extraData = abi.encode(l2BlockNumber);
 
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM _vm = new AlphabetVM(absolutePrestate, IPreimageOracle(address(new PreimageOracle(0, 0))));
 
         // Use a 7 day delayed WETH to simulate withdrawals.
         IDelayedWETH _weth = IDelayedWETH(payable(new DelayedWETH(7 days)));

--- a/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
+++ b/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import { IBigStepper, IPreimageOracle } from "src/dispute/interfaces/IBigStepper.sol";
-import { PreimageOracle, PreimageKeyLib } from "src/cannon/PreimageOracle.sol";
+// Libraries
+import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
 import "src/dispute/lib/Types.sol";
+
+// Interfaces
+import { IBigStepper, IPreimageOracle } from "src/dispute/interfaces/IBigStepper.sol";
 
 /// @title AlphabetVM
 /// @dev A mock VM for the purpose of testing the dispute game infrastructure. Note that this only works
@@ -12,7 +15,7 @@ contract AlphabetVM is IBigStepper {
     Claim internal immutable ABSOLUTE_PRESTATE;
     IPreimageOracle public oracle;
 
-    constructor(Claim _absolutePrestate, PreimageOracle _oracle) {
+    constructor(Claim _absolutePrestate, IPreimageOracle _oracle) {
         ABSOLUTE_PRESTATE = _absolutePrestate;
         oracle = _oracle;
     }

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -9,9 +9,9 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 // Contracts
 import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
-import { Proxy } from "src/universal/Proxy.sol";
 
 // Interfaces
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
 import { IOptimismMintableERC20Factory } from "src/universal/interfaces/IOptimismMintableERC20Factory.sol";
 
 contract OptimismMintableTokenFactory_Test is Bridge_Initializer {
@@ -33,7 +33,7 @@ contract OptimismMintableTokenFactory_Test is Bridge_Initializer {
 
     /// @notice Tests that the upgrade is successful.
     function test_upgrading_succeeds() external {
-        Proxy proxy = Proxy(deploy.mustGetAddress("OptimismMintableERC20FactoryProxy"));
+        IProxy proxy = IProxy(deploy.mustGetAddress("OptimismMintableERC20FactoryProxy"));
         // Check an unused slot before upgrading.
         bytes32 slot21Before = vm.load(address(l1OptimismMintableERC20Factory), bytes32(uint256(21)));
         assertEq(bytes32(0), slot21Before);

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
 import { Test } from "forge-std/Test.sol";
+import { SimpleStorage } from "test/universal/Proxy.t.sol";
+
+// Contracts
 import { Proxy } from "src/universal/Proxy.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
-import { SimpleStorage } from "test/universal/Proxy.t.sol";
+import { AddressManager } from "src/legacy/AddressManager.sol";
 import { L1ChugSplashProxy } from "src/legacy/L1ChugSplashProxy.sol";
 import { ResolvedDelegateProxy } from "src/legacy/ResolvedDelegateProxy.sol";
-import { AddressManager } from "src/legacy/AddressManager.sol";
+
+// Interfaces
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
 
 contract ProxyAdmin_Test is Test {
     address alice = address(64);
@@ -45,7 +51,7 @@ contract ProxyAdmin_Test is Test {
         // Set the address of the address manager in the admin so that it
         // can resolve the implementation address of legacy
         // ResolvedDelegateProxy based proxies.
-        admin.setAddressManager(addressManager);
+        admin.setAddressManager(IAddressManager(address(addressManager)));
         // Set the reverse lookup of the ResolvedDelegateProxy
         // proxy
         admin.setImplementationName(address(resolved), "a");
@@ -67,7 +73,7 @@ contract ProxyAdmin_Test is Test {
 
     function test_setAddressManager_notOwner_reverts() external {
         vm.expectRevert("Ownable: caller is not the owner");
-        admin.setAddressManager(AddressManager((address(0))));
+        admin.setAddressManager(IAddressManager((address(0))));
     }
 
     function test_setImplementationName_notOwner_reverts() external {


### PR DESCRIPTION
Adds a few remaining interfaces required before we can migrate OPCM to use interfaces over source contracts.

Closes #11686