### PR TITLE
op-challenger: Log warning and continue if game impl not available

### DIFF
--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -1,0 +1,71 @@
+package fault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterOracle_MissingGameImpl(t *testing.T) {
+	gameFactoryAddr := common.Address{0xaa}
+	rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
+	m := metrics.NoopMetrics
+	caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
+	gameFactory := contracts.NewDisputeGameFactoryContract(m, gameFactoryAddr, caller)
+
+	logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+	oracles := registry.NewOracleRegistry()
+	gameType := faultTypes.CannonGameType
+
+	rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{common.Address{}})
+
+	err := registerOracle(context.Background(), logger, m, oracles, gameFactory, caller, gameType)
+	require.NoError(t, err)
+	require.NotNil(t, logs.FindLog(
+		testlog.NewMessageFilter("No game implementation set for game type"),
+		testlog.NewAttributesFilter("gameType", gameType.String())))
+}
+
+func TestRegisterOracle_AddsOracle(t *testing.T) {
+	gameFactoryAddr := common.Address{0xaa}
+	gameImplAddr := common.Address{0xbb}
+	vmAddr := common.Address{0xcc}
+	oracleAddr := common.Address{0xdd}
+	rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
+	rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
+	rpc.AddContract(vmAddr, snapshots.LoadMIPSABI())
+	rpc.AddContract(oracleAddr, snapshots.LoadPreimageOracleABI())
+	m := metrics.NoopMetrics
+	caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
+	gameFactory := contracts.NewDisputeGameFactoryContract(m, gameFactoryAddr, caller)
+
+	logger := testlog.Logger(t, log.LvlInfo)
+	oracles := registry.NewOracleRegistry()
+	gameType := faultTypes.CannonGameType
+
+	// Use the latest v1 of these contracts. Doesn't have to be an exact match for the version.
+	rpc.SetResponse(gameImplAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
+	rpc.SetResponse(oracleAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
+
+	rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{gameImplAddr})
+	rpc.SetResponse(gameImplAddr, "vm", rpcblock.Latest, []interface{}{}, []interface{}{vmAddr})
+	rpc.SetResponse(vmAddr, "oracle", rpcblock.Latest, []interface{}{}, []interface{}{oracleAddr})
+
+	err := registerOracle(context.Background(), logger, m, oracles, gameFactory, caller, gameType)
+	require.NoError(t, err)
+	registered := oracles.Oracles()
+	require.Len(t, registered, 1)
+	require.Equal(t, oracleAddr, registered[0].Addr())
+}


### PR DESCRIPTION
**Description**

When starting `op-challenger` if the game implementation is not set for a game type challenger has been told to support, log a warning rather than failing startup. If the game implementation is later set and games created, challenger will still act on them as expected.

This does mean that the preimage oracle for that game type is not registered (because its address can't be found). It will still be registered and monitored once a game is created. It is also likely to be the same oracle used by other game types so already monitored anyway.

There is a risk challenger can't close here where a PreimageOracle is deployed but not used in an activate game type implementation so isn't monitored by op-challenger. Someone could then post an invalid large preimage and finalise it. Later if the oracle is used in a dispute game implementation the invalid large preimage could be used to incorrectly affect a game.  Even if challenger polled and started monitoring the oracle as soon as the game type implementation was set, an invalid large preimage could have been posted before then.

**Tests**

Added unit tests.  Tested against local devnet.

**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/12537