### PR TITLE
op-deployer: Update dockerfile

### DIFF
--- a/op-deployer/Dockerfile.default
+++ b/op-deployer/Dockerfile.default
@@ -1,3 +1,9 @@
 FROM debian:bookworm-20240812-slim
 ENTRYPOINT ["/op-deployer"]
 COPY op-deployer /op-deployer
+
+# Install ca-certificates so that HTTPS requests work
+RUN apt-get update && apt-get install -y ca-certificates
+
+# Symlink onto the PATH
+RUN ln -s /op-deployer /usr/local/bin/op-deployer


### PR DESCRIPTION
Update the op-deployer Dockerfile to install CA certificates and symlink /op-deployer into /usr/local/bin so that it's on the container's PATH.
