### PR TITLE
Add binary deserialization to asterisc's state converter trace function

### DIFF
--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"

--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -85,7 +85,7 @@ func NewCannonRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m c
 }
 
 func NewAsteriscRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor) *RegisterTask {
-	stateConverter := asterisc.NewStateConverter()
+	stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 	return &RegisterTask{
 		gameType: gameType,
 		getPrestateProvider: cachePrestates(
@@ -117,7 +117,7 @@ func NewAsteriscRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m
 }
 
 func NewAsteriscKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor) *RegisterTask {
-	stateConverter := asterisc.NewStateConverter()
+	stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 	return &RegisterTask{
 		gameType: gameType,
 		getPrestateProvider: cachePrestates(

--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -49,7 +49,7 @@ func NewTraceProvider(logger log.Logger, m vm.Metricer, cfg vm.Config, vmCfg vm.
 			return kvstore.NewDiskKV(logger, vm.PreimageDir(dir), kvtypes.DataFormatFile)
 		}),
 		PrestateProvider: prestateProvider,
-		stateConverter:   NewStateConverter(),
+		stateConverter:   NewStateConverter(cfg),
 		cfg:              cfg,
 	}
 }
@@ -173,7 +173,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		preimageLoader: utils.NewPreimageLoader(func() (utils.PreimageSource, error) {
 			return kvstore.NewDiskKV(logger, vm.PreimageDir(dir), kvtypes.DataFormatFile)
 		}),
-		stateConverter: NewStateConverter(),
+		stateConverter: NewStateConverter(cfg.Asterisc),
 		cfg:            cfg.Asterisc,
 	}
 	return &AsteriscTraceProviderForTest{p}

--- a/op-challenger/game/fault/trace/asterisc/provider_test.go
+++ b/op-challenger/game/fault/trace/asterisc/provider_test.go
@@ -23,6 +23,7 @@ import (
 
 //go:embed test_data
 var testData embed.FS
+var asteriscWitnessLen = 362
 
 func PositionFromTraceIndex(provider *AsteriscTraceProvider, idx *big.Int) types.Position {
 	return types.NewPosition(provider.gameDepth, idx)

--- a/op-challenger/game/fault/trace/asterisc/state_converter.go
+++ b/op-challenger/game/fault/trace/asterisc/state_converter.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"os/exec"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"

--- a/op-challenger/game/fault/trace/asterisc/state_converter_test.go
+++ b/op-challenger/game/fault/trace/asterisc/state_converter_test.go
@@ -1,83 +1,79 @@
 package asterisc
 
 import (
-	"compress/gzip"
-	_ "embed"
+	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
+	"errors"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-//go:embed test_data/state.json
-var testState []byte
+const testBinary = "./somewhere/asterisc"
 
-func TestLoadState(t *testing.T) {
-	t.Run("Uncompressed", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "state.json")
-		require.NoError(t, os.WriteFile(path, testState, 0644))
-
-		state, err := parseState(path)
-		require.NoError(t, err)
-
-		var expected VMState
-		require.NoError(t, json.Unmarshal(testState, &expected))
-		require.Equal(t, &expected, state)
-	})
-
-	t.Run("Gzipped", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "state.json.gz")
-		f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
-		require.NoError(t, err)
-		defer f.Close()
-		writer := gzip.NewWriter(f)
-		_, err = writer.Write(testState)
-		require.NoError(t, err)
-		require.NoError(t, writer.Close())
-
-		state, err := parseState(path)
-		require.NoError(t, err)
-
-		var expected VMState
-		require.NoError(t, json.Unmarshal(testState, &expected))
-		require.Equal(t, &expected, state)
-	})
-
-	t.Run("InvalidStateWitness", func(t *testing.T) {
-		invalidWitnessLen := asteriscWitnessLen - 1
-		state := &VMState{
-			Step:    10,
-			Exited:  true,
-			Witness: make([]byte, invalidWitnessLen),
+func TestStateConverter(t *testing.T) {
+	setup := func(t *testing.T) (*StateConverter, *capturingExecutor) {
+		vmCfg := vm.Config{
+			VmBin: testBinary,
 		}
-		err := state.validateState()
-		require.ErrorContains(t, err, "invalid witness")
+		executor := &capturingExecutor{}
+		converter := NewStateConverter(vmCfg)
+		converter.cmdExecutor = executor.exec
+		return converter, executor
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		converter, executor := setup(t)
+		data := VMState{
+			Witness:   []byte{1, 2, 3, 4},
+			StateHash: common.Hash{0xab},
+			Step:      42,
+			Exited:    true,
+			PC:        11,
+		}
+		ser, err := json.Marshal(data)
+		require.NoError(t, err)
+		executor.stdOut = string(ser)
+		proof, step, exited, err := converter.ConvertStateToProof(context.Background(), "foo.json")
+		require.NoError(t, err)
+		require.Equal(t, data.Exited, exited)
+		require.Equal(t, data.Step, step)
+		require.Equal(t, data.StateHash, proof.ClaimValue)
+		require.Equal(t, data.Witness, proof.StateData)
+		require.NotNil(t, proof.ProofData, "later validations require this to be non-nil")
+
+		require.Equal(t, testBinary, executor.binary)
+		require.Equal(t, []string{"witness", "--input", "foo.json"}, executor.args)
 	})
 
-	t.Run("InvalidStateHash", func(t *testing.T) {
-		state := &VMState{
-			Step:    10,
-			Exited:  true,
-			Witness: make([]byte, asteriscWitnessLen),
-		}
-		// Unknown exit code
-		state.StateHash[0] = 37
-		err := state.validateState()
-		require.ErrorContains(t, err, "invalid stateHash: unknown exitCode")
-		// Exited but ExitCode is VMStatusUnfinished
-		state.StateHash[0] = 3
-		err = state.validateState()
-		require.ErrorContains(t, err, "invalid stateHash: invalid exitCode")
-		// Not Exited but ExitCode is not VMStatusUnfinished
-		state.Exited = false
-		for exitCode := 0; exitCode < 3; exitCode++ {
-			state.StateHash[0] = byte(exitCode)
-			err = state.validateState()
-			require.ErrorContains(t, err, "invalid stateHash: invalid exitCode")
-		}
+	t.Run("CommandError", func(t *testing.T) {
+		converter, executor := setup(t)
+		executor.err = errors.New("boom")
+		_, _, _, err := converter.ConvertStateToProof(context.Background(), "foo.json")
+		require.ErrorIs(t, err, executor.err)
 	})
+
+	t.Run("InvalidOutput", func(t *testing.T) {
+		converter, executor := setup(t)
+		executor.stdOut = "blah blah"
+		_, _, _, err := converter.ConvertStateToProof(context.Background(), "foo.json")
+		require.ErrorContains(t, err, "failed to parse state data")
+	})
+}
+
+type capturingExecutor struct {
+	binary string
+	args   []string
+
+	stdOut string
+	stdErr string
+	err    error
+}
+
+func (c *capturingExecutor) exec(_ context.Context, binary string, args ...string) (string, string, error) {
+	c.binary = binary
+	c.args = args
+	return c.stdOut, c.stdErr, c.err
 }

--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -40,7 +40,7 @@ func createTraceProvider(
 		return cannon.NewTraceProvider(logger, m, cfg.Cannon, serverExecutor, prestateProvider, prestate, localInputs, dir, 42), nil
 	case types.TraceTypeAsterisc:
 		serverExecutor := vm.NewOpProgramServerExecutor()
-		stateConverter := asterisc.NewStateConverter()
+		stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 		prestate, err := getPrestate(ctx, prestateHash, cfg.AsteriscAbsolutePreStateBaseURL, cfg.AsteriscAbsolutePreState, dir, stateConverter)
 		if err != nil {
 			return nil, err
@@ -49,7 +49,7 @@ func createTraceProvider(
 		return asterisc.NewTraceProvider(logger, m, cfg.Asterisc, serverExecutor, prestateProvider, prestate, localInputs, dir, 42), nil
 	case types.TraceTypeAsteriscKona:
 		serverExecutor := vm.NewKonaExecutor()
-		stateConverter := asterisc.NewStateConverter()
+		stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 		prestate, err := getPrestate(ctx, prestateHash, cfg.AsteriscKonaAbsolutePreStateBaseURL, cfg.AsteriscKonaAbsolutePreState, dir, stateConverter)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds support for binary serialization of VMState for Asterisc, while preserving compatibility with JSON snapshots. We infer the type of the snapshot by looking at the file type, and dynamically choose whether to use binary representation of json representation.

This is dependency PR of Asterisc PR here: https://github.com/ethereum-optimism/asterisc/pull/82

This is used in Asterisc's op-e2e tests, where a prestate file is converted into VMState instance in op-challenger trace provider