### PR TITLE
maint(ci): bump heavy fuzz runs

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -76,7 +76,7 @@ runs = 256
 depth = 32
 
 [profile.ciheavy]
-fuzz = { runs = 10000 }
+fuzz = { runs = 20000 }
 
 [profile.ciheavy.invariant]
 runs = 128


### PR DESCRIPTION
Bumps the number of heavy fuzz runs to 20k. 10k recently missed a flake so bumping to 20k to try to avoid that in the future. Not perfect but it will reduce the probability a bit. Developers can still manually set the number of fuzz runs for a particular test with annotations if 20k is too high.