### PR TITLE
Interop: block-range receipt fetching

### DIFF
--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -112,6 +112,15 @@ func (m *MockEthClient) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo
 	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, err)
 }
 
+func (m *MockEthClient) BatchFetchReceipts(ctx context.Context, blockHashes []common.Hash) ([]eth.BlockInfo, []types.Receipts, error) {
+	out := m.Mock.Called(blockHashes)
+	return out.Get(0).([]eth.BlockInfo), out.Get(1).([]types.Receipts), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectBatchFetchReceipts(blockHashes []common.Hash, infos []eth.BlockInfo, receipts []types.Receipts, err error) {
+	m.Mock.On("BatchFetchReceipts", blockHashes).Once().Return(infos, receipts, err)
+}
+
 func (m *MockEthClient) GetProof(ctx context.Context, address common.Address, storage []common.Hash, blockTag string) (*eth.AccountResult, error) {
 	out := m.Mock.Called(address, storage, blockTag)
 	return out.Get(0).(*eth.AccountResult), out.Error(1)

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -167,11 +167,20 @@ func (db *ChainsDB) CrossDerivedFromBlockRef(chainID types.ChainID, derived eth.
 // Check calls the underlying logDB to determine if the given log entry exists at the given location.
 // If the block-seal of the block that includes the log is known, it is returned. It is fully zeroed otherwise, if the block is in-progress.
 func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+	db.logger.Warn("Check", "chain", chain, "blockNum", blockNum, "logIdx", logIdx, "logHash", logHash)
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
+		db.logger.Warn("Check UnknownChain", "chain", chain)
+		db.logDBs.Range(func(c types.ChainID, v LogStorage) bool {
+			db.logger.Warn("Check KnownChain", "chain", c)
+			return true
+		})
 		return types.BlockSeal{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
 	}
-	return logDB.Contains(blockNum, logIdx, logHash)
+	ret, err := logDB.Contains(blockNum, logIdx, logHash)
+	db.logger.Warn("Check", "chain", chain, "blockNum", blockNum, "logIdx", logIdx, "logHash", logHash, "ret", ret, "err", err)
+	return ret, err
+	//return logDB.Contains(blockNum, logIdx, logHash)
 }
 
 // OpenBlock returns the Executing Messages for the block at the given number on the given chain.

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -20,6 +20,7 @@ import (
 type Source interface {
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethtypes.Receipts, error)
+	BatchFetchReceipts(ctx context.Context, blockHashes []common.Hash) ([]eth.BlockInfo, []gethtypes.Receipts, error)
 }
 
 type LogProcessor interface {
@@ -62,20 +63,24 @@ type ChainProcessor struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	// configuration which would do well in a config struc if there were more
+	maxBatchSize int // maximum number of blocks to request receipts for in a single batch
 }
 
 func NewChainProcessor(log log.Logger, chain types.ChainID, processor LogProcessor, rewinder DatabaseRewinder, onIndexed func()) *ChainProcessor {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := &ChainProcessor{
-		log:       log.New("chain", chain),
-		client:    nil,
-		chain:     chain,
-		processor: processor,
-		rewinder:  rewinder,
-		newHead:   make(chan struct{}, 1),
-		onIndexed: onIndexed,
-		ctx:       ctx,
-		cancel:    cancel,
+		log:          log.New("chain", chain),
+		client:       nil,
+		chain:        chain,
+		processor:    processor,
+		rewinder:     rewinder,
+		newHead:      make(chan struct{}, 1),
+		onIndexed:    onIndexed,
+		ctx:          ctx,
+		cancel:       cancel,
+		maxBatchSize: 10,
 	}
 	return out
 }
@@ -132,7 +137,7 @@ func (s *ChainProcessor) work() {
 			return
 		}
 		target := s.nextNum()
-		if err := s.update(target); err != nil {
+		if err := s.rangeUpdate(target); err != nil {
 			if errors.Is(err, ethereum.NotFound) {
 				s.log.Debug("Event-indexer cannot find next block yet", "target", target, "err", err)
 			} else if errors.Is(err, types.ErrNoRPCSource) {
@@ -151,50 +156,75 @@ func (s *ChainProcessor) work() {
 	}
 }
 
-func (s *ChainProcessor) update(nextNum uint64) error {
+// rangeUpdate processes a range of blocks from a given starting height
+// it fetches blocks until it reaches the maximum batch size or the end of the chain
+// and then fetches the receipts for those blocks in a single batch call
+// and forwards each block and its receipts to be processed
+func (s *ChainProcessor) rangeUpdate(startNum uint64) error {
 	s.clientLock.Lock()
 	defer s.clientLock.Unlock()
 
 	if s.client == nil {
 		return types.ErrNoRPCSource
 	}
-
+	blockRefs := []eth.BlockRef{}
+	blocksToSync := []common.Hash{}
+	// collect up to the maximum number of blocks to sync by hash
+	for i := startNum; i < startNum+uint64(s.maxBatchSize); i++ {
+		ctx, cancel := context.WithTimeout(s.ctx, time.Second*10)
+		next, err := s.client.L1BlockRefByNumber(ctx, i)
+		cancel()
+		// if this block doesn't exist, we're done adding to the range
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				break
+			} else {
+				return fmt.Errorf("failed to fetch next block: %w", err)
+			}
+		}
+		blocksToSync = append(blocksToSync, next.Hash)
+		blockRefs = append(blockRefs, next)
+	}
+	// if we have no blocks to sync, we're done
+	if len(blockRefs) == 0 {
+		return nil
+	}
+	// Try to fetch the receipts for the range of blocks
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second*10)
-	nextL1, err := s.client.L1BlockRefByNumber(ctx, nextNum)
-	next := eth.BlockRef{
-		Hash:       nextL1.Hash,
-		ParentHash: nextL1.ParentHash,
-		Number:     nextL1.Number,
-		Time:       nextL1.Time,
-	}
+	_, receipts, err := s.client.BatchFetchReceipts(ctx, blocksToSync)
 	cancel()
 	if err != nil {
-		return fmt.Errorf("failed to fetch next block: %w", err)
+		return fmt.Errorf("failed to fetch receipts of block range: %w", err)
 	}
-
-	// Try and fetch the receipts
-	ctx, cancel = context.WithTimeout(s.ctx, time.Second*10)
-	_, receipts, err := s.client.FetchReceipts(ctx, next.Hash)
-	cancel()
-	if err != nil {
-		return fmt.Errorf("failed to fetch receipts of block: %w", err)
+	if len(receipts) != len(blockRefs) {
+		return fmt.Errorf("expected %d blocks of receipts receipts but got %d", len(blockRefs), len(receipts))
 	}
-	if err := s.processor.ProcessLogs(ctx, next, receipts); err != nil {
-		s.log.Error("Failed to process block", "block", next, "err", err)
+	// for each block in the range, process the logs
+	for i := range receipts {
+		if err := s.process(ctx, blockRefs[i], receipts[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-		if next.Number == 0 { // cannot rewind genesis
+func (s *ChainProcessor) process(ctx context.Context, block eth.BlockRef, receipts gethtypes.Receipts) error {
+	if err := s.processor.ProcessLogs(ctx, block, receipts); err != nil {
+		s.log.Error("Failed to process block", "block", block, "err", err)
+
+		if block.Number == 0 { // cannot rewind genesis
 			return nil
 		}
 
 		// Try to rewind the database to the previous block to remove any logs from this block that were written
-		if err := s.rewinder.Rewind(s.chain, nextNum-1); err != nil {
+		if err := s.rewinder.Rewind(s.chain, block.Number-1); err != nil {
 			// If any logs were written, our next attempt to write will fail and we'll retry this rewind.
 			// If no logs were written successfully then the rewind wouldn't have done anything anyway.
-			s.log.Error("Failed to rewind after error processing block", "block", next, "err", err)
+			s.log.Error("Failed to rewind after error processing block", "block", block, "err", err)
 		}
 		return err
 	}
-	s.log.Info("Indexed block events", "block", next, "txs", len(receipts))
+	s.log.Info("Indexed block events", "block", block, "txs", len(receipts))
 	s.onIndexed()
 	return nil
 }


### PR DESCRIPTION
# What
Makes the Supervisor use a range of up to 10 blocks at a time when fetching block receipts

# Why
In the interest of reducing the RPC pressure the supervisor exerts when syncing, we should move calls into batches where possible. Fetching of receipts was the most obvious place to start.

# How
Extends from this PR: https://github.com/ethereum-optimism/optimism/pull/12992
- Makes the Chain Processor's `Source` interface aware of `BatchFetchReceipts`, which takes a slice of Block Hashes.
- Changes `update` to `rangeUpdate`. Now:
  - The "NextNum" is just a starting point
  - The Chain Processor will advance through block-hash queries until one is not found, or the maximum is reached
  - The block hashes are sent to the Batch functionality
  - The results are individually sent to `process`, which was decomposed from the original `update` function

# Testing
I tested this visually/locally by inserting custom logging and running the `interop_blockBuilding` E2E test. I found that when the supervisor first started up, it needed to cache more data, and averaged 2 blocks per request. Once it had caught up it went down to just one block per request.

Actual test code is yet to come.
