### PR TITLE
feat: opcm mainnet deploy.

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -133,9 +133,8 @@ func CommitForDeployTag(tag string) (string, error) {
 func ManagerImplementationAddrFor(chainID uint64) (common.Address, error) {
 	switch chainID {
 	case 1:
-		// Generated using the bootstrap command on 10/18/2024.
-		// TODO: @blmalone this needs re-bootstrapped because it's still proxied
-		return common.HexToAddress(""), nil
+		// Generated using the bootstrap command on 11/18/2024.
+		return common.HexToAddress("0x9bc0a1ed534bfb31a6be69e5b767cba332f14347"), nil
 	case 11155111:
 		// Generated using the bootstrap command on 11/15/2024.
 		return common.HexToAddress("0xde9eacb994a6eb12997445f8a63a22772c5c4313"), nil


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

As per recent OPCM redesign we still needed to deploy a mainnet version of OPCM which targets a single release.
<!--
A clear and concise description of the features you're adding in this pull request.
-->