### PR TITLE
cannon: Bump step count for 64-bit map_test

### DIFF
--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -157,7 +157,7 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 				"Map test passed",
 			},
 			programName: "mt-map",
-			steps:       100_000_000,
+			steps:       150_000_000,
 		},
 		{
 			name: "pool test",


### PR DESCRIPTION
Fix flakes on CCI