### PR TITLE
op-deployer: Remove zeroed out allocs and deployer addr

### DIFF
--- a/op-chain-ops/script/context.go
+++ b/op-chain-ops/script/context.go
@@ -19,6 +19,8 @@ var (
 	ConsoleAddr = common.HexToAddress("0x000000000000000000636F6e736F6c652e6c6f67")
 	// ScriptDeployer is used for temporary scripts address(uint160(uint256(keccak256("op-stack script deployer"))))
 	ScriptDeployer = common.HexToAddress("0x76Ce131128F3616871f8CDA86d18fAB44E4d0D8B")
+	// ForgeDeployer is used by some scripts as a default deployer address, e.g. makeAddr("deployer")
+	ForgeDeployer = common.HexToAddress("0xaE0bDc4eEAC5E950B67C6819B118761CaAF61946")
 )
 
 const (

--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -677,8 +677,25 @@ func (h *Host) StateDump() (*foundry.ForgeAllocs, error) {
 		delete(allocs.Accounts, scriptAddr)
 	}
 
+	// Clean out empty storage slots in the dump - this is necessary for compatibility
+	// with the superchain registry.
+	for _, account := range allocs.Accounts {
+		toDelete := make([]common.Hash, 0)
+
+		for slot, value := range account.Storage {
+			if value == (common.Hash{}) {
+				toDelete = append(toDelete, slot)
+			}
+		}
+
+		for _, slot := range toDelete {
+			delete(account.Storage, slot)
+		}
+	}
+
 	// Remove the script deployer from the output
 	delete(allocs.Accounts, ScriptDeployer)
+	delete(allocs.Accounts, ForgeDeployer)
 
 	// The cheatcodes VM has a placeholder bytecode,
 	// because solidity checks if the code exists prior to regular EVM-calls to it.


### PR DESCRIPTION
Cleans up some things to enable Superchain Registry validation:

- Removes the foundry deployer address used by L2Genesis.sol from the outputted allocs file.
- Removes storage slots with zero values from any state dump.
