### PR TITLE
packages/contracts-bedrock: make check-interfaces.sh warn on old versions of bash

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-interfaces.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-interfaces.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Warn users of Mac OSX who have not ever upgraded bash from the default that they may experience
+# performance issues.
+if [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
+    echo "WARNING: your bash installation is very old, and may cause this script to run extremely slowly. Please upgrade bash to at least version 5 if you have performance issues."
+fi
+
 # This script checks for ABI consistency between interfaces and their corresponding contracts.
 # It compares the ABIs of interfaces (files starting with 'I') with their implementation contracts,
 # excluding certain predefined files. Constructors are expected to be represented in interfaces by a


### PR DESCRIPTION
**Description**

The check-interfaces.sh script has become incredibly slow (like 10+ minutes slow) on Mac OSX due to its antiquated default bash installation, so this PR adds a warning on old bash versions informing the caller to upgrade bash if there are performance issues.
