### PR TITLE
op-chain-ops: remove L1 clique option

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -854,12 +854,6 @@ func (d *L1DependenciesConfig) CheckAddresses(dependencyContext DependencyContex
 // The genesis generation may log warnings, do a best-effort support attempt,
 // or ignore these attributes completely.
 type LegacyDeployConfig struct {
-	// CliqueSignerAddress represents the signer address for the clique consensus engine.
-	// It is used in the multi-process devnet to sign blocks.
-	CliqueSignerAddress common.Address `json:"cliqueSignerAddress"`
-	// L1UseClique represents whether or not to use the clique consensus engine.
-	L1UseClique bool `json:"l1UseClique"`
-
 	// DeploymentWaitConfirmations is the number of confirmations to wait during
 	// deployment. This is DEPRECATED and should be removed in a future PR.
 	DeploymentWaitConfirmations int `json:"deploymentWaitConfirmations"`

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -6,8 +6,6 @@
   "maxSequencerDrift": 20,
   "sequencerWindowSize": 100,
   "channelTimeout": 30,
-  "l1UseClique": false,
-  "cliqueSignerAddress": "0x0000000000000000000000000000000000000000",
   "customGasTokenAddress": "0x0000000000000000000000000000000000000000",
   "p2pSequencerAddress": "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
   "batchInboxAddress": "0x42000000000000000000000000000000000000ff",

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -201,9 +201,6 @@ func initAllocType(root string, allocType AllocType) {
 		panic(err)
 	}
 
-	// Do not use clique in the in memory tests. Otherwise block building
-	// would be much more complex.
-	dc.L1UseClique = false
 	// Set the L1 genesis block timestamp to now
 	dc.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	dc.FundDevAccounts = true

--- a/op-e2e/e2eutils/secrets.go
+++ b/op-e2e/e2eutils/secrets.go
@@ -19,8 +19,8 @@ const defaultHDPathPrefix = "m/44'/60'/0'/0/"
 // If these values are changed, it is subject to breaking tests. They
 // must be in sync with the values in the DeployConfig used to create the system.
 var DefaultMnemonicConfig = &MnemonicConfig{
-	Mnemonic:     "test test test test test test test test test test test junk",
-	CliqueSigner: "m/44'/60'/0'/0/0",
+	Mnemonic: "test test test test test test test test test test test junk",
+	// Note: "m/44'/60'/0'/0/0" is a legacy mnemonic path, used for the L1 clique signer.
 	Proposer:     "m/44'/60'/0'/0/1",
 	Batcher:      "m/44'/60'/0'/0/2",
 	Deployer:     "m/44'/60'/0'/0/3",
@@ -36,9 +36,8 @@ var DefaultMnemonicConfig = &MnemonicConfig{
 type MnemonicConfig struct {
 	Mnemonic string
 
-	CliqueSigner string
-	Deployer     string
-	SysCfgOwner  string
+	Deployer    string
+	SysCfgOwner string
 
 	// rollup actors
 	Proposer     string
@@ -63,10 +62,6 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 	}
 
 	deployer, err := wallet.PrivateKey(account(m.Deployer))
-	if err != nil {
-		return nil, err
-	}
-	cliqueSigner, err := wallet.PrivateKey(account(m.CliqueSigner))
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +97,6 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 	return &Secrets{
 		Deployer:     deployer,
 		SysCfgOwner:  sysCfgOwner,
-		CliqueSigner: cliqueSigner,
 		Proposer:     proposer,
 		Batcher:      batcher,
 		SequencerP2P: sequencerP2P,
@@ -115,9 +109,8 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 
 // Secrets bundles secp256k1 private keys for all common rollup actors for testing purposes.
 type Secrets struct {
-	Deployer     *ecdsa.PrivateKey
-	CliqueSigner *ecdsa.PrivateKey
-	SysCfgOwner  *ecdsa.PrivateKey
+	Deployer    *ecdsa.PrivateKey
+	SysCfgOwner *ecdsa.PrivateKey
 
 	// rollup actors
 	Proposer     *ecdsa.PrivateKey
@@ -138,7 +131,6 @@ type Secrets struct {
 func (s *Secrets) Addresses() *Addresses {
 	return &Addresses{
 		Deployer:     crypto.PubkeyToAddress(s.Deployer.PublicKey),
-		CliqueSigner: crypto.PubkeyToAddress(s.CliqueSigner.PublicKey),
 		SysCfgOwner:  crypto.PubkeyToAddress(s.SysCfgOwner.PublicKey),
 		Proposer:     crypto.PubkeyToAddress(s.Proposer.PublicKey),
 		Batcher:      crypto.PubkeyToAddress(s.Batcher.PublicKey),
@@ -151,9 +143,8 @@ func (s *Secrets) Addresses() *Addresses {
 
 // Addresses bundles the addresses for all common rollup addresses for testing purposes.
 type Addresses struct {
-	Deployer     common.Address
-	CliqueSigner common.Address
-	SysCfgOwner  common.Address
+	Deployer    common.Address
+	SysCfgOwner common.Address
 
 	// rollup actors
 	Proposer     common.Address
@@ -169,7 +160,6 @@ type Addresses struct {
 func (a *Addresses) All() []common.Address {
 	return []common.Address{
 		a.Deployer,
-		a.CliqueSigner,
 		a.SysCfgOwner,
 		a.Proposer,
 		a.Batcher,

--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -138,7 +138,7 @@ func (ch *Cheater) RunAndClose(fn HeadFn) error {
 
 	// Geth stores the TD for each block separately from the block itself. We must update this
 	// manually, otherwise Geth thinks we haven't reached TTD yet and tries to build a block
-	// using Clique consensus, which causes a panic.
+	// using pre-merge consensus, which causes a panic.
 	rawdb.WriteTd(batch, blockHash, preID.Number, ch.Blockchain.GetTd(preID.Hash, preID.Number))
 
 	// Need to copy over receipts since they are keyed by block hash.

--- a/packages/contracts-bedrock/deploy-config/sepolia-devnet-0.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia-devnet-0.json
@@ -15,8 +15,6 @@
   "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleProposer": "0x95014c45078354ff839f14192228108eac82e00a",
   "l2OutputOracleChallenger": "0x8c20c40180751d93e939dddee3517ae0d1ebead2",
-  "cliqueSignerAddress": "0x0000000000000000000000000000000000000000",
-  "l1UseClique": false,
   "l1BlockTime": 12,
   "l1GenesisBlockTimestamp": "0x0",
   "l1GenesisBlockNonce": "0x0",


### PR DESCRIPTION
**Description**

This PR removes the L1 clique configuration option from the op-chain-ops deploy config / tooling.

Our L1 contracts assume Shanghai is active, which assumes merge is active, which has an extra-data limit of 32 bytes, which conflicts with Clique. It's really just legacy code that we can remove.

This supersedes #12557

**Tests**

Removes dead code

**Additional context**

I tried to attribute author info, but the author of the commits appears as:
```
commit 7e0f148cd56108aa8dfafe033c02b22b9b7a8d53 (HEAD)
Author: = <=>
Date:   Mon Oct 21 23:44:57 2024 +0100

```
And I don't have permission to push to the branch that the PR was opened with (`develop`, not a proper feature branch).


**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

Fix https://github.com/ethereum-optimism/optimism/issues/12518
