### PR TITLE
op-deployer: Add support for deploying interop chains

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -75,7 +75,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxyAddress,
 			OpcmProxyOwner:                  st.SuperchainDeployment.ProxyAdminAddress,
 			StandardVersionsToml:            standardVersionsTOML,
-			UseInterop:                      false,
+			UseInterop:                      intent.UseInterop,
 		},
 	)
 	if err != nil {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -40,6 +40,8 @@ type Intent struct {
 
 	FundDevAccounts bool `json:"fundDevAccounts" toml:"fundDevAccounts"`
 
+	UseInterop bool `json:"useInterop" toml:"useInterop"`
+
 	L1ContractsLocator *opcm.ArtifactsLocator `json:"l1ContractsLocator" toml:"l1ContractsLocator"`
 
 	L2ContractsLocator *opcm.ArtifactsLocator `json:"l2ContractsLocator" toml:"l2ContractsLocator"`


### PR DESCRIPTION
Stacked on https://github.com/ethereum-optimism/optimism/pull/12732.

Closes https://github.com/ethereum-optimism/optimism/issues/12738.