### PR TITLE
fix(ci): contracts test names check failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -685,6 +685,10 @@ jobs:
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
       - run:
+          name: Lint forge test names
+          command: just lint-forge-tests-check-no-build
+          working_directory: packages/contracts-bedrock
+      - run:
           name: Run tests
           command: |
             TEST_FILES=$(<<parameters.test_list>>)
@@ -750,22 +754,7 @@ jobs:
       - run-contracts-check:
           command: unused-imports-check-no-build
       - run-contracts-check:
-          command: lint-forge-tests-check-no-build
-
-  contracts-bedrock-validate-spacers:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: medium
-    steps:
-      - checkout
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
-      - check-changed:
-          patterns: contracts-bedrock
-      - run:
-          name: validate spacers
-          command: just validate-spacers-no-build
-          working_directory: packages/contracts-bedrock
+          command: validate-spacers-no-build
 
   todo-issues:
     parameters:
@@ -1364,9 +1353,6 @@ workflows:
           test_profile: ciheavy
       - contracts-bedrock-coverage
       - contracts-bedrock-checks:
-          requires:
-            - contracts-bedrock-build
-      - contracts-bedrock-validate-spacers:
           requires:
             - contracts-bedrock-build
       - semgrep-scan:


### PR DESCRIPTION
lint-forge-tests-check-no-build was causing issues in CI because it was running as part of contracts-bedrock-checks which depends on contracts-bedrock-build. contracts-bedrock-build builds the contract files EXCEPT for tests whenever contracts-bedrock has changed. This means that contracts-bedrock-build would not build any test files and therefore lint-forge-tests-check-no-build would not find any test files to check and the job would do nothing. However, when contracts-bedrock is NOT changed, the build job gets the full set of artifacts INCLUDING test artifacts from the cache. This would trigger the full check to actually be run and it would properly fail.

This PR moves that particular check into contracts-bedrock-tests so that it's guaranteed to have all of the compiled contracts.