### PR TITLE
op-e2e: Retry the receipts fetcher test

### DIFF
--- a/op-service/sources/receipts_basic_test.go
+++ b/op-service/sources/receipts_basic_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -104,32 +106,48 @@ func TestBasicRPCReceiptsFetcher_Concurrency(t *testing.T) {
 	for _, rec := range receipts {
 		recMap[rec.TxHash] = rec
 	}
-	mrpc := new(mockRPC)
-	rp := NewBasicRPCReceiptsFetcher(mrpc, batchSize)
 
-	// prepare mock
-	var numCalls atomic.Int32
-	mrpc.On("BatchCallContext", mock.Anything, mock.AnythingOfType("[]rpc.BatchElem")).
-		Run(func(args mock.Arguments) {
-			numCalls.Add(1)
-			els := args.Get(1).([]rpc.BatchElem)
-			for _, el := range els {
-				if el.Method == "eth_getTransactionReceipt" {
-					txHash := el.Args[0].(common.Hash)
-					// The IterativeBatchCall expects that the values are written
-					// to the fields of the allocated *types.Receipt.
-					**(el.Result.(**types.Receipt)) = *recMap[txHash]
+	boff := &retry.ExponentialStrategy{
+		Min:       0,
+		Max:       time.Second,
+		MaxJitter: 100 * time.Millisecond,
+	}
+	err := retry.Do0(context.Background(), 10, boff, func() error {
+		mrpc := new(mockRPC)
+		rp := NewBasicRPCReceiptsFetcher(mrpc, batchSize)
+
+		// prepare mock
+		var numCalls atomic.Int32
+		mrpc.On("BatchCallContext", mock.Anything, mock.AnythingOfType("[]rpc.BatchElem")).
+			Run(func(args mock.Arguments) {
+				numCalls.Add(1)
+				els := args.Get(1).([]rpc.BatchElem)
+				for _, el := range els {
+					if el.Method == "eth_getTransactionReceipt" {
+						txHash := el.Args[0].(common.Hash)
+						// The IterativeBatchCall expects that the values are written
+						// to the fields of the allocated *types.Receipt.
+						**(el.Result.(**types.Receipt)) = *recMap[txHash]
+					}
 				}
-			}
-		}).
-		Return([]error{nil})
+			}).
+			Return([]error{nil})
 
-	runConcurrentFetchingTest(t, rp, numFetchers, receipts, block)
+		runConcurrentFetchingTest(t, rp, numFetchers, receipts, block)
 
-	mrpc.AssertExpectations(t)
-	finalNumCalls := int(numCalls.Load())
-	require.NotZero(finalNumCalls, "BatchCallContext should have been called.")
-	require.Less(finalNumCalls, numFetchers*numBatchCalls, "Some IterativeBatchCalls should have been shared.")
+		mrpc.AssertExpectations(t)
+		finalNumCalls := int(numCalls.Load())
+
+		if finalNumCalls == 0 {
+			return errors.New("batchCallContext should have been called")
+		}
+
+		if finalNumCalls >= numFetchers*numBatchCalls {
+			return errors.New("some IterativeBatchCalls should have been shared")
+		}
+		return nil
+	})
+	require.NoError(err)
 }
 
 func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers int, receipts types.Receipts, block *RPCBlock) {


### PR DESCRIPTION
This is one of our flakiest tests since it's very dependent on the test runner's CPU usage.
