### PR TITLE
feat: Update `kona` in `proofs-tools` image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -207,7 +207,7 @@ target "proofs-tools" {
   context = "."
   args = {
     CHALLENGER_VERSION="b46bffed42db3442d7484f089278d59f51503049"
-    KONA_VERSION="kona-client-v0.1.0-alpha.6"
+    KONA_VERSION="kona-client-v0.1.0-alpha.7"
   }
   target="proofs-tools"
   platforms = split(",", PLATFORMS)


### PR DESCRIPTION
## Overview

Updates `kona` in the `proofs-tools` image to `kona-client-v0.1.0-alpha.7`

Image: https://github.com/anton-rs/kona/pkgs/container/kona%2Fkona-fpp-asterisc/300273760?tag=kona-client-v0.1.0-alpha.7

Release: https://github.com/anton-rs/kona/releases/tag/kona-client-v0.1.0-alpha.7
