### PR TITLE
op-supervisor: improve logging, add update signals to trigger worker routines faster

### DIFF
--- a/op-supervisor/supervisor/backend/cross/worker.go
+++ b/op-supervisor/supervisor/backend/cross/worker.go
@@ -71,7 +71,7 @@ func (s *Worker) worker() {
 				return
 			}
 			if errors.Is(err, types.ErrFuture) {
-				s.log.Debug("Failed to process work", "err", err)
+				s.log.Debug("Worker awaits more data", "err", err)
 			} else {
 				s.log.Warn("Failed to process work", "err", err)
 			}
@@ -92,14 +92,13 @@ func (s *Worker) worker() {
 	}
 }
 
-func (s *Worker) OnNewData() error {
+func (s *Worker) OnNewData() {
 	// signal that we have something to process
 	select {
 	case s.poke <- struct{}{}:
 	default:
 		// already requested an update
 	}
-	return nil
 }
 
 func (s *Worker) Close() {

--- a/op-supervisor/supervisor/backend/cross/worker_test.go
+++ b/op-supervisor/supervisor/backend/cross/worker_test.go
@@ -55,7 +55,7 @@ func TestWorker(t *testing.T) {
 			return count == 1
 		}, 2*time.Second, 100*time.Millisecond)
 		// when OnNewData is called, the worker runs again
-		require.NoError(t, w.OnNewData())
+		w.OnNewData()
 		require.Eventually(t, func() bool {
 			return count == 2
 		}, 2*time.Second, 100*time.Millisecond)

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -55,8 +55,8 @@ type ChainProcessor struct {
 	// channel with capacity of 1, full if there is work to do
 	newHead chan struct{}
 
-	// channel with capacity of 1, to signal work complete if running in synchroneous mode
-	out chan struct{}
+	// to signal to the other services that new indexed data is available
+	onIndexed func()
 
 	// lifetime management of the chain processor
 	ctx    context.Context
@@ -64,7 +64,7 @@ type ChainProcessor struct {
 	wg     sync.WaitGroup
 }
 
-func NewChainProcessor(log log.Logger, chain types.ChainID, processor LogProcessor, rewinder DatabaseRewinder) *ChainProcessor {
+func NewChainProcessor(log log.Logger, chain types.ChainID, processor LogProcessor, rewinder DatabaseRewinder, onIndexed func()) *ChainProcessor {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := &ChainProcessor{
 		log:       log.New("chain", chain),
@@ -73,7 +73,7 @@ func NewChainProcessor(log log.Logger, chain types.ChainID, processor LogProcess
 		processor: processor,
 		rewinder:  rewinder,
 		newHead:   make(chan struct{}, 1),
-		out:       make(chan struct{}, 1),
+		onIndexed: onIndexed,
 		ctx:       ctx,
 		cancel:    cancel,
 	}
@@ -134,7 +134,7 @@ func (s *ChainProcessor) work() {
 		target := s.nextNum()
 		if err := s.update(target); err != nil {
 			if errors.Is(err, ethereum.NotFound) {
-				s.log.Info("Cannot find next block yet", "target", target, "err", err)
+				s.log.Debug("Event-indexer cannot find next block yet", "target", target, "err", err)
 			} else if errors.Is(err, types.ErrNoRPCSource) {
 				s.log.Warn("No RPC source configured, cannot process new blocks")
 			} else {
@@ -192,7 +192,10 @@ func (s *ChainProcessor) update(nextNum uint64) error {
 			// If no logs were written successfully then the rewind wouldn't have done anything anyway.
 			s.log.Error("Failed to rewind after error processing block", "block", next, "err", err)
 		}
+		return err
 	}
+	s.log.Info("Indexed block events", "block", next, "txs", len(receipts))
+	s.onIndexed()
 	return nil
 }
 


### PR DESCRIPTION
**Description**

The op-supervisor has 3 background routines per chain, that wait for data of the previous routine to complete:

- new unsafe block -> new index work to do (signal was already implemented)
- new indexed unsafe data -> new cross-unsafe verification work to do (new signal)
- new local safe data -> new cross-safe work to do (new signal)

These new triggers will help the supervisor to rely less on the polling, and process the data as soon as it's ready.

This PR also improves logging of these updates, and removes an unused struct field from the chain processor.

**Tests**

The interop e2e system tests covers these update signal code-paths

