### PR TITLE
op-deployer: Most implementation addresses not set in state.json when standard release tag used

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editorconfig.generateAuto": false,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+  "makefile.configureOnOpen": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
   "editorconfig.generateAuto": false,
-  "files.trimTrailingWhitespace": true,
-  "makefile.configureOnOpen": false
+  "files.trimTrailingWhitespace": true
 }

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -275,6 +275,16 @@ func validateOPChainDeployment(t *testing.T, ctx context.Context, l1Client *ethc
 			})
 		}
 
+		require.NotEmpty(t, st.ImplementationsDeployment.DelayedWETHImplAddress, "DelayedWETHImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.OptimismPortalImplAddress, "OptimismPortalImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.SystemConfigImplAddress, "SystemConfigImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.L1CrossDomainMessengerImplAddress, "L1CrossDomainMessengerImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.L1ERC721BridgeImplAddress, "L1ERC721BridgeImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.L1StandardBridgeImplAddress, "L1StandardBridgeImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.OptimismMintableERC20FactoryImplAddress, "OptimismMintableERC20FactoryImplAddress should be set")
+		require.NotEmpty(t, st.ImplementationsDeployment.DisputeGameFactoryImplAddress, "DisputeGameFactoryImplAddress should be set")
+		// TODO: Need to check that 'mipsSingletonAddress' and 'preimageOracleSingletonAddress' are set
+
 		t.Run("l2 genesis", func(t *testing.T) {
 			require.Greater(t, len(chainState.Allocs), 0)
 			l2Allocs, _ := chainState.UnmarshalAllocs()

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -100,7 +100,7 @@ func DeployOPChain(ctx context.Context, env *Env, bundle ArtifactsBundle, intent
 	currentBlockHash := block.Hash()
 
 	// If any of the implementations addresses (excluding OpcmProxy) are empty,
-	// we need to set them using the addresses of the corresponding proxies.
+	// we need to set them using the implementation address read from their corresponding proxy.
 	// The reason these might be empty is because we're only invoking DeployOPChain.s.sol as part of the pipeline.
 	// TODO: Need to initialize 'mipsSingletonAddress' and 'preimageOracleSingletonAddress'
 	setEIP1967ImplementationAddress(ctx, env.L1Client, dco.DelayedWETHPermissionedGameProxy, currentBlockHash, &st.ImplementationsDeployment.DelayedWETHImplAddress)


### PR DESCRIPTION
When users run `op-deployer`, it's likely that they're going to be using a standard release version e.g. `op-contracts/v*`. This means that most executions of `op-deployer` will only be executing `DeployOPChain.s.sol` under the hood. When `DeployOPChain.s.sol` is executed, the `implementationsDeployment` property in `state.json` isn't set properly. This is because these addresses normally only get set in `DeployImplementations.s.sol`, which is skipped in this case. This PR adds these addresses to `state.json` when only the `DeployOPChain.s.sol` pipeline is executed. 

Note: there is a TODO left in the code:
```go
TODO: Need to initialize 'mipsSingletonAddress' and 'preimageOracleSingletonAddress'
```
This will be left for a later PR. 


Related issue: https://github.com/ethereum-optimism/platforms-team/issues/347 