### PR TITLE
cannon: Implement bltzal

### DIFF
--- a/cannon/mipsevm/README.md
+++ b/cannon/mipsevm/README.md
@@ -15,6 +15,7 @@ Supported 63 instructions:
 | `Conditional Branch` | `bgezal`      | Branch and link on greater than or equal to zero.     |
 | `Conditional Branch` | `blez`        | Branch on less than or equal to zero.        |
 | `Conditional Branch` | `bltz`        | Branch on less than zero.                    |
+| `Conditional Branch` | `bltzal`      | Branch and link on less than zero.           |
 | `Conditional Branch` | `bne`         | Branch on not equal.                         |
 | `Logical`            | `clo`         | Count leading ones.                          |
 | `Logical`            | `clz`         | Count leading zeros.                         |

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -486,6 +486,11 @@ func HandleBranch(cpu *mipsevm.CpuScalars, registers *[32]Word, opcode uint32, i
 		if rtv == 0 { // bltz
 			shouldBranch = arch.SignedInteger(rs) < 0
 		}
+		if rtv == 0x10 { // bltzal
+			shouldBranch = arch.SignedInteger(rs) < 0
+			registers[31] = cpu.PC + 8 // always set regardless of branch taken
+			linked = true
+		}
 		if rtv == 1 { // bgez
 			shouldBranch = arch.SignedInteger(rs) >= 0
 		}

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1032,6 +1032,15 @@ func TestEVMSingleStepBranch(t *testing.T) {
 		{name: "bltz sign-extended offset", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: -1, offset: 0x80_00, expectNextPC: 0xFF_FE_00_14},
 		{name: "bltz large offset no-sign", pc: 0x10, opcode: 0x1, regimm: 0x0, rs: -1, offset: 0x7F_FF, expectNextPC: 0x2_00_10},
 
+		// bltzal t0, $x
+		{name: "bltzal", pc: 0, opcode: 0x1, regimm: 0x10, rs: 0x5, offset: 0x100, expectNextPC: 0x8, expectLink: true},
+		{name: "bltzal large rs", pc: 0x10, opcode: 0x1, regimm: 0x10, rs: 0x7F_FF_FF_FF, offset: 0x100, expectNextPC: 0x18, expectLink: true},
+		{name: "bltzal zero rs", pc: 0x10, opcode: 0x1, regimm: 0x10, rs: 0x0, offset: 0x100, expectNextPC: 0x18, expectLink: true},
+		{name: "bltzal sign rs", pc: 0x10, opcode: 0x1, regimm: 0x10, rs: -1, offset: 0x100, expectNextPC: 0x414, expectLink: true},
+		{name: "bltzal rs only sign bit set", pc: 0x10, opcode: 0x1, regimm: 0x10, rs: testutil.ToSignedInteger(0x80_00_00_00), offset: 0x100, expectNextPC: 0x414, expectLink: true},
+		{name: "bltzal sign-extended offset", pc: 0x10, opcode: 0x1, regimm: 0x10, rs: -1, offset: 0x80_00, expectNextPC: 0xFF_FE_00_14, expectLink: true},
+		{name: "bltzal large offset no-sign", pc: 0x10, opcode: 0x1, regimm: 0x10, rs: -1, offset: 0x7F_FF, expectNextPC: 0x2_00_10, expectLink: true},
+
 		// bgez t0, $x
 		{name: "bgez", pc: 0, opcode: 0x1, regimm: 0x1, rs: 0x5, offset: 0x100, expectNextPC: 0x404},
 		{name: "bgez large rs", pc: 0x10, opcode: 0x1, regimm: 0x1, rs: 0x7F_FF_FF_FF, offset: 0x100, expectNextPC: 0x414},

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x0fa0633a769e73f5937514c0003ba7947a1c275bbe5b85d78879c42f0ed8895b"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0x94f2e8f7818a990c009cccb501216a7f6df29b05d8f178cfff10a40288bf588e",
-    "sourceCodeHash": "0x786d4947488a771a426cc38de307ae99b2c2af1efca38b7655c60be7c019371f"
+    "initCodeHash": "0xa3cbf121bad13c00227ea4fef128853d9a86b7ec9158de894f99b58d38d7630a",
+    "sourceCodeHash": "0xd8467700c80b3e62fa37193dc6513bac35282094b686b50e162e157f704dde00"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x3744036fa240c7d57f39307c0bf27cb7027d05d6b4f52142d5122b6e538ee0b2",
-    "sourceCodeHash": "0x5f79a0f99a288d570df243ea9560e67a319d1685b3209ae457fc714a76ff2908"
+    "initCodeHash": "0x478fdad3eccd158822ce2025971a9242c37c976024f419fba417fe54158269b7",
+    "sourceCodeHash": "0x81dc3329c1644afa30ecd2684f44f8b96b5a17612dcfa6476432eed697209e63"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -44,8 +44,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.2.1-beta.6
-    string public constant version = "1.2.1-beta.6";
+    /// @custom:semver 1.2.1-beta.7
+    string public constant version = "1.2.1-beta.7";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -60,8 +60,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.19
-    string public constant version = "1.0.0-beta.19";
+    /// @custom:semver 1.0.0-beta.20
+    string public constant version = "1.0.0-beta.20";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -495,6 +495,11 @@ library MIPSInstructions {
                 if (rtv == 0) {
                     shouldBranch = int32(_rs) < 0;
                 }
+                // bltzal
+                if (rtv == 0x10) {
+                    shouldBranch = int32(_rs) < 0;
+                    _registers[31] = _cpu.pc + 8; // always set regardless of branch taken
+                }
                 if (rtv == 1) {
                     shouldBranch = int32(_rs) >= 0;
                 }


### PR DESCRIPTION
Implements the bltzal instruction. This is implemented for completeness even though the Go compiler doesn't seem to use this instruction.

**Note that this alters the STF of the 32-bit VMs. However, the Go compiler does not emit `bltzal` for 32-bit targets. So this does not alter the execution traces of 32-bit programs.**

## Metadata
Builds on https://github.com/ethereum-optimism/optimism/pull/12594
Fixes https://github.com/ethereum-optimism/optimism/issues/12550