### PR TITLE
op-e2e/actions: improve Holocene tests by adding log assertions

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -28,6 +28,7 @@ import (
 // L2FaultProofEnv is a test harness for a fault provable L2 chain.
 type L2FaultProofEnv struct {
 	log       log.Logger
+	Logs      *testlog.CapturingHandler
 	Batcher   *helpers.L2Batcher
 	Sequencer *helpers.L2Sequencer
 	Engine    *helpers.L2Engine
@@ -40,7 +41,8 @@ type L2FaultProofEnv struct {
 }
 
 func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eutils.TestParams, batcherCfg *helpers.BatcherCfg) *L2FaultProofEnv {
-	log := testlog.Logger(t, log.LvlDebug)
+	log, logs := testlog.CaptureLogger(t, log.LevelDebug)
+
 	dp := NewDeployParams(t, tp, func(dp *e2eutils.DeployParams) {
 		genesisBlock := hexutil.Uint64(0)
 
@@ -111,6 +113,7 @@ func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eut
 
 	return &L2FaultProofEnv{
 		log:       log,
+		Logs:      logs,
 		Batcher:   batcher,
 		Sequencer: sequencer,
 		Engine:    engine,

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -27,8 +27,8 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		{
 			name: "case-0", blocks: []uint{1, 2, 3},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 3,
-				safeHeadHolocene:    3,
+				preHolocene: expectations{safeHead: 3},
+				holocene:    expectations{safeHead: 3},
 			},
 		},
 
@@ -36,30 +36,30 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		{
 			name: "case-2a", blocks: []uint{1, 3, 2},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 3, // batches are buffered, so the block ordering does not matter
-				safeHeadHolocene:    1, // batch for block 3 is considered invalid because it is from the future. This batch + remaining channel is dropped.
+				preHolocene: expectations{safeHead: 3}, // batches are buffered, so the block ordering does not matter
+				holocene:    expectations{safeHead: 1}, // batch for block 3 is considered invalid because it is from the future. This batch + remaining channel is dropped.
 			},
 		},
 		{
 			name: "case-2b", blocks: []uint{2, 1, 3},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 3, // batches are buffered, so the block ordering does not matter
-				safeHeadHolocene:    0, // batch for block 2 is considered invalid because it is from the future. This batch + remaining channel is dropped.
+				preHolocene: expectations{safeHead: 3}, // batches are buffered, so the block ordering does not matter
+				holocene:    expectations{safeHead: 0}, // batch for block 2 is considered invalid because it is from the future. This batch + remaining channel is dropped.
 			},
 		},
 
 		{
 			name: "case-2c", blocks: []uint{1, 1, 2, 3},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 3, // duplicate batches are silently dropped, so this reduceds to case-0
-				safeHeadHolocene:    3, // duplicate batches are silently dropped
+				preHolocene: expectations{safeHead: 3}, // duplicate batches are silently dropped, so this reduceds to case-0
+				holocene:    expectations{safeHead: 3}, // duplicate batches are silently dropped
 			},
 		},
 		{
 			name: "case-2d", blocks: []uint{2, 2, 1, 3},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 3, // duplicate batches are silently dropped, so this reduces to case-2b
-				safeHeadHolocene:    0, // duplicate batches are silently dropped, so this reduces to case-2b
+				preHolocene: expectations{safeHead: 3}, // duplicate batches are silently dropped, so this reduces to case-2b
+				holocene:    expectations{safeHead: 0}, // duplicate batches are silently dropped, so this reduces to case-2b
 			},
 		},
 	}
@@ -113,7 +113,7 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 
 		l2SafeHead := env.Sequencer.L2Safe()
 		isHolocene := testCfg.Hardfork.Precedence >= helpers.Holocene.Precedence
-		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, isHolocene, env.Engine)
+		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
 		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -25,7 +25,7 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 	testCases := []testCase{
 		// Standard channel composition
 		{
-			name: "case-0", blocks: []uint{1, 2, 3},
+			name: "ordered", blocks: []uint{1, 2, 3},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3},
 				holocene:    expectations{safeHead: 3},
@@ -34,14 +34,14 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 
 		// Non-standard channel composition
 		{
-			name: "case-2a", blocks: []uint{1, 3, 2},
+			name: "disordered-a", blocks: []uint{1, 3, 2},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // batches are buffered, so the block ordering does not matter
 				holocene:    expectations{safeHead: 1}, // batch for block 3 is considered invalid because it is from the future. This batch + remaining channel is dropped.
 			},
 		},
 		{
-			name: "case-2b", blocks: []uint{2, 1, 3},
+			name: "disordered-b", blocks: []uint{2, 1, 3},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // batches are buffered, so the block ordering does not matter
 				holocene:    expectations{safeHead: 0}, // batch for block 2 is considered invalid because it is from the future. This batch + remaining channel is dropped.
@@ -49,7 +49,7 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		},
 
 		{
-			name: "case-2c", blocks: []uint{1, 1, 2, 3},
+			name: "duplicates", blocks: []uint{1, 1, 2, 3},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // duplicate batches are silently dropped, so this reduceds to case-0
 				holocene:    expectations{safeHead: 3}, // duplicate batches are silently dropped

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -112,8 +112,8 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l2SafeHead := env.Sequencer.L2Safe()
-		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, testCfg.Hardfork.Precedence < helpers.Holocene.Precedence, env.Engine)
-
+		isHolocene := testCfg.Hardfork.Precedence >= helpers.Holocene.Precedence
+		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, isHolocene, env.Engine)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
 		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type logExcpectations struct {
+	role   string
+	filter string
+	num    int
+}
 type expectations struct {
 	safeHead uint64
-	logs     []struct {
-		role   string
-		filter string
-		num    int
-	}
+	logs     []logExcpectations
 }
 type holoceneExpectations struct {
 	preHolocene, holocene expectations
@@ -40,7 +41,7 @@ func (h holoceneExpectations) RequireExpectedProgressAndLogs(t actionsHelpers.St
 	for _, l := range exp.logs {
 		t.Helper()
 		recs := logs.FindLogs(testlog.NewMessageContainsFilter(l.filter), testlog.NewAttributesFilter("role", l.role))
-		require.Len(t, recs, l.num)
+		require.Len(t, recs, l.num, "searching for %d instances of '%s' in logs from role %s", l.num, l.filter, l.role)
 	}
 
 }

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -19,12 +19,12 @@ type holoceneExpectations struct {
 
 func (h holoceneExpectations) RequireExpectedProgress(t actionsHelpers.StatefulTesting, actualSafeHead eth.L2BlockRef, isHolocene bool, engine *actionsHelpers.L2Engine) {
 	if isHolocene {
-		require.Equal(t, h.safeHeadPreHolocene, actualSafeHead.Number)
-		expectedHash := engine.L2Chain().GetBlockByNumber(h.safeHeadPreHolocene).Hash()
-		require.Equal(t, expectedHash, actualSafeHead.Hash)
-	} else {
 		require.Equal(t, h.safeHeadHolocene, actualSafeHead.Number)
 		expectedHash := engine.L2Chain().GetBlockByNumber(h.safeHeadHolocene).Hash()
+		require.Equal(t, expectedHash, actualSafeHead.Hash)
+	} else {
+		require.Equal(t, h.safeHeadPreHolocene, actualSafeHead.Number)
+		expectedHash := engine.L2Chain().GetBlockByNumber(h.safeHeadPreHolocene).Hash()
 		require.Equal(t, expectedHash, actualSafeHead.Hash)
 	}
 }
@@ -126,8 +126,8 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 
 		l2SafeHead := env.Sequencer.L2Safe()
 
-		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, testCfg.Hardfork.Precedence < helpers.Holocene.Precedence, env.Engine)
-
+		isHolocene := testCfg.Hardfork.Precedence >= helpers.Holocene.Precedence
+		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, isHolocene, env.Engine)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
 		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -59,7 +59,7 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 	testCases := []testCase{
 		// Standard frame submission,
 		{
-			name: "case-0", frames: []uint{0, 1, 2},
+			name: "ordered", frames: []uint{0, 1, 2},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3},
 				holocene:    expectations{safeHead: 3},
@@ -68,21 +68,21 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 
 		// Non-standard frame submission
 		{
-			name: "case-1a", frames: []uint{2, 1, 0},
+			name: "disordered-a", frames: []uint{2, 1, 0},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // frames are buffered, so ordering does not matter
 				holocene:    expectations{safeHead: 0}, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
 			},
 		},
 		{
-			name: "case-1b", frames: []uint{0, 1, 0, 2},
+			name: "disordered-b", frames: []uint{0, 1, 0, 2},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // frames are buffered, so ordering does not matter
 				holocene:    expectations{safeHead: 0}, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
 			},
 		},
 		{
-			name: "case-1c", frames: []uint{0, 1, 1, 2},
+			name: "duplicates", frames: []uint{0, 1, 1, 2},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // frames are buffered, so ordering does not matter
 				holocene:    expectations{safeHead: 3}, // non-contiguous frames are dropped. So this reduces to case-0.

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type logExcpectations struct {
+type logExpectations struct {
 	role   string
 	filter string
 	num    int
 }
 type expectations struct {
 	safeHead uint64
-	logs     []logExcpectations
+	logs     []logExpectations
 }
 type holoceneExpectations struct {
 	preHolocene, holocene expectations

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -36,8 +36,7 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 			name: "disordered-a", frames: []uint{2, 1, 0},
 			holoceneExpectations: holoceneExpectations{
 				preHolocene: expectations{safeHead: 3}, // frames are buffered, so ordering does not matter
-				holocene: expectations{safeHead: 0, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
-					logs: sequencerOnce("dropping future batch")},
+				holocene:    expectations{safeHead: 0}, // non-first frames will be dropped b/c it is the first seen with that channel Id. The safe head won't move until the channel is closed/completed.
 			},
 		},
 		{

--- a/op-e2e/actions/proofs/holocene_helpers_test.go
+++ b/op-e2e/actions/proofs/holocene_helpers_test.go
@@ -1,0 +1,45 @@
+package proofs
+
+import (
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/stretchr/testify/require"
+)
+
+type logExpectations struct {
+	role   string
+	filter string
+	num    int
+}
+type expectations struct {
+	safeHead uint64
+	logs     []logExpectations
+}
+type holoceneExpectations struct {
+	preHolocene, holocene expectations
+}
+
+func (h holoceneExpectations) RequireExpectedProgressAndLogs(t actionsHelpers.StatefulTesting, actualSafeHead eth.L2BlockRef, isHolocene bool, engine *actionsHelpers.L2Engine, logs *testlog.CapturingHandler) {
+	var exp expectations
+	if isHolocene {
+		exp = h.holocene
+	} else {
+		exp = h.preHolocene
+	}
+
+	require.Equal(t, exp.safeHead, actualSafeHead.Number)
+	expectedHash := engine.L2Chain().GetBlockByNumber(exp.safeHead).Hash()
+	require.Equal(t, expectedHash, actualSafeHead.Hash)
+
+	for _, l := range exp.logs {
+		t.Helper()
+		recs := logs.FindLogs(testlog.NewMessageContainsFilter(l.filter), testlog.NewAttributesFilter("role", l.role))
+		require.Len(t, recs, l.num, "searching for %d instances of '%s' in logs from role %s", l.num, l.filter, l.role)
+	}
+
+}
+
+func sequencerOnce(filter string) []logExpectations {
+	return []logExpectations{{filter: filter, role: "sequencer", num: 1}}
+}

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -53,10 +53,6 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 		twoThousandBlocks[i] = uint(i) + 1
 	}
 
-	sequencerOnce := func(filter string) []logExpectations {
-		return []logExpectations{{filter: filter, role: "sequencer", num: 1}}
-	}
-
 	// Depending on the blocks list, whether the channel is built as
 	// as span batch channel, and whether the blocks are modified / invalidated
 	// we expect a different progression of the safe head under Holocene

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -62,7 +62,7 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 		{
 			name: "valid", blocks: []uint{1, 2, 3},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 3, safeHeadHolocene: 3,
+				preHolocene: expectations{safeHead: 3}, holocene: expectations{safeHead: 3},
 			},
 		},
 
@@ -70,24 +70,24 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			name: "invalid-payload", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
 			useSpanBatch: false,
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 1, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-				safeHeadHolocene:    2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+				preHolocene: expectations{safeHead: 1}, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+				holocene:    expectations{safeHead: 2}, // We expect the safe head to move to 2 due to creation of an deposit-only block.
 			},
 		},
 		{
 			name: "invalid-payload-span", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
 			useSpanBatch: true,
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 0, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-				safeHeadHolocene:    2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+				preHolocene: expectations{safeHead: 0}, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+				holocene:    expectations{safeHead: 2}, // We expect the safe head to move to 2 due to creation of an deposit-only block.
 			},
 		},
 
 		{
 			name: "invalid-parent-hash", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidParentHash, nil},
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 1, // Invalid parentHash in block 2 causes an invalid batch to be dropped.
-				safeHeadHolocene:    1, // Same with Holocene.
+				preHolocene: expectations{safeHead: 1}, // Invalid parentHash in block 2 causes an invalid batch to be dropped.
+				holocene:    expectations{safeHead: 1}, // Same with Holocene.
 			},
 		},
 		{
@@ -95,8 +95,8 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			useSpanBatch:            true,
 			breachMaxSequencerDrift: true,
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 0,    // Entire span batch invalidated.
-				safeHeadHolocene:    1800, // We expect partial validity until we hit sequencer drift.
+				preHolocene: expectations{safeHead: 0},    // Entire span batch invalidated.
+				holocene:    expectations{safeHead: 1800}, // We expect partial validity until we hit sequencer drift.
 			},
 		},
 		{
@@ -105,8 +105,8 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			useSpanBatch:        true,
 			overAdvanceL1Origin: 3, // this will over-advance the L1 origin of block 3
 			holoceneExpectations: holoceneExpectations{
-				safeHeadPreHolocene: 0, // Entire span batch invalidated.
-				safeHeadHolocene:    2, // We expect partial validity, safe head should move to block 2, dropping invalid block 3 and remaining channel.
+				preHolocene: expectations{safeHead: 0}, // Entire span batch invalidated.
+				holocene:    expectations{safeHead: 2}, // We expect partial validity, safe head should move to block 2, dropping invalid block 3 and remaining channel.
 			},
 		},
 	}
@@ -205,7 +205,7 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 		l2SafeHead := env.Sequencer.L2Safe()
 
 		isHolocene := testCfg.Hardfork.Precedence >= helpers.Holocene.Precedence
-		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, isHolocene, env.Engine)
+		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
 		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -95,8 +95,23 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			useSpanBatch:            true,
 			breachMaxSequencerDrift: true,
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 0},    // Entire span batch invalidated.
-				holocene:    expectations{safeHead: 1800}, // We expect partial validity until we hit sequencer drift.
+				preHolocene: expectations{safeHead: 0, // Entire span batch invalidated.
+					logs: []logExcpectations{
+						{
+							filter: "batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid",
+							role:   "sequencer",
+							num:    1,
+						},
+					}},
+				holocene: expectations{safeHead: 1800, // We expect partial validity until we hit sequencer drift.
+					logs: []logExcpectations{
+						{
+							filter: "batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid",
+							role:   "sequencer",
+							num:    1,
+						},
+					},
+				},
 			},
 		},
 		{

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -74,16 +74,25 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			name: "invalid-payload", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
 			useSpanBatch: false,
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 1}, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-				holocene:    expectations{safeHead: 2}, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+				preHolocene: expectations{safeHead: 1, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+					logs: sequencerOnce("could not process payload attributes"),
+				},
+				holocene: expectations{safeHead: 2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+					logs: sequencerOnce("could not process payload attributes"),
+				},
 			},
 		},
 		{
 			name: "invalid-payload-span", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
 			useSpanBatch: true,
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 0}, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-				holocene:    expectations{safeHead: 2}, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+				preHolocene: expectations{safeHead: 0, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+					logs: sequencerOnce("could not process payload attributes"),
+				},
+
+				holocene: expectations{safeHead: 2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+					logs: sequencerOnce("could not process payload attributes"),
+				},
 			},
 		},
 

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -77,8 +77,11 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 				preHolocene: expectations{safeHead: 1, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
 					logs: sequencerOnce("could not process payload attributes"),
 				},
-				holocene: expectations{safeHead: 2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
-					logs: sequencerOnce("could not process payload attributes"),
+				holocene: expectations{safeHead: 2, // We expect the safe head to move to 2 due to creation of a deposit-only block.
+					logs: append(
+						sequencerOnce("Holocene active, requesting deposits-only attributes"),
+						sequencerOnce("could not process payload attributes")...,
+					),
 				},
 			},
 		},

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -204,8 +204,8 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 
 		l2SafeHead := env.Sequencer.L2Safe()
 
-		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, testCfg.Hardfork.Precedence < helpers.Holocene.Precedence, env.Engine)
-
+		isHolocene := testCfg.Hardfork.Precedence >= helpers.Holocene.Precedence
+		testCfg.Custom.RequireExpectedProgress(t, l2SafeHead, isHolocene, env.Engine)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
 		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {


### PR DESCRIPTION
This also fixes two bugs which were cancelling each other out -- we were inverting the `isHolocene` bool when switching the assertions of the tests.