### PR TITLE
signer: Restore default of enabling TLS.

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -937,6 +937,18 @@ func TestAdditionalBondClaimants(t *testing.T) {
 	})
 }
 
+func TestSignerTLS(t *testing.T) {
+	t.Run("EnabledByDefault", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs(types.TraceTypeAlphabet))
+		require.True(t, cfg.TxMgrConfig.SignerCLIConfig.TLSConfig.Enabled)
+	})
+
+	t.Run("Disabled", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs(types.TraceTypeAlphabet, "--signer.tls.enabled=false"))
+		require.False(t, cfg.TxMgrConfig.SignerCLIConfig.TLSConfig.Enabled)
+	})
+}
+
 func verifyArgsInvalid(t *testing.T, messageContains string, cliArgs []string) {
 	_, _, err := dryRunWithArgs(cliArgs)
 	require.ErrorContains(t, err, messageContains)

--- a/op-service/tls/cli.go
+++ b/op-service/tls/cli.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	TLSCaCertFlagName = "tls.ca"
-	TLSCertFlagName   = "tls.cert"
-	TLSKeyFlagName    = "tls.key"
+	TLSCaCertFlagName  = "tls.ca"
+	TLSCertFlagName    = "tls.cert"
+	TLSKeyFlagName     = "tls.key"
+	TLSEnabledFlagName = "tls.enabled"
 )
 
 // CLIFlags returns flags with env var envPrefix
@@ -24,9 +25,10 @@ func CLIFlags(envPrefix string) []cli.Flag {
 }
 
 var (
-	defaultTLSCaCert = "tls/ca.crt"
-	defaultTLSCert   = "tls/tls.crt"
-	defaultTLSKey    = "tls/tls.key"
+	defaultTLSCaCert  = "tls/ca.crt"
+	defaultTLSCert    = "tls/tls.crt"
+	defaultTLSKey     = "tls/tls.key"
+	defaultTLSEnabled = true
 )
 
 // CLIFlagsWithFlagPrefix returns flags with env var and cli flag prefixes
@@ -39,6 +41,12 @@ func CLIFlagsWithFlagPrefix(envPrefix string, flagPrefix string) []cli.Flag {
 		return opservice.PrefixEnvVar(envPrefix, name)
 	}
 	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    prefixFunc(TLSEnabledFlagName),
+			Usage:   "Enable or disable TLS client authentication for the signer",
+			Value:   defaultTLSEnabled,
+			EnvVars: prefixEnvVars("TLS_ENABLED"),
+		},
 		&cli.StringFlag{
 			Name:    prefixFunc(TLSCaCertFlagName),
 			Usage:   "tls ca cert path",
@@ -72,7 +80,7 @@ func NewCLIConfig() CLIConfig {
 		TLSCaCert: defaultTLSCaCert,
 		TLSCert:   defaultTLSCert,
 		TLSKey:    defaultTLSKey,
-		Enabled:   false,
+		Enabled:   true,
 	}
 }
 
@@ -95,7 +103,7 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		TLSCaCert: ctx.String(TLSCaCertFlagName),
 		TLSCert:   ctx.String(TLSCertFlagName),
 		TLSKey:    ctx.String(TLSKeyFlagName),
-		Enabled:   ctx.IsSet(TLSCaCertFlagName) || ctx.IsSet(TLSCertFlagName) || ctx.IsSet(TLSKeyFlagName),
+		Enabled:   ctx.Bool(TLSEnabledFlagName),
 	}
 }
 
@@ -109,6 +117,6 @@ func ReadCLIConfigWithPrefix(ctx *cli.Context, flagPrefix string) CLIConfig {
 		TLSCaCert: ctx.String(prefixFunc(TLSCaCertFlagName)),
 		TLSCert:   ctx.String(prefixFunc(TLSCertFlagName)),
 		TLSKey:    ctx.String(prefixFunc(TLSKeyFlagName)),
-		Enabled:   ctx.IsSet(TLSCaCertFlagName) || ctx.IsSet(TLSCertFlagName) || ctx.IsSet(TLSKeyFlagName),
+		Enabled:   ctx.Bool(prefixFunc(TLSEnabledFlagName)),
 	}
 }

--- a/op-service/tls/cli_test.go
+++ b/op-service/tls/cli_test.go
@@ -1,6 +1,7 @@
 package tls
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,12 @@ func TestInvalidConfig(t *testing.T) {
 			test.configChange(&cfg)
 			err := cfg.Check()
 			require.ErrorContains(t, err, "all tls flags must be set if at least one is set")
+		})
+		t.Run(fmt.Sprintf("%sAllowedWhenDisabled", test.name), func(t *testing.T) {
+			cfg := NewCLIConfig()
+			cfg.Enabled = false
+			test.configChange(&cfg)
+			require.NoError(t, cfg.Check())
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Restore default of enabling TLS in signer (used by txmgr in op-challenger, op-proposer, op-batcher and possibly other places).

Can be disabled with --signer.tls.enabled=false. Avoids breaking existing deployments that default to TLS enabled.

The default changed from enabled to disabled in https://github.com/ethereum-optimism/optimism/pull/12407/ which hasn' yet made it into a release. op-challenger RC broke on deployment because of the change though.

**Tests**

Updated unit tests.