### PR TITLE
ci: Fix proofs-team reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1031,7 +1031,7 @@ jobs:
           paths:
             - "/root/.cache/go-build"
       - notify-failures-on-develop:
-          mentions: "@proofs-squad"
+          mentions: "@proofs-team"
 
   semgrep-scan:
     parameters:


### PR DESCRIPTION
**Description**

Update the `@proofs-squad` reference to `@proofs-team` for the cannon-stf-verify job.
