### PR TITLE
fix(ci): add files to semgrep ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1210,7 +1210,7 @@ jobs:
           # --timeout (in seconds) limits the time per rule and file.
           #   SEMGREP_TIMEOUT is the same, but docs have conflicting defaults (5s in CLI flag, 1800 in some places)
           #    https://semgrep.dev/docs/troubleshooting/semgrep-app#if-the-job-is-aborted-due-to-taking-too-long
-          command: semgrep ci --timeout=100
+          command: semgrep ci --timeout=100 --no-suppress-errors
           # If semgrep hangs, stop the scan after 20m, to prevent a useless 5h job
           no_output_timeout: 20m
       - notify-failures-on-develop

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -41,3 +41,5 @@ packages/contracts-bedrock/src/L2/SuperchainWETH.sol
 packages/contracts-bedrock/src/L2/interfaces/ISuperchainWETH.sol
 packages/contracts-bedrock/src/governance/GovernanceToken.sol
 packages/contracts-bedrock/src/governance/interfaces/IGovernanceToken.sol
+packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
+packages/contracts-bedrock/src/dispute/interfaces/IPermissionedDisputeGame.sol


### PR DESCRIPTION
FaultDisputeGame and PermissionedDisputeGame interface files are annoying because the semgrep ignore comment doesn't seem to work properly.