### PR TITLE
op-program: Switch fpp-verify back to running in separate process.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1677,7 +1677,7 @@ workflows:
 
   scheduled-fpp:
     when:
-      equal: [ build_four_hours, <<pipeline.schedule.name>> ]
+      equal: [ build_hourly, <<pipeline.schedule.name>> ]
     jobs:
       - fpp-verify:
           context:


### PR DESCRIPTION
**Description**

Try to reproduce the missing prestate failure we saw previously and believed to be due to non-deterministic trie update orders.  Also now runs hourly instead of 4 hourly to increase chances of finding a failing case.

The in-process code is kept around so we can switch back easily if/when we reproduce the issue, it's just disabled by a boolean constant.