### PR TITLE
source: Add FetchReceiptRange

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -315,6 +315,19 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 	return info, receipts, nil
 }
 
+func (s *EthClient) BatchFetchReceipts(ctx context.Context, blockHashes []common.Hash) ([]blockReceipts, error) {
+	batch := make([]blockTxHashes, 0)
+	for _, blockHash := range blockHashes {
+		info, txs, err := s.InfoAndTxsByHash(ctx, blockHash)
+		if err != nil {
+			return nil, fmt.Errorf("querying block: %w", err)
+		}
+		newHashes, _ := eth.TransactionsToHashes(txs), eth.ToBlockID(info)
+		batch = append(batch, blockTxHashes{info, newHashes})
+	}
+	return s.recProvider.FetchReceiptsRange(ctx, batch)
+}
+
 // ExecutionWitness fetches execution witness data for a block number.
 func (s *EthClient) ExecutionWitness(ctx context.Context, blockNum uint64) (*eth.ExecutionWitness, error) {
 	var witness *eth.ExecutionWitness

--- a/op-service/sources/receipts.go
+++ b/op-service/sources/receipts.go
@@ -10,11 +10,25 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
+type blockTxHashes struct {
+	block    eth.BlockInfo
+	txHashes []common.Hash
+}
+type blockReceipts struct {
+	block    eth.BlockInfo
+	receipts types.Receipts
+}
+
 type ReceiptsProvider interface {
 	// FetchReceipts returns a block info and all of the receipts associated with transactions in the block.
 	// It verifies the receipt hash in the block header against the receipt hash of the fetched receipts
 	// to ensure that the execution engine did not fail to return any receipts.
 	FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (types.Receipts, error)
+
+	// FetchReceiptsRange fetches receipts for multiple blocks worth of transactions at once.
+	// It verifies the receipt hash in the block header against the receipt hash of the fetched receipts per block
+	// and returns the receipts, packaged with their respective block infos.
+	FetchReceiptsRange(ctx context.Context, blocksAndTxs []blockTxHashes) ([]blockReceipts, error)
 }
 
 // validateReceipts validates that the receipt contents are valid.

--- a/op-service/sources/receipts_basic.go
+++ b/op-service/sources/receipts_basic.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -19,7 +20,7 @@ type BasicRPCReceiptsFetcher struct {
 	maxBatchSize int
 
 	// calls caches uncompleted batch calls
-	calls   map[common.Hash]*receiptsBatchCall
+	calls   map[receiptCacheKey]*receiptsBatchCall
 	callsMu sync.Mutex
 }
 
@@ -27,15 +28,28 @@ func NewBasicRPCReceiptsFetcher(client rpcClient, maxBatchSize int) *BasicRPCRec
 	return &BasicRPCReceiptsFetcher{
 		client:       client,
 		maxBatchSize: maxBatchSize,
-		calls:        make(map[common.Hash]*receiptsBatchCall),
+		calls:        make(map[receiptCacheKey]*receiptsBatchCall),
 	}
 }
 
 // FetchReceipts fetches receipts for the given block and transaction hashes
 // it does not validate receipts, and expects the caller to do so
 func (f *BasicRPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.BlockInfo, txHashes []common.Hash) (types.Receipts, error) {
-	block := eth.ToBlockID(blockInfo)
-	call := f.getOrCreateBatchCall(block.Hash, txHashes)
+	ret, err := f.FetchReceiptsRange(ctx, []blockTxHashes{{blockInfo, txHashes}})
+	if err != nil {
+		return nil, err
+	}
+	return ret[0].receipts, nil
+}
+
+func (f *BasicRPCReceiptsFetcher) FetchReceiptsRange(ctx context.Context, blocks []blockTxHashes) ([]blockReceipts, error) {
+	key := newCacheKey(blocks)
+	// merge all requested tx hashes into one batch call
+	allTx := []common.Hash{}
+	for _, b := range blocks {
+		allTx = append(allTx, b.txHashes...)
+	}
+	call := f.getOrCreateBatchCall(key, allTx)
 
 	// Fetch all receipts
 	for {
@@ -50,14 +64,37 @@ func (f *BasicRPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo e
 		return nil, err
 	}
 	// call successful, remove from cache
-	f.deleteBatchCall(block.Hash)
-	return res, nil
+	f.deleteBatchCall(key)
+
+	// single block, no need to sort results
+	if len(blocks) == 1 {
+		return []blockReceipts{{blocks[0].block, res}}, nil
+	}
+
+	// split the single batch result into block results
+	blockRes := make([]blockReceipts, len(blocks))
+	// also maintain pointers to each item so we can refer to them while sorting
+	blockResMap := make(map[common.Hash]*blockReceipts, len(blocks))
+	for i, b := range blocks {
+		blockRes[i] = blockReceipts{
+			block:    b.block,
+			receipts: make(types.Receipts, len(b.txHashes))}
+		blockResMap[b.block.Hash()] = &blockRes[i]
+	}
+	for _, r := range res {
+		if _, ok := blockResMap[r.BlockHash]; !ok {
+			return nil, fmt.Errorf("unexpected receipt for block %s", r.BlockHash)
+		}
+		blockResMap[r.BlockHash].receipts = append(blockResMap[r.BlockHash].receipts, r)
+	}
+
+	return blockRes, nil
 }
 
-func (f *BasicRPCReceiptsFetcher) getOrCreateBatchCall(blockHash common.Hash, txHashes []common.Hash) *receiptsBatchCall {
+func (f *BasicRPCReceiptsFetcher) getOrCreateBatchCall(key receiptCacheKey, txHashes []common.Hash) *receiptsBatchCall {
 	f.callsMu.Lock()
 	defer f.callsMu.Unlock()
-	if call, ok := f.calls[blockHash]; ok {
+	if call, ok := f.calls[key]; ok {
 		return call
 	}
 	call := batching.NewIterativeBatchCall[common.Hash, *types.Receipt](
@@ -67,14 +104,14 @@ func (f *BasicRPCReceiptsFetcher) getOrCreateBatchCall(blockHash common.Hash, tx
 		f.client.CallContext,
 		f.maxBatchSize,
 	)
-	f.calls[blockHash] = call
+	f.calls[key] = call
 	return call
 }
 
-func (f *BasicRPCReceiptsFetcher) deleteBatchCall(blockHash common.Hash) {
+func (f *BasicRPCReceiptsFetcher) deleteBatchCall(key receiptCacheKey) {
 	f.callsMu.Lock()
 	defer f.callsMu.Unlock()
-	delete(f.calls, blockHash)
+	delete(f.calls, key)
 }
 
 func makeReceiptRequest(txHash common.Hash) (*types.Receipt, rpc.BatchElem) {

--- a/op-service/sources/receipts_caching_test.go
+++ b/op-service/sources/receipts_caching_test.go
@@ -23,6 +23,11 @@ func (m *mockReceiptsProvider) FetchReceipts(ctx context.Context, blockInfo eth.
 	return args.Get(0).(types.Receipts), args.Error(1)
 }
 
+func (m *mockReceiptsProvider) FetchReceiptsRange(ctx context.Context, blocks []blockTxHashes) ([]blockReceipts, error) {
+	args := m.Called(ctx, blocks)
+	return args.Get(0).([]blockReceipts), args.Error(1)
+}
+
 func TestCachingReceiptsProvider_Caching(t *testing.T) {
 	block, receipts := randomRpcBlockAndReceipts(rand.New(rand.NewSource(69)), 4)
 	txHashes := receiptTxHashes(receipts)


### PR DESCRIPTION
# What
Wires in `BatchFetchReceipts` on the eth client and `FetchReceiptRange` in the underlying receipt providers, in order to fetch multiple blocks worth of receipt data at once.

# Why
The Supervisor, when far behind, must collect receipt data from many blocks. We have observed that backfilling large block ranges ends up moving *slower* than real-time block production, meaning the Supervisor would never catch up.

One large reason for this is our process of getting Receipts. The Supervisor requests receipts for one block at a time, which uses one  `L1BlockRefByNumber` to get the blockHash, one `eth_getBlockByHash` to get the Tx Hashes and one batched `eth_getReceipt` call. For 100 blocks, that's 300 calls

We can significantly reduce call load by collecting multiple blocks of requests and making batch calls. Ideally that would let you do 3 batches of size-100 with the above scenario. This PR addresses one of the three calls.


# How
- `receiptCacheKey` is a `string` type that replaces the `common.Hash` that had been used in multiple layers of Receipt Fetch caching. This is because now some calls will represent *multiple* blocks worth of data.
- `blockTxHashes` has been introduced to package a `[]common.Hash` along with the related `blockInfo`
- `blockReceipts` has been introduced to package a `types.Receipts` along with the related `blockInfo`
- `blockTxHashes` can be turned into `receiptCacheKey`s, so the unique range provided by the caller always maps to a single cache key
- When calling `FetchReceiptsRange`, the provider merges the transactions into one large batch call, and then sorts them back into their respective blocks when returned
- When calling `FetchReceipts`, the `Range` function is used with a length of one, and the wrapping/unwrapping is handled so that existing callers don't experience any interruption to the interface.

Note! The underlying behaviors here are not restricted to literal "ranges", callers could submit any "set" of blockInfo, and they would be merged into a unique key. I did not want to make any assumptions about the implicit "completeness" of any batch calls, in case multiple calls could resolve to the same cache key (in which case we'd have a confusing time when the values get used inappropriately)

# Testing
CCI in this PR only so far. We should put in some batch tests

# WIP
Maybe we should also batch the `eth_getBlockByHash` call to reduce the RPC load further? It's somewhat out of scope to this PR though.

I will be stacking another PR on this one for the Supervisor to use this new batch functionality.