### PR TITLE
cannon: Avoid page allocation for empty reads

### DIFF
--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -280,18 +280,22 @@ func (m *Memory) SetMemoryRange(addr Word, r io.Reader) error {
 	for {
 		pageIndex := addr >> PageAddrSize
 		pageAddr := addr & PageAddrMask
-		p, ok := m.pageLookup(pageIndex)
-		if !ok {
-			p = m.AllocPage(pageIndex)
-		}
-		p.InvalidateFull()
-		n, err := r.Read(p.Data[pageAddr:])
+		readLen := PageSize - pageAddr
+		chunk := make([]byte, readLen)
+		n, err := r.Read(chunk)
 		if err != nil {
 			if err == io.EOF {
 				return nil
 			}
 			return err
 		}
+
+		p, ok := m.pageLookup(pageIndex)
+		if !ok {
+			p = m.AllocPage(pageIndex)
+		}
+		p.InvalidateFull()
+		copy(p.Data[pageAddr:], chunk)
 		addr += Word(n)
 	}
 }

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -295,7 +295,7 @@ func (m *Memory) SetMemoryRange(addr Word, r io.Reader) error {
 			p = m.AllocPage(pageIndex)
 		}
 		p.InvalidateFull()
-		copy(p.Data[pageAddr:], chunk)
+		copy(p.Data[pageAddr:], chunk[:n])
 		addr += Word(n)
 	}
 }

--- a/cannon/mipsevm/memory/memory64_test.go
+++ b/cannon/mipsevm/memory/memory64_test.go
@@ -140,6 +140,35 @@ func TestMemory64ReadWrite(t *testing.T) {
 		require.Equal(t, make([]byte, 10), res[len(res)-10:], "empty end")
 	})
 
+	t.Run("empty range", func(t *testing.T) {
+		m := NewMemory()
+		addr := Word(0xAABBCC00)
+		rr := bytes.NewReader(nil)
+		r := io.Reader(io.NewSectionReader(rr, 0, 0))
+		pre := m.MerkleRoot()
+		preJSON, err := m.MarshalJSON()
+		require.NoError(t, err)
+		var preSerialized bytes.Buffer
+		require.NoError(t, m.Serialize(&preSerialized))
+
+		require.NoError(t, m.SetMemoryRange(addr, r))
+		v := m.GetWord(0)
+		require.Equal(t, Word(0), v)
+		post := m.MerkleRoot()
+		require.Equal(t, pre, post)
+
+		// Assert that there are no extra zero pages in serialization
+		postJSON, err := m.MarshalJSON()
+		require.NoError(t, err)
+		require.Equal(t, preJSON, postJSON)
+
+		var postSerialized bytes.Buffer
+		require.NoError(t, m.Serialize(&postSerialized))
+		require.Equal(t, preSerialized.Bytes(), postSerialized.Bytes())
+	})
+
+
+
 	t.Run("read-write", func(t *testing.T) {
 		m := NewMemory()
 		m.SetWord(16, 0xAABBCCDD_EEFF1122)

--- a/cannon/mipsevm/memory/memory_test.go
+++ b/cannon/mipsevm/memory/memory_test.go
@@ -139,6 +139,33 @@ func TestMemoryReadWrite(t *testing.T) {
 		require.Equal(t, make([]byte, 10), res[len(res)-10:], "empty end")
 	})
 
+	t.Run("empty range", func(t *testing.T) {
+		m := NewMemory()
+		addr := Word(0xAABBCC00)
+		rr := bytes.NewReader(nil)
+		r := io.Reader(io.NewSectionReader(rr, 0, 0))
+		pre := m.MerkleRoot()
+		preJSON, err := m.MarshalJSON()
+		require.NoError(t, err)
+		var preSerialized bytes.Buffer
+		require.NoError(t, m.Serialize(&preSerialized))
+
+		require.NoError(t, m.SetMemoryRange(addr, r))
+		v := m.GetWord(0)
+		require.Equal(t, Word(0), v)
+		post := m.MerkleRoot()
+		require.Equal(t, pre, post)
+
+		// Assert that there are no extra zero pages in serialization
+		postJSON, err := m.MarshalJSON()
+		require.NoError(t, err)
+		require.Equal(t, preJSON, postJSON)
+
+		var postSerialized bytes.Buffer
+		require.NoError(t, m.Serialize(&postSerialized))
+		require.Equal(t, preSerialized.Bytes(), postSerialized.Bytes())
+	})
+
 	t.Run("read-write", func(t *testing.T) {
 		m := NewMemory()
 		m.SetWord(12, 0xAABBCCDD)

--- a/cannon/mipsevm/tests/fuzz_evm_common64_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common64_test.go
@@ -91,12 +91,6 @@ func FuzzStateConsistencyMultuOp(f *testing.F) {
 	})
 }
 
-type insn struct {
-	opcode      uint32
-	expectRdReg bool
-	funct       uint32
-}
-
 func mulOpConsistencyCheck(
 	t *testing.T, versions []VersionedVMTestCase,
 	opcode uint32, expectRdReg bool, funct uint32,


### PR DESCRIPTION
This saves a couple page allocations, resulting in a smaller cannon program memory state. This change does not alter the memory root of a loaded program. The elided pages are can still be read as usual as a zeroed page.

Note that this alters the serialized program produced via `load-elf`. A follow up PR will update the `cannon-stf-verify` job to use the latest cannon.