### PR TITLE
op-deployer: update default gas limit values.

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -42,7 +42,7 @@ func DeployOPChain(ctx context.Context, env *Env, bundle ArtifactsBundle, intent
 		L2ChainId:               chainID.Big(),
 		OpcmProxy:               st.ImplementationsDeployment.OpcmProxyAddress,
 		SaltMixer:               st.Create2Salt.String(), // passing through salt generated at state initialization
-		GasLimit:                30_000_000,
+		GasLimit:                60_000_000,
 		DisputeGameType:         1, // PERMISSIONED_CANNON Game Type
 		DisputeAbsolutePrestate: common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
 		DisputeMaxGameDepth:     73,

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -22,7 +22,7 @@ func DefaultDeployConfig(chainIntent *ChainIntent) genesis.DeployConfig {
 	return genesis.DeployConfig{
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
-				L2GenesisBlockGasLimit:      30_000_000,
+				L2GenesisBlockGasLimit:      60_000_000,
 				L2GenesisBlockBaseFeePerGas: &l2GenesisBlockBaseFeePerGas,
 			},
 			L2VaultsDeployConfig: genesis.L2VaultsDeployConfig{


### PR DESCRIPTION
reflecting op mainnet default gas limit value updates: https://github.com/ethereum-optimism/superchain-ops/tree/main/tasks/eth/020-set-gas-target 