### PR TITLE
ci: Cannon v2 STF verify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1171,6 +1171,8 @@ jobs:
           key: golang-build-cache-cannon-stf-verify-{{ checksum "go.sum" }}
           paths:
             - "/root/.cache/go-build"
+      - notify-failures-on-develop:
+          mentions: "@proofs-squad"
 
   semgrep-scan:
     parameters:
@@ -1708,6 +1710,8 @@ workflows:
       - cannon-stf-verify:
           requires:
             - go-mod-download
+          context:
+            - slack
       - contracts-bedrock-build:
           skip_pattern: test
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1729,7 +1729,6 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
-            - cannon-stf-verify
           context:
             - slack
 

--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -23,12 +23,12 @@ ARG GIT_DATE
 
 ARG TARGETOS TARGETARCH
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.0.0-alpha.2 AS cannon-v1
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.1 AS cannon-v2
 
 FROM --platform=$BUILDPLATFORM builder as cannon-verify
-COPY --from=cannon-v1 /usr/local/bin/cannon /usr/local/bin/cannon-v1
-# verify the latest singlethreaded VM behavior against cannon-v1
-RUN cd cannon && make diff-singlethreaded-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v1
+COPY --from=cannon-v2 /usr/local/bin/cannon /usr/local/bin/cannon-v2
+# verify the latest singlethreaded VM behavior against cannon-v2
+RUN cd cannon && make diff-singlethreaded-2-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v2
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && \
-    make diff-singlethreaded-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v1 \
+    make diff-singlethreaded-2-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v2 \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE


### PR DESCRIPTION
- Update the `cannon-stf-verify job` to assert V2 behavior
- Fix `cannon-stf-verify` job notification settings.