### PR TITLE
cannon: Default load-elf to output state.bin.gz

### DIFF
--- a/cannon/README.md
+++ b/cannon/README.md
@@ -29,8 +29,8 @@ cd ../cannon
 make cannon
 
 # Transform MIPS op-program client binary into first VM state.
-# This outputs state.json (VM state) and meta.json (for debug symbols).
-./bin/cannon load-elf --type singlethreaded --path=../op-program/bin/op-program-client.elf
+# This outputs state.bin.gz (VM state) and meta.json (for debug symbols).
+./bin/cannon load-elf --type singlethreaded-2 --path=../op-program/bin/op-program-client.elf
 
 # Run cannon emulator (with example inputs)
 # Note that the server-mode op-program command is passed into cannon (after the --),
@@ -45,7 +45,7 @@ make cannon
     --proof-at '=<TRACE_INDEX>' \
     --stop-at '=<STOP_INDEX>' \
     --snapshot-at '%1000000000' \
-    --input ./state.json \
+    --input ./state.bin.gz \
     -- \
     ../op-program/bin/op-program \
     --network op-mainnet \

--- a/cannon/cmd/load_elf.go
+++ b/cannon/cmd/load_elf.go
@@ -32,7 +32,7 @@ var (
 	LoadELFOutFlag = &cli.PathFlag{
 		Name:     "out",
 		Usage:    "Output path to write state to. State is dumped to stdout if set to '-'. Not written if empty. Use file extension '.bin', '.bin.gz', or '.json' for binary, compressed binary, or JSON formats.",
-		Value:    "state.json",
+		Value:    "state.bin.gz",
 		Required: false,
 	}
 	LoadELFMetaFlag = &cli.PathFlag{


### PR DESCRIPTION
**Description**
Switch default output file for `cannon load-elf` to be `state.bin.gz` instead of `state.json`.

Update README to use singlethreaded-2 since the old singlethreaded likely isn't available if just compiling the latest version and to refer to `state.bin.gz` as the input in the example cannon run command.