### PR TITLE
fix: use eth_getBlockReceipts for Infura RPC kind

### DIFF
--- a/op-service/sources/receipts_rpc.go
+++ b/op-service/sources/receipts_rpc.go
@@ -329,8 +329,7 @@ func AvailableReceiptsFetchingMethods(kind RPCProviderKind) ReceiptsFetchingMeth
 	case RPCKindQuickNode:
 		return DebugGetRawReceipts | EthGetBlockReceipts | EthGetTransactionReceiptBatch
 	case RPCKindInfura:
-		// Infura is big, but sadly does not support more optimized receipts fetching methods (yet?)
-		return EthGetTransactionReceiptBatch
+		return EthGetBlockReceipts | EthGetTransactionReceiptBatch
 	case RPCKindParity:
 		return ParityGetBlockReceipts | EthGetTransactionReceiptBatch
 	case RPCKindNethermind:

--- a/op-service/sources/receipts_test.go
+++ b/op-service/sources/receipts_test.go
@@ -283,7 +283,7 @@ func TestEthClient_FetchReceipts(t *testing.T) {
 		{
 			name:         "infura",
 			providerKind: RPCKindInfura,
-			setup:        fallbackCase(4, EthGetTransactionReceiptBatch),
+			setup:        fallbackCase(4, EthGetBlockReceipts, EthGetTransactionReceiptBatch),
 		},
 		{
 			name:         "nethermind",


### PR DESCRIPTION
Infura does provide support for eth_getBlockReceipts.

```
curl https://mainnet.infura.io/v3/xx \
         -X POST \
         -H "Content-Type: application/json" \
         -d '{"jsonrpc": "2.0", "method": "eth_getBlockReceipts", "params": ["latest"], "id": 1}'
```