### PR TITLE
fix: Make public DeployUtils lib functions internal

### DIFF
--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -279,7 +279,10 @@ library DeployUtils {
 
     /// @notice Builds an L1ChugSplashProxy with a dummy implementation.
     /// @param _proxyImplName Name of the implementation contract.
-    function buildL1ChugSplashProxyWithImpl(string memory _proxyImplName) public returns (IL1ChugSplashProxy proxy_) {
+    function buildL1ChugSplashProxyWithImpl(string memory _proxyImplName)
+        internal
+        returns (IL1ChugSplashProxy proxy_)
+    {
         proxy_ = IL1ChugSplashProxy(
             create1({
                 _name: "L1ChugSplashProxy",
@@ -299,7 +302,7 @@ library DeployUtils {
         IAddressManager _addressManager,
         string memory _proxyImplName
     )
-        public
+        internal
         returns (IResolvedDelegateProxy proxy_)
     {
         proxy_ = IResolvedDelegateProxy(
@@ -316,7 +319,7 @@ library DeployUtils {
     }
 
     /// @notice Builds an AddressManager contract.
-    function buildAddressManager() public returns (IAddressManager addressManager_) {
+    function buildAddressManager() internal returns (IAddressManager addressManager_) {
         addressManager_ = IAddressManager(
             create1({
                 _name: "AddressManager",


### PR DESCRIPTION
This should fix the recent flakes we're seeing in forge fuzz tests, as they appear to be related to https://github.com/foundry-rs/foundry/issues/8639, and we had a few `public` library functions.

