### PR TITLE
op-e2e: Fix how output_cannon_test waits for resolved game status

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -252,9 +252,7 @@ func testOutputCannonDefendStep(t *testing.T, allocType config.AllocType) {
 	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
-	game.WaitForInactivity(ctx, 10, true)
-	game.LogGameData(ctx)
-	require.EqualValues(t, gameTypes.GameStatusChallengerWon, game.Status(ctx))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
 }
 
 func TestOutputCannonStepWithLargePreimage_Standard(t *testing.T) {
@@ -502,9 +500,7 @@ func testOutputCannonProposedOutputRootValid(t *testing.T, allocType config.Allo
 			sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
 			require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
-			game.WaitForInactivity(ctx, 10, true)
-			game.LogGameData(ctx)
-			require.EqualValues(t, gameTypes.GameStatusDefenderWon, game.Status(ctx))
+			game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
 		})
 	}
 }
@@ -1003,9 +999,7 @@ func testOutputCannonHonestSafeTraceExtensionValidRoot(t *testing.T, allocType c
 	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
-	game.WaitForInactivity(ctx, 10, true)
-	game.LogGameData(ctx)
-	require.EqualValues(t, gameTypes.GameStatusDefenderWon, game.Status(ctx))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
 }
 
 func TestOutputCannonHonestSafeTraceExtension_InvalidRoot_Standard(t *testing.T) {
@@ -1052,9 +1046,7 @@ func testOutputCannonHonestSafeTraceExtensionInvalidRoot(t *testing.T, allocType
 	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
-	game.WaitForInactivity(ctx, 10, true)
-	game.LogGameData(ctx)
-	require.EqualValues(t, gameTypes.GameStatusChallengerWon, game.Status(ctx))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
 }
 
 func TestAgreeFirstBlockWithOriginOf1_Standard(t *testing.T) {


### PR DESCRIPTION
**Description**

Fixes flakiness in output_cannon_test caused by it waiting a fixed number of L1 blocks for inactivity rather than waiting for the game to actually be resolved. When the system is overloaded (e.g. after we just time travelled so we can resolve games...) the inactivity can be reached before the game is finished being resolved.