### PR TITLE
op-e2e: Fix flakiness in TestP2PFull

### DIFF
--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net"
 	"slices"
+	gosync "sync"
 	"testing"
 	"time"
 
@@ -126,9 +127,12 @@ func TestP2PFull(t *testing.T) {
 
 	conns := make(chan network.Conn, 1)
 	hostA := nodeA.Host()
+	var once gosync.Once
 	hostA.Network().Notify(&network.NotifyBundle{
 		ConnectedF: func(n network.Network, conn network.Conn) {
-			conns <- conn
+			once.Do(func() {
+				conns <- conn
+			})
 		}})
 
 	backend := NewP2PAPIBackend(nodeA, logA, nil)


### PR DESCRIPTION
The ConnectedF callback was sending to a channel that was only ever read from once. This causes the test to time out under certain conditions.
