### PR TITLE
batcher: use queue.Queue type for channelBuilder.frames and .blocks

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -58,7 +58,7 @@ func (s *channel) TxFailed(id string) {
 		// Note: when the batcher is changed to send multiple frames per tx,
 		// this needs to be changed to iterate over all frames of the tx data
 		// and re-queue them.
-		s.channelBuilder.PushFrames(data.Frames()...)
+		s.channelBuilder.EnqueueFrames(data.Frames()...)
 		delete(s.pendingTransactions, id)
 	} else {
 		s.log.Warn("unknown transaction marked as failed", "id", id)

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -66,7 +66,7 @@ type ChannelBuilder struct {
 	// current channel
 	co derive.ChannelOut
 	// list of blocks in the channel. Saved in case the channel must be rebuilt
-	blocks []*types.Block
+	blocks queue.Queue[*types.Block]
 	// latestL1Origin is the latest L1 origin of all the L2 blocks that have been added to the channel
 	latestL1Origin eth.BlockID
 	// oldestL1Origin is the oldest L1 origin of all the L2 blocks that have been added to the channel
@@ -191,7 +191,7 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 		return l1info, fmt.Errorf("adding block to channel out: %w", err)
 	}
 
-	c.blocks = append(c.blocks, block)
+	c.blocks.Enqueue(block)
 	c.updateSwTimeout(batch)
 
 	if l1info.Number > c.latestL1Origin.Number {

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -409,7 +409,7 @@ func (c *ChannelBuilder) TotalFrames() int {
 }
 
 // HasFrame returns whether there's any available frame. If true, it can be
-// popped using NextFrame().
+// dequeued using NextFrame().
 //
 // Call OutputFrames before to create new frames from the channel out
 // compression pipeline.
@@ -434,9 +434,9 @@ func (c *ChannelBuilder) NextFrame() frameData {
 	return f
 }
 
-// PushFrames adds the frames back to the internal frames queue. Panics if not of
+// EnqueueFrames enqueues the frames back to the internal frames queue. Panics if not of
 // the same channel.
-func (c *ChannelBuilder) PushFrames(frames ...frameData) {
+func (c *ChannelBuilder) EnqueueFrames(frames ...frameData) {
 	for _, f := range frames {
 		if f.id.chID != c.ID() {
 			panic("wrong channel")

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -340,7 +340,7 @@ func TestChannelBuilder_NextFrame(t *testing.T) {
 		},
 		data: expectedBytes,
 	}
-	cb.PushFrames(frameData)
+	cb.EnqueueFrames(frameData)
 
 	// There should only be 1 frame in the channel builder
 	require.Equal(t, 1, cb.PendingFrames())
@@ -385,7 +385,7 @@ func ChannelBuilder_OutputWrongFramePanic(t *testing.T, batchType uint) {
 			},
 			data: buf.Bytes(),
 		}
-		cb.PushFrames(frame)
+		cb.EnqueueFrames(frame)
 	})
 }
 

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -656,8 +656,8 @@ func ChannelBuilder_AddBlock(t *testing.T, batchType uint) {
 		expectedInputBytes = 47
 	}
 	require.Equal(t, expectedInputBytes, cb.co.InputBytes())
-	require.Equal(t, 1, len(cb.blocks))
-	require.Equal(t, 0, len(cb.frames))
+	require.Equal(t, 1, cb.blocks.Len())
+	require.Equal(t, 0, cb.frames.Len())
 	require.True(t, cb.IsFull())
 
 	// Since the channel output is full, the next call to AddBlock

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -478,23 +478,24 @@ func (s *channelManager) Close() error {
 	return nil
 }
 
-// Requeue rebuilds the channel manager state by
-// rewinding blocks back from the channel queue, and setting the defaultCfg.
+// Requeue rewinds blocks back from the current channel
+// and sets the defaultCfg.
+// Should only be called when the channel in question
+// exists and has not started to submit data.
 func (s *channelManager) Requeue(newCfg ChannelConfig) {
-	newChannelQueue := []*channel{}
-	blocksToRequeue := []*types.Block{}
-	for _, channel := range s.channelQueue {
-		if !channel.NoneSubmitted() {
-			newChannelQueue = append(newChannelQueue, channel)
-			continue
-		}
-		blocksToRequeue = append(blocksToRequeue, channel.channelBuilder.Blocks()...)
+
+	// Remove the current channel from the back of the queue
+	channelToDiscard := s.channelQueue[len(s.channelQueue)-1]
+	if channelToDiscard != s.currentChannel {
+		panic("current channel is not at the back of the channel queue")
 	}
+	s.channelQueue = s.channelQueue[:len(s.channelQueue)-1]
 
 	// We put the blocks back at the front of the queue:
-	s.blocks.Prepend(blocksToRequeue...)
-	// Channels which where already being submitted are put back
-	s.channelQueue = newChannelQueue
+	// Here it is safe to prepend because we know nothing can have
+	// dequeued anything since we dequeued blocksToRequeue,
+	// therefore the block ordering will be preserved
+	s.blocks.Prepend(channelToDiscard.channelBuilder.Blocks()...)
 	s.currentChannel = nil
 	// Setting the defaultCfg will cause new channels
 	// to pick up the new ChannelConfig

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -612,9 +612,7 @@ func TestChannelManager_TxData(t *testing.T) {
 // TestChannelManager_Requeue seeds the channel manager with blocks,
 // takes a state snapshot, triggers the blocks->channels pipeline,
 // and then calls Requeue. Finally, it asserts the channel manager's
-// state is equal to the snapshot. It repeats this for a channel
-// which has a pending transaction and verifies that Requeue is then
-// a noop.
+// state is equal to the snapshot.
 func TestChannelManager_Requeue(t *testing.T) {
 	l := testlog.Logger(t, log.LevelCrit)
 	cfg := channelManagerTestConfig(100, derive.SingularBatchType)
@@ -645,26 +643,4 @@ func TestChannelManager_Requeue(t *testing.T) {
 	// Ensure we got back to the state above
 	require.Equal(t, m.blocks, stateSnapshot)
 	require.Empty(t, m.channelQueue)
-
-	// Trigger the blocks -> channelQueue data pipelining again
-	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
-	require.NotEmpty(t, m.channelQueue)
-	require.NoError(t, m.processBlocks())
-
-	// Assert that at least one block was processed into the channel
-	require.NotContains(t, m.blocks, blockA)
-
-	// Now mark the 0th channel in the queue as already
-	// starting to send on chain
-	channel0 := m.channelQueue[0]
-	channel0.pendingTransactions["foo"] = txData{}
-	require.False(t, channel0.NoneSubmitted())
-
-	// Call the function we are testing
-	m.Requeue(m.defaultCfg)
-
-	// The requeue shouldn't affect the pending channel
-	require.Contains(t, m.channelQueue, channel0)
-
-	require.NotContains(t, m.blocks, blockA)
 }

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -104,7 +104,7 @@ func TestChannelManager_NextTxData(t *testing.T) {
 			frameNumber: uint16(0),
 		},
 	}
-	channel.channelBuilder.PushFrames(frame)
+	channel.channelBuilder.EnqueueFrames(frame)
 	require.Equal(t, 1, channel.PendingFrames())
 
 	// Now the nextTxData function should return the frame
@@ -133,7 +133,7 @@ func TestChannel_NextTxData_singleFrameTx(t *testing.T) {
 
 	mockframes := makeMockFrameDatas(chID, n+1)
 	// put multiple frames into channel, but less than target
-	ch.channelBuilder.PushFrames(mockframes[:n-1]...)
+	ch.channelBuilder.EnqueueFrames(mockframes[:n-1]...)
 
 	requireTxData := func(i int) {
 		require.True(ch.HasTxData(), "expected tx data %d", i)
@@ -151,7 +151,7 @@ func TestChannel_NextTxData_singleFrameTx(t *testing.T) {
 	require.False(ch.HasTxData())
 
 	// put in last two
-	ch.channelBuilder.PushFrames(mockframes[n-1 : n+1]...)
+	ch.channelBuilder.EnqueueFrames(mockframes[n-1 : n+1]...)
 	for i := n - 1; i < n+1; i++ {
 		requireTxData(i)
 	}
@@ -174,11 +174,11 @@ func TestChannel_NextTxData_multiFrameTx(t *testing.T) {
 
 	mockframes := makeMockFrameDatas(chID, n+1)
 	// put multiple frames into channel, but less than target
-	ch.channelBuilder.PushFrames(mockframes[:n-1]...)
+	ch.channelBuilder.EnqueueFrames(mockframes[:n-1]...)
 	require.False(ch.HasTxData())
 
 	// put in last two
-	ch.channelBuilder.PushFrames(mockframes[n-1 : n+1]...)
+	ch.channelBuilder.EnqueueFrames(mockframes[n-1 : n+1]...)
 	require.True(ch.HasTxData())
 	txdata := ch.NextTxData()
 	require.Len(txdata.frames, n)
@@ -231,7 +231,7 @@ func TestChannelTxConfirmed(t *testing.T) {
 			frameNumber: uint16(0),
 		},
 	}
-	m.currentChannel.channelBuilder.PushFrames(frame)
+	m.currentChannel.channelBuilder.EnqueueFrames(frame)
 	require.Equal(t, 1, m.currentChannel.PendingFrames())
 	returnedTxData, err := m.nextTxData(m.currentChannel)
 	expectedTxData := singleFrameTxData(frame)
@@ -282,7 +282,7 @@ func TestChannelTxFailed(t *testing.T) {
 			frameNumber: uint16(0),
 		},
 	}
-	m.currentChannel.channelBuilder.PushFrames(frame)
+	m.currentChannel.channelBuilder.EnqueueFrames(frame)
 	require.Equal(t, 1, m.currentChannel.PendingFrames())
 	returnedTxData, err := m.nextTxData(m.currentChannel)
 	expectedTxData := singleFrameTxData(frame)


### PR DESCRIPTION
This is just a tidy up / small refactor towards #12123.

For extra context, my plan is to move towards an implementation that strictly enqueues / dequeues data in the batcher's pipeline. 

Step 1: audit and highlight all queue operations in use at the moment (enqueue / dequeue / prepend / search-and-delete / etc)
Step 2: remove everything apart from enqueue / dequeue

This PR is part of step 1. 

I also simplified the Requeue method, since we can deduce it will only ever operate on the last channel in the channel queue.