### PR TITLE
op-e2e: remove flaky assertion

### DIFF
--- a/op-service/sources/receipts_basic_test.go
+++ b/op-service/sources/receipts_basic_test.go
@@ -128,7 +128,6 @@ func TestBasicRPCReceiptsFetcher_Concurrency(t *testing.T) {
 	mrpc.AssertExpectations(t)
 	finalNumCalls := int(numCalls.Load())
 	require.NotZero(finalNumCalls, "BatchCallContext should have been called.")
-	require.Less(finalNumCalls, numFetchers, "Some IterativeBatchCalls should have been shared.")
 }
 
 func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers int, receipts types.Receipts, block *RPCBlock) {


### PR DESCRIPTION
Removes an assertion that causes this test to fail often when the CI executor is under load. You can verify this failure for yourself by running the test with `GOMAXPROCS=1`. The assertion didn't seem to be providing much value, so I just removed it.
