### PR TITLE
Cache `SystemConfig` for next payload attributes

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -67,7 +67,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	conduc := &conductor.NoOpConductor{}
 	asyncGossip := async.NoOpGossiper{}
 	seq := sequencing.NewSequencer(t.Ctx(), log, cfg, attrBuilder, l1OriginSelector,
-		seqStateListener, conduc, asyncGossip, metr)
+		seqStateListener, conduc, asyncGossip, metr, eng)
 	opts := event.DefaultRegisterOpts()
 	opts.Emitter = event.EmitterOpts{
 		Limiting: true,

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -88,6 +88,7 @@ type L2API interface {
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
 	BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error)
 	ChainID(ctx context.Context) (*big.Int, error)
+	SystemConfigByL2Payload(payload *eth.ExecutionPayload) (eth.SystemConfig, error)
 }
 
 type safeDB interface {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -69,6 +69,7 @@ type L2Chain interface {
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
+	SystemConfigByL2Payload(payload *eth.ExecutionPayload) (eth.SystemConfig, error)
 }
 
 type DerivationPipeline interface {
@@ -249,7 +250,7 @@ func NewDriver(
 		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
 		sys.Register("origin-selector", findL1Origin, opts)
 		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
-			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)
+			sequencerStateListener, sequencerConductor, asyncGossiper, metrics, l2)
 		sys.Register("sequencer", sequencer, opts)
 	} else {
 		sequencer = sequencing.DisabledSequencer{}

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -613,6 +613,14 @@ func TestSequencerBuild(t *testing.T) {
 	require.Equal(t, testClock.Now(), nextTime, "start asap on the next block")
 }
 
+type l2ConfigFetcher struct {
+	cfg *rollup.Config
+}
+
+func (f l2ConfigFetcher) SystemConfigByL2Payload(payload *eth.ExecutionPayload) (eth.SystemConfig, error) {
+	return derive.PayloadToSystemConfig(f.cfg, payload)
+}
+
 type sequencerTestDeps struct {
 	cfg              *rollup.Config
 	attribBuilder    *FakeAttributesBuilder
@@ -661,7 +669,7 @@ func createSequencer(log log.Logger) (*Sequencer, *sequencerTestDeps) {
 	}
 	seq := NewSequencer(context.Background(), log, cfg, deps.attribBuilder,
 		deps.l1OriginSelector, deps.seqState, deps.conductor,
-		deps.asyncGossip, metrics.NoopMetrics)
+		deps.asyncGossip, metrics.NoopMetrics, l2ConfigFetcher{cfg})
 	// We create mock payloads, with the epoch-id as tx[0], rather than proper L1Block-info deposit tx.
 	seq.toBlockRef = func(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.L2BlockRef, error) {
 		return eth.L2BlockRef{

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -147,6 +147,10 @@ func (o *OracleEngine) L2BlockRefByNumber(ctx context.Context, n uint64) (eth.L2
 	return o.L2BlockRefByHash(ctx, hash)
 }
 
+func (o *OracleEngine) SystemConfigByL2Payload(payload *eth.ExecutionPayload) (eth.SystemConfig, error) {
+	return derive.PayloadToSystemConfig(o.rollupCfg, payload)
+}
+
 func (o *OracleEngine) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
 	payload, err := o.PayloadByHash(ctx, hash)
 	if err != nil {

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -152,6 +152,17 @@ func (s *L2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.
 	return ref, nil
 }
 
+// SystemConfigByL2Payload returns the [eth.SystemConfig] (matching the config updates up to and including the L1 origin) for the given L2 payload.
+// It also caches it so that next query might be faster
+func (s *L2Client) SystemConfigByL2Payload(payload *eth.ExecutionPayload) (eth.SystemConfig, error) {
+	cfg, err := derive.PayloadToSystemConfig(s.rollupCfg, payload)
+	if err != nil {
+		return eth.SystemConfig{}, err
+	}
+	s.systemConfigsCache.Add(payload.BlockHash, cfg)
+	return cfg, nil
+}
+
 // SystemConfigByL2Hash returns the [eth.SystemConfig] (matching the config updates up to and including the L1 origin) for the given L2 block hash.
 // The returned [eth.SystemConfig] may not be in the canonical chain when the hash is not canonical.
 func (s *L2Client) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
@@ -164,12 +175,7 @@ func (s *L2Client) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (
 		// w%: wrap to preserve ethereum.NotFound case
 		return eth.SystemConfig{}, fmt.Errorf("failed to determine block-hash of hash %v, could not get payload: %w", hash, err)
 	}
-	cfg, err := derive.PayloadToSystemConfig(s.rollupCfg, envelope.ExecutionPayload)
-	if err != nil {
-		return eth.SystemConfig{}, err
-	}
-	s.systemConfigsCache.Add(hash, cfg)
-	return cfg, nil
+	return s.SystemConfigByL2Payload(envelope.ExecutionPayload)
 }
 
 func (s *L2Client) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We at @risechain hit a bottleneck during payload attributes generation. Each time, OP-node wants to generate `PayloadAttributes` it needs the `SystemConfig` of the parent block and for that it basically queries the engine for parent payload. As our payloads are quite big, we bottleneck and wait for 800ms just to fetch system config.

So basically this pr primitively tries to cache `SystemConfig` after successfully generating payload on the engine side, so we don't have to query the engine right away.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
