### PR TITLE
op-batcher: Don't log DA post failures on context cancel

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -782,7 +782,11 @@ func (l *BatchSubmitter) publishToAltDAAndL1(txdata txData, queue *txmgr.Queue[t
 		// So we prefer to mimic the behavior of txmgr and cancel all pending DA/txmgr requests when the batcher is stopped.
 		comm, err := l.AltDA.SetInput(l.shutdownCtx, txdata.CallData())
 		if err != nil {
-			l.Log.Error("Failed to post input to Alt DA", "error", err)
+			// Don't log context cancelled events because they are expected,
+			// and can happen after tests complete which causes a panic.
+			if !errors.Is(err, context.Canceled) {
+				l.Log.Error("Failed to post input to Alt DA", "error", err)
+			}
 			// requeue frame if we fail to post to the DA Provider so it can be retried
 			// note: this assumes that the da server caches requests, otherwise it might lead to resubmissions of the blobs
 			l.recordFailedDARequest(txdata.ID(), err)

--- a/op-e2e/system/altda/concurrent_test.go
+++ b/op-e2e/system/altda/concurrent_test.go
@@ -34,7 +34,9 @@ func TestBatcherConcurrentAltDARequests(t *testing.T) {
 	cfg.DisableBatcher = true
 	sys, err := cfg.Start(t)
 	require.NoError(t, err, "Error starting up system")
-	defer sys.Close()
+	t.Cleanup(func() {
+		sys.Close()
+	})
 
 	// make every request take 5 seconds, such that only concurrent requests will be able to make progress fast enough
 	sys.FakeAltDAServer.SetPutRequestLatency(5 * time.Second)


### PR DESCRIPTION
This was causing flakes.
