### PR TITLE
Time-Based Smart Contract Fuzzing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,27 +615,22 @@ jobs:
   contracts-bedrock-tests:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: xlarge
     parameters:
+      test_command:
+        description: Command to run tests
+        type: string
+        default: forge test
       test_parallelism:
         description: Number of test jobs to run in parallel
         type: integer
         default: 4
+      test_resource_class:
+        description: Resource class to use for running tests
+        type: string
+        default: xlarge
       test_list:
         description: List of test files to run
         type: string
-      test_fuzz_runs:
-        description: Number of fuzz runs to apply
-        type: integer
-        default: 512
-      test_invariant_runs:
-        description: Number of invariant runs to apply
-        type: integer
-        default: 32
-      test_invariant_depth:
-        description: Depth of invariant runs
-        type: integer
-        default: 64
       test_timeout:
         description: Timeout for running tests
         type: string
@@ -644,6 +639,7 @@ jobs:
         description: Profile to use for testing
         type: string
         default: ci
+    resource_class: <<parameters.test_resource_class>>
     parallelism: <<parameters.test_parallelism>>
     steps:
       - checkout
@@ -691,7 +687,7 @@ jobs:
             TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
             TEST_FILES=$(echo "$TEST_FILES" | sed 's|^test/||')
             MATCH_PATH="./test/{$(echo "$TEST_FILES" | paste -sd "," -)}"
-            forge test --match-path "$MATCH_PATH"
+            <<parameters.test_command>> --match-path "$MATCH_PATH"
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
           working_directory: packages/contracts-bedrock
@@ -1351,6 +1347,8 @@ workflows:
           test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
           test_timeout: 1h
           test_profile: ciheavy
+          test_resource_class: 2xlarge
+          test_command: go run scripts/checks/hotfuzz/main.go --max-seconds 600 --max-fuzz-runs 20000 --max-invariant-runs 128 --max-invariant-depth 512 --max-concurrency 4
       - contracts-bedrock-coverage
       - contracts-bedrock-checks:
           requires:

--- a/packages/contracts-bedrock/scripts/checks/hotfuzz/main.go
+++ b/packages/contracts-bedrock/scripts/checks/hotfuzz/main.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type TestInfo struct {
+	Name         string
+	ContractPath string
+	ContractName string
+}
+
+type TestConfig struct {
+	maxSeconds        int
+	maxFuzzRuns       int
+	maxInvariantRuns  int
+	maxInvariantDepth int
+	maxConcurrency    int
+	matchPaths        string
+}
+
+type TestResult struct {
+	TestInfo
+	Message  string
+	Error    error
+	Duration time.Duration
+}
+
+func main() {
+	config := parseFlags()
+
+	log.Println("Finding tests to run...")
+	tests, err := findTests(config.matchPaths)
+	if err != nil {
+		log.Fatalf("Error getting test names: %v", err)
+	}
+
+	if len(tests) == 0 {
+		log.Println("No tests found matching the criteria")
+		return
+	}
+
+	log.Println("Running heavy fuzz tests...")
+	ok := true
+	for result := range runTestGroup(tests, config) {
+		if result.Error != nil {
+			ok = false
+			log.Printf("FAIL: %s (%s)\n%v\n%s\n", result.Name, result.ContractName, result.Error, result.Message)
+		} else {
+			log.Printf("PASS: %s (%s) [%s]\n", result.Name, result.ContractName, result.Message)
+		}
+	}
+
+	if !ok {
+		os.Exit(1)
+	}
+}
+
+func parseFlags() TestConfig {
+	maxSeconds := flag.Int("max-seconds", -1, "maximum seconds per test (required)")
+	maxFuzzRuns := flag.Int("max-fuzz-runs", -1, "maximum number of fuzz runs per test (required)")
+	maxInvariantRuns := flag.Int("max-invariant-runs", -1, "maximum number of invariant runs per test (required)")
+	maxInvariantDepth := flag.Int("max-invariant-depth", -1, "maximum depth of invariant runs per test (required)")
+	maxConcurrency := flag.Int("max-concurrency", runtime.NumCPU(), "maximum number of concurrent test processes")
+	matchPaths := flag.String("match-path", "", "path pattern to match for test files")
+	flag.Parse()
+
+	if *maxSeconds <= 0 {
+		log.Fatal("max-seconds must be set with a positive value")
+	}
+	if *maxFuzzRuns <= 0 {
+		log.Fatal("max-fuzz-runs must be set with a positive value")
+	}
+	if *maxInvariantRuns <= 0 {
+		log.Fatal("max-invariant-runs must be set with a positive value")
+	}
+	if *maxInvariantDepth <= 0 {
+		log.Fatal("max-invariant-depth must be set with a positive value")
+	}
+	if *maxConcurrency <= 0 {
+		log.Fatal("max-concurrency must be set with a positive value")
+	}
+
+	log.Printf("Running with config:")
+	log.Printf("  max-seconds: %d", *maxSeconds)
+	log.Printf("  max-fuzz-runs: %d", *maxFuzzRuns)
+	log.Printf("  max-invariant-runs: %d", *maxInvariantRuns)
+	log.Printf("  max-invariant-depth: %d", *maxInvariantDepth)
+	log.Printf("  max-concurrency: %d", *maxConcurrency)
+
+	return TestConfig{
+		maxSeconds:        *maxSeconds,
+		maxFuzzRuns:       *maxFuzzRuns,
+		maxInvariantRuns:  *maxInvariantRuns,
+		maxInvariantDepth: *maxInvariantDepth,
+		matchPaths:        *matchPaths,
+		maxConcurrency:    *maxConcurrency,
+	}
+}
+
+func findTests(matchPaths string) ([]TestInfo, error) {
+	args := []string{"test", "--fuzz-runs", "1"}
+	if matchPaths != "" {
+		args = append(args, "--match-path", matchPaths)
+	}
+
+	cmd := exec.Command("forge", args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("error creating stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("error starting command: %w", err)
+	}
+
+	var tests []TestInfo
+	scanner := bufio.NewScanner(stdout)
+	testPattern := regexp.MustCompile(`(?:testFuzz_|invariant_)[^\s(]+`)
+	contractPattern := regexp.MustCompile(`Ran \d+ tests? for ([^\s]+)`)
+	currentContract := ""
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if matches := contractPattern.FindStringSubmatch(line); len(matches) > 1 {
+			currentContract = matches[1]
+			continue
+		}
+
+		if matches := testPattern.FindString(line); matches != "" {
+			testName := matches
+			if idx := strings.Index(testName, "("); idx != -1 {
+				testName = testName[:idx]
+			}
+
+			contractParts := strings.Split(currentContract, ":")
+			if len(contractParts) != 2 {
+				return nil, fmt.Errorf("invalid contract format '%s': expected 'path:name'", currentContract)
+			}
+			contractPath := contractParts[0]
+			contractName := contractParts[1]
+
+			tests = append(tests, TestInfo{
+				Name:         testName,
+				ContractPath: contractPath,
+				ContractName: contractName,
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning output: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("error waiting for command: %w", err)
+	}
+
+	for _, test := range tests {
+		log.Printf("Found test: %s\n", test.Name)
+	}
+
+	return tests, nil
+}
+
+func runTest(test TestInfo, config TestConfig, wg *sync.WaitGroup, results chan<- TestResult) {
+	defer wg.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.maxSeconds)*time.Second)
+	defer cancel()
+
+	args := []string{
+		"test",
+		"--match-test", test.Name,
+		"--match-contract", test.ContractName,
+		"--match-path", test.ContractPath,
+		"--fuzz-runs", strconv.Itoa(config.maxFuzzRuns),
+		"--threads", "1",
+		"--fail-fast",
+	}
+
+	cmd := exec.CommandContext(ctx, "forge", args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("FOUNDRY_INVARIANT_RUNS=%d", config.maxInvariantRuns))
+	cmd.Env = append(cmd.Environ(), fmt.Sprintf("FOUNDRY_INVARIANT_DEPTH=%d", config.maxInvariantDepth))
+
+	start := time.Now()
+	output, err := cmd.CombinedOutput()
+	duration := time.Since(start)
+
+	result := TestResult{
+		TestInfo: test,
+		Duration: duration,
+	}
+
+	if err != nil {
+		result.Message = string(output)
+		result.Error = err
+	} else if ctx.Err() == context.DeadlineExceeded {
+		result.Message = "timeout without failure"
+	} else {
+		result.Message = "completed"
+	}
+
+	results <- result
+}
+
+func runTestGroup(tests []TestInfo, config TestConfig) <-chan TestResult {
+	results := make(chan TestResult, len(tests))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, config.maxConcurrency)
+
+	for _, test := range tests {
+		wg.Add(1)
+		go func(t TestInfo) {
+			sem <- struct{}{}
+			runTest(t, config, &wg, results)
+			<-sem
+		}(test)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	return results
+}

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -201,7 +201,6 @@ contract OptimismPortal_Test is CommonTest {
     }
 
     /// @dev Tests that `depositTransaction` succeeds when msg.sender == tx.origin and non-custom gas is used.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_senderIsOrigin_succeeds(
         address _to,
         uint256 _mint,
@@ -227,7 +226,6 @@ contract OptimismPortal_Test is CommonTest {
     }
 
     /// @dev Tests that `depositTransaction` succeeds when msg.sender != tx.origin and non-custom gas is used.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_senderNotOrigin_succeeds(
         address _to,
         uint256 _mint,
@@ -310,7 +308,6 @@ contract OptimismPortal_Test is CommonTest {
     }
 
     /// @dev Tests that `depositTransaction` succeeds for an EOA.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_eoa_succeeds(
         address _to,
         uint64 _gasLimit,
@@ -355,7 +352,6 @@ contract OptimismPortal_Test is CommonTest {
     }
 
     /// @dev Tests that `depositTransaction` succeeds for a contract.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_contract_succeeds(
         address _to,
         uint64 _gasLimit,
@@ -1214,7 +1210,6 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
     }
 
     /// @dev Tests that `finalizeWithdrawalTransaction` succeeds.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testDiff_finalizeWithdrawalTransaction_succeeds(
         address _sender,
         address _target,
@@ -1337,7 +1332,6 @@ contract OptimismPortalResourceFuzz_Test is CommonTest {
     uint256 constant MAX_GAS_LIMIT = 30_000_000;
 
     /// @dev Test that various values of the resource metering config will not break deposits.
-    /// forge-config: ciheavy.fuzz.runs = 10000
     function testFuzz_systemConfigDeposit_succeeds(
         uint32 _maxResourceLimit,
         uint8 _elasticityMultiplier,
@@ -1357,23 +1351,26 @@ contract OptimismPortalResourceFuzz_Test is CommonTest {
 
         // Bound resource config
         _maxResourceLimit = uint32(bound(_maxResourceLimit, 21000, MAX_GAS_LIMIT / 8));
+        _maxResourceLimit = uint32(bound(_maxResourceLimit, _maxResourceLimit, gasLimit));
         _gasLimit = uint64(bound(_gasLimit, 21000, _maxResourceLimit));
+        _gasLimit = uint64(bound(_gasLimit, _gasLimit, gasLimit));
         _prevBaseFee = uint128(bound(_prevBaseFee, 0, 3 gwei));
         _prevBoughtGas = uint64(bound(_prevBoughtGas, 0, _maxResourceLimit - _gasLimit));
         _blockDiff = uint8(bound(_blockDiff, 0, 3));
         _baseFeeMaxChangeDenominator = uint8(bound(_baseFeeMaxChangeDenominator, 2, type(uint8).max));
         _elasticityMultiplier = uint8(bound(_elasticityMultiplier, 1, type(uint8).max));
+        _maximumBaseFee = uint128(bound(_maximumBaseFee, 1, type(uint128).max));
+        _minimumBaseFee = uint32(bound(_minimumBaseFee, 0, _maximumBaseFee - 1));
+        _systemTxMaxGas = uint32(bound(_systemTxMaxGas, 0, gasLimit - _maxResourceLimit));
 
         // Prevent values that would cause reverts
-        vm.assume(gasLimit >= _gasLimit);
-        vm.assume(_minimumBaseFee < _maximumBaseFee);
-        vm.assume(uint256(_maxResourceLimit) + uint256(_systemTxMaxGas) <= gasLimit);
         vm.assume(((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier) == _maxResourceLimit);
 
         // Base fee can increase quickly and mean that we can't buy the amount of gas we want.
         // Here we add a VM assumption to bound the potential increase.
         // Compute the maximum possible increase in base fee.
         uint256 maxPercentIncrease = uint256(_elasticityMultiplier - 1) * 100 / uint256(_baseFeeMaxChangeDenominator);
+
         // Assume that we have enough gas to burn.
         // Compute the maximum amount of gas we'd need to burn.
         // Assume we need 1/5 of our gas to do other stuff.
@@ -1472,7 +1469,6 @@ contract OptimismPortalWithMockERC20_Test is OptimismPortal_FinalizeWithdrawal_T
     }
 
     /// @dev Tests that `depositERC20Transaction` succeeds when msg.sender == tx.origin.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositERC20Transaction_senderIsOrigin_succeeds(
         address _to,
         uint256 _mint,
@@ -1498,7 +1494,6 @@ contract OptimismPortalWithMockERC20_Test is OptimismPortal_FinalizeWithdrawal_T
     }
 
     /// @dev Tests that `depositERC20Transaction` succeeds when msg.sender != tx.origin.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositERC20Transaction_senderNotOrigin_succeeds(
         address _to,
         uint256 _mint,
@@ -1697,7 +1692,6 @@ contract OptimismPortalWithMockERC20_Test is OptimismPortal_FinalizeWithdrawal_T
     }
 
     /// @dev Tests that `depositTransaction` succeeds when a custom gas token is used but the msg.value is zero.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_customGasTokenWithNoValueAndSenderIsOrigin_succeeds(
         address _to,
         uint256 _value,
@@ -1721,7 +1715,6 @@ contract OptimismPortalWithMockERC20_Test is OptimismPortal_FinalizeWithdrawal_T
     }
 
     /// @dev Tests that `depositTransaction` succeeds when a custom gas token is used but the msg.value is zero.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_customGasTokenWithNoValueAndSenderNotOrigin_succeeds(
         address _to,
         uint256 _value,

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -211,7 +211,6 @@ contract OptimismPortal2_Test is CommonTest {
     }
 
     /// @dev Tests that `depositTransaction` succeeds for an EOA.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_eoa_succeeds(
         address _to,
         uint64 _gasLimit,
@@ -256,7 +255,6 @@ contract OptimismPortal2_Test is CommonTest {
     }
 
     /// @dev Tests that `depositTransaction` succeeds for a contract.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_contract_succeeds(
         address _to,
         uint64 _gasLimit,
@@ -1326,7 +1324,6 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     }
 
     /// @dev Tests that `finalizeWithdrawalTransaction` succeeds.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testDiff_finalizeWithdrawalTransaction_succeeds(
         address _sender,
         address _target,
@@ -1610,7 +1607,6 @@ contract OptimismPortal2_ResourceFuzz_Test is CommonTest {
     }
 
     /// @dev Test that various values of the resource metering config will not break deposits.
-    /// forge-config: ciheavy.fuzz.runs = 10000
     function testFuzz_systemConfigDeposit_succeeds(
         uint32 _maxResourceLimit,
         uint8 _elasticityMultiplier,
@@ -1630,24 +1626,26 @@ contract OptimismPortal2_ResourceFuzz_Test is CommonTest {
 
         // Bound resource config
         _maxResourceLimit = uint32(bound(_maxResourceLimit, 21000, MAX_GAS_LIMIT / 8));
+        _maxResourceLimit = uint32(bound(_maxResourceLimit, _maxResourceLimit, gasLimit));
         _gasLimit = uint64(bound(_gasLimit, 21000, _maxResourceLimit));
+        _gasLimit = uint64(bound(_gasLimit, _gasLimit, gasLimit));
         _prevBaseFee = uint128(bound(_prevBaseFee, 0, 3 gwei));
         _prevBoughtGas = uint64(bound(_prevBoughtGas, 0, _maxResourceLimit - _gasLimit));
         _blockDiff = uint8(bound(_blockDiff, 0, 3));
         _baseFeeMaxChangeDenominator = uint8(bound(_baseFeeMaxChangeDenominator, 2, type(uint8).max));
         _elasticityMultiplier = uint8(bound(_elasticityMultiplier, 1, type(uint8).max));
+        _maximumBaseFee = uint128(bound(_maximumBaseFee, 1, type(uint128).max));
+        _minimumBaseFee = uint32(bound(_minimumBaseFee, 0, _maximumBaseFee - 1));
+        _systemTxMaxGas = uint32(bound(_systemTxMaxGas, 0, gasLimit - _maxResourceLimit));
 
         // Prevent values that would cause reverts
-        vm.assume(gasLimit >= _gasLimit);
-        vm.assume(_minimumBaseFee < _maximumBaseFee);
-        vm.assume(_baseFeeMaxChangeDenominator > 1);
-        vm.assume(uint256(_maxResourceLimit) + uint256(_systemTxMaxGas) <= gasLimit);
         vm.assume(((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier) == _maxResourceLimit);
 
         // Base fee can increase quickly and mean that we can't buy the amount of gas we want.
         // Here we add a VM assumption to bound the potential increase.
         // Compute the maximum possible increase in base fee.
         uint256 maxPercentIncrease = uint256(_elasticityMultiplier - 1) * 100 / uint256(_baseFeeMaxChangeDenominator);
+
         // Assume that we have enough gas to burn.
         // Compute the maximum amount of gas we'd need to burn.
         // Assume we need 1/5 of our gas to do other stuff.
@@ -1746,7 +1744,6 @@ contract OptimismPortal2WithMockERC20_Test is OptimismPortal2_FinalizeWithdrawal
     }
 
     /// @dev Tests that `depositERC20Transaction` succeeds when msg.sender == tx.origin.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositERC20Transaction_senderIsOrigin_succeeds(
         address _to,
         uint256 _mint,
@@ -1772,7 +1769,6 @@ contract OptimismPortal2WithMockERC20_Test is OptimismPortal2_FinalizeWithdrawal
     }
 
     /// @dev Tests that `depositERC20Transaction` succeeds when msg.sender != tx.origin.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositERC20Transaction_senderNotOrigin_succeeds(
         address _to,
         uint256 _mint,
@@ -1980,7 +1976,6 @@ contract OptimismPortal2WithMockERC20_Test is OptimismPortal2_FinalizeWithdrawal
     }
 
     /// @dev Tests that `depositTransaction` succeeds when a custom gas token is used but the msg.value is zero.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_customGasTokenWithNoValueAndSenderIsOrigin_succeeds(
         address _to,
         uint256 _value,
@@ -2004,7 +1999,6 @@ contract OptimismPortal2WithMockERC20_Test is OptimismPortal2_FinalizeWithdrawal
     }
 
     /// @dev Tests that `depositTransaction` succeeds when a custom gas token is used but the msg.value is zero.
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_depositTransaction_customGasTokenWithNoValueAndSenderNotOrigin_succeeds(
         address _to,
         uint256 _value,

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -889,7 +889,6 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
     /// @notice Tests that squeezing a large preimage proposal after the challenge period has passed always succeeds and
     ///         persists the correct data.
-    /// forge-config: ciheavy.fuzz.runs = 512
     function testFuzz_squeezeLPP_succeeds(uint256 _numBlocks, uint32 _partOffset) public {
         _numBlocks = bound(_numBlocks, 1, 2 ** 8);
         _partOffset = uint32(bound(_partOffset, 0, _numBlocks * LibKeccak.BLOCK_SIZE_BYTES + 8 - 1));
@@ -1087,7 +1086,6 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
 
     /// @notice Tests that challenging the first divergence in a large preimage proposal at an arbitrary location
     ///         in the leaf values always succeeds.
-    /// forge-config: ciheavy.fuzz.runs = 512
     function testFuzz_challenge_arbitraryLocation_succeeds(uint256 _lastCorrectLeafIdx, uint256 _numBlocks) public {
         _numBlocks = bound(_numBlocks, 1, 2 ** 8);
         _lastCorrectLeafIdx = bound(_lastCorrectLeafIdx, 0, _numBlocks - 1);
@@ -1140,7 +1138,6 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
     }
 
     /// @notice Tests that challenging the a divergence in a large preimage proposal at the first leaf always succeeds.
-    /// forge-config: ciheavy.fuzz.runs = 1024
     function testFuzz_challengeFirst_succeeds(uint256 _numBlocks) public {
         _numBlocks = bound(_numBlocks, 1, 2 ** 8);
 

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -228,7 +228,6 @@ contract LivenessGuard_FuzzOwnerManagement_Test is StdCheats, StdUtils, Liveness
     mapping(address => uint256) privateKeys;
 
     /// @dev Tests that the guard correctly manages the lastLive mapping when owners are added, removed, or swapped
-    /// forge-config: ciheavy.fuzz.runs = 8192
     function testFuzz_ownerManagement_works(
         uint256 initialOwners,
         uint256 threshold,

--- a/packages/contracts-bedrock/test/setup/DeployVariations.t.sol
+++ b/packages/contracts-bedrock/test/setup/DeployVariations.t.sol
@@ -22,7 +22,6 @@ contract DeployVariations_Test is CommonTest {
         }
     }
 
-    /// forge-config: ciheavy.fuzz.runs = 512
     /// @dev It should be possible to enable Fault Proofs with any mix of CGT and Alt-DA.
     function testFuzz_enableFaultProofs_succeeds(bool _enableCGT, bool _enableAltDa) public virtual {
         enableAddOns(_enableCGT, _enableAltDa);
@@ -30,7 +29,6 @@ contract DeployVariations_Test is CommonTest {
         super.setUp();
     }
 
-    /// forge-config: ciheavy.fuzz.runs = 512
     /// @dev It should be possible to enable Fault Proofs and Interop with any mix of CGT and Alt-DA.
     function test_enableInteropAndFaultProofs_succeeds(bool _enableCGT, bool _enableAltDa) public virtual {
         enableAddOns(_enableCGT, _enableAltDa);


### PR DESCRIPTION


**Description**
Adds in a script + CI changes so that our fuzzing tests can run based on time intervals rather than fuzzing runs, which should help offer our test suite a much more consistent run time.

**Tests**
I've made changes to our existing tests, but no new tests have been introduced 

**Additional context**

The main reasoning behind this test is that we often run very extensive and heavy CI fuzz profiles, which can result in inconsistent and long CI times, so the goal is to reduce this by defining fuzz limits based on time, not based on runs.

**Metadata**

