### PR TITLE
feat(ci): allow solc warnings on tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,7 +665,7 @@ jobs:
             MATCH_PATH="./test/{$(echo "$TEST_FILES" | paste -sd "," -)}"
             export FOUNDRY_INVARIANT_RUNS=<<parameters.test_invariant_runs>>
             export FOUNDRY_INVARIANT_DEPTH=<<parameters.test_invariant_depth>>
-            forge test --deny-warnings --fuzz-runs <<parameters.test_fuzz_runs>> --match-path "$MATCH_PATH"
+            forge test --fuzz-runs <<parameters.test_fuzz_runs>> --match-path "$MATCH_PATH"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock

--- a/packages/contracts-bedrock/test/setup/DeployVariations.sol
+++ b/packages/contracts-bedrock/test/setup/DeployVariations.sol
@@ -12,7 +12,7 @@ contract DeployVariations_Test is CommonTest {
     }
 
     // Enable features which should be possible to enable or disable regardless of other options.
-    function enableAddOns(bool _enableCGT, bool _enableAltDa, bool _unusedVarInATest) public {
+    function enableAddOns(bool _enableCGT, bool _enableAltDa) public {
         if (_enableCGT) {
             ERC20 token = new ERC20("Silly", "SIL");
             super.enableCustomGasToken(address(token));
@@ -24,14 +24,14 @@ contract DeployVariations_Test is CommonTest {
 
     /// @dev It should be possible to enable Fault Proofs with any mix of CGT and Alt-DA.
     function testFuzz_enableFaultProofs(bool _enableCGT, bool _enableAltDa) public virtual {
-        enableAddOns(_enableCGT, _enableAltDa, false);
+        enableAddOns(_enableCGT, _enableAltDa);
         super.enableFaultProofs();
         super.setUp();
     }
 
     /// @dev It should be possible to enable Fault Proofs and Interop with any mix of CGT and Alt-DA.
     function test_enableInteropAndFaultProofs(bool _enableCGT, bool _enableAltDa) public virtual {
-        enableAddOns(_enableCGT, _enableAltDa, false);
+        enableAddOns(_enableCGT, _enableAltDa);
         super.enableInterop();
         super.enableFaultProofs();
         super.setUp();

--- a/packages/contracts-bedrock/test/setup/DeployVariations.sol
+++ b/packages/contracts-bedrock/test/setup/DeployVariations.sol
@@ -12,7 +12,7 @@ contract DeployVariations_Test is CommonTest {
     }
 
     // Enable features which should be possible to enable or disable regardless of other options.
-    function enableAddOns(bool _enableCGT, bool _enableAltDa) public {
+    function enableAddOns(bool _enableCGT, bool _enableAltDa, bool _unusedVarInATest) public {
         if (_enableCGT) {
             ERC20 token = new ERC20("Silly", "SIL");
             super.enableCustomGasToken(address(token));
@@ -24,14 +24,14 @@ contract DeployVariations_Test is CommonTest {
 
     /// @dev It should be possible to enable Fault Proofs with any mix of CGT and Alt-DA.
     function testFuzz_enableFaultProofs(bool _enableCGT, bool _enableAltDa) public virtual {
-        enableAddOns(_enableCGT, _enableAltDa);
+        enableAddOns(_enableCGT, _enableAltDa, false);
         super.enableFaultProofs();
         super.setUp();
     }
 
     /// @dev It should be possible to enable Fault Proofs and Interop with any mix of CGT and Alt-DA.
     function test_enableInteropAndFaultProofs(bool _enableCGT, bool _enableAltDa) public virtual {
-        enableAddOns(_enableCGT, _enableAltDa);
+        enableAddOns(_enableCGT, _enableAltDa, false);
         super.enableInterop();
         super.enableFaultProofs();
         super.setUp();


### PR DESCRIPTION
**Description**

The [Build Contracts](https://github.com/ethereum-optimism/optimism/blob/develop/deploy-opcm/.circleci/config.yml#L270) job runs with `--deny-warnings` so CI will fail if there is a compiler warning, but it would be nice to also learn if there are solidity test failures unrelated to the compiler warning. 

This will allow the tests to continue running, without allowing warnings to get through CI.
