### PR TITLE
feat(ci): check that Kontrol summary files are unchanged

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,6 +677,8 @@ jobs:
           name: print forge version
           command: forge --version
       - run-contracts-check:
+          command: check-kontrol-summaries-unchanged
+      - run-contracts-check:
           command: semgrep-test-validity-check
       - run-contracts-check:
           command: semgrep

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -193,6 +193,12 @@ validate-spacers-no-build:
 # Checks that spacer variables are correctly inserted.
 validate-spacers: build validate-spacers-no-build
 
+# Checks that the Kontrol summary dummy files have not been modified.
+# If you have changed the summary files deliberately, update the hashes in the script.
+# Use `openssl dgst -sha256` to generate the hash for a file.
+check-kontrol-summaries-unchanged:
+  ./scripts/checks/check-kontrol-summaries-unchanged.sh
+
 # Runs semgrep on the contracts.
 semgrep:
   cd ../../ && semgrep scan --config=semgrep ./packages/contracts-bedrock

--- a/packages/contracts-bedrock/scripts/checks/check-file-unchanged.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-file-unchanged.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if both arguments are provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <file_path> <expected_hash>"
+    exit 1
+fi
+
+file_path="$1"
+expected_hash="$2"
+
+# Check if the file exists
+if [ ! -f "$file_path" ]; then
+    echo "Error: File '$file_path' does not exist."
+    exit 1
+fi
+
+# Calculate the actual hash of the file
+actual_hash=$(openssl dgst -sha256 -r "$file_path" | awk '{print $1}')
+
+# Compare the hashes
+if [ "$actual_hash" = "$expected_hash" ]; then
+    exit 0
+else
+    echo "File '$file_path' has changed when it shouldn't have"
+    echo "Expected hash: $expected_hash"
+    echo "Actual hash:   $actual_hash"
+    exit 1
+fi

--- a/packages/contracts-bedrock/scripts/checks/check-kontrol-summaries-unchanged.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-kontrol-summaries-unchanged.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the file unchanged script for each of the Kontrol summary files.
+# Update these hashes if you have changed the summary files deliberately.
+# Use `openssl dgst -sha256` to generate the hash for a file.
+./scripts/checks/check-file-unchanged.sh ./test/kontrol/proofs/utils/DeploymentSummary.sol 73e1ed1f3c8bd9e46bb348b774443458206b2399e4eac303e2a92ac987eeefc6
+./scripts/checks/check-file-unchanged.sh ./test/kontrol/proofs/utils/DeploymentSummaryCode.sol ffe7298024464a6a282ceb549db401cce4b36fe3342113250a6c674a3b4203ba
+./scripts/checks/check-file-unchanged.sh ./test/kontrol/proofs/utils/DeploymentSummaryFaultProofs.sol 5ec8b19a00b47f15a2a8c8d632ab83933e19b0c2bbb04c905a2cda926e56038f
+./scripts/checks/check-file-unchanged.sh ./test/kontrol/proofs/utils/DeploymentSummaryFaultProofsCode.sol 1215a561a2bffb5af62b532a2608c4048a22368e505f7ae1d237c16b4ef6a45e


### PR DESCRIPTION
Updates CI to check that the Kontrol summary dummy files are not modified by any PR unless the change is deliberate. Committed files are dummy files and aren't meant to change.

Alternative here would be to generate the dummy files with a script that gets triggered before forge builds stuff. Main concern with using an autogen script is that the script would need to be added in front of build commands all over the place. Committing the files and checking that they aren't changed is slightly more janky but people rarely re-generate these files anyway so the projected impact is minimal.

If this becomes a devx hassle we can consider autogen.