### PR TITLE
op-batcher: Wait for queue to drain before shutdown

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -482,6 +482,9 @@ func (l *BatchSubmitter) mainLoop(ctx context.Context, receiptsCh chan txmgr.TxR
 
 			l.publishStateToL1(queue, receiptsCh, daGroup, l.Config.PollInterval)
 		case <-ctx.Done():
+			if err := queue.Wait(); err != nil {
+				l.Log.Error("error waiting for transactions to complete", "err", err)
+			}
 			l.Log.Warn("main loop returning")
 			return
 		}


### PR DESCRIPTION
Tests are flaking because the batcher's txmgr still polls for receipts after shutdown. Those polls emit logs, which then cause the tests to panic. To fix, I updated the batcher shutdown code to wait for all pending transactions in the tx queue to complete.
