### PR TITLE
interop: Handle ErrParentToFirst from PreviousDerivedFrom

### DIFF
--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -189,7 +189,8 @@ func (db *DB) PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom type
 		if self.derivedFrom.Number == 0 {
 			return types.BlockSeal{}, nil
 		} else {
-			return types.BlockSeal{}, fmt.Errorf("cannot find previous derived before start of database: %s", derivedFrom)
+			return types.BlockSeal{},
+				fmt.Errorf("cannot find previous derived before start of database: %s (%w)", derivedFrom, types.ErrPreviousToFirst)
 		}
 	}
 	prev, err := db.readAt(selfIndex - 1)

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -20,6 +20,9 @@ var (
 	// ErrOutOfScope is when data is accessed, but access is not allowed, because of a limited scope.
 	// E.g. when limiting scope to L2 blocks derived from a specific subset of the L1 chain.
 	ErrOutOfScope = errors.New("out of scope")
+	// ErrPreviousToFirst is when you try to get the previous block of the first block
+	// E.g. when calling PreviousDerivedFrom on the first L1 block in the DB.
+	ErrPreviousToFirst = errors.New("cannot get parent of first block in the database")
 	// ErrUnknownChain is when a chain is unknown, not in the dependency set.
 	ErrUnknownChain = errors.New("unknown chain")
 	// ErrNoRPCSource happens when a sub-service needs an RPC data source, but is not configured with one.


### PR DESCRIPTION
Prior PRs changed the behavior of `WithParent` and `PreviousDerivedFrom` to not panic, and instead error, when the PreviousDerivedFrom can't be determined.

However, the codepaths which use this are expected to function even on the first row of the database. Functions like `CrossDerivedFromBlockRef` and `CanddiateCrossSafe` need to handle the fact that there is no parent item for the `DerivedFrom` in question.

This PR adds the same basic handling -- if the error matches `ErrPreviousToFirst`, the calling functions use `ForceWithParent(BlockRef{})` instead of erroring *or* panicing.

The devnet is currently running, but we see a *lot* of
```
t=2024-11-05T22:16:57+0000 lvl=warn msg="Failed to process work" chain=11473209 err="failed to determine candidate block for cross-safe: failed to find parent-block of cross-derived-from BlockSeal(hash:0xa39fd1a98c35ba3bc981366b87def30b7e796896bdc52988e4c1008524c415ae, number:7012090, time:1730748744): cannot find previous derived before start of database: 0xa39fd1a98c35ba3bc981366b87def30b7e796896bdc52988e4c1008524c415ae:7012090"
```
in the logs. This is because the workflows which expect to be function on the first row of the database are returning errors inappropriately.