### PR TITLE
batcher: fix state inconsistency

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -565,3 +565,10 @@ func (m *channelManager) CheckExpectedProgress(syncStatus eth.SyncStatus) error 
 	}
 	return nil
 }
+
+func (m *channelManager) LastStoredBlock() eth.BlockID {
+	if m.blocks.Len() == 0 {
+		return eth.BlockID{}
+	}
+	return eth.ToBlockID(m.blocks[m.blocks.Len()-1])
+}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -480,6 +480,7 @@ func (s *channelManager) pruneSafeBlocks(newSafeHead eth.L2BlockRef) {
 
 	if newSafeHead.Number+1 < oldestBlock.NumberU64() {
 		// This could happen if there was an L1 reorg.
+		// Or if the sequencer restarted.
 		s.log.Warn("safe head reversed, clearing channel manager state",
 			"oldestBlock", eth.ToBlockID(oldestBlock),
 			"newSafeBlock", newSafeHead)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -370,7 +370,7 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 	// Check last stored to see if it needs to be set on startup OR set if is lagged behind.
 	// It lagging implies that the op-node processed some batches that were submitted prior to the current instance of the batcher being alive.
 	if lastStoredBlock == (eth.BlockID{}) {
-		l.Log.Info("Starting batch-submitter work at safe-head", "safe", syncStatus.SafeL2)
+		l.Log.Info("Resuming batch-submitter work at safe-head", "safe", syncStatus.SafeL2)
 		lastStoredBlock = syncStatus.SafeL2.ID()
 	} else if lastStoredBlock.Number < syncStatus.SafeL2.Number {
 		l.Log.Warn("Last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", l.lastStoredBlock, "safe", syncStatus.SafeL2)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -372,14 +372,14 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 	start := l.state.LastStoredBlock()
 	end := syncStatus.UnsafeL2.ID()
 
-	// Check last stored to see if it is empty or has lagged behind.
+	// Check last stored block to see if it is empty or has lagged behind.
 	// It lagging implies that the op-node processed some batches that
 	// were submitted prior to the current instance of the batcher being alive.
 	if lastStoredBlock == (eth.BlockID{}) {
 		l.Log.Info("Resuming batch-submitter work at safe-head", "safe", syncStatus.SafeL2)
 		start = syncStatus.SafeL2.ID()
 	} else if lastStoredBlock.Number < syncStatus.SafeL2.Number {
-		l.Log.Warn("Last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", lastStoredBlock, "safe", syncStatus.SafeL2)
+		l.Log.Warn("Last stored block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", lastStoredBlock, "safe", syncStatus.SafeL2)
 		start = syncStatus.SafeL2.ID()
 	}
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -369,7 +369,7 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 	}
 
 	lastStoredBlock := l.state.LastStoredBlock()
-	start := l.state.LastStoredBlock()
+	start := lastStoredBlock
 	end := syncStatus.UnsafeL2.ID()
 
 	// Check last stored block to see if it is empty or has lagged behind.

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -373,7 +373,7 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 		l.Log.Info("Resuming batch-submitter work at safe-head", "safe", syncStatus.SafeL2)
 		lastStoredBlock = syncStatus.SafeL2.ID()
 	} else if lastStoredBlock.Number < syncStatus.SafeL2.Number {
-		l.Log.Warn("Last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", l.lastStoredBlock, "safe", syncStatus.SafeL2)
+		l.Log.Warn("Last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", lastStoredBlock, "safe", syncStatus.SafeL2)
 		lastStoredBlock = syncStatus.SafeL2.ID()
 	}
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -698,7 +698,7 @@ func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[t
 		l.Log.Error("Failed to query L1 tip", "err", err)
 		return err
 	}
-	l.recordL1Tip(l1tip)
+	l.Metr.RecordLatestL1Block(l1tip)
 
 	// Collect next transaction data. This pulls data out of the channel, so we need to make sure
 	// to put it back if ever da or txmgr requests fail, by calling l.recordFailedDARequest/recordFailedTx.
@@ -878,10 +878,6 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 	} else {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
 	}
-}
-
-func (l *BatchSubmitter) recordL1Tip(l1tip eth.L1BlockRef) {
-	l.Metr.RecordLatestL1Block(l1tip)
 }
 
 func (l *BatchSubmitter) recordFailedDARequest(id txID, err error) {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -114,10 +114,6 @@ type BatchSubmitter struct {
 	txpoolState       TxPoolState
 	txpoolBlockedBlob bool
 
-	// lastStoredBlock is the last block loaded into `state`. If it is empty it should be set to the l2 safe head.
-	lastStoredBlock eth.BlockID
-	lastL1Tip       eth.L1BlockRef
-
 	state *channelManager
 }
 
@@ -147,7 +143,6 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 	l.shutdownCtx, l.cancelShutdownCtx = context.WithCancel(context.Background())
 	l.killCtx, l.cancelKillCtx = context.WithCancel(context.Background())
 	l.clearState(l.shutdownCtx)
-	l.lastStoredBlock = eth.BlockID{}
 
 	if err := l.waitForL2Genesis(); err != nil {
 		return fmt.Errorf("error waiting for L2 genesis: %w", err)
@@ -271,13 +266,11 @@ func (l *BatchSubmitter) loadBlocksIntoState(syncStatus eth.SyncStatus, ctx cont
 		block, err := l.loadBlockIntoState(ctx, i)
 		if errors.Is(err, ErrReorg) {
 			l.Log.Warn("Found L2 reorg", "block_number", i)
-			l.lastStoredBlock = eth.BlockID{}
 			return err
 		} else if err != nil {
 			l.Log.Warn("Failed to load block into state", "err", err)
 			return err
 		}
-		l.lastStoredBlock = eth.ToBlockID(block)
 		latestBlock = block
 	}
 
@@ -373,14 +366,15 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 		return eth.BlockID{}, eth.BlockID{}, errors.New("empty sync status")
 	}
 
+	lastStoredBlock := l.state.LastStoredBlock()
 	// Check last stored to see if it needs to be set on startup OR set if is lagged behind.
 	// It lagging implies that the op-node processed some batches that were submitted prior to the current instance of the batcher being alive.
-	if l.lastStoredBlock == (eth.BlockID{}) {
+	if lastStoredBlock == (eth.BlockID{}) {
 		l.Log.Info("Starting batch-submitter work at safe-head", "safe", syncStatus.SafeL2)
-		l.lastStoredBlock = syncStatus.SafeL2.ID()
-	} else if l.lastStoredBlock.Number < syncStatus.SafeL2.Number {
+		lastStoredBlock = syncStatus.SafeL2.ID()
+	} else if lastStoredBlock.Number < syncStatus.SafeL2.Number {
 		l.Log.Warn("Last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", l.lastStoredBlock, "safe", syncStatus.SafeL2)
-		l.lastStoredBlock = syncStatus.SafeL2.ID()
+		lastStoredBlock = syncStatus.SafeL2.ID()
 	}
 
 	// Check if we should even attempt to load any blocks. TODO: May not need this check
@@ -388,7 +382,7 @@ func (l *BatchSubmitter) calculateL2BlockRangeToStore(syncStatus eth.SyncStatus)
 		return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("L2 safe head(%d) ahead of L2 unsafe head(%d)", syncStatus.SafeL2.Number, syncStatus.UnsafeL2.Number)
 	}
 
-	return l.lastStoredBlock, syncStatus.UnsafeL2.ID(), nil
+	return lastStoredBlock, syncStatus.UnsafeL2.ID(), nil
 }
 
 // The following things occur:
@@ -887,10 +881,6 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 }
 
 func (l *BatchSubmitter) recordL1Tip(l1tip eth.L1BlockRef) {
-	if l.lastL1Tip == l1tip {
-		return
-	}
-	l.lastL1Tip = l1tip
 	l.Metr.RecordLatestL1Block(l1tip)
 }
 


### PR DESCRIPTION
The new batcher got into a bad state when rolled out to devnet. 

1. The batcher started up and behaved normally
2. The sequencer restarted
3. When it came back up, it's safe head went backwards
4. The batcher detected this, and tried to clear out its state and start work from the new safe head
5. It did not clear its state properly, and the consistency caused it to constantly run into 4 over and over. 

This PR removes some redundant state which was not being cleared, which should fix the problem.
