### PR TITLE
feat: allow arguments to contracts test recipe

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -54,8 +54,8 @@ clean:
 ########################################################
 
 # Runs standard contract tests.
-test: build-go-ffi
-  forge test
+test *ARGS: build-go-ffi
+  forge test {{ARGS}}
 
 # Runs standard contract tests with rerun flag.
 test-rerun: build-go-ffi


### PR DESCRIPTION
Adds the ability to supply arguments to the "just test" recipe in the contracts package. Developers frequently need to add arguments to test specific contracts and running "just test" as the unified testing command is better than flipping to "forge test".