### PR TITLE
op-e2e: add regression test for new batcher / safe head reversal

### DIFF
--- a/op-batcher/batcher/test_batch_submitter.go
+++ b/op-batcher/batcher/test_batch_submitter.go
@@ -3,10 +3,13 @@ package batcher
 import (
 	"context"
 	"errors"
+	"math"
+	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
@@ -63,4 +66,17 @@ func (l *TestBatchSubmitter) WaitOnJammingTx(ctx context.Context) error {
 	}
 	l.Log.Info("done waiting on jamming tx", "err", err)
 	return nil
+}
+
+// ForceOldestBlockIntoFuture sets the oldest block in the batcher's state
+// to an empty block with a number = math.MaxInt64.
+// It helps trigger a situation where there is a gap between the safe head of the sequencer
+// (which the batcher perviously started working from) and the oldest block stored by the batcher.
+func (l *TestBatchSubmitter) ForceOldestBlockIntoFuture() {
+	b := types.Block{}
+	h := types.Header{
+		Number: big.NewInt(math.MaxInt64),
+	}
+	f := b.WithSeal(&h)
+	l.state.blocks = []*types.Block{f}
 }

--- a/op-batcher/batcher/test_batch_submitter.go
+++ b/op-batcher/batcher/test_batch_submitter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
@@ -78,5 +79,6 @@ func (l *TestBatchSubmitter) ForceOldestBlockIntoFuture() {
 		Number: big.NewInt(math.MaxInt64),
 	}
 	f := b.WithSeal(&h)
+	l.lastStoredBlock = eth.ToBlockID(f)
 	l.state.blocks = []*types.Block{f}
 }

--- a/op-e2e/system/da/startstop_test.go
+++ b/op-e2e/system/da/startstop_test.go
@@ -124,15 +124,12 @@ func testStartStopBatcher(t *testing.T, cfgMod func(*e2esys.SystemConfig)) {
 // TestBatcherSafeHeadGap tests that the batcher can handle
 // an (effective) reversal in the sequencer's safe head.
 // This can happen when the sequencer restarts, e.g. during a rollout.
-// To simulate the reversal of the safe head, we instead delete the oldest
-// block in the batcher's state.
+// To simulate the reversal of the safe head, we instead set a single
+// block in the batcher's state with a huge block number.
 func TestBatcherSafeHeadGap(t *testing.T) {
 	op_e2e.InitParallel(t)
-
 	cfg := e2esys.DefaultSystemConfig(t)
-
 	sys, err := cfg.Start(t)
-
 	require.NoError(t, err, "Error starting up system")
 
 	l2Seq := sys.NodeClient("sequencer")


### PR DESCRIPTION
Adds a test which triggers the behaviour seen on our recent devnet when rolling out the latest version of the batcher. The test is expected to fail. 

I plan to tack on the fix for this, using the regression test as an acceptance test. See for example #12981 .

The approach of this test is not a perfect simulation of the scenario I want to set up. I tried using `debug_setHead` on the sequencer, but sets back both the safe and unsafe heads (triggering an entirely different code path in the batcher). 

Still, it does test the ability of the batcher to self heal when it gets into a state which is inconsistent with the sequencer's sync status. 