### PR TITLE
feat(ct): add semgrep rule to use encodeCall

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
@@ -570,9 +570,7 @@ contract DeployImplementations is Script {
             OPContractsManager.InitializerInputs(_blueprints, _setters, _release, true);
 
         vm.startBroadcast(msg.sender);
-        proxy.upgradeToAndCall(
-            address(opcmImpl), abi.encodeWithSelector(opcmImpl.initialize.selector, initializerInputs)
-        );
+        proxy.upgradeToAndCall(address(opcmImpl), abi.encodeCall(opcmImpl.initialize, (initializerInputs)));
 
         proxy.changeAdmin(address(opcmProxyOwner)); // transfer ownership of Proxy contract to the ProxyAdmin contract
         vm.stopBroadcast();
@@ -1146,9 +1144,7 @@ contract DeployImplementationsInterop is DeployImplementations {
             OPContractsManager.InitializerInputs(_blueprints, _setters, _release, true);
 
         vm.startBroadcast(msg.sender);
-        proxy.upgradeToAndCall(
-            address(opcmImpl), abi.encodeWithSelector(opcmImpl.initialize.selector, initializerInputs)
-        );
+        proxy.upgradeToAndCall(address(opcmImpl), abi.encodeCall(opcmImpl.initialize, (initializerInputs)));
 
         proxy.changeAdmin(opcmProxyOwner); // transfer ownership of Proxy contract to the ProxyAdmin contract
         vm.stopBroadcast();

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -12,8 +12,8 @@
     "sourceCodeHash": "0x848ec3774be17bcc8ba65a23d08e35e979b3f39f9d2ac8a810188f945c69c9ea"
   },
   "src/L1/L1ERC721Bridge.sol": {
-    "initCodeHash": "0x63dc4da75200f4b968f57e27e81834e6eb3f6625826410882526ab1eec7847ff",
-    "sourceCodeHash": "0xfec29cfbb7aa05473e32a6c2484deebfc1ff50c0e08c42e8ee70696ad701ceaa"
+    "initCodeHash": "0xb3bf093ea83a24574a6093bebf5b2aea707355ed8d6702b2b5eb292e75b6ae42",
+    "sourceCodeHash": "0x289de9f40898b6305deecc6b60cdf566aa6c6a1444f713c3a0af23ea7878207e"
   },
   "src/L1/L1StandardBridge.sol": {
     "initCodeHash": "0x2868b09ecbe9f2bbc885605c2886b4c79f1c8e4171626c63776603b1b84698a8",
@@ -88,8 +88,8 @@
     "sourceCodeHash": "0x56edf0f36366326a92722ae3c7502bce3d80b2ee5e354181dc09ba801437a488"
   },
   "src/L2/L2ERC721Bridge.sol": {
-    "initCodeHash": "0x558fff5939a26b9d5d86e6b907d9dd9c7c917eaef7657a8b5acfeb58de1442f0",
-    "sourceCodeHash": "0xca9acd19fd5f42e6a7a5b1de6359f2d841814fb54d377664c2fe9c3f9c6be34a"
+    "initCodeHash": "0xb8236514beabcc1830e5e7e9eccb965e30d01f8bbb5a2d8b4f3d241c2d12819b",
+    "sourceCodeHash": "0x268e34289b7b8a5d1785af1907bd07d1c8ce4a9e3ea1685bdd9a77904dab3557"
   },
   "src/L2/L2StandardBridge.sol": {
     "initCodeHash": "0x651eed10044d0b19b7e4eba864345df15e252be1401f39a552ec0d2f9c4df064",

--- a/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
@@ -28,8 +28,8 @@ contract L1ERC721Bridge is ERC721Bridge, ISemver {
     ISuperchainConfig public superchainConfig;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.1.1-beta.4
-    string public constant version = "2.1.1-beta.4";
+    /// @custom:semver 2.2.0-beta.1
+    string public constant version = "2.2.0-beta.1";
 
     /// @notice Constructs the L1ERC721Bridge contract.
     constructor() ERC721Bridge() {
@@ -107,8 +107,8 @@ contract L1ERC721Bridge is ERC721Bridge, ISemver {
         require(_remoteToken != address(0), "L1ERC721Bridge: remote token cannot be address(0)");
 
         // Construct calldata for _l2Token.finalizeBridgeERC721(_to, _tokenId)
-        bytes memory message = abi.encodeWithSelector(
-            IL2ERC721Bridge.finalizeBridgeERC721.selector, _remoteToken, _localToken, _from, _to, _tokenId, _extraData
+        bytes memory message = abi.encodeCall(
+            IL2ERC721Bridge.finalizeBridgeERC721, (_remoteToken, _localToken, _from, _to, _tokenId, _extraData)
         );
 
         // Lock token into bridge

--- a/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
@@ -26,8 +26,8 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 ///         wait for the one-week challenge period to elapse before their Optimism-native NFT
 ///         can be refunded on L2.
 contract L2ERC721Bridge is ERC721Bridge, ISemver {
-    /// @custom:semver 1.7.1-beta.3
-    string public constant version = "1.7.1-beta.3";
+    /// @custom:semver 1.8.0-beta.1
+    string public constant version = "1.8.0-beta.1";
 
     /// @notice Constructs the L2ERC721Bridge contract.
     constructor() ERC721Bridge() {
@@ -117,8 +117,8 @@ contract L2ERC721Bridge is ERC721Bridge, ISemver {
         // slither-disable-next-line reentrancy-events
         IOptimismMintableERC721(_localToken).burn(_from, _tokenId);
 
-        bytes memory message = abi.encodeWithSelector(
-            IL1ERC721Bridge.finalizeBridgeERC721.selector, remoteToken, _localToken, _from, _to, _tokenId, _extraData
+        bytes memory message = abi.encodeCall(
+            IL1ERC721Bridge.finalizeBridgeERC721, (remoteToken, _localToken, _from, _to, _tokenId, _extraData)
         );
 
         // Send message to L1 bridge

--- a/semgrep/sol-rules.yaml
+++ b/semgrep/sol-rules.yaml
@@ -129,9 +129,6 @@ rules:
     paths:
       exclude:
         - packages/contracts-bedrock/test
-        - packages/contracts-bedrock/scripts/DeployImplementations.s.sol
-        - packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
         - packages/contracts-bedrock/src/L1/OPContractsManager.sol
         - packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
-        - packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
         - packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol

--- a/semgrep/sol-rules.yaml
+++ b/semgrep/sol-rules.yaml
@@ -118,3 +118,20 @@ rules:
       exclude:
         - packages/contracts-bedrock/test
         - packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+
+  - id: sol-style-use-abi-encodecall
+    languages: [solidity]
+    severity: ERROR
+    message: Use abi.encodeCall instead of abi.encodeWithSelector
+    patterns:
+      - pattern: |
+          abi.encodeWithSelector(...);
+    paths:
+      exclude:
+        - packages/contracts-bedrock/test
+        - packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+        - packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+        - packages/contracts-bedrock/src/L1/OPContractsManager.sol
+        - packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
+        - packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
+        - packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol


### PR DESCRIPTION
encodeCall is almost always better than encodeWithSelector because
it maintains type safety. Prefer encodeCall unless
encodeWithSelector is actually necessary.