### PR TITLE
ci: Revert kurtosis test back to CCI runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -796,9 +796,22 @@ jobs:
         description: Test directory
         type: string
         default: "./..."
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    machine:
+      image: <<pipeline.parameters.base_image>>
+    resource_class: xlarge
     steps:
+      - run:
+          name: Install components
+          command: |
+            go version
+            go install gotest.tools/gotestsum@v1.11.0
+      - run:
+          name: Install Kurtosis
+          command: |
+            echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+            sudo apt update
+            sudo apt install kurtosis-cli=1.3.0
+            kurtosis engine start
       - checkout
       - when:
           condition: <<parameters.uses_artifacts>>


### PR DESCRIPTION
We're seeing issues with concurrent usage of CCI that are causing builds to fail.
