### PR TITLE
vm-runner: Check L1 head sync status

### DIFF
--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -199,6 +199,9 @@ func (r *Runner) createGameInputs(ctx context.Context, client *sources.RollupCli
 		// This only matters if op-node is behind and hasn't processed all finalized L1 blocks yet.
 		l1Head = status.CurrentL1
 	}
+	if l1Head.Number == 0 {
+		return utils.LocalGameInputs{}, errors.New("l1 head is 0")
+	}
 	blockNumber, err := r.findL2BlockNumberToDispute(ctx, client, l1Head.Number, status.FinalizedL2.Number)
 	if err != nil {
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to find l2 block number to dispute: %w", err)


### PR DESCRIPTION
This fixes an issue where the vm-runner generates an invalid input containing a zero L1 head (i.e. `--l1.head=0x0000000000000000000000000000000000000000000000000000000000000000`). This occurs because the `optimism_syncStatus` RPC may return a zeroed sync status shortly after the op-node is rebooted.

The check for a non-zero `SyncStatus.FinalizedL2.Number` is insufficient for the case where L1 finality hasn't yet been updated. This could happen as finality signals from L1 are decoupled from L2 - so the op-node updates their statuses separately and not in a particular order.