### PR TITLE
ctb: Fix flake in TestExtractTestNames

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-names/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/test-names/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/solc"
@@ -272,6 +273,8 @@ func TestExtractTestNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := extractTestNames(tt.artifact)
+			slices.Sort(got)
+			slices.Sort(tt.want)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("extractTestNames() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Golang map iteration order is random, so we need to sort first.
