### PR TITLE
interop: Fix AtLeastAsSafe ; Geth Mempool Filter E2E Test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.1-rc.5
+replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.1-rc.5.0.20241105034859-ed40f84241fd
 
 //replace github.com/ethereum/go-ethereum => ../go-ethereum
 

--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.1-rc.5.0.20241105034859-ed40f84241fd
+replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.1-rc.6
 
 //replace github.com/ethereum/go-ethereum => ../go-ethereum
 

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101411.1-rc.5.0.20241105034859-ed40f84241fd h1:+sIYV3svO5ougW6Ze8ZqvQg990R7lbZLTnmtlghKi5E=
-github.com/ethereum-optimism/op-geth v1.101411.1-rc.5.0.20241105034859-ed40f84241fd/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
+github.com/ethereum-optimism/op-geth v1.101411.1-rc.6 h1:VvUBIVFbnU9486CWHa9Js5XYY3o6OsdQcI8gE3XjCDE=
+github.com/ethereum-optimism/op-geth v1.101411.1-rc.6/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101411.1-rc.5 h1:LDSP85xTczjDYMBK0mOF5mzpZifLGz1TTW/6NgQsytc=
-github.com/ethereum-optimism/op-geth v1.101411.1-rc.5/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
+github.com/ethereum-optimism/op-geth v1.101411.1-rc.5.0.20241105034859-ed40f84241fd h1:+sIYV3svO5ougW6Ze8ZqvQg990R7lbZLTnmtlghKi5E=
+github.com/ethereum-optimism/op-geth v1.101411.1-rc.5.0.20241105034859-ed40f84241fd/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -278,13 +278,15 @@ func TestInteropBlockBuilding(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 			defer cancel()
 			// Send an executing message, but with different payload.
-			// We expect the miner to be unable to include this tx, and confirmation to thus time out.
-			_, err := s2.ExecuteMessage(ctx, chainB, "Alice", identifier, bobAddr, invalidPayload)
-			require.NotNil(t, err)
-			require.ErrorIs(t, err, ctx.Err())
 			if s2.(*interopE2ESystem).config.mempoolFiltering {
-				require.ErrorIs(t, ctx.Err(), gethCore.ErrTxFilteredOut)
+				// We expect the traqnsaction to be filtered out by the mempool if mempool filtering is enabled.
+				// ExecuteMessage the ErrTxFilteredOut error is checked when sending the tx.
+				_, err := s2.ExecuteMessage(ctx, chainB, "Alice", identifier, bobAddr, invalidPayload, gethCore.ErrTxFilteredOut)
+				require.ErrorContains(t, err, gethCore.ErrTxFilteredOut.Error())
 			} else {
+				// We expect the miner to be unable to include this tx, and confirmation to thus time out, if mempool filtering is disabled.
+				_, err := s2.ExecuteMessage(ctx, chainB, "Alice", identifier, bobAddr, invalidPayload, nil)
+				require.ErrorIs(t, err, ctx.Err())
 				require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
 			}
 		}
@@ -295,22 +297,25 @@ func TestInteropBlockBuilding(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 			defer cancel()
 			// Send an executing message with the correct identifier / payload
-			rec, err := s2.ExecuteMessage(ctx, chainB, "Alice", identifier, bobAddr, msgPayload)
+			rec, err := s2.ExecuteMessage(ctx, chainB, "Alice", identifier, bobAddr, msgPayload, nil)
 			require.NoError(t, err, "expecting tx to be confirmed")
 			t.Logf("confirmed executing msg in block %s", rec.BlockNumber)
 		}
 		t.Log("Done")
 	}
 
-	config := SuperSystemConfig{
-		mempoolFiltering: false,
-	}
-	// run once without mempool filtering to observe the miner behavior
-	setupAndRun(t, config, test)
+	t.Run("without mempool filtering", func(t *testing.T) {
+		config := SuperSystemConfig{
+			mempoolFiltering: false,
+		}
+		setupAndRun(t, config, test)
+	})
 
-	config = SuperSystemConfig{
-		mempoolFiltering: true,
-	}
-	// run again with mempool filtering to observe the behavior of the mempool filter
-	setupAndRun(t, config, test)
+	t.Run("with mempool filtering", func(t *testing.T) {
+		config := SuperSystemConfig{
+			mempoolFiltering: true,
+		}
+		// run again with mempool filtering to observe the behavior of the mempool filter
+		setupAndRun(t, config, test)
+	})
 }


### PR DESCRIPTION
Demonstrates that Mempool Filtering works as expected.

- adds a config to SuperSystem containing `MempoolFiltering` boolean flag
- flag is passed down to `geth` on SuperSystem startup
- existing tests were expanded to use filtering, or to disable it to check for miner behavior.

In the process of writing this test, I discovered that `AtLeastAsSafe` wasn't fully implemented, so I fixed that here too.