### PR TITLE
cannon: Detect input/output codec mismatch before trace execution

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -279,6 +279,9 @@ func Run(ctx *cli.Context) error {
 	if ctx.Bool(RunPProfCPU.Name) {
 		defer profile.Start(profile.NoShutdownHook, profile.ProfilePath("."), profile.CPUProfile).Stop()
 	}
+	if err := checkFlags(ctx); err != nil {
+		return err
+	}
 
 	guestLogger := Logger(os.Stderr, log.LevelInfo)
 	outLog := &mipsevm.LoggingWriter{Log: guestLogger.With("module", "guest", "stream", "stdout")}
@@ -524,3 +527,13 @@ func CreateRunCommand(action cli.ActionFunc) *cli.Command {
 }
 
 var RunCommand = CreateRunCommand(Run)
+
+func checkFlags(ctx *cli.Context) error {
+	if output := ctx.Path(RunOutputFlag.Name); output != "" {
+		input := ctx.Path(RunInputFlag.Name)
+		if serialize.IsBinaryFile(input) != serialize.IsBinaryFile(output) {
+			return errors.New("Invalid --input and --output flags. Their file formats must be identical")
+		}
+	}
+	return nil
+}

--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -531,12 +531,12 @@ var RunCommand = CreateRunCommand(Run)
 func checkFlags(ctx *cli.Context) error {
 	if output := ctx.Path(RunOutputFlag.Name); output != "" {
 		if !serialize.IsBinaryFile(output) {
-			return errors.New("Invalid --output file format. Only binary file formats (ending in .bin or bin.gz) are supported")
+			return errors.New("invalid --output file format. Only binary file formats (ending in .bin or bin.gz) are supported")
 		}
 	}
 	if snapshotFmt := ctx.String(RunSnapshotFmtFlag.Name); snapshotFmt != "" {
 		if !serialize.IsBinaryFile(fmt.Sprintf(snapshotFmt, 0)) {
-			return errors.New("Invalid --snapshot-fmt file format. Only binary file formats (ending in .bin or bin.gz) are supported")
+			return errors.New("invalid --snapshot-fmt file format. Only binary file formats (ending in .bin or bin.gz) are supported")
 		}
 	}
 	return nil

--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -29,16 +29,16 @@ import (
 var (
 	RunInputFlag = &cli.PathFlag{
 		Name:      "input",
-		Usage:     "path of input JSON state. Stdin if left empty.",
+		Usage:     "path of input binary state. Stdin if left empty.",
 		TakesFile: true,
-		Value:     "state.json",
+		Value:     "state.bin.gz",
 		Required:  true,
 	}
 	RunOutputFlag = &cli.PathFlag{
 		Name:      "output",
-		Usage:     "path of output JSON state. Not written if empty, use - to write to Stdout.",
+		Usage:     "path of output binary state. Not written if empty, use - to write to Stdout.",
 		TakesFile: true,
-		Value:     "out.json",
+		Value:     "out.bin.gz",
 		Required:  false,
 	}
 	patternHelp    = "'never' (default), 'always', '=123' at exactly step 123, '%123' for every 123 steps"
@@ -63,7 +63,7 @@ var (
 	RunSnapshotFmtFlag = &cli.StringFlag{
 		Name:     "snapshot-fmt",
 		Usage:    "format for snapshot output file names.",
-		Value:    "state-%d.json",
+		Value:    "state-%d.bin.gz",
 		Required: false,
 	}
 	RunStopAtFlag = &cli.GenericFlag{
@@ -530,9 +530,13 @@ var RunCommand = CreateRunCommand(Run)
 
 func checkFlags(ctx *cli.Context) error {
 	if output := ctx.Path(RunOutputFlag.Name); output != "" {
-		input := ctx.Path(RunInputFlag.Name)
-		if serialize.IsBinaryFile(input) != serialize.IsBinaryFile(output) {
-			return errors.New("Invalid --input and --output flags. Their file formats must be identical")
+		if !serialize.IsBinaryFile(output) {
+			return errors.New("Invalid --output file format. Only binary file formats (ending in .bin or bin.gz) are supported")
+		}
+	}
+	if snapshotFmt := ctx.String(RunSnapshotFmtFlag.Name); snapshotFmt != "" {
+		if !serialize.IsBinaryFile(fmt.Sprintf(snapshotFmt, 0)) {
+			return errors.New("Invalid --snapshot-fmt file format. Only binary file formats (ending in .bin or bin.gz) are supported")
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously, when running cannon with mismatched input and output formats (ex: `--input x.bin.gz --output x.json`), an error would only surface after the entire trace completed execution, which could take hours.

The error occurs because state version codecs support either binary encoding (via `Serializable` interface) or JSON, but not both. The mismatch between input/output formats would only be detected during the write to the `--output` at the end of a run.

This patch adds upfront validation of the input and output file extensions to fail fast when incompatible formats are specified, preventing wasted computation time.