### PR TITLE
feat: Add ChainAssertions for deploySuperchain contracts

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -422,7 +422,8 @@ library ChainAssertions {
     function checkSuperchainConfig(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
-        bool _isPaused
+        bool _isPaused,
+        bool _isProxy
     )
         internal
         view
@@ -433,8 +434,13 @@ library ChainAssertions {
         // Check that the contract is initialized
         assertSlotValueIsOne({ _contractAddress: address(superchainConfig), _slot: 0, _offset: 0 });
 
-        require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
-        require(superchainConfig.paused() == _isPaused);
+        if (_isProxy) {
+            require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
+            require(superchainConfig.paused() == _isPaused);
+        } else {
+            require(superchainConfig.guardian() == address(0));
+            require(superchainConfig.paused() == false);
+        }
     }
 
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -318,12 +318,18 @@ contract Deploy is Deployer {
         save("ProtocolVersionsProxy", address(dso.protocolVersionsProxy()));
         save("ProtocolVersions", address(dso.protocolVersionsImpl()));
 
-        // Run chain assertions.
-        // Run assertions for ProtocolVersions and SuperchainConfig proxy contracts.
-        ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isProxy: true });
-        ChainAssertions.checkSuperchainConfig({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isPaused: false });
-        // TODO: Add assertions for SuperchainConfig and ProtocolVersions impl contracts.
-        // TODO: Add assertions for SuperchainProxyAdmin.
+        // First run assertions for the ProtocolVersions and SuperchainConfig proxy contracts.
+        Types.ContractSet memory contracts = _proxiesUnstrict();
+        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: true });
+        ChainAssertions.checkSuperchainConfig({ _contracts: contracts, _cfg: cfg, _isPaused: false, _isProxy: true });
+
+        // Then replace the ProtocolVersions proxy with the implementation address and run assertions on it.
+        contracts.ProtocolVersions = mustGetAddress("ProtocolVersions");
+        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: false });
+
+        // Finally replace the SuperchainConfig proxy with the implementation address and run assertions on it.
+        contracts.SuperchainConfig = mustGetAddress("SuperchainConfig");
+        ChainAssertions.checkSuperchainConfig({ _contracts: contracts, _cfg: cfg, _isPaused: false, _isProxy: false });
     }
 
     /// @notice Deploy all of the OP Chain specific contracts

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -321,7 +321,7 @@ contract Deploy is Deployer {
         // First run assertions for the ProtocolVersions and SuperchainConfig proxy contracts.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: true });
-        ChainAssertions.checkSuperchainConfig({ _contracts: contracts, _cfg: cfg, _isPaused: false, _isProxy: true });
+        ChainAssertions.checkSuperchainConfig({ _contracts: contracts, _cfg: cfg, _isProxy: true, _isPaused: false });
 
         // Then replace the ProtocolVersions proxy with the implementation address and run assertions on it.
         contracts.ProtocolVersions = mustGetAddress("ProtocolVersions");


### PR DESCRIPTION
Adds `ChainAssertions` to verify the initialization of `SuperchainConfig` and `ProtocolVersions` impls.