### PR TITLE
op-node/rollup: Implement Holocene invalid payload attributes handling

### DIFF
--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -146,8 +146,8 @@ func (s *L2Batcher) Reset() {
 
 // ActL2BatchBuffer adds the next L2 block to the batch buffer.
 // If the buffer is being submitted, the buffer is wiped.
-func (s *L2Batcher) ActL2BatchBuffer(t Testing) {
-	require.NoError(t, s.Buffer(t), "failed to add block to channel")
+func (s *L2Batcher) ActL2BatchBuffer(t Testing, opts ...BlockModifier) {
+	require.NoError(t, s.Buffer(t, opts...), "failed to add block to channel")
 }
 
 type BlockModifier = func(block *types.Block)

--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -26,14 +26,13 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Alice.L2.ActCheckReceiptStatusOfLastTx(true)(t)
 
 	// Instruct the batcher to submit a faulty channel, with an invalid tx.
-	err := env.Batcher.Buffer(t, func(block *types.Block) {
+	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
 		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
 		txs[1] = newTx
 		require.NoError(t, err)
 	})
-	require.NoError(t, err)
 	env.Batcher.ActL2ChannelClose(t)
 	env.Batcher.ActL2BatchSubmit(t)
 

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -62,6 +62,7 @@ func (eq *AttributesHandler) OnEvent(ev event.Event) bool {
 		eq.onPendingSafeUpdate(x)
 	case derive.DerivedAttributesEvent:
 		eq.attributes = x.Attributes
+		eq.sentAttributes = false
 		eq.emitter.Emit(derive.ConfirmReceivedAttributesEvent{})
 		// to make sure we have a pre-state signal to process the attributes from
 		eq.emitter.Emit(engine.PendingSafeRequestEvent{})
@@ -71,7 +72,7 @@ func (eq *AttributesHandler) OnEvent(ev event.Event) bool {
 	case rollup.EngineTemporaryErrorEvent:
 		eq.sentAttributes = false
 	case engine.InvalidPayloadAttributesEvent:
-		if x.Attributes.DerivedFrom == (eth.L1BlockRef{}) {
+		if !x.Attributes.IsDerived() {
 			return true // from sequencing
 		}
 		eq.sentAttributes = false

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -27,10 +27,6 @@ import (
 // It is internally responsible for making sure that batches with L1 inclusions block outside it's
 // working range are not considered or pruned.
 
-type ChannelFlusher interface {
-	FlushChannel()
-}
-
 type NextBatchProvider interface {
 	ChannelFlusher
 	Origin() eth.L1BlockRef
@@ -269,6 +265,12 @@ func (bq *BatchQueue) Reset(_ context.Context, base eth.L1BlockRef, _ eth.System
 	bq.baseBatchStage.reset(base)
 	bq.batches = bq.batches[:0]
 	return io.EOF
+}
+
+func (bq *BatchQueue) FlushChannel() {
+	// We need to implement the ChannelFlusher interface with the BatchQueue but it's never called
+	// of which the BatchMux takes care.
+	panic("BatchQueue: invalid FlushChannel call")
 }
 
 func (bq *BatchQueue) AddBatch(ctx context.Context, batch Batch, parent eth.L2BlockRef) {

--- a/op-node/rollup/derive/channel_assembler.go
+++ b/op-node/rollup/derive/channel_assembler.go
@@ -51,6 +51,10 @@ func (ca *ChannelAssembler) Reset(context.Context, eth.L1BlockRef, eth.SystemCon
 	return io.EOF
 }
 
+func (ca *ChannelAssembler) FlushChannel() {
+	ca.resetChannel()
+}
+
 func (ca *ChannelAssembler) resetChannel() {
 	ca.channel = nil
 }

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -203,6 +203,12 @@ func (cb *ChannelBank) Reset(ctx context.Context, base eth.L1BlockRef, _ eth.Sys
 	return io.EOF
 }
 
+func (bq *ChannelBank) FlushChannel() {
+	// We need to implement the ChannelFlusher interface with the ChannelBank but it's never called
+	// of which the ChannelMux takes care.
+	panic("ChannelBank: invalid FlushChannel call")
+}
+
 type L1BlockRefByHashFetcher interface {
 	L1BlockRefByHash(context.Context, common.Hash) (eth.L1BlockRef, error)
 }

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -32,6 +32,7 @@ var (
 
 type RawChannelProvider interface {
 	ResettableStage
+	ChannelFlusher
 	Origin() eth.L1BlockRef
 	NextRawChannel(ctx context.Context) ([]byte, error)
 }
@@ -134,5 +135,5 @@ func (cr *ChannelInReader) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.Sy
 
 func (cr *ChannelInReader) FlushChannel() {
 	cr.nextBatchFn = nil
-	// TODO(12157): cr.prev.FlushChannel() - when we do wiring with ChannelStage
+	cr.prev.FlushChannel()
 }

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -64,6 +65,18 @@ func (ev PipelineStepEvent) String() string {
 	return "pipeline-step"
 }
 
+// DepositsOnlyPayloadAttributesRequestEvent requests a deposits-only version of the attributes from
+// the pipeline. It is sent by the engine deriver and received by the PipelineDeriver.
+// This event got introduced with Holocene.
+type DepositsOnlyPayloadAttributesRequestEvent struct {
+	Parent      eth.BlockID
+	DerivedFrom eth.L1BlockRef
+}
+
+func (ev DepositsOnlyPayloadAttributesRequestEvent) String() string {
+	return "deposits-only-payload-attributes-request"
+}
+
 type PipelineDeriver struct {
 	pipeline *DerivationPipeline
 
@@ -122,8 +135,7 @@ func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 			d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
 		} else {
 			if attrib != nil {
-				d.needAttributesConfirmation = true
-				d.emitter.Emit(DerivedAttributesEvent{Attributes: attrib})
+				d.emitDerivedAttributesEvent(attrib)
 			} else {
 				d.emitter.Emit(DeriverMoreEvent{}) // continue with the next step if we can
 			}
@@ -132,8 +144,21 @@ func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 		d.pipeline.ConfirmEngineReset()
 	case ConfirmReceivedAttributesEvent:
 		d.needAttributesConfirmation = false
+	case DepositsOnlyPayloadAttributesRequestEvent:
+		d.pipeline.log.Warn("Deriving deposits-only attributes", "origin", d.pipeline.Origin())
+		attrib, err := d.pipeline.DepositsOnlyAttributes(x.Parent, x.DerivedFrom)
+		if err != nil {
+			d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("deriving deposits-only attributes: %w", err)})
+			return true
+		}
+		d.emitDerivedAttributesEvent(attrib)
 	default:
 		return false
 	}
 	return true
+}
+
+func (d *PipelineDeriver) emitDerivedAttributesEvent(attrib *AttributesWithParent) {
+	d.needAttributesConfirmation = true
+	d.emitter.Emit(DerivedAttributesEvent{Attributes: attrib})
 }

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -38,6 +38,13 @@ type ResettableStage interface {
 	Reset(ctx context.Context, base eth.L1BlockRef, baseCfg eth.SystemConfig) error
 }
 
+// A ChannelFlusher flushes all internal state related to the current channel and then
+// calls FlushChannel on the stage it owns. Note that this is in contrast to Reset, which
+// is called by the owning Pipeline in a loop over all stages.
+type ChannelFlusher interface {
+	FlushChannel()
+}
+
 type ForkTransformer interface {
 	Transform(rollup.ForkName)
 }
@@ -89,16 +96,16 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 	dataSrc := NewDataSourceFactory(log, rollupCfg, l1Fetcher, l1Blobs, altDA) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, rollupCfg, l1Src)
-	bank := NewChannelMux(log, spec, frameQueue, metrics)
-	chInReader := NewChannelInReader(rollupCfg, log, bank, metrics)
-	batchQueue := NewBatchMux(log, rollupCfg, chInReader, l2Source)
+	channelMux := NewChannelMux(log, spec, frameQueue, metrics)
+	chInReader := NewChannelInReader(rollupCfg, log, channelMux, metrics)
+	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source)
 	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1Fetcher, l2Source)
-	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchQueue)
+	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux)
 
 	// Reset from ResetEngine then up from L1 Traversal. The stages do not talk to each other during
 	// the ResetEngine, but after the ResetEngine, this is the order in which the stages could talk to each other.
 	// Note: The ResetEngine is the only reset that can fail.
-	stages := []ResettableStage{l1Traversal, l1Src, altDA, frameQueue, bank, chInReader, batchQueue, attributesQueue}
+	stages := []ResettableStage{l1Traversal, l1Src, altDA, frameQueue, channelMux, chInReader, batchMux, attributesQueue}
 
 	return &DerivationPipeline{
 		log:       log,
@@ -125,6 +132,10 @@ func (dp *DerivationPipeline) Reset() {
 	dp.resetSysConfig = eth.SystemConfig{}
 	dp.resetL2Safe = eth.L2BlockRef{}
 	dp.engineIsReset = false
+}
+
+func (dp *DerivationPipeline) DepositsOnlyAttributes(parent eth.BlockID, derivedFrom eth.L1BlockRef) (*AttributesWithParent, error) {
+	return dp.attrib.DepositsOnlyAttributes(parent, derivedFrom)
 }
 
 // Origin is the L1 block of the inner-most stage of the derivation pipeline,

--- a/op-node/rollup/engine/build_invalid.go
+++ b/op-node/rollup/engine/build_invalid.go
@@ -3,10 +3,9 @@ package engine
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // BuildInvalidEvent is an internal engine event, to post-process upon invalid attributes.
@@ -33,20 +32,19 @@ func (ev InvalidPayloadAttributesEvent) String() string {
 func (eq *EngDeriver) onBuildInvalid(ev BuildInvalidEvent) {
 	eq.log.Warn("could not process payload attributes", "err", ev.Err)
 
-	// Count the number of deposits to see if the tx list is deposit only.
-	depositCount := 0
-	for _, tx := range ev.Attributes.Attributes.Transactions {
-		if len(tx) > 0 && tx[0] == types.DepositTxType {
-			depositCount += 1
-		}
-	}
 	// Deposit transaction execution errors are suppressed in the execution engine, but if the
 	// block is somehow invalid, there is nothing we can do to recover & we should exit.
-	if len(ev.Attributes.Attributes.Transactions) == depositCount {
+	if ev.Attributes.Attributes.IsDepositsOnly() {
 		eq.log.Error("deposit only block was invalid", "parent", ev.Attributes.Parent, "err", ev.Err)
 		eq.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("failed to process block with only deposit transactions: %w", ev.Err)})
 		return
 	}
+
+	if ev.Attributes.IsDerived() && eq.cfg.IsHolocene(ev.Attributes.DerivedFrom.Time) {
+		eq.emitDepositsOnlyPayloadAttributesRequest(ev.Attributes.Parent.ID(), ev.Attributes.DerivedFrom)
+		return
+	}
+
 	// Revert the pending safe head to the safe head.
 	eq.ec.SetPendingSafeL2Head(eq.ec.SafeL2Head())
 	// suppress the error b/c we want to retry with the next batch from the batch queue
@@ -60,4 +58,13 @@ func (eq *EngDeriver) onBuildInvalid(ev BuildInvalidEvent) {
 
 	// Signal that we deemed the attributes as unfit
 	eq.emitter.Emit(InvalidPayloadAttributesEvent(ev))
+}
+
+func (eq *EngDeriver) emitDepositsOnlyPayloadAttributesRequest(parent eth.BlockID, derivedFrom eth.L1BlockRef) {
+	eq.log.Warn("Holocene active, requesting deposits-only attributes", "parent", parent, "derived_from", derivedFrom)
+	// request deposits-only version
+	eq.emitter.Emit(derive.DepositsOnlyPayloadAttributesRequestEvent{
+		Parent:      parent,
+		DerivedFrom: derivedFrom,
+	})
 }

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -25,8 +25,7 @@ type Metrics interface {
 // forkchoice-update event, to signal the latest forkchoice to other derivers.
 // This helps decouple derivers from the actual engine state,
 // while also not making the derivers wait for a forkchoice update at random.
-type ForkchoiceRequestEvent struct {
-}
+type ForkchoiceRequestEvent struct{}
 
 func (ev ForkchoiceRequestEvent) String() string {
 	return "forkchoice-request"
@@ -184,8 +183,7 @@ func (ev ProcessAttributesEvent) String() string {
 	return "process-attributes"
 }
 
-type PendingSafeRequestEvent struct {
-}
+type PendingSafeRequestEvent struct{}
 
 func (ev PendingSafeRequestEvent) String() string {
 	return "pending-safe-request"
@@ -199,15 +197,13 @@ func (ev ProcessUnsafePayloadEvent) String() string {
 	return "process-unsafe-payload"
 }
 
-type TryBackupUnsafeReorgEvent struct {
-}
+type TryBackupUnsafeReorgEvent struct{}
 
 func (ev TryBackupUnsafeReorgEvent) String() string {
 	return "try-backup-unsafe-reorg"
 }
 
-type TryUpdateEngineEvent struct {
-}
+type TryUpdateEngineEvent struct{}
 
 func (ev TryUpdateEngineEvent) String() string {
 	return "try-update-engine"
@@ -277,7 +273,8 @@ type EngDeriver struct {
 var _ event.Deriver = (*EngDeriver)(nil)
 
 func NewEngDeriver(log log.Logger, ctx context.Context, cfg *rollup.Config,
-	metrics Metrics, ec *EngineController) *EngDeriver {
+	metrics Metrics, ec *EngineController,
+) *EngDeriver {
 	return &EngDeriver{
 		log:     log,
 		cfg:     cfg,
@@ -471,10 +468,10 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 		d.onBuildStart(x)
 	case BuildStartedEvent:
 		d.onBuildStarted(x)
-	case BuildSealedEvent:
-		d.onBuildSealed(x)
 	case BuildSealEvent:
 		d.onBuildSeal(x)
+	case BuildSealedEvent:
+		d.onBuildSealed(x)
 	case BuildInvalidEvent:
 		d.onBuildInvalid(x)
 	case BuildCancelEvent:

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -36,8 +36,8 @@ func (eq *EngDeriver) onPayloadProcess(ev PayloadProcessEvent) {
 	}
 	switch status.Status {
 	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
-		// TODO: I'm not sure how derivation can reach this point. By my understand, it would
-		// already fail earlier during the FCU call.
+		// Depending on execution engine, not all block-validity checks run immediately on build-start
+		// at the time of the forkchoiceUpdated engine-API call, nor during getPayload.
 		if ev.DerivedFrom != (eth.L1BlockRef{}) && eq.cfg.IsHolocene(ev.DerivedFrom.Time) {
 			eq.emitDepositsOnlyPayloadAttributesRequest(ev.Ref.ParentID(), ev.DerivedFrom)
 			return

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -30,21 +30,31 @@ func (eq *EngDeriver) onPayloadProcess(ev PayloadProcessEvent) {
 		ev.Envelope.ExecutionPayload, ev.Envelope.ParentBeaconBlockRoot)
 	if err != nil {
 		eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{
-			Err: fmt.Errorf("failed to insert execution payload: %w", err)})
+			Err: fmt.Errorf("failed to insert execution payload: %w", err),
+		})
 		return
 	}
 	switch status.Status {
 	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
+		// TODO: I'm not sure how derivation can reach this point. By my understand, it would
+		// already fail earlier during the FCU call.
+		if ev.DerivedFrom != (eth.L1BlockRef{}) && eq.cfg.IsHolocene(ev.DerivedFrom.Time) {
+			eq.emitDepositsOnlyPayloadAttributesRequest(ev.Ref.ParentID(), ev.DerivedFrom)
+			return
+		}
+
 		eq.emitter.Emit(PayloadInvalidEvent{
 			Envelope: ev.Envelope,
-			Err:      eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status)})
+			Err:      eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+		})
 		return
 	case eth.ExecutionValid:
 		eq.emitter.Emit(PayloadSuccessEvent(ev))
 		return
 	default:
 		eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{
-			Err: eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status)})
+			Err: eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+		})
 		return
 	}
 }

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -358,6 +358,31 @@ type PayloadAttributes struct {
 	EIP1559Params *Bytes8 `json:"eip1559Params,omitempty"`
 }
 
+// IsDepositsOnly returns whether all transactions of the PayloadAttributes are of Deposit
+// type. Empty transactions are also considered non-Deposit transactions.
+func (a *PayloadAttributes) IsDepositsOnly() bool {
+	for _, tx := range a.Transactions {
+		if len(tx) == 0 || tx[0] != types.DepositTxType {
+			return false
+		}
+	}
+	return true
+}
+
+// WithDepositsOnly return a shallow clone with all non-Deposit transactions stripped from its
+// transactions. The order is preserved.
+func (a *PayloadAttributes) WithDepositsOnly() *PayloadAttributes {
+	clone := *a
+	depositTxs := make([]Data, 0, len(a.Transactions))
+	for _, tx := range a.Transactions {
+		if len(tx) > 0 && tx[0] == types.DepositTxType {
+			depositTxs = append(depositTxs, tx)
+		}
+	}
+	clone.Transactions = depositTxs
+	return &clone
+}
+
 type ExecutePayloadStatus string
 
 const (


### PR DESCRIPTION
**Description**

Implements the remaining Holocene derivation feature: invalid payload attribute replacement with a deposits-only (DO) version.

The current approach is to request a DO version of the invalid payload attributes from the engine deriver, by having the `BuildInvalidEvent` handler emit a new `DepositsOnlyPayloadAttributesRequestEvent` that is directly processed by the pipeline deriver. It doesn't reset the pending safe, as before, but gives this DO version a second chance. The DO request event is handled by the pipeline as following:
- The pipeline deriver requests the DO version of the last attributes from the attributes queue stage.
    - The attributes queue performs a few sanity checks,
    - flushes the current channel of the previous stages (this is a new Holocene derivation rule),
    - and then returns the DO-version of the last attributes.
- The pipeline deriver emits a regular `DerivedAttributesEvent` with the DO-version of the attributes, which is then processed by the `AttributesHandler`, as before, and so enters the regular attributes derivation flow.
- These new attributes land in the engine deriver via the usual `PendingSafeRequestEvent`->`PendingSafeUpdateEvent`->`BuildStartEvent` flow.
- If the DO-version is still invalid, as before, this is a critical pipeline error and the program stops.
- Because the new `DepositsOnlyPayloadAttributesRequestEvent` is directly processed by the pipeline deriver, the `ProgramDeriver` of the op-program just works™️.

This approach breaks with the current invariant to not have the pipeline and engine derivers talk to each other directly, only via the attributes deriver, or the program deriver in the case of the fault proof program. The reason this approach was taken is that this makes it work automatically with the op-program's program deriver. The program deriver otherwise has to reimplement the attributes handler deriver logic, which felt like a less scalable and brittle approach. Since the DO-attributes request is also directly addressed to the pipeline, this seems clean.

Changes to pending safe/safe promotion are done in [follow-up work](https://github.com/ethereum-optimism/optimism/issues/12695).

**Tests**

Added an action test `TestHoloceneInvalidPayload` that shows the correct derivation behavior upon finding an invalid payload.

**Additional context**

I started a flow diagram on how the different derivers interact with each other [here](https://www.figma.com/board/X5wMQPwDjin7UepQLs243l/Derivation-Deriver-Flow?node-id=0-1&t=k6JVFUrF8yOk92no-1).

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/11316
