### PR TITLE
Typo fix Update build-legacy-cannons.sh

### DIFF
--- a/cannon/scripts/build-legacy-cannons.sh
+++ b/cannon/scripts/build-legacy-cannons.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # This script builds a version of the cannon executable that includes support for both current and legacy state versions.
-# Each cannon release is built
+# Each cannon release is built separately.
 
 TMP_DIR=$(mktemp -d)
 function cleanup() {


### PR DESCRIPTION
### Description:  

This PR addresses a typo in the build script (`build-cannon.sh`) that could lead to confusion when reading the comments.  

#### Original Comment:  
```bash
# Each cannon release is built
```  

#### Updated Comment:  
```bash
# Each cannon release is built separately.
```  

### Why this is important:  
The original comment was incomplete and ambiguous. By clarifying it, the script's intent becomes easier to understand for developers who work with this repository. Precise documentation is especially crucial in scripts that automate build processes, as unclear comments can lead to misunderstandings or misuse of the script.  

This small improvement contributes to the overall maintainability and readability of the codebase.  

### Testing:  
No code functionality was affected. Only the comment was updated for clarity.  
