### PR TITLE
improve delayedWeth test and coverage

### DIFF
--- a/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
+++ b/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
@@ -58,6 +58,7 @@ contract DataAvailabilityChallengeTest is CommonTest {
         // EntryPoint will revert if using amount > type(uint112).max.
         vm.assume(sender != Preinstalls.EntryPoint_v060);
         vm.assume(sender != address(dataAvailabilityChallenge));
+        vm.assume(sender != deploy.mustGetAddress("DataAvailabilityChallenge"));
         vm.assume(sender.balance == 0);
         vm.deal(sender, amount);
 

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -82,7 +82,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         vm.expectEmit(true, true, false, false);
         emit Withdrawal(address(alice), 1 ether);
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 1 ether);
+        delayedWeth.withdraw(1 ether);
         assertEq(address(alice).balance, balance + 1 ether);
     }
 
@@ -96,7 +96,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         // Withdraw fails when unlock not called.
         vm.expectRevert("DelayedWETH: withdrawal not unlocked");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 0 ether);
+        delayedWeth.withdraw(0 ether);
         assertEq(address(alice).balance, balance);
     }
 
@@ -117,7 +117,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         // Withdraw fails when delay not met.
         vm.expectRevert("DelayedWETH: withdrawal delay not met");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 1 ether);
+        delayedWeth.withdraw(1 ether);
         assertEq(address(alice).balance, balance);
     }
 
@@ -138,7 +138,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         // Withdraw too much fails.
         vm.expectRevert("DelayedWETH: insufficient unlocked withdrawal");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 2 ether);
+        delayedWeth.withdraw(2 ether);
         assertEq(address(alice).balance, balance);
     }
 
@@ -163,7 +163,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         // Withdraw fails.
         vm.expectRevert("DelayedWETH: contract is paused");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 1 ether);
+        delayedWeth.withdraw(1 ether);
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -167,6 +167,110 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
     }
 }
 
+contract DelayedWETH_WithdrawFrom_Test is DelayedWETH_Init {
+    /// @dev Tests that withdrawing while unlocked and delay has passed is successful.
+    function test_withdraw_whileUnlocked_succeeds() public {
+        // Deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: 1 ether }();
+        uint256 balance = address(alice).balance;
+
+        // Unlock the withdrawal.
+        vm.prank(alice);
+        delayedWeth.unlock(alice, 1 ether);
+
+        // Wait for the delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1);
+
+        // Withdraw the WETH.
+        vm.expectEmit(true, true, false, false);
+        emit Withdrawal(address(alice), 1 ether);
+        vm.prank(alice);
+        delayedWeth.withdraw(alice, 1 ether);
+        assertEq(address(alice).balance, balance + 1 ether);
+    }
+
+    /// @dev Tests that withdrawing when unlock was not called fails.
+    function test_withdraw_whileLocked_fails() public {
+        // Deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: 1 ether }();
+        uint256 balance = address(alice).balance;
+
+        // Withdraw fails when unlock not called.
+        vm.expectRevert("DelayedWETH: withdrawal not unlocked");
+        vm.prank(alice);
+        delayedWeth.withdraw(alice, 0 ether);
+        assertEq(address(alice).balance, balance);
+    }
+
+    /// @dev Tests that withdrawing while locked and delay has not passed fails.
+    function test_withdraw_whileLockedNotLongEnough_fails() public {
+        // Deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: 1 ether }();
+        uint256 balance = address(alice).balance;
+
+        // Call unlock.
+        vm.prank(alice);
+        delayedWeth.unlock(alice, 1 ether);
+
+        // Wait for the delay, but not long enough.
+        vm.warp(block.timestamp + delayedWeth.delay() - 1);
+
+        // Withdraw fails when delay not met.
+        vm.expectRevert("DelayedWETH: withdrawal delay not met");
+        vm.prank(alice);
+        delayedWeth.withdraw(alice, 1 ether);
+        assertEq(address(alice).balance, balance);
+    }
+
+    /// @dev Tests that withdrawing more than unlocked amount fails.
+    function test_withdraw_tooMuch_fails() public {
+        // Deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: 1 ether }();
+        uint256 balance = address(alice).balance;
+
+        // Unlock the withdrawal.
+        vm.prank(alice);
+        delayedWeth.unlock(alice, 1 ether);
+
+        // Wait for the delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1);
+
+        // Withdraw too much fails.
+        vm.expectRevert("DelayedWETH: insufficient unlocked withdrawal");
+        vm.prank(alice);
+        delayedWeth.withdraw(alice, 2 ether);
+        assertEq(address(alice).balance, balance);
+    }
+
+    /// @dev Tests that withdrawing while paused fails.
+    function test_withdraw_whenPaused_fails() public {
+        // Deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: 1 ether }();
+
+        // Unlock the withdrawal.
+        vm.prank(alice);
+        delayedWeth.unlock(alice, 1 ether);
+
+        // Wait for the delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1);
+
+        // Pause the contract.
+        address guardian = optimismPortal.guardian();
+        vm.prank(guardian);
+        superchainConfig.pause("identifier");
+
+        // Withdraw fails.
+        vm.expectRevert("DelayedWETH: contract is paused");
+        vm.prank(alice);
+        delayedWeth.withdraw(alice, 1 ether);
+    }
+}
+
 contract DelayedWETH_Recover_Test is DelayedWETH_Init {
     /// @dev Tests that recovering WETH succeeds. Makes sure that doing so succeeds with any amount
     ///      of ETH in the contract and any amount of gas used in the fallback function up to a


### PR DESCRIPTION
I'm of the opinion that the withdraw(uint256) method used in DelayedWETH tests should be that of the DelayedWETH contract (which in turn calls the withdraw(address,uint256) method). SInce the former calls the latter, that means the latter is tested for too indirectly.
This helps with test coverage.

Other alternatives:
- Write tests for withdraw(uint256) also which (the test) are basically a clone of that of withdraw(address,uint256)? This is also a better approach maybe since modifications to any of the 2 functions will be tested for already.
- Leave it as is?
