### PR TITLE
op-deployer: Fee Recipients and Gas Params added to intent

### DIFF
--- a/op-chain-ops/deployer/init.go
+++ b/op-chain-ops/deployer/init.go
@@ -79,9 +79,11 @@ func Init(cfg InitConfig) error {
 		FundDevAccounts:            true,
 		ContractsRelease:           "op-contracts/v1.6.0",
 		ContractArtifactsURL:       V160ArtifactsURL,
-		BaseFeeVaultRecipient:      common.HexToAddress("0x4200000000000000000000000000000000000019"),
-		L1FeeVaultRecipient:        common.HexToAddress("0x420000000000000000000000000000000000001A"),
-		SequencerFeeVaultRecipient: common.HexToAddress("0x4200000000000000000000000000000000000011"),
+		BaseFeeVaultRecipient:      common.Address{},
+		L1FeeVaultRecipient:        common.Address{},
+		SequencerFeeVaultRecipient: common.Address{},
+		Eip1559Denominator:         50,
+		Eip1559Elasticity:          6,
 	}
 
 	l1ChainIDBig := intent.L1ChainIDBig()

--- a/op-chain-ops/deployer/init.go
+++ b/op-chain-ops/deployer/init.go
@@ -75,15 +75,10 @@ func Init(cfg InitConfig) error {
 	}
 
 	intent := &state.Intent{
-		L1ChainID:                  cfg.L1ChainID,
-		FundDevAccounts:            true,
-		ContractsRelease:           "op-contracts/v1.6.0",
-		ContractArtifactsURL:       V160ArtifactsURL,
-		BaseFeeVaultRecipient:      common.Address{},
-		L1FeeVaultRecipient:        common.Address{},
-		SequencerFeeVaultRecipient: common.Address{},
-		Eip1559Denominator:         50,
-		Eip1559Elasticity:          6,
+		L1ChainID:            cfg.L1ChainID,
+		FundDevAccounts:      true,
+		ContractsRelease:     "op-contracts/v1.6.0",
+		ContractArtifactsURL: V160ArtifactsURL,
 	}
 
 	l1ChainIDBig := intent.L1ChainIDBig()
@@ -110,7 +105,12 @@ func Init(cfg InitConfig) error {
 	for _, l2ChainID := range cfg.L2ChainIDs {
 		l2ChainIDBig := l2ChainID.Big()
 		intent.Chains = append(intent.Chains, &state.ChainIntent{
-			ID: l2ChainID,
+			ID:                         l2ChainID,
+			BaseFeeVaultRecipient:      common.Address{},
+			L1FeeVaultRecipient:        common.Address{},
+			SequencerFeeVaultRecipient: common.Address{},
+			Eip1559Denominator:         50,
+			Eip1559Elasticity:          6,
 			Roles: state.ChainRoles{
 				ProxyAdminOwner:      addrFor(devkeys.L2ProxyAdminOwnerRole.Key(l2ChainIDBig)),
 				SystemConfigOwner:    addrFor(devkeys.SystemConfigOwner.Key(l2ChainIDBig)),

--- a/op-chain-ops/deployer/init.go
+++ b/op-chain-ops/deployer/init.go
@@ -75,10 +75,13 @@ func Init(cfg InitConfig) error {
 	}
 
 	intent := &state.Intent{
-		L1ChainID:            cfg.L1ChainID,
-		FundDevAccounts:      true,
-		ContractsRelease:     "op-contracts/v1.6.0",
-		ContractArtifactsURL: V160ArtifactsURL,
+		L1ChainID:                  cfg.L1ChainID,
+		FundDevAccounts:            true,
+		ContractsRelease:           "op-contracts/v1.6.0",
+		ContractArtifactsURL:       V160ArtifactsURL,
+		BaseFeeVaultRecipient:      common.Address{},
+		L1FeeVaultRecipient:        common.Address{},
+		SequencerFeeVaultRecipient: common.Address{},
 	}
 
 	l1ChainIDBig := intent.L1ChainIDBig()

--- a/op-chain-ops/deployer/init.go
+++ b/op-chain-ops/deployer/init.go
@@ -79,9 +79,9 @@ func Init(cfg InitConfig) error {
 		FundDevAccounts:            true,
 		ContractsRelease:           "op-contracts/v1.6.0",
 		ContractArtifactsURL:       V160ArtifactsURL,
-		BaseFeeVaultRecipient:      common.Address{},
-		L1FeeVaultRecipient:        common.Address{},
-		SequencerFeeVaultRecipient: common.Address{},
+		BaseFeeVaultRecipient:      common.HexToAddress("0x4200000000000000000000000000000000000019"),
+		L1FeeVaultRecipient:        common.HexToAddress("0x420000000000000000000000000000000000001A"),
+		SequencerFeeVaultRecipient: common.HexToAddress("0x4200000000000000000000000000000000000011"),
 	}
 
 	l1ChainIDBig := intent.L1ChainIDBig()

--- a/op-chain-ops/deployer/integration_test/apply_test.go
+++ b/op-chain-ops/deployer/integration_test/apply_test.go
@@ -219,6 +219,9 @@ func makeIntent(
 				},
 			},
 		},
+		BaseFeeVaultRecipient:      addrFor(devkeys.BaseFeeVaultRecipientRole.Key(l1ChainID)),
+		L1FeeVaultRecipient:        addrFor(devkeys.L1FeeVaultRecipientRole.Key(l1ChainID)),
+		SequencerFeeVaultRecipient: addrFor(devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainID)),
 	}
 	st := &state.State{
 		Version: 1,

--- a/op-chain-ops/deployer/state/deploy_config.go
+++ b/op-chain-ops/deployer/state/deploy_config.go
@@ -18,7 +18,7 @@ var (
 	vaultMinWithdrawalAmount = mustHexBigFromHex("0x8ac7230489e80000")
 )
 
-func DefaultDeployConfig(intent *Intent) genesis.DeployConfig {
+func DefaultDeployConfig(chainIntent *ChainIntent) genesis.DeployConfig {
 	return genesis.DeployConfig{
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
@@ -32,9 +32,9 @@ func DefaultDeployConfig(intent *Intent) genesis.DeployConfig {
 				SequencerFeeVaultMinimumWithdrawalAmount: vaultMinWithdrawalAmount,
 				BaseFeeVaultMinimumWithdrawalAmount:      vaultMinWithdrawalAmount,
 				L1FeeVaultMinimumWithdrawalAmount:        vaultMinWithdrawalAmount,
-				BaseFeeVaultRecipient:                    intent.BaseFeeVaultRecipient,
-				L1FeeVaultRecipient:                      intent.L1FeeVaultRecipient,
-				SequencerFeeVaultRecipient:               intent.SequencerFeeVaultRecipient,
+				BaseFeeVaultRecipient:                    chainIntent.BaseFeeVaultRecipient,
+				L1FeeVaultRecipient:                      chainIntent.L1FeeVaultRecipient,
+				SequencerFeeVaultRecipient:               chainIntent.SequencerFeeVaultRecipient,
 			},
 			GovernanceDeployConfig: genesis.GovernanceDeployConfig{
 				EnableGovernance:      true,
@@ -46,9 +46,9 @@ func DefaultDeployConfig(intent *Intent) genesis.DeployConfig {
 				GasPriceOracleBlobBaseFeeScalar: 810949,
 			},
 			EIP1559DeployConfig: genesis.EIP1559DeployConfig{
-				EIP1559Denominator:       intent.Eip1559Denominator,
+				EIP1559Denominator:       chainIntent.Eip1559Denominator,
 				EIP1559DenominatorCanyon: 250,
-				EIP1559Elasticity:        intent.Eip1559Elasticity,
+				EIP1559Elasticity:        chainIntent.Eip1559Elasticity,
 			},
 			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
 				L2GenesisRegolithTimeOffset: u64UtilPtr(0),
@@ -79,7 +79,8 @@ func DefaultDeployConfig(intent *Intent) genesis.DeployConfig {
 }
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
-	cfg := DefaultDeployConfig(intent)
+	firstChainIntent := intent.Chains[0]
+	cfg := DefaultDeployConfig(firstChainIntent)
 
 	var err error
 	if len(intent.GlobalDeployOverrides) > 0 {

--- a/op-chain-ops/deployer/state/deploy_config.go
+++ b/op-chain-ops/deployer/state/deploy_config.go
@@ -18,7 +18,7 @@ var (
 	vaultMinWithdrawalAmount = mustHexBigFromHex("0x8ac7230489e80000")
 )
 
-func DefaultDeployConfig() genesis.DeployConfig {
+func DefaultDeployConfig(intent *Intent) genesis.DeployConfig {
 	return genesis.DeployConfig{
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
@@ -32,6 +32,9 @@ func DefaultDeployConfig() genesis.DeployConfig {
 				SequencerFeeVaultMinimumWithdrawalAmount: vaultMinWithdrawalAmount,
 				BaseFeeVaultMinimumWithdrawalAmount:      vaultMinWithdrawalAmount,
 				L1FeeVaultMinimumWithdrawalAmount:        vaultMinWithdrawalAmount,
+				BaseFeeVaultRecipient:                    intent.BaseFeeVaultRecipient,
+				L1FeeVaultRecipient:                      intent.L1FeeVaultRecipient,
+				SequencerFeeVaultRecipient:               intent.SequencerFeeVaultRecipient,
 			},
 			GovernanceDeployConfig: genesis.GovernanceDeployConfig{
 				EnableGovernance:      true,
@@ -43,9 +46,9 @@ func DefaultDeployConfig() genesis.DeployConfig {
 				GasPriceOracleBlobBaseFeeScalar: 810949,
 			},
 			EIP1559DeployConfig: genesis.EIP1559DeployConfig{
-				EIP1559Denominator:       50,
+				EIP1559Denominator:       intent.Eip1559Denominator,
 				EIP1559DenominatorCanyon: 250,
-				EIP1559Elasticity:        6,
+				EIP1559Elasticity:        intent.Eip1559Elasticity,
 			},
 			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
 				L2GenesisRegolithTimeOffset: u64UtilPtr(0),
@@ -76,7 +79,7 @@ func DefaultDeployConfig() genesis.DeployConfig {
 }
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
-	cfg := DefaultDeployConfig()
+	cfg := DefaultDeployConfig(intent)
 
 	var err error
 	if len(intent.GlobalDeployOverrides) > 0 {

--- a/op-chain-ops/deployer/state/intent.go
+++ b/op-chain-ops/deployer/state/intent.go
@@ -26,16 +26,6 @@ type Intent struct {
 	Chains []*ChainIntent `json:"chains" toml:"chains"`
 
 	GlobalDeployOverrides map[string]any `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
-
-	BaseFeeVaultRecipient common.Address `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
-
-	L1FeeVaultRecipient common.Address `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
-
-	SequencerFeeVaultRecipient common.Address `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
-
-	Eip1559Denominator uint64 `json:"eip1559Denominator" toml:"eip1559Denominator"`
-
-	Eip1559Elasticity uint64 `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
 }
 
 func (c *Intent) L1ChainIDBig() *big.Int {
@@ -106,6 +96,16 @@ type SuperchainRoles struct {
 
 type ChainIntent struct {
 	ID common.Hash `json:"id" toml:"id"`
+
+	BaseFeeVaultRecipient common.Address `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
+
+	L1FeeVaultRecipient common.Address `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
+
+	SequencerFeeVaultRecipient common.Address `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
+
+	Eip1559Denominator uint64 `json:"eip1559Denominator" toml:"eip1559Denominator"`
+
+	Eip1559Elasticity uint64 `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
 
 	Roles ChainRoles `json:"roles" toml:"roles"`
 

--- a/op-chain-ops/deployer/state/intent.go
+++ b/op-chain-ops/deployer/state/intent.go
@@ -26,6 +26,12 @@ type Intent struct {
 	Chains []*ChainIntent `json:"chains" toml:"chains"`
 
 	GlobalDeployOverrides map[string]any `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
+
+	BaseFeeVaultRecipient common.Address `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
+
+	L1FeeVaultRecipient common.Address `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
+
+	SequencerFeeVaultRecipient common.Address `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
 }
 
 func (c *Intent) L1ChainIDBig() *big.Int {

--- a/op-chain-ops/deployer/state/intent.go
+++ b/op-chain-ops/deployer/state/intent.go
@@ -32,6 +32,10 @@ type Intent struct {
 	L1FeeVaultRecipient common.Address `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
 
 	SequencerFeeVaultRecipient common.Address `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
+
+	Eip1559Denominator uint64 `json:"eip1559Denominator" toml:"eip1559Denominator"`
+
+	Eip1559Elasticity uint64 `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
 }
 
 func (c *Intent) L1ChainIDBig() *big.Int {


### PR DESCRIPTION
Issue originating from: https://github.com/ethereum-optimism/platforms-team/issues/284 

### Fee Recipients

The existing integration test: `op-chain-ops/deployer/integration_test/apply_test.go` applies a pipeline of tasks for op-deployer. As we know, the last task in the pipeline after performing an `apply` is `generate-l2-genesis` (see [here](https://github.com/ethereum-optimism/optimism/blob/develop/op-chain-ops/deployer/apply.go#L172)).

In this PR, I'm adding configurable fee recipient addresses to the intent file. These addresses will be injected as immutables into three predeploy contracts:

- BaseFeeVault
- L1FeeVault
- SequencerFeeVault

In the `apply_test.go` integration test, I'm verifying that these addresses exist in the runtime bytecode of the three contracts mentioned above. This existence check is a best effort check to ensure that the immutables were injected correctly into the contracts. 

### Gas Params 
Params defined in this PR have been taken from [here](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/deploy-config/mainnet.json#L39-L40).