### PR TITLE
add disallowUnknownFields to `MergeJSON`

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -51,7 +51,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			ProofMaturityDelaySeconds:       standard.ProofMaturityDelaySeconds,
 			DisputeGameFinalityDelaySeconds: standard.DisputeGameFinalityDelaySeconds,
 			MIPSVersion:                     standard.MIPSVersion,
-		},
+		}, false,
 		intent.GlobalDeployOverrides,
 	)
 	if err != nil {

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -51,8 +51,8 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			ProofMaturityDelaySeconds:       standard.ProofMaturityDelaySeconds,
 			DisputeGameFinalityDelaySeconds: standard.DisputeGameFinalityDelaySeconds,
 			MIPSVersion:                     standard.MIPSVersion,
-		}, false,
-		intent.GlobalDeployOverrides,
+		},
+		intent.SuperchainProofOverrides,
 	)
 	if err != nil {
 		return fmt.Errorf("error merging proof params from overrides: %w", err)

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -237,7 +237,7 @@ func makeDCIV160(intent *state.Intent, thisIntent *state.ChainIntent, chainID co
 			DisputeSplitDepth:       standard.DisputeSplitDepth,
 			DisputeClockExtension:   standard.DisputeClockExtension,
 			DisputeMaxClockDuration: standard.DisputeMaxClockDuration,
-		},
+		}, false,
 		intent.GlobalDeployOverrides,
 		thisIntent.DeployOverrides,
 	)

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -237,9 +237,9 @@ func makeDCIV160(intent *state.Intent, thisIntent *state.ChainIntent, chainID co
 			DisputeSplitDepth:       standard.DisputeSplitDepth,
 			DisputeClockExtension:   standard.DisputeClockExtension,
 			DisputeMaxClockDuration: standard.DisputeMaxClockDuration,
-		}, false,
-		intent.GlobalDeployOverrides,
-		thisIntent.DeployOverrides,
+		},
+		intent.GlobalChainProofOverrides,
+		thisIntent.ChainProofOverrides,
 	)
 	if err != nil {
 		return opcm.DeployOPChainInputV160{}, fmt.Errorf("error merging proof params from overrides: %w", err)

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -145,7 +145,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 	// Apply overrides after setting the main values.
 	var err error
 	if len(intent.GlobalDeployOverrides) > 0 {
-		cfg, err = jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides)
+		cfg, err = jsonutil.MergeJSON(cfg, true, intent.GlobalDeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging global L2 overrides: %w", err)
 
@@ -153,7 +153,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 	}
 
 	if len(chainIntent.DeployOverrides) > 0 {
-		cfg, err = jsonutil.MergeJSON(cfg, chainIntent.DeployOverrides)
+		cfg, err = jsonutil.MergeJSON(cfg, true, chainIntent.DeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging chain L2 overrides: %w", err)
 		}

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -145,7 +145,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 	// Apply overrides after setting the main values.
 	var err error
 	if len(intent.GlobalDeployOverrides) > 0 {
-		cfg, err = jsonutil.MergeJSON(cfg, true, intent.GlobalDeployOverrides)
+		cfg, err = jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging global L2 overrides: %w", err)
 
@@ -153,7 +153,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 	}
 
 	if len(chainIntent.DeployOverrides) > 0 {
-		cfg, err = jsonutil.MergeJSON(cfg, true, chainIntent.DeployOverrides)
+		cfg, err = jsonutil.MergeJSON(cfg, chainIntent.DeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging chain L2 overrides: %w", err)
 		}

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -50,8 +50,8 @@ type Intent struct {
 
 	Chains []*ChainIntent `json:"chains" toml:"chains"`
 
-	SuperchainProofOverrides  map[string]any `json:"superchainProofOverrides" toml:"superchainProofOverrides"`
-	GlobalChainProofOverrides map[string]any `json:"globalChainProofOverrides" toml:"globalChainProofOverrides"`
+	SuperchainProofOverrides  map[string]any `json:"dangerousSuperchainProofOverrides" toml:"dangerousSuperchainProofOverrides"`
+	GlobalChainProofOverrides map[string]any `json:"dangerousGlobalChainProofOverrides" toml:"dangerousGlobalChainProofOverrides"`
 	GlobalDeployOverrides     map[string]any `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
 }
 
@@ -166,7 +166,7 @@ type ChainIntent struct {
 
 	Roles ChainRoles `json:"roles" toml:"roles"`
 
-	ChainProofOverrides map[string]any `json:"chainProofOverrides" toml:"chainProofOverrides"`
+	ChainProofOverrides map[string]any `json:"dangerousChainProofOverrides" toml:"dangerousChainProofOverrides"`
 	DeployOverrides     map[string]any `json:"deployOverrides" toml:"deployOverrides"`
 
 	DangerousAltDAConfig genesis.AltDADeployConfig `json:"dangerousAltDAConfig,omitempty" toml:"dangerousAltDAConfig,omitempty"`

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -50,7 +50,9 @@ type Intent struct {
 
 	Chains []*ChainIntent `json:"chains" toml:"chains"`
 
-	GlobalDeployOverrides map[string]any `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
+	SuperchainProofOverrides  map[string]any `json:"superchainProofOverrides" toml:"superchainProofOverrides"`
+	GlobalChainProofOverrides map[string]any `json:"globalChainProofOverrides" toml:"globalChainProofOverrides"`
+	GlobalDeployOverrides     map[string]any `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
 }
 
 func (c *Intent) L1ChainIDBig() *big.Int {
@@ -164,7 +166,8 @@ type ChainIntent struct {
 
 	Roles ChainRoles `json:"roles" toml:"roles"`
 
-	DeployOverrides map[string]any `json:"deployOverrides" toml:"deployOverrides"`
+	ChainProofOverrides map[string]any `json:"chainProofOverrides" toml:"chainProofOverrides"`
+	DeployOverrides     map[string]any `json:"deployOverrides" toml:"deployOverrides"`
 
 	DangerousAltDAConfig genesis.AltDADeployConfig `json:"dangerousAltDAConfig,omitempty" toml:"dangerousAltDAConfig,omitempty"`
 }

--- a/op-service/jsonutil/merge.go
+++ b/op-service/jsonutil/merge.go
@@ -9,7 +9,7 @@ import (
 // must be JSON-serializable for this to work. Overrides are applied in
 // order of precedence - i.e., the last overrides will override keys from
 // all preceding overrides.
-func MergeJSON[T any](in T, disallowUnknownFields bool, overrides ...map[string]any) (T, error) {
+func MergeJSON[T any](in T, overrides ...map[string]any) (T, error) {
 	var out T
 	inJSON, err := json.Marshal(in)
 	if err != nil {
@@ -32,16 +32,10 @@ func MergeJSON[T any](in T, disallowUnknownFields bool, overrides ...map[string]
 		return out, err
 	}
 
-	if disallowUnknownFields {
-		dec := json.NewDecoder(bytes.NewReader(inJSON))
-		dec.DisallowUnknownFields()
-		if err := dec.Decode(&out); err != nil {
-			return out, err
-		}
-	} else {
-		if err := json.Unmarshal(inJSON, &out); err != nil {
-			return out, err
-		}
+	dec := json.NewDecoder(bytes.NewReader(inJSON))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&out); err != nil {
+		return out, err
 	}
 
 	return out, nil

--- a/op-service/jsonutil/merge_test.go
+++ b/op-service/jsonutil/merge_test.go
@@ -18,13 +18,10 @@ func TestMergeJSON(t *testing.T) {
 			"hello",
 			42,
 			true,
-		},
+		}, true,
 		map[string]any{
 			"a": "world",
 			"c": false,
-		},
-		map[string]any{
-			"d": "shouldn't show up",
 		},
 	)
 	require.NoError(t, err)
@@ -33,4 +30,13 @@ func TestMergeJSON(t *testing.T) {
 		42,
 		false,
 	})
+
+	_, err = MergeJSON(out, true, map[string]any{
+		"d": "shouldn't show up",
+	})
+	require.Error(t, err)
+	_, err = MergeJSON(out, false, map[string]any{
+		"d": "shouldn't show up",
+	})
+	require.NoError(t, err)
 }

--- a/op-service/jsonutil/merge_test.go
+++ b/op-service/jsonutil/merge_test.go
@@ -18,7 +18,7 @@ func TestMergeJSON(t *testing.T) {
 			"hello",
 			42,
 			true,
-		}, true,
+		},
 		map[string]any{
 			"a": "world",
 			"c": false,
@@ -31,12 +31,8 @@ func TestMergeJSON(t *testing.T) {
 		false,
 	})
 
-	_, err = MergeJSON(out, true, map[string]any{
+	_, err = MergeJSON(out, map[string]any{
 		"d": "shouldn't show up",
 	})
 	require.Error(t, err)
-	_, err = MergeJSON(out, false, map[string]any{
-		"d": "shouldn't show up",
-	})
-	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR adds a `disallowUnknownFields` parameter to `MergeJSON`, so that when applying it to `DeployConfig` as a whole, it will disallow unknown fields, since `NewDeployConfig` already does it [so](https://github.com/ethereum-optimism/optimism/blob/1a067802bbd753d09bfb0b9ee1ee6e51cb7366ce/op-chain-ops/genesis/config.go#L1031).

But when applying it to partial structs within `DeployConfig`, it will allow unknown fields.

This way the user can be notified early when he specifies something wrong.