### PR TITLE
ci(lint): fix the lint-shellcheck target

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ semgrep-test:
   semgrep scan --test semgrep/
 
 lint-shellcheck:
-  find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path './packages/contracts-bedrock/lib/*' -not -path './packages/contracts-bedrock/kout*/*' -exec sh -c 'echo \"Checking $1\"; shellcheck \"$1\"' _ {} \\;
+  find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path './packages/contracts-bedrock/lib/*' -not -path './packages/contracts-bedrock/kout*/*' -exec sh -c 'echo "Checking $1"; shellcheck "$1"' _ {} \;
 
 install-foundry:
   curl -L https://foundry.paradigm.xyz | bash && just update-foundry

--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -207,13 +207,13 @@ get_log_results
 
 # Now you can use ${results[0]} and ${results[1]}
 # to check the results of kontrol_build and kontrol_prove, respectively
-if [ ${results[0]} -ne 0 ] && [ ${results[1]} -ne 0 ]; then
+if [ "${results[0]}" -ne 0 ] && [ "${results[1]}" -ne 0 ]; then
   echo "Kontrol Build and Prove Failed"
   exit 1
-elif [ ${results[0]} -ne 0 ]; then
+elif [ "${results[0]}" -ne 0 ]; then
   echo "Kontrol Build Failed"
   exit 1
-elif [ ${results[1]} -ne 0 ]; then
+elif [ "${results[1]}" -ne 0 ]; then
   echo "Kontrol Prove Failed"
   exit 2
 else


### PR DESCRIPTION
Excessive backslashing made the command invalid.
Also address the lint-shellcheck current discoveries.
