### PR TITLE
op-challenger: Set op-program log level based on the challenger level

### DIFF
--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -68,13 +68,13 @@ func RegisterGameTypes(
 
 	var registerTasks []*RegisterTask
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeCannon) {
-		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor()))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger)))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypePermissioned) {
-		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor()))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger)))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsterisc) {
-		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor()))
+		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor(logger)))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsteriscKona) {
 		registerTasks = append(registerTasks, NewAsteriscKonaRegisterTask(faultTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaExecutor()))

--- a/op-challenger/game/fault/trace/asterisc/provider.go
+++ b/op-challenger/game/fault/trace/asterisc/provider.go
@@ -168,7 +168,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		logger:    logger,
 		dir:       dir,
 		prestate:  cfg.AsteriscAbsolutePreState,
-		generator: vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramServerExecutor(), cfg.AsteriscAbsolutePreState, localInputs),
+		generator: vm.NewExecutor(logger, m, cfg.Asterisc, vm.NewOpProgramServerExecutor(logger), cfg.AsteriscAbsolutePreState, localInputs),
 		gameDepth: gameDepth,
 		preimageLoader: utils.NewPreimageLoader(func() (utils.PreimageSource, error) {
 			return kvstore.NewDiskKV(logger, vm.PreimageDir(dir), kvtypes.DataFormatFile)

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -167,7 +167,7 @@ func NewTraceProviderForTest(logger log.Logger, m vm.Metricer, cfg *config.Confi
 		logger:    logger,
 		dir:       dir,
 		prestate:  cfg.CannonAbsolutePreState,
-		generator: vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramServerExecutor(), cfg.CannonAbsolutePreState, localInputs),
+		generator: vm.NewExecutor(logger, m, cfg.Cannon, vm.NewOpProgramServerExecutor(logger), cfg.CannonAbsolutePreState, localInputs),
 		gameDepth: gameDepth,
 		preimageLoader: utils.NewPreimageLoader(func() (utils.PreimageSource, error) {
 			return kvstore.NewDiskKV(logger, vm.PreimageDir(dir), kvtypes.DataFormatFile)

--- a/op-challenger/game/fault/trace/vm/executor_test.go
+++ b/op-challenger/game/fault/trace/vm/executor_test.go
@@ -41,7 +41,7 @@ func TestGenerateProof(t *testing.T) {
 	}
 	captureExec := func(t *testing.T, cfg Config, proofAt uint64) (string, string, map[string]string) {
 		m := &stubVmMetrics{}
-		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, NewOpProgramServerExecutor(), prestate, inputs)
+		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, NewOpProgramServerExecutor(testlog.Logger(t, log.LvlInfo)), prestate, inputs)
 		executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64, binary bool) (string, error) {
 			return input, nil
 		}

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -1,16 +1,20 @@
 package vm
 
 import (
+	"context"
+
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type OpProgramServerExecutor struct {
+	logger log.Logger
 }
 
 var _ OracleServerExecutor = (*OpProgramServerExecutor)(nil)
 
-func NewOpProgramServerExecutor() *OpProgramServerExecutor {
-	return &OpProgramServerExecutor{}
+func NewOpProgramServerExecutor(logger log.Logger) *OpProgramServerExecutor {
+	return &OpProgramServerExecutor{logger: logger}
 }
 
 func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
@@ -35,5 +39,20 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 	if cfg.L2GenesisPath != "" {
 		args = append(args, "--l2.genesis", cfg.L2GenesisPath)
 	}
+	var logLevel string
+	if s.logger.Enabled(context.Background(), log.LevelTrace) {
+		logLevel = "TRACE"
+	} else if s.logger.Enabled(context.Background(), log.LevelDebug) {
+		logLevel = "DEBUG"
+	} else if s.logger.Enabled(context.Background(), log.LevelInfo) {
+		logLevel = "INFO"
+	} else if s.logger.Enabled(context.Background(), log.LevelWarn) {
+		logLevel = "WARN"
+	} else if s.logger.Enabled(context.Background(), log.LevelError) {
+		logLevel = "ERROR"
+	} else {
+		logLevel = "CRIT"
+	}
+	args = append(args, "--log.level", logLevel)
 	return args, nil
 }

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"slices"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
@@ -16,32 +15,6 @@ import (
 
 func TestOpProgramFillHostCommand(t *testing.T) {
 	dir := "mockdir"
-	cfg := Config{
-		L1:       "http://localhost:8888",
-		L1Beacon: "http://localhost:9000",
-		L2:       "http://localhost:9999",
-		Server:   "./bin/mockserver",
-	}
-	inputs := utils.LocalGameInputs{
-		L1Head:        common.Hash{0x11},
-		L2Head:        common.Hash{0x22},
-		L2OutputRoot:  common.Hash{0x33},
-		L2Claim:       common.Hash{0x44},
-		L2BlockNumber: big.NewInt(3333),
-	}
-
-	validateStandard := func(t *testing.T, args []string) {
-		require.True(t, slices.Contains(args, "--server"))
-		require.True(t, slices.Contains(args, "--l1"))
-		require.True(t, slices.Contains(args, "--l1.beacon"))
-		require.True(t, slices.Contains(args, "--l2"))
-		require.True(t, slices.Contains(args, "--datadir"))
-		require.True(t, slices.Contains(args, "--l1.head"))
-		require.True(t, slices.Contains(args, "--l2.head"))
-		require.True(t, slices.Contains(args, "--l2.outputroot"))
-		require.True(t, slices.Contains(args, "--l2.claim"))
-		require.True(t, slices.Contains(args, "--l2.blocknumber"))
-	}
 
 	toPairs := func(args []string) map[string]string {
 		pairs := make(map[string]string, len(args)/2)
@@ -51,61 +24,77 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		return pairs
 	}
 
-	t.Run("NoExtras", func(t *testing.T) {
-		vmConfig := NewOpProgramServerExecutor(testlog.Logger(t, log.LvlInfo))
+	oracleCommand := func(t *testing.T, lvl slog.Level, configModifier func(c *Config)) map[string]string {
+		cfg := Config{
+			L1:       "http://localhost:8888",
+			L1Beacon: "http://localhost:9000",
+			L2:       "http://localhost:9999",
+			Server:   "./bin/mockserver",
+		}
+		inputs := utils.LocalGameInputs{
+			L1Head:        common.Hash{0x11},
+			L2Head:        common.Hash{0x22},
+			L2OutputRoot:  common.Hash{0x33},
+			L2Claim:       common.Hash{0x44},
+			L2BlockNumber: big.NewInt(3333),
+		}
+		configModifier(&cfg)
+		executor := NewOpProgramServerExecutor(testlog.Logger(t, lvl))
 
-		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
+		args, err := executor.OracleCommand(cfg, dir, inputs)
 		require.NoError(t, err)
+		pairs := toPairs(args)
+		// Validate standard options
+		require.Equal(t, "--server", pairs[cfg.Server])
+		require.Equal(t, cfg.L1, pairs["--l1"])
+		require.Equal(t, cfg.L1Beacon, pairs["--l1.beacon"])
+		require.Equal(t, cfg.L2, pairs["--l2"])
+		require.Equal(t, dir, pairs["--datadir"])
+		require.Equal(t, inputs.L1Head.Hex(), pairs["--l1.head"])
+		require.Equal(t, inputs.L2Head.Hex(), pairs["--l2.head"])
+		require.Equal(t, inputs.L2OutputRoot.Hex(), pairs["--l2.outputroot"])
+		require.Equal(t, inputs.L2Claim.Hex(), pairs["--l2.claim"])
+		require.Equal(t, inputs.L2BlockNumber.String(), pairs["--l2.blocknumber"])
+		return pairs
+	}
 
-		validateStandard(t, args)
+	t.Run("NoExtras", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {})
+		require.NotContains(t, pairs, "--network")
+		require.NotContains(t, pairs, "--rollup.config")
+		require.NotContains(t, pairs, "--l2.genesis")
 	})
 
 	t.Run("WithNetwork", func(t *testing.T) {
-		cfg.Network = "op-test"
-		vmConfig := NewOpProgramServerExecutor(testlog.Logger(t, log.LvlInfo))
-
-		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
-		require.NoError(t, err)
-
-		validateStandard(t, args)
-		require.True(t, slices.Contains(args, "--network"))
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+			c.Network = "op-test"
+		})
+		require.Equal(t, "op-test", pairs["--network"])
 	})
 
 	t.Run("WithRollupConfigPath", func(t *testing.T) {
-		cfg.RollupConfigPath = "rollup.config"
-		vmConfig := NewOpProgramServerExecutor(testlog.Logger(t, log.LvlInfo))
-
-		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
-		require.NoError(t, err)
-
-		validateStandard(t, args)
-		require.True(t, slices.Contains(args, "--rollup.config"))
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+			c.RollupConfigPath = "rollup.config.json"
+		})
+		require.Equal(t, "rollup.config.json", pairs["--rollup.config"])
 	})
 
 	t.Run("WithL2GenesisPath", func(t *testing.T) {
-		cfg.L2GenesisPath = "l2.genesis"
-		vmConfig := NewOpProgramServerExecutor(testlog.Logger(t, log.LvlInfo))
-
-		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
-		require.NoError(t, err)
-
-		validateStandard(t, args)
-		require.True(t, slices.Contains(args, "--l2.genesis"))
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+			c.L2GenesisPath = "genesis.json"
+		})
+		require.Equal(t, "genesis.json", pairs["--l2.genesis"])
 	})
 
 	t.Run("WithAllExtras", func(t *testing.T) {
-		cfg.Network = "op-test"
-		cfg.RollupConfigPath = "rollup.config"
-		cfg.L2GenesisPath = "l2.genesis"
-		vmConfig := NewOpProgramServerExecutor(testlog.Logger(t, log.LvlInfo))
-
-		args, err := vmConfig.OracleCommand(cfg, dir, inputs)
-		require.NoError(t, err)
-
-		validateStandard(t, args)
-		require.True(t, slices.Contains(args, "--network"))
-		require.True(t, slices.Contains(args, "--rollup.config"))
-		require.True(t, slices.Contains(args, "--l2.genesis"))
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+			c.Network = "op-test"
+			c.RollupConfigPath = "rollup.config.json"
+			c.L2GenesisPath = "genesis.json"
+		})
+		require.Equal(t, "op-test", pairs["--network"])
+		require.Equal(t, "rollup.config.json", pairs["--rollup.config"])
+		require.Equal(t, "genesis.json", pairs["--l2.genesis"])
 	})
 
 	logTests := []struct {
@@ -122,14 +111,8 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	for _, logTest := range logTests {
 		logTest := logTest
 		t.Run(fmt.Sprintf("LogLevel-%v", logTest.arg), func(t *testing.T) {
-			vmConfig := NewOpProgramServerExecutor(testlog.Logger(t, logTest.level))
-
-			args, err := vmConfig.OracleCommand(cfg, dir, inputs)
-			require.NoError(t, err)
-
-			validateStandard(t, args)
-
-			require.Equal(t, toPairs(args)["--log.level"], logTest.arg)
+			pairs := oracleCommand(t, logTest.level, func(c *Config) {})
+			require.Equal(t, pairs["--log.level"], logTest.arg)
 		})
 	}
 }

--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -30,7 +30,7 @@ func createTraceProvider(
 ) (types.TraceProvider, error) {
 	switch traceType {
 	case types.TraceTypeCannon:
-		serverExecutor := vm.NewOpProgramServerExecutor()
+		serverExecutor := vm.NewOpProgramServerExecutor(logger)
 		stateConverter := cannon.NewStateConverter(cfg.Cannon)
 		prestate, err := getPrestate(ctx, prestateHash, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState, dir, stateConverter)
 		if err != nil {
@@ -39,7 +39,7 @@ func createTraceProvider(
 		prestateProvider := vm.NewPrestateProvider(prestate, stateConverter)
 		return cannon.NewTraceProvider(logger, m, cfg.Cannon, serverExecutor, prestateProvider, prestate, localInputs, dir, 42), nil
 	case types.TraceTypeAsterisc:
-		serverExecutor := vm.NewOpProgramServerExecutor()
+		serverExecutor := vm.NewOpProgramServerExecutor(logger)
 		stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 		prestate, err := getPrestate(ctx, prestateHash, cfg.AsteriscAbsolutePreStateBaseURL, cfg.AsteriscAbsolutePreState, dir, stateConverter)
 		if err != nil {
@@ -70,7 +70,7 @@ func createMTTraceProvider(
 	localInputs utils.LocalGameInputs,
 	dir string,
 ) (types.TraceProvider, error) {
-	executor := vm.NewOpProgramServerExecutor()
+	executor := vm.NewOpProgramServerExecutor(logger)
 	stateConverter := cannon.NewStateConverter(vmConfig)
 
 	prestateSource := prestates.NewMultiPrestateProvider(absolutePrestateBaseURL, filepath.Join(dir, "prestates"), stateConverter)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -89,7 +89,7 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, actorCfg.PrestateBlock)
 	l1Head := g.GetL1Head(ctx)
 	accessor, err := outputs.NewOutputCannonTraceAccessor(
-		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramServerExecutor(), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, actorCfg.PrestateBlock, actorCfg.PoststateBlock)
+		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramServerExecutor(logger), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, actorCfg.PrestateBlock, actorCfg.PoststateBlock)
 	g.Require.NoError(err, "Failed to create output cannon trace accessor")
 	return NewOutputHonestHelper(g.T, g.Require, &g.OutputGameHelper, g.Game, accessor)
 }

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -276,7 +276,7 @@ func runCannon(t *testing.T, ctx context.Context, sys *e2esys.System, inputs uti
 	cannonOpts(&cfg)
 
 	logger := testlog.Logger(t, log.LevelInfo).New("role", "cannon")
-	executor := vm.NewExecutor(logger, metrics.NoopMetrics.VmMetrics("cannon"), cfg.Cannon, vm.NewOpProgramServerExecutor(), cfg.CannonAbsolutePreState, inputs)
+	executor := vm.NewExecutor(logger, metrics.NoopMetrics.VmMetrics("cannon"), cfg.Cannon, vm.NewOpProgramServerExecutor(logger), cfg.CannonAbsolutePreState, inputs)
 
 	t.Log("Running cannon")
 	err := executor.DoGenerateProof(ctx, proofsDir, math.MaxUint, math.MaxUint, extraVmArgs...)


### PR DESCRIPTION
**Description**

Set the `op-program` (host) log level to match op-challenger's log level.

**Tests**

Updated unit tests, including reworking them to actually assert the value for options rather than just that the option was specified.