### PR TITLE
op-node: Noop RemovePeer when closing

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -346,6 +346,9 @@ func (s *SyncClient) AddPeer(id peer.ID) {
 func (s *SyncClient) RemovePeer(id peer.ID) {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
+	if s.closingPeers {
+		return
+	}
 	cancel, ok := s.peers[id]
 	if !ok {
 		s.log.Warn("cannot remove peer from sync duties, peer was not registered", "peer", id)


### PR DESCRIPTION
Sometimes, disconnection events happen after the sync client is closed. This can (among other things) lead to panics in tests due to logs occurring after the test has exited. This PR makes RemovePeer a noop when `s.closingPeers == true`, which is the same functionality as `AddPeer`.
