### PR TITLE
fix(ci): temporarily make semgrep scan ok on err

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1167,7 +1167,7 @@ jobs:
           # --timeout (in seconds) limits the time per rule and file.
           #   SEMGREP_TIMEOUT is the same, but docs have conflicting defaults (5s in CLI flag, 1800 in some places)
           #    https://semgrep.dev/docs/troubleshooting/semgrep-app#if-the-job-is-aborted-due-to-taking-too-long
-          command: semgrep ci --timeout=100 --no-suppress-errors
+          command: semgrep ci --timeout=100
           # If semgrep hangs, stop the scan after 20m, to prevent a useless 5h job
           no_output_timeout: 20m
       - notify-failures-on-develop


### PR DESCRIPTION
Temporarily makes semgrep-scan not fail on error. Currently this is a problem for external contributions because semgrep-scan loads rules from the online app which requires a login. External contributors don't get access to this login.
