### PR TITLE
e2e/actions: enhance holocene activation action test to cover execution layer

### DIFF
--- a/op-e2e/actions/proofs/holocene_activation_test.go
+++ b/op-e2e/actions/proofs/holocene_activation_test.go
@@ -26,12 +26,12 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 
 		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), setHoloceneTime)
 
-		t.Log("HoloceneTime:  ", env.Sequencer.RollupCfg.HoloceneTime)
+		t.Logf("L2 Genesis Time: %d, HoloceneTime: %d ", env.Sequencer.RollupCfg.Genesis.L2Time, *env.Sequencer.RollupCfg.HoloceneTime)
 
-		// Build the L2 chain
-		blocks := []uint{1, 2}
-		targetHeadNumber := 2
-		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+		// Build the L2 chain until the Holocene activation time,
+		// which for the Execution Engine is an L2 block timestamp
+		// https://specs.optimism.io/protocol/holocene/exec-engine.html?highlight=holocene#timestamp-activation
+		for env.Engine.L2Chain().CurrentBlock().Time < *env.Sequencer.RollupCfg.HoloceneTime {
 			env.Sequencer.ActL2StartBlock(t)
 			// Send an L2 tx
 			env.Alice.L2.ActResetTxOpts(t)
@@ -39,15 +39,28 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 			env.Alice.L2.ActMakeTx(t)
 			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
 			env.Sequencer.ActL2EndBlock(t)
+			b := env.Engine.L2Chain().GetBlockByHash(env.Sequencer.L2Unsafe().Hash)
+			t.Log("Unsafe block with timestamp %d", b.Time)
+			if b.Time() < *env.Sequencer.RollupCfg.HoloceneTime {
+				require.Equal(t, "", string(b.Extra()), "extra data should be empty before Holocene activation")
+			} else {
+				require.NotEqual(t, "", string(b.Extra()), "extra data should be NOT be empty after Holocene activation")
+			}
 		}
 
 		// Build up a local list of frames
-		orderedFrames := make([][]byte, 0, 2)
+		orderedFrames := make([][]byte, 0, 1)
+		// Submit the first two blocks, this will be enough to trigger Holocene _derivation_
+		// which is activated by the L1 inclusion block timestamp
+		// https://specs.optimism.io/protocol/holocene/derivation.html?highlight=holoce#activation
+		// block 1 will be 12 seconda after genesis, and 2 seconds before Holocene activation
+		// block 2 will be 24 seconds after genesis, and 10 seconds after Holocene activation
+		blocksToSubmit := []uint{1, 2}
 		// Buffer the blocks in the batcher and populate orderedFrames list
 		env.Batcher.ActCreateChannel(t, false)
-		for i, blockNum := range blocks {
+		for i, blockNum := range blocksToSubmit {
 			env.Batcher.ActAddBlockByNumber(t, int64(blockNum), actionsHelpers.BlockLogger(t))
-			if i == len(blocks)-1 {
+			if i == len(blocksToSubmit)-1 {
 				env.Batcher.ActL2ChannelClose(t)
 			}
 			frame := env.Batcher.ReadNextOutputFrame(t)
@@ -64,7 +77,7 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 
 		// Submit first frame
 		env.Batcher.ActL2BatchSubmitRaw(t, orderedFrames[0])
-		includeBatchTx() // block should have a timestamp of 12s after genesis
+		includeBatchTx() // L1 block should have a timestamp of 12s after genesis
 
 		// Holocene should activate 14s after genesis, so that the previous l1 block
 		// was before HoloceneTime and the next l1 block is after it
@@ -78,8 +91,11 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l2SafeHead := env.Sequencer.L2Safe()
+		t.Log(l2SafeHead.Time)
 		require.EqualValues(t, uint64(0), l2SafeHead.Number) // channel should be dropped, so no safe head progression
-		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
+		if uint64(0) == l2SafeHead.Number {
+			t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
+		}
 
 		// Log assertions
 		filters := []string{
@@ -92,7 +108,6 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 			recs := env.Logs.FindLogs(testlog.NewMessageContainsFilter(filter), testlog.NewAttributesFilter("role", "sequencer"))
 			require.Len(t, recs, 1, "searching for %d instances of '%s' in logs from role %s", 1, filter, "sequencer")
 		}
-
 		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 

--- a/op-e2e/actions/proofs/holocene_activation_test.go
+++ b/op-e2e/actions/proofs/holocene_activation_test.go
@@ -32,6 +32,8 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 		// which for the Execution Engine is an L2 block timestamp
 		// https://specs.optimism.io/protocol/holocene/exec-engine.html?highlight=holocene#timestamp-activation
 		for env.Engine.L2Chain().CurrentBlock().Time < *env.Sequencer.RollupCfg.HoloceneTime {
+			b := env.Engine.L2Chain().GetBlockByHash(env.Sequencer.L2Unsafe().Hash)
+			require.Equal(t, "", string(b.Extra()), "extra data should be empty before Holocene activation")
 			env.Sequencer.ActL2StartBlock(t)
 			// Send an L2 tx
 			env.Alice.L2.ActResetTxOpts(t)
@@ -39,14 +41,10 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 			env.Alice.L2.ActMakeTx(t)
 			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
 			env.Sequencer.ActL2EndBlock(t)
-			b := env.Engine.L2Chain().GetBlockByHash(env.Sequencer.L2Unsafe().Hash)
 			t.Log("Unsafe block with timestamp %d", b.Time)
-			if b.Time() < *env.Sequencer.RollupCfg.HoloceneTime {
-				require.Equal(t, "", string(b.Extra()), "extra data should be empty before Holocene activation")
-			} else {
-				require.NotEqual(t, "", string(b.Extra()), "extra data should be NOT be empty after Holocene activation")
-			}
 		}
+		b := env.Engine.L2Chain().GetBlockByHash(env.Sequencer.L2Unsafe().Hash)
+		require.Len(t, b.Extra(), 9, "extra data should be 9 bytes after Holocene activation")
 
 		// Build up a local list of frames
 		orderedFrames := make([][]byte, 0, 1)


### PR DESCRIPTION
These seems a prudent sanity check.

One subtlety here is that consensus layer and execution layers actually activate their "features" at different logical moments. The activation timestamp is the same, but for the former it is an l1 inclusion block timestamp and for the latter it is an l2 block timestamp. 