### PR TITLE
goreleaser: cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1257,7 +1257,7 @@ jobs:
           command: |
             mkdir -p /tmp/goreleaser
             cd /tmp/goreleaser
-            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.3.2-pro/goreleaser-pro_Linux_x86_64.tar.gz
+            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.4.3-pro/goreleaser-pro_Linux_x86_64.tar.gz
             tar -xzvf goreleaser.tgz
             mv goreleaser /usr/local/bin/goreleaser
       - run:

--- a/op-deployer/.goreleaser.yaml
+++ b/op-deployer/.goreleaser.yaml
@@ -1,9 +1,4 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
-
-# The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
 version: 2


### PR DESCRIPTION
No functional change.

This bumps the version of goreleaser-pro we use to the latest available,
and fixes the json schema used when editing goreleaser config files.
