### PR TITLE
cannon: use constant instead of magic value for solidity part

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x2ab6be69795109a1ee04c5693a34d6ce0ff90b62e404cdeb18178bab18d06784"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0x3e426acc53ebd6ad01037ea321410fab2df08e1d1183195c15be9ff48fef4d44",
-    "sourceCodeHash": "0xaf7416f27db1b393092f51d290a29293184105bc5f0d89cd6048f687cebc7d69"
+    "initCodeHash": "0x8fb590d45fa06fdc7ae55860827d6b1abf070c9dc5e18cd28176e844fa1da6c9",
+    "sourceCodeHash": "0x01d3d59020ec29ce78f68f977da5b7754455743121bda65626509864ab6c9da9"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0xd04c55d731400f777f4bb7c6520943e0f350868122bf992377ee3262cda8ee90",
-    "sourceCodeHash": "0x0fd936b1b09a5c3cb4e7ae71c294f168ce9a57a173bcd56b9f20383624de296e"
+    "initCodeHash": "0x88acf3297642c2c9e0c1e92b48f59f7015915f25fb816cac44ee0073a1c93ccb",
+    "sourceCodeHash": "0x3dd89839f268569cbf2659beb42e3ac3c53887472cfc94a6e339d2b3a963b941"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x64ea814bf9769257c91da57928675d3f8462374b0c23bdf860ccfc79f41f7801",

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -44,8 +44,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.2.1-beta.3
-    string public constant version = "1.2.1-beta.3";
+    /// @custom:semver 1.2.1-beta.4
+    string public constant version = "1.2.1-beta.4";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -60,8 +60,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.16
-    string public constant version = "1.0.0-beta.16";
+    /// @custom:semver 1.0.0-beta.17
+    string public constant version = "1.0.0-beta.17";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -128,6 +128,23 @@ library MIPSSyscalls {
     uint32 internal constant VALID_SYS_CLONE_FLAGS =
         CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD;
 
+    // FYI: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File
+    //      https://refspecs.linuxfoundation.org/elf/mipsabi.pdf
+    uint32 internal constant REG_V0 = 2;
+    uint32 internal constant REG_A0 = 4;
+    uint32 internal constant REG_A1 = 5;
+    uint32 internal constant REG_A2 = 6;
+    uint32 internal constant REG_A3 = 7;
+
+    // FYI: https://web.archive.org/web/20231223163047/https://www.linux-mips.org/wiki/Syscall
+    uint32 internal constant REG_SYSCALL_NUM = REG_V0;
+    uint32 internal constant REG_SYSCALL_ERRNO = REG_A3;
+    uint32 internal constant REG_SYSCALL_RET1 = REG_V0;
+    uint32 internal constant REG_SYSCALL_PARAM1 = REG_A0;
+    uint32 internal constant REG_SYSCALL_PARAM2 = REG_A1;
+    uint32 internal constant REG_SYSCALL_PARAM3 = REG_A2;
+    uint32 internal constant REG_SYSCALL_PARAM4 = REG_A3;
+
     /// @notice Extract syscall num and arguments from registers.
     /// @param _registers The cpu registers.
     /// @return sysCallNum_ The syscall number.
@@ -141,12 +158,12 @@ library MIPSSyscalls {
         returns (uint32 sysCallNum_, uint32 a0_, uint32 a1_, uint32 a2_, uint32 a3_)
     {
         unchecked {
-            sysCallNum_ = _registers[2];
+            sysCallNum_ = _registers[REG_SYSCALL_NUM];
 
-            a0_ = _registers[4];
-            a1_ = _registers[5];
-            a2_ = _registers[6];
-            a3_ = _registers[7];
+            a0_ = _registers[REG_SYSCALL_PARAM1];
+            a1_ = _registers[REG_SYSCALL_PARAM2];
+            a2_ = _registers[REG_SYSCALL_PARAM3];
+            a3_ = _registers[REG_SYSCALL_PARAM4];
 
             return (sysCallNum_, a0_, a1_, a2_, a3_);
         }
@@ -397,8 +414,8 @@ library MIPSSyscalls {
     {
         unchecked {
             // Write the results back to the state registers
-            _registers[2] = _v0;
-            _registers[7] = _v1;
+            _registers[REG_SYSCALL_RET1] = _v0;
+            _registers[REG_SYSCALL_ERRNO] = _v1;
 
             // Update the PC and nextPC
             _cpu.pc = _cpu.nextPC;


### PR DESCRIPTION
This is a follow-up PR for [this](https://github.com/ethereum-optimism/optimism/pull/12386) one, which does the same to the solidity part.