### PR TITLE
maint(ct): clean up import styles globally

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
@@ -76,10 +76,15 @@ for contract in $changed_contracts; do
     # increased properly.
     # Check if the version changed.
     if [ "$old_version" = "$new_version" ]; then
-        echo "❌ Error: $contract has changes in semver-lock.json but no version change"
-        echo "   Old version: $old_version"
-        echo "   New version: $new_version"
-        has_errors=true
+        # If both versions start with "+", ignore the equality
+        if [[ "$old_version" == +* ]] && [[ "$new_version" == +* ]]; then
+            echo "✅ $contract: version unchanged but starts with '+' ($old_version)"
+        else
+            echo "❌ Error: $contract has changes in semver-lock.json but no version change"
+            echo "   Old version: $old_version"
+            echo "   New version: $new_version"
+            has_errors=true
+        fi
     else
         echo "✅ $contract: version changed from $old_version to $new_version"
     fi

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -48,12 +48,12 @@
     "sourceCodeHash": "0x6401b81f04093863557ef46192f56793daa0d412618065383ab353b2ed2929d8"
   },
   "src/L1/ProtocolVersions.sol": {
-    "initCodeHash": "0x8f033874dd8b36615b2209d553660dcff1ff91ca2bad3ca1de7b441dbfba4842",
-    "sourceCodeHash": "0x5a7e91e02224e02a5a4bbf0fea7e9bd4a1168e2fe5e787023c9a75bcb6c26204"
+    "initCodeHash": "0xf7a9ed8c772cfb1234988fd6fd195dc21615b216bb39e728e7699b875040d902",
+    "sourceCodeHash": "0x2c7c8c8869a789e7dc91a18c554c16c828d3a058f07dd8a5ee10008f14cdc507"
   },
   "src/L1/SuperchainConfig.sol": {
-    "initCodeHash": "0xfca12d9016c746e5c275b186e0ca40cfd65cf45a5665aab7589a669fea3abb47",
-    "sourceCodeHash": "0x39489a85bc3a5c8560f82d41b31bf7fe22f5b648f4ed538f61695a73092ea9eb"
+    "initCodeHash": "0xebe9a9dbf6df5288fae3634a9d71ce12bd8acb461086de28a2fb4239097dcf80",
+    "sourceCodeHash": "0xd931c19a85a070119f5b670d1f4dc90512847b408aa4ee29c98231257cf0c77c"
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0x2fc36af5b3c493a423a19e0b597f6ff230b756b861b68099f3192d69b6088dc0",
@@ -64,12 +64,12 @@
     "sourceCodeHash": "0x441d1e3e8e987f829f55996b5b6c850da8c59ad48f09cf7e0a69a1fa559d42a2"
   },
   "src/L2/BaseFeeVault.sol": {
-    "initCodeHash": "0x3bfcd57e25ad54b66c374f63e24e33a6cf107044aa8f5f69ef21202c380b5c5b",
-    "sourceCodeHash": "0x2dc2284cf7c68e743da50e4113e96ffeab435de2390aeba2eab2f1e8ca411ce9"
+    "initCodeHash": "0xbf49824cf37e201181484a8a423fcad8f504dc925921a2b28e83398197858dec",
+    "sourceCodeHash": "0x370a3bc6a9893c90cb161c624eb479e329331d66280ac9819c0eccb5b4b0af3c"
   },
   "src/L2/CrossL2Inbox.sol": {
-    "initCodeHash": "0x66b052adce7e9194d054952d67d08b53964120067600358243ec86c85b90877b",
-    "sourceCodeHash": "0x38e6127ec6be99eb8c38c2c9d6e82761b33dde446bba250dc2c1b84983449e4e"
+    "initCodeHash": "0x31ecaebf368ab3333e80c6dc004b3c9f9a31f813c3138ab388bb3eead9f1b4ee",
+    "sourceCodeHash": "0xfb8ebd64c63b8e83ca071709cefe9c1c7bf60651e3ea8559b234d886cfdd5747"
   },
   "src/L2/ETHLiquidity.sol": {
     "initCodeHash": "0x713c18f95a6a746d0703f475f3ae10c106c9b9ecb64d881a2e61b8969b581371",
@@ -80,16 +80,16 @@
     "sourceCodeHash": "0x4f21025d4b5c9c74cf7040db6f8e9ce605b82931e3012fee51d3f5d9fbd7b73f"
   },
   "src/L2/L1Block.sol": {
-    "initCodeHash": "0x48d118de2a69fb0fbf6a8da4603025e12da1360da8fb70a5e56342ba64b3ff5f",
-    "sourceCodeHash": "0x04d25cbf0c4ea5025b0dd3f79f0a32f6623ddb869cff35649072ab3ad964b310"
+    "initCodeHash": "0xee3cac74c0c84657af61436056352947f041770b1e22f73a54d132f5309972c4",
+    "sourceCodeHash": "0x92515effb212ee8f5a2330cac1a44e94631a3a6083472d3b1cefee7f12ccc3d6"
   },
   "src/L2/L1BlockInterop.sol": {
-    "initCodeHash": "0x7f87e0b8be9801cb242c469ec7999eb80221f65063aedd4ca4923a5e0fb0e5a7",
+    "initCodeHash": "0xd9b5cb7271ef1707056912fa2f6bd311c2604e436ed0df1998da47ab54283490",
     "sourceCodeHash": "0x722071a9d08dcbeda9cdaadeb2dd679a8bc192563e4a0439f4cd74439fa75581"
   },
   "src/L2/L1FeeVault.sol": {
-    "initCodeHash": "0x3bfcd57e25ad54b66c374f63e24e33a6cf107044aa8f5f69ef21202c380b5c5b",
-    "sourceCodeHash": "0x927cc729bf5c9f209112df597f649493f276c4c50e17a57f7da02c2be266b192"
+    "initCodeHash": "0xbf49824cf37e201181484a8a423fcad8f504dc925921a2b28e83398197858dec",
+    "sourceCodeHash": "0x1e448a65169e8d53cd216b5d2d558ca7f56085148034beab37b1c73fa7ab34df"
   },
   "src/L2/L2CrossDomainMessenger.sol": {
     "initCodeHash": "0xcc4527d21cceeedbb3cbf8e7028e22fe12bc1ab30365dbebd0713499451b959d",
@@ -108,28 +108,28 @@
     "sourceCodeHash": "0x6c814f4536d9fb8f384ed2195957f868abd15252e36d6dd243f3d60349a61994"
   },
   "src/L2/L2ToL1MessagePasser.sol": {
-    "initCodeHash": "0x13fe3729beb9ed966c97bef09acb9fe5043fe651d453145073d05f2567fa988d",
-    "sourceCodeHash": "0xd08a2e6514dbd44e16aa312a1b27b2841a9eab5622cbd05a39c30f543fad673c"
+    "initCodeHash": "0xe65929ad618380e7f005f042a0a9c8e662ad10d6e1c53bfb7f518a54b848fd79",
+    "sourceCodeHash": "0xd61a1face234756e99b7ab8383eef40e62833a91f727a77997d6f0e384526637"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0x6f19eb8ff0950156b65cd92872240c0153ac5f3b6f0861d57bf561fdbcacbeac",
-    "sourceCodeHash": "0xfea53344596d735eff3be945ed1300dc75a6f8b7b2c02c0043af5b0036f5f239"
+    "initCodeHash": "0xe298f4116374fd7c13f8b5c05e15b58590614b61f5e5134df1a27018ca771111",
+    "sourceCodeHash": "0x5baebac6b3184716483d729b32d83bbc1c77234e984fe792e0f208fd6f3a5cf4"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
-    "initCodeHash": "0xe3dbb0851669708901a4c6bb7ad7d55f9896deeec02cbe53ac58d689ff95b88b",
-    "sourceCodeHash": "0xe853817da47d32b4ec5bb5392405278c82a1e9620aef377491dcb371fbbe682f"
+    "initCodeHash": "0xfa03663351a516bd95a59678689eab57e63bdff5b5ceadfd5cbb2dd1017990f5",
+    "sourceCodeHash": "0x50d423d84e2d7be3bfca948bd879635577a66f0a006b1e9f9612ebed95e3011a"
   },
   "src/L2/OptimismSuperchainERC20Beacon.sol": {
-    "initCodeHash": "0x99ce8095b23c124850d866cbc144fee6cee05dbc6bb5d83acadfe00b90cf42c7",
-    "sourceCodeHash": "0x5e58b7c867fafa49fe39d68d83875425e9cf94f05f2835bdcdaa08fc8bc6b68e"
+    "initCodeHash": "0x230fba0f709ca5b7075fb6d47af33b40b949fd38da4d6a47c57be6a9e372630c",
+    "sourceCodeHash": "0x519533359714525f2dad08ba88d8184e138022f8970093e4da5887a518b2c549"
   },
   "src/L2/OptimismSuperchainERC20Factory.sol": {
-    "initCodeHash": "0x524bc58927ca60ba2fbc4b036ad00c5055758d5c5b2ebb3d75cb9b996175f2cb",
-    "sourceCodeHash": "0x155a4b22ff8e266560d1fae72e1db7fc164afd84b8a81afb74c69414e0d5438e"
+    "initCodeHash": "0x43ec413140b05bfb83ec453b0d4f82b33a2d560bf8c76405d08de17565b87053",
+    "sourceCodeHash": "0xb09e50749cf461876b45f905cd331849c87278a4d535e98f6e74391e95a4c3fe"
   },
   "src/L2/SequencerFeeVault.sol": {
-    "initCodeHash": "0x2e6551705e493bacba8cffe22e564d5c401ae5bb02577a5424e0d32784e13e74",
-    "sourceCodeHash": "0xd56922cb04597dea469c65e5a49d4b3c50c171e603601e6f41da9517cae0b11a"
+    "initCodeHash": "0xcaadbf08057b5d47f7704257e9385a29e42a7a08c818646d109c5952d3d35218",
+    "sourceCodeHash": "0xd13b113d52041d7bd464a272a4ccce98ccb8aa4cfdf3a7aabd521723bea06ccc"
   },
   "src/L2/SuperchainWETH.sol": {
     "initCodeHash": "0x4ccd25f37a816205bc26f8532afa66e02f2b36ca7b7404d0fa48a4313ed16f0c",
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x2ab6be69795109a1ee04c5693a34d6ce0ff90b62e404cdeb18178bab18d06784"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0x3992081512da36af76b707aee7d8ef9e084c54fb1dc9f8ce9989ed16d1216f01",
-    "sourceCodeHash": "0x7630362c20fbca071452031b88c9384d3215c4f2cbee24c7989901de63b0c178"
+    "initCodeHash": "0xa9a9db7bedf25800f20c947df10310c64beb2ead8eb6be991c83189e975df0fe",
+    "sourceCodeHash": "0x77444a5b6bcb0abfb30bfe69ee2466ac9ca31b0f92e9add028f7bd9be30b18c0"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x590be819d8f02a7f9eb04ddc447f93ccbfd8bc9339f7c2e65336f9805b6c9a66",
-    "sourceCodeHash": "0x5bc0ab24cf926953b2ea9eb40b929821e280a7181c6cb18e7954bc3f7dc59be1"
+    "initCodeHash": "0x6742aa53b48dd65a37dc3c9f1f1466accf1d52fb50b300d634acc1f77893e92c",
+    "sourceCodeHash": "0xd98098a4b1ac70bac89b5a784197954b58b25e24571b5cf193153dc57883bb24"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xa0b19e18561da9990c95ebea9750dd901f73147b32b8b234eca0f35073c5a970",
@@ -168,8 +168,8 @@
     "sourceCodeHash": "0x223428ee91532af397cef72356430ff59221e0ac0cbf697a881d36bb1d672392"
   },
   "src/legacy/DeployerWhitelist.sol": {
-    "initCodeHash": "0x0b8177ed75b69eddbb9ce6537683f69a9935efed86a1d6faa8feaafbd151c1bd",
-    "sourceCodeHash": "0xc8fe9571fcf8fcb51a4dcb00ffa97f43a9ce811c323c4926e710b28c90a9005f"
+    "initCodeHash": "0xf232863fde5cd65368bcb4a79b41b5a4a09c59ede5070f82fd3f13f681bea7d8",
+    "sourceCodeHash": "0xd8d65492470907907d75574c1260fb349903af22c89098ea091439fc809310a9"
   },
   "src/legacy/L1BlockNumber.sol": {
     "initCodeHash": "0x542955f1a84b304eaf291f76633b03e4c87c2654f7eff46c3bea94d27346ea1f",
@@ -180,51 +180,51 @@
     "sourceCodeHash": "0xaa08a61448f485b277af57251d2089cc6a80ce0a763bf7184d48ffed5034ef69"
   },
   "src/periphery/op-nft/AttestationStation.sol": {
-    "initCodeHash": "0x2e665d9ee554430980f64bcb6d2611a1cb03dbacfd58bb0d6f5d32951a267bde",
-    "sourceCodeHash": "0xe0bc805b22c7d04b5a9444cddd4c0e1bcb3006c69c03610494277ab2cc83f553"
+    "initCodeHash": "0x2a1d3027a03d1116a72f6954ac57a66156a73a0fb5bc90b5eddac1f9f6118125",
+    "sourceCodeHash": "0x702c3a831bcdeb323ff7003d62785b9e2ad0896a0a70b2627cd4f1eef6bbb3a4"
   },
   "src/periphery/op-nft/Optimist.sol": {
-    "initCodeHash": "0x8fccdef5fb6e6d51215b39acc449faad8ba15416699c9b3af77866f4297805a3",
-    "sourceCodeHash": "0xfa9354827b642803e10415ed30ca789be1bd23d88fac14f7adaa65c6eb1c1643"
+    "initCodeHash": "0x3b5166a2fa5665f7acf7fc27d55bffa6657dea9aed1290a478096a2e32a04e64",
+    "sourceCodeHash": "0xbd09268fab51a4e5c4a6a82e9e0b77a9469018e83e35c0c32115a9bbfcf72ac7"
   },
   "src/periphery/op-nft/OptimistAllowlist.sol": {
-    "initCodeHash": "0x166dd3fc18cb238895f2faa7fdd635af48ce2c54e21ed2d6dae857c3731c4d6c",
-    "sourceCodeHash": "0x3a5f61046f729c9a70274b8b2a739382987ec5eb77705b259e8a3210a5f43462"
+    "initCodeHash": "0x92964c31bb1ada707043edd6dd4f2607accf9da6b791cb8018e0910c17829aed",
+    "sourceCodeHash": "0x280c5f7c7ba6be72c07aa9d1e71486646c3369a314874bfcc48744ced6bc0b12"
   },
   "src/periphery/op-nft/OptimistInviter.sol": {
-    "initCodeHash": "0x28dfa6676702a7abd19609cc773158d1f958210bc0a38c008d67a002dc1df862",
-    "sourceCodeHash": "0x3a0a294932d6deba043f6a2b46b4e8477ee96e7fb054d7e7229a43ce4352c68d"
+    "initCodeHash": "0x956affaa74e3f2ec2bcbf1c649f455bb4e34af8dec44e25b59762b0e8ecb7615",
+    "sourceCodeHash": "0xbafca756e5fb320108c88424b7a35ce2405419631a164ef9bc812c5f22aa0ff6"
   },
   "src/safe/DeputyGuardianModule.sol": {
     "initCodeHash": "0x308212d163aad169a5e42ce703a1ce36f5425ad96037850c0747177041f6596e",
     "sourceCodeHash": "0xde1a289c1cb0bf92138daf8f3db7457be2f84bedaa111b536f646dd6e121718c"
   },
   "src/safe/LivenessGuard.sol": {
-    "initCodeHash": "0x9ac0b039b1591f7c00cf11cb758d118c9b42e6e08250b619d6b6fd605a43d5ee",
-    "sourceCodeHash": "0xc1a968b0c6fbc4d82c2821c917b273feaaa224d258886b394416e84ee250d026"
+    "initCodeHash": "0xd449cef5d62dea387f5c4fd18382f5427532c443d29b3dcf0f645dbb6756ccb4",
+    "sourceCodeHash": "0xf9fa3d14d49df66e8ac641877ccbd7041d574db6752efbc8146ebe86a6679c67"
   },
   "src/safe/LivenessModule.sol": {
-    "initCodeHash": "0xcfccdd9e423c95a0ddc6e09ccb6333d5fc8429ed2b8fc872f1290d392ae13aad",
-    "sourceCodeHash": "0xd1479c60087f352385b6d5379ef3cc07839f671d617626b4c94ece91da781ef2"
+    "initCodeHash": "0xb16fd6cdfe5125dbb065ab1b6fcd7a58665e9fc4907b1089c8a496576be5d4f7",
+    "sourceCodeHash": "0x17e70b1d4ffc876fde920eaeb5874ff8a39dfa03b1e24044dc73aff2820db1ef"
   },
   "src/universal/OptimismMintableERC20.sol": {
-    "initCodeHash": "0x28c88484e1932253d6d12954492ac8a70744dc15c84429089af9944e5b158fd9",
-    "sourceCodeHash": "0x740b4043436d1b314ee3ba145acfcde60b6abd8416ea594f2b8e890b5d0bce6b"
+    "initCodeHash": "0x9cd677275b175812f1d5f90a127dbf7b3592714fd842a7a0de3988d716ca3eac",
+    "sourceCodeHash": "0x8f42bd415de9e0b380e670065589cf90a050ae48881f6044fcaf3c4b3a4c6b23"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {
-    "initCodeHash": "0x9cd4102d3ca811d5dc67ae99ce7de95812264575a789f96a6057600e55dcab64",
-    "sourceCodeHash": "0xc70c8c11d6e754eabe746bbee47a5e1051f71f7a83913f62ebcce8db989a1357"
+    "initCodeHash": "0x03ad07bd7f89a29f1850fa8b5d377daf0e1d5aef6cb458a127df520549e8e8e6",
+    "sourceCodeHash": "0x7e080f512df9f21cc62e3b69c4ce1fe43030ea64888f62829ab6ecc011989a17"
   },
   "src/universal/OptimismMintableERC721.sol": {
-    "initCodeHash": "0xec037be7fc28e072944b0a9e55d4278b92d6c68ccb41049ab52eafca59c6e023",
-    "sourceCodeHash": "0x5ea7c1b0cef5609f25c4193f5795fc9ce8f3ae08dbbf2945afe38e5af58f32c3"
+    "initCodeHash": "0x8b36aa3ab893dd2d8ca61298c2391665a54f48bd823ebc9f33709ca79446d401",
+    "sourceCodeHash": "0xce11165ae0146b48019b3d3eaef75f2d210f66c53a85111e1fc4299e32616d34"
   },
   "src/universal/OptimismMintableERC721Factory.sol": {
-    "initCodeHash": "0x1e247d46b5ac3cc8ac6b51193917cd5b88ff00fbea7bf768c65fa35a115f8607",
-    "sourceCodeHash": "0x1c4bc4727f08d80e8364561b49397ee57bb485072cb004b7a430559cbfa019a6"
+    "initCodeHash": "0x565d566cb2aaac25895bfc149b276103f7eb38edd871a4535715e008842492b7",
+    "sourceCodeHash": "0xec5a91f9e712fb59197c8fa263768b6a6de10372619826355c63676c8e5d021e"
   },
   "src/universal/StorageSetter.sol": {
-    "initCodeHash": "0x21b3059e9b13b330f76d02b61f61dcfa3abf3517a0b56afa0895c4b8291740bf",
-    "sourceCodeHash": "0xc1ea12a87e3a7ef9c950f0a41a4e35b60d4d9c4c816ff671dbfca663861c16f4"
+    "initCodeHash": "0x049f3c86965e575a370b14f7f49f3f15436ffb5ee1059615bb708659d7aae7de",
+    "sourceCodeHash": "0x5dc6b0b4ae4ab29085c52f74a4498d8a3d04928b844491749cd7186623e8b967"
   }
 }

--- a/packages/contracts-bedrock/snapshots/abi/ResolvedDelegateProxy.json
+++ b/packages/contracts-bedrock/snapshots/abi/ResolvedDelegateProxy.json
@@ -2,7 +2,7 @@
   {
     "inputs": [
       {
-        "internalType": "contract AddressManager",
+        "internalType": "contract IAddressManager",
         "name": "_addressManager",
         "type": "address"
       },

--- a/packages/contracts-bedrock/snapshots/storageLayout/ResolvedDelegateProxy.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ResolvedDelegateProxy.json
@@ -11,6 +11,6 @@
     "label": "addressManager",
     "offset": 0,
     "slot": "1",
-    "type": "mapping(address => contract AddressManager)"
+    "type": "mapping(address => contract IAddressManager)"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Ccntracts
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { Storage } from "src/libraries/Storage.sol";
 import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @notice ProtocolVersion is a numeric identifier of the protocol version.
 type ProtocolVersion is uint256;
@@ -37,8 +42,8 @@ contract ProtocolVersions is OwnableUpgradeable, ISemver {
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1-beta.1
-    string public constant version = "1.0.1-beta.1";
+    /// @custom:semver 1.0.1-beta.2
+    string public constant version = "1.0.1-beta.2";
 
     /// @notice Constructs the ProtocolVersion contract. Cannot set
     ///         the owner to `address(0)` due to the Ownable contract's

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { Storage } from "src/libraries/Storage.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:audit none This contracts is not yet audited.
@@ -36,8 +41,8 @@ contract SuperchainConfig is Initializable, ISemver {
     event ConfigUpdate(UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Constructs the SuperchainConfig contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { FeeVault } from "src/universal/FeeVault.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000019
@@ -10,8 +13,8 @@ import { FeeVault } from "src/universal/FeeVault.sol";
 /// @notice The BaseFeeVault accumulates the base fee that is paid by transactions.
 contract BaseFeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.0-beta.2
-    string public constant version = "1.5.0-beta.2";
+    /// @custom:semver 1.5.0-beta.3
+    string public constant version = "1.5.0-beta.3";
 
     /// @notice Constructs the BaseFeeVault contract.
     /// @param _recipient           Wallet that will receive the fees.

--- a/packages/contracts-bedrock/src/L2/CrossDomainOwnable.sol
+++ b/packages/contracts-bedrock/src/L2/CrossDomainOwnable.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+// Libraries
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 /// @title CrossDomainOwnable

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { TransientContext, TransientReentrancyAware } from "src/libraries/TransientContext.sol";
+import { SafeCall } from "src/libraries/SafeCall.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { ICrossL2Inbox } from "src/L2/interfaces/ICrossL2Inbox.sol";
-import { SafeCall } from "src/libraries/SafeCall.sol";
 import { IDependencySet } from "src/L2/interfaces/IDependencySet.sol";
 import { IL1BlockInterop } from "src/L2/interfaces/IL1BlockInterop.sol";
 
@@ -65,8 +68,8 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.8
-    string public constant version = "1.0.0-beta.8";
+    /// @custom:semver 1.0.0-beta.9
+    string public constant version = "1.0.0-beta.9";
 
     /// @notice Emitted when a cross chain message is being executed.
     /// @param msgHash Hash of message payload being executed.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { Constants } from "src/libraries/Constants.sol";
+// Libraries
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
+import { Constants } from "src/libraries/Constants.sol";
 import "src/libraries/L1BlockErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -63,9 +66,9 @@ contract L1Block is ISemver, IGasToken {
     /// @notice The eip-1550 base fee change elasticity value.
     uint64 public eip1559Elasticity;
 
-    /// @custom:semver 1.5.1-beta.3
+    /// @custom:semver 1.5.1-beta.4
     function version() public pure virtual returns (string memory) {
-        return "1.5.1-beta.3";
+        return "1.5.1-beta.4";
     }
 
     /// @notice Returns the gas paying token, its decimals, name and symbol.

--- a/packages/contracts-bedrock/src/L2/L1FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/L1FeeVault.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { FeeVault } from "src/universal/FeeVault.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x420000000000000000000000000000000000001A
@@ -10,8 +13,8 @@ import { FeeVault } from "src/universal/FeeVault.sol";
 /// @notice The L1FeeVault accumulates the L1 portion of the transaction fees.
 contract L1FeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.0-beta.2
-    string public constant version = "1.5.0-beta.2";
+    /// @custom:semver 1.5.0-beta.3
+    string public constant version = "1.5.0-beta.3";
 
     /// @notice Constructs the L1FeeVault contract.
     /// @param _recipient           Wallet that will receive the fees.

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Burn } from "src/libraries/Burn.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
@@ -48,8 +51,8 @@ contract L2ToL1MessagePasser is ISemver {
     /// @param amount Amount of ETh that was burned.
     event WithdrawerBalanceBurnt(uint256 indexed amount);
 
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Allows users to withdraw ETH by sending directly to this contract.
     receive() external payable {

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+// Libraries
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { CrossL2Inbox } from "src/L2/CrossL2Inbox.sol";
+import { SafeCall } from "src/libraries/SafeCall.sol";
+import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
+
+// Interfaces
 import { ICrossL2Inbox } from "src/L2/interfaces/ICrossL2Inbox.sol";
 import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { SafeCall } from "src/libraries/SafeCall.sol";
-import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
 
 /// @notice Thrown when a non-written slot in transient storage is attempted to be read from.
 error NotEntered();
@@ -64,8 +66,8 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.7
-    string public constant version = "1.0.0-beta.7";
+    /// @custom:semver 1.0.0-beta.8
+    string public constant version = "1.0.0-beta.8";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -161,7 +163,7 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
         }
 
         // Signal that this is a cross chain call that needs to have the identifier validated
-        CrossL2Inbox(Predeploys.CROSS_L2_INBOX).validateMessage(_id, keccak256(_sentMessage));
+        ICrossL2Inbox(Predeploys.CROSS_L2_INBOX).validateMessage(_id, keccak256(_sentMessage));
 
         // Decode the payload
         (uint256 destination, address target, uint256 nonce, address sender, bytes memory message) =

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { IOptimismSuperchainERC20Extension } from "src/L2/interfaces/IOptimismSuperchainERC20.sol";
-import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
-import { ERC20 } from "@solady/tokens/ERC20.sol";
-import { SuperchainERC20 } from "src/L2/SuperchainERC20.sol";
+// Contracts
 import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 import { ERC165 } from "@openzeppelin/contracts-v5/utils/introspection/ERC165.sol";
+import { ERC20 } from "@solady/tokens/ERC20.sol";
+import { SuperchainERC20 } from "src/L2/SuperchainERC20.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IOptimismSuperchainERC20Extension } from "src/L2/interfaces/IOptimismSuperchainERC20.sol";
+import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
 
 /// @notice Thrown when attempting to mint or burn tokens and the function caller is not the StandardBridge.
 error OnlyBridge();
@@ -63,8 +68,8 @@ contract OptimismSuperchainERC20 is
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.4
-    string public constant version = "1.0.0-beta.4";
+    /// @custom:semver 1.0.0-beta.6
+    string public constant version = "1.0.0-beta.6";
 
     /// @notice Constructs the OptimismSuperchainERC20 contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Interfaces
 import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
@@ -13,8 +14,8 @@ contract OptimismSuperchainERC20Beacon is IBeacon, ISemver {
     address internal immutable IMPLEMENTATION;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.1
-    string public constant version = "1.0.0-beta.1";
+    /// @custom:semver 1.0.0-beta.3
+    string public constant version = "1.0.0-beta.3";
 
     constructor(address _implementation) {
         IMPLEMENTATION = _implementation;

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Factory.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Factory.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { IOptimismERC20Factory } from "src/L2/interfaces/IOptimismERC20Factory.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
+// Contracts
 import { BeaconProxy } from "@openzeppelin/contracts-v5/proxy/beacon/BeaconProxy.sol";
+import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
+
+// Libraries
 import { CREATE3 } from "@rari-capital/solmate/src/utils/CREATE3.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IOptimismERC20Factory } from "src/L2/interfaces/IOptimismERC20Factory.sol";
 
 /// @custom:proxied
 /// @custom:predeployed 0x4200000000000000000000000000000000000026
@@ -27,8 +32,8 @@ contract OptimismSuperchainERC20Factory is IOptimismERC20Factory, ISemver {
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.2
-    string public constant version = "1.0.0-beta.2";
+    /// @custom:semver 1.0.0-beta.3
+    string public constant version = "1.0.0-beta.3";
 
     /// @notice Deploys a OptimismSuperchainERC20 Beacon Proxy using CREATE3.
     /// @param _remoteToken      Address of the remote token.

--- a/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { FeeVault } from "src/universal/FeeVault.sol";
+
+// Libraries
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000011
@@ -10,8 +13,8 @@ import { FeeVault } from "src/universal/FeeVault.sol";
 /// @notice The SequencerFeeVault is the contract that holds any fees paid to the Sequencer during
 ///         transaction processing and block production.
 contract SequencerFeeVault is FeeVault, ISemver {
-    /// @custom:semver 1.5.0-beta.2
-    string public constant version = "1.5.0-beta.2";
+    /// @custom:semver 1.5.0-beta.3
+    string public constant version = "1.5.0-beta.3";
 
     /// @notice Constructs the SequencerFeeVault contract.
     /// @param _recipient           Wallet that will receive the fees.

--- a/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { ISuperchainERC20Extensions, ISuperchainERC20Errors } from "src/L2/interfaces/ISuperchainERC20.sol";
+// Contracts
 import { ERC20 } from "@solady/tokens/ERC20.sol";
-import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
+
+// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
+import { ISuperchainERC20Extensions, ISuperchainERC20Errors } from "src/L2/interfaces/ISuperchainERC20.sol";
 
 /// @title SuperchainERC20
 /// @notice SuperchainERC20 is a standard extension of the base ERC20 token contract that unifies ERC20 token

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
-import { PreimageKeyLib } from "./PreimageKeyLib.sol";
+// Libraries
+import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
 import { MIPSInstructions as ins } from "src/cannon/libraries/MIPSInstructions.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { InvalidRMWInstruction } from "src/cannon/libraries/CannonErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 /// @title MIPS
 /// @notice The MIPS contract emulates a single MIPS instruction.
@@ -45,8 +48,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.2.1-beta.1
-    string public constant version = "1.2.1-beta.1";
+    /// @custom:semver 1.2.1-beta.2
+    string public constant version = "1.2.1-beta.2";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
+// Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
@@ -11,6 +10,10 @@ import { VMStatuses } from "src/dispute/lib/Types.sol";
 import {
     InvalidMemoryProof, InvalidRMWInstruction, InvalidSecondMemoryProof
 } from "src/cannon/libraries/CannonErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 /// @title MIPS2
 /// @notice The MIPS2 contract emulates a single MIPS instruction.
@@ -57,8 +60,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.13
-    string public constant version = "1.0.0-beta.13";
+    /// @custom:semver 1.0.0-beta.14
+    string public constant version = "1.0.0-beta.14";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import "src/cannon/libraries/CannonErrors.sol";
 
 library MIPSMemory {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";
 
 library MIPSState {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
 import "src/dispute/lib/LibUDT.sol";
 
 ////////////////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
 import "src/dispute/lib/LibPosition.sol";
 
 using LibClaim for Claim global;

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
 import "src/dispute/lib/LibUDT.sol";
 
 /// @notice The current status of the dispute game.

--- a/packages/contracts-bedrock/src/legacy/AddressManager.sol
+++ b/packages/contracts-bedrock/src/legacy/AddressManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @custom:legacy true

--- a/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
+++ b/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:legacy true
@@ -41,8 +42,8 @@ contract DeployerWhitelist is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Adds or removes an address from the deployment whitelist.
     /// @param _deployer      Address to update permissions for.

--- a/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
 import { IL1ChugSplashDeployer } from "src/legacy/interfaces/IL1ChugSplashProxy.sol";
 
 /// @custom:legacy true

--- a/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// Interfaces
 import { ILegacyMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 
 /// @title LegacyMintableERC20

--- a/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { AddressManager } from "src/legacy/AddressManager.sol";
+// Contracts
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
 
 /// @custom:legacy true
 /// @title ResolvedDelegateProxy
@@ -20,11 +21,11 @@ contract ResolvedDelegateProxy {
     ///         implementation address will be resolved from. Same concept here as with the above
     ///         mapping. Also generally unsafe but fine if the implementation doesn't keep a mapping
     ///         in the second storage slot.
-    mapping(address => AddressManager) private addressManager;
+    mapping(address => IAddressManager) private addressManager;
 
     /// @param _addressManager  Address of the AddressManager.
     /// @param _implementationName implementationName of the contract to proxy to.
-    constructor(AddressManager _addressManager, string memory _implementationName) {
+    constructor(IAddressManager _addressManager, string memory _implementationName) {
         addressManager[address(this)] = _addressManager;
         implementationName[address(this)] = _implementationName;
     }

--- a/packages/contracts-bedrock/src/libraries/Arithmetic.sol
+++ b/packages/contracts-bedrock/src/libraries/Arithmetic.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import { FixedPointMathLib } from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interfaces
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
 
 /// @title Constants

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";

--- a/packages/contracts-bedrock/src/libraries/GasPayingToken.sol
+++ b/packages/contracts-bedrock/src/libraries/GasPayingToken.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
+import { LibString } from "@solady/utils/LibString.sol";
 import { Storage } from "src/libraries/Storage.sol";
 import { Constants } from "src/libraries/Constants.sol";
-import { LibString } from "@solady/utils/LibString.sol";
 
 /// @title IGasToken
 /// @notice Implemented by contracts that are aware of the custom gas token used

--- a/packages/contracts-bedrock/src/libraries/Hashing.sol
+++ b/packages/contracts-bedrock/src/libraries/Hashing.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 

--- a/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
+++ b/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
-import "./RLPErrors.sol";
+// Libraries
+import "src/libraries/rlp/RLPErrors.sol";
 
 /// @custom:attribution https://github.com/hamdiallam/Solidity-RLP
 /// @title RLPReader

--- a/packages/contracts-bedrock/src/libraries/trie/MerkleTrie.sol
+++ b/packages/contracts-bedrock/src/libraries/trie/MerkleTrie.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Bytes } from "../Bytes.sol";
-import { RLPReader } from "../rlp/RLPReader.sol";
+// Libraries
+import { Bytes } from "src/libraries/Bytes.sol";
+import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 
 /// @title MerkleTrie
 /// @notice MerkleTrie is a small library for verifying standard Ethereum Merkle-Patricia trie

--- a/packages/contracts-bedrock/src/periphery/AssetReceiver.sol
+++ b/packages/contracts-bedrock/src/periphery/AssetReceiver.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Contracts
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
-import { Transactor } from "./Transactor.sol";
+import { Transactor } from "src/periphery/Transactor.sol";
 
 /// @title AssetReceiver
 /// @notice AssetReceiver is a minimal contract for receiving funds assets in the form of either

--- a/packages/contracts-bedrock/src/periphery/Transactor.sol
+++ b/packages/contracts-bedrock/src/periphery/Transactor.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Contracts
 import { Owned } from "@rari-capital/solmate/src/auth/Owned.sol";
 
 /// @title Transactor

--- a/packages/contracts-bedrock/src/periphery/TransferOnion.sol
+++ b/packages/contracts-bedrock/src/periphery/TransferOnion.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { AssetReceiver } from "../AssetReceiver.sol";
-import { IDripCheck } from "./IDripCheck.sol";
+// Contracts
+import { AssetReceiver } from "src/periphery/AssetReceiver.sol";
+
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title Drippie
 /// @notice Drippie is a system for managing automated contract interactions. A specific interaction

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckBalanceLow
 /// @notice DripCheck for checking if an account's balance is below a given threshold.

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 import { IGelatoTreasury } from "src/vendor/interfaces/IGelatoTreasury.sol";
 
 /// @title CheckGelatoLow

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckSecrets
 /// @notice DripCheck that checks if specific secrets exist (or not). Supports having a secret that

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckTrue
 /// @notice DripCheck that always returns true.

--- a/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IFaucetAuthModule } from "src/periphery/faucet/authmodules/IFaucetAuthModule.sol";
+// Libraries
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { SafeSend } from "src/universal/SafeSend.sol";
+
+// Interfaces
+import { IFaucetAuthModule } from "src/periphery/faucet/authmodules/IFaucetAuthModule.sol";
 
 /// @title  Faucet
 /// @notice Faucet contract that drips ETH to users.

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
+import { Faucet } from "src/periphery/faucet/Faucet.sol";
+
+// Libraries
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
-import { IFaucetAuthModule } from "./IFaucetAuthModule.sol";
-import { Faucet } from "../Faucet.sol";
+
+// Interfaces
+import { IFaucetAuthModule } from "src/periphery/faucet/authmodules/IFaucetAuthModule.sol";
 
 /// @title  AdminFaucetAuthModule
 /// @notice FaucetAuthModule that allows an admin to sign off on a given faucet drip. Takes an admin

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Faucet } from "../Faucet.sol";
+// Contracts
+import { Faucet } from "src/periphery/faucet/Faucet.sol";
 
 /// @title  IFaucetAuthModule
 /// @notice Interface for faucet authentication modules.

--- a/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title AttestationStation
@@ -29,8 +30,8 @@ contract AttestationStation is ISemver {
     event AttestationCreated(address indexed creator, address indexed about, bytes32 indexed key, bytes val);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.1-beta.1
-    string public constant version = "1.2.1-beta.1";
+    /// @custom:semver 1.2.1-beta.2
+    string public constant version = "1.2.1-beta.2";
 
     /// @notice Allows anyone to create an attestation.
     /// @param _about Address that the attestation is about.

--- a/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { ERC721BurnableUpgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
 import { OptimistAllowlist } from "src/periphery/op-nft/OptimistAllowlist.sol";
+
+// Libraries
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @author Optimism Collective
 /// @author Gitcoin
@@ -26,8 +31,8 @@ contract Optimist is ERC721BurnableUpgradeable, ISemver {
     OptimistAllowlist public immutable OPTIMIST_ALLOWLIST;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.1.1-beta.1
-    string public constant version = "2.1.1-beta.1";
+    /// @custom:semver 2.1.1-beta.2
+    string public constant version = "2.1.1-beta.2";
 
     /// @param _name               Token name.
     /// @param _symbol             Token symbol.

--- a/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
 import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title  OptimistAllowlist
 /// @notice Source of truth for whether an address is able to mint an Optimist NFT.
@@ -31,8 +34,8 @@ contract OptimistAllowlist is ISemver {
     address public immutable OPTIMIST_INVITER;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @param _attestationStation    Address of the AttestationStation contract.
     /// @param _allowlistAttestor     Address of the allowlist attestor.

--- a/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
+++ b/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
-import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import { EIP712Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol";
+
+// Libraries
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:upgradeable
 /// @title  OptimistInviter
@@ -88,8 +93,8 @@ contract OptimistInviter is ISemver, EIP712Upgradeable {
     mapping(address => uint256) public inviteCounts;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @param _inviteGranter      Address of the invite granter.
     /// @param _attestationStation Address of the AttestationStation contract.

--- a/packages/contracts-bedrock/src/safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessGuard.sol
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Safe
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Guard as BaseGuard } from "safe-contracts/base/GuardManager.sol";
-import { SafeSigners } from "src/safe/SafeSigners.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Contracts
+import { SafeSigners } from "src/safe/SafeSigners.sol";
+
+// Libraries
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title LivenessGuard
 /// @notice This Guard contract is used to track the liveness of Safe owners.
@@ -25,8 +32,8 @@ contract LivenessGuard is ISemver, BaseGuard {
     event OwnerRecorded(address owner);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1-beta.2
-    string public constant version = "1.0.1-beta.2";
+    /// @custom:semver 1.0.1-beta.3
+    string public constant version = "1.0.1-beta.3";
 
     /// @notice The safe account for which this contract will be the guard.
     Safe internal immutable SAFE;

--- a/packages/contracts-bedrock/src/safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Safe
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
+
+// Contracts
 import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title LivenessModule
@@ -53,8 +58,8 @@ contract LivenessModule is ISemver {
     uint256 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.1-beta.1
-    string public constant version = "1.2.1-beta.1";
+    /// @custom:semver 1.2.1-beta.2
+    string public constant version = "1.2.1-beta.2";
 
     // Constructor to initialize the Safe and baseModule instances
     constructor(

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+// Libraries
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";

--- a/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+// Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+// Libraries
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+// Interfaces
+import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
 
 /// @title ERC721Bridge
 /// @notice ERC721Bridge is a base contract for the L1 and L2 ERC721 bridges.

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import { ILegacyMintableERC20, IOptimismMintableERC20 } from "src/universal/interfaces/IOptimismMintableERC20.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
+
+// Interfaces
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { ILegacyMintableERC20, IOptimismMintableERC20 } from "src/universal/interfaces/IOptimismMintableERC20.sol";
 
 /// @title OptimismMintableERC20
 /// @notice OptimismMintableERC20 is a standard extension of the base ERC20 token contract designed
@@ -41,8 +46,8 @@ contract OptimismMintableERC20 is IOptimismMintableERC20, ILegacyMintableERC20, 
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.0-beta.1
-    string public constant version = "1.4.0-beta.1";
+    /// @custom:semver 1.4.0-beta.2
+    string public constant version = "1.4.0-beta.2";
 
     /// @notice Getter function for the permit2 address. It deterministically deployed
     ///         so it will always be at the same address. It is also included as a preinstall,

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { IOptimismERC20Factory } from "src/L2/interfaces/IOptimismERC20Factory.sol";
@@ -48,8 +51,8 @@ contract OptimismMintableERC20Factory is ISemver, Initializable, IOptimismERC20F
     ///         the OptimismMintableERC20 token contract since this contract
     ///         is responsible for deploying OptimismMintableERC20 contracts.
     /// @notice Semantic version.
-    /// @custom:semver 1.10.1-beta.3
-    string public constant version = "1.10.1-beta.3";
+    /// @custom:semver 1.10.1-beta.4
+    string public constant version = "1.10.1-beta.4";
 
     /// @notice Constructs the OptimismMintableERC20Factory contract.
     constructor() {

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+// Libraries
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { IOptimismMintableERC721 } from "src/universal/interfaces/IOptimismMintableERC721.sol";
+
+// Interfaces
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IOptimismMintableERC721 } from "src/universal/interfaces/IOptimismMintableERC721.sol";
 
 /// @title OptimismMintableERC721
 /// @notice This contract is the remote representation for some token that lives on another network,
@@ -32,8 +37,8 @@ contract OptimismMintableERC721 is ERC721Enumerable, IOptimismMintableERC721, IS
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1-beta.2
-    string public constant version = "1.3.1-beta.2";
+    /// @custom:semver 1.3.1-beta.3
+    string public constant version = "1.3.1-beta.3";
 
     /// @param _bridge        Address of the bridge on this network.
     /// @param _remoteChainId Chain ID where the remote token is deployed.

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { OptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title OptimismMintableERC721Factory
@@ -23,8 +26,8 @@ contract OptimismMintableERC721Factory is ISemver {
     event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.1-beta.2
-    string public constant version = "1.4.1-beta.2";
+    /// @custom:semver 1.4.1-beta.3
+    string public constant version = "1.4.1-beta.3";
 
     /// @notice The semver MUST be bumped any time that there is a change in
     ///         the OptimismMintableERC721 token contract since this contract

--- a/packages/contracts-bedrock/src/universal/Proxy.sol
+++ b/packages/contracts-bedrock/src/universal/Proxy.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Constants } from "src/libraries/Constants.sol";
 
 /// @title Proxy

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// Contracts
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
+
+// Libraries
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
+import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IOptimismMintableERC20, ILegacyMintableERC20 } from "src/universal/interfaces/IOptimismMintableERC20.sol";
 import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
-import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
-import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import { Constants } from "src/libraries/Constants.sol";
 
 /// @custom:upgradeable
 /// @title StandardBridge

--- a/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Libraries
 import { Storage } from "src/libraries/Storage.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title StorageSetter
 /// @notice A simple contract that allows setting arbitrary storage slots.
@@ -16,8 +19,8 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.1-beta.2
-    string public constant version = "1.2.1-beta.2";
+    /// @custom:semver 1.2.1-beta.3
+    string public constant version = "1.2.1-beta.3";
 
     /// @notice Stores a bytes32 `_value` at `_slot`. Any storage slots that
     ///         are packed should be set through this interface.

--- a/packages/contracts-bedrock/src/universal/WETH98.sol
+++ b/packages/contracts-bedrock/src/universal/WETH98.sol
@@ -19,6 +19,7 @@
 
 pragma solidity 0.8.15;
 
+// Interfaces
 import { IWETH } from "src/universal/interfaces/IWETH.sol";
 
 /// @title WETH98

--- a/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { Test } from "forge-std/Test.sol";
 
-// Target contract dependencies
+// Contracts
 import { AddressManager } from "src/legacy/AddressManager.sol";
-
-// Target contract
 import { ResolvedDelegateProxy } from "src/legacy/ResolvedDelegateProxy.sol";
+
+// Interfaces
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
 
 contract ResolvedDelegateProxy_Test is Test {
     AddressManager internal addressManager;
@@ -23,7 +24,9 @@ contract ResolvedDelegateProxy_Test is Test {
         addressManager.setAddress("SimpleImplementation", address(impl));
 
         // Set up the proxy.
-        proxy = SimpleImplementation(address(new ResolvedDelegateProxy(addressManager, "SimpleImplementation")));
+        proxy = SimpleImplementation(
+            address(new ResolvedDelegateProxy(IAddressManager(address(addressManager)), "SimpleImplementation"))
+        );
     }
 
     /// @dev Tests that the proxy properly bubbles up returndata when the delegatecall succeeds.
@@ -43,7 +46,9 @@ contract ResolvedDelegateProxy_Test is Test {
     ///      address manager is not set.
     function test_fallback_addressManagerNotSet_reverts() public {
         AddressManager am = new AddressManager();
-        SimpleImplementation p = SimpleImplementation(address(new ResolvedDelegateProxy(am, "SimpleImplementation")));
+        SimpleImplementation p = SimpleImplementation(
+            address(new ResolvedDelegateProxy(IAddressManager(address(am)), "SimpleImplementation"))
+        );
 
         vm.expectRevert("ResolvedDelegateProxy: target address must be initialized");
         p.foo(0);

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -44,7 +44,7 @@ contract ProxyAdmin_Test is Test {
         // Deploy a legacy ResolvedDelegateProxy with the name `a`.
         // Whatever `a` is set to in AddressManager will be the address
         // that is used for the implementation.
-        resolved = new ResolvedDelegateProxy(addressManager, "a");
+        resolved = new ResolvedDelegateProxy(IAddressManager(address(addressManager)), "a");
 
         // Impersonate alice for setting up the admin.
         vm.startPrank(alice);


### PR DESCRIPTION
Cleans up imports globally to use the new style that we've landed on to keep imports cleanly separated. We're probably going to want to automate this down the line but whatever for now.