### PR TITLE
Refactor TestGasPriceIncrease ; Add Test Case

### DIFF
--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -1220,8 +1220,8 @@ func TestIncreaseGasPrice(t *testing.T) {
 				_, newTx, err := doGasPriceIncrease(t, 100, 2200, 100, 2000, overPrice)
 				require.NoError(t, err)
 				t.Log("Vals:", newTx.GasFeeCap(), newTx.GasTipCap())
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(5302)) == 0, "new tx fee must be based on the original value")
-				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(242)) == 0, "new tx tip must be based no the original value")
+				require.Zero(t, newTx.GasFeeCap().Cmp(big.NewInt(5302)), "new tx fee must be based on the original value")
+				require.Zero(t, newTx.GasTipCap().Cmp(big.NewInt(242)), "new tx tip must be based no the original value")
 			},
 		},
 		{


### PR DESCRIPTION
@mslipper recently changed behavior in the Tx Manager, and I realized there was an opportunity to add testing around it.

* Added a `txMod func` to the existing tests, which modifies the transaction prior to increasing the gas
* used a No-Op modification in all test cases, except for...
* the new Test case which I added, injects inflated gas prices into the original transaction, and confirms that the original value is the one that gets used.
* I also reorganized the other tests, as I noticed that if the increase ever fails, `err` is the last thing that gets checked, meaning you'll end up hitting a null pointer on the other checks first.