### PR TITLE
op-challenger: Avoid cancelling context until response data has been fully read

### DIFF
--- a/op-challenger/game/fault/trace/prestates/multi.go
+++ b/op-challenger/game/fault/trace/prestates/multi.go
@@ -69,7 +69,9 @@ func (m *MultiPrestateProvider) fetchPrestate(ctx context.Context, hash common.H
 		return fmt.Errorf("error creating prestate dir: %w", err)
 	}
 	prestateUrl := m.baseUrl.JoinPath(hash.Hex() + fileType)
-	in, err := m.fetch(ctx, prestateUrl)
+	tCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	in, err := m.fetch(tCtx, prestateUrl)
 	if err != nil {
 		return err
 	}
@@ -111,9 +113,7 @@ func (m *MultiPrestateProvider) fetch(ctx context.Context, prestateUrl *url.URL)
 		}
 		return in, err
 	}
-	tCtx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-	req, err := http.NewRequestWithContext(tCtx, "GET", prestateUrl.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", prestateUrl.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create prestate request: %w", err)
 	}

--- a/op-challenger/game/fault/trace/prestates/multi_test.go
+++ b/op-challenger/game/fault/trace/prestates/multi_test.go
@@ -22,7 +22,13 @@ func TestDownloadPrestateHTTP(t *testing.T) {
 	for _, ext := range supportedFileTypes {
 		t.Run(ext, func(t *testing.T) {
 			dir := t.TempDir()
-			server := prestateHTTPServer(ext)
+			mkContent := func(path string) []byte {
+				// Large enough to be bigger than a single write buffer.
+				out := make([]byte, 16192)
+				copy(out, path)
+				return out
+			}
+			server := prestateHTTPServer(ext, mkContent)
 			defer server.Close()
 			hash := common.Hash{0xaa}
 			provider := NewMultiPrestateProvider(parseURL(t, server.URL), dir, &stubStateConverter{hash: hash})
@@ -33,7 +39,7 @@ func TestDownloadPrestateHTTP(t *testing.T) {
 			defer in.Close()
 			content, err := io.ReadAll(in)
 			require.NoError(t, err)
-			require.Equal(t, "/"+hash.Hex()+ext, string(content))
+			require.Equal(t, mkContent("/"+hash.Hex()+ext), content)
 		})
 	}
 }
@@ -65,7 +71,7 @@ func TestCreateDirectory(t *testing.T) {
 		t.Run(ext, func(t *testing.T) {
 			dir := t.TempDir()
 			dir = filepath.Join(dir, "test")
-			server := prestateHTTPServer(ext)
+			server := prestateHTTPServer(ext, func(path string) []byte { return []byte(path) })
 			defer server.Close()
 			hash := common.Hash{0xaa}
 			provider := NewMultiPrestateProvider(parseURL(t, server.URL), dir, &stubStateConverter{hash: hash})
@@ -188,10 +194,10 @@ func parseURL(t *testing.T, str string) *url.URL {
 	return parsed
 }
 
-func prestateHTTPServer(ext string) *httptest.Server {
+func prestateHTTPServer(ext string, content func(path string) []byte) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ext) {
-			_, _ = w.Write([]byte(r.URL.Path))
+			_, _ = w.Write(content(r.URL.Path))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION
**Description**

The context used for downloading prestates via HTTP was being exited after the request headers were read, but potentially before the full body was read which could lead to `context cancelled` errors while copying the response data to file.

Moves the timeout handling up a level so the context is only cancelled after the request is fully dealt with.

**Tests**

Increased size of response content in unit test so it reproduces the bug.
