### PR TITLE
interop: correct error in prior WithParent commit

### DIFF
--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -246,7 +246,7 @@ func (db *ChainsDB) CandidateCrossSafe(chain types.ChainID) (derivedFromScope, c
 				derivedFromRef = derivedFrom.ForceWithParent(eth.BlockID{})
 			}
 			// the first derived must be the genesis block, panic otherwise
-			derivedRef := derived.MustWithParent(derivedFrom.ID())
+			derivedRef := derived.MustWithParent(eth.BlockID{})
 			return derivedFromRef, derivedRef, nil
 		}
 		return eth.BlockRef{}, eth.BlockRef{}, err


### PR DESCRIPTION
Apologies for the PR thrash, I made an error in the prior PR which was missed:

`derived.WithParent(eth.BlockID{})` accidentally changed to `derivedRef := derived.MustWithParent(derivedFrom.ID())`, which is fundamentally incorrect.