### PR TITLE
Remove loose imports

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -28,16 +28,16 @@
     "sourceCodeHash": "0x7bfa6eff76176649fe600303cd60009a0f6e282cbaec55836b5ea1f8875cbeb5"
   },
   "src/L1/OptimismPortal.sol": {
-    "initCodeHash": "0xbe2c0c81b3459014f287d8c89cdc0d27dde5d1f44e5d024fa1e4773ddc47c190",
-    "sourceCodeHash": "0xb3dd8068477dd304ef1562acf69c2ce460b08cc36aef53b5bbe489fd7d992104"
+    "initCodeHash": "0x152167cfa18635ae4918a6eb3371a599cfa084418c0a652799cdb48bfc0ee0cc",
+    "sourceCodeHash": "0xbe34b82900d02f71bb0949818eabe49531f7e0d8d8bae01f6dac4a296530d1aa"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0xc94c609e04ab8ffee880806550dffff53478dfffdfb079f7c487abe0e2996f3c",
-    "sourceCodeHash": "0x3fb97859f66c078573753b6ba5ec370449ab03b8eca9e7779fce8db5bb23b7c0"
+    "initCodeHash": "0x218358b48f640b3fcb2d239f00dc1cd3b11517ad46c8e1efa44953d38da63540",
+    "sourceCodeHash": "0x66ac1212760db53a2bb1839e4cd17dc071d9273b8e6fb80646b79e91b3371c1a"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0xfeaa67ccd652bda9103fea507e4357b2bd4e93210b03ff85eb357d7145f1606c",
-    "sourceCodeHash": "0x6401b81f04093863557ef46192f56793daa0d412618065383ab353b2ed2929d8"
+    "initCodeHash": "0x39f66ac74341ec235fbdd0d79546283210bd8ac35a2ab2c4bd36c9722ce18411",
+    "sourceCodeHash": "0xbb98144285b9530e336f957d10b20363b350876597e30fd34821940896a2bae8"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0xefd4806e8737716d5d2022ca2e9e9fba0a0cb5714b026166b58e472222c7d15f",
@@ -72,12 +72,12 @@
     "sourceCodeHash": "0x4f21025d4b5c9c74cf7040db6f8e9ce605b82931e3012fee51d3f5d9fbd7b73f"
   },
   "src/L2/L1Block.sol": {
-    "initCodeHash": "0xd12353c5bf71c6765cc9292eecf262f216e67f117f4ba6287796a5207dbca00f",
-    "sourceCodeHash": "0xfe3a9585d9bfca8428e12759cab68a3114374e5c37371cfe08bb1976a9a5a041"
+    "initCodeHash": "0xa919d2aa76a7ecdfd076e2b1dbece499cc85706075f16eb6fa7b1a0fa7b38c1b",
+    "sourceCodeHash": "0x692cfcbc06dba6328f6e5c6b500741df04e4bdf730b2069aeb5d168355ea7b6f"
   },
   "src/L2/L1BlockInterop.sol": {
-    "initCodeHash": "0x77b3b2151fe14ea36a640469115a5e4de27f7654a9606a9d0701522c6a4ad887",
-    "sourceCodeHash": "0x7417677643e1df1ae1782513b94c7821097b9529d3f8626c3bcb8b3a9ae0d180"
+    "initCodeHash": "0x62e9cc59daaf72066ac20597a666db33e9a7b3f7be71a3d47ea4841a9aca9d07",
+    "sourceCodeHash": "0xe57627347366d74029a0d24f0b45d7b9cf82b81c94681d0f633d5e5c37c8de4a"
   },
   "src/L2/L1FeeVault.sol": {
     "initCodeHash": "0xbf49824cf37e201181484a8a423fcad8f504dc925921a2b28e83398197858dec",
@@ -148,24 +148,24 @@
     "sourceCodeHash": "0x3dd89839f268569cbf2659beb42e3ac3c53887472cfc94a6e339d2b3a963b941"
   },
   "src/cannon/PreimageOracle.sol": {
-    "initCodeHash": "0x64ea814bf9769257c91da57928675d3f8462374b0c23bdf860ccfc79f41f7801",
-    "sourceCodeHash": "0xac290a77986d54efe404c73ee58d11429e1b1fb47e4d06d4c38b6ecc20751d78"
+    "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",
+    "sourceCodeHash": "0x979d8595d925c70a123e72c062fa58c9ef94777c2e93b6bc3231d6679e2e9055"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0x13d00eef8c3f769863fc766180acc8586f5da309ca0a098e67d4d90bd3243341",
-    "sourceCodeHash": "0x39a23c91d4c5380d285f49660b858d39f3fa27bdbfbc72e0e14587e7c57dfae9"
+    "initCodeHash": "0x7bdbf9dc5125c953ea1833ccf0ad0e07d25b6f6c47e23da5374413324a38c5f9",
+    "sourceCodeHash": "0x1d918a536d9f6c900efdf069e96c2a27bb49340d6d1ebaa92dd6b481835a9a82"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0x835b322de7d5c84b415e99f2cb1000411df18995b5476f2116ac6f897f2d0910",
     "sourceCodeHash": "0xdbd64724b73f8f9d6f1cc72bb662a99b9955ab72950a8f6ffeb1d2454997f60b"
   },
   "src/dispute/DisputeGameFactory.sol": {
-    "initCodeHash": "0xb91623cca41e63e6e5a75c681b0d9ef7cb8bf68e7ff5e202a217629899fae099",
-    "sourceCodeHash": "0xc8f21c777b2c5a37c2d2f92e8eeceba3b231b500a7d9cb0b607b774478f8be6b"
+    "initCodeHash": "0xd72eced7cb5400d93188038a707fe6c1b04077f059cd8e2f5253e871de2cee3b",
+    "sourceCodeHash": "0x9cb0851b6e471461f2bb369bd72eef4cffe8a0d1345546608a2aa6795540211d"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x04e6c36ee49f7744e5277c1d83ba78616ef3e3cef62406d32e2d9c72bca2010a",
-    "sourceCodeHash": "0x9b9e971748d253790b3ce9da0b1cbbcb6df77bb252ee2d1c5088bb6bae6491aa"
+    "initCodeHash": "0xf97d35adc72c7bcbb5415ff1b183af0a4e3c951696d1dde213df61df50c848b9",
+    "sourceCodeHash": "0x27b4ab6f75004d01ff177b2b26e500a8ad06e906fcd36b920daa067f27f97da6"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x0b8177ed75b69eddbb9ce6537683f69a9935efed86a1d6faa8feaafbd151c1bd",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -14,7 +14,19 @@ import { Hashing } from "src/libraries/Hashing.sol";
 import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
-import "src/libraries/PortalErrors.sol";
+import {
+    BadTarget,
+    LargeCalldata,
+    SmallGasLimit,
+    TransferFailed,
+    OnlyCustomGasToken,
+    NoValue,
+    Unauthorized,
+    CallPaused,
+    GasEstimation,
+    NonReentrant,
+    Unproven
+} from "src/libraries/PortalErrors.sol";
 
 // Interfaces
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -134,9 +146,9 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.8.1-beta.3
+    /// @custom:semver 2.8.1-beta.4
     function version() public pure virtual returns (string memory) {
-        return "2.8.1-beta.3";
+        return "2.8.1-beta.4";
     }
 
     /// @notice Constructs the OptimismPortal contract.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -14,8 +14,27 @@ import { Hashing } from "src/libraries/Hashing.sol";
 import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
-import "src/libraries/PortalErrors.sol";
-import "src/dispute/lib/Types.sol";
+import {
+    BadTarget,
+    LargeCalldata,
+    SmallGasLimit,
+    TransferFailed,
+    OnlyCustomGasToken,
+    NoValue,
+    Unauthorized,
+    CallPaused,
+    GasEstimation,
+    NonReentrant,
+    InvalidProof,
+    InvalidGameType,
+    InvalidDisputeGame,
+    InvalidMerkleProof,
+    Blacklisted,
+    Unproven,
+    ProposalNotValidated,
+    AlreadyFinalized
+} from "src/libraries/PortalErrors.sol";
+import { GameStatus, GameType, Claim, Timestamp, Hash } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -164,9 +183,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.11.0-beta.5
+    /// @custom:semver 3.11.0-beta.6
     function version() public pure virtual returns (string memory) {
-        return "3.11.0-beta.5";
+        return "3.11.0-beta.6";
     }
 
     /// @notice Constructs the OptimismPortal contract.

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -8,7 +8,7 @@ import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Constants } from "src/libraries/Constants.sol";
-import "src/libraries/PortalErrors.sol";
+import { Unauthorized } from "src/libraries/PortalErrors.sol";
 
 /// @custom:proxied true
 /// @title OptimismPortalInterop
@@ -23,9 +23,9 @@ contract OptimismPortalInterop is OptimismPortal2 {
         OptimismPortal2(_proofMaturityDelaySeconds, _disputeGameFinalityDelaySeconds)
     { }
 
-    /// @custom:semver +interop-beta.1
+    /// @custom:semver +interop-beta.2
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.1");
+        return string.concat(super.version(), "+interop-beta.2");
     }
 
     /// @notice Sets static configuration options for the L2 system.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
-import "src/libraries/L1BlockErrors.sol";
+import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -57,9 +57,9 @@ contract L1Block is ISemver, IGasToken {
     /// @notice The latest L1 blob base fee.
     uint256 public blobBaseFee;
 
-    /// @custom:semver 1.5.1-beta.2
+    /// @custom:semver 1.5.1-beta.3
     function version() public pure virtual returns (string memory) {
-        return "1.5.1-beta.2";
+        return "1.5.1-beta.3";
     }
 
     /// @notice Returns the gas paying token, its decimals, name and symbol.

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -9,7 +9,14 @@ import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableS
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import "src/libraries/L1BlockErrors.sol";
+import {
+    NotDepositor,
+    NotCrossL2Inbox,
+    NotDependency,
+    DependencySetSizeTooLarge,
+    AlreadyDependency,
+    CantRemovedDependency
+} from "src/libraries/L1BlockErrors.sol";
 
 /// @notice Enum representing different types of configurations that can be set on L1BlockInterop.
 /// @custom:value SET_GAS_PAYING_TOKEN  Represents the config type for setting the gas paying token.
@@ -42,9 +49,9 @@ contract L1BlockInterop is L1Block {
     /// keccak256(abi.encode(uint256(keccak256("l1Block.identifier.isDeposit")) - 1)) & ~bytes32(uint256(0xff))
     uint256 internal constant IS_DEPOSIT_SLOT = 0x921bd3a089295c6e5540e8fba8195448d253efd6f2e3e495b499b627dc36a300;
 
-    /// @custom:semver +interop
+    /// @custom:semver +interop-beta.1
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop");
+        return string.concat(super.version(), "+interop-beta.1");
     }
 
     /// @notice Returns whether the call was triggered from a a deposit or not.

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -4,8 +4,26 @@ pragma solidity 0.8.15;
 // Libraries
 import { LibKeccak } from "@lib-keccak/LibKeccak.sol";
 import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";
-import "src/cannon/libraries/CannonErrors.sol";
-import "src/cannon/libraries/CannonTypes.sol";
+import {
+    PartOffsetOOB,
+    NotEnoughGas,
+    InvalidProof,
+    InvalidPreimage,
+    InvalidInputSize,
+    WrongStartingBlock,
+    StatesNotContiguous,
+    PostStateMatches,
+    TreeSizeOverflow,
+    AlreadyFinalized,
+    ActiveProposal,
+    BadProposal,
+    NotInitialized,
+    AlreadyInitialized,
+    NotEOA,
+    InsufficientBond,
+    BondTransferFailed
+} from "src/cannon/libraries/CannonErrors.sol";
+import { LPPMetaData } from "src/cannon/libraries/CannonTypes.sol";
 
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
@@ -33,8 +51,8 @@ contract PreimageOracle is ISemver {
     uint256 public constant PRECOMPILE_CALL_RESERVED_GAS = 100_000;
 
     /// @notice The semantic version of the Preimage Oracle contract.
-    /// @custom:semver 1.1.3-beta.5
-    string public constant version = "1.1.3-beta.5";
+    /// @custom:semver 1.1.3-beta.6
+    string public constant version = "1.1.3-beta.6";
 
     ////////////////////////////////////////////////////////////////
     //                 Authorized Preimage Parts                  //

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.15;
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 // Libraries
-import "src/dispute/lib/Types.sol";
+import { GameType, OutputRoot, Claim, GameStatus, Hash } from "src/dispute/lib/Types.sol";
 import { Unauthorized } from "src/libraries/errors/CommonErrors.sol";
 import { UnregisteredGame, InvalidGameStatus } from "src/dispute/lib/Errors.sol";
 
@@ -30,8 +30,8 @@ contract AnchorStateRegistry is Initializable, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.0.1-beta.3
-    string public constant version = "2.0.1-beta.3";
+    /// @custom:semver 2.0.1-beta.4
+    string public constant version = "2.0.1-beta.4";
 
     /// @notice DisputeGameFactory address.
     IDisputeGameFactory internal immutable DISPUTE_GAME_FACTORY;

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -6,8 +6,8 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 
 // Libraries
 import { LibClone } from "@solady/utils/LibClone.sol";
-import "src/dispute/lib/Types.sol";
-import "src/dispute/lib/Errors.sol";
+import { GameType, Claim, GameId, Timestamp, Hash, LibGameId } from "src/dispute/lib/Types.sol";
+import { NoImplementation, IncorrectBondAmount, GameAlreadyExists } from "src/dispute/lib/Errors.sol";
 
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
@@ -49,8 +49,8 @@ contract DisputeGameFactory is OwnableUpgradeable, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1-beta.2
-    string public constant version = "1.0.1-beta.2";
+    /// @custom:semver 1.0.1-beta.3
+    string public constant version = "1.0.1-beta.3";
 
     /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
     ///         `IDisputeGame` implementations.

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -8,8 +8,52 @@ import { Clone } from "@solady/utils/Clone.sol";
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
-import "src/dispute/lib/Types.sol";
-import "src/dispute/lib/Errors.sol";
+import {
+    GameStatus,
+    GameType,
+    Claim,
+    Position,
+    Clock,
+    Duration,
+    Timestamp,
+    Hash,
+    OutputRoot,
+    LibPosition,
+    LibClock,
+    LocalPreimageKey,
+    VMStatuses
+} from "src/dispute/lib/Types.sol";
+import {
+    InvalidParent,
+    ClaimAlreadyExists,
+    ClaimAlreadyResolved,
+    OutOfOrderResolution,
+    InvalidChallengePeriod,
+    InvalidSplitDepth,
+    InvalidClockExtension,
+    MaxDepthTooLarge,
+    AnchorRootNotFound,
+    AlreadyInitialized,
+    UnexpectedRootClaim,
+    GameNotInProgress,
+    InvalidPrestate,
+    ValidStep,
+    GameDepthExceeded,
+    L2BlockNumberChallenged,
+    InvalidDisputedClaimIndex,
+    ClockTimeExceeded,
+    DuplicateStep,
+    CannotDefendRootClaim,
+    IncorrectBondAmount,
+    InvalidLocalIdent,
+    BlockNumberMatches,
+    InvalidHeaderRLP,
+    ClockNotExpired,
+    BondTransferFailed,
+    NoCreditToClaim,
+    InvalidOutputRootProof,
+    ClaimAboveSplit
+} from "src/dispute/lib/Errors.sol";
 
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
@@ -103,8 +147,8 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1-beta.4
-    string public constant version = "1.3.1-beta.4";
+    /// @custom:semver 1.3.1-beta.5
+    string public constant version = "1.3.1-beta.5";
 
     /// @notice The starting timestamp of the game
     Timestamp public createdAt;

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -5,8 +5,8 @@ pragma solidity 0.8.15;
 import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
 
 // Libraries
-import "src/dispute/lib/Types.sol";
-import "src/dispute/lib/Errors.sol";
+import { GameType, Claim, Duration } from "src/dispute/lib/Types.sol";
+import { BadAuth } from "src/dispute/lib/Errors.sol";
 
 // Interfaces
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";

--- a/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import { ERC20Votes, ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @custom:predeploy 0x4200000000000000000000000000000000000042
 /// @title GovernanceToken

--- a/packages/contracts-bedrock/src/governance/MintManager.sol
+++ b/packages/contracts-bedrock/src/governance/MintManager.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Contracts
-import "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 // Interfaces
 import { IGovernanceToken } from "src/governance/interfaces/IGovernanceToken.sol";


### PR DESCRIPTION
This PR replaces loose imports across contracts within `packages/contracts-bedrock/src/`. This is required as the script i'm currently writing for auto generation of interfaces also checks for loose imports, if detected, it skips generation for that contract and reports the loose imports. 
Loose imports are generally not a preferable pattern and also make interface generation and resolving of where imported user defined types and enums come from harder.