### PR TITLE
op-e2e: Attempt fix for alt-da test flakiness

### DIFF
--- a/op-e2e/system/altda/concurrent_test.go
+++ b/op-e2e/system/altda/concurrent_test.go
@@ -55,23 +55,20 @@ func TestBatcherConcurrentAltDARequests(t *testing.T) {
 	err = driver.StartBatchSubmitting()
 	require.NoError(t, err)
 
-	totalBatcherTxsCount := int64(0)
-	// wait for up to 5 L1 blocks, expecting 10 L2 batcher txs in them.
-	// usually only 3 is required, but it's possible additional L1 blocks will be created
-	// before the batcher starts, so we wait additional blocks.
-	for i := int64(0); i < 5; i++ {
-		block, err := geth.WaitForBlock(big.NewInt(int64(startingL1BlockNum)+i), l1Client, time.Duration(cfg.DeployConfig.L1BlockTime*2)*time.Second)
+	// Iterate over up to 10 blocks. The number of transactions sent by the batcher should
+	// exceed the number of blocks.
+	checkBlocks := 10
+	for i := 0; i < checkBlocks; i++ {
+		block, err := geth.WaitForBlock(big.NewInt(int64(startingL1BlockNum)+int64(i)), l1Client, time.Duration(cfg.DeployConfig.L1BlockTime*2)*time.Second)
 		require.NoError(t, err, "Waiting for l1 blocks")
 		// there are possibly other services (proposer/challenger) in the background sending txs
 		// so we only count the batcher txs
 		batcherTxCount, err := transactions.TransactionsBySender(block, cfg.DeployConfig.BatchSenderAddress)
 		require.NoError(t, err)
-		totalBatcherTxsCount += int64(batcherTxCount)
-
-		if totalBatcherTxsCount >= numL1TxsExpected {
+		if batcherTxCount > 1 {
 			return
 		}
 	}
 
-	t.Fatal("Expected at least 10 transactions from the batcher")
+	t.Fatalf("did not find more than 1 batcher tx per block in %d blocks", checkBlocks)
 }


### PR DESCRIPTION
This test fails a lot when executors are under load. This PR changes the test to find the first block with more than one batcher transaction in it, which should be sufficient to assert that the batcher is submitting multiple transactions at once.
