### PR TITLE
feat(ci): add local semgrep scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1175,6 +1175,9 @@ jobs:
       diff_branch:
         type: string
         default: develop
+      scan_command:
+        type: string
+        default: semgrep ci --timeout=100
     environment:
       TEMPORARY_BASELINE_REF: << parameters.diff_branch >>
       SEMGREP_REPO_URL: << pipeline.project.git_url >>
@@ -1206,7 +1209,7 @@ jobs:
           # --timeout (in seconds) limits the time per rule and file.
           #   SEMGREP_TIMEOUT is the same, but docs have conflicting defaults (5s in CLI flag, 1800 in some places)
           #    https://semgrep.dev/docs/troubleshooting/semgrep-app#if-the-job-is-aborted-due-to-taking-too-long
-          command: semgrep ci --timeout=100
+          command: << parameters.scan_command >>
           # If semgrep hangs, stop the scan after 20m, to prevent a useless 5h job
           no_output_timeout: 20m
       - notify-failures-on-develop
@@ -1415,6 +1418,9 @@ workflows:
           requires:
             - contracts-bedrock-build
       - semgrep-scan
+      - semgrep-scan:
+          name: semgrep-scan-local
+          scan_command: semgrep scan --timeout=100 --config=./.semgrep --strict --error .
       - go-lint:
           requires:
             - go-mod-download

--- a/.semgrep/sol-rules.yaml
+++ b/.semgrep/sol-rules.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: sol-safety-deployutils-args
+    pattern-regex: DeployUtils\.(create1|create2|create1AndSave|create2AndSave)\s*\(\s*\{[^}]*?_args\s*:\s*(?!\s*DeployUtils\.encodeConstructor\()\s*[^}]*?\}\s*\)
+    message: _args parameter should be wrapped with DeployUtils.encodeConstructor
+    severity: ERROR
+    languages:
+      - solidity
+  - id: sol-style-input-arg-fmt
+    pattern-regex: function\s+\w+\s*\(\s*([^)]*?\b\w+\s+(?!_)(?!memory\b)(?!calldata\b)(?!storage\b)(?!payable\b)\w+\s*(?=,|\)))
+    message: Named inputs to functions must be prepended with an underscore
+    severity: ERROR
+    languages:
+      - solidity
+  - id: sol-style-return-arg-fmt
+    pattern-regex: returns\s*(\w+\s*)?\(\s*([^)]*?\b\w+\s+(?!memory\b)(?!calldata\b)(?!storage\b)(?!payable\b)\w+(?<!_)\s*(?=,|\)))
+    message: Named return arguments to functions must be appended with an underscore
+    severity: ERROR
+    languages:
+      - solidity


### PR DESCRIPTION
Adds local semgrep scanning with blocking CI rules. Since this is local it will run without needing to log in to semgrep and can therefore run on external branches.