### PR TITLE
op-program: Compile op-program for Cannon64

### DIFF
--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -26,7 +26,7 @@ ARG OP_PROGRAM_VERSION=v0.0.0
 
 ARG TARGETOS TARGETARCH
 
-# Build the cannon, op-program, and op-program-client.elf binaries.
+# Build the cannon and op-program-client.elf binaries.
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-client-mips  \

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -29,14 +29,13 @@ ARG TARGETOS TARGETARCH
 # Build the cannon, op-program, and op-program-client.elf binaries.
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
-RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-host  \
-  GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-client-mips  \
   GOOS=linux GOARCH=mips GOMIPS=softfloat GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
 
 # Run the op-program-client.elf binary directly through cannon's load-elf subcommand.
-RUN /app/cannon/bin/cannon load-elf --type singlethreaded-2 --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate.bin.gz --meta ""
-RUN /app/cannon/bin/cannon load-elf --type multithreaded --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate-mt.bin.gz --meta ""
+RUN /app/cannon/bin/cannon load-elf --type singlethreaded-2 --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate.bin.gz --meta "/app/op-program/bin/meta.json"
+RUN /app/cannon/bin/cannon load-elf --type multithreaded --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate-mt.bin.gz --meta "/app/op-program/bin/meta-mt.json"
+RUN /app/cannon/bin/cannon load-elf --type multithreaded64 --path /app/op-program/bin/op-program-client64.elf --out /app/op-program/bin/prestate-mt64.bin.gz --meta "/app/op-program/bin/meta-mt64.json"
 
 # Generate the prestate proof containing the absolute pre-state hash.
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d.json' --output ""
@@ -45,13 +44,21 @@ RUN mv /app/op-program/bin/0.json /app/op-program/bin/prestate-proof.json
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt.json' --output ""
 RUN mv /app/op-program/bin/0-mt.json /app/op-program/bin/prestate-proof-mt.json
 
+RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt64.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt64.json' --output ""
+RUN mv /app/op-program/bin/0-mt64.json /app/op-program/bin/prestate-proof-mt64.json
+
 # Exports files to the specified output location.
 # Writing files to host requires buildkit to be enabled.
 # e.g. `BUILDKIT=1 docker build ...`
 FROM scratch AS export-stage
-COPY --from=builder /app/op-program/bin/op-program .
 COPY --from=builder /app/op-program/bin/op-program-client.elf .
+COPY --from=builder /app/op-program/bin/op-program-client64.elf .
+COPY --from=builder /app/op-program/bin/meta.json .
 COPY --from=builder /app/op-program/bin/prestate.bin.gz .
 COPY --from=builder /app/op-program/bin/prestate-proof.json .
+COPY --from=builder /app/op-program/bin/meta-mt.json .
 COPY --from=builder /app/op-program/bin/prestate-mt.bin.gz .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .
+COPY --from=builder /app/op-program/bin/meta-mt64.json .
+COPY --from=builder /app/op-program/bin/prestate-mt64.bin.gz .
+COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -26,10 +26,17 @@ op-program-host:
 op-program-client:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client ./client/cmd/main.go
 
-op-program-client-mips:
+op-program-client-mips: op-program-client-mips32 op-program-client-mips64
+
+op-program-client-mips32:
 	env GO111MODULE=on GOOS=linux GOARCH=mips GOMIPS=softfloat go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client.elf ./client/cmd/main.go
 	# verify output with: readelf -h bin/op-program-client.elf
 	# result is mips32, big endian, R3000
+
+op-program-client-mips64:
+	env GO111MODULE=on GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client64.elf ./client/cmd/main.go
+	# verify output with: readelf -h bin/op-program-client64.elf
+	# result is mips64, big endian, R3000
 
 op-program-client-riscv:
 	env GO111MODULE=on GOOS=linux GOARCH=riscv64 go build -v -gcflags="all=-d=softfloat" -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client-riscv.elf ./client/cmd/main.go
@@ -40,6 +47,8 @@ reproducible-prestate:
 	@cat ./bin/prestate-proof.json | jq -r .pre
 	@echo "MT-Cannon Absolute prestate hash: "
 	@cat ./bin/prestate-proof-mt.json | jq -r .pre
+	@echo "Cannon64 Absolute prestate hash: "
+	@cat ./bin/prestate-proof-mt64.json | jq -r .pre
 .PHONY: reproducible-prestate
 
 clean:
@@ -95,6 +104,8 @@ verify-compat: verify-sepolia-delta verify-sepolia-ecotone verify-mainnet-genesi
 	op-program-host \
 	op-program-client \
 	op-program-client-mips \
+	op-program-client-mips32 \
+	op-program-client-mips64 \
 	op-program-client-riscv \
 	clean \
 	test \


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Update `reproducible-prestate` and `op-program-client-mips` tasks to include 64-bit MTCannon targets. 

Also:
- Make a few modifications to Dockerfile.repro:
  - Don't make and then copy op-program back to the host
  - Generate meta files and copy them back to the host 
