### PR TITLE
op-e2e: fix interop tests

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -17,6 +17,7 @@ import { Process } from "scripts/libraries/Process.sol";
 import { ChainAssertions } from "scripts/deploy/ChainAssertions.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { DeploySuperchainInput, DeploySuperchain, DeploySuperchainOutput } from "scripts/DeploySuperchain.s.sol";
+import { DeployOPChain } from "scripts/DeployOPChain.s.sol"; // generates required artifacts for op-e2e/interop tests
 import {
     DeployImplementationsInput,
     DeployImplementations,
@@ -444,6 +445,12 @@ contract Deploy is Deployer {
     /// @notice Deploy all of the OP Chain specific contracts
     function deployOpChain() public {
         console.log("Deploying OP Chain");
+
+        // The lines below are only to prevent unused import error for DeployOPChain.sol which forces generation
+        // of the DeployOPChain.sol artifact needed by op-e2e interop tests.
+        DeployOPChain dop = new DeployOPChain();
+        dop.etchIOContracts();
+
         // Ensure that the requisite contracts are deployed
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
         OPContractsManager opcm = OPContractsManager(mustGetAddress("OPContractsManagerProxy"));


### PR DESCRIPTION
**Description**

op-e2e/interop tests are currently failing when run in a fresh repo because "make devnet-allocs" isn't generating all the necessary forge artifacts, specifically DeployOPChain.sol.   This PR adds the appropriate dependency to generate it.
