### PR TITLE
op-node: Alphabetize CLI network lists

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -2,6 +2,7 @@ package chaincfg
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
@@ -36,6 +37,7 @@ func AvailableNetworks() []string {
 	for _, cfg := range superchain.OPChains {
 		networks = append(networks, cfg.Chain+"-"+cfg.Superchain)
 	}
+	sort.Strings(networks)
 	return networks
 }
 


### PR DESCRIPTION
## Description

Alphabetize the list of networks returned from `AvailableNetworks()`.  This list is used to display available networks in a few different CLIs.  For example, `./bin/op-program --help` now displays an alphabetized list of networks for its `--network` flag:
```
    --network value                                                        ($OP_PROGRAM_NETWORK)
          Predefined network selection. Available networks: base-devnet-0-sepolia-dev-0,
          base-mainnet, base-sepolia, lyra-mainnet, metal-mainnet, metal-sepolia,
          mode-mainnet, mode-sepolia, op-mainnet, op-sepolia,
          oplabs-devnet-0-sepolia-dev-0, orderly-mainnet, race-mainnet, race-sepolia,
          tbn-mainnet, zora-mainnet, zora-sepolia
```