### PR TITLE
txmgr: `Queue.Send()` uses `q.txMgr.SendAsync`

### DIFF
--- a/op-challenger/sender/sender_test.go
+++ b/op-challenger/sender/sender_test.go
@@ -129,8 +129,14 @@ func (s *stubTxMgr) Send(ctx context.Context, candidate txmgr.TxCandidate) (*typ
 	return <-ch, nil
 }
 
+// SendAsync simply wraps Send to make it non blocking. It does not guarantee transaction nonce ordering,
+// unlike the production txMgr.
 func (s *stubTxMgr) SendAsync(ctx context.Context, candidate txmgr.TxCandidate, ch chan txmgr.SendResponse) {
-	panic("unimplemented")
+	go func() {
+		receipt, err := s.Send(ctx, candidate)
+		resp := txmgr.SendResponse{Receipt: receipt, Err: err}
+		ch <- resp
+	}()
 }
 
 func (s *stubTxMgr) recordTx(candidate txmgr.TxCandidate) chan *types.Receipt {

--- a/op-service/txmgr/queue.go
+++ b/op-service/txmgr/queue.go
@@ -107,16 +107,6 @@ func (q *Queue[T]) TrySend(id T, candidate TxCandidate, receiptCh chan TxReceipt
 	}
 }
 
-func (q *Queue[T]) sendTx(ctx context.Context, id T, candidate TxCandidate, receiptCh chan TxReceipt[T]) error {
-	receipt, err := q.txMgr.Send(ctx, candidate)
-	receiptCh <- TxReceipt[T]{
-		ID:      id,
-		Receipt: receipt,
-		Err:     err,
-	}
-	return err
-}
-
 // groupContext returns a Group and a Context to use when sending a tx.
 //
 // If any of the pending transactions returned an error, the queue's shared error Group is

--- a/op-service/txmgr/queue.go
+++ b/op-service/txmgr/queue.go
@@ -51,6 +51,20 @@ func (q *Queue[T]) Wait() error {
 	return q.group.Wait()
 }
 
+// HandleResponse will wait for the response on the first passed channel,
+// and then forward it on the second passed channel (attaching the id). It returns
+// the response error or the context error if the context is canceled.
+func HandleResponse[T any](ctx context.Context, c chan SendResponse, d chan TxReceipt[T], id T) error {
+	select {
+	case response := <-c:
+		d <- TxReceipt[T]{ID: id, Receipt: response.Receipt, Err: response.Err}
+		return response.Err
+	case <-ctx.Done():
+		d <- TxReceipt[T]{ID: id, Err: ctx.Err()}
+		return ctx.Err()
+	}
+}
+
 // Send will wait until the number of pending txs is below the max pending,
 // and then send the next tx asynchronously. The nonce of the transaction is
 // determined synchronously, so transactions should be confirmed on chain in
@@ -63,18 +77,10 @@ func (q *Queue[T]) Send(id T, candidate TxCandidate, receiptCh chan TxReceipt[T]
 	group, ctx := q.groupContext()
 	responseChan := make(chan SendResponse, 1)
 	handleResponse := func() error {
-		// This handler will wait for the response from the txMgr, and then send the receipt
-		select {
-		case response := <-responseChan:
-			receiptCh <- TxReceipt[T]{ID: id, Receipt: response.Receipt, Err: response.Err}
-			return response.Err
-		case <-ctx.Done():
-			receiptCh <- TxReceipt[T]{ID: id, Err: ctx.Err()}
-			return ctx.Err()
-		}
+		return HandleResponse(ctx, responseChan, receiptCh, id)
 	}
-	group.Go(handleResponse) // This blocks until the number of handlers is below the limit
-	q.txMgr.SendAsync(ctx, candidate, responseChan)
+	group.Go(handleResponse)                        // This blocks until the number of handlers is below the limit
+	q.txMgr.SendAsync(ctx, candidate, responseChan) // Nonce management handled synchronously, i.e. before this returns
 }
 
 // TrySend sends the next tx, but only if the number of pending txs is below the
@@ -90,17 +96,9 @@ func (q *Queue[T]) TrySend(id T, candidate TxCandidate, receiptCh chan TxReceipt
 	group, ctx := q.groupContext()
 	responseChan := make(chan SendResponse, 1)
 	handleResponse := func() error {
-		// This handler will wait for the response from the txMgr, and then send the receipt
-		select {
-		case response := <-responseChan:
-			receiptCh <- TxReceipt[T]{ID: id, Receipt: response.Receipt, Err: response.Err}
-			return response.Err
-		case <-ctx.Done():
-			receiptCh <- TxReceipt[T]{ID: id, Err: ctx.Err()}
-			return ctx.Err()
-		}
+		return HandleResponse(ctx, responseChan, receiptCh, id)
 	}
-	ok := group.TryGo(handleResponse) // This blocks until the number of handlers is below the limit
+	ok := group.TryGo(handleResponse)
 	if !ok {
 		return false
 	} else {

--- a/op-service/txmgr/queue.go
+++ b/op-service/txmgr/queue.go
@@ -52,16 +52,29 @@ func (q *Queue[T]) Wait() error {
 }
 
 // Send will wait until the number of pending txs is below the max pending,
-// and then send the next tx.
+// and then send the next tx asynchronously. The nonce of the transaction is
+// determined synchronously, so transactions should be confirmed on chain in
+// the order they are sent using this method.
 //
 // The actual tx sending is non-blocking, with the receipt returned on the
 // provided receipt channel. If the channel is unbuffered, the goroutine is
 // blocked from completing until the channel is read from.
 func (q *Queue[T]) Send(id T, candidate TxCandidate, receiptCh chan TxReceipt[T]) {
 	group, ctx := q.groupContext()
-	group.Go(func() error {
-		return q.sendTx(ctx, id, candidate, receiptCh)
-	})
+	responseChan := make(chan SendResponse, 1)
+	handleResponse := func() error {
+		// This handler will wait for the response from the txMgr, and then send the receipt
+		select {
+		case response := <-responseChan:
+			receiptCh <- TxReceipt[T]{ID: id, Receipt: response.Receipt, Err: response.Err}
+			return response.Err
+		case <-ctx.Done():
+			receiptCh <- TxReceipt[T]{ID: id, Err: ctx.Err()}
+			return ctx.Err()
+		}
+	}
+	group.Go(handleResponse) // This blocks until the number of handlers is below the limit
+	q.txMgr.SendAsync(ctx, candidate, responseChan)
 }
 
 // TrySend sends the next tx, but only if the number of pending txs is below the


### PR DESCRIPTION
This should ensure that transactions are confirmed on chain in the order Queue.Send() is called, without sacrificing parallel tx submission.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updates the txMgr `Queue.Send()` entrypoint to use `txMgr.SendAsync()`

**Tests**

See #13124 

**Additional context**

Since Holocene, the order of batches landing on chain must be strictly adhered to. The batcher has been hardened to keep batches ordered before they get to the txMgr, but the txMgr fails to preserve the order of txs that the batcher sends to it. This caused a safe head stall on Base Sepolia.

The changes here also affect `op-challenger`.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/12947
