### PR TITLE
maint: clean src imports

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x4132ff37d267cb12224b75ea806c0aa7d25407b0d66ce526d7fcda8f7d223882"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xd038cc35325d023499151264232d75fa4ecc81f04a8c8353e6b50c43af224d6e",
-    "sourceCodeHash": "0xa13f3ab2b8744015290dbabe5f20fdd44774607e6a7ad3e5e016303fc4aa8c12"
+    "initCodeHash": "0xdc41db13327e1f51ce996c088538c227a82c37d62906eca1aa456d71fa605ff3",
+    "sourceCodeHash": "0x08aca8a70f42a0556f0fc7b1cd4d4aaf152215ab246c132e23074558497fe03b"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0x152167cfa18635ae4918a6eb3371a599cfa084418c0a652799cdb48bfc0ee0cc",
@@ -32,32 +32,32 @@
     "sourceCodeHash": "0x66ac1212760db53a2bb1839e4cd17dc071d9273b8e6fb80646b79e91b3371c1a"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x39f66ac74341ec235fbdd0d79546283210bd8ac35a2ab2c4bd36c9722ce18411",
-    "sourceCodeHash": "0xbb98144285b9530e336f957d10b20363b350876597e30fd34821940896a2bae8"
+    "initCodeHash": "0x902ce448a29a72805cd74b7fc62519fa3d12338851b518b7d01e8a40ba232c72",
+    "sourceCodeHash": "0x8de1b2d4675624a2a3aee135ad8780a07ca91002a5952f2b6501fdf20c92b753"
   },
   "src/L1/ProtocolVersions.sol": {
-    "initCodeHash": "0xefd4806e8737716d5d2022ca2e9e9fba0a0cb5714b026166b58e472222c7d15f",
-    "sourceCodeHash": "0x15205131bf420aa6d03c558bb75dd49cd7439caed7ccdcbfd89c4170a48c94f5"
+    "initCodeHash": "0x98dc9a7ecd1919a8cf4bcca4fb28b112641b2aa5132fb5467a349fb80974957a",
+    "sourceCodeHash": "0x9b953cdbc049492d20a15d48a9081977a91f8e7c72eee3792d86871e70b1a40a"
   },
   "src/L1/SuperchainConfig.sol": {
-    "initCodeHash": "0xfca12d9016c746e5c275b186e0ca40cfd65cf45a5665aab7589a669fea3abb47",
-    "sourceCodeHash": "0x39489a85bc3a5c8560f82d41b31bf7fe22f5b648f4ed538f61695a73092ea9eb"
+    "initCodeHash": "0xebe9a9dbf6df5288fae3634a9d71ce12bd8acb461086de28a2fb4239097dcf80",
+    "sourceCodeHash": "0xd931c19a85a070119f5b670d1f4dc90512847b408aa4ee29c98231257cf0c77c"
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0x0eda38e2fb2687a324289f04ec8ad0d2afe51f45219d074740fb4a0e24ea6569",
     "sourceCodeHash": "0x6dbbe8716ca8cd2fba3da8dcae0ca0c4b1f3e9dd04220fb24a15666b23300927"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0x443fd84f8dbc38f03e59a56b99099b5e4b28de3e860a5d16c1a21101745622a4",
-    "sourceCodeHash": "0x5c2e00cd8939a538eb38580d76e70d27dd1e8e6cd9328e1978468981017736e6"
+    "initCodeHash": "0x845af4e83836221a014f46544fe2a29c66706513b7eed39c59f0505d2662731a",
+    "sourceCodeHash": "0x8df468eb79cf68ee38bada32e7d7c87449c129f1955d464fa774977c770715c7"
   },
   "src/L2/BaseFeeVault.sol": {
-    "initCodeHash": "0xbf49824cf37e201181484a8a423fcad8f504dc925921a2b28e83398197858dec",
-    "sourceCodeHash": "0x983e8e248c61e362ba6a01dd2e217a535c9bb828dc0b4421f5f27e0577f2e14c"
+    "initCodeHash": "0xc23d0437deb5c2e9f8831b9325c77e9d07467c9286f81c0ef47cfef4e242f96b",
+    "sourceCodeHash": "0x2f3f64d4307a081311222b34afa76e587aca3789367f6ea77bc1bfb6d9b39563"
   },
   "src/L2/CrossL2Inbox.sol": {
-    "initCodeHash": "0x31ecaebf368ab3333e80c6dc004b3c9f9a31f813c3138ab388bb3eead9f1b4ee",
-    "sourceCodeHash": "0xa1779d84a14332dcdd167293171d0fe2629d759a23d7cc34ffe2bde7e1605dbc"
+    "initCodeHash": "0x753a7685c4ab405b71a19a7f8aa20a2517b4943bee5d5e616a6fccd8f0531993",
+    "sourceCodeHash": "0xc74277f9502338def330444413ff77157e200110cd7f57cd9a18f9ffe4a18a6c"
   },
   "src/L2/ETHLiquidity.sol": {
     "initCodeHash": "0x713c18f95a6a746d0703f475f3ae10c106c9b9ecb64d881a2e61b8969b581371",
@@ -68,16 +68,16 @@
     "sourceCodeHash": "0xa12ce15ded3cca681b2fc9facaebbb45d740dd6f9c9496333c1c46689c9a2d99"
   },
   "src/L2/L1Block.sol": {
-    "initCodeHash": "0xa919d2aa76a7ecdfd076e2b1dbece499cc85706075f16eb6fa7b1a0fa7b38c1b",
-    "sourceCodeHash": "0x692cfcbc06dba6328f6e5c6b500741df04e4bdf730b2069aeb5d168355ea7b6f"
+    "initCodeHash": "0xb25ff86c5b199f0e4db9f814f3d107cd929278a39e838c541af79d49d472b646",
+    "sourceCodeHash": "0xa44964dc0178949b83fc4100c03933c6d6f66e9654ce6b4aff5847a889a189d4"
   },
   "src/L2/L1BlockInterop.sol": {
-    "initCodeHash": "0x62e9cc59daaf72066ac20597a666db33e9a7b3f7be71a3d47ea4841a9aca9d07",
-    "sourceCodeHash": "0xe57627347366d74029a0d24f0b45d7b9cf82b81c94681d0f633d5e5c37c8de4a"
+    "initCodeHash": "0xb59a6a62926084b9979e337183ee54b4c4e9ceeda7e39bd70bd7b4228464d2e0",
+    "sourceCodeHash": "0x5681bb385bf1685cb204a612ef8a891e91763e699c7738a3a97b171852d585b5"
   },
   "src/L2/L1FeeVault.sol": {
-    "initCodeHash": "0xbf49824cf37e201181484a8a423fcad8f504dc925921a2b28e83398197858dec",
-    "sourceCodeHash": "0xc7cda130f2bb3648e04d5a480082aa1789e16456c1280954d822b05d30100b2d"
+    "initCodeHash": "0xc23d0437deb5c2e9f8831b9325c77e9d07467c9286f81c0ef47cfef4e242f96b",
+    "sourceCodeHash": "0x3f0acc4427d6f72debe4393c746b759c7c736f28b8c4f42391de622c9be3bcb3"
   },
   "src/L2/L2CrossDomainMessenger.sol": {
     "initCodeHash": "0xc496495496b96ea0eaf417c5e56b295836c12db3e6aafe2e607563e7a50b5b65",
@@ -88,40 +88,40 @@
     "sourceCodeHash": "0xf8569c75b801f38f8a5a41e94e90f159ddc5f5412804b26e3e564755a50631b8"
   },
   "src/L2/L2StandardBridge.sol": {
-    "initCodeHash": "0xcb4aa19f0cd43a35cb5c65f26c3cfd7c41f1d1e5bcc15aef6096d385df7272c9",
-    "sourceCodeHash": "0x89771b53b7f6e64d943afb2a4bf15395efcf20d5302b76a18e52fa7cce8cdc56"
+    "initCodeHash": "0x959ce0daeb14884127cff4d701b294fb29b5d7c2d890ec4fdf704c451164811e",
+    "sourceCodeHash": "0xd5f91687a178254714203c702afe0c2343c45c4684b914aa873dcb641e73e725"
   },
   "src/L2/L2StandardBridgeInterop.sol": {
-    "initCodeHash": "0xc4eaece28d2cfca3c51247c3cce320a167a83c7fd13aea5736549d2b25e0b139",
-    "sourceCodeHash": "0x9e80044adf5f83c30b520ee153b75be5a152081c9e1271e7e618ecfccd1fb4ac"
+    "initCodeHash": "0x745f5e3a0deb6cd8fa5a339c83cc91f9ce63de570a7ed23e2da645bebaa79494",
+    "sourceCodeHash": "0x0ca6d8900a02c213acca44c8cb56df816fa1bebd6903a9ea6d4c21525c936c12"
   },
   "src/L2/L2ToL1MessagePasser.sol": {
-    "initCodeHash": "0x13fe3729beb9ed966c97bef09acb9fe5043fe651d453145073d05f2567fa988d",
-    "sourceCodeHash": "0xd08a2e6514dbd44e16aa312a1b27b2841a9eab5622cbd05a39c30f543fad673c"
+    "initCodeHash": "0xe65929ad618380e7f005f042a0a9c8e662ad10d6e1c53bfb7f518a54b848fd79",
+    "sourceCodeHash": "0xd61a1face234756e99b7ab8383eef40e62833a91f727a77997d6f0e384526637"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0xc1c80c662aafebb639f62f17d9fefd6954947fd43dc31c278950727491471a94",
-    "sourceCodeHash": "0xac12ab96ffe91c75bfe74768271a725e1cbe3996b16284171440dd71bcc215b6"
+    "initCodeHash": "0x085c83fd07ce54b9d007e548008dd9d4c31d19cae9b9ca3aa1496191f84499fa",
+    "sourceCodeHash": "0x20d6a4f42b3169c17f938cfe479de7bd558c6ded816e1fcfddcdc5d86583b42b"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
-    "initCodeHash": "0x22fed5371ad9b4c2711ce5cbee889d332887aa5f5ff6b37e36c31acefe3bbeee",
-    "sourceCodeHash": "0xf68baaee0a09ea51d5a4e821df79976c0914369ebc8e5fd27bbbf89072254fc8"
+    "initCodeHash": "0x0e76b7ffa8af16f1bc5f74a55eb3ed64016228032b67c5f45afa7fd6fe4acf7e",
+    "sourceCodeHash": "0x92f370d0e167b7cec0deaded71d9c4a5a8303a2b921320123d3c32eeca1cc100"
   },
   "src/L2/OptimismSuperchainERC20Beacon.sol": {
-    "initCodeHash": "0x23dba3ceb9e58646695c306996c9e15251ac79acc6339c1a93d10a4c79da6dab",
-    "sourceCodeHash": "0xf4379e49665823c877f5732f35068435ce06e2394fce6910a5e113d16cdc9f95"
+    "initCodeHash": "0xb032e99f5c205c8b474da89887e350277cdd05b99ee28374b97bfae18ef7a72c",
+    "sourceCodeHash": "0xc9ec1a022f82a3b463fad11d2cd6ade74bb0801ae797fdc0494840587fc595dd"
   },
   "src/L2/OptimismSuperchainERC20Factory.sol": {
-    "initCodeHash": "0x18a362c57f08b611db98dfde96121385e938f995c84e3547c1c03fd49f9db2fd",
-    "sourceCodeHash": "0x450cd89d0aae7bbc85ff57a14a6d3468c24c6743f25943f6d895d34b1456c456"
+    "initCodeHash": "0xe6a098346699c3df248050fc3301197661d391f8e4849a93f00afeac17cae317",
+    "sourceCodeHash": "0x51980d07914ae48fd632aa54df24f3d6e2d335d0223a1d2ddd4ca5ced1797c16"
   },
   "src/L2/SequencerFeeVault.sol": {
-    "initCodeHash": "0xcaadbf08057b5d47f7704257e9385a29e42a7a08c818646d109c5952d3d35218",
-    "sourceCodeHash": "0x05bbc6039e5a9ff38987e7b9b89c69e2ee8aa4b7ca20dd002ea1bbd3d70f27f3"
+    "initCodeHash": "0xf05acc7dcb80474e48ea36a3511bd4cbb35da065ed6280918b87a47c13a22cfc",
+    "sourceCodeHash": "0x3c0d09bd700b9db218445ecce76006574cabfe8c40c2156a6787c8a1360d7835"
   },
   "src/L2/SuperchainERC20.sol": {
     "initCodeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-    "sourceCodeHash": "0x77adb9ea7a9e9cf3dc5943607dcacacf7a703bd110d2a5627e7075b766aae29f"
+    "sourceCodeHash": "0x4c40f0249c1c9871efd2e957dd9c769cc52b88d896385dd4d547f82eb06284be"
   },
   "src/L2/SuperchainTokenBridge.sol": {
     "initCodeHash": "0x1cd2afdae6dd1b6ebc17f1d529e7d74c9b8b21b02db8589b8e389e2d5523d775",
@@ -136,20 +136,20 @@
     "sourceCodeHash": "0x0fa0633a769e73f5937514c0003ba7947a1c275bbe5b85d78879c42f0ed8895b"
   },
   "src/asterisc/RISCV.sol": {
-    "initCodeHash": "0x6b4323061187f2c8efe8de43bf1ecdc0798e2d95ad69470ed4151dadc094fedf",
-    "sourceCodeHash": "0xd824f1ead87a1214fa8a4b435f493a80b7340ec2c959d2c1e1e9e8c062a42c4a"
+    "initCodeHash": "0x8d47aa0b81d7fe6bd0aeac18f26d7c0b285f58740bb9d92dac0ddf706c85309f",
+    "sourceCodeHash": "0xaebcda0a16da65fc7833672073ea6872c40d1ba722f0a6515c4a293e380f96c6"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0xa3cbf121bad13c00227ea4fef128853d9a86b7ec9158de894f99b58d38d7630a",
-    "sourceCodeHash": "0xd8467700c80b3e62fa37193dc6513bac35282094b686b50e162e157f704dde00"
+    "initCodeHash": "0xb4aec227019dacd6194d6aeb9ca68c23c60b95618d18a4ebc09243514aeb1f05",
+    "sourceCodeHash": "0x4d43b3f2918486aa76d2d59ac42e4f6aa2f58538c7e95a5cb99b63c9588b5f1c"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0xc38c76ab3aad78c81ca01b3235b402614972d6604b22fda1e870f1bf47be1194",
-    "sourceCodeHash": "0x3d38b1924669d1bde756f1306601c764a6d31f428ac72667a3dd194b3388210d"
+    "initCodeHash": "0xe3879b5772820d837bc1c77c32a1200eb26cf901d9302dff9f0e9759331e380e",
+    "sourceCodeHash": "0x1c45a8f4c8c9ded7043d63965cb114d17f801c6cd4d8233cb16838c5f9a02675"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0x93aa8d7f9fd3c22276c0d303a3fefdf8f73cc55807b35e483bba64c92d02aaef",
-    "sourceCodeHash": "0x171d66c651fdad2ac9c287da92689815a5b09589945ada092179508ad2326306"
+    "initCodeHash": "0xa4a761f480a26ec1926c5a8b4831440211c0441bd41d503b0aad189e030d35dc",
+    "sourceCodeHash": "0x7ddcf8584f9bd92abd1eb45bc198f5b0ec54acaf292f60e919d674cc56fb8abc"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",
@@ -172,48 +172,48 @@
     "sourceCodeHash": "0x730eff9147294c115a0a53e7e75771bcc4a517beb48457140ab929a8d1510893"
   },
   "src/legacy/DeployerWhitelist.sol": {
-    "initCodeHash": "0x0b8177ed75b69eddbb9ce6537683f69a9935efed86a1d6faa8feaafbd151c1bd",
-    "sourceCodeHash": "0xc8fe9571fcf8fcb51a4dcb00ffa97f43a9ce811c323c4926e710b28c90a9005f"
+    "initCodeHash": "0xf232863fde5cd65368bcb4a79b41b5a4a09c59ede5070f82fd3f13f681bea7d8",
+    "sourceCodeHash": "0xd8d65492470907907d75574c1260fb349903af22c89098ea091439fc809310a9"
   },
   "src/legacy/L1BlockNumber.sol": {
     "initCodeHash": "0x542955f1a84b304eaf291f76633b03e4c87c2654f7eff46c3bea94d27346ea1f",
     "sourceCodeHash": "0x898c239e6367a0971a075df18030a033cdada26983fa8a5cd6e7b88ec90d4958"
   },
   "src/legacy/LegacyMessagePasser.sol": {
-    "initCodeHash": "0xefc6ed9e325c2d614ea0d28c3eabfff1b345f7c6054e90253c6a091c29508267",
-    "sourceCodeHash": "0xaa08a61448f485b277af57251d2089cc6a80ce0a763bf7184d48ffed5034ef69"
+    "initCodeHash": "0x11802672c929c4e92faeb7bee66617574b249b60a210f11ce29a5caa0e3d6bac",
+    "sourceCodeHash": "0x851ab8a2cd40798fce25698d4cfdb9dbf9c4c1e53f3cc8d1a325a6dd368807b0"
   },
   "src/safe/DeputyGuardianModule.sol": {
     "initCodeHash": "0xd95e562f395d4eb6e332f4474dffab660ada9e9da7c79f58fb6052278e0904df",
     "sourceCodeHash": "0x45daabe094de0287e244e6fea4f1887b9adc09b07c47dc77361b1678645a1470"
   },
   "src/safe/LivenessGuard.sol": {
-    "initCodeHash": "0x9ac0b039b1591f7c00cf11cb758d118c9b42e6e08250b619d6b6fd605a43d5ee",
-    "sourceCodeHash": "0xc1a968b0c6fbc4d82c2821c917b273feaaa224d258886b394416e84ee250d026"
+    "initCodeHash": "0xd449cef5d62dea387f5c4fd18382f5427532c443d29b3dcf0f645dbb6756ccb4",
+    "sourceCodeHash": "0x745f72d907d9a8e95b5fdfe9fd9a910456f2417c42b81b0a3a764c20c13d7ed7"
   },
   "src/safe/LivenessModule.sol": {
-    "initCodeHash": "0xcfccdd9e423c95a0ddc6e09ccb6333d5fc8429ed2b8fc872f1290d392ae13aad",
-    "sourceCodeHash": "0xd1479c60087f352385b6d5379ef3cc07839f671d617626b4c94ece91da781ef2"
+    "initCodeHash": "0xb16fd6cdfe5125dbb065ab1b6fcd7a58665e9fc4907b1089c8a496576be5d4f7",
+    "sourceCodeHash": "0x17e70b1d4ffc876fde920eaeb5874ff8a39dfa03b1e24044dc73aff2820db1ef"
   },
   "src/universal/OptimismMintableERC20.sol": {
-    "initCodeHash": "0x9cd677275b175812f1d5f90a127dbf7b3592714fd842a7a0de3988d716ca3eac",
-    "sourceCodeHash": "0x5611d8082f68af566554d7f09640b4b1f0e3efee4da1372b68fc7fc538a35ac7"
+    "initCodeHash": "0xc97c9502af8e83f1d9bd81f711c3d73db298dfdba465f463b3faa43a8208ed47",
+    "sourceCodeHash": "0x7e7ada21d7e5fb92521dad343ff71da9bdabd6e04882c81b8c8f74854f755ba6"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {
-    "initCodeHash": "0x03ad07bd7f89a29f1850fa8b5d377daf0e1d5aef6cb458a127df520549e8e8e6",
-    "sourceCodeHash": "0xdb6ec93782a4a217475195507740794a4f5553b9032e7ba31dc48b81f579a940"
+    "initCodeHash": "0x4ba75c8864565ac14aa213d2aacda58ce0f82b197fa72393328ac6968edb54fb",
+    "sourceCodeHash": "0xcd09be31be4e0fda6d329bd6ac6dccded3f029514be4908860db4d757ebb7bc7"
   },
   "src/universal/OptimismMintableERC721.sol": {
-    "initCodeHash": "0x8aa309f2676d5267b6c9e411f88dc6e4badce414b8d66b330df3f60e9836380e",
-    "sourceCodeHash": "0x03bf7ad4d2b751bdead9930fc8f89b8e55d40dd4b2f5670fd339e87ae81f8b49"
+    "initCodeHash": "0xc7c5dbc9d19314f8ad00bd867a9186d04e7471502671c3daa23d90c1e3e16320",
+    "sourceCodeHash": "0x089ee309a0d9061646ab7a2781f80e5d94a74cc38fe808a3696e3984683d0a89"
   },
   "src/universal/OptimismMintableERC721Factory.sol": {
-    "initCodeHash": "0x5ea977ba35558c3b75bebe28900548c763d205e40d6cf7660292b8e96bf3aea8",
-    "sourceCodeHash": "0x063ca3a0a2e3c592173af6157e383b5aaeff752000f98648a5c71260bb26590a"
+    "initCodeHash": "0xf62b7daa5e5005d989d9afb177c314868bef48641a7069ddf1d6c6656e064929",
+    "sourceCodeHash": "0x2ea30e241a348bfdd3dae41375b8a5db8c6eb609650f49a0945e6d453b5b6a41"
   },
   "src/universal/StorageSetter.sol": {
-    "initCodeHash": "0x21b3059e9b13b330f76d02b61f61dcfa3abf3517a0b56afa0895c4b8291740bf",
-    "sourceCodeHash": "0xc1ea12a87e3a7ef9c950f0a41a4e35b60d4d9c4c816ff671dbfca663861c16f4"
+    "initCodeHash": "0x049f3c86965e575a370b14f7f49f3f15436ffb5ee1059615bb708659d7aae7de",
+    "sourceCodeHash": "0x5dc6b0b4ae4ab29085c52f74a4498d8a3d04928b844491749cd7186623e8b967"
   },
   "src/vendor/eas/EAS.sol": {
     "initCodeHash": "0xf96d1ebc530ed95e2dffebcfa2b4a1f18103235e6352d97838b77b7a2c14567b",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
+import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
 import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
@@ -11,16 +14,12 @@ import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
-
 import { IProxyAdmin } from "src/universal/interfaces/IProxyAdmin.sol";
-
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "src/dispute/interfaces/IPermissionedDisputeGame.sol";
-import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
-
 import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
 import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
 import { IOptimismPortal2 } from "src/L1/interfaces/IOptimismPortal2.sol";
@@ -115,8 +114,8 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.21
-    string public constant version = "1.0.0-beta.21";
+    /// @custom:semver 1.0.0-beta.22
+    string public constant version = "1.0.0-beta.22";
 
     /// @notice Represents the interface version so consumers know how to decode the DeployOutput struct
     /// that's emitted in the `Deployed` event. Whenever that struct changes, a new version should be used.

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+
+// Interfaces
 import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
 import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -3,12 +3,14 @@ pragma solidity 0.8.15;
 
 // Contracts
 import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
-import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Unauthorized } from "src/libraries/PortalErrors.sol";
+
+// Interfaces
+import { IL1BlockInterop, ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 /// @custom:proxied true
 /// @title OptimismPortalInterop
@@ -23,9 +25,9 @@ contract OptimismPortalInterop is OptimismPortal2 {
         OptimismPortal2(_proofMaturityDelaySeconds, _disputeGameFinalityDelaySeconds)
     { }
 
-    /// @custom:semver +interop-beta.2
+    /// @custom:semver +interop-beta.3
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.2");
+        return string.concat(super.version(), "+interop-beta.3");
     }
 
     /// @notice Sets static configuration options for the L2 system.
@@ -48,7 +50,7 @@ contract OptimismPortalInterop is OptimismPortal2 {
                 uint256(0), // value
                 uint64(SYSTEM_DEPOSIT_GAS_LIMIT), // gasLimit
                 false, // isCreation,
-                abi.encodeCall(L1BlockInterop.setConfig, (_type, _value))
+                abi.encodeCall(IL1BlockInterop.setConfig, (_type, _value))
             )
         );
     }

--- a/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { Storage } from "src/libraries/Storage.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @notice ProtocolVersion is a numeric identifier of the protocol version.
 type ProtocolVersion is uint256;
@@ -36,8 +41,8 @@ contract ProtocolVersions is OwnableUpgradeable, ISemver {
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1-beta.3
-    string public constant version = "1.0.1-beta.3";
+    /// @custom:semver 1.0.1-beta.4
+    string public constant version = "1.0.1-beta.4";
 
     /// @notice Constructs the ProtocolVersion contract. Cannot set
     ///         the owner to `address(0)` due to the Ownable contract's

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { Storage } from "src/libraries/Storage.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:audit none This contracts is not yet audited.
@@ -36,8 +41,8 @@ contract SuperchainConfig is Initializable, ISemver {
     event ConfigUpdate(UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Constructs the SuperchainConfig contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.15;
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { IOptimismPortalInterop as IOptimismPortal } from "src/L1/interfaces/IOptimismPortalInterop.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
-import { ConfigType } from "src/L2/L1BlockInterop.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
@@ -14,7 +12,9 @@ import { StaticConfig } from "src/libraries/StaticConfig.sol";
 import { Storage } from "src/libraries/Storage.sol";
 
 // Interfaces
+import { IOptimismPortalInterop as IOptimismPortal } from "src/L1/interfaces/IOptimismPortalInterop.sol";
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
+import { ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 /// @custom:proxied true
 /// @title SystemConfigInterop
@@ -68,9 +68,9 @@ contract SystemConfigInterop is SystemConfig {
         Storage.setAddress(DEPENDENCY_MANAGER_SLOT, _dependencyManager);
     }
 
-    /// @custom:semver +interop-beta.4
+    /// @custom:semver +interop-beta.5
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.4");
+        return string.concat(super.version(), "+interop-beta.5");
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.

--- a/packages/contracts-bedrock/src/L1/interfaces/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/interfaces/IOptimismPortalInterop.sol
@@ -7,7 +7,7 @@ import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.sol";
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
 import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
-import { ConfigType } from "src/L2/L1BlockInterop.sol";
+import { ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 interface IOptimismPortalInterop {
     error AlreadyFinalized();

--- a/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000019
@@ -12,8 +16,8 @@ import { Types } from "src/libraries/Types.sol";
 /// @notice The BaseFeeVault accumulates the base fee that is paid by transactions.
 contract BaseFeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.0-beta.3
-    string public constant version = "1.5.0-beta.3";
+    /// @custom:semver 1.5.0-beta.4
+    string public constant version = "1.5.0-beta.4";
 
     /// @notice Constructs the BaseFeeVault contract.
     /// @param _recipient           Wallet that will receive the fees.

--- a/packages/contracts-bedrock/src/L2/CrossDomainOwnable.sol
+++ b/packages/contracts-bedrock/src/L2/CrossDomainOwnable.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+// Libraries
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 /// @title CrossDomainOwnable

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { TransientContext, TransientReentrancyAware } from "src/libraries/TransientContext.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IDependencySet } from "src/L2/interfaces/IDependencySet.sol";
 import { IL1BlockInterop } from "src/L2/interfaces/IL1BlockInterop.sol";
 
@@ -73,8 +76,8 @@ contract CrossL2Inbox is ISemver, TransientReentrancyAware {
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.9
-    string public constant version = "1.0.0-beta.9";
+    /// @custom:semver 1.0.0-beta.10
+    string public constant version = "1.0.0-beta.10";
 
     /// @notice Emitted when a cross chain message is being executed.
     /// @param msgHash Hash of message payload being executed.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Libraries
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -57,9 +60,9 @@ contract L1Block is ISemver, IGasToken {
     /// @notice The latest L1 blob base fee.
     uint256 public blobBaseFee;
 
-    /// @custom:semver 1.5.1-beta.3
+    /// @custom:semver 1.5.1-beta.4
     function version() public pure virtual returns (string memory) {
-        return "1.5.1-beta.3";
+        return "1.5.1-beta.4";
     }
 
     /// @notice Returns the gas paying token, its decimals, name and symbol.

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -49,9 +49,9 @@ contract L1BlockInterop is L1Block {
     /// keccak256(abi.encode(uint256(keccak256("l1Block.identifier.isDeposit")) - 1)) & ~bytes32(uint256(0xff))
     uint256 internal constant IS_DEPOSIT_SLOT = 0x921bd3a089295c6e5540e8fba8195448d253efd6f2e3e495b499b627dc36a300;
 
-    /// @custom:semver +interop-beta.1
+    /// @custom:semver +interop-beta.2
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.1");
+        return string.concat(super.version(), "+interop-beta.2");
     }
 
     /// @notice Returns whether the call was triggered from a a deposit or not.

--- a/packages/contracts-bedrock/src/L2/L1FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/L1FeeVault.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x420000000000000000000000000000000000001A
@@ -12,8 +16,8 @@ import { Types } from "src/libraries/Types.sol";
 /// @notice The L1FeeVault accumulates the L1 portion of the transaction fees.
 contract L1FeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.0-beta.3
-    string public constant version = "1.5.0-beta.3";
+    /// @custom:semver 1.5.0-beta.4
+    string public constant version = "1.5.0-beta.4";
 
     /// @notice Constructs the L1FeeVault contract.
     /// @param _recipient           Wallet that will receive the fees.

--- a/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.15;
 
 // Contracts
 import { StandardBridge } from "src/universal/StandardBridge.sol";
-import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
@@ -11,6 +10,7 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
+import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
 
 /// @custom:proxied true
@@ -58,9 +58,9 @@ contract L2StandardBridge is StandardBridge, ISemver {
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 1.11.1-beta.3
+    /// @custom:semver 1.11.1-beta.4
     function version() public pure virtual returns (string memory) {
-        return "1.11.1-beta.3";
+        return "1.11.1-beta.4";
     }
 
     /// @notice Constructs the L2StandardBridge contract.

--- a/packages/contracts-bedrock/src/L2/L2StandardBridgeInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridgeInterop.sol
@@ -40,9 +40,9 @@ contract L2StandardBridgeInterop is L2StandardBridge {
     event Converted(address indexed from, address indexed to, address indexed caller, uint256 amount);
 
     /// @notice Semantic version.
-    /// @custom:semver +interop-beta.2
+    /// @custom:semver +interop-beta.3
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.2");
+        return string.concat(super.version(), "+interop-beta.3");
     }
 
     /// @notice Converts `amount` of `from` token to `to` token.

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Burn } from "src/libraries/Burn.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
@@ -48,8 +51,8 @@ contract L2ToL1MessagePasser is ISemver {
     /// @param amount Amount of ETh that was burned.
     event WithdrawerBalanceBurnt(uint256 indexed amount);
 
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Allows users to withdraw ETH by sending directly to this contract.
     receive() external payable {

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+// Libraries
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { CrossL2Inbox, Identifier } from "src/L2/CrossL2Inbox.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IDependencySet } from "src/L2/interfaces/IDependencySet.sol";
+import { ICrossL2Inbox, Identifier } from "src/L2/interfaces/ICrossL2Inbox.sol";
 
 /// @notice Thrown when a non-written slot in transient storage is attempted to be read from.
 error NotEntered();
@@ -69,8 +72,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.11
-    string public constant version = "1.0.0-beta.11";
+    /// @custom:semver 1.0.0-beta.12
+    string public constant version = "1.0.0-beta.12";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -164,7 +167,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
         }
 
         // Signal that this is a cross chain call that needs to have the identifier validated
-        CrossL2Inbox(Predeploys.CROSS_L2_INBOX).validateMessage(_id, keccak256(_sentMessage));
+        ICrossL2Inbox(Predeploys.CROSS_L2_INBOX).validateMessage(_id, keccak256(_sentMessage));
 
         // Decode the payload
         (uint256 destination, address target, uint256 nonce, address sender, bytes memory message) =

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { IOptimismSuperchainERC20 } from "src/L2/interfaces/IOptimismSuperchainERC20.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
-import { SuperchainERC20 } from "src/L2/SuperchainERC20.sol";
+// Contracts
 import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
+import { SuperchainERC20 } from "src/L2/SuperchainERC20.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
 import { ZeroAddress, Unauthorized } from "src/libraries/errors/CommonErrors.sol";
+
+// Interfaces
+import { IOptimismSuperchainERC20 } from "src/L2/interfaces/IOptimismSuperchainERC20.sol";
 
 /// @custom:proxied true
 /// @title OptimismSuperchainERC20
@@ -58,8 +63,8 @@ contract OptimismSuperchainERC20 is SuperchainERC20, Initializable {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.10
-    string public constant override version = "1.0.0-beta.10";
+    /// @custom:semver 1.0.0-beta.11
+    string public constant override version = "1.0.0-beta.11";
 
     /// @notice Constructs the OptimismSuperchainERC20 contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
 import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
 
 /// @custom:proxied true
 /// @custom:predeployed 0x4200000000000000000000000000000000000027
@@ -11,8 +14,8 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 /// @notice OptimismSuperchainERC20Beacon is the beacon proxy for the OptimismSuperchainERC20 implementation.
 contract OptimismSuperchainERC20Beacon is IBeacon, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.2
-    string public constant version = "1.0.0-beta.2";
+    /// @custom:semver 1.0.0-beta.3
+    string public constant version = "1.0.0-beta.3";
 
     /// @inheritdoc IBeacon
     function implementation() external pure override returns (address) {

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Factory.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Factory.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
+// Contracts
 import { BeaconProxy } from "@openzeppelin/contracts-v5/proxy/beacon/BeaconProxy.sol";
+import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
+
+// Libraries
 import { CREATE3 } from "@rari-capital/solmate/src/utils/CREATE3.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied
 /// @custom:predeployed 0x4200000000000000000000000000000000000026
@@ -22,8 +27,8 @@ contract OptimismSuperchainERC20Factory is ISemver {
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.4
-    string public constant version = "1.0.0-beta.4";
+    /// @custom:semver 1.0.0-beta.5
+    string public constant version = "1.0.0-beta.5";
 
     /// @notice Mapping of the deployed OptimismSuperchainERC20 to the remote token address.
     ///         This is used to keep track of the token deployments.

--- a/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000011
@@ -12,8 +16,8 @@ import { Types } from "src/libraries/Types.sol";
 /// @notice The SequencerFeeVault is the contract that holds any fees paid to the Sequencer during
 ///         transaction processing and block production.
 contract SequencerFeeVault is FeeVault, ISemver {
-    /// @custom:semver 1.5.0-beta.3
-    string public constant version = "1.5.0-beta.3";
+    /// @custom:semver 1.5.0-beta.4
+    string public constant version = "1.5.0-beta.4";
 
     /// @notice Constructs the SequencerFeeVault contract.
     /// @param _recipient           Wallet that will receive the fees.

--- a/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
@@ -1,21 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { IERC7802, IERC165 } from "src/L2/interfaces/IERC7802.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
+// Contracts
 import { ERC20 } from "@solady-v0.0.245/tokens/ERC20.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Unauthorized } from "src/libraries/errors/CommonErrors.sol";
+
+// Interfaces
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IERC7802, IERC165 } from "src/L2/interfaces/IERC7802.sol";
 
 /// @title SuperchainERC20
 /// @notice A standard ERC20 extension implementing IERC7802 for unified cross-chain fungibility across
 ///         the Superchain. Allows the SuperchainTokenBridge to mint and burn tokens as needed.
 abstract contract SuperchainERC20 is ERC20, IERC7802, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.6
+    /// @custom:semver 1.0.0-beta.7
     function version() external view virtual returns (string memory) {
-        return "1.0.0-beta.6";
+        return "1.0.0-beta.7";
     }
 
     /// @notice Allows the SuperchainTokenBridge to mint tokens.

--- a/packages/contracts-bedrock/src/asterisc/RISCV.sol
+++ b/packages/contracts-bedrock/src/asterisc/RISCV.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Interfaces
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
 
@@ -15,8 +16,8 @@ contract RISCV is IBigStepper {
     IPreimageOracle public oracle;
 
     /// @notice The version of the contract.
-    /// @custom:semver 1.1.0-rc.2
-    string public constant version = "1.1.0-rc.2";
+    /// @custom:semver 1.1.0-rc.3
+    string public constant version = "1.1.0-rc.3";
 
     /// @param _oracle The preimage oracle contract.
     constructor(IPreimageOracle _oracle) {

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
+// Libraries
 import { MIPSInstructions as ins } from "src/cannon/libraries/MIPSInstructions.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { InvalidRMWInstruction } from "src/cannon/libraries/CannonErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 /// @title MIPS
 /// @notice The MIPS contract emulates a single MIPS instruction.
@@ -44,8 +47,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.2.1-beta.7
-    string public constant version = "1.2.1-beta.7";
+    /// @custom:semver 1.2.1-beta.8
+    string public constant version = "1.2.1-beta.8";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
+// Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSSyscalls as sys } from "src/cannon/libraries/MIPSSyscalls.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
@@ -11,6 +10,10 @@ import { VMStatuses } from "src/dispute/lib/Types.sol";
 import {
     InvalidMemoryProof, InvalidRMWInstruction, InvalidSecondMemoryProof
 } from "src/cannon/libraries/CannonErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 /// @title MIPS2
 /// @notice The MIPS2 contract emulates a single MIPS instruction.
@@ -60,8 +63,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.22
-    string public constant version = "1.0.0-beta.22";
+    /// @custom:semver 1.0.0-beta.23
+    string public constant version = "1.0.0-beta.23";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";
+// Libraries
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";
 import { MIPS64Syscalls as sys } from "src/cannon/libraries/MIPS64Syscalls.sol";
 import { MIPS64State as st } from "src/cannon/libraries/MIPS64State.sol";
@@ -12,6 +11,10 @@ import { VMStatuses } from "src/dispute/lib/Types.sol";
 import {
     InvalidMemoryProof, InvalidRMWInstruction, InvalidSecondMemoryProof
 } from "src/cannon/libraries/CannonErrors.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 
 /// @title MIPS64
 /// @notice The MIPS64 contract emulates a single MIPS instruction.
@@ -64,8 +67,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.0.0-beta.4
-    string public constant version = "1.0.0-beta.4";
+    /// @custom:semver 1.0.0-beta.5
+    string public constant version = "1.0.0-beta.5";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";
 import { MIPS64State as st } from "src/cannon/libraries/MIPS64State.sol";
 import { MIPS64Arch as arch } from "src/cannon/libraries/MIPS64Arch.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { InvalidMemoryProof } from "src/cannon/libraries/CannonErrors.sol";
 
 library MIPS64Memory {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";
 
 library MIPS64State {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";
 import { MIPS64State as st } from "src/cannon/libraries/MIPS64State.sol";
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { InvalidMemoryProof } from "src/cannon/libraries/CannonErrors.sol";
 
 library MIPSMemory {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";
 
 library MIPSState {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";
 import { MIPSState as st } from "src/cannon/libraries/MIPSState.sol";
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
 import { GameType, Hash, Claim } from "src/dispute/lib/LibUDT.sol";
 
 ////////////////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
 import { Position } from "src/dispute/lib/LibPosition.sol";
 
 using LibClaim for Claim global;

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
 import {
     Position,
     Hash,

--- a/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import { ERC20Votes, ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";

--- a/packages/contracts-bedrock/src/legacy/AddressManager.sol
+++ b/packages/contracts-bedrock/src/legacy/AddressManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @custom:legacy true

--- a/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
+++ b/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:legacy true
@@ -41,8 +42,8 @@ contract DeployerWhitelist is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Adds or removes an address from the deployment whitelist.
     /// @param _deployer      Address to update permissions for.

--- a/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
 import { IL1ChugSplashDeployer } from "src/legacy/interfaces/IL1ChugSplashProxy.sol";
 
 /// @custom:legacy true

--- a/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @custom:legacy true
@@ -14,8 +15,8 @@ contract LegacyMessagePasser is ISemver {
     mapping(bytes32 => bool) public sentMessages;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1-beta.1
-    string public constant version = "1.1.1-beta.1";
+    /// @custom:semver 1.1.1-beta.2
+    string public constant version = "1.1.1-beta.2";
 
     /// @notice Passes a message to L1.
     /// @param _message Message to pass to L1.

--- a/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// Interfaces
 import { ILegacyMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 
 /// @title LegacyMintableERC20

--- a/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { AddressManager } from "src/legacy/AddressManager.sol";
 
 /// @custom:legacy true

--- a/packages/contracts-bedrock/src/libraries/Arithmetic.sol
+++ b/packages/contracts-bedrock/src/libraries/Arithmetic.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import { FixedPointMathLib } from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Interfaces
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
 
 /// @title Constants

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";

--- a/packages/contracts-bedrock/src/libraries/GasPayingToken.sol
+++ b/packages/contracts-bedrock/src/libraries/GasPayingToken.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
+import { LibString } from "@solady/utils/LibString.sol";
 import { Storage } from "src/libraries/Storage.sol";
 import { Constants } from "src/libraries/Constants.sol";
-import { LibString } from "@solady/utils/LibString.sol";
 
 /// @title IGasToken
 /// @notice Implemented by contracts that are aware of the custom gas token used

--- a/packages/contracts-bedrock/src/libraries/Hashing.sol
+++ b/packages/contracts-bedrock/src/libraries/Hashing.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 

--- a/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
+++ b/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
+// Libraries
 import {
     EmptyItem,
     UnexpectedString,
@@ -8,7 +9,7 @@ import {
     ContentLengthMismatch,
     InvalidHeader,
     UnexpectedList
-} from "./RLPErrors.sol";
+} from "src/libraries/rlp/RLPErrors.sol";
 
 /// @custom:attribution https://github.com/hamdiallam/Solidity-RLP
 /// @title RLPReader

--- a/packages/contracts-bedrock/src/libraries/trie/MerkleTrie.sol
+++ b/packages/contracts-bedrock/src/libraries/trie/MerkleTrie.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Bytes } from "../Bytes.sol";
-import { RLPReader } from "../rlp/RLPReader.sol";
+// Libraries
+import { Bytes } from "src/libraries/Bytes.sol";
+import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 
 /// @title MerkleTrie
 /// @notice MerkleTrie is a small library for verifying standard Ethereum Merkle-Patricia trie

--- a/packages/contracts-bedrock/src/libraries/trie/SecureMerkleTrie.sol
+++ b/packages/contracts-bedrock/src/libraries/trie/SecureMerkleTrie.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { MerkleTrie } from "./MerkleTrie.sol";
+// Libraries
+import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";
 
 /// @title SecureMerkleTrie
 /// @notice SecureMerkleTrie is a thin wrapper around the MerkleTrie library that hashes the input

--- a/packages/contracts-bedrock/src/periphery/AssetReceiver.sol
+++ b/packages/contracts-bedrock/src/periphery/AssetReceiver.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Contracts
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
-import { Transactor } from "./Transactor.sol";
+import { Transactor } from "src/periphery/Transactor.sol";
 
 /// @title AssetReceiver
 /// @notice AssetReceiver is a minimal contract for receiving funds assets in the form of either

--- a/packages/contracts-bedrock/src/periphery/Transactor.sol
+++ b/packages/contracts-bedrock/src/periphery/Transactor.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// Contracts
 import { Owned } from "@rari-capital/solmate/src/auth/Owned.sol";
 
 /// @title Transactor

--- a/packages/contracts-bedrock/src/periphery/TransferOnion.sol
+++ b/packages/contracts-bedrock/src/periphery/TransferOnion.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// Libraries
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title  TransferOnion

--- a/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { AssetReceiver } from "../AssetReceiver.sol";
-import { IDripCheck } from "./IDripCheck.sol";
+// Contracts
+import { AssetReceiver } from "src/periphery/AssetReceiver.sol";
+
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title Drippie
 /// @notice Drippie is a system for managing automated contract interactions. A specific interaction

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckBalanceLow
 /// @notice DripCheck for checking if an account's balance is below a given threshold.

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
 import { IGelatoTreasury } from "src/vendor/interfaces/IGelatoTreasury.sol";
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckGelatoLow
 /// @notice DripCheck for checking if an account's Gelato ETH balance is below some threshold.

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckSecrets
 /// @notice DripCheck that checks if specific secrets exist (or not). Supports having a secret that

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IDripCheck } from "../IDripCheck.sol";
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title CheckTrue
 /// @notice DripCheck that always returns true.

--- a/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IFaucetAuthModule } from "src/periphery/faucet/authmodules/IFaucetAuthModule.sol";
-import { SafeCall } from "src/libraries/SafeCall.sol";
+// Contracts
 import { SafeSend } from "src/universal/SafeSend.sol";
+
+// Libraries
+import { SafeCall } from "src/libraries/SafeCall.sol";
+
+// Interfaces
+import { IFaucetAuthModule } from "src/periphery/faucet/authmodules/IFaucetAuthModule.sol";
 
 /// @title  Faucet
 /// @notice Faucet contract that drips ETH to users.

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
-import { IFaucetAuthModule } from "./IFaucetAuthModule.sol";
-import { Faucet } from "../Faucet.sol";
+
+// Interfaces
+import { IFaucetAuthModule } from "src/periphery/faucet/authmodules/IFaucetAuthModule.sol";
+import { Faucet } from "src/periphery/faucet/Faucet.sol";
 
 /// @title  AdminFaucetAuthModule
 /// @notice FaucetAuthModule that allows an admin to sign off on a given faucet drip. Takes an admin

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Faucet } from "../Faucet.sol";
+// Contracts
+import { Faucet } from "src/periphery/faucet/Faucet.sol";
 
 /// @title  IFaucetAuthModule
 /// @notice Interface for faucet authentication modules.

--- a/packages/contracts-bedrock/src/safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessGuard.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Safe
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Guard as BaseGuard } from "safe-contracts/base/GuardManager.sol";
-import { SafeSigners } from "src/safe/SafeSigners.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+
+// Libraries
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { SafeSigners } from "src/safe/SafeSigners.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title LivenessGuard
 /// @notice This Guard contract is used to track the liveness of Safe owners.
@@ -25,8 +30,8 @@ contract LivenessGuard is ISemver, BaseGuard {
     event OwnerRecorded(address owner);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1-beta.2
-    string public constant version = "1.0.1-beta.2";
+    /// @custom:semver 1.0.1-beta.3
+    string public constant version = "1.0.1-beta.3";
 
     /// @notice The safe account for which this contract will be the guard.
     Safe internal immutable SAFE;

--- a/packages/contracts-bedrock/src/safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Safe
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
+
+// Contracts
 import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title LivenessModule
@@ -53,8 +58,8 @@ contract LivenessModule is ISemver {
     uint256 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.1-beta.1
-    string public constant version = "1.2.1-beta.1";
+    /// @custom:semver 1.2.1-beta.2
+    string public constant version = "1.2.1-beta.2";
 
     // Constructor to initialize the Safe and baseModule instances
     constructor(

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { Hashing } from "src/libraries/Hashing.sol";

--- a/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+// Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+// Libraries
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+// Interfaces
+import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
 
 /// @title ERC721Bridge
 /// @notice ERC721Bridge is a base contract for the L1 and L2 ERC721 bridges.

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
+
+// Libraries
+import { Preinstalls } from "src/libraries/Preinstalls.sol";
+
+// Interfaces
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IOptimismMintableERC20 } from "src/universal/interfaces/IOptimismMintableERC20.sol";
 import { ILegacyMintableERC20 } from "src/universal/interfaces/ILegacyMintableERC20.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { Preinstalls } from "src/libraries/Preinstalls.sol";
 
 /// @title OptimismMintableERC20
 /// @notice OptimismMintableERC20 is a standard extension of the base ERC20 token contract designed
@@ -42,8 +47,8 @@ contract OptimismMintableERC20 is ERC20Permit, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.0-beta.2
-    string public constant version = "1.4.0-beta.2";
+    /// @custom:semver 1.4.0-beta.3
+    string public constant version = "1.4.0-beta.3";
 
     /// @notice Getter function for the permit2 address. It deterministically deployed
     ///         so it will always be at the same address. It is also included as a preinstall,

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IOptimismERC20Factory } from "src/L2/interfaces/IOptimismERC20Factory.sol";
 
 /// @custom:proxied true
@@ -48,8 +51,8 @@ contract OptimismMintableERC20Factory is ISemver, Initializable, IOptimismERC20F
     ///         the OptimismMintableERC20 token contract since this contract
     ///         is responsible for deploying OptimismMintableERC20 contracts.
     /// @notice Semantic version.
-    /// @custom:semver 1.10.1-beta.4
-    string public constant version = "1.10.1-beta.4";
+    /// @custom:semver 1.10.1-beta.5
+    string public constant version = "1.10.1-beta.5";
 
     /// @notice Constructs the OptimismMintableERC20Factory contract.
     constructor() {

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+// Libraries
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { IOptimismMintableERC721 } from "src/universal/interfaces/IOptimismMintableERC721.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
+import { IOptimismMintableERC721 } from "src/universal/interfaces/IOptimismMintableERC721.sol";
 
 /// @title OptimismMintableERC721
 /// @notice This contract is the remote representation for some token that lives on another network,
@@ -41,8 +46,8 @@ contract OptimismMintableERC721 is ERC721Enumerable, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1-beta.3
-    string public constant version = "1.3.1-beta.3";
+    /// @custom:semver 1.3.1-beta.4
+    string public constant version = "1.3.1-beta.4";
 
     /// @param _bridge        Address of the bridge on this network.
     /// @param _remoteChainId Chain ID where the remote token is deployed.

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Contracts
 import { OptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";
+
+// Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title OptimismMintableERC721Factory
@@ -25,8 +28,8 @@ contract OptimismMintableERC721Factory is ISemver {
     event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.1-beta.4
-    string public constant version = "1.4.1-beta.4";
+    /// @custom:semver 1.4.1-beta.5
+    string public constant version = "1.4.1-beta.5";
 
     /// @notice The semver MUST be bumped any time that there is a change in
     ///         the OptimismMintableERC721 token contract since this contract

--- a/packages/contracts-bedrock/src/universal/Proxy.sol
+++ b/packages/contracts-bedrock/src/universal/Proxy.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Libraries
 import { Constants } from "src/libraries/Constants.sol";
 
 /// @title Proxy

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+// Contracts
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+// Libraries
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
+import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IOptimismMintableERC20 } from "src/universal/interfaces/IOptimismMintableERC20.sol";
 import { ILegacyMintableERC20 } from "src/universal/interfaces/ILegacyMintableERC20.sol";
 import { ICrossDomainMessenger } from "src/universal/interfaces/ICrossDomainMessenger.sol";
-import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
-import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import { Constants } from "src/libraries/Constants.sol";
 
 /// @custom:upgradeable
 /// @title StandardBridge
@@ -294,7 +298,7 @@ abstract contract StandardBridge is Initializable {
                 "StandardBridge: wrong remote token for Optimism Mintable ERC20 local token"
             );
 
-            OptimismMintableERC20(_localToken).mint(_to, _amount);
+            IOptimismMintableERC20(_localToken).mint(_to, _amount);
         } else {
             deposits[_localToken][_remoteToken] = deposits[_localToken][_remoteToken] - _amount;
             IERC20(_localToken).safeTransfer(_to, _amount);
@@ -364,7 +368,7 @@ abstract contract StandardBridge is Initializable {
                 "StandardBridge: wrong remote token for Optimism Mintable ERC20 local token"
             );
 
-            OptimismMintableERC20(_localToken).burn(_from, _amount);
+            IOptimismMintableERC20(_localToken).burn(_from, _amount);
         } else {
             IERC20(_localToken).safeTransferFrom(_from, address(this), _amount);
             deposits[_localToken][_remoteToken] = deposits[_localToken][_remoteToken] + _amount;

--- a/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ISemver } from "src/universal/interfaces/ISemver.sol";
+// Libraries
 import { Storage } from "src/libraries/Storage.sol";
+
+// Interfaces
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title StorageSetter
 /// @notice A simple contract that allows setting arbitrary storage slots.
@@ -16,8 +19,8 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.1-beta.2
-    string public constant version = "1.2.1-beta.2";
+    /// @custom:semver 1.2.1-beta.3
+    string public constant version = "1.2.1-beta.3";
 
     /// @notice Stores a bytes32 `_value` at `_slot`. Any storage slots that
     ///         are packed should be set through this interface.

--- a/packages/contracts-bedrock/src/vendor/eas/resolver/ISchemaResolver.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/resolver/ISchemaResolver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Attestation } from "../Common.sol";
+import { Attestation } from "src/vendor/eas/Common.sol";
 
 /// @title ISchemaResolver
 /// @notice The interface of an optional schema resolver.

--- a/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
@@ -9,12 +9,8 @@ import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import "src/libraries/PortalErrors.sol";
 
-// Target contract dependencies
-import "src/libraries/PortalErrors.sol";
-import { OptimismPortalInterop } from "src/L1/OptimismPortalInterop.sol";
-import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
-
 // Interfaces
+import { IL1BlockInterop, ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 import { IOptimismPortalInterop } from "src/L1/interfaces/IOptimismPortalInterop.sol";
 
 contract OptimismPortalInterop_Test is CommonTest {
@@ -35,7 +31,7 @@ contract OptimismPortalInterop_Test is CommonTest {
             _mint: 0,
             _gasLimit: 200_000,
             _isCreation: false,
-            _data: abi.encodeCall(L1BlockInterop.setConfig, (ConfigType.SET_GAS_PAYING_TOKEN, _value))
+            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.SET_GAS_PAYING_TOKEN, _value))
         });
 
         vm.prank(address(_optimismPortalInterop().systemConfig()));
@@ -58,7 +54,7 @@ contract OptimismPortalInterop_Test is CommonTest {
             _mint: 0,
             _gasLimit: 200_000,
             _isCreation: false,
-            _data: abi.encodeCall(L1BlockInterop.setConfig, (ConfigType.ADD_DEPENDENCY, _value))
+            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.ADD_DEPENDENCY, _value))
         });
 
         vm.prank(address(_optimismPortalInterop().systemConfig()));
@@ -81,7 +77,7 @@ contract OptimismPortalInterop_Test is CommonTest {
             _mint: 0,
             _gasLimit: 200_000,
             _isCreation: false,
-            _data: abi.encodeCall(L1BlockInterop.setConfig, (ConfigType.REMOVE_DEPENDENCY, _value))
+            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.REMOVE_DEPENDENCY, _value))
         });
 
         vm.prank(address(_optimismPortalInterop().systemConfig()));

--- a/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfigInterop.t.sol
@@ -6,7 +6,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { ConfigType } from "src/L2/L1BlockInterop.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
@@ -17,6 +16,7 @@ import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
 import { ISystemConfigInterop } from "src/L1/interfaces/ISystemConfigInterop.sol";
 import { IOptimismPortalInterop } from "src/L1/interfaces/IOptimismPortalInterop.sol";
+import { ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 contract SystemConfigInterop_Test is CommonTest {
     /// @notice Marked virtual to be overridden in

--- a/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
-
-// Target contract dependencies
-import { L1BlockInterop, ConfigType } from "src/L2/L1BlockInterop.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import "src/libraries/L1BlockErrors.sol";
+
+// Interfaces
+import { IL1BlockInterop, ConfigType } from "src/L2/interfaces/IL1BlockInterop.sol";
 
 contract L1BlockInteropTest is CommonTest {
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
@@ -199,8 +199,8 @@ contract L1BlockInteropTest is CommonTest {
     }
 
     /// @dev Returns the L1BlockInterop instance.
-    function _l1BlockInterop() internal view returns (L1BlockInterop) {
-        return L1BlockInterop(address(l1Block));
+    function _l1BlockInterop() internal view returns (IL1BlockInterop) {
+        return IL1BlockInterop(address(l1Block));
     }
 }
 
@@ -261,7 +261,7 @@ contract L1BlockInteropSetL1BlockValuesInterop_Test is L1BlockInteropTest {
 
         vm.prank(_l1BlockInterop().DEPOSITOR_ACCOUNT());
         (bool success,) = address(l1Block).call(
-            abi.encodePacked(L1BlockInterop.setL1BlockValuesInterop.selector, setValuesEcotoneCalldata)
+            abi.encodePacked(IL1BlockInterop.setL1BlockValuesInterop.selector, setValuesEcotoneCalldata)
         );
         assertTrue(success, "function call failed");
 

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -10,7 +10,6 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 
 // Target contract
-import { CrossL2Inbox, Identifier } from "src/L2/CrossL2Inbox.sol";
 import {
     L2ToL2CrossDomainMessenger,
     NotEntered,
@@ -26,6 +25,9 @@ import {
     IDependencySet,
     InvalidChainId
 } from "src/L2/L2ToL2CrossDomainMessenger.sol";
+
+// Interfaces
+import { ICrossL2Inbox, Identifier } from "src/L2/interfaces/ICrossL2Inbox.sol";
 
 /// @title L2ToL2CrossDomainMessengerWithModifiableTransientStorage
 /// @dev L2ToL2CrossDomainMessenger contract with methods to modify the transient storage.
@@ -264,7 +266,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -308,7 +310,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -371,7 +373,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -452,7 +454,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -534,7 +536,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -573,7 +575,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -615,7 +617,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -665,7 +667,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 
@@ -715,7 +717,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure the CrossL2Inbox validates this message
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(CrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
+            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
             returnData: ""
         });
 

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -4,16 +4,16 @@ pragma solidity 0.8.15;
 // Testing
 import { Test } from "forge-std/Test.sol";
 
-// Contracts
-import { IL1BlockNumber } from "src/legacy/interfaces/IL1BlockNumber.sol";
-import { L1Block } from "src/L2/L1Block.sol";
-
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
+// Interfaces
+import { IL1BlockNumber } from "src/legacy/interfaces/IL1BlockNumber.sol";
+import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
+
 contract L1BlockNumberTest is Test {
-    L1Block lb;
+    IL1Block lb;
     IL1BlockNumber bn;
 
     uint64 constant number = 99;
@@ -21,7 +21,7 @@ contract L1BlockNumberTest is Test {
     /// @dev Sets up the test suite.
     function setUp() external {
         vm.etch(Predeploys.L1_BLOCK_ATTRIBUTES, vm.getDeployedCode("L1Block.sol:L1Block"));
-        lb = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
+        lb = IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
         bn = IL1BlockNumber(
             DeployUtils.create1({
                 _name: "L1BlockNumber",


### PR DESCRIPTION
Cleans up import statments in all contracts within the src/ directory. We should probably add a semgrep rule or a check that confirms that everything looks good. I'll leave that part for another commit.