### PR TITLE
op-conductor: adds miner_setMaxDASize to conductor execution proxy

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -247,6 +247,11 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 			Namespace: conductorrpc.ExecutionRPCNamespace,
 			Service:   executionProxy,
 		})
+		execMinerProxy := conductorrpc.NewExecutionMinerProxyBackend(oc.log, oc, execClient)
+		server.AddAPI(rpc.API{
+			Namespace: conductorrpc.ExecutionMinerRPCNamespace,
+			Service:   execMinerProxy,
+		})
 
 		nodeClient, err := dial.DialRollupClientWithTimeout(ctx, 1*time.Minute, oc.log, oc.cfg.NodeRPC)
 		if err != nil {

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
@@ -61,13 +62,19 @@ type API interface {
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
 }
 
-// ExecutionProxyAPI defines the methods proxied to the execution rpc backend
+// ExecutionProxyAPI defines the methods proxied to the execution 'eth_' rpc backend
 // This should include all methods that are called by op-batcher or op-proposer
 type ExecutionProxyAPI interface {
 	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error)
 }
 
-// NodeProxyAPI defines the methods proxied to the node rpc backend
+// ExecutionMinerProxyAPI defines the methods proxied to the execution 'miner_' rpc backend
+// This should include all methods that are called by op-batcher or op-proposer
+type ExecutionMinerProxyAPI interface {
+	SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) bool
+}
+
+// NodeProxyAPI defines the methods proxied to the node 'optimism_' rpc backend
 // This should include all methods that are called by op-batcher or op-proposer
 type NodeProxyAPI interface {
 	OutputAtBlock(ctx context.Context, blockNumString string) (*eth.OutputResponse, error)
@@ -75,7 +82,7 @@ type NodeProxyAPI interface {
 	RollupConfig(ctx context.Context) (*rollup.Config, error)
 }
 
-// NodeProxyAPI defines the methods proxied to the node rpc backend
+// NodeAdminProxyAPI defines the methods proxied to the node 'admin_' rpc backend
 // This should include all methods that are called by op-batcher or op-proposer
 type NodeAdminProxyAPI interface {
 	SequencerActive(ctx context.Context) (bool, error)

--- a/op-conductor/rpc/excecution_miner_proxy.go
+++ b/op-conductor/rpc/excecution_miner_proxy.go
@@ -1,0 +1,40 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var ExecutionMinerRPCNamespace = "miner"
+
+// ExecutionMinerProxyBackend implements an execution rpc proxy with a leadership check before each call.
+type ExecutionMinerProxyBackend struct {
+	log    log.Logger
+	con    conductor
+	client *ethclient.Client
+}
+
+var _ ExecutionMinerProxyAPI = (*ExecutionMinerProxyBackend)(nil)
+
+func NewExecutionMinerProxyBackend(log log.Logger, con conductor, client *ethclient.Client) *ExecutionMinerProxyBackend {
+	return &ExecutionMinerProxyBackend{
+		log:    log,
+		con:    con,
+		client: client,
+	}
+}
+
+func (api *ExecutionMinerProxyBackend) SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) bool {
+	var result bool
+	if !api.con.Leader(ctx) {
+		return false
+	}
+	err := api.client.Client().Call(&result, "miner_setMaxDASize", maxTxSize, maxBlockSize)
+	if err != nil {
+		return false
+	}
+	return result
+}


### PR DESCRIPTION
**Description**

Adds new execution rpc `miner_setMaxDASize` to the conductor proxy that is required by op-batcher.

**Tests**

Deployed to devnet, tested manually that the rpc is proxied correctly.
Will look into adding e2e tests to cover this since missing rpcs can cause safe head stalls.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
