### PR TITLE
cannon: Define 64-bit syscalls

### DIFF
--- a/cannon/mipsevm/arch/arch32.go
+++ b/cannon/mipsevm/arch/arch32.go
@@ -31,6 +31,61 @@ const (
 	HighMemoryStart = 0x7f_ff_d0_00
 )
 
+// 32-bit Syscall codes
+const (
+	SysMmap         = 4090
+	SysBrk          = 4045
+	SysClone        = 4120
+	SysExitGroup    = 4246
+	SysRead         = 4003
+	SysWrite        = 4004
+	SysFcntl        = 4055
+	SysExit         = 4001
+	SysSchedYield   = 4162
+	SysGetTID       = 4222
+	SysFutex        = 4238
+	SysOpen         = 4005
+	SysNanosleep    = 4166
+	SysClockGetTime = 4263
+	SysGetpid       = 4020
+)
+
+// Noop Syscall codes
+const (
+	SysMunmap        = 4091
+	SysGetAffinity   = 4240
+	SysMadvise       = 4218
+	SysRtSigprocmask = 4195
+	SysSigaltstack   = 4206
+	SysRtSigaction   = 4194
+	SysPrlimit64     = 4338
+	SysClose         = 4006
+	SysPread64       = 4200
+	SysFstat         = 4108
+	SysFstat64       = 4215
+	SysOpenAt        = 4288
+	SysReadlink      = 4085
+	SysReadlinkAt    = 4298
+	SysIoctl         = 4054
+	SysEpollCreate1  = 4326
+	SysPipe2         = 4328
+	SysEpollCtl      = 4249
+	SysEpollPwait    = 4313
+	SysGetRandom     = 4353
+	SysUname         = 4122
+	SysStat64        = 4213
+	SysGetuid        = 4024
+	SysGetgid        = 4047
+	SysLlseek        = 4140
+	SysMinCore       = 4217
+	SysTgkill        = 4266
+	// Profiling-related syscalls
+	SysSetITimer    = 4104
+	SysTimerCreate  = 4257
+	SysTimerSetTime = 4258
+	SysTimerDelete  = 4261
+)
+
 var ByteOrderWord = byteOrder32{}
 
 type byteOrder32 struct{}

--- a/cannon/mipsevm/arch/arch64.go
+++ b/cannon/mipsevm/arch/arch64.go
@@ -31,6 +31,67 @@ const (
 	HighMemoryStart = 0x7F_FF_FF_FF_D0_00_00_00
 )
 
+// MIPS64 syscall table - https://github.com/torvalds/linux/blob/3efc57369a0ce8f76bf0804f7e673982384e4ac9/arch/mips/kernel/syscalls/syscall_n64.tbl. Generate the syscall numbers using the Makefile in that directory.
+// See https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html for the generated syscalls
+
+// 64-bit Syscall numbers - new
+const (
+	SysMmap         = 5009
+	SysBrk          = 5012
+	SysClone        = 5055
+	SysExitGroup    = 5205
+	SysRead         = 5000
+	SysWrite        = 5001
+	SysFcntl        = 5070
+	SysExit         = 5058
+	SysSchedYield   = 5023
+	SysGetTID       = 5178
+	SysFutex        = 5194
+	SysOpen         = 5002
+	SysNanosleep    = 5034
+	SysClockGetTime = 5222
+	SysGetpid       = 5038
+)
+
+// Noop Syscall numbers
+const (
+	// UndefinedSysNr is the value used for 32-bit syscall numbers that aren't supported for 64-bits
+	UndefinedSysNr = ^Word(0)
+
+	SysMunmap        = 5011
+	SysGetAffinity   = 5196
+	SysMadvise       = 5027
+	SysRtSigprocmask = 5014
+	SysSigaltstack   = 5129
+	SysRtSigaction   = 5013
+	SysPrlimit64     = 5297
+	SysClose         = 5003
+	SysPread64       = 5016
+	SysFstat         = 5005
+	SysFstat64       = UndefinedSysNr
+	SysOpenAt        = 5247
+	SysReadlink      = 5087
+	SysReadlinkAt    = 5257
+	SysIoctl         = 5015
+	SysEpollCreate1  = 5285
+	SysPipe2         = 5287
+	SysEpollCtl      = 5208
+	SysEpollPwait    = 5272
+	SysGetRandom     = 5313
+	SysUname         = 5061
+	SysStat64        = UndefinedSysNr
+	SysGetuid        = 5100
+	SysGetgid        = 5102
+	SysLlseek        = UndefinedSysNr
+	SysMinCore       = 5026
+	SysTgkill        = 5225
+	// Profiling-related syscalls
+	SysSetITimer    = 5036
+	SysTimerCreate  = 5216
+	SysTimerSetTime = 5217
+	SysTimerDelete  = 5220
+)
+
 var ByteOrderWord = byteOrder64{}
 
 type byteOrder64 struct{}

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -19,61 +19,6 @@ const (
 	AddressMask = arch.AddressMask
 )
 
-// TODO(#12205): redefine syscalls for MIPS64
-// Syscall codes
-const (
-	SysMmap         = 4090
-	SysBrk          = 4045
-	SysClone        = 4120
-	SysExitGroup    = 4246
-	SysRead         = 4003
-	SysWrite        = 4004
-	SysFcntl        = 4055
-	SysExit         = 4001
-	SysSchedYield   = 4162
-	SysGetTID       = 4222
-	SysFutex        = 4238
-	SysOpen         = 4005
-	SysNanosleep    = 4166
-	SysClockGetTime = 4263
-	SysGetpid       = 4020
-)
-
-// Noop Syscall codes
-const (
-	SysMunmap        = 4091
-	SysGetAffinity   = 4240
-	SysMadvise       = 4218
-	SysRtSigprocmask = 4195
-	SysSigaltstack   = 4206
-	SysRtSigaction   = 4194
-	SysPrlimit64     = 4338
-	SysClose         = 4006
-	SysPread64       = 4200
-	SysFstat64       = 4215
-	SysOpenAt        = 4288
-	SysReadlink      = 4085
-	SysReadlinkAt    = 4298
-	SysIoctl         = 4054
-	SysEpollCreate1  = 4326
-	SysPipe2         = 4328
-	SysEpollCtl      = 4249
-	SysEpollPwait    = 4313
-	SysGetRandom     = 4353
-	SysUname         = 4122
-	SysStat64        = 4213
-	SysGetuid        = 4024
-	SysGetgid        = 4047
-	SysLlseek        = 4140
-	SysMinCore       = 4217
-	SysTgkill        = 4266
-	// Profiling-related syscalls
-	SysSetITimer    = 4104
-	SysTimerCreate  = 4257
-	SysTimerSetTime = 4258
-	SysTimerDelete  = 4261
-)
-
 // File descriptors
 const (
 	FdStdin         = 0

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -78,10 +78,11 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			state, _ := testutil.LoadELFProgram(t, "../../testdata/example/bin/alloc.elf", CreateInitialState, false)
+			state, meta := testutil.LoadELFProgram(t, "../../testdata/example/bin/alloc.elf", CreateInitialState, false)
 			oracle := testutil.AllocOracle(t, test.numAllocs, test.allocSize)
 
-			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), nil)
+			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta)
+			require.NoError(t, us.InitDebug())
 			// emulation shouldn't take more than 20 B steps
 			for i := 0; i < 20_000_000_000; i++ {
 				if us.GetState().GetExited() {

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -25,13 +25,13 @@ func (m *InstrumentedState) handleSyscall() error {
 
 	//fmt.Printf("syscall: %d\n", syscallNum)
 	switch syscallNum {
-	case exec.SysMmap:
+	case arch.SysMmap:
 		var newHeap Word
 		v0, v1, newHeap = exec.HandleSysMmap(a0, a1, m.state.Heap)
 		m.state.Heap = newHeap
-	case exec.SysBrk:
+	case arch.SysBrk:
 		v0 = program.PROGRAM_BREAK
-	case exec.SysClone: // clone
+	case arch.SysClone: // clone
 		// a0 = flag bitmask, a1 = stack pointer
 		if exec.ValidCloneFlags != a0 {
 			m.state.Exited = true
@@ -72,11 +72,11 @@ func (m *InstrumentedState) handleSyscall() error {
 		// to ensure we are tracking in the context of the new thread
 		m.stackTracker.PushStack(stackCaller, stackTarget)
 		return nil
-	case exec.SysExitGroup:
+	case arch.SysExitGroup:
 		m.state.Exited = true
 		m.state.ExitCode = uint8(a0)
 		return nil
-	case exec.SysRead:
+	case arch.SysRead:
 		var newPreimageOffset Word
 		var memUpdated bool
 		var memAddr Word
@@ -85,7 +85,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		if memUpdated {
 			m.handleMemoryUpdate(memAddr)
 		}
-	case exec.SysWrite:
+	case arch.SysWrite:
 		var newLastHint hexutil.Bytes
 		var newPreimageKey common.Hash
 		var newPreimageOffset Word
@@ -93,12 +93,12 @@ func (m *InstrumentedState) handleSyscall() error {
 		m.state.LastHint = newLastHint
 		m.state.PreimageKey = newPreimageKey
 		m.state.PreimageOffset = newPreimageOffset
-	case exec.SysFcntl:
+	case arch.SysFcntl:
 		v0, v1 = exec.HandleSysFcntl(a0, a1)
-	case exec.SysGetTID:
+	case arch.SysGetTID:
 		v0 = thread.ThreadId
 		v1 = 0
-	case exec.SysExit:
+	case arch.SysExit:
 		thread.Exited = true
 		thread.ExitCode = uint8(a0)
 		if m.lastThreadRemaining() {
@@ -106,7 +106,7 @@ func (m *InstrumentedState) handleSyscall() error {
 			m.state.ExitCode = uint8(a0)
 		}
 		return nil
-	case exec.SysFutex:
+	case arch.SysFutex:
 		// args: a0 = addr, a1 = op, a2 = val, a3 = timeout
 		effAddr := a0 & arch.AddressMask
 		switch a1 {
@@ -143,16 +143,16 @@ func (m *InstrumentedState) handleSyscall() error {
 			v0 = exec.SysErrorSignal
 			v1 = exec.MipsEINVAL
 		}
-	case exec.SysSchedYield, exec.SysNanosleep:
+	case arch.SysSchedYield, arch.SysNanosleep:
 		v0 = 0
 		v1 = 0
 		exec.HandleSyscallUpdates(&thread.Cpu, &thread.Registers, v0, v1)
 		m.preemptThread(thread)
 		return nil
-	case exec.SysOpen:
+	case arch.SysOpen:
 		v0 = exec.SysErrorSignal
 		v1 = exec.MipsEBADF
-	case exec.SysClockGetTime:
+	case arch.SysClockGetTime:
 		switch a0 {
 		case exec.ClockGettimeRealtimeFlag, exec.ClockGettimeMonotonicFlag:
 			v0, v1 = 0, 0
@@ -175,44 +175,45 @@ func (m *InstrumentedState) handleSyscall() error {
 			v0 = exec.SysErrorSignal
 			v1 = exec.MipsEINVAL
 		}
-	case exec.SysGetpid:
+	case arch.SysGetpid:
 		v0 = 0
 		v1 = 0
-	case exec.SysMunmap:
-	case exec.SysGetAffinity:
-	case exec.SysMadvise:
-	case exec.SysRtSigprocmask:
-	case exec.SysSigaltstack:
-	case exec.SysRtSigaction:
-	case exec.SysPrlimit64:
-	// TODO(#12205): may be needed for 64-bit Cannon
-	// case exec.SysGetRtLimit:
-	case exec.SysClose:
-	case exec.SysPread64:
-	case exec.SysFstat64:
-	case exec.SysOpenAt:
-	case exec.SysReadlink:
-	case exec.SysReadlinkAt:
-	case exec.SysIoctl:
-	case exec.SysEpollCreate1:
-	case exec.SysPipe2:
-	case exec.SysEpollCtl:
-	case exec.SysEpollPwait:
-	case exec.SysGetRandom:
-	case exec.SysUname:
-	case exec.SysStat64:
-	case exec.SysGetuid:
-	case exec.SysGetgid:
-	case exec.SysLlseek:
-	case exec.SysMinCore:
-	case exec.SysTgkill:
-	case exec.SysSetITimer:
-	case exec.SysTimerCreate:
-	case exec.SysTimerSetTime:
-	case exec.SysTimerDelete:
+	case arch.SysMunmap:
+	case arch.SysGetAffinity:
+	case arch.SysMadvise:
+	case arch.SysRtSigprocmask:
+	case arch.SysSigaltstack:
+	case arch.SysRtSigaction:
+	case arch.SysPrlimit64:
+	case arch.SysClose:
+	case arch.SysPread64:
+	case arch.SysFstat:
+	case arch.SysOpenAt:
+	case arch.SysReadlink:
+	case arch.SysReadlinkAt:
+	case arch.SysIoctl:
+	case arch.SysEpollCreate1:
+	case arch.SysPipe2:
+	case arch.SysEpollCtl:
+	case arch.SysEpollPwait:
+	case arch.SysGetRandom:
+	case arch.SysUname:
+	case arch.SysGetuid:
+	case arch.SysGetgid:
+	case arch.SysMinCore:
+	case arch.SysTgkill:
+	case arch.SysSetITimer:
+	case arch.SysTimerCreate:
+	case arch.SysTimerSetTime:
+	case arch.SysTimerDelete:
 	default:
-		m.Traceback()
-		panic(fmt.Sprintf("unrecognized syscall: %d", syscallNum))
+		// These syscalls have the same values on 64-bit. So we use if-stmts here to avoid "duplicate case" compiler error for the cannon64 build
+		if arch.IsMips32 && syscallNum == arch.SysFstat64 || syscallNum == arch.SysStat64 || syscallNum == arch.SysLlseek {
+			// noop
+		} else {
+			m.Traceback()
+			panic(fmt.Sprintf("unrecognized syscall: %d", syscallNum))
+		}
 	}
 
 	exec.HandleSyscallUpdates(&thread.Cpu, &thread.Registers, v0, v1)

--- a/cannon/mipsevm/singlethreaded/mips.go
+++ b/cannon/mipsevm/singlethreaded/mips.go
@@ -20,23 +20,23 @@ func (m *InstrumentedState) handleSyscall() error {
 
 	//fmt.Printf("syscall: %d\n", syscallNum)
 	switch syscallNum {
-	case exec.SysMmap:
+	case arch.SysMmap:
 		var newHeap Word
 		v0, v1, newHeap = exec.HandleSysMmap(a0, a1, m.state.Heap)
 		m.state.Heap = newHeap
-	case exec.SysBrk:
+	case arch.SysBrk:
 		v0 = arch.ProgramBreak
-	case exec.SysClone: // clone (not supported)
+	case arch.SysClone: // clone (not supported)
 		v0 = 1
-	case exec.SysExitGroup:
+	case arch.SysExitGroup:
 		m.state.Exited = true
 		m.state.ExitCode = uint8(a0)
 		return nil
-	case exec.SysRead:
+	case arch.SysRead:
 		var newPreimageOffset Word
 		v0, v1, newPreimageOffset, _, _ = exec.HandleSysRead(a0, a1, a2, m.state.PreimageKey, m.state.PreimageOffset, m.preimageOracle, m.state.Memory, m.memoryTracker)
 		m.state.PreimageOffset = newPreimageOffset
-	case exec.SysWrite:
+	case arch.SysWrite:
 		var newLastHint hexutil.Bytes
 		var newPreimageKey common.Hash
 		var newPreimageOffset Word
@@ -44,7 +44,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		m.state.LastHint = newLastHint
 		m.state.PreimageKey = newPreimageKey
 		m.state.PreimageOffset = newPreimageOffset
-	case exec.SysFcntl:
+	case arch.SysFcntl:
 		v0, v1 = exec.HandleSysFcntl(a0, a1)
 	}
 

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -346,7 +346,7 @@ func TestEVM_MMap(t *testing.T) {
 				state := goVm.GetState()
 
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = exec.SysMmap
+				state.GetRegistersRef()[2] = arch.SysMmap
 				state.GetRegistersRef()[4] = c.address
 				state.GetRegistersRef()[5] = c.size
 				step := state.GetStep()
@@ -546,7 +546,7 @@ func TestEVMSysWriteHint(t *testing.T) {
 				oracle := testutil.HintTrackingOracle{}
 				goVm := v.VMFactory(&oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithLastHint(tt.lastHint))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysWrite
+				state.GetRegistersRef()[2] = arch.SysWrite
 				state.GetRegistersRef()[4] = exec.FdHintWrite
 				state.GetRegistersRef()[5] = arch.Word(tt.memOffset)
 				state.GetRegistersRef()[6] = arch.Word(tt.bytesToWrite)

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -261,7 +261,7 @@ func TestEVM_MT_SysRead_Preimage(t *testing.T) {
 				// Set up state
 				state.PreimageKey = preimageKey
 				state.PreimageOffset = c.preimageOffset
-				state.GetRegistersRef()[2] = exec.SysRead
+				state.GetRegistersRef()[2] = arch.SysRead
 				state.GetRegistersRef()[4] = exec.FdPreimageRead
 				state.GetRegistersRef()[5] = c.addr
 				state.GetRegistersRef()[6] = c.count
@@ -414,7 +414,7 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			state := multithreaded.CreateEmptyState()
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysClone // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
 			state.GetRegistersRef()[4] = c.flags       // Set first argument
 			curStep := state.Step
 
@@ -467,7 +467,7 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 			goVm, state, contracts := setup(t, i, nil)
 			mttestutil.InitializeSingleThread(i*333, state, c.traverseRight)
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysClone        // the syscall number
+			state.GetRegistersRef()[2] = arch.SysClone        // the syscall number
 			state.GetRegistersRef()[4] = exec.ValidCloneFlags // a0 - first argument, clone flags
 			state.GetRegistersRef()[5] = stackPtr             // a1 - the stack pointer
 			step := state.GetStep()
@@ -530,7 +530,7 @@ func TestEVM_SysGetTID(t *testing.T) {
 
 			state.GetCurrentThread().ThreadId = c.threadId
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysGetTID // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
 			step := state.Step
 
 			// Set up post-state expectations
@@ -573,7 +573,7 @@ func TestEVM_SysExit(t *testing.T) {
 			mttestutil.SetupThreads(int64(i*1111), state, i%2 == 0, c.threadCount, 0)
 
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysExit   // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysExit   // Set syscall number
 			state.GetRegistersRef()[4] = Word(exitCode) // The first argument (exit code)
 			step := state.Step
 
@@ -682,7 +682,7 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
 			state.Memory.SetWord(c.effAddr, c.actualValue)
-			state.GetRegistersRef()[2] = exec.SysFutex // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = c.addressParam
 			state.GetRegistersRef()[5] = exec.FutexWaitPrivate
 			state.GetRegistersRef()[6] = c.targetValue
@@ -752,7 +752,7 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 			step := state.Step
 
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysFutex // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = c.addressParam
 			state.GetRegistersRef()[5] = exec.FutexWakePrivate
 
@@ -837,7 +837,7 @@ func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {
 			step := state.GetStep()
 
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysFutex // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[5] = op
 
 			// Setup expectations
@@ -863,11 +863,11 @@ func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {
 }
 
 func TestEVM_SysYield(t *testing.T) {
-	runPreemptSyscall(t, "SysSchedYield", exec.SysSchedYield)
+	runPreemptSyscall(t, "SysSchedYield", arch.SysSchedYield)
 }
 
 func TestEVM_SysNanosleep(t *testing.T) {
-	runPreemptSyscall(t, "SysNanosleep", exec.SysNanosleep)
+	runPreemptSyscall(t, "SysNanosleep", arch.SysNanosleep)
 }
 
 func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
@@ -922,7 +922,7 @@ func TestEVM_SysOpen(t *testing.T) {
 	goVm, state, contracts := setup(t, 5512, nil)
 
 	state.Memory.SetMemory(state.GetPC(), syscallInsn)
-	state.GetRegistersRef()[2] = exec.SysOpen // Set syscall number
+	state.GetRegistersRef()[2] = arch.SysOpen // Set syscall number
 	step := state.Step
 
 	// Set up post-state expectations
@@ -947,7 +947,7 @@ func TestEVM_SysGetPID(t *testing.T) {
 	goVm, state, contracts := setup(t, 1929, nil)
 
 	state.Memory.SetMemory(state.GetPC(), syscallInsn)
-	state.GetRegistersRef()[2] = exec.SysGetpid // Set syscall number
+	state.GetRegistersRef()[2] = arch.SysGetpid // Set syscall number
 	step := state.Step
 
 	// Set up post-state expectations
@@ -1030,7 +1030,7 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 				}
 
 				state.Memory.SetMemory(state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = exec.SysClockGetTime // Set syscall number
+				state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
 				state.GetRegistersRef()[4] = clkid                // a0
 				state.GetRegistersRef()[5] = c.timespecAddr       // a1
 				state.LLReservationActive = v.llReservationActive
@@ -1074,7 +1074,7 @@ func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
 
 	timespecAddr := Word(0x1000)
 	state.Memory.SetMemory(state.GetPC(), syscallInsn)
-	state.GetRegistersRef()[2] = exec.SysClockGetTime // Set syscall number
+	state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
 	state.GetRegistersRef()[4] = 0xDEAD               // a0 - invalid clockid
 	state.GetRegistersRef()[5] = timespecAddr         // a1
 	step := state.Step
@@ -1103,6 +1103,7 @@ var NoopSyscalls = map[string]uint32{
 	"SysPrlimit64":     4338,
 	"SysClose":         4006,
 	"SysPread64":       4200,
+	"SysFstat":         4108,
 	"SysFstat64":       4215,
 	"SysOpenAt":        4288,
 	"SysReadlink":      4085,
@@ -1162,7 +1163,7 @@ func TestEVM_UnsupportedSyscall(t *testing.T) {
 	var tracer *tracing.Hooks
 
 	var NoopSyscallNums = maps.Values(NoopSyscalls)
-	var SupportedSyscalls = []uint32{exec.SysMmap, exec.SysBrk, exec.SysClone, exec.SysExitGroup, exec.SysRead, exec.SysWrite, exec.SysFcntl, exec.SysExit, exec.SysSchedYield, exec.SysGetTID, exec.SysFutex, exec.SysOpen, exec.SysNanosleep, exec.SysClockGetTime, exec.SysGetpid}
+	var SupportedSyscalls = []uint32{arch.SysMmap, arch.SysBrk, arch.SysClone, arch.SysExitGroup, arch.SysRead, arch.SysWrite, arch.SysFcntl, arch.SysExit, arch.SysSchedYield, arch.SysGetTID, arch.SysFutex, arch.SysOpen, arch.SysNanosleep, arch.SysClockGetTime, arch.SysGetpid}
 	unsupportedSyscalls := make([]uint32, 0, 400)
 	for i := 4000; i < 4400; i++ {
 		candidate := uint32(i)
@@ -1476,7 +1477,7 @@ func TestEVM_SchedQuantumThreshold(t *testing.T) {
 			goVm, state, contracts := setup(t, i*789, nil)
 			// Setup basic getThreadId syscall instruction
 			state.Memory.SetMemory(state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = exec.SysGetTID // Set syscall number
+			state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
 			state.StepsSinceLastContextSwitch = c.stepsSinceLastContextSwitch
 			step := state.Step
 

--- a/cannon/mipsevm/tests/evm_singlethreaded_test.go
+++ b/cannon/mipsevm/tests/evm_singlethreaded_test.go
@@ -166,7 +166,7 @@ func TestEVM_SysRead_Preimage(t *testing.T) {
 			step := state.GetStep()
 
 			// Set up state
-			state.GetRegistersRef()[2] = exec.SysRead
+			state.GetRegistersRef()[2] = arch.SysRead
 			state.GetRegistersRef()[4] = exec.FdPreimageRead
 			state.GetRegistersRef()[5] = c.addr
 			state.GetRegistersRef()[6] = c.count

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -27,7 +27,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 			t.Run(v.Name, func(t *testing.T) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysBrk
+				state.GetRegistersRef()[2] = arch.SysBrk
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
 				step := state.GetStep()
 
@@ -65,7 +65,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 				state := goVm.GetState()
 				step := state.GetStep()
 
-				state.GetRegistersRef()[2] = exec.SysMmap
+				state.GetRegistersRef()[2] = arch.SysMmap
 				state.GetRegistersRef()[4] = addr
 				state.GetRegistersRef()[5] = siz
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
@@ -112,7 +112,7 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
 					testutil.WithRandomization(seed))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysExitGroup
+				state.GetRegistersRef()[2] = arch.SysExitGroup
 				state.GetRegistersRef()[4] = Word(exitCode)
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
 				step := state.GetStep()
@@ -141,7 +141,7 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
 					testutil.WithRandomization(seed))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysFcntl
+				state.GetRegistersRef()[2] = arch.SysFcntl
 				state.GetRegistersRef()[4] = fd
 				state.GetRegistersRef()[5] = cmd
 				state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
@@ -201,7 +201,7 @@ func FuzzStateHintRead(f *testing.F) {
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
 					testutil.WithRandomization(seed), testutil.WithPreimageKey(preimageKey))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysRead
+				state.GetRegistersRef()[2] = arch.SysRead
 				state.GetRegistersRef()[4] = exec.FdHintRead
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
@@ -245,7 +245,7 @@ func FuzzStatePreimageRead(f *testing.F) {
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
 					testutil.WithRandomization(seed), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(preimageOffset), testutil.WithPCAndNextPC(pc))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysRead
+				state.GetRegistersRef()[2] = arch.SysRead
 				state.GetRegistersRef()[4] = exec.FdPreimageRead
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
@@ -324,7 +324,7 @@ func FuzzStateHintWrite(f *testing.F) {
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
 					testutil.WithRandomization(randSeed), testutil.WithLastHint(lastHint), testutil.WithPCAndNextPC(pc))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysWrite
+				state.GetRegistersRef()[2] = arch.SysWrite
 				state.GetRegistersRef()[4] = exec.FdHintWrite
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
@@ -390,7 +390,7 @@ func FuzzStatePreimageWrite(f *testing.F) {
 				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
 					testutil.WithRandomization(seed), testutil.WithPreimageKey(preimageKey), testutil.WithPreimageOffset(128), testutil.WithPCAndNextPC(pc))
 				state := goVm.GetState()
-				state.GetRegistersRef()[2] = exec.SysWrite
+				state.GetRegistersRef()[2] = arch.SysWrite
 				state.GetRegistersRef()[4] = exec.FdPreimageWrite
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
@@ -27,7 +28,7 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 		// Setup
 		state.NextThreadId = nextThreadId
 		state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
-		state.GetRegistersRef()[2] = exec.SysClone
+		state.GetRegistersRef()[2] = arch.SysClone
 		state.GetRegistersRef()[4] = exec.ValidCloneFlags
 		state.GetRegistersRef()[5] = stackPtr
 		step := state.GetStep()

--- a/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
@@ -16,7 +16,7 @@ func FuzzStateSyscallCloneST(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
 		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 		state := goVm.GetState()
-		state.GetRegistersRef()[2] = exec.SysClone
+		state.GetRegistersRef()[2] = arch.SysClone
 		state.GetMemory().SetMemory(state.GetPC(), syscallInsn)
 		step := state.GetStep()
 

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x2ab6be69795109a1ee04c5693a34d6ce0ff90b62e404cdeb18178bab18d06784"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0x3992081512da36af76b707aee7d8ef9e084c54fb1dc9f8ce9989ed16d1216f01",
-    "sourceCodeHash": "0x7630362c20fbca071452031b88c9384d3215c4f2cbee24c7989901de63b0c178"
+    "initCodeHash": "0xa9a9db7bedf25800f20c947df10310c64beb2ead8eb6be991c83189e975df0fe",
+    "sourceCodeHash": "0x83aabf115ac0ad407868e633a521602c41d86864d82198e6abbf69d33daaea65"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x590be819d8f02a7f9eb04ddc447f93ccbfd8bc9339f7c2e65336f9805b6c9a66",
-    "sourceCodeHash": "0x5bc0ab24cf926953b2ea9eb40b929821e280a7181c6cb18e7954bc3f7dc59be1"
+    "initCodeHash": "0xbb203b0d83efddfa0f664dbc63ec55844318b48fe8133758307f64e87c892a47",
+    "sourceCodeHash": "0x16614cc0e6abf7e81e1e5dc2c0773ee7101cb38af40e0907a8800ca7eddd3b5a"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xa0b19e18561da9990c95ebea9750dd901f73147b32b8b234eca0f35073c5a970",

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -45,8 +45,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.2.1-beta.1
-    string public constant version = "1.2.1-beta.1";
+    /// @custom:semver 1.2.1-beta.2
+    string public constant version = "1.2.1-beta.2";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -534,7 +534,7 @@ contract MIPS2 is ISemver {
                 // ignored
             } else if (syscall_no == sys.SYS_PREAD64) {
                 // ignored
-            } else if (syscall_no == sys.SYS_FSTAT64) {
+            } else if (syscall_no == sys.SYS_FSTAT) {
                 // ignored
             } else if (syscall_no == sys.SYS_OPENAT) {
                 // ignored
@@ -556,13 +556,9 @@ contract MIPS2 is ISemver {
                 // ignored
             } else if (syscall_no == sys.SYS_UNAME) {
                 // ignored
-            } else if (syscall_no == sys.SYS_STAT64) {
-                // ignored
             } else if (syscall_no == sys.SYS_GETUID) {
                 // ignored
             } else if (syscall_no == sys.SYS_GETGID) {
-                // ignored
-            } else if (syscall_no == sys.SYS_LLSEEK) {
                 // ignored
             } else if (syscall_no == sys.SYS_MINCORE) {
                 // ignored
@@ -577,7 +573,11 @@ contract MIPS2 is ISemver {
             } else if (syscall_no == sys.SYS_TIMERDELETE) {
                 // ignored
             } else {
-                revert("MIPS2: unimplemented syscall");
+                if (syscall_no == sys.SYS_FSTAT64 || syscall_no == sys.SYS_STAT64 || syscall_no == sys.SYS_LLSEEK) {
+                    // noop
+                } else {
+                    revert("MIPS2: unimplemented syscall");
+                }
             }
 
             st.CpuScalars memory cpu = getCpuScalars(thread);

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -57,8 +57,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.13
-    string public constant version = "1.0.0-beta.13";
+    /// @custom:semver 1.0.0-beta.14
+    string public constant version = "1.0.0-beta.14";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -53,6 +53,7 @@ library MIPSSyscalls {
     uint32 internal constant SYS_PRLIMIT64 = 4338;
     uint32 internal constant SYS_CLOSE = 4006;
     uint32 internal constant SYS_PREAD64 = 4200;
+    uint32 internal constant SYS_FSTAT = 4108;
     uint32 internal constant SYS_FSTAT64 = 4215;
     uint32 internal constant SYS_OPENAT = 4288;
     uint32 internal constant SYS_READLINK = 4085;


### PR DESCRIPTION
SYS_FSTAT on Linux/MIPS64 is equivalent to SYS_FSTAT64 on Linux/MIPS32. So the 64-bit VM similarly emulates `SYS_FSTAT` as a no-op syscall.

Fixes #12245