### PR TITLE
ci: upload `go-tests` test results to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ orbs:
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@4.10.1
   shellcheck: circleci/shellcheck@3.2.0
+  codecov: codecov/codecov@5.0.3
 commands:
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
@@ -202,10 +203,10 @@ jobs:
                   gotestsum --format=testname --junitfile=../tmp/test-results/cannon-32.xml --jsonfile=../tmp/testlogs/log-32.json \
                   -- -parallel=$(nproc) -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage-32.out ./...
                 working_directory: cannon
-            - run:
-                name: Upload Cannon coverage
-                command: codecov --verbose --clean --flags cannon-go-tests-32 -f ./coverage-32.out
-                working_directory: cannon
+            - codecov/upload:
+                disable_search: true
+                files: ./cannon/coverage-32.out
+                flags: cannon-go-tests-32
       - when:
           condition:
             equal: [64, <<parameters.mips_word_size>>]
@@ -217,10 +218,10 @@ jobs:
                   gotestsum --format=testname --junitfile=../tmp/test-results/cannon-64.xml --jsonfile=../tmp/testlogs/log-64.json \
                   -- --tags=cannon64 -parallel=$(nproc) -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage-64.out ./...
                 working_directory: cannon
-            - run:
-                name: Upload Cannon coverage
-                command: codecov --verbose --clean --flags cannon-go-tests-64 -f ./coverage-64.out
-                working_directory: cannon
+            - codecov/upload:
+                disable_search: true
+                files: ./cannon/coverage-64.out
+                flags: cannon-go-tests-64
       - store_test_results:
           path: ./tmp/test-results
       - store_artifacts:
@@ -606,11 +607,10 @@ jobs:
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
-      - run:
-          name: upload coverage
-          command: codecov --verbose --clean --flags contracts-bedrock-tests
-          environment:
-            FOUNDRY_PROFILE: ci
+      - codecov/upload:
+          disable_search: true
+          files: ./packages/contracts-bedrock/coverage/lcov.info
+          flags: contracts-bedrock-tests
 
   contracts-bedrock-tests:
     docker:
@@ -903,7 +903,7 @@ jobs:
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
             mkdir -p ./tmp/test-results && mkdir -p ./tmp/testlogs
-            
+
             cd op-e2e && make pre-test && cd ..
 
             packages=(
@@ -920,7 +920,7 @@ jobs:
             export ENABLE_ANVIL=true
             export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
             export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
-            
+
             <<parameters.environment_overrides>>
 
             gotestsum --format=testname \
@@ -929,6 +929,9 @@ jobs:
               --rerun-fails=2 \
               --packages="$formatted_packages" \
               -- -coverprofile=coverage.out -timeout=60m
+      - codecov/upload:
+          disable_search: true
+          files: ./coverage.out
       - store_test_results:
           path: ./tmp/test-results
       - store_artifacts:


### PR DESCRIPTION
Closes #12999

I have added the relevant token to our CI environment following [these instructions. ](https://docs.codecov.com/docs/codecov-tokens)