### PR TITLE
maint(ct): use L1Block interfaces in tests

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x66ac1212760db53a2bb1839e4cd17dc071d9273b8e6fb80646b79e91b3371c1a"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x39f66ac74341ec235fbdd0d79546283210bd8ac35a2ab2c4bd36c9722ce18411",
-    "sourceCodeHash": "0xbb98144285b9530e336f957d10b20363b350876597e30fd34821940896a2bae8"
+    "initCodeHash": "0x902ce448a29a72805cd74b7fc62519fa3d12338851b518b7d01e8a40ba232c72",
+    "sourceCodeHash": "0x8de1b2d4675624a2a3aee135ad8780a07ca91002a5952f2b6501fdf20c92b753"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0xefd4806e8737716d5d2022ca2e9e9fba0a0cb5714b026166b58e472222c7d15f",
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0x5ca776041a4ddc0d28ec55db7012d669481cd4601b0e71dbd3493a67b8a7e5a5"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0x277a61dcabed81a15739a8e9ed50615252bcc687cebea852e00191d0a1fbe11f",
-    "sourceCodeHash": "0x38361a4f70a19e1b7819e933932a0c9fd2bcebaaebcbc7942f5c00dfaa2c28df"
+    "initCodeHash": "0x594970feb88f2e656c89879b6dc4fe338a99dc7bcf6205c8fe072271bde3eeb9",
+    "sourceCodeHash": "0x72fed1345f42e383ca3846e9ab8ed5537a41fccc04769572cbf6fffc674689be"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0xbf49824cf37e201181484a8a423fcad8f504dc925921a2b28e83398197858dec",

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -3,12 +3,14 @@ pragma solidity 0.8.15;
 
 // Contracts
 import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
-import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Unauthorized } from "src/libraries/PortalErrors.sol";
+
+// Interfaces
+import { IL1BlockInterop, ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 /// @custom:proxied true
 /// @title OptimismPortalInterop
@@ -23,9 +25,9 @@ contract OptimismPortalInterop is OptimismPortal2 {
         OptimismPortal2(_proofMaturityDelaySeconds, _disputeGameFinalityDelaySeconds)
     { }
 
-    /// @custom:semver +interop-beta.2
+    /// @custom:semver +interop-beta.3
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.2");
+        return string.concat(super.version(), "+interop-beta.3");
     }
 
     /// @notice Sets static configuration options for the L2 system.
@@ -48,7 +50,7 @@ contract OptimismPortalInterop is OptimismPortal2 {
                 uint256(0), // value
                 uint64(SYSTEM_DEPOSIT_GAS_LIMIT), // gasLimit
                 false, // isCreation,
-                abi.encodeCall(L1BlockInterop.setConfig, (_type, _value))
+                abi.encodeCall(IL1BlockInterop.setConfig, (_type, _value))
             )
         );
     }

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.15;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IOptimismPortalInterop as IOptimismPortal } from "src/L1/interfaces/IOptimismPortalInterop.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
-import { ConfigType } from "src/L2/L1BlockInterop.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
@@ -15,6 +14,7 @@ import { Storage } from "src/libraries/Storage.sol";
 
 // Interfaces
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
+import { ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 /// @custom:proxied true
 /// @title SystemConfigInterop
@@ -68,9 +68,9 @@ contract SystemConfigInterop is SystemConfig {
         Storage.setAddress(DEPENDENCY_MANAGER_SLOT, _dependencyManager);
     }
 
-    /// @custom:semver +interop-beta.3
+    /// @custom:semver +interop-beta.4
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.3");
+        return string.concat(super.version(), "+interop-beta.4");
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.

--- a/packages/contracts-bedrock/src/L1/interfaces/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/interfaces/IOptimismPortalInterop.sol
@@ -7,7 +7,7 @@ import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.sol";
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
 import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
-import { ConfigType } from "src/L2/L1BlockInterop.sol";
+import { ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 interface IOptimismPortalInterop {
     error AlreadyFinalized();

--- a/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
@@ -9,13 +9,9 @@ import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import "src/libraries/PortalErrors.sol";
 
-// Target contract dependencies
-import "src/libraries/PortalErrors.sol";
-import { OptimismPortalInterop } from "src/L1/OptimismPortalInterop.sol";
-import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
-
 // Interfaces
 import { IOptimismPortalInterop } from "src/L1/interfaces/IOptimismPortalInterop.sol";
+import { IL1BlockInterop, ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 contract OptimismPortalInterop_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
@@ -35,7 +31,7 @@ contract OptimismPortalInterop_Test is CommonTest {
             _mint: 0,
             _gasLimit: 200_000,
             _isCreation: false,
-            _data: abi.encodeCall(L1BlockInterop.setConfig, (ConfigType.SET_GAS_PAYING_TOKEN, _value))
+            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.SET_GAS_PAYING_TOKEN, _value))
         });
 
         vm.prank(address(_optimismPortalInterop().systemConfig()));
@@ -58,7 +54,7 @@ contract OptimismPortalInterop_Test is CommonTest {
             _mint: 0,
             _gasLimit: 200_000,
             _isCreation: false,
-            _data: abi.encodeCall(L1BlockInterop.setConfig, (ConfigType.ADD_DEPENDENCY, _value))
+            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.ADD_DEPENDENCY, _value))
         });
 
         vm.prank(address(_optimismPortalInterop().systemConfig()));
@@ -81,7 +77,7 @@ contract OptimismPortalInterop_Test is CommonTest {
             _mint: 0,
             _gasLimit: 200_000,
             _isCreation: false,
-            _data: abi.encodeCall(L1BlockInterop.setConfig, (ConfigType.REMOVE_DEPENDENCY, _value))
+            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.REMOVE_DEPENDENCY, _value))
         });
 
         vm.prank(address(_optimismPortalInterop().systemConfig()));

--- a/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -6,7 +6,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { ConfigType } from "src/L2/L1BlockInterop.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
@@ -17,6 +16,7 @@ import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
 import { ISystemConfigInterop } from "src/L1/interfaces/ISystemConfigInterop.sol";
 import { IOptimismPortalInterop } from "src/L1/interfaces/IOptimismPortalInterop.sol";
+import { ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 contract SystemConfigInterop_Test is CommonTest {
     /// @notice Marked virtual to be overridden in

--- a/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
-
-// Target contract dependencies
-import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import "src/libraries/L1BlockErrors.sol";
+
+// Interfaces
+import { IL1BlockInterop, ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 contract L1BlockInteropTest is CommonTest {
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
@@ -199,8 +199,8 @@ contract L1BlockInteropTest is CommonTest {
     }
 
     /// @dev Returns the L1BlockInterop instance.
-    function _l1BlockInterop() internal view returns (L1BlockInterop) {
-        return L1BlockInterop(address(l1Block));
+    function _l1BlockInterop() internal view returns (IL1BlockInterop) {
+        return IL1BlockInterop(address(l1Block));
     }
 }
 
@@ -261,7 +261,7 @@ contract L1BlockInteropSetL1BlockValuesInterop_Test is L1BlockInteropTest {
 
         vm.prank(_l1BlockInterop().DEPOSITOR_ACCOUNT());
         (bool success,) = address(l1Block).call(
-            abi.encodePacked(L1BlockInterop.setL1BlockValuesInterop.selector, setValuesEcotoneCalldata)
+            abi.encodePacked(IL1BlockInterop.setL1BlockValuesInterop.selector, setValuesEcotoneCalldata)
         );
         assertTrue(success, "function call failed");
 

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -4,24 +4,32 @@ pragma solidity 0.8.15;
 // Testing
 import { Test } from "forge-std/Test.sol";
 
-// Contracts
-import { L1BlockNumber } from "src/legacy/L1BlockNumber.sol";
-import { L1Block } from "src/L2/L1Block.sol";
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 
+// Interfaces
+import { IL1BlockNumber } from "src/legacy/interfaces/IL1BlockNumber.sol";
+import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
+
 contract L1BlockNumberTest is Test {
-    L1Block lb;
-    L1BlockNumber bn;
+    IL1Block lb;
+    IL1BlockNumber bn;
 
     uint64 constant number = 99;
 
     /// @dev Sets up the test suite.
     function setUp() external {
-        vm.etch(Predeploys.L1_BLOCK_ATTRIBUTES, address(new L1Block()).code);
-        lb = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
-        bn = new L1BlockNumber();
+        vm.etch(Predeploys.L1_BLOCK_ATTRIBUTES, vm.getDeployedCode("L1Block"));
+        lb = IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
+        bn = IL1BlockNumber(
+            DeployUtils.create1({
+                _name: "L1BlockNumber",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1BlockNumber.__constructor__, ()))
+            })
+        );
         vm.prank(lb.DEPOSITOR_ACCOUNT());
 
         lb.setL1BlockValues({

--- a/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
@@ -7,14 +7,17 @@ import { Vm } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { Bridge_Initializer } from "test/setup/Bridge_Initializer.sol";
 
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
 // Libraries
 import { Types } from "src/libraries/Types.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
-import { L1BlockInterop } from "src/L2/L1BlockInterop.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 
 // Interfaces
 import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
+import { IL1BlockInterop } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 // Free function for setting the prevBaseFee param in the OptimismPortal.
 function setPrevBaseFee(Vm _vm, address _op, uint128 _prevBaseFee) {
@@ -257,11 +260,16 @@ contract GasBenchMark_L1Block_SetValuesEcotone_Warm is GasBenchMark_L1Block {
 }
 
 contract GasBenchMark_L1BlockInterop is GasBenchMark_L1Block {
-    L1BlockInterop l1BlockInterop;
+    IL1BlockInterop l1BlockInterop;
 
     function setUp() public virtual override {
         super.setUp();
-        l1BlockInterop = new L1BlockInterop();
+        l1BlockInterop = IL1BlockInterop(
+            DeployUtils.create1({
+                _name: "L1BlockInterop",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1BlockInterop.__constructor__, ()))
+            })
+        );
         setValuesCalldata = Encoding.encodeSetL1BlockValuesInterop(
             type(uint32).max,
             type(uint32).max,


### PR DESCRIPTION
Updates some tests to use the interfaces for L1Block and L1BlockNumber to cut down compile time.
