### PR TITLE
ci: Move develop-fault-proofs e2e job onto dedicated runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1593,6 +1593,7 @@ workflows:
           target: test-cannon
           notify: true
           mentions: "@proofs-team"
+          resource_class: ethereum-optimism/latitude-fps-1
           requires:
             - contracts-bedrock-build
             - cannon-prestate


### PR DESCRIPTION
This job is CPU-heavy, and causes other workflows to fail due to resource exhaustion. This PR moves this job onto a dedicated Latitude runner and resource class. The resource class is configured so that it can only run one job at a time, which is fine since this job only runs on commits to develop.
