### PR TITLE
op-program: Avoid parsing op-sepolia and op-mainnet rollup and chain configs in init() methods

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -9,18 +9,17 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
-var Mainnet, Sepolia *rollup.Config
+// OPSepolia loads the op-sepolia rollup config. This is intended for tests that need an arbitrary, valid rollup config.
+func OPSepolia() *rollup.Config {
+	return mustLoadRollupConfig("op-sepolia")
+}
 
-func init() {
-	mustCfg := func(name string) *rollup.Config {
-		cfg, err := GetRollupConfig(name)
-		if err != nil {
-			panic(fmt.Errorf("failed to load rollup config %q: %w", name, err))
-		}
-		return cfg
+func mustLoadRollupConfig(name string) *rollup.Config {
+	cfg, err := GetRollupConfig(name)
+	if err != nil {
+		panic(fmt.Errorf("failed to load rollup config %q: %w", name, err))
 	}
-	Mainnet = mustCfg("op-mainnet")
-	Sepolia = mustCfg("op-sepolia")
+	return cfg
 }
 
 var L2ChainIDToNetworkDisplayName = func() map[string]string {

--- a/op-node/p2p/peer_params_test.go
+++ b/op-node/p2p/peer_params_test.go
@@ -43,14 +43,14 @@ func (testSuite *PeerParamsTestSuite) TestNewPeerScoreThresholds() {
 
 // TestGetPeerScoreParams validates the peer score parameters.
 func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_None() {
-	params, err := GetScoringParams("none", chaincfg.Sepolia)
+	params, err := GetScoringParams("none", chaincfg.OPSepolia())
 	testSuite.NoError(err)
 	testSuite.Nil(params)
 }
 
 // TestLightPeerScoreParams validates the light peer score params.
 func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
-	cfg := chaincfg.Sepolia
+	cfg := chaincfg.OPSepolia()
 	cfg.BlockTime = 1
 	slot := time.Duration(cfg.BlockTime) * time.Second
 	epoch := 6 * slot
@@ -98,7 +98,7 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 
 // TestParamsZeroBlockTime validates peer score params use default slot for 0 block time.
 func (testSuite *PeerParamsTestSuite) TestParamsZeroBlockTime() {
-	cfg := chaincfg.Sepolia
+	cfg := chaincfg.OPSepolia()
 	cfg.BlockTime = 0
 	slot := 2 * time.Second
 	params, err := GetScoringParams("light", cfg)

--- a/op-program/chainconfig/chaincfg.go
+++ b/op-program/chainconfig/chaincfg.go
@@ -3,27 +3,14 @@ package chainconfig
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/params"
 )
 
-var OPSepoliaChainConfig, OPMainnetChainConfig *params.ChainConfig
-
-func init() {
-	mustLoadConfig := func(chainID uint64) *params.ChainConfig {
-		cfg, err := params.LoadOPStackChainConfig(chainID)
-		if err != nil {
-			panic(err)
-		}
-		return cfg
-	}
-	OPSepoliaChainConfig = mustLoadConfig(11155420)
-	OPMainnetChainConfig = mustLoadConfig(10)
-}
-
-var L2ChainConfigsByChainID = map[uint64]*params.ChainConfig{
-	11155420: OPSepoliaChainConfig,
-	10:       OPMainnetChainConfig,
+// OPSepoliaChainConfig loads the op-sepolia chain config. This is intended for tests that need an arbitrary, valid chain config.
+func OPSepoliaChainConfig() *params.ChainConfig {
+	return mustLoadChainConfig("op-sepolia")
 }
 
 func RollupConfigByChainID(chainID uint64) (*rollup.Config, error) {
@@ -36,4 +23,16 @@ func RollupConfigByChainID(chainID uint64) (*rollup.Config, error) {
 
 func ChainConfigByChainID(chainID uint64) (*params.ChainConfig, error) {
 	return params.LoadOPStackChainConfig(chainID)
+}
+
+func mustLoadChainConfig(name string) *params.ChainConfig {
+	chainCfg := chaincfg.ChainByName(name)
+	if chainCfg == nil {
+		panic(fmt.Errorf("unknown chain config %q", name))
+	}
+	cfg, err := ChainConfigByChainID(chainCfg.ChainID)
+	if err != nil {
+		panic(fmt.Errorf("failed to load rollup config: %q: %w", name, err))
+	}
+	return cfg
 }

--- a/op-program/client/boot_test.go
+++ b/op-program/client/boot_test.go
@@ -14,14 +14,15 @@ import (
 )
 
 func TestBootstrapClient(t *testing.T) {
+	rollupCfg := chaincfg.OPSepolia()
 	bootInfo := &BootInfo{
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1,
-		L2ChainID:          chaincfg.Sepolia.L2ChainID.Uint64(),
-		L2ChainConfig:      chainconfig.OPSepoliaChainConfig,
-		RollupConfig:       chaincfg.Sepolia,
+		L2ChainID:          rollupCfg.L2ChainID.Uint64(),
+		L2ChainConfig:      chainconfig.OPSepoliaChainConfig(),
+		RollupConfig:       rollupCfg,
 	}
 	mockOracle := &mockBoostrapOracle{bootInfo, false}
 	readBootInfo := NewBootstrapClient(mockOracle).BootInfo()
@@ -35,8 +36,8 @@ func TestBootstrapClient_CustomChain(t *testing.T) {
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1,
 		L2ChainID:          CustomChainIDIndicator,
-		L2ChainConfig:      chainconfig.OPSepoliaChainConfig,
-		RollupConfig:       chaincfg.Sepolia,
+		L2ChainConfig:      chainconfig.OPSepoliaChainConfig(),
+		RollupConfig:       chaincfg.OPSepolia(),
 	}
 	mockOracle := &mockBoostrapOracle{bootInfo, true}
 	readBootInfo := NewBootstrapClient(mockOracle).BootInfo()

--- a/op-program/client/l2/engine_test.go
+++ b/op-program/client/l2/engine_test.go
@@ -165,13 +165,13 @@ func createOracleEngine(t *testing.T) (*OracleEngine, *stubEngineBackend) {
 	}
 	engine := OracleEngine{
 		backend:   backend,
-		rollupCfg: chaincfg.Sepolia,
+		rollupCfg: chaincfg.OPSepolia(),
 	}
 	return &engine, backend
 }
 
 func createL2Block(t *testing.T, number int) *types.Block {
-	tx, err := derive.L1InfoDeposit(chaincfg.Sepolia, eth.SystemConfig{}, uint64(1), eth.HeaderBlockInfo(&types.Header{
+	tx, err := derive.L1InfoDeposit(chaincfg.OPSepolia(), eth.SystemConfig{}, uint64(1), eth.HeaderBlockInfo(&types.Header{
 		Number:  big.NewInt(32),
 		BaseFee: big.NewInt(7),
 	}), 0)

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -73,7 +73,7 @@ func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	defaultCfg := config.NewConfig(
 		rollupCfg,
-		chainconfig.OPSepoliaChainConfig,
+		chainconfig.OPSepoliaChainConfig(),
 		common.HexToHash(l1HeadValue),
 		common.HexToHash(l2HeadValue),
 		common.HexToHash(l2OutputRoot),
@@ -100,7 +100,7 @@ func TestNetwork(t *testing.T) {
 		genesisFile := writeValidGenesis(t)
 
 		cfg := configForArgs(t, addRequiredArgsExcept("--network", "--rollup.config", configFile, "--l2.genesis", genesisFile))
-		require.Equal(t, *chaincfg.Sepolia, *cfg.Rollup)
+		require.Equal(t, *chaincfg.OPSepolia(), *cfg.Rollup)
 	})
 
 	for _, name := range chaincfg.AvailableNetworks() {
@@ -154,9 +154,9 @@ func TestL2Genesis(t *testing.T) {
 		require.Equal(t, l2GenesisConfig, cfg.L2ChainConfig)
 	})
 
-	t.Run("NotRequiredForGoerli", func(t *testing.T) {
+	t.Run("NotRequiredForSepolia", func(t *testing.T) {
 		cfg := configForArgs(t, replaceRequiredArg("--network", "sepolia"))
-		require.Equal(t, chainconfig.OPSepoliaChainConfig, cfg.L2ChainConfig)
+		require.Equal(t, chainconfig.OPSepoliaChainConfig(), cfg.L2ChainConfig)
 	})
 }
 
@@ -388,7 +388,7 @@ func writeValidGenesis(t *testing.T) string {
 
 func writeValidRollupConfig(t *testing.T) string {
 	dir := t.TempDir()
-	j, err := json.Marshal(chaincfg.Sepolia)
+	j, err := json.Marshal(chaincfg.OPSepolia())
 	require.NoError(t, err)
 	cfgFile := dir + "/rollup.json"
 	require.NoError(t, os.WriteFile(cfgFile, j, 0666))

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	validRollupConfig    = chaincfg.Sepolia
-	validL2Genesis       = chainconfig.OPSepoliaChainConfig
+	validRollupConfig    = chaincfg.OPSepolia()
+	validL2Genesis       = chainconfig.OPSepoliaChainConfig()
 	validL1Head          = common.Hash{0xaa}
 	validL2Head          = common.Hash{0xbb}
 	validL2Claim         = common.Hash{0xcc}

--- a/op-program/host/host_test.go
+++ b/op-program/host/host_test.go
@@ -24,7 +24,7 @@ func TestServerMode(t *testing.T) {
 
 	l1Head := common.Hash{0x11}
 	l2OutputRoot := common.Hash{0x33}
-	cfg := config.NewConfig(chaincfg.Sepolia, chainconfig.OPSepoliaChainConfig, l1Head, common.Hash{0x22}, l2OutputRoot, common.Hash{0x44}, 1000)
+	cfg := config.NewConfig(chaincfg.OPSepolia(), chainconfig.OPSepoliaChainConfig(), l1Head, common.Hash{0x22}, l2OutputRoot, common.Hash{0x44}, 1000)
 	cfg.DataDir = dir
 	cfg.ServerMode = true
 

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestLocalPreimageSource(t *testing.T) {
 	cfg := &config.Config{
-		Rollup:             chaincfg.Sepolia,
+		Rollup:             chaincfg.OPSepolia(),
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),

--- a/op-program/verify/mainnet/cmd/mainnet.go
+++ b/op-program/verify/mainnet/cmd/mainnet.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/verify"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+const opMainnetChainID = 10
 
 func main() {
 	var l1RpcUrl string
@@ -44,7 +45,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "op-mainnet", chainconfig.OPMainnetChainConfig)
+	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "op-mainnet", opMainnetChainID)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())
 		os.Exit(1)

--- a/op-program/verify/sepolia/cmd/sepolia.go
+++ b/op-program/verify/sepolia/cmd/sepolia.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/verify"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+const opSepoliaChainID = 11155420
 
 func main() {
 	var l1RpcUrl string
@@ -44,7 +45,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "op-sepolia", chainconfig.OPSepoliaChainConfig)
+	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "op-sepolia", opSepoliaChainID)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())
 		os.Exit(1)

--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/host"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -43,7 +44,7 @@ type Runner struct {
 	rollupCfg   *rollup.Config
 }
 
-func NewRunner(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string, dataDir string, network string, chainCfg *params.ChainConfig) (*Runner, error) {
+func NewRunner(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string, dataDir string, network string, chainID uint64) (*Runner, error) {
 	ctx := context.Background()
 	logCfg := oplog.DefaultCLIConfig()
 	logCfg.Level = log.LevelDebug
@@ -55,9 +56,14 @@ func NewRunner(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl s
 		return nil, fmt.Errorf("dial L2 client: %w", err)
 	}
 
-	rollupCfg, err := rollup.LoadOPStackRollupConfig(chainCfg.ChainID.Uint64())
+	rollupCfg, err := rollup.LoadOPStackRollupConfig(chainID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load rollup config: %w", err)
+	}
+
+	chainCfg, err := chainconfig.ChainConfigByChainID(chainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load chain config: %w", err)
 	}
 
 	l2ClientCfg := sources.L2ClientDefaultConfig(rollupCfg, false)


### PR DESCRIPTION
**Description**

This was causing op-program to spend cycles parsing the config JSON files to set constants that weren't actually used. During native execution that's insignificant but it's wasted cycles and memory allocations in cannon that we can avoid easily.

**Tests**

Updated tests to load op-sepolia config via a method so they still have easy access to a valid config.