### PR TITLE
op-e2e: Don't override the sequencer window in tests where it shouldn't be needed

### DIFF
--- a/op-e2e/faultproofs/cannon_benchmark_test.go
+++ b/op-e2e/faultproofs/cannon_benchmark_test.go
@@ -49,9 +49,6 @@ func testBenchmarkCannonFPP(t *testing.T, allocType config.AllocType) {
 	cfg := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(allocType))
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
-	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks
-	// But not too small to ensure that our claim and subsequent state change is published
-	cfg.DeployConfig.SequencerWindowSize = 16
 	minTs := hexutil.Uint64(0)
 	cfg.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	cfg.DeployConfig.L2GenesisEcotoneTimeOffset = &minTs

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -91,9 +91,6 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 			cfg.AllocType = allocType
 			// We don't need a verifier - just the sequencer is enough
 			delete(cfg.Nodes, "verifier")
-			// Use a small sequencer window size to avoid test timeout while waiting for empty blocks
-			// But not too small to ensure that our claim and subsequent state change is published
-			cfg.DeployConfig.SequencerWindowSize = 16
 
 			sys, err := cfg.Start(t)
 			require.Nil(t, err, "Error starting up system")
@@ -199,9 +196,6 @@ func testGranitePrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 	cfg.AllocType = allocType
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
-	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks
-	// But not too small to ensure that our claim and subsequent state change is published
-	cfg.DeployConfig.SequencerWindowSize = 16
 
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")

--- a/op-e2e/system/proofs/system_fpp_test.go
+++ b/op-e2e/system/proofs/system_fpp_test.go
@@ -99,7 +99,7 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActi
 	delete(cfg.Nodes, "verifier")
 	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks
 	// But not too small to ensure that our claim and subsequent state change is published
-	cfg.DeployConfig.SequencerWindowSize = 16
+	cfg.DeployConfig.SequencerWindowSize = 30
 	applySpanBatchActivation(spanBatchActivated, cfg.DeployConfig)
 
 	sys, err := cfg.Start(t)


### PR DESCRIPTION
**Description**

Use a longer window in the one test it may affect - 16 does get hit unexpectedly in CI.

We get flakes when the sequencer window is hit and causes an unexpected reorg.
