### PR TITLE
op-batcher: add `channel.straddlesActivation` method (for Holocene) and wire it up

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -86,7 +86,7 @@ func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef, holoceneTi
 	}
 
 	// If this channel timed out or if the confirmed tranactions straddle the Holocene activation time
-	// return true so that the the caller can reset the state abd build a new channel.
+	// return true so that the the caller can reset the state and build a new channel.
 	if c.isTimedOut() || c.straddlesActivation(holoceneTime) {
 		c.metr.RecordChannelTimedOut(c.ID())
 		c.log.Warn("Channel timed out", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -93,7 +93,7 @@ func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef, holoceneTi
 		return true
 	}
 
-	// If this channel had confirmed tranactions straddling the Holocene activation time
+	// If this channel had confirmed transactions straddling the Holocene activation time
 	// return true so that the the caller can reset the state and build a new channel.
 	if c.straddlesActivation(holoceneTime) {
 		c.log.Warn("Channel straddled Holocene activation time, invalidating", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -85,11 +85,18 @@ func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef, holoceneTi
 		c.log.Info("Channel is fully submitted", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
 	}
 
-	// If this channel timed out or if the confirmed tranactions straddle the Holocene activation time
+	// If this channel timed out
 	// return true so that the the caller can reset the state and build a new channel.
-	if c.isTimedOut() || c.straddlesActivation(holoceneTime) {
+	if c.isTimedOut() {
 		c.metr.RecordChannelTimedOut(c.ID())
-		c.log.Warn("Channel timed out", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
+		c.log.Warn("Channel timed out, invalidating", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
+		return true
+	}
+
+	// If this channel had confirmed tranactions straddling the Holocene activation time
+	// return true so that the the caller can reset the state and build a new channel.
+	if c.straddlesActivation(holoceneTime) {
+		c.log.Warn("Channel straddled Holocene activation time, invalidating", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
 		return true
 	}
 

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -63,7 +63,7 @@ func (c *channel) TxFailed(id string) {
 
 // TxConfirmed marks a transaction as confirmed on L1. Returns a bool indicating
 // whether the channel was invalidated.
-func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef, holoceneTime *uint64) bool {
+func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef) bool {
 	c.metr.RecordBatchTxSuccess()
 	c.log.Debug("marked transaction as confirmed", "id", id, "block", inclusionBlock)
 	if _, ok := c.pendingTransactions[id]; !ok {
@@ -95,7 +95,7 @@ func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef, holoceneTi
 
 	// If this channel had confirmed transactions straddling the Holocene activation time
 	// return true so that the the caller can reset the state and build a new channel.
-	if c.straddlesActivation(holoceneTime) {
+	if c.straddlesActivation(c.channelBuilder.rollupCfg.HoloceneTime) {
 		c.log.Warn("Channel straddled Holocene activation time, invalidating", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
 		return true
 	}

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -23,7 +23,7 @@ type channel struct {
 	// Set of unconfirmed txID -> tx data. For tx resubmission
 	pendingTransactions map[string]txData
 	// Set of confirmed txID -> inclusion block. For determining if the channel is timed out
-	confirmedTransactions map[string]eth.BlockID
+	confirmedTransactions map[string]eth.L1BlockRef
 
 	// Inclusion block number of first confirmed TX
 	minInclusionBlock uint64
@@ -39,7 +39,7 @@ func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, rollup
 		cfg:                   cfg,
 		channelBuilder:        cb,
 		pendingTransactions:   make(map[string]txData),
-		confirmedTransactions: make(map[string]eth.BlockID),
+		confirmedTransactions: make(map[string]eth.BlockRef),
 		minInclusionBlock:     math.MaxUint64,
 	}
 }
@@ -62,8 +62,8 @@ func (c *channel) TxFailed(id string) {
 }
 
 // TxConfirmed marks a transaction as confirmed on L1. Returns a bool indicating
-// whether the channel timed out on chain.
-func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockID) bool {
+// whether the channel was invalidated.
+func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockRef, holoceneTime *uint64) bool {
 	c.metr.RecordBatchTxSuccess()
 	c.log.Debug("marked transaction as confirmed", "id", id, "block", inclusionBlock)
 	if _, ok := c.pendingTransactions[id]; !ok {
@@ -85,9 +85,9 @@ func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockID) bool {
 		c.log.Info("Channel is fully submitted", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
 	}
 
-	// If this channel timed out, put the pending blocks back into the local saved blocks
-	// and then reset this state so it can try to build a new channel.
-	if c.isTimedOut() {
+	// If this channel timed out or if the confirmed tranactions straddle the Holocene activation time
+	// return true so that the the caller can reset the state abd build a new channel.
+	if c.isTimedOut() || c.straddlesActivation(holoceneTime) {
 		c.metr.RecordChannelTimedOut(c.ID())
 		c.log.Warn("Channel timed out", "id", c.ID(), "min_inclusion_block", c.minInclusionBlock, "max_inclusion_block", c.maxInclusionBlock)
 		return true
@@ -109,6 +109,24 @@ func (c *channel) isTimedOut() bool {
 	// to believe the channel timed out when it was valid. It would then resubmit the blocks needlessly.
 	// This wastes batcher funds but doesn't cause any problems for the chain progressing safe head.
 	return len(c.confirmedTransactions) > 0 && c.maxInclusionBlock-c.minInclusionBlock >= c.cfg.ChannelTimeout
+}
+
+// straddlesActivation returns true if at least one transaction
+// for the channel was confirmed before the supplied activation time and
+// at least one transaction was confirmed at or after the supplied activation time.
+func (c *channel) straddlesActivation(activationTime *uint64) bool {
+	if activationTime == nil {
+		return false
+	}
+	var before, after bool
+	for _, block := range c.confirmedTransactions {
+		if block.Time < *activationTime {
+			before = true
+		} else {
+			after = true
+		}
+	}
+	return before && after
 }
 
 // isFullySubmitted returns true if the channel has been fully submitted (all transactions are confirmed).

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -116,7 +116,7 @@ func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockRef) {
 	id := _id.String()
 	if channel, ok := s.txChannels[id]; ok {
 		delete(s.txChannels, id)
-		if invalidated := channel.TxConfirmed(id, inclusionBlock, s.rollupCfg.HoloceneTime); invalidated {
+		if invalidated := channel.TxConfirmed(id, inclusionBlock); invalidated {
 			s.handleChannelInvalidated(channel)
 		}
 	} else {

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -64,8 +64,8 @@ func TestChannelTimeout(t *testing.T) {
 	require.False(t, timeout)
 
 	// Manually confirm transactions
-	channel.TxConfirmed(zeroFrameTxID(0).String(), eth.BlockRef{Number: 0}, nil)
-	channel.TxConfirmed(zeroFrameTxID(1).String(), eth.BlockRef{Number: 99}, nil)
+	channel.TxConfirmed(zeroFrameTxID(0).String(), eth.BlockRef{Number: 0})
+	channel.TxConfirmed(zeroFrameTxID(1).String(), eth.BlockRef{Number: 99})
 
 	// Since the ChannelTimeout is 100, the
 	// pending channel should not be timed out
@@ -74,7 +74,7 @@ func TestChannelTimeout(t *testing.T) {
 
 	// Add a confirmed transaction with a higher number
 	// than the ChannelTimeout
-	channel.TxConfirmed(zeroFrameTxID(2).String(), eth.BlockRef{Number: 101}, nil)
+	channel.TxConfirmed(zeroFrameTxID(2).String(), eth.BlockRef{Number: 101})
 
 	// Now the pending channel should be timed out
 	timeout = channel.isTimedOut()

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -64,8 +64,8 @@ func TestChannelTimeout(t *testing.T) {
 	require.False(t, timeout)
 
 	// Manually confirm transactions
-	channel.TxConfirmed(zeroFrameTxID(0).String(), eth.BlockID{Number: 0})
-	channel.TxConfirmed(zeroFrameTxID(1).String(), eth.BlockID{Number: 99})
+	channel.TxConfirmed(zeroFrameTxID(0).String(), eth.BlockRef{Number: 0}, nil)
+	channel.TxConfirmed(zeroFrameTxID(1).String(), eth.BlockRef{Number: 99}, nil)
 
 	// Since the ChannelTimeout is 100, the
 	// pending channel should not be timed out
@@ -74,7 +74,7 @@ func TestChannelTimeout(t *testing.T) {
 
 	// Add a confirmed transaction with a higher number
 	// than the ChannelTimeout
-	channel.TxConfirmed(zeroFrameTxID(2).String(), eth.BlockID{Number: 101})
+	channel.TxConfirmed(zeroFrameTxID(2).String(), eth.BlockRef{Number: 101}, nil)
 
 	// Now the pending channel should be timed out
 	timeout = channel.isTimedOut()
@@ -258,7 +258,7 @@ func TestChannelTxConfirmed(t *testing.T) {
 	unknownChannelID := derive.ChannelID([derive.ChannelIDLength]byte{0x69})
 	require.NotEqual(t, actualChannelID, unknownChannelID)
 	unknownTxID := singleFrameTxID(unknownChannelID, 0)
-	blockID := eth.BlockID{Number: 0, Hash: common.Hash{0x69}}
+	blockID := eth.BlockRef{Number: 0, Hash: common.Hash{0x69}}
 	m.TxConfirmed(unknownTxID, blockID)
 	require.Empty(t, m.currentChannel.confirmedTransactions)
 	require.Len(t, m.currentChannel.pendingTransactions, 1)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
@@ -482,9 +483,17 @@ func (l *BatchSubmitter) processReceiptsLoop(ctx context.Context, receiptsCh cha
 				l.Log.Info("txpool may no longer be blocked", "err", r.Err)
 			}
 			l.Log.Info("Handling receipt", "id", r.ID)
-			l.handleReceipt(r)
+			err := l.handleReceipt(r)
+			if err != nil {
+				// This error may be caused when we cannot get the block
+				// referenced (by number) in the receipt.
+				// In this case we would potetntially not detect
+				// a channel being invalidated on chain (timing out
+				// or straddling Holocene activation).
+				l.Log.Error("Error handling receipt", "error", err)
+			}
 		case <-ctx.Done():
-			l.Log.Info("Receipt processing loop done")
+			l.Log.Info("Receipts processing loop done")
 			return
 		}
 	}
@@ -877,7 +886,9 @@ func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) erro
 	l.Log.Info("Transaction confirmed", logFields(id, receipt)...)
 	tctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
 	defer cancel()
-	header, err := l.L1Client.HeaderByNumber(tctx, receipt.BlockNumber)
+	header, err := retry.Do(tctx, 3, retry.Fixed(1), func() (*types.Header, error) {
+		return l.L1Client.HeaderByNumber(tctx, receipt.BlockNumber)
+	})
 	if err != nil {
 		return err
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -466,7 +466,7 @@ func (l *BatchSubmitter) mainLoop(ctx context.Context, receiptsCh chan txmgr.TxR
 }
 
 // processReceiptsLoop handles transaction receipts from the DA layer
-func (l *BatchSubmitter) processReceipstsLoop(ctx context.Context, receiptsCh chan txmgr.TxReceipt[txRef]) {
+func (l *BatchSubmitter) processReceiptsLoop(ctx context.Context, receiptsCh chan txmgr.TxReceipt[txRef]) {
 	defer l.wg.Done()
 	l.Log.Info("Starting receipts processing loop")
 	for {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
@@ -483,15 +482,7 @@ func (l *BatchSubmitter) processReceiptsLoop(ctx context.Context, receiptsCh cha
 				l.Log.Info("txpool may no longer be blocked", "err", r.Err)
 			}
 			l.Log.Info("Handling receipt", "id", r.ID)
-			err := l.handleReceipt(r)
-			if err != nil {
-				// This error may be caused when we cannot get the block
-				// referenced (by number) in the receipt.
-				// In this case we would potetntially not detect
-				// a channel being invalidated on chain (timing out
-				// or straddling Holocene activation).
-				l.Log.Error("Error handling receipt", "error", err)
-			}
+			l.handleReceipt(r)
 		case <-ctx.Done():
 			l.Log.Info("Receipts processing loop done")
 			return
@@ -860,13 +851,12 @@ func (l *BatchSubmitter) calldataTxCandidate(data []byte) *txmgr.TxCandidate {
 	}
 }
 
-func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) error {
+func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 	// Record TX Status
 	if r.Err != nil {
 		l.recordFailedTx(r.ID.id, r.Err)
-		return nil
 	} else {
-		return l.recordConfirmedTx(r.ID.id, r.Receipt)
+		l.recordConfirmedTx(r.ID.id, r.Receipt)
 	}
 }
 
@@ -882,24 +872,21 @@ func (l *BatchSubmitter) recordFailedTx(id txID, err error) {
 	l.state.TxFailed(id)
 }
 
-func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) error {
+func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) {
 	l.Log.Info("Transaction confirmed", logFields(id, receipt)...)
 	tctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
 	defer cancel()
-	header, err := retry.Do(tctx, 3, retry.Fixed(1), func() (*types.Header, error) {
-		return l.L1Client.HeaderByNumber(tctx, receipt.BlockNumber)
-	})
-	if err != nil {
-		return err
+
+	var header *types.Header
+	var err error
+	for {
+		header, err = l.L1Client.HeaderByNumber(tctx, receipt.BlockNumber)
+		if err != nil {
+			break
+		}
 	}
-	br := eth.BlockRef{
-		Hash:       receipt.BlockHash,
-		Number:     receipt.BlockNumber.Uint64(),
-		ParentHash: header.ParentHash,
-		Time:       header.Time,
-	}
-	l.state.TxConfirmed(id, br)
-	return nil
+
+	l.state.TxConfirmed(id, eth.InfoToL1BlockRef(eth.HeaderBlockInfo(header)))
 }
 
 // l1Tip gets the current L1 tip as a L1BlockRef. The passed context is assumed

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -851,12 +851,13 @@ func (l *BatchSubmitter) calldataTxCandidate(data []byte) *txmgr.TxCandidate {
 	}
 }
 
-func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
+func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) error {
 	// Record TX Status
 	if r.Err != nil {
 		l.recordFailedTx(r.ID.id, r.Err)
+		return nil
 	} else {
-		l.recordConfirmedTx(r.ID.id, r.Receipt)
+		return l.recordConfirmedTx(r.ID.id, r.Receipt)
 	}
 }
 
@@ -872,10 +873,22 @@ func (l *BatchSubmitter) recordFailedTx(id txID, err error) {
 	l.state.TxFailed(id)
 }
 
-func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) {
+func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) error {
 	l.Log.Info("Transaction confirmed", logFields(id, receipt)...)
-	l1block := eth.ReceiptBlockID(receipt)
-	l.state.TxConfirmed(id, l1block)
+	tctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
+	defer cancel()
+	header, err := l.L1Client.HeaderByNumber(tctx, receipt.BlockNumber)
+	if err != nil {
+		return err
+	}
+	br := eth.BlockRef{
+		Hash:       receipt.BlockHash,
+		Number:     receipt.BlockNumber.Uint64(),
+		ParentHash: header.ParentHash,
+		Time:       header.Time,
+	}
+	l.state.TxConfirmed(id, br)
+	return nil
 }
 
 // l1Tip gets the current L1 tip as a L1BlockRef. The passed context is assumed


### PR DESCRIPTION
To trigger same flow as a channel timing out, when the channel confirmations straddle the Holocene activation timestamp

Closes https://github.com/ethereum-optimism/optimism/issues/12122

~⚠️ stacked on https://github.com/ethereum-optimism/optimism/pull/12390, don't merge yet.~