### PR TITLE
test: Remove exceptions for unlabelled fdg contracts

### DIFF
--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -216,13 +216,6 @@ abstract contract Artifacts {
 
     /// @notice Returns the value of the internal `_initialized` storage slot for a given contract.
     function loadInitializedSlot(string memory _contractName) public returns (uint8 initialized_) {
-        // FaultDisputeGame and PermissionedDisputeGame are initializable but cannot be loaded with
-        // this function yet because they are not properly labeled in the deploy script.
-        // TODO: Remove this restriction once the deploy script is fixed.
-        if (LibString.eq(_contractName, "FaultDisputeGame") || LibString.eq(_contractName, "PermissionedDisputeGame")) {
-            revert UnsupportedInitializableContract(_contractName);
-        }
-
         address contractAddress;
         // Check if the contract name ends with `Proxy` and, if so, get the implementation address
         if (LibString.endsWith(_contractName, "Proxy")) {

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -473,19 +473,9 @@ contract Initializer_Test is Bridge_Initializer {
             InitializeableContract memory _contract = contracts[i];
             string memory name = _getRealContractName(_contract.name);
 
-            // Grab the value of the "initialized" storage slot. Must handle special case for the
-            // FaultDisputeGame and PermissionedDisputeGame contracts since these have a different
-            // name for the "initialized" storage slot and are currently not properly labeled in
-            // the deployment script.
-            // TODO: Update deployment script to properly label the dispute game contracts.
+            // Grab the value of the "initialized" storage slot.
             uint8 initializedSlotVal;
-            if (LibString.eq(name, "FaultDisputeGame") || LibString.eq(name, "PermissionedDisputeGame")) {
-                StorageSlot memory slot = ForgeArtifacts.getInitializedSlot(name);
-                bytes32 slotVal = vm.load(_contract.target, bytes32(vm.parseUint(slot.slot)));
-                initializedSlotVal = uint8((uint256(slotVal) >> (slot.offset * 8)) & 0xFF);
-            } else {
-                initializedSlotVal = deploy.loadInitializedSlot(name);
-            }
+            initializedSlotVal = deploy.loadInitializedSlot(name);
 
             // Assert that the contract is already initialized.
             assertTrue(

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -6,7 +6,7 @@ import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";
 
 // Scripts
 import { Executables } from "scripts/libraries/Executables.sol";
-import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
+import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 import { Process } from "scripts/libraries/Process.sol";
 
 // Libraries


### PR DESCRIPTION
### TL;DR

Removed special handling for `FaultDisputeGame` and `PermissionedDisputeGame` contracts in initialization checks. We no longer need them as the Deploy script labels them properly.

### What changed?

- Removed the restriction on loading initialized slots for FaultDisputeGame and PermissionedDisputeGame in `Artifacts.s.sol`.
- Simplified the initialization check in `Initializable.t.sol` by removing the special case handling for these contracts.

