### PR TITLE
chore: Bump `kona` in `proofs-tools` image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -207,7 +207,7 @@ target "proofs-tools" {
   context = "."
   args = {
     CHALLENGER_VERSION="b46bffed42db3442d7484f089278d59f51503049"
-    KONA_VERSION="kona-client-v0.1.0-beta.1"
+    KONA_VERSION="kona-client-v0.1.0-beta.3"
   }
   target="proofs-tools"
   platforms = split(",", PLATFORMS)


### PR DESCRIPTION
## Overview

Bumps the version of `kona` in the `proofs-tools` image to the [latest release](https://github.com/anton-rs/kona/releases/tag/kona-client-v0.1.0-beta.3).