### PR TITLE
Add block building health checks to leading sequencers and all other nodes

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -372,6 +372,13 @@ var (
 		Value:    time.Second * 1,
 		Category: SequencerCategory,
 	}
+	BlockBuildingThresholdFlag = &cli.Uint64Flag{
+		Name:     "block-building.threshold",
+		Usage:    "Block building healthcheck threshold (default: 2 seconds)",
+		EnvVars:  prefixEnvVars("BLOCK_BUILDING_THRESHOLD"),
+		Value:    2,
+		Category: RollupCategory,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -419,6 +426,7 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
 	L2EngineKind,
+	BlockBuildingThresholdFlag,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -813,3 +813,6 @@ func (n *noopMetricer) RecordAccept(allow bool) {
 }
 func (n *noopMetricer) ReportProtocolVersions(local, engine, recommended, required params.ProtocolVersion) {
 }
+
+func (n *noopMetricer) RecordBlockBuildingHealthCheck(status string) {
+}

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -430,8 +430,8 @@ func NewMetrics(procName string) *Metrics {
 		AltDAMetrics: altda.MakeMetrics(ns, factory),
 		BlockBuildingHealthChecks: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: Namespace,
-			Name:      "block_building_health_checks_total",
-			Help:      "Total number of block building health checks performed",
+			Name:      "block_building_health_checks",
+			Help:      "Number of healthy/unhealthy block building for each node",
 		}, []string{"status"}),
 
 		registry: registry,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -185,6 +185,7 @@ func (s *Driver) eventLoop() {
 			<-sequencerCh
 		}
 		delta := time.Until(nextAction)
+		// 111
 		s.log.Info("Scheduled sequencer action", "delta", delta)
 		sequencerTimer.Reset(delta)
 	}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -266,6 +266,8 @@ func (d *EngDeriver) AttachEmitter(em event.Emitter) {
 	d.emitter = em
 }
 
+const blockTimeThreshold uint64 = 2
+
 func (d *EngDeriver) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
 	case TryBackupUnsafeReorgEvent:
@@ -332,12 +334,14 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 				if latestBlockTimeStamp <= currentTime {
 					timeDiff := currentTime - latestBlockTimeStamp
 
-					if timeDiff < 2 {
+					if timeDiff < blockTimeThreshold {
 						// Node is healthy
-						d.log.Info("Node is healthy, time difference within last 2 seconds", "time_diff", timeDiff)
+						d.log.Info("Node is healthy, time difference within threshold",
+							"time_diff", timeDiff, "threshold", blockTimeThreshold)
 					} else {
 						// Node is stale
-						d.log.Warn("Node is stale, time difference greater than 2 seconds", "time_diff", timeDiff)
+						d.log.Warn("Node is stale, time difference exceeds threshold",
+							"time_diff", timeDiff, "threshold", blockTimeThreshold)
 					}
 				} else {
 					d.log.Info("Cannot compute time difference, block timestamp is in the future",

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -336,7 +336,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 
 					if timeDiff < blockBuildingThreshold {
 						// Node is healthy
-						d.log.Info("Node is healthy, time difference within threshold",
+						d.log.Debug("Node is healthy, time difference within threshold",
 							"time_diff", timeDiff, "threshold", blockBuildingThreshold)
 						d.metrics.RecordBlockBuildingHealthCheck("healthy")
 					} else {
@@ -346,7 +346,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 						d.metrics.RecordBlockBuildingHealthCheck("stale")
 					}
 				} else {
-					d.log.Info("Cannot compute time difference, block timestamp is in the future",
+					d.log.Debug("Cannot compute time difference, block timestamp is in the future",
 						"current_timestamp", currentTime, "block_timestamp", latestBlockTimeStamp)
 					d.metrics.RecordBlockBuildingHealthCheck("future_timestamp")
 				}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -331,7 +331,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 				latestBlockTimeStamp := uint64(payload.Timestamp)
 				currentTime := uint64(time.Now().Unix())
 
-				if latestBlockTimeStamp <= currentTime+1 {
+				if latestBlockTimeStamp <= currentTime {
 					timeDiff := time.Duration(currentTime-latestBlockTimeStamp) * time.Second
 
 					if timeDiff < blockBuildingThreshold {
@@ -346,9 +346,8 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 						d.metrics.RecordBlockBuildingHealthCheck("stale")
 					}
 				} else {
-					d.log.Debug("Cannot compute time difference, block timestamp is in the future",
-						"current_timestamp", currentTime, "block_timestamp", latestBlockTimeStamp)
-					d.metrics.RecordBlockBuildingHealthCheck("future_timestamp")
+					d.log.Debug("Node is healthy, time difference within threshold", "threshold", blockBuildingThreshold)
+					d.metrics.RecordBlockBuildingHealthCheck("healthy")
 				}
 			}
 		}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -331,7 +331,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 				latestBlockTimeStamp := uint64(payload.Timestamp)
 				currentTime := uint64(time.Now().Unix())
 
-				if latestBlockTimeStamp <= currentTime {
+				if latestBlockTimeStamp <= currentTime+1 {
 					timeDiff := time.Duration(currentTime-latestBlockTimeStamp) * time.Second
 
 					if timeDiff < blockBuildingThreshold {

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -36,7 +36,7 @@ type Metrics interface {
 	RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.BlockID)
 	RecordSequencerReset()
 	RecordSequencingError()
-	RecordBlockBuildingHealth(status string)
+	RecordBlockBuildingHealthCheck(status string)
 }
 
 type SequencerStateListener interface {
@@ -343,18 +343,18 @@ func (d *Sequencer) onPayloadSuccess(x engine.PayloadSuccessEvent) {
 				// Node is healthy
 				d.log.Debug("Node is healthy, time difference within threshold",
 					"time_diff", timeDiff, "threshold", blockBuildingThreshold)
-				d.metrics.RecordBlockBuildingHealth("healthy")
+				d.metrics.RecordBlockBuildingHealthCheck("healthy")
 			} else {
 				// Node is stale
 				d.log.Warn("Node is stale, time difference exceeds threshold",
 					"time_diff", timeDiff, "threshold", blockBuildingThreshold)
-				d.metrics.RecordBlockBuildingHealth("stale")
+				d.metrics.RecordBlockBuildingHealthCheck("stale")
 			}
 		} else {
 			// TODO: remove this log once we know why the latestBlockTimeStamp is in the future
 			d.log.Debug("Cannot compute time difference, block timestamp is in the future",
 				"current_timestamp", currentTime, "block_timestamp", latestBlockTimeStamp)
-			d.metrics.RecordBlockBuildingHealth("future_timestamp")
+			d.metrics.RecordBlockBuildingHealthCheck("future_timestamp")
 		}
 	}
 	// The payload was already published upon sealing.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -137,6 +137,9 @@ type Config struct {
 
 	// AltDAConfig. We are in the process of migrating to the AltDAConfig from these legacy top level values
 	AltDAConfig *AltDAConfig `json:"alt_da,omitempty"`
+
+	// Block building shreshold for block building healthchecks, defaults to 2 seconds
+	BlockBuildingThreshold time.Duration `json:"block_building_threshold,omitempty"`
 }
 
 // ValidateL1Config checks L1 config variables for errors.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
@@ -107,6 +108,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		SafeDBPath:                  ctx.String(flags.SafeDBPath.Name),
 		Sync:                        *syncConfig,
 		RollupHalt:                  haltOption,
+		BlockBuildingThreshold:      time.Duration(blockBuildingThreshold) * time.Second,
 
 		ConductorEnabled:    ctx.Bool(flags.ConductorEnabledFlag.Name),
 		ConductorRpc:        ctx.String(flags.ConductorRpcFlag.Name),
@@ -212,7 +214,8 @@ func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, e
 	if ctx.Bool(flags.BetaExtraNetworks.Name) {
 		log.Warn("The beta.extra-networks flag is deprecated and can be omitted safely.")
 	}
-	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath)
+	blockBuildingThreshold := ctx.Uint64(flags.BlockBuildingThresholdFlag.Name)
+	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath, blockBuildingThreshold)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +223,7 @@ func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, e
 	return rollupConfig, nil
 }
 
-func NewRollupConfig(log log.Logger, network string, rollupConfigPath string) (*rollup.Config, error) {
+func NewRollupConfig(log log.Logger, network string, rollupConfigPath string, blockBuidlingThreshold uint64) (*rollup.Config, error) {
 	if network != "" {
 		if rollupConfigPath != "" {
 			log.Error(`Cannot configure network and rollup-config at the same time.
@@ -247,6 +250,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
+	rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 	return &rollupConfig, nil
 }
 

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -251,7 +251,8 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
-	log.Info("***222 the block building threshold is set to", "threshold", time.Duration(blockBuidlingThreshold)*time.Second)
+	log.Info("***222 the block building threshold is set to", "threshold", blockBuidlingThreshold)
+	log.Info("***333 the block building threshold is set to", "threshold", time.Duration(blockBuidlingThreshold)*time.Second)
 	rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 	return &rollupConfig, nil
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -108,7 +108,6 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		SafeDBPath:                  ctx.String(flags.SafeDBPath.Name),
 		Sync:                        *syncConfig,
 		RollupHalt:                  haltOption,
-		BlockBuildingThreshold:      time.Duration(blockBuildingThreshold) * time.Second,
 
 		ConductorEnabled:    ctx.Bool(flags.ConductorEnabledFlag.Name),
 		ConductorRpc:        ctx.String(flags.ConductorRpcFlag.Name),

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -214,7 +214,9 @@ func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, e
 		log.Warn("The beta.extra-networks flag is deprecated and can be omitted safely.")
 	}
 	blockBuildingThreshold := ctx.Uint64(flags.BlockBuildingThresholdFlag.Name)
+	log.Info("***111 the block building threshold is set to", "threshold", blockBuildingThreshold)
 	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath, blockBuildingThreshold)
+	log.Info("***222 the block building threshold is set to", "threshold", rollupConfig.BlockBuildingThreshold)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -251,6 +251,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
+	log.Info("***333 the block building threshold is set to", "threshold", time.Duration(blockBuidlingThreshold)*time.Second)
 	rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 	return &rollupConfig, nil
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -216,7 +216,7 @@ func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, e
 	blockBuildingThreshold := ctx.Uint64(flags.BlockBuildingThresholdFlag.Name)
 	log.Info("***111 the block building threshold is set to", "threshold", blockBuildingThreshold)
 	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath, blockBuildingThreshold)
-	log.Info("***222 the block building threshold is set to", "threshold", rollupConfig.BlockBuildingThreshold)
+	// log.Info("***222 the block building threshold is set to", "threshold", rollupConfig.BlockBuildingThreshold)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
-	log.Info("***333 the block building threshold is set to", "threshold", time.Duration(blockBuidlingThreshold)*time.Second)
+	log.Info("***222 the block building threshold is set to", "threshold", time.Duration(blockBuidlingThreshold)*time.Second)
 	rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 	return &rollupConfig, nil
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -236,6 +236,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 		if err != nil {
 			return nil, err
 		}
+		rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 		return rollupConfig, nil
 	}
 
@@ -251,8 +252,6 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
-	log.Info("***222 the block building threshold is set to", "threshold", blockBuidlingThreshold)
-	log.Info("***333 the block building threshold is set to", "threshold", time.Duration(blockBuidlingThreshold)*time.Second)
 	rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 	return &rollupConfig, nil
 }

--- a/op-service/testutils/metrics.go
+++ b/op-service/testutils/metrics.go
@@ -26,6 +26,9 @@ func (t *TestDerivationMetrics) RecordSequencerBuildingDiffTime(duration time.Du
 func (t *TestDerivationMetrics) RecordSequencerSealingTime(duration time.Duration) {
 }
 
+func (t *TestDerivationMetrics) RecordBlockBuildingHealthCheck(status string) {
+}
+
 func (t *TestDerivationMetrics) RecordL1ReorgDepth(d uint64) {
 	if t.FnRecordL1ReorgDepth != nil {
 		t.FnRecordL1ReorgDepth(d)

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -155,14 +155,16 @@ func BuildBlock(ctx context.Context, client *sources.EngineAPIClient, status *St
 	case <-time.After(settings.BuildTime):
 	}
 
+	// *** STEP1
 	payload, err := client.GetPayload(ctx, eth.PayloadInfo{ID: *pre.PayloadID, Timestamp: timestamp})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payload %v, %d time after instructing engine to build it: %w", pre.PayloadID, settings.BuildTime, err)
 	}
-
+	// *** STEP2
 	if err := insertBlock(ctx, client, payload); err != nil {
 		return nil, err
 	}
+	// *** STEP3
 	if err := updateForkchoice(ctx, client, payload.ExecutionPayload.BlockHash, status.Safe.Hash, status.Finalized.Hash); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR adds health checks on all nodes' block production. Unlike the prometheus metrics provided already, this provides per block granularity and checks the health of the unsafe block production. 

**Tests**
test in sepolia alpha
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**
As we increase our gas target, we would like to have precise metrics on how well we are producing blocks. This will help us determine when to increase or stop increasing gas target, as well as help us refine our SLO. In the future, we could potentially use this to monitor our chain when we implement sub second block time. 
<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
