### PR TITLE
moving AnchorStateRegistryImplAddress to ImplementationsDeployment

### DIFF
--- a/op-deployer/pkg/deployer/inspect/l1.go
+++ b/op-deployer/pkg/deployer/inspect/l1.go
@@ -36,7 +36,6 @@ type OpChainDeployment struct {
 	OptimismPortalProxyAddress               common.Address `json:"optimismPortalProxyAddress"`
 	DisputeGameFactoryProxyAddress           common.Address `json:"disputeGameFactoryProxyAddress"`
 	AnchorStateRegistryProxyAddress          common.Address `json:"anchorStateRegistryProxyAddress"`
-	AnchorStateRegistryImplAddress           common.Address `json:"anchorStateRegistryImplAddress"`
 	// FaultDisputeGameAddress                  common.Address `json:"faultDisputeGameAddress"`
 	PermissionedDisputeGameAddress          common.Address `json:"permissionedDisputeGameAddress"`
 	DelayedWETHPermissionedGameProxyAddress common.Address `json:"delayedWETHPermissionedGameProxyAddress"`
@@ -55,6 +54,7 @@ type ImplementationsDeployment struct {
 	L1StandardBridgeImplAddress             common.Address `json:"l1StandardBridgeImplAddress"`
 	OptimismMintableERC20FactoryImplAddress common.Address `json:"optimismMintableERC20FactoryImplAddress"`
 	DisputeGameFactoryImplAddress           common.Address `json:"disputeGameFactoryImplAddress"`
+	AnchorStateRegistryImplAddress          common.Address `json:"anchorStateRegistryImplAddress"`
 }
 
 func L1CLI(cliCtx *cli.Context) error {
@@ -92,7 +92,6 @@ func L1CLI(cliCtx *cli.Context) error {
 			OptimismPortalProxyAddress:               chainState.OptimismPortalProxyAddress,
 			DisputeGameFactoryProxyAddress:           chainState.DisputeGameFactoryProxyAddress,
 			AnchorStateRegistryProxyAddress:          chainState.AnchorStateRegistryProxyAddress,
-			AnchorStateRegistryImplAddress:           chainState.AnchorStateRegistryImplAddress,
 			// FaultDisputeGameAddress:                  chainState.FaultDisputeGameAddress,
 			PermissionedDisputeGameAddress:          chainState.PermissionedDisputeGameAddress,
 			DelayedWETHPermissionedGameProxyAddress: chainState.DelayedWETHPermissionedGameProxyAddress,
@@ -110,6 +109,7 @@ func L1CLI(cliCtx *cli.Context) error {
 			L1StandardBridgeImplAddress:             globalState.ImplementationsDeployment.L1StandardBridgeImplAddress,
 			OptimismMintableERC20FactoryImplAddress: globalState.ImplementationsDeployment.OptimismMintableERC20FactoryImplAddress,
 			DisputeGameFactoryImplAddress:           globalState.ImplementationsDeployment.DisputeGameFactoryImplAddress,
+			AnchorStateRegistryImplAddress:          globalState.ImplementationsDeployment.AnchorStateRegistryImplAddress,
 		},
 	}
 

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -207,7 +207,6 @@ func makeChainState(chainID common.Hash, dco opcm.DeployOPChainOutput) *state.Ch
 		OptimismPortalProxyAddress:                dco.OptimismPortalProxy,
 		DisputeGameFactoryProxyAddress:            dco.DisputeGameFactoryProxy,
 		AnchorStateRegistryProxyAddress:           dco.AnchorStateRegistryProxy,
-		AnchorStateRegistryImplAddress:            dco.AnchorStateRegistryImpl,
 		FaultDisputeGameAddress:                   dco.FaultDisputeGame,
 		PermissionedDisputeGameAddress:            dco.PermissionedDisputeGame,
 		DelayedWETHPermissionedGameProxyAddress:   dco.DelayedWETHPermissionedGameProxy,

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -75,6 +75,7 @@ type ImplementationsDeployment struct {
 	L1StandardBridgeImplAddress             common.Address `json:"l1StandardBridgeImplAddress"`
 	OptimismMintableERC20FactoryImplAddress common.Address `json:"optimismMintableERC20FactoryImplAddress"`
 	DisputeGameFactoryImplAddress           common.Address `json:"disputeGameFactoryImplAddress"`
+	AnchorStateRegistryImplAddress          common.Address `json:"anchorStateRegistryImplAddress"`
 }
 
 type ChainState struct {
@@ -90,7 +91,6 @@ type ChainState struct {
 	OptimismPortalProxyAddress                common.Address `json:"optimismPortalProxyAddress"`
 	DisputeGameFactoryProxyAddress            common.Address `json:"disputeGameFactoryProxyAddress"`
 	AnchorStateRegistryProxyAddress           common.Address `json:"anchorStateRegistryProxyAddress"`
-	AnchorStateRegistryImplAddress            common.Address `json:"anchorStateRegistryImplAddress"`
 	FaultDisputeGameAddress                   common.Address `json:"faultDisputeGameAddress"`
 	PermissionedDisputeGameAddress            common.Address `json:"permissionedDisputeGameAddress"`
 	DelayedWETHPermissionedGameProxyAddress   common.Address `json:"delayedWETHPermissionedGameProxyAddress"`


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

While trying out the deployer tool, I noticed that `AnchorStateRegistryImplAddress` was grouped with all the proxy addresses. You can use the following command on a deployed network `state.json` to see what I mean:

```
../bin/op-deployer inspect l1 12345

{
...
  "opChainDeployment": {
    ...
    "anchorStateRegistryProxyAddress": "0x3c46febda48ac5e6293a07340a020083df151eb8",
 >  "anchorStateRegistryImplAddress": "0x0000000000000000000000000000000000000000"
    ...
  },
  "implementationsDeployment": {
     ...
  }
}
```

This PR changes the output to:

```
{
  "superchainDeployment": {
    ...
  },
  "opChainDeployment": {
   ...
  },
  "implementationsDeployment": {
    ...
 >  "anchorStateRegistryImplAddress": "0x0000000000000000000000000000000000000000"
  }
}
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

I'm not sure how to test this

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
