### PR TITLE
feat: add experimental L2 source flag to runner

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -52,6 +52,14 @@ func TestLogLevel(t *testing.T) {
 	}
 }
 
+func TestL2Experimental(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		url := "http://example.com:8888"
+		cfg := configForArgs(t, addRequiredArgs(types.TraceTypeAlphabet, "--l2-experimental-eth-rpc="+url))
+		require.Equal(t, url, cfg.Cannon.L2Experimental)
+	})
+}
+
 func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs(t, addRequiredArgs(types.TraceTypeAlphabet))
 	defaultCfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, l1Beacon, rollupRpc, l2EthRpc, datadir, types.TraceTypeAlphabet)

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -93,6 +93,11 @@ var (
 		Usage:   "URLs of L2 JSON-RPC endpoints to use (eth and debug namespace required)",
 		EnvVars: prefixEnvVars("L2_ETH_RPC"),
 	}
+	L2ExperimentalEthRpcFlag = &cli.StringFlag{
+		Name:    "l2-experimental-eth-rpc",
+		Usage:   "L2 Address of L2 JSON-RPC endpoint to use (eth and debug namespace required with execution witness support)  (cannon/asterisc trace type only)",
+		EnvVars: prefixEnvVars("L2_EXPERIMENTAL_ETH_RPC"),
+	}
 	MaxPendingTransactionsFlag = &cli.Uint64Flag{
 		Name:    "max-pending-tx",
 		Usage:   "The maximum number of pending transactions. 0 for no limit.",
@@ -241,6 +246,7 @@ var optionalFlags = []cli.Flag{
 	MaxConcurrencyFlag,
 	SupervisorRpcFlag,
 	L2EthRpcFlag,
+	L2ExperimentalEthRpcFlag,
 	MaxPendingTransactionsFlag,
 	HTTPPollInterval,
 	AdditionalBondClaimants,
@@ -533,6 +539,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 	l1EthRpc := ctx.String(L1EthRpcFlag.Name)
 	l1Beacon := ctx.String(L1BeaconFlag.Name)
 	l2Rpcs := ctx.StringSlice(L2EthRpcFlag.Name)
+	l2Experimental := ctx.String(L2ExperimentalEthRpcFlag.Name)
 	return &config.Config{
 		// Required Flags
 		L1EthRpc:                l1EthRpc,
@@ -553,6 +560,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 			L1:                l1EthRpc,
 			L1Beacon:          l1Beacon,
 			L2s:               l2Rpcs,
+			L2Experimental:    l2Experimental,
 			VmBin:             ctx.String(CannonBinFlag.Name),
 			Server:            ctx.String(CannonServerFlag.Name),
 			Networks:          networks,
@@ -572,6 +580,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 			L1:                l1EthRpc,
 			L1Beacon:          l1Beacon,
 			L2s:               l2Rpcs,
+			L2Experimental:    l2Experimental,
 			VmBin:             ctx.String(AsteriscBinFlag.Name),
 			Server:            ctx.String(AsteriscServerFlag.Name),
 			Networks:          networks,
@@ -588,6 +597,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 			L1:                l1EthRpc,
 			L1Beacon:          l1Beacon,
 			L2s:               l2Rpcs,
+			L2Experimental:    l2Experimental,
 			VmBin:             ctx.String(AsteriscBinFlag.Name),
 			Server:            ctx.String(AsteriscKonaServerFlag.Name),
 			Networks:          networks,

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -49,6 +49,7 @@ type Config struct {
 	L1                string
 	L1Beacon          string
 	L2s               []string
+	L2Experimental    string
 	Server            string // Path to the executable that provides the pre-image oracle server
 	Networks          []string
 	L2Custom          bool

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -40,6 +40,9 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 	if len(cfg.L2GenesisPaths) != 0 {
 		args = append(args, "--l2.genesis", strings.Join(cfg.L2GenesisPaths, ","))
 	}
+	if cfg.L2Experimental != "" {
+		args = append(args, "--l2.experimental", cfg.L2Experimental)
+	}
 	var logLevel string
 	if s.logger.Enabled(context.Background(), log.LevelTrace) {
 		logLevel = "TRACE"


### PR DESCRIPTION
**Description**

Allow experimental source to be used by op-challenger.

**Additional context**

This will allow us to start testing L2 source changes in `op-program` using `op-challenger run-trace`.