### PR TITLE
chore(op-e2e): Run `BadTxInBatch` tests on Granite only

### DIFF
--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -144,14 +144,14 @@ func Test_ProgramAction_BadTxInBatch(gt *testing.T) {
 	matrix.AddTestCase(
 		"HonestClaim",
 		nil,
-		helpers.LatestForkOnly,
+		helpers.NewForkMatrix(helpers.Granite),
 		runBadTxInBatchTest,
 		helpers.ExpectNoError(),
 	)
 	matrix.AddTestCase(
 		"JunkClaim",
 		nil,
-		helpers.LatestForkOnly,
+		helpers.NewForkMatrix(helpers.Granite),
 		runBadTxInBatchTest,
 		helpers.ExpectError(claim.ErrClaimNotValid),
 		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
@@ -159,14 +159,14 @@ func Test_ProgramAction_BadTxInBatch(gt *testing.T) {
 	matrix.AddTestCase(
 		"ResubmitBadFirstFrame-HonestClaim",
 		nil,
-		helpers.LatestForkOnly,
+		helpers.NewForkMatrix(helpers.Granite),
 		runBadTxInBatch_ResubmitBadFirstFrame_Test,
 		helpers.ExpectNoError(),
 	)
 	matrix.AddTestCase(
 		"ResubmitBadFirstFrame-JunkClaim",
 		nil,
-		helpers.LatestForkOnly,
+		helpers.NewForkMatrix(helpers.Granite),
 		runBadTxInBatch_ResubmitBadFirstFrame_Test,
 		helpers.ExpectError(claim.ErrClaimNotValid),
 		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),


### PR DESCRIPTION
## Overview

Runs the `BadTxInBatch` action tests against Granite only. These will start to fail once the reference implementation implements the [Holocene `EngineQueue` modifications](https://specs.optimism.io/protocol/holocene/derivation.html#engine-queue), since they all submit a payload that has an invalid user-space transaction. When the engine rejects that payload, the rollup node must re-submit the payload attributes with only the deposit transactions. So, in these test cases, the formerly bad payload would actually be accepted as a deposit-only block.

We should however keep these tests to back-test against <= Granite derivation functionality, and make new ones to cover the new Holocene behavior.
