### PR TITLE
fix(ci): use forge-build in dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1369,7 +1369,7 @@ jobs:
           name: Build contracts
           environment:
             FOUNDRY_PROFILE: ci
-          command: just build
+          command: just forge-build
           working_directory: packages/contracts-bedrock
       - run:
           name: Publish artifacts

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -31,7 +31,7 @@ COPY .gitmodules ./.gitmodules
 
 RUN git submodule update --init --recursive \
     && cd packages/contracts-bedrock \
-    && just build \
+    && just forge-build \
     && echo $(git rev-parse HEAD) > .gitcommit
 
 FROM --platform=linux/amd64 debian:bookworm-20240812-slim as contracts-bedrock


### PR DESCRIPTION
Updates the dockerfile for building contracts-bedrock to use just forge-build instead of just build since just build now does a few other things for the sake of devex.
