### PR TITLE
go: set default versions to v0.0.0

### DIFF
--- a/op-alt-da/cmd/daserver/main.go
+++ b/op-alt-da/cmd/daserver/main.go
@@ -13,7 +13,7 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 )
 
-var Version = "v0.0.1"
+var Version = "v0.0.0"
 
 func main() {
 	oplog.SetupDefaults()

--- a/op-batcher/cmd/main.go
+++ b/op-batcher/cmd/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	Version   = "v0.10.14"
+	Version   = "v0.0.0"
 	GitCommit = ""
 	GitDate   = ""
 )

--- a/op-dispute-mon/version/version.go
+++ b/op-dispute-mon/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 var (
-	Version = "v0.1.0"
+	Version = "v0.0.0"
 	Meta    = "dev"
 )
 

--- a/op-node/version/version.go
+++ b/op-node/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	Version = "v0.10.14"
+	Version = "v0.0.0"
 	Meta    = "dev"
 )

--- a/op-program/host/version/version.go
+++ b/op-program/host/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	Version = "v0.10.14"
+	Version = "v0.0.0"
 	Meta    = "dev"
 )

--- a/op-proposer/cmd/main.go
+++ b/op-proposer/cmd/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	Version   = "v0.10.14"
+	Version   = "v0.0.0"
 	GitCommit = ""
 	GitDate   = ""
 )

--- a/op-supervisor/cmd/main.go
+++ b/op-supervisor/cmd/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	Version   = "v0.0.1"
+	Version   = "v0.0.0"
 	GitCommit = ""
 	GitDate   = ""
 )


### PR DESCRIPTION
**Description**

Previously:
```bash
go run ./op-node/cmd --version
op-node version v0.10.14-dev
```

The output here is misleading. This is a 2 year old hardcoded string.
When we build through a makefile / docker we override it, but by default we should print something that makes it more obvious it wasn't set, rather than using a very old version.

This changes it to `v0.0.0` in each service.
