### PR TITLE
(WIP): Collect Block Building Metrics from Sequencers

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -372,6 +372,13 @@ var (
 		Value:    time.Second * 1,
 		Category: SequencerCategory,
 	}
+	BlockBuildingThresholdFlag = &cli.Uint64Flag{
+		Name:     "block-building.threshold",
+		Usage:    "Block building healthcheck threshold (default: 2 seconds)",
+		EnvVars:  prefixEnvVars("BLOCK_BUILDING_THRESHOLD"),
+		Value:    2,
+		Category: SequencerCategory,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -419,6 +426,7 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
 	L2EngineKind,
+	BlockBuildingThresholdFlag,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -36,6 +36,7 @@ type Metrics interface {
 	RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.BlockID)
 	RecordSequencerReset()
 	RecordSequencingError()
+	RecordSequencerBlockBuildingHealth(status string)
 }
 
 type SequencerStateListener interface {
@@ -328,6 +329,33 @@ func (d *Sequencer) onPayloadSuccess(x engine.PayloadSuccessEvent) {
 	d.latest = BuildingState{}
 	d.log.Info("Sequencer inserted block",
 		"block", x.Ref, "parent", x.Envelope.ExecutionPayload.ParentID())
+	// Check if the node is healthy
+	payload := x.Envelope.ExecutionPayload
+	blockBuildingThreshold := d.rollupCfg.BlockBuildingThreshold
+	if payload != nil {
+		latestBlockTimeStamp := uint64(payload.Timestamp)
+		currentTime := uint64(time.Now().Unix())
+
+		if latestBlockTimeStamp <= currentTime+1 { // TODO: Remove the +1 once we have a better way to handle this
+			timeDiff := time.Duration(currentTime-latestBlockTimeStamp) * time.Second
+
+			if timeDiff < blockBuildingThreshold {
+				// Node is healthy
+				d.log.Debug("Node is healthy, time difference within threshold",
+					"time_diff", timeDiff, "threshold", blockBuildingThreshold)
+				d.metrics.RecordSequencerBlockBuildingHealth("healthy")
+			} else {
+				// Node is stale
+				d.log.Warn("Node is stale, time difference exceeds threshold",
+					"time_diff", timeDiff, "threshold", blockBuildingThreshold)
+				d.metrics.RecordSequencerBlockBuildingHealth("stale")
+			}
+		} else {
+			d.log.Debug("Cannot compute time difference, block timestamp is in the future",
+				"current_timestamp", currentTime, "block_timestamp", latestBlockTimeStamp)
+			d.metrics.RecordSequencerBlockBuildingHealth("future_timestamp")
+		}
+	}
 	// The payload was already published upon sealing.
 	// Now that we have processed it ourselves we don't need it anymore.
 	d.asyncGossip.Clear()

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -137,6 +137,8 @@ type Config struct {
 
 	// AltDAConfig. We are in the process of migrating to the AltDAConfig from these legacy top level values
 	AltDAConfig *AltDAConfig `json:"alt_da,omitempty"`
+
+	BlockBuildingThreshold time.Duration `json:"block_building_threshold,omitempty"`
 }
 
 // ValidateL1Config checks L1 config variables for errors.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
@@ -212,7 +213,8 @@ func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, e
 	if ctx.Bool(flags.BetaExtraNetworks.Name) {
 		log.Warn("The beta.extra-networks flag is deprecated and can be omitted safely.")
 	}
-	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath)
+	blockBuildingThreshold := ctx.Uint64(flags.BlockBuildingThresholdFlag.Name)
+	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath, blockBuildingThreshold)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +222,7 @@ func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, e
 	return rollupConfig, nil
 }
 
-func NewRollupConfig(log log.Logger, network string, rollupConfigPath string) (*rollup.Config, error) {
+func NewRollupConfig(log log.Logger, network string, rollupConfigPath string, blockBuidlingThreshold uint64) (*rollup.Config, error) {
 	if network != "" {
 		if rollupConfigPath != "" {
 			log.Error(`Cannot configure network and rollup-config at the same time.
@@ -232,6 +234,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 		if err != nil {
 			return nil, err
 		}
+		rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 		return rollupConfig, nil
 	}
 
@@ -247,6 +250,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := dec.Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
+	rollupConfig.BlockBuildingThreshold = time.Duration(blockBuidlingThreshold) * time.Second
 	return &rollupConfig, nil
 }
 


### PR DESCRIPTION
**Description**
This PR adds health checks on sequencer's block production. Unlike the prometheus metrics provided already, this provides per block granularity and checks the health of the unsafe block production. This PR only focuses on collecting the healthchecks from sequencers

**Tests**
test in sepolia alpha

**Additional context**
As we increase our gas target, we would like to have precise metrics on how well we are producing blocks. This will help us determine when to increase or stop increasing gas target, as well as help us refine our SLO. In the future, we could potentially use this to monitor our chain when we implement sub second block time.