### PR TITLE
feat: add sol-expectrevert-no-args locally

### DIFF
--- a/.semgrep/sol-rules.yaml
+++ b/.semgrep/sol-rules.yaml
@@ -23,3 +23,10 @@ rules:
     severity: ERROR
     message: Javadoc-style comments are not allowed, use `///` style doc comments instead
     pattern-regex: (\/\*\*\n(\s+\*\s.*\n)+\s+\*\/)
+
+  - id: sol-expectrevert-no-args
+    languages: [solidity]
+    severity: ERROR
+    message: vm.expectRevert() must specify the revert reason
+    patterns:
+      - pattern: vm.expectRevert()


### PR DESCRIPTION
Adds the sol-expectrevert-no-args semgrep rule locally.
