### PR TITLE
chore(opc): Bump `asterisc` version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ anvil = "nightly-143abd6a768eeb52a5785240b763d72a56987b4a"
 # Put things here if you need to track versions of tools or projects that can't
 # actually be managed by mise (yet). Make sure that anything you put in here is
 # also found inside of disabled_tools or mise will try to install it.
-asterisc = "1.1.1"
+asterisc = "1.2.0"
 kontrol = "1.0.53"
 binary_signer = "1.0.4"
 

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -212,8 +212,8 @@
     "sourceCodeHash": "0x5dc6b0b4ae4ab29085c52f74a4498d8a3d04928b844491749cd7186623e8b967"
   },
   "src/vendor/asterisc/RISCV.sol": {
-    "initCodeHash": "0x6b4323061187f2c8efe8de43bf1ecdc0798e2d95ad69470ed4151dadc094fedf",
-    "sourceCodeHash": "0x26cae049cf171efcc84c946a400704c30ebec5dba4f1548d1f1529f68f56c1ec"
+    "initCodeHash": "0x7329cca924e189eeaa2d883234f6cb5fd787c8bf3339d8298e721778c2947ce5",
+    "sourceCodeHash": "0xf85f3dac3e0fcc7f52fb62f8e66b74f2bc6798b6c9fb43e1a610c5edc04be412"
   },
   "src/vendor/eas/EAS.sol": {
     "initCodeHash": "0xf96d1ebc530ed95e2dffebcfa2b4a1f18103235e6352d97838b77b7a2c14567b",

--- a/packages/contracts-bedrock/src/vendor/asterisc/RISCV.sol
+++ b/packages/contracts-bedrock/src/vendor/asterisc/RISCV.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
@@ -14,8 +14,8 @@ contract RISCV is IBigStepper {
     IPreimageOracle public oracle;
 
     /// @notice The version of the contract.
-    /// @custom:semver 1.1.0-rc.2
-    string public constant version = "1.1.0-rc.2";
+    /// @custom:semver 1.2.0-rc.1
+    string public constant version = "1.2.0-rc.1";
 
     /// @param _oracle The preimage oracle contract.
     constructor(IPreimageOracle _oracle) {


### PR DESCRIPTION
## Overview

Bumps the version of `asterisc` to `v1.2.0`.