### PR TITLE
fix(make): rm devent-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,6 @@ devnet-up: pre-devnet ## Starts the local devnet
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=.
 .PHONY: devnet-up
 
-devnet-test: pre-devnet ## Runs tests on the local devnet
-	make -C op-e2e test-devnet
-.PHONY: devnet-test
-
 devnet-down: ## Stops the local devnet
 	@(cd ./ops-bedrock && GENESIS_TIMESTAMP=$(shell date +%s) docker compose stop)
 .PHONY: devnet-down

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -38,10 +38,6 @@ test-fault-proofs: pre-test
 	$(go_test) $(go_test_flags) ./faultproofs
 .PHONY: test-faultproofs
 
-test-devnet: pre-test
-	$(go_test) $(go_test_flags) ./devnet
-.PHONY: test-devnet
-
 cannon-prestates:
 	make -C .. cannon-prestate
 	make -C .. cannon-prestate-mt
@@ -76,4 +72,3 @@ fuzz:
 	go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFjordCostFunction ./opgeth
 	go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzGethSolidity ./opgeth
 	go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzCgo ./opgeth
-


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

rm `make devent-test` task, as the devent tests were removed in https://github.com/ethereum-optimism/optimism/pull/12216, so when I'm running `make devnet-test`, it failed as below:


```bash
$ make devnet-test
git submodule update --init --recursive
make[1]: Entering directory '/md0/code/ethereum/optimism'
./ops/scripts/geth-version-checker.sh && \
        (echo "Geth versions match, not installing geth..."; true) || \
                (echo "Versions do not match, installing geth!"; \
                        go install -v github.com/ethereum/go-ethereum/cmd/geth@v1.14.7; \
                        echo "Installed geth!"; true)
Geth version v1.14.7-stable is correct!
Geth versions match, not installing geth...
make[1]: Leaving directory '/md0/code/ethereum/optimism'
make[1]: Entering directory '/md0/code/ethereum/optimism'
go install -v github.com/protolambda/eth2-testnet-genesis@v0.10.0
make[1]: Leaving directory '/md0/code/ethereum/optimism'
make -C op-e2e test-devnet
make[1]: Entering directory '/md0/code/ethereum/optimism/op-e2e'
go test -v ./devnet
stat /md0/code/ethereum/optimism/op-e2e/devnet: directory not found
make[1]: *** [Makefile:42: test-devnet] Error 1
make[1]: Leaving directory '/md0/code/ethereum/optimism/op-e2e'
make: *** [Makefile:190: devnet-test] Error 2
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
