### PR TITLE
fix: Allow reading the initialized slot of a Proxy

### DIFF
--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -7,10 +7,8 @@ import { Vm } from "forge-std/Vm.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Config } from "scripts/libraries/Config.sol";
 import { StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
-import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
 import { Process } from "scripts/libraries/Process.sol";
 
 /// @notice Represents a deployment. Is serialized to JSON as a key/value

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -218,20 +218,14 @@ abstract contract Artifacts {
 
     /// @notice Returns the value of the internal `_initialized` storage slot for a given contract.
     function loadInitializedSlot(string memory _contractName) public returns (uint8 initialized_) {
-        address contractAddress;
-        // Check if the contract name ends with `Proxy` and, if so, get the implementation address
+        address contractAddress = mustGetAddress(_contractName);
+
+        // Check if the contract name ends with `Proxy` and, if so override the contract name which is used to
+        // retrieve the storage layout.
         if (LibString.endsWith(_contractName, "Proxy")) {
-            contractAddress = EIP1967Helper.getImplementation(getAddress(_contractName));
             _contractName = LibString.slice(_contractName, 0, bytes(_contractName).length - 5);
-            // If the EIP1967 implementation address is 0, we try to get the implementation address from legacy
-            // AddressManager, which would work if the proxy is ResolvedDelegateProxy like L1CrossDomainMessengerProxy.
-            if (contractAddress == address(0)) {
-                contractAddress =
-                    IAddressManager(mustGetAddress("AddressManager")).getAddress(string.concat("OVM_", _contractName));
-            }
-        } else {
-            contractAddress = mustGetAddress(_contractName);
         }
+
         StorageSlot memory slot = ForgeArtifacts.getInitializedSlot(_contractName);
         bytes32 slotVal = vm.load(contractAddress, bytes32(vm.parseUint(slot.slot)));
         initialized_ = uint8((uint256(slotVal) >> (slot.offset * 8)) & 0xFF);


### PR DESCRIPTION
Fixes #12422

I spoke with @tynes who had initially written the logic, and he also felt that it was a bug to prevent reading the Proxy's initialized slot.