### PR TITLE
[Batcher] Fix memory leak, reverse prepended blocks

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -118,6 +118,7 @@ func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
 		delete(s.txChannels, id)
 		done, blocksToRequeue := channel.TxConfirmed(id, inclusionBlock)
 		if done {
+			s.removePendingChannel(channel)
 			if len(blocksToRequeue) > 0 {
 				s.blocks.Prepend(blocksToRequeue...)
 			}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -118,8 +118,10 @@ func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
 		delete(s.txChannels, id)
 		done, blocksToRequeue := channel.TxConfirmed(id, inclusionBlock)
 		if done {
+			if len(blocksToRequeue) > 0 {
+				s.blocks.Prepend(blocksToRequeue...)
+			}
 			for _, b := range blocksToRequeue {
-				s.blocks.Prepend(b)
 				s.metr.RecordL2BlockInPendingQueue(b)
 			}
 		}
@@ -505,8 +507,8 @@ func (s *channelManager) Requeue(newCfg ChannelConfig) {
 	}
 
 	// We put the blocks back at the front of the queue:
+	s.blocks.Prepend(blocksToRequeue...)
 	for _, b := range blocksToRequeue {
-		s.blocks.Prepend(b)
 		s.metr.RecordL2BlockInPendingQueue(b)
 	}
 

--- a/ops-bedrock/l2-op-geth.Dockerfile
+++ b/ops-bedrock/l2-op-geth.Dockerfile
@@ -1,4 +1,4 @@
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:optimism
+FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.1-rc.6
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

#12810 removed the call to `removePendingChannel` which is causing a memory leak in the batcher.

Also revert the reverse ordering change introduced by that PR, and fix the devnet that was broken in #12840.

**Tests**

Tested by running the devnet locally, and checking the memory usage doesn't grow in pprof.

**Additional context**

We're seeing our batcher process OOM on Base Sepolia.
