### PR TITLE
do `forge clean` when `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ mod-tidy: ## Cleans up unused dependencies in Go modules
 
 clean: ## Removes all generated files under bin/
 	rm -rf ./bin
+	cd packages/contracts-bedrock/ && forge clean
 .PHONY: clean
 
 nuke: clean devnet-clean ## Completely clean the project directory


### PR DESCRIPTION
`clean` target is a good place to do `forge clean`.

Currently each time I switch the branch, I have to manually run `forge clean` under `packages/contracts-bedrock`.