### PR TITLE
cannon: use constant instead of magic value

### DIFF
--- a/cannon/mipsevm/exec/calling_convention.go
+++ b/cannon/mipsevm/exec/calling_convention.go
@@ -1,0 +1,56 @@
+package exec
+
+// FYI: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File
+const (
+	Reg0  = 0
+	RegAt = 1
+	// syscall number; 1st return value
+	RegV0 = 2
+	// 2nd return value
+	RegV1 = 3
+	// syscall arguments; returned unmodified
+	RegA0 = 4
+	RegA1 = 5
+	RegA2 = 6
+	// 4th syscall argument; set to 0/1 for success/error
+	RegA3 = 7
+	// caller saved
+	RegT0 = 8
+	RegT1 = 9
+	RegT2 = 10
+	RegT3 = 11
+	RegT4 = 12
+	RegT5 = 13
+	RegT6 = 14
+	RegT7 = 15
+	// callee saved
+	RegS0 = 16
+	RegS1 = 17
+	RegS2 = 18
+	RegS3 = 19
+	RegS4 = 20
+	RegS5 = 21
+	RegS6 = 22
+	RegS7 = 23
+
+	RegT8 = 24
+	RegT9 = 25
+	RegK0 = 26
+	RegK1 = 27
+	RegGP = 28
+	RegSP = 29
+	RegFP = 30
+	RegRA = 31
+)
+
+// FYI: https://web.archive.org/web/20231223163047/https://www.linux-mips.org/wiki/Syscall
+const (
+	RegSyscallNum    = RegV0
+	RegSyscallRet1   = RegV0
+	RegSyscallRet2   = RegV1
+	RegSyscallResult = RegA3
+	RegSyscallParam1 = RegA0
+	RegSyscallParam2 = RegA1
+	RegSyscallParam3 = RegA2
+	RegSyscallParam4 = RegA3
+)

--- a/cannon/mipsevm/exec/calling_convention.go
+++ b/cannon/mipsevm/exec/calling_convention.go
@@ -1,13 +1,15 @@
 package exec
 
 // FYI: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File
+//
+//	https://refspecs.linuxfoundation.org/elf/mipsabi.pdf
 const (
-	Reg0  = 0
-	RegAt = 1
+	// Reg0  = 0
+	// RegAt = 1
 	// syscall number; 1st return value
 	RegV0 = 2
 	// 2nd return value
-	RegV1 = 3
+	// RegV1 = 3
 	// syscall arguments; returned unmodified
 	RegA0 = 4
 	RegA1 = 5
@@ -15,40 +17,39 @@ const (
 	// 4th syscall argument; set to 0/1 for success/error
 	RegA3 = 7
 	// caller saved
-	RegT0 = 8
-	RegT1 = 9
-	RegT2 = 10
-	RegT3 = 11
-	RegT4 = 12
-	RegT5 = 13
-	RegT6 = 14
-	RegT7 = 15
+	// RegT0 = 8
+	// RegT1 = 9
+	// RegT2 = 10
+	// RegT3 = 11
+	// RegT4 = 12
+	// RegT5 = 13
+	// RegT6 = 14
+	// RegT7 = 15
 	// callee saved
-	RegS0 = 16
-	RegS1 = 17
-	RegS2 = 18
-	RegS3 = 19
-	RegS4 = 20
-	RegS5 = 21
-	RegS6 = 22
-	RegS7 = 23
+	// RegS0 = 16
+	// RegS1 = 17
+	// RegS2 = 18
+	// RegS3 = 19
+	// RegS4 = 20
+	// RegS5 = 21
+	// RegS6 = 22
+	// RegS7 = 23
 
-	RegT8 = 24
-	RegT9 = 25
-	RegK0 = 26
-	RegK1 = 27
-	RegGP = 28
-	RegSP = 29
-	RegFP = 30
-	RegRA = 31
+	// RegT8 = 24
+	// RegT9 = 25
+	// RegK0 = 26
+	// RegK1 = 27
+	// RegGP = 28
+	// RegSP = 29
+	// RegFP = 30
+	// RegRA = 31
 )
 
-// FYI: https://web.archive.org/web/20231223163047/https://www.linux-mips.org/wiki/Syscall
 const (
-	RegSyscallNum    = RegV0
-	RegSyscallRet1   = RegV0
-	RegSyscallRet2   = RegV1
-	RegSyscallResult = RegA3
+	RegSyscallNum  = RegV0
+	RegSyscallRet1 = RegV0
+	// RegSyscallRet2   = RegV1
+	RegSyscallError  = RegA3
 	RegSyscallParam1 = RegA0
 	RegSyscallParam2 = RegA1
 	RegSyscallParam3 = RegA2

--- a/cannon/mipsevm/exec/calling_convention.go
+++ b/cannon/mipsevm/exec/calling_convention.go
@@ -4,52 +4,21 @@ package exec
 //
 //	https://refspecs.linuxfoundation.org/elf/mipsabi.pdf
 const (
-	// Reg0  = 0
-	// RegAt = 1
 	// syscall number; 1st return value
 	RegV0 = 2
-	// 2nd return value
-	// RegV1 = 3
 	// syscall arguments; returned unmodified
 	RegA0 = 4
 	RegA1 = 5
 	RegA2 = 6
 	// 4th syscall argument; set to 0/1 for success/error
 	RegA3 = 7
-	// caller saved
-	// RegT0 = 8
-	// RegT1 = 9
-	// RegT2 = 10
-	// RegT3 = 11
-	// RegT4 = 12
-	// RegT5 = 13
-	// RegT6 = 14
-	// RegT7 = 15
-	// callee saved
-	// RegS0 = 16
-	// RegS1 = 17
-	// RegS2 = 18
-	// RegS3 = 19
-	// RegS4 = 20
-	// RegS5 = 21
-	// RegS6 = 22
-	// RegS7 = 23
-
-	// RegT8 = 24
-	// RegT9 = 25
-	// RegK0 = 26
-	// RegK1 = 27
-	// RegGP = 28
-	// RegSP = 29
-	// RegFP = 30
-	// RegRA = 31
 )
 
+// FYI: https://web.archive.org/web/20231223163047/https://www.linux-mips.org/wiki/Syscall
+
 const (
-	RegSyscallNum  = RegV0
-	RegSyscallRet1 = RegV0
-	// RegSyscallRet2   = RegV1
-	RegSyscallError  = RegA3
+	RegSyscallNum    = RegV0
+	RegSyscallRet1   = RegV0
 	RegSyscallParam1 = RegA0
 	RegSyscallParam2 = RegA1
 	RegSyscallParam3 = RegA2

--- a/cannon/mipsevm/exec/calling_convention.go
+++ b/cannon/mipsevm/exec/calling_convention.go
@@ -18,6 +18,7 @@ const (
 
 const (
 	RegSyscallNum    = RegV0
+	RegSyscallErrno  = RegA3
 	RegSyscallRet1   = RegV0
 	RegSyscallParam1 = RegA0
 	RegSyscallParam2 = RegA1

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -99,12 +99,12 @@ const (
 )
 
 func GetSyscallArgs(registers *[32]Word) (syscallNum, a0, a1, a2, a3 Word) {
-	syscallNum = registers[2] // v0
+	syscallNum = registers[RegSyscallNum] // v0
 
-	a0 = registers[4]
-	a1 = registers[5]
-	a2 = registers[6]
-	a3 = registers[7]
+	a0 = registers[RegSyscallParam1]
+	a1 = registers[RegSyscallParam2]
+	a2 = registers[RegSyscallParam3]
+	a3 = registers[RegSyscallParam4]
 
 	return syscallNum, a0, a1, a2, a3
 }
@@ -281,8 +281,8 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 }
 
 func HandleSyscallUpdates(cpu *mipsevm.CpuScalars, registers *[32]Word, v0, v1 Word) {
-	registers[2] = v0
-	registers[7] = v1
+	registers[RegSyscallRet1] = v0
+	registers[RegSyscallResult] = v1
 
 	cpu.PC = cpu.NextPC
 	cpu.NextPC = cpu.NextPC + 4

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -282,7 +282,7 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 
 func HandleSyscallUpdates(cpu *mipsevm.CpuScalars, registers *[32]Word, v0, v1 Word) {
 	registers[RegSyscallRet1] = v0
-	registers[RegSyscallResult] = v1
+	registers[RegSyscallError] = v1
 
 	cpu.PC = cpu.NextPC
 	cpu.NextPC = cpu.NextPC + 4

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -282,7 +282,7 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 
 func HandleSyscallUpdates(cpu *mipsevm.CpuScalars, registers *[32]Word, v0, v1 Word) {
 	registers[RegSyscallRet1] = v0
-	registers[RegA3] = v1
+	registers[RegSyscallErrno] = v1
 
 	cpu.PC = cpu.NextPC
 	cpu.NextPC = cpu.NextPC + 4

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -282,7 +282,7 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 
 func HandleSyscallUpdates(cpu *mipsevm.CpuScalars, registers *[32]Word, v0, v1 Word) {
 	registers[RegSyscallRet1] = v0
-	registers[RegSyscallError] = v1
+	registers[RegA3] = v1
 
 	cpu.PC = cpu.NextPC
 	cpu.NextPC = cpu.NextPC + 4

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -60,7 +60,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		newThread.Registers[29] = a1
 		// the child will perceive a 0 value as returned value instead, and no error
 		newThread.Registers[exec.RegSyscallRet1] = 0
-		newThread.Registers[exec.RegSyscallResult] = 0
+		newThread.Registers[exec.RegSyscallError] = 0
 		m.state.NextThreadId++
 
 		// Preempt this thread for the new one. But not before updating PCs

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -59,8 +59,8 @@ func (m *InstrumentedState) handleSyscall() error {
 
 		newThread.Registers[29] = a1
 		// the child will perceive a 0 value as returned value instead, and no error
-		newThread.Registers[2] = 0
-		newThread.Registers[7] = 0
+		newThread.Registers[exec.RegSyscallRet1] = 0
+		newThread.Registers[exec.RegSyscallResult] = 0
 		m.state.NextThreadId++
 
 		// Preempt this thread for the new one. But not before updating PCs

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -60,7 +60,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		newThread.Registers[29] = a1
 		// the child will perceive a 0 value as returned value instead, and no error
 		newThread.Registers[exec.RegSyscallRet1] = 0
-		newThread.Registers[exec.RegSyscallError] = 0
+		newThread.Registers[exec.RegA3] = 0
 		m.state.NextThreadId++
 
 		// Preempt this thread for the new one. But not before updating PCs

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -60,7 +60,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		newThread.Registers[29] = a1
 		// the child will perceive a 0 value as returned value instead, and no error
 		newThread.Registers[exec.RegSyscallRet1] = 0
-		newThread.Registers[exec.RegA3] = 0
+		newThread.Registers[exec.RegSyscallErrno] = 0
 		m.state.NextThreadId++
 
 		// Preempt this thread for the new one. But not before updating PCs


### PR DESCRIPTION
This PR does 2 things:
1. Define a constant name for each register according to the [spec](https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File), so that we can reference to them by name instead of magic number.
2. Encode the calling convention below into alias constant names.

![image](https://github.com/user-attachments/assets/8dee4f2a-841f-47a8-af76-23c4dc1d2284)

Gradually we should shift to these constant names and stop using magic numbers.