### PR TITLE
fix(ct): kontrol summary bug

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/scripts/make-summary-deployment.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/make-summary-deployment.sh
@@ -56,9 +56,12 @@ if [ "$KONTROL_FP_DEPLOYMENT" = true ]; then
   SCRIPT_SIG="runKontrolDeploymentFaultProofs()"
 fi
 
+# Sender just needs to be anything but the default sender (0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38)
+# Otherwise state changes inside of Deploy.s.sol get stored in the state diff under the default script address (0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496)
+# Conflicts with other stuff that happens inside of Kontrol and leads to errors that are hard to debug
 DEPLOY_CONFIG_PATH=deploy-config/hardhat.json \
 DEPLOYMENT_OUTFILE="$CONTRACT_NAMES" \
-  forge script -vvv test/kontrol/deployment/KontrolDeployment.sol:KontrolDeployment --sig $SCRIPT_SIG
+  forge script --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 -vvv test/kontrol/deployment/KontrolDeployment.sol:KontrolDeployment --sig $SCRIPT_SIG
 echo "Created state diff json"
 
 # Clean and store the state diff json in snapshots/state-diff/Kontrol-Deploy.json


### PR DESCRIPTION
Fixes an annoying bug inside of make-summary-deployment that only became apparent with a recent commit that caused state diffs to start to appear under the address of Deploy.s.sol.