### PR TITLE
op-batcher: fix a deadlock

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -557,6 +557,7 @@ func (l *BatchSubmitter) throttlingLoop(ctx context.Context) {
 			// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
+			// Call StopBatchSubmitting in another goroutine to avoid deadlock.
 			go func() {
 				// Always returns nil. An error is only returned to expose this function as an RPC.
 				_ = l.StopBatchSubmitting(ctx)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -557,8 +557,10 @@ func (l *BatchSubmitter) throttlingLoop(ctx context.Context) {
 			// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			// Always returns nil. An error is only returned to expose this function as an RPC.
-			_ = l.StopBatchSubmitting(ctx)
+			go func() {
+				// Always returns nil. An error is only returned to expose this function as an RPC.
+				_ = l.StopBatchSubmitting(ctx)
+			}()
 			return
 		} else if err != nil {
 			l.Log.Error("SetMaxDASize rpc failed, retrying.", "err", err)


### PR DESCRIPTION
When calling `StopBatchSubmitting` in throttlingLoop [here](https://github.com/ethereum-optimism/optimism/blob/042433b89ce38ccc15456e9673829f6783bb97ac/op-batcher/batcher/driver.go#L561), it will wait on the `WaitGroup` [here](https://github.com/ethereum-optimism/optimism/blob/042433b89ce38ccc15456e9673829f6783bb97ac/op-batcher/batcher/driver.go#L242).

But the problem is that `throttlingLoop` is also in this `WaitGroup`([source](https://github.com/ethereum-optimism/optimism/blob/042433b89ce38ccc15456e9673829f6783bb97ac/op-batcher/batcher/driver.go#L169)), thus it'll deadlock.