### PR TITLE
packages/contracts-bedrock: fix lint issue

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-foundry-install.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-foundry-install.sh
@@ -41,5 +41,5 @@ if [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ]; then
 else
   echo "Mismatch between installed Foundry version ($INSTALLED_VERSION) and expected version ($EXPECTED_VERSION)."
   echo "Your version of Foundry may either not be up to date, or it could be a later version."
-  echo "Running just update-foundry will install the expected version."
+  echo "Running 'just update-foundry' from the repository root will install the expected version."
 fi

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -215,29 +215,29 @@ library Encoding {
     }
 
     /// @notice Returns an appropriately encoded call to L1Block.setL1BlockValuesHolocene
-    /// @param baseFeeScalar       L1 base fee Scalar
-    /// @param blobBaseFeeScalar   L1 blob base fee Scalar
-    /// @param sequenceNumber      Number of L2 blocks since epoch start.
-    /// @param timestamp           L1 timestamp.
-    /// @param number              L1 blocknumber.
-    /// @param baseFee             L1 base fee.
-    /// @param blobBaseFee         L1 blob base fee.
-    /// @param hash                L1 blockhash.
-    /// @param batcherHash         Versioned hash to authenticate batcher by.
-    /// @param eip1559Elasticity   EIP-1559 elasticity parameter
-    /// @param eip1559Denominator EIP-1559 denominator parameter
+    /// @param _baseFeeScalar       L1 base fee Scalar
+    /// @param _blobBaseFeeScalar   L1 blob base fee Scalar
+    /// @param _sequenceNumber      Number of L2 blocks since epoch start.
+    /// @param _timestamp           L1 timestamp.
+    /// @param _number              L1 blocknumber.
+    /// @param _baseFee             L1 base fee.
+    /// @param _blobBaseFee         L1 blob base fee.
+    /// @param _hash                L1 blockhash.
+    /// @param _batcherHash         Versioned hash to authenticate batcher by.
+    /// @param _eip1559Elasticity   EIP-1559 elasticity parameter
+    /// @param _eip1559Denominator EIP-1559 denominator parameter
     function encodeSetL1BlockValuesHolocene(
-        uint32 baseFeeScalar,
-        uint32 blobBaseFeeScalar,
-        uint64 sequenceNumber,
-        uint64 timestamp,
-        uint64 number,
-        uint256 baseFee,
-        uint256 blobBaseFee,
-        bytes32 hash,
-        bytes32 batcherHash,
-        uint64 eip1559Elasticity,
-        uint64 eip1559Denominator
+        uint32 _baseFeeScalar,
+        uint32 _blobBaseFeeScalar,
+        uint64 _sequenceNumber,
+        uint64 _timestamp,
+        uint64 _number,
+        uint256 _baseFee,
+        uint256 _blobBaseFee,
+        bytes32 _hash,
+        bytes32 _batcherHash,
+        uint64 _eip1559Elasticity,
+        uint64 _eip1559Denominator
     )
         internal
         pure
@@ -246,17 +246,17 @@ library Encoding {
         bytes4 functionSignature = bytes4(keccak256("setL1BlockValuesHolocene()"));
         return abi.encodePacked(
             functionSignature,
-            baseFeeScalar,
-            blobBaseFeeScalar,
-            sequenceNumber,
-            timestamp,
-            number,
-            baseFee,
-            blobBaseFee,
-            hash,
-            batcherHash,
-            eip1559Elasticity,
-            eip1559Denominator
+            _baseFeeScalar,
+            _blobBaseFeeScalar,
+            _sequenceNumber,
+            _timestamp,
+            _number,
+            _baseFee,
+            _blobBaseFee,
+            _hash,
+            _batcherHash,
+            _eip1559Elasticity,
+            _eip1559Denominator
         );
     }
 }


### PR DESCRIPTION
**Description**

- fix lint issue introduced in https://github.com/ethereum-optimism/optimism/pull/12096

- clarify that 'just update-foundry' needs to be run from the root of the repo in check-foundry script. Usually the user will be in contracts-bedrock/src when seeing this message, and the justfile there doesn't handle it.

