### PR TITLE
cannon: Add noop stat syscall to MIPS64.sol

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0x9fa2d1297ad1e93b4d3c5c0fed08bedcd8f746807589f0fd3369e79347c6a027"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0x47c2bdd1e6fbb4941caa20a2ba5c2a66de198a8c7b540a9d4a0d84dbe8d3bfea",
-    "sourceCodeHash": "0xdb7f8a92ed552a2720f5fe3c0a32e4069026f0b23933145493ead88403206814"
+    "initCodeHash": "0x5094e3f488de838cba1422b508a899444ee27905abc9c0b97961d4b8b7392289",
+    "sourceCodeHash": "0xdc2393d2073348218a9c6e169c2e7f687590e237773b8fde53fae9cf84395978"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -64,8 +64,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.0.0-beta.1
-    string public constant version = "1.0.0-beta.1";
+    /// @custom:semver 1.0.0-beta.2
+    string public constant version = "1.0.0-beta.2";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -597,6 +597,8 @@ contract MIPS64 is ISemver {
             } else if (syscall_no == sys.SYS_CLOSE) {
                 // ignored
             } else if (syscall_no == sys.SYS_PREAD64) {
+                // ignored
+            } else if (syscall_no == sys.SYS_STAT) {
                 // ignored
             } else if (syscall_no == sys.SYS_FSTAT) {
                 // ignored

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -58,6 +58,7 @@ library MIPS64Syscalls {
     uint32 internal constant SYS_PRLIMIT64 = 5297;
     uint32 internal constant SYS_CLOSE = 5003;
     uint32 internal constant SYS_PREAD64 = 5016;
+    uint32 internal constant SYS_STAT = 5004;
     uint32 internal constant SYS_FSTAT = 5005;
     //uint32 internal constant SYS_FSTAT64 = 0xFFFFFFFF;  // UndefinedSysNr - not supported by MIPS64
     uint32 internal constant SYS_OPENAT = 5247;


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The `stat` (noop) syscall was missing from the on-chain 64-bit VM implementation: add it to `MIPS64.sol`.

**Tests**

We have tests that should catch discrepancies like this, but we're in the process of enabling them for the 64-bit VM.  See issues:
- https://github.com/ethereum-optimism/optimism/issues/12252
- https://github.com/ethereum-optimism/optimism/issues/12598

Relevant tests are [here](https://github.com/ethereum-optimism/optimism/blob/5e209a5256b2f011a99bc12a83e126a29a5cc3d6/cannon/mipsevm/tests/evm_multithreaded_test.go#L1072-L1171).


