### PR TITLE
op-challenger: Add some info on run-trace to the README

### DIFF
--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -23,6 +23,7 @@ accessed by running `./op-challenger --help`.
 
 To run `op-challenger` against the local devnet, first clean and run
 the devnet from the root of the repository.
+
 ```shell
 make devnet-clean
 make devnet-up
@@ -31,6 +32,7 @@ make devnet-up
 Then build the `op-challenger` with `make op-challenger`.
 
 Run the `op-challenger` with:
+
 ```shell
 DISPUTE_GAME_FACTORY=$(jq -r .DisputeGameFactoryProxy .devnet/addresses.json)
 ./op-challenger/bin/op-challenger \
@@ -84,6 +86,9 @@ in the L2 output oracle.
 
 Optionally, you may specify the game type (aka "trace type") using the `--trace-type`
 flag, which is set to the cannon trace type by default.
+
+For known networks, the `--game-factory-address` option can be replaced by `--network`. See the `--help` output for a
+list of predefined networks.
 
 ### move
 
@@ -154,13 +159,16 @@ If the game is resolved successfully, the result is printed.
 ```shell
 ./bin/op-challenger list-games \
   --l1-eth-rpc <L1_ETH_RPC> \
-  --network <Predefined_Network>
+  --game-factory-address <GAME_FACTORY_ADDRESS>
 ```
 
 Prints the games created by the game factory along with their current status.
 
 * `L1_ETH_RPC` - the RPC endpoint of the L1 endpoint to use (e.g. `http://localhost:8545`).
 * `GAME_FACTORY_ADDRESS` - the address of the dispute game factory contract on L1.
+
+For known networks, the `--game-factory-address` option can be replaced by `--network`. See the `--help` output for a
+list of predefined networks.
 
 ### list-claims
 
@@ -174,3 +182,39 @@ Prints the list of current claims in a dispute game.
 
 * `L1_ETH_RPC` - the RPC endpoint of the L1 endpoint to use (e.g. `http://localhost:8545`).
 * `GAME_ADDRESS` - the address of the dispute game to list the move in.
+
+### run-trace
+
+```shell
+./bin/op-challenger run-trace \
+  --network <PREDEFINED_NETWORK> \
+  --l1-eth-rpc=<L1_ETH_RPC> \
+  --l1-beacon=<L1_BEACON> \
+  --l2-eth-rpc=<L2_ETH_RPC> \
+  --rollup-rpc=<ROLLUP_RPC> \
+  --data-dir=<DATA_DIR> \
+  --prestates-url=<PRESTATES_URL> \
+  --run=<RUN_CONFIG>
+```
+
+* `PREDEFINED_NETWORK` - the name of a predefined L2 network.
+* `L1_ETH_RPC` - the RPC endpoint of the L1 endpoint to use (e.g. `http://localhost:8545`).
+* `L1_BEACON` - the REST endpoint of the L1 beacon node to use (e.g. `http://localhost:5100`).
+* `L2_ETH_RPC` - the RPC endpoint of the L2 execution client to use
+* `ROLLUP_RPC` - the RPC endpoint of the L2 consensus client to use
+* `DATA_DIR` - the directory to use to store data
+* `PRESTATES_URL` - the base URL to download required prestates from
+* `RUN_CONFIG` - the trace providers and prestates to run. e.g. `cannon,asterisc-kona/kona-0.1.0-alpha.5/0x03c50fbef46a05f93ea7665fa89015c2108e10c1b4501799c0663774bd35a9c5`
+
+Testing utility that continuously runs the specified trace providers against real chain data. The trace providers can be
+configured with multiple different prestates. This allows testing both the current and potential future prestates with
+the fault proofs virtual machine used by the trace provider.
+
+The same CLI options as `op-challenger` itself are supported to configure the trace providers. The additional `--run`
+option allows specifying which prestates to use. The format is `traceType/name/prestateHash` where traceType is the
+trace type to use with the prestate (e.g cannon or asterisc-kona), name is an arbitrary name for the prestate to use
+when reporting metrics and prestateHash is the hex encoded absolute prestate commitment to use. If name is omitted the
+trace type name is used.If the prestateHash is omitted, the absolute prestate hash used for new games on-chain.
+
+For example to run both the production cannon prestate and a custom
+prestate, use `--run cannon,cannon/next-prestate/0x03c1f0d45248190f80430a4c31e24f8108f05f80ff8b16ecb82d20df6b1b43f3`.


### PR DESCRIPTION
**Description**

Update the op-challenger readme to include some basic info on `run-trace` subcommand. Not intended to be comprehensive since it's just a testing tool for advanced users but worth noting it's available and what it does.