### PR TITLE
feat(SuperchainWETH): enable sending and relaying `ETH` via `SuperchainWETH` contract

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/SuperchainWETH.json
+++ b/packages/contracts-bedrock/snapshots/abi/SuperchainWETH.json
@@ -146,6 +146,53 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "relayETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "sendETH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "msgHash_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes4",
         "name": "_interfaceId",
         "type": "bytes4"
@@ -367,6 +414,68 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "source",
+        "type": "uint256"
+      }
+    ],
+    "name": "RelayETH",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "destination",
+        "type": "uint256"
+      }
+    ],
+    "name": "SendETH",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "src",
         "type": "address"
       },
@@ -407,12 +516,22 @@
   },
   {
     "inputs": [],
+    "name": "InvalidCrossDomainSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NotCustomGasToken",
     "type": "error"
   },
   {
     "inputs": [],
     "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
     "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -128,8 +128,8 @@
     "sourceCodeHash": "0x617aa994f659c5d8ebd54128d994f86f5b175ceca095b024b8524a7898e8ae62"
   },
   "src/L2/SuperchainWETH.sol": {
-    "initCodeHash": "0x90aad5698e09994909331dd9665d99a8d5a53e45ba792bf47e4c2efbd48f7699",
-    "sourceCodeHash": "0x35f0ffcfa027f736b496f3fd2640c043648a49ce325083486ce27f63bfec6d08"
+    "initCodeHash": "0xac4cab1ee7f0a5de8362ddc37e1de92e816aee3fdd4e31c0ba0fd9b03568f0f0",
+    "sourceCodeHash": "0x1fc6439f7a5fac2e264d5e057593844d252cdaa12c2b1eaa2fb08cbb911a9f35"
   },
   "src/L2/WETH.sol": {
     "initCodeHash": "0x17ea1b1c5d5a622d51c2961fde886a5498de63584e654ed1d69ee80dddbe0b17",

--- a/packages/contracts-bedrock/src/L2/interfaces/ISuperchainWETH.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISuperchainWETH.sol
@@ -8,10 +8,18 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 interface ISuperchainWETH is IWETH98, IERC7802, ISemver {
     error Unauthorized();
     error NotCustomGasToken();
+    error InvalidCrossDomainSender();
+    error ZeroAddress();
+
+    event SendETH(address indexed from, address indexed to, uint256 amount, uint256 destination);
+
+    event RelayETH(address indexed from, address indexed to, uint256 amount, uint256 source);
 
     function balanceOf(address src) external view returns (uint256);
     function withdraw(uint256 _amount) external;
     function supportsInterface(bytes4 _interfaceId) external view returns (bool);
+    function sendETH(address _to, uint256 _chainId) external payable returns (bytes32 msgHash_);
+    function relayETH(address _from, address _to, uint256 _amount) external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
@@ -6,7 +6,7 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { NotCustomGasToken } from "src/libraries/errors/CommonErrors.sol";
+import { NotCustomGasToken, Unauthorized, ZeroAddress } from "src/libraries/errors/CommonErrors.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 
 // Interfaces
@@ -14,6 +14,7 @@ import { IETHLiquidity } from "src/L2/interfaces/IETHLiquidity.sol";
 import { ISuperchainWETH } from "src/L2/interfaces/ISuperchainWETH.sol";
 import { IERC7802, IERC165 } from "src/L2/interfaces/IERC7802.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
 
 /// @title SuperchainWETH_Test
 /// @notice Contract for testing the SuperchainWETH contract.
@@ -32,6 +33,10 @@ contract SuperchainWETH_Test is CommonTest {
 
     /// @notice Emitted when a crosschain transfer burns tokens.
     event CrosschainBurn(address indexed from, uint256 amount, address indexed sender);
+
+    event SendETH(address indexed from, address indexed to, uint256 amount, uint256 destination);
+
+    event RelayETH(address indexed from, address indexed to, uint256 amount, uint256 source);
 
     address internal constant ZERO_ADDRESS = address(0);
 
@@ -474,5 +479,207 @@ contract SuperchainWETH_Test is CommonTest {
         vm.assume(_interfaceId != type(IERC7802).interfaceId);
         vm.assume(_interfaceId != type(IERC20).interfaceId);
         assertFalse(superchainWeth.supportsInterface(_interfaceId));
+    }
+
+    /// @notice Tests the `sendETH` function reverts when the address `_to` is zero.
+    function testFuzz_sendETH_zeroAddressTo_reverts(address _sender, uint256 _amount, uint256 _chainId) public {
+        // Expect the revert with `ZeroAddress` selector
+        vm.expectRevert(ZeroAddress.selector);
+
+        vm.deal(_sender, _amount);
+        vm.prank(_sender);
+        // Call the `sendETH` function with the zero address as `_to`
+        superchainWeth.sendETH{ value: _amount }(ZERO_ADDRESS, _chainId);
+    }
+
+    /// @notice Tests the `sendETH` function burns the sender ETH, sends the message, and emits the `SendETH`
+    /// event.
+    function testFuzz_sendETH_fromNonCustomGasTokenChain_succeeds(
+        address _sender,
+        address _to,
+        uint256 _amount,
+        uint256 _chainId,
+        bytes32 _msgHash
+    )
+        external
+    {
+        // Assume
+        vm.assume(_sender != ZERO_ADDRESS);
+        vm.assume(_to != ZERO_ADDRESS);
+        _amount = bound(_amount, 0, type(uint248).max - 1);
+
+        // Arrange
+        vm.deal(_sender, _amount);
+        _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(false));
+
+        // Get the total balance of `_sender` before the send to compare later on the assertions
+        uint256 _senderBalanceBefore = _sender.balance;
+
+        // Look for the emit of the `SendETH` event
+        vm.expectEmit(address(superchainWeth));
+        emit SendETH(_sender, _to, _amount, _chainId);
+
+        // Expect the call to the `burn` function in the `ETHLiquidity` contract
+        vm.expectCall(Predeploys.ETH_LIQUIDITY, abi.encodeCall(IETHLiquidity.burn, ()), 1);
+
+        // Mock the call over the `sendMessage` function and expect it to be called properly
+        bytes memory _message = abi.encodeCall(superchainWeth.relayETH, (_sender, _to, _amount));
+        _mockAndExpect(
+            Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
+            abi.encodeCall(IL2ToL2CrossDomainMessenger.sendMessage, (_chainId, address(superchainWeth), _message)),
+            abi.encode(_msgHash)
+        );
+
+        // Call the `sendETH` function
+        vm.prank(_sender);
+        bytes32 _returnedMsgHash = superchainWeth.sendETH{ value: _amount }(_to, _chainId);
+
+        // Check the message hash was generated correctly
+        assertEq(_msgHash, _returnedMsgHash);
+
+        // Check the total supply and balance of `_sender` after the send were updated correctly
+        assertEq(_sender.balance, _senderBalanceBefore - _amount);
+    }
+
+    /// @notice Tests the `sendETH` function reverts when called on a custom gas token chain.
+    function testFuzz_sendETH_fromCustomGasTokenChain_fails(
+        address _sender,
+        address _to,
+        uint256 _amount,
+        uint256 _chainId
+    )
+        external
+    {
+        // Assume
+        vm.assume(_sender != ZERO_ADDRESS);
+        vm.assume(_to != ZERO_ADDRESS);
+        _amount = bound(_amount, 0, type(uint248).max - 1);
+
+        // Arrange
+        vm.deal(_sender, _amount);
+        _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(true));
+
+        // Call the `sendETH` function
+        vm.prank(_sender);
+        vm.expectRevert(NotCustomGasToken.selector);
+        superchainWeth.sendETH{ value: _amount }(_to, _chainId);
+    }
+
+    /// @notice Tests the `relayETH` function reverts when the caller is not the L2ToL2CrossDomainMessenger.
+    function testFuzz_relayETH_notMessenger_reverts(address _caller, address _to, uint256 _amount) public {
+        // Ensure the caller is not the messenger
+        vm.assume(_caller != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+
+        // Expect the revert with `Unauthorized` selector
+        vm.expectRevert(Unauthorized.selector);
+
+        // Call the `relayETH` function with the non-messenger caller
+        vm.prank(_caller);
+        superchainWeth.relayETH(_caller, _to, _amount);
+    }
+
+    /// @notice Tests the `relayETH` function reverts when the `crossDomainMessageSender` that sent the message is not
+    /// the same SuperchainWETH.
+    function testFuzz_relayETH_notCrossDomainSender_reverts(
+        address _crossDomainMessageSender,
+        uint256 _source,
+        address _to,
+        uint256 _amount
+    )
+        public
+    {
+        vm.assume(_crossDomainMessageSender != address(superchainWeth));
+
+        // Mock the call over the `crossDomainMessageContext` function setting a wrong sender
+        vm.mockCall(
+            Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
+            abi.encodeCall(IL2ToL2CrossDomainMessenger.crossDomainMessageContext, ()),
+            abi.encode(_crossDomainMessageSender, _source)
+        );
+
+        // Expect the revert with `InvalidCrossDomainSender` selector
+        vm.expectRevert(ISuperchainWETH.InvalidCrossDomainSender.selector);
+
+        // Call the `relayETH` function with the sender caller
+        vm.prank(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        superchainWeth.relayETH(_crossDomainMessageSender, _to, _amount);
+    }
+
+    /// @notice Tests the `relayETH` function succeeds and sends SuperchainWETH to the recipient on a custom gas token
+    /// chain.
+    function testFuzz_relayETH_fromCustomGasTokenChain_succeeds(
+        address _from,
+        address _to,
+        uint256 _amount,
+        uint256 _source
+    )
+        public
+    {
+        // Assume
+        vm.assume(_to != ZERO_ADDRESS);
+        _amount = bound(_amount, 0, type(uint248).max - 1);
+
+        // Get the balance of `_to` before the mint to compare later on the assertions
+        uint256 _toBalanceBefore = superchainWeth.balanceOf(_to);
+
+        // Look for the emit of the `Transfer` event
+        vm.expectEmit(address(superchainWeth));
+        emit Transfer(ZERO_ADDRESS, _to, _amount);
+
+        // Look for the emit of the `RelayETH` event
+        vm.expectEmit(address(superchainWeth));
+        emit RelayETH(_from, _to, _amount, _source);
+
+        // Arrange
+        _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(true));
+        _mockAndExpect(
+            Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
+            abi.encodeCall(IL2ToL2CrossDomainMessenger.crossDomainMessageContext, ()),
+            abi.encode(address(superchainWeth), _source)
+        );
+        // Expect to not call the `mint` function in the `ETHLiquidity` contract
+        vm.expectCall(Predeploys.ETH_LIQUIDITY, abi.encodeCall(IETHLiquidity.mint, (_amount)), 0);
+
+        // Act
+        vm.prank(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        superchainWeth.relayETH(_from, _to, _amount);
+
+        // Check the total supply and balance of `_to` after the mint were updated correctly
+        assertEq(superchainWeth.balanceOf(_to), _toBalanceBefore + _amount);
+        assertEq(superchainWeth.totalSupply(), 0);
+        assertEq(address(superchainWeth).balance, 0);
+    }
+
+    /// @notice Tests the `relayETH` function relays the proper amount of ETH and emits the `RelayETH` event.
+    function testFuzz_relayETH_succeeds(address _from, address _to, uint256 _amount, uint256 _source) public {
+        // Assume
+        vm.assume(_to != ZERO_ADDRESS);
+        assumePayable(_to);
+        _amount = bound(_amount, 0, type(uint248).max - 1);
+
+        // Arrange
+        vm.deal(address(superchainWeth), _amount);
+        vm.deal(Predeploys.ETH_LIQUIDITY, _amount);
+        _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(false));
+        _mockAndExpect(
+            Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
+            abi.encodeCall(IL2ToL2CrossDomainMessenger.crossDomainMessageContext, ()),
+            abi.encode(address(superchainWeth), _source)
+        );
+
+        uint256 _toBalanceBefore = _to.balance;
+
+        // Look for the emit of the `RelayETH` event
+        vm.expectEmit(address(superchainWeth));
+        emit RelayETH(_from, _to, _amount, _source);
+
+        // Expect the call to the `mint` function in the `ETHLiquidity` contract
+        vm.expectCall(Predeploys.ETH_LIQUIDITY, abi.encodeCall(IETHLiquidity.mint, (_amount)), 1);
+
+        // Call the `RelayETH` function with the messenger caller
+        vm.prank(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        superchainWeth.relayETH(_from, _to, _amount);
+
+        assertEq(_to.balance, _toBalanceBefore + _amount);
     }
 }


### PR DESCRIPTION
Implements: https://github.com/ethereum-optimism/design-docs/pull/146

Adds two new functions to the `SuperchainWETH` contract: `sendETH` and `relayETH`. 

- **`sendETH`**: Deposits `ETH` in the `ETHLiquidity` contract and sends a message to the destination chain, encoding the relay details.
- **`relayETH`**: Withdraws the specified amount of `ETH` from `ETHLiquidity` on the destination chain and transfers it to the recipient.

This update streamlines L2-to-L2 `ETH` transfers, bypassing the need for separate wrapping and unwrapping steps. Notably, custom gas token chains are excluded from this simplification to maintain compatibility and reduce risk.