### PR TITLE
make default game type the same as `standard.DisputeGameType`

### DIFF
--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -63,7 +64,7 @@ var (
 	DisputeGameTypeFlag = &cli.UintFlag{
 		Name:    "game-type",
 		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
-		Value:   0,
+		Value:   uint(standard.DisputeGameType),
 		EnvVars: prefixEnvVars("GAME_TYPE"),
 	}
 	ActiveSequencerCheckDurationFlag = &cli.DurationFlag{


### PR DESCRIPTION
The default game type deployed by op-deployer is `1`, but the default game type of op-proposer is `0`, if the user start op-proposer without specifying game-type, he'll get such an error:

```
t=2024-11-22T01:48:46+0000 lvl=error msg="Failed to send proposal transaction" err="failed to create the tx: operation failed permanently after 30 attempts: failed to estimate gas: execution reverted, reason: 0x031c6de40000000000000000000000000000000000000000000000000000000000000000" l1blocknum=7126333 l1blockhash=0xf254e1207242ccbfd849b1d6e0bbe29d03cdc406b7d22a7e31bbd48e83e2b016 l1head=7126337
```
which is very confusing to new users.

This PR makes the default game type of op-proposer be the same as the default of op-deployer.