### PR TITLE
op-program: Only allow requests for rollup config and l2 chain config for custom chains

### DIFF
--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -48,8 +48,14 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 		}
 		return binary.BigEndian.AppendUint64(nil, chainID), nil
 	case l2ChainConfigKey:
+		if !s.config.IsCustomChainConfig {
+			return nil, ErrNotFound
+		}
 		return json.Marshal(s.config.L2ChainConfig)
 	case rollupKey:
+		if !s.config.IsCustomChainConfig {
+			return nil, ErrNotFound
+		}
 		return json.Marshal(s.config.Rollup)
 	default:
 		return nil, ErrNotFound

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -33,8 +33,8 @@ func TestLocalPreimageSource(t *testing.T) {
 		{"L2Claim", l2ClaimKey, cfg.L2Claim.Bytes()},
 		{"L2ClaimBlockNumber", l2ClaimBlockNumberKey, binary.BigEndian.AppendUint64(nil, cfg.L2ClaimBlockNumber)},
 		{"L2ChainID", l2ChainIDKey, binary.BigEndian.AppendUint64(nil, cfg.L2ChainConfig.ChainID.Uint64())},
-		{"Rollup", rollupKey, asJson(t, cfg.Rollup)},
-		{"ChainConfig", l2ChainConfigKey, asJson(t, cfg.L2ChainConfig)},
+		{"Rollup", rollupKey, nil},             // Only available for custom chain configs
+		{"ChainConfig", l2ChainConfigKey, nil}, // Only available for custom chain configs
 		{"Unknown", preimage.LocalIndexKey(1000).PreimageKey(), nil},
 	}
 	for _, test := range tests {
@@ -48,6 +48,25 @@ func TestLocalPreimageSource(t *testing.T) {
 			require.Equal(t, test.expected, result)
 		})
 	}
+}
+
+func TestGetCustomChainConfigPreimages(t *testing.T) {
+	cfg := &config.Config{
+		Rollup:              chaincfg.OPSepolia(),
+		IsCustomChainConfig: true,
+		L1Head:              common.HexToHash("0x1111"),
+		L2OutputRoot:        common.HexToHash("0x2222"),
+		L2Claim:             common.HexToHash("0x3333"),
+		L2ClaimBlockNumber:  1234,
+		L2ChainConfig:       params.SepoliaChainConfig,
+	}
+	source := NewLocalPreimageSource(cfg)
+	actualRollup, err := source.Get(rollupKey)
+	require.NoError(t, err)
+	require.Equal(t, asJson(t, cfg.Rollup), actualRollup)
+	actualChainConfig, err := source.Get(l2ChainConfigKey)
+	require.NoError(t, err)
+	require.Equal(t, asJson(t, cfg.L2ChainConfig), actualChainConfig)
 }
 
 func asJson(t *testing.T, v any) []byte {


### PR DESCRIPTION
**Description**

Modifies op-program host to refuse to return the rollup config and L2 chain config unless the chain ID is the custom chain ID marker value. Those keys aren't available on chain since the contracts can't populate them. The client won't request them unless the right chain ID is used, but worth being safe and making op-program host as compatible with on-chain as possible too.

**Tests**

Updated unit tests.