### PR TITLE
op-challenger: Use info log level for kona not default

### DIFF
--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -34,7 +34,6 @@ func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.Lo
 		"--l2-output-root", inputs.L2OutputRoot.Hex(),
 		"--l2-claim", inputs.L2Claim.Hex(),
 		"--l2-block-number", inputs.L2BlockNumber.Text(10),
-		"-v",
 	}
 
 	if s.nativeMode {


### PR DESCRIPTION
Kona changed the default log level so the -v is undesirable now.
