### PR TITLE
maint(ci): apply expectRevert rule to tests

### DIFF
--- a/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
@@ -105,7 +105,7 @@ contract ETHLiquidity_Test is CommonTest {
         uint256 amount = STARTING_LIQUIDITY_BALANCE + 1;
 
         // Act
-        vm.expectRevert();
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
         ethLiquidity.mint(amount);
 
         // Assert

--- a/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
@@ -314,7 +314,7 @@ contract SuperchainWETH_Test is CommonTest {
         superchainWeth.deposit{ value: _amount }();
 
         // Act
-        vm.expectRevert();
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
         superchainWeth.crosschainBurn(_from, _amount + 1);
     }
 

--- a/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
@@ -351,7 +351,7 @@ contract MerkleTrie_get_Test is Test {
 
         // Ambiguous revert check- all that we care is that it *does* fail. This case may
         // fail within different branches.
-        vm.expectRevert();
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
         MerkleTrie.get(key, proof, root);
     }
 

--- a/semgrep/sol-rules.yaml
+++ b/semgrep/sol-rules.yaml
@@ -37,7 +37,7 @@ rules:
       - pattern: vm.expectRevert()
     paths:
       exclude:
-        - packages/contracts-bedrock/test
+        - packages/contracts-bedrock/test/dispute/WETH98.t.sol
 
   - id: sol-style-input-arg-fmt
     languages: [solidity]
@@ -79,7 +79,6 @@ rules:
     paths:
       exclude:
         - packages/contracts-bedrock/test/safe-tools/CompatibilityFallbackHandler_1_3_0.sol
-
 
   - id: sol-style-malformed-require
     languages: [solidity]


### PR DESCRIPTION
Updates semgrep config to apply expectRevert to tests. Fixes a few instances where this wasn't being followed.
