### PR TITLE
op-deployer: Safety and validation improvements

### DIFF
--- a/op-deployer/pkg/deployer/artifacts/downloader_test.go
+++ b/op-deployer/pkg/deployer/artifacts/downloader_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 )
 
-func TestDownloadArtifacts(t *testing.T) {
+func TestDownloadArtifacts_MockArtifacts(t *testing.T) {
 	f, err := os.OpenFile("testdata/artifacts.tar.gz", os.O_RDONLY, 0o644)
 	require.NoError(t, err)
 	defer f.Close()
@@ -20,6 +22,9 @@ func TestDownloadArtifacts(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := io.Copy(w, f)
+		require.NoError(t, err)
+		// Seek to beginning of file for next request
+		_, err = f.Seek(0, 0)
 		require.NoError(t, err)
 	}))
 	defer ts.Close()
@@ -31,14 +36,50 @@ func TestDownloadArtifacts(t *testing.T) {
 		URL: artifactsURL,
 	}
 
-	fs, cleanup, err := Download(ctx, loc, nil)
-	require.NoError(t, err)
-	require.NotNil(t, fs)
-	defer func() {
-		require.NoError(t, cleanup())
-	}()
+	t.Run("success", func(t *testing.T) {
+		fs, cleanup, err := Download(ctx, loc, nil)
+		require.NoError(t, err)
+		require.NotNil(t, fs)
+		defer func() {
+			require.NoError(t, cleanup())
+		}()
 
-	info, err := fs.Stat("WETH98.sol/WETH98.json")
-	require.NoError(t, err)
-	require.Greater(t, info.Size(), int64(0))
+		info, err := fs.Stat("WETH98.sol/WETH98.json")
+		require.NoError(t, err)
+		require.Greater(t, info.Size(), int64(0))
+	})
+
+	t.Run("bad integrity", func(t *testing.T) {
+		_, _, err := downloadURL(ctx, loc.URL, nil, &hashIntegrityChecker{
+			hash: common.Hash{'B', 'A', 'D'},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "integrity check failed")
+	})
+
+	t.Run("ok integrity", func(t *testing.T) {
+		_, _, err := downloadURL(ctx, loc.URL, nil, &hashIntegrityChecker{
+			hash: common.HexToHash("0x0f814df0c4293aaaadd468ac37e6c92f0b40fd21df848076835cb2c21d2a516f"),
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestDownloadArtifacts_TaggedVersions(t *testing.T) {
+	tags := []string{
+		"op-contracts/v1.6.0",
+		"op-contracts/v1.7.0-beta.1+l2-contracts",
+	}
+	for _, tag := range tags {
+		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
+
+			loc := MustNewLocatorFromTag(tag)
+			_, cleanup, err := Download(context.Background(), loc, nil)
+			t.Cleanup(func() {
+				require.NoError(t, cleanup())
+			})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
+++ b/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
@@ -11,15 +11,20 @@ import (
 var (
 	// baseFeePadFactor = 50% as a divisor
 	baseFeePadFactor = big.NewInt(2)
-	// tipMulFactor = 20 as a multiplier
-	tipMulFactor = big.NewInt(20)
+	// tipMulFactor = 5 as a multiplier
+	tipMulFactor = big.NewInt(5)
 	// dummyBlobFee is a dummy value for the blob fee. Since this gas estimator will never
 	// post blobs, it's just set to 1.
 	dummyBlobFee = big.NewInt(1)
+	// maxTip is the maximum tip that can be suggested by this estimator.
+	maxTip = big.NewInt(50 * 1e9)
+	// minTip is the minimum tip that can be suggested by this estimator.
+	minTip = big.NewInt(1 * 1e9)
 )
 
 // DeployerGasPriceEstimator is a custom gas price estimator for use with op-deployer.
-// It pads the base fee by 50% and multiplies the suggested tip by 20.
+// It pads the base fee by 50% and multiplies the suggested tip by 5 up to a max of
+// 50 gwei.
 func DeployerGasPriceEstimator(ctx context.Context, client txmgr.ETHBackend) (*big.Int, *big.Int, *big.Int, error) {
 	chainHead, err := client.HeaderByNumber(ctx, nil)
 	if err != nil {
@@ -34,5 +39,14 @@ func DeployerGasPriceEstimator(ctx context.Context, client txmgr.ETHBackend) (*b
 	baseFeePad := new(big.Int).Div(chainHead.BaseFee, baseFeePadFactor)
 	paddedBaseFee := new(big.Int).Add(chainHead.BaseFee, baseFeePad)
 	paddedTip := new(big.Int).Mul(tip, tipMulFactor)
+
+	if paddedTip.Cmp(minTip) < 0 {
+		paddedTip.Set(minTip)
+	}
+
+	if paddedTip.Cmp(maxTip) > 0 {
+		paddedTip.Set(maxTip)
+	}
+
 	return paddedTip, paddedBaseFee, dummyBlobFee, nil
 }

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -35,10 +35,12 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 	var err error
 	if intent.L1ContractsLocator.IsTag() && intent.DeploymentStrategy == state.DeploymentStrategyLive {
 		standardVersionsTOML, err = standard.L1VersionsDataFor(intent.L1ChainID)
-		if err != nil {
-			return fmt.Errorf("error getting standard versions TOML: %w", err)
+		if err == nil {
+			contractsRelease = intent.L1ContractsLocator.Tag
+		} else {
+			contractsRelease = "dev"
 		}
-		contractsRelease = intent.L1ContractsLocator.Tag
+
 	} else {
 		contractsRelease = "dev"
 	}

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -184,6 +184,17 @@ func ArtifactsURLForTag(tag string) (*url.URL, error) {
 	}
 }
 
+func ArtifactsHashForTag(tag string) (common.Hash, error) {
+	switch tag {
+	case "op-contracts/v1.6.0":
+		return common.HexToHash("d20a930cc0ff204c2d93b7aa60755ec7859ba4f328b881f5090c6a6a2a86dcba"), nil
+	case "op-contracts/v1.7.0-beta.1+l2-contracts":
+		return common.HexToHash("9e3ad322ec9b2775d59143ce6874892f9b04781742c603ad59165159e90b00b9"), nil
+	default:
+		return common.Hash{}, fmt.Errorf("unsupported tag: %s", tag)
+	}
+}
+
 func standardArtifactsURL(checksum string) string {
 	return fmt.Sprintf("https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-%s.tar.gz", checksum)
 }

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -63,6 +63,11 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 				EIP1559DenominatorCanyon: 250,
 				EIP1559Elasticity:        chainIntent.Eip1559Elasticity,
 			},
+
+			// STOP! This struct sets the _default_ upgrade schedule for all chains.
+			// Any upgrades you enable here will be enabled for all new deployments.
+			// In-development hardforks should never be activated here. Instead, they
+			// should be specified as overrides.
 			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
 				L2GenesisRegolithTimeOffset: u64UtilPtr(0),
 				L2GenesisCanyonTimeOffset:   u64UtilPtr(0),

--- a/op-service/testutils/anvil/anvil.go
+++ b/op-service/testutils/anvil/anvil.go
@@ -38,6 +38,8 @@ func New(l1RPCURL string, logger log.Logger) (*Runner, error) {
 		"--fork-url", l1RPCURL,
 		"--port",
 		"0",
+		"--base-fee",
+		"1000000000",
 	)
 	stdout, err := proc.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
- Enables support for deploying tagged versions against new chains, but behind a huge warning that requires user input to bypass. Since our tagged release versions do not contain all implementations, using op-deployer in this way will deploy contracts that haven't been governance approved. Since this workflow is useful for development but bad for prod, I've added support for it but users have to bypass a large warning that describes the risks.
- Validates the hashes of tagged version artifacts after downloading them. This prevents users from downloading tampered versions of the artifacts from GCS.
