### PR TITLE
add runSingleOpChain to Deploy

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -219,6 +219,12 @@ contract Deploy is Deployer {
         _run();
     }
 
+    /// @notice Deploy all of the L1 contracts necessary for a single Op Chain.
+    function runSingleOpChain() public {
+        console.log("Deploying a fresh OP Stack");
+        _run(false);
+    }
+
     /// @notice Deploy a new OP Chain using an existing SuperchainConfig and ProtocolVersions
     /// @param _superchainConfigProxy Address of the existing SuperchainConfig proxy
     /// @param _protocolVersionsProxy Address of the existing ProtocolVersions proxy


### PR DESCRIPTION
This PR adds a `runSingleOpChain` function to `Deploy` to allow deploying a fresh OP Stack without being SuperChain.

It's useful for custom deployments of OP Stack now that fault proof for custom OP chains is already supported by [this PR](https://github.com/ethereum-optimism/optimism/pull/12310).