### PR TITLE
interop-devnet: monitor logs of L1 BN/VC/EL and L2 EL containers

### DIFF
--- a/interop-devnet/monitoring/promtail/config.yaml
+++ b/interop-devnet/monitoring/promtail/config.yaml
@@ -25,7 +25,7 @@ scrape_configs:
         filters:
           - name: name
             # Filter logging to just our containers
-            values: ["op-batcher-*", "op-proposer-*", "op-node-*", "op-supervisor-*"]
+            values: ["op-batcher-*", "op-proposer-*", "op-node-*", "op-supervisor-*", "l1-*", "l1-bn-*", "l1-vc-*", "l2-a-*", "l2-b-*"]
     relabel_configs:
       - source_labels: ["__meta_docker_container_name"]
         regex: "/(.*)"


### PR DESCRIPTION
**Description**

I missed a few interop-devnet targets to collect log data from.
This PR adds these targets. Tested these on local devnet.
