### PR TITLE
op-e2e/actions: Add Holocene FP action tests

### DIFF
--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -150,7 +150,48 @@ func (s *L2Batcher) ActL2BatchBuffer(t Testing, opts ...BlockModifier) {
 	require.NoError(t, s.Buffer(t, opts...), "failed to add block to channel")
 }
 
-type BlockModifier = func(block *types.Block)
+// ActCreateChannel creates a channel if we don't have one yet.
+func (s *L2Batcher) ActCreateChannel(t Testing, useSpanChannelOut bool) {
+	var err error
+	if s.L2ChannelOut == nil {
+		var ch ChannelOutIface
+		if s.l2BatcherCfg.GarbageCfg != nil {
+			ch, err = NewGarbageChannelOut(s.l2BatcherCfg.GarbageCfg)
+		} else {
+			target := batcher.MaxDataSize(1, s.l2BatcherCfg.MaxL1TxSize)
+			c, e := compressor.NewShadowCompressor(compressor.Config{
+				TargetOutputSize: target,
+				CompressionAlgo:  derive.Zlib,
+			})
+			require.NoError(t, e, "failed to create compressor")
+
+			if s.l2BatcherCfg.ForceSubmitSingularBatch && s.l2BatcherCfg.ForceSubmitSpanBatch {
+				t.Fatalf("ForceSubmitSingularBatch and ForceSubmitSpanBatch cannot be set to true at the same time")
+			} else {
+				chainSpec := rollup.NewChainSpec(s.rollupCfg)
+				// use span batch if we're forcing it or if we're at/beyond delta
+				if s.l2BatcherCfg.ForceSubmitSpanBatch || useSpanChannelOut {
+					ch, err = derive.NewSpanChannelOut(target, derive.Zlib, chainSpec)
+					// use singular batches in all other cases
+				} else {
+					ch, err = derive.NewSingularChannelOut(c, chainSpec)
+				}
+			}
+		}
+		require.NoError(t, err, "failed to create channel")
+		s.L2ChannelOut = ch
+	}
+}
+
+type BlockModifier = func(block *types.Block) *types.Block
+
+func BlockLogger(t e2eutils.TestingBase) BlockModifier {
+	f := func(block *types.Block) *types.Block {
+		t.Log("added block", "num", block.Number(), "txs", block.Transactions(), "time", block.Time())
+		return block
+	}
+	return f
+}
 
 func (s *L2Batcher) Buffer(t Testing, opts ...BlockModifier) error {
 	if s.l2Submitting { // break ongoing submitting work if necessary
@@ -197,38 +238,13 @@ func (s *L2Batcher) Buffer(t Testing, opts ...BlockModifier) error {
 
 	// Apply modifications to the block
 	for _, f := range opts {
-		f(block)
-	}
-
-	// Create channel if we don't have one yet
-	if s.L2ChannelOut == nil {
-		var ch ChannelOutIface
-		if s.l2BatcherCfg.GarbageCfg != nil {
-			ch, err = NewGarbageChannelOut(s.l2BatcherCfg.GarbageCfg)
-		} else {
-			target := batcher.MaxDataSize(1, s.l2BatcherCfg.MaxL1TxSize)
-			c, e := compressor.NewShadowCompressor(compressor.Config{
-				TargetOutputSize: target,
-				CompressionAlgo:  derive.Zlib,
-			})
-			require.NoError(t, e, "failed to create compressor")
-
-			if s.l2BatcherCfg.ForceSubmitSingularBatch && s.l2BatcherCfg.ForceSubmitSpanBatch {
-				t.Fatalf("ForceSubmitSingularBatch and ForceSubmitSpanBatch cannot be set to true at the same time")
-			} else {
-				chainSpec := rollup.NewChainSpec(s.rollupCfg)
-				// use span batch if we're forcing it or if we're at/beyond delta
-				if s.l2BatcherCfg.ForceSubmitSpanBatch || s.rollupCfg.IsDelta(block.Time()) {
-					ch, err = derive.NewSpanChannelOut(target, derive.Zlib, chainSpec)
-					// use singular batches in all other cases
-				} else {
-					ch, err = derive.NewSingularChannelOut(c, chainSpec)
-				}
-			}
+		if f != nil {
+			block = f(block)
 		}
-		require.NoError(t, err, "failed to create channel")
-		s.L2ChannelOut = ch
 	}
+
+	s.ActCreateChannel(t, s.rollupCfg.IsDelta(block.Time()))
+
 	if _, err := s.L2ChannelOut.AddBlock(s.rollupCfg, block); err != nil {
 		return err
 	}
@@ -236,6 +252,30 @@ func (s *L2Batcher) Buffer(t Testing, opts ...BlockModifier) error {
 	require.NoError(t, err, "failed to get L2BlockRef")
 	s.L2BufferedBlock = ref
 	return nil
+}
+
+// ActAddBlockByNumber causes the batcher to pull the block with the provided
+// number, and add it to its ChannelOut.
+func (s *L2Batcher) ActAddBlockByNumber(t Testing, blockNumber int64, opts ...BlockModifier) {
+	block, err := s.l2.BlockByNumber(t.Ctx(), big.NewInt(blockNumber))
+	require.NoError(t, err)
+	require.NotNil(t, block)
+
+	// cache block hash before we modify the block
+	blockHash := block.Hash()
+
+	// Apply modifications to the block
+	for _, f := range opts {
+		if f != nil {
+			block = f(block)
+		}
+	}
+
+	_, err = s.L2ChannelOut.AddBlock(s.rollupCfg, block)
+	require.NoError(t, err)
+	ref, err := s.engCl.L2BlockRefByHash(t.Ctx(), blockHash)
+	require.NoError(t, err, "failed to get L2BlockRef")
+	s.L2BufferedBlock = ref
 }
 
 func (s *L2Batcher) ActL2ChannelClose(t Testing) {

--- a/op-e2e/actions/helpers/l2_engine.go
+++ b/op-e2e/actions/helpers/l2_engine.go
@@ -191,9 +191,30 @@ func (e *L2Engine) ActL2RPCFail(t Testing, err error) {
 	}
 }
 
+// ActL2IncludeTx includes the next transaction from the given address in the block that is being built,
+// skipping the usual check for e.EngineApi.ForcedEmpty()
+func (e *L2Engine) ActL2IncludeTxIgnoreForcedEmpty(from common.Address) Action {
+	return func(t Testing) {
+		if e.EngineApi.ForcedEmpty() {
+			e.log.Info("Ignoring e.L2ForceEmpty=true")
+		}
+
+		tx := firstValidTx(t, from, e.EngineApi.PendingIndices, e.Eth.TxPool().ContentFrom, e.EthClient().NonceAt)
+		err := e.EngineApi.IncludeTx(tx, from)
+		if errors.Is(err, engineapi.ErrNotBuildingBlock) {
+			t.InvalidAction(err.Error())
+		} else if errors.Is(err, engineapi.ErrUsesTooMuchGas) {
+			t.InvalidAction("included tx uses too much gas: %v", err)
+		} else if err != nil {
+			require.NoError(t, err, "include tx")
+		}
+	}
+}
+
 // ActL2IncludeTx includes the next transaction from the given address in the block that is being built
 func (e *L2Engine) ActL2IncludeTx(from common.Address) Action {
 	return func(t Testing) {
+
 		if e.EngineApi.ForcedEmpty() {
 			e.log.Info("Skipping including a transaction because e.L2ForceEmpty is true")
 			return

--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -26,12 +26,13 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Alice.L2.ActCheckReceiptStatusOfLastTx(true)(t)
 
 	// Instruct the batcher to submit a faulty channel, with an invalid tx.
-	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) {
+	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
 		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
 		txs[1] = newTx
 		require.NoError(t, err)
+		return block
 	})
 	env.Batcher.ActL2ChannelClose(t)
 	env.Batcher.ActL2BatchSubmit(t)
@@ -90,12 +91,13 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	// Instruct the batcher to submit a faulty channel, with an invalid tx in the second block
 	// within the span batch.
 	env.Batcher.ActL2BatchBuffer(t)
-	err := env.Batcher.Buffer(t, func(block *types.Block) {
+	err := env.Batcher.Buffer(t, func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
 		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
 		txs[1] = newTx
 		require.NoError(t, err)
+		return block
 	})
 	require.NoError(t, err)
 	env.Batcher.ActL2ChannelClose(t)

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -153,7 +153,12 @@ func WithL2BlockNumber(num uint64) FixtureInputParam {
 
 func (env *L2FaultProofEnv) RunFaultProofProgram(t helpers.Testing, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
 	// Fetch the pre and post output roots for the fault proof.
-	preRoot, err := env.Sequencer.RollupClient().OutputAtBlock(t.Ctx(), l2ClaimBlockNum-1)
+	l2PreBlockNum := l2ClaimBlockNum - 1
+	if l2ClaimBlockNum == 0 {
+		// If we are at genesis, we assert that we don't move the chain at all.
+		l2PreBlockNum = 0
+	}
+	preRoot, err := env.Sequencer.RollupClient().OutputAtBlock(t.Ctx(), l2PreBlockNum)
 	require.NoError(t, err)
 	claimRoot, err := env.Sequencer.RollupClient().OutputAtBlock(t.Ctx(), l2ClaimBlockNum)
 	require.NoError(t, err)

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -1,0 +1,144 @@
+package proofs
+
+import (
+	"fmt"
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
+
+	type testCase struct {
+		name        string
+		blocks      []uint // blocks is an ordered list of blocks (by number) to add to a single channel.
+		isSpanBatch bool
+		holoceneExpectations
+	}
+
+	// Depending on the blocks list,  we expect a different
+	// progression of the safe head under Holocene
+	// derivation rules, compared with pre Holocene.
+	var testCases = []testCase{
+		// Standard channel composition
+		{name: "case-0", blocks: []uint{1, 2, 3},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3,
+				safeHeadHolocene:    3,
+			},
+		},
+
+		// Non-standard channel composition
+		{name: "case-2a", blocks: []uint{1, 3, 2},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // batches are buffered, so the block ordering does not matter
+				safeHeadHolocene:    1, // batch for block 3 is considered invalid because it is from the future. This batch + remaining channel is dropped.
+			},
+		},
+		{name: "case-2b", blocks: []uint{2, 1, 3},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // batches are buffered, so the block ordering does not matter
+				safeHeadHolocene:    0, // batch for block 2 is considered invalid because it is from the future. This batch + remaining channel is dropped.
+			},
+		},
+
+		{name: "case-2c", blocks: []uint{1, 1, 2, 3},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // duplicate batches are silently dropped, so this reduceds to case-0
+				safeHeadHolocene:    3, // duplicate batches are silently dropped
+			},
+		},
+		{name: "case-2d", blocks: []uint{2, 2, 1, 3},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // duplicate batches are silently dropped, so this reduces to case-2b
+				safeHeadHolocene:    0, // duplicate batches are silently dropped, so this reduces to case-2b
+			},
+		},
+	}
+
+	runHoloceneDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
+		t := actionsHelpers.NewDefaultTesting(gt)
+		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+		includeBatchTx := func() {
+			// Include the last transaction submitted by the batcher.
+			env.Miner.ActL1StartBlock(12)(t)
+			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+			env.Miner.ActL1EndBlock(t)
+
+			// Finalize the block with the first channel frame on L1.
+			env.Miner.ActL1SafeNext(t)
+			env.Miner.ActL1FinalizeNext(t)
+		}
+
+		var max = func(input []uint) uint {
+			max := uint(0)
+			for _, val := range input {
+				if val > max {
+					max = val
+				}
+			}
+			return max
+		}
+
+		targetHeadNumber := max(testCfg.Custom.blocks)
+		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+			env.Sequencer.ActL2StartBlock(t)
+			// Send an L2 tx
+			env.Alice.L2.ActResetTxOpts(t)
+			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+			env.Alice.L2.ActMakeTx(t)
+			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+			env.Sequencer.ActL2EndBlock(t)
+		}
+
+		// Buffer the blocks in the batcher.
+		env.Batcher.ActCreateChannel(t, testCfg.Custom.isSpanBatch)
+		for _, blockNum := range testCfg.Custom.blocks {
+			env.Batcher.ActAddBlockByNumber(t, int64(blockNum), actionsHelpers.BlockLogger(t))
+		}
+		env.Batcher.ActL2ChannelClose(t)
+		frame := env.Batcher.ReadNextOutputFrame(t)
+		require.NotEmpty(t, frame)
+		env.Batcher.ActL2BatchSubmitRaw(t, frame)
+		includeBatchTx()
+
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l2SafeHead := env.Sequencer.L2Safe()
+		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, testCfg.Hardfork.Precedence < helpers.Holocene.Precedence, env.Engine)
+
+		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
+
+		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {
+			env.RunFaultProofProgram(t, safeHeadNumber, testCfg.CheckResult, testCfg.InputParams...)
+		}
+	}
+
+	matrix := helpers.NewMatrix[testCase]()
+	defer matrix.Run(gt)
+
+	for _, ordering := range testCases {
+		matrix.AddTestCase(
+			fmt.Sprintf("HonestClaim-%s", ordering.name),
+			ordering,
+			helpers.NewForkMatrix(helpers.Granite, helpers.LatestFork),
+			runHoloceneDerivationTest,
+			helpers.ExpectNoError(),
+		)
+		matrix.AddTestCase(
+			fmt.Sprintf("JunkClaim-%s", ordering.name),
+			ordering,
+			helpers.NewForkMatrix(helpers.Granite, helpers.LatestFork),
+			runHoloceneDerivationTest,
+			helpers.ExpectError(claim.ErrClaimNotValid),
+			helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+		)
+	}
+}

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -1,0 +1,153 @@
+package proofs
+
+import (
+	"fmt"
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+type holoceneExpectations struct {
+	safeHeadPreHolocene uint64
+	safeHeadHolocene    uint64
+}
+
+func (h holoceneExpectations) RequireExpectedProgress(t actionsHelpers.StatefulTesting, actualSafeHead eth.L2BlockRef, isHolocene bool, engine *actionsHelpers.L2Engine) {
+	if isHolocene {
+		require.Equal(t, h.safeHeadPreHolocene, actualSafeHead.Number)
+		expectedHash := engine.L2Chain().GetBlockByNumber(h.safeHeadPreHolocene).Hash()
+		require.Equal(t, expectedHash, actualSafeHead.Hash)
+	} else {
+		require.Equal(t, h.safeHeadHolocene, actualSafeHead.Number)
+		expectedHash := engine.L2Chain().GetBlockByNumber(h.safeHeadHolocene).Hash()
+		require.Equal(t, expectedHash, actualSafeHead.Hash)
+	}
+}
+func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
+
+	type testCase struct {
+		name   string
+		frames []uint
+		holoceneExpectations
+	}
+
+	// An ordered list of frames to read from the channel and submit
+	// on L1. We expect a different progression of the safe head under Holocene
+	// derivation rules, compared with pre Holocene.
+	var testCases = []testCase{
+		// Standard frame submission,
+		{name: "case-0", frames: []uint{0, 1, 2},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3,
+				safeHeadHolocene:    3},
+		},
+
+		// Non-standard frame submission
+		{name: "case-1a", frames: []uint{2, 1, 0},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // frames are buffered, so ordering does not matter
+				safeHeadHolocene:    0, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
+			},
+		},
+		{name: "case-1b", frames: []uint{0, 1, 0, 2},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // frames are buffered, so ordering does not matter
+				safeHeadHolocene:    0, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
+			},
+		},
+		{name: "case-1c", frames: []uint{0, 1, 1, 2},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, // frames are buffered, so ordering does not matter
+				safeHeadHolocene:    3, // non-contiguous frames are dropped. So this reduces to case-0.
+			},
+		},
+	}
+
+	runHoloceneDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
+		t := actionsHelpers.NewDefaultTesting(gt)
+		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+		blocks := []uint{1, 2, 3}
+		targetHeadNumber := 3
+		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+			env.Sequencer.ActL2StartBlock(t)
+			// Send an L2 tx
+			env.Alice.L2.ActResetTxOpts(t)
+			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+			env.Alice.L2.ActMakeTx(t)
+			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+			env.Sequencer.ActL2EndBlock(t)
+		}
+
+		// Build up a local list of frames
+		orderedFrames := make([][]byte, 0, len(testCfg.Custom.frames))
+		// Buffer the blocks in the batcher and populat orderedFrames list
+		env.Batcher.ActCreateChannel(t, false)
+		for i, blockNum := range blocks {
+			env.Batcher.ActAddBlockByNumber(t, int64(blockNum), actionsHelpers.BlockLogger(t))
+			if i == len(blocks)-1 {
+				env.Batcher.ActL2ChannelClose(t)
+			}
+			frame := env.Batcher.ReadNextOutputFrame(t)
+			require.NotEmpty(t, frame, "frame %d", i)
+			orderedFrames = append(orderedFrames, frame)
+		}
+
+		includeBatchTx := func() {
+			// Include the last transaction submitted by the batcher.
+			env.Miner.ActL1StartBlock(12)(t)
+			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+			env.Miner.ActL1EndBlock(t)
+
+			// Finalize the block with the first channel frame on L1.
+			env.Miner.ActL1SafeNext(t)
+			env.Miner.ActL1FinalizeNext(t)
+		}
+
+		// Submit frames in specified order order
+		for _, j := range testCfg.Custom.frames {
+			env.Batcher.ActL2BatchSubmitRaw(t, orderedFrames[j])
+			includeBatchTx()
+		}
+
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l2SafeHead := env.Sequencer.L2Safe()
+
+		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, testCfg.Hardfork.Precedence < helpers.Holocene.Precedence, env.Engine)
+
+		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
+
+		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {
+			env.RunFaultProofProgram(t, safeHeadNumber, testCfg.CheckResult, testCfg.InputParams...)
+		}
+	}
+
+	matrix := helpers.NewMatrix[testCase]()
+	defer matrix.Run(gt)
+
+	for _, ordering := range testCases {
+		matrix.AddTestCase(
+			fmt.Sprintf("HonestClaim-%s", ordering.name),
+			ordering,
+			helpers.NewForkMatrix(helpers.Granite, helpers.LatestFork),
+			runHoloceneDerivationTest,
+			helpers.ExpectNoError(),
+		)
+		matrix.AddTestCase(
+			fmt.Sprintf("JunkClaim-%s", ordering.name),
+			ordering,
+			helpers.NewForkMatrix(helpers.Granite, helpers.LatestFork),
+			runHoloceneDerivationTest,
+			helpers.ExpectError(claim.ErrClaimNotValid),
+			helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+		)
+	}
+}

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -28,8 +28,8 @@ func (h holoceneExpectations) RequireExpectedProgress(t actionsHelpers.StatefulT
 		require.Equal(t, expectedHash, actualSafeHead.Hash)
 	}
 }
-func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 
+func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 	type testCase struct {
 		name   string
 		frames []uint
@@ -39,28 +39,33 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 	// An ordered list of frames to read from the channel and submit
 	// on L1. We expect a different progression of the safe head under Holocene
 	// derivation rules, compared with pre Holocene.
-	var testCases = []testCase{
+	testCases := []testCase{
 		// Standard frame submission,
-		{name: "case-0", frames: []uint{0, 1, 2},
+		{
+			name: "case-0", frames: []uint{0, 1, 2},
 			holoceneExpectations: holoceneExpectations{
 				safeHeadPreHolocene: 3,
-				safeHeadHolocene:    3},
+				safeHeadHolocene:    3,
+			},
 		},
 
 		// Non-standard frame submission
-		{name: "case-1a", frames: []uint{2, 1, 0},
+		{
+			name: "case-1a", frames: []uint{2, 1, 0},
 			holoceneExpectations: holoceneExpectations{
 				safeHeadPreHolocene: 3, // frames are buffered, so ordering does not matter
 				safeHeadHolocene:    0, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
 			},
 		},
-		{name: "case-1b", frames: []uint{0, 1, 0, 2},
+		{
+			name: "case-1b", frames: []uint{0, 1, 0, 2},
 			holoceneExpectations: holoceneExpectations{
 				safeHeadPreHolocene: 3, // frames are buffered, so ordering does not matter
 				safeHeadHolocene:    0, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
 			},
 		},
-		{name: "case-1c", frames: []uint{0, 1, 1, 2},
+		{
+			name: "case-1c", frames: []uint{0, 1, 1, 2},
 			holoceneExpectations: holoceneExpectations{
 				safeHeadPreHolocene: 3, // frames are buffered, so ordering does not matter
 				safeHeadHolocene:    3, // non-contiguous frames are dropped. So this reduces to case-0.
@@ -125,9 +130,7 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
-		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {
-			env.RunFaultProofProgram(t, safeHeadNumber, testCfg.CheckResult, testCfg.InputParams...)
-		}
+		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[testCase]()

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -15,20 +15,19 @@ import (
 )
 
 func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
-
 	type testCase struct {
 		name                    string
 		blocks                  []uint // An ordered list of blocks (by number) to add to a single channel.
-		isSpanBatch             bool
+		useSpanBatch            bool
 		blockModifiers          []actionsHelpers.BlockModifier
 		breachMaxSequencerDrift bool
-		overAdvanceL1Origin     bool
+		overAdvanceL1Origin     int // block number at which to over-advance
 		holoceneExpectations
 	}
 
 	// invalidPayload invalidates the signature for the second transaction in the block.
 	// This should result in an invalid payload in the engine queue.
-	var invalidPayload = func(block *types.Block) *types.Block {
+	invalidPayload := func(block *types.Block) *types.Block {
 		alice := types.NewCancunSigner(big.NewInt(901))
 		txs := block.Transactions()
 		newTx, err := txs[1].WithSignature(alice, make([]byte, 65))
@@ -42,84 +41,72 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 	// invalidParentHash invalidates the parentHash of the block.
 	// This should result in an invalid batch being derived,
 	// but only for singular (not for span) batches.
-	var invalidParentHash = func(block *types.Block) *types.Block {
+	invalidParentHash := func(block *types.Block) *types.Block {
 		headerCopy := block.Header()
 		headerCopy.ParentHash = common.MaxHash
 		return block.WithSeal(headerCopy)
 	}
 
 	k := 2000
-	var twoThousandBlocks = make([]uint, k)
+	twoThousandBlocks := make([]uint, k)
 	for i := 0; i < k; i++ {
 		twoThousandBlocks[i] = uint(i) + 1
-	}
-
-	partiallyValidSpanBatchFrame := []byte{
-		0,                                                                           // version_byte
-		207, 193, 36, 120, 131, 193, 183, 227, 45, 196, 92, 103, 218, 173, 173, 192, // channel_id
-		0, 0, // frame_number
-		0, 0, 2, 58, // frame_data_length = 570 bytes
-		// BEGIN frame_data
-		120, 1, // zlib header
-		0, 42, 2, 213, 253, // initial DEFLATE block indicating 554 uncompressed bytes
-		185, 2, 39, // rlp prefix for long string 569 bytes
-		//// BEGIN encoded span batch
-		1,                                                                                          // batch_version (span)
-		1,                                                                                          // rel_timestamp
-		1,                                                                                          // l1_origin_num
-		137, 125, 54, 181, 103, 34, 6, 165, 204, 60, 141, 71, 165, 172, 31, 148, 75, 246, 120, 219, // parent_check
-		79, 189, 89, 43, 191, 92, 73, 34, 21, 146, 178, 246, 188, 199, 119, 72, 77, 120, 66, 191, // l1_origin_check
-		6,                // block_count
-		4,                // origin_bits 0b000100 -- here's where we make the 4th block invalid, by advancing the l1_origin (+12s) so it is ahead of the block timestamp (+8s)
-		1, 1, 1, 1, 1, 1, // block_tx_counts
-		// txs (not broken down here):
-		63, 2, 8, 224, 4, 89, 43, 169, 191, 250, 124, 3, 145, 72, 46, 23, 29, 16, 64, 186, 32, 226, 85, 58, 152, 158, 64, 16, 147, 44, 134, 199, 179, 5, 66, 34, 121, 141, 214, 128, 187, 62, 59, 172, 109, 72, 7, 96, 10, 91, 221, 190, 58, 214, 243, 19, 175, 160, 252, 152, 216, 203, 106, 120, 54, 122, 85, 66, 157, 73, 172, 176, 195, 53, 71, 163, 114, 211, 248, 81, 77, 58, 69, 14, 116, 157, 33, 160, 242, 210, 117, 137, 203, 26, 115, 181, 24, 243, 113, 185, 45, 230, 246, 26, 148, 19, 18, 181, 9, 67, 240, 253, 156, 52, 142, 188, 255, 136, 176, 146, 9, 115, 233, 79, 128, 239, 98, 105, 145, 13, 214, 245, 165, 70, 93, 34, 53, 201, 58, 86, 81, 153, 245, 214, 222, 235, 35, 125, 248, 119, 136, 226, 99, 38, 217, 238, 213, 227, 209, 77, 68, 12, 120, 171, 98, 56, 100, 72, 135, 11, 223, 87, 230, 79, 74, 94, 80, 244, 41, 10, 82, 52, 254, 58, 158, 184, 13, 16, 199, 54, 229, 101, 227, 182, 7, 88, 96, 154, 168, 39, 92, 201, 197, 241, 5, 174, 52, 209, 34, 15, 241, 73, 92, 123, 55, 247, 55, 33, 48, 170, 68, 20, 174, 90, 169, 95, 6, 36, 105, 122, 14, 143, 66, 133, 102, 248, 144, 226, 246, 10, 177, 152, 135, 67, 65, 58, 183, 90, 181, 125, 180, 254, 90, 154, 152, 87, 243, 249, 195, 28, 21, 47, 229, 13, 226, 162, 135, 186, 172, 31, 143, 207, 66, 14, 63, 43, 138, 215, 237, 40, 155, 71, 13, 37, 194, 72, 196, 144, 174, 1, 1, 214, 40, 144, 44, 173, 71, 17, 168, 31, 106, 78, 198, 244, 240, 223, 88, 166, 215, 200, 52, 148, 209, 124, 128, 197, 164, 204, 161, 185, 18, 170, 180, 9, 82, 214, 186, 63, 244, 213, 132, 147, 12, 118, 37, 79, 145, 197, 4, 80, 10, 61, 190, 48, 154, 196, 44, 176, 46, 228, 99, 144, 237, 208, 39, 112, 1, 110, 111, 135, 38, 206, 24, 208, 218, 234, 94, 171, 109, 151, 34, 74, 241, 89, 83, 190, 194, 140, 52, 1, 194, 80, 80, 71, 30, 254, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 0, 1, 2, 3, 4, 5, 161, 164, 3, 161, 164, 3, 161, 164, 3, 161, 164, 3, 161, 164, 3, 161, 164, 3,
-		//// END encoded span batch
-		1, 0, 0, 255, 255, // terminal DEFLATE block
-		199, 158, 250, 29, // 4-byte Adler-32 checksum
-		// END frame_data
-		1, // is_last
 	}
 
 	// Depending on the blocks list, whether the channel is built as
 	// as span batch channel, and whether the blocks are modified / invalidated
 	// we expect a different progression of the safe head under Holocene
 	// derivation rules, compared with pre Holocene.
-	var testCases = []testCase{
+	testCases := []testCase{
 		// Standard frame submission, standard channel composition
-		{name: "case-0", blocks: []uint{1, 2, 3},
+		{
+			name: "valid", blocks: []uint{1, 2, 3},
 			holoceneExpectations: holoceneExpectations{
 				safeHeadPreHolocene: 3, safeHeadHolocene: 3,
 			},
 		},
 
-		{name: "case-3a", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
-			isSpanBatch: true,
+		{
+			name: "invalid-payload", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
+			useSpanBatch: false,
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 1, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+				safeHeadHolocene:    2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+			},
+		},
+		{
+			name: "invalid-payload-span", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
+			useSpanBatch: true,
 			holoceneExpectations: holoceneExpectations{
 				safeHeadPreHolocene: 0, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-				safeHeadHolocene:    0, // TODO with full Holocene implementation, we expect the safe head to move to 2 due to creation of an deposit-only block.
+				safeHeadHolocene:    2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
 			},
 		},
-		{name: "case-3b", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidParentHash, nil},
+
+		{
+			name: "invalid-parent-hash", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidParentHash, nil},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 1, // Invalid parentHash in block 2 causes an invalid batch to be derived.
-				safeHeadHolocene:    1, // Invalid parentHash in block 2 causes an invalid batch to be derived. This batch + remaining channel is dropped.
+				safeHeadPreHolocene: 1, // Invalid parentHash in block 2 causes an invalid batch to be dropped.
+				safeHeadHolocene:    1, // Same with Holocene.
 			},
 		},
-		{name: "case-3c", blocks: twoThousandBlocks, // if we artificially stall the l1 origin, this should be enough to trigger violation of the max sequencer drift
-			isSpanBatch:             true,
+		{
+			name: "seq-drift-span", blocks: twoThousandBlocks, // if we artificially stall the l1 origin, this should be enough to trigger violation of the max sequencer drift
+			useSpanBatch:            true,
 			breachMaxSequencerDrift: true,
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 0, // entire span batch invalidated
-				safeHeadHolocene:    0, // TODO we expect partial validity, safe head should move to  block 1800. So far only pending safe head moves.
+				safeHeadPreHolocene: 0,    // Entire span batch invalidated.
+				safeHeadHolocene:    1800, // We expect partial validity until we hit sequencer drift.
 			},
 		},
-		{name: "case-3d",
-			isSpanBatch:         true,
-			overAdvanceL1Origin: true, // this will trigger the use of the partiallyValidSpanBatchFrame and bypass the sequencer entirely
+		{
+			name:                "future-l1-origin-span",
+			blocks:              []uint{1, 2, 3, 4},
+			useSpanBatch:        true,
+			overAdvanceL1Origin: 3, // this will over-advance the L1 origin of block 3
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 0, // entire span batch invalidated
-				safeHeadHolocene:    0, // TODO we expect partial validity, safe head should move to block 4.  So far only pending safe head moves.
+				safeHeadPreHolocene: 0, // Entire span batch invalidated.
+				safeHeadHolocene:    2, // We expect partial validity, safe head should move to block 2, dropping invalid block 3 and remaining channel.
 			},
 		},
 	}
@@ -143,9 +130,9 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			env.Miner.ActL1FinalizeNext(t)
 		}
 
-		env.Batcher.ActCreateChannel(t, testCfg.Custom.isSpanBatch)
+		env.Batcher.ActCreateChannel(t, testCfg.Custom.useSpanBatch)
 
-		var max = func(input []uint) uint {
+		max := func(input []uint) uint {
 			max := uint(0)
 			for _, val := range input {
 				if val > max {
@@ -155,12 +142,20 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			return max
 		}
 
+		if testCfg.Custom.overAdvanceL1Origin > 0 {
+			// Generate future L1 origin or we cannot advance to it.
+			env.Miner.ActEmptyBlock(t)
+		}
+
 		targetHeadNumber := max(testCfg.Custom.blocks)
 		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+			parentNum := env.Engine.L2Chain().CurrentBlock().Number.Uint64()
 
 			if testCfg.Custom.breachMaxSequencerDrift {
 				// prevent L1 origin from progressing
 				env.Sequencer.ActL2KeepL1Origin(t)
+			} else if oa := testCfg.Custom.overAdvanceL1Origin; oa > 0 && oa == int(parentNum)+1 {
+				env.Sequencer.ActL2ForceAdvanceL1Origin(t)
 			}
 
 			env.Sequencer.ActL2StartBlock(t)
@@ -174,9 +169,9 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			}
 
 			if testCfg.Custom.breachMaxSequencerDrift &&
-				env.Engine.L2Chain().CurrentBlock().Number.Uint64() == 1799 ||
-				env.Engine.L2Chain().CurrentBlock().Number.Uint64() == 1800 ||
-				env.Engine.L2Chain().CurrentBlock().Number.Uint64() == 1801 {
+				parentNum == 1799 ||
+				parentNum == 1800 ||
+				parentNum == 1801 {
 				// Send an L2 tx and force sequencer to include it
 				env.Alice.L2.ActResetTxOpts(t)
 				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
@@ -187,27 +182,21 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			env.Sequencer.ActL2EndBlock(t)
 		}
 
-		if testCfg.Custom.overAdvanceL1Origin {
-			// Here we bypass the sequencer entirely, and simply submit a hand rolled batcher tx
-			env.Batcher.ActL2BatchSubmitRaw(t, partiallyValidSpanBatchFrame)
-			includeBatchTx()
-		} else {
-			// Buffer the blocks in the batcher.
-			for i, blockNum := range testCfg.Custom.blocks {
-
-				var blockModifier actionsHelpers.BlockModifier
-				if len(testCfg.Custom.blockModifiers) > i {
-					blockModifier = testCfg.Custom.blockModifiers[i]
-				}
-				env.Batcher.ActAddBlockByNumber(t, int64(blockNum), blockModifier, actionsHelpers.BlockLogger(t))
-
+		// Buffer the blocks in the batcher.
+		for i, blockNum := range testCfg.Custom.blocks {
+			var blockModifier actionsHelpers.BlockModifier
+			if len(testCfg.Custom.blockModifiers) > i {
+				blockModifier = testCfg.Custom.blockModifiers[i]
 			}
-			env.Batcher.ActL2ChannelClose(t)
-			frame := env.Batcher.ReadNextOutputFrame(t)
-			require.NotEmpty(t, frame)
-			env.Batcher.ActL2BatchSubmitRaw(t, frame)
-			includeBatchTx()
+			env.Batcher.ActAddBlockByNumber(t, int64(blockNum), blockModifier, actionsHelpers.BlockLogger(t))
+
 		}
+
+		env.Batcher.ActL2ChannelClose(t)
+		frame := env.Batcher.ReadNextOutputFrame(t)
+		require.NotEmpty(t, frame)
+		env.Batcher.ActL2BatchSubmitRaw(t, frame)
+		includeBatchTx()
 
 		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
 		env.Sequencer.ActL1HeadSignal(t)

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -1,0 +1,247 @@
+package proofs
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
+
+	type testCase struct {
+		name                    string
+		blocks                  []uint // An ordered list of blocks (by number) to add to a single channel.
+		isSpanBatch             bool
+		blockModifiers          []actionsHelpers.BlockModifier
+		breachMaxSequencerDrift bool
+		overAdvanceL1Origin     bool
+		holoceneExpectations
+	}
+
+	// invalidPayload invalidates the signature for the second transaction in the block.
+	// This should result in an invalid payload in the engine queue.
+	var invalidPayload = func(block *types.Block) *types.Block {
+		alice := types.NewCancunSigner(big.NewInt(901))
+		txs := block.Transactions()
+		newTx, err := txs[1].WithSignature(alice, make([]byte, 65))
+		if err != nil {
+			panic(err)
+		}
+		txs[1] = newTx
+		return block
+	}
+
+	// invalidParentHash invalidates the parentHash of the block.
+	// This should result in an invalid batch being derived,
+	// but only for singular (not for span) batches.
+	var invalidParentHash = func(block *types.Block) *types.Block {
+		headerCopy := block.Header()
+		headerCopy.ParentHash = common.MaxHash
+		return block.WithSeal(headerCopy)
+	}
+
+	k := 2000
+	var twoThousandBlocks = make([]uint, k)
+	for i := 0; i < k; i++ {
+		twoThousandBlocks[i] = uint(i) + 1
+	}
+
+	partiallyValidSpanBatchFrame := []byte{
+		0,                                                                           // version_byte
+		207, 193, 36, 120, 131, 193, 183, 227, 45, 196, 92, 103, 218, 173, 173, 192, // channel_id
+		0, 0, // frame_number
+		0, 0, 2, 58, // frame_data_length = 570 bytes
+		// BEGIN frame_data
+		120, 1, // zlib header
+		0, 42, 2, 213, 253, // initial DEFLATE block indicating 554 uncompressed bytes
+		185, 2, 39, // rlp prefix for long string 569 bytes
+		//// BEGIN encoded span batch
+		1,                                                                                          // batch_version (span)
+		1,                                                                                          // rel_timestamp
+		1,                                                                                          // l1_origin_num
+		137, 125, 54, 181, 103, 34, 6, 165, 204, 60, 141, 71, 165, 172, 31, 148, 75, 246, 120, 219, // parent_check
+		79, 189, 89, 43, 191, 92, 73, 34, 21, 146, 178, 246, 188, 199, 119, 72, 77, 120, 66, 191, // l1_origin_check
+		6,                // block_count
+		4,                // origin_bits 0b000100 -- here's where we make the 4th block invalid, by advancing the l1_origin (+12s) so it is ahead of the block timestamp (+8s)
+		1, 1, 1, 1, 1, 1, // block_tx_counts
+		// txs (not broken down here):
+		63, 2, 8, 224, 4, 89, 43, 169, 191, 250, 124, 3, 145, 72, 46, 23, 29, 16, 64, 186, 32, 226, 85, 58, 152, 158, 64, 16, 147, 44, 134, 199, 179, 5, 66, 34, 121, 141, 214, 128, 187, 62, 59, 172, 109, 72, 7, 96, 10, 91, 221, 190, 58, 214, 243, 19, 175, 160, 252, 152, 216, 203, 106, 120, 54, 122, 85, 66, 157, 73, 172, 176, 195, 53, 71, 163, 114, 211, 248, 81, 77, 58, 69, 14, 116, 157, 33, 160, 242, 210, 117, 137, 203, 26, 115, 181, 24, 243, 113, 185, 45, 230, 246, 26, 148, 19, 18, 181, 9, 67, 240, 253, 156, 52, 142, 188, 255, 136, 176, 146, 9, 115, 233, 79, 128, 239, 98, 105, 145, 13, 214, 245, 165, 70, 93, 34, 53, 201, 58, 86, 81, 153, 245, 214, 222, 235, 35, 125, 248, 119, 136, 226, 99, 38, 217, 238, 213, 227, 209, 77, 68, 12, 120, 171, 98, 56, 100, 72, 135, 11, 223, 87, 230, 79, 74, 94, 80, 244, 41, 10, 82, 52, 254, 58, 158, 184, 13, 16, 199, 54, 229, 101, 227, 182, 7, 88, 96, 154, 168, 39, 92, 201, 197, 241, 5, 174, 52, 209, 34, 15, 241, 73, 92, 123, 55, 247, 55, 33, 48, 170, 68, 20, 174, 90, 169, 95, 6, 36, 105, 122, 14, 143, 66, 133, 102, 248, 144, 226, 246, 10, 177, 152, 135, 67, 65, 58, 183, 90, 181, 125, 180, 254, 90, 154, 152, 87, 243, 249, 195, 28, 21, 47, 229, 13, 226, 162, 135, 186, 172, 31, 143, 207, 66, 14, 63, 43, 138, 215, 237, 40, 155, 71, 13, 37, 194, 72, 196, 144, 174, 1, 1, 214, 40, 144, 44, 173, 71, 17, 168, 31, 106, 78, 198, 244, 240, 223, 88, 166, 215, 200, 52, 148, 209, 124, 128, 197, 164, 204, 161, 185, 18, 170, 180, 9, 82, 214, 186, 63, 244, 213, 132, 147, 12, 118, 37, 79, 145, 197, 4, 80, 10, 61, 190, 48, 154, 196, 44, 176, 46, 228, 99, 144, 237, 208, 39, 112, 1, 110, 111, 135, 38, 206, 24, 208, 218, 234, 94, 171, 109, 151, 34, 74, 241, 89, 83, 190, 194, 140, 52, 1, 194, 80, 80, 71, 30, 254, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 2, 205, 128, 132, 119, 53, 148, 0, 132, 119, 53, 148, 2, 128, 192, 0, 1, 2, 3, 4, 5, 161, 164, 3, 161, 164, 3, 161, 164, 3, 161, 164, 3, 161, 164, 3, 161, 164, 3,
+		//// END encoded span batch
+		1, 0, 0, 255, 255, // terminal DEFLATE block
+		199, 158, 250, 29, // 4-byte Adler-32 checksum
+		// END frame_data
+		1, // is_last
+	}
+
+	// Depending on the blocks list, whether the channel is built as
+	// as span batch channel, and whether the blocks are modified / invalidated
+	// we expect a different progression of the safe head under Holocene
+	// derivation rules, compared with pre Holocene.
+	var testCases = []testCase{
+		// Standard frame submission, standard channel composition
+		{name: "case-0", blocks: []uint{1, 2, 3},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 3, safeHeadHolocene: 3,
+			},
+		},
+
+		{name: "case-3a", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
+			isSpanBatch: true,
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 0, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+				safeHeadHolocene:    0, // TODO with full Holocene implementation, we expect the safe head to move to 2 due to creation of an deposit-only block.
+			},
+		},
+		{name: "case-3b", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidParentHash, nil},
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 1, // Invalid parentHash in block 2 causes an invalid batch to be derived.
+				safeHeadHolocene:    1, // Invalid parentHash in block 2 causes an invalid batch to be derived. This batch + remaining channel is dropped.
+			},
+		},
+		{name: "case-3c", blocks: twoThousandBlocks, // if we artificially stall the l1 origin, this should be enough to trigger violation of the max sequencer drift
+			isSpanBatch:             true,
+			breachMaxSequencerDrift: true,
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 0, // entire span batch invalidated
+				safeHeadHolocene:    0, // TODO we expect partial validity, safe head should move to  block 1800. So far only pending safe head moves.
+			},
+		},
+		{name: "case-3d",
+			isSpanBatch:         true,
+			overAdvanceL1Origin: true, // this will trigger the use of the partiallyValidSpanBatchFrame and bypass the sequencer entirely
+			holoceneExpectations: holoceneExpectations{
+				safeHeadPreHolocene: 0, // entire span batch invalidated
+				safeHeadHolocene:    0, // TODO we expect partial validity, safe head should move to block 4.  So far only pending safe head moves.
+			},
+		},
+	}
+
+	runHoloceneDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
+		t := actionsHelpers.NewDefaultTesting(gt)
+		tp := helpers.NewTestParams(func(tp *e2eutils.TestParams) {
+			// Set the channel timeout to 10 blocks, 12x lower than the sequencing window.
+			tp.ChannelTimeout = 10
+		})
+
+		env := helpers.NewL2FaultProofEnv(t, testCfg, tp, helpers.NewBatcherCfg())
+
+		includeBatchTx := func() {
+			// Include the last transaction submitted by the batcher.
+			env.Miner.ActL1StartBlock(12)(t)
+			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+			env.Miner.ActL1EndBlock(t)
+			// Finalize the block with the first channel frame on L1.
+			env.Miner.ActL1SafeNext(t)
+			env.Miner.ActL1FinalizeNext(t)
+		}
+
+		env.Batcher.ActCreateChannel(t, testCfg.Custom.isSpanBatch)
+
+		var max = func(input []uint) uint {
+			max := uint(0)
+			for _, val := range input {
+				if val > max {
+					max = val
+				}
+			}
+			return max
+		}
+
+		targetHeadNumber := max(testCfg.Custom.blocks)
+		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+
+			if testCfg.Custom.breachMaxSequencerDrift {
+				// prevent L1 origin from progressing
+				env.Sequencer.ActL2KeepL1Origin(t)
+			}
+
+			env.Sequencer.ActL2StartBlock(t)
+
+			if !testCfg.Custom.breachMaxSequencerDrift {
+				// Send an L2 tx
+				env.Alice.L2.ActResetTxOpts(t)
+				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+				env.Alice.L2.ActMakeTx(t)
+				env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+			}
+
+			if testCfg.Custom.breachMaxSequencerDrift &&
+				env.Engine.L2Chain().CurrentBlock().Number.Uint64() == 1799 ||
+				env.Engine.L2Chain().CurrentBlock().Number.Uint64() == 1800 ||
+				env.Engine.L2Chain().CurrentBlock().Number.Uint64() == 1801 {
+				// Send an L2 tx and force sequencer to include it
+				env.Alice.L2.ActResetTxOpts(t)
+				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+				env.Alice.L2.ActMakeTx(t)
+				env.Engine.ActL2IncludeTxIgnoreForcedEmpty(env.Alice.Address())(t)
+			}
+
+			env.Sequencer.ActL2EndBlock(t)
+		}
+
+		if testCfg.Custom.overAdvanceL1Origin {
+			// Here we bypass the sequencer entirely, and simply submit a hand rolled batcher tx
+			env.Batcher.ActL2BatchSubmitRaw(t, partiallyValidSpanBatchFrame)
+			includeBatchTx()
+		} else {
+			// Buffer the blocks in the batcher.
+			for i, blockNum := range testCfg.Custom.blocks {
+
+				var blockModifier actionsHelpers.BlockModifier
+				if len(testCfg.Custom.blockModifiers) > i {
+					blockModifier = testCfg.Custom.blockModifiers[i]
+				}
+				env.Batcher.ActAddBlockByNumber(t, int64(blockNum), blockModifier, actionsHelpers.BlockLogger(t))
+
+			}
+			env.Batcher.ActL2ChannelClose(t)
+			frame := env.Batcher.ReadNextOutputFrame(t)
+			require.NotEmpty(t, frame)
+			env.Batcher.ActL2BatchSubmitRaw(t, frame)
+			includeBatchTx()
+		}
+
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l2SafeHead := env.Sequencer.L2Safe()
+
+		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, testCfg.Hardfork.Precedence < helpers.Holocene.Precedence, env.Engine)
+
+		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
+
+		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {
+			env.RunFaultProofProgram(t, safeHeadNumber, testCfg.CheckResult, testCfg.InputParams...)
+		}
+	}
+
+	matrix := helpers.NewMatrix[testCase]()
+	defer matrix.Run(gt)
+
+	for _, ordering := range testCases {
+		matrix.AddTestCase(
+			fmt.Sprintf("HonestClaim-%s", ordering.name),
+			ordering,
+			helpers.NewForkMatrix(helpers.Granite, helpers.LatestFork),
+			runHoloceneDerivationTest,
+			helpers.ExpectNoError(),
+		)
+		matrix.AddTestCase(
+			fmt.Sprintf("JunkClaim-%s", ordering.name),
+			ordering,
+			helpers.NewForkMatrix(helpers.Granite, helpers.LatestFork),
+			runHoloceneDerivationTest,
+			helpers.ExpectError(claim.ErrClaimNotValid),
+			helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+		)
+	}
+}

--- a/op-e2e/actions/proofs/l1_lookback_test.go
+++ b/op-e2e/actions/proofs/l1_lookback_test.go
@@ -73,11 +73,12 @@ func runL1LookbackTest_ReopenChannel(gt *testing.T, testCfg *helpers.TestCfg[any
 	env.Miner.ActL1SafeNext(t)
 
 	// Re-submit the first L2 block frame w/ different transaction data.
-	err := env.Batcher.Buffer(t, func(block *types.Block) {
+	err := env.Batcher.Buffer(t, func(block *types.Block) *types.Block {
 		env.Bob.L2.ActResetTxOpts(t)
 		env.Bob.L2.ActSetTxToAddr(&env.Dp.Addresses.Mallory)
 		tx := env.Bob.L2.MakeTransaction(t)
 		block.Transactions()[1] = tx
+		return block
 	})
 	require.NoError(t, err)
 	env.Batcher.ActL2BatchSubmit(t)

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -618,8 +618,8 @@ func TestBackupUnsafeReorgForkChoiceNotInputError(gt *testing.T) {
 	// check pendingSafe is reset
 	require.Equal(t, sequencer.L2PendingSafe().Number, uint64(0))
 	// check backupUnsafe is applied
-	require.Equal(t, sequencer.L2Unsafe().Hash, targetUnsafeHeadHash)
-	require.Equal(t, sequencer.L2Unsafe().Number, uint64(5))
+	require.Equal(t, uint64(5), sequencer.L2Unsafe().Number)
+	require.Equal(t, targetUnsafeHeadHash, sequencer.L2Unsafe().Hash)
 	// safe head cannot be advanced because batch contained invalid blocks
 	require.Equal(t, sequencer.L2Safe().Number, uint64(0))
 }

--- a/op-e2e/actions/upgrades/holocene_fork_test.go
+++ b/op-e2e/actions/upgrades/holocene_fork_test.go
@@ -170,12 +170,13 @@ func TestHoloceneInvalidPayload(gt *testing.T) {
 	require.Len(t, b.Transactions(), 2)
 
 	// buffer into the batcher, invalidating the tx via signature zeroing
-	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) {
+	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
 		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
 		require.NoError(t, err)
 		txs[1] = newTx
+		return block
 	})
 
 	// generate two more empty blocks

--- a/op-e2e/opgeth/op_geth_test.go
+++ b/op-e2e/opgeth/op_geth_test.go
@@ -7,13 +7,9 @@ import (
 	"testing"
 	"time"
 
-	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -22,8 +18,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var (
@@ -51,8 +52,9 @@ func TestMissingGasLimit(t *testing.T) {
 
 	res, err := opGeth.StartBlockBuilding(ctx, attrs)
 	require.Error(t, err)
-	require.ErrorIs(t, err, eth.InputError{})
-	require.Equal(t, eth.InvalidPayloadAttributes, err.(eth.InputError).Code)
+	var rpcErr rpc.Error
+	require.ErrorAs(t, err, &rpcErr)
+	require.EqualValues(t, eth.InvalidPayloadAttributes, rpcErr.ErrorCode())
 	require.Nil(t, res)
 }
 

--- a/op-node/rollup/engine/build_cancel.go
+++ b/op-node/rollup/engine/build_cancel.go
@@ -2,6 +2,9 @@ package engine
 
 import (
 	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -23,7 +26,9 @@ func (eq *EngDeriver) onBuildCancel(ev BuildCancelEvent) {
 	eq.log.Warn("cancelling old block building job", "info", ev.Info)
 	_, err := eq.ec.engine.GetPayload(ctx, ev.Info)
 	if err != nil {
-		if x, ok := err.(eth.InputError); ok && x.Code == eth.UnknownPayload { //nolint:all
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
+			eq.log.Warn("tried cancelling unknown block building job", "info", ev.Info, "err", err)
 			return // if unknown, then it did not need to be cancelled anymore.
 		}
 		eq.log.Error("failed to cancel block building job", "info", ev.Info, "err", err)

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -2,8 +2,11 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -58,7 +61,8 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 	sealingStart := time.Now()
 	envelope, err := eq.ec.engine.GetPayload(ctx, ev.Info)
 	if err != nil {
-		if x, ok := err.(eth.InputError); ok && x.Code == eth.UnknownPayload { //nolint:all
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
 			eq.log.Warn("Cannot seal block, payload ID is unknown",
 				"payloadID", ev.Info.ID, "payload_time", ev.Info.Timestamp,
 				"started_time", ev.BuildStarted)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -86,7 +87,8 @@ type EngineController struct {
 }
 
 func NewEngineController(engine ExecEngine, log log.Logger, metrics derive.Metrics,
-	rollupCfg *rollup.Config, syncCfg *sync.Config, emitter event.Emitter) *EngineController {
+	rollupCfg *rollup.Config, syncCfg *sync.Config, emitter event.Emitter,
+) *EngineController {
 	syncStatus := syncStatusCL
 	if syncCfg.SyncMode == sync.ELSync {
 		syncStatus = syncStatusWillStartEL
@@ -283,11 +285,11 @@ func (e *EngineController) TryUpdateEngine(ctx context.Context) error {
 	defer logFn()
 	fcRes, err := e.engine.ForkchoiceUpdate(ctx, &fc, nil)
 	if err != nil {
-		var inputErr eth.InputError
-		if errors.As(err, &inputErr) {
-			switch inputErr.Code {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
+			switch eth.ErrorCode(rpcErr.ErrorCode()) {
 			case eth.InvalidForkchoiceState:
-				return derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", inputErr.Unwrap()))
+				return derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr))
 			default:
 				return derive.NewTemporaryError(fmt.Errorf("unexpected error code in forkchoice-updated response: %w", err))
 			}
@@ -361,11 +363,11 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	defer logFn()
 	fcRes, err := e.engine.ForkchoiceUpdate(ctx, &fc, nil)
 	if err != nil {
-		var inputErr eth.InputError
-		if errors.As(err, &inputErr) {
-			switch inputErr.Code {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
+			switch eth.ErrorCode(rpcErr.ErrorCode()) {
 			case eth.InvalidForkchoiceState:
-				return derive.NewResetError(fmt.Errorf("pre-unsafe-block forkchoice update was inconsistent with engine, need reset to resolve: %w", inputErr.Unwrap()))
+				return derive.NewResetError(fmt.Errorf("pre-unsafe-block forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr))
 			default:
 				return derive.NewTemporaryError(fmt.Errorf("unexpected error code in forkchoice-updated response: %w", err))
 			}
@@ -439,12 +441,12 @@ func (e *EngineController) TryBackupUnsafeReorg(ctx context.Context) (bool, erro
 	defer logFn()
 	fcRes, err := e.engine.ForkchoiceUpdate(ctx, &fc, nil)
 	if err != nil {
-		var inputErr eth.InputError
-		if errors.As(err, &inputErr) {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
 			e.SetBackupUnsafeL2Head(eth.L2BlockRef{}, false)
-			switch inputErr.Code {
+			switch eth.ErrorCode(rpcErr.ErrorCode()) {
 			case eth.InvalidForkchoiceState:
-				return true, derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", inputErr.Unwrap()))
+				return true, derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr))
 			default:
 				return true, derive.NewTemporaryError(fmt.Errorf("unexpected error code in forkchoice-updated response: %w", err))
 			}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -401,6 +401,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 		// Only promote if not already stale.
 		// Resets/overwrites happen through engine-resets, not through promotion.
 		if x.Ref.Number > d.ec.PendingSafeL2Head().Number {
+			d.log.Debug("Updating pending safe", "pending_safe", x.Ref, "local_safe", d.ec.LocalSafeL2Head(), "unsafe", d.ec.UnsafeL2Head(), "concluding", x.Concluding)
 			d.ec.SetPendingSafeL2Head(x.Ref)
 			d.emitter.Emit(PendingSafeUpdateEvent{
 				PendingSafe: d.ec.PendingSafeL2Head(),
@@ -419,6 +420,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			DerivedFrom: x.DerivedFrom,
 		})
 	case PromoteLocalSafeEvent:
+		d.log.Debug("Updating local safe", "local_safe", x.Ref, "safe", d.ec.SafeL2Head(), "unsafe", d.ec.UnsafeL2Head())
 		d.ec.SetLocalSafeHead(x.Ref)
 		d.emitter.Emit(LocalSafeUpdateEvent(x))
 	case LocalSafeUpdateEvent:
@@ -427,6 +429,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			d.emitter.Emit(PromoteSafeEvent(x))
 		}
 	case PromoteSafeEvent:
+		d.log.Debug("Updating safe", "safe", x.Ref, "unsafe", d.ec.UnsafeL2Head())
 		d.ec.SetSafeHead(x.Ref)
 		// Finalizer can pick up this safe cross-block now
 		d.emitter.Emit(SafeDerivedEvent{Safe: x.Ref, DerivedFrom: x.DerivedFrom})

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -62,6 +62,10 @@ func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
 			d.logger.Info("Derivation complete: reached L2 block", "head", x.SafeL2Head)
 			d.closing = true
 		}
+	case derive.DeriverIdleEvent:
+		// We dont't close the deriver yet, as the engine may still be processing events to reach
+		// the target. A ForkchoiceUpdateEvent will close the deriver when the target is reached.
+		d.logger.Info("Derivation complete: no further L1 data to process")
 	case rollup.ResetEvent:
 		d.closing = true
 		d.result = fmt.Errorf("unexpected reset error: %w", x.Err)

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -130,9 +130,9 @@ func (ea *L2EngineAPI) IncludeTx(tx *types.Transaction, from common.Address) err
 	if ea.blockProcessor == nil {
 		return ErrNotBuildingBlock
 	}
+
 	if ea.l2ForceEmpty {
 		ea.log.Info("Skipping including a transaction because e.L2ForceEmpty is true")
-		// t.InvalidAction("cannot include any sequencer txs")
 		return nil
 	}
 

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -38,8 +38,7 @@ const (
 
 var ErrBedrockScalarPaddingNotEmpty = errors.New("version 0 scalar value has non-empty padding")
 
-// InputError distinguishes an user-input error from regular rpc errors,
-// to help the (Engine) API user divert from accidental input mistakes.
+// InputError can be used to create rpc.Error instances with a specific error code.
 type InputError struct {
 	Inner error
 	Code  ErrorCode
@@ -47,6 +46,11 @@ type InputError struct {
 
 func (ie InputError) Error() string {
 	return fmt.Sprintf("input error %d: %s", ie.Code, ie.Inner.Error())
+}
+
+// Makes InputError implement the rpc.Error interface
+func (ie InputError) ErrorCode() int {
+	return int(ie.Code)
 }
 
 func (ie InputError) Unwrap() error {

--- a/op-service/eth/types_test.go
+++ b/op-service/eth/types_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +22,10 @@ func TestInputError(t *testing.T) {
 		t.Fatalf("need InputError to be detected as such")
 	}
 	require.ErrorIs(t, err, InputError{}, "need to detect input error with errors.Is")
+
+	var rpcErr rpc.Error
+	require.ErrorAs(t, err, &rpcErr, "need input error to be rpc.Error with errors.As")
+	require.EqualValues(t, err.Code, rpcErr.ErrorCode())
 }
 
 type scalarTest struct {


### PR DESCRIPTION
This PR adds action tests to cover consensus changes introduced by the Holocene hardfork. The action tests also run against the fault proof program.

A few changes to consensus code are introduced as well, which were identified during debugging of the action tests:
- Handle `rpc.Error`s directly instead of relying on `eth.InputError`s (https://github.com/ethereum-optimism/optimism/pull/12520/commits/2f6922dc678765ec6219ef3a5c32034b0e6e45d2 https://github.com/ethereum-optimism/optimism/pull/12520/commits/e6f8a0904ce4cdcf3bb777b89957aa68e21ca573)
The fault proof program's L2 Engine API doesn't return `eth.InputError`s,
like the sources engine client, but directly returns `rpc.Error`s.
So instead of relying on this translation, derivers need to deal
directly with `rpc.Error`s.
- [op-program: Don't close deriver when derivation goes idle](https://github.com/ethereum-optimism/optimism/pull/12520/commits/89c59724fbe7ee51fb16fb2cf7ac03503d609252)
The FCU event will close the deriver in time. If we cannot reach the
target otherwise, it doesn't matter that we don't close.
In Holocene, if the last attributes are invalid, deposit-only attributes
are retried. Due to event race conditions, the deriver may then already
get idle while the engine is still processing events. So the program can
close without having updated the safe head to pending/local yet.

*- @sebastianst*

Closes #12449 