### PR TITLE
proofs-tools: Update kona to alpha 5

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -207,7 +207,7 @@ target "proofs-tools" {
   context = "."
   args = {
     CHALLENGER_VERSION="e7085e537b4a0c95d41b048cfcfdd7ad24808337"
-    KONA_VERSION="kona-client-v0.1.0-alpha.4"
+    KONA_VERSION="kona-client-v0.1.0-alpha.5"
     ASTERISC_VERSION="v1.0.3-alpha1"
   }
   target="proofs-tools"


### PR DESCRIPTION
Update kona to alpha 5 in proofs tools.