### PR TITLE
batcher refactor: flatten out go routines

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -226,11 +226,9 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	defer cancel()
 	go func() {
 		<-wrapped.Done()
-		l.Log.Warn("calling cancelKillCtx")
 		cancelKill()
 	}()
 
-	l.Log.Warn("calling cancelShutdownCtx")
 	l.cancelShutdownCtx()
 	l.wg.Wait()
 	l.cancelKillCtx()

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -111,7 +111,7 @@ type BatchSubmitter struct {
 	running bool
 
 	txpoolMutex       sync.Mutex // guards txpoolState and txpoolBlockedBlob
-	txpoolState       int
+	txpoolState       TxPoolState
 	txpoolBlockedBlob bool
 
 	// lastStoredBlock is the last block loaded into `state`. If it is empty it should be set to the l2 safe head.
@@ -393,6 +393,8 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 // Submitted batch, but it is not valid
 // Missed L2 block somehow.
 
+type TxPoolState int
+
 const (
 	// Txpool states.  Possible state transitions:
 	//   TxpoolGood -> TxpoolBlocked:
@@ -402,33 +404,34 @@ const (
 	//     send a cancellation transaction.
 	//   TxpoolCancelPending -> TxpoolGood:
 	//     happens once the cancel transaction completes, whether successfully or in error.
-	TxpoolGood int = iota
+	TxpoolGood TxPoolState = iota
 	TxpoolBlocked
 	TxpoolCancelPending
 )
 
+// setTxPoolState locks the mutex, sets the parameters to the supplied ones, and release the mutex.
+func (l *BatchSubmitter) setTxPoolState(txPoolState TxPoolState, txPoolBlockedBlob bool) {
+	l.txpoolMutex.Lock()
+	l.txpoolState = txPoolState
+	l.txpoolBlockedBlob = txPoolBlockedBlob
+	l.txpoolMutex.Unlock()
+}
+
 // receiptsLoop handles transaction receipts from the DA layer
 func (l *BatchSubmitter) receiptsLoop(ctx context.Context, receiptsCh chan txmgr.TxReceipt[txRef]) {
 	defer l.wg.Done()
-	l.txpoolMutex.Lock()
-	l.txpoolState = TxpoolGood
-	l.txpoolMutex.Unlock()
-
 	for {
 		select {
 		case r := <-receiptsCh:
-			l.txpoolMutex.Lock()
 			if errors.Is(r.Err, txpool.ErrAlreadyReserved) && l.txpoolState == TxpoolGood {
-				l.txpoolState = TxpoolBlocked
-				l.txpoolBlockedBlob = r.ID.isBlob
+				l.setTxPoolState(TxpoolBlocked, r.ID.isBlob)
 				l.Log.Info("incompatible tx in txpool", "is_blob", r.ID.isBlob)
 			} else if r.ID.isCancel && l.txpoolState == TxpoolCancelPending {
 				// Set state to TxpoolGood even if the cancellation transaction ended in error
 				// since the stuck transaction could have cleared while we were waiting.
-				l.txpoolState = TxpoolGood
+				l.setTxPoolState(TxpoolGood, l.txpoolBlockedBlob)
 				l.Log.Info("txpool may no longer be blocked", "err", r.Err)
 			}
-			l.txpoolMutex.Unlock()
 			l.Log.Info("Handling receipt", "id", r.ID)
 			l.handleReceipt(r)
 		case <-ctx.Done():

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -425,7 +425,7 @@ func (l *BatchSubmitter) receiptsLoop(ctx context.Context, receiptsCh chan txmgr
 		case r := <-receiptsCh:
 			if errors.Is(r.Err, txpool.ErrAlreadyReserved) && l.txpoolState == TxpoolGood {
 				l.setTxPoolState(TxpoolBlocked, r.ID.isBlob)
-				l.Log.Info("incompatible tx in txpool", "is_blob", r.ID.isBlob)
+				l.Log.Warn("incompatible tx in txpool", "id", r.ID, "is_blob", r.ID.isBlob)
 			} else if r.ID.isCancel && l.txpoolState == TxpoolCancelPending {
 				// Set state to TxpoolGood even if the cancellation transaction ended in error
 				// since the stuck transaction could have cleared while we were waiting.

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -161,7 +161,7 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 	}
 
 	receiptsCh := make(chan txmgr.TxReceipt[txRef])
-
+	l.wg.Add(2)
 	go l.receiptsLoop(receiptsCh)
 	go l.mainLoop(receiptsCh)
 
@@ -407,7 +407,6 @@ const (
 )
 
 func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef]) {
-	l.wg.Add(1)
 	defer l.wg.Done()
 	l.txpoolMutex.Lock()
 	l.txpoolState = TxpoolGood
@@ -438,7 +437,6 @@ func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef]) {
 }
 
 func (l *BatchSubmitter) mainLoop(receiptsCh chan txmgr.TxReceipt[txRef]) {
-	l.wg.Add(1)
 	defer l.wg.Done()
 
 	queue := txmgr.NewQueue[txRef](l.killCtx, l.Txmgr, l.Config.MaxPendingTransactions)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -520,6 +520,7 @@ func (l *BatchSubmitter) mainLoop(ctx context.Context, receiptsCh chan txmgr.TxR
 // continuously, we ensure the engine currently in use is always going to be reset to the proper throttling settings
 // even in the event of sequencer failover.
 func (l *BatchSubmitter) throttlingLoop(ctx context.Context) {
+	defer l.wg.Done()
 	l.Log.Info("Starting DA throttling loop")
 	ticker := time.NewTicker(l.Config.ThrottleInterval)
 	defer ticker.Stop()

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -409,6 +409,7 @@ const (
 	TxpoolCancelPending
 )
 
+// receiptsLoop handles transaction receipts from the DA layer
 func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef], done chan struct{}) {
 	defer l.wg.Done()
 	l.txpoolMutex.Lock()
@@ -439,6 +440,12 @@ func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef], do
 	}
 }
 
+// mainLoop periodically:
+// -  polls the sequencer,
+// -  prunes the channel manager state (i.e. safe blocks)
+// -  loads unsafe blocks from the sequencer
+// -  drives the creation of channels and frames
+// -  sends transactions to the DA layer
 func (l *BatchSubmitter) mainLoop(receiptsCh chan txmgr.TxReceipt[txRef], receiptsLoopDone chan struct{}) {
 	defer l.wg.Done()
 	defer close(receiptsLoopDone)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -162,8 +162,9 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	receiptsCh := make(chan txmgr.TxReceipt[txRef])
 	l.wg.Add(2)
-	go l.receiptsLoop(receiptsCh)
-	go l.mainLoop(receiptsCh)
+	receiptsLoopDone := make(chan struct{})
+	go l.receiptsLoop(receiptsCh, receiptsLoopDone) // receives from receiptsCh
+	go l.mainLoop(receiptsCh, receiptsLoopDone)     // sends on receiptsCh, responsible for closing goroutine above
 
 	l.Log.Info("Batch Submitter started")
 	return nil
@@ -225,9 +226,11 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	defer cancel()
 	go func() {
 		<-wrapped.Done()
+		l.Log.Warn("calling cancelKillCtx")
 		cancelKill()
 	}()
 
+	l.Log.Warn("calling cancelShutdownCtx")
 	l.cancelShutdownCtx()
 	l.wg.Wait()
 	l.cancelKillCtx()
@@ -406,7 +409,7 @@ const (
 	TxpoolCancelPending
 )
 
-func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef]) {
+func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef], done chan struct{}) {
 	defer l.wg.Done()
 	l.txpoolMutex.Lock()
 	l.txpoolState = TxpoolGood
@@ -429,15 +432,16 @@ func (l *BatchSubmitter) receiptsLoop(receiptsCh chan txmgr.TxReceipt[txRef]) {
 			l.txpoolMutex.Unlock()
 			l.Log.Info("Handling receipt", "id", r.ID)
 			l.handleReceipt(r)
-		case <-l.shutdownCtx.Done():
+		case <-done:
 			l.Log.Info("Receipt processing loop done")
 			return
 		}
 	}
 }
 
-func (l *BatchSubmitter) mainLoop(receiptsCh chan txmgr.TxReceipt[txRef]) {
+func (l *BatchSubmitter) mainLoop(receiptsCh chan txmgr.TxReceipt[txRef], receiptsLoopDone chan struct{}) {
 	defer l.wg.Done()
+	defer close(receiptsLoopDone)
 
 	queue := txmgr.NewQueue[txRef](l.killCtx, l.Txmgr, l.Config.MaxPendingTransactions)
 	daGroup := &errgroup.Group{}

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -50,7 +50,7 @@ When an L2 unsafe reorg is detected, the batch submitter will reset its state, a
 When a Tx fails, an asynchronous receipts handler is triggered. The channel from whence the Tx's frames came has its `frameCursor` rewound, so that all the frames can be resubmitted in order.
 
 ### Channel Times Out
-When at Tx is confirmed, an asynchronous receipts handler is triggered. We only update the batcher's state if the channel timed out on chain. In that case, the `blockCursor` is rewound to the first block added to that channel, and the channel queue is cleared out. This allows the batcher to start fresh building a new channel starting from the same block -- it does not need to refetch blocks from the sequencer.
+When a Tx is confirmed, an asynchronous receipts handler is triggered. We only update the batcher's state if the channel timed out on chain. In that case, the `blockCursor` is rewound to the first block added to that channel, and the channel queue is cleared out. This allows the batcher to start fresh building a new channel starting from the same block -- it does not need to refetch blocks from the sequencer.
 
 ## Design Principles and Optimization Targets
 At the current time, the batcher should be optimized for correctness, simplicity and robustness. It is considered preferable to prioritize these properties, even at the expense of other potentially desirable properties such as frugality. For example, it is preferable to have the batcher resubmit some data from time to time ("wasting" money on data availability costs) instead of avoiding that by e.g. adding some persistent state to the batcher.


### PR DESCRIPTION
This is a refactor to try and make the ~two~ three goroutines spawned by the driver equally clear.

* ~Names the previously anonymous receiptsLoop~ This got done already while this PR was open.
* Adds some godoc comments about what each loop does
* Tries to be a little more idiomatic about passing contexts in to functions