### PR TITLE
op-deployer: use dev keys for vaults in new intent

### DIFF
--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -118,9 +118,9 @@ func Init(cfg InitConfig) error {
 		l2ChainIDBig := l2ChainID.Big()
 		intent.Chains = append(intent.Chains, &state.ChainIntent{
 			ID:                         l2ChainID,
-			BaseFeeVaultRecipient:      common.Address{},
-			L1FeeVaultRecipient:        common.Address{},
-			SequencerFeeVaultRecipient: common.Address{},
+			BaseFeeVaultRecipient:      addrFor(devkeys.BaseFeeVaultRecipientRole.Key(l1ChainIDBig)),
+			L1FeeVaultRecipient:        addrFor(devkeys.L1FeeVaultRecipientRole.Key(l1ChainIDBig)),
+			SequencerFeeVaultRecipient: addrFor(devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainIDBig)),
 			Eip1559Denominator:         50,
 			Eip1559Elasticity:          6,
 			Roles: state.ChainRoles{

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -118,9 +118,9 @@ func Init(cfg InitConfig) error {
 		l2ChainIDBig := l2ChainID.Big()
 		intent.Chains = append(intent.Chains, &state.ChainIntent{
 			ID:                         l2ChainID,
-			BaseFeeVaultRecipient:      addrFor(devkeys.BaseFeeVaultRecipientRole.Key(l1ChainIDBig)),
-			L1FeeVaultRecipient:        addrFor(devkeys.L1FeeVaultRecipientRole.Key(l1ChainIDBig)),
-			SequencerFeeVaultRecipient: addrFor(devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainIDBig)),
+			BaseFeeVaultRecipient:      addrFor(devkeys.BaseFeeVaultRecipientRole.Key(l2ChainIDBig)),
+			L1FeeVaultRecipient:        addrFor(devkeys.L1FeeVaultRecipientRole.Key(l2ChainIDBig)),
+			SequencerFeeVaultRecipient: addrFor(devkeys.SequencerFeeVaultRecipientRole.Key(l2ChainIDBig)),
 			Eip1559Denominator:         50,
 			Eip1559Elasticity:          6,
 			Roles: state.ChainRoles{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Instead of zero address use dev keys for all the vaults recipient when init a new intent.

Having zero address would fail during l2 genesis generation when consolidating the deploy config. I was adapting the op kurtosis package to work with the updated `op-deployer` and default intent fails to deploy

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
(pretty straightforward, but let me know if I should add test)
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
