### PR TITLE
feat: add sol-style-doc-comment locally

### DIFF
--- a/.semgrep/sol-rules.yaml
+++ b/.semgrep/sol-rules.yaml
@@ -17,3 +17,9 @@ rules:
     severity: ERROR
     languages:
       - solidity
+
+  - id: sol-style-doc-comment
+    languages: [solidity]
+    severity: ERROR
+    message: Javadoc-style comments are not allowed, use `///` style doc comments instead
+    pattern-regex: (\/\*\*\n(\s+\*\s.*\n)+\s+\*\/)

--- a/packages/contracts-bedrock/src/safe/SafeSigners.sol
+++ b/packages/contracts-bedrock/src/safe/SafeSigners.sol
@@ -26,12 +26,10 @@ library SafeSigners {
             let signaturePos := mul(0x41, _pos)
             r_ := mload(add(_signatures, add(signaturePos, 0x20)))
             s_ := mload(add(_signatures, add(signaturePos, 0x40)))
-            /**
-             * Here we are loading the last 32 bytes, including 31 bytes
-             * of 's'. There is no 'mload8' to do this.
-             * 'byte' is not working due to the Solidity parser, so lets
-             * use the second best option, 'and'
-             */
+            // Here we are loading the last 32 bytes, including 31 bytes
+            // of 's'. There is no 'mload8' to do this.
+            // 'byte' is not working due to the Solidity parser, so lets
+            // use the second best option, 'and'
             v_ := and(mload(add(_signatures, add(signaturePos, 0x41))), 0xff)
         }
     }


### PR DESCRIPTION
Adds the sol-style-doc-comment semgrep rule locally. Fixes one instance that was caught by the rule.
