### PR TITLE
cannon: Update version of go used in cannon stf-diff

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine3.18 as builder
+FROM golang:1.22.7-alpine3.20 as builder
 
 RUN apk add --no-cache make bash
 


### PR DESCRIPTION
**Description**

The cannon examples were switched to go1.22 - update the stf diff check to use a docker image with go 1.22 (cannon itself is still go 1.21 along with the rest of the monorepo but we want to test compatibility with go 1.22).
