### PR TITLE
cannon: Fix 64-bit test compilation

### DIFF
--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -647,11 +647,11 @@ func TestEVMFault(t *testing.T) {
 		nextPC               arch.Word
 		insn                 uint32
 		errMsg               string
-		memoryProofAddresses []uint32
+		memoryProofAddresses []Word
 	}{
-		{"illegal instruction", 0, 0xFF_FF_FF_FF, "invalid instruction", []uint32{0xa7ef00cc}},
-		{"branch in delay-slot", 8, 0x11_02_00_03, "branch in delay slot", []uint32{0}},
-		{"jump in delay-slot", 8, 0x0c_00_00_0c, "jump in delay slot", []uint32{0}},
+		{"illegal instruction", 0, 0xFF_FF_FF_FF, "invalid instruction", []Word{0xa7ef00cc}},
+		{"branch in delay-slot", 8, 0x11_02_00_03, "branch in delay slot", []Word{}},
+		{"jump in delay-slot", 8, 0x0c_00_00_0c, "jump in delay slot", []Word{}},
 	}
 
 	for _, v := range versions {
@@ -665,7 +665,7 @@ func TestEVMFault(t *testing.T) {
 				state.GetRegistersRef()[31] = testutil.EndAddr
 
 				proofData := v.ProofGenerator(t, goVm.GetState(), tt.memoryProofAddresses...)
-				require.Panics(t, func() { _, _ = goVm.Step(true) })
+				require.Panics(t, func() { _, _ = goVm.Step(false) })
 				testutil.AssertEVMReverts(t, state, v.Contracts, tracer, proofData, tt.errMsg)
 			})
 		}

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
@@ -50,9 +51,9 @@ func multiThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.Prei
 	return fpvm
 }
 
-type ProofGenerator func(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...uint32) []byte
+type ProofGenerator func(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...arch.Word) []byte
 
-func singalThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...uint32) []byte {
+func singalThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...arch.Word) []byte {
 	var proofData []byte
 
 	insnProof := state.GetMemory().MerkleProof(state.GetPC())
@@ -66,7 +67,7 @@ func singalThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, m
 	return proofData
 }
 
-func multiThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...uint32) []byte {
+func multiThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...arch.Word) []byte {
 	mtState, ok := state.(*multithreaded.State)
 	if !ok {
 		require.Fail(t, "Failed to cast FPVMState to multithreaded State type")
@@ -116,8 +117,15 @@ func GetMultiThreadedTestCase(t require.TestingT) VersionedVMTestCase {
 }
 
 func GetMipsVersionTestCases(t require.TestingT) []VersionedVMTestCase {
-	return []VersionedVMTestCase{
-		GetSingleThreadedTestCase(t),
-		GetMultiThreadedTestCase(t),
+	if arch.IsMips32 {
+		return []VersionedVMTestCase{
+			GetSingleThreadedTestCase(t),
+			GetMultiThreadedTestCase(t),
+		}
+	} else {
+		// 64-bit only supports MTCannon
+		return []VersionedVMTestCase{
+			GetMultiThreadedTestCase(t),
+		}
 	}
 }

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -53,7 +53,7 @@ func multiThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.Prei
 
 type ProofGenerator func(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...arch.Word) []byte
 
-func singalThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...arch.Word) []byte {
+func singleThreadedProofGenerator(t require.TestingT, state mipsevm.FPVMState, memoryProofAddresses ...arch.Word) []byte {
 	var proofData []byte
 
 	insnProof := state.GetMemory().MerkleProof(state.GetPC())
@@ -101,7 +101,7 @@ func GetSingleThreadedTestCase(t require.TestingT) VersionedVMTestCase {
 		StateHashFn:    singlethreaded.GetStateHashFn(),
 		VMFactory:      singleThreadedVmFactory,
 		ElfVMFactory:   singleThreadElfVmFactory,
-		ProofGenerator: singalThreadedProofGenerator,
+		ProofGenerator: singleThreadedProofGenerator,
 	}
 }
 

--- a/cannon/mipsevm/testutil/mips.go
+++ b/cannon/mipsevm/testutil/mips.go
@@ -196,13 +196,11 @@ func AssertEVMReverts(t *testing.T, state mipsevm.FPVMState, contracts *Contract
 	env.Config.Tracer = tracer
 	sender := common.Address{0x13, 0x37}
 	ret, _, err := env.Call(vm.AccountRef(sender), contracts.Addresses.MIPS, input, startingGas, common.U2560)
+
 	require.EqualValues(t, err, vm.ErrExecutionReverted)
-
 	require.Greater(t, len(ret), 4, "Return data length should be greater than 4 bytes")
-
 	unpacked, decodeErr := abi.UnpackRevert(ret)
 	require.NoError(t, decodeErr, "Failed to unpack revert reason")
-
 	require.Equal(t, expectedReason, unpacked, "Revert reason mismatch")
 
 	logs := evmState.Logs()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Follow-up to https://github.com/ethereum-optimism/optimism/pull/12200 - fix 64-bit test compilation by switching types from `uint32` to `Word`.  

Also:
- Update testutil to generate test cases based on architecture.
- Cleanup white space
- Make small tweaks to `TestEVMFault`

**Metadata**
Follow-up to https://github.com/ethereum-optimism/optimism/issues/12198
