### PR TITLE
Typo fix Update commitment.go

### DIFF
--- a/op-alt-da/commitment.go
+++ b/op-alt-da/commitment.go
@@ -108,7 +108,7 @@ func (c Keccak256Commitment) CommitmentType() CommitmentType {
 	return Keccak256CommitmentType
 }
 
-// Encode adds a commitment type prefix self describing the commitment.
+// Encode adds a commitment type prefix that describes the commitment.
 func (c Keccak256Commitment) Encode() []byte {
 	return append([]byte{byte(Keccak256CommitmentType)}, c...)
 }


### PR DESCRIPTION
**Description**  
This pull request corrects a typo in the comment for the `Encode` method of the `Keccak256Commitment` type.  

### Issue:  
The original comment contained an incorrect word:  
```go
// Encode adds a commitment type prefix self describing the commitment.
```

The word "self" is not appropriate in this context and should be replaced with "that" to make the sentence grammatically correct and clear.  

### Fix:  
The corrected comment is:  
```go
// Encode adds a commitment type prefix that describes the commitment.
```

### Importance:  
Accurate and clear comments are essential for maintaining code readability and understanding. This fix ensures that future developers reading the code will not be confused by the incorrect use of "self" in the comment.  

### Changes:  
- Updated the comment for the `Encode` method in the `Keccak256Commitment` type.  

Let me know if there are additional areas to improve!  