### PR TITLE
docs: fix ParserError in code block

### DIFF
--- a/packages/contracts-bedrock/INTERFACES.md
+++ b/packages/contracts-bedrock/INTERFACES.md
@@ -36,7 +36,7 @@ contract MyContract {
 You can use an interface:
 
 ```solidity
-import "./interfaces/IComplexContract.sol";`
+import "./interfaces/IComplexContract.sol";
 
 contract MyContract {
     IComplexContract public complexContract;


### PR DESCRIPTION
**Description**

A backtick is misplaced in the code block, which will lead to a ParserError.
The backtick is removed now.

**Tests**

No test is required as the change is only in the document
