### PR TITLE
Interop: Integrate for new input flow

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -2,7 +2,6 @@ package interop
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -86,14 +85,12 @@ func TestInteropTrivial(t *testing.T) {
 	require.Equal(t, expectedBalance, bobBalance)
 
 	s2.DeployEmitterContract(chainA, "Alice")
-	rec := s2.EmitData(chainA, "Alice", "0x1234567890abcdef")
-
-	fmt.Println("Result of emitting event:", rec)
-
 	s2.DeployEmitterContract(chainB, "Alice")
-	rec = s2.EmitData(chainB, "Alice", "0x1234567890abcdef")
+	for i := 0; i < 1; i++ {
+		s2.EmitData(chainA, "Alice", "0x1234567890abcdef")
 
-	fmt.Println("Result of emitting event:", rec)
+		s2.EmitData(chainB, "Alice", "0x1234567890abcdef")
+	}
 
 	time.Sleep(60 * time.Second)
 

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -68,7 +67,12 @@ func (cl *SupervisorClient) AddL2RPC(
 
 func (cl *SupervisorClient) UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
 	var result types.ReferenceView
-	err := cl.client.CallContext(ctx, &result, "supervisor_unsafeView", (*hexutil.U256)(&chainID), unsafe)
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_unsafeView",
+		chainID,
+		unsafe)
 	if err != nil {
 		return types.ReferenceView{}, fmt.Errorf("failed to share unsafe block view %s (chain %s): %w", unsafe, chainID, err)
 	}
@@ -77,7 +81,12 @@ func (cl *SupervisorClient) UnsafeView(ctx context.Context, chainID types.ChainI
 
 func (cl *SupervisorClient) SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
 	var result types.ReferenceView
-	err := cl.client.CallContext(ctx, &result, "supervisor_safeView", (*hexutil.U256)(&chainID), safe)
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_safeView",
+		chainID,
+		safe)
 	if err != nil {
 		return types.ReferenceView{}, fmt.Errorf("failed to share safe block view %s (chain %s): %w", safe, chainID, err)
 	}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -220,9 +220,9 @@ func (su *SupervisorBackend) CheckBlock(chainID *hexutil.U256, blockHash common.
 	return safest, nil
 }
 
-func (su *SupervisorBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.L2BlockRef) {
+func (su *SupervisorBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.BlockRef) {
 	// l2 to l1 block ref
-	ref := eth.L1BlockRef{
+	ref := eth.BlockRef{
 		ParentHash: head.ParentHash,
 		Hash:       head.Hash,
 		Number:     head.Number,
@@ -233,11 +233,11 @@ func (su *SupervisorBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.L
 	su.db.UpdateLocalUnsafe(chainID, head)
 }
 
-func (su *SupervisorBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) {
+func (su *SupervisorBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
 	su.db.UpdateLocalSafe(chainID, derivedFrom, lastDerived)
 }
 
-func (su *SupervisorBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.L1BlockRef) {
+func (su *SupervisorBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.BlockRef) {
 	su.db.UpdateFinalizedL1(finalized)
 }
 

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -202,7 +202,7 @@ func (db *ChainsDB) Close() error {
 	return combined
 }
 
-func (db *ChainsDB) UpdateLocalUnsafe(chain types.ChainID, head eth.L2BlockRef) error {
+func (db *ChainsDB) UpdateLocalUnsafe(chain types.ChainID, head eth.BlockRef) error {
 	err := db.safetyIndex.UpdateLocalUnsafe(chain, head)
 	if err != nil {
 		return fmt.Errorf("failed to update local-unsafe: %w", err)
@@ -210,7 +210,7 @@ func (db *ChainsDB) UpdateLocalUnsafe(chain types.ChainID, head eth.L2BlockRef) 
 	return nil
 }
 
-func (db *ChainsDB) UpdateLocalSafe(chain types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+func (db *ChainsDB) UpdateLocalSafe(chain types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) error {
 	err := db.safetyIndex.UpdateLocalSafe(chain, derivedFrom, lastDerived)
 	if err != nil {
 		return fmt.Errorf("failed to update local-safe: %w", err)
@@ -218,7 +218,7 @@ func (db *ChainsDB) UpdateLocalSafe(chain types.ChainID, derivedFrom eth.L1Block
 	return nil
 }
 
-func (db *ChainsDB) UpdateFinalizedL1(finalized eth.L1BlockRef) error {
+func (db *ChainsDB) UpdateFinalizedL1(finalized eth.BlockRef) error {
 	return db.safetyIndex.UpdateFinalizeL1(finalized)
 }
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -34,6 +34,26 @@ const (
 	FlagPadding2 EntryTypeFlag = FlagPadding << 1
 )
 
+var FlagNames = map[EntryTypeFlag]string{
+	FlagSearchCheckpoint: "searchCheckpoint",
+	FlagCanonicalHash:    "canonicalHash",
+	FlagInitiatingEvent:  "initiatingEvent",
+	FlagExecutingLink:    "executingLink",
+	FlagExecutingCheck:   "executingCheck",
+	FlagPadding:          "padding",
+	FlagPadding2:         "padding2",
+}
+
+func EntryFlagsToStrings(flags EntryTypeFlag) []string {
+	res := make([]string, 0, 8)
+	for k, v := range FlagNames {
+		if flags.Any(k) {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
 func (ex EntryTypeFlag) Any(v EntryTypeFlag) bool {
 	return ex&v != 0
 }

--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -128,12 +128,10 @@ func (l *logContext) ExecMessage() *types.ExecutingMessage {
 }
 
 func (l *logContext) HeadPointer() (heads.HeadPointer, error) {
-	// temporary: other bugs above this might be causing incomplete states
-	// we should revive this check once we are sure the state is always complete.
-	//if l.need != 0 {
-	//	needs := entrydb.EntryFlagsToStrings(l.need)
-	//	return heads.HeadPointer{}, fmt.Errorf("cannot provide head pointer while state is incomplete. needs: %v", needs)
-	//}
+	if l.need != 0 {
+		needs := entrydb.EntryFlagsToStrings(l.need)
+		return heads.HeadPointer{}, fmt.Errorf("cannot provide head pointer while state is incomplete. needs: %v", needs)
+	}
 	return heads.HeadPointer{
 		LastSealedBlockHash: l.blockHash,
 		LastSealedBlockNum:  l.blockNum,

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -72,13 +72,13 @@ func (m *MockBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
-func (m *MockBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.L2BlockRef) {
+func (m *MockBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.BlockRef) {
 }
 
-func (m *MockBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) {
+func (m *MockBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
 }
 
-func (m *MockBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.L1BlockRef) {
+func (m *MockBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.BlockRef) {
 }
 
 func (m *MockBackend) Close() error {

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -60,6 +60,27 @@ func (m *MockBackend) DerivedFrom(ctx context.Context, t types.ChainID, parentHa
 	return eth.BlockRef{}, nil
 }
 
+func (m *MockBackend) UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
+	return types.ReferenceView{}, nil
+}
+
+func (m *MockBackend) SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
+	return types.ReferenceView{}, nil
+}
+
+func (m *MockBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+	return eth.BlockID{}, nil
+}
+
+func (m *MockBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.L2BlockRef) {
+}
+
+func (m *MockBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) {
+}
+
+func (m *MockBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.L1BlockRef) {
+}
+
 func (m *MockBackend) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/backend/safety/safety.go
+++ b/op-supervisor/supervisor/backend/safety/safety.go
@@ -146,7 +146,7 @@ func (r *safetyIndex) advanceCrossSafe() {
 			r.log.Error("Failed to update cross-safe view", "chain", chainID, "err", err)
 		}
 		cross, _ := r.safe[chainID].Cross()
-		r.log.Debug("Updated local safe head", "chainID", chainID, "cross", cross)
+		r.log.Debug("Updated cross safe head", "chainID", chainID, "cross", cross)
 	}
 	r.advanceFinalized()
 }

--- a/op-supervisor/supervisor/backend/source/chain.go
+++ b/op-supervisor/supervisor/backend/source/chain.go
@@ -10,67 +10,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-// TODO(optimism#11032) Make these configurable and a sensible default
-const epochPollInterval = 3 * time.Second
-const pollInterval = 2 * time.Second
-const trustRpc = false
-const rpcKind = sources.RPCKindStandard
-
-type Metrics interface {
-	caching.Metrics
-}
-
-type Storage interface {
-	ChainsDBClientForLogProcessor
-	DatabaseRewinder
-	LatestBlockNum(chainID types.ChainID) (num uint64, ok bool)
-}
-
-// ChainMonitor monitors a source L2 chain, retrieving the data required to populate the database and perform
-// interop consolidation. It detects and notifies when reorgs occur.
-type ChainMonitor struct {
-	log            log.Logger
-	headMonitor    *HeadMonitor
-	chainProcessor *ChainProcessor
-}
-
-func NewChainMonitor(ctx context.Context, logger log.Logger, m Metrics, chainID types.ChainID, rpc string, client client.RPC, store Storage) (*ChainMonitor, error) {
-	logger = logger.New("chainID", chainID)
-	cl, err := newClient(ctx, logger, m, rpc, client, pollInterval, trustRpc, rpcKind)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create the log processor and fetcher
-	processLogs := newLogProcessor(chainID, store)
-	unsafeBlockProcessor := NewChainProcessor(logger, cl, chainID, processLogs, store)
-
-	unsafeProcessors := []HeadProcessor{unsafeBlockProcessor}
-
-	callback := newHeadUpdateProcessor(logger, unsafeProcessors, nil, nil)
-	headMonitor := NewHeadMonitor(logger, epochPollInterval, cl, callback)
-
-	return &ChainMonitor{
-		log:            logger,
-		headMonitor:    headMonitor,
-		chainProcessor: unsafeBlockProcessor,
-	}, nil
-}
-
-func (c *ChainMonitor) Start() error {
-	c.log.Info("Started monitoring chain")
-	return c.headMonitor.Start()
-}
-
-func (c *ChainMonitor) Stop() error {
-	c.chainProcessor.Close()
-	return c.headMonitor.Stop()
-}
-
-func newClient(ctx context.Context, logger log.Logger, m caching.Metrics, rpc string, rpcClient client.RPC, pollRate time.Duration, trustRPC bool, kind sources.RPCProviderKind) (*sources.L1Client, error) {
+func NewL1Client(ctx context.Context, logger log.Logger, m caching.Metrics, rpc string, rpcClient client.RPC, pollRate time.Duration, trustRPC bool, kind sources.RPCProviderKind) (*sources.L1Client, error) {
 	c, err := client.NewRPCWithClient(ctx, logger, rpc, rpcClient, pollRate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new RPC client: %w", err)

--- a/op-supervisor/supervisor/backend/source/log_processor.go
+++ b/op-supervisor/supervisor/backend/source/log_processor.go
@@ -34,7 +34,7 @@ type logProcessor struct {
 	eventDecoder EventDecoder
 }
 
-func newLogProcessor(chain types.ChainID, logStore LogStorage) *logProcessor {
+func NewLogProcessor(chain types.ChainID, logStore LogStorage) *logProcessor {
 	return &logProcessor{
 		chain:        chain,
 		logStore:     logStore,

--- a/op-supervisor/supervisor/backend/source/log_processor_test.go
+++ b/op-supervisor/supervisor/backend/source/log_processor_test.go
@@ -25,7 +25,7 @@ func TestLogProcessor(t *testing.T) {
 	}
 	t.Run("NoOutputWhenLogsAreEmpty", func(t *testing.T) {
 		store := &stubLogStorage{}
-		processor := newLogProcessor(logProcessorChainID, store)
+		processor := NewLogProcessor(logProcessorChainID, store)
 
 		err := processor.ProcessLogs(ctx, block1, ethTypes.Receipts{})
 		require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestLogProcessor(t *testing.T) {
 			},
 		}
 		store := &stubLogStorage{}
-		processor := newLogProcessor(logProcessorChainID, store)
+		processor := NewLogProcessor(logProcessorChainID, store)
 
 		err := processor.ProcessLogs(ctx, block1, rcpts)
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestLogProcessor(t *testing.T) {
 			Hash:      common.Hash{0xaa},
 		}
 		store := &stubLogStorage{}
-		processor := newLogProcessor(types.ChainID{4}, store)
+		processor := NewLogProcessor(types.ChainID{4}, store)
 		processor.eventDecoder = EventDecoderFn(func(l *ethTypes.Log) (types.ExecutingMessage, error) {
 			require.Equal(t, rcpts[0].Logs[0], l)
 			return execMsg, nil

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -21,6 +21,9 @@ type QueryBackend interface {
 	CheckMessages(messages []types.Message, minSafety types.SafetyLevel) error
 	CheckBlock(chainID *hexutil.U256, blockHash common.Hash, blockNumber hexutil.Uint64) (types.SafetyLevel, error)
 	DerivedFrom(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.BlockRef, error)
+	UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error)
+	SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error)
+	Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
 }
 
 type UpdatesBackend interface {
@@ -32,6 +35,7 @@ type UpdatesBackend interface {
 type Backend interface {
 	AdminBackend
 	QueryBackend
+	UpdatesBackend
 }
 
 type QueryFrontend struct {
@@ -53,23 +57,19 @@ func (q *QueryFrontend) CheckMessages(
 }
 
 func (q *QueryFrontend) UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
-	// TODO(#12358): attach to backend
-	return types.ReferenceView{}, nil
+	return q.Supervisor.UnsafeView(ctx, chainID, unsafe)
 }
 
 func (q *QueryFrontend) SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
-	// TODO(#12358): attach to backend
-	return types.ReferenceView{}, nil
+	return q.Supervisor.SafeView(ctx, chainID, safe)
 }
 
 func (q *QueryFrontend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
-	// TODO(#12358): attach to backend
-	return eth.BlockID{}, nil
+	return q.Supervisor.Finalized(ctx, chainID)
 }
 
 func (q *QueryFrontend) DerivedFrom(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.BlockRef, error) {
-	// TODO(#12358): attach to backend
-	return eth.BlockRef{}, nil
+	return q.Supervisor.DerivedFrom(ctx, chainID, blockHash, blockNumber)
 }
 
 type AdminFrontend struct {

--- a/op-supervisor/supervisor/service.go
+++ b/op-supervisor/supervisor/service.go
@@ -149,6 +149,11 @@ func (su *SupervisorService) initRPCServer(cfg *config.Config) error {
 		Service:       &frontend.QueryFrontend{Supervisor: su.backend},
 		Authenticated: false,
 	})
+	server.AddAPI(rpc.API{
+		Namespace:     "supervisor",
+		Service:       &frontend.UpdatesFrontend{Supervisor: su.backend},
+		Authenticated: false,
+	})
 	su.rpcServer = server
 	return nil
 }


### PR DESCRIPTION
Builds from: https://github.com/ethereum-optimism/optimism/pull/12204
The fixes so far are:

- New APIs not linked to Server ✅ 
- Supervisor client was casting the chainID inappropriately ✅
- Supervisor Backend had no implementation for
    - Update Local Unsafe ✅
    - Update Local Safe ✅
    - Update Finaliazed L1 ✅
    - Unsafe View ✅
    - Safe View ✅
    - Finalized ✅
- ChainsDB had no implementation for
    - Update Local Unsafe✅
    - Update Local Safe✅
    - Update Finalized✅
    - Unsafe View✅
    - Safe View✅
    - Finalized✅

## Currently Tracking Down:
## Incomplete State when calling HeadPointer()

When attempting to get HeadPointers from the State, I see

```
failed to check unsafe-level view: failed to share unsafe block view View(local: 0x88b33dd0b4f00107715a99f2f5340f17f6a7214f45611248822367485a90f90e:8, cross: 0xf5afaa7bd6b330fce0251d91c2eb58c94ac421e45d6561a676d2e7b9a04886c7:6) (chain 900200): failed to get unsafe view: cannot provide head pointer while state is incomplete"
```

To address this, I added logging to the error which shows which flags are still needed.

(note: `needs` is a set of bitmap flags which signal to the iterator state that it is expecting to infer some data

In all cases, it was reported that the `CanonicalHash` flag was still set.

Investigating `CanonicalHash` flag, I see it gets triggered for the iterator state from four locations:

- During `infer` after a checkpoint
- During DB Initialization
- When a new iterator is created with `NewIteratorAt`
- During `ProcessEntry`

I've debugged this off and on this week, but haven't figured out why the iterator is dirty. I suspect there might be an edge-case where `CanonicalHash` is `needed` for multiple reasons, and only gets satisfied once due to some race condition when removing the `need`.