### PR TITLE
SendDepositTx: make `applyL2Opts` nil-able

### DIFF
--- a/op-e2e/actions/batcher/l2_batcher_test.go
+++ b/op-e2e/actions/batcher/l2_batcher_test.go
@@ -408,7 +408,7 @@ func ExtendedTimeWithoutL1Batches(gt *testing.T, deltaTimeOffset *hexutil.Uint64
 //   - Fill 40 L2 blocks to near max-capacity, with txs of 120 KB each
 //   - Buffer the L2 blocks into channels together as much as possible, submit data-txs only when necessary
 //     (just before crossing the max RLP channel size)
-//   - Limit the data-tx size to 40 KB, to force data to be split across multiple datat-txs
+//   - Limit the data-tx size to 40 KB, to force data to be split across multiple data-txs
 //   - Defer all data-tx inclusion till the end
 //   - Fill L1 blocks with data-txs until we have processed them all
 //   - Run the verifier, and check if it derives the same L2 chain as was created by the sequencer.

--- a/op-e2e/system/da/brotli_batcher_test.go
+++ b/op-e2e/system/da/brotli_batcher_test.go
@@ -43,7 +43,7 @@ func setupAliceAccount(t *testing.T, cfg e2esys.SystemConfig, sys *e2esys.System
 	require.NoError(t, err)
 	mintAmount := big.NewInt(1_000_000_000_000)
 	opts.Value = mintAmount
-	helpers.SendDepositTx(t, cfg, l1Client, l2Verif, opts, func(l2Opts *helpers.DepositTxOpts) {})
+	helpers.SendDepositTx(t, cfg, l1Client, l2Verif, opts, nil)
 
 	// Confirm balance
 	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -120,7 +120,7 @@ func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAva
 	require.NoError(t, err)
 	mintAmount := big.NewInt(1_000_000_000_000)
 	opts.Value = mintAmount
-	helpers.SendDepositTx(t, cfg, l1Client, l2Verif, opts, func(l2Opts *helpers.DepositTxOpts) {})
+	helpers.SendDepositTx(t, cfg, l1Client, l2Verif, opts, nil)
 
 	// Confirm balance
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 20*time.Second)

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -57,7 +57,6 @@ func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAva
 	cfg.BatcherBatchType = derive.SpanBatchType
 	cfg.DeployConfig.L1GenesisBlockBaseFeePerGas = (*hexutil.Big)(big.NewInt(7000))
 
-	const maxBlobs = eth.MaxBlobsPerBlobTx
 	var maxL1TxSize int
 	if multiBlob {
 		cfg.BatcherTargetNumFrames = eth.MaxBlobsPerBlobTx
@@ -214,7 +213,8 @@ func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAva
 	if !multiBlob {
 		require.NotZero(t, numBlobs, "single-blob: expected to find L1 blob tx")
 	} else {
-		require.Equal(t, maxBlobs, numBlobs, fmt.Sprintf("multi-blob: expected to find L1 blob tx with %d blobs", eth.MaxBlobsPerBlobTx))
+		const maxBlobs = eth.MaxBlobsPerBlobTx
+		require.Equal(t, maxBlobs, numBlobs, fmt.Sprintf("multi-blob: expected to find L1 blob tx with %d blobs", maxBlobs))
 		// blob tx should have filled up all but last blob
 		bcl := sys.L1BeaconHTTPClient()
 		hashes := toIndexedBlobHashes(blobTx.BlobHashes()...)

--- a/op-e2e/system/helpers/tx_helper.go
+++ b/op-e2e/system/helpers/tx_helper.go
@@ -28,7 +28,9 @@ import (
 // Returns the receipt of the L2 transaction
 func SendDepositTx(t *testing.T, cfg e2esys.SystemConfig, l1Client *ethclient.Client, l2Client *ethclient.Client, l1Opts *bind.TransactOpts, applyL2Opts DepositTxOptsFn) *types.Receipt {
 	l2Opts := defaultDepositTxOpts(l1Opts)
-	applyL2Opts(l2Opts)
+	if applyL2Opts != nil {
+		applyL2Opts(l2Opts)
+	}
 
 	// Find deposit contract
 	depositContract, err := bindings.NewOptimismPortal(cfg.L1Deployments.OptimismPortalProxy, l1Client)

--- a/op-e2e/system/verifier/basic_test.go
+++ b/op-e2e/system/verifier/basic_test.go
@@ -71,7 +71,7 @@ func runE2ESystemTest(t *testing.T, sys *e2esys.System) {
 	require.Nil(t, err)
 	mintAmount := big.NewInt(1_000_000_000_000)
 	opts.Value = mintAmount
-	helpers.SendDepositTx(t, sys.Cfg, l1Client, l2Verif, opts, func(l2Opts *helpers.DepositTxOpts) {})
+	helpers.SendDepositTx(t, sys.Cfg, l1Client, l2Verif, opts, nil)
 
 	// Confirm balance
 	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)


### PR DESCRIPTION
So that we can just pass `nil` in place of empty function.