### PR TITLE
Corrected potential type conversion inconsistency

### DIFF
--- a/op-alt-da/commitment.go
+++ b/op-alt-da/commitment.go
@@ -140,7 +140,7 @@ func DecodeGenericCommitment(commitment []byte) (GenericCommitment, error) {
 	if len(commitment) == 0 {
 		return nil, ErrInvalidCommitment
 	}
-	return commitment[:], nil
+	return GenericCommitment(commitment), nil
 }
 
 // CommitmentType returns the commitment type of Generic Commitment.


### PR DESCRIPTION
**Description**

In the original code, the following line:

```go
return commitment[:], nil
```

was used to return a `GenericCommitment` type. This can be misleading as it slices the byte array, but doesn't explicitly cast it to the correct type.

The updated line:

```go
return GenericCommitment(commitment), nil
```

explicitly converts the byte array to the `GenericCommitment` type, making the code clearer and more consistent with the rest of the type handling.

This change helps to avoid potential confusion and ensures that type conversions are handled explicitly, improving code clarity and reducing the risk of errors in the future.

