### PR TITLE
maint(ct): use mips and oracle interfaces in tests

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -26,7 +26,7 @@ var excludeContracts = []string{
 	"IEAS", "ISchemaResolver", "ISchemaRegistry",
 
 	// TODO: Interfaces that need to be fixed
-	"IInitializable", "IPreimageOracle", "ILegacyMintableERC20", "IOptimismMintableERC20",
+	"IInitializable", "ILegacyMintableERC20", "IOptimismMintableERC20",
 	"IOptimismMintableERC721", "KontrolCheatsBase", "IWETH", "IDelayedWETH", "ISuperchainWETH",
 	"IL2ToL2CrossDomainMessenger", "ICrossL2Inbox", "ISystemConfigInterop", "IResolvedDelegateProxy",
 }

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS.sol
@@ -7,6 +7,21 @@ import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 /// @title IMIPS
 /// @notice Interface for the MIPS contract.
 interface IMIPS is ISemver {
+    struct State {
+        bytes32 memRoot;
+        bytes32 preimageKey;
+        uint32 preimageOffset;
+        uint32 pc;
+        uint32 nextPC;
+        uint32 lo;
+        uint32 hi;
+        uint32 heap;
+        uint8 exitCode;
+        bool exited;
+        uint64 step;
+        uint32[32] registers;
+    }
+
     error InvalidMemoryProof();
     error InvalidRMWInstruction();
 

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
@@ -7,6 +7,39 @@ import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 /// @title IMIPS2
 /// @notice Interface for the MIPS2 contract.
 interface IMIPS2 is ISemver {
+    struct ThreadState {
+        uint32 threadID;
+        uint8 exitCode;
+        bool exited;
+        uint32 futexAddr;
+        uint32 futexVal;
+        uint64 futexTimeoutStep;
+        uint32 pc;
+        uint32 nextPC;
+        uint32 lo;
+        uint32 hi;
+        uint32[32] registers;
+    }
+
+    struct State {
+        bytes32 memRoot;
+        bytes32 preimageKey;
+        uint32 preimageOffset;
+        uint32 heap;
+        uint8 llReservationStatus;
+        uint32 llAddress;
+        uint32 llOwnerThread;
+        uint8 exitCode;
+        bool exited;
+        uint64 step;
+        uint64 stepsSinceLastContextSwitch;
+        uint32 wakeup;
+        bool traverseRight;
+        bytes32 leftThreadStack;
+        bytes32 rightThreadStack;
+        uint32 nextThreadID;
+    }
+
     error InvalidExitedValue();
     error InvalidMemoryProof();
     error InvalidSecondMemoryProof();

--- a/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
@@ -1,41 +1,74 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @title IPreimageOracle
-/// @notice Interface for a preimage oracle.
+import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
+import { LPPMetaData } from "src/cannon/libraries/CannonTypes.sol";
+
 interface IPreimageOracle {
-    /// @notice Returns the length of the large preimage proposal challenge period.
-    /// @return challengePeriod_ The length of the challenge period in seconds.
+    struct Leaf {
+        bytes input;
+        uint256 index;
+        bytes32 stateCommitment;
+    }
+
+    error ActiveProposal();
+    error AlreadyFinalized();
+    error AlreadyInitialized();
+    error BadProposal();
+    error BondTransferFailed();
+    error InsufficientBond();
+    error InvalidInputSize();
+    error InvalidPreimage();
+    error InvalidProof();
+    error NotEOA();
+    error NotInitialized();
+    error PartOffsetOOB();
+    error PostStateMatches();
+    error StatesNotContiguous();
+    error TreeSizeOverflow();
+    error WrongStartingBlock();
+
+    function KECCAK_TREE_DEPTH() external view returns (uint256);
+    function MAX_LEAF_COUNT() external view returns (uint256);
+    function MIN_BOND_SIZE() external view returns (uint256);
+    function PRECOMPILE_CALL_RESERVED_GAS() external view returns (uint256);
+    function addLeavesLPP(
+        uint256 _uuid,
+        uint256 _inputStartBlock,
+        bytes memory _input,
+        bytes32[] memory _stateCommitments,
+        bool _finalize
+    )
+        external;
+    function challengeFirstLPP(
+        address _claimant,
+        uint256 _uuid,
+        Leaf memory _postState,
+        bytes32[] memory _postStateProof
+    )
+        external;
+    function challengeLPP(
+        address _claimant,
+        uint256 _uuid,
+        LibKeccak.StateMatrix memory _stateMatrix,
+        Leaf memory _preState,
+        bytes32[] memory _preStateProof,
+        Leaf memory _postState,
+        bytes32[] memory _postStateProof
+    )
+        external;
     function challengePeriod() external view returns (uint256 challengePeriod_);
-
-    /// @notice Reads a preimage from the oracle.
-    /// @param _key The key of the preimage to read.
-    /// @param _offset The offset of the preimage to read.
-    /// @return dat_ The preimage data.
-    /// @return datLen_ The length of the preimage data.
-    function readPreimage(bytes32 _key, uint256 _offset) external view returns (bytes32 dat_, uint256 datLen_);
-
-    /// @notice Loads of local data part into the preimage oracle.
-    /// @param _ident The identifier of the local data.
-    /// @param _localContext The local key context for the preimage oracle. Optionally, can be set as a constant
-    ///                      if the caller only requires one set of local keys.
-    /// @param _word The local data word.
-    /// @param _size The number of bytes in `_word` to load.
-    /// @param _partOffset The offset of the local data part to write to the oracle.
-    /// @dev The local data parts are loaded into the preimage oracle under the context
-    ///      of the caller - no other account can write to the caller's context
-    ///      specific data.
-    ///
-    ///      There are 5 local data identifiers:
-    ///      ┌────────────┬────────────────────────┐
-    ///      │ Identifier │      Data              │
-    ///      ├────────────┼────────────────────────┤
-    ///      │          1 │ L1 Head Hash (bytes32) │
-    ///      │          2 │ Output Root (bytes32)  │
-    ///      │          3 │ Root Claim (bytes32)   │
-    ///      │          4 │ L2 Block Number (u64)  │
-    ///      │          5 │ Chain ID (u64)         │
-    ///      └────────────┴────────────────────────┘
+    function getTreeRootLPP(address _owner, uint256 _uuid) external view returns (bytes32 treeRoot_);
+    function initLPP(uint256 _uuid, uint32 _partOffset, uint32 _claimedSize) external payable;
+    function loadBlobPreimagePart(
+        uint256 _z,
+        uint256 _y,
+        bytes memory _commitment,
+        bytes memory _proof,
+        uint256 _partOffset
+    )
+        external;
+    function loadKeccak256PreimagePart(uint256 _partOffset, bytes memory _preimage) external;
     function loadLocalData(
         uint256 _ident,
         bytes32 _localContext,
@@ -45,52 +78,40 @@ interface IPreimageOracle {
     )
         external
         returns (bytes32 key_);
-
-    /// @notice Prepares a preimage to be read by keccak256 key, starting at the given offset and up to 32 bytes
-    ///         (clipped at preimage length, if out of data).
-    /// @param _partOffset The offset of the preimage to read.
-    /// @param _preimage The preimage data.
-    function loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external;
-
-    /// @notice Prepares a preimage to be read by sha256 key, starting at the given offset and up to 32 bytes
-    ///         (clipped at preimage length, if out of data).
-    /// @param _partOffset The offset of the preimage to read.
-    /// @param _preimage The preimage data.
-    function loadSha256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external;
-
-    /// @notice Verifies that `p(_z) = _y` given `_commitment` that corresponds to the polynomial `p(x)` and a KZG
-    //          proof. The value `y` is the pre-image, and the preimage key is `5 ++ keccak256(_commitment ++ z)[1:]`.
-    /// @param _z Big endian point value. Part of the preimage key.
-    /// @param _y Big endian point value. The preimage for the key.
-    /// @param _commitment The commitment to the polynomial. 48 bytes, part of the preimage key.
-    /// @param _proof The KZG proof, part of the preimage key.
-    /// @param _partOffset The offset of the preimage to store.
-    function loadBlobPreimagePart(
-        uint256 _z,
-        uint256 _y,
-        bytes calldata _commitment,
-        bytes calldata _proof,
-        uint256 _partOffset
-    )
-        external;
-
-    /// @notice Prepares a precompile result to be read by a precompile key for the specified offset.
-    ///         The precompile result data is a concatenation of the precompile call status byte and its return data.
-    ///         The preimage key is `6 ++ keccak256(precompile ++ input)[1:]`.
-    /// @param _partOffset The offset of the precompile result being loaded.
-    /// @param _precompile The precompile address
-    /// @param _requiredGas The gas required to fully execute an L1 precompile.
-    /// @param _input The input to the precompile call.
     function loadPrecompilePreimagePart(
         uint256 _partOffset,
         address _precompile,
         uint64 _requiredGas,
-        bytes calldata _input
+        bytes memory _input
     )
         external;
-
-    /// @notice Returns the minimum size (in bytes) of a large preimage proposal.
-    function minProposalSize() external view returns (uint256);
+    function loadSha256PreimagePart(uint256 _partOffset, bytes memory _preimage) external;
+    function minProposalSize() external view returns (uint256 minProposalSize_);
+    function preimageLengths(bytes32) external view returns (uint256);
+    function preimagePartOk(bytes32, uint256) external view returns (bool);
+    function preimageParts(bytes32, uint256) external view returns (bytes32);
+    function proposalBlocks(address, uint256, uint256) external view returns (uint64);
+    function proposalBlocksLen(address _claimant, uint256 _uuid) external view returns (uint256 len_);
+    function proposalBonds(address, uint256) external view returns (uint256);
+    function proposalBranches(address, uint256, uint256) external view returns (bytes32);
+    function proposalCount() external view returns (uint256 count_);
+    function proposalMetadata(address, uint256) external view returns (LPPMetaData);
+    function proposalParts(address, uint256) external view returns (bytes32);
+    function proposals(uint256) external view returns (address claimant, uint256 uuid); // nosemgrep:
+        // sol-style-return-arg-fmt
+    function readPreimage(bytes32 _key, uint256 _offset) external view returns (bytes32 dat_, uint256 datLen_);
+    function squeezeLPP(
+        address _claimant,
+        uint256 _uuid,
+        LibKeccak.StateMatrix memory _stateMatrix,
+        Leaf memory _preState,
+        bytes32[] memory _preStateProof,
+        Leaf memory _postState,
+        bytes32[] memory _postStateProof
+    )
+        external;
+    function version() external view returns (string memory);
+    function zeroHashes(uint256) external view returns (bytes32);
 
     function __constructor__(uint256 _minProposalSize, uint256 _challengePeriod) external;
 }

--- a/packages/contracts-bedrock/test/cannon/MIPS.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS.t.sol
@@ -4,9 +4,8 @@ pragma solidity 0.8.15;
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-// Contracts
-import { MIPS } from "src/cannon/MIPS.sol";
-import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { MIPSInstructions } from "src/cannon/libraries/MIPSInstructions.sol";
@@ -15,16 +14,27 @@ import { InvalidExitedValue, InvalidMemoryProof } from "src/cannon/libraries/Can
 import "src/dispute/lib/Types.sol";
 
 // Interfaces
+import { IMIPS } from "src/cannon/interfaces/IMIPS.sol";
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 contract MIPS_Test is CommonTest {
-    MIPS internal mips;
-    PreimageOracle internal oracle;
+    IMIPS internal mips;
+    IPreimageOracle internal oracle;
 
     function setUp() public virtual override {
         super.setUp();
-        oracle = new PreimageOracle(0, 0);
-        mips = new MIPS(IPreimageOracle(address(oracle)));
+        oracle = IPreimageOracle(
+            DeployUtils.create1({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+            })
+        );
+        mips = IMIPS(
+            DeployUtils.create1({
+                _name: "MIPS",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS.__constructor__, (oracle)))
+            })
+        );
         vm.store(address(mips), 0x0, bytes32(abi.encode(address(oracle))));
         vm.label(address(oracle), "PreimageOracle");
         vm.label(address(mips), "MIPS");
@@ -53,7 +63,7 @@ contract MIPS_Test is CommonTest {
     function test_step_abi_succeeds() external {
         uint32[32] memory registers;
         registers[16] = 0xbfff0000;
-        MIPS.State memory state = MIPS.State({
+        IMIPS.State memory state = IMIPS.State({
             memRoot: hex"30be14bdf94d7a93989a6263f1e116943dc052d584730cae844bf330dfddce2f",
             preimageKey: bytes32(0),
             preimageOffset: 0,
@@ -82,7 +92,7 @@ contract MIPS_Test is CommonTest {
             // Rest of this stuff doesn't matter very much, just setting up some state to edit.
             // Here just using the parameters for the ADD test below.
             uint32 insn = encodespec(17, 18, 8, 0x20);
-            (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+            (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
 
             // Compute the encoded state and manipulate it.
             bytes memory enc = encodeState(state);
@@ -102,12 +112,12 @@ contract MIPS_Test is CommonTest {
 
     function test_add_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x20); // add t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 12;
         state.registers[18] = 20;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -122,12 +132,12 @@ contract MIPS_Test is CommonTest {
 
     function test_addu_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x21); // addu t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 12;
         state.registers[18] = 20;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -143,12 +153,12 @@ contract MIPS_Test is CommonTest {
     function test_addi_succeeds() external {
         uint16 imm = 40;
         uint32 insn = encodeitype(0x8, 17, 8, imm); // addi t0, s1, 40
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
         state.registers[17] = 4; // s1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -163,12 +173,12 @@ contract MIPS_Test is CommonTest {
     function test_addiSign_succeeds() external {
         uint16 imm = 0xfffe; // -2
         uint32 insn = encodeitype(0x8, 17, 8, imm); // addi t0, s1, 40
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
         state.registers[17] = 2; // s1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -183,12 +193,12 @@ contract MIPS_Test is CommonTest {
     function test_addui_succeeds() external {
         uint16 imm = 40;
         uint32 insn = encodeitype(0x9, 17, 8, imm); // addui t0, s1, 40
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
         state.registers[17] = 4; // s1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -202,12 +212,12 @@ contract MIPS_Test is CommonTest {
 
     function test_sub_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x22); // sub t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 20;
         state.registers[18] = 12;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -222,12 +232,12 @@ contract MIPS_Test is CommonTest {
 
     function test_subu_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x23); // subu t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 20;
         state.registers[18] = 12;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -242,12 +252,12 @@ contract MIPS_Test is CommonTest {
 
     function test_and_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x24); // and t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 1200;
         state.registers[18] = 490;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -263,12 +273,12 @@ contract MIPS_Test is CommonTest {
     function test_andi_succeeds() external {
         uint16 imm = 40;
         uint32 insn = encodeitype(0xc, 17, 8, imm); // andi t0, s1, 40
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
         state.registers[17] = 4; // s1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -282,12 +292,12 @@ contract MIPS_Test is CommonTest {
 
     function test_or_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x25); // or t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 1200;
         state.registers[18] = 490;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -303,12 +313,12 @@ contract MIPS_Test is CommonTest {
     function test_ori_succeeds() external {
         uint16 imm = 40;
         uint32 insn = encodeitype(0xd, 17, 8, imm); // ori t0, s1, 40
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
         state.registers[17] = 4; // s1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -322,12 +332,12 @@ contract MIPS_Test is CommonTest {
 
     function test_xor_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x26); // xor t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 1200;
         state.registers[18] = 490;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -343,12 +353,12 @@ contract MIPS_Test is CommonTest {
     function test_xori_succeeds() external {
         uint16 imm = 40;
         uint32 insn = encodeitype(0xe, 17, 8, imm); // xori t0, s1, 40
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
         state.registers[17] = 4; // s1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -362,12 +372,12 @@ contract MIPS_Test is CommonTest {
 
     function test_nor_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x27); // nor t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 1200;
         state.registers[18] = 490;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -382,11 +392,11 @@ contract MIPS_Test is CommonTest {
 
     function test_slt_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x2a); // slt t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 0xFF_FF_FF_FE; // -2
         state.registers[18] = 5;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -411,12 +421,12 @@ contract MIPS_Test is CommonTest {
 
     function test_sltu_succeeds() external {
         uint32 insn = encodespec(17, 18, 8, 0x2b); // sltu t0, s1, s2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[17] = 1200;
         state.registers[18] = 490;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -432,12 +442,12 @@ contract MIPS_Test is CommonTest {
     function test_lb_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x20, 0x9, 0x8, 0x4); // lb $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_00_00_00);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_00_00_00);
         state.registers[8] = 0; // t0
         state.registers[9] = t1;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -454,12 +464,12 @@ contract MIPS_Test is CommonTest {
         uint32 val = 0x12_23_00_00;
         uint32 insn = encodeitype(0x21, 0x9, 0x8, 0x4); // lh $t0, 4($t1)
 
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, val);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, val);
         state.registers[8] = 0; // t0
         state.registers[9] = t1;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -476,12 +486,12 @@ contract MIPS_Test is CommonTest {
         uint32 val = 0x12_23_45_67;
         uint32 insn = encodeitype(0x23, 0x9, 0x8, 0x4); // lw $t0, 4($t1)
 
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, val);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, val);
         state.registers[8] = 0; // t0
         state.registers[9] = t1;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -496,12 +506,12 @@ contract MIPS_Test is CommonTest {
     function test_lbu_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x24, 0x9, 0x8, 0x4); // lbu $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_23_00_00);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_23_00_00);
         state.registers[8] = 0; // t0
         state.registers[9] = t1;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -516,12 +526,12 @@ contract MIPS_Test is CommonTest {
     function test_lhu_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x25, 0x9, 0x8, 0x4); // lhu $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_23_00_00);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_23_00_00);
         state.registers[8] = 0; // t0
         state.registers[9] = t1;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -536,11 +546,11 @@ contract MIPS_Test is CommonTest {
     function test_lwl_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x22, 0x9, 0x8, 0x4); // lwl $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_34_56_78);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_34_56_78);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -563,11 +573,11 @@ contract MIPS_Test is CommonTest {
     function test_lwr_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x26, 0x9, 0x8, 0x4); // lwr $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_34_56_78);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0x12_34_56_78);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -591,11 +601,11 @@ contract MIPS_Test is CommonTest {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x28, 0x9, 0x8, 0x4); // sb $t0, 4($t1)
         // note. cannon memory is zero-initalized. mem[t+4] = 0 is a no-op
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, t1 + 4, 0xdd_00_00_00);
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -610,11 +620,11 @@ contract MIPS_Test is CommonTest {
     function test_sh_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x29, 0x9, 0x8, 0x4); // sh $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, t1 + 4, 0xcc_dd_00_00);
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -629,11 +639,11 @@ contract MIPS_Test is CommonTest {
     function test_swl_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x2a, 0x9, 0x8, 0x4); // swl $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, t1 + 4, 0xaa_bb_cc_dd);
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -648,11 +658,11 @@ contract MIPS_Test is CommonTest {
     function test_sw_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x2b, 0x9, 0x8, 0x4); // sw $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, t1 + 4, 0xaa_bb_cc_dd);
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -667,11 +677,11 @@ contract MIPS_Test is CommonTest {
     function test_swr_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x2e, 0x9, 0x8, 0x5); // swr $t0, 5($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, t1 + 4, 0xcc_dd_00_00);
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -688,12 +698,12 @@ contract MIPS_Test is CommonTest {
         uint32 val = 0x12_23_45_67;
         uint32 insn = encodeitype(0x30, 0x9, 0x8, 0x4); // ll $t0, 4($t1)
 
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, val);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, val);
         state.registers[8] = 0; // t0
         state.registers[9] = t1;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -708,11 +718,11 @@ contract MIPS_Test is CommonTest {
     function test_sc_succeeds() external {
         uint32 t1 = 0x100;
         uint32 insn = encodeitype(0x38, 0x9, 0x8, 0x4); // sc $t0, 4($t1)
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, t1 + 4, 0);
         state.registers[8] = 0xaa_bb_cc_dd; // t0
         state.registers[9] = t1;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         (expect.memRoot,) = ffi.getCannonMemoryProof(0, insn, t1 + 4, 0xaa_bb_cc_dd);
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -727,12 +737,12 @@ contract MIPS_Test is CommonTest {
     function test_movn_succeeds() external {
         // test mips mov instruction
         uint32 insn = encodespec(0x9, 0xa, 0x8, 0xb); // movn $t0, $t1, $t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xa; // t0
         state.registers[9] = 0xb; // t1
         state.registers[10] = 0x1; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -754,12 +764,12 @@ contract MIPS_Test is CommonTest {
     function test_movz_succeeds() external {
         // test mips mov instruction
         uint32 insn = encodespec(0x9, 0xa, 0x8, 0xa); // movz $t0, $t1, $t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xa; // t0
         state.registers[9] = 0xb; // t1
         state.registers[10] = 0x0; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -780,10 +790,10 @@ contract MIPS_Test is CommonTest {
 
     function test_mflo_succeeds() external {
         uint32 insn = encodespec(0x0, 0x0, 0x8, 0x12); // mflo $t0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.lo = 0xdeadbeef;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -797,10 +807,10 @@ contract MIPS_Test is CommonTest {
 
     function test_mfhi_succeeds() external {
         uint32 insn = encodespec(0x0, 0x0, 0x8, 0x10); // mfhi $t0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.hi = 0xdeadbeef;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -814,10 +824,10 @@ contract MIPS_Test is CommonTest {
 
     function test_mthi_succeeds() external {
         uint32 insn = encodespec(0x8, 0x0, 0x0, 0x11); // mthi $t0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xdeadbeef; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -831,10 +841,10 @@ contract MIPS_Test is CommonTest {
 
     function test_mtlo_succeeds() external {
         uint32 insn = encodespec(0x8, 0x0, 0x0, 0x13); // mtlo $t0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xdeadbeef; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -848,11 +858,11 @@ contract MIPS_Test is CommonTest {
 
     function test_mul_succeeds() external {
         uint32 insn = encodespec2(0x9, 0xa, 0x8, 0x2); // mul t0, t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 5; // t1
         state.registers[10] = 2; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -867,11 +877,11 @@ contract MIPS_Test is CommonTest {
 
     function test_mult_succeeds() external {
         uint32 insn = encodespec(0x9, 0xa, 0x0, 0x18); // mult t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x0F_FF_00_00; // t1
         state.registers[10] = 100; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -888,11 +898,11 @@ contract MIPS_Test is CommonTest {
 
     function test_multu_succeeds() external {
         uint32 insn = encodespec(0x9, 0xa, 0x0, 0x19); // multu t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x0F_FF_00_00; // t1
         state.registers[10] = 100; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -909,11 +919,11 @@ contract MIPS_Test is CommonTest {
 
     function test_div_succeeds() external {
         uint32 insn = encodespec(0x9, 0xa, 0x0, 0x1a); // div t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 5; // t1
         state.registers[10] = 2; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -930,11 +940,11 @@ contract MIPS_Test is CommonTest {
 
     function test_divu_succeeds() external {
         uint32 insn = encodespec(0x9, 0xa, 0x0, 0x1b); // divu t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 5; // t1
         state.registers[10] = 2; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -951,7 +961,7 @@ contract MIPS_Test is CommonTest {
 
     function test_div_byZero_fails() external {
         uint32 insn = encodespec(0x9, 0xa, 0x0, 0x1a); // div t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 5; // t1
         state.registers[10] = 0; // t2
 
@@ -961,7 +971,7 @@ contract MIPS_Test is CommonTest {
 
     function test_divu_byZero_fails() external {
         uint32 insn = encodespec(0x9, 0xa, 0x0, 0x1b); // divu t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 5; // t1
         state.registers[10] = 0; // t2
 
@@ -972,11 +982,11 @@ contract MIPS_Test is CommonTest {
     function test_beq_succeeds() external {
         uint16 boff = 0x10;
         uint32 insn = encodeitype(0x4, 0x9, 0x8, boff); // beq $t0, $t1, 16
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xdeadbeef; // t0
         state.registers[9] = 0xdeadbeef; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + (uint32(boff) << 2);
@@ -998,11 +1008,11 @@ contract MIPS_Test is CommonTest {
     function test_bne_succeeds() external {
         uint16 boff = 0x10;
         uint32 insn = encodeitype(0x5, 0x9, 0x8, boff); // bne $t0, $t1, 16
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xdeadbeef; // t0
         state.registers[9] = 0xaa; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + (uint32(boff) << 2);
@@ -1017,10 +1027,10 @@ contract MIPS_Test is CommonTest {
     function test_blez_succeeds() external {
         uint16 boff = 0x10;
         uint32 insn = encodeitype(0x6, 0x8, 0x0, boff); // blez $t0, 16
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + (uint32(boff) << 2);
@@ -1034,10 +1044,10 @@ contract MIPS_Test is CommonTest {
     function test_bgtz_succeeds() external {
         uint16 boff = 0xa0;
         uint32 insn = encodeitype(0x7, 0x8, 0x0, boff); // bgtz $t0, 0xa0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 1; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + (uint32(boff) << 2);
@@ -1052,10 +1062,10 @@ contract MIPS_Test is CommonTest {
     function test_bltz_succeeds() external {
         uint16 boff = 0x10;
         uint32 insn = encodeitype(0x1, 0x8, 0x0, boff); // bltz $t0, 16
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xF0_00_00_00; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + (uint32(boff) << 2);
@@ -1069,10 +1079,10 @@ contract MIPS_Test is CommonTest {
     function test_bgez_succeeds() external {
         uint16 boff = 0x10;
         uint32 insn = encodeitype(0x1, 0x8, 0x1, boff); // bgez $t0, 16
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0x00_00_00_01; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + (uint32(boff) << 2);
@@ -1086,9 +1096,9 @@ contract MIPS_Test is CommonTest {
     function test_jump_succeeds() external {
         uint32 label = 0x02_00_00_02; // set the 26th bit to assert no sign extension
         uint32 insn = uint32(0x08_00_00_00) | label; // j label
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = label << 2;
@@ -1102,9 +1112,9 @@ contract MIPS_Test is CommonTest {
         uint32 pcRegion1 = 0x10000000;
         uint32 label = 0x2;
         uint32 insn = uint32(0x08_00_00_00) | label; // j label
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(pcRegion1, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(pcRegion1, insn, 0x4, 0);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = (state.nextPC & 0xF0_00_00_00) | (uint32(label) << 2);
@@ -1118,9 +1128,9 @@ contract MIPS_Test is CommonTest {
     function test_jal_succeeds() external {
         uint32 label = 0x02_00_00_02; // set the 26th bit to assert no sign extension
         uint32 insn = uint32(0x0c_00_00_00) | label; // jal label
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = label << 2;
@@ -1135,9 +1145,9 @@ contract MIPS_Test is CommonTest {
         uint32 pcRegion1 = 0x10000000;
         uint32 label = 0x2;
         uint32 insn = uint32(0x0c_00_00_00) | label; // jal label
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(pcRegion1, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(pcRegion1, insn, 0x4, 0);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = (state.nextPC & 0xF0_00_00_00) | (uint32(label) << 2);
@@ -1151,10 +1161,10 @@ contract MIPS_Test is CommonTest {
     function test_jr_succeeds() external {
         uint16 tgt = 0x34;
         uint32 insn = encodespec(0x8, 0, 0, 0x8); // jr t0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = tgt;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = tgt;
@@ -1168,10 +1178,10 @@ contract MIPS_Test is CommonTest {
     function test_jalr_succeeds() external {
         uint16 tgt = 0x34;
         uint32 insn = encodespec(0x8, 0, 0x9, 0x9); // jalr t1, t0
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = tgt; // t0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = tgt;
@@ -1186,10 +1196,10 @@ contract MIPS_Test is CommonTest {
     function test_sll_succeeds() external {
         uint8 shiftamt = 4;
         uint32 insn = encodespec(0x0, 0x9, 0x8, uint16(shiftamt) << 6); // sll t0, t1, 3
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x20; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1205,10 +1215,10 @@ contract MIPS_Test is CommonTest {
     function test_srl_succeeds() external {
         uint8 shiftamt = 4;
         uint32 insn = encodespec(0x0, 0x9, 0x8, uint16(shiftamt) << 6 | 2); // srl t0, t1, 3
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x20; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1224,10 +1234,10 @@ contract MIPS_Test is CommonTest {
     function test_sra_succeeds() external {
         uint8 shiftamt = 4;
         uint32 insn = encodespec(0x0, 0x9, 0x8, uint16(shiftamt) << 6 | 3); // sra t0, t1, 3
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x80_00_00_20; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1242,11 +1252,11 @@ contract MIPS_Test is CommonTest {
 
     function test_sllv_succeeds() external {
         uint32 insn = encodespec(0xa, 0x9, 0x8, 4); // sllv t0, t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x20; // t1
         state.registers[10] = 4; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1262,11 +1272,11 @@ contract MIPS_Test is CommonTest {
 
     function test_srlv_succeeds() external {
         uint32 insn = encodespec(0xa, 0x9, 0x8, 6); // srlv t0, t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x20_00; // t1
         state.registers[10] = 4; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1282,11 +1292,11 @@ contract MIPS_Test is CommonTest {
 
     function test_srav_succeeds() external {
         uint32 insn = encodespec(0xa, 0x9, 0x8, 7); // srav t0, t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0xdeafbeef; // t1
         state.registers[10] = 12; // t2
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1310,14 +1320,14 @@ contract MIPS_Test is CommonTest {
         _rs = uint32(bound(uint256(_rs), 0x20, type(uint32).max));
 
         uint32 insn = encodespec(0xa, 0x9, 0x8, 7); // srav t0, t1, t2
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0xdeadbeef; // t1
         state.registers[10] = _rs; // t2
 
         // Calculate shamt
         uint32 shamt = state.registers[10] & 0x1F;
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1333,10 +1343,10 @@ contract MIPS_Test is CommonTest {
 
     function test_lui_succeeds() external {
         uint32 insn = encodeitype(0xf, 0x0, 0x8, 0x4); // lui $t0, 0x04
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1349,10 +1359,10 @@ contract MIPS_Test is CommonTest {
 
     function test_clo_succeeds() external {
         uint32 insn = encodespec2(0x9, 0x0, 0x8, 0x21); // clo t0, t1
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0xFF_00_00_00; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1366,10 +1376,10 @@ contract MIPS_Test is CommonTest {
 
     function test_clz_succeeds() external {
         uint32 insn = encodespec2(0x9, 0x0, 0x8, 0x20); // clz t0, t1
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[9] = 0x00_00_F0_00; // t1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1394,7 +1404,7 @@ contract MIPS_Test is CommonTest {
         registers[5] = a1; // addr
         registers[6] = 4; // count
 
-        MIPS.State memory state = MIPS.State({
+        IMIPS.State memory state = IMIPS.State({
             memRoot: memRoot,
             preimageKey: bytes32(uint256(1) << 248 | 0x01),
             preimageOffset: 8, // start reading past the pre-image length prefix
@@ -1416,7 +1426,7 @@ contract MIPS_Test is CommonTest {
         uint8 partOffset = 8;
         oracle.loadLocalData(uint256(state.preimageKey), 0, word, size, partOffset);
 
-        MIPS.State memory expect = state;
+        IMIPS.State memory expect = state;
         expect.preimageOffset += 4;
         expect.pc = state.nextPC;
         expect.nextPC += 4;
@@ -1443,7 +1453,7 @@ contract MIPS_Test is CommonTest {
         registers[5] = a1; // addr
         registers[6] = 4; // count
 
-        MIPS.State memory state = MIPS.State({
+        IMIPS.State memory state = IMIPS.State({
             memRoot: memRoot,
             preimageKey: bytes32(0),
             preimageOffset: 1,
@@ -1459,7 +1469,7 @@ contract MIPS_Test is CommonTest {
         });
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect = state;
+        IMIPS.State memory expect = state;
         expect.preimageOffset = 0; // preimage write resets offset
         expect.pc = state.nextPC;
         expect.nextPC += 4;
@@ -1476,7 +1486,7 @@ contract MIPS_Test is CommonTest {
         uint32 insn = 0x0000000c; // syscall
         (bytes32 memRoot, bytes memory proof) = ffi.getCannonMemoryProof(0, insn);
 
-        MIPS.State memory state;
+        IMIPS.State memory state;
         state.memRoot = memRoot;
         state.nextPC = 4;
         state.registers[2] = 4090; // mmap syscall
@@ -1484,7 +1494,7 @@ contract MIPS_Test is CommonTest {
         state.registers[5] = 4095; // a1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         // assert page allocation is aligned to 4k
         expect.step = state.step + 1;
@@ -1503,7 +1513,7 @@ contract MIPS_Test is CommonTest {
         uint32 insn = 0x0000000c; // syscall
         (bytes32 memRoot, bytes memory proof) = ffi.getCannonMemoryProof(0, insn);
 
-        MIPS.State memory state;
+        IMIPS.State memory state;
         state.memRoot = memRoot;
         state.nextPC = 4;
         state.heap = sys.HEAP_END - 4096; // Set up to increase heap to its limit
@@ -1512,7 +1522,7 @@ contract MIPS_Test is CommonTest {
         state.registers[5] = 4095; // a1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         // assert page allocation is aligned to 4k
         expect.step = state.step + 1;
@@ -1532,7 +1542,7 @@ contract MIPS_Test is CommonTest {
         uint32 insn = 0x0000000c; // syscall
         (bytes32 memRoot, bytes memory proof) = ffi.getCannonMemoryProof(0, insn);
 
-        MIPS.State memory state;
+        IMIPS.State memory state;
         state.memRoot = memRoot;
         state.nextPC = 4;
         state.heap = sys.HEAP_END - 4096; // Set up to increase heap beyond its limit
@@ -1541,7 +1551,7 @@ contract MIPS_Test is CommonTest {
         state.registers[5] = 4097; // a1
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         // assert page allocation is aligned to 4k
         expect.step = state.step + 1;
@@ -1559,12 +1569,12 @@ contract MIPS_Test is CommonTest {
 
     function test_brk_succeeds() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[2] = 4045; // brk syscall
         state.registers[4] = 0xdead;
         bytes memory encodedState = encodeState(state);
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.step = state.step + 1;
         expect.pc = state.nextPC;
@@ -1578,10 +1588,10 @@ contract MIPS_Test is CommonTest {
 
     function test_clone_succeeds() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[2] = 4120; // clone syscall
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.step = state.step + 1;
         expect.pc = state.nextPC;
@@ -1595,11 +1605,11 @@ contract MIPS_Test is CommonTest {
 
     function test_exit_succeeds() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[2] = 4246; // exit_group syscall
         state.registers[4] = 0x5; // a0
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.pc;
         expect.nextPC = state.nextPC;
@@ -1615,12 +1625,12 @@ contract MIPS_Test is CommonTest {
 
     function test_fcntl_getfl_succeeds() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[2] = 4055; // fcntl syscall
         state.registers[4] = 0x0; // a0
         state.registers[5] = 0x3; // a1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1641,12 +1651,12 @@ contract MIPS_Test is CommonTest {
 
     function test_fcntl_getfd_succeeds() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[2] = 4055; // fcntl syscall
         state.registers[4] = 0x0; // a0
         state.registers[5] = 0x1; // a1
 
-        MIPS.State memory expect;
+        IMIPS.State memory expect;
         expect.memRoot = state.memRoot;
         expect.pc = state.nextPC;
         expect.nextPC = state.nextPC + 4;
@@ -1660,7 +1670,7 @@ contract MIPS_Test is CommonTest {
 
     function test_prestate_exited_succeeds() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.exited = true;
 
         bytes memory enc = encodeState(state);
@@ -1675,7 +1685,7 @@ contract MIPS_Test is CommonTest {
         uint32 addr = 0xFF_FF_FF_FC; // 4-byte aligned ff..ff
         (bytes32 memRoot, bytes memory proof) = ffi.getCannonMemoryProof(0, illegal_insn, addr, 0);
 
-        MIPS.State memory state;
+        IMIPS.State memory state;
         state.memRoot = memRoot;
         bytes memory encodedState = encodeState(state);
         vm.expectRevert("invalid instruction");
@@ -1684,7 +1694,7 @@ contract MIPS_Test is CommonTest {
 
     function test_invalid_root_fails() external {
         uint32 insn = 0x0000000c; // syscall
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[2] = 4246; // exit_group syscall
         state.registers[4] = 0x5; // a0
 
@@ -1703,7 +1713,7 @@ contract MIPS_Test is CommonTest {
         // and the memory address, but for a different leaf that does not contain the
         // instruction @ pc nor the memory address being read.
         uint32 pc = 0;
-        MIPS.State memory state;
+        IMIPS.State memory state;
         bytes memory proof;
         (state.memRoot, proof) = ffi.getCannonMemoryProofWrongLeaf(pc, insn, 0x4, 0);
         state.pc = pc;
@@ -1718,7 +1728,7 @@ contract MIPS_Test is CommonTest {
     function test_jump_inDelaySlot_fails() external {
         uint16 label = 0x2;
         uint32 insn = uint32(0x08_00_00_00) | label; // j label
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.nextPC = 0xa;
 
         vm.expectRevert("jump in delay slot");
@@ -1728,7 +1738,7 @@ contract MIPS_Test is CommonTest {
     function test_branch_inDelaySlot_fails() external {
         uint16 boff = 0x10;
         uint32 insn = encodeitype(0x4, 0x9, 0x8, boff); // beq $t0, $t1, 16
-        (MIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
+        (IMIPS.State memory state, bytes memory proof) = constructMIPSState(0, insn, 0x4, 0);
         state.registers[8] = 0xdeadbeef; // t0
         state.registers[9] = 0xdeadbeef; // t1
         state.nextPC = 0xa;
@@ -1737,7 +1747,7 @@ contract MIPS_Test is CommonTest {
         mips.step(encodeState(state), proof, 0);
     }
 
-    function encodeState(MIPS.State memory state) internal pure returns (bytes memory) {
+    function encodeState(IMIPS.State memory state) internal pure returns (bytes memory) {
         bytes memory registers;
         for (uint256 i = 0; i < state.registers.length; i++) {
             registers = bytes.concat(registers, abi.encodePacked(state.registers[i]));
@@ -1763,7 +1773,7 @@ contract MIPS_Test is CommonTest {
     ///      1. Exited with success (Invalid)
     ///      2. Exited with failure (Panic)
     ///      3. Unfinished
-    function vmStatus(MIPS.State memory state) internal pure returns (VMStatus out_) {
+    function vmStatus(IMIPS.State memory state) internal pure returns (VMStatus out_) {
         if (!state.exited) {
             return VMStatuses.UNFINISHED;
         } else if (state.exitCode == 0) {
@@ -1775,7 +1785,7 @@ contract MIPS_Test is CommonTest {
         }
     }
 
-    function outputState(MIPS.State memory state) internal pure returns (bytes32 out_) {
+    function outputState(IMIPS.State memory state) internal pure returns (bytes32 out_) {
         bytes memory enc = encodeState(state);
         VMStatus status = vmStatus(state);
         assembly {
@@ -1791,7 +1801,7 @@ contract MIPS_Test is CommonTest {
         uint32 val
     )
         internal
-        returns (MIPS.State memory state, bytes memory proof)
+        returns (IMIPS.State memory state, bytes memory proof)
     {
         (state.memRoot, proof) = ffi.getCannonMemoryProof(pc, insn, addr, val);
         state.pc = pc;

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -1,22 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
 import { Test, Vm, console2 as console } from "forge-std/Test.sol";
 
-import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
-import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
 import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
+import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
 import { Bytes } from "src/libraries/Bytes.sol";
 import { Process } from "scripts/libraries/Process.sol";
 import "src/cannon/libraries/CannonErrors.sol";
 import "src/cannon/libraries/CannonTypes.sol";
 
+// Interfaces
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
+
 contract PreimageOracle_Test is Test {
-    PreimageOracle oracle;
+    IPreimageOracle oracle;
 
     /// @notice Sets up the testing suite.
     function setUp() public {
-        oracle = new PreimageOracle(0, 0);
+        oracle = IPreimageOracle(
+            DeployUtils.create1({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+            })
+        );
         vm.label(address(oracle), "PreimageOracle");
     }
 
@@ -25,7 +37,10 @@ contract PreimageOracle_Test is Test {
     function testFuzz_constructor_challengePeriodTooLarge_reverts(uint256 _challengePeriod) public {
         _challengePeriod = bound(_challengePeriod, uint256(type(uint64).max) + 1, type(uint256).max);
         vm.expectRevert("PreimageOracle: challenge period too large");
-        new PreimageOracle(0, _challengePeriod);
+        DeployUtils.create1({
+            _name: "PreimageOracle",
+            _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, _challengePeriod)))
+        });
     }
 
     /// @notice Test the pre-image key computation with a known pre-image.
@@ -306,11 +321,18 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     uint256 internal constant CHALLENGE_PERIOD = 1 days;
     uint256 internal constant TEST_UUID = 0xFACADE;
 
-    PreimageOracle internal oracle;
+    IPreimageOracle internal oracle;
 
     /// @notice Sets up the testing suite.
     function setUp() public {
-        oracle = new PreimageOracle({ _minProposalSize: MIN_SIZE_BYTES, _challengePeriod: CHALLENGE_PERIOD });
+        oracle = IPreimageOracle(
+            DeployUtils.create1({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IPreimageOracle.__constructor__, (MIN_SIZE_BYTES, CHALLENGE_PERIOD))
+                )
+            })
+        );
         vm.label(address(oracle), "PreimageOracle");
 
         // Set `tx.origin` and `msg.sender` to `address(this)` so that it may behave like an EOA for `addLeavesLPP`.
@@ -336,7 +358,14 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
     /// @notice Tests that the `initLPP` function reverts when the part offset is out of bounds of the full preimage.
     function test_initLPP_sizeTooSmall_reverts() public {
-        oracle = new PreimageOracle({ _minProposalSize: 1000, _challengePeriod: CHALLENGE_PERIOD });
+        oracle = IPreimageOracle(
+            DeployUtils.create1({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IPreimageOracle.__constructor__, (1000, CHALLENGE_PERIOD))
+                )
+            })
+        );
 
         // Allocate the preimage data.
         bytes memory data = new bytes(136);
@@ -552,7 +581,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -607,7 +636,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
 
@@ -676,7 +705,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -723,7 +752,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Finalize the proposal.
         vm.expectRevert(ActiveProposal.selector);
@@ -751,7 +780,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Finalize the proposal.
         vm.expectRevert(ActiveProposal.selector);
@@ -784,7 +813,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -830,7 +859,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -883,7 +912,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
             // Construct the leaf preimage data for the blocks added.
             LibKeccak.StateMatrix memory matrixB;
-            PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
+            IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
 
             // Fetch the merkle proofs for the pre/post state leaves in the proposal tree.
             bytes32 canonicalRoot = oracle.getTreeRootLPP(address(this), TEST_UUID);
@@ -950,7 +979,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory p = new bytes32[](16);
@@ -990,7 +1019,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
 
@@ -1030,7 +1059,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
 
@@ -1079,7 +1108,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added and corrupt the state commitments.
         LibKeccak.StateMatrix memory matrixB;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
         for (uint256 i = _lastCorrectLeafIdx + 1; i < leaves.length; i++) {
             leaves[i].stateCommitment = 0;
         }
@@ -1130,7 +1159,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added and corrupt the state commitments.
         LibKeccak.StateMatrix memory matrixB;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrixB, data);
         for (uint256 i = 0; i < leaves.length; i++) {
             leaves[i].stateCommitment = 0;
         }
@@ -1169,7 +1198,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, data);
 
         // Create a proof array with 16 elements.
         bytes32[] memory preProof = new bytes32[](16);
@@ -1221,7 +1250,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
         leaves[2].stateCommitment = stateCommitments[2];
@@ -1275,7 +1304,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
         leaves[2].stateCommitment = stateCommitments[2];
@@ -1329,7 +1358,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
         // Construct the leaf preimage data for the blocks added.
         LibKeccak.StateMatrix memory matrix;
-        PreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
+        IPreimageOracle.Leaf[] memory leaves = _generateLeaves(matrix, phonyData);
         leaves[0].stateCommitment = stateCommitments[0];
         leaves[1].stateCommitment = stateCommitments[1];
         leaves[2].stateCommitment = stateCommitments[2];
@@ -1366,7 +1395,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     }
 
     /// @notice Hashes leaf data for the preimage proposals tree
-    function _hashLeaf(PreimageOracle.Leaf memory _leaf) internal pure returns (bytes32 leaf_) {
+    function _hashLeaf(IPreimageOracle.Leaf memory _leaf) internal pure returns (bytes32 leaf_) {
         leaf_ = keccak256(abi.encodePacked(_leaf.input, _leaf.index, _leaf.stateCommitment));
     }
 
@@ -1377,18 +1406,18 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     )
         internal
         pure
-        returns (PreimageOracle.Leaf[] memory leaves_)
+        returns (IPreimageOracle.Leaf[] memory leaves_)
     {
         bytes memory data = LibKeccak.padMemory(_data);
         uint256 numCommitments = data.length / LibKeccak.BLOCK_SIZE_BYTES;
 
-        leaves_ = new PreimageOracle.Leaf[](numCommitments);
+        leaves_ = new IPreimageOracle.Leaf[](numCommitments);
         for (uint256 i = 0; i < numCommitments; i++) {
             bytes memory blockSlice = Bytes.slice(data, i * LibKeccak.BLOCK_SIZE_BYTES, LibKeccak.BLOCK_SIZE_BYTES);
             LibKeccak.absorb(_stateMatrix, blockSlice);
             LibKeccak.permutation(_stateMatrix);
 
-            leaves_[i] = PreimageOracle.Leaf({
+            leaves_[i] = IPreimageOracle.Leaf({
                 input: blockSlice,
                 index: uint32(i),
                 stateCommitment: keccak256(abi.encode(_stateMatrix))
@@ -1440,7 +1469,7 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     ///         constructed with `_leaves`.
     function _generateProof(
         uint256 _leafIdx,
-        PreimageOracle.Leaf[] memory _leaves
+        IPreimageOracle.Leaf[] memory _leaves
     )
         internal
         returns (bytes32 root_, bytes32[] memory proof_)


### PR DESCRIPTION
Updates all contracts and tests to use the MIPS and PreimageOracle interfaces. Also fixes the PreimageOracle interface finally.