### PR TITLE
use interface and deployutils for remaining contracts in l2genesis

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -10,14 +10,7 @@ import { Deployer } from "scripts/deploy/Deployer.sol";
 import { Config, OutputMode, OutputModeUtils, Fork, ForkUtils, LATEST_FORK } from "scripts/libraries/Config.sol";
 import { Process } from "scripts/libraries/Process.sol";
 import { SetPreinstalls } from "scripts/SetPreinstalls.s.sol";
-
-// Contracts
-import { SequencerFeeVault } from "src/L2/SequencerFeeVault.sol";
-import { BaseFeeVault } from "src/L2/BaseFeeVault.sol";
-import { L1FeeVault } from "src/L2/L1FeeVault.sol";
-import { OptimismSuperchainERC20Beacon } from "src/L2/OptimismSuperchainERC20Beacon.sol";
-import { OptimismMintableERC721Factory } from "src/universal/OptimismMintableERC721Factory.sol";
-import { GovernanceToken } from "src/governance/GovernanceToken.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
@@ -25,6 +18,12 @@ import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { Types } from "src/libraries/Types.sol";
 
 // Interfaces
+import { ISequencerFeeVault } from "src/L2/interfaces/ISequencerFeeVault.sol";
+import { IBaseFeeVault } from "src/L2/interfaces/IBaseFeeVault.sol";
+import { IL1FeeVault } from "src/L2/interfaces/IL1FeeVault.sol";
+import { IOptimismSuperchainERC20Beacon } from "src/L2/interfaces/IOptimismSuperchainERC20Beacon.sol";
+import { IOptimismMintableERC721Factory } from "src/universal/interfaces/IOptimismMintableERC721Factory.sol";
+import { IGovernanceToken } from "src/governance/interfaces/IGovernanceToken.sol";
 import { IOptimismMintableERC20Factory } from "src/universal/interfaces/IOptimismMintableERC20Factory.sol";
 import { IL2StandardBridge } from "src/L2/interfaces/IL2StandardBridge.sol";
 import { IL2ERC721Bridge } from "src/L2/interfaces/IL2ERC721Bridge.sol";
@@ -338,11 +337,21 @@ contract L2Genesis is Deployer {
 
     /// @notice This predeploy is following the safety invariant #2,
     function setSequencerFeeVault() public {
-        SequencerFeeVault vault = new SequencerFeeVault({
-            _recipient: cfg.sequencerFeeVaultRecipient(),
-            _minWithdrawalAmount: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
-            _withdrawalNetwork: Types.WithdrawalNetwork(cfg.sequencerFeeVaultWithdrawalNetwork())
-        });
+        ISequencerFeeVault vault = ISequencerFeeVault(
+            DeployUtils.create1(
+                "SequencerFeeVault",
+                DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        ISequencerFeeVault.__constructor__,
+                        (
+                            cfg.sequencerFeeVaultRecipient(),
+                            cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
+                            Types.WithdrawalNetwork(cfg.sequencerFeeVaultWithdrawalNetwork())
+                        )
+                    )
+                )
+            )
+        );
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.SEQUENCER_FEE_WALLET);
         console.log("Setting %s implementation at: %s", "SequencerFeeVault", impl);
@@ -366,8 +375,16 @@ contract L2Genesis is Deployer {
 
     /// @notice This predeploy is following the safety invariant #2,
     function setOptimismMintableERC721Factory() public {
-        OptimismMintableERC721Factory factory =
-            new OptimismMintableERC721Factory({ _bridge: Predeploys.L2_ERC721_BRIDGE, _remoteChainId: cfg.l1ChainID() });
+        IOptimismMintableERC721Factory factory = IOptimismMintableERC721Factory(
+            DeployUtils.create1(
+                "OptimismMintableERC721Factory",
+                DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IOptimismMintableERC721Factory.__constructor__, (Predeploys.L2_ERC721_BRIDGE, cfg.l1ChainID())
+                    )
+                )
+            )
+        );
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY);
         console.log("Setting %s implementation at: %s", "OptimismMintableERC721Factory", impl);
@@ -422,11 +439,21 @@ contract L2Genesis is Deployer {
 
     /// @notice This predeploy is following the safety invariant #2.
     function setBaseFeeVault() public {
-        BaseFeeVault vault = new BaseFeeVault({
-            _recipient: cfg.baseFeeVaultRecipient(),
-            _minWithdrawalAmount: cfg.baseFeeVaultMinimumWithdrawalAmount(),
-            _withdrawalNetwork: Types.WithdrawalNetwork(cfg.baseFeeVaultWithdrawalNetwork())
-        });
+        IBaseFeeVault vault = IBaseFeeVault(
+            DeployUtils.create1(
+                "BaseFeeVault",
+                DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IBaseFeeVault.__constructor__,
+                        (
+                            cfg.baseFeeVaultRecipient(),
+                            cfg.baseFeeVaultMinimumWithdrawalAmount(),
+                            Types.WithdrawalNetwork(cfg.baseFeeVaultWithdrawalNetwork())
+                        )
+                    )
+                )
+            )
+        );
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.BASE_FEE_VAULT);
         console.log("Setting %s implementation at: %s", "BaseFeeVault", impl);
@@ -439,11 +466,21 @@ contract L2Genesis is Deployer {
 
     /// @notice This predeploy is following the safety invariant #2.
     function setL1FeeVault() public {
-        L1FeeVault vault = new L1FeeVault({
-            _recipient: cfg.l1FeeVaultRecipient(),
-            _minWithdrawalAmount: cfg.l1FeeVaultMinimumWithdrawalAmount(),
-            _withdrawalNetwork: Types.WithdrawalNetwork(cfg.l1FeeVaultWithdrawalNetwork())
-        });
+        IL1FeeVault vault = IL1FeeVault(
+            DeployUtils.create1(
+                "L1FeeVault",
+                DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IL1FeeVault.__constructor__,
+                        (
+                            cfg.l1FeeVaultRecipient(),
+                            cfg.l1FeeVaultMinimumWithdrawalAmount(),
+                            Types.WithdrawalNetwork(cfg.l1FeeVaultWithdrawalNetwork())
+                        )
+                    )
+                )
+            )
+        );
 
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.L1_FEE_VAULT);
         console.log("Setting %s implementation at: %s", "L1FeeVault", impl);
@@ -461,7 +498,11 @@ contract L2Genesis is Deployer {
             return;
         }
 
-        GovernanceToken token = new GovernanceToken();
+        IGovernanceToken token = IGovernanceToken(
+            DeployUtils.create1(
+                "GovernanceToken", DeployUtils.encodeConstructor(abi.encodeCall(IGovernanceToken.__constructor__, ()))
+            )
+        );
         console.log("Setting %s implementation at: %s", "GovernanceToken", Predeploys.GOVERNANCE_TOKEN);
         vm.etch(Predeploys.GOVERNANCE_TOKEN, address(token).code);
 
@@ -541,7 +582,15 @@ contract L2Genesis is Deployer {
         console.log("Setting %s implementation at: %s", "OptimismSuperchainERC20", superchainERC20Impl);
         vm.etch(superchainERC20Impl, vm.getDeployedCode("OptimismSuperchainERC20.sol:OptimismSuperchainERC20"));
 
-        OptimismSuperchainERC20Beacon beacon = new OptimismSuperchainERC20Beacon(superchainERC20Impl);
+        IOptimismSuperchainERC20Beacon beacon = IOptimismSuperchainERC20Beacon(
+            DeployUtils.create1(
+                "OptimismSuperchainERC20Beacon",
+                DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOptimismSuperchainERC20Beacon.__constructor__, (superchainERC20Impl))
+                )
+            )
+        );
+
         address beaconImpl = Predeploys.predeployToCodeNamespace(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON);
 
         console.log("Setting %s implementation at: %s", "OptimismSuperchainERC20Beacon", beaconImpl);

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -116,8 +116,8 @@
     "sourceCodeHash": "0x5e58b7c867fafa49fe39d68d83875425e9cf94f05f2835bdcdaa08fc8bc6b68e"
   },
   "src/L2/OptimismSuperchainERC20Factory.sol": {
-    "initCodeHash": "0x524bc58927ca60ba2fbc4b036ad00c5055758d5c5b2ebb3d75cb9b996175f2cb",
-    "sourceCodeHash": "0x155a4b22ff8e266560d1fae72e1db7fc164afd84b8a81afb74c69414e0d5438e"
+    "initCodeHash": "0x43ec413140b05bfb83ec453b0d4f82b33a2d560bf8c76405d08de17565b87053",
+    "sourceCodeHash": "0x1e02d78a4e7ee93a07f7af7a78fe1773d0e87711f23a4ccd10a8692b47644a34"
   },
   "src/L2/SequencerFeeVault.sol": {
     "initCodeHash": "0xcaadbf08057b5d47f7704257e9385a29e42a7a08c818646d109c5952d3d35218",

--- a/packages/contracts-bedrock/snapshots/abi/OptimismSuperchainERC20Factory.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismSuperchainERC20Factory.json
@@ -37,7 +37,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "superchainToken",
+        "name": "_superchainToken",
         "type": "address"
       }
     ],
@@ -45,7 +45,7 @@
     "outputs": [
       {
         "internalType": "address",
-        "name": "remoteToken",
+        "name": "remoteToken_",
         "type": "address"
       }
     ],

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Factory.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Factory.sol
@@ -16,7 +16,7 @@ import { CREATE3 } from "@rari-capital/solmate/src/utils/CREATE3.sol";
 contract OptimismSuperchainERC20Factory is IOptimismERC20Factory, ISemver {
     /// @notice Mapping of the deployed OptimismSuperchainERC20 to the remote token address.
     ///         This is used to keep track of the token deployments.
-    mapping(address superchainToken => address remoteToken) public deployments;
+    mapping(address _superchainToken => address remoteToken_) public deployments;
 
     /// @notice Emitted when an OptimismSuperchainERC20 is deployed.
     /// @param superchainToken  Address of the SuperchainERC20 deployment.
@@ -27,8 +27,8 @@ contract OptimismSuperchainERC20Factory is IOptimismERC20Factory, ISemver {
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.2
-    string public constant version = "1.0.0-beta.2";
+    /// @custom:semver 1.0.0-beta.3
+    string public constant version = "1.0.0-beta.3";
 
     /// @notice Deploys a OptimismSuperchainERC20 Beacon Proxy using CREATE3.
     /// @param _remoteToken      Address of the remote token.

--- a/packages/contracts-bedrock/src/L2/interfaces/IBaseFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IBaseFeeVault.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-library Types {
-    enum WithdrawalNetwork {
-        L1,
-        L2
-    }
-}
+import { Types } from "src/libraries/Types.sol";
 
 interface IBaseFeeVault {
     event Withdrawal(uint256 value, address to, address from);

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1FeeVault.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-library Types {
-    enum WithdrawalNetwork {
-        L1,
-        L2
-    }
-}
+import { Types } from "src/libraries/Types.sol";
 
 interface IL1FeeVault {
     event Withdrawal(uint256 value, address to, address from);

--- a/packages/contracts-bedrock/src/L2/interfaces/IOptimismSuperchainERC20Beacon.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IOptimismSuperchainERC20Beacon.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+/// @title IOptimismSuperchainERC20Beacon
+/// @notice Interface for the OptimismSuperchainERC20Beacon contract
+interface IOptimismSuperchainERC20Beacon is IBeacon, ISemver {
+    function version() external view returns (string memory);
+    function implementation() external view override returns (address);
+
+    function __constructor__(address _implementation) external;
+}

--- a/packages/contracts-bedrock/src/L2/interfaces/IOptimismSuperchainERC20Factory.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IOptimismSuperchainERC20Factory.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IOptimismERC20Factory } from "src/L2/interfaces/IOptimismERC20Factory.sol";
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+/// @title IOptimismSuperchainERC20Factory
+/// @notice Interface for the OptimismSuperchainERC20Factory contract
+interface IOptimismSuperchainERC20Factory is IOptimismERC20Factory, ISemver {
+    event OptimismSuperchainERC20Created(
+        address indexed superchainToken, address indexed remoteToken, address deployer
+    );
+
+    function deployments(address superchainToken) external view override returns (address remoteToken);
+    function version() external view override returns (string memory);
+    function deploy(
+        address _remoteToken,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    )
+        external
+        returns (address superchainERC20_);
+
+    function __constructor__() external;
+}

--- a/packages/contracts-bedrock/src/L2/interfaces/IOptimismSuperchainERC20Factory.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IOptimismSuperchainERC20Factory.sol
@@ -11,7 +11,7 @@ interface IOptimismSuperchainERC20Factory is IOptimismERC20Factory, ISemver {
         address indexed superchainToken, address indexed remoteToken, address deployer
     );
 
-    function deployments(address superchainToken) external view override returns (address remoteToken);
+    function deployments(address _superchainToken) external view override returns (address remoteToken_);
     function version() external view override returns (string memory);
     function deploy(
         address _remoteToken,

--- a/packages/contracts-bedrock/src/L2/interfaces/ISequencerFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISequencerFeeVault.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-library Types {
-    enum WithdrawalNetwork {
-        L1,
-        L2
-    }
-}
+import { Types } from "src/libraries/Types.sol";
 
 interface ISequencerFeeVault {
     event Withdrawal(uint256 value, address to, address from);


### PR DESCRIPTION
Use interface and `DeployUtils` for remaining contracts in `L2genesis.s.sol`. This greatly helps improve compilation time.
