### PR TITLE
feat: use bound in testFuzz_slice_lengthOverflows_reverts

### DIFF
--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -127,11 +127,14 @@ contract Bytes_slice_TestFail is Test {
     /// @notice Tests that, when given an input bytes array of length `n`, the `slice` function will
     ///         always revert if `_start + _length > n`.
     function testFuzz_slice_outOfBounds_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
-        // We want a valid start index and a length that will not overflow.
-        vm.assume(_start < _input.length && _length < type(uint256).max - 31);
-        // But, we want an invalid slice length.
-        vm.assume(_start + _length > _input.length);
+        // We want a valid start index for the given input
+        uint256 maxStart = _input.length == 0 ? 0 : _input.length - 1;
+        _start = bound(_start, 0, maxStart);
 
+        // The length needs to be large enough that the end point will be out of bounds, but not overflow
+        _length = bound(_length, _input.length - _start, type(uint256).max - _start - 32);
+
+        // Expect a revert
         vm.expectRevert("slice_outOfBounds");
         Bytes.slice(_input, _start, _length);
     }

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -140,7 +140,8 @@ contract Bytes_slice_TestFail is Test {
     ///         the `slice` function reverts.
     function testFuzz_slice_lengthOverflows_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
         // Ensure that the `_length` will overflow if a number >= 31 is added to it.
-        vm.assume(_length > type(uint256).max - 31);
+        // bound() is inclusive of the min and max, so we subtract 30 to meet the requirement.
+        _length = bound(_length, type(uint256).max - 30, type(uint256).max);
 
         vm.expectRevert("slice_overflow");
         Bytes.slice(_input, _start, _length);

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -131,8 +131,11 @@ contract Bytes_slice_TestFail is Test {
         uint256 maxStart = _input.length == 0 ? 0 : _input.length - 1;
         _start = bound(_start, 0, maxStart);
 
-        // The length needs to be large enough that the end point will be out of bounds, but not overflow
-        _length = bound(_length, _input.length - _start, type(uint256).max - _start - 32);
+        // The length needs to be large enough that the end point will be out of bounds...
+        uint256 minLength = _input.length - _start + 1;
+        // ...but not so large that it will overflow.
+        uint256 maxLength = type(uint256).max - _start - 31;
+        _length = bound(_length, minLength, maxLength);
 
         // Expect a revert
         vm.expectRevert("slice_outOfBounds");


### PR DESCRIPTION
Should fix [this issue](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/70334/workflows/5a238997-43c2-46ff-b0d6-01ffcf818ae5/jobs/2901192?invite=true#step-112-2445) in the heavy fuzz tests

```
[FAIL. Reason: The `vm.assume` cheatcode rejected too many inputs (65536 allowed)] testFuzz_slice_lengthOverflows_reverts(bytes,uint256,uint256) (runs: 2140, μ: 4212, ~: 4212)
```

By bounding the inputs rather than throwing them out.