### PR TITLE
txmgr: reinstate fee metrics

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -891,6 +891,10 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 		return nil, nil, nil, fmt.Errorf("failed to get gas price estimates: %w", err)
 	}
 
+	m.metr.RecordTipCap(tip)
+	m.metr.RecordBaseFee(baseFee)
+	m.metr.RecordBlobBaseFee(blobFee)
+
 	// Enforce minimum base fee and tip cap
 	minTipCap := m.cfg.MinTipCap.Load()
 	minBaseFee := m.cfg.MinBaseFee.Load()


### PR DESCRIPTION
Following #12239, we've seen metrics disappear from e.g. the batcher. This puts them back. 