### PR TITLE
op-supervisor: do not return zeroed included-in block

### DIFF
--- a/op-supervisor/supervisor/backend/cross/worker.go
+++ b/op-supervisor/supervisor/backend/cross/worker.go
@@ -70,9 +70,7 @@ func (s *Worker) worker() {
 			if errors.Is(err, s.ctx.Err()) {
 				return
 			}
-			if errors.Is(err, types.ErrIndexing) {
-				s.log.Debug("Worker awaits data that is being indexed", "err", err)
-			} else if errors.Is(err, types.ErrFuture) {
+			if errors.Is(err, types.ErrFuture) {
 				s.log.Debug("Worker awaits additional blocks", "err", err)
 			} else {
 				s.log.Warn("Failed to process work", "err", err)

--- a/op-supervisor/supervisor/backend/cross/worker.go
+++ b/op-supervisor/supervisor/backend/cross/worker.go
@@ -70,8 +70,10 @@ func (s *Worker) worker() {
 			if errors.Is(err, s.ctx.Err()) {
 				return
 			}
-			if errors.Is(err, types.ErrFuture) {
-				s.log.Debug("Worker awaits more data", "err", err)
+			if errors.Is(err, types.ErrIndexing) {
+				s.log.Debug("Worker awaits data that is being indexed", "err", err)
+			} else if errors.Is(err, types.ErrFuture) {
+				s.log.Debug("Worker awaits additional blocks", "err", err)
 			} else {
 				s.log.Warn("Failed to process work", "err", err)
 			}

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -307,8 +307,8 @@ func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (typ
 		panic("expected iterator to stop with error")
 	}
 	if errors.Is(err, types.ErrFuture) {
-		// Log is known, but as part of an unsealed block.
-		return types.BlockSeal{}, nil
+		// Log is known, but as part of an unsealed block (we did not reach the block number yet).
+		return types.BlockSeal{}, types.ErrIndexing
 	}
 	if errors.Is(err, types.ErrStop) {
 		h, n, _ := iter.SealedBlock()

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -280,6 +280,11 @@ func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (typ
 	defer db.rwLock.RUnlock()
 	db.log.Trace("Checking for log", "blockNum", blockNum, "logIdx", logIdx, "hash", logHash)
 
+	// Hot-path: check if we have the block
+	if db.lastEntryContext.hasCompleteBlock() && db.lastEntryContext.blockNum < blockNum {
+		return types.BlockSeal{}, types.ErrFuture
+	}
+
 	evtHash, iter, err := db.findLogInfo(blockNum, logIdx)
 	if err != nil {
 		return types.BlockSeal{}, err // may be ErrConflict if the block does not have as many logs
@@ -305,10 +310,6 @@ func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (typ
 	})
 	if err == nil {
 		panic("expected iterator to stop with error")
-	}
-	if errors.Is(err, types.ErrFuture) {
-		// Log is known, but as part of an unsealed block (we did not reach the block number yet).
-		return types.BlockSeal{}, types.ErrIndexing
 	}
 	if errors.Is(err, types.ErrStop) {
 		h, n, _ := iter.SealedBlock()

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -13,8 +13,6 @@ var (
 	ErrSkipped = errors.New("skipped data")
 	// ErrFuture happens when data is just not yet available
 	ErrFuture = errors.New("future data")
-	// ErrIndexing happens when data is there, but indexed and ready to use yet.
-	ErrIndexing = errors.New("indexing data")
 	// ErrConflict happens when we know for sure that there is different canonical data
 	ErrConflict = errors.New("conflicting data")
 	// ErrStop can be used in iterators to indicate iteration has to stop

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -13,6 +13,8 @@ var (
 	ErrSkipped = errors.New("skipped data")
 	// ErrFuture happens when data is just not yet available
 	ErrFuture = errors.New("future data")
+	// ErrIndexing happens when data is there, but indexed and ready to use yet.
+	ErrIndexing = errors.New("indexing data")
 	// ErrConflict happens when we know for sure that there is different canonical data
 	ErrConflict = errors.New("conflicting data")
 	// ErrStop can be used in iterators to indicate iteration has to stop


### PR DESCRIPTION
**Description**

`logs.DB.Contains` was returning a zeroed block ID if the log was seen but the block wasn't fully indexed. This PR changes that to return an unindexed error. This is meant to help unblock the cross-safe update routine, which needs a block ID to verify if the message is safe.

**Tests**

Work in progress. We need to setup a test to see what happens if the DB contains some of the log data, but not complete data yet. (Can also happen if data is corrupted for some reason).

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
