### PR TITLE
cannon: No-op SYS_STAT for the mt stf

### DIFF
--- a/cannon/mipsevm/arch/arch32.go
+++ b/cannon/mipsevm/arch/arch32.go
@@ -61,6 +61,7 @@ const (
 	SysPrlimit64     = 4338
 	SysClose         = 4006
 	SysPread64       = 4200
+	SysStat          = 4106
 	SysFstat         = 4108
 	SysFstat64       = 4215
 	SysOpenAt        = 4288

--- a/cannon/mipsevm/arch/arch64.go
+++ b/cannon/mipsevm/arch/arch64.go
@@ -69,6 +69,7 @@ const (
 	SysPrlimit64     = 5297
 	SysClose         = 5003
 	SysPread64       = 5016
+	SysStat          = 5004
 	SysFstat         = 5005
 	SysFstat64       = UndefinedSysNr
 	SysOpenAt        = 5247

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -187,6 +187,7 @@ func (m *InstrumentedState) handleSyscall() error {
 	case arch.SysPrlimit64:
 	case arch.SysClose:
 	case arch.SysPread64:
+	case arch.SysStat:
 	case arch.SysFstat:
 	case arch.SysOpenAt:
 	case arch.SysReadlink:

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -1103,6 +1103,7 @@ var NoopSyscalls = map[string]uint32{
 	"SysPrlimit64":     4338,
 	"SysClose":         4006,
 	"SysPread64":       4200,
+	"SysStat":          4106,
 	"SysFstat":         4108,
 	"SysFstat64":       4215,
 	"SysOpenAt":        4288,

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -144,8 +144,8 @@
     "sourceCodeHash": "0xd8467700c80b3e62fa37193dc6513bac35282094b686b50e162e157f704dde00"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x478fdad3eccd158822ce2025971a9242c37c976024f419fba417fe54158269b7",
-    "sourceCodeHash": "0x81dc3329c1644afa30ecd2684f44f8b96b5a17612dcfa6476432eed697209e63"
+    "initCodeHash": "0xaedf0d0b0e94a0c5e7d987331d2fdba84230f5704a6ca33677e70cde7051b17e",
+    "sourceCodeHash": "0x9fa2d1297ad1e93b4d3c5c0fed08bedcd8f746807589f0fd3369e79347c6a027"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -60,8 +60,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.20
-    string public constant version = "1.0.0-beta.20";
+    /// @custom:semver 1.0.0-beta.21
+    string public constant version = "1.0.0-beta.21";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -554,6 +554,8 @@ contract MIPS2 is ISemver {
             } else if (syscall_no == sys.SYS_CLOSE) {
                 // ignored
             } else if (syscall_no == sys.SYS_PREAD64) {
+                // ignored
+            } else if (syscall_no == sys.SYS_STAT) {
                 // ignored
             } else if (syscall_no == sys.SYS_FSTAT) {
                 // ignored

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -53,6 +53,7 @@ library MIPSSyscalls {
     uint32 internal constant SYS_PRLIMIT64 = 4338;
     uint32 internal constant SYS_CLOSE = 4006;
     uint32 internal constant SYS_PREAD64 = 4200;
+    uint32 internal constant SYS_STAT = 4106;
     uint32 internal constant SYS_FSTAT = 4108;
     uint32 internal constant SYS_FSTAT64 = 4215;
     uint32 internal constant SYS_OPENAT = 4288;


### PR DESCRIPTION
This patch fixes a panic during 64-bit op-program execution.
The op-program uses the `stat(2)` syscall for the 64-bit MT-Cannon VM for prometheus metrics initialization.
When a 64-bit op-program is executed, cannon64 crashes with the following error:
```
traceback at pc=16dc0. step=56588742
        0 16da0 in runtime/internal/syscall.Syscall6 caller=00016d6c
        1 16d28 in syscall.RawSyscall6 caller=000d3888
        2 d3848 in syscall.Syscall caller=000d36c4
        3 d3610 in syscall.stat caller=000cda9c
        4 cda40 in syscall.Stat caller=001194a4
        5 119428 in os.statNolog caller=00118dd8
        6 118d80 in os.Stat caller=0088c028
        7 88bfe8 in github.com/prometheus/procfs/internal/fs.NewFS caller=0088cab0
        8 88ca70 in github.com/prometheus/procfs.NewFS caller=0089f114
        9 89f0c8 in github.com/prometheus/client_golang/prometheus.canCollectProcess caller=0089ec64
        10 89e468 in github.com/prometheus/client_golang/prometheus.NewProcessCollector caller=008a0258
        11 8a0218 in github.com/prometheus/client_golang/prometheus.init.0 caller=0007fea8
        12 7fd90 in runtime.doInit1 caller=00069ea0
        13 b6400 in runtime.gogo caller=00072300
        14 720a8 in runtime.execute caller=00075798
        15 75438 in runtime.schedule caller=0006e748
        16 6e648 in runtime.mstart1 caller=0006e61c
        17 6e5a8 in runtime.mstart0 caller=000b63e4
        18 b63d8 in runtime.mstart caller=000b63a8
        19 b9a78 in main caller=000b9a60
        20 b9a58 in _main caller=000b9a68
panic: unrecognized syscall: 5004
```

The `stat` syscall is only used at this callsite. And implementing `stat(2)` as a no-op is sufficient to successfully generate a 64-bit trace of the op-program.

Note that while this patch also no-ops `SYS_STAT` for 32-bit MT-Cannon, it isn't needed for that VM. The no-op is added to both 32-bit and 64-bit multithreaded VMs anyways to simplify syscall handling.

## Testing

- Unit tests
- 64-bit op-program execution