### PR TITLE
chore(op-challenger): Update kona native mode flag

### DIFF
--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -9,8 +9,7 @@ import (
 )
 
 type KonaExecutor struct {
-	nativeMode    bool
-	clientBinPath string
+	nativeMode bool
 }
 
 var _ OracleServerExecutor = (*KonaExecutor)(nil)
@@ -19,8 +18,8 @@ func NewKonaExecutor() *KonaExecutor {
 	return &KonaExecutor{nativeMode: false}
 }
 
-func NewNativeKonaExecutor(clientBinPath string) *KonaExecutor {
-	return &KonaExecutor{nativeMode: true, clientBinPath: clientBinPath}
+func NewNativeKonaExecutor() *KonaExecutor {
+	return &KonaExecutor{nativeMode: true}
 }
 
 func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
@@ -37,7 +36,7 @@ func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.Lo
 	}
 
 	if s.nativeMode {
-		args = append(args, "--exec", s.clientBinPath)
+		args = append(args, "--native")
 	} else {
 		args = append(args, "--server")
 		args = append(args, "--data-dir", dataDir)

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -16,15 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var konaHostPath, konaClientPath string
+var konaHostPath string
 
 func init() {
 	konaHostPath = os.Getenv("KONA_HOST_PATH")
-	konaClientPath = os.Getenv("KONA_CLIENT_PATH")
 }
 
 func IsKonaConfigured() bool {
-	return konaHostPath != "" && konaClientPath != ""
+	return konaHostPath != ""
 }
 
 func RunKonaNative(
@@ -57,7 +56,7 @@ func RunKonaNative(
 		L2Claim:       fixtureInputs.L2Claim,
 		L2BlockNumber: big.NewInt(int64(fixtureInputs.L2BlockNumber)),
 	}
-	hostCmd, err := vm.NewNativeKonaExecutor(konaClientPath).OracleCommand(vmCfg, workDir, inputs)
+	hostCmd, err := vm.NewNativeKonaExecutor().OracleCommand(vmCfg, workDir, inputs)
 	require.NoError(t, err)
 
 	cmd := exec.Command(hostCmd[0], hostCmd[1:]...)


### PR DESCRIPTION
## Overview

Updates the `op-challenger`'s server executor for kona to use the new `--native` flag over `--exec <client_bin_path>`. The client program is now ran in-process.

The only consumer of this at the moment is the action tests runner for kona, which only runs in over in that repository. Should be fine to roll this change out without breaking releases running old versions of kona.