### PR TITLE
cannon: Fix remaining mips64 emulation bugs

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -43,7 +43,7 @@ elf:
 	make -C ./testdata/example elf
 
 sanitize-program:
-	@if ! { mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM | awk '{print $3}' | grep -Ew -m1 '(bgezal|bltzal)'; }; then \
+	@if ! { mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM | awk '{print $3}' | grep -Ew -m1 '(bltzal)'; }; then \
 		echo "guest program is sanitized for unsupported instructions"; \
 	else \
 		echo "found unsupported instructions in the guest program"; \

--- a/cannon/mipsevm/README.md
+++ b/cannon/mipsevm/README.md
@@ -12,6 +12,7 @@ Supported 63 instructions:
 | `Conditional Branch` | `beq`         | Branch on equal.                             |
 | `Conditional Branch` | `bgez`        | Branch on greater than or equal to zero.     |
 | `Conditional Branch` | `bgtz`        | Branch on greater than zero.                 |
+| `Conditional Branch` | `bgezal`      | Branch and link on greater than or equal to zero.     |
 | `Conditional Branch` | `blez`        | Branch on less than or equal to zero.        |
 | `Conditional Branch` | `bltz`        | Branch on less than zero.                    |
 | `Conditional Branch` | `bne`         | Branch on not equal.                         |

--- a/cannon/mipsevm/arch/arch32.go
+++ b/cannon/mipsevm/arch/arch32.go
@@ -79,6 +79,8 @@ const (
 	SysLlseek        = 4140
 	SysMinCore       = 4217
 	SysTgkill        = 4266
+	SysGetRLimit     = 4076
+	SysLseek         = 4019
 	// Profiling-related syscalls
 	SysSetITimer    = 4104
 	SysTimerCreate  = 4257

--- a/cannon/mipsevm/arch/arch64.go
+++ b/cannon/mipsevm/arch/arch64.go
@@ -25,10 +25,12 @@ const (
 	AddressMask = 0xFFFFFFFFFFFFFFF8
 	ExtMask     = 0x7
 
-	HeapStart       = 0x10_00_00_00_00_00_00_00
-	HeapEnd         = 0x60_00_00_00_00_00_00_00
-	ProgramBreak    = 0x40_00_00_00_00_00_00_00
-	HighMemoryStart = 0x7F_FF_FF_FF_D0_00_00_00
+	// Ensure virtual address is limited to 48-bits as many user programs assume such to implement packed pointers
+	// limit          0x00_00_FF_FF_FF_FF_FF_FF
+	HeapStart       = 0x00_00_10_00_00_00_00_00
+	HeapEnd         = 0x00_00_60_00_00_00_00_00
+	ProgramBreak    = 0x00_00_40_00_00_00_00_00
+	HighMemoryStart = 0x00_00_7F_FF_FF_FF_F0_00
 )
 
 // MIPS64 syscall table - https://github.com/torvalds/linux/blob/3efc57369a0ce8f76bf0804f7e673982384e4ac9/arch/mips/kernel/syscalls/syscall_n64.tbl. Generate the syscall numbers using the Makefile in that directory.
@@ -85,6 +87,8 @@ const (
 	SysLlseek        = UndefinedSysNr
 	SysMinCore       = 5026
 	SysTgkill        = 5225
+	SysGetRLimit     = 5095
+	SysLseek         = 5008
 	// Profiling-related syscalls
 	SysSetITimer    = 5036
 	SysTimerCreate  = 5216

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -16,6 +16,9 @@ const (
 	OpStoreConditional64 = 0x3c
 	OpLoadDoubleLeft     = 0x1A
 	OpLoadDoubleRight    = 0x1B
+
+	// Return address register
+	RegRA = 31
 )
 
 func GetInstructionDetails(pc Word, memory *memory.Memory) (insn, opcode, fun uint32) {
@@ -31,7 +34,7 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 	if opcode == 2 || opcode == 3 {
 		linkReg := Word(0)
 		if opcode == 3 {
-			linkReg = 31
+			linkReg = RegRA
 		}
 		// Take the top bits of the next PC (its 256 MB region), and concatenate with the 26-bit offset
 		target := (cpu.NextPC & SignExtend(0xF0000000, 32)) | Word((insn&0x03FFFFFF)<<2)
@@ -523,7 +526,7 @@ func HandleBranch(cpu *mipsevm.CpuScalars, registers *[32]Word, opcode uint32, i
 		}
 		if rtv == 0x11 { // bgezal (i.e. bal mnemonic)
 			shouldBranch = arch.SignedInteger(rs) >= 0
-			registers[31] = cpu.PC + 8 // always set regardless of branch taken
+			registers[RegRA] = cpu.PC + 8 // always set regardless of branch taken
 			linked = true
 		}
 	}

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
-func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
-	return NewInstrumentedState(state, po, stdOut, stdErr, log, nil)
+func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta *program.Metadata) mipsevm.FPVM {
+	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta)
 }
 
 func TestInstrumentedState_OpenMips(t *testing.T) {
@@ -35,7 +36,7 @@ func TestInstrumentedState_Claim(t *testing.T) {
 
 func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 	t.Parallel()
-	state, _ := testutil.LoadELFProgram(t, "../../testdata/example/bin/multithreaded.elf", CreateInitialState, false)
+	state, _ := testutil.LoadELFProgram(t, testutil.ProgramPath("multithreaded"), CreateInitialState, false)
 	oracle := testutil.StaticOracle(t, []byte{})
 
 	var stdOutBuf, stdErrBuf bytes.Buffer
@@ -78,7 +79,7 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			state, meta := testutil.LoadELFProgram(t, "../../testdata/example/bin/alloc.elf", CreateInitialState, false)
+			state, meta := testutil.LoadELFProgram(t, testutil.ProgramPath("alloc"), CreateInitialState, false)
 			oracle := testutil.AllocOracle(t, test.numAllocs, test.allocSize)
 
 			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta)

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -168,9 +168,9 @@ func (m *InstrumentedState) handleSyscall() error {
 			m.memoryTracker.TrackMemAccess(effAddr)
 			m.state.Memory.SetWord(effAddr, secs)
 			m.handleMemoryUpdate(effAddr)
-			m.memoryTracker.TrackMemAccess2(effAddr + 4)
-			m.state.Memory.SetWord(effAddr+4, nsecs)
-			m.handleMemoryUpdate(effAddr + 4)
+			m.memoryTracker.TrackMemAccess2(effAddr + arch.WordSizeBytes)
+			m.state.Memory.SetWord(effAddr+arch.WordSizeBytes, nsecs)
+			m.handleMemoryUpdate(effAddr + arch.WordSizeBytes)
 		default:
 			v0 = exec.SysErrorSignal
 			v1 = exec.MipsEINVAL
@@ -206,6 +206,8 @@ func (m *InstrumentedState) handleSyscall() error {
 	case arch.SysTimerCreate:
 	case arch.SysTimerSetTime:
 	case arch.SysTimerDelete:
+	case arch.SysGetRLimit:
+	case arch.SysLseek:
 	default:
 		// These syscalls have the same values on 64-bit. So we use if-stmts here to avoid "duplicate case" compiler error for the cannon64 build
 		if arch.IsMips32 && syscallNum == arch.SysFstat64 || syscallNum == arch.SysStat64 || syscallNum == arch.SysLlseek {

--- a/cannon/mipsevm/singlethreaded/instrumented_test.go
+++ b/cannon/mipsevm/singlethreaded/instrumented_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
-func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
+func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta *program.Metadata) mipsevm.FPVM {
 	return NewInstrumentedState(state, po, stdOut, stdErr, nil)
 }
 

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -562,5 +563,96 @@ func TestEVMSingleStep_DivMult(t *testing.T) {
 				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts, nil)
 			}
 		})
+	}
+}
+
+func TestEVMSingleStepBranch64(t *testing.T) {
+	var tracer *tracing.Hooks
+
+	versions := GetMipsVersionTestCases(t)
+	cases := []struct {
+		name         string
+		pc           Word
+		expectNextPC Word
+		opcode       uint32
+		regimm       uint32
+		expectLink   bool
+		rs           arch.SignedInteger
+		rt           Word
+		offset       uint16
+	}{
+		// blez
+		{name: "blez", pc: 0, opcode: 0x6, rs: 0x5, offset: 0x100, expectNextPC: 0x8},
+		{name: "blez large rs", pc: 0x10, opcode: 0x6, rs: 0x7F_FF_FF_FF_FF_FF_FF_FF, offset: 0x100, expectNextPC: 0x18},
+		{name: "blez zero rs", pc: 0x10, opcode: 0x6, rs: 0x0, offset: 0x100, expectNextPC: 0x414},
+		{name: "blez sign rs", pc: 0x10, opcode: 0x6, rs: -1, offset: 0x100, expectNextPC: 0x414},
+		{name: "blez rs only sign bit set", pc: 0x10, opcode: 0x6, rs: testutil.ToSignedInteger(0x80_00_00_00_00_00_00_00), offset: 0x100, expectNextPC: 0x414},
+		{name: "blez sign-extended offset", pc: 0x10, opcode: 0x6, rs: -1, offset: 0x80_00, expectNextPC: 0xFF_FF_FF_FF_FF_FE_00_14},
+
+		// bgtz
+		{name: "bgtz", pc: 0, opcode: 0x7, rs: 0x5, offset: 0x100, expectNextPC: 0x404},
+		{name: "bgtz sign-extended offset", pc: 0x10, opcode: 0x7, rs: 0x5, offset: 0x80_00, expectNextPC: 0xFF_FF_FF_FF_FF_FE_00_14},
+		{name: "bgtz large rs", pc: 0x10, opcode: 0x7, rs: 0x7F_FF_FF_FF_FF_FF_FF_FF, offset: 0x100, expectNextPC: 0x414},
+		{name: "bgtz zero rs", pc: 0x10, opcode: 0x7, rs: 0x0, offset: 0x100, expectNextPC: 0x18},
+		{name: "bgtz sign rs", pc: 0x10, opcode: 0x7, rs: -1, offset: 0x100, expectNextPC: 0x18},
+		{name: "bgtz rs only sign bit set", pc: 0x10, opcode: 0x7, rs: testutil.ToSignedInteger(0x80_00_00_00_00_00_00_00), offset: 0x100, expectNextPC: 0x18},
+
+		// bltz t0, $x
+		{name: "bltz", pc: 0, opcode: 0x1, regimm: 0x0, rs: 0x5, offset: 0x100, expectNextPC: 0x8},
+		{name: "bltz large rs", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: 0x7F_FF_FF_FF_FF_FF_FF_FF, offset: 0x100, expectNextPC: 0x18},
+		{name: "bltz zero rs", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: 0x0, offset: 0x100, expectNextPC: 0x18},
+		{name: "bltz sign rs", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: -1, offset: 0x100, expectNextPC: 0x414},
+		{name: "bltz rs only sign bit set", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: testutil.ToSignedInteger(0x80_00_00_00_00_00_00_00), offset: 0x100, expectNextPC: 0x414},
+		{name: "bltz sign-extended offset", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: -1, offset: 0x80_00, expectNextPC: 0xFF_FF_FF_FF_FF_FE_00_14},
+		{name: "bltz large offset no-sign", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: -1, offset: 0x7F_FF, expectNextPC: 0x2_00_10},
+
+		// bgez t0, $x
+		{name: "bgez", pc: 0, opcode: 0x1, regimm: 0x1, rs: 0x5, offset: 0x100, expectNextPC: 0x404},
+		{name: "bgez large rs", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: 0x7F_FF_FF_FF_FF_FF_FF_FF, offset: 0x100, expectNextPC: 0x414},
+		{name: "bgez zero rs", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: 0x0, offset: 0x100, expectNextPC: 0x414},
+		{name: "bgez branch not taken", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: -1, offset: 0x100, expectNextPC: 0x18},
+		{name: "bgez sign-extended offset", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: 1, offset: 0x80_00, expectNextPC: 0xFF_FF_FF_FF_FF_FE_00_14},
+		{name: "bgez large offset no-sign", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: 1, offset: 0x70_00, expectNextPC: 0x1_C0_14},
+		{name: "bgez fill bit offset except sign", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: 1, offset: 0x7F_FF, expectNextPC: 0x2_00_10},
+
+		// bgezal t0, $x
+		{name: "bgezal", pc: 0, opcode: 0x1, regimm: 0x11, rs: 0x5, offset: 0x100, expectNextPC: 0x404, expectLink: true},
+		{name: "bgezal large rs", pc: 0x10, opcode: 0x1, regimm: 0x11, rs: 0x7F_FF_FF_FF_FF_FF_FF_FF, offset: 0x100, expectNextPC: 0x414, expectLink: true},
+		{name: "bgezal zero rs", pc: 0x10, opcode: 0x1, regimm: 0x11, rs: 0x0, offset: 0x100, expectNextPC: 0x414, expectLink: true},
+		{name: "bgezal branch not taken", pc: 0x10, opcode: 0x1, regimm: 0x11, rs: -1, offset: 0x100, expectNextPC: 0x18, expectLink: true},
+		{name: "bgezal sign-extended offset", pc: 0x10, opcode: 0x1, regimm: 0x11, rs: 1, offset: 0x80_00, expectNextPC: 0xFF_FF_FF_FF_FF_FE_00_14, expectLink: true},
+		{name: "bgezal large offset no-sign", pc: 0x10, opcode: 0x1, regimm: 0x11, rs: 1, offset: 0x70_00, expectNextPC: 0x1_C0_14, expectLink: true},
+		{name: "bgezal fill bit offset except sign", pc: 0x10, opcode: 0x1, regimm: 0x11, rs: 1, offset: 0x7F_FF, expectNextPC: 0x2_00_10, expectLink: true},
+	}
+
+	for _, v := range versions {
+		for i, tt := range cases {
+			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
+			t.Run(testName, func(t *testing.T) {
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithPCAndNextPC(tt.pc))
+				state := goVm.GetState()
+				const rsReg = 8 // t0
+				insn := tt.opcode<<26 | rsReg<<21 | tt.regimm<<16 | uint32(tt.offset)
+				state.GetMemory().SetUint32(tt.pc, insn)
+				state.GetRegistersRef()[rsReg] = Word(tt.rs)
+				step := state.GetStep()
+
+				// Setup expectations
+				expected := testutil.NewExpectedState(state)
+				expected.Step += 1
+				expected.PC = state.GetCpu().NextPC
+				expected.NextPC = tt.expectNextPC
+				if tt.expectLink {
+					expected.Registers[31] = state.GetPC() + 8
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts, tracer)
+			})
+		}
 	}
 }

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -1011,7 +1011,7 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 				goVm, state, contracts := setup(t, 2101, nil)
 				mttestutil.InitializeSingleThread(2101+i, state, i%2 == 1)
 				effAddr := c.timespecAddr & arch.AddressMask
-				effAddr2 := effAddr + 4
+				effAddr2 := effAddr + arch.WordSizeBytes
 				step := state.Step
 
 				// Define LL-related params
@@ -1121,6 +1121,8 @@ var NoopSyscalls = map[string]uint32{
 	"SysLlseek":        4140,
 	"SysMinCore":       4217,
 	"SysTgkill":        4266,
+	"SysGetRLimit":     4076,
+	"SysLseek":         4019,
 	"SysMunmap":        4091,
 	"SysSetITimer":     4104,
 	"SysTimerCreate":   4257,

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -40,3 +40,9 @@ func SetMemoryUint64(t require.TestingT, mem *memory.Memory, addr Word, value ui
 	actual := mem.GetWord(effAddr)
 	require.Equal(t, Word(value), actual)
 }
+
+// ToSignedInteger converts the unsigend Word to a SignedInteger.
+// Useful for avoiding Go compiler warnings for literals that don't fit in a signed type
+func ToSignedInteger(x Word) arch.SignedInteger {
+	return arch.SignedInteger(x)
+}

--- a/cannon/mipsevm/testutil/elf.go
+++ b/cannon/mipsevm/testutil/elf.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 )
 
@@ -25,4 +26,13 @@ func LoadELFProgram[T mipsevm.FPVMState](t require.TestingT, name string, initSt
 
 	require.NoError(t, program.PatchStack(state), "add initial stack")
 	return state, meta
+}
+
+// ProgramPath returns the appropriate ELF test program for the current architecture
+func ProgramPath(programName string) string {
+	basename := programName + ".elf"
+	if !arch.IsMips32 {
+		basename = programName + ".64.elf"
+	}
+	return "../../testdata/example/bin/" + basename
 }

--- a/cannon/mipsevm/testutil/oracle.go
+++ b/cannon/mipsevm/testutil/oracle.go
@@ -67,7 +67,7 @@ func StaticPrecompileOracle(t *testing.T, precompile common.Address, requiredGas
 }
 
 func ClaimTestOracle(t *testing.T) (po mipsevm.PreimageOracle, stdOut string, stdErr string) {
-	s := uint64(1000)
+	s := uint64(0x00FFFFFF_00001000)
 	a := uint64(3)
 	b := uint64(4)
 

--- a/cannon/testdata/example/Makefile
+++ b/cannon/testdata/example/Makefile
@@ -1,7 +1,13 @@
 all: elf
 
+.PHONY: elf32
+elf32: $(patsubst %/go.mod,bin/%.elf,$(wildcard */go.mod))
+
+.PHONY: elf64
+elf64: $(patsubst %/go.mod,bin/%.64.elf,$(wildcard */go.mod))
+
 .PHONY: elf
-elf: $(patsubst %/go.mod,bin/%.elf,$(wildcard */go.mod))
+elf: elf32 elf64
 
 .PHONY: dump
 dump: $(patsubst %/go.mod,bin/%.dump,$(wildcard */go.mod))
@@ -14,6 +20,9 @@ bin:
 # result is mips32, big endian, R3000
 bin/%.elf: bin
 	cd $(@:bin/%.elf=%) && GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o ../$@ .
+
+bin/%.64.elf: bin
+	cd $(@:bin/%.64.elf=%) && GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -o ../$@ .
 
 # take any ELF and dump it
 # TODO: currently have the little-endian toolchain, but should use the big-endian one. The -EB compat flag works though.

--- a/cannon/testdata/example/Makefile
+++ b/cannon/testdata/example/Makefile
@@ -22,7 +22,7 @@ bin/%.elf: bin
 	cd $(@:bin/%.elf=%) && GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o ../$@ .
 
 bin/%.64.elf: bin
-	cd $(@:bin/%.64.elf=%) && GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -o ../$@ .
+	cd $(patsubst bin/%.64.elf,%,$@) && GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -o ../$@ .
 
 # take any ELF and dump it
 # TODO: currently have the little-endian toolchain, but should use the big-endian one. The -EB compat flag works though.

--- a/cannon/testdata/example/Makefile
+++ b/cannon/testdata/example/Makefile
@@ -15,14 +15,14 @@ dump: $(patsubst %/go.mod,bin/%.dump,$(wildcard */go.mod))
 bin:
 	mkdir bin
 
+bin/%.64.elf: bin
+	cd $(@:bin/%.64.elf=%) && GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -o ../$@ .
+
 # take any directory with a go mod, and build an ELF
 # verify output with: readelf -h bin/<name>.elf
 # result is mips32, big endian, R3000
 bin/%.elf: bin
 	cd $(@:bin/%.elf=%) && GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o ../$@ .
-
-bin/%.64.elf: bin
-	cd $(patsubst bin/%.64.elf,%,$@) && GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -o ../$@ .
 
 # take any ELF and dump it
 # TODO: currently have the little-endian toolchain, but should use the big-endian one. The -EB compat flag works though.

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x2ab6be69795109a1ee04c5693a34d6ce0ff90b62e404cdeb18178bab18d06784"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0x8fb590d45fa06fdc7ae55860827d6b1abf070c9dc5e18cd28176e844fa1da6c9",
-    "sourceCodeHash": "0x01d3d59020ec29ce78f68f977da5b7754455743121bda65626509864ab6c9da9"
+    "initCodeHash": "0x696c3ce334c11d0f9633945babac22b1b65848ff00d2cf6c4cb18116bbf138b2",
+    "sourceCodeHash": "0x3c2e5d6d39b29a60dcd1a776363518c87fcfef9a8d80e38696f56b6eec5bd53a"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x88acf3297642c2c9e0c1e92b48f59f7015915f25fb816cac44ee0073a1c93ccb",
-    "sourceCodeHash": "0x3dd89839f268569cbf2659beb42e3ac3c53887472cfc94a6e339d2b3a963b941"
+    "initCodeHash": "0x5c292882075bd06e68b89119be9096040bc913f51bb878ce4a9dfdd674330dd5",
+    "sourceCodeHash": "0x17c7b0edb9d20932eaf1b038e3e05e457f0461d2c8691ba1940fb4c2b0dfd123"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -44,8 +44,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.2.1-beta.4
-    string public constant version = "1.2.1-beta.4";
+    /// @custom:semver 1.2.1-beta.5
+    string public constant version = "1.2.1-beta.5";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -60,8 +60,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.17
-    string public constant version = "1.0.0-beta.17";
+    /// @custom:semver 1.0.0-beta.18
+    string public constant version = "1.0.0-beta.18";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -592,6 +592,10 @@ contract MIPS2 is ISemver {
             } else if (syscall_no == sys.SYS_TIMERSETTIME) {
                 // ignored
             } else if (syscall_no == sys.SYS_TIMERDELETE) {
+                // ignored
+            } else if (syscall_no == sys.SYS_GETRLIMIT) {
+                // ignored
+            } else if (syscall_no == sys.SYS_LSEEK) {
                 // ignored
             } else {
                 if (syscall_no == sys.SYS_FSTAT64 || syscall_no == sys.SYS_STAT64 || syscall_no == sys.SYS_LLSEEK) {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -501,6 +501,11 @@ library MIPSInstructions {
                 if (rtv == 1) {
                     shouldBranch = int32(_rs) >= 0;
                 }
+                // bgezal (i.e. bal mnemonic)
+                if (rtv == 0x11) {
+                    shouldBranch = int32(_rs) >= 0;
+                    _registers[31] = _cpu.pc + 8; // always set regardless of branch taken
+                }
             }
 
             // Update the state's previous PC

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -7,6 +7,7 @@ import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 library MIPSInstructions {
     uint32 internal constant OP_LOAD_LINKED = 0x30;
     uint32 internal constant OP_STORE_CONDITIONAL = 0x38;
+    uint32 internal constant REG_RA = 31;
 
     struct CoreStepLogicParams {
         /// @param opcode The opcode value parsed from insn_.
@@ -504,7 +505,7 @@ library MIPSInstructions {
                 // bgezal (i.e. bal mnemonic)
                 if (rtv == 0x11) {
                     shouldBranch = int32(_rs) >= 0;
-                    _registers[31] = _cpu.pc + 8; // always set regardless of branch taken
+                    _registers[REG_RA] = _cpu.pc + 8; // always set regardless of branch taken
                 }
             }
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -71,6 +71,8 @@ library MIPSSyscalls {
     uint32 internal constant SYS_LLSEEK = 4140;
     uint32 internal constant SYS_MINCORE = 4217;
     uint32 internal constant SYS_TGKILL = 4266;
+    uint32 internal constant SYS_GETRLIMIT = 4076;
+    uint32 internal constant SYS_LSEEK = 4019;
 
     // profiling-related syscalls - ignored
     uint32 internal constant SYS_SETITIMER = 4104;


### PR DESCRIPTION
Fixes sycall emulation, address layout, and adds tests that execute 64-bit Go programs.

Contains the following changes:
- no-op syscall emulated for `lseek`. `lseek` is sometimes used by the Go runtime to load timezone data when timezone info is used by the program. We no-op this syscall since there's no filesystem to load tzdata from and the Go runtime is robust against unavailable tz info.
- no-op syscall emulated for `getrlimit`. This syscall is only used by the [Go runtime during init](https://github.com/golang/go/blob/d0631b90a3b0934d0fe223e2d889d785d297f083/src/syscall/rlimit.go#L30) to retrieve file limits from the kernel. A no-op implementation leaves the rlimit output zeroed. Which Go treats as no limit being set. This is only pertinent when a Go process is fork-exec'd and the op-program does not do this.
- Implements the `bgezal` instruction. **Note that this also alters STF of the 32-bit VMs. However, the Go compiler does not emit `bgezal` for 32-bit targets. So this does not alter the execution traces of 32-bit programs**.

## Testing

The 64-bit tests are not yet enabled on CI since we don't yet have the solidity VM implementation. Thus, testing was done locally for the Go VM only:
```
go test -tags=cannon64 -run 'TestInstrumentedState_.*'  -v ./mipsevm/multithreaded
```
This asserts correct execution of the hello, claim, and alloc Go programs on 64-bit cannon.

## Meta

Builds on https://github.com/ethereum-optimism/optimism/pull/12483
Fixes https://github.com/ethereum-optimism/optimism/issues/12249