### PR TITLE
make riscv compile without the optimizer turned on

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x0fa0633a769e73f5937514c0003ba7947a1c275bbe5b85d78879c42f0ed8895b"
   },
   "src/asterisc/RISCV.sol": {
-    "initCodeHash": "0xb3f9c337d694b62704b63d86d7d412a661925f254e7af376a5e02717a455487e",
-    "sourceCodeHash": "0x92a8689e26a736868f90c6c208ef01782c3d9ce196fcef0a85aef4da936c6339"
+    "initCodeHash": "0x6b4323061187f2c8efe8de43bf1ecdc0798e2d95ad69470ed4151dadc094fedf",
+    "sourceCodeHash": "0xd824f1ead87a1214fa8a4b435f493a80b7340ec2c959d2c1e1e9e8c062a42c4a"
   },
   "src/cannon/MIPS.sol": {
     "initCodeHash": "0xa3cbf121bad13c00227ea4fef128853d9a86b7ec9158de894f99b58d38d7630a",

--- a/packages/contracts-bedrock/src/asterisc/RISCV.sol
+++ b/packages/contracts-bedrock/src/asterisc/RISCV.sol
@@ -646,16 +646,18 @@ contract RISCV is IBigStepper {
                     rightShamt := sub64(sub64(toU64(64), alignment), size)
                 }
 
+                let addr_ := addr
+                let size_ := size
                 // left: prepare for byte-taking by right-aligning
                 left := shr(u64ToU256(shl64(toU64(3), leftShamt)), left)
                 // right: right-align for byte-taking by right-aligning
                 right := shr(u64ToU256(shl64(toU64(3), rightShamt)), right)
                 // loop:
-                for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                for { let i := 0 } lt(i, size_) { i := add(i, 1) } {
                     // translate to reverse byte lookup, since we are reading little-endian memory, and need the highest
                     // byte first.
                     // effAddr := (addr + size - 1 - i) &^ 31
-                    let effAddr := and64(sub64(sub64(add64(addr, size), toU64(1)), toU64(i)), not64(toU64(31)))
+                    let effAddr := and64(sub64(sub64(add64(addr_, size_), toU64(1)), toU64(i)), not64(toU64(31)))
                     // take a byte from either left or right, depending on the effective address
                     let b := toU256(0)
                     switch eq64(effAddr, leftAddr)
@@ -672,7 +674,7 @@ contract RISCV is IBigStepper {
                 }
 
                 if signed {
-                    let signBitShift := sub64(shl64(toU64(3), size), toU64(1))
+                    let signBitShift := sub64(shl64(toU64(3), size_), toU64(1))
                     out := signExtend64(out, signBitShift)
                 }
             }
@@ -824,21 +826,24 @@ contract RISCV is IBigStepper {
                     count := pdatlen
                 }
 
-                let bits := shl64(toU64(3), sub64(toU64(32), count)) // 32-count, in bits
+                let addr_ := addr
+                let count_ := count
+                let bits := shl64(toU64(3), sub64(toU64(32), count_)) // 32-count, in bits
                 let mask := not(sub(shl(u64ToU256(bits), toU256(1)), toU256(1))) // left-aligned mask for count bytes
                 let alignmentBits := u64ToU256(shl64(toU64(3), alignment))
                 mask := shr(alignmentBits, mask) // mask of count bytes, shifted by alignment
                 let pdat := shr(alignmentBits, b32asBEWord(pdatB32)) // pdat, shifted by alignment
 
                 // update pre-image reader with updated offset
-                let newOffset := add64(offset, count)
+                let newOffset := add64(offset, count_)
                 setPreimageOffset(newOffset)
+                out := count_
 
-                let node := getMemoryB32(sub64(addr, alignment), 1)
+                let node := getMemoryB32(sub64(addr_, alignment), 1)
                 let dat := and(b32asBEWord(node), not(mask)) // keep old bytes outside of mask
                 dat := or(dat, and(pdat, mask)) // fill with bytes from pdat
-                setMemoryB32(sub64(addr, alignment), beWordAsB32(dat), 1)
-                out := count
+                setMemoryB32(sub64(addr_, alignment), beWordAsB32(dat), 1)
+                // out := count_
             }
 
             //
@@ -1141,6 +1146,7 @@ contract RISCV is IBigStepper {
 
             switch opcode
             case 0x03 {
+                let pc_ := _pc
                 // 000_0011: memory loading
                 // LB, LH, LW, LD, LBU, LHU, LWU
                 let imm := parseImmTypeI(instr)
@@ -1150,9 +1156,10 @@ contract RISCV is IBigStepper {
                 let memIndex := add64(rs1Value, signExtend64(imm, toU64(11)))
                 let rdValue := loadMem(memIndex, size, signed, 1, 2)
                 setRegister(rd, rdValue)
-                setPC(add64(_pc, toU64(4)))
+                setPC(add64(pc_, toU64(4)))
             }
             case 0x23 {
+                let pc_ := _pc
                 // 010_0011: memory storing
                 // SB, SH, SW, SD
                 let imm := parseImmTypeS(instr)
@@ -1161,7 +1168,7 @@ contract RISCV is IBigStepper {
                 let rs1Value := getRegister(rs1)
                 let memIndex := add64(rs1Value, signExtend64(imm, toU64(11)))
                 storeMem(memIndex, size, value, 1, 2)
-                setPC(add64(_pc, toU64(4)))
+                setPC(add64(pc_, toU64(4)))
             }
             case 0x63 {
                 // 110_0011: branching

--- a/packages/contracts-bedrock/src/asterisc/RISCV.sol
+++ b/packages/contracts-bedrock/src/asterisc/RISCV.sol
@@ -6,18 +6,17 @@ import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
 
 /// @title RISCV
 /// @notice The RISCV contract emulates a single RISCV hart cycle statelessly, using memory proofs to verify the
-///         instruction and optional memory access' inclusion in the memory merkle root provided in the prestate
-///         witness.
-///
+///         instruction and optional memory access' inclusion in the memory merkle root provided in the trusted
+///         prestate witness.
 ///         This contract has been vendorized from the Asterisc project. The original source code can be found at
-///         https://github.com/ethereum-optimism/asterisc
+/// @dev https://github.com/ethereum-optimism/asterisc
 contract RISCV is IBigStepper {
     /// @notice The preimage oracle contract.
     IPreimageOracle public oracle;
 
     /// @notice The version of the contract.
-    /// @custom:semver 1.1.0-rc.1
-    string public constant version = "1.1.0-rc.1";
+    /// @custom:semver 1.1.0-rc.2
+    string public constant version = "1.1.0-rc.2";
 
     /// @param _oracle The preimage oracle contract.
     constructor(IPreimageOracle _oracle) {
@@ -837,13 +836,13 @@ contract RISCV is IBigStepper {
                 // update pre-image reader with updated offset
                 let newOffset := add64(offset, count_)
                 setPreimageOffset(newOffset)
+
                 out := count_
 
                 let node := getMemoryB32(sub64(addr_, alignment), 1)
                 let dat := and(b32asBEWord(node), not(mask)) // keep old bytes outside of mask
                 dat := or(dat, and(pdat, mask)) // fill with bytes from pdat
                 setMemoryB32(sub64(addr_, alignment), beWordAsB32(dat), 1)
-                // out := count_
             }
 
             //

--- a/versions.json
+++ b/versions.json
@@ -11,5 +11,5 @@
   "just": "1.34.0",
   "binary_signer": "1.0.4",
   "semgrep": "1.90.0",
-  "asterisc": "cl/contract-updates"
+  "asterisc": "v1.1.1"
 }

--- a/versions.json
+++ b/versions.json
@@ -11,5 +11,5 @@
   "just": "1.34.0",
   "binary_signer": "1.0.4",
   "semgrep": "1.90.0",
-  "asterisc": "v1.1.1"
+  "asterisc": "v1.1.2"
 }


### PR DESCRIPTION
This PR makeS riscv.sol compile without the optimizer turned on. Important for forge coverage to work.