### PR TITLE
fix: just build-go-ffi command

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -25,7 +25,7 @@ build: prebuild
 
 # Builds the go-ffi tool for contract tests.
 build-go-ffi:
-  cd scripts/go-ffi && go build
+  cd ./scripts/go-ffi && go build
 
 # Cleans build artifacts and deployments.
 clean:


### PR DESCRIPTION
Fixes an issue on MacOS where calling `just build-go-ffi` has the following erro: 

```
cd scripts/go-ffi && go build
sh: line 0: cd: scripts/go-ffi: No such file or directory
error: Recipe `build-go-ffi` failed on line 28 with exit code 1
```