### PR TITLE
op-node: Change EIP1559Params to a pointer

### DIFF
--- a/op-e2e/opgeth/op_geth.go
+++ b/op-e2e/opgeth/op_geth.go
@@ -237,7 +237,7 @@ func (d *OpGeth) CreatePayloadAttributes(txs ...*types.Transaction) (*eth.Payloa
 	}
 	if d.L2ChainConfig.IsHolocene(uint64(timestamp)) {
 		attrs.EIP1559Params = new(eth.Bytes8)
-		*attrs.EIP1559Params = d.SystemConfig.EIP1559Params
+		copy(attrs.EIP1559Params[:], d.SystemConfig.EIP1559Params[:])
 	}
 	return &attrs, nil
 }

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -161,7 +161,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	}
 	if ba.rollupCfg.IsHolocene(nextL2Time) {
 		r.EIP1559Params = new(eth.Bytes8)
-		*r.EIP1559Params = sysConfig.EIP1559Params
+		r.EIP1559Params = sysConfig.EIP1559Params
 	}
 
 	return r, nil

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -300,7 +300,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 			BatcherAddr:   common.Address{42},
 			Overhead:      [32]byte{},
 			Scalar:        [32]byte{},
-			EIP1559Params: eip1559Params,
+			EIP1559Params: &eip1559Params,
 		}
 		l1CfgFetcher.ExpectSystemConfigByL2Hash(l2Parent.Hash, testSysCfg, nil)
 		defer l1CfgFetcher.AssertExpectations(t)

--- a/op-node/rollup/derive/payload_util.go
+++ b/op-node/rollup/derive/payload_util.go
@@ -95,6 +95,7 @@ func PayloadToSystemConfig(rollupCfg *rollup.Config, payload *eth.ExecutionPaylo
 			return eth.SystemConfig{}, err
 		}
 		d, e := eip1559.DecodeHoloceneExtraData(payload.ExtraData)
+		r.EIP1559Params = new(eth.Bytes8)
 		copy(r.EIP1559Params[:], eip1559.EncodeHolocene1559Params(d, e))
 	}
 	return r, nil

--- a/op-node/rollup/derive/system_config.go
+++ b/op-node/rollup/derive/system_config.go
@@ -155,6 +155,7 @@ func ProcessSystemConfigUpdateLogEvent(destSysCfg *eth.SystemConfig, ev *types.L
 		if !solabi.EmptyReader(reader) {
 			return NewCriticalError(errors.New("too many bytes"))
 		}
+		destSysCfg.EIP1559Params = new(eth.Bytes8)
 		copy(destSysCfg.EIP1559Params[:], params[24:32])
 		return nil
 	case SystemConfigUpdateUnsafeBlockSigner:

--- a/op-node/rollup/derive/system_config_test.go
+++ b/op-node/rollup/derive/system_config_test.go
@@ -32,7 +32,8 @@ var (
 	oneUint256 = abi.Arguments{
 		{Type: uint256T},
 	}
-	eip1559Params = []byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
+	eip1559Params       = []byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
+	eip1559ParamsBytes8 = eth.Bytes8(eip1559Params)
 )
 
 // TestProcessSystemConfigUpdateLogEvent tests the parsing of an event and mutating the
@@ -204,7 +205,7 @@ func TestProcessSystemConfigUpdateLogEvent(t *testing.T) {
 				return log
 			},
 			config: eth.SystemConfig{
-				EIP1559Params: eth.Bytes8(eip1559Params),
+				EIP1559Params: &eip1559ParamsBytes8,
 			},
 			err: false,
 		},

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -419,7 +419,7 @@ type SystemConfig struct {
 	// EIP1559Params contains the Holocene-encoded EIP-1559 parameters. This
 	// value will be 0 if Holocene is not active, or if derivation has yet to
 	// process any EIP_1559_PARAMS system config update events.
-	EIP1559Params Bytes8 `json:"eip1559Params,omitempty"`
+	EIP1559Params *Bytes8 `json:"eip1559Params,omitempty"`
 	// More fields can be added for future SystemConfig versions.
 }
 


### PR DESCRIPTION
The EIP1559Params value in the SystemConfig struct is always outputted in JSON, which causes older versions of the op-node to reject rollup configs generated by this version of the code. This is annoying for users of op-deployer, who generate rollup configs for pre-Holocene chains all the time.

To resolve, I converted the field to a pointer so `omitempty` would work. `omitempty` does not work for custom types, so a pointer is necessary. In some places I needed to update assignment logic to handle the case where the field is `nil`.

Closes https://github.com/ethereum-optimism/optimism/issues/12615.
