### PR TITLE
Typo Update README.md

### DIFF
--- a/cannon/docs/README.md
+++ b/cannon/docs/README.md
@@ -30,7 +30,7 @@ The difference is that it has access to the full memory, and pre-image oracle.
 And as it executes each step, it can optionally produce the witness data for the step, to repeat it onchain.
 
 The Cannon CLI is used to load a program into an initial state,
-transition it to N steps quickly without witness generation, and 1 step while producing a witness.
+transition it to N steps quickly without witness generation, and one step while producing a witness.
 
 `mipsevm` is instrumented for proof generation and handles delay-slots by isolating each individual instruction
 and tracking `nextPC` to emulate the delayed `PC` changes after delay-slot execution.


### PR DESCRIPTION
**Description of the Issue:**
In the documentation, there is a minor typographical inconsistency in the following sentence:

> "...and 1 step while producing a witness."

The numeral "1" is used instead of the word "one," which disrupts the stylistic consistency of the text. Consistency in writing enhances readability and ensures a professional tone throughout the documentation.

**Proposed Fix:**
The sentence is corrected to:

> "...and one step while producing a witness."

**Importance of the Fix:**
This adjustment aligns the style of the text, maintaining uniformity in how numbers are presented (spelled out rather than using numerals) where appropriate. Such consistency is especially crucial in technical documentation, as it helps convey a polished and cohesive message to readers. 

Thank you for considering this improvement!
