### PR TITLE
op-deployer: add intent-config-type

### DIFF
--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -141,6 +141,9 @@ func ApplyPipeline(
 	opts ApplyPipelineOpts,
 ) error {
 	intent := opts.Intent
+	if err := intent.Check(); err != nil {
+		return err
+	}
 	st := opts.State
 
 	progressor := func(curr, total int64) {

--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -70,11 +70,7 @@ func (a *Locator) MarshalText() ([]byte, error) {
 		return []byte(a.URL.String()), nil
 	}
 
-	if a.Tag != "" {
-		return []byte("tag://" + a.Tag), nil
-	}
-
-	return nil, fmt.Errorf("no URL, path or tag set")
+	return []byte("tag://" + a.Tag), nil
 }
 
 func (a *Locator) IsTag() bool {

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -20,6 +20,7 @@ const (
 	OutdirFlagName             = "outdir"
 	PrivateKeyFlagName         = "private-key"
 	DeploymentStrategyFlagName = "deployment-strategy"
+	IntentConfigTypeFlagName   = "intent-config-type"
 )
 
 var (
@@ -62,6 +63,17 @@ var (
 		EnvVars: PrefixEnvVar("DEPLOYMENT_STRATEGY"),
 		Value:   string(state.DeploymentStrategyLive),
 	}
+	IntentConfigTypeFlag = &cli.StringFlag{
+		Name: IntentConfigTypeFlagName,
+		Usage: fmt.Sprintf("Intent config type to use. Options: %s (default), %s, %s, %s, %s",
+			state.IntentConfigTypeStandard,
+			state.IntentConfigTypeCustom,
+			state.IntentConfigTypeStrict,
+			state.IntentConfigTypeStandardOverrides,
+			state.IntentConfigTypeStrictOverrides),
+		EnvVars: PrefixEnvVar("INTENT_CONFIG_TYPE"),
+		Value:   string(state.IntentConfigTypeStandard),
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -71,6 +83,7 @@ var InitFlags = []cli.Flag{
 	L2ChainIDsFlag,
 	WorkdirFlag,
 	DeploymentStrategyFlag,
+	IntentConfigTypeFlag,
 }
 
 var ApplyFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -36,7 +36,7 @@ var (
 		Name:    L1ChainIDFlagName,
 		Usage:   "Chain ID of the L1 chain.",
 		EnvVars: PrefixEnvVar("L1_CHAIN_ID"),
-		Value:   900,
+		Value:   11155111,
 	}
 	L2ChainIDsFlag = &cli.StringFlag{
 		Name:    L2ChainIDsFlagName,

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -7,19 +7,17 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
-
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 
-	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"
 )
 
 type InitConfig struct {
 	DeploymentStrategy state.DeploymentStrategy
+	IntentConfigType   state.IntentConfigType
 	L1ChainID          uint64
 	Outdir             string
 	L2ChainIDs         []common.Hash
@@ -51,6 +49,7 @@ func InitCLI() func(ctx *cli.Context) error {
 		l1ChainID := ctx.Uint64(L1ChainIDFlagName)
 		outdir := ctx.String(OutdirFlagName)
 		l2ChainIDsRaw := ctx.String(L2ChainIDsFlagName)
+		intentConfigType := ctx.String(IntentConfigTypeFlagName)
 
 		if len(l2ChainIDsRaw) == 0 {
 			return fmt.Errorf("must specify at least one L2 chain ID")
@@ -68,6 +67,7 @@ func InitCLI() func(ctx *cli.Context) error {
 
 		err := Init(InitConfig{
 			DeploymentStrategy: state.DeploymentStrategy(deploymentStrategy),
+			IntentConfigType:   state.IntentConfigType(intentConfigType),
 			L1ChainID:          l1ChainID,
 			Outdir:             outdir,
 			L2ChainIDs:         l2ChainIDs,
@@ -88,52 +88,14 @@ func Init(cfg InitConfig) error {
 
 	intent := &state.Intent{
 		DeploymentStrategy: cfg.DeploymentStrategy,
+		IntentConfigType:   cfg.IntentConfigType,
 		L1ChainID:          cfg.L1ChainID,
-		FundDevAccounts:    true,
-		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
-		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
 	}
 
-	l1ChainIDBig := intent.L1ChainIDBig()
-
-	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
-	if err != nil {
-		return fmt.Errorf("failed to create dev keys: %w", err)
-	}
-
-	addrFor := func(key devkeys.Key) common.Address {
-		// The error below should never happen, so panic if it does.
-		addr, err := dk.Address(key)
-		if err != nil {
-			panic(err)
+	if cfg.IntentConfigType == state.IntentConfigTypeTest {
+		if err := intent.SetTestValues(cfg.L2ChainIDs); err != nil {
+			return err
 		}
-		return addr
-	}
-	intent.SuperchainRoles = &state.SuperchainRoles{
-		ProxyAdminOwner:       addrFor(devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig)),
-		ProtocolVersionsOwner: addrFor(devkeys.SuperchainProtocolVersionsOwner.Key(l1ChainIDBig)),
-		Guardian:              addrFor(devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig)),
-	}
-
-	for _, l2ChainID := range cfg.L2ChainIDs {
-		l2ChainIDBig := l2ChainID.Big()
-		intent.Chains = append(intent.Chains, &state.ChainIntent{
-			ID:                         l2ChainID,
-			BaseFeeVaultRecipient:      addrFor(devkeys.BaseFeeVaultRecipientRole.Key(l2ChainIDBig)),
-			L1FeeVaultRecipient:        addrFor(devkeys.L1FeeVaultRecipientRole.Key(l2ChainIDBig)),
-			SequencerFeeVaultRecipient: addrFor(devkeys.SequencerFeeVaultRecipientRole.Key(l2ChainIDBig)),
-			Eip1559Denominator:         50,
-			Eip1559Elasticity:          6,
-			Roles: state.ChainRoles{
-				L1ProxyAdminOwner: addrFor(devkeys.L1ProxyAdminOwnerRole.Key(l2ChainIDBig)),
-				L2ProxyAdminOwner: addrFor(devkeys.L2ProxyAdminOwnerRole.Key(l2ChainIDBig)),
-				SystemConfigOwner: addrFor(devkeys.SystemConfigOwner.Key(l2ChainIDBig)),
-				UnsafeBlockSigner: addrFor(devkeys.SequencerP2PRole.Key(l2ChainIDBig)),
-				Batcher:           addrFor(devkeys.BatcherRole.Key(l2ChainIDBig)),
-				Proposer:          addrFor(devkeys.ProposerRole.Key(l2ChainIDBig)),
-				Challenger:        addrFor(devkeys.ChallengerRole.Key(l2ChainIDBig)),
-			},
-		})
 	}
 
 	st := &state.State{

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -92,10 +92,12 @@ func Init(cfg InitConfig) error {
 		L1ChainID:          cfg.L1ChainID,
 	}
 
-	if cfg.IntentConfigType == state.IntentConfigTypeTest {
-		if err := intent.SetTestValues(cfg.L2ChainIDs); err != nil {
-			return err
-		}
+	if err := intent.SetInitValues(cfg.L2ChainIDs); err != nil {
+		return err
+	}
+
+	if err := intent.Check(); err != nil {
+		return err
 	}
 
 	st := &state.State{

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -86,15 +86,12 @@ func Init(cfg InitConfig) error {
 		return fmt.Errorf("invalid config for init: %w", err)
 	}
 
-	intent := &state.Intent{
-		DeploymentStrategy: cfg.DeploymentStrategy,
-		IntentConfigType:   cfg.IntentConfigType,
-		L1ChainID:          cfg.L1ChainID,
-	}
-
-	if err := intent.SetInitValues(cfg.L2ChainIDs); err != nil {
+	intent, err := state.NewIntent(cfg.IntentConfigType, cfg.DeploymentStrategy, cfg.L1ChainID, cfg.L2ChainIDs)
+	if err != nil {
 		return err
 	}
+	intent.DeploymentStrategy = cfg.DeploymentStrategy
+	intent.ConfigType = cfg.IntentConfigType
 
 	st := &state.State{
 		Version: 1,

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -96,10 +96,6 @@ func Init(cfg InitConfig) error {
 		return err
 	}
 
-	if err := intent.Check(); err != nil {
-		return err
-	}
-
 	st := &state.State{
 		Version: 1,
 	}

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -714,6 +714,7 @@ func newIntent(
 	l2Loc *artifacts.Locator,
 ) (*state.Intent, *state.State) {
 	intent := &state.Intent{
+		IntentConfigType:   state.IntentConfigTypeTest,
 		DeploymentStrategy: state.DeploymentStrategyLive,
 		L1ChainID:          l1ChainID.Uint64(),
 		SuperchainRoles: &state.SuperchainRoles{

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -714,7 +714,7 @@ func newIntent(
 	l2Loc *artifacts.Locator,
 ) (*state.Intent, *state.State) {
 	intent := &state.Intent{
-		IntentConfigType:   state.IntentConfigTypeTest,
+		ConfigType:         state.IntentConfigTypeCustom,
 		DeploymentStrategy: state.DeploymentStrategyLive,
 		L1ChainID:          l1ChainID.Uint64(),
 		SuperchainRoles: &state.SuperchainRoles{
@@ -741,8 +741,9 @@ func newChainIntent(t *testing.T, dk *devkeys.MnemonicDevKeys, l1ChainID *big.In
 		BaseFeeVaultRecipient:      addrFor(t, dk, devkeys.BaseFeeVaultRecipientRole.Key(l1ChainID)),
 		L1FeeVaultRecipient:        addrFor(t, dk, devkeys.L1FeeVaultRecipientRole.Key(l1ChainID)),
 		SequencerFeeVaultRecipient: addrFor(t, dk, devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainID)),
-		Eip1559Denominator:         50,
-		Eip1559Elasticity:          6,
+		Eip1559DenominatorCanyon:   standard.Eip1559DenominatorCanyon,
+		Eip1559Denominator:         standard.Eip1559Denominator,
+		Eip1559Elasticity:          standard.Eip1559Elasticity,
 		Roles: state.ChainRoles{
 			L1ProxyAdminOwner: addrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainID)),
 			L2ProxyAdminOwner: addrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainID)),

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -26,7 +26,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 	lgr := env.Logger.New("stage", "init", "strategy", "live")
 	lgr.Info("initializing pipeline")
 
-	if err := initCommonChecks(st, intent); err != nil {
+	if err := initCommonChecks(st); err != nil {
 		return err
 	}
 
@@ -100,11 +100,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 	return nil
 }
 
-func initCommonChecks(st *state.State, intent *state.Intent) error {
-	if err := intent.ValidateIntentConfigType(); err != nil {
-		return err
-	}
-
+func initCommonChecks(st *state.State) error {
 	// Ensure the state version is supported.
 	if !IsSupportedStateVersion(st.Version) {
 		return fmt.Errorf("unsupported state version: %d", st.Version)
@@ -123,7 +119,7 @@ func InitGenesisStrategy(env *Env, intent *state.Intent, st *state.State) error 
 	lgr := env.Logger.New("stage", "init", "strategy", "genesis")
 	lgr.Info("initializing pipeline")
 
-	if err := initCommonChecks(st, intent); err != nil {
+	if err := initCommonChecks(st); err != nil {
 		return err
 	}
 

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -102,7 +102,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 
 func initCommonChecks(st *state.State, intent *state.Intent) error {
 	if err := intent.ValidateIntentConfigType(); err != nil {
-		return fmt.Errorf("failed to validate against intent config type: %w", err)
+		return err
 	}
 
 	// Ensure the state version is supported.
@@ -145,10 +145,10 @@ func displayWarning() error {
 ####################### WARNING! WARNING WARNING! #######################
 
 You are deploying a tagged release to a chain with no pre-deployed OPCM.
-The contracts you are deploying may not be audited, or match a governance 
+The contracts you are deploying may not be audited, or match a governance
 approved release.
 
-USE OF THIS DEPLOYMENT IS NOT RECOMMENDED FOR PRODUCTION. USE AT YOUR OWN 
+USE OF THIS DEPLOYMENT IS NOT RECOMMENDED FOR PRODUCTION. USE AT YOUR OWN
 RISK. BUGS OR LOSS OF FUNDS MAY OCCUR. WE HOPE YOU KNOW WHAT YOU ARE
 DOING.
 

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -26,7 +26,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 	lgr := env.Logger.New("stage", "init", "strategy", "live")
 	lgr.Info("initializing pipeline")
 
-	if err := initCommonChecks(st); err != nil {
+	if err := initCommonChecks(st, intent); err != nil {
 		return err
 	}
 
@@ -100,7 +100,11 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 	return nil
 }
 
-func initCommonChecks(st *state.State) error {
+func initCommonChecks(st *state.State, intent *state.Intent) error {
+	if err := intent.ValidateIntentConfigType(); err != nil {
+		return fmt.Errorf("failed to validate against intent config type: %w", err)
+	}
+
 	// Ensure the state version is supported.
 	if !IsSupportedStateVersion(st.Version) {
 		return fmt.Errorf("unsupported state version: %d", st.Version)
@@ -119,7 +123,7 @@ func InitGenesisStrategy(env *Env, intent *state.Intent, st *state.State) error 
 	lgr := env.Logger.New("stage", "init", "strategy", "genesis")
 	lgr.Info("initializing pipeline")
 
-	if err := initCommonChecks(st); err != nil {
+	if err := initCommonChecks(st, intent); err != nil {
 		return err
 	}
 

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -128,7 +128,7 @@ func makeDCIV160(intent *state.Intent, thisIntent *state.ChainIntent, chainID co
 		L2ChainId:                    chainID.Big(),
 		Opcm:                         st.ImplementationsDeployment.OpcmAddress,
 		SaltMixer:                    st.Create2Salt.String(), // passing through salt generated at state initialization
-		GasLimit:                     standard.BlockGasLimit,
+		GasLimit:                     standard.GasLimit,
 		DisputeGameType:              proofParams.DisputeGameType,
 		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
 		DisputeMaxGameDepth:          proofParams.DisputeMaxGameDepth,

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -128,7 +128,7 @@ func makeDCIV160(intent *state.Intent, thisIntent *state.ChainIntent, chainID co
 		L2ChainId:                    chainID.Big(),
 		Opcm:                         st.ImplementationsDeployment.OpcmAddress,
 		SaltMixer:                    st.Create2Salt.String(), // passing through salt generated at state initialization
-		GasLimit:                     standard.GasLimit,
+		GasLimit:                     standard.BlockGasLimit,
 		DisputeGameType:              proofParams.DisputeGameType,
 		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
 		DisputeMaxGameDepth:          proofParams.DisputeMaxGameDepth,

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	BlockGasLimit                   uint64 = 60_000_000
+	GasLimit                        uint64 = 60_000_000
 	BasefeeScalar                   uint32 = 1368
 	BlobBaseFeeScalar               uint32 = 801949
 	WithdrawalDelaySeconds          uint64 = 604800

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	GasLimit                        uint64 = 60_000_000
+	BlockGasLimit                   uint64 = 60_000_000
 	BasefeeScalar                   uint32 = 1368
 	BlobBaseFeeScalar               uint32 = 801949
 	WithdrawalDelaySeconds          uint64 = 604800

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -26,6 +26,9 @@ const (
 	DisputeSplitDepth               uint64 = 30
 	DisputeClockExtension           uint64 = 10800
 	DisputeMaxClockDuration         uint64 = 302400
+	Eip1559DenominatorCanyon        uint64 = 250
+	Eip1559Denominator              uint64 = 50
+	Eip1559Elasticity               uint64 = 6
 
 	ContractsV160Tag        = "op-contracts/v1.6.0"
 	ContractsV170Beta1L2Tag = "op-contracts/v1.7.0-beta.1+l2-contracts"
@@ -97,6 +100,28 @@ func L1VersionsFor(chainID uint64) (L1Versions, error) {
 	}
 }
 
+func GuardianAddressFor(chainID uint64) (common.Address, error) {
+	switch chainID {
+	case 1:
+		return common.HexToAddress("0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2"), nil
+	case 11155111:
+		return common.HexToAddress("0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"), nil
+	default:
+		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}
+
+func ChallengerAddressFor(chainID uint64) (common.Address, error) {
+	switch chainID {
+	case 1:
+		return common.HexToAddress("0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A"), nil
+	case 11155111:
+		return common.HexToAddress("0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"), nil
+	default:
+		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}
+
 func SuperchainFor(chainID uint64) (*superchain.Superchain, error) {
 	switch chainID {
 	case 1:
@@ -115,7 +140,7 @@ func ChainNameFor(chainID uint64) (string, error) {
 	case 11155111:
 		return "sepolia", nil
 	default:
-		return "", fmt.Errorf("unrecognized chain ID: %d", chainID)
+		return "", fmt.Errorf("unrecognized l1 chain ID: %d", chainID)
 	}
 }
 

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -198,6 +198,17 @@ func SystemOwnerAddrFor(chainID uint64) (common.Address, error) {
 	}
 }
 
+func L1ProxyAdminOwner(chainID uint64) (common.Address, error) {
+	switch chainID {
+	case 1:
+		return common.HexToAddress("0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A"), nil
+	case 11155111:
+		return common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2"), nil
+	default:
+		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}
+
 func ArtifactsURLForTag(tag string) (*url.URL, error) {
 	switch tag {
 	case "op-contracts/v1.6.0":

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -31,6 +31,10 @@ type ChainRoles struct {
 	Challenger        common.Address `json:"challenger" toml:"challenger"`
 }
 
+var ErrChainRoleZeroAddress = fmt.Errorf("ChainRole is set to zero address")
+var ErrFeeVaultZeroAddress = fmt.Errorf("chain has a fee vault set to zero address")
+var ErrNonStandardValue = fmt.Errorf("chain contains non-standard config value")
+
 func (c *ChainIntent) Check() error {
 	var emptyHash common.Hash
 	if c.ID == emptyHash {
@@ -75,7 +79,7 @@ func (cr *ChainRoles) CheckNoZeroAddresses() error {
 		fieldName := typ.Field(i).Name
 
 		if fieldValue.Interface() == (common.Address{}) {
-			return fmt.Errorf("ChainRoles %s contains is set to zero-value address", fieldName)
+			return fmt.Errorf("%w: %s", ErrChainRoleZeroAddress, fieldName)
 		}
 	}
 

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -1,0 +1,83 @@
+package state
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ChainIntent struct {
+	ID                         common.Hash               `json:"id" toml:"id"`
+	BaseFeeVaultRecipient      common.Address            `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
+	L1FeeVaultRecipient        common.Address            `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
+	SequencerFeeVaultRecipient common.Address            `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
+	Eip1559DenominatorCanyon   uint64                    `json:"eip1559DenominatorCanyon" toml:"eip1559DenominatorCanyon"`
+	Eip1559Denominator         uint64                    `json:"eip1559Denominator" toml:"eip1559Denominator"`
+	Eip1559Elasticity          uint64                    `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
+	Roles                      ChainRoles                `json:"roles" toml:"roles"`
+	DeployOverrides            map[string]any            `json:"deployOverrides" toml:"deployOverrides"`
+	DangerousAltDAConfig       genesis.AltDADeployConfig `json:"dangerousAltDAConfig,omitempty" toml:"dangerousAltDAConfig,omitempty"`
+}
+
+type ChainRoles struct {
+	L1ProxyAdminOwner common.Address `json:"l1ProxyAdminOwner" toml:"l1ProxyAdminOwner"`
+	L2ProxyAdminOwner common.Address `json:"l2ProxyAdminOwner" toml:"l2ProxyAdminOwner"`
+	SystemConfigOwner common.Address `json:"systemConfigOwner" toml:"systemConfigOwner"`
+	UnsafeBlockSigner common.Address `json:"unsafeBlockSigner" toml:"unsafeBlockSigner"`
+	Batcher           common.Address `json:"batcher" toml:"batcher"`
+	Proposer          common.Address `json:"proposer" toml:"proposer"`
+	Challenger        common.Address `json:"challenger" toml:"challenger"`
+}
+
+func (c *ChainIntent) Check() error {
+	var emptyHash common.Hash
+	if c.ID == emptyHash {
+		return fmt.Errorf("id must be set")
+	}
+
+	if c.Roles.L1ProxyAdminOwner == emptyAddress {
+		return fmt.Errorf("proxyAdminOwner must be set")
+	}
+
+	if c.Roles.L2ProxyAdminOwner == emptyAddress {
+		return fmt.Errorf("l2ProxyAdminOwner must be set")
+	}
+
+	if c.Roles.SystemConfigOwner == emptyAddress {
+		c.Roles.SystemConfigOwner = c.Roles.L1ProxyAdminOwner
+	}
+
+	if c.Roles.UnsafeBlockSigner == emptyAddress {
+		return fmt.Errorf("unsafeBlockSigner must be set")
+	}
+
+	if c.Roles.Batcher == emptyAddress {
+		return fmt.Errorf("batcher must be set")
+	}
+
+	if c.DangerousAltDAConfig.UseAltDA {
+		return c.DangerousAltDAConfig.Check(nil)
+	}
+
+	return nil
+}
+
+// Returns an error if any fields in ChainRoles is set to common.Address{}
+func (cr *ChainRoles) CheckNoZeroAddresses() error {
+	val := reflect.ValueOf(*cr)
+	typ := reflect.TypeOf(*cr)
+
+	// Iterate through all the fields
+	for i := 0; i < val.NumField(); i++ {
+		fieldValue := val.Field(i)
+		fieldName := typ.Field(i).Name
+
+		if fieldValue.Interface() == (common.Address{}) {
+			return fmt.Errorf("ChainRoles %s contains is set to zero-value address", fieldName)
+		}
+	}
+
+	return nil
+}

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -38,42 +37,10 @@ var ErrNonStandardValue = fmt.Errorf("chain contains non-standard config value")
 var ErrEip1559ZeroValue = fmt.Errorf("eip1559 param is set to zero value")
 
 func (c *ChainIntent) Check() error {
-	var emptyHash common.Hash
 	if c.ID == emptyHash {
 		return fmt.Errorf("id must be set")
 	}
 
-	if c.Roles.L1ProxyAdminOwner == emptyAddress {
-		return fmt.Errorf("proxyAdminOwner must be set")
-	}
-
-	if c.Roles.L2ProxyAdminOwner == emptyAddress {
-		return fmt.Errorf("l2ProxyAdminOwner must be set")
-	}
-
-	if c.Roles.SystemConfigOwner == emptyAddress {
-		c.Roles.SystemConfigOwner = c.Roles.L1ProxyAdminOwner
-	}
-
-	if c.Roles.UnsafeBlockSigner == emptyAddress {
-		return fmt.Errorf("unsafeBlockSigner must be set")
-	}
-
-	if c.Roles.Batcher == emptyAddress {
-		return fmt.Errorf("batcher must be set")
-	}
-
-	if c.DangerousAltDAConfig.UseAltDA {
-		return c.DangerousAltDAConfig.Check(nil)
-	}
-
-	return nil
-}
-
-func (c *ChainIntent) CheckNoZeroValues() error {
-	if c.ID == emptyHash {
-		return errors.New("missing l2 chain ID")
-	}
 	if err := c.Roles.CheckNoZeroAddresses(); err != nil {
 		return err
 	}
@@ -87,6 +54,10 @@ func (c *ChainIntent) CheckNoZeroValues() error {
 		c.L1FeeVaultRecipient == emptyAddress ||
 		c.SequencerFeeVaultRecipient == emptyAddress {
 		return fmt.Errorf("%w: chainId=%s", ErrFeeVaultZeroAddress, c.ID)
+	}
+
+	if c.DangerousAltDAConfig.UseAltDA {
+		return c.DangerousAltDAConfig.Check(nil)
 	}
 
 	return nil

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -102,9 +102,11 @@ func (c *Intent) ValidateIntentConfigType() error {
 		if err := c.validateStrictConfig(); err != nil {
 			return fmt.Errorf("failed to validate intent-config-type=strict: %w", err)
 		}
-	case IntentConfigTypeTest:
-		return nil
 	case IntentConfigTypeStandardOverrides, IntentConfigTypeStrictOverrides:
+		if err := c.validateCustomConfig(); err != nil {
+			return fmt.Errorf("failed to validate intent-config-type=%s: %w", c.IntentConfigType, err)
+		}
+	case IntentConfigTypeTest:
 		return nil
 	default:
 		return fmt.Errorf("intent-config-type unsupported: %s", c.IntentConfigType)
@@ -218,6 +220,12 @@ func (c *Intent) SetInitValues(l2ChainIds []common.Hash) error {
 
 	case IntentConfigTypeStrict:
 		return c.setStrictValues(l2ChainIds)
+
+	case IntentConfigTypeStrictOverrides:
+		return c.setStrictValues(l2ChainIds)
+
+	case IntentConfigTypeStandardOverrides:
+		return c.setStandardValues(l2ChainIds)
 
 	case IntentConfigTypeTest:
 		return c.setTestValues(l2ChainIds)

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -107,7 +107,7 @@ func (c *Intent) validateCustomConfig() error {
 	}
 
 	for _, chain := range c.Chains {
-		if err := chain.CheckNoZeroValues(); err != nil {
+		if err := chain.Check(); err != nil {
 			return err
 		}
 	}
@@ -154,7 +154,7 @@ func (c *Intent) validateStandardValues() error {
 	}
 
 	for _, chain := range c.Chains {
-		if err := chain.CheckNoZeroValues(); err != nil {
+		if err := chain.Check(); err != nil {
 			return err
 		}
 		if chain.Eip1559DenominatorCanyon != standard.Eip1559DenominatorCanyon ||

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
@@ -32,35 +33,132 @@ func (d DeploymentStrategy) Check() error {
 	}
 }
 
+type IntentConfigType string
+
+const (
+	IntentConfigTypeTest              IntentConfigType = "test"
+	IntentConfigTypeStandard          IntentConfigType = "standard"
+	IntentConfigTypeCustom            IntentConfigType = "custom"
+	IntentConfigTypeStrict            IntentConfigType = "strict"
+	IntentConfigTypeStandardOverrides IntentConfigType = "standard-overrides"
+	IntentConfigTypeStrictOverrides   IntentConfigType = "strict-overrides"
+)
+
 var emptyAddress common.Address
 
 type Intent struct {
-	DeploymentStrategy DeploymentStrategy `json:"deploymentStrategy" toml:"deploymentStrategy"`
-
-	L1ChainID uint64 `json:"l1ChainID" toml:"l1ChainID"`
-
-	SuperchainRoles *SuperchainRoles `json:"superchainRoles" toml:"superchainRoles,omitempty"`
-
-	FundDevAccounts bool `json:"fundDevAccounts" toml:"fundDevAccounts"`
-
-	UseInterop bool `json:"useInterop" toml:"useInterop"`
-
-	L1ContractsLocator *artifacts.Locator `json:"l1ContractsLocator" toml:"l1ContractsLocator"`
-
-	L2ContractsLocator *artifacts.Locator `json:"l2ContractsLocator" toml:"l2ContractsLocator"`
-
-	Chains []*ChainIntent `json:"chains" toml:"chains"`
-
-	GlobalDeployOverrides map[string]any `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
+	DeploymentStrategy    DeploymentStrategy `json:"deploymentStrategy" toml:"deploymentStrategy"`
+	IntentConfigType      IntentConfigType   `json:"intentConfigType" toml:"intentConfigType"`
+	L1ChainID             uint64             `json:"l1ChainID" toml:"l1ChainID"`
+	SuperchainRoles       *SuperchainRoles   `json:"superchainRoles" toml:"superchainRoles,omitempty"`
+	FundDevAccounts       bool               `json:"fundDevAccounts" toml:"fundDevAccounts"`
+	UseInterop            bool               `json:"useInterop" toml:"useInterop"`
+	L1ContractsLocator    *artifacts.Locator `json:"l1ContractsLocator" toml:"l1ContractsLocator"`
+	L2ContractsLocator    *artifacts.Locator `json:"l2ContractsLocator" toml:"l2ContractsLocator"`
+	Chains                []*ChainIntent     `json:"chains" toml:"chains"`
+	GlobalDeployOverrides map[string]any     `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
 }
 
 func (c *Intent) L1ChainIDBig() *big.Int {
 	return big.NewInt(int64(c.L1ChainID))
 }
 
+func (c *Intent) ValidateIntentConfig() error {
+	switch c.IntentConfigType {
+	case IntentConfigTypeStandard:
+		return c.validateStandardConfig()
+
+	case IntentConfigTypeCustom:
+		return c.validateCustomConfig()
+
+	case IntentConfigTypeStrict:
+		return c.validateStrictConfig()
+
+	case IntentConfigTypeStandardOverrides, IntentConfigTypeStrictOverrides:
+		return nil
+	default:
+		return fmt.Errorf("intent config type is invalid")
+	}
+}
+
+func (c *Intent) validateStandardConfig() error {
+	if c.SuperchainRoles != nil || c.L1ContractsLocator != nil || c.L2ContractsLocator != nil {
+		return errors.New("standard config: only certain fields should be set")
+	}
+
+	// Block time and gas limit could be validated further if they are part of Intent's parameters.
+
+	return nil
+}
+
+func (c *Intent) validateCustomConfig() error {
+	if c.L1ChainID == 0 || c.L1ContractsLocator == nil || c.L2ContractsLocator == nil || len(c.Chains) == 0 {
+		return errors.New("custom config: all fields must be explicitly specified")
+	}
+	return nil
+}
+
+func (c *Intent) validateStrictConfig() error {
+	for _, chain := range c.Chains {
+		if chain.BaseFeeVaultRecipient != (common.Address{}) {
+			return errors.New("for 'strict' config, opChainProxyAdminOwner and challenger cannot be set")
+		}
+	}
+	return nil
+}
+
+func (c *Intent) SetTestValues(l2ChainIds []common.Hash) error {
+	c.FundDevAccounts = true
+	c.L1ContractsLocator = artifacts.DefaultL1ContractsLocator
+	c.L2ContractsLocator = artifacts.DefaultL2ContractsLocator
+
+	l1ChainIDBig := c.L1ChainIDBig()
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	if err != nil {
+		return fmt.Errorf("failed to create dev keys: %w", err)
+	}
+
+	addrFor := func(key devkeys.Key) common.Address {
+		// The error below should never happen, so panic if it does.
+		addr, err := dk.Address(key)
+		if err != nil {
+			panic(err)
+		}
+		return addr
+	}
+	c.SuperchainRoles = &SuperchainRoles{
+		ProxyAdminOwner:       addrFor(devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig)),
+		ProtocolVersionsOwner: addrFor(devkeys.SuperchainProtocolVersionsOwner.Key(l1ChainIDBig)),
+		Guardian:              addrFor(devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig)),
+	}
+
+	for _, l2ChainID := range l2ChainIds {
+		l2ChainIDBig := l2ChainID.Big()
+		c.Chains = append(c.Chains, &ChainIntent{
+			ID:                         l2ChainID,
+			BaseFeeVaultRecipient:      addrFor(devkeys.BaseFeeVaultRecipientRole.Key(l2ChainIDBig)),
+			L1FeeVaultRecipient:        addrFor(devkeys.L1FeeVaultRecipientRole.Key(l2ChainIDBig)),
+			SequencerFeeVaultRecipient: addrFor(devkeys.SequencerFeeVaultRecipientRole.Key(l2ChainIDBig)),
+			Eip1559Denominator:         50,
+			Eip1559Elasticity:          6,
+			Roles: ChainRoles{
+				L1ProxyAdminOwner: addrFor(devkeys.L1ProxyAdminOwnerRole.Key(l2ChainIDBig)),
+				L2ProxyAdminOwner: addrFor(devkeys.L2ProxyAdminOwnerRole.Key(l2ChainIDBig)),
+				SystemConfigOwner: addrFor(devkeys.SystemConfigOwner.Key(l2ChainIDBig)),
+				UnsafeBlockSigner: addrFor(devkeys.SequencerP2PRole.Key(l2ChainIDBig)),
+				Batcher:           addrFor(devkeys.BatcherRole.Key(l2ChainIDBig)),
+				Proposer:          addrFor(devkeys.ProposerRole.Key(l2ChainIDBig)),
+				Challenger:        addrFor(devkeys.ChallengerRole.Key(l2ChainIDBig)),
+			},
+		})
+	}
+	return nil
+}
+
 func (c *Intent) Check() error {
-	if c.DeploymentStrategy != DeploymentStrategyLive && c.DeploymentStrategy != DeploymentStrategyGenesis {
-		return fmt.Errorf("deploymentStrategy must be 'live' or 'local'")
+	if err := c.DeploymentStrategy.Check(); err != nil {
+		return err
 	}
 
 	if c.L1ChainID == 0 {
@@ -151,23 +249,15 @@ type SuperchainRoles struct {
 }
 
 type ChainIntent struct {
-	ID common.Hash `json:"id" toml:"id"`
-
-	BaseFeeVaultRecipient common.Address `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
-
-	L1FeeVaultRecipient common.Address `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
-
-	SequencerFeeVaultRecipient common.Address `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
-
-	Eip1559Denominator uint64 `json:"eip1559Denominator" toml:"eip1559Denominator"`
-
-	Eip1559Elasticity uint64 `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
-
-	Roles ChainRoles `json:"roles" toml:"roles"`
-
-	DeployOverrides map[string]any `json:"deployOverrides" toml:"deployOverrides"`
-
-	DangerousAltDAConfig genesis.AltDADeployConfig `json:"dangerousAltDAConfig,omitempty" toml:"dangerousAltDAConfig,omitempty"`
+	ID                         common.Hash               `json:"id" toml:"id"`
+	BaseFeeVaultRecipient      common.Address            `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
+	L1FeeVaultRecipient        common.Address            `json:"l1FeeVaultRecipient" toml:"l1FeeVaultRecipient"`
+	SequencerFeeVaultRecipient common.Address            `json:"sequencerFeeVaultRecipient" toml:"sequencerFeeVaultRecipient"`
+	Eip1559Denominator         uint64                    `json:"eip1559Denominator" toml:"eip1559Denominator"`
+	Eip1559Elasticity          uint64                    `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
+	Roles                      ChainRoles                `json:"roles" toml:"roles"`
+	DeployOverrides            map[string]any            `json:"deployOverrides" toml:"deployOverrides"`
+	DangerousAltDAConfig       genesis.AltDADeployConfig `json:"dangerousAltDAConfig,omitempty" toml:"dangerousAltDAConfig,omitempty"`
 }
 
 type ChainRoles struct {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -173,11 +173,11 @@ func getStandardSuperchainRoles(l1ChainId uint64) (*SuperchainRoles, error) {
 		return nil, fmt.Errorf("error getting superchain config: %w", err)
 	}
 
-	proxyAdmin, _ := standard.ManagerOwnerAddrFor(l1ChainId)
+	proxyAdminOwner, _ := standard.L1ProxyAdminOwner(l1ChainId)
 	guardian, _ := standard.GuardianAddressFor(l1ChainId)
 
 	superchainRoles := &SuperchainRoles{
-		ProxyAdminOwner:       proxyAdmin,
+		ProxyAdminOwner:       proxyAdminOwner,
 		ProtocolVersionsOwner: common.Address(*superCfg.Config.ProtocolVersionsAddr),
 		Guardian:              guardian,
 	}

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -8,33 +8,26 @@ import (
 )
 
 func TestValidateStandardValues(t *testing.T) {
-	intent := initStandardIntent()
-	err := intent.ValidateIntentConfigType()
+	intent, err := NewIntentStandard(DeploymentStrategyLive, 1, []common.Hash{common.HexToHash("0x336")})
+	require.NoError(t, err)
+
+	err = intent.Check()
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrChainRoleZeroAddress)
 
-	setChainRoles(intent)
-	err = intent.ValidateIntentConfigType()
+	setChainRoles(&intent)
+	err = intent.Check()
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFeeVaultZeroAddress)
 
-	setFeeAddresses(intent)
-	err = intent.ValidateIntentConfigType()
+	setFeeAddresses(&intent)
+	err = intent.Check()
 	require.NoError(t, err)
 
 	intent.Chains[0].Eip1559Denominator = 3 // set to non-standard value
-	err = intent.ValidateIntentConfigType()
+	err = intent.Check()
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrNonStandardValue)
-}
-
-func initStandardIntent() *Intent {
-	intent := Intent{
-		L1ChainID:        1,
-		IntentConfigType: IntentConfigTypeStandard,
-	}
-	_ = intent.setStandardValues([]common.Hash{common.HexToHash("0x336")})
-	return &intent
 }
 
 func setChainRoles(intent *Intent) {

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -30,6 +30,48 @@ func TestValidateStandardValues(t *testing.T) {
 	require.ErrorIs(t, err, ErrNonStandardValue)
 }
 
+func TestValidateCustomValues(t *testing.T) {
+	intent, err := NewIntentCustom(DeploymentStrategyLive, 1, []common.Hash{common.HexToHash("0x336")})
+	require.NoError(t, err)
+
+	err = intent.Check()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSuperchainRoleZeroAddress)
+
+	setSuperchainRoles(&intent)
+	err = intent.Check()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrChainRoleZeroAddress)
+
+	setChainRoles(&intent)
+	err = intent.Check()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEip1559ZeroValue)
+
+	setEip1559Params(&intent)
+	err = intent.Check()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrFeeVaultZeroAddress)
+
+	setFeeAddresses(&intent)
+	err = intent.Check()
+	require.NoError(t, err)
+}
+
+func setSuperchainRoles(intent *Intent) {
+	intent.SuperchainRoles = &SuperchainRoles{
+		ProxyAdminOwner:       common.HexToAddress("0xa"),
+		ProtocolVersionsOwner: common.HexToAddress("0xb"),
+		Guardian:              common.HexToAddress("0xc"),
+	}
+}
+
+func setEip1559Params(intent *Intent) {
+	intent.Chains[0].Eip1559Denominator = 5000
+	intent.Chains[0].Eip1559DenominatorCanyon = 5000
+	intent.Chains[0].Eip1559Elasticity = 5000
+}
+
 func setChainRoles(intent *Intent) {
 	intent.Chains[0].Roles.L1ProxyAdminOwner = common.HexToAddress("0x01")
 	intent.Chains[0].Roles.L2ProxyAdminOwner = common.HexToAddress("0x02")

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -44,6 +44,7 @@ func setChainRoles(intent *Intent) {
 	intent.Chains[0].Roles.UnsafeBlockSigner = common.HexToAddress("0x04")
 	intent.Chains[0].Roles.Batcher = common.HexToAddress("0x05")
 	intent.Chains[0].Roles.Proposer = common.HexToAddress("0x06")
+	intent.Chains[0].Roles.Challenger = common.HexToAddress("0x07")
 }
 
 func setFeeAddresses(intent *Intent) {

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -1,0 +1,53 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStandardValues(t *testing.T) {
+	intent := initStandardIntent()
+	err := intent.ValidateIntentConfigType()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrChainRoleZeroAddress)
+
+	setChainRoles(intent)
+	err = intent.ValidateIntentConfigType()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrFeeVaultZeroAddress)
+
+	setFeeAddresses(intent)
+	err = intent.ValidateIntentConfigType()
+	require.NoError(t, err)
+
+	intent.Chains[0].Eip1559Denominator = 3
+	err = intent.ValidateIntentConfigType()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNonStandardValue)
+}
+
+func initStandardIntent() *Intent {
+	intent := Intent{
+		L1ChainID:        1,
+		IntentConfigType: IntentConfigTypeStandard,
+	}
+	intent.setStandardValues([]common.Hash{common.HexToHash("0x336")})
+	return &intent
+}
+
+func setChainRoles(intent *Intent) {
+	intent.Chains[0].Roles.L1ProxyAdminOwner = common.HexToAddress("0x01")
+	intent.Chains[0].Roles.L2ProxyAdminOwner = common.HexToAddress("0x01")
+	intent.Chains[0].Roles.SystemConfigOwner = common.HexToAddress("0x01")
+	intent.Chains[0].Roles.UnsafeBlockSigner = common.HexToAddress("0x01")
+	intent.Chains[0].Roles.Batcher = common.HexToAddress("0x01")
+	intent.Chains[0].Roles.Proposer = common.HexToAddress("0x01")
+}
+
+func setFeeAddresses(intent *Intent) {
+	intent.Chains[0].BaseFeeVaultRecipient = common.HexToAddress("0x08")
+	intent.Chains[0].L1FeeVaultRecipient = common.HexToAddress("0x09")
+	intent.Chains[0].SequencerFeeVaultRecipient = common.HexToAddress("0x0A")
+}

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -33,17 +33,17 @@ func initStandardIntent() *Intent {
 		L1ChainID:        1,
 		IntentConfigType: IntentConfigTypeStandard,
 	}
-	intent.setStandardValues([]common.Hash{common.HexToHash("0x336")})
+	_ = intent.setStandardValues([]common.Hash{common.HexToHash("0x336")})
 	return &intent
 }
 
 func setChainRoles(intent *Intent) {
 	intent.Chains[0].Roles.L1ProxyAdminOwner = common.HexToAddress("0x01")
-	intent.Chains[0].Roles.L2ProxyAdminOwner = common.HexToAddress("0x01")
-	intent.Chains[0].Roles.SystemConfigOwner = common.HexToAddress("0x01")
-	intent.Chains[0].Roles.UnsafeBlockSigner = common.HexToAddress("0x01")
-	intent.Chains[0].Roles.Batcher = common.HexToAddress("0x01")
-	intent.Chains[0].Roles.Proposer = common.HexToAddress("0x01")
+	intent.Chains[0].Roles.L2ProxyAdminOwner = common.HexToAddress("0x02")
+	intent.Chains[0].Roles.SystemConfigOwner = common.HexToAddress("0x03")
+	intent.Chains[0].Roles.UnsafeBlockSigner = common.HexToAddress("0x04")
+	intent.Chains[0].Roles.Batcher = common.HexToAddress("0x05")
+	intent.Chains[0].Roles.Proposer = common.HexToAddress("0x06")
 }
 
 func setFeeAddresses(intent *Intent) {

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -22,7 +22,7 @@ func TestValidateStandardValues(t *testing.T) {
 	err = intent.ValidateIntentConfigType()
 	require.NoError(t, err)
 
-	intent.Chains[0].Eip1559Denominator = 3
+	intent.Chains[0].Eip1559Denominator = 3 // set to non-standard value
 	err = intent.ValidateIntentConfigType()
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrNonStandardValue)


### PR DESCRIPTION
Creates the concept of `intent-config-type`. Based on the selection, some fields are auto-populated and others are expected to be populated by the user prior to running `op-deployer apply`. Valid options are:
* `test` used by current test suite, deterministically generates addresses/keys used in testing
* `standard` (default, uses standard values as defined in superchain-registry where possible)
* `custom` requires all params to be populated by user, errors during `apply` if any don't get set
* `strict` same as "standard", but sets additional params
* `standard-overrides`
* `strict-overrides`

## Design Details
* `op-deployer init`
  * `intent.SetInitValues`: generates initial intent (with many empty fields)
  * user expected to fill out empty/zero-value fields before running `op-deployer apply`
* `op-deployer apply`
  * pipeline stage: `init`
    * `intent.ValidateIntentConfigType`: validates that all fields have been populated, and that values meet expectation (e.g. standard values are used if `intent-config-type=standard`

## Open questions
Which fields should the`standard-overrides`/`strict-overrides` settings allow to be overridden? The way this is currently implemented:
* `standard-overrides`: 
  * `op-deployer init`: sets intent.toml standard values
  * `op-deployer apply`: validates that all values are populated (i.e. non zero value) but doesn't require specific values
* `strict-overrides`:
  * `op-deployer init`: sets intent.toml strict values
  * `op-deployer apply`: validates that all values are populated (i.e. non zero value) but doesn't require specific values

## Meta
Closes https://github.com/ethereum-optimism/platforms-team/issues/305