### PR TITLE
Revert "ci: reduce heavy fuzz runs temporarily"

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -76,9 +76,7 @@ runs = 256
 depth = 32
 
 [profile.ciheavy]
-# temp reduce fuzz runs for 1 pr
-# fuzz = { runs = 20000 }
-fuzz = { runs = 200 }
+fuzz = { runs = 20000 }
 
 [profile.ciheavy.invariant]
 runs = 128


### PR DESCRIPTION
This reverts commit 65f03fa0893709455d22541ddaee5133f1fdc000, which temporarily reduced the number of heavy fuzz runs because the merge queue was removing it.

**DO NOT MERGE UNTIL #12746 is merged to develop**