### PR TITLE
op-deployer/ctb: Add DeployOPCM script

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { LibString } from "@solady/utils/LibString.sol";
+
+import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
+import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+
+contract DeployOPCMInput is BaseDeployIO {
+    ISuperchainConfig internal _superchainConfig;
+    IProtocolVersions internal _protocolVersions;
+    string internal _l1ContractsRelease;
+
+    address internal _addressManagerBlueprint;
+    address internal _proxyBlueprint;
+    address internal _proxyAdminBlueprint;
+    address internal _l1ChugSplashProxyBlueprint;
+    address internal _resolvedDelegateProxyBlueprint;
+    address internal _anchorStateRegistryBlueprint;
+    address internal _permissionedDisputeGame1Blueprint;
+    address internal _permissionedDisputeGame2Blueprint;
+
+    address internal _l1ERC721BridgeImpl;
+    address internal _optimismPortalImpl;
+    address internal _systemConfigImpl;
+    address internal _optimismMintableERC20FactoryImpl;
+    address internal _l1CrossDomainMessengerImpl;
+    address internal _l1StandardBridgeImpl;
+    address internal _disputeGameFactoryImpl;
+    address internal _delayedWETHImpl;
+    address internal _mipsImpl;
+
+    // Setter for address type
+    function set(bytes4 _sel, address _addr) public {
+        require(_addr != address(0), "DeployOPCMInput: cannot set zero address");
+
+        if (_sel == this.superchainConfig.selector) _superchainConfig = ISuperchainConfig(_addr);
+        else if (_sel == this.protocolVersions.selector) _protocolVersions = IProtocolVersions(_addr);
+        else if (_sel == this.addressManagerBlueprint.selector) _addressManagerBlueprint = _addr;
+        else if (_sel == this.proxyBlueprint.selector) _proxyBlueprint = _addr;
+        else if (_sel == this.proxyAdminBlueprint.selector) _proxyAdminBlueprint = _addr;
+        else if (_sel == this.l1ChugSplashProxyBlueprint.selector) _l1ChugSplashProxyBlueprint = _addr;
+        else if (_sel == this.resolvedDelegateProxyBlueprint.selector) _resolvedDelegateProxyBlueprint = _addr;
+        else if (_sel == this.anchorStateRegistryBlueprint.selector) _anchorStateRegistryBlueprint = _addr;
+        else if (_sel == this.permissionedDisputeGame1Blueprint.selector) _permissionedDisputeGame1Blueprint = _addr;
+        else if (_sel == this.permissionedDisputeGame2Blueprint.selector) _permissionedDisputeGame2Blueprint = _addr;
+        else if (_sel == this.l1ERC721BridgeImpl.selector) _l1ERC721BridgeImpl = _addr;
+        else if (_sel == this.optimismPortalImpl.selector) _optimismPortalImpl = _addr;
+        else if (_sel == this.systemConfigImpl.selector) _systemConfigImpl = _addr;
+        else if (_sel == this.optimismMintableERC20FactoryImpl.selector) _optimismMintableERC20FactoryImpl = _addr;
+        else if (_sel == this.l1CrossDomainMessengerImpl.selector) _l1CrossDomainMessengerImpl = _addr;
+        else if (_sel == this.l1StandardBridgeImpl.selector) _l1StandardBridgeImpl = _addr;
+        else if (_sel == this.disputeGameFactoryImpl.selector) _disputeGameFactoryImpl = _addr;
+        else if (_sel == this.delayedWETHImpl.selector) _delayedWETHImpl = _addr;
+        else if (_sel == this.mipsImpl.selector) _mipsImpl = _addr;
+        else revert("DeployOPCMInput: unknown selector");
+    }
+
+    // Setter for string type
+    function set(bytes4 _sel, string memory _value) public {
+        require(!LibString.eq(_value, ""), "DeployOPCMInput: cannot set empty string");
+        if (_sel == this.l1ContractsRelease.selector) _l1ContractsRelease = _value;
+        else revert("DeployOPCMInput: unknown selector");
+    }
+
+    // Getters
+    function superchainConfig() public view returns (ISuperchainConfig) {
+        require(address(_superchainConfig) != address(0), "DeployOPCMInput: not set");
+        return _superchainConfig;
+    }
+
+    function protocolVersions() public view returns (IProtocolVersions) {
+        require(address(_protocolVersions) != address(0), "DeployOPCMInput: not set");
+        return _protocolVersions;
+    }
+
+    function l1ContractsRelease() public view returns (string memory) {
+        require(!LibString.eq(_l1ContractsRelease, ""), "DeployOPCMInput: not set");
+        return _l1ContractsRelease;
+    }
+
+    function addressManagerBlueprint() public view returns (address) {
+        require(_addressManagerBlueprint != address(0), "DeployOPCMInput: not set");
+        return _addressManagerBlueprint;
+    }
+
+    function proxyBlueprint() public view returns (address) {
+        require(_proxyBlueprint != address(0), "DeployOPCMInput: not set");
+        return _proxyBlueprint;
+    }
+
+    function proxyAdminBlueprint() public view returns (address) {
+        require(_proxyAdminBlueprint != address(0), "DeployOPCMInput: not set");
+        return _proxyAdminBlueprint;
+    }
+
+    function l1ChugSplashProxyBlueprint() public view returns (address) {
+        require(_l1ChugSplashProxyBlueprint != address(0), "DeployOPCMInput: not set");
+        return _l1ChugSplashProxyBlueprint;
+    }
+
+    function resolvedDelegateProxyBlueprint() public view returns (address) {
+        require(_resolvedDelegateProxyBlueprint != address(0), "DeployOPCMInput: not set");
+        return _resolvedDelegateProxyBlueprint;
+    }
+
+    function anchorStateRegistryBlueprint() public view returns (address) {
+        require(_anchorStateRegistryBlueprint != address(0), "DeployOPCMInput: not set");
+        return _anchorStateRegistryBlueprint;
+    }
+
+    function permissionedDisputeGame1Blueprint() public view returns (address) {
+        require(_permissionedDisputeGame1Blueprint != address(0), "DeployOPCMInput: not set");
+        return _permissionedDisputeGame1Blueprint;
+    }
+
+    function permissionedDisputeGame2Blueprint() public view returns (address) {
+        require(_permissionedDisputeGame2Blueprint != address(0), "DeployOPCMInput: not set");
+        return _permissionedDisputeGame2Blueprint;
+    }
+
+    function l1ERC721BridgeImpl() public view returns (address) {
+        require(_l1ERC721BridgeImpl != address(0), "DeployOPCMInput: not set");
+        return _l1ERC721BridgeImpl;
+    }
+
+    function optimismPortalImpl() public view returns (address) {
+        require(_optimismPortalImpl != address(0), "DeployOPCMInput: not set");
+        return _optimismPortalImpl;
+    }
+
+    function systemConfigImpl() public view returns (address) {
+        require(_systemConfigImpl != address(0), "DeployOPCMInput: not set");
+        return _systemConfigImpl;
+    }
+
+    function optimismMintableERC20FactoryImpl() public view returns (address) {
+        require(_optimismMintableERC20FactoryImpl != address(0), "DeployOPCMInput: not set");
+        return _optimismMintableERC20FactoryImpl;
+    }
+
+    function l1CrossDomainMessengerImpl() public view returns (address) {
+        require(_l1CrossDomainMessengerImpl != address(0), "DeployOPCMInput: not set");
+        return _l1CrossDomainMessengerImpl;
+    }
+
+    function l1StandardBridgeImpl() public view returns (address) {
+        require(_l1StandardBridgeImpl != address(0), "DeployOPCMInput: not set");
+        return _l1StandardBridgeImpl;
+    }
+
+    function disputeGameFactoryImpl() public view returns (address) {
+        require(_disputeGameFactoryImpl != address(0), "DeployOPCMInput: not set");
+        return _disputeGameFactoryImpl;
+    }
+
+    function delayedWETHImpl() public view returns (address) {
+        require(_delayedWETHImpl != address(0), "DeployOPCMInput: not set");
+        return _delayedWETHImpl;
+    }
+
+    function mipsImpl() public view returns (address) {
+        require(_mipsImpl != address(0), "DeployOPCMInput: not set");
+        return _mipsImpl;
+    }
+}
+
+contract DeployOPCMOutput is BaseDeployIO {
+    OPContractsManager internal _opcm;
+
+    // Setter for address type
+    function set(bytes4 _sel, address _addr) public {
+        require(_addr != address(0), "DeployOPCMOutput: cannot set zero address");
+        if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
+        else revert("DeployOPCMOutput: unknown selector");
+    }
+
+    // Getter
+    function opcm() public view returns (OPContractsManager) {
+        require(address(_opcm) != address(0), "DeployOPCMOutput: not set");
+        return _opcm;
+    }
+}
+
+contract DeployOPCM is Script {
+    function run(DeployOPCMInput _doi, DeployOPCMOutput _doo) public {
+        OPContractsManager.Blueprints memory blueprints = OPContractsManager.Blueprints({
+            addressManager: _doi.addressManagerBlueprint(),
+            proxy: _doi.proxyBlueprint(),
+            proxyAdmin: _doi.proxyAdminBlueprint(),
+            l1ChugSplashProxy: _doi.l1ChugSplashProxyBlueprint(),
+            resolvedDelegateProxy: _doi.resolvedDelegateProxyBlueprint(),
+            anchorStateRegistry: _doi.anchorStateRegistryBlueprint(),
+            permissionedDisputeGame1: _doi.permissionedDisputeGame1Blueprint(),
+            permissionedDisputeGame2: _doi.permissionedDisputeGame2Blueprint()
+        });
+        OPContractsManager.Implementations memory implementations = OPContractsManager.Implementations({
+            l1ERC721BridgeImpl: address(_doi.l1ERC721BridgeImpl()),
+            optimismPortalImpl: address(_doi.optimismPortalImpl()),
+            systemConfigImpl: address(_doi.systemConfigImpl()),
+            optimismMintableERC20FactoryImpl: address(_doi.optimismMintableERC20FactoryImpl()),
+            l1CrossDomainMessengerImpl: address(_doi.l1CrossDomainMessengerImpl()),
+            l1StandardBridgeImpl: address(_doi.l1StandardBridgeImpl()),
+            disputeGameFactoryImpl: address(_doi.disputeGameFactoryImpl()),
+            delayedWETHImpl: address(_doi.delayedWETHImpl()),
+            mipsImpl: address(_doi.mipsImpl())
+        });
+
+        OPContractsManager opcm_ = deployOPCM(
+            _doi.superchainConfig(), _doi.protocolVersions(), blueprints, implementations, _doi.l1ContractsRelease()
+        );
+        _doo.set(_doo.opcm.selector, address(opcm_));
+
+        assertValidOpcm(_doi, _doo);
+    }
+
+    function deployOPCM(
+        ISuperchainConfig _superchainConfig,
+        IProtocolVersions _protocolVersions,
+        OPContractsManager.Blueprints memory _blueprints,
+        OPContractsManager.Implementations memory _implementations,
+        string memory _l1ContractsRelease
+    )
+        public
+        returns (OPContractsManager opcm_)
+    {
+        vm.broadcast(msg.sender);
+        opcm_ = new OPContractsManager(
+            _superchainConfig, _protocolVersions, _l1ContractsRelease, _blueprints, _implementations
+        );
+        vm.label(address(opcm_), "OPContractsManager");
+    }
+
+    function assertValidOpcm(DeployOPCMInput _doi, DeployOPCMOutput _doo) public view {
+        OPContractsManager impl = OPContractsManager(address(_doo.opcm()));
+        require(address(impl.superchainConfig()) == address(_doi.superchainConfig()), "OPCMI-10");
+        require(address(impl.protocolVersions()) == address(_doi.protocolVersions()), "OPCMI-20");
+        require(LibString.eq(impl.l1ContractsRelease(), _doi.l1ContractsRelease()));
+
+        OPContractsManager.Blueprints memory blueprints = impl.blueprints();
+        require(blueprints.addressManager == _doi.addressManagerBlueprint(), "OPCMI-40");
+        require(blueprints.proxy == _doi.proxyBlueprint(), "OPCMI-50");
+        require(blueprints.proxyAdmin == _doi.proxyAdminBlueprint(), "OPCMI-60");
+        require(blueprints.l1ChugSplashProxy == _doi.l1ChugSplashProxyBlueprint(), "OPCMI-70");
+        require(blueprints.resolvedDelegateProxy == _doi.resolvedDelegateProxyBlueprint(), "OPCMI-80");
+        require(blueprints.anchorStateRegistry == _doi.anchorStateRegistryBlueprint(), "OPCMI-90");
+        require(blueprints.permissionedDisputeGame1 == _doi.permissionedDisputeGame1Blueprint(), "OPCMI-100");
+        require(blueprints.permissionedDisputeGame2 == _doi.permissionedDisputeGame2Blueprint(), "OPCMI-110");
+
+        OPContractsManager.Implementations memory implementations = impl.implementations();
+        require(implementations.l1ERC721BridgeImpl == _doi.l1ERC721BridgeImpl(), "OPCMI-120");
+        require(implementations.optimismPortalImpl == _doi.optimismPortalImpl(), "OPCMI-130");
+        require(implementations.systemConfigImpl == _doi.systemConfigImpl(), "OPCMI-140");
+        require(
+            implementations.optimismMintableERC20FactoryImpl == _doi.optimismMintableERC20FactoryImpl(), "OPCMI-150"
+        );
+        require(implementations.l1CrossDomainMessengerImpl == _doi.l1CrossDomainMessengerImpl(), "OPCMI-160");
+        require(implementations.l1StandardBridgeImpl == _doi.l1StandardBridgeImpl(), "OPCMI-170");
+        require(implementations.disputeGameFactoryImpl == _doi.disputeGameFactoryImpl(), "OPCMI-180");
+        require(implementations.delayedWETHImpl == _doi.delayedWETHImpl(), "OPCMI-190");
+        require(implementations.mipsImpl == _doi.mipsImpl(), "OPCMI-200");
+    }
+
+    function etchIOContracts() public returns (DeployOPCMInput doi_, DeployOPCMOutput doo_) {
+        (doi_, doo_) = getIOContracts();
+        vm.etch(address(doi_), type(DeployOPCMInput).runtimeCode);
+        vm.etch(address(doo_), type(DeployOPCMOutput).runtimeCode);
+    }
+
+    function getIOContracts() public view returns (DeployOPCMInput doi_, DeployOPCMOutput doo_) {
+        doi_ = DeployOPCMInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPCMInput"));
+        doo_ = DeployOPCMOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPCMOutput"));
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -80,7 +80,7 @@ contract DeployOPCMInput_Test is Test {
 
     // Below setter tests are split into two parts to avoid stack too deep errors
 
-    function test_set_succeeds_part1() public {
+    function test_set_part1_succeeds() public {
         ISuperchainConfig superchainConfig = ISuperchainConfig(makeAddr("superchainConfig"));
         IProtocolVersions protocolVersions = IProtocolVersions(makeAddr("protocolVersions"));
         address addressManagerBlueprint = makeAddr("addressManagerBlueprint");

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { DeployOPCM, DeployOPCMInput, DeployOPCMOutput } from "scripts/deploy/DeployOPCM.s.sol";
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { DeployOPCM, DeployOPCMInput, DeployOPCMOutput } from "scripts/deploy/DeployOPCM.s.sol";
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
 import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { DeployOPCM, DeployOPCMInput, DeployOPCMOutput } from "scripts/deploy/DeployOPCM.s.sol";
+import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
+
+contract DeployOPCMInput_Test is Test {
+    DeployOPCMInput dii;
+    string release = "1.0.0";
+
+    function setUp() public {
+        dii = new DeployOPCMInput();
+    }
+
+    function test_getters_whenNotSet_reverts() public {
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.superchainConfig();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.protocolVersions();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1ContractsRelease();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.addressManagerBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.proxyBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.proxyAdminBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1ChugSplashProxyBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.resolvedDelegateProxyBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.anchorStateRegistryBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.permissionedDisputeGame1Blueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.permissionedDisputeGame2Blueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1ERC721BridgeImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.optimismPortalImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.systemConfigImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.optimismMintableERC20FactoryImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1CrossDomainMessengerImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1StandardBridgeImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.disputeGameFactoryImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.delayedWETHImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.mipsImpl();
+    }
+
+    // Below setter tests are split into two parts to avoid stack too deep errors
+
+    function test_set_succeeds_part1() public {
+        ISuperchainConfig superchainConfig = ISuperchainConfig(makeAddr("superchainConfig"));
+        IProtocolVersions protocolVersions = IProtocolVersions(makeAddr("protocolVersions"));
+        address addressManagerBlueprint = makeAddr("addressManagerBlueprint");
+        address proxyBlueprint = makeAddr("proxyBlueprint");
+        address proxyAdminBlueprint = makeAddr("proxyAdminBlueprint");
+        address l1ChugSplashProxyBlueprint = makeAddr("l1ChugSplashProxyBlueprint");
+        address resolvedDelegateProxyBlueprint = makeAddr("resolvedDelegateProxyBlueprint");
+        address anchorStateRegistryBlueprint = makeAddr("anchorStateRegistryBlueprint");
+        address permissionedDisputeGame1Blueprint = makeAddr("permissionedDisputeGame1Blueprint");
+        address permissionedDisputeGame2Blueprint = makeAddr("permissionedDisputeGame2Blueprint");
+
+        dii.set(dii.superchainConfig.selector, address(superchainConfig));
+        dii.set(dii.protocolVersions.selector, address(protocolVersions));
+        dii.set(dii.l1ContractsRelease.selector, release);
+        dii.set(dii.addressManagerBlueprint.selector, addressManagerBlueprint);
+        dii.set(dii.proxyBlueprint.selector, proxyBlueprint);
+        dii.set(dii.proxyAdminBlueprint.selector, proxyAdminBlueprint);
+        dii.set(dii.l1ChugSplashProxyBlueprint.selector, l1ChugSplashProxyBlueprint);
+        dii.set(dii.resolvedDelegateProxyBlueprint.selector, resolvedDelegateProxyBlueprint);
+        dii.set(dii.anchorStateRegistryBlueprint.selector, anchorStateRegistryBlueprint);
+        dii.set(dii.permissionedDisputeGame1Blueprint.selector, permissionedDisputeGame1Blueprint);
+        dii.set(dii.permissionedDisputeGame2Blueprint.selector, permissionedDisputeGame2Blueprint);
+
+        assertEq(address(dii.superchainConfig()), address(superchainConfig), "50");
+        assertEq(address(dii.protocolVersions()), address(protocolVersions), "100");
+        assertEq(dii.l1ContractsRelease(), release, "150");
+        assertEq(dii.addressManagerBlueprint(), addressManagerBlueprint, "200");
+        assertEq(dii.proxyBlueprint(), proxyBlueprint, "250");
+        assertEq(dii.proxyAdminBlueprint(), proxyAdminBlueprint, "300");
+        assertEq(dii.l1ChugSplashProxyBlueprint(), l1ChugSplashProxyBlueprint, "350");
+        assertEq(dii.resolvedDelegateProxyBlueprint(), resolvedDelegateProxyBlueprint, "400");
+        assertEq(dii.anchorStateRegistryBlueprint(), anchorStateRegistryBlueprint, "450");
+        assertEq(dii.permissionedDisputeGame1Blueprint(), permissionedDisputeGame1Blueprint, "500");
+        assertEq(dii.permissionedDisputeGame2Blueprint(), permissionedDisputeGame2Blueprint, "550");
+    }
+
+    function test_set_succeeds_part2() public {
+        address l1ERC721BridgeImpl = makeAddr("l1ERC721BridgeImpl");
+        address optimismPortalImpl = makeAddr("optimismPortalImpl");
+        address systemConfigImpl = makeAddr("systemConfigImpl");
+        address optimismMintableERC20FactoryImpl = makeAddr("optimismMintableERC20FactoryImpl");
+        address l1CrossDomainMessengerImpl = makeAddr("l1CrossDomainMessengerImpl");
+        address l1StandardBridgeImpl = makeAddr("l1StandardBridgeImpl");
+        address disputeGameFactoryImpl = makeAddr("disputeGameFactoryImpl");
+        address delayedWETHImpl = makeAddr("delayedWETHImpl");
+        address mipsImpl = makeAddr("mipsImpl");
+
+        dii.set(dii.l1ERC721BridgeImpl.selector, l1ERC721BridgeImpl);
+        dii.set(dii.optimismPortalImpl.selector, optimismPortalImpl);
+        dii.set(dii.systemConfigImpl.selector, systemConfigImpl);
+        dii.set(dii.optimismMintableERC20FactoryImpl.selector, optimismMintableERC20FactoryImpl);
+        dii.set(dii.l1CrossDomainMessengerImpl.selector, l1CrossDomainMessengerImpl);
+        dii.set(dii.l1StandardBridgeImpl.selector, l1StandardBridgeImpl);
+        dii.set(dii.disputeGameFactoryImpl.selector, disputeGameFactoryImpl);
+        dii.set(dii.delayedWETHImpl.selector, delayedWETHImpl);
+        dii.set(dii.mipsImpl.selector, mipsImpl);
+
+        assertEq(dii.l1ERC721BridgeImpl(), l1ERC721BridgeImpl, "600");
+        assertEq(dii.optimismPortalImpl(), optimismPortalImpl, "650");
+        assertEq(dii.systemConfigImpl(), systemConfigImpl, "700");
+        assertEq(dii.optimismMintableERC20FactoryImpl(), optimismMintableERC20FactoryImpl, "750");
+        assertEq(dii.l1CrossDomainMessengerImpl(), l1CrossDomainMessengerImpl, "800");
+        assertEq(dii.l1StandardBridgeImpl(), l1StandardBridgeImpl, "850");
+        assertEq(dii.disputeGameFactoryImpl(), disputeGameFactoryImpl, "900");
+        assertEq(dii.delayedWETHImpl(), delayedWETHImpl, "950");
+        assertEq(dii.mipsImpl(), mipsImpl, "1000");
+    }
+
+    function test_set_withZeroAddress_reverts() public {
+        vm.expectRevert("DeployOPCMInput: cannot set zero address");
+        dii.set(dii.superchainConfig.selector, address(0));
+    }
+
+    function test_set_withEmptyString_reverts() public {
+        vm.expectRevert("DeployOPCMInput: cannot set empty string");
+        dii.set(dii.l1ContractsRelease.selector, "");
+    }
+
+    function test_set_withInvalidSelector_reverts() public {
+        vm.expectRevert("DeployOPCMInput: unknown selector");
+        dii.set(bytes4(0xdeadbeef), address(1));
+    }
+
+    function test_set_withInvalidStringSelector_reverts() public {
+        vm.expectRevert("DeployOPCMInput: unknown selector");
+        dii.set(bytes4(0xdeadbeef), "test");
+    }
+}
+
+contract DeployOPCMOutput_Test is Test {
+    DeployOPCMOutput doo;
+
+    function setUp() public {
+        doo = new DeployOPCMOutput();
+    }
+
+    function test_getters_whenNotSet_reverts() public {
+        vm.expectRevert("DeployOPCMOutput: not set");
+        doo.opcm();
+    }
+
+    function test_set_succeeds() public {
+        OPContractsManager opcm = OPContractsManager(makeAddr("opcm"));
+        vm.etch(address(opcm), hex"01");
+
+        doo.set(doo.opcm.selector, address(opcm));
+
+        assertEq(address(doo.opcm()), address(opcm), "50");
+    }
+
+    function test_set_withZeroAddress_reverts() public {
+        vm.expectRevert("DeployOPCMOutput: cannot set zero address");
+        doo.set(doo.opcm.selector, address(0));
+    }
+
+    function test_set_withInvalidSelector_reverts() public {
+        vm.expectRevert("DeployOPCMOutput: unknown selector");
+        doo.set(bytes4(0xdeadbeef), makeAddr("test"));
+    }
+}
+
+contract DeployOPCMTest is Test {
+    DeployOPCM deployOPCM;
+    DeployOPCMInput doi;
+    DeployOPCMOutput doo;
+
+    ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
+    IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+
+    function setUp() public virtual {
+        deployOPCM = new DeployOPCM();
+        (doi, doo) = deployOPCM.etchIOContracts();
+    }
+
+    function test_run_succeeds() public {
+        doi.set(doi.superchainConfig.selector, address(superchainConfigProxy));
+        doi.set(doi.protocolVersions.selector, address(protocolVersionsProxy));
+        doi.set(doi.l1ContractsRelease.selector, "1.0.0");
+
+        // Set and etch blueprints
+        doi.set(doi.addressManagerBlueprint.selector, makeAddr("addressManagerBlueprint"));
+        doi.set(doi.proxyBlueprint.selector, makeAddr("proxyBlueprint"));
+        doi.set(doi.proxyAdminBlueprint.selector, makeAddr("proxyAdminBlueprint"));
+        doi.set(doi.l1ChugSplashProxyBlueprint.selector, makeAddr("l1ChugSplashProxyBlueprint"));
+        doi.set(doi.resolvedDelegateProxyBlueprint.selector, makeAddr("resolvedDelegateProxyBlueprint"));
+        doi.set(doi.anchorStateRegistryBlueprint.selector, makeAddr("anchorStateRegistryBlueprint"));
+        doi.set(doi.permissionedDisputeGame1Blueprint.selector, makeAddr("permissionedDisputeGame1Blueprint"));
+        doi.set(doi.permissionedDisputeGame2Blueprint.selector, makeAddr("permissionedDisputeGame2Blueprint"));
+
+        // Set and etch implementations
+        doi.set(doi.l1ERC721BridgeImpl.selector, makeAddr("l1ERC721BridgeImpl"));
+        doi.set(doi.optimismPortalImpl.selector, makeAddr("optimismPortalImpl"));
+        doi.set(doi.systemConfigImpl.selector, makeAddr("systemConfigImpl"));
+        doi.set(doi.optimismMintableERC20FactoryImpl.selector, makeAddr("optimismMintableERC20FactoryImpl"));
+        doi.set(doi.l1CrossDomainMessengerImpl.selector, makeAddr("l1CrossDomainMessengerImpl"));
+        doi.set(doi.l1StandardBridgeImpl.selector, makeAddr("l1StandardBridgeImpl"));
+        doi.set(doi.disputeGameFactoryImpl.selector, makeAddr("disputeGameFactoryImpl"));
+        doi.set(doi.delayedWETHImpl.selector, makeAddr("delayedWETHImpl"));
+        doi.set(doi.mipsImpl.selector, makeAddr("mipsImpl"));
+
+        // Etch all addresses with dummy bytecode
+        vm.etch(address(doi.superchainConfig()), hex"01");
+        vm.etch(address(doi.protocolVersions()), hex"01");
+
+        vm.etch(doi.addressManagerBlueprint(), hex"01");
+        vm.etch(doi.proxyBlueprint(), hex"01");
+        vm.etch(doi.proxyAdminBlueprint(), hex"01");
+        vm.etch(doi.l1ChugSplashProxyBlueprint(), hex"01");
+        vm.etch(doi.resolvedDelegateProxyBlueprint(), hex"01");
+        vm.etch(doi.anchorStateRegistryBlueprint(), hex"01");
+        vm.etch(doi.permissionedDisputeGame1Blueprint(), hex"01");
+        vm.etch(doi.permissionedDisputeGame2Blueprint(), hex"01");
+
+        vm.etch(doi.l1ERC721BridgeImpl(), hex"01");
+        vm.etch(doi.optimismPortalImpl(), hex"01");
+        vm.etch(doi.systemConfigImpl(), hex"01");
+        vm.etch(doi.optimismMintableERC20FactoryImpl(), hex"01");
+        vm.etch(doi.l1CrossDomainMessengerImpl(), hex"01");
+        vm.etch(doi.l1StandardBridgeImpl(), hex"01");
+        vm.etch(doi.disputeGameFactoryImpl(), hex"01");
+        vm.etch(doi.delayedWETHImpl(), hex"01");
+        vm.etch(doi.mipsImpl(), hex"01");
+
+        deployOPCM.run(doi, doo);
+
+        assertNotEq(address(doo.opcm()), address(0));
+
+        // sanity check to ensure that the OPCM is validated
+        deployOPCM.assertValidOpcm(doi, doo);
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -117,7 +117,7 @@ contract DeployOPCMInput_Test is Test {
         assertEq(dii.permissionedDisputeGame2Blueprint(), permissionedDisputeGame2Blueprint, "550");
     }
 
-    function test_set_succeeds_part2() public {
+    function test_set_part2_succeeds() public {
         address l1ERC721BridgeImpl = makeAddr("l1ERC721BridgeImpl");
         address optimismPortalImpl = makeAddr("optimismPortalImpl");
         address systemConfigImpl = makeAddr("systemConfigImpl");


### PR DESCRIPTION
Adds a dedicated script to deploy OPCM for use with a future op-deployer bootstrap command. We'll use this for the Holocene deployment.
