### PR TITLE
`standardVersionsToml` should be toml instead of file path

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -380,7 +380,8 @@ contract Deploy is Deployer {
         string memory release = "dev";
         dii.set(dii.release.selector, release);
         dii.set(
-            dii.standardVersionsToml.selector, string.concat(vm.projectRoot(), "/test/fixtures/standard-versions.toml")
+            dii.standardVersionsToml.selector,
+            vm.readFile(string.concat(vm.projectRoot(), "/test/fixtures/standard-versions.toml"))
         );
         dii.set(dii.superchainConfigProxy.selector, mustGetAddress("SuperchainConfigProxy"));
         dii.set(dii.protocolVersionsProxy.selector, mustGetAddress("ProtocolVersionsProxy"));


### PR DESCRIPTION
The `standardVersionsToml` is finally used [here](https://github.com/ethereum-optimism/optimism/blob/bc9b6cd588588c9c4167c926a1782c658e5df921/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol#L1069), which expects it to be toml string instead of file path.