### PR TITLE
Typo Update pr-guidelines.md

### DIFF
--- a/docs/handbook/pr-guidelines.md
+++ b/docs/handbook/pr-guidelines.md
@@ -46,4 +46,4 @@ This is organized by current state of PR, so it can be easily referenced frequen
 ### Merging PRs
 
 - **Resolve all Comments**: Comments can be resolved by (1) the PR author for nits/optionals, (2) the author or reviewer after discussions, or (3) extracting the comment into an issue to address in a future PR. For (3), ensure the new issue links to the specific comment thread. This is currently enforced by GitHub's merge requirements.
-- **Other Standard Merge Requirements**: The PR must be approved by the appropriate reviewers, CI must passing, and other standard merge requirements apply.
+- **Other Standard Merge Requirements**: The PR must be approved by the appropriate reviewers, CI must pass, and other standard merge requirements apply.


### PR DESCRIPTION
**Description**:

This PR fixes a typo in the merge requirements section of the PR guidelines. Specifically, the phrase **"CI must passing"** has been corrected to **"CI must pass"**.

**Issue**: 

- The original phrase **"CI must passing"** is incorrect because after the modal verb **"must"**, the main verb should be used in its base form (i.e., **"pass"**). **"Passing"** is a present participle, which does not fit grammatically in this context.

**Importance**:

- Correcting this typo is important for clarity and accuracy. Using the correct grammatical structure ensures that the guidelines are clear and understandable for all contributors. Additionally, it helps maintain the professional quality of the documentation.

Please review and approve the change. 