### PR TITLE
op-supervisor: make frontend/backend/client interfaces consistent

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -41,12 +41,12 @@ func TestInteropVerifier(gt *testing.T) {
 		helpers.WithInteropBackend(verMockBackend))
 
 	// Genesis block will be registered as local-safe when we first trigger the derivation pipeline
-	seqMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+	seqMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 		require.Equal(t, sd.RollupCfg.Genesis.L1, derivedFrom.ID())
 		require.Equal(t, sd.RollupCfg.Genesis.L2, lastDerived.ID())
 		return nil
 	}
-	verMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+	verMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 		require.Equal(t, sd.RollupCfg.Genesis.L1, derivedFrom.ID())
 		require.Equal(t, sd.RollupCfg.Genesis.L2, lastDerived.ID())
 		return nil
@@ -56,7 +56,7 @@ func TestInteropVerifier(gt *testing.T) {
 	ver.ActL2PipelineFull(t)
 
 	l2ChainID := types.ChainIDFromBig(sd.RollupCfg.L2ChainID)
-	seqMockBackend.UpdateLocalUnsafeFn = func(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {
+	seqMockBackend.UpdateLocalUnsafeFn = func(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 		require.Equal(t, chainID, l2ChainID)
 		require.Equal(t, uint64(1), head.Number)
 		return nil
@@ -105,7 +105,7 @@ func TestInteropVerifier(gt *testing.T) {
 	// Sync the L1 block, to verify the L2 block as local-safe.
 	seqMockBackend.UpdateLocalUnsafeFn = nil
 	nextL2 := uint64(0)
-	seqMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+	seqMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 		require.Equal(t, nextL2, lastDerived.Number)
 		nextL2 += 1
 		return nil
@@ -153,12 +153,12 @@ func TestInteropVerifier(gt *testing.T) {
 	require.Equal(t, uint64(1), status.SafeL2.Number, "cross-safe reached")
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
 
-	verMockBackend.UpdateLocalUnsafeFn = func(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {
+	verMockBackend.UpdateLocalUnsafeFn = func(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 		require.Equal(t, uint64(1), head.Number)
 		return nil
 	}
 	nextL2 = 0
-	verMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+	verMockBackend.UpdateLocalSafeFn = func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 		require.Equal(t, nextL2, lastDerived.Number)
 		nextL2 += 1
 		require.Equal(t, l1Head.ID(), derivedFrom.ID())

--- a/op-node/rollup/interop/interop_test.go
+++ b/op-node/rollup/interop/interop_test.go
@@ -36,7 +36,7 @@ func TestInteropDeriver(t *testing.T) {
 	t.Run("local-unsafe blocks push to supervisor and trigger cross-unsafe attempts", func(t *testing.T) {
 		emitter.ExpectOnce(engine.RequestCrossUnsafeEvent{})
 		unsafeHead := testutils.RandomL2BlockRef(rng)
-		interopBackend.ExpectUpdateLocalUnsafe(chainID, unsafeHead, nil)
+		interopBackend.ExpectUpdateLocalUnsafe(chainID, unsafeHead.BlockRef(), nil)
 		interopDeriver.OnEvent(engine.UnsafeUpdateEvent{Ref: unsafeHead})
 		emitter.AssertExpectations(t)
 		interopBackend.AssertExpectations(t)
@@ -93,7 +93,7 @@ func TestInteropDeriver(t *testing.T) {
 		emitter.ExpectOnce(engine.RequestCrossSafeEvent{})
 		derivedFrom := testutils.RandomBlockRef(rng)
 		localSafe := testutils.RandomL2BlockRef(rng)
-		interopBackend.ExpectUpdateLocalSafe(chainID, derivedFrom, localSafe, nil)
+		interopBackend.ExpectUpdateLocalSafe(chainID, derivedFrom, localSafe.BlockRef(), nil)
 		interopDeriver.OnEvent(engine.InteropPendingSafeChangedEvent{
 			Ref:         localSafe,
 			DerivedFrom: derivedFrom,

--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -49,6 +49,15 @@ func (id L2BlockRef) TerminalString() string {
 	return fmt.Sprintf("%s:%d", id.Hash.TerminalString(), id.Number)
 }
 
+func (id L2BlockRef) BlockRef() BlockRef {
+	return BlockRef{
+		Hash:       id.Hash,
+		Number:     id.Number,
+		ParentHash: id.ParentHash,
+		Time:       id.Time,
+	}
+}
+
 type L1BlockRef struct {
 	Hash       common.Hash `json:"hash"`
 	Number     uint64      `json:"number"`

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -97,17 +97,17 @@ func (cl *SupervisorClient) Finalized(ctx context.Context, chainID types.ChainID
 	return result, err
 }
 
-func (cl *SupervisorClient) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
-	var result eth.L1BlockRef
+func (cl *SupervisorClient) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.BlockRef, error) {
+	var result eth.BlockRef
 	err := cl.client.CallContext(ctx, &result, "supervisor_derivedFrom", chainID, derived)
 	return result, err
 }
 
-func (cl *SupervisorClient) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {
+func (cl *SupervisorClient) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 	return cl.client.CallContext(ctx, nil, "supervisor_updateLocalUnsafe", chainID, head)
 }
 
-func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 	return cl.client.CallContext(ctx, nil, "supervisor_updateLocalSafe", chainID, derivedFrom, lastDerived)
 }
 

--- a/op-service/testutils/fake_interop_backend.go
+++ b/op-service/testutils/fake_interop_backend.go
@@ -12,8 +12,8 @@ type FakeInteropBackend struct {
 	SafeViewFn          func(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error)
 	FinalizedFn         func(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
 	DerivedFromFn       func(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error)
-	UpdateLocalUnsafeFn func(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error
-	UpdateLocalSafeFn   func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error
+	UpdateLocalUnsafeFn func(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error
+	UpdateLocalSafeFn   func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error
 	UpdateFinalizedL1Fn func(ctx context.Context, chainID types.ChainID, finalized eth.L1BlockRef) error
 }
 
@@ -33,11 +33,11 @@ func (m *FakeInteropBackend) DerivedFrom(ctx context.Context, chainID types.Chai
 	return m.DerivedFromFn(ctx, chainID, derived)
 }
 
-func (m *FakeInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {
+func (m *FakeInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 	return m.UpdateLocalUnsafeFn(ctx, chainID, head)
 }
 
-func (m *FakeInteropBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+func (m *FakeInteropBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 	return m.UpdateLocalSafeFn(ctx, chainID, derivedFrom, lastDerived)
 }
 

--- a/op-service/testutils/mock_interop_backend.go
+++ b/op-service/testutils/mock_interop_backend.go
@@ -67,12 +67,12 @@ func (m *MockInteropBackend) ExpectDerivedFrom(chainID types.ChainID, derived et
 	m.Mock.On("DerivedFrom", chainID, derived).Once().Return(result, &err)
 }
 
-func (m *MockInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.L2BlockRef) error {
+func (m *MockInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 	result := m.Mock.MethodCalled("UpdateLocalUnsafe", chainID, head)
 	return *result.Get(0).(*error)
 }
 
-func (m *MockInteropBackend) ExpectUpdateLocalUnsafe(chainID types.ChainID, head eth.L2BlockRef, err error) {
+func (m *MockInteropBackend) ExpectUpdateLocalUnsafe(chainID types.ChainID, head eth.BlockRef, err error) {
 	m.Mock.On("UpdateLocalUnsafe", chainID, head).Once().Return(&err)
 }
 
@@ -80,12 +80,12 @@ func (m *MockInteropBackend) ExpectAnyUpdateLocalUnsafe(chainID types.ChainID, e
 	m.Mock.On("UpdateLocalUnsafe", chainID, mock.Anything).Once().Return(&err)
 }
 
-func (m *MockInteropBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef) error {
+func (m *MockInteropBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 	result := m.Mock.MethodCalled("UpdateLocalSafe", chainID, derivedFrom, lastDerived)
 	return *result.Get(0).(*error)
 }
 
-func (m *MockInteropBackend) ExpectUpdateLocalSafe(chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.L2BlockRef, err error) {
+func (m *MockInteropBackend) ExpectUpdateLocalSafe(chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef, err error) {
 	m.Mock.On("UpdateLocalSafe", chainID, derivedFrom, lastDerived).Once().Return(&err)
 }
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -402,21 +402,21 @@ func (su *SupervisorBackend) Finalized(ctx context.Context, chainID types.ChainI
 	return v.ID(), nil
 }
 
-func (su *SupervisorBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockID, err error) {
+func (su *SupervisorBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	su.mu.RLock()
 	defer su.mu.RUnlock()
 
 	v, err := su.chainDBs.DerivedFrom(chainID, derived)
 	if err != nil {
-		return eth.BlockID{}, err
+		return eth.BlockRef{}, err
 	}
-	return v.ID(), nil
+	return v, nil
 }
 
 // Update methods
 // ----------------------------
 
-func (su *SupervisorBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.BlockRef) error {
+func (su *SupervisorBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 	su.mu.RLock()
 	defer su.mu.RUnlock()
 	ch, ok := su.chainProcessors[chainID]
@@ -426,14 +426,14 @@ func (su *SupervisorBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.B
 	return ch.OnNewHead(head)
 }
 
-func (su *SupervisorBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) error {
+func (su *SupervisorBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) error {
 	su.mu.RLock()
 	defer su.mu.RUnlock()
 
 	return su.chainDBs.UpdateLocalSafe(chainID, derivedFrom, lastDerived)
 }
 
-func (su *SupervisorBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.BlockRef) error {
+func (su *SupervisorBackend) UpdateFinalizedL1(ctx context.Context, chainID types.ChainID, finalized eth.BlockRef) error {
 	su.mu.RLock()
 	defer su.mu.RUnlock()
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -113,7 +113,7 @@ func TestBackendLifetime(t *testing.T) {
 
 	src.ExpectL1BlockRefByNumber(2, eth.L1BlockRef{}, ethereum.NotFound)
 
-	err = b.UpdateLocalUnsafe(chainA, blockY)
+	err = b.UpdateLocalUnsafe(context.Background(), chainA, blockY)
 	require.NoError(t, err)
 	// Make the processing happen, so we can rely on the new chain information,
 	// and not run into errors for future data that isn't mocked at this time.

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -167,15 +167,23 @@ func (db *ChainsDB) LastDerivedFrom(chainID types.ChainID, derivedFrom eth.Block
 	return crossDB.LastDerivedAt(derivedFrom)
 }
 
-func (db *ChainsDB) DerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (db *ChainsDB) DerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
 	localDB, ok := db.localDBs[chainID]
 	if !ok {
-		return types.BlockSeal{}, types.ErrUnknownChain
+		return eth.BlockRef{}, types.ErrUnknownChain
 	}
-	return localDB.DerivedFrom(derived)
+	res, err := localDB.DerivedFrom(derived)
+	if err != nil {
+		return eth.BlockRef{}, err
+	}
+	parent, err := localDB.PreviousDerivedFrom(res.ID())
+	if err != nil {
+		return eth.BlockRef{}, err
+	}
+	return res.WithParent(parent.ID()), nil
 }
 
 // Check calls the underlying logDB to determine if the given log entry exists at the given location.

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -62,19 +62,19 @@ func (m *MockBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
-func (m *MockBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockID, err error) {
-	return eth.BlockID{}, nil
+func (m *MockBackend) DerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+	return eth.BlockRef{}, nil
 }
 
-func (m *MockBackend) UpdateLocalUnsafe(chainID types.ChainID, head eth.BlockRef) error {
+func (m *MockBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
 	return nil
 }
 
-func (m *MockBackend) UpdateLocalSafe(chainID types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) error {
+func (m *MockBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) error {
 	return nil
 }
 
-func (m *MockBackend) UpdateFinalizedL1(chainID types.ChainID, finalized eth.BlockRef) error {
+func (m *MockBackend) UpdateFinalizedL1(ctx context.Context, chainID types.ChainID, finalized eth.BlockRef) error {
 	return nil
 }
 


### PR DESCRIPTION
**Description**

Fixes `DerivedFrom` return argument type, and fixes `ctx` usage to be more consistent, to make all interop-backend interfaces / implementations compatible.

**Tests**

Added type assertions for compile-time checking of the interface consistency.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/12698