### PR TITLE
cannon: Update stf verify image

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -23,7 +23,7 @@ ARG GIT_DATE
 
 ARG TARGETOS TARGETARCH
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.1 AS cannon-v2
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.2 AS cannon-v2
 
 FROM --platform=$BUILDPLATFORM builder as cannon-verify
 COPY --from=cannon-v2 /usr/local/bin/cannon /usr/local/bin/cannon-v2


### PR DESCRIPTION
Updates the base cannon image version used to assert that cannon execution does not change.

The singlethreaded-2-cannon VM STF was updated to supported [two new branch instructions](https://github.com/ethereum-optimism/optimism/issues/12550). However, this doesn't alter the execution trace because Go doesn't emit the two instructions for 32-bit MIPS.