### PR TITLE
op-challenger: Allow specifying a chain ID as network.

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -177,6 +177,13 @@ func TestNetwork(t *testing.T) {
 	t.Run("UnknownNetwork", func(t *testing.T) {
 		verifyArgsInvalid(t, "unknown chain: not-a-network", addRequiredArgsExcept(types.TraceTypeAlphabet, "--game-factory-address", "--network=not-a-network"))
 	})
+
+	t.Run("ChainIDAllowedWhenGameFactoryAddressSupplied", func(t *testing.T) {
+		addr := common.Address{0xbb, 0xcc, 0xdd}
+		cfg := configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--game-factory-address", "--network=1234", "--game-factory-address="+addr.Hex()))
+		require.Equal(t, addr, cfg.GameFactoryAddress)
+		require.Equal(t, "1234", cfg.Cannon.Network)
+	})
 }
 
 func TestGameAllowlist(t *testing.T) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"runtime"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
@@ -230,7 +231,10 @@ func (c Config) Check() error {
 				return ErrCannonNetworkAndL2Genesis
 			}
 			if ch := chaincfg.ChainByName(c.Cannon.Network); ch == nil {
-				return fmt.Errorf("%w: %v", ErrCannonNetworkUnknown, c.Cannon.Network)
+				// Check if this looks like a chain ID that could be a custom chain configuration.
+				if _, err := strconv.ParseUint(c.Cannon.Network, 10, 32); err != nil {
+					return fmt.Errorf("%w: %v", ErrCannonNetworkUnknown, c.Cannon.Network)
+				}
 			}
 		}
 		if c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -232,6 +232,18 @@ func TestCannonRequiredArgs(t *testing.T) {
 			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
 		})
 
+		t.Run(fmt.Sprintf("TestNetworkMayBeAnyChainID-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.Cannon.Network = "467294"
+			require.NoError(t, cfg.Check())
+		})
+
+		t.Run(fmt.Sprintf("TestNetworkInvalidWhenNotEntirelyNumeric-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.Cannon.Network = "467294a"
+			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
+		})
+
 		t.Run(fmt.Sprintf("TestDebugInfoEnabled-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(traceType)
 			require.True(t, cfg.Cannon.DebugInfo)


### PR DESCRIPTION
op-program supports custom configs identified by chain ID so make sure op-challenger can pass through a chain ID option even if it isn't a known network.