### PR TITLE
op-chain-ops/script: remove an impossible condition in `Host.onOpcode`

### DIFF
--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -573,7 +573,7 @@ func (h *Host) onOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpCo
 		})
 	}
 	// Sanity check that top of the call-stack matches the scope context now
-	if len(h.callStack) == 0 || h.callStack[len(h.callStack)-1].Ctx != scopeCtx {
+	if h.callStack[len(h.callStack)-1].Ctx != scopeCtx {
 		panic("scope context changed without call-frame pop/push")
 	}
 	cf := h.callStack[len(h.callStack)-1]


### PR DESCRIPTION
The [preceding](https://github.com/ethereum-optimism/optimism/blob/b1efd7c52f3f79ed1940ada7c7ade3bdbc6cdc63/op-chain-ops/script/script.go#L566-L574) code already ensures that `callStack` won't be empty.