### PR TITLE
MTCannon: improve consistency & add EmptyThreadStack test

### DIFF
--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -1193,6 +1193,32 @@ func TestEVM_UnsupportedSyscall(t *testing.T) {
 	}
 }
 
+func TestEVM_EmptyThreadStacks(t *testing.T) {
+	t.Parallel()
+	var tracer *tracing.Hooks
+
+	cases := []struct {
+		name            string
+		activeStackSize int
+		otherStackSize  int
+		traverseRight   bool
+	}{
+		{name: "Empty stacks, traverse right", activeStackSize: 0, otherStackSize: 0, traverseRight: true},
+		{name: "Empty stacks, traverse left", activeStackSize: 0, otherStackSize: 0, traverseRight: false},
+	}
+
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, state, contracts := setup(t, i*123, nil)
+			mttestutil.SetupThreads(int64(i*123), state, c.traverseRight, c.activeStackSize, c.otherStackSize)
+			proofData := emptyThreadedProofGenerator(state)
+
+			errorMessage := "MIPS2: illegal vm state"
+			testutil.AssertEVMReverts(t, state, contracts, tracer, proofData, errorMessage)
+		})
+	}
+}
+
 func TestEVM_NormalTraversalStep_HandleWaitingThread(t *testing.T) {
 	var tracer *tracing.Hooks
 	cases := []struct {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -1198,20 +1198,21 @@ func TestEVM_EmptyThreadStacks(t *testing.T) {
 	var tracer *tracing.Hooks
 
 	cases := []struct {
-		name            string
-		activeStackSize int
-		otherStackSize  int
-		traverseRight   bool
+		name           string
+		otherStackSize int
+		traverseRight  bool
 	}{
-		{name: "Empty stacks, traverse right", activeStackSize: 0, otherStackSize: 0, traverseRight: true},
-		{name: "Empty stacks, traverse left", activeStackSize: 0, otherStackSize: 0, traverseRight: false},
+		{name: "Empty stacks, traverse right", otherStackSize: 0, traverseRight: true},
+		{name: "Empty stacks, traverse left", otherStackSize: 0, traverseRight: false},
 	}
 
 	for i, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, state, contracts := setup(t, i*123, nil)
-			mttestutil.SetupThreads(int64(i*123), state, c.traverseRight, c.activeStackSize, c.otherStackSize)
+			goVm, state, contracts := setup(t, i*123, nil)
+			mttestutil.SetupThreads(int64(i*123), state, c.traverseRight, 0, c.otherStackSize)
 			proofData := emptyThreadedProofGenerator(state)
+
+			require.PanicsWithValue(t, "Active thread stack is empty", func() { _, _ = goVm.Step(false) })
 
 			errorMessage := "MIPS2: illegal vm state"
 			testutil.AssertEVMReverts(t, state, contracts, tracer, proofData, errorMessage)

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -84,19 +84,6 @@ func multiThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, me
 	return proofData
 }
 
-func emptyThreadedProofGenerator(state mipsevm.FPVMState, memoryProofAddresses ...uint32) []byte {
-	proofData := make([]byte, 0)
-	insnProof := state.GetMemory().MerkleProof(0)
-	proofData = append(proofData, insnProof[:]...)
-
-	for _, addr := range memoryProofAddresses {
-		memProof := state.GetMemory().MerkleProof(addr)
-		proofData = append(proofData, memProof[:]...)
-	}
-
-	return proofData
-}
-
 type VersionedVMTestCase struct {
 	Name           string
 	Contracts      *testutil.ContractMetadata

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -121,3 +121,20 @@ func GetMipsVersionTestCases(t require.TestingT) []VersionedVMTestCase {
 		GetMultiThreadedTestCase(t),
 	}
 }
+
+type threadProofTestcase struct {
+	Name  string
+	Proof []byte
+}
+
+func GenerateEmptyThreadProofVariations(t require.TestingT) []threadProofTestcase {
+	defaultThreadProof := multiThreadedProofGenerator(t, multithreaded.CreateEmptyState())
+	zeroBytesThreadProof := make([]byte, multithreaded.THREAD_WITNESS_SIZE)
+	copy(zeroBytesThreadProof[multithreaded.SERIALIZED_THREAD_SIZE:], defaultThreadProof[multithreaded.SERIALIZED_THREAD_SIZE:])
+	nilBytesThreadProof := defaultThreadProof[multithreaded.SERIALIZED_THREAD_SIZE:]
+	return []threadProofTestcase{
+		{Name: "default thread proof", Proof: defaultThreadProof},
+		{Name: "zeroed thread bytes proof", Proof: zeroBytesThreadProof},
+		{Name: "nil thread bytes proof", Proof: nilBytesThreadProof},
+	}
+}

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -84,6 +84,19 @@ func multiThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, me
 	return proofData
 }
 
+func emptyThreadedProofGenerator(state mipsevm.FPVMState, memoryProofAddresses ...uint32) []byte {
+	proofData := make([]byte, 0)
+	insnProof := state.GetMemory().MerkleProof(0)
+	proofData = append(proofData, insnProof[:]...)
+
+	for _, addr := range memoryProofAddresses {
+		memProof := state.GetMemory().MerkleProof(addr)
+		proofData = append(proofData, memProof[:]...)
+	}
+
+	return proofData
+}
+
 type VersionedVMTestCase struct {
 	Name           string
 	Contracts      *testutil.ContractMetadata

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0xaf7416f27db1b393092f51d290a29293184105bc5f0d89cd6048f687cebc7d69"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0xbb203b0d83efddfa0f664dbc63ec55844318b48fe8133758307f64e87c892a47",
-    "sourceCodeHash": "0x16614cc0e6abf7e81e1e5dc2c0773ee7101cb38af40e0907a8800ca7eddd3b5a"
+    "initCodeHash": "0x9ba94a69090a8c89786cdb2a5980deba4b5b16bbf5909f8275e090dbcd65e5c3",
+    "sourceCodeHash": "0x3859b4bf63f485800b0eb6ffb83a79c8d134f7e4cbbe93fbc72cc2ccd4f91b82"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x64ea814bf9769257c91da57928675d3f8462374b0c23bdf860ccfc79f41f7801",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -162,8 +162,9 @@ contract MIPS2 is ISemver {
                 return outputState();
             }
 
-            if (state.leftThreadStack == EMPTY_THREAD_ROOT && state.rightThreadStack == EMPTY_THREAD_ROOT) {
-                revert("MIPS2: illegal vm state");
+            if ((state.leftThreadStack == EMPTY_THREAD_ROOT && !state.traverseRight) ||
+                (state.rightThreadStack == EMPTY_THREAD_ROOT && state.traverseRight)) {
+                revert("MIPS2: active thread stack is empty");
             }
 
             state.step += 1;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -162,8 +162,10 @@ contract MIPS2 is ISemver {
                 return outputState();
             }
 
-            if ((state.leftThreadStack == EMPTY_THREAD_ROOT && !state.traverseRight) ||
-                (state.rightThreadStack == EMPTY_THREAD_ROOT && state.traverseRight)) {
+            if (
+                (state.leftThreadStack == EMPTY_THREAD_ROOT && !state.traverseRight)
+                    || (state.rightThreadStack == EMPTY_THREAD_ROOT && state.traverseRight)
+            ) {
                 revert("MIPS2: active thread stack is empty");
             }
 

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -57,8 +57,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.14
-    string public constant version = "1.0.0-beta.14";
+    /// @custom:semver 1.0.0-beta.15
+    string public constant version = "1.0.0-beta.15";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;


### PR DESCRIPTION
Finish https://github.com/ethereum-optimism/optimism/issues/11977 
@Inphi @mbaxter  Hope it looks good at this time ; ) 

using `<insn-memory-proof>` here for proof data cause I think its the only case matching the thread stack number is both 0 for generating `state-data-data` which `left&right ThreadStack` is both equal `EmptyThreadsRoot`