### PR TITLE
cannon: Add a script to build multicannon with support for legacy versions

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -21,6 +21,10 @@ cannon32-impl:
 cannon64-impl:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build --tags=cannon64 -v $(LDFLAGS) -o ./bin/cannon64-impl .
 
+# Note: This target is used by ./scripts/build-legacy-cannons.sh
+# It should build the individual versions of cannons and copy them into place in hte multicannon/embeds directory
+# Ideally, preserve backwards compatibility with this behaviour but if it needs to change, build-legacy-cannons.sh will
+# need to be updated to account for different behaviours in different versions.
 cannon-embeds: cannon32-impl cannon64-impl
 	# singlethreaded-v2
 	@cp bin/cannon32-impl ./multicannon/embeds/cannon-2

--- a/cannon/scripts/build-legacy-cannons.sh
+++ b/cannon/scripts/build-legacy-cannons.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# This script builds a version of the cannon executable that includes support for both current and legacy state versions.
+# Each cannon release is built
+
+TMP_DIR=$(mktemp -d)
+function cleanup() {
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+echo "Using temp dir: ${TMP_DIR}"
+cd "${TMP_DIR}"
+
+# Need to check out a fresh copy of the monorepo so we can switch to specific tags without it also affecting the
+# contents of this script (which is checked into the repo).
+git clone https://github.com/ethereum-optimism/optimism --recurse-submodules
+
+CANNON_DIR="${SCRIPTS_DIR}/../"
+EMBEDS_DIR="${CANNON_DIR}/multicannon/embeds"
+LOGS_DIR="${CANNON_DIR}/temp/logs"
+REPO_DIR="${TMP_DIR}/optimism"
+BIN_DIR="${REPO_DIR}/cannon/multicannon/embeds"
+
+mkdir -p "${LOGS_DIR}"
+
+cd "${REPO_DIR}"
+
+function buildVersion() {
+  TAG=${1}
+  LOG_FILE="${LOGS_DIR}/build-$(echo "${TAG}" | cut -c 8-).txt"
+  echo "Building Version: ${TAG} Logs: ${LOG_FILE}"
+  git checkout "${TAG}" > "${LOG_FILE}" 2>&1
+  git submodule update --init --recursive >> "${LOG_FILE}" 2>&1
+  rm -rf "${BIN_DIR}/cannon-"*
+  make -C "${REPO_DIR}/cannon" cannon-embeds >> "${LOG_FILE}" 2>&1
+  cp "${BIN_DIR}/cannon-"* "${EMBEDS_DIR}/"
+  echo "Built ${TAG} with versions:"
+  (cd "${BIN_DIR}" && ls cannon-*)
+}
+
+# Build each release of cannon from earliest to latest. Releases with qualifiers (e.g. `-rc`, `-alpha` etc are skipped.
+# If the same state version is supported by multiple version tags built, the build from the last tag listed will be used
+# The currently checked out code is built after this list to include the currently supported state versions and
+# build the final cannon executable.
+VERSIONS=$(git tag --list 'cannon/v*' --sort taggerdate | grep -v -- '-')
+for VERSION in ${VERSIONS}
+do
+  buildVersion "$VERSION"
+done
+
+cd "${CANNON_DIR}"
+LOG_FILE="${LOGS_DIR}/build-current.txt"
+echo "Building current version of cannon Logs: ${LOG_FILE}"
+make cannon > "${LOG_FILE}" 2>&1
+
+echo "All cannon versions successfully built and available in ${EMBEDS_DIR}"
+"${CANNON_DIR}/bin/cannon" list

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -47,7 +47,7 @@ ARG TARGETARCH
 # The "id" defaults to the value of "target", the cache will thus be reused during this build.
 # "sharing" defaults to "shared", the cache will thus be available to other concurrent docker builds.
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.0.0-alpha.3 AS cannon-builder-0
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.0.0 AS cannon-builder-0
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-builder
 ARG CANNON_VERSION=v0.0.0


### PR DESCRIPTION
**Description**

Adds `cannon/scripts/build-legacy-cannons.sh` script that builds `cannon` including support for legacy state versions. This may be useful for anyone building cannon locally, but mostly serves as executable documentation for how to perform this build if not using the standard docker images.

cannon/v1.0.0-alpha.3 has now been tagged as cannon/v1.0.0 since it is the last version that supports state version 0. References have been updated and the script can then build each final cannon release rather than needing a list of specific tags to build so as long as we tag a release before dropping support for any state version the script will auto-update with new versions.

**Metadata**

Fixes #12374 