### PR TITLE
op-e2e: Build the op-program client upfront

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -899,6 +899,10 @@ jobs:
       - attach_workspace:
           at: "."
       - run:
+          name: build op-program-client
+          command: make op-program-client
+          working_directory: op-program
+      - run:
           name: run tests
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |

--- a/op-e2e/system/proofs/build_helper.go
+++ b/op-e2e/system/proofs/build_helper.go
@@ -2,7 +2,9 @@ package proofs
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,15 @@ import (
 
 // BuildOpProgramClient builds the `op-program` client executable and returns the path to the resulting executable
 func BuildOpProgramClient(t *testing.T) string {
+	clientPath, err := filepath.Abs("../../../op-program/bin/op-program-client")
+	require.NoError(t, err)
+
+	_, err = os.Stat(clientPath)
+	if err == nil {
+		return clientPath
+	}
+	require.ErrorIs(t, err, os.ErrNotExist)
+
 	t.Log("Building op-program-client")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()


### PR DESCRIPTION
Now that multiple test processes are running at once, multiple threads are compiling the op-program client in the tests. This PR builds the client upfront to avoid this condition.
