### PR TITLE
feat : Cleanup L1 Genesis Generation , all references and removed unu…

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -854,12 +854,6 @@ func (d *L1DependenciesConfig) CheckAddresses(dependencyContext DependencyContex
 // The genesis generation may log warnings, do a best-effort support attempt,
 // or ignore these attributes completely.
 type LegacyDeployConfig struct {
-	// CliqueSignerAddress represents the signer address for the clique consensus engine.
-	// It is used in the multi-process devnet to sign blocks.
-	CliqueSignerAddress common.Address `json:"cliqueSignerAddress"`
-	// L1UseClique represents whether or not to use the clique consensus engine.
-	L1UseClique bool `json:"l1UseClique"`
-
 	// DeploymentWaitConfirmations is the number of confirmations to wait during
 	// deployment. This is DEPRECATED and should be removed in a future PR.
 	DeploymentWaitConfirmations int `json:"deploymentWaitConfirmations"`

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -146,21 +145,11 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 	}
 
 	extraData := make([]byte, 0)
-	if config.L1UseClique {
-		// warning: clique has an overly strict block header timestamp check against the system wallclock,
-		// causing blocks to get scheduled as "future block" and not get mined instantly when produced.
-		chainConfig.Clique = &params.CliqueConfig{
-			Period: config.L1BlockTime,
-			Epoch:  30000,
-		}
-		extraData = append(append(make([]byte, 32), config.CliqueSignerAddress[:]...), make([]byte, crypto.SignatureLength)...)
-	} else {
-		chainConfig.MergeNetsplitBlock = big.NewInt(0)
-		chainConfig.TerminalTotalDifficulty = big.NewInt(0)
-		chainConfig.TerminalTotalDifficultyPassed = true
-		chainConfig.ShanghaiTime = u64ptr(0)
-		chainConfig.CancunTime = u64ptr(0)
-	}
+	chainConfig.MergeNetsplitBlock = big.NewInt(0)
+	chainConfig.TerminalTotalDifficulty = big.NewInt(0)
+	chainConfig.TerminalTotalDifficultyPassed = true
+	chainConfig.ShanghaiTime = u64ptr(0)
+	chainConfig.CancunTime = u64ptr(0)
 
 	gasLimit := config.L1GenesisBlockGasLimit
 	if gasLimit == 0 {
@@ -178,7 +167,7 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 	if timestamp == 0 {
 		timestamp = hexutil.Uint64(time.Now().Unix())
 	}
-	if !config.L1UseClique && config.L1CancunTimeOffset != nil {
+	if config.L1CancunTimeOffset != nil {
 		cancunTime := uint64(timestamp) + uint64(*config.L1CancunTimeOffset)
 		chainConfig.CancunTime = &cancunTime
 	}

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -6,8 +6,6 @@
   "maxSequencerDrift": 20,
   "sequencerWindowSize": 100,
   "channelTimeout": 30,
-  "l1UseClique": false,
-  "cliqueSignerAddress": "0x0000000000000000000000000000000000000000",
   "customGasTokenAddress": "0x0000000000000000000000000000000000000000",
   "p2pSequencerAddress": "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
   "batchInboxAddress": "0x42000000000000000000000000000000000000ff",

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -201,9 +201,6 @@ func initAllocType(root string, allocType AllocType) {
 		panic(err)
 	}
 
-	// Do not use clique in the in memory tests. Otherwise block building
-	// would be much more complex.
-	dc.L1UseClique = false
 	// Set the L1 genesis block timestamp to now
 	dc.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	dc.FundDevAccounts = true

--- a/packages/contracts-bedrock/deploy-config/sepolia-devnet-0.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia-devnet-0.json
@@ -15,8 +15,6 @@
   "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleProposer": "0x95014c45078354ff839f14192228108eac82e00a",
   "l2OutputOracleChallenger": "0x8c20c40180751d93e939dddee3517ae0d1ebead2",
-  "cliqueSignerAddress": "0x0000000000000000000000000000000000000000",
-  "l1UseClique": false,
   "l1BlockTime": 12,
   "l1GenesisBlockTimestamp": "0x0",
   "l1GenesisBlockNonce": "0x0",


### PR DESCRIPTION
Description
Cleanup L1 Genesis Generation by removing clique support

Tests

There was no need for additional tests as this was a refactor
all former tests passes

-closes https://github.com/ethereum-optimism/optimism/issues/12518

Fixing issues with below PR
https://github.com/ethereum-optimism/optimism/pull/12557