### PR TITLE
op-service/sources: Fix receipts fetcher concurrency test

### DIFF
--- a/op-service/sources/receipts_basic_test.go
+++ b/op-service/sources/receipts_basic_test.go
@@ -97,7 +97,8 @@ func TestBasicRPCReceiptsFetcher_Reuse(t *testing.T) {
 func TestBasicRPCReceiptsFetcher_Concurrency(t *testing.T) {
 	require := require.New(t)
 	const numFetchers = 32
-	batchSize, txCount := 4, uint64(18) // 4.5 * 4
+	const batchSize, txCount = 4, 16
+	const numBatchCalls = txCount / batchSize
 	block, receipts := randomRpcBlockAndReceipts(rand.New(rand.NewSource(123)), txCount)
 	recMap := make(map[common.Hash]*types.Receipt, len(receipts))
 	for _, rec := range receipts {
@@ -128,6 +129,7 @@ func TestBasicRPCReceiptsFetcher_Concurrency(t *testing.T) {
 	mrpc.AssertExpectations(t)
 	finalNumCalls := int(numCalls.Load())
 	require.NotZero(finalNumCalls, "BatchCallContext should have been called.")
+	require.Less(finalNumCalls, numFetchers*numBatchCalls, "Some IterativeBatchCalls should have been shared.")
 }
 
 func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers int, receipts types.Receipts, block *RPCBlock) {


### PR DESCRIPTION
**Description**

It got effectively disabled in #12533 and while investigating a fix, I realized that its original assertion was too strict. The new assertion adds as a factor the number of batch calls that each individual fetcher would make if no batch calls were shared.

I confirmed with local testing that if all fetchers run sequentially, the last assertion would fail. Since 32 fetchers run in parallel, I deem it safe that this assertion should always succeed, even on very slow machines.