### PR TITLE
feat: add sender to ERC7802 events

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/OptimismSuperchainERC20.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismSuperchainERC20.json
@@ -454,6 +454,12 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
       }
     ],
     "name": "CrosschainBurn",
@@ -473,6 +479,12 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
       }
     ],
     "name": "CrosschainMint",

--- a/packages/contracts-bedrock/snapshots/abi/SuperchainWETH.json
+++ b/packages/contracts-bedrock/snapshots/abi/SuperchainWETH.json
@@ -306,6 +306,12 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
       }
     ],
     "name": "CrosschainBurn",
@@ -325,6 +331,12 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
       }
     ],
     "name": "CrosschainMint",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -104,8 +104,8 @@
     "sourceCodeHash": "0xa76133db7f449ae742f9ba988ad86ccb5672475f61298b9fefe411b63b63e9f6"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
-    "initCodeHash": "0x5bc5824030ecdb531e1f615d207cb73cdaa702e198769445d0ddbe717271eba9",
-    "sourceCodeHash": "0x0819c9411a155dca592d19b60c4176954202e4fe5d632a4ffbf88d465461252c"
+    "initCodeHash": "0x22fed5371ad9b4c2711ce5cbee889d332887aa5f5ff6b37e36c31acefe3bbeee",
+    "sourceCodeHash": "0xf68baaee0a09ea51d5a4e821df79976c0914369ebc8e5fd27bbbf89072254fc8"
   },
   "src/L2/OptimismSuperchainERC20Beacon.sol": {
     "initCodeHash": "0x23dba3ceb9e58646695c306996c9e15251ac79acc6339c1a93d10a4c79da6dab",
@@ -121,15 +121,15 @@
   },
   "src/L2/SuperchainERC20.sol": {
     "initCodeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-    "sourceCodeHash": "0xcf39c16893cace1e7d61350bfff05a27f3ce8da8eb0ac02cb5ac7bf603f163fa"
+    "sourceCodeHash": "0x77adb9ea7a9e9cf3dc5943607dcacacf7a703bd110d2a5627e7075b766aae29f"
   },
   "src/L2/SuperchainTokenBridge.sol": {
     "initCodeHash": "0x1cd2afdae6dd1b6ebc17f1d529e7d74c9b8b21b02db8589b8e389e2d5523d775",
     "sourceCodeHash": "0x617aa994f659c5d8ebd54128d994f86f5b175ceca095b024b8524a7898e8ae62"
   },
   "src/L2/SuperchainWETH.sol": {
-    "initCodeHash": "0x5aef986a7c9c102b1e9b3068e2a2b66adce0a71dd5f39e03694622bf494f8d97",
-    "sourceCodeHash": "0xa62101a23b860e97f393027c898082a1c73d50679eceb6c6793844af29702359"
+    "initCodeHash": "0x90aad5698e09994909331dd9665d99a8d5a53e45ba792bf47e4c2efbd48f7699",
+    "sourceCodeHash": "0x35f0ffcfa027f736b496f3fd2640c043648a49ce325083486ce27f63bfec6d08"
   },
   "src/L2/WETH.sol": {
     "initCodeHash": "0x17ea1b1c5d5a622d51c2961fde886a5498de63584e654ed1d69ee80dddbe0b17",

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
@@ -58,8 +58,8 @@ contract OptimismSuperchainERC20 is SuperchainERC20, Initializable {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.9
-    string public constant override version = "1.0.0-beta.9";
+    /// @custom:semver 1.0.0-beta.10
+    string public constant override version = "1.0.0-beta.10";
 
     /// @notice Constructs the OptimismSuperchainERC20 contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
@@ -13,9 +13,9 @@ import { Unauthorized } from "src/libraries/errors/CommonErrors.sol";
 ///         the Superchain. Allows the SuperchainTokenBridge to mint and burn tokens as needed.
 abstract contract SuperchainERC20 is ERC20, IERC7802, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.5
+    /// @custom:semver 1.0.0-beta.6
     function version() external view virtual returns (string memory) {
-        return "1.0.0-beta.5";
+        return "1.0.0-beta.6";
     }
 
     /// @notice Allows the SuperchainTokenBridge to mint tokens.
@@ -26,7 +26,7 @@ abstract contract SuperchainERC20 is ERC20, IERC7802, ISemver {
 
         _mint(_to, _amount);
 
-        emit CrosschainMint(_to, _amount);
+        emit CrosschainMint(_to, _amount, msg.sender);
     }
 
     /// @notice Allows the SuperchainTokenBridge to burn tokens.
@@ -37,7 +37,7 @@ abstract contract SuperchainERC20 is ERC20, IERC7802, ISemver {
 
         _burn(_from, _amount);
 
-        emit CrosschainBurn(_from, _amount);
+        emit CrosschainBurn(_from, _amount, msg.sender);
     }
 
     /// @inheritdoc IERC165

--- a/packages/contracts-bedrock/src/L2/SuperchainWETH.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainWETH.sol
@@ -24,8 +24,8 @@ import { Unauthorized, NotCustomGasToken } from "src/libraries/errors/CommonErro
 ///         do not use a custom gas token.
 contract SuperchainWETH is WETH98, IERC7802, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.10
-    string public constant version = "1.0.0-beta.10";
+    /// @custom:semver 1.0.0-beta.11
+    string public constant version = "1.0.0-beta.11";
 
     /// @inheritdoc WETH98
     function deposit() public payable override {
@@ -74,7 +74,7 @@ contract SuperchainWETH is WETH98, IERC7802, ISemver {
             IETHLiquidity(Predeploys.ETH_LIQUIDITY).mint(_amount);
         }
 
-        emit CrosschainMint(_to, _amount);
+        emit CrosschainMint(_to, _amount, msg.sender);
     }
 
     /// @notice Allows the SuperchainTokenBridge to burn tokens.
@@ -90,7 +90,7 @@ contract SuperchainWETH is WETH98, IERC7802, ISemver {
             IETHLiquidity(Predeploys.ETH_LIQUIDITY).burn{ value: _amount }();
         }
 
-        emit CrosschainBurn(_from, _amount);
+        emit CrosschainBurn(_from, _amount, msg.sender);
     }
 
     /// @inheritdoc IERC165

--- a/packages/contracts-bedrock/src/L2/interfaces/IERC7802.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IERC7802.sol
@@ -9,12 +9,14 @@ interface IERC7802 is IERC165 {
     /// @notice Emitted when a crosschain transfer mints tokens.
     /// @param to       Address of the account tokens are being minted for.
     /// @param amount   Amount of tokens minted.
-    event CrosschainMint(address indexed to, uint256 amount);
+    /// @param sender   Address of the account that finilized the crosschain transfer.
+    event CrosschainMint(address indexed to, uint256 amount, address indexed sender);
 
     /// @notice Emitted when a crosschain transfer burns tokens.
     /// @param from     Address of the account tokens are being burned from.
     /// @param amount   Amount of tokens burned.
-    event CrosschainBurn(address indexed from, uint256 amount);
+    /// @param sender   Address of the account that initiated the crosschain transfer.
+    event CrosschainBurn(address indexed from, uint256 amount, address indexed sender);
 
     /// @notice Mint tokens through a crosschain transfer.
     /// @param _to     Address to mint tokens to.

--- a/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
@@ -62,7 +62,7 @@ contract SuperchainERC20Test is Test {
 
         // Look for the emit of the `CrosschainMint` event
         vm.expectEmit(address(superchainERC20));
-        emit IERC7802.CrosschainMint(_to, _amount);
+        emit IERC7802.CrosschainMint(_to, _amount, SUPERCHAIN_TOKEN_BRIDGE);
 
         // Call the `mint` function with the bridge caller
         vm.prank(SUPERCHAIN_TOKEN_BRIDGE);
@@ -105,7 +105,7 @@ contract SuperchainERC20Test is Test {
 
         // Look for the emit of the `CrosschainBurn` event
         vm.expectEmit(address(superchainERC20));
-        emit IERC7802.CrosschainBurn(_from, _amount);
+        emit IERC7802.CrosschainBurn(_from, _amount, SUPERCHAIN_TOKEN_BRIDGE);
 
         // Call the `burn` function with the bridge caller
         vm.prank(SUPERCHAIN_TOKEN_BRIDGE);

--- a/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
@@ -28,10 +28,10 @@ contract SuperchainWETH_Test is CommonTest {
     event Withdrawal(address indexed src, uint256 wad);
 
     /// @notice Emitted when a crosschain transfer mints tokens.
-    event CrosschainMint(address indexed to, uint256 amount);
+    event CrosschainMint(address indexed to, uint256 amount, address indexed sender);
 
     /// @notice Emitted when a crosschain transfer burns tokens.
-    event CrosschainBurn(address indexed from, uint256 amount);
+    event CrosschainBurn(address indexed from, uint256 amount, address indexed sender);
 
     address internal constant ZERO_ADDRESS = address(0);
 
@@ -162,7 +162,7 @@ contract SuperchainWETH_Test is CommonTest {
 
         // Look for the emit of the `CrosschainMint` event
         vm.expectEmit(address(superchainWeth));
-        emit CrosschainMint(_to, _amount);
+        emit CrosschainMint(_to, _amount, Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
 
         // Mock the `isCustomGasToken` function to return false
         _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(false));
@@ -195,7 +195,7 @@ contract SuperchainWETH_Test is CommonTest {
 
         // Look for the emit of the `CrosschainMint` event
         vm.expectEmit(address(superchainWeth));
-        emit CrosschainMint(_to, _amount);
+        emit CrosschainMint(_to, _amount, Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
 
         // Mock the `isCustomGasToken` function to return false
         _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(true));
@@ -248,7 +248,7 @@ contract SuperchainWETH_Test is CommonTest {
 
         // Look for the emit of the `CrosschainBurn` event
         vm.expectEmit(address(superchainWeth));
-        emit CrosschainBurn(_from, _amount);
+        emit CrosschainBurn(_from, _amount, Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
 
         // Mock the `isCustomGasToken` function to return false
         _mockAndExpect(address(l1Block), abi.encodeCall(l1Block.isCustomGasToken, ()), abi.encode(false));
@@ -290,7 +290,7 @@ contract SuperchainWETH_Test is CommonTest {
 
         // Look for the emit of the `CrosschainBurn` event
         vm.expectEmit(address(superchainWeth));
-        emit CrosschainBurn(_from, _amount);
+        emit CrosschainBurn(_from, _amount, Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
 
         // Expect to not call the `burn` function in the `ETHLiquidity` contract
         vm.expectCall(Predeploys.ETH_LIQUIDITY, abi.encodeCall(IETHLiquidity.burn, ()), 0);


### PR DESCRIPTION
**Description**

Based on the discussions around ERC7802, we are including `msg.sender` in the `CrosschainMint` and `CrosschainBurn` events.

**Tests**

Adjust `SuperchainERC20` and `SuperchainWETH` tests

**Additional context**

ERC7802 discussion: https://github.com/ethereum/ERCs/pull/692#discussion_r1829865880

**Metadata**

Closes https://github.com/ethereum-optimism/optimism/issues/13018