### PR TITLE
op-program: Increase timeout for the verify job.

### DIFF
--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -252,7 +252,7 @@ func (r *Runner) run(ctx context.Context, l1Head common.Hash, agreedBlockInfo et
 }
 
 func runFaultProofProgram(ctx context.Context, args []string) error {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Hour)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "./bin/op-program", args...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
**Description**

Until recently we were running in-process and didn't have any timeout at all. Seems worth having but we're hitting the 1 hour timeout.
