### PR TITLE
proofs-tools: Use asterisc version from kona release

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -206,9 +206,8 @@ target "proofs-tools" {
   dockerfile = "./ops/docker/proofs-tools/Dockerfile"
   context = "."
   args = {
-    CHALLENGER_VERSION="e7085e537b4a0c95d41b048cfcfdd7ad24808337"
+    CHALLENGER_VERSION="de795648c5d920f1925ca2cc8bea7c480feefa58"
     KONA_VERSION="kona-client-v0.1.0-alpha.5"
-    ASTERISC_VERSION="v1.0.3-alpha1"
   }
   target="proofs-tools"
   platforms = split(",", PLATFORMS)

--- a/ops/docker/proofs-tools/Dockerfile
+++ b/ops/docker/proofs-tools/Dockerfile
@@ -3,11 +3,9 @@ ARG GIT_DATE
 
 ARG CHALLENGER_VERSION
 ARG KONA_VERSION
-ARG ASTERISC_VERSION
 
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger:$CHALLENGER_VERSION AS challenger
 FROM --platform=$BUILDPLATFORM ghcr.io/anton-rs/kona/kona-fpp-asterisc:$KONA_VERSION AS kona
-FROM --platform=$BUILDPLATFORM ghcr.io/ethereum-optimism/asterisc/asterisc:$ASTERISC_VERSION AS asterisc
 
 FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS proofs-tools
 RUN apt-get update && apt-get install -y --no-install-recommends musl openssl ca-certificates
@@ -19,8 +17,7 @@ ENV OP_CHALLENGER_CANNON_SERVER=/usr/local/bin/op-program
 
 COPY --from=kona /kona-host /usr/local/bin/
 ENV OP_CHALLENGER_ASTERISC_KONA_SERVER=/usr/local/bin/kona-host
-
-COPY --from=asterisc /usr/local/bin/asterisc /usr/local/bin/
+COPY --from=kona /asterisc /usr/local/bin/
 ENV OP_CHALLENGER_ASTERISC_BIN=/usr/local/bin/asterisc
 
 CMD /usr/local/bin/op-challenger


### PR DESCRIPTION
**Description**

Since kona and asterisc are considered a pair, pull both kona and asterisc from the kona release since it includes the version of asterisc it was tested with.

Also updates op-challenger to the latest develop.