### PR TITLE
feat(ci): add semgrep to contracts checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.53.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.54.0
   ci_builder_rust_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:latest
@@ -701,6 +701,8 @@ jobs:
       - run:
           name: print forge version
           command: forge --version
+      - run-contracts-check:
+          command: semgrep
       - run-contracts-check:
           command: semver-lock
       - run-contracts-check:

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -193,6 +193,10 @@ validate-spacers-no-build:
 # Checks that spacer variables are correctly inserted.
 validate-spacers: build validate-spacers-no-build
 
+# Runs semgrep on the contracts.
+semgrep:
+  cd ../../ && semgrep scan --config=.semgrep ./packages/contracts-bedrock
+
 # TODO: Also run lint-forge-tests-check but we need to fix the test names first.
 # Runs all checks.
 check:


### PR DESCRIPTION
Adds the semgrep step to contracts-bedrock checks now that semgrep is added to the latest version of ci-builder.

