### PR TITLE
op-deployer: Fix init bug

### DIFF
--- a/op-chain-ops/deployer/state/artifacts_url.go
+++ b/op-chain-ops/deployer/state/artifacts_url.go
@@ -16,3 +16,19 @@ func (a *ArtifactsURL) UnmarshalText(text []byte) error {
 	*a = ArtifactsURL(*u)
 	return nil
 }
+
+func ParseArtifactsURL(in string) (*ArtifactsURL, error) {
+	u, err := url.Parse(in)
+	if err != nil {
+		return nil, err
+	}
+	return (*ArtifactsURL)(u), nil
+}
+
+func MustParseArtifactsURL(in string) *ArtifactsURL {
+	u, err := ParseArtifactsURL(in)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
The array was being appended to, but it was already a fixed length. This cause an empty chain to be added during `init`.
