### PR TITLE
feat: make Cannon libraries verison agnostic

### DIFF
--- a/packages/contracts-bedrock/src/cannon/libraries/CannonErrors.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/CannonErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 /// @notice Thrown when a passed part offset is out of bounds.
 error PartOffsetOOB();

--- a/packages/contracts-bedrock/src/cannon/libraries/CannonTypes.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/CannonTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 using LPPMetadataLib for LPPMetaData global;
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Arch.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Arch.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 library MIPS64Arch {
     uint64 internal constant WORD_SIZE = 64;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { InvalidMemoryProof } from "src/cannon/libraries/CannonErrors.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { InvalidMemoryProof } from "src/cannon/libraries/CannonErrors.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { InvalidExitedValue } from "src/cannon/libraries/CannonErrors.sol";

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 // Libraries
 import { MIPSMemory } from "src/cannon/libraries/MIPSMemory.sol";


### PR DESCRIPTION
Updates the Cannon libraries to be version agnostic instead of
being pinned to 0.8.15. This is OK because we do not deploy
libraries outside of contracts that have pinned contract versions.