### PR TITLE
op-batcher: Enable throttling by default, shutdown on broken RPC

### DIFF
--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -86,7 +86,6 @@ func TestBatchSubmitter_SafeL1Origin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.failsToFetchSyncStatus {
 				ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{}, errors.New("failed to fetch sync status"))
-
 			} else {
 				ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{
 					SafeL2: eth.L2BlockRef{
@@ -107,7 +106,6 @@ func TestBatchSubmitter_SafeL1Origin(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestBatchSubmitter_SafeL1Origin_FailsToResolveRollupClient(t *testing.T) {

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -157,9 +157,9 @@ var (
 		EnvVars: prefixEnvVars("WAIT_NODE_SYNC"),
 	}
 	ThrottleIntervalFlag = &cli.DurationFlag{
-		Name: "throttle-interval",
-		Usage: "Interval between potential DA throttling actions. Zero (default) disables throttling. " +
-			"Recommended to be set to L2 block time if enabling.",
+		Name:    "throttle-interval",
+		Usage:   "Interval between potential DA throttling actions. Zero disables throttling.",
+		Value:   2 * time.Second,
 		EnvVars: prefixEnvVars("THROTTLE_INTERVAL"),
 	}
 	ThrottleThresholdFlag = &cli.IntFlag{

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -25,9 +25,14 @@ func (c ErrorCode) IsEngineError() bool {
 	return -38100 < c && c <= -38000
 }
 
+func (c ErrorCode) IsGenericRPCError() bool {
+	return -32700 < c && c <= -32600
+}
+
 // Engine error codes used to be -3200x, but were rebased to -3800x:
 // https://github.com/ethereum/execution-apis/pull/214
 const (
+	MethodNotFound           ErrorCode = -32601 // RPC method not found or not available.
 	InvalidParams            ErrorCode = -32602
 	UnknownPayload           ErrorCode = -38001 // Payload does not exist / is not available.
 	InvalidForkchoiceState   ErrorCode = -38002 // Forkchoice state is invalid / inconsistent.


### PR DESCRIPTION

**Description**

This is a follow-up to https://github.com/ethereum-optimism/optimism/pull/12735 and enables throttling by default. The batcher is also shut down if the RPC endpoint is broken (e.g., the method is not available, or invalid parameters).

**Tests**

I wanted to add a test, but then realized that unfortunately, the `EthClient.Client()` method returns an `*rpc.Client` and not an interface, so this part cannot currently be mocked. It would require a non-trivial refactor to return an interface. Since the change is rather simple and non-critical, I don't deem it worth the effort at this point.

**Additional context**

This makes sure that if throttling is enabled, it is also actually supported and enabled by the execution layer client.
