### PR TITLE
op-program: Remove governanceApproved flag from pre-1.0 prestates

### DIFF
--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -41,17 +41,14 @@
   },
   {
     "version": "0.3.0",
-    "hash": "0x034c8cc69f22c35ae386a97136715dd48aaf97fd190942a111bfa680c2f2f421",
-    "governanceApproved": true
+    "hash": "0x034c8cc69f22c35ae386a97136715dd48aaf97fd190942a111bfa680c2f2f421"
   },
   {
     "version": "0.2.0",
-    "hash": "0x031e3b504740d0b1264e8cf72b6dde0d497184cfb3f98e451c6be8b33bd3f808",
-    "governanceApproved": true
+    "hash": "0x031e3b504740d0b1264e8cf72b6dde0d497184cfb3f98e451c6be8b33bd3f808"
   },
   {
     "version": "0.1.0",
-    "hash": "0x038942ec840131a63c49fa514a3f0577ae401fd5584d56ad50cdf5a8b41d4538",
-    "governanceApproved": true
+    "hash": "0x038942ec840131a63c49fa514a3f0577ae401fd5584d56ad50cdf5a8b41d4538"
   }
 ]


### PR DESCRIPTION
**Description**

The pre-1.0 releases of op-program were not shipped to mainnet and not governance approved. Remove those flags from the releases.json.