### PR TITLE
interop: Handle first L1 Parent Ref in CandidateCrossSafe

### DIFF
--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -57,7 +57,7 @@ func CrossSafeUpdate(ctx context.Context, logger log.Logger, chainID types.Chain
 	if err != nil {
 		return fmt.Errorf("cannot find parent-block of cross-safe: %w", err)
 	}
-	crossSafeRef := currentCrossSafe.WithParent(parent.ID())
+	crossSafeRef := currentCrossSafe.MustWithParent(parent.ID())
 	logger.Debug("Bumping cross-safe scope", "scope", newScope, "crossSafe", crossSafeRef)
 	if err := d.UpdateCrossSafe(chainID, newScope, crossSafeRef); err != nil {
 		return fmt.Errorf("failed to update cross-safe head with L1 scope increment to %s and repeat of L2 block %s: %w", candidateScope, crossSafeRef, err)

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -102,7 +102,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, chainID, updatingChain)
 		require.Equal(t, newScope, updatingCandidateScope)
-		crossSafeRef := currentCrossSafe.WithParent(parent.ID())
+		crossSafeRef := currentCrossSafe.MustWithParent(parent.ID())
 		require.Equal(t, crossSafeRef, updatingCandidate)
 	})
 	t.Run("NextDerivedFrom returns error", func(t *testing.T) {

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -240,12 +240,29 @@ func (s BlockSeal) ID() eth.BlockID {
 	return eth.BlockID{Hash: s.Hash, Number: s.Number}
 }
 
-func (s BlockSeal) WithParent(parent eth.BlockID) eth.BlockRef {
+func (s BlockSeal) MustWithParent(parent eth.BlockID) eth.BlockRef {
+	ref, err := s.WithParent(parent)
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
+func (s BlockSeal) WithParent(parent eth.BlockID) (eth.BlockRef, error) {
 	// prevent parent attachment if the parent is not the previous block,
 	// and the block is not the genesis block
 	if s.Number != parent.Number+1 && s.Number != 0 {
-		panic(fmt.Errorf("invalid parent block %s to combine with %s", parent, s))
+		return eth.BlockRef{}, fmt.Errorf("invalid parent block %s to combine with %s", parent, s)
 	}
+	return eth.BlockRef{
+		Hash:       s.Hash,
+		Number:     s.Number,
+		ParentHash: parent.Hash,
+		Time:       s.Timestamp,
+	}, nil
+}
+
+func (s BlockSeal) ForceWithParent(parent eth.BlockID) eth.BlockRef {
 	return eth.BlockRef{
 		Hash:       s.Hash,
 		Number:     s.Number,


### PR DESCRIPTION
Extends: https://github.com/ethereum-optimism/optimism/pull/12818/files

The prior commit made it so that getting `PreviousDerivedFrom` would fail when there wasn't data behind the query. This should solve instances where the code attempts to attach 0-value parents to the L1 in `WithParent`.

However! The `CanddiateCrossSafe` function will manually use a zero-value ID to build parents into the L1 when the database is empty. This totally side-steps the returned error in the prior PR.

Infrastructure on L1 is failing with this line called out:
```
goroutine 140 [running]:
github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types.BlockSeal.WithParent({{0x4d, 0x0, 0xfd, 0x89, 0x12, 0x1d, 0x13, 0xac, 0xff, 0x9a, ...}, ...}, ...)
    /app/op-supervisor/supervisor/types/types.go:247 +0x12e
github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db.(*ChainsDB).CandidateCrossSafe(0xc000320c60, {0xaf1139, 0x0, 0x0, 0x0})
    /app/op-supervisor/supervisor/backend/db/query.go:242 +0x459
github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/cr
```