### PR TITLE
Interop: Generic EntryDB

### DIFF
--- a/entrydb/entry.go
+++ b/entrydb/entry.go
@@ -1,0 +1,23 @@
+package entrydb
+
+type EntryHeader struct {
+	Type       byte
+	FrameCount byte
+	ID         SequenceValue
+}
+
+func (e EntryHeader) Frame() Frame {
+	return Frame{
+		Type:  e.Type,
+		Index: 0,
+		Total: e.FrameCount,
+		Data:  e.ID[:],
+	}
+}
+
+type Entry interface {
+	Type() byte
+	Encode() (EntryHeader, []byte, error)
+	Decode(EntryHeader, []byte) (Entry, error)
+	SequenceValue() SequenceValue
+}

--- a/entrydb/entrydb.go
+++ b/entrydb/entrydb.go
@@ -1,0 +1,260 @@
+package entrydb
+
+import (
+	"errors"
+	"io"
+)
+
+/* Entry DB
+EntryDB has the following constraints:
+- Frame based data chunking
+- Regular interval checkpoints
+- Append only
+- Non-Decrementing sequence numbers only
+- Fixed-size byte identifier for each entry
+- Maximum 255 data types (0-254, 255 is reserved for checkpoints)
+- Maximum 256 Frames per entry
+
+From these constraints we get the following properties:
+- O(1) append time
+- O(log n) lookup time using binary search over checkpoints
+- Configurable data width for compact use cases
+- Corruption resistant using checkpoint trimming
+*/
+
+const SequenceValueSize = 32
+const CheckpointType = byte(255)
+
+var ErrSequenceValueDecrease = errors.New("sequence values must not decrease")
+
+type SequenceValue [SequenceValueSize]byte
+
+type EntryDB interface {
+	Get(sv SequenceValue, e Entry) (Entry, error)
+	Put(entry Entry) error
+}
+
+type entryDB struct {
+	typeMap        map[byte]Entry
+	width          int // true Frame width is width + 2
+	length         int
+	checkpointFreq int
+	persistence    ReaderWriterSeeker
+
+	// track the last written sequence value
+	lastWritten SequenceValue
+}
+
+func NewEntryDB(
+	typeMap map[byte]Entry,
+	width int,
+	checkpointFreq int,
+	persistence ReaderWriterSeeker) EntryDB {
+	if _, ok := typeMap[CheckpointType]; ok {
+		panic("typeMap cannot overload CheckpointType")
+	}
+	if width < SequenceValueSize {
+		panic("width must be at least SequenceValueSize")
+	}
+	return &entryDB{
+		typeMap:        typeMap,
+		width:          width,
+		checkpointFreq: checkpointFreq,
+		persistence:    persistence,
+	}
+}
+
+func (db *entryDB) Put(entry Entry) error {
+	db.persistence.Seek(0, io.SeekEnd)
+	header, data, err := entry.Encode()
+	if err != nil {
+		return err
+	}
+	if db.lastWritten != (SequenceValue{}) {
+		if compareSequenceValues(db.lastWritten, header.ID) == 1 {
+			return ErrSequenceValueDecrease
+		}
+	}
+	// store the header as the first frame
+	frames := []Frame{header.Frame()}
+	// turn the data into frames with width-sized data
+	for i := 0; i < len(data); i += db.width {
+		j := i + db.width
+		if j > len(data) {
+			j = len(data)
+		}
+		// offset is 1-indexed because the first frame is the header
+		offset := (i / db.width) + 1
+		frame := Frame{
+			Type:  header.Type,
+			Index: byte(offset),
+			Data:  data[i:j],
+		}
+		frames = append(frames, frame)
+	}
+	// attach the total frame count to each frame
+	for i := range frames {
+		frames[i].Total = byte(len(frames))
+	}
+	// write all the frames
+	for i := 0; i < len(frames); i++ {
+		err := db.writeFrame(frames[i])
+		if err != nil {
+			return err
+		}
+		// if this is the last frame, update the last written sequence value
+		// prior to checkpointing
+		if i == len(frames)-1 {
+			db.lastWritten = header.ID
+		}
+		err = db.MaybeCheckpoint()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *entryDB) frameSize() int {
+	return db.width + Frame{}.Overhead()
+}
+
+func (db *entryDB) writeFrame(frame Frame) error {
+	fbytes := make([]byte, db.frameSize())
+	copy(fbytes, frame.Encode())
+	_, err := db.persistence.Write(fbytes)
+	if err != nil {
+		return err
+	}
+	db.length++
+	return nil
+}
+
+func (db *entryDB) readFrame() Frame {
+	buf := make([]byte, db.width+Frame{}.Overhead())
+	db.persistence.Read(buf)
+	return Frame{
+		Type:  buf[0],
+		Index: buf[1],
+		Total: buf[2],
+		Data:  buf[3:],
+	}
+}
+
+func (db *entryDB) readFrames(n byte) []Frame {
+	frames := make([]Frame, n)
+	for i := 0; i < int(n); i++ {
+		frames[i] = db.readFrame()
+	}
+	return frames
+}
+
+func framesToBytes(frames []Frame) []byte {
+	ret := []byte{}
+	for _, frame := range frames {
+		ret = append(ret, frame.Data...)
+	}
+	return ret
+}
+
+func (db *entryDB) MaybeCheckpoint() error {
+	if db.length%db.checkpointFreq != 0 {
+		return nil
+	}
+	if db.lastWritten == (SequenceValue{}) {
+		// this could happen if the first entry written creates more frames
+		// should be impossible for checkpointFreq > 256
+		panic("lastWritten should not be empty")
+	}
+	checkpoint := Frame{
+		Type:  CheckpointType,
+		Index: 0,
+		Total: 1,
+		Data:  db.lastWritten[:],
+	}
+	err := db.writeFrame(checkpoint)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *entryDB) Get(sequenceValue SequenceValue, e Entry) (Entry, error) {
+	if db.length == 0 {
+		return nil, errors.New("database is empty")
+	}
+	err := db.seekToCheckpointPriorTo(sequenceValue)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		headerFrame := db.readFrame()
+		if headerFrame.Index != 0 {
+			panic("expected entry header")
+		}
+		sv := SequenceValue(headerFrame.Data[:SequenceValueSize])
+		if compareSequenceValues(sv, sequenceValue) == 0 {
+			h := EntryHeader{
+				Type:       headerFrame.Type,
+				FrameCount: headerFrame.Total,
+				ID:         sv,
+			}
+			// we already read the header, so we need to read the rest of the frames
+			fs := db.readFrames(headerFrame.Total - 1)
+			return e.Decode(h, framesToBytes(fs))
+		}
+		if compareSequenceValues(sv, sequenceValue) == -1 {
+			return nil, errors.New("sequence value not found")
+		}
+		db.seekFrames(int(headerFrame.Total) - 1)
+	}
+}
+
+// seekFrames advances the persistence by the width of a frame
+func (db *entryDB) seekFrames(n int) error {
+	size := db.width + Frame{}.Overhead()
+	return db.seekAdvance(n * size)
+}
+
+func (db *entryDB) seekAdvance(n int) error {
+	_, err := db.persistence.Seek(int64(n), io.SeekCurrent)
+	return err
+}
+
+// seekToCheckpointPriorTo travels to the index of the first checkpoint behind the given sequence value
+// it can be used to seek to a known good state before the given sequence value
+// TODO: this function can be a binary search instead of a linear search
+func (db *entryDB) seekToCheckpointPriorTo(sequenceValue SequenceValue) error {
+	if db.length == 0 {
+		return errors.New("database is empty")
+	}
+	if compareSequenceValues(sequenceValue, db.lastWritten) == 1 {
+		return errors.New("sequence value is ahead of last written")
+	}
+	// start at the beginning
+	db.persistence.Seek(0, io.SeekStart)
+	// if there are fewer frames than the checkpoint frequency, we can't seek
+	if db.length <= db.checkpointFreq {
+		return nil
+	}
+	db.seekFrames(db.checkpointFreq)
+	f := 0
+	for {
+		db.seekFrames(db.checkpointFreq)
+		f += db.checkpointFreq
+		frame := db.readFrame()
+		if frame.Type != CheckpointType {
+			panic("expected checkpoint type")
+		}
+		sv := SequenceValue(frame.Data[:SequenceValueSize])
+		if compareSequenceValues(sv, sequenceValue) > 0 {
+			break
+		}
+		// reverse one frame to get back to the checkpoint
+		db.seekFrames(-1)
+	}
+	db.seekFrames(-1)
+	db.seekFrames(-1 * db.checkpointFreq)
+	// once we exit the loop, rewind one checkpoint
+	return nil
+}

--- a/entrydb/entrydb_test.go
+++ b/entrydb/entrydb_test.go
@@ -1,0 +1,290 @@
+package entrydb
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testEntryWidth = 32
+var testCheckpointFreq = 100
+var testEntryType1 = byte(0)
+var testEntryType2 = byte(1)
+
+func EntryDBForTesting(t *testing.T) EntryDB {
+	typeMap := make(map[byte]Entry)
+	typeMap[testEntryType1] = &MockEntry{}
+	typeMap[testEntryType2] = &MockEntry2{}
+
+	dbdir := t.TempDir()
+	dbFile, err := os.Create(path.Join(dbdir, "test.db"))
+	require.NoError(t, err)
+	return NewEntryDB(
+		typeMap,
+		testEntryWidth,
+		testCheckpointFreq,
+		dbFile,
+	)
+}
+
+func TestEntryDBRead(t *testing.T) {
+	t.Run("single item in db", func(t *testing.T) {
+		db := EntryDBForTesting(t)
+		entry := &MockEntry{
+			ID:   1,
+			Name: "Alice",
+			Age:  30 + i,
+		}
+		err := db.Put(entry)
+		require.NoError(t, err)
+
+		// get the entry
+		ret, err := db.Get(entry.SequenceValue(), &MockEntry{})
+		require.NoError(t, err)
+		require.Equal(t, entry, ret)
+	})
+	t.Run("many items in db", func(t *testing.T) {
+		db := EntryDBForTesting(t)
+
+		entries := make([]*MockEntry, 100)
+		for i := 0; i < 100; i++ {
+			entries[i] = &MockEntry{
+				ID:   uint64(i),
+				Name: "Alice",
+				Age:  30,
+			}
+		}
+
+		// put all the entries
+		for _, entry := range entries {
+			err := db.Put(entry)
+			require.NoError(t, err)
+		}
+
+		// get all the entries
+		for _, entry := range entries {
+			fmt.Println("looking for", entry.SequenceValue())
+			ret, err := db.Get(entry.SequenceValue(), &MockEntry{})
+			require.NoError(t, err)
+			require.Equal(t, entry, ret)
+		}
+	})
+}
+func TestEntryDBWrite(t *testing.T) {
+	t.Run("write single entry", func(t *testing.T) {
+		db := EntryDBForTesting(t)
+		entry := &MockEntry{
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		}
+		err := db.Put(entry)
+		require.NoError(t, err)
+		header, data, err := entry.Encode()
+		require.NoError(t, err)
+		// there's at least the header in the database
+		expectedLen := 1
+		// if there's data, there's more frames
+		if len(data) > 0 {
+			if len(data)%testEntryWidth == 0 {
+				expectedLen += len(data) / testEntryWidth
+			} else {
+				// account for the last frame that's not full
+				expectedLen += len(data)/testEntryWidth + 1
+			}
+		}
+		// check the length of the database
+		require.Equal(t, expectedLen, db.(*entryDB).length)
+		// check the last written sequence value
+		expectedSeq := header.ID
+		require.Equal(t, expectedSeq, db.(*entryDB).lastWritten)
+	})
+	t.Run("write incrementing entries", func(t *testing.T) {
+		db := EntryDBForTesting(t)
+		num := 1
+		expectedLen := 0
+		var header EntryHeader
+		for i := 0; i < num; i++ {
+			entry := &MockEntry{
+				ID:   uint64(i),
+				Name: "Alice",
+				Age:  30,
+			}
+			err := db.Put(entry)
+			require.NoError(t, err)
+			// there's at least the header in the database
+			expectedLen += 1
+			h, data, err := entry.Encode()
+			header = h
+			require.NoError(t, err)
+			// if there's data, there's more frames
+			if len(data) > 0 {
+				if len(data)%testEntryWidth == 0 {
+					expectedLen += len(data) / testEntryWidth
+				} else {
+					// account for the last frame that's not full
+					expectedLen += len(data)/testEntryWidth + 1
+				}
+			}
+		}
+		// we checkpointed every testCheckpointFreq writes
+		expectedLen += expectedLen / testCheckpointFreq
+		// check the length of the database
+		require.Equal(t, expectedLen, db.(*entryDB).length)
+		// check the last written sequence value
+		expectedSeq := header.ID
+		require.Equal(t, expectedSeq, db.(*entryDB).lastWritten)
+	})
+	t.Run("write many entries", func(t *testing.T) {
+		db := EntryDBForTesting(t)
+		entry := &MockEntry{
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		}
+		num := 100
+		for i := 0; i < num; i++ {
+			err := db.Put(entry)
+			require.NoError(t, err)
+		}
+		header, data, err := entry.Encode()
+		require.NoError(t, err)
+		// there's at least the header in the database
+		expectedLen := 1
+		// if there's data, there's more frames
+		if len(data) > 0 {
+			if len(data)%testEntryWidth == 0 {
+				expectedLen += len(data) / testEntryWidth
+			} else {
+				// account for the last frame that's not full
+				expectedLen += len(data)/testEntryWidth + 1
+			}
+		}
+		// we wrote the data num times
+		expectedLen *= num
+		// and we checkpointed every testCheckpointFreq writes
+		expectedLen += expectedLen / testCheckpointFreq
+		// check the length of the database
+		require.Equal(t, expectedLen, db.(*entryDB).length)
+		// check the last written sequence value
+		expectedSeq := header.ID
+		require.Equal(t, expectedSeq, db.(*entryDB).lastWritten)
+	})
+	t.Run("write mixed entries", func(t *testing.T) {
+		db := EntryDBForTesting(t)
+		entryA := &MockEntry{
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		}
+		entryB := &MockEntry2{
+			ID: 1,
+		}
+		num := 50
+		for i := 0; i < num; i++ {
+			err := db.Put(entryA)
+			require.NoError(t, err)
+			err = db.Put(entryB)
+			require.NoError(t, err)
+		}
+		header, data, err := entryA.Encode()
+		require.NoError(t, err)
+		// there's at least the header
+		expectedLen := 1
+		// if there's data, there's more frames
+		if len(data) > 0 {
+			if len(data)%testEntryWidth == 0 {
+				expectedLen += len(data) / testEntryWidth
+			} else {
+				// account for the last frame that's not full
+				expectedLen += len(data)/testEntryWidth + 1
+			}
+		}
+		// we wrote the data num times
+		expectedLen *= num
+		// we also wrote header-only data num times
+		expectedLen += num
+		// and we checkpointed every testCheckpointFreq writes
+		expectedLen += expectedLen / testCheckpointFreq
+		// check the length of the database
+		require.Equal(t, expectedLen, db.(*entryDB).length)
+		// check the last written sequence value
+		expectedSeq := header.ID
+		require.Equal(t, expectedSeq, db.(*entryDB).lastWritten)
+	})
+}
+
+type MockEntry struct {
+	ID   uint64
+	Name string
+	Age  uint64
+}
+
+func (e *MockEntry) SequenceValue() SequenceValue {
+	ret := SequenceValue{}
+	ret[0] = byte(e.ID)
+	return ret
+}
+
+func (e *MockEntry) Type() byte {
+	return testEntryType1
+}
+
+func (e *MockEntry) Encode() (EntryHeader, []byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(e)
+	if err != nil {
+		return EntryHeader{}, nil, err
+	}
+	header := EntryHeader{
+		Type:       testEntryType1,
+		FrameCount: byte(buf.Len() / testEntryWidth),
+		ID:         e.SequenceValue(),
+	}
+	return header, buf.Bytes(), nil
+}
+
+func (e *MockEntry) Decode(_ EntryHeader, data []byte) (Entry, error) {
+	var entry MockEntry
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	err := dec.Decode(&entry)
+	if err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+type MockEntry2 struct {
+	ID byte
+}
+
+func (e *MockEntry2) Type() byte {
+	return testEntryType2
+}
+
+func (e *MockEntry2) SequenceValue() SequenceValue {
+	ret := SequenceValue{}
+	ret[0] = e.ID
+	return ret
+}
+
+func (e *MockEntry2) Encode() (EntryHeader, []byte, error) {
+	header := EntryHeader{
+		Type:       testEntryType1,
+		FrameCount: 0,
+		ID:         e.SequenceValue(),
+	}
+	return header, nil, nil
+}
+
+func (e *MockEntry2) Decode(header EntryHeader, _ []byte) (Entry, error) {
+	return &MockEntry2{
+		ID: byte(header.ID[0]),
+	}, nil
+}

--- a/entrydb/frame.go
+++ b/entrydb/frame.go
@@ -1,0 +1,24 @@
+package entrydb
+
+// Frame is a single chunk of data
+type Frame struct {
+	Type  byte
+	Index byte
+	Total byte
+	Data  []byte
+}
+
+func (f Frame) Encode() []byte {
+	ret := make([]byte, 3+len(f.Data))
+	ret[0] = f.Type
+	ret[1] = f.Index
+	ret[2] = f.Total
+	copy(ret[3:], f.Data)
+	return ret
+}
+
+// Overhead returns the number of bytes used by the frame
+// it is always 3 bytes for the type, index, and total fields
+func (f Frame) Overhead() int {
+	return 3
+}

--- a/entrydb/util.go
+++ b/entrydb/util.go
@@ -1,0 +1,24 @@
+package entrydb
+
+import "io"
+
+// Wrap the io.Reader, io.Writer, and io.Seeker interfaces into a single interface
+type ReaderWriterSeeker interface {
+	io.Reader
+	io.Writer
+	io.Seeker
+}
+
+// CompareBytes compares two SequenceValues
+// which are just fixed-size byte arrays
+// it returns -1 if a < b, 0 if a == b, and 1 if a > b
+func compareSequenceValues(a, b SequenceValue) int {
+	for i := 0; i < len(a); i++ {
+		if a[i] < b[i] {
+			return -1 // a is less than b
+		} else if a[i] > b[i] {
+			return 1 // a is greater than b
+		}
+	}
+	return 0 // a is equal to b
+}


### PR DESCRIPTION
# What
This PR introduces a generic `EntryDB` which can be used for data storage across multiple projects and applications.

It uses the following constraints:
- Frame based data chunking
- Regular interval checkpoints
- Append only
- Non-Decrementing sequence numbers only
- Fixed-size byte identifier for each entry
- Maximum 255 data types (0-254, 255 is reserved for checkpoints)
- Maximum 256 Frames per entry

And as a result, callers can insert arbitrary data types and use the `EntryDB` as a black-box for storage

# Why
We have a new `EntryDB` in the `Supervisor` which manages the logs from blocks over time for safety measurements. There are two opportunities in this code:
* The Supervisor has leaky abstractions around its database, which make it hard to make code changes without having to know the database internals.
* We also want to use `EntryDB` in other scenarios, like the Safety Index.

By making a generic version, we isolate the complexities of database management from business logic, and give ourselves the opportunity to use this database style in the future.

# How
This Entrydb uses the notion of a "Sequence Value" - by default a 32 byte slice which *must not* decrease between entries.

### Entries
Any structs which you might want to put into the entrydb must support:
* Type (byte)
* Encode
* Decode
* SequenceValue

For block/log data being stored, the Sequence Value would be something like `BlockNumber:LogIndex`

### Entry Headers
Every new entry starts with an `EntryHeader`, which contains:
* The Entry Type Byte
* Index (value 0)
* Total (at least 1)
* Sequence Value

All remaining data for the Entry is serialized and cut up into more frames which contain:
* The Entry Type Byte
* Index (Incrementing from the header)
* Total
* Up to `width` arbitrary data ([]byte)

Using the Index and Total values, you can easily traverse the database, even if you find yourself part-way through an entry (if you account for checkpoints, you can skip forward or back)

### Frames
Frames are the final database-serialized form of data. They are the atomic entities in the database, and are the ones who maintain the `Type/Index/Total` bytes

### Checkpoints
Much like the Supervisor `entrydb`, checkpoints are inserted at regular intervals into the database. The act of writing frames will automatically insert checkpoints.
Checkpoints are a reserved EntryType for the database which contain:
* CheckpointType (255)
* Index (0)
* Total (1)
* The `Sequence Value` of the most recently written Entry

Because checkpoints exist at set intervals, and contain the most recent Sequence Value, they can be used to binary search the database.

Notes:
* the DB intentionally does not have a checkpoint at i=0 because there is no prior Sequence Value

# Testing
I put together Write and Read tests. This code isn't totally functional, and the getters are still tricky. In particular, there's some logic that fast-forwards the Seek head on the database which is ignoring the existence of checkpoints.

# Format Example

Here, 3 similar entries are written to the database:
```
frames 3
0 {0 0 3 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}
1 {0 1 3 [46 127 3 1 1 9 77 111 99 107 69 110 116 114 121 1 255 128 0 1 3 1 2 73 68 1 6 0 1 4 78 97]}
2 {0 2 3 [109 101 1 12 0 1 3 65 103 101 1 6 0 0 0 12 255 128 2 5 65 108 105 99 101 1 30 0]}
frames 3
3 {0 0 3 [1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}
4 {0 1 3 [46 127 3 1 1 9 77 111 99 107 69 110 116 114 121 1 255 128 0 1 3 1 2 73 68 1 6 0 1 4 78 97]}
5 {0 2 3 [109 101 1 12 0 1 3 65 103 101 1 6 0 0 0 14 255 128 1 1 1 5 65 108 105 99 101 1 30 0]}
frames 3
6 {0 0 3 [2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}
7 {0 1 3 [46 127 3 1 1 9 77 111 99 107 69 110 116 114 121 1 255 128 0 1 3 1 2 73 68 1 6 0 1 4 78 97]}
8 {0 2 3 [109 101 1 12 0 1 3 65 103 101 1 6 0 0 0 14 255 128 1 2 1 5 65 108 105 99 101 1 30 0]}
```

You can see that each entry is made of 3 frames, and each frame has the data-type (0), the index (0-2) and the total size (3).

Later, an item is inserted and a checkpoint is injected into it:
```
frames 3
199 {0 0 3 [66 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}
checkpointing 200
200 {255 0 1 [65 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}
201 {0 1 3 [46 127 3 1 1 9 77 111 99 107 69 110 116 114 121 1 255 128 0 1 3 1 2 73 68 1 6 0 1 4 78 97]}
202 {0 2 3 [109 101 1 12 0 1 3 65 103 101 1 6 0 0 0 14 255 128 1 66 1 5 65 108 105 99 101 1 30 0]}
```
You can see that the Entry wrote the header during the Entry write, and it contains the `Sequence Value` (65) of the prior written Entry.