### PR TITLE
op-node/rollup: Promote all attributes to safe post-Holocene

### DIFF
--- a/op-e2e/actions/upgrades/holocene_fork_test.go
+++ b/op-e2e/actions/upgrades/holocene_fork_test.go
@@ -190,8 +190,7 @@ func TestHoloceneInvalidPayload(gt *testing.T) {
 	env.Seq.ActL1HeadSignal(t)
 	env.Seq.ActL2PipelineFull(t)
 
-	// TODO(12695): need to properly update safe after completed L1 block derivation
-	l2Safe := env.Seq.L2PendingSafe()
+	l2Safe := env.Seq.L2Safe()
 	require.EqualValues(t, invalidNum, l2Safe.Number)
 	require.NotEqual(t, l2Safe.Hash, l2Unsafe.Hash, // old L2Unsafe above
 		"block-3 should have been replaced by deposit-only version")

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -194,7 +194,7 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 		}
 		eq.emitter.Emit(engine.PromotePendingSafeEvent{
 			Ref:         ref,
-			Safe:        attributes.IsLastInSpan,
+			Concluding:  attributes.Concluding,
 			DerivedFrom: attributes.DerivedFrom,
 		})
 	}

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -117,9 +117,9 @@ func TestAttributesHandler(t *testing.T) {
 			NoTxPool:              false,
 			GasLimit:              &payloadA1.ExecutionPayload.GasLimit,
 		},
-		Parent:       refA0,
-		IsLastInSpan: true,
-		DerivedFrom:  refB,
+		Parent:      refA0,
+		Concluding:  true,
+		DerivedFrom: refB,
 	}
 	refA1, err := derive.PayloadToBlockRef(cfg, payloadA1.ExecutionPayload)
 	require.NoError(t, err)
@@ -154,9 +154,9 @@ func TestAttributesHandler(t *testing.T) {
 			NoTxPool:              false,
 			GasLimit:              &payloadA1Alt.ExecutionPayload.GasLimit,
 		},
-		Parent:       refA0,
-		IsLastInSpan: true,
-		DerivedFrom:  refBAlt,
+		Parent:      refA0,
+		Concluding:  true,
+		DerivedFrom: refBAlt,
 	}
 
 	refA1Alt, err := derive.PayloadToBlockRef(cfg, payloadA1Alt.ExecutionPayload)
@@ -272,7 +272,7 @@ func TestAttributesHandler(t *testing.T) {
 			require.Nil(t, ah.attributes, "drop when attributes are successful")
 		})
 		t.Run("consolidation passes", func(t *testing.T) {
-			fn := func(t *testing.T, lastInSpan bool) {
+			fn := func(t *testing.T, concluding bool) {
 				logger := testlog.Logger(t, log.LevelInfo)
 				l2 := &testutils.MockL2Client{}
 				emitter := &testutils.MockEmitter{}
@@ -280,10 +280,10 @@ func TestAttributesHandler(t *testing.T) {
 				ah.AttachEmitter(emitter)
 
 				attr := &derive.AttributesWithParent{
-					Attributes:   attrA1.Attributes, // attributes will match, passing consolidation
-					Parent:       attrA1.Parent,
-					IsLastInSpan: lastInSpan,
-					DerivedFrom:  refB,
+					Attributes:  attrA1.Attributes, // attributes will match, passing consolidation
+					Parent:      attrA1.Parent,
+					Concluding:  concluding,
+					DerivedFrom: refB,
 				}
 				emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 				emitter.ExpectOnce(engine.PendingSafeRequestEvent{})
@@ -296,7 +296,7 @@ func TestAttributesHandler(t *testing.T) {
 
 				emitter.ExpectOnce(engine.PromotePendingSafeEvent{
 					Ref:         refA1,
-					Safe:        lastInSpan, // last in span becomes safe instantaneously
+					Concluding:  concluding,
 					DerivedFrom: refB,
 				})
 				ah.OnEvent(engine.PendingSafeUpdateEvent{
@@ -340,7 +340,7 @@ func TestAttributesHandler(t *testing.T) {
 		require.NotNil(t, ah.attributes, "queued up derived attributes")
 
 		// sanity check test setup
-		require.True(t, attrA1Alt.IsLastInSpan, "must be last in span for attributes to become safe")
+		require.True(t, attrA1Alt.Concluding, "must be concluding attributes")
 
 		// attrA1Alt will fit right on top of A0
 		emitter.ExpectOnce(engine.BuildStartEvent{Attributes: attrA1Alt})
@@ -396,5 +396,4 @@ func TestAttributesHandler(t *testing.T) {
 		l2.AssertExpectations(t)
 		emitter.AssertExpectations(t)
 	})
-
 }

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -70,7 +70,7 @@ func (bs *BatchStage) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		// We only consider empty batch generation after we've drained all batches from the local
 		// span batch queue and the previous stage.
 		empty, err := bs.deriveNextEmptyBatch(ctx, true, parent)
-		// An empty batch always advances the safe head.
+		// An empty batch always advances the (local) safe head.
 		return empty, true, err
 	} else if err != nil {
 		return nil, false, err
@@ -81,7 +81,8 @@ func (bs *BatchStage) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 	switch validity {
 	case BatchAccept: // continue
 		batch.LogContext(bs.Log()).Debug("Found next singular batch")
-		return batch, len(bs.nextSpan) == 0, nil
+		// BatchStage is only used with Holocene, where blocks immediately become (local) safe
+		return batch, true, nil
 	case BatchPast:
 		batch.LogContext(bs.Log()).Warn("Dropping past singular batch")
 		// NotEnoughData to read in next batch until we're through all past batches

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -14,8 +14,8 @@ type PayloadSealInvalidEvent struct {
 	Info eth.PayloadInfo
 	Err  error
 
-	IsLastInSpan bool
-	DerivedFrom  eth.L1BlockRef
+	Concluding  bool
+	DerivedFrom eth.L1BlockRef
 }
 
 func (ev PayloadSealInvalidEvent) String() string {
@@ -30,8 +30,8 @@ type PayloadSealExpiredErrorEvent struct {
 	Info eth.PayloadInfo
 	Err  error
 
-	IsLastInSpan bool
-	DerivedFrom  eth.L1BlockRef
+	Concluding  bool
+	DerivedFrom eth.L1BlockRef
 }
 
 func (ev PayloadSealExpiredErrorEvent) String() string {
@@ -42,7 +42,7 @@ type BuildSealEvent struct {
 	Info         eth.PayloadInfo
 	BuildStarted time.Time
 	// if payload should be promoted to safe (must also be pending safe, see DerivedFrom)
-	IsLastInSpan bool
+	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
 }
@@ -69,10 +69,10 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 		// same attributes with a new block-building job from here to recover from this error.
 		// We name it "expired", as this generally identifies a timeout, unknown job, or otherwise invalidated work.
 		eq.emitter.Emit(PayloadSealExpiredErrorEvent{
-			Info:         ev.Info,
-			Err:          fmt.Errorf("failed to seal execution payload (ID: %s): %w", ev.Info.ID, err),
-			IsLastInSpan: ev.IsLastInSpan,
-			DerivedFrom:  ev.DerivedFrom,
+			Info:        ev.Info,
+			Err:         fmt.Errorf("failed to seal execution payload (ID: %s): %w", ev.Info.ID, err),
+			Concluding:  ev.Concluding,
+			DerivedFrom: ev.DerivedFrom,
 		})
 		return
 	}
@@ -82,8 +82,8 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 			Info: ev.Info,
 			Err: fmt.Errorf("failed sanity-check of execution payload contents (ID: %s, blockhash: %s): %w",
 				ev.Info.ID, envelope.ExecutionPayload.BlockHash, err),
-			IsLastInSpan: ev.IsLastInSpan,
-			DerivedFrom:  ev.DerivedFrom,
+			Concluding:  ev.Concluding,
+			DerivedFrom: ev.DerivedFrom,
 		})
 		return
 	}
@@ -91,10 +91,10 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 	ref, err := derive.PayloadToBlockRef(eq.cfg, envelope.ExecutionPayload)
 	if err != nil {
 		eq.emitter.Emit(PayloadSealInvalidEvent{
-			Info:         ev.Info,
-			Err:          fmt.Errorf("failed to decode L2 block ref from payload: %w", err),
-			IsLastInSpan: ev.IsLastInSpan,
-			DerivedFrom:  ev.DerivedFrom,
+			Info:        ev.Info,
+			Err:         fmt.Errorf("failed to decode L2 block ref from payload: %w", err),
+			Concluding:  ev.Concluding,
+			DerivedFrom: ev.DerivedFrom,
 		})
 		return
 	}
@@ -112,10 +112,10 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 		"txs", txnCount, "time", ref.Time, "seal_time", sealTime, "build_time", buildTime)
 
 	eq.emitter.Emit(BuildSealedEvent{
-		IsLastInSpan: ev.IsLastInSpan,
-		DerivedFrom:  ev.DerivedFrom,
-		Info:         ev.Info,
-		Envelope:     envelope,
-		Ref:          ref,
+		Concluding:  ev.Concluding,
+		DerivedFrom: ev.DerivedFrom,
+		Info:        ev.Info,
+		Envelope:    envelope,
+		Ref:         ref,
 	})
 }

--- a/op-node/rollup/engine/build_sealed.go
+++ b/op-node/rollup/engine/build_sealed.go
@@ -7,8 +7,8 @@ import (
 // BuildSealedEvent is emitted by the engine when a payload finished building,
 // but is not locally inserted as canonical block yet
 type BuildSealedEvent struct {
-	// if payload should be promoted to safe (must also be pending safe, see DerivedFrom)
-	IsLastInSpan bool
+	// if payload should be promoted to (local) safe (must also be pending safe, see DerivedFrom)
+	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
 
@@ -25,10 +25,10 @@ func (eq *EngDeriver) onBuildSealed(ev BuildSealedEvent) {
 	// If a (pending) safe block, immediately process the block
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
 		eq.emitter.Emit(PayloadProcessEvent{
-			IsLastInSpan: ev.IsLastInSpan,
-			DerivedFrom:  ev.DerivedFrom,
-			Envelope:     ev.Envelope,
-			Ref:          ev.Ref,
+			Concluding:  ev.Concluding,
+			DerivedFrom: ev.DerivedFrom,
+			Envelope:    ev.Envelope,
+			Ref:         ev.Ref,
 		})
 	}
 }

--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -68,7 +68,7 @@ func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
 	eq.emitter.Emit(BuildStartedEvent{
 		Info:         eth.PayloadInfo{ID: id, Timestamp: uint64(ev.Attributes.Attributes.Timestamp)},
 		BuildStarted: buildStartTime,
-		IsLastInSpan: ev.Attributes.IsLastInSpan,
+		Concluding:   ev.Attributes.Concluding,
 		DerivedFrom:  ev.Attributes.DerivedFrom,
 		Parent:       ev.Attributes.Parent,
 	})

--- a/op-node/rollup/engine/build_started.go
+++ b/op-node/rollup/engine/build_started.go
@@ -13,8 +13,8 @@ type BuildStartedEvent struct {
 
 	Parent eth.L2BlockRef
 
-	// if payload should be promoted to safe (must also be pending safe, see DerivedFrom)
-	IsLastInSpan bool
+	// if payload should be promoted to (local) safe (must also be pending safe, see DerivedFrom)
+	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
 }
@@ -29,7 +29,7 @@ func (eq *EngDeriver) onBuildStarted(ev BuildStartedEvent) {
 		eq.emitter.Emit(BuildSealEvent{
 			Info:         ev.Info,
 			BuildStarted: ev.BuildStarted,
-			IsLastInSpan: ev.IsLastInSpan,
+			Concluding:   ev.Concluding,
 			DerivedFrom:  ev.DerivedFrom,
 		})
 	}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -109,7 +109,7 @@ func (ev InteropPendingSafeChangedEvent) String() string {
 // PromotePendingSafeEvent signals that a block can be marked as pending-safe, and/or safe.
 type PromotePendingSafeEvent struct {
 	Ref         eth.L2BlockRef
-	Safe        bool
+	Concluding  bool // Concludes the pending phase, so can be promoted to (local) safe
 	DerivedFrom eth.L1BlockRef
 }
 
@@ -407,7 +407,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 				Unsafe:      d.ec.UnsafeL2Head(),
 			})
 		}
-		if x.Safe && x.Ref.Number > d.ec.LocalSafeL2Head().Number {
+		if x.Concluding && x.Ref.Number > d.ec.LocalSafeL2Head().Number {
 			d.emitter.Emit(PromoteLocalSafeEvent{
 				Ref:         x.Ref,
 				DerivedFrom: x.DerivedFrom,

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -9,8 +9,8 @@ import (
 )
 
 type PayloadProcessEvent struct {
-	// if payload should be promoted to safe (must also be pending safe, see DerivedFrom)
-	IsLastInSpan bool
+	// if payload should be promoted to (local) safe (must also be pending safe, see DerivedFrom)
+	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
 

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -5,8 +5,8 @@ import (
 )
 
 type PayloadSuccessEvent struct {
-	// if payload should be promoted to safe (must also be pending safe, see DerivedFrom)
-	IsLastInSpan bool
+	// if payload should be promoted to (local) safe (must also be pending safe, see DerivedFrom)
+	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
 
@@ -25,7 +25,7 @@ func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
 		eq.emitter.Emit(PromotePendingSafeEvent{
 			Ref:         ev.Ref,
-			Safe:        ev.IsLastInSpan,
+			Concluding:  ev.Concluding,
 			DerivedFrom: ev.DerivedFrom,
 		})
 	}
@@ -34,7 +34,7 @@ func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
 	eq.log.Info("Inserted block", "hash", payload.BlockHash, "number", uint64(payload.BlockNumber),
 		"state_root", payload.StateRoot, "timestamp", uint64(payload.Timestamp), "parent", payload.ParentHash,
 		"prev_randao", payload.PrevRandao, "fee_recipient", payload.FeeRecipient,
-		"txs", len(payload.Transactions), "last_in_span", ev.IsLastInSpan, "derived_from", ev.DerivedFrom)
+		"txs", len(payload.Transactions), "concluding", ev.Concluding, "derived_from", ev.DerivedFrom)
 
 	eq.emitter.Emit(TryUpdateEngineEvent{})
 }

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -281,10 +281,10 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 	d.asyncGossip.Gossip(x.Envelope)
 	// Now after having gossiped the block, try to put it in our own canonical chain
 	d.emitter.Emit(engine.PayloadProcessEvent{
-		IsLastInSpan: x.IsLastInSpan,
-		DerivedFrom:  x.DerivedFrom,
-		Envelope:     x.Envelope,
-		Ref:          x.Ref,
+		Concluding:  x.Concluding,
+		DerivedFrom: x.DerivedFrom,
+		Envelope:    x.Envelope,
+		Ref:         x.Ref,
 	})
 	d.latest.Ref = x.Ref
 	d.latestSealed = x.Ref
@@ -334,7 +334,7 @@ func (d *Sequencer) onPayloadSuccess(x engine.PayloadSuccessEvent) {
 	d.asyncGossip.Clear()
 }
 
-func (d *Sequencer) onSequencerAction(x SequencerActionEvent) {
+func (d *Sequencer) onSequencerAction(SequencerActionEvent) {
 	d.log.Debug("Sequencer action")
 	payload := d.asyncGossip.Get()
 	if payload != nil {
@@ -356,10 +356,10 @@ func (d *Sequencer) onSequencerAction(x SequencerActionEvent) {
 		// meaning that we have seen BuildSealedEvent already.
 		// We can retry processing to make it canonical.
 		d.emitter.Emit(engine.PayloadProcessEvent{
-			IsLastInSpan: false,
-			DerivedFrom:  eth.L1BlockRef{},
-			Envelope:     payload,
-			Ref:          ref,
+			Concluding:  false,
+			DerivedFrom: eth.L1BlockRef{},
+			Envelope:    payload,
+			Ref:         ref,
 		})
 		d.latest.Ref = ref
 	} else {
@@ -371,7 +371,7 @@ func (d *Sequencer) onSequencerAction(x SequencerActionEvent) {
 			d.emitter.Emit(engine.BuildSealEvent{
 				Info:         d.latest.Info,
 				BuildStarted: d.latest.Started,
-				IsLastInSpan: false,
+				Concluding:   false,
 				DerivedFrom:  eth.L1BlockRef{},
 			})
 		} else if d.latest == (BuildingState{}) {
@@ -416,7 +416,7 @@ func (d *Sequencer) onReset(x rollup.ResetEvent) {
 	d.nextActionOK = false
 }
 
-func (d *Sequencer) onEngineResetConfirmedEvent(x engine.EngineResetConfirmedEvent) {
+func (d *Sequencer) onEngineResetConfirmedEvent(engine.EngineResetConfirmedEvent) {
 	d.nextActionOK = d.active.Load()
 	// Before sequencing we can wait a block,
 	// assuming the execution-engine just churned through some work for the reset.
@@ -552,10 +552,10 @@ func (d *Sequencer) startBuildingBlock() {
 
 	// Start a payload building process.
 	withParent := &derive.AttributesWithParent{
-		Attributes:   attrs,
-		Parent:       l2Head,
-		IsLastInSpan: false,
-		DerivedFrom:  eth.L1BlockRef{}, // zero, not going to be pending-safe / safe
+		Attributes:  attrs,
+		Parent:      l2Head,
+		Concluding:  false,
+		DerivedFrom: eth.L1BlockRef{}, // zero, not going to be pending-safe / safe
 	}
 
 	// Don't try to start building a block again, until we have heard back from this attempt

--- a/op-node/rollup/sequencing/sequencer_chaos_test.go
+++ b/op-node/rollup/sequencing/sequencer_chaos_test.go
@@ -91,7 +91,7 @@ func (c *ChaoticEngine) OnEvent(ev event.Event) bool {
 				Info:         c.currentPayloadInfo,
 				BuildStarted: c.clock.Now(),
 				Parent:       x.Attributes.Parent,
-				IsLastInSpan: false,
+				Concluding:   false,
 				DerivedFrom:  eth.L1BlockRef{},
 			})
 		}
@@ -124,10 +124,10 @@ func (c *ChaoticEngine) OnEvent(ev event.Event) bool {
 
 		if c.currentPayloadInfo == (eth.PayloadInfo{}) {
 			c.emitter.Emit(engine.PayloadSealExpiredErrorEvent{
-				Info:         x.Info,
-				Err:          errors.New("job was cancelled"),
-				IsLastInSpan: false,
-				DerivedFrom:  eth.L1BlockRef{},
+				Info:        x.Info,
+				Err:         errors.New("job was cancelled"),
+				Concluding:  false,
+				DerivedFrom: eth.L1BlockRef{},
 			})
 			return true
 		}
@@ -142,17 +142,17 @@ func (c *ChaoticEngine) OnEvent(ev event.Event) bool {
 		switch {
 		case p < 0.03: // 3%
 			c.emitter.Emit(engine.PayloadSealInvalidEvent{
-				Info:         x.Info,
-				Err:          errors.New("mock invalid seal"),
-				IsLastInSpan: x.IsLastInSpan,
-				DerivedFrom:  x.DerivedFrom,
+				Info:        x.Info,
+				Err:         errors.New("mock invalid seal"),
+				Concluding:  x.Concluding,
+				DerivedFrom: x.DerivedFrom,
 			})
 		case p < 0.08: // 5%
 			c.emitter.Emit(engine.PayloadSealExpiredErrorEvent{
-				Info:         x.Info,
-				Err:          errors.New("mock temp engine error"),
-				IsLastInSpan: x.IsLastInSpan,
-				DerivedFrom:  x.DerivedFrom,
+				Info:        x.Info,
+				Err:         errors.New("mock temp engine error"),
+				Concluding:  x.Concluding,
+				DerivedFrom: x.DerivedFrom,
 			})
 		default:
 			payloadEnvelope := &eth.ExecutionPayloadEnvelope{
@@ -178,11 +178,11 @@ func (c *ChaoticEngine) OnEvent(ev event.Event) bool {
 				SequenceNumber: 0, // ignored
 			}
 			c.emitter.Emit(engine.BuildSealedEvent{
-				Info:         x.Info,
-				Envelope:     payloadEnvelope,
-				Ref:          payloadRef,
-				IsLastInSpan: x.IsLastInSpan,
-				DerivedFrom:  x.DerivedFrom,
+				Info:        x.Info,
+				Envelope:    payloadEnvelope,
+				Ref:         payloadRef,
+				Concluding:  x.Concluding,
+				DerivedFrom: x.DerivedFrom,
 			})
 		}
 		c.currentPayloadInfo = eth.PayloadInfo{}

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -46,7 +46,8 @@ func decodeID(data []byte) eth.BlockID {
 }
 
 func (m *FakeAttributesBuilder) PreparePayloadAttributes(ctx context.Context,
-	l2Parent eth.L2BlockRef, epoch eth.BlockID) (attrs *eth.PayloadAttributes, err error) {
+	l2Parent eth.L2BlockRef, epoch eth.BlockID,
+) (attrs *eth.PayloadAttributes, err error) {
 	gasLimit := eth.Uint64Quantity(30_000_000)
 	attrs = &eth.PayloadAttributes{
 		Timestamp:             eth.Uint64Quantity(l2Parent.Time + m.cfg.BlockTime),
@@ -315,7 +316,7 @@ func TestSequencer_StaleBuild(t *testing.T) {
 		Info:         payloadInfo,
 		BuildStarted: startedTime,
 		Parent:       head,
-		IsLastInSpan: false,
+		Concluding:   false,
 		DerivedFrom:  eth.L1BlockRef{},
 	})
 
@@ -325,7 +326,7 @@ func TestSequencer_StaleBuild(t *testing.T) {
 	emitter.ExpectOnce(engine.BuildSealEvent{
 		Info:         payloadInfo,
 		BuildStarted: startedTime,
-		IsLastInSpan: false,
+		Concluding:   false,
 		DerivedFrom:  eth.L1BlockRef{},
 	})
 	seq.OnEvent(SequencerActionEvent{})
@@ -355,18 +356,18 @@ func TestSequencer_StaleBuild(t *testing.T) {
 		SequenceNumber: 0,
 	}
 	emitter.ExpectOnce(engine.PayloadProcessEvent{
-		IsLastInSpan: false,
-		DerivedFrom:  eth.L1BlockRef{},
-		Envelope:     payloadEnvelope,
-		Ref:          payloadRef,
+		Concluding:  false,
+		DerivedFrom: eth.L1BlockRef{},
+		Envelope:    payloadEnvelope,
+		Ref:         payloadRef,
 	})
 	// And report back the sealing result to the engine
 	seq.OnEvent(engine.BuildSealedEvent{
-		IsLastInSpan: false,
-		DerivedFrom:  eth.L1BlockRef{},
-		Info:         payloadInfo,
-		Envelope:     payloadEnvelope,
-		Ref:          payloadRef,
+		Concluding:  false,
+		DerivedFrom: eth.L1BlockRef{},
+		Info:        payloadInfo,
+		Envelope:    payloadEnvelope,
+		Ref:         payloadRef,
 	})
 	// The sequencer should start processing the payload
 	emitter.AssertExpectations(t)
@@ -521,7 +522,7 @@ func TestSequencerBuild(t *testing.T) {
 		Info:         payloadInfo,
 		BuildStarted: startedTime,
 		Parent:       head,
-		IsLastInSpan: false,
+		Concluding:   false,
 		DerivedFrom:  eth.L1BlockRef{},
 	})
 	// The sealing should now be scheduled as next action.
@@ -535,7 +536,7 @@ func TestSequencerBuild(t *testing.T) {
 	emitter.ExpectOnce(engine.BuildSealEvent{
 		Info:         payloadInfo,
 		BuildStarted: startedTime,
-		IsLastInSpan: false,
+		Concluding:   false,
 		DerivedFrom:  eth.L1BlockRef{},
 	})
 	seq.OnEvent(SequencerActionEvent{})
@@ -564,18 +565,18 @@ func TestSequencerBuild(t *testing.T) {
 		SequenceNumber: 0,
 	}
 	emitter.ExpectOnce(engine.PayloadProcessEvent{
-		IsLastInSpan: false,
-		DerivedFrom:  eth.L1BlockRef{},
-		Envelope:     payloadEnvelope,
-		Ref:          payloadRef,
+		Concluding:  false,
+		DerivedFrom: eth.L1BlockRef{},
+		Envelope:    payloadEnvelope,
+		Ref:         payloadRef,
 	})
 	// And report back the sealing result to the engine
 	seq.OnEvent(engine.BuildSealedEvent{
-		IsLastInSpan: false,
-		DerivedFrom:  eth.L1BlockRef{},
-		Info:         payloadInfo,
-		Envelope:     payloadEnvelope,
-		Ref:          payloadRef,
+		Concluding:  false,
+		DerivedFrom: eth.L1BlockRef{},
+		Info:        payloadInfo,
+		Envelope:    payloadEnvelope,
+		Ref:         payloadRef,
 	})
 	// The sequencer should start processing the payload
 	emitter.AssertExpectations(t)
@@ -587,10 +588,10 @@ func TestSequencerBuild(t *testing.T) {
 
 	// Mock that the processing was successful
 	seq.OnEvent(engine.PayloadSuccessEvent{
-		IsLastInSpan: false,
-		DerivedFrom:  eth.L1BlockRef{},
-		Envelope:     payloadEnvelope,
-		Ref:          payloadRef,
+		Concluding:  false,
+		DerivedFrom: eth.L1BlockRef{},
+		Envelope:    payloadEnvelope,
+		Ref:         payloadRef,
 	})
 	require.Nil(t, deps.asyncGossip.payload, "async gossip should have cleared,"+
 		" after previous publishing and now having persisted the block ourselves")


### PR DESCRIPTION
**Description**

Holocene removes backwards-invalidation by span batches. So all derived attributes can immediately be promoted to **safe**. This is the only change in logic of this PR.

The PR also renames fields `IsLastInSpan` to `Concluding` in many structs because that's semantically clearer. That a last batch in a span batch is pre-Holocene the indicator for a safe block promotion is an implementation detail. It's better to name the *effect* rather than the *reason*. Concluding was chosen, since these attributes conclude the pending phase.

**Tests**

Changed an assertion in a test from using pending safe to safe to test this change. It failed before.

**Additional context**

Holocene skips overlapping span batch checks, which in a constructed malicious sequencer setting can lead to a local chain split of nodes that force-restarted mid-way through block derivation. However, the same situation can already be applied pre-Holocene with singular batches, because they are also fast-dropped and overlapping singular batches are not tested to match an existing safe chain. So we may actually want to change the mechanics of safe chain promotion from pending safe to only promote after a full L1 block has been derived. This is reserved for a follow, more details can be found here: https://github.com/ethereum-optimism/optimism/issues/12695
