### PR TITLE
feat(ct): Proofs - Basic DelayedWETH Capability Expansion

### DIFF
--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -109,7 +109,7 @@ contract DelayedWETH is OwnableUpgradeable, WETH98, ISemver {
     /// @notice Allows the owner to pause or unpause withdrawals and transfers.
     /// @param _paused True if withdrawals and transfers should be paused, false otherwise.
     function setDelayedWethPaused(bool _paused) external {
-        require(msg.sender == owner(), "DelayedWETH: not owner");
+        require(msg.sender == config.guardian(), "DelayedWETH: not guardian");
         delayedWethPaused = _paused;
         emit DelayedWethPausedSet(_paused);
     }

--- a/packages/contracts-bedrock/src/dispute/interfaces/IDelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IDelayedWETH.sol
@@ -17,8 +17,10 @@ interface IDelayedWETH {
     receive() external payable;
 
     function config() external view returns (ISuperchainConfig);
+    function withdrawalsPaused() external view returns (bool);
     function delay() external view returns (uint256);
     function hold(address _guy, uint256 _wad) external;
+    function setWithdrawalsPaused(bool _paused) external;
     function initialize(address _owner, ISuperchainConfig _config) external;
     function owner() external view returns (address);
     function recover(uint256 _wad) external;

--- a/packages/contracts-bedrock/src/dispute/interfaces/IDelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IDelayedWETH.sol
@@ -17,10 +17,10 @@ interface IDelayedWETH {
     receive() external payable;
 
     function config() external view returns (ISuperchainConfig);
-    function withdrawalsPaused() external view returns (bool);
+    function delayedWethPaused() external view returns (bool);
     function delay() external view returns (uint256);
     function hold(address _guy, uint256 _wad) external;
-    function setWithdrawalsPaused(bool _paused) external;
+    function setDelayedWethPaused(bool _paused) external;
     function initialize(address _owner, ISuperchainConfig _config) external;
     function owner() external view returns (address);
     function recover(uint256 _wad) external;

--- a/packages/contracts-bedrock/src/universal/WETH98.sol
+++ b/packages/contracts-bedrock/src/universal/WETH98.sol
@@ -132,7 +132,7 @@ contract WETH98 {
     /// @param dst The address to transfer the WETH to.
     /// @param wad The amount of WETH to transfer.
     /// @return True if the transfer was successful.
-    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
+    function transferFrom(address src, address dst, uint256 wad) public virtual returns (bool) {
         require(_balanceOf[src] >= wad);
 
         uint256 senderAllowance = allowance(src, msg.sender);

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -64,6 +64,26 @@ contract DelayedWETH_Unlock_Test is DelayedWETH_Init {
     }
 }
 
+contract DelayedWETH_Transfer_Test is DelayedWETH_Init {
+    function testFuzz_transfer_succeeds(address _to, uint256 _amount) public {
+        vm.assume(_to != alice);
+        uint256 _depositAmount = 1 ether;
+        _amount = bound(_amount, 0, _depositAmount);
+        // Deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: _depositAmount }();
+        uint256 balance = address(alice).balance;
+
+        // transfer it.
+        vm.prank(alice);
+        delayedWeth.transfer(_to, _amount);
+        assertEq(delayedWeth.balanceOf(_to), _amount);
+    }
+
+    // TODO: transfer fails when pause is active
+    // TODO: same 2 tests for transferFrom
+}
+
 contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
     /// @dev Tests that withdrawing while unlocked and delay has passed is successful.
     function test_withdraw_whileUnlocked_succeeds() public {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Draft PR expanding DelayedWETH, per #12174 

Note: This draft PR is preliminary, created in order to facilitate spec formulation. See spec PR here: https://github.com/ethereum-optimism/specs/pull/453

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
- added a test asserting that withdrawals can't happen when the local `withdrawalsPaused` flag is `true`
- modified `test_hold_succeeds`, revising assertions according to new balance transfer functionality
- added `setWithdrawalsPaused` tests

**Additional context**

<!--
Add any other context about the problem you're solving.
-->
Questions:
- should I refactor more of the DelayedWETH tests to fuzz?
- As DelayedWETH is upgradeable, should storage layout changes be triple-checked?


**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Resolves #12174 
