### PR TITLE
fix(ci): apply doc comment rule to tests

### DIFF
--- a/.semgrep/sol-rules.yaml
+++ b/.semgrep/sol-rules.yaml
@@ -44,7 +44,7 @@ rules:
     pattern-regex: (\/\*\*\n(\s+\*\s.*\n)+\s+\*\/)
     paths:
       exclude:
-        - packages/contracts-bedrock/test
+        - packages/contracts-bedrock/test/safe-tools/CompatibilityFallbackHandler_1_3_0.sol
 
   - id: sol-expectrevert-no-args
     languages: [solidity]


### PR DESCRIPTION
Updates semgrep config to apply doc comment rule to tests. Updates tests to fix instances where this was violated.
