### PR TITLE
Use circleci-ip-ranges for fpp-verify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1112,6 +1112,7 @@ jobs:
       - run: echo Done
 
   fpp-verify:
+    circleci_ip_ranges: true
     docker:
       - image: cimg/go:1.21
     steps:


### PR DESCRIPTION
**Description**
Have switched the RPC url to our proxyd-ci endpoint which is ip-whitelisted.

