### PR TITLE
op-e2e: Recover gracefully from log-after-exit panics

### DIFF
--- a/op-service/testlog/testlog.go
+++ b/op-service/testlog/testlog.go
@@ -159,9 +159,19 @@ func (l *logger) flush() {
 
 	scanner := bufio.NewScanner(l.buf)
 	for scanner.Scan() {
-		l.t.Logf("%*s%s", padding, "", scanner.Text())
+		l.internalFlush("%*s%s", padding, "", scanner.Text())
 	}
 	l.buf.Reset()
+}
+
+func (l *logger) internalFlush(format string, args ...any) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warn("testlog: panic during flush", "recover", r)
+		}
+	}()
+
+	l.t.Logf(format, args...)
 }
 
 // The Go testing lib uses the runtime package to get info about the calling site, and then decorates the line.

--- a/op-service/testlog/testlog.go
+++ b/op-service/testlog/testlog.go
@@ -171,6 +171,7 @@ func (l *logger) internalFlush(format string, args ...any) {
 		}
 	}()
 
+	l.t.Helper()
 	l.t.Logf(format, args...)
 }
 


### PR DESCRIPTION
There are a lot of places where we log after tests exit. This PR recovers from those panics so tests can continue.
