### PR TITLE
cannon: Rework RMW ops for 64-bit compatibility

### DIFF
--- a/cannon/mipsevm/exec/mips_instructions32_test.go
+++ b/cannon/mipsevm/exec/mips_instructions32_test.go
@@ -1,0 +1,108 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
+)
+
+// TestLoadSubWord_32bits validates LoadSubWord with 32-bit offsets (up to 3 bytes)
+func TestLoadSubWord_32bits(t *testing.T) {
+	cases := []struct {
+		name          string
+		byteLength    Word
+		addr          uint32
+		memVal        uint32
+		signExtend    bool
+		expectedValue uint32
+	}{
+		{name: "32-bit", byteLength: 4, addr: 0xFF00_0000, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
+		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0001, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
+		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0002, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
+		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0003, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
+		{name: "16-bit, offset=0", byteLength: 2, addr: 0x00, memVal: 0x1234_5678, expectedValue: 0x1234},
+		{name: "16-bit, offset=0, extra bit set", byteLength: 2, addr: 0x01, memVal: 0x1234_5678, expectedValue: 0x1234},
+		{name: "16-bit, offset=2", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678},
+		{name: "16-bit, offset=2, extra bit set", byteLength: 2, addr: 0x03, memVal: 0x1234_5678, expectedValue: 0x5678},
+		{name: "16-bit, sign extend positive val", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678, signExtend: true},
+		{name: "16-bit, sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xFFFF_F678, signExtend: true},
+		{name: "16-bit, do not sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xF678, signExtend: false},
+		{name: "8-bit, offset=0", byteLength: 1, addr: 0x1230, memVal: 0x1234_5678, expectedValue: 0x12},
+		{name: "8-bit, offset=1", byteLength: 1, addr: 0x1231, memVal: 0x1234_5678, expectedValue: 0x34},
+		{name: "8-bit, offset=2", byteLength: 1, addr: 0x1232, memVal: 0x1234_5678, expectedValue: 0x56},
+		{name: "8-bit, offset=3", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78},
+		{name: "8-bit, sign extend positive", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78, signExtend: true},
+		{name: "8-bit, sign extend negative", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0xFFFF_FF88, signExtend: true},
+		{name: "8-bit, do not sign extend neg value", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0x88, signExtend: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mem := memory.NewMemory()
+			memTracker := NewMemoryTracker(mem)
+
+			effAddr := Word(c.addr) & arch.AddressMask
+			// Shift memval for consistency across architectures
+			memVal := Word(c.memVal) << (arch.WordSize - 32)
+			mem.SetWord(effAddr, memVal)
+
+			retVal := LoadSubWord(mem, Word(c.addr), c.byteLength, c.signExtend, memTracker)
+
+			// If sign extending, make sure retVal is consistent across architectures
+			expected := Word(c.expectedValue)
+			if c.signExtend {
+				expected = testutil.SignExtend(expected, 32)
+			}
+			require.Equal(t, expected, retVal)
+		})
+	}
+}
+
+// TestStoreSubWord_32bits validates LoadSubWord with 32-bit offsets (up to 3 bytes)
+func TestStoreSubWord_32bits(t *testing.T) {
+	memVal := 0xFFFF_FFFF
+	value := 0x1234_5678
+
+	cases := []struct {
+		name          string
+		byteLength    Word
+		addr          uint32
+		expectedValue uint32
+	}{
+		{name: "32-bit", byteLength: 4, addr: 0xFF00_0000, expectedValue: 0x1234_5678},
+		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0001, expectedValue: 0x1234_5678},
+		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0002, expectedValue: 0x1234_5678},
+		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0003, expectedValue: 0x1234_5678},
+		{name: "16-bit, subword offset=0", byteLength: 2, addr: 0x00, expectedValue: 0x5678_FFFF},
+		{name: "16-bit, subword offset=0, extra bit set", byteLength: 2, addr: 0x01, expectedValue: 0x5678_FFFF},
+		{name: "16-bit, subword offset=2", byteLength: 2, addr: 0x02, expectedValue: 0xFFFF_5678},
+		{name: "16-bit, subword offset=2, extra bit set", byteLength: 2, addr: 0x03, expectedValue: 0xFFFF_5678},
+		{name: "8-bit, offset=0", byteLength: 1, addr: 0x1230, expectedValue: 0x78FF_FFFF},
+		{name: "8-bit, offset=1", byteLength: 1, addr: 0x1231, expectedValue: 0xFF78_FFFF},
+		{name: "8-bit, offset=2", byteLength: 1, addr: 0x1232, expectedValue: 0xFFFF_78FF},
+		{name: "8-bit, offset=3", byteLength: 1, addr: 0x1233, expectedValue: 0xFFFF_FF78},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mem := memory.NewMemory()
+			memTracker := NewMemoryTracker(mem)
+
+			effAddr := Word(c.addr) & arch.AddressMask
+			// Shift memval for consistency across architectures
+			memVal := Word(memVal) << (arch.WordSize - 32)
+			mem.SetWord(effAddr, memVal)
+
+			StoreSubWord(mem, Word(c.addr), c.byteLength, Word(value), memTracker)
+			newMemVal := mem.GetWord(effAddr)
+
+			// Make sure expectation is consistent across architectures
+			expected := Word(c.expectedValue) << (arch.WordSize - 32)
+			require.Equal(t, expected, newMemVal)
+		})
+	}
+}

--- a/cannon/mipsevm/exec/mips_instructions32_test.go
+++ b/cannon/mipsevm/exec/mips_instructions32_test.go
@@ -8,18 +8,18 @@ import (
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
 // TestLoadSubWord_32bits validates LoadSubWord with 32-bit offsets (up to 3 bytes)
 func TestLoadSubWord_32bits(t *testing.T) {
 	cases := []struct {
-		name          string
-		byteLength    Word
-		addr          uint32
-		memVal        uint32
-		signExtend    bool
-		expectedValue uint32
+		name             string
+		byteLength       Word
+		addr             uint32
+		memVal           uint32
+		signExtend       bool
+		shouldSignExtend bool
+		expectedValue    uint32
 	}{
 		{name: "32-bit", byteLength: 4, addr: 0xFF00_0000, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
 		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0001, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
@@ -29,15 +29,15 @@ func TestLoadSubWord_32bits(t *testing.T) {
 		{name: "16-bit, offset=0, extra bit set", byteLength: 2, addr: 0x01, memVal: 0x1234_5678, expectedValue: 0x1234},
 		{name: "16-bit, offset=2", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678},
 		{name: "16-bit, offset=2, extra bit set", byteLength: 2, addr: 0x03, memVal: 0x1234_5678, expectedValue: 0x5678},
-		{name: "16-bit, sign extend positive val", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678, signExtend: true},
-		{name: "16-bit, sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xFFFF_F678, signExtend: true},
+		{name: "16-bit, sign extend positive val", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678, signExtend: true, shouldSignExtend: false},
+		{name: "16-bit, sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xFFFF_F678, signExtend: true, shouldSignExtend: true},
 		{name: "16-bit, do not sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xF678, signExtend: false},
 		{name: "8-bit, offset=0", byteLength: 1, addr: 0x1230, memVal: 0x1234_5678, expectedValue: 0x12},
 		{name: "8-bit, offset=1", byteLength: 1, addr: 0x1231, memVal: 0x1234_5678, expectedValue: 0x34},
 		{name: "8-bit, offset=2", byteLength: 1, addr: 0x1232, memVal: 0x1234_5678, expectedValue: 0x56},
 		{name: "8-bit, offset=3", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78},
-		{name: "8-bit, sign extend positive", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78, signExtend: true},
-		{name: "8-bit, sign extend negative", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0xFFFF_FF88, signExtend: true},
+		{name: "8-bit, sign extend positive", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78, signExtend: true, shouldSignExtend: false},
+		{name: "8-bit, sign extend negative", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0xFFFF_FF88, signExtend: true, shouldSignExtend: true},
 		{name: "8-bit, do not sign extend neg value", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0x88, signExtend: false},
 	}
 
@@ -55,8 +55,9 @@ func TestLoadSubWord_32bits(t *testing.T) {
 
 			// If sign extending, make sure retVal is consistent across architectures
 			expected := Word(c.expectedValue)
-			if c.signExtend {
-				expected = testutil.SignExtend(expected, 32)
+			if c.shouldSignExtend {
+				signedBits := ^Word(0xFFFF_FFFF)
+				expected = expected | signedBits
 			}
 			require.Equal(t, expected, retVal)
 		})

--- a/cannon/mipsevm/exec/mips_instructions32_test.go
+++ b/cannon/mipsevm/exec/mips_instructions32_test.go
@@ -1,3 +1,4 @@
+// These tests target architectures that are 32-bit or larger
 package exec
 
 import (

--- a/cannon/mipsevm/exec/mips_instructions64_test.go
+++ b/cannon/mipsevm/exec/mips_instructions64_test.go
@@ -1,0 +1,110 @@
+//go:build cannon64
+// +build cannon64
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+)
+
+// TestLoadSubWord_64bits extends TestLoadSubWord_32bits by testing up to 64-bits (7 byte) offsets
+func TestLoadSubWord_64bits(t *testing.T) {
+	memVal := uint64(0x1234_5678_9876_5432)
+	cases := []struct {
+		name          string
+		byteLength    Word
+		addr          uint64
+		memVal        uint64
+		signExtend    bool
+		expectedValue uint64
+	}{
+		{name: "64-bit", byteLength: 8, addr: 0xFF00_0000, memVal: 0x8234_5678_9876_5432, expectedValue: 0x8234_5678_9876_5432},
+		{name: "64-bit w sign extension", byteLength: 8, addr: 0xFF00_0000, memVal: 0x8234_5678_9876_5432, expectedValue: 0x8234_5678_9876_5432, signExtend: true},
+		{name: "32-bit, offset=0", byteLength: 4, addr: 0xFF00_0000, memVal: memVal, expectedValue: 0x1234_5678},
+		{name: "32-bit, offset=0, extra bits", byteLength: 4, addr: 0xFF00_0001, memVal: memVal, expectedValue: 0x1234_5678},
+		{name: "32-bit, offset=0, extra bits", byteLength: 4, addr: 0xFF00_0002, memVal: memVal, expectedValue: 0x1234_5678},
+		{name: "32-bit, offset=0, extra bits", byteLength: 4, addr: 0xFF00_0003, memVal: memVal, expectedValue: 0x1234_5678},
+		{name: "32-bit, offset=4", byteLength: 4, addr: 0xFF00_0004, memVal: memVal, expectedValue: 0x9876_5432},
+		{name: "32-bit, offset=4, extra bits", byteLength: 4, addr: 0xFF00_0005, memVal: memVal, expectedValue: 0x9876_5432},
+		{name: "32-bit, offset=4, extra bits", byteLength: 4, addr: 0xFF00_0006, memVal: memVal, expectedValue: 0x9876_5432},
+		{name: "32-bit, offset=4, extra bits", byteLength: 4, addr: 0xFF00_0007, memVal: memVal, expectedValue: 0x9876_5432},
+		{name: "32-bit, sign extend negative", byteLength: 4, addr: 0xFF00_0006, memVal: 0x1234_5678_F1E2_A1B1, expectedValue: 0xFFFF_FFFF_F1E2_A1B1, signExtend: true},
+		{name: "32-bit, sign extend positive", byteLength: 4, addr: 0xFF00_0007, memVal: 0x1234_5678_7876_5432, expectedValue: 0x7876_5432, signExtend: true},
+		{name: "16-bit, subword offset=4", byteLength: 2, addr: 0x04, memVal: memVal, expectedValue: 0x9876},
+		{name: "16-bit, subword offset=4, extra bit set", byteLength: 2, addr: 0x05, memVal: memVal, expectedValue: 0x9876},
+		{name: "16-bit, subword offset=6", byteLength: 2, addr: 0x06, memVal: memVal, expectedValue: 0x5432},
+		{name: "16-bit, subword offset=6, extra bit set", byteLength: 2, addr: 0x07, memVal: memVal, expectedValue: 0x5432},
+		{name: "16-bit, sign extend negative val", byteLength: 2, addr: 0x04, memVal: 0x1234_5678_8BEE_CCDD, expectedValue: 0xFFFF_FFFF_FFFF_8BEE, signExtend: true},
+		{name: "16-bit, sign extend positive val", byteLength: 2, addr: 0x04, memVal: 0x1234_5678_7876_5432, expectedValue: 0x7876, signExtend: true},
+		{name: "8-bit, offset=4", byteLength: 1, addr: 0x1234, memVal: memVal, expectedValue: 0x98},
+		{name: "8-bit, offset=5", byteLength: 1, addr: 0x1235, memVal: memVal, expectedValue: 0x76},
+		{name: "8-bit, offset=6", byteLength: 1, addr: 0x1236, memVal: memVal, expectedValue: 0x54},
+		{name: "8-bit, offset=7", byteLength: 1, addr: 0x1237, memVal: memVal, expectedValue: 0x32},
+		{name: "8-bit, sign extend positive", byteLength: 1, addr: 0x1237, memVal: memVal, expectedValue: 0x32, signExtend: true},
+		{name: "8-bit, sign extend negative", byteLength: 1, addr: 0x1237, memVal: 0x1234_5678_8764_4381, expectedValue: 0xFFFF_FFFF_FFFF_FF81, signExtend: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mem := memory.NewMemory()
+			memTracker := NewMemoryTracker(mem)
+
+			effAddr := Word(c.addr) & arch.AddressMask
+			mem.SetWord(effAddr, c.memVal)
+
+			retVal := LoadSubWord(mem, Word(c.addr), c.byteLength, c.signExtend, memTracker)
+			require.Equal(t, c.expectedValue, retVal)
+		})
+	}
+}
+
+// TestStoreSubWord_64bits extends TestStoreSubWord_32bits by testing up to 64-bits (7 byte) offsets
+func TestStoreSubWord_64bits(t *testing.T) {
+	memVal := uint64(0xFFFF_FFFF_FFFF_FFFF)
+	value := uint64(0x1234_5678_9876_5432)
+
+	cases := []struct {
+		name          string
+		byteLength    Word
+		addr          uint64
+		expectedValue uint64
+	}{
+		{name: "64-bit", byteLength: 8, addr: 0xFF00_0000, expectedValue: value},
+		{name: "32-bit, offset 0", byteLength: 4, addr: 0xFF00_0000, expectedValue: 0x9876_5432_FFFF_FFFF},
+		{name: "32-bit, offset 0, extra addr bits", byteLength: 4, addr: 0xFF00_0001, expectedValue: 0x9876_5432_FFFF_FFFF},
+		{name: "32-bit, offset 0, extra addr bits", byteLength: 4, addr: 0xFF00_0002, expectedValue: 0x9876_5432_FFFF_FFFF},
+		{name: "32-bit, offset 0, extra addr bits", byteLength: 4, addr: 0xFF00_0003, expectedValue: 0x9876_5432_FFFF_FFFF},
+		{name: "32-bit, offset 4", byteLength: 4, addr: 0xFF00_0004, expectedValue: 0xFFFF_FFFF_9876_5432},
+		{name: "32-bit, offset 4, extra addr bits", byteLength: 4, addr: 0xFF00_0005, expectedValue: 0xFFFF_FFFF_9876_5432},
+		{name: "32-bit, offset 4, extra addr bits", byteLength: 4, addr: 0xFF00_0006, expectedValue: 0xFFFF_FFFF_9876_5432},
+		{name: "32-bit, offset 4, extra addr bits", byteLength: 4, addr: 0xFF00_0007, expectedValue: 0xFFFF_FFFF_9876_5432},
+		{name: "16-bit, offset=4", byteLength: 2, addr: 0x04, expectedValue: 0xFFFF_FFFF_5432_FFFF},
+		{name: "16-bit, offset=4, extra bit set", byteLength: 2, addr: 0x05, expectedValue: 0xFFFF_FFFF_5432_FFFF},
+		{name: "16-bit, offset=6", byteLength: 2, addr: 0x06, expectedValue: 0xFFFF_FFFF_FFFF_5432},
+		{name: "16-bit, offset=6, extra bit set", byteLength: 2, addr: 0x07, expectedValue: 0xFFFF_FFFF_FFFF_5432},
+		{name: "8-bit, offset=4", byteLength: 1, addr: 0x1234, expectedValue: 0xFFFF_FFFF_32FF_FFFF},
+		{name: "8-bit, offset=5", byteLength: 1, addr: 0x1235, expectedValue: 0xFFFF_FFFF_FF32_FFFF},
+		{name: "8-bit, offset=6", byteLength: 1, addr: 0x1236, expectedValue: 0xFFFF_FFFF_FFFF_32FF},
+		{name: "8-bit, offset=7", byteLength: 1, addr: 0x1237, expectedValue: 0xFFFF_FFFF_FFFF_FF32},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mem := memory.NewMemory()
+			memTracker := NewMemoryTracker(mem)
+
+			effAddr := Word(c.addr) & arch.AddressMask
+			mem.SetWord(effAddr, memVal)
+
+			StoreSubWord(mem, Word(c.addr), c.byteLength, Word(value), memTracker)
+			newMemVal := mem.GetWord(effAddr)
+
+			require.Equal(t, c.expectedValue, newMemVal)
+		})
+	}
+}

--- a/cannon/mipsevm/exec/mips_instructions64_test.go
+++ b/cannon/mipsevm/exec/mips_instructions64_test.go
@@ -1,6 +1,7 @@
 //go:build cannon64
 // +build cannon64
 
+// These tests target architectures that are 64-bit or larger
 package exec
 
 import (

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -9,9 +9,10 @@ import (
 	"slices"
 	"sort"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/exp/maps"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 )
 
 // Note: 2**12 = 4 KiB, the min phys page size in the Go runtime.
@@ -193,8 +194,8 @@ func (m *Memory) pageLookup(pageIndex Word) (*CachedPage, bool) {
 }
 
 func (m *Memory) SetUint32(addr Word, v uint32) {
-	// addr must be aligned to WordSizeBytes bytes
-	if addr&arch.ExtMask != 0 {
+	// addr must be aligned to 4-byte (32-bit) boundaries
+	if addr&3 != 0 {
 		panic(fmt.Errorf("unaligned memory access: %x", addr))
 	}
 

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -9,10 +9,9 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/exp/maps"
-
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 )
 
 // Note: 2**12 = 4 KiB, the min phys page size in the Go runtime.
@@ -194,8 +193,8 @@ func (m *Memory) pageLookup(pageIndex Word) (*CachedPage, bool) {
 }
 
 func (m *Memory) SetUint32(addr Word, v uint32) {
-	// addr must be aligned to 4-byte (32-bit) boundaries
-	if addr&3 != 0 {
+	// addr must be aligned to WordSizeBytes bytes
+	if addr&arch.ExtMask != 0 {
 		panic(fmt.Errorf("unaligned memory access: %x", addr))
 	}
 

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -354,7 +354,7 @@ func (m *InstrumentedState) handleRMWOps(insn, opcode uint32) error {
 		} else {
 			subwordSizeBytes = 8
 		}
-		retVal = exec.LoadSubWord(m.state.GetMemory(), addr, subwordSizeBytes, false, m.memoryTracker)
+		retVal = exec.LoadSubWord(m.state.GetMemory(), addr, subwordSizeBytes, true, m.memoryTracker)
 
 		m.state.LLReservationActive = true
 		m.state.LLAddress = addr

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -368,8 +368,8 @@ func (m *InstrumentedState) handleRMWOps(insn, opcode uint32) error {
 			// Complete atomic update: set memory and return 1 for success
 			m.clearLLMemoryReservation()
 
-			memWriteVal := m.state.GetRegistersRef()[rtReg]
-			exec.StoreSubWord(m.state.GetMemory(), addr, byteLength, memWriteVal, m.memoryTracker)
+			val := m.state.GetRegistersRef()[rtReg]
+			exec.StoreSubWord(m.state.GetMemory(), addr, byteLength, val, m.memoryTracker)
 
 			retVal = 1
 		} else {

--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -40,16 +40,24 @@ const (
 	STATE_WITNESS_SIZE = THREAD_ID_WITNESS_OFFSET + arch.WordSizeBytes
 )
 
+type LLReservationStatus uint8
+
+const (
+	LLStatusNone        LLReservationStatus = 0x0
+	LLStatusActive32bit LLReservationStatus = 0x1
+	LLStatusActive64bit LLReservationStatus = 0x2
+)
+
 type State struct {
 	Memory *memory.Memory
 
 	PreimageKey    common.Hash
 	PreimageOffset Word // note that the offset includes the 8-byte length prefix
 
-	Heap                Word // to handle mmap growth
-	LLReservationActive bool // Whether there is an active memory reservation initiated via the LL (load linked) op
-	LLAddress           Word // The "linked" memory address reserved via the LL (load linked) op
-	LLOwnerThread       Word // The id of the thread that holds the reservation on LLAddress
+	Heap                Word                // to handle mmap growth
+	LLReservationStatus LLReservationStatus // Determines whether there is an active memory reservation, and what type
+	LLAddress           Word                // The "linked" memory address reserved via the LL (load linked) op
+	LLOwnerThread       Word                // The id of the thread that holds the reservation on LLAddress
 
 	ExitCode uint8
 	Exited   bool
@@ -75,7 +83,7 @@ func CreateEmptyState() *State {
 	return &State{
 		Memory:              memory.NewMemory(),
 		Heap:                0,
-		LLReservationActive: false,
+		LLReservationStatus: LLStatusNone,
 		LLAddress:           0,
 		LLOwnerThread:       0,
 		ExitCode:            0,
@@ -199,7 +207,7 @@ func (s *State) EncodeWitness() ([]byte, common.Hash) {
 	out = append(out, s.PreimageKey[:]...)
 	out = arch.ByteOrderWord.AppendWord(out, s.PreimageOffset)
 	out = arch.ByteOrderWord.AppendWord(out, s.Heap)
-	out = mipsevm.AppendBoolToWitness(out, s.LLReservationActive)
+	out = append(out, byte(s.LLReservationStatus))
 	out = arch.ByteOrderWord.AppendWord(out, s.LLAddress)
 	out = arch.ByteOrderWord.AppendWord(out, s.LLOwnerThread)
 	out = append(out, s.ExitCode)
@@ -278,7 +286,7 @@ func (s *State) Serialize(out io.Writer) error {
 	if err := bout.WriteUInt(s.Heap); err != nil {
 		return err
 	}
-	if err := bout.WriteBool(s.LLReservationActive); err != nil {
+	if err := bout.WriteUInt(s.LLReservationStatus); err != nil {
 		return err
 	}
 	if err := bout.WriteUInt(s.LLAddress); err != nil {
@@ -347,7 +355,7 @@ func (s *State) Deserialize(in io.Reader) error {
 	if err := bin.ReadUInt(&s.Heap); err != nil {
 		return err
 	}
-	if err := bin.ReadBool(&s.LLReservationActive); err != nil {
+	if err := bin.ReadUInt(&s.LLReservationStatus); err != nil {
 		return err
 	}
 	if err := bin.ReadUInt(&s.LLAddress); err != nil {

--- a/cannon/mipsevm/multithreaded/state_test.go
+++ b/cannon/mipsevm/multithreaded/state_test.go
@@ -56,7 +56,7 @@ func TestState_EncodeWitness(t *testing.T) {
 		state.PreimageKey = preimageKey
 		state.PreimageOffset = preimageOffset
 		state.Heap = heap
-		state.LLReservationActive = true
+		state.LLReservationStatus = LLStatusActive32bit
 		state.LLAddress = llAddress
 		state.LLOwnerThread = llThreadOwner
 		state.Step = step
@@ -185,7 +185,7 @@ func TestSerializeStateRoundTrip(t *testing.T) {
 		PreimageKey:                 common.Hash{0xFF},
 		PreimageOffset:              5,
 		Heap:                        0xc0ffee,
-		LLReservationActive:         true,
+		LLReservationStatus:         LLStatusActive64bit,
 		LLAddress:                   0x12345678,
 		LLOwnerThread:               0x02,
 		ExitCode:                    1,

--- a/cannon/mipsevm/multithreaded/testutil/expectations.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations.go
@@ -18,7 +18,7 @@ type ExpectedMTState struct {
 	PreimageKey         common.Hash
 	PreimageOffset      arch.Word
 	Heap                arch.Word
-	LLReservationActive bool
+	LLReservationStatus multithreaded.LLReservationStatus
 	LLAddress           arch.Word
 	LLOwnerThread       arch.Word
 	ExitCode            uint8
@@ -69,7 +69,7 @@ func NewExpectedMTState(fromState *multithreaded.State) *ExpectedMTState {
 		PreimageKey:         fromState.GetPreimageKey(),
 		PreimageOffset:      fromState.GetPreimageOffset(),
 		Heap:                fromState.GetHeap(),
-		LLReservationActive: fromState.LLReservationActive,
+		LLReservationStatus: fromState.LLReservationStatus,
 		LLAddress:           fromState.LLAddress,
 		LLOwnerThread:       fromState.LLOwnerThread,
 		ExitCode:            fromState.GetExitCode(),
@@ -180,7 +180,7 @@ func (e *ExpectedMTState) Validate(t require.TestingT, actualState *multithreade
 	require.Equalf(t, e.PreimageKey, actualState.GetPreimageKey(), "Expect preimageKey = %v", e.PreimageKey)
 	require.Equalf(t, e.PreimageOffset, actualState.GetPreimageOffset(), "Expect preimageOffset = %v", e.PreimageOffset)
 	require.Equalf(t, e.Heap, actualState.GetHeap(), "Expect heap = 0x%x", e.Heap)
-	require.Equalf(t, e.LLReservationActive, actualState.LLReservationActive, "Expect LLReservationActive = %v", e.LLReservationActive)
+	require.Equalf(t, e.LLReservationStatus, actualState.LLReservationStatus, "Expect LLReservationStatus = %v", e.LLReservationStatus)
 	require.Equalf(t, e.LLAddress, actualState.LLAddress, "Expect LLAddress = 0x%x", e.LLAddress)
 	require.Equalf(t, e.LLOwnerThread, actualState.LLOwnerThread, "Expect LLOwnerThread = %v", e.LLOwnerThread)
 	require.Equalf(t, e.ExitCode, actualState.GetExitCode(), "Expect exitCode = 0x%x", e.ExitCode)

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -29,7 +29,7 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 		{name: "PreimageKey", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.PreimageKey = emptyHash }},
 		{name: "PreimageOffset", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.PreimageOffset += 1 }},
 		{name: "Heap", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.Heap += 1 }},
-		{name: "LLReservationActive", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.LLReservationActive = !e.LLReservationActive }},
+		{name: "LLReservationStatus", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.LLReservationStatus = e.LLReservationStatus + 1 }},
 		{name: "LLAddress", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.LLAddress += 1 }},
 		{name: "LLOwnerThread", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.LLOwnerThread += 1 }},
 		{name: "ExitCode", mut: func(e *ExpectedMTState, st *multithreaded.State) { e.ExitCode += 1 }},

--- a/cannon/mipsevm/multithreaded/testutil/mutators.go
+++ b/cannon/mipsevm/multithreaded/testutil/mutators.go
@@ -36,8 +36,8 @@ func (m *StateMutatorMultiThreaded) Randomize(randSeed int64) {
 	// Randomize memory-related fields
 	halfMemory := math.MaxUint32 / 2
 	m.state.Heap = arch.Word(r.Intn(halfMemory) + halfMemory)
-	m.state.LLReservationActive = r.Intn(2) == 1
-	if m.state.LLReservationActive {
+	m.state.LLReservationStatus = multithreaded.LLReservationStatus(r.Intn(3))
+	if m.state.LLReservationStatus != multithreaded.LLStatusNone {
 		m.state.LLAddress = arch.Word(r.Intn(halfMemory))
 		m.state.LLOwnerThread = arch.Word(r.Intn(10))
 	}

--- a/cannon/mipsevm/multithreaded/testutil/thread.go
+++ b/cannon/mipsevm/multithreaded/testutil/thread.go
@@ -21,7 +21,7 @@ func RandomThread(randSeed int64) *multithreaded.ThreadState {
 	return thread
 }
 
-func InitializeSingleThread(randSeed int, state *multithreaded.State, traverseRight bool) {
+func InitializeSingleThread(randSeed int, state *multithreaded.State, traverseRight bool, opts ...testutil.StateOption) {
 	singleThread := RandomThread(int64(randSeed))
 
 	state.NextThreadId = singleThread.ThreadId + 1
@@ -32,6 +32,11 @@ func InitializeSingleThread(randSeed int, state *multithreaded.State, traverseRi
 	} else {
 		state.RightThreadStack = []*multithreaded.ThreadState{}
 		state.LeftThreadStack = []*multithreaded.ThreadState{singleThread}
+	}
+
+	mutator := NewStateMutatorMultiThreaded(state)
+	for _, opt := range opts {
+		opt(mutator)
 	}
 }
 

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -34,13 +34,13 @@ func TestEVM_MT64_LL(t *testing.T) {
 		{name: "8-byte-aligned addr", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "8-byte-aligned addr, neg value", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memValNeg, retVal: 0xFFFFFFFF_F1223344, retReg: 5},
 		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0109, addr: 0x010A, memVal: memVal, retVal: 0x11223344, retReg: 5},
-		{name: "8-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, memVal: memVal, retVal: 0x11223344, retReg: 5},
-		{name: "8-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF07, addr: 0x0000_0000_0FFF_FF08, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "8-byte-aligned addr, addr signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "8-byte-aligned addr, addr signed extended w overflow", base: 0x1000_0001, offset: 0xFF07, addr: 0x0000_0000_0FFF_FF08, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "4-byte-aligned addr", base: 0x01, offset: 0x0103, addr: 0x0104, memVal: memVal, retVal: 0x55667788, retReg: 5},
 		{name: "4-byte-aligned addr, neg value", base: 0x01, offset: 0x0104, addr: 0x0105, memVal: memValNeg, retVal: 0xFFFFFFFF_F5667788, retReg: 5},
 		{name: "4-byte-aligned addr, extra bits", base: 0x01, offset: 0x0105, addr: 0x0106, memVal: memVal, retVal: 0x55667788, retReg: 5},
-		{name: "4-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF33, addr: 0xFFFF_FFFF_FFFF_FF34, memVal: memVal, retVal: 0x55667788, retReg: 5},
-		{name: "4-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF03, addr: 0x0000_0000_0FFF_FF04, memVal: memVal, retVal: 0x55667788, retReg: 5},
+		{name: "4-byte-aligned addr, addr signed extended", base: 0x01, offset: 0xFF33, addr: 0xFFFF_FFFF_FFFF_FF34, memVal: memVal, retVal: 0x55667788, retReg: 5},
+		{name: "4-byte-aligned addr, addr signed extended w overflow", base: 0x1000_0001, offset: 0xFF03, addr: 0x0000_0000_0FFF_FF04, memVal: memVal, retVal: 0x55667788, retReg: 5},
 		{name: "Return register set to 0", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 0},
 	}
 	for i, c := range cases {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -51,15 +51,12 @@ func TestEVM_MT64_LL(t *testing.T) {
 
 				retReg := c.retReg
 				baseReg := 6
-				pc := Word(0x44)
 				insn := uint32((0b11_0000 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
-				goVm, state, contracts := setup(t, i, nil)
+				goVm, state, contracts := setup(t, i, nil, testutil.WithPCAndNextPC(0x40))
 				step := state.GetStep()
 
 				// Set up state
-				state.GetCurrentThread().Cpu.PC = pc
-				state.GetCurrentThread().Cpu.NextPC = pc + 4
-				state.GetMemory().SetUint32(pc, insn)
+				state.GetMemory().SetUint32(state.GetPC(), insn)
 				state.GetMemory().SetWord(effAddr, c.memVal)
 				state.GetRegistersRef()[baseReg] = c.base
 				if withExistingReservation {
@@ -141,10 +138,9 @@ func TestEVM_MT64_SC(t *testing.T) {
 				// Setup
 				rtReg := c.rtReg
 				baseReg := 6
-				pc := Word(0x44)
 				insn := uint32((0b11_1000 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
 				goVm, state, contracts := setup(t, i, nil)
-				mttestutil.InitializeSingleThread(i*23456, state, i%2 == 1)
+				mttestutil.InitializeSingleThread(i*23456, state, i%2 == 1, testutil.WithPCAndNextPC(0x40))
 				step := state.GetStep()
 
 				// Define LL-related params
@@ -162,9 +158,7 @@ func TestEVM_MT64_SC(t *testing.T) {
 
 				// Setup state
 				state.GetCurrentThread().ThreadId = c.threadId
-				state.GetCurrentThread().Cpu.PC = pc
-				state.GetCurrentThread().Cpu.NextPC = pc + 4
-				state.GetMemory().SetUint32(pc, insn)
+				state.GetMemory().SetUint32(state.GetPC(), insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = c.value
 				state.LLReservationStatus = v.llReservationStatus
@@ -233,15 +227,12 @@ func TestEVM_MT64_LLD(t *testing.T) {
 
 				retReg := c.retReg
 				baseReg := 6
-				pc := Word(0x44)
 				insn := uint32((0b11_0100 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
-				goVm, state, contracts := setup(t, i, nil)
+				goVm, state, contracts := setup(t, i, nil, testutil.WithPCAndNextPC(0x40))
 				step := state.GetStep()
 
 				// Set up state
-				state.GetCurrentThread().Cpu.PC = pc
-				state.GetCurrentThread().Cpu.NextPC = pc + 4
-				state.GetMemory().SetUint32(pc, insn)
+				state.GetMemory().SetUint32(state.GetPC(), insn)
 				state.GetMemory().SetWord(effAddr, c.memVal)
 				state.GetRegistersRef()[baseReg] = c.base
 				if withExistingReservation {
@@ -324,10 +315,9 @@ func TestEVM_MT64_SCD(t *testing.T) {
 				// Setup
 				rtReg := c.rtReg
 				baseReg := 6
-				pc := Word(0x44)
 				insn := uint32((0b11_1100 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
 				goVm, state, contracts := setup(t, i, nil)
-				mttestutil.InitializeSingleThread(i*23456, state, i%2 == 1)
+				mttestutil.InitializeSingleThread(i*23456, state, i%2 == 1, testutil.WithPCAndNextPC(0x40))
 				step := state.GetStep()
 
 				// Define LL-related params
@@ -345,9 +335,7 @@ func TestEVM_MT64_SCD(t *testing.T) {
 
 				// Setup state
 				state.GetCurrentThread().ThreadId = c.threadId
-				state.GetCurrentThread().Cpu.PC = pc
-				state.GetCurrentThread().Cpu.NextPC = pc + 4
-				state.GetMemory().SetUint32(pc, insn)
+				state.GetMemory().SetUint32(state.GetPC(), insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = value
 				state.LLReservationStatus = v.llReservationStatus

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -63,11 +63,11 @@ func TestEVM_MT64_LL(t *testing.T) {
 				state.GetMemory().SetWord(effAddr, c.memVal)
 				state.GetRegistersRef()[baseReg] = c.base
 				if withExistingReservation {
-					state.LLReservationActive = true
+					state.LLReservationStatus = multithreaded.LLStatusActive32bit
 					state.LLAddress = c.addr + 1
 					state.LLOwnerThread = 123
 				} else {
-					state.LLReservationActive = false
+					state.LLReservationStatus = multithreaded.LLStatusNone
 					state.LLAddress = 0
 					state.LLOwnerThread = 0
 				}
@@ -75,7 +75,7 @@ func TestEVM_MT64_LL(t *testing.T) {
 				// Set up expectations
 				expected := mttestutil.NewExpectedMTState(state)
 				expected.ExpectStep()
-				expected.LLReservationActive = true
+				expected.LLReservationStatus = multithreaded.LLStatusActive32bit
 				expected.LLAddress = c.addr
 				expected.LLOwnerThread = state.GetCurrentThread().ThreadId
 				if retReg != 0 {
@@ -98,16 +98,17 @@ func TestEVM_MT64_SC(t *testing.T) {
 
 	llVariations := []struct {
 		name                string
-		llReservationActive bool
+		llReservationStatus multithreaded.LLReservationStatus
 		matchThreadId       bool
 		matchAddr           bool
 		shouldSucceed       bool
 	}{
-		{name: "should succeed", llReservationActive: true, matchThreadId: true, matchAddr: true, shouldSucceed: true},
-		{name: "mismatch addr", llReservationActive: true, matchThreadId: false, matchAddr: true, shouldSucceed: false},
-		{name: "mismatched thread", llReservationActive: true, matchThreadId: true, matchAddr: false, shouldSucceed: false},
-		{name: "mismatched addr & thread", llReservationActive: true, matchThreadId: false, matchAddr: false, shouldSucceed: false},
-		{name: "no active reservation", llReservationActive: false, matchThreadId: true, matchAddr: true, shouldSucceed: false},
+		{name: "should succeed", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: true, shouldSucceed: true},
+		{name: "mismatch addr", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
+		{name: "mismatched thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
+		{name: "mismatched addr & thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: false, shouldSucceed: false},
+		{name: "mismatched reservation status", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchAddr: true, shouldSucceed: false},
+		{name: "no active reservation", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchAddr: true, shouldSucceed: false},
 	}
 
 	cases := []struct {
@@ -166,7 +167,7 @@ func TestEVM_MT64_SC(t *testing.T) {
 				state.GetMemory().SetUint32(pc, insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = c.value
-				state.LLReservationActive = v.llReservationActive
+				state.LLReservationStatus = v.llReservationStatus
 				state.LLAddress = llAddress
 				state.LLOwnerThread = llOwnerThread
 
@@ -177,7 +178,7 @@ func TestEVM_MT64_SC(t *testing.T) {
 				if v.shouldSucceed {
 					retVal = 1
 					expected.ExpectMemoryWordWrite(effAddr, c.expectedMemVal)
-					expected.LLReservationActive = false
+					expected.LLReservationStatus = multithreaded.LLStatusNone
 					expected.LLAddress = 0
 					expected.LLOwnerThread = 0
 				} else {
@@ -244,11 +245,11 @@ func TestEVM_MT64_LLD(t *testing.T) {
 				state.GetMemory().SetWord(effAddr, c.memVal)
 				state.GetRegistersRef()[baseReg] = c.base
 				if withExistingReservation {
-					state.LLReservationActive = true
+					state.LLReservationStatus = multithreaded.LLStatusActive64bit
 					state.LLAddress = c.addr + 1
 					state.LLOwnerThread = 123
 				} else {
-					state.LLReservationActive = false
+					state.LLReservationStatus = multithreaded.LLStatusNone
 					state.LLAddress = 0
 					state.LLOwnerThread = 0
 				}
@@ -256,7 +257,7 @@ func TestEVM_MT64_LLD(t *testing.T) {
 				// Set up expectations
 				expected := mttestutil.NewExpectedMTState(state)
 				expected.ExpectStep()
-				expected.LLReservationActive = true
+				expected.LLReservationStatus = multithreaded.LLStatusActive64bit
 				expected.LLAddress = c.addr
 				expected.LLOwnerThread = state.GetCurrentThread().ThreadId
 				if retReg != 0 {
@@ -280,16 +281,17 @@ func TestEVM_MT64_SCD(t *testing.T) {
 	value := Word(0x11223344_55667788)
 	llVariations := []struct {
 		name                string
-		llReservationActive bool
+		llReservationStatus multithreaded.LLReservationStatus
 		matchThreadId       bool
 		matchAddr           bool
 		shouldSucceed       bool
 	}{
-		{name: "should succeed", llReservationActive: true, matchThreadId: true, matchAddr: true, shouldSucceed: true},
-		{name: "mismatch addr", llReservationActive: true, matchThreadId: false, matchAddr: true, shouldSucceed: false},
-		{name: "mismatched thread", llReservationActive: true, matchThreadId: true, matchAddr: false, shouldSucceed: false},
-		{name: "mismatched addr & thread", llReservationActive: true, matchThreadId: false, matchAddr: false, shouldSucceed: false},
-		{name: "no active reservation", llReservationActive: false, matchThreadId: true, matchAddr: true, shouldSucceed: false},
+		{name: "should succeed", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchAddr: true, shouldSucceed: true},
+		{name: "mismatch addr", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
+		{name: "mismatched thread", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
+		{name: "mismatched addr & thread", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, matchAddr: false, shouldSucceed: false},
+		{name: "mismatched status", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: true, shouldSucceed: false},
+		{name: "no active reservation", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchAddr: true, shouldSucceed: false},
 	}
 
 	cases := []struct {
@@ -348,7 +350,7 @@ func TestEVM_MT64_SCD(t *testing.T) {
 				state.GetMemory().SetUint32(pc, insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = value
-				state.LLReservationActive = v.llReservationActive
+				state.LLReservationStatus = v.llReservationStatus
 				state.LLAddress = llAddress
 				state.LLOwnerThread = llOwnerThread
 
@@ -359,7 +361,7 @@ func TestEVM_MT64_SCD(t *testing.T) {
 				if v.shouldSucceed {
 					retVal = 1
 					expected.ExpectMemoryWordWrite(effAddr, value)
-					expected.LLReservationActive = false
+					expected.LLReservationStatus = multithreaded.LLStatusNone
 					expected.LLAddress = 0
 					expected.LLOwnerThread = 0
 				} else {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -1,0 +1,199 @@
+//go:build cannon64
+// +build cannon64
+
+// These tests target architectures that are 64-bit or larger
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
+	mttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
+)
+
+func TestEVM_MT64_LL(t *testing.T) {
+	var tracer *tracing.Hooks
+
+	memVal := Word(0x11223344_55667788)
+	memValNeg := Word(0xF1223344_F5667788)
+	cases := []struct {
+		name   string
+		base   Word
+		offset int
+		addr   Word
+		memVal Word
+		retReg int
+		retVal Word
+	}{
+		{name: "8-byte-aligned addr", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "8-byte-aligned addr, neg value", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memValNeg, retVal: 0xFFFFFFFF_F1223344, retReg: 5},
+		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "8-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "8-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF07, addr: 0x0000_0000_0FFF_FF08, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "4-byte-aligned addr", base: 0x01, offset: 0x0103, addr: 0x0104, memVal: memVal, retVal: 0x55667788, retReg: 5},
+		{name: "4-byte-aligned addr, neg value", base: 0x01, offset: 0x0104, addr: 0x0105, memVal: memValNeg, retVal: 0xFFFFFFFF_F5667788, retReg: 5},
+		{name: "4-byte-aligned addr, extra bits", base: 0x01, offset: 0x0105, addr: 0x0106, memVal: memVal, retVal: 0x55667788, retReg: 5},
+		{name: "4-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF33, addr: 0xFFFF_FFFF_FFFF_FF34, memVal: memVal, retVal: 0x55667788, retReg: 5},
+		{name: "4-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF03, addr: 0x0000_0000_0FFF_FF04, memVal: memVal, retVal: 0x55667788, retReg: 5},
+		{name: "Return register set to 0", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 0},
+	}
+	for i, c := range cases {
+		for _, withExistingReservation := range []bool{true, false} {
+			tName := fmt.Sprintf("%v (withExistingReservation = %v)", c.name, withExistingReservation)
+			t.Run(tName, func(t *testing.T) {
+				effAddr := arch.AddressMask & c.addr
+
+				retReg := c.retReg
+				baseReg := 6
+				pc := Word(0x44)
+				insn := uint32((0b11_0000 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
+				goVm, state, contracts := setup(t, i, nil)
+				step := state.GetStep()
+
+				// Set up state
+				state.GetCurrentThread().Cpu.PC = pc
+				state.GetCurrentThread().Cpu.NextPC = pc + 4
+				state.GetMemory().SetUint32(pc, insn)
+				state.GetMemory().SetWord(effAddr, c.memVal)
+				state.GetRegistersRef()[baseReg] = c.base
+				if withExistingReservation {
+					state.LLReservationActive = true
+					state.LLAddress = c.addr + 1
+					state.LLOwnerThread = 123
+				} else {
+					state.LLReservationActive = false
+					state.LLAddress = 0
+					state.LLOwnerThread = 0
+				}
+
+				// Set up expectations
+				expected := mttestutil.NewExpectedMTState(state)
+				expected.ExpectStep()
+				expected.LLReservationActive = true
+				expected.LLAddress = c.addr
+				expected.LLOwnerThread = state.GetCurrentThread().ThreadId
+				if retReg != 0 {
+					expected.ActiveThread().Registers[retReg] = c.retVal
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), contracts, tracer)
+			})
+		}
+	}
+}
+
+func TestEVM_MT64_SC(t *testing.T) {
+	var tracer *tracing.Hooks
+
+	llVariations := []struct {
+		name                string
+		llReservationActive bool
+		matchThreadId       bool
+		matchAddr           bool
+		shouldSucceed       bool
+	}{
+		{name: "should succeed", llReservationActive: true, matchThreadId: true, matchAddr: true, shouldSucceed: true},
+		{name: "mismatch addr", llReservationActive: true, matchThreadId: false, matchAddr: true, shouldSucceed: false},
+		{name: "mismatched thread", llReservationActive: true, matchThreadId: true, matchAddr: false, shouldSucceed: false},
+		{name: "mismatched addr & thread", llReservationActive: true, matchThreadId: false, matchAddr: false, shouldSucceed: false},
+		{name: "no active reservation", llReservationActive: false, matchThreadId: true, matchAddr: true, shouldSucceed: false},
+	}
+
+	cases := []struct {
+		name           string
+		base           Word
+		offset         int
+		addr           Word
+		value          Word
+		expectedMemVal Word
+		rtReg          int
+		threadId       Word
+	}{
+		{name: "8-byte-aligned addr", base: 0x01, offset: 0x0137, addr: 0x0138, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
+		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0138, addr: 0x0139, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
+		{name: "8-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
+		{name: "8-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF37, addr: 0x0FFF_FF38, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
+		{name: "4-byte-aligned addr", base: 0x01, offset: 0x0133, addr: 0x0134, value: 0xABCD, expectedMemVal: 0x_0000_0000_0000_ABCD, rtReg: 5, threadId: 4},
+		{name: "4-byte-aligned addr, extra bits", base: 0x01, offset: 0x0134, addr: 0x0135, value: 0xABCD, expectedMemVal: 0x_0000_0000_0000_ABCD, rtReg: 5, threadId: 4},
+		{name: "4-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF33, addr: 0xFFFF_FFFF_FFFF_FF34, value: 0xABCD, expectedMemVal: 0x_0000_0000_0000_ABCD, rtReg: 5, threadId: 4},
+		{name: "4-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF33, addr: 0x0FFF_FF34, value: 0xABCD, expectedMemVal: 0x_0000_0000_0000_ABCD, rtReg: 5, threadId: 4},
+		{name: "Return register set to 0", base: 0x01, offset: 0x0138, addr: 0x0139, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 0, threadId: 4},
+		{name: "Zero valued ll args", base: 0x0, offset: 0x0, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 0},
+	}
+	for i, c := range cases {
+		for _, v := range llVariations {
+			tName := fmt.Sprintf("%v (%v)", c.name, v.name)
+			t.Run(tName, func(t *testing.T) {
+				effAddr := arch.AddressMask & c.addr
+
+				// Setup
+				rtReg := c.rtReg
+				baseReg := 6
+				pc := Word(0x44)
+				insn := uint32((0b11_1000 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
+				goVm, state, contracts := setup(t, i, nil)
+				mttestutil.InitializeSingleThread(i*23456, state, i%2 == 1)
+				step := state.GetStep()
+
+				// Define LL-related params
+				var llAddress, llOwnerThread Word
+				if v.matchAddr {
+					llAddress = c.addr
+				} else {
+					llAddress = c.addr + 1
+				}
+				if v.matchThreadId {
+					llOwnerThread = c.threadId
+				} else {
+					llOwnerThread = c.threadId + 1
+				}
+
+				// Setup state
+				state.GetCurrentThread().ThreadId = c.threadId
+				state.GetCurrentThread().Cpu.PC = pc
+				state.GetCurrentThread().Cpu.NextPC = pc + 4
+				state.GetMemory().SetUint32(pc, insn)
+				state.GetRegistersRef()[baseReg] = c.base
+				state.GetRegistersRef()[rtReg] = c.value
+				state.LLReservationActive = v.llReservationActive
+				state.LLAddress = llAddress
+				state.LLOwnerThread = llOwnerThread
+
+				// Setup expectations
+				expected := mttestutil.NewExpectedMTState(state)
+				expected.ExpectStep()
+				var retVal Word
+				if v.shouldSucceed {
+					retVal = 1
+					expected.ExpectMemoryWordWrite(effAddr, c.expectedMemVal)
+					expected.LLReservationActive = false
+					expected.LLAddress = 0
+					expected.LLOwnerThread = 0
+				} else {
+					retVal = 0
+				}
+				if rtReg != 0 {
+					expected.ActiveThread().Registers[rtReg] = retVal
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), contracts, tracer)
+			})
+		}
+	}
+}

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -33,7 +33,7 @@ func TestEVM_MT64_LL(t *testing.T) {
 	}{
 		{name: "8-byte-aligned addr", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "8-byte-aligned addr, neg value", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memValNeg, retVal: 0xFFFFFFFF_F1223344, retReg: 5},
-		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 5},
+		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0109, addr: 0x010A, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "8-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "8-byte-aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF07, addr: 0x0000_0000_0FFF_FF08, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "4-byte-aligned addr", base: 0x01, offset: 0x0103, addr: 0x0104, memVal: memVal, retVal: 0x55667788, retReg: 5},
@@ -177,6 +177,188 @@ func TestEVM_MT64_SC(t *testing.T) {
 				if v.shouldSucceed {
 					retVal = 1
 					expected.ExpectMemoryWordWrite(effAddr, c.expectedMemVal)
+					expected.LLReservationActive = false
+					expected.LLAddress = 0
+					expected.LLOwnerThread = 0
+				} else {
+					retVal = 0
+				}
+				if rtReg != 0 {
+					expected.ActiveThread().Registers[rtReg] = retVal
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), contracts, tracer)
+			})
+		}
+	}
+}
+
+func TestEVM_MT64_LLD(t *testing.T) {
+	var tracer *tracing.Hooks
+
+	memVal := Word(0x11223344_55667788)
+	memValNeg := Word(0xF1223344_F5667788)
+	cases := []struct {
+		name   string
+		base   Word
+		offset int
+		addr   Word
+		memVal Word
+		retReg int
+	}{
+		{name: "Aligned addr", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retReg: 5},
+		{name: "Aligned addr, neg value", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memValNeg, retReg: 5},
+		{name: "Unaligned addr, offset=1", base: 0x01, offset: 0x0100, addr: 0x0101, memVal: memVal, retReg: 5},
+		{name: "Unaligned addr, offset=2", base: 0x02, offset: 0x0100, addr: 0x0102, memVal: memVal, retReg: 5},
+		{name: "Unaligned addr, offset=3", base: 0x03, offset: 0x0100, addr: 0x0103, memVal: memVal, retReg: 5},
+		{name: "Unaligned addr, offset=4", base: 0x04, offset: 0x0100, addr: 0x0104, memVal: memVal, retReg: 5},
+		{name: "Unaligned addr, offset=5", base: 0x05, offset: 0x0100, addr: 0x0105, memVal: memVal, retReg: 5},
+		{name: "Unaligned addr, offset=6", base: 0x06, offset: 0x0100, addr: 0x0106, memVal: memVal, retReg: 5},
+		{name: "Unaligned addr, offset=7", base: 0x07, offset: 0x0100, addr: 0x0107, memVal: memVal, retReg: 5},
+		{name: "Aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, memVal: memVal, retReg: 5},
+		{name: "Aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF07, addr: 0x0000_0000_0FFF_FF08, memVal: memVal, retReg: 5},
+		{name: "Return register set to 0", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retReg: 0},
+	}
+	for i, c := range cases {
+		for _, withExistingReservation := range []bool{true, false} {
+			tName := fmt.Sprintf("%v (withExistingReservation = %v)", c.name, withExistingReservation)
+			t.Run(tName, func(t *testing.T) {
+				effAddr := arch.AddressMask & c.addr
+
+				retReg := c.retReg
+				baseReg := 6
+				pc := Word(0x44)
+				insn := uint32((0b11_0100 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
+				goVm, state, contracts := setup(t, i, nil)
+				step := state.GetStep()
+
+				// Set up state
+				state.GetCurrentThread().Cpu.PC = pc
+				state.GetCurrentThread().Cpu.NextPC = pc + 4
+				state.GetMemory().SetUint32(pc, insn)
+				state.GetMemory().SetWord(effAddr, c.memVal)
+				state.GetRegistersRef()[baseReg] = c.base
+				if withExistingReservation {
+					state.LLReservationActive = true
+					state.LLAddress = c.addr + 1
+					state.LLOwnerThread = 123
+				} else {
+					state.LLReservationActive = false
+					state.LLAddress = 0
+					state.LLOwnerThread = 0
+				}
+
+				// Set up expectations
+				expected := mttestutil.NewExpectedMTState(state)
+				expected.ExpectStep()
+				expected.LLReservationActive = true
+				expected.LLAddress = c.addr
+				expected.LLOwnerThread = state.GetCurrentThread().ThreadId
+				if retReg != 0 {
+					expected.ActiveThread().Registers[retReg] = c.memVal
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), contracts, tracer)
+			})
+		}
+	}
+}
+
+func TestEVM_MT64_SCD(t *testing.T) {
+	var tracer *tracing.Hooks
+
+	value := Word(0x11223344_55667788)
+	llVariations := []struct {
+		name                string
+		llReservationActive bool
+		matchThreadId       bool
+		matchAddr           bool
+		shouldSucceed       bool
+	}{
+		{name: "should succeed", llReservationActive: true, matchThreadId: true, matchAddr: true, shouldSucceed: true},
+		{name: "mismatch addr", llReservationActive: true, matchThreadId: false, matchAddr: true, shouldSucceed: false},
+		{name: "mismatched thread", llReservationActive: true, matchThreadId: true, matchAddr: false, shouldSucceed: false},
+		{name: "mismatched addr & thread", llReservationActive: true, matchThreadId: false, matchAddr: false, shouldSucceed: false},
+		{name: "no active reservation", llReservationActive: false, matchThreadId: true, matchAddr: true, shouldSucceed: false},
+	}
+
+	cases := []struct {
+		name     string
+		base     Word
+		offset   int
+		addr     Word
+		rtReg    int
+		threadId Word
+	}{
+		{name: "Aligned addr", base: 0x01, offset: 0x0137, addr: 0x0138, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=1", base: 0x01, offset: 0x0100, addr: 0x0101, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=2", base: 0x02, offset: 0x0100, addr: 0x0102, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=3", base: 0x03, offset: 0x0100, addr: 0x0103, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=4", base: 0x04, offset: 0x0100, addr: 0x0104, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=5", base: 0x05, offset: 0x0100, addr: 0x0105, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=6", base: 0x06, offset: 0x0100, addr: 0x0106, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, offset=7", base: 0x07, offset: 0x0100, addr: 0x0107, rtReg: 5, threadId: 4},
+		{name: "Aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, rtReg: 5, threadId: 4},
+		{name: "Aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF37, addr: 0x0FFF_FF38, rtReg: 5, threadId: 4},
+		{name: "Return register set to 0", base: 0x01, offset: 0x0138, addr: 0x0139, rtReg: 0, threadId: 4},
+		{name: "Zero valued ll args", base: 0x0, offset: 0x0, rtReg: 5, threadId: 0},
+	}
+	for i, c := range cases {
+		for _, v := range llVariations {
+			tName := fmt.Sprintf("%v (%v)", c.name, v.name)
+			t.Run(tName, func(t *testing.T) {
+				effAddr := arch.AddressMask & c.addr
+
+				// Setup
+				rtReg := c.rtReg
+				baseReg := 6
+				pc := Word(0x44)
+				insn := uint32((0b11_1100 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
+				goVm, state, contracts := setup(t, i, nil)
+				mttestutil.InitializeSingleThread(i*23456, state, i%2 == 1)
+				step := state.GetStep()
+
+				// Define LL-related params
+				var llAddress, llOwnerThread Word
+				if v.matchAddr {
+					llAddress = c.addr
+				} else {
+					llAddress = c.addr + 1
+				}
+				if v.matchThreadId {
+					llOwnerThread = c.threadId
+				} else {
+					llOwnerThread = c.threadId + 1
+				}
+
+				// Setup state
+				state.GetCurrentThread().ThreadId = c.threadId
+				state.GetCurrentThread().Cpu.PC = pc
+				state.GetCurrentThread().Cpu.NextPC = pc + 4
+				state.GetMemory().SetUint32(pc, insn)
+				state.GetRegistersRef()[baseReg] = c.base
+				state.GetRegistersRef()[rtReg] = value
+				state.LLReservationActive = v.llReservationActive
+				state.LLAddress = llAddress
+				state.LLOwnerThread = llOwnerThread
+
+				// Setup expectations
+				expected := mttestutil.NewExpectedMTState(state)
+				expected.ExpectStep()
+				var retVal Word
+				if v.shouldSucceed {
+					retVal = 1
+					expected.ExpectMemoryWordWrite(effAddr, value)
 					expected.LLReservationActive = false
 					expected.LLAddress = 0
 					expected.LLOwnerThread = 0

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -1,3 +1,4 @@
+// These tests target architectures that are 64-bit or larger
 package tests
 
 import (
@@ -121,16 +122,15 @@ func TestEVM_MT_SC(t *testing.T) {
 		base     Word
 		offset   int
 		value    Word
-		addr     Word
 		rtReg    int
 		threadId Word
 	}{
-		{name: "Aligned addr", base: 0x00_00_00_01, offset: 0x0133, value: 0xABCD, addr: 0x00_00_01_34, rtReg: 5, threadId: 4},
-		{name: "Aligned addr, signed extended", base: 0x00_00_00_01, offset: 0xFF33, value: 0xABCD, addr: 0xFF_FF_FF_34, rtReg: 5, threadId: 4},
-		{name: "Unaligned addr", base: 0xFF_12_00_01, offset: 0x3401, value: 0xABCD, addr: 0xFF_12_34_02, rtReg: 5, threadId: 4},
-		{name: "Unaligned addr, sign extended w overflow", base: 0xFF_12_00_01, offset: 0x8401, value: 0xABCD, addr: 0xFF_11_84_02, rtReg: 5, threadId: 4},
-		{name: "Return register set to 0", base: 0xFF_12_00_01, offset: 0x8401, value: 0xABCD, addr: 0xFF_11_84_02, rtReg: 0, threadId: 4},
-		{name: "Zero valued ll args", base: 0x00_00_00_00, offset: 0x0, value: 0xABCD, addr: 0x00_00_00_00, rtReg: 5, threadId: 0},
+		{name: "Aligned addr", base: 0x00_00_00_01, offset: 0x0133, value: 0xABCD, rtReg: 5, threadId: 4},
+		{name: "Aligned addr, signed extended", base: 0x00_00_00_01, offset: 0xFF33, value: 0xABCD, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr", base: 0xFF_12_00_01, offset: 0x3401, value: 0xABCD, rtReg: 5, threadId: 4},
+		{name: "Unaligned addr, sign extended w overflow", base: 0xFF_12_00_01, offset: 0x8401, value: 0xABCD, rtReg: 5, threadId: 4},
+		{name: "Return register set to 0", base: 0xFF_12_00_01, offset: 0x8401, value: 0xABCD, rtReg: 0, threadId: 4},
+		{name: "Zero valued ll args", base: 0x00_00_00_00, offset: 0x0, value: 0xABCD, rtReg: 5, threadId: 0},
 	}
 	for i, c := range cases {
 		for _, v := range llVariations {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -110,8 +110,8 @@ func TestEVM_MT_SC(t *testing.T) {
 		shouldSucceed       bool
 	}{
 		{name: "should succeed", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: true, shouldSucceed: true},
-		{name: "mismatch addr", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
-		{name: "mismatched thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
+		{name: "mismatch thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
+		{name: "mismatched addr", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
 		{name: "mismatched addr & thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: false, shouldSucceed: false},
 		{name: "mismatched status", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchAddr: true, shouldSucceed: false},
 		{name: "no active reservation", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchAddr: true, shouldSucceed: false},

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
+
+func SignExtend(value arch.Word, bitToCheck int) arch.Word {
+	mostSigBit := value >> (bitToCheck - 1) & 0x1
+	if mostSigBit == 1 {
+		signBits := ^arch.Word(0) << bitToCheck
+		return signBits | value
+	}
+
+	return value
+}

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -2,12 +2,32 @@ package testutil
 
 import "github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 
-func SignExtend(value arch.Word, valueBitLength int) arch.Word {
-	mostSigBit := value >> (valueBitLength - 1) & 0x1
-	if mostSigBit == 1 {
-		signBits := ^arch.Word(0) << valueBitLength
-		return signBits | value
+type Word = arch.Word
+
+// PlaceUint32InWord places a uint32 value into a Word based on the architecture and address.
+// For example, in 64-bit architectures, a 32-bit value written to address 0x04 is
+// written to the rightmost 32-bits of the word at address 0x00, while a 32-bit value written to address 0x08
+// is written to the leftmost 32-bits of the 64-bit Word at address 0x08
+func PlaceUint32InWord(addr, value Word) Word {
+	offsetMask := Word(arch.ExtMask) & 0x4
+	wordOffset := addr & offsetMask
+	maxWordByteOffset := Word(arch.WordSizeBytes - 4)
+	memBitOffset := (maxWordByteOffset - wordOffset) * 8
+
+	return (value & 0xFFFF_FFFF) << memBitOffset
+}
+
+// SignExtendImmediate takes a 16-bit value and sign- or zero- extends it up to the arch.Word size
+func SignExtendImmediate(imm Word) (Word, bool) {
+	signExtended := false
+	immediateMask := Word(0xFFFF)
+	imm = imm & immediateMask
+
+	if imm>>15 == 0x01 {
+		// Sign extend
+		imm = imm | ^immediateMask
+		signExtended = true
 	}
 
-	return value
+	return imm, signExtended
 }

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -2,10 +2,10 @@ package testutil
 
 import "github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 
-func SignExtend(value arch.Word, bitToCheck int) arch.Word {
-	mostSigBit := value >> (bitToCheck - 1) & 0x1
+func SignExtend(value arch.Word, valueBitLength int) arch.Word {
+	mostSigBit := value >> (valueBitLength - 1) & 0x1
 	if mostSigBit == 1 {
-		signBits := ^arch.Word(0) << bitToCheck
+		signBits := ^arch.Word(0) << valueBitLength
 		return signBits | value
 	}
 

--- a/cannon/mipsevm/testutil/memory.go
+++ b/cannon/mipsevm/testutil/memory.go
@@ -1,0 +1,17 @@
+package testutil
+
+import "encoding/binary"
+
+func Uint32ToBytes(val uint32) []byte {
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, val)
+
+	return data
+}
+
+func Uint64ToBytes(val uint64) []byte {
+	data := make([]byte, 8)
+	binary.BigEndian.PutUint64(data, val)
+
+	return data
+}

--- a/cannon/mipsevm/testutil/mips.go
+++ b/cannon/mipsevm/testutil/mips.go
@@ -172,6 +172,12 @@ func LogStepFailureAtCleanup(t *testing.T, mipsEvm *MIPSEVM) {
 
 // ValidateEVM runs a single evm step and validates against an FPVM poststate
 func ValidateEVM(t *testing.T, stepWitness *mipsevm.StepWitness, step uint64, goVm mipsevm.FPVM, hashFn mipsevm.HashFn, contracts *ContractMetadata, tracer *tracing.Hooks) {
+	if !arch.IsMips32 {
+		// TODO(#12250) Re-enable EVM validation once 64-bit MIPS contracts are completed
+		t.Logf("WARNING: Skipping EVM validation for 64-bit MIPS")
+		return
+	}
+
 	evm := NewMIPSEVM(contracts)
 	evm.SetTracer(tracer)
 	LogStepFailureAtCleanup(t, evm)

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -119,7 +119,7 @@ func WithRandomization(seed int64) StateOption {
 func AlignPC(pc arch.Word) arch.Word {
 	// Memory-align random pc and leave room for nextPC
 	pc = pc & arch.AddressMask // Align address
-	if pc >= arch.AddressMask && arch.IsMips32 {
+	if pc >= arch.AddressMask {
 		// Leave room to set and then increment nextPC
 		pc = arch.AddressMask - 8
 	}

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0xaf7416f27db1b393092f51d290a29293184105bc5f0d89cd6048f687cebc7d69"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x9ba94a69090a8c89786cdb2a5980deba4b5b16bbf5909f8275e090dbcd65e5c3",
-    "sourceCodeHash": "0x3859b4bf63f485800b0eb6ffb83a79c8d134f7e4cbbe93fbc72cc2ccd4f91b82"
+    "initCodeHash": "0xd04c55d731400f777f4bb7c6520943e0f350868122bf992377ee3262cda8ee90",
+    "sourceCodeHash": "0x0fd936b1b09a5c3cb4e7ae71c294f168ce9a57a173bcd56b9f20383624de296e"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x64ea814bf9769257c91da57928675d3f8462374b0c23bdf860ccfc79f41f7801",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -60,8 +60,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.15
-    string public constant version = "1.0.0-beta.15";
+    /// @custom:semver 1.0.0-beta.16
+    string public constant version = "1.0.0-beta.16";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS2.t.sol
@@ -185,7 +185,7 @@ contract MIPS2_Test is CommonTest {
             preimageKey: bytes32(0),
             preimageOffset: 0,
             heap: 0,
-            llReservationActive: false,
+            llReservationStatus: 0,
             llAddress: 0,
             llOwnerThread: 0,
             exitCode: 0,
@@ -2017,7 +2017,7 @@ contract MIPS2_Test is CommonTest {
         updateThreadStacks(state, thread);
 
         MIPS2.State memory expect = arithmeticPostState(state, thread, 8, memVal);
-        expect.llReservationActive = true;
+        expect.llReservationStatus = 1;
         expect.llAddress = effAddr;
         expect.llOwnerThread = thread.threadID;
 
@@ -2034,7 +2034,7 @@ contract MIPS2_Test is CommonTest {
 
         (MIPS2.State memory state, MIPS2.ThreadState memory thread, bytes memory memProof) =
             constructMIPSState(0, insn, effAddr, 0);
-        state.llReservationActive = true;
+        state.llReservationStatus = 1;
         state.llAddress = effAddr;
         state.llOwnerThread = thread.threadID;
         thread.registers[8] = writeMemVal;
@@ -2044,7 +2044,7 @@ contract MIPS2_Test is CommonTest {
 
         MIPS2.State memory expect = arithmeticPostState(state, thread, 8, 0x1);
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, effAddr, writeMemVal);
-        expect.llReservationActive = false;
+        expect.llReservationStatus = 0;
         expect.llAddress = 0;
         expect.llOwnerThread = 0;
 
@@ -2764,7 +2764,7 @@ contract MIPS2_Test is CommonTest {
             _state.preimageKey,
             _state.preimageOffset,
             _state.heap,
-            _state.llReservationActive,
+            _state.llReservationStatus,
             _state.llAddress,
             _state.llOwnerThread,
             _state.exitCode,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Rework RMW ops for 64-bit compatibility.

Changes include:
- `State.LLAddress` now holds the requested address rather than the effective address (which has the lower bits zeroed out).  It is necessary to retain some of the less significant bits in order to ensure that LL and SC operations are targeting the same 32-bit value when executing on 64-bit architectures.
- `bool State.LLReservationActive` has been changed to `uint8 State. LLReservationStatus`.  This allows us to store the type of reservation that was made (LL operations load a 32-bit value, LLD operations load a 64-bit value) so that the SC (32-bit) and SCD (64-bit) operations only succeed if a matching reservation has been made. 

**Tests**

- Updated existing ll, sc tests to work for 32- and 64-bit architectures
- Added 64-bit specific tests

**Metadata**
Fixes https://github.com/ethereum-optimism/optimism/issues/12242
