### PR TITLE
op-node: disable finality based on local-safe when interop is active

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -191,6 +191,10 @@ func TestInteropVerifier(gt *testing.T) {
 		require.Equal(t, l1Head, finalized)
 		return nil
 	}
+	// Allow the supervisor to promote the cross-safe L2 block to finalized.
+	seqMockBackend.FinalizedFn = func(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+		return seq.SyncStatus().SafeL2.ID(), nil
+	}
 	// signal that L1 finalized; the cross-safe block we have should get finalized too
 	l1Miner.ActL1SafeNext(t)
 	l1Miner.ActL1FinalizeNext(t)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Before interop, the finality is determined based on L1 finality signals and the tracking of which data is locally derived from which L1 block. I.e. it uses local-safe. After interop, it needs to anchor to cross-safe to ensure all data of other L2s that it depends on is also confirmed on L1 and dependencies are checked. So we disable the finalizer from finalizing any post-interop data, and finalize using the interop deriver instead (we already implemented/tested the interop deriver side).

**Tests**

Test that the finality deriver covers the pre-interop block, but not the post-interop block.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/12357
