### PR TITLE
feat(ci): add semgrep rule for memory safe asm

### DIFF
--- a/op-chain-ops/script/testdata/scripts/ScriptExample.s.sol
+++ b/op-chain-ops/script/testdata/scripts/ScriptExample.s.sol
@@ -22,7 +22,7 @@ library console {
     function _castLogPayloadViewToPure(
         function(bytes memory) internal view fnIn
     ) internal pure returns (function(bytes memory) internal pure fnOut) {
-        assembly {
+        assembly ("memory-safe") {
             fnOut := fnIn
         }
     }
@@ -34,8 +34,7 @@ library console {
     function _sendLogPayloadView(bytes memory payload) private view {
         uint256 payloadLength = payload.length;
         address consoleAddress = CONSOLE_ADDRESS;
-        /// @solidity memory-safe-assembly
-        assembly {
+        assembly ("memory-safe") {
             let payloadStart := add(payload, 32)
             let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
         }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -537,7 +537,7 @@ contract L2Genesis is Deployer {
         bytes memory code = vm.getCode(string.concat(cname, ".sol:", cname));
 
         address eas;
-        assembly {
+        assembly ("memory-safe") {
             eas := create(0, add(code, 0x20), mload(code))
         }
 

--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -26,7 +26,7 @@ library DeployUtils {
     /// @return addr_ Address of the deployed contract.
     function create1(string memory _name, bytes memory _args) internal returns (address payable addr_) {
         bytes memory bytecode = abi.encodePacked(vm.getCode(_name), _args);
-        assembly {
+        assembly ("memory-safe") {
             addr_ := create(0, add(bytecode, 0x20), mload(bytecode))
         }
         assertValidContractAddress(addr_);
@@ -101,7 +101,7 @@ library DeployUtils {
         bytes memory initCode = abi.encodePacked(vm.getCode(_name), _args);
         address preComputedAddress = vm.computeCreate2Address(_salt, keccak256(initCode));
         require(preComputedAddress.code.length == 0, "DeployUtils: contract already deployed");
-        assembly {
+        assembly ("memory-safe") {
             addr_ := create2(0, add(initCode, 0x20), mload(initCode), _salt)
             if iszero(addr_) {
                 let size := returndatasize()

--- a/packages/contracts-bedrock/scripts/periphery/deploy/DeployPeriphery.s.sol
+++ b/packages/contracts-bedrock/scripts/periphery/deploy/DeployPeriphery.s.sol
@@ -274,7 +274,7 @@ contract DeployPeriphery is Script, Artifacts {
             }
             addr_ = preComputedAddress;
         } else {
-            assembly {
+            assembly ("memory-safe") {
                 addr_ := create2(0, add(initCode, 0x20), mload(initCode), salt)
             }
             require(addr_ != address(0), "DeployPeriphery: deployment failed");

--- a/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
+++ b/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
@@ -69,8 +69,8 @@ contract DelayedVetoable is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1-beta.2
-    string public constant version = "1.0.1-beta.2";
+    /// @custom:semver 1.0.1-beta.3
+    string public constant version = "1.0.1-beta.3";
 
     /// @notice Sets the target admin during contract deployment.
     /// @param _vetoer Address of the vetoer.
@@ -181,11 +181,11 @@ contract DelayedVetoable is ISemver {
         emit Forwarded(_callHash, msg.data);
         (bool success, bytes memory returndata) = TARGET.call(msg.data);
         if (success == true) {
-            assembly {
+            assembly ("memory-safe") {
                 return(add(returndata, 0x20), mload(returndata))
             }
         } else {
-            assembly {
+            assembly ("memory-safe") {
                 revert(add(returndata, 0x20), mload(returndata))
             }
         }

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -65,8 +65,8 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.8
-    string public constant version = "1.0.0-beta.8";
+    /// @custom:semver 1.0.0-beta.9
+    string public constant version = "1.0.0-beta.9";
 
     /// @notice Emitted when a cross chain message is being executed.
     /// @param msgHash Hash of message payload being executed.
@@ -83,7 +83,7 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
         if (interopStart() != 0) revert InteropStartAlreadySet();
 
         // Set Interop Start to block.timestamp
-        assembly {
+        assembly ("memory-safe") {
             sstore(INTEROP_START_SLOT, timestamp())
         }
     }
@@ -91,7 +91,7 @@ contract CrossL2Inbox is ICrossL2Inbox, ISemver, TransientReentrancyAware {
     /// @notice Returns the interop start timestamp.
     /// @return interopStart_ interop start timestamp.
     function interopStart() public view returns (uint256 interopStart_) {
-        assembly {
+        assembly ("memory-safe") {
             interopStart_ := sload(INTEROP_START_SLOT)
         }
     }

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -151,7 +151,7 @@ contract L1Block is ISemver, IGasToken {
     ///   9. _batcherHash        Versioned hash to authenticate batcher by.
     function _setL1BlockValuesEcotone() internal {
         address depositor = DEPOSITOR_ACCOUNT();
-        assembly {
+        assembly ("memory-safe") {
             // Revert if the caller is not the depositor account.
             if xor(caller(), depositor) {
                 mstore(0x00, 0x3cc50b45) // 0x3cc50b45 is the 4-byte selector of "NotDepositor()"

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -58,7 +58,7 @@ contract L1BlockInterop is L1Block {
     /// @notice This function is only callable by the CrossL2Inbox contract.
     function isDeposit() external view returns (bool isDeposit_) {
         if (msg.sender != Predeploys.CROSS_L2_INBOX) revert NotCrossL2Inbox();
-        assembly {
+        assembly ("memory-safe") {
             isDeposit_ := sload(IS_DEPOSIT_SLOT)
         }
     }
@@ -82,7 +82,7 @@ contract L1BlockInterop is L1Block {
     ///         It forwards the calldata to the internally-used `setL1BlockValuesEcotone` function.
     function setL1BlockValuesInterop() external {
         // Set the isDeposit flag to true.
-        assembly {
+        assembly ("memory-safe") {
             sstore(IS_DEPOSIT_SLOT, 1)
         }
 
@@ -95,7 +95,7 @@ contract L1BlockInterop is L1Block {
         if (msg.sender != DEPOSITOR_ACCOUNT()) revert NotDepositor();
 
         // Set the isDeposit flag to false.
-        assembly {
+        assembly ("memory-safe") {
             sstore(IS_DEPOSIT_SLOT, 0)
         }
     }

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -67,8 +67,8 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.9
-    string public constant version = "1.0.0-beta.9";
+    /// @custom:semver 1.0.0-beta.10
+    string public constant version = "1.0.0-beta.10";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -98,7 +98,7 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     /// @notice Retrieves the sender of the current cross domain message. If not entered, reverts.
     /// @return sender_ Address of the sender of the current cross domain message.
     function crossDomainMessageSender() external view onlyEntered returns (address sender_) {
-        assembly {
+        assembly ("memory-safe") {
             sender_ := tload(CROSS_DOMAIN_MESSAGE_SENDER_SLOT)
         }
     }
@@ -106,7 +106,7 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     /// @notice Retrieves the source of the current cross domain message. If not entered, reverts.
     /// @return source_ Chain ID of the source of the current cross domain message.
     function crossDomainMessageSource() external view onlyEntered returns (uint256 source_) {
-        assembly {
+        assembly ("memory-safe") {
             source_ := tload(CROSS_DOMAIN_MESSAGE_SOURCE_SLOT)
         }
     }
@@ -115,7 +115,7 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     /// @return sender_ Address of the sender of the current cross domain message.
     /// @return source_ Chain ID of the source of the current cross domain message.
     function crossDomainMessageContext() external view onlyEntered returns (address sender_, uint256 source_) {
-        assembly {
+        assembly ("memory-safe") {
             sender_ := tload(CROSS_DOMAIN_MESSAGE_SENDER_SLOT)
             source_ := tload(CROSS_DOMAIN_MESSAGE_SOURCE_SLOT)
         }
@@ -218,7 +218,7 @@ contract L2ToL2CrossDomainMessenger is IL2ToL2CrossDomainMessenger, ISemver, Tra
     /// @param _source Chain ID of the source chain.
     /// @param _sender Address of the sender of the message.
     function _storeMessageMetadata(uint256 _source, address _sender) internal {
-        assembly {
+        assembly ("memory-safe") {
             tstore(CROSS_DOMAIN_MESSAGE_SENDER_SLOT, _sender)
             tstore(CROSS_DOMAIN_MESSAGE_SOURCE_SLOT, _source)
         }

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
@@ -47,7 +47,7 @@ contract OptimismSuperchainERC20 is SuperchainERC20, Initializable, ERC165 {
 
     /// @notice Returns the storage for the OptimismSuperchainERC20Metadata.
     function _getStorage() private pure returns (OptimismSuperchainERC20Metadata storage storage_) {
-        assembly {
+        assembly ("memory-safe") {
             storage_.slot := OPTIMISM_SUPERCHAIN_ERC20_METADATA_SLOT
         }
     }

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -294,7 +294,7 @@ contract FaultDisputeGame is Clone, ISemver {
         // - 0x20 l1 head
         // - 0x20 extraData
         // - 0x02 CWIA bytes
-        assembly {
+        assembly ("memory-safe") {
             if iszero(eq(calldatasize(), 0x7A)) {
                 // Store the selector for `BadExtraData()` & revert
                 mstore(0x00, 0x9824bdab)

--- a/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
@@ -22,7 +22,7 @@ library LibPosition {
     /// @param _indexAtDepth The index at the depth of the position.
     /// @return position_ The computed generalized index.
     function wrap(uint8 _depth, uint128 _indexAtDepth) internal pure returns (Position position_) {
-        assembly {
+        assembly ("memory-safe") {
             // gindex = 2^{_depth} + _indexAtDepth
             position_ := add(shl(_depth, 1), _indexAtDepth)
         }
@@ -34,7 +34,7 @@ library LibPosition {
     /// @custom:attribution Solady <https://github.com/Vectorized/Solady>
     function depth(Position _position) internal pure returns (uint8 depth_) {
         // Return the most significant bit offset, which signifies the depth of the gindex.
-        assembly {
+        assembly ("memory-safe") {
             depth_ := or(depth_, shl(6, lt(0xffffffffffffffff, shr(depth_, _position))))
             depth_ := or(depth_, shl(5, lt(0xffffffff, shr(depth_, _position))))
 
@@ -67,7 +67,7 @@ library LibPosition {
         // Return bits p_{msb-1}...p_{0}. This effectively pulls the 2^{depth} out of the gindex,
         // leaving only the `indexAtDepth`.
         uint256 msb = depth(_position);
-        assembly {
+        assembly ("memory-safe") {
             indexAtDepth_ := sub(_position, shl(msb, 1))
         }
     }
@@ -76,7 +76,7 @@ library LibPosition {
     /// @param _position The position to get the left position of.
     /// @return left_ The position to the left of `position`.
     function left(Position _position) internal pure returns (Position left_) {
-        assembly {
+        assembly ("memory-safe") {
             left_ := shl(1, _position)
         }
     }
@@ -85,7 +85,7 @@ library LibPosition {
     /// @param _position The position to get the right position of.
     /// @return right_ The position to the right of `position`.
     function right(Position _position) internal pure returns (Position right_) {
-        assembly {
+        assembly ("memory-safe") {
             right_ := or(1, shl(1, _position))
         }
     }
@@ -94,7 +94,7 @@ library LibPosition {
     /// @param _position The position to get the parent position of.
     /// @return parent_ The parent position of `position`.
     function parent(Position _position) internal pure returns (Position parent_) {
-        assembly {
+        assembly ("memory-safe") {
             parent_ := shr(1, _position)
         }
     }
@@ -106,7 +106,7 @@ library LibPosition {
     /// @return rightIndex_ The deepest, right most gindex relative to the `position`.
     function rightIndex(Position _position, uint256 _maxDepth) internal pure returns (Position rightIndex_) {
         uint256 msb = depth(_position);
-        assembly {
+        assembly ("memory-safe") {
             let remaining := sub(_maxDepth, msb)
             rightIndex_ := or(shl(remaining, _position), sub(shl(remaining, 1), 1))
         }
@@ -120,7 +120,7 @@ library LibPosition {
     /// @return traceIndex_ The trace index relative to the `position`.
     function traceIndex(Position _position, uint256 _maxDepth) internal pure returns (uint256 traceIndex_) {
         uint256 msb = depth(_position);
-        assembly {
+        assembly ("memory-safe") {
             let remaining := sub(_maxDepth, msb)
             traceIndex_ := sub(or(shl(remaining, _position), sub(shl(remaining, 1), 1)), shl(_maxDepth, 1))
         }
@@ -133,14 +133,14 @@ library LibPosition {
     function traceAncestor(Position _position) internal pure returns (Position ancestor_) {
         // Create a field with only the lowest unset bit of `_position` set.
         Position lsb;
-        assembly {
+        assembly ("memory-safe") {
             lsb := and(not(_position), add(_position, 1))
         }
         // Find the index of the lowest unset bit within the field.
         uint256 msb = depth(lsb);
         // The highest ancestor that commits to the same trace index is the original position
         // shifted right by the index of the lowest unset bit.
-        assembly {
+        assembly ("memory-safe") {
             let a := shr(msb, _position)
             // Bound the ancestor to the minimum gindex, 1.
             ancestor_ := or(a, iszero(a))
@@ -163,7 +163,7 @@ library LibPosition {
     {
         // This function only works for positions that are below the upper bound.
         if (_position.depth() <= _upperBoundExclusive) {
-            assembly {
+            assembly ("memory-safe") {
                 // Revert with `ClaimAboveSplit()`
                 mstore(0x00, 0xb34b5c22)
                 revert(0x1C, 0x04)
@@ -188,7 +188,7 @@ library LibPosition {
     /// @param _isAttack Whether or not the move is an attack move.
     /// @return move_ The move position relative to `position`.
     function move(Position _position, bool _isAttack) internal pure returns (Position move_) {
-        assembly {
+        assembly ("memory-safe") {
             move_ := shl(1, or(iszero(_isAttack), _position))
         }
     }
@@ -197,7 +197,7 @@ library LibPosition {
     /// @param _position The position to get the value of.
     /// @return raw_ The value of the `position` as a uint128 type.
     function raw(Position _position) internal pure returns (uint128 raw_) {
-        assembly {
+        assembly ("memory-safe") {
             raw_ := _position
         }
     }

--- a/semgrep/sol-rules.t.sol
+++ b/semgrep/sol-rules.t.sol
@@ -120,6 +120,20 @@ contract SemgrepTest__sol_safety_expectrevert_no_args {
     }
 }
 
+contract SemgrepTest__sol_safety_memory_safe_asm {
+    function test() {
+        // TODO: We cannot test the negative case for this rule because Semgrep currently has a bug
+        // and cannot parse the "memory-safe" annotation properly. Semgrep rule still works
+        // correctly but you'll just have to take my word for it until the issue is fixed.
+        // Semgrep issue: https://github.com/semgrep/semgrep/issues/10617
+
+        // ruleid: sol-safety-memory-safe-asm
+        assembly {
+            // ...
+        }
+    }
+}
+
 contract SemgrepTest__sol_style_input_arg_fmt {
     // ok: sol-style-input-arg-fmt
     event Test(address indexed src, address indexed guy, uint256 wad);

--- a/semgrep/sol-rules.yaml
+++ b/semgrep/sol-rules.yaml
@@ -39,6 +39,22 @@ rules:
       exclude:
         - packages/contracts-bedrock/test
 
+  - id: sol-safety-memory-safe-asm
+    languages: [solidity]
+    severity: ERROR
+    message: Assembly blocks must be memory safe
+    patterns:
+      - pattern-regex: assembly(?P<ARGS>.*)\{
+      - focus-metavariable: $ARGS
+      - pattern-not-regex: "memory-safe"
+    paths:
+      exclude:
+        - packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+        - packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+        - packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
+        - packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+        - packages/contracts-bedrock/test/safe-tools/
+
   - id: sol-style-input-arg-fmt
     languages: [solidity]
     severity: ERROR


### PR DESCRIPTION
Adds a new semgrep rule that asserts that assembly must be memory safe.
