### PR TITLE
cannon: Add post-state checks

### DIFF
--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -224,6 +224,23 @@ func (m *InstrumentedState) handleSyscall() error {
 }
 
 func (m *InstrumentedState) mipsStep() error {
+	err := m.doMipsStep()
+	if err != nil {
+		return err
+	}
+
+	m.assertPostStateChecks()
+	return err
+}
+
+func (m *InstrumentedState) assertPostStateChecks() {
+	activeStack := m.state.getActiveThreadStack()
+	if len(activeStack) == 0 {
+		panic("post-state active thread stack is empty")
+	}
+}
+
+func (m *InstrumentedState) doMipsStep() error {
 	if m.state.Exited {
 		return nil
 	}

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0x9fa2d1297ad1e93b4d3c5c0fed08bedcd8f746807589f0fd3369e79347c6a027"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0xc615a8f321f3bfb29c9459705f3012e512c463ba9ba2e1bcb6f9349f2d911d10",
-    "sourceCodeHash": "0x8fd0f4167d80f48010ad1241a9f6fb93576887dcc1f97be6b05adaf0086a537b"
+    "initCodeHash": "0x83f580644893438b1331f97d1315788528ec85aa0a25a0b4b2e7078965d73d1c",
+    "sourceCodeHash": "0x5a1b0a10e15c4a82cb0d8d8aaa7504fa76e49443ab9114c6b2020bf56b027e23"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0x9fa2d1297ad1e93b4d3c5c0fed08bedcd8f746807589f0fd3369e79347c6a027"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0x83f580644893438b1331f97d1315788528ec85aa0a25a0b4b2e7078965d73d1c",
-    "sourceCodeHash": "0x5a1b0a10e15c4a82cb0d8d8aaa7504fa76e49443ab9114c6b2020bf56b027e23"
+    "initCodeHash": "0x93aa8d7f9fd3c22276c0d303a3fefdf8f73cc55807b35e483bba64c92d02aaef",
+    "sourceCodeHash": "0x171d66c651fdad2ac9c287da92689815a5b09589945ada092179508ad2326306"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",

--- a/packages/contracts-bedrock/snapshots/abi/MIPS64.json
+++ b/packages/contracts-bedrock/snapshots/abi/MIPS64.json
@@ -45,7 +45,7 @@
     "outputs": [
       {
         "internalType": "bytes32",
-        "name": "",
+        "name": "postState_",
         "type": "bytes32"
       }
     ],

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -106,7 +106,39 @@ contract MIPS64 is ISemver {
     /// the current thread stack.
     /// @param _localContext The local key context for the preimage oracle. Optional, can be set as a constant
     ///                      if the caller only requires one set of local keys.
-    function step(bytes calldata _stateData, bytes calldata _proof, bytes32 _localContext) public returns (bytes32) {
+    /// @return postState_ The hash of the post state witness after the state transition.
+    function step(
+        bytes calldata _stateData,
+        bytes calldata _proof,
+        bytes32 _localContext
+    )
+        public
+        returns (bytes32 postState_)
+    {
+        postState_ = doStep(_stateData, _proof, _localContext);
+        assertPostStateChecks();
+    }
+
+    function assertPostStateChecks() internal pure {
+        State memory state;
+        assembly {
+            state := STATE_MEM_OFFSET
+        }
+
+        bytes32 activeStack = state.traverseRight ? state.rightThreadStack : state.leftThreadStack;
+        if (activeStack == EMPTY_THREAD_ROOT) {
+            revert("MIPS64: post-state active thread stack is empty");
+        }
+    }
+
+    function doStep(
+        bytes calldata _stateData,
+        bytes calldata _proof,
+        bytes32 _localContext
+    )
+        internal
+        returns (bytes32)
+    {
         unchecked {
             State memory state;
             ThreadState memory thread;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -64,8 +64,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.0.0-beta.3
-    string public constant version = "1.0.0-beta.3";
+    /// @custom:semver 1.0.0-beta.4
+    string public constant version = "1.0.0-beta.4";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add some post-state checks after MIPS step() logic is executed to confirm that the active thread stack is non-empty. 

**Tests**

This change doesn't require new tests because it should not be possible to fail the post-state checks.  If existing test coverage fails due to these changes, we have a bug. 

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/12160
