### PR TITLE
op-e2e: Retrieve AllocType from System instead of env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -908,9 +908,6 @@ jobs:
 
   go-e2e-test:
     parameters:
-      variant:
-        type: string
-        default: ''
       module:
         description: Go Module Name
         type: string
@@ -935,13 +932,6 @@ jobs:
     parallelism: <<parameters.parallelism>>
     steps:
       - checkout
-      - when:
-          condition:
-            equal: ['-mt-cannon', <<parameters.variant>>]
-          steps:
-            - run:
-                name: Set OP_E2E_ALLOC_TYPE = mt-cannon
-                command: echo 'export OP_E2E_ALLOC_TYPE=mt-cannon' >> $BASH_ENV
       - check-changed:
           patterns: op-(.+),cannon,contracts-bedrock
       - run:
@@ -979,7 +969,7 @@ jobs:
             # want it to.
             export OP_E2E_CANNON_ENABLED="false"
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
-            # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
+            # constraint that gotestsum does not currently (nor likely will) accept files from different packages when building.
             JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml JSON_LOG_FILE=/testlogs/test.log make <<parameters.target>>
           working_directory: <<parameters.module>>
       - store_artifacts:
@@ -1685,13 +1675,10 @@ workflows:
           context:
             - slack
       - go-e2e-test:
-          name: op-e2e-cannon-tests<< matrix.variant >>
-          matrix:
-            parameters:
-              variant: ["", "-mt-cannon"]
+          name: op-e2e-cannon-tests
           module: op-e2e
           target: test-cannon
-          parallelism: 4
+          parallelism: 8
           notify: true
           mentions: "@proofs-squad"
           requires:

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -212,15 +212,3 @@ func initAllocType(root string, allocType AllocType) {
 	dc.SetDeployments(l1Deployments)
 	deployConfigsByType[allocType] = dc
 }
-
-func AllocTypeFromEnv() AllocType {
-	allocType := os.Getenv("OP_E2E_ALLOC_TYPE")
-	if allocType == "" {
-		return DefaultAllocType
-	}
-	out := AllocType(allocType)
-	if err := out.Check(); err != nil {
-		panic(err)
-	}
-	return out
-}

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	e2econfig "github.com/ethereum-optimism/optimism/op-e2e/config"
-
 	"github.com/ethereum-optimism/optimism/op-service/crypto"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -39,6 +38,11 @@ type EndpointProvider interface {
 	L1BeaconEndpoint() endpoint.RestHTTP
 }
 
+type System interface {
+	RollupCfg() *rollup.Config
+	L2Genesis() *core.Genesis
+	AllocType() e2econfig.AllocType
+}
 type Helper struct {
 	log     log.Logger
 	t       *testing.T
@@ -142,17 +146,17 @@ func applyCannonConfig(c *config.Config, t *testing.T, rollupCfg *rollup.Config,
 	c.Cannon.RollupConfigPath = rollupFile
 }
 
-func WithCannon(t *testing.T, rollupCfg *rollup.Config, l2Genesis *core.Genesis, allocType e2econfig.AllocType) Option {
+func WithCannon(t *testing.T, system System) Option {
 	return func(c *config.Config) {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypeCannon)
-		applyCannonConfig(c, t, rollupCfg, l2Genesis, allocType)
+		applyCannonConfig(c, t, system.RollupCfg(), system.L2Genesis(), system.AllocType())
 	}
 }
 
-func WithPermissioned(t *testing.T, rollupCfg *rollup.Config, l2Genesis *core.Genesis, allocType e2econfig.AllocType) Option {
+func WithPermissioned(t *testing.T, system System) Option {
 	return func(c *config.Config) {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypePermissioned)
-		applyCannonConfig(c, t, rollupCfg, l2Genesis, allocType)
+		applyCannonConfig(c, t, system.RollupCfg(), system.L2Genesis(), system.AllocType())
 	}
 }
 

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -83,6 +83,7 @@ type DisputeSystem interface {
 	L1Deployments() *genesis.L1Deployments
 	RollupCfg() *rollup.Config
 	L2Genesis() *core.Genesis
+	AllocType() config.AllocType
 
 	AdvanceTime(time.Duration)
 }
@@ -117,7 +118,7 @@ func NewFactoryHelper(t *testing.T, ctx context.Context, system DisputeSystem, o
 	chainID, err := client.ChainID(ctx)
 	require.NoError(err)
 
-	allocType := config.AllocTypeFromEnv()
+	allocType := system.AllocType()
 	require.True(allocType.UsesProofs(), "AllocType %v does not support proofs", allocType)
 
 	factoryCfg := &FactoryCfg{PrivKey: TestKey}

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -35,7 +35,7 @@ type OutputCannonGameHelper struct {
 
 func (g *OutputCannonGameHelper) StartChallenger(ctx context.Context, name string, options ...challenger.Option) *challenger.Helper {
 	opts := []challenger.Option{
-		challenger.WithCannon(g.T, g.System.RollupCfg(), g.System.L2Genesis(), g.AllocType),
+		challenger.WithCannon(g.T, g.System),
 		challenger.WithFactoryAddress(g.FactoryAddr),
 		challenger.WithGameAddress(g.Addr),
 	}
@@ -331,7 +331,7 @@ func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, 
 
 func (g *OutputCannonGameHelper) defaultChallengerOptions() []challenger.Option {
 	return []challenger.Option{
-		challenger.WithCannon(g.T, g.System.RollupCfg(), g.System.L2Genesis(), g.AllocType),
+		challenger.WithCannon(g.T, g.System),
 		challenger.WithFactoryAddress(g.FactoryAddr),
 		challenger.WithGameAddress(g.Addr),
 	}

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -42,7 +42,6 @@ type OutputGameHelper struct {
 	Addr                  common.Address
 	CorrectOutputProvider *outputs.OutputTraceProvider
 	System                DisputeSystem
-	AllocType             config.AllocType
 }
 
 func NewOutputGameHelper(t *testing.T, require *require.Assertions, client *ethclient.Client, opts *bind.TransactOpts, privKey *ecdsa.PrivateKey,
@@ -58,7 +57,6 @@ func NewOutputGameHelper(t *testing.T, require *require.Assertions, client *ethc
 		Addr:                  addr,
 		CorrectOutputProvider: correctOutputProvider,
 		System:                system,
-		AllocType:             allocType,
 	}
 }
 

--- a/op-e2e/faultproofs/cannon_benchmark_test.go
+++ b/op-e2e/faultproofs/cannon_benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -32,12 +33,20 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-func TestBenchmarkCannon_FPP(t *testing.T) {
+func TestBenchmarkCannonFPP_Standard(t *testing.T) {
+	testBenchmarkCannonFPP(t, config.AllocTypeStandard)
+}
+
+func TestBenchmarkCannonFPP_Multithreaded(t *testing.T) {
+	testBenchmarkCannonFPP(t, config.AllocTypeMTCannon)
+}
+
+func testBenchmarkCannonFPP(t *testing.T, allocType config.AllocType) {
 	t.Skip("TODO(client-pod#906): Compare total witness size for assertions against pages allocated by the VM")
 
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	cfg := e2esys.DefaultSystemConfig(t)
+	cfg := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(allocType))
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
 	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks

--- a/op-e2e/faultproofs/cannon_benchmark_test.go
+++ b/op-e2e/faultproofs/cannon_benchmark_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -38,7 +37,7 @@ func TestBenchmarkCannon_FPP(t *testing.T) {
 
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	cfg := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(config.AllocTypeFromEnv()))
+	cfg := e2esys.DefaultSystemConfig(t)
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
 	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks

--- a/op-e2e/faultproofs/multi_test.go
+++ b/op-e2e/faultproofs/multi_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
-
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
@@ -29,7 +27,7 @@ func TestMultipleGameTypes(t *testing.T) {
 
 	// Start a challenger with both cannon and alphabet support
 	gameFactory.StartChallenger(ctx, "TowerDefense",
-		challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg, config.AllocTypeFromEnv()),
+		challenger.WithCannon(t, sys),
 		challenger.WithAlphabet(),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 	)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
-
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
@@ -18,10 +18,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutputCannonGame(t *testing.T) {
+func TestOutputCannonGame_Standard(t *testing.T) {
+	testOutputCannonGame(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonGame_Multithreaded(t *testing.T) {
+	testOutputCannonGame(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonGame(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -73,11 +81,19 @@ func TestOutputCannonGame(t *testing.T) {
 	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
 }
 
-func TestOutputCannon_ChallengeAllZeroClaim(t *testing.T) {
+func TestOutputCannon_ChallengeAllZeroClaim_Standard(t *testing.T) {
+	testOutputCannonChallengeAllZeroClaim(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannon_ChallengeAllZeroClaim_Multithreaded(t *testing.T) {
+	testOutputCannonChallengeAllZeroClaim(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonChallengeAllZeroClaim(t *testing.T, allocType config.AllocType) {
 	// The dishonest actor always posts claims with all zeros.
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -102,7 +118,15 @@ func TestOutputCannon_ChallengeAllZeroClaim(t *testing.T) {
 	game.LogGameData(ctx)
 }
 
-func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
+func TestOutputCannon_PublishCannonRootClaim_Standard(t *testing.T) {
+	testOutputCannonPublishCannonRootClaim(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannon_PublishCannonRootClaim_Multithreaded(t *testing.T) {
+	testOutputCannonPublishCannonRootClaim(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonPublishCannonRootClaim(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	tests := []struct {
 		disputeL2BlockNumber uint64
@@ -116,7 +140,7 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 			ctx := context.Background()
-			sys, _ := StartFaultDisputeSystem(t)
+			sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 
 			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 			game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", test.disputeL2BlockNumber, common.Hash{0x01})
@@ -131,7 +155,16 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 	}
 }
 
-func TestOutputCannonDisputeGame(t *testing.T) {
+func TestOutputCannonDisputeGame_Standard(t *testing.T) {
+	testOutputCannonDisputeGame(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonDisputeGame_Multithreaded(t *testing.T) {
+	testOutputCannonDisputeGame(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonDisputeGame(t *testing.T, allocType config.AllocType) {
+
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	tests := []struct {
 		name             string
@@ -147,7 +180,7 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 			ctx := context.Background()
-			sys, l1Client := StartFaultDisputeSystem(t)
+			sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 			t.Cleanup(sys.Close)
 
 			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -180,11 +213,19 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 	}
 }
 
-func TestOutputCannonDefendStep(t *testing.T) {
+func TestOutputCannonDefendStep_Standard(t *testing.T) {
+	testOutputCannonDefendStep(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonDefendStep_Multithreaded(t *testing.T) {
+	testOutputCannonDefendStep(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonDefendStep(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -216,11 +257,19 @@ func TestOutputCannonDefendStep(t *testing.T) {
 	require.EqualValues(t, gameTypes.GameStatusChallengerWon, game.Status(ctx))
 }
 
-func TestOutputCannonStepWithLargePreimage(t *testing.T) {
+func TestOutputCannonStepWithLargePreimage_Standard(t *testing.T) {
+	testOutputCannonStepWithLargePreimage(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonStepWithLargePreimage_Multithreaded(t *testing.T) {
+	testOutputCannonStepWithLargePreimage(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonStepWithLargePreimage(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, _ := StartFaultDisputeSystem(t, WithBatcherStopped())
+	sys, _ := StartFaultDisputeSystem(t, WithBatcherStopped(), WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	// Manually send a tx from the correct batcher key to the batcher input with very large (invalid) data
@@ -257,13 +306,21 @@ func TestOutputCannonStepWithLargePreimage(t *testing.T) {
 	// So we don't waste time resolving the game - that's tested elsewhere.
 }
 
-func TestOutputCannonStepWithPreimage(t *testing.T) {
+func TestOutputCannonStepWithPreimage_Standard(t *testing.T) {
+	testOutputCannonStepWithPreimage(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonStepWithPreimage_Multithreaded(t *testing.T) {
+	testOutputCannonStepWithPreimage(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonStepWithPreimage(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	testPreimageStep := func(t *testing.T, preimageType utils.PreimageOpt, preloadPreimage bool) {
 		op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 		ctx := context.Background()
-		sys, _ := StartFaultDisputeSystem(t, WithBlobBatches())
+		sys, _ := StartFaultDisputeSystem(t, WithBlobBatches(), WithAllocType(allocType))
 		t.Cleanup(sys.Close)
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -299,14 +356,22 @@ func TestOutputCannonStepWithPreimage(t *testing.T) {
 	})
 }
 
-func TestOutputCannonStepWithKZGPointEvaluation(t *testing.T) {
+func TestOutputCannonStepWithKZGPointEvaluation_Standard(t *testing.T) {
+	testOutputCannonStepWithKzgPointEvaluation(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonStepWithKZGPointEvaluation_Multithreaded(t *testing.T) {
+	testOutputCannonStepWithKzgPointEvaluation(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonStepWithKzgPointEvaluation(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	testPreimageStep := func(t *testing.T, preloadPreimage bool) {
 		op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 		ctx := context.Background()
-		sys, _ := StartFaultDisputeSystem(t, WithEcotone())
+		sys, _ := StartFaultDisputeSystem(t, WithEcotone(), WithAllocType(allocType))
 		t.Cleanup(sys.Close)
 
 		// NOTE: Flake prevention
@@ -347,7 +412,15 @@ func TestOutputCannonStepWithKZGPointEvaluation(t *testing.T) {
 	})
 }
 
-func TestOutputCannonProposedOutputRootValid(t *testing.T) {
+func TestOutputCannonProposedOutputRootValid_Standard(t *testing.T) {
+	testOutputCannonProposedOutputRootValid(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonProposedOutputRootValid_Multithreaded(t *testing.T) {
+	testOutputCannonProposedOutputRootValid(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonProposedOutputRootValid(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
 	honestStepsFail := func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
@@ -406,7 +479,7 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 			ctx := context.Background()
-			sys, l1Client := StartFaultDisputeSystem(t)
+			sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 			t.Cleanup(sys.Close)
 
 			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -436,11 +509,19 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 	}
 }
 
-func TestOutputCannonPoisonedPostState(t *testing.T) {
+func TestOutputCannonPoisonedPostState_Standard(t *testing.T) {
+	testOutputCannonPoisonedPostState(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonPoisonedPostState_Multithreaded(t *testing.T) {
+	testOutputCannonPoisonedPostState(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonPoisonedPostState(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -500,11 +581,19 @@ func TestOutputCannonPoisonedPostState(t *testing.T) {
 	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
 }
 
-func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot(t *testing.T) {
+func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot_Standard(t *testing.T) {
+	testDisputeOutputRootBeyondProposedBlockValidOutputRoot(t, config.AllocTypeStandard)
+}
+
+func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot_Multithreaded(t *testing.T) {
+	testDisputeOutputRootBeyondProposedBlockValidOutputRoot(t, config.AllocTypeMTCannon)
+}
+
+func testDisputeOutputRootBeyondProposedBlockValidOutputRoot(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -550,11 +639,19 @@ func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot(t *testing.T) {
 	game.LogGameData(ctx)
 }
 
-func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot(t *testing.T) {
+func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot_Standard(t *testing.T) {
+	testDisputeOutputRootBeyondProposedBlockInvalidOutputRoot(t, config.AllocTypeStandard)
+}
+
+func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot_Multithreaded(t *testing.T) {
+	testDisputeOutputRootBeyondProposedBlockInvalidOutputRoot(t, config.AllocTypeMTCannon)
+}
+
+func testDisputeOutputRootBeyondProposedBlockInvalidOutputRoot(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -601,11 +698,19 @@ func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot(t *testing.T) {
 	game.LogGameData(ctx)
 }
 
-func TestDisputeOutputRoot_ChangeClaimedOutputRoot(t *testing.T) {
+func TestTestDisputeOutputRoot_ChangeClaimedOutputRoot_Standard(t *testing.T) {
+	testTestDisputeOutputRootChangeClaimedOutputRoot(t, config.AllocTypeStandard)
+}
+
+func TestTestDisputeOutputRoot_ChangeClaimedOutputRoot_Multithreaded(t *testing.T) {
+	testTestDisputeOutputRootChangeClaimedOutputRoot(t, config.AllocTypeMTCannon)
+}
+
+func testTestDisputeOutputRootChangeClaimedOutputRoot(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -661,7 +766,15 @@ func TestDisputeOutputRoot_ChangeClaimedOutputRoot(t *testing.T) {
 	game.LogGameData(ctx)
 }
 
-func TestInvalidateUnsafeProposal(t *testing.T) {
+func TestInvalidateUnsafeProposal_Standard(t *testing.T) {
+	testInvalidateUnsafeProposal(t, config.AllocTypeStandard)
+}
+
+func TestInvalidateUnsafeProposal_Multithreaded(t *testing.T) {
+	testInvalidateUnsafeProposal(t, config.AllocTypeMTCannon)
+}
+
+func testInvalidateUnsafeProposal(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 
@@ -693,7 +806,7 @@ func TestInvalidateUnsafeProposal(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
-			sys, l1Client := StartFaultDisputeSystem(t, WithSequencerWindowSize(100000), WithBatcherStopped())
+			sys, l1Client := StartFaultDisputeSystem(t, WithSequencerWindowSize(100000), WithBatcherStopped(), WithAllocType(allocType))
 			t.Cleanup(sys.Close)
 
 			blockNum := uint64(1)
@@ -723,7 +836,15 @@ func TestInvalidateUnsafeProposal(t *testing.T) {
 	}
 }
 
-func TestInvalidateProposalForFutureBlock(t *testing.T) {
+func TestInvalidateProposalForFutureBlock_Standard(t *testing.T) {
+	testInvalidateProposalForFutureBlock(t, config.AllocTypeStandard)
+}
+
+func TestInvalidateProposalForFutureBlock_Multithreaded(t *testing.T) {
+	testInvalidateProposalForFutureBlock(t, config.AllocTypeMTCannon)
+}
+
+func testInvalidateProposalForFutureBlock(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 
@@ -755,7 +876,7 @@ func TestInvalidateProposalForFutureBlock(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
-			sys, l1Client := StartFaultDisputeSystem(t, WithSequencerWindowSize(100000))
+			sys, l1Client := StartFaultDisputeSystem(t, WithSequencerWindowSize(100000), WithAllocType(allocType))
 			t.Cleanup(sys.Close)
 
 			farFutureBlockNum := uint64(10_000_000)
@@ -785,11 +906,19 @@ func TestInvalidateProposalForFutureBlock(t *testing.T) {
 	}
 }
 
-func TestInvalidateCorrectProposalFutureBlock(t *testing.T) {
+func TestInvalidateCorrectProposalFutureBlock_Standard(t *testing.T) {
+	testInvalidateCorrectProposalFutureBlock(t, config.AllocTypeStandard)
+}
+
+func TestInvalidateCorrectProposalFutureBlock_Multithreaded(t *testing.T) {
+	testInvalidateCorrectProposalFutureBlock(t, config.AllocTypeMTCannon)
+}
+
+func testInvalidateCorrectProposalFutureBlock(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	// Spin up the system without the batcher so the safe head doesn't advance
-	sys, l1Client := StartFaultDisputeSystem(t, WithBatcherStopped(), WithSequencerWindowSize(100000))
+	sys, l1Client := StartFaultDisputeSystem(t, WithBatcherStopped(), WithSequencerWindowSize(100000), WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	// Create a dispute game factory helper.
@@ -817,11 +946,19 @@ func TestInvalidateCorrectProposalFutureBlock(t *testing.T) {
 	game.LogGameData(ctx)
 }
 
-func TestOutputCannonHonestSafeTraceExtension_ValidRoot(t *testing.T) {
+func TestOutputCannonHonestSafeTraceExtension_ValidRoot_Standard(t *testing.T) {
+	testOutputCannonHonestSafeTraceExtensionValidRoot(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonHonestSafeTraceExtension_ValidRoot_Multithreaded(t *testing.T) {
+	testOutputCannonHonestSafeTraceExtensionValidRoot(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonHonestSafeTraceExtensionValidRoot(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	// Wait for there to be there are safe L2 blocks past the claimed safe head that have data available on L1 within
@@ -871,11 +1008,19 @@ func TestOutputCannonHonestSafeTraceExtension_ValidRoot(t *testing.T) {
 	require.EqualValues(t, gameTypes.GameStatusDefenderWon, game.Status(ctx))
 }
 
-func TestOutputCannonHonestSafeTraceExtension_InvalidRoot(t *testing.T) {
+func TestOutputCannonHonestSafeTraceExtension_InvalidRoot_Standard(t *testing.T) {
+	testOutputCannonHonestSafeTraceExtensionInvalidRoot(t, config.AllocTypeStandard)
+}
+
+func TestOutputCannonHonestSafeTraceExtension_InvalidRoot_Multithreaded(t *testing.T) {
+	testOutputCannonHonestSafeTraceExtensionInvalidRoot(t, config.AllocTypeMTCannon)
+}
+
+func testOutputCannonHonestSafeTraceExtensionInvalidRoot(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t)
+	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	// Wait for there to be there are safe L2 blocks past the claimed safe head that have data available on L1 within
@@ -912,11 +1057,19 @@ func TestOutputCannonHonestSafeTraceExtension_InvalidRoot(t *testing.T) {
 	require.EqualValues(t, gameTypes.GameStatusChallengerWon, game.Status(ctx))
 }
 
-func TestAgreeFirstBlockWithOriginOf1(t *testing.T) {
+func TestAgreeFirstBlockWithOriginOf1_Standard(t *testing.T) {
+	testAgreeFirstBlockWithOriginOf1(t, config.AllocTypeStandard)
+}
+
+func TestAgreeFirstBlockWithOriginOf1_Multithreaded(t *testing.T) {
+	testAgreeFirstBlockWithOriginOf1(t, config.AllocTypeMTCannon)
+}
+
+func testAgreeFirstBlockWithOriginOf1(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, _ := StartFaultDisputeSystem(t)
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	rollupClient := sys.RollupClient("sequencer")

--- a/op-e2e/faultproofs/permissioned_test.go
+++ b/op-e2e/faultproofs/permissioned_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
-
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
@@ -28,7 +26,7 @@ func TestPermissionedGameType(t *testing.T) {
 	gameFactory.StartChallenger(ctx, "TowerDefense",
 		challenger.WithValidPrestateRequired(),
 		challenger.WithInvalidCannonPrestate(),
-		challenger.WithPermissioned(t, sys.RollupConfig, sys.L2GenesisCfg, config.AllocTypeFromEnv()),
+		challenger.WithPermissioned(t, sys),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 	)
 

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	e2econfig "github.com/ethereum-optimism/optimism/op-e2e/config"
-
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
@@ -252,7 +250,7 @@ func runCannon(t *testing.T, ctx context.Context, sys *e2esys.System, inputs uti
 	l1Beacon := sys.L1BeaconEndpoint().RestHTTP()
 	rollupEndpoint := sys.RollupEndpoint("sequencer").RPC()
 	l2Endpoint := sys.NodeEndpoint("sequencer").RPC()
-	cannonOpts := challenger.WithCannon(t, sys.RollupCfg(), sys.L2Genesis(), e2econfig.AllocTypeFromEnv())
+	cannonOpts := challenger.WithCannon(t, sys)
 	dir := t.TempDir()
 	proofsDir := filepath.Join(dir, "cannon-proofs")
 	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, rollupEndpoint, l2Endpoint, dir)

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	e2e_config "github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 
@@ -29,7 +30,15 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-func TestPrecompiles(t *testing.T) {
+func TestPrecompiles_Standard(t *testing.T) {
+	testPrecompiles(t, e2e_config.AllocTypeStandard)
+}
+
+func TestPrecompiles_Multithreaded(t *testing.T) {
+	testPrecompiles(t, e2e_config.AllocTypeMTCannon)
+}
+
+func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	// precompile test vectors copied from go-ethereum
 	tests := []struct {
@@ -79,6 +88,7 @@ func TestPrecompiles(t *testing.T) {
 			ctx := context.Background()
 			genesisTime := hexutil.Uint64(0)
 			cfg := e2esys.EcotoneSystemConfig(t, &genesisTime)
+			cfg.AllocType = allocType
 			// We don't need a verifier - just the sequencer is enough
 			delete(cfg.Nodes, "verifier")
 			// Use a small sequencer window size to avoid test timeout while waiting for empty blocks
@@ -139,7 +149,7 @@ func TestPrecompiles(t *testing.T) {
 				t.Skipf("%v is not accelerated so no preimgae to upload", test.name)
 			}
 			ctx := context.Background()
-			sys, _ := StartFaultDisputeSystem(t, WithBlobBatches())
+			sys, _ := StartFaultDisputeSystem(t, WithBlobBatches(), WithAllocType(allocType))
 
 			l2Seq := sys.NodeClient("sequencer")
 			aliceKey := sys.Cfg.Secrets.Alice
@@ -173,11 +183,20 @@ func TestPrecompiles(t *testing.T) {
 	}
 }
 
-func TestGranitePrecompiles(t *testing.T) {
+func TestGranitePrecompiles_Standard(t *testing.T) {
+	testGranitePrecompiles(t, e2e_config.AllocTypeStandard)
+}
+
+func TestGranitePrecompiles_Multithreaded(t *testing.T) {
+	testGranitePrecompiles(t, e2e_config.AllocTypeMTCannon)
+}
+
+func testGranitePrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	genesisTime := hexutil.Uint64(0)
 	cfg := e2esys.GraniteSystemConfig(t, &genesisTime)
+	cfg.AllocType = allocType
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
 	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 
@@ -46,6 +47,12 @@ func WithEcotone() faultDisputeConfigOpts {
 func WithSequencerWindowSize(size uint64) faultDisputeConfigOpts {
 	return func(cfg *e2esys.SystemConfig) {
 		cfg.DeployConfig.SequencerWindowSize = size
+	}
+}
+
+func WithAllocType(allocType config.AllocType) faultDisputeConfigOpts {
+	return func(cfg *e2esys.SystemConfig) {
+		cfg.AllocType = allocType
 	}
 }
 

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 
@@ -51,7 +50,7 @@ func WithSequencerWindowSize(size uint64) faultDisputeConfigOpts {
 }
 
 func StartFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts) (*e2esys.System, *ethclient.Client) {
-	cfg := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(config.AllocTypeFromEnv()))
+	cfg := e2esys.DefaultSystemConfig(t)
 	delete(cfg.Nodes, "verifier")
 	cfg.Nodes["sequencer"].SafeDBPath = t.TempDir()
 	cfg.DeployConfig.SequencerWindowSize = 4

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -404,6 +404,10 @@ func (sys *System) L2Genesis() *core.Genesis {
 	return sys.L2GenesisCfg
 }
 
+func (sys *System) AllocType() config.AllocType {
+	return sys.Cfg.AllocType
+}
+
 func (sys *System) L1Slot(l1Timestamp uint64) uint64 {
 	return (l1Timestamp - uint64(sys.Cfg.DeployConfig.L1GenesisBlockTimestamp)) /
 		sys.Cfg.DeployConfig.L1BlockTime


### PR DESCRIPTION
Based on https://github.com/ethereum-optimism/optimism/pull/12216/ but tidies up the handling of AllocType in the dispute game helpers.