### PR TITLE
op-deployer: don't write `superchainRoles` stanza to `intent.toml`

### DIFF
--- a/op-chain-ops/deployer/state/intent.go
+++ b/op-chain-ops/deployer/state/intent.go
@@ -15,7 +15,7 @@ var emptyAddress common.Address
 type Intent struct {
 	L1ChainID uint64 `json:"l1ChainID" toml:"l1ChainID"`
 
-	SuperchainRoles SuperchainRoles `json:"superchainRoles" toml:"superchainRoles"`
+	SuperchainRoles SuperchainRoles `json:"superchainRoles" toml:"-"`
 
 	FundDevAccounts bool `json:"fundDevAccounts" toml:"fundDevAccounts"`
 


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/platforms-team/issues/284

>  Remove `superchainRoles` stanza from default intent

Previously the default intent from running `op-deployer init --l1-chain-id 11155111 --l2-chain-ids 12345 --workdir .deployer` looked like this:
```toml
l1ChainID = 11155111
fundDevAccounts = true
contractArtifactsURL = "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-ee07c78c3d8d4cd8f7a933c050f5afeebaa281b57b226cc6f092b19de2a8d61f.tar.gz"
contractsRelease = "op-contracts/v1.6.0"

[superchainRoles]
  proxyAdminOwner = "0xb9cdf788704088a4c0191d045c151fcbe2db14a4"
  protocolVersionsOwner = "0x85d646ed26c3f46400ede51236d8d7528196849b"
  guardian = "0x8c7e4a51acb17719d225bd17598b8a94b46c8767"

[[chains]]
  id = "0x0000000000000000000000000000000000000000000000000000000000003039"
  [chains.roles]
    proxyAdminOwner = "0x7759a8a43aa6a7ee9434ddb597beed64180c40fd"
    systemConfigOwner = "0x8e35d9523a0c4c9ac537d254079c2398c6f3b35f"
    governanceTokenOwner = "0x7759a8a43aa6a7ee9434ddb597beed64180c40fd"
    unsafeBlockSigner = "0xbb19dce4ce51f353a98dbab31b5fa3bc80dc7769"
    batcher = "0x0e9c62712ab826e06b16b2236ce542f711eaffaf"
    proposer = "0x86dfafe0689e20685f7872e0cb264868454627bc"
    challenger = "0xf1658da627dd0738c555f9572f658617511c49d5"
```

This PR changes it so the `[superchainRoles]` section is not written. This is desirable because by default chains will be deployed as standard chains, meaning the addresses used for the `[superchainRoles]` accounts are static and should not be set by the user. The resulting TOML file looks like this:

```toml
l1ChainID = 11155111
fundDevAccounts = true
contractArtifactsURL = "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-ee07c78c3d8d4cd8f7a933c050f5afeebaa281b57b226cc6f092b19de2a8d61f.tar.gz"
contractsRelease = "op-contracts/v1.6.0"

[[chains]]
  id = "0x0000000000000000000000000000000000000000000000000000000000003039"
  [chains.roles]
    proxyAdminOwner = "0x7759a8a43aa6a7ee9434ddb597beed64180c40fd"
    systemConfigOwner = "0x8e35d9523a0c4c9ac537d254079c2398c6f3b35f"
    governanceTokenOwner = "0x7759a8a43aa6a7ee9434ddb597beed64180c40fd"
    unsafeBlockSigner = "0xbb19dce4ce51f353a98dbab31b5fa3bc80dc7769"
    batcher = "0x0e9c62712ab826e06b16b2236ce542f711eaffaf"
    proposer = "0x86dfafe0689e20685f7872e0cb264868454627bc"
    challenger = "0xf1658da627dd0738c555f9572f658617511c49d5"
```