### PR TITLE
txmgr/Queue: add additional assertions to test to check for tx ordering

### DIFF
--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -238,14 +238,15 @@ func TestQueue_Send(t *testing.T) {
 			// check that the nonces match
 			slices.Sort(nonces)
 			require.Equal(t, test.nonces, nonces, "expected nonces do not match")
-			for i, id := range test.confirmedIds { // iterate over nonces in order
-				require.Equal(t, nonces[i], nonceForTxId[id],
-					"nonce for tx id %d was %d instead of %d", id, nonceForTxId[id], nonces[i])
-			}
+
 			// NOTE the backend in this test does not order transactions based on the nonce
 			// So what we want to check is that the txs match expectations when they are ordered
 			// in the same way as the nonces.
-			// require.EqualValues(t, test.confirmedIds, txIds, "expected tx Ids list does not match")
+			for i, id := range test.confirmedIds {
+				require.Equal(t, nonces[i], nonceForTxId[id],
+					"nonce for tx id %d was %d instead of %d", id, nonceForTxId[id], nonces[i])
+			}
+
 			// check receipts
 			for i, c := range test.calls {
 				if !c.queued {

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -221,6 +221,13 @@ func TestQueue_Send(t *testing.T) {
 					TxData: []byte{byte(i)},
 					To:     &common.Address{},
 				}
+				if i == 0 {
+					// Make the first tx much larger to expose
+					// any race conditions in the queue
+					for j := 0; j < 100_000; j++ {
+						candidate.TxData = append(candidate.TxData, 1)
+					}
+				}
 				receiptChs[i] = make(chan TxReceipt[int], 1)
 				queued := c.call(i, candidate, receiptChs[i], queue)
 				require.Equal(t, c.queued, queued, msg)

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -228,9 +228,7 @@ func TestQueue_Send(t *testing.T) {
 				if i == 0 {
 					// Make the first tx much larger to expose
 					// any race conditions in the queue
-					for j := 0; j < 100_000; j++ {
-						candidate.TxData = append(candidate.TxData, 1)
-					}
+					candidate.TxData = make([]byte, 100_000)
 				}
 				receiptChs[i] = make(chan TxReceipt[int], 1)
 				queued := c.call(i, candidate, receiptChs[i], queue)


### PR DESCRIPTION
Related to #13120 , this adds a test which exposes the existing risk of txs being confirmed out of order. This test fails without the fix of #13120.