### PR TITLE
op-program: Run until all events are exhausted instead of running until the derivation is idle

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -145,6 +145,12 @@ func WithL2Claim(claim common.Hash) FixtureInputParam {
 	}
 }
 
+func WithL2BlockNumber(num uint64) FixtureInputParam {
+	return func(f *FixtureInputs) {
+		f.L2BlockNumber = num
+	}
+}
+
 func (env *L2FaultProofEnv) RunFaultProofProgram(t helpers.Testing, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
 	// Fetch the pre and post output roots for the fault proof.
 	preRoot, err := env.Sequencer.RollupClient().OutputAtBlock(t.Ctx(), l2ClaimBlockNum-1)

--- a/op-e2e/actions/proofs/trace_extension_test.go
+++ b/op-e2e/actions/proofs/trace_extension_test.go
@@ -1,0 +1,68 @@
+package proofs
+
+import (
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func runSafeHeadTraceExtensionTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	t := actionsHelpers.NewDefaultTesting(gt)
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+	// Build an empty block on L2
+	env.Sequencer.ActL2StartBlock(t)
+	env.Sequencer.ActL2EndBlock(t)
+
+	// Instruct the batcher to submit the block to L1, and include the transaction.
+	env.Batcher.ActSubmitAll(t)
+	env.Miner.ActL1StartBlock(12)(t)
+	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+	env.Miner.ActL1EndBlock(t)
+
+	// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+	env.Sequencer.ActL1HeadSignal(t)
+	env.Sequencer.ActL2PipelineFull(t)
+
+	l1Head := env.Miner.L1Chain().CurrentBlock()
+	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
+
+	// Ensure there is only 1 block on L1.
+	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	// Ensure the block is marked as safe before we attempt to fault prove it.
+	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+
+	// Set claimed L2 block number to be past the actual safe head (still using the safe head output as the claim)
+	params := []helpers.FixtureInputParam{helpers.WithL2BlockNumber(l2SafeHead.Number.Uint64() + 1)}
+	params = append(params, testCfg.InputParams...)
+	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, params...)
+}
+
+// Test_ProgramAction_SafeHeadTraceExtension checks that op-program correctly handles the trace extension case where
+// the claimed l2 block number is after the safe head. The honest actor should repeat the output root from the safe head
+// and op-program should consider it valid even though the claimed l2 block number is not reached.
+// Output roots other than from the safe head should be invalid if the claimed l2 block number is not reached.
+func Test_ProgramAction_SafeHeadTraceExtension(gt *testing.T) {
+	matrix := helpers.NewMatrix[any]()
+	defer matrix.Run(gt)
+
+	matrix.AddTestCase(
+		"HonestClaim",
+		nil,
+		helpers.LatestForkOnly,
+		runSafeHeadTraceExtensionTest,
+		helpers.ExpectNoError(),
+	)
+	matrix.AddTestCase(
+		"JunkClaim",
+		nil,
+		helpers.LatestForkOnly,
+		runSafeHeadTraceExtensionTest,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
+}

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -73,15 +73,14 @@ func (d *Driver) Emit(ev event.Event) {
 	d.events = append(d.events, ev)
 }
 
-var ExhaustErr = errors.New("exhausted events before completing program")
-
 func (d *Driver) RunComplete() error {
 	// Initial reset
 	d.Emit(engine.ResetEngineRequestEvent{})
 
 	for !d.end.Closing() {
 		if len(d.events) == 0 {
-			return ExhaustErr
+			d.logger.Info("Derivation complete: no further data to process")
+			return d.end.Result()
 		}
 		if len(d.events) > 10000 { // sanity check, in case of bugs. Better than going OOM.
 			return errors.New("way too many events queued up, something is wrong")

--- a/op-program/client/driver/driver_test.go
+++ b/op-program/client/driver/driver_test.go
@@ -92,7 +92,8 @@ func TestDriver(t *testing.T) {
 			}
 			count += 1
 		})
-		require.ErrorIs(t, ExhaustErr, d.RunComplete())
+		// No further processing to be done so evaluate if the claims output root is correct.
+		require.NoError(t, d.RunComplete())
 	})
 
 	t.Run("queued events", func(t *testing.T) {
@@ -104,7 +105,7 @@ func TestDriver(t *testing.T) {
 			}
 			count += 1
 		})
-		require.ErrorIs(t, ExhaustErr, d.RunComplete())
+		require.NoError(t, d.RunComplete())
 		// add 1 for initial event that RunComplete fires
 		require.Equal(t, 1+3*2, count, "must have queued up 2 events 3 times")
 	})

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -62,10 +62,6 @@ func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
 			d.logger.Info("Derivation complete: reached L2 block", "head", x.SafeL2Head)
 			d.closing = true
 		}
-	case derive.DeriverIdleEvent:
-		// Not enough data to reach target
-		d.closing = true
-		d.logger.Info("Derivation complete: no further data to process")
 	case rollup.ResetEvent:
 		d.closing = true
 		d.result = fmt.Errorf("unexpected reset error: %w", x.Err)

--- a/op-program/client/driver/program_test.go
+++ b/op-program/client/driver/program_test.go
@@ -104,12 +104,12 @@ func TestProgramDeriver(t *testing.T) {
 			require.NoError(t, p.result)
 		})
 	})
-	// on exhaustion of input data: stop without error
+	// Do not stop processing when the deriver is idle, the engine may still be busy and create further events.
 	t.Run("deriver idle", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
 		p.OnEvent(derive.DeriverIdleEvent{})
 		m.AssertExpectations(t)
-		require.True(t, p.closing)
+		require.False(t, p.closing)
 		require.Nil(t, p.result)
 	})
 	// on inconsistent chain data: stop with error


### PR DESCRIPTION
**Description**

Handles a case introduced in holocene where the derivation may become idle but the engine later generates another event that keeps the process moving.


**Tests**

Updated unit tests. Keeps https://github.com/ethereum-optimism/optimism/pull/12803 passing to ensure trace extension is still working correctly.
