### PR TITLE
use RWMap for Supervisor Backend

### DIFF
--- a/op-service/locks/rwmap.go
+++ b/op-service/locks/rwmap.go
@@ -46,3 +46,10 @@ func (m *RWMap[K, V]) Range(f func(key K, value V) bool) {
 		}
 	}
 }
+
+// Clear removes all key-value pairs from the map.
+func (m *RWMap[K, V]) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inner = make(map[K]V, 0)
+}

--- a/op-service/locks/rwmap.go
+++ b/op-service/locks/rwmap.go
@@ -51,5 +51,5 @@ func (m *RWMap[K, V]) Range(f func(key K, value V) bool) {
 func (m *RWMap[K, V]) Clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.inner = make(map[K]V, 0)
+	clear(m.inner)
 }

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -117,7 +117,8 @@ func TestBackendLifetime(t *testing.T) {
 	require.NoError(t, err)
 	// Make the processing happen, so we can rely on the new chain information,
 	// and not run into errors for future data that isn't mocked at this time.
-	b.chainProcessors[chainA].ProcessToHead()
+	proc, _ := b.chainProcessors.Get(chainA)
+	proc.ProcessToHead()
 
 	_, err = b.UnsafeView(context.Background(), chainA, types.ReferenceView{})
 	require.ErrorIs(t, err, types.ErrFuture, "still no data yet, need cross-unsafe")


### PR DESCRIPTION
Replaces the single backend lock with a lock-map `locks.RWMap`.

Wherever I removed the old lock I traced down and saw the RWMap was being used now, either here in the backend or in the underlying DBs.