### PR TITLE
feat: op-program --network flag accepts number as chainid

### DIFF
--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -2,8 +2,10 @@ package rollup
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"time"
 
@@ -647,6 +649,15 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"interop_time", fmtForkTimeOrUnset(c.InteropTime),
 		"alt_da", c.AltDAConfig != nil,
 	)
+}
+
+func (c *Config) ParseRollupConfig(in io.Reader) error {
+	dec := json.NewDecoder(in)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(c); err != nil {
+		return fmt.Errorf("failed to decode rollup config: %w", err)
+	}
+	return nil
 }
 
 func fmtForkTimeOrUnset(v *uint64) string {

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -51,7 +51,7 @@ test:
 verify-sepolia: op-program-host op-program-client
 	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l1.beacon $$SEPOLIA_BEACON_URL --l2 $$SEPOLIA_L2URL --datadir /tmp/test-sepolia
 
-verify-devnet:
+verify-devnet: op-program-host op-program-client
 	env GO111MODULE=on go run ./verify/devnet/cmd/devnet.go --l1 http://localhost:8545 --l1.beacon http://localhost:5052 --l2 http://localhost:9545 --datadir /tmp/test-devnet
 
 capture-mainnet-genesis: op-program-host op-program-client

--- a/op-program/chainconfig/chaincfg.go
+++ b/op-program/chainconfig/chaincfg.go
@@ -37,13 +37,10 @@ func rollupConfigByChainID(chainID uint64, customChainFS embed.FS) (*rollup.Conf
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to get rollup config for chain ID %d: %w", chainID, err)
 	}
-	dec := json.NewDecoder(file)
-	dec.DisallowUnknownFields()
+	defer file.Close()
+
 	var customRollupConfig rollup.Config
-	if err := dec.Decode(&customRollupConfig); err != nil {
-		return nil, fmt.Errorf("failed to parse rollup config for chain ID %d: %w", chainID, err)
-	}
-	return &customRollupConfig, nil
+	return &customRollupConfig, customRollupConfig.ParseRollupConfig(file)
 }
 
 func ChainConfigByChainID(chainID uint64) (*params.ChainConfig, error) {

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -180,7 +180,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		if chainID, err = strconv.ParseUint(networkName, 10, 64); err != nil {
 			ch := chaincfg.ChainByName(networkName)
 			if ch == nil {
-				return nil, fmt.Errorf("flag %s is required for network %s", flags.L2GenesisPath.Name, networkName)
+				return nil, fmt.Errorf("invalid network: %q", networkName)
 			}
 			chainID = ch.ChainID
 		}

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strconv"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 
-	opnode "github.com/ethereum-optimism/optimism/op-node"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/host/flags"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -146,10 +147,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	if err := flags.CheckRequired(ctx); err != nil {
 		return nil, err
 	}
-	rollupCfg, err := opnode.NewRollupConfigFromCLI(log, ctx)
-	if err != nil {
-		return nil, err
-	}
+
 	l2Head := common.HexToHash(ctx.String(flags.L2Head.Name))
 	if l2Head == (common.Hash{}) {
 		return nil, ErrInvalidL2Head
@@ -171,27 +169,46 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	if l1Head == (common.Hash{}) {
 		return nil, ErrInvalidL1Head
 	}
-	l2GenesisPath := ctx.String(flags.L2GenesisPath.Name)
+
+	var err error
+	var rollupCfg *rollup.Config
 	var l2ChainConfig *params.ChainConfig
 	var isCustomConfig bool
-	if l2GenesisPath == "" {
-		networkName := ctx.String(flags.Network.Name)
-		ch := chaincfg.ChainByName(networkName)
-		if ch == nil {
-			return nil, fmt.Errorf("flag %s is required for network %s", flags.L2GenesisPath.Name, networkName)
+	networkName := ctx.String(flags.Network.Name)
+	if networkName != "" {
+		var chainID uint64
+		if chainID, err = strconv.ParseUint(networkName, 10, 64); err != nil {
+			ch := chaincfg.ChainByName(networkName)
+			if ch == nil {
+				return nil, fmt.Errorf("flag %s is required for network %s", flags.L2GenesisPath.Name, networkName)
+			}
+			chainID = ch.ChainID
 		}
-		cfg, err := params.LoadOPStackChainConfig(ch.ChainID)
+
+		l2ChainConfig, err = chainconfig.ChainConfigByChainID(chainID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load chain config for chain %d: %w", ch.ChainID, err)
+			return nil, fmt.Errorf("failed to load chain config for chain %d: %w", chainID, err)
 		}
-		l2ChainConfig = cfg
+		rollupCfg, err = chainconfig.RollupConfigByChainID(chainID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load rollup config for chain %d: %w", chainID, err)
+		}
 	} else {
+		l2GenesisPath := ctx.String(flags.L2GenesisPath.Name)
 		l2ChainConfig, err = loadChainConfigFromGenesis(l2GenesisPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid genesis: %w", err)
+		}
+
+		rollupConfigPath := ctx.String(flags.RollupConfig.Name)
+		rollupCfg, err = loadRollupConfig(rollupConfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rollup config: %w", err)
+		}
+
 		isCustomConfig = true
 	}
-	if err != nil {
-		return nil, fmt.Errorf("invalid genesis: %w", err)
-	}
+
 	dbFormat := types.DataFormat(ctx.String(flags.DataFormat.Name))
 	if !slices.Contains(types.SupportedDataFormats, dbFormat) {
 		return nil, fmt.Errorf("invalid %w: %v", ErrInvalidDataFormat, dbFormat)
@@ -228,4 +245,20 @@ func loadChainConfigFromGenesis(path string) (*params.ChainConfig, error) {
 		return nil, fmt.Errorf("parse l2 genesis file: %w", err)
 	}
 	return genesis.Config, nil
+}
+
+func loadRollupConfig(rollupConfigPath string) (*rollup.Config, error) {
+	file, err := os.Open(rollupConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rollup config: %w", err)
+	}
+	defer file.Close()
+
+	var rollupConfig rollup.Config
+	dec := json.NewDecoder(file)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rollupConfig); err != nil {
+		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
+	}
+	return &rollupConfig, nil
 }

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -255,10 +255,5 @@ func loadRollupConfig(rollupConfigPath string) (*rollup.Config, error) {
 	defer file.Close()
 
 	var rollupConfig rollup.Config
-	dec := json.NewDecoder(file)
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&rollupConfig); err != nil {
-		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
-	}
-	return &rollupConfig, nil
+	return &rollupConfig, rollupConfig.ParseRollupConfig(file)
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -158,6 +158,9 @@ func CheckRequired(ctx *cli.Context) error {
 	if network == "" && ctx.String(L2GenesisPath.Name) == "" {
 		return fmt.Errorf("flag %s is required for custom networks", L2GenesisPath.Name)
 	}
+	if ctx.String(L2GenesisPath.Name) != "" && network != "" {
+		return fmt.Errorf("cannot specify both %s and %s", L2GenesisPath.Name, Network.Name)
+	}
 	for _, flag := range requiredFlags {
 		if !ctx.IsSet(flag.Names()[0]) {
 			return fmt.Errorf("flag %s is required", flag.Names()[0])

--- a/op-program/verify/devnet/cmd/devnet.go
+++ b/op-program/verify/devnet/cmd/devnet.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Apply the custom configs by running op-program in the same process
-	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "", 901, true)
+	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "901", 901, false)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())
 		os.Exit(1)

--- a/op-program/verify/devnet/cmd/devnet.go
+++ b/op-program/verify/devnet/cmd/devnet.go
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	// Apply the custom configs by running op-program in the same process
+	// Apply the custom configs by running op-program
 	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "901", 901, false)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This will allow the `op-program` to use the embedded custom rollup config, where the chainid of the custom rollup is passed via `--network` flag. This way, we can now verify `op-program` in the independent process mode.

**Tests**

Run devnet locally, then pass `make verify-devnet` under the `op-program` folder.

**Additional context**

**Metadata**

