### PR TITLE
feat: better e2e deploy check

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -1018,7 +1018,7 @@ func (d *L1Deployments) Check(deployConfig *DeployConfig) error {
 			continue
 		}
 		if deployConfig.UseFaultProofs &&
-			(name == "OptimismPortal") {
+			(name == "OptimismPortal" || name == "L2OutputOracle") {
 			continue
 		}
 		if !deployConfig.UseAltDA &&

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -1018,7 +1018,7 @@ func (d *L1Deployments) Check(deployConfig *DeployConfig) error {
 			continue
 		}
 		if deployConfig.UseFaultProofs &&
-			(name == "OptimismPortal" || name == "L2OutputOracle") {
+			(name == "OptimismPortal" || name == "L2OutputOracle" || name == "L2OutputOracleProxy") {
 			continue
 		}
 		if !deployConfig.UseAltDA &&


### PR DESCRIPTION
**Description**

Now that the regular e2e test runs with fault proofs on, adding these checks
can enable the deploy script to not need to deploy the legacy contracts when
fault proofs are off. This will save real ether when doing contract deployments.
Fix in a follow up PR.

- **e2e: attempt fix L1Deployments check**
- **e2e: attempt another fix**

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
