### PR TITLE
Interop: Fix DerivedFrom Client Signature

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
@@ -137,8 +136,8 @@ func TestInteropVerifier(gt *testing.T) {
 		out.Cross = request.Local
 		return out, nil
 	}
-	seqMockBackend.DerivedFromFn = func(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.L1BlockRef, error) {
-		require.Equal(t, uint64(1), blockNumber)
+	seqMockBackend.DerivedFromFn = func(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
+		require.Equal(t, uint64(1), derived.Number)
 		return l1Head, nil
 	}
 	seqMockBackend.FinalizedFn = func(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {

--- a/op-node/rollup/interop/interop.go
+++ b/op-node/rollup/interop/interop.go
@@ -25,7 +25,7 @@ type InteropBackend interface {
 	SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error)
 	Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
 
-	DerivedFrom(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.L1BlockRef, error)
+	DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error)
 
 	UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error
 	UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error
@@ -220,7 +220,11 @@ func (d *InteropDeriver) onCrossSafeUpdateEvent(x engine.CrossSafeUpdateEvent) e
 		//  and then reset derivation, so this op-node can help get the supervisor back in sync.
 		return nil
 	}
-	derivedFrom, err := d.backend.DerivedFrom(ctx, d.chainID, result.Cross.Hash, result.Cross.Number)
+	derived := eth.BlockID{
+		Hash:   result.Cross.Hash,
+		Number: result.Cross.Number,
+	}
+	derivedFrom, err := d.backend.DerivedFrom(ctx, d.chainID, derived)
 	if err != nil {
 		return fmt.Errorf("failed to get derived-from of %s: %w", result.Cross, err)
 	}

--- a/op-node/rollup/interop/interop_test.go
+++ b/op-node/rollup/interop/interop_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -114,7 +115,11 @@ func TestInteropDeriver(t *testing.T) {
 			Cross: nextCrossSafe.ID(),
 		}
 		interopBackend.ExpectSafeView(chainID, localView, supervisorView, nil)
-		interopBackend.ExpectDerivedFrom(chainID, nextCrossSafe.Hash, nextCrossSafe.Number, derivedFrom, nil)
+		derived := eth.BlockID{
+			Hash:   nextCrossSafe.Hash,
+			Number: nextCrossSafe.Number,
+		}
+		interopBackend.ExpectDerivedFrom(chainID, derived, derivedFrom, nil)
 		l2Source.ExpectL2BlockRefByHash(nextCrossSafe.Hash, nextCrossSafe, nil)
 		emitter.ExpectOnce(engine.PromoteSafeEvent{
 			Ref:         nextCrossSafe,

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -99,9 +97,9 @@ func (cl *SupervisorClient) Finalized(ctx context.Context, chainID types.ChainID
 	return result, err
 }
 
-func (cl *SupervisorClient) DerivedFrom(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.L1BlockRef, error) {
+func (cl *SupervisorClient) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
 	var result eth.L1BlockRef
-	err := cl.client.CallContext(ctx, &result, "supervisor_derivedFrom", chainID, blockHash, blockNumber)
+	err := cl.client.CallContext(ctx, &result, "supervisor_derivedFrom", chainID, derived)
 	return result, err
 }
 

--- a/op-service/testutils/fake_interop_backend.go
+++ b/op-service/testutils/fake_interop_backend.go
@@ -3,8 +3,6 @@ package testutils
 import (
 	"context"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -13,7 +11,7 @@ type FakeInteropBackend struct {
 	UnsafeViewFn        func(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error)
 	SafeViewFn          func(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error)
 	FinalizedFn         func(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
-	DerivedFromFn       func(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.L1BlockRef, error)
+	DerivedFromFn       func(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error)
 	UpdateLocalUnsafeFn func(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error
 	UpdateLocalSafeFn   func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error
 	UpdateFinalizedL1Fn func(ctx context.Context, chainID types.ChainID, finalized eth.L1BlockRef) error
@@ -31,8 +29,8 @@ func (m *FakeInteropBackend) Finalized(ctx context.Context, chainID types.ChainI
 	return m.FinalizedFn(ctx, chainID)
 }
 
-func (m *FakeInteropBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.L1BlockRef, error) {
-	return m.DerivedFromFn(ctx, chainID, blockHash, blockNumber)
+func (m *FakeInteropBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
+	return m.DerivedFromFn(ctx, chainID, derived)
 }
 
 func (m *FakeInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {

--- a/op-service/testutils/mock_interop_backend.go
+++ b/op-service/testutils/mock_interop_backend.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -60,13 +58,13 @@ func (m *MockInteropBackend) ExpectFinalized(chainID types.ChainID, result eth.B
 	m.Mock.On("Finalized", chainID).Once().Return(result, &err)
 }
 
-func (m *MockInteropBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, blockHash common.Hash, blockNumber uint64) (eth.L1BlockRef, error) {
-	result := m.Mock.MethodCalled("DerivedFrom", chainID, blockHash, blockNumber)
+func (m *MockInteropBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
+	result := m.Mock.MethodCalled("DerivedFrom", chainID, derived)
 	return result.Get(0).(eth.L1BlockRef), *result.Get(1).(*error)
 }
 
-func (m *MockInteropBackend) ExpectDerivedFrom(chainID types.ChainID, blockHash common.Hash, blockNumber uint64, result eth.L1BlockRef, err error) {
-	m.Mock.On("DerivedFrom", chainID, blockHash, blockNumber).Once().Return(result, &err)
+func (m *MockInteropBackend) ExpectDerivedFrom(chainID types.ChainID, derived eth.BlockID, result eth.L1BlockRef, err error) {
+	m.Mock.On("DerivedFrom", chainID, derived).Once().Return(result, &err)
 }
 
 func (m *MockInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {


### PR DESCRIPTION
The signature used by clients to call DerivedFrom needed to be updated to BlockID.