### PR TITLE
[batcher] Add Channel interface and factory

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -85,6 +85,7 @@ type DriverSetup struct {
 	EndpointProvider dial.L2EndpointProvider
 	ChannelConfig    ChannelConfigProvider
 	AltDA            *altda.DAClient
+	ChannelFactory   ChannelFactory
 }
 
 // BatchSubmitter encapsulates a service responsible for submitting L2 tx
@@ -117,7 +118,7 @@ type BatchSubmitter struct {
 func NewBatchSubmitter(setup DriverSetup) *BatchSubmitter {
 	return &BatchSubmitter{
 		DriverSetup: setup,
-		state:       NewChannelManager(setup.Log, setup.Metr, setup.ChannelConfig, setup.RollupConfig),
+		state:       NewChannelManager(setup.Log, setup.Metr, setup.ChannelConfig, setup.RollupConfig, setup.ChannelFactory),
 	}
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a `Channel` interface, and the ability to customize the `Channel` implementation by passing in a `ChannelFactory` function to the `DriverSetup` / `BatcherService`.

**Tests**

Added test for factory, and updated existing tests to work with new interface.

**Additional context**

The L3 project needs the ability to customize what happens on Block and Tx submission. This PR provides the required hooks.