### PR TITLE
fix: restore asterisc bytecode, vendor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
           command: |
             # Clone asterisc @ the pinned version to fetch remote `RISCV.sol`
             ASTERISC_REV="$(cat ../../versions.json | jq -r .asterisc)"
-            REMOTE_ASTERISC_PATH="./src/asterisc/RISCV_Remote.sol"
+            REMOTE_ASTERISC_PATH="./src/vendor/asterisc/RISCV_Remote.sol"
             git clone https://github.com/ethereum-optimism/asterisc \
               -b $ASTERISC_REV && \
               cp ./asterisc/rvsol/src/RISCV.sol $REMOTE_ASTERISC_PATH
@@ -1324,6 +1324,7 @@ workflows:
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build
+      - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
@@ -1691,17 +1692,6 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
-            - slack
-
-  scheduled-diff-asterisc-bytecode:
-    when:
-      or:
-        - equal: [build_daily, <<pipeline.schedule.name>>]
-        # Trigger on manual triggers if explicitly requested
-        - equal: [true, <<pipeline.parameters.diff_asterisc_bytecode_dispatch>>]
-    jobs:
-      - diff-asterisc-bytecode:
-          context:
             - slack
 
   scheduled-preimage-reproducibility:

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -135,10 +135,6 @@
     "initCodeHash": "0x17ea1b1c5d5a622d51c2961fde886a5498de63584e654ed1d69ee80dddbe0b17",
     "sourceCodeHash": "0x0fa0633a769e73f5937514c0003ba7947a1c275bbe5b85d78879c42f0ed8895b"
   },
-  "src/asterisc/RISCV.sol": {
-    "initCodeHash": "0x8d47aa0b81d7fe6bd0aeac18f26d7c0b285f58740bb9d92dac0ddf706c85309f",
-    "sourceCodeHash": "0xaebcda0a16da65fc7833672073ea6872c40d1ba722f0a6515c4a293e380f96c6"
-  },
   "src/cannon/MIPS.sol": {
     "initCodeHash": "0xb4aec227019dacd6194d6aeb9ca68c23c60b95618d18a4ebc09243514aeb1f05",
     "sourceCodeHash": "0x4d43b3f2918486aa76d2d59ac42e4f6aa2f58538c7e95a5cb99b63c9588b5f1c"
@@ -214,6 +210,10 @@
   "src/universal/StorageSetter.sol": {
     "initCodeHash": "0x049f3c86965e575a370b14f7f49f3f15436ffb5ee1059615bb708659d7aae7de",
     "sourceCodeHash": "0x5dc6b0b4ae4ab29085c52f74a4498d8a3d04928b844491749cd7186623e8b967"
+  },
+  "src/vendor/asterisc/RISCV.sol": {
+    "initCodeHash": "0x6b4323061187f2c8efe8de43bf1ecdc0798e2d95ad69470ed4151dadc094fedf",
+    "sourceCodeHash": "0x26cae049cf171efcc84c946a400704c30ebec5dba4f1548d1f1529f68f56c1ec"
   },
   "src/vendor/eas/EAS.sol": {
     "initCodeHash": "0xf96d1ebc530ed95e2dffebcfa2b4a1f18103235e6352d97838b77b7a2c14567b",

--- a/packages/contracts-bedrock/src/vendor/asterisc/RISCV.sol
+++ b/packages/contracts-bedrock/src/vendor/asterisc/RISCV.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Interfaces
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
 
@@ -9,15 +8,14 @@ import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
 /// @notice The RISCV contract emulates a single RISCV hart cycle statelessly, using memory proofs to verify the
 ///         instruction and optional memory access' inclusion in the memory merkle root provided in the trusted
 ///         prestate witness.
-///         This contract has been vendorized from the Asterisc project. The original source code can be found at
 /// @dev https://github.com/ethereum-optimism/asterisc
 contract RISCV is IBigStepper {
     /// @notice The preimage oracle contract.
     IPreimageOracle public oracle;
 
     /// @notice The version of the contract.
-    /// @custom:semver 1.1.0-rc.3
-    string public constant version = "1.1.0-rc.3";
+    /// @custom:semver 1.1.0-rc.2
+    string public constant version = "1.1.0-rc.2";
 
     /// @param _oracle The preimage oracle contract.
     constructor(IPreimageOracle _oracle) {


### PR DESCRIPTION
Restores the correct asterisc RISCV bytecode, moves the contract to the vendor folder, and changes CI so that it performs the check on the asterisc bytecode when attempting to merge into develop.