### PR TITLE
ci: Remove hosted semgrep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1314,7 +1314,6 @@ workflows:
       - contracts-bedrock-validate-spacers:
           requires:
             - contracts-bedrock-build
-      - semgrep-scan
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config=./semgrep --error .


### PR DESCRIPTION
We're not getting a lot of value from hosted Semgrep. This PR removes that in favor of just adding rules to the `semgrep/` directory so they can be run locally in CI.
