### PR TITLE
chore(op-service): Add missing fields to blob API types

### DIFF
--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -127,6 +127,7 @@ func (f *FakeBeacon) Start(addr string) error {
 						Slot:      eth.Uint64String(slot),
 					},
 				},
+				InclusionProof: make([]eth.Bytes32, 0),
 			}
 			copy(sidecars[i].Blob[:], bundle.Blobs[ix])
 		}

--- a/op-service/eth/blobs_api.go
+++ b/op-service/eth/blobs_api.go
@@ -1,5 +1,7 @@
 package eth
 
+import "github.com/ethereum/go-ethereum/common/hexutil"
+
 type BlobSidecar struct {
 	Blob          Blob         `json:"blob"`
 	Index         Uint64String `json:"index"`
@@ -13,8 +15,7 @@ type APIBlobSidecar struct {
 	KZGCommitment     Bytes48                 `json:"kzg_commitment"`
 	KZGProof          Bytes48                 `json:"kzg_proof"`
 	SignedBlockHeader SignedBeaconBlockHeader `json:"signed_block_header"`
-	// The inclusion-proof of the blob-sidecar into the beacon-block is ignored,
-	// since we verify blobs by their versioned hashes against the execution-layer block instead.
+	InclusionProof    []Bytes32               `json:"kzg_commitment_inclusion_proof"`
 }
 
 func (sc *APIBlobSidecar) BlobSidecar() *BlobSidecar {
@@ -27,8 +28,8 @@ func (sc *APIBlobSidecar) BlobSidecar() *BlobSidecar {
 }
 
 type SignedBeaconBlockHeader struct {
-	Message BeaconBlockHeader `json:"message"`
-	// signature is ignored, since we verify blobs against EL versioned-hashes
+	Message   BeaconBlockHeader `json:"message"`
+	Signature hexutil.Bytes            `json:"signature"`
 }
 
 type BeaconBlockHeader struct {

--- a/op-service/eth/blobs_api.go
+++ b/op-service/eth/blobs_api.go
@@ -29,7 +29,7 @@ func (sc *APIBlobSidecar) BlobSidecar() *BlobSidecar {
 
 type SignedBeaconBlockHeader struct {
 	Message   BeaconBlockHeader `json:"message"`
-	Signature hexutil.Bytes            `json:"signature"`
+	Signature hexutil.Bytes     `json:"signature"`
 }
 
 type BeaconBlockHeader struct {

--- a/op-service/eth/blobs_api_test.go
+++ b/op-service/eth/blobs_api_test.go
@@ -82,17 +82,19 @@ func TestAPIGetBlobSidecarsResponse(t *testing.T) {
 	var resp eth.APIGetBlobSidecarsResponse
 	require.NoError(json.Unmarshal(jsonStr, &resp))
 	require.NotEmpty(resp.Data)
-	require.Equal(5, reflect.TypeOf(*resp.Data[0]).NumField(), "APIBlobSidecar changed, adjust test")
-	require.Equal(1, reflect.TypeOf(resp.Data[0].SignedBlockHeader).NumField(), "SignedBeaconBlockHeader changed, adjust test")
+	require.Equal(6, reflect.TypeOf(*resp.Data[0]).NumField(), "APIBlobSidecar changed, adjust test")
+	require.Equal(2, reflect.TypeOf(resp.Data[0].SignedBlockHeader).NumField(), "SignedBeaconBlockHeader changed, adjust test")
 	require.Equal(5, reflect.TypeOf(resp.Data[0].SignedBlockHeader.Message).NumField(), "BeaconBlockHeader changed, adjust test")
 
 	require.NotZero(resp.Data[0].Blob)
 	require.NotZero(resp.Data[1].Index)
 	require.NotZero(resp.Data[0].KZGCommitment)
 	require.NotZero(resp.Data[0].KZGProof)
+	require.NotZero(resp.Data[0].InclusionProof)
 	require.NotZero(resp.Data[0].SignedBlockHeader.Message.Slot)
 	require.NotZero(resp.Data[0].SignedBlockHeader.Message.ParentRoot)
 	require.NotZero(resp.Data[0].SignedBlockHeader.Message.BodyRoot)
 	require.NotZero(resp.Data[0].SignedBlockHeader.Message.ProposerIndex)
 	require.NotZero(resp.Data[0].SignedBlockHeader.Message.StateRoot)
+	require.NotZero(resp.Data[0].SignedBlockHeader.Signature)
 }


### PR DESCRIPTION
## Overview

Adds missing fields to `op-service`'s blob API response types. The fields added in this PR are required within the beacon chain spec [here](https://github.com/ethereum/beacon-APIs/blob/master/types/deneb/block.yaml#L69) and [here](https://github.com/ethereum/beacon-APIs/blob/master/types/deneb/blob_sidecar.yaml#L19).