### PR TITLE
cannon: Remove memory.SetUint32

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -93,8 +93,6 @@ fuzz:
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallCloneST ./mipsevm/tests
 	# Multi-threaded tests
 	go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallCloneMT ./mipsevm/tests
-	# 64-bit tests
-	go test $(FUZZLDFLAGS) -tags=cannon64 -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateDmultInsn ./mipsevm/tests
 
 .PHONY: \
 	cannon32-impl \

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -192,25 +192,6 @@ func (m *Memory) pageLookup(pageIndex Word) (*CachedPage, bool) {
 	return p, ok
 }
 
-func (m *Memory) SetUint32(addr Word, v uint32) {
-	// addr must be aligned to WordSizeBytes bytes
-	if addr&arch.ExtMask != 0 {
-		panic(fmt.Errorf("unaligned memory access: %x", addr))
-	}
-
-	pageIndex := addr >> PageAddrSize
-	pageAddr := addr & PageAddrMask
-	p, ok := m.pageLookup(pageIndex)
-	if !ok {
-		// allocate the page if we have not already.
-		// Go may mmap relatively large ranges, but we only allocate the pages just in time.
-		p = m.AllocPage(pageIndex)
-	} else {
-		m.invalidate(addr) // invalidate this branch of memory, now that the value changed
-	}
-	binary.BigEndian.PutUint32(p.Data[pageAddr:pageAddr+4], v)
-}
-
 // SetWord stores [arch.Word] sized values at the specified address
 func (m *Memory) SetWord(addr Word, v Word) {
 	// addr must be aligned to WordSizeBytes bytes

--- a/cannon/mipsevm/multithreaded/testutil/expectations.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations.go
@@ -138,12 +138,6 @@ func (e *ExpectedMTState) ExpectMemoryWordWrite(addr arch.Word, val arch.Word) {
 	e.MemoryRoot = e.expectedMemory.MerkleRoot()
 }
 
-func (e *ExpectedMTState) ExpectMemoryWriteMultiple(addr arch.Word, val uint32, addr2 arch.Word, val2 uint32) {
-	e.expectedMemory.SetUint32(addr, val)
-	e.expectedMemory.SetUint32(addr2, val2)
-	e.MemoryRoot = e.expectedMemory.MerkleRoot()
-}
-
 func (e *ExpectedMTState) ExpectPreemption(preState *multithreaded.State) {
 	e.ActiveThreadId = FindNextThread(preState).ThreadId
 	e.StepsSinceLastContextSwitch = 0

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -117,7 +117,7 @@ func TestEVMSingleStep_Operators64(t *testing.T) {
 				state.GetRegistersRef()[rsReg] = tt.rs
 				state.GetRegistersRef()[rtReg] = tt.rt
 			}
-			state.GetMemory().SetUint32(0, insn)
+			testutil.StoreInstruction(state.GetMemory(), 0, insn)
 			step := state.GetStep()
 
 			// Setup expectations
@@ -200,7 +200,7 @@ func TestEVMSingleStep_Shift(t *testing.T) {
 			insn = rtReg<<16 | rdReg<<11 | tt.sa<<6 | tt.funct
 			state.GetRegistersRef()[rdReg] = tt.rd
 			state.GetRegistersRef()[rtReg] = tt.rt
-			state.GetMemory().SetUint32(0, insn)
+			testutil.StoreInstruction(state.GetMemory(), 0, insn)
 			step := state.GetStep()
 
 			// Setup expectations
@@ -438,7 +438,7 @@ func TestEVMSingleStep_LoadStore64(t *testing.T) {
 			state.GetRegistersRef()[rtReg] = tt.rt
 			state.GetRegistersRef()[baseReg] = t1
 
-			state.GetMemory().SetUint32(0, insn)
+			testutil.StoreInstruction(state.GetMemory(), 0, insn)
 			state.GetMemory().SetWord(t1&arch.AddressMask, tt.memVal)
 			step := state.GetStep()
 
@@ -543,7 +543,7 @@ func TestEVMSingleStep_DivMult(t *testing.T) {
 			insn := rsReg<<21 | rtReg<<16 | tt.funct
 			state.GetRegistersRef()[rsReg] = tt.rs
 			state.GetRegistersRef()[rtReg] = tt.rt
-			state.GetMemory().SetUint32(0, insn)
+			testutil.StoreInstruction(state.GetMemory(), 0, insn)
 			step := state.GetStep()
 
 			// Setup expectations
@@ -633,7 +633,7 @@ func TestEVMSingleStepBranch64(t *testing.T) {
 				state := goVm.GetState()
 				const rsReg = 8 // t0
 				insn := tt.opcode<<26 | rsReg<<21 | tt.regimm<<16 | uint32(tt.offset)
-				state.GetMemory().SetUint32(tt.pc, insn)
+				testutil.StoreInstruction(state.GetMemory(), tt.pc, insn)
 				state.GetRegistersRef()[rsReg] = Word(tt.rs)
 				step := state.GetStep()
 

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -140,7 +140,7 @@ func TestEVMSingleStep_Jump(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithPC(tt.pc), testutil.WithNextPC(tt.nextPC))
 				state := goVm.GetState()
-				state.GetMemory().SetUint32(tt.pc, tt.insn)
+				testutil.StoreInstruction(state.GetMemory(), tt.pc, tt.insn)
 				step := state.GetStep()
 
 				// Setup expectations
@@ -217,7 +217,7 @@ func TestEVMSingleStep_Operators(t *testing.T) {
 					state.GetRegistersRef()[baseReg] = tt.rs
 					state.GetRegistersRef()[rtReg] = tt.rt
 				}
-				state.GetMemory().SetUint32(0, insn)
+				testutil.StoreInstruction(state.GetMemory(), 0, insn)
 				step := state.GetStep()
 
 				// Setup expectations
@@ -311,7 +311,7 @@ func TestEVMSingleStep_LoadStore(t *testing.T) {
 				insn := tt.opcode<<26 | baseReg<<21 | rtReg<<16 | tt.imm
 				state.GetRegistersRef()[rtReg] = tt.rt
 				state.GetRegistersRef()[baseReg] = tt.base
-				state.GetMemory().SetUint32(0, insn)
+				testutil.StoreInstruction(state.GetMemory(), 0, insn)
 				state.GetMemory().SetWord(effAddr, tt.memVal)
 				step := state.GetStep()
 
@@ -365,7 +365,7 @@ func TestEVMSingleStep_MovzMovn(t *testing.T) {
 				state.GetRegistersRef()[rtReg] = t2
 				state.GetRegistersRef()[rsReg] = Word(0xb)
 				state.GetRegistersRef()[rdReg] = Word(0xa)
-				state.GetMemory().SetUint32(0, insn)
+				testutil.StoreInstruction(state.GetMemory(), 0, insn)
 				step := state.GetStep()
 				// Setup expectations
 				expected := testutil.NewExpectedState(state)
@@ -420,7 +420,7 @@ func TestEVMSingleStep_MfhiMflo(t *testing.T) {
 				state := goVm.GetState()
 				rdReg := uint32(8)
 				insn := rdReg<<11 | tt.funct
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				step := state.GetStep()
 				// Setup expectations
 				expected := testutil.NewExpectedState(state)
@@ -475,7 +475,7 @@ func TestEVMSingleStep_MulDiv(t *testing.T) {
 				insn = tt.opcode<<26 | baseReg<<21 | rtReg<<16 | tt.rdReg<<11 | tt.funct
 				state.GetRegistersRef()[rtReg] = tt.rt
 				state.GetRegistersRef()[baseReg] = tt.rs
-				state.GetMemory().SetUint32(0, insn)
+				testutil.StoreInstruction(state.GetMemory(), 0, insn)
 
 				if tt.expectRevert != "" {
 					proofData := v.ProofGenerator(t, goVm.GetState())
@@ -529,7 +529,7 @@ func TestEVMSingleStep_MthiMtlo(t *testing.T) {
 				state := goVm.GetState()
 				rsReg := uint32(8)
 				insn := rsReg<<21 | tt.funct
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetRegistersRef()[rsReg] = val
 				step := state.GetStep()
 				// Setup expectations
@@ -580,7 +580,7 @@ func TestEVM_MMap(t *testing.T) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithHeap(c.heap))
 				state := goVm.GetState()
 
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 				state.GetRegistersRef()[2] = arch.SysMmap
 				state.GetRegistersRef()[4] = c.address
 				state.GetRegistersRef()[5] = c.size
@@ -788,7 +788,7 @@ func TestEVMSysWriteHint(t *testing.T) {
 
 				err := state.GetMemory().SetMemoryRange(arch.Word(tt.memOffset), bytes.NewReader(tt.hintData))
 				require.NoError(t, err)
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				step := state.GetStep()
 
 				expected := testutil.NewExpectedState(state)
@@ -832,7 +832,7 @@ func TestEVMFault(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithNextPC(tt.nextPC))
 				state := goVm.GetState()
-				state.GetMemory().SetUint32(0, tt.insn)
+				testutil.StoreInstruction(state.GetMemory(), 0, tt.insn)
 				// set the return address ($ra) to jump into when test completes
 				state.GetRegistersRef()[31] = testutil.EndAddr
 
@@ -1059,7 +1059,7 @@ func TestEVMSingleStepBranch(t *testing.T) {
 				state := goVm.GetState()
 				const rsReg = 8 // t0
 				insn := tt.opcode<<26 | rsReg<<21 | tt.regimm<<16 | uint32(tt.offset)
-				state.GetMemory().SetUint32(tt.pc, insn)
+				testutil.StoreInstruction(state.GetMemory(), tt.pc, insn)
 				state.GetRegistersRef()[rsReg] = Word(tt.rs)
 				step := state.GetStep()
 

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -56,7 +56,7 @@ func TestEVM_MT64_LL(t *testing.T) {
 				step := state.GetStep()
 
 				// Set up state
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetMemory().SetWord(effAddr, c.memVal)
 				state.GetRegistersRef()[baseReg] = c.base
 				if withExistingReservation {
@@ -158,7 +158,7 @@ func TestEVM_MT64_SC(t *testing.T) {
 
 				// Setup state
 				state.GetCurrentThread().ThreadId = c.threadId
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = c.value
 				state.LLReservationStatus = v.llReservationStatus
@@ -232,7 +232,7 @@ func TestEVM_MT64_LLD(t *testing.T) {
 				step := state.GetStep()
 
 				// Set up state
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetMemory().SetWord(effAddr, c.memVal)
 				state.GetRegistersRef()[baseReg] = c.base
 				if withExistingReservation {
@@ -335,7 +335,7 @@ func TestEVM_MT64_SCD(t *testing.T) {
 
 				// Setup state
 				state.GetCurrentThread().ThreadId = c.threadId
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = value
 				state.LLReservationStatus = v.llReservationStatus

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -63,7 +63,7 @@ func TestEVM_MT_LL(t *testing.T) {
 
 				// Set up state
 				testutil.SetMemoryUint64(t, state.GetMemory(), Word(c.expectedAddr), c.memValue)
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetRegistersRef()[baseReg] = Word(c.base)
 				if withExistingReservation {
 					state.LLReservationStatus = multithreaded.LLStatusActive32bit
@@ -160,7 +160,7 @@ func TestEVM_MT_SC(t *testing.T) {
 				// Setup state
 				testutil.SetMemoryUint64(t, state.GetMemory(), Word(c.expectedAddr), memValue)
 				state.GetCurrentThread().ThreadId = c.threadId
-				state.GetMemory().SetUint32(state.GetPC(), insn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 				state.GetRegistersRef()[baseReg] = c.base
 				state.GetRegistersRef()[rtReg] = Word(c.storeValue)
 				state.LLReservationStatus = v.llReservationStatus
@@ -224,8 +224,8 @@ func TestEVM_MT_SysRead_Preimage(t *testing.T) {
 		count          Word
 		writeLen       Word
 		preimageOffset Word
-		prestateMem    uint32
-		postateMem     uint32
+		prestateMem    Word
+		postateMem     Word
 		shouldPanic    bool
 	}{
 		{name: "Aligned addr, write 1 byte", addr: 0x00_00_FF_00, count: 1, writeLen: 1, preimageOffset: 8, prestateMem: 0xFF_FF_FF_FF, postateMem: 0x12_FF_FF_FF},
@@ -269,11 +269,11 @@ func TestEVM_MT_SysRead_Preimage(t *testing.T) {
 				state.GetRegistersRef()[4] = exec.FdPreimageRead
 				state.GetRegistersRef()[5] = c.addr
 				state.GetRegistersRef()[6] = c.count
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 				state.LLReservationStatus = v.llReservationStatus
 				state.LLAddress = llAddress
 				state.LLOwnerThread = llOwnerThread
-				state.GetMemory().SetUint32(effAddr, c.prestateMem)
+				state.GetMemory().SetWord(effAddr, c.prestateMem)
 
 				// Setup expectations
 				expected := mttestutil.NewExpectedMTState(state)
@@ -281,7 +281,7 @@ func TestEVM_MT_SysRead_Preimage(t *testing.T) {
 				expected.ActiveThread().Registers[2] = c.writeLen
 				expected.ActiveThread().Registers[7] = 0 // no error
 				expected.PreimageOffset += c.writeLen
-				expected.ExpectMemoryWriteUint32(t, effAddr, c.postateMem)
+				expected.ExpectMemoryWordWrite(effAddr, c.postateMem)
 				if v.shouldClearReservation {
 					expected.LLReservationStatus = multithreaded.LLStatusNone
 					expected.LLAddress = 0
@@ -334,8 +334,8 @@ func TestEVM_MT_StoreOpsClearMemReservation(t *testing.T) {
 		offset  int
 		base    Word
 		effAddr Word
-		preMem  uint32
-		postMem uint32
+		preMem  Word
+		postMem Word
 	}{
 		{name: "Store byte", opcode: 0b10_1000, base: 0xFF_00_00_04, offset: 0xFF_00_00_08, effAddr: 0xFF_00_00_0C, preMem: 0xFF_FF_FF_FF, postMem: 0x78_FF_FF_FF},
 		{name: "Store halfword", opcode: 0b10_1001, base: 0xFF_00_00_04, offset: 0xFF_00_00_08, effAddr: 0xFF_00_00_0C, preMem: 0xFF_FF_FF_FF, postMem: 0x56_78_FF_FF},
@@ -361,8 +361,8 @@ func TestEVM_MT_StoreOpsClearMemReservation(t *testing.T) {
 				// Setup state
 				state.GetRegistersRef()[rtReg] = rt
 				state.GetRegistersRef()[baseReg] = c.base
-				state.GetMemory().SetUint32(state.GetPC(), insn)
-				state.GetMemory().SetUint32(c.effAddr, c.preMem)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+				state.GetMemory().SetWord(c.effAddr, c.preMem)
 				state.LLReservationStatus = v.llReservationStatus
 				state.LLAddress = llAddress
 				state.LLOwnerThread = llOwnerThread
@@ -370,7 +370,7 @@ func TestEVM_MT_StoreOpsClearMemReservation(t *testing.T) {
 				// Setup expectations
 				expected := mttestutil.NewExpectedMTState(state)
 				expected.ExpectStep()
-				expected.ExpectMemoryWriteUint32(t, c.effAddr, c.postMem)
+				expected.ExpectMemoryWordWrite(c.effAddr, c.postMem)
 				if v.shouldClearReservation {
 					expected.LLReservationStatus = multithreaded.LLStatusNone
 					expected.LLAddress = 0
@@ -411,7 +411,7 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			state := multithreaded.CreateEmptyState()
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
 			state.GetRegistersRef()[4] = c.flags       // Set first argument
 			curStep := state.Step
@@ -464,7 +464,7 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 
 			goVm, state, contracts := setup(t, i, nil)
 			mttestutil.InitializeSingleThread(i*333, state, c.traverseRight)
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysClone        // the syscall number
 			state.GetRegistersRef()[4] = exec.ValidCloneFlags // a0 - first argument, clone flags
 			state.GetRegistersRef()[5] = stackPtr             // a1 - the stack pointer
@@ -527,7 +527,7 @@ func TestEVM_SysGetTID(t *testing.T) {
 			mttestutil.InitializeSingleThread(i*789, state, false)
 
 			state.GetCurrentThread().ThreadId = c.threadId
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
 			step := state.Step
 
@@ -570,7 +570,7 @@ func TestEVM_SysExit(t *testing.T) {
 			goVm, state, contracts := setup(t, i*133, nil)
 			mttestutil.SetupThreads(int64(i*1111), state, i%2 == 0, c.threadCount, 0)
 
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysExit   // Set syscall number
 			state.GetRegistersRef()[4] = Word(exitCode) // The first argument (exit code)
 			step := state.Step
@@ -678,7 +678,7 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 			goVm, state, contracts := setup(t, i*1234, nil)
 			step := state.GetStep()
 
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.Memory.SetWord(c.effAddr, c.actualValue)
 			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = c.addressParam
@@ -749,7 +749,7 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 			mttestutil.SetupThreads(int64(i*2244), state, c.traverseRight, c.activeThreadCount, c.inactiveThreadCount)
 			step := state.Step
 
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = c.addressParam
 			state.GetRegistersRef()[5] = exec.FutexWakePrivate
@@ -834,7 +834,7 @@ func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {
 			goVm, state, contracts := setup(t, int(op), nil)
 			step := state.GetStep()
 
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[5] = op
 
@@ -889,7 +889,7 @@ func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
 				goVm, state, contracts := setup(t, i*789, nil)
 				mttestutil.SetupThreads(int64(i*3259), state, traverseRight, c.activeThreads, c.inactiveThreads)
 
-				state.Memory.SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 				state.GetRegistersRef()[2] = Word(syscallNum) // Set syscall number
 				step := state.Step
 
@@ -919,7 +919,7 @@ func TestEVM_SysOpen(t *testing.T) {
 
 	goVm, state, contracts := setup(t, 5512, nil)
 
-	state.Memory.SetUint32(state.GetPC(), syscallInsn)
+	testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 	state.GetRegistersRef()[2] = arch.SysOpen // Set syscall number
 	step := state.Step
 
@@ -944,7 +944,7 @@ func TestEVM_SysGetPID(t *testing.T) {
 	var tracer *tracing.Hooks
 	goVm, state, contracts := setup(t, 1929, nil)
 
-	state.Memory.SetUint32(state.GetPC(), syscallInsn)
+	testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 	state.GetRegistersRef()[2] = arch.SysGetpid // Set syscall number
 	step := state.Step
 
@@ -1029,7 +1029,7 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 					llOwnerThread = state.GetCurrentThread().ThreadId + 1
 				}
 
-				state.Memory.SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 				state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
 				state.GetRegistersRef()[4] = clkid                // a0
 				state.GetRegistersRef()[5] = c.timespecAddr       // a1
@@ -1073,7 +1073,7 @@ func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
 	goVm, state, contracts := setup(t, 2101, nil)
 
 	timespecAddr := Word(0x1000)
-	state.Memory.SetUint32(state.GetPC(), syscallInsn)
+	testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 	state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
 	state.GetRegistersRef()[4] = 0xDEAD               // a0 - invalid clockid
 	state.GetRegistersRef()[5] = timespecAddr         // a1
@@ -1136,7 +1136,7 @@ func TestEVM_NoopSyscall(t *testing.T) {
 		t.Run(noopName, func(t *testing.T) {
 			goVm, state, contracts := setup(t, int(noopVal), nil)
 
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = Word(noopVal) // Set syscall number
 			step := state.Step
 
@@ -1183,7 +1183,7 @@ func TestEVM_UnsupportedSyscall(t *testing.T) {
 			t.Parallel()
 			goVm, state, contracts := setup(t, i*3434, nil)
 			// Setup basic getThreadId syscall instruction
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = Word(syscallNum)
 			proofData := multiThreadedProofGenerator(t, state)
 			// Set up post-state expectations
@@ -1587,7 +1587,7 @@ func TestEVM_SchedQuantumThreshold(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goVm, state, contracts := setup(t, i*789, nil)
 			// Setup basic getThreadId syscall instruction
-			state.Memory.SetUint32(state.GetPC(), syscallInsn)
+			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
 			state.StepsSinceLastContextSwitch = c.stepsSinceLastContextSwitch
 			step := state.Step

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"encoding/binary"
 	"math"
 	"os"
 	"testing"
@@ -28,7 +27,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = arch.SysBrk
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 				step := state.GetStep()
 
 				expected := testutil.NewExpectedState(state)
@@ -68,7 +67,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 				state.GetRegistersRef()[2] = arch.SysMmap
 				state.GetRegistersRef()[4] = addr
 				state.GetRegistersRef()[5] = siz
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 
 				expected := testutil.NewExpectedState(state)
 				expected.Step += 1
@@ -114,7 +113,7 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 				state := goVm.GetState()
 				state.GetRegistersRef()[2] = arch.SysExitGroup
 				state.GetRegistersRef()[4] = Word(exitCode)
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 				step := state.GetStep()
 
 				expected := testutil.NewExpectedState(state)
@@ -144,7 +143,7 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 				state.GetRegistersRef()[2] = arch.SysFcntl
 				state.GetRegistersRef()[4] = fd
 				state.GetRegistersRef()[5] = cmd
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 				step := state.GetStep()
 
 				expected := testutil.NewExpectedState(state)
@@ -205,7 +204,7 @@ func FuzzStateHintRead(f *testing.F) {
 				state.GetRegistersRef()[4] = exec.FdHintRead
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 				step := state.GetStep()
 
 				expected := testutil.NewExpectedState(state)
@@ -249,8 +248,8 @@ func FuzzStatePreimageRead(f *testing.F) {
 				state.GetRegistersRef()[4] = exec.FdPreimageRead
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
-				state.GetMemory().SetUint32(effAddr, binary.BigEndian.Uint32(preexistingMemoryVal[:]))
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+				state.GetMemory().SetWord(effAddr, arch.ByteOrderWord.Word(preexistingMemoryVal[:]))
 				step := state.GetStep()
 
 				alignment := addr & arch.ExtMask
@@ -275,7 +274,7 @@ func FuzzStatePreimageRead(f *testing.F) {
 					// Expect a memory write
 					expectedMemory := preexistingMemoryVal
 					copy(expectedMemory[alignment:], preimageData[preimageOffset:preimageOffset+writeLen])
-					expected.ExpectMemoryWrite(effAddr, binary.BigEndian.Uint32(expectedMemory[:]))
+					expected.ExpectMemoryWriteWord(effAddr, arch.ByteOrderWord.Word(expectedMemory[:]))
 				}
 
 				stepWitness, err := goVm.Step(true)
@@ -331,7 +330,7 @@ func FuzzStateHintWrite(f *testing.F) {
 				step := state.GetStep()
 				err := state.GetMemory().SetMemoryRange(addr, bytes.NewReader(hintData[int(lastHintLen):]))
 				require.NoError(t, err)
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 
 				// Set up expectations
 				expected := testutil.NewExpectedState(state)
@@ -394,8 +393,8 @@ func FuzzStatePreimageWrite(f *testing.F) {
 				state.GetRegistersRef()[4] = exec.FdPreimageWrite
 				state.GetRegistersRef()[5] = addr
 				state.GetRegistersRef()[6] = count
-				state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
-				state.GetMemory().SetUint32(effAddr, binary.BigEndian.Uint32(preexistingMemoryVal[:]))
+				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+				state.GetMemory().SetWord(effAddr, arch.ByteOrderWord.Word(preexistingMemoryVal[:]))
 				step := state.GetStep()
 
 				expectBytesWritten := count

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -27,7 +27,7 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 
 		// Setup
 		state.NextThreadId = nextThreadId
-		state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = arch.SysClone
 		state.GetRegistersRef()[4] = exec.ValidCloneFlags
 		state.GetRegistersRef()[5] = stackPtr

--- a/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_singlethreaded_test.go
@@ -17,7 +17,7 @@ func FuzzStateSyscallCloneST(f *testing.F) {
 		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 		state := goVm.GetState()
 		state.GetRegistersRef()[2] = arch.SysClone
-		state.GetMemory().SetUint32(state.GetPC(), syscallInsn)
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		step := state.GetStep()
 
 		expected := testutil.NewExpectedState(state)

--- a/cannon/mipsevm/testutil/memory.go
+++ b/cannon/mipsevm/testutil/memory.go
@@ -1,6 +1,12 @@
 package testutil
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+)
 
 func Uint32ToBytes(val uint32) []byte {
 	data := make([]byte, 4)
@@ -15,3 +21,15 @@ func Uint64ToBytes(val uint64) []byte {
 
 	return data
 }
+
+// StoreInstruction writes a 4-byte instruction to memory
+func StoreInstruction(mem *memory.Memory, pc Word, insn uint32) {
+	if pc&0x3 != 0 {
+		panic(fmt.Errorf("unaligned memory access: %x", pc))
+	}
+	exec.StoreSubWord(mem, pc, 4, Word(insn), new(noopMemTracker))
+}
+
+type noopMemTracker struct{}
+
+func (n *noopMemTracker) TrackMemAccess(Word) {}

--- a/cannon/mipsevm/testutil/state.go
+++ b/cannon/mipsevm/testutil/state.go
@@ -177,11 +177,6 @@ func (e *ExpectedState) ExpectStep() {
 	e.NextPC += 4
 }
 
-func (e *ExpectedState) ExpectMemoryWrite(addr arch.Word, val uint32) {
-	e.expectedMemory.SetUint32(addr, val)
-	e.MemoryRoot = e.expectedMemory.MerkleRoot()
-}
-
 func (e *ExpectedState) ExpectMemoryWriteWord(addr arch.Word, val arch.Word) {
 	e.expectedMemory.SetWord(addr, val)
 	e.MemoryRoot = e.expectedMemory.MerkleRoot()

--- a/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/hashdb"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -369,7 +370,7 @@ func DiffTestUtils() {
 		checkErr(err, "Error decoding addr")
 		insn, err := strconv.ParseUint(args[2], 10, 32)
 		checkErr(err, "Error decoding insn")
-		mem.SetWord(uint32(pc), uint32(insn))
+		mem.SetWord(arch.Word(pc), arch.Word(insn))
 
 		var insnProof, memProof [896]byte
 		if len(args) >= 5 {
@@ -377,18 +378,18 @@ func DiffTestUtils() {
 			checkErr(err, "Error decoding memAddr")
 			memValue, err := strconv.ParseUint(args[4], 10, 32)
 			checkErr(err, "Error decoding memValue")
-			mem.SetWord(uint32(memAddr), uint32(memValue))
-			memProof = mem.MerkleProof(uint32(memAddr))
+			mem.SetWord(arch.Word(memAddr), arch.Word(memValue))
+			memProof = mem.MerkleProof(arch.Word(memAddr))
 		}
 		if len(args) == 7 {
 			memAddr, err := strconv.ParseUint(args[5], 10, 32)
 			checkErr(err, "Error decoding memAddr")
 			memValue, err := strconv.ParseUint(args[6], 10, 32)
 			checkErr(err, "Error decoding memValue")
-			mem.SetWord(uint32(memAddr), uint32(memValue))
-			memProof = mem.MerkleProof(uint32(memAddr))
+			mem.SetWord(arch.Word(memAddr), arch.Word(memValue))
+			memProof = mem.MerkleProof(arch.Word(memAddr))
 		}
-		insnProof = mem.MerkleProof(uint32(pc))
+		insnProof = mem.MerkleProof(arch.Word(pc))
 
 		output := struct {
 			MemRoot common.Hash
@@ -411,18 +412,18 @@ func DiffTestUtils() {
 		checkErr(err, "Error decoding addr")
 		insn, err := strconv.ParseUint(args[2], 10, 32)
 		checkErr(err, "Error decoding insn")
-		mem.SetWord(uint32(pc), uint32(insn))
+		mem.SetWord(arch.Word(pc), arch.Word(insn))
 
 		var memProof [896]byte
 		memAddr, err := strconv.ParseUint(args[3], 10, 32)
 		checkErr(err, "Error decoding memAddr")
 		memValue, err := strconv.ParseUint(args[4], 10, 32)
 		checkErr(err, "Error decoding memValue")
-		mem.SetWord(uint32(memAddr), uint32(memValue))
+		mem.SetWord(arch.Word(memAddr), arch.Word(memValue))
 
 		memAddr2, err := strconv.ParseUint(args[5], 10, 32)
 		checkErr(err, "Error decoding memAddr")
-		memProof = mem.MerkleProof(uint32(memAddr2))
+		memProof = mem.MerkleProof(arch.Word(memAddr2))
 
 		output := struct {
 			MemRoot common.Hash
@@ -444,18 +445,18 @@ func DiffTestUtils() {
 		checkErr(err, "Error decoding addr")
 		insn, err := strconv.ParseUint(args[2], 10, 32)
 		checkErr(err, "Error decoding insn")
-		mem.SetWord(uint32(pc), uint32(insn))
+		mem.SetWord(arch.Word(pc), arch.Word(insn))
 
 		var insnProof, memProof [896]byte
 		memAddr, err := strconv.ParseUint(args[3], 10, 32)
 		checkErr(err, "Error decoding memAddr")
 		memValue, err := strconv.ParseUint(args[4], 10, 32)
 		checkErr(err, "Error decoding memValue")
-		mem.SetWord(uint32(memAddr), uint32(memValue))
+		mem.SetWord(arch.Word(memAddr), arch.Word(memValue))
 
 		// Compute a valid proof for the root, but for the wrong leaves.
-		memProof = mem.MerkleProof(uint32(memAddr + 32))
-		insnProof = mem.MerkleProof(uint32(pc + 32))
+		memProof = mem.MerkleProof(arch.Word(memAddr + 32))
+		insnProof = mem.MerkleProof(arch.Word(pc + 32))
 
 		output := struct {
 			MemRoot common.Hash

--- a/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
@@ -369,7 +369,7 @@ func DiffTestUtils() {
 		checkErr(err, "Error decoding addr")
 		insn, err := strconv.ParseUint(args[2], 10, 32)
 		checkErr(err, "Error decoding insn")
-		mem.SetUint32(uint32(pc), uint32(insn))
+		mem.SetWord(uint32(pc), uint32(insn))
 
 		var insnProof, memProof [896]byte
 		if len(args) >= 5 {
@@ -377,7 +377,7 @@ func DiffTestUtils() {
 			checkErr(err, "Error decoding memAddr")
 			memValue, err := strconv.ParseUint(args[4], 10, 32)
 			checkErr(err, "Error decoding memValue")
-			mem.SetUint32(uint32(memAddr), uint32(memValue))
+			mem.SetWord(uint32(memAddr), uint32(memValue))
 			memProof = mem.MerkleProof(uint32(memAddr))
 		}
 		if len(args) == 7 {
@@ -385,7 +385,7 @@ func DiffTestUtils() {
 			checkErr(err, "Error decoding memAddr")
 			memValue, err := strconv.ParseUint(args[6], 10, 32)
 			checkErr(err, "Error decoding memValue")
-			mem.SetUint32(uint32(memAddr), uint32(memValue))
+			mem.SetWord(uint32(memAddr), uint32(memValue))
 			memProof = mem.MerkleProof(uint32(memAddr))
 		}
 		insnProof = mem.MerkleProof(uint32(pc))
@@ -411,14 +411,14 @@ func DiffTestUtils() {
 		checkErr(err, "Error decoding addr")
 		insn, err := strconv.ParseUint(args[2], 10, 32)
 		checkErr(err, "Error decoding insn")
-		mem.SetUint32(uint32(pc), uint32(insn))
+		mem.SetWord(uint32(pc), uint32(insn))
 
 		var memProof [896]byte
 		memAddr, err := strconv.ParseUint(args[3], 10, 32)
 		checkErr(err, "Error decoding memAddr")
 		memValue, err := strconv.ParseUint(args[4], 10, 32)
 		checkErr(err, "Error decoding memValue")
-		mem.SetUint32(uint32(memAddr), uint32(memValue))
+		mem.SetWord(uint32(memAddr), uint32(memValue))
 
 		memAddr2, err := strconv.ParseUint(args[5], 10, 32)
 		checkErr(err, "Error decoding memAddr")
@@ -444,14 +444,14 @@ func DiffTestUtils() {
 		checkErr(err, "Error decoding addr")
 		insn, err := strconv.ParseUint(args[2], 10, 32)
 		checkErr(err, "Error decoding insn")
-		mem.SetUint32(uint32(pc), uint32(insn))
+		mem.SetWord(uint32(pc), uint32(insn))
 
 		var insnProof, memProof [896]byte
 		memAddr, err := strconv.ParseUint(args[3], 10, 32)
 		checkErr(err, "Error decoding memAddr")
 		memValue, err := strconv.ParseUint(args[4], 10, 32)
 		checkErr(err, "Error decoding memValue")
-		mem.SetUint32(uint32(memAddr), uint32(memValue))
+		mem.SetWord(uint32(memAddr), uint32(memValue))
 
 		// Compute a valid proof for the root, but for the wrong leaves.
 		memProof = mem.MerkleProof(uint32(memAddr + 32))


### PR DESCRIPTION
Remove uint32 word stores from the `mipsevm.memory` interface. `SetUint32` is inflexible due to its arch-specific word-alignment constraint. This prevents tests for 32 and 64-bit VMs from using the same program counter values when writing instructions to memory.
Instead, tests should use the new `testutil.StoreInstruction` utility function to write instructions to any naturally aligned memory location.

## Meta

Fixes https://github.com/ethereum-optimism/optimism/issues/12488