### PR TITLE
test: longer Eventually timeout for TestWorker

### DIFF
--- a/op-supervisor/supervisor/backend/cross/worker_test.go
+++ b/op-supervisor/supervisor/backend/cross/worker_test.go
@@ -94,7 +94,7 @@ func TestWorker(t *testing.T) {
 		w.StartBackground()
 		require.Eventually(t, func() bool {
 			return count == 10
-		}, 2*time.Second, 100*time.Millisecond)
+		}, 10*time.Second, time.Second)
 		// once the worker is closed, it stops running
 		// and the count does not increment
 		w.Close()


### PR DESCRIPTION
This test was flaking while waiting `2s` for the expected count to hit `10`. This is most likely because the timeout is very tight for CI purposes. The test itself isn't even focused on this line, it's more concerned that the worker doesn't continue.