### PR TITLE
Interop: Add error case for parent of start of database

### DIFF
--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -184,8 +184,13 @@ func (db *DB) PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom type
 	if self.derivedFrom.ID() != derivedFrom {
 		return types.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derivedFrom, derivedFrom, types.ErrConflict)
 	}
-	if selfIndex == 0 { // genesis block has a zeroed block as parent block
-		return types.BlockSeal{}, nil
+	if selfIndex == 0 {
+		// genesis block has a zeroed block as parent block
+		if self.derivedFrom.Number == 0 {
+			return types.BlockSeal{}, nil
+		} else {
+			return types.BlockSeal{}, fmt.Errorf("cannot find previous derived before start of database: %s", derivedFrom)
+		}
 	}
 	prev, err := db.readAt(selfIndex - 1)
 	if err != nil {


### PR DESCRIPTION
Initial infrastructure is crash-looping due to:

```
panic: invalid parent block 0x0000000000000000000000000000000000000000000000000000000000000000:0 to combine with BlockSeal(hash:0x4d00fd89121d13acff9a926e0404c25b9447a5068d44144e3187da526f468361, number:7013365, time:1730764932)
```

This happens because `WithParent` is being called for L1 blocks during calls like `CrossDerivedFromBlockRef`. In the underlying `PreviousDerivedFrom`, if the entry we are getting the parent for is `index=0`, we assume it is the genesis block and return no error.

However, for things like L1 data, this assumption is broken. In the above panic message, the L1 block at Genesis was assumed to *be* the L1 genesis, which of course panics when we attempt to add the 0-parent.

There is a chance that this additional error will cause the interactions between Node and Supervisor to fail more, but I assume derivers will be able to recover from this failure and move on to future calls which have valid parents.

I am undecided on the better direction to go longer term with this conflict:
* We could allow these errors to happen and accept that Nodes will need to swallow the error and survive until later (hopefully just the no-op solution)
* We could attempt to collect pre-database parents in the Supervisor so that these errors never happen
* We could make Nodes considerate of the fact that they are requesting a parentage of data which the Supervisor should not have, and make Nodes therefore repair the data or otherwise work around it.

I ordered these options by preference, but mostly I just don't like option-3 and would prefer one of the other two. @protolambda and @tyler-smith for opinions.