### PR TITLE
Eth: BlockRef

### DIFF
--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -85,6 +85,10 @@ func (id L1BlockRef) ParentID() BlockID {
 	}
 }
 
+// BlockRef is a Block Ref indepdendent of L1 or L2
+// Because L1BlockRefs are strict subsets of L2BlockRefs, BlockRef is a direct alias of L1BlockRef
+type BlockRef = L1BlockRef
+
 func (id L2BlockRef) ID() BlockID {
 	return BlockID{
 		Hash:   id.Hash,

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -167,7 +167,7 @@ func (db *ChainsDB) AddLog(
 
 func (db *ChainsDB) SealBlock(
 	chain types.ChainID,
-	block eth.L2BlockRef) error {
+	block eth.BlockRef) error {
 	logDB, ok := db.logDBs[chain]
 	if !ok {
 		return fmt.Errorf("%w: %v", ErrUnknownChain, chain)

--- a/op-supervisor/supervisor/backend/safety/views.go
+++ b/op-supervisor/supervisor/backend/safety/views.go
@@ -15,7 +15,7 @@ type View struct {
 	iter logs.Iterator
 
 	localView        heads.HeadPointer
-	localDerivedFrom eth.L1BlockRef
+	localDerivedFrom eth.BlockRef
 
 	validWithinView func(l1View uint64, execMsg *types.ExecutingMessage) error
 }
@@ -31,7 +31,7 @@ func (vi *View) Local() (heads.HeadPointer, error) {
 	return vi.localView, nil
 }
 
-func (vi *View) UpdateLocal(at eth.L1BlockRef, ref eth.L2BlockRef) error {
+func (vi *View) UpdateLocal(at eth.BlockRef, ref eth.BlockRef) error {
 	vi.localView = heads.HeadPointer{
 		LastSealedBlockHash: ref.Hash,
 		LastSealedBlockNum:  ref.Number,

--- a/op-supervisor/supervisor/backend/source/chain_processor.go
+++ b/op-supervisor/supervisor/backend/source/chain_processor.go
@@ -21,7 +21,7 @@ type Source interface {
 }
 
 type LogProcessor interface {
-	ProcessLogs(ctx context.Context, block eth.L2BlockRef, receipts gethtypes.Receipts) error
+	ProcessLogs(ctx context.Context, block eth.BlockRef, receipts gethtypes.Receipts) error
 }
 
 type DatabaseRewinder interface {
@@ -29,9 +29,9 @@ type DatabaseRewinder interface {
 	LatestBlockNum(chain types.ChainID) (num uint64, ok bool)
 }
 
-type BlockProcessorFn func(ctx context.Context, block eth.L1BlockRef) error
+type BlockProcessorFn func(ctx context.Context, block eth.BlockRef) error
 
-func (fn BlockProcessorFn) ProcessBlock(ctx context.Context, block eth.L1BlockRef) error {
+func (fn BlockProcessorFn) ProcessBlock(ctx context.Context, block eth.BlockRef) error {
 	return fn(ctx, block)
 }
 
@@ -131,7 +131,7 @@ func (s *ChainProcessor) worker() {
 func (s *ChainProcessor) update(nextNum uint64) error {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second*10)
 	nextL1, err := s.client.L1BlockRefByNumber(ctx, nextNum)
-	next := eth.L2BlockRef{
+	next := eth.BlockRef{
 		Hash:       nextL1.Hash,
 		ParentHash: nextL1.ParentHash,
 		Number:     nextL1.Number,
@@ -166,7 +166,7 @@ func (s *ChainProcessor) update(nextNum uint64) error {
 	return nil
 }
 
-func (s *ChainProcessor) OnNewHead(ctx context.Context, head eth.L1BlockRef) error {
+func (s *ChainProcessor) OnNewHead(ctx context.Context, head eth.BlockRef) error {
 	// update the latest target
 	s.lastHead.Store(head.Number)
 	// signal that we have something to process

--- a/op-supervisor/supervisor/backend/source/log_processor.go
+++ b/op-supervisor/supervisor/backend/source/log_processor.go
@@ -15,12 +15,12 @@ import (
 )
 
 type LogStorage interface {
-	SealBlock(chain types.ChainID, block eth.L2BlockRef) error
+	SealBlock(chain types.ChainID, block eth.BlockRef) error
 	AddLog(chain types.ChainID, logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error
 }
 
 type ChainsDBClientForLogProcessor interface {
-	SealBlock(chain types.ChainID, block eth.L2BlockRef) error
+	SealBlock(chain types.ChainID, block eth.BlockRef) error
 	AddLog(chain types.ChainID, logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error
 }
 
@@ -44,7 +44,7 @@ func newLogProcessor(chain types.ChainID, logStore LogStorage) *logProcessor {
 
 // ProcessLogs processes logs from a block and stores them in the log storage
 // for any logs that are related to executing messages, they are decoded and stored
-func (p *logProcessor) ProcessLogs(_ context.Context, block eth.L2BlockRef, rcpts ethTypes.Receipts) error {
+func (p *logProcessor) ProcessLogs(_ context.Context, block eth.BlockRef, rcpts ethTypes.Receipts) error {
 	for _, rcpt := range rcpts {
 		for _, l := range rcpt.Logs {
 			// log hash represents the hash of *this* log as a potentially initiating message

--- a/op-supervisor/supervisor/backend/source/log_processor_test.go
+++ b/op-supervisor/supervisor/backend/source/log_processor_test.go
@@ -17,7 +17,7 @@ var logProcessorChainID = types.ChainIDFromUInt64(4)
 
 func TestLogProcessor(t *testing.T) {
 	ctx := context.Background()
-	block1 := eth.L2BlockRef{
+	block1 := eth.BlockRef{
 		ParentHash: common.Hash{0x42},
 		Number:     100,
 		Hash:       common.Hash{0x11},
@@ -205,7 +205,7 @@ type stubLogStorage struct {
 	seals []storedSeal
 }
 
-func (s *stubLogStorage) SealBlock(chainID types.ChainID, block eth.L2BlockRef) error {
+func (s *stubLogStorage) SealBlock(chainID types.ChainID, block eth.BlockRef) error {
 	if logProcessorChainID != chainID {
 		return fmt.Errorf("chain id mismatch, expected %v but got %v", logProcessorChainID, chainID)
 	}


### PR DESCRIPTION
Adds an alias for `L1BlockRef` called `BlockRef` and uses it throughout the Supervisor.

This is because the supervisor was dealing with a mix of L1 and L2 block references. Even though logically most references are *L2*, we only need as much data as the *L1* reference had, so they were being used interchangeably. This way everything is using the same type.