### PR TITLE
fix(ct): no public functions in libraries

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -201,6 +201,10 @@ check-kontrol-summaries-unchanged:
 semgrep:
   cd ../../ && semgrep scan --config=semgrep ./packages/contracts-bedrock
 
+# Runs semgrep tests.
+semgrep-test:
+  cd ../../ && semgrep scan --test semgrep
+
 # TODO: Also run lint-forge-tests-check but we need to fix the test names first.
 # Runs all checks.
 check:

--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -263,7 +263,7 @@ library DeployUtils {
 
     /// @notice Builds an ERC1967 Proxy with a dummy implementation.
     /// @param _proxyImplName Name of the implementation contract.
-    function buildERC1967ProxyWithImpl(string memory _proxyImplName) public returns (IProxy genericProxy_) {
+    function buildERC1967ProxyWithImpl(string memory _proxyImplName) internal returns (IProxy genericProxy_) {
         genericProxy_ = IProxy(
             create1({
                 _name: "Proxy",

--- a/semgrep/sol-rules.t.sol
+++ b/semgrep/sol-rules.t.sol
@@ -154,6 +154,128 @@ contract SemgrepTest__sol_safety_natspec_semver_match {
     }
 }
 
+library SemgrepTest__sol_safety_no_public_in_libraries {
+    // ok: sol-safety-no-public-in-libraries
+    function test() internal {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() private {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test(uint256 _value, address _addr) internal {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test(uint256 _value, address _addr) private {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() internal pure returns (uint256) {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() private pure returns (uint256) {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() internal view returns (uint256, address) {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() private view returns (uint256, address) {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() internal returns (uint256 amount_, bool success_) {
+        // ...
+    }
+
+    // ok: sol-safety-no-public-in-libraries
+    function test() private returns (uint256 amount_, bool success_) {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() public {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() external {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() public pure {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() external pure {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() public view {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() external view {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test(uint256 _value, address _addr) public {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test(uint256 _value, address _addr) external {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() public pure returns (uint256) {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() external pure returns (uint256) {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() public view returns (uint256, address) {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() external view returns (uint256, address) {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() public returns (uint256 amount_, bool success_) {
+        // ...
+    }
+
+    // ruleid: sol-safety-no-public-in-libraries
+    function test() external returns (uint256 amount_, bool success_) {
+        // ...
+    }
+}
+
 contract SemgrepTest__sol_style_input_arg_fmt {
     // ok: sol-style-input-arg-fmt
     event Test(address indexed src, address indexed guy, uint256 wad);

--- a/semgrep/sol-rules.yaml
+++ b/semgrep/sol-rules.yaml
@@ -66,6 +66,17 @@ rules:
       include:
         - packages/contracts-bedrock/src
 
+  - id: sol-safety-no-public-in-libraries
+    languages: [generic]
+    severity: ERROR
+    message: Public functions in libraries are not allowed
+    patterns:
+      - pattern-inside: |
+          library $LIBRARY {
+              ...
+          }
+      - pattern-regex: function\s+\w+\s*\([^)]*\)\s+(?:.*\s+)?(public|external)\s+.*\{
+
   - id: sol-style-input-arg-fmt
     languages: [solidity]
     severity: ERROR


### PR DESCRIPTION
Adds a new semgrep rule that blocks the usage of public functions in libraries. We don't use linked libraries and they cause issues with foundry.