### PR TITLE
op-challenger: Support running multiple prestates the same game type in run-trace

### DIFF
--- a/op-challenger/cmd/run_trace_test.go
+++ b/op-challenger/cmd/run_trace_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/runner"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRunArg(t *testing.T) {
+	tests := []struct {
+		arg      string
+		expected runner.RunConfig
+		err      error
+	}{
+		{arg: "unknown/test1/0x1234", err: ErrUnknownTraceType},
+		{arg: "cannon", expected: runner.RunConfig{TraceType: types.TraceTypeCannon, Name: types.TraceTypeCannon.String()}},
+		{arg: "asterisc", expected: runner.RunConfig{TraceType: types.TraceTypeAsterisc, Name: types.TraceTypeAsterisc.String()}},
+		{arg: "cannon/test1", expected: runner.RunConfig{TraceType: types.TraceTypeCannon, Name: "test1"}},
+		{arg: "cannon/test1/0x1234", expected: runner.RunConfig{TraceType: types.TraceTypeCannon, Name: "test1", Prestate: common.HexToHash("0x1234")}},
+		{arg: "cannon/test1/invalid", err: ErrInvalidPrestateHash},
+	}
+	for _, test := range tests {
+		test := test
+		// Slash characters in test names confuse some things that parse the output as it looks like a subtest
+		t.Run(strings.ReplaceAll(test.arg, "/", "_"), func(t *testing.T) {
+			actual, err := parseRunArg(test.arg)
+			require.ErrorIs(t, err, test.err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -60,28 +60,6 @@ func createTraceProvider(
 	return nil, errors.New("invalid trace type")
 }
 
-func createMTTraceProvider(
-	ctx context.Context,
-	logger log.Logger,
-	m vm.Metricer,
-	vmConfig vm.Config,
-	prestateHash common.Hash,
-	absolutePrestateBaseURL *url.URL,
-	localInputs utils.LocalGameInputs,
-	dir string,
-) (types.TraceProvider, error) {
-	executor := vm.NewOpProgramServerExecutor(logger)
-	stateConverter := cannon.NewStateConverter(vmConfig)
-
-	prestateSource := prestates.NewMultiPrestateProvider(absolutePrestateBaseURL, filepath.Join(dir, "prestates"), stateConverter)
-	prestatePath, err := prestateSource.PrestatePath(ctx, prestateHash)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get prestate %v: %w", prestateHash, err)
-	}
-	prestateProvider := vm.NewPrestateProvider(prestatePath, stateConverter)
-	return cannon.NewTraceProvider(logger, m, vmConfig, executor, prestateProvider, prestatePath, localInputs, dir, 42), nil
-}
-
 func getPrestate(ctx context.Context, prestateHash common.Hash, prestateBaseUrl *url.URL, prestatePath string, dataDir string, stateConverter vm.StateConverter) (string, error) {
 	prestateSource := prestates.NewPrestateSource(
 		prestateBaseUrl,


### PR DESCRIPTION
**Description**

Add a `--run` CLI arg to the `run-trace` subcommand that allows specifying a custom run configuration. The format is a little bit "creative" to fit in the CLI but gives both flexibility and improved metrics: `traceType/name/prestateHash` - only the traceType must be specified.

* `traceType` - the trace provider to use eg `cannon`, `asterisc`, `asterisc-kona`
* `name` - the name to use for metrics/logs for this run. Arbitrary. If not provided, defaults to the name of the trace type
* `prestateHash` the hash of the prestate to use. Will be downloaded from the prestates URL. If not provided, defaults to the prestate used for new games on chain.

The custom support for running an additional cannon trace with a MT cannon prestate has been removed as it can be achieved with this option. The one difference is that previously the runner guaranteed that MT cannon and singlethreaded cannon would execute with the exact same inputs, whereas now they both operate independently. The key check is that it should consider the output root valid (since it was taken from our actual node) so we still know that MT cannon is getting the right result.  The advantage is that we now continuously execute the VM instead of waiting for both singlethreaded and multithreaded prestates to complete which means we're verifying more blocks and getting more test coverage.

**Tests**

Added unit tests for parsing the CLI args.


**Metadata**

https://github.com/ethereum-optimism/optimism/issues/12442
