### PR TITLE
fix: stack too deep in PermissionedDisputeGame

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
@@ -270,19 +270,17 @@ contract DeployDisputeGame is Script {
 
     function deployDisputeGameImpl(DeployDisputeGameInput _dgi, DeployDisputeGameOutput _dgo) internal {
         // Shove the arguments into a struct to avoid stack-too-deep errors.
-        DisputeGameConstructorArgs memory args = DisputeGameConstructorArgs({
+        IFaultDisputeGame.GameConstructorParams memory args = IFaultDisputeGame.GameConstructorParams({
             gameType: GameType.wrap(uint32(_dgi.gameType())),
             absolutePrestate: Claim.wrap(_dgi.absolutePrestate()),
             maxGameDepth: _dgi.maxGameDepth(),
             splitDepth: _dgi.splitDepth(),
             clockExtension: Duration.wrap(uint64(_dgi.clockExtension())),
             maxClockDuration: Duration.wrap(uint64(_dgi.maxClockDuration())),
-            gameVm: IBigStepper(address(_dgi.vmAddress())),
-            delayedWethProxy: _dgi.delayedWethProxy(),
-            anchorStateRegistryProxy: _dgi.anchorStateRegistryProxy(),
-            l2ChainId: _dgi.l2ChainId(),
-            proposer: _dgi.proposer(),
-            challenger: _dgi.challenger()
+            vm: IBigStepper(address(_dgi.vmAddress())),
+            weth: _dgi.delayedWethProxy(),
+            anchorStateRegistry: _dgi.anchorStateRegistryProxy(),
+            l2ChainId: _dgi.l2ChainId()
         });
 
         // PermissionedDisputeGame is used as the type here because it is a superset of
@@ -294,23 +292,7 @@ contract DeployDisputeGame is Script {
             impl = IPermissionedDisputeGame(
                 DeployUtils.create1({
                     _name: "FaultDisputeGame",
-                    _args: DeployUtils.encodeConstructor(
-                        abi.encodeCall(
-                            IFaultDisputeGame.__constructor__,
-                            (
-                                args.gameType,
-                                args.absolutePrestate,
-                                args.maxGameDepth,
-                                args.splitDepth,
-                                args.clockExtension,
-                                args.maxClockDuration,
-                                args.gameVm,
-                                args.delayedWethProxy,
-                                args.anchorStateRegistryProxy,
-                                args.l2ChainId
-                            )
-                        )
-                    )
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IFaultDisputeGame.__constructor__, (args)))
                 })
             );
         } else {
@@ -318,23 +300,7 @@ contract DeployDisputeGame is Script {
                 DeployUtils.create1({
                     _name: "PermissionedDisputeGame",
                     _args: DeployUtils.encodeConstructor(
-                        abi.encodeCall(
-                            IPermissionedDisputeGame.__constructor__,
-                            (
-                                args.gameType,
-                                args.absolutePrestate,
-                                args.maxGameDepth,
-                                args.splitDepth,
-                                args.clockExtension,
-                                args.maxClockDuration,
-                                args.gameVm,
-                                args.delayedWethProxy,
-                                args.anchorStateRegistryProxy,
-                                args.l2ChainId,
-                                args.proposer,
-                                args.challenger
-                            )
-                        )
+                        abi.encodeCall(IPermissionedDisputeGame.__constructor__, (args, _dgi.proposer(), _dgi.challenger()))
                     )
                 })
             );

--- a/packages/contracts-bedrock/scripts/upgrades/holocene/DeployUpgrade.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/holocene/DeployUpgrade.s.sol
@@ -138,16 +138,18 @@ contract DeployUpgrade is Deployer {
         bytes memory constructorInput = abi.encodeCall(
             IFaultDisputeGame.__constructor__,
             (
-                GameTypes.CANNON,
-                Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate())),
-                cfg.faultGameMaxDepth(),
-                cfg.faultGameSplitDepth(),
-                Duration.wrap(uint64(cfg.faultGameClockExtension())),
-                Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
-                IBigStepper(mustGetAddress("MIPS")),
-                IDelayedWETH(payable(mustGetAddress("DelayedWETHProxyFDG"))),
-                IAnchorStateRegistry(mustGetAddress("AnchorStateRegistry")),
-                cfg.l2ChainID()
+                IFaultDisputeGame.GameConstructorParams({
+                    gameType: GameTypes.CANNON,
+                    absolutePrestate: Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate())),
+                    maxGameDepth: cfg.faultGameMaxDepth(),
+                    splitDepth: cfg.faultGameSplitDepth(),
+                    clockExtension: Duration.wrap(uint64(cfg.faultGameClockExtension())),
+                    maxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
+                    vm: IBigStepper(mustGetAddress("MIPS")),
+                    weth: IDelayedWETH(payable(mustGetAddress("DelayedWETHProxyFDG"))),
+                    anchorStateRegistry: IAnchorStateRegistry(mustGetAddress("AnchorStateRegistry")),
+                    l2ChainId: cfg.l2ChainID()
+                })
             )
         );
 
@@ -197,16 +199,18 @@ contract DeployUpgrade is Deployer {
         bytes memory constructorInput = abi.encodeCall(
             IPermissionedDisputeGame.__constructor__,
             (
-                GameTypes.PERMISSIONED_CANNON,
-                Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate())),
-                cfg.faultGameMaxDepth(),
-                cfg.faultGameSplitDepth(),
-                Duration.wrap(uint64(cfg.faultGameClockExtension())),
-                Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
-                IBigStepper(mustGetAddress("MIPS")),
-                IDelayedWETH(payable(mustGetAddress("DelayedWETHProxyPDG"))),
-                IAnchorStateRegistry(mustGetAddress("AnchorStateRegistry")),
-                cfg.l2ChainID(),
+                IFaultDisputeGame.GameConstructorParams({
+                    gameType: GameTypes.PERMISSIONED_CANNON,
+                    absolutePrestate: Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate())),
+                    maxGameDepth: cfg.faultGameMaxDepth(),
+                    splitDepth: cfg.faultGameSplitDepth(),
+                    clockExtension: Duration.wrap(uint64(cfg.faultGameClockExtension())),
+                    maxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
+                    vm: IBigStepper(mustGetAddress("MIPS")),
+                    weth: IDelayedWETH(payable(mustGetAddress("DelayedWETHProxyPDG"))),
+                    anchorStateRegistry: IAnchorStateRegistry(mustGetAddress("AnchorStateRegistry")),
+                    l2ChainId: cfg.l2ChainID()
+                }),
                 cfg.l2OutputOracleProposer(),
                 cfg.l2OutputOracleChallenger()
             )

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
@@ -2,54 +2,61 @@
   {
     "inputs": [
       {
-        "internalType": "GameType",
-        "name": "_gameType",
-        "type": "uint32"
-      },
-      {
-        "internalType": "Claim",
-        "name": "_absolutePrestate",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_maxGameDepth",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_splitDepth",
-        "type": "uint256"
-      },
-      {
-        "internalType": "Duration",
-        "name": "_clockExtension",
-        "type": "uint64"
-      },
-      {
-        "internalType": "Duration",
-        "name": "_maxClockDuration",
-        "type": "uint64"
-      },
-      {
-        "internalType": "contract IBigStepper",
-        "name": "_vm",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IDelayedWETH",
-        "name": "_weth",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IAnchorStateRegistry",
-        "name": "_anchorStateRegistry",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_l2ChainId",
-        "type": "uint256"
+        "components": [
+          {
+            "internalType": "GameType",
+            "name": "gameType",
+            "type": "uint32"
+          },
+          {
+            "internalType": "Claim",
+            "name": "absolutePrestate",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxGameDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "splitDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "Duration",
+            "name": "clockExtension",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Duration",
+            "name": "maxClockDuration",
+            "type": "uint64"
+          },
+          {
+            "internalType": "contract IBigStepper",
+            "name": "vm",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IDelayedWETH",
+            "name": "weth",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IAnchorStateRegistry",
+            "name": "anchorStateRegistry",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2ChainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct FaultDisputeGame.GameConstructorParams",
+        "name": "_params",
+        "type": "tuple"
       }
     ],
     "stateMutability": "nonpayable",

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
@@ -2,54 +2,61 @@
   {
     "inputs": [
       {
-        "internalType": "GameType",
-        "name": "_gameType",
-        "type": "uint32"
-      },
-      {
-        "internalType": "Claim",
-        "name": "_absolutePrestate",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_maxGameDepth",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_splitDepth",
-        "type": "uint256"
-      },
-      {
-        "internalType": "Duration",
-        "name": "_clockExtension",
-        "type": "uint64"
-      },
-      {
-        "internalType": "Duration",
-        "name": "_maxClockDuration",
-        "type": "uint64"
-      },
-      {
-        "internalType": "contract IBigStepper",
-        "name": "_vm",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IDelayedWETH",
-        "name": "_weth",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IAnchorStateRegistry",
-        "name": "_anchorStateRegistry",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_l2ChainId",
-        "type": "uint256"
+        "components": [
+          {
+            "internalType": "GameType",
+            "name": "gameType",
+            "type": "uint32"
+          },
+          {
+            "internalType": "Claim",
+            "name": "absolutePrestate",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxGameDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "splitDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "Duration",
+            "name": "clockExtension",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Duration",
+            "name": "maxClockDuration",
+            "type": "uint64"
+          },
+          {
+            "internalType": "contract IBigStepper",
+            "name": "vm",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IDelayedWETH",
+            "name": "weth",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IAnchorStateRegistry",
+            "name": "anchorStateRegistry",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2ChainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct FaultDisputeGame.GameConstructorParams",
+        "name": "_params",
+        "type": "tuple"
       },
       {
         "internalType": "address",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x9cb0851b6e471461f2bb369bd72eef4cffe8a0d1345546608a2aa6795540211d"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0xa352179f5055232764aac6b66a3ff5a6b3bfae2101d20c077f714b0ed7e40eef",
-    "sourceCodeHash": "0x730eff9147294c115a0a53e7e75771bcc4a517beb48457140ab929a8d1510893"
+    "initCodeHash": "0x7441e418d3b4229f519c8c027f3fd7a5487206b833110b794cca104a1a2c73fe",
+    "sourceCodeHash": "0x8f4bf662fe8d56e9aabaa7742033880f0900cd6221c7711c1dbefe985a841104"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0xf232863fde5cd65368bcb4a79b41b5a4a09c59ede5070f82fd3f13f681bea7d8",

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -5,13 +5,8 @@ pragma solidity 0.8.15;
 import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
 
 // Libraries
-import { GameType, Claim, Duration } from "src/dispute/lib/Types.sol";
+import { Claim } from "src/dispute/lib/Types.sol";
 import { BadAuth } from "src/dispute/lib/Errors.sol";
-
-// Interfaces
-import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
-import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
-import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
 
 /// @title PermissionedDisputeGame
 /// @notice PermissionedDisputeGame is a contract that inherits from `FaultDisputeGame`, and contains two roles:
@@ -36,44 +31,15 @@ contract PermissionedDisputeGame is FaultDisputeGame {
         _;
     }
 
-    /// @param _gameType The type ID of the game.
-    /// @param _absolutePrestate The absolute prestate of the instruction trace.
-    /// @param _maxGameDepth The maximum depth of bisection.
-    /// @param _splitDepth The final depth of the output bisection portion of the game.
-    /// @param _clockExtension The clock extension to perform when the remaining duration is less than the extension.
-    /// @param _maxClockDuration The maximum amount of time that may accumulate on a team's chess clock.
-    /// @param _vm An onchain VM that performs single instruction steps on an FPP trace.
-    /// @param _weth WETH contract for holding ETH.
-    /// @param _anchorStateRegistry The contract that stores the anchor state for each game type.
-    /// @param _l2ChainId Chain ID of the L2 network this contract argues about.
+    /// @param _params Parameters for creating a new FaultDisputeGame.
     /// @param _proposer Address that is allowed to create instances of this contract.
     /// @param _challenger Address that is allowed to challenge instances of this contract.
     constructor(
-        GameType _gameType,
-        Claim _absolutePrestate,
-        uint256 _maxGameDepth,
-        uint256 _splitDepth,
-        Duration _clockExtension,
-        Duration _maxClockDuration,
-        IBigStepper _vm,
-        IDelayedWETH _weth,
-        IAnchorStateRegistry _anchorStateRegistry,
-        uint256 _l2ChainId,
+        GameConstructorParams memory _params,
         address _proposer,
         address _challenger
     )
-        FaultDisputeGame(
-            _gameType,
-            _absolutePrestate,
-            _maxGameDepth,
-            _splitDepth,
-            _clockExtension,
-            _maxClockDuration,
-            _vm,
-            _weth,
-            _anchorStateRegistry,
-            _l2ChainId
-        )
+        FaultDisputeGame(_params)
     {
         PROPOSER = _proposer;
         CHALLENGER = _challenger;

--- a/packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
@@ -26,6 +26,19 @@ interface IFaultDisputeGame is IDisputeGame {
         address counteredBy;
     }
 
+    struct GameConstructorParams {
+        GameType gameType;
+        Claim absolutePrestate;
+        uint256 maxGameDepth;
+        uint256 splitDepth;
+        Duration clockExtension;
+        Duration maxClockDuration;
+        IBigStepper vm;
+        IDelayedWETH weth;
+        IAnchorStateRegistry anchorStateRegistry;
+        uint256 l2ChainId;
+    }
+
     error AlreadyInitialized();
     error AnchorRootNotFound();
     error BlockNumberMatches();
@@ -113,17 +126,5 @@ interface IFaultDisputeGame is IDisputeGame {
     function vm() external view returns (IBigStepper vm_);
     function weth() external view returns (IDelayedWETH weth_);
 
-    function __constructor__(
-        GameType _gameType,
-        Claim _absolutePrestate,
-        uint256 _maxGameDepth,
-        uint256 _splitDepth,
-        Duration _clockExtension,
-        Duration _maxClockDuration,
-        IBigStepper _vm,
-        IDelayedWETH _weth,
-        IAnchorStateRegistry _anchorStateRegistry,
-        uint256 _l2ChainId
-    )
-        external;
+    function __constructor__(GameConstructorParams memory _params) external;
 }

--- a/packages/contracts-bedrock/src/dispute/interfaces/IPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IPermissionedDisputeGame.sol
@@ -2,12 +2,13 @@
 pragma solidity ^0.8.0;
 
 import { Types } from "src/libraries/Types.sol";
-import { GameType, Claim, Position, Clock, Hash, Duration } from "src/dispute/lib/Types.sol";
+import { Claim, Position, Clock, Hash, Duration } from "src/dispute/lib/Types.sol";
 
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
+import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
 
 interface IPermissionedDisputeGame is IDisputeGame {
     struct ClaimData {
@@ -120,16 +121,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function challenger() external view returns (address challenger_);
 
     function __constructor__(
-        GameType _gameType,
-        Claim _absolutePrestate,
-        uint256 _maxGameDepth,
-        uint256 _splitDepth,
-        Duration _clockExtension,
-        Duration _maxClockDuration,
-        IBigStepper _vm,
-        IDelayedWETH _weth,
-        IAnchorStateRegistry _anchorStateRegistry,
-        uint256 _l2ChainId,
+        IFaultDisputeGame.GameConstructorParams memory _params,
         address _proposer,
         address _challenger
     )

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -73,16 +73,18 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
                     abi.encodeCall(
                         IFaultDisputeGame.__constructor__,
                         (
-                            GAME_TYPE,
-                            absolutePrestate,
-                            2 ** 3,
-                            2 ** 2,
-                            Duration.wrap(3 hours),
-                            Duration.wrap(3.5 days),
-                            _vm,
-                            delayedWeth,
-                            anchorStateRegistry,
-                            10
+                            IFaultDisputeGame.GameConstructorParams({
+                                gameType: GAME_TYPE,
+                                absolutePrestate: absolutePrestate,
+                                maxGameDepth: 2 ** 3,
+                                splitDepth: 2 ** 2,
+                                clockExtension: Duration.wrap(3 hours),
+                                maxClockDuration: Duration.wrap(3.5 days),
+                                vm: _vm,
+                                weth: delayedWeth,
+                                anchorStateRegistry: anchorStateRegistry,
+                                l2ChainId: 10
+                            })
                         )
                     )
                 )
@@ -154,16 +156,18 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
                 abi.encodeCall(
                     IFaultDisputeGame.__constructor__,
                     (
-                        GAME_TYPE,
-                        absolutePrestate,
-                        _maxGameDepth,
-                        _maxGameDepth + 1,
-                        Duration.wrap(3 hours),
-                        Duration.wrap(3.5 days),
-                        alphabetVM,
-                        IDelayedWETH(payable(address(0))),
-                        IAnchorStateRegistry(address(0)),
-                        10
+                        IFaultDisputeGame.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            absolutePrestate: absolutePrestate,
+                            maxGameDepth: _maxGameDepth,
+                            splitDepth: _maxGameDepth + 1,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days),
+                            vm: alphabetVM,
+                            weth: IDelayedWETH(payable(address(0))),
+                            anchorStateRegistry: IAnchorStateRegistry(address(0)),
+                            l2ChainId: 10
+                        })
                     )
                 )
             )
@@ -196,16 +200,18 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
                 abi.encodeCall(
                     IFaultDisputeGame.__constructor__,
                     (
-                        GAME_TYPE,
-                        absolutePrestate,
-                        2 ** 3,
-                        2 ** 2,
-                        Duration.wrap(3 hours),
-                        Duration.wrap(3.5 days),
-                        alphabetVM,
-                        IDelayedWETH(payable(address(0))),
-                        IAnchorStateRegistry(address(0)),
-                        10
+                        IFaultDisputeGame.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            absolutePrestate: absolutePrestate,
+                            maxGameDepth: 2 ** 3,
+                            splitDepth: 2 ** 2,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days),
+                            vm: alphabetVM,
+                            weth: IDelayedWETH(payable(address(0))),
+                            anchorStateRegistry: IAnchorStateRegistry(address(0)),
+                            l2ChainId: 10
+                        })
                     )
                 )
             )
@@ -234,16 +240,18 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
                 abi.encodeCall(
                     IFaultDisputeGame.__constructor__,
                     (
-                        GAME_TYPE,
-                        absolutePrestate,
-                        maxGameDepth,
-                        _splitDepth,
-                        Duration.wrap(3 hours),
-                        Duration.wrap(3.5 days),
-                        alphabetVM,
-                        IDelayedWETH(payable(address(0))),
-                        IAnchorStateRegistry(address(0)),
-                        10
+                        IFaultDisputeGame.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            absolutePrestate: absolutePrestate,
+                            maxGameDepth: maxGameDepth,
+                            splitDepth: _splitDepth,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days),
+                            vm: alphabetVM,
+                            weth: IDelayedWETH(payable(address(0))),
+                            anchorStateRegistry: IAnchorStateRegistry(address(0)),
+                            l2ChainId: 10
+                        })
                     )
                 )
             )
@@ -272,16 +280,18 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
                 abi.encodeCall(
                     IFaultDisputeGame.__constructor__,
                     (
-                        GAME_TYPE,
-                        absolutePrestate,
-                        2 ** 3,
-                        _splitDepth,
-                        Duration.wrap(3 hours),
-                        Duration.wrap(3.5 days),
-                        alphabetVM,
-                        IDelayedWETH(payable(address(0))),
-                        IAnchorStateRegistry(address(0)),
-                        10
+                        IFaultDisputeGame.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            absolutePrestate: absolutePrestate,
+                            maxGameDepth: 2 ** 3,
+                            splitDepth: _splitDepth,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days),
+                            vm: alphabetVM,
+                            weth: IDelayedWETH(payable(address(0))),
+                            anchorStateRegistry: IAnchorStateRegistry(address(0)),
+                            l2ChainId: 10
+                        })
                     )
                 )
             )
@@ -318,16 +328,18 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
                 abi.encodeCall(
                     IFaultDisputeGame.__constructor__,
                     (
-                        GAME_TYPE,
-                        absolutePrestate,
-                        16,
-                        8,
-                        Duration.wrap(_clockExtension),
-                        Duration.wrap(_maxClockDuration),
-                        alphabetVM,
-                        IDelayedWETH(payable(address(0))),
-                        IAnchorStateRegistry(address(0)),
-                        10
+                        IFaultDisputeGame.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            absolutePrestate: absolutePrestate,
+                            maxGameDepth: 16,
+                            splitDepth: 8,
+                            clockExtension: Duration.wrap(_clockExtension),
+                            maxClockDuration: Duration.wrap(_maxClockDuration),
+                            vm: alphabetVM,
+                            weth: IDelayedWETH(payable(address(0))),
+                            anchorStateRegistry: IAnchorStateRegistry(address(0)),
+                            l2ChainId: 10
+                        })
                     )
                 )
             )

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -17,6 +17,7 @@ import "src/dispute/lib/Errors.sol";
 import { IPreimageOracle } from "src/dispute/interfaces/IBigStepper.sol";
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IPermissionedDisputeGame } from "src/dispute/interfaces/IPermissionedDisputeGame.sol";
+import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
 
 contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
@@ -67,16 +68,18 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
                     abi.encodeCall(
                         IPermissionedDisputeGame.__constructor__,
                         (
-                            GAME_TYPE,
-                            absolutePrestate,
-                            2 ** 3,
-                            2 ** 2,
-                            Duration.wrap(3 hours),
-                            Duration.wrap(3.5 days),
-                            _vm,
-                            _weth,
-                            anchorStateRegistry,
-                            10,
+                            IFaultDisputeGame.GameConstructorParams({
+                                gameType: GAME_TYPE,
+                                absolutePrestate: absolutePrestate,
+                                maxGameDepth: 2 ** 3,
+                                splitDepth: 2 ** 2,
+                                clockExtension: Duration.wrap(3 hours),
+                                maxClockDuration: Duration.wrap(3.5 days),
+                                vm: _vm,
+                                weth: _weth,
+                                anchorStateRegistry: anchorStateRegistry,
+                                l2ChainId: 10
+                            }),
                             PROPOSER,
                             CHALLENGER
                         )


### PR DESCRIPTION
Fixes the stack-too-deep error in the PermissionedDisputeGame by updating the game to use a struct as the constructor parameter.