### PR TITLE
fix(ct): give kontrol access to full src

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -87,7 +87,7 @@ optimizer = false
 # See test/kontrol/README.md for an explanation of how the profiles are configured
 
 [profile.kdeploy]
-src = 'src/L1'
+src = 'src'
 out = 'kout-deployment'
 test = 'test/kontrol'
 script = 'scripts-kontrol'


### PR DESCRIPTION
Kontrol profile was originally just looking at the L1 contracts which caused issues now that we're deploying via vm.getCode.