### PR TITLE
codecov: fix config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ ignore:
   - "packages/contracts-bedrock/test/**/*.sol"
   - "packages/contracts-bedrock/scripts/**/*.sol"
   - "packages/contracts-bedrock/contracts/vendor/WETH9.sol"
-  - 'packages/contracts-bedrock/contracts/EAS/**/*.sol'
+  - 'packages/contracts-bedrock/contracts/vendor/eas/**/*.sol'
 coverage:
   status:
     patch:
@@ -37,5 +37,3 @@ flag_management:
         - type: patch
           target: 100%
     - name: bedrock-go-tests
-    - name: contracts-tests
-    - name: sdk-tests


### PR DESCRIPTION
**Description**

codecov is currently only configured for `cannon`, it should work for
all of the go unit tests as well as the contracts. Found some small out
of date config in the codecov given the repo has been refactored a bunch
recently.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

