### PR TITLE
Add `kontrol.toml` for CI Kontrol tests

### DIFF
--- a/packages/contracts-bedrock/kontrol.toml
+++ b/packages/contracts-bedrock/kontrol.toml
@@ -1,0 +1,53 @@
+[build.default]
+foundry-project-root       = '.'
+regen                      = true
+rekompile                  = true
+verbose                    = false
+debug                      = false
+require                    = 'test/kontrol/pausability-lemmas.md'
+module-import              = 'OptimismPortalKontrol:PAUSABILITY'
+no-metadata                = true
+# auxiliary-lemmas         = true
+# o2                       = true
+
+[prove.default]
+foundry-project-root       = '.'
+verbose                    = false
+debug                      = false
+max-depth                  = 10000
+max-iterations             = 10000
+reinit                     = false
+cse                        = false
+workers                    = 16
+maintenance-rate           = 16
+assume-defined             = true
+no-log-rewrites            = true
+no-stack-checks            = true
+kore-rpc-command           = 'kore-rpc-booster --no-post-exec-simplify --equation-max-recursion 100 --equation-max-iterations 1000'
+failure-information        = true
+counterexample-information = true
+minimize-proofs            = false
+fail-fast                  = true
+smt-timeout                = 16000
+smt-retry-limit            = 0
+break-every-step           = false
+break-on-jumpi             = false
+break-on-calls             = false
+break-on-storage           = false
+break-on-basic-blocks      = false
+break-on-cheatcodes        = false
+run-constructor            = false
+symbolic-immutables        = false
+init-node-from-diff        = './snapshots/state-diff/Kontrol-31337.json'
+xml-test-report            = true
+# max-frontier-parallel    = 6
+
+[show.default]
+foundry-project-root       = '.'
+verbose                    = false
+debug                      = false
+use-hex-encoding           = false
+
+[view-kcfg.default]
+foundry-project-root       = '.'
+use-hex-encoding           = true

--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -15,12 +15,7 @@ parse_args "$@"
 kontrol_build() {
   notif "Kontrol Build"
   # shellcheck disable=SC2086
-  run kontrol build \
-    --require $lemmas \
-    --module-import $module \
-    --no-metadata \
-    ${rekompile} \
-    ${regen}
+  run kontrol build
   return $?
 }
 
@@ -28,24 +23,8 @@ kontrol_prove() {
   notif "Kontrol Prove"
   # shellcheck disable=SC2086
   run kontrol prove \
-    --max-depth $max_depth \
-    --max-iterations $max_iterations \
-    --smt-timeout $smt_timeout \
     --workers $workers \
-    $reinit \
-    $bug_report \
-    $break_on_calls \
-    $break_every_step \
-    $tests \
-    --init-node-from-diff $state_diff \
-    --kore-rpc-command 'kore-rpc-booster --no-post-exec-simplify --equation-max-recursion 100 --equation-max-iterations 1000' \
-    --xml-test-report \
-    --maintenance-rate 16 \
-    --assume-defined \
-    --no-log-rewrites \
-    --smt-timeout 16000 \
-    --smt-retry-limit 0 \
-    --no-stack-checks
+    $tests
   return $?
 }
 
@@ -103,21 +82,6 @@ on_failure() {
   exit 1
 }
 
-#########################
-# kontrol build options #
-#########################
-# NOTE: This script has a recurring pattern of setting and unsetting variables,
-# such as `rekompile`. Such a pattern is intended for easy use while locally
-# developing and executing the proofs via this script. Comment/uncomment the
-# empty assignment to activate/deactivate the corresponding flag
-lemmas=test/kontrol/pausability-lemmas.md
-base_module=PAUSABILITY-LEMMAS
-module=OptimismPortalKontrol:$base_module
-rekompile=--rekompile
-# rekompile=
-regen=--regen
-# regen=
-
 #################################
 # Tests to symbolically execute #
 #################################
@@ -165,9 +129,6 @@ done
 #########################
 # kontrol prove options #
 #########################
-max_depth=10000
-max_iterations=10000
-smt_timeout=100000
 max_workers=16 # Set to 16 since there are 16 proofs to run
 # workers is the minimum between max_workers and the length of test_list unless
 # no test arguments are provided, in which case we default to max_workers
@@ -176,15 +137,6 @@ if [ "$CUSTOM_TESTS" == 0 ] && [ "$SCRIPT_TESTS" == false ]; then
 else
   workers=$((${#test_list[@]}>max_workers ? max_workers : ${#test_list[@]}))
 fi
-reinit=--reinit
-reinit=
-break_on_calls=--break-on-calls
-break_on_calls=
-break_every_step=--break-every-step
-break_every_step=
-bug_report=--bug-report
-bug_report=
-state_diff="./snapshots/state-diff/Kontrol-31337.json"
 
 #############
 # RUN TESTS #


### PR DESCRIPTION
**Description**

This PR brings in the `kontrol.toml` file which configures the options for `kontrol build` and `kontrol prove` runs; it is an alternative to doing it via a script as done right now. 

At the moment, `kontrol.toml` does not define `match-test` values as there's a different test selection logic depending on whether `SCRIPT_TESTS` or `CUSTOM_TESTS` is enabled. Is also preserves the `workers` calculation logic in the script.
