### PR TITLE
deploy: get superchain proxy impls using zero address

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -238,6 +238,9 @@ contract Deploy is Deployer {
 
         console.log("Deploying a fresh OP Stack with existing SuperchainConfig and ProtocolVersions");
 
+        // Set msg.sender to zero address because the proxies will return implementation only for
+        // zero address or admin.
+        vm.startPrank(0x0000000000000000000000000000000000000000);
         IProxy scProxy = IProxy(_superchainConfigProxy);
         save("SuperchainConfig", scProxy.implementation());
         save("SuperchainConfigProxy", _superchainConfigProxy);
@@ -245,6 +248,7 @@ contract Deploy is Deployer {
         IProxy pvProxy = IProxy(_protocolVersionsProxy);
         save("ProtocolVersions", pvProxy.implementation());
         save("ProtocolVersionsProxy", _protocolVersionsProxy);
+        vm.stopPrank();
 
         _run(false);
 

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -240,7 +240,7 @@ contract Deploy is Deployer {
 
         // Set msg.sender to zero address because the proxies will return implementation only for
         // zero address or admin.
-        vm.startPrank(0x0000000000000000000000000000000000000000);
+        vm.startPrank(address(0));
         IProxy scProxy = IProxy(_superchainConfigProxy);
         save("SuperchainConfig", scProxy.implementation());
         save("SuperchainConfigProxy", _superchainConfigProxy);


### PR DESCRIPTION

**Description**

Deploy using the existing superchain config will fail because calling `implementation()` of the superchain proxies will be reverted.  An example error is below:

```
[22332] Deploy::runWithSuperchain(0xDc82c0362A241Aa94d53546648EACe48C9773dAa, 0x856e75e9c0Da547F9753c17746D6cc139b668e5c, false)
    ├─ [2352] DeployConfig::l1ChainID() [staticcall]
    │   └─ ← [Return] 900
    ├─ [0] VM::chainId(900)
    │   └─ ← [Return] 
    ├─ [0] console::log("Deploying a fresh OP Stack with existing SuperchainConfig and ProtocolVersions") [staticcall]
    │   └─ ← [Stop] 
    ├─ [7333] 0xDc82c0362A241Aa94d53546648EACe48C9773dAa::implementation()
    │   ├─ [193] 0x238213078DbD09f2D15F4c14c02300FA1b2A81BB::implementation() [delegatecall]
    │   │   └─ ← [Revert] EvmError: Revert
    │   └─ ← [Revert] EvmError: Revert
    └─ ← [Revert] EvmError: Revert
```

The reason is that `implementation()` only returns when `msg.sender` is zero address or admin. If not, the proxy will forward the call to the implementation, which will revert the call.

The fix uses the zero address as `msg.sender` so that the proxy will return the implementation.

**Tests**

run `... forge script scripts/deploy/Deploy.s.sol:Deploy --sig 'runWithSuperchain(address,address,bool)' ...`, got the following logs

Before
```
DeployConfig: reading file deploy-config/devnetL1.json
  Deploying a fresh OP Stack with existing SuperchainConfig and ProtocolVersions
Error: 
script failed: <empty revert data>
```

After
```
...
Deploying a fresh OP Stack with existing SuperchainConfig and ProtocolVersions
  Saving SuperchainConfig: 0x238213078DbD09f2D15F4c14c02300FA1b2A81BB
  Saving SuperchainConfigProxy: 0xDc82c0362A241Aa94d53546648EACe48C9773dAa
  Saving ProtocolVersions: 0xd85BdcdaE4db1FAEB8eF93331525FE68D7C8B3f0
  Saving ProtocolVersionsProxy: 0x856e75e9c0Da547F9753c17746D6cc139b668e5c
  start of L1 Deploy!
...
```
where the implementations are retrieved and printed.
**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
