### PR TITLE
Initialize using Dependency Set Configuration

### DIFF
--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	// MockRun runs the service with a mock backend
 	MockRun bool
 
+	// SynchronousProcessors disables background-workers,
+	// requiring manual triggers for the backend to process anything.
+	SynchronousProcessors bool
+
 	L2RPCs  []string
 	Datadir string
 }

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -1,10 +1,10 @@
 package metrics
 
 import (
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/prometheus/client_golang/prometheus"
 
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 const Namespace = "op_supervisor"
@@ -18,7 +18,7 @@ type Metricer interface {
 	CacheAdd(chainID types.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID types.ChainID, label string, hit bool)
 
-	RecordDBEntryCount(chainID types.ChainID, count int64)
+	RecordDBEntryCount(chainID types.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID types.ChainID, count int64)
 
 	Document() []opmetrics.DocumentedMetric
@@ -106,9 +106,10 @@ func NewMetrics(procName string) *Metrics {
 		DBEntryCountVec: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "logdb_entries_current",
-			Help:      "Current number of entries in the log database by chain ID",
+			Help:      "Current number of entries in the database of specified kind and chain ID",
 		}, []string{
 			"chain",
+			"kind",
 		}),
 		DBSearchEntriesReadVec: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: ns,
@@ -159,8 +160,8 @@ func (m *Metrics) CacheGet(chainID types.ChainID, label string, hit bool) {
 	}
 }
 
-func (m *Metrics) RecordDBEntryCount(chainID types.ChainID, count int64) {
-	m.DBEntryCountVec.WithLabelValues(chainIDLabel(chainID)).Set(float64(count))
+func (m *Metrics) RecordDBEntryCount(chainID types.ChainID, kind string, count int64) {
+	m.DBEntryCountVec.WithLabelValues(chainIDLabel(chainID), kind).Set(float64(count))
 }
 
 func (m *Metrics) RecordDBSearchEntriesRead(chainID types.ChainID, count int64) {

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -19,5 +19,5 @@ func (*noopMetrics) RecordUp()                 {}
 func (m *noopMetrics) CacheAdd(_ types.ChainID, _ string, _ int, _ bool) {}
 func (m *noopMetrics) CacheGet(_ types.ChainID, _ string, _ bool)        {}
 
-func (m *noopMetrics) RecordDBEntryCount(_ types.ChainID, _ int64)        {}
-func (m *noopMetrics) RecordDBSearchEntriesRead(_ types.ChainID, _ int64) {}
+func (m *noopMetrics) RecordDBEntryCount(_ types.ChainID, _ string, _ int64) {}
+func (m *noopMetrics) RecordDBSearchEntriesRead(_ types.ChainID, _ int64)    {}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -166,6 +166,9 @@ func (su *SupervisorBackend) attachRPC(ctx context.Context, rpc string) error {
 	if err != nil {
 		return err
 	}
+	if !su.depSet.HasChain(chainID) {
+		return fmt.Errorf("chain %s is not part of the interop dependency set: %w", chainID, db.ErrUnknownChain)
+	}
 	cm, ok := su.chainMetrics[chainID]
 	if !ok {
 		return fmt.Errorf("failed to find metrics for chain %v", chainID)

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -259,7 +259,6 @@ func (su *SupervisorBackend) AddL2RPC(ctx context.Context, rpc string) error {
 	su.mu.RLock() // read-lock: we only modify an existing chain, we don't add/remove chains
 	defer su.mu.RUnlock()
 
-	// start the monitor immediately, as the backend is assumed to already be running
 	return su.attachRPC(ctx, rpc)
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -1,0 +1,138 @@
+package backend
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	types2 "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-supervisor/config"
+	"github.com/ethereum-optimism/optimism/op-supervisor/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/entrydb"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestBackendLifetime(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	m := metrics.NoopMetrics
+	dataDir := t.TempDir()
+	chainA := types.ChainIDFromUInt64(900)
+	chainB := types.ChainIDFromUInt64(901)
+	cfg := &config.Config{
+		Version:       "test",
+		LogConfig:     oplog.CLIConfig{},
+		MetricsConfig: opmetrics.CLIConfig{},
+		PprofConfig:   oppprof.CLIConfig{},
+		RPC:           oprpc.CLIConfig{},
+		DependencySetSource: &depset.StaticConfigDependencySet{
+			Dependencies: map[types.ChainID]*depset.StaticConfigDependency{
+				chainA: {
+					ActivationTime: 42,
+					HistoryMinTime: 100,
+				},
+				chainB: {
+					ActivationTime: 30,
+					HistoryMinTime: 20,
+				},
+			},
+		},
+		SynchronousProcessors: true,
+		MockRun:               false,
+		L2RPCs:                nil,
+		Datadir:               dataDir,
+	}
+
+	b, err := NewSupervisorBackend(context.Background(), logger, m, cfg)
+	require.NoError(t, err)
+	t.Log("initialized!")
+
+	src := &testutils.MockL1Source{}
+
+	blockX := eth.BlockRef{
+		Hash:       common.Hash{0xaa},
+		Number:     0,
+		ParentHash: common.Hash{}, // genesis has no parent hash
+		Time:       10000,
+	}
+	blockY := eth.BlockRef{
+		Hash:       common.Hash{0xbb},
+		Number:     blockX.Number + 1,
+		ParentHash: blockX.Hash,
+		Time:       blockX.Time + 2,
+	}
+
+	require.NoError(t, b.AttachProcessorSource(chainA, src))
+
+	require.FileExists(t, filepath.Join(cfg.Datadir, "900", "log.db"), "must have logs DB 900")
+	require.FileExists(t, filepath.Join(cfg.Datadir, "901", "log.db"), "must have logs DB 901")
+	require.FileExists(t, filepath.Join(cfg.Datadir, "900", "local_safe.db"), "must have local safe DB 900")
+	require.FileExists(t, filepath.Join(cfg.Datadir, "901", "local_safe.db"), "must have local safe DB 901")
+	require.FileExists(t, filepath.Join(cfg.Datadir, "900", "cross_safe.db"), "must have cross safe DB 900")
+	require.FileExists(t, filepath.Join(cfg.Datadir, "901", "cross_safe.db"), "must have cross safe DB 901")
+
+	err = b.Start(context.Background())
+	require.NoError(t, err)
+	t.Log("started!")
+
+	_, err = b.UnsafeView(context.Background(), chainA, types.ReferenceView{})
+	require.ErrorIs(t, err, entrydb.ErrFuture, "no data yet, need local-unsafe")
+
+	src.ExpectL1BlockRefByNumber(0, blockX, nil)
+	src.ExpectFetchReceipts(blockX.Hash, &testutils.MockBlockInfo{
+		InfoHash:        blockX.Hash,
+		InfoParentHash:  blockX.ParentHash,
+		InfoNum:         blockX.Number,
+		InfoTime:        blockX.Time,
+		InfoReceiptRoot: types2.EmptyReceiptsHash,
+	}, nil, nil)
+
+	src.ExpectL1BlockRefByNumber(1, blockY, nil)
+	src.ExpectFetchReceipts(blockY.Hash, &testutils.MockBlockInfo{
+		InfoHash:        blockY.Hash,
+		InfoParentHash:  blockY.ParentHash,
+		InfoNum:         blockY.Number,
+		InfoTime:        blockY.Time,
+		InfoReceiptRoot: types2.EmptyReceiptsHash,
+	}, nil, nil)
+
+	src.ExpectL1BlockRefByNumber(2, eth.L1BlockRef{}, ethereum.NotFound)
+
+	err = b.UpdateLocalUnsafe(chainA, blockY)
+	require.NoError(t, err)
+	// Make the processing happen, so we can rely on the new chain information,
+	// and not run into errors for future data that isn't mocked at this time.
+	b.chainProcessors[chainA].ProcessToHead()
+
+	_, err = b.UnsafeView(context.Background(), chainA, types.ReferenceView{})
+	require.ErrorIs(t, err, entrydb.ErrFuture, "still no data yet, need cross-unsafe")
+
+	err = b.chainDBs.UpdateCrossUnsafe(chainA, types.BlockSeal{
+		Hash:      blockX.Hash,
+		Number:    blockX.Number,
+		Timestamp: blockX.Time,
+	})
+	require.NoError(t, err)
+
+	v, err := b.UnsafeView(context.Background(), chainA, types.ReferenceView{})
+	require.NoError(t, err, "have a functioning cross/local unsafe view now")
+	require.Equal(t, blockX.ID(), v.Cross)
+	require.Equal(t, blockY.ID(), v.Local)
+
+	err = b.Stop(context.Background())
+	require.NoError(t, err)
+	t.Log("stopped!")
+}

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -10,7 +10,7 @@ type Metrics interface {
 	CacheAdd(chainID types.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID types.ChainID, label string, hit bool)
 
-	RecordDBEntryCount(chainID types.ChainID, count int64)
+	RecordDBEntryCount(chainID types.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID types.ChainID, count int64)
 }
 
@@ -36,8 +36,8 @@ func (c *chainMetrics) CacheGet(label string, hit bool) {
 	c.delegate.CacheGet(c.chainID, label, hit)
 }
 
-func (c *chainMetrics) RecordDBEntryCount(count int64) {
-	c.delegate.RecordDBEntryCount(c.chainID, count)
+func (c *chainMetrics) RecordDBEntryCount(kind string, count int64) {
+	c.delegate.RecordDBEntryCount(c.chainID, kind, count)
 }
 
 func (c *chainMetrics) RecordDBSearchEntriesRead(count int64) {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -104,7 +104,12 @@ func (db *ChainsDB) AddLogDB(chain types.ChainID, logDB LogStorage) {
 	if db.logDBs[chain] != nil {
 		log.Warn("overwriting existing logDB for chain", "chain", chain)
 	}
+
 	db.logDBs[chain] = logDB
+	// TODO: Add derived-from storage
+	//db.localDBs[chain] =
+	//db.crossDBs[chain] =
+	// db.crossUnsafe[chain] = types.BlockSeal{}
 }
 
 // ResumeFromLastSealedBlock prepares the chains db to resume recording events after a restart.

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -10,11 +10,14 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/fromda"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-var ErrUnknownChain = errors.New("unknown chain")
+var (
+	ErrUnknownChain = errors.New("unknown chain")
+)
 
 type LogStorage interface {
 	io.Closer
@@ -46,11 +49,13 @@ type LogStorage interface {
 }
 
 type LocalDerivedFromStorage interface {
-	Last() (derivedFrom eth.BlockRef, derived eth.BlockRef, err error)
+	Latest() (derivedFrom types.BlockSeal, derived types.BlockSeal, err error)
 	AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error
-	LastDerived(derivedFrom eth.BlockID) (derived eth.BlockID, err error)
-	DerivedFrom(derived eth.BlockID) (derivedFrom eth.BlockID, err error)
+	LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error)
+	DerivedFrom(derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 }
+
+var _ LocalDerivedFromStorage = (*fromda.DB)(nil)
 
 type CrossDerivedFromStorage interface {
 	LocalDerivedFromStorage
@@ -71,6 +76,7 @@ type ChainsDB struct {
 	logDBs map[types.ChainID]LogStorage
 
 	// cross-unsafe: how far we have processed the unsafe data.
+	// If present but set to a zeroed value the cross-unsafe will fallback to cross-safe.
 	crossUnsafe map[types.ChainID]types.BlockSeal
 
 	// local-safe: index of what we optimistically know about L2 blocks being derived from L1
@@ -97,19 +103,47 @@ func NewChainsDB(l log.Logger) *ChainsDB {
 	}
 }
 
-func (db *ChainsDB) AddLogDB(chain types.ChainID, logDB LogStorage) {
+func (db *ChainsDB) AddLogDB(chainID types.ChainID, logDB LogStorage) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	if db.logDBs[chain] != nil {
-		log.Warn("overwriting existing logDB for chain", "chain", chain)
+	if _, ok := db.logDBs[chainID]; ok {
+		db.logger.Warn("overwriting existing log DB for chain", "chain", chainID)
 	}
 
-	db.logDBs[chain] = logDB
-	// TODO: Add derived-from storage
-	//db.localDBs[chain] =
-	//db.crossDBs[chain] =
-	// db.crossUnsafe[chain] = types.BlockSeal{}
+	db.logDBs[chainID] = logDB
+}
+
+func (db *ChainsDB) AddLocalDerivedFromDB(chainID types.ChainID, dfDB LocalDerivedFromStorage) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if _, ok := db.localDBs[chainID]; ok {
+		db.logger.Warn("overwriting existing local derived-from DB for chain", "chain", chainID)
+	}
+
+	db.localDBs[chainID] = dfDB
+}
+
+func (db *ChainsDB) AddCrossDerivedFromDB(chainID types.ChainID, dfDB CrossDerivedFromStorage) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if _, ok := db.crossDBs[chainID]; ok {
+		db.logger.Warn("overwriting existing cross derived-from DB for chain", "chain", chainID)
+	}
+
+	db.crossDBs[chainID] = dfDB
+}
+
+func (db *ChainsDB) AddCrossUnsafeTracker(chainID types.ChainID) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if _, ok := db.crossUnsafe[chainID]; ok {
+		db.logger.Warn("overwriting existing cross-unsafe tracker for chain", "chain", chainID)
+	}
+	db.crossUnsafe[chainID] = types.BlockSeal{}
 }
 
 // ResumeFromLastSealedBlock prepares the chains db to resume recording events after a restart.

--- a/op-supervisor/supervisor/backend/db/file_layout.go
+++ b/op-supervisor/supervisor/backend/db/file_layout.go
@@ -1,4 +1,4 @@
-package backend
+package db
 
 import (
 	"fmt"
@@ -7,6 +7,22 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
+
+func prepLocalDerivedFromDBPath(chainID types.ChainID, datadir string) (string, error) {
+	dir, err := prepChainDir(chainID, datadir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "local_safe.db"), nil
+}
+
+func prepCrossDerivedFromDBPath(chainID types.ChainID, datadir string) (string, error) {
+	dir, err := prepChainDir(chainID, datadir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cross_safe.db"), nil
+}
 
 func prepLogDBPath(chainID types.ChainID, datadir string) (string, error) {
 	dir, err := prepChainDir(chainID, datadir)
@@ -24,7 +40,7 @@ func prepChainDir(chainID types.ChainID, datadir string) (string, error) {
 	return dir, nil
 }
 
-func prepDataDir(datadir string) error {
+func PrepDataDir(datadir string) error {
 	if err := os.MkdirAll(datadir, 0755); err != nil {
 		return fmt.Errorf("failed to create data directory %v: %w", datadir, err)
 	}

--- a/op-supervisor/supervisor/backend/db/file_layout_test.go
+++ b/op-supervisor/supervisor/backend/db/file_layout_test.go
@@ -1,4 +1,4 @@
-package backend
+package db
 
 import (
 	"math/big"

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -13,10 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-type Metrics interface {
-	RecordDBDerivedEntryCount(count int64)
-}
-
 type EntryStore interface {
 	Size() int64
 	LastEntryIdx() entrydb.EntryIdx

--- a/op-supervisor/supervisor/backend/db/fromda/metrics.go
+++ b/op-supervisor/supervisor/backend/db/fromda/metrics.go
@@ -1,0 +1,25 @@
+package fromda
+
+type Metrics interface {
+	RecordDBDerivedEntryCount(count int64)
+}
+
+type ChainMetrics interface {
+	RecordDBEntryCount(kind string, count int64)
+}
+
+type delegate struct {
+	inner ChainMetrics
+	kind  string
+}
+
+func (d *delegate) RecordDBDerivedEntryCount(count int64) {
+	d.inner.RecordDBEntryCount(d.kind, count)
+}
+
+func AdaptMetrics(chainMetrics ChainMetrics, kind string) Metrics {
+	return &delegate{
+		kind:  kind,
+		inner: chainMetrics,
+	}
+}

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -295,7 +295,7 @@ func (db *DB) newIteratorAt(blockNum uint64, logIndex uint32) (*iterator, error)
 	}()
 	// First walk up to the block that we are sealed up to (incl.)
 	for {
-		if _, n, _ := iter.SealedBlock(); n == blockNum { // we may already have it exactly
+		if _, n, ok := iter.SealedBlock(); ok && n == blockNum { // we may already have it exactly
 			break
 		}
 		if err := iter.NextBlock(); errors.Is(err, entrydb.ErrFuture) {

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -21,7 +21,7 @@ const (
 )
 
 type Metrics interface {
-	RecordDBEntryCount(count int64)
+	RecordDBEntryCount(kind string, count int64)
 	RecordDBSearchEntriesRead(count int64)
 }
 
@@ -122,7 +122,7 @@ func (db *DB) trimToLastSealed() error {
 }
 
 func (db *DB) updateEntryCountMetric() {
-	db.m.RecordDBEntryCount(db.store.Size())
+	db.m.RecordDBEntryCount("log", db.store.Size())
 }
 
 func (db *DB) IteratorStartingAt(sealedNum uint64, logsSince uint32) (Iterator, error) {

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -1133,7 +1133,7 @@ type stubMetrics struct {
 	entriesReadForSearch int64
 }
 
-func (s *stubMetrics) RecordDBEntryCount(count int64) {
+func (s *stubMetrics) RecordDBEntryCount(kind string, count int64) {
 	s.entryCount = count
 }
 

--- a/op-supervisor/supervisor/backend/db/open.go
+++ b/op-supervisor/supervisor/backend/db/open.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/fromda"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func OpenLogDB(logger log.Logger, chainID types.ChainID, dataDir string, m logs.Metrics) (*logs.DB, error) {
+	path, err := prepLogDBPath(chainID, dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create datadir for chain %s: %w", chainID, err)
+	}
+	logDB, err := logs.NewFromFile(logger, m, path, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logdb for chain %s at %v: %w", chainID, path, err)
+	}
+	return logDB, nil
+}
+
+func OpenLocalDerivedFromDB(logger log.Logger, chainID types.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
+	path, err := prepLocalDerivedFromDBPath(chainID, dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare datadir for chain %s: %w", chainID, err)
+	}
+	db, err := fromda.NewFromFile(logger, fromda.AdaptMetrics(m, "local_derived"), path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local-derived for chain %s at %q: %w", chainID, path, err)
+	}
+	return db, nil
+}
+
+func OpenCrossDerivedFromDB(logger log.Logger, chainID types.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
+	path, err := prepCrossDerivedFromDBPath(chainID, dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare datadir for chain %s: %w", chainID, err)
+	}
+	db, err := fromda.NewFromFile(logger, fromda.AdaptMetrics(m, "cross_derived"), path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cross-derived for chain %s at %q: %w", chainID, path, err)
+	}
+	return db, nil
+}

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -31,5 +31,5 @@ type DependencySet interface {
 
 	// HasChain determines if a chain is being tracked for interop purposes.
 	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
-	HasChain(chainID types.ChainID) (bool, error)
+	HasChain(chainID types.ChainID) bool
 }

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -25,4 +25,7 @@ type DependencySet interface {
 	// This may return an error if the query temporarily cannot be answered.
 	// E.g. if the DependencySet is syncing new changes.
 	CanInitiateAt(chainID types.ChainID, initTimestamp uint64) (bool, error)
+
+	// Chains returns the list of chains that are part of the dependency set.
+	Chains() []types.ChainID
 }

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -28,4 +28,8 @@ type DependencySet interface {
 
 	// Chains returns the list of chains that are part of the dependency set.
 	Chains() []types.ChainID
+
+	// HasChain determines if a chain is being tracked for interop purposes.
+	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
+	HasChain(chainID types.ChainID) (bool, error)
 }

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -36,6 +36,12 @@ func TestDependencySet(t *testing.T) {
 	result, err := loader.LoadDependencySet(context.Background())
 	require.NoError(t, err)
 
+	chainIDs := result.Chains()
+	require.Equal(t, []types.ChainID{
+		types.ChainIDFromUInt64(900),
+		types.ChainIDFromUInt64(901),
+	}, chainIDs)
+
 	v, err := result.CanExecuteAt(types.ChainIDFromUInt64(900), 42)
 	require.NoError(t, err)
 	require.True(t, v)

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -46,3 +46,11 @@ func (ds *StaticConfigDependencySet) CanInitiateAt(chainID types.ChainID, initTi
 	}
 	return initTimestamp >= dep.HistoryMinTime, nil
 }
+
+func (ds *StaticConfigDependencySet) Chains() []types.ChainID {
+	var out []types.ChainID
+	for chainID := range ds.Dependencies {
+		out = append(out, chainID)
+	}
+	return out
+}

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -2,6 +2,9 @@ package depset
 
 import (
 	"context"
+	"sort"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -48,9 +51,9 @@ func (ds *StaticConfigDependencySet) CanInitiateAt(chainID types.ChainID, initTi
 }
 
 func (ds *StaticConfigDependencySet) Chains() []types.ChainID {
-	var out []types.ChainID
-	for chainID := range ds.Dependencies {
-		out = append(out, chainID)
-	}
+	out := maps.Keys(ds.Dependencies)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Cmp(out[j]) < 0
+	})
 	return out
 }

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -58,7 +58,7 @@ func (ds *StaticConfigDependencySet) Chains() []types.ChainID {
 	return out
 }
 
-func (ds *StaticConfigDependencySet) HasChain(chainID types.ChainID) (bool, error) {
+func (ds *StaticConfigDependencySet) HasChain(chainID types.ChainID) bool {
 	_, ok := ds.Dependencies[chainID]
-	return ok, nil
+	return ok
 }

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -57,3 +57,8 @@ func (ds *StaticConfigDependencySet) Chains() []types.ChainID {
 	})
 	return out
 }
+
+func (ds *StaticConfigDependencySet) HasChain(chainID types.ChainID) (bool, error) {
+	_, ok := ds.Dependencies[chainID]
+	return ok, nil
+}

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -182,6 +182,10 @@ func (id *ChainID) UnmarshalText(data []byte) error {
 	return nil
 }
 
+func (id ChainID) Cmp(other ChainID) int {
+	return (*uint256.Int)(&id).Cmp((*uint256.Int)(&other))
+}
+
 type ReferenceView struct {
 	Local eth.BlockID `json:"local"`
 	Cross eth.BlockID `json:"cross"`


### PR DESCRIPTION
# What
Uses the new Dependency Set Configuration to spin up database constructs for exactly the chains specified.

# How
I split out the "AddL2FromRPC" functionality into two parts:

### openChainDBs

Creates the LogDB and FromDA DBs for the given chain and attaches it to the `SupervisorBackend.chainsDB`.

### ~~addProcessorFromRPC~~ attachRPC

Connects via RPC to determine ChainID, and then attaches a new processor to `SupervisorBackend.ChainProcessors`.
If the discovered ChainID is not part of the dependency set (determined by known processors), this attachment fails.

Chain-Processors are now instantiated upfront, to allow attaching of RPCs during runtime, and to make the test-setup a little more sane (we can attach a mock source with `AttachProcessorSource` now)

### Additionally
The `SupervisorBackend` now tracks a map for `ChainMetrics`, as both the Processor and Database want to use it, and the processor may not be attached until later.

Now, when users use the `AddRPC` function on the Supervisor, it *only* follows the `addProcessorFromRPC` path.

And a minor bugfix in the `logs` db, to read the full block seal properly.

# TODO:
* ~~Unit Tests~~ (done: there's a backend test asserting the presence of DBs and unsafe/cross-unsafe block functionality)
* ~~Creating the `fromda` objects inside the `ChainsDB` when the call is made~~ (done)

# Metadata

Fix https://github.com/ethereum-optimism/optimism/issues/12487