### PR TITLE
add challenger account to `wallets.sh`

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/wallets.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/wallets.sh
@@ -10,18 +10,21 @@ wallet1=$(cast wallet new)
 wallet2=$(cast wallet new)
 wallet3=$(cast wallet new)
 wallet4=$(cast wallet new)
+wallet5=$(cast wallet new)
 
 # Grab wallet addresses
 address1=$(echo "$wallet1" | awk '/Address/ { print $2 }')
 address2=$(echo "$wallet2" | awk '/Address/ { print $2 }')
 address3=$(echo "$wallet3" | awk '/Address/ { print $2 }')
 address4=$(echo "$wallet4" | awk '/Address/ { print $2 }')
+address5=$(echo "$wallet5" | awk '/Address/ { print $2 }')
 
 # Grab wallet private keys
 key1=$(echo "$wallet1" | awk '/Private key/ { print $3 }')
 key2=$(echo "$wallet2" | awk '/Private key/ { print $3 }')
 key3=$(echo "$wallet3" | awk '/Private key/ { print $3 }')
 key4=$(echo "$wallet4" | awk '/Private key/ { print $3 }')
+key5=$(echo "$wallet5" | awk '/Private key/ { print $3 }')
 
 # Print out the environment variables to copy
 echo "# Copy the following into your .envrc file:"
@@ -41,3 +44,7 @@ echo
 echo "# Sequencer account"
 echo "export GS_SEQUENCER_ADDRESS=$address4"
 echo "export GS_SEQUENCER_PRIVATE_KEY=$key4"
+echo
+echo "# Challenger account"
+echo "export GS_CHALLENGER_ADDRESS=$address5"
+echo "export GS_CHALLENGER_PRIVATE_KEY=$key5"


### PR DESCRIPTION
Now that FDG is on by default, it makes sense to include the challenger account in `wallets.sh`.