### PR TITLE
cannon: Port post-state checks to MIPS2.sol

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/MIPS2.json
+++ b/packages/contracts-bedrock/snapshots/abi/MIPS2.json
@@ -45,7 +45,7 @@
     "outputs": [
       {
         "internalType": "bytes32",
-        "name": "",
+        "name": "postState_",
         "type": "bytes32"
       }
     ],

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -144,8 +144,8 @@
     "sourceCodeHash": "0xd8467700c80b3e62fa37193dc6513bac35282094b686b50e162e157f704dde00"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0xaedf0d0b0e94a0c5e7d987331d2fdba84230f5704a6ca33677e70cde7051b17e",
-    "sourceCodeHash": "0x9fa2d1297ad1e93b4d3c5c0fed08bedcd8f746807589f0fd3369e79347c6a027"
+    "initCodeHash": "0xc38c76ab3aad78c81ca01b3235b402614972d6604b22fda1e870f1bf47be1194",
+    "sourceCodeHash": "0x3d38b1924669d1bde756f1306601c764a6d31f428ac72667a3dd194b3388210d"
   },
   "src/cannon/MIPS64.sol": {
     "initCodeHash": "0x93aa8d7f9fd3c22276c0d303a3fefdf8f73cc55807b35e483bba64c92d02aaef",

--- a/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/interfaces/IMIPS2.sol
@@ -46,7 +46,13 @@ interface IMIPS2 is ISemver {
     error InvalidRMWInstruction();
 
     function oracle() external view returns (IPreimageOracle oracle_);
-    function step(bytes memory _stateData, bytes memory _proof, bytes32 _localContext) external returns (bytes32);
+    function step(
+        bytes memory _stateData,
+        bytes memory _proof,
+        bytes32 _localContext
+    )
+        external
+        returns (bytes32 postState_);
 
     function __constructor__(IPreimageOracle _oracle) external;
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Port `MIPS64.sol` changes from https://github.com/ethereum-optimism/optimism/pull/12809 to `MIPS2.sol`.

**Tests**

This change doesn't require new tests because it should not be possible to fail the post-state checks. If existing test coverage fails due to these changes, we have a bug.

**Additional context**

This should not be merged until after the [code freeze](https://github.com/ethereum-optimism/optimism/discussions/12725) is over. 

**Metadata**

Fixes: https://github.com/ethereum-optimism/optimism/issues/12160
