### PR TITLE
[Batcher] Fix memory leak, reverse prepended blocks

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -118,6 +118,7 @@ func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
 		delete(s.txChannels, id)
 		done, blocksToRequeue := channel.TxConfirmed(id, inclusionBlock)
 		if done {
+			s.removePendingChannel(channel)
 			if len(blocksToRequeue) > 0 {
 				s.blocks.Prepend(blocksToRequeue...)
 			}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -118,8 +118,10 @@ func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
 		delete(s.txChannels, id)
 		done, blocksToRequeue := channel.TxConfirmed(id, inclusionBlock)
 		if done {
+			if len(blocksToRequeue) > 0 {
+				s.blocks.Prepend(blocksToRequeue...)
+			}
 			for _, b := range blocksToRequeue {
-				s.blocks.Prepend(b)
 				s.metr.RecordL2BlockInPendingQueue(b)
 			}
 		}
@@ -505,8 +507,8 @@ func (s *channelManager) Requeue(newCfg ChannelConfig) {
 	}
 
 	// We put the blocks back at the front of the queue:
+	s.blocks.Prepend(blocksToRequeue...)
 	for _, b := range blocksToRequeue {
-		s.blocks.Prepend(b)
 		s.metr.RecordL2BlockInPendingQueue(b)
 	}
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

#12810 removed the call to `removePendingChannel` which is causing a memory leak in the batcher.

Also revert the reverse ordering change introduced by that PR.

**Tests**

Tested by running the devnet locally, and checking the memory usage doesn't grow in pprof.

**Additional context**

We're seeing our batcher process OOM on Base Sepolia.
