### PR TITLE
move `NewChannelBuilder` to test file

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -88,18 +88,6 @@ type ChannelBuilder struct {
 	outputBytes int
 }
 
-// NewChannelBuilder creates a new channel builder or returns an error if the
-// channel out could not be created.
-// it acts as a factory for either a span or singular channel out
-func NewChannelBuilder(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64) (*ChannelBuilder, error) {
-	co, err := NewChannelOut(cfg, rollupCfg)
-	if err != nil {
-		return nil, fmt.Errorf("creating channel out: %w", err)
-	}
-
-	return NewChannelBuilderWithChannelOut(cfg, rollupCfg, latestL1OriginBlockNum, co), nil
-}
-
 func NewChannelBuilderWithChannelOut(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64, channelOut derive.ChannelOut) *ChannelBuilder {
 	cb := &ChannelBuilder{
 		cfg:       cfg,


### PR DESCRIPTION
This PR moves `NewChannelBuilder` to test file since it is only used in test, this makes analyzing the caller of `NewChannelBuilderWithChannelOut`(e.g., when tracing `latestL1OriginBlockNum`) in op-batcher easier since there's only one caller in non-test file now.