### PR TITLE
cannon: Bump go tests to go1.22

### DIFF
--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -41,7 +41,7 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 
 	var stdOutBuf, stdErrBuf bytes.Buffer
 	us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), nil)
-	for i := 0; i < 1_000_000; i++ {
+	for i := 0; i < 2_000_000; i++ {
 		if us.GetState().GetExited() {
 			break
 		}

--- a/cannon/testdata/example/alloc/go.mod
+++ b/cannon/testdata/example/alloc/go.mod
@@ -1,8 +1,8 @@
 module alloc
 
-go 1.21
+go 1.22
 
-toolchain go1.21.1
+toolchain go1.22.0
 
 require github.com/ethereum-optimism/optimism v0.0.0
 

--- a/cannon/testdata/example/claim/go.mod
+++ b/cannon/testdata/example/claim/go.mod
@@ -1,8 +1,8 @@
 module claim
 
-go 1.21
+go 1.22
 
-toolchain go1.21.1
+toolchain go1.22.0
 
 require github.com/ethereum-optimism/optimism v0.0.0
 

--- a/cannon/testdata/example/entry/go.mod
+++ b/cannon/testdata/example/entry/go.mod
@@ -1,3 +1,5 @@
 module entry
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0

--- a/cannon/testdata/example/hello/go.mod
+++ b/cannon/testdata/example/hello/go.mod
@@ -1,3 +1,5 @@
 module hello
 
-go 1.20
+go 1.22
+
+toolchain go1.22.0

--- a/cannon/testdata/example/multithreaded/go.mod
+++ b/cannon/testdata/example/multithreaded/go.mod
@@ -1,3 +1,5 @@
 module multithreaded
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Bump go test programs up to go1.22.

**Metadata**

Fixes #12146
