### PR TITLE
[cleanup] Replace manual `CheckRequired` functions with urfave/cli `Required: true`

### DIFF
--- a/op-alt-da/cmd/daserver/entrypoint.go
+++ b/op-alt-da/cmd/daserver/entrypoint.go
@@ -11,10 +11,6 @@ import (
 )
 
 func StartDAServer(cliCtx *cli.Context) error {
-	if err := CheckRequired(cliCtx); err != nil {
-		return err
-	}
-
 	cfg := ReadCLIConfig(cliCtx)
 	if err := cfg.Check(); err != nil {
 		return err

--- a/op-alt-da/cmd/daserver/flags.go
+++ b/op-alt-da/cmd/daserver/flags.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/urfave/cli/v2"
 
@@ -29,16 +28,18 @@ func prefixEnvVars(name string) []string {
 
 var (
 	ListenAddrFlag = &cli.StringFlag{
-		Name:    ListenAddrFlagName,
-		Usage:   "server listening address",
-		Value:   "127.0.0.1",
-		EnvVars: prefixEnvVars("ADDR"),
+		Name:     ListenAddrFlagName,
+		Usage:    "server listening address",
+		Value:    "127.0.0.1",
+		EnvVars:  prefixEnvVars("ADDR"),
+		Required: true,
 	}
 	PortFlag = &cli.IntFlag{
-		Name:    PortFlagName,
-		Usage:   "server listening port",
-		Value:   3100,
-		EnvVars: prefixEnvVars("PORT"),
+		Name:     PortFlagName,
+		Usage:    "server listening port",
+		Value:    3100,
+		EnvVars:  prefixEnvVars("PORT"),
+		Required: true,
 	}
 	FileStorePathFlag = &cli.StringFlag{
 		Name:    FileStorePathFlagName,
@@ -76,12 +77,10 @@ var (
 	}
 )
 
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	ListenAddrFlag,
 	PortFlag,
-}
-
-var optionalFlags = []cli.Flag{
 	FileStorePathFlag,
 	S3BucketFlag,
 	S3EndpointFlag,
@@ -91,12 +90,8 @@ var optionalFlags = []cli.Flag{
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	Flags = append(requiredFlags, optionalFlags...)
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
 }
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
 
 type CLIConfig struct {
 	FileStoreDirPath  string
@@ -146,13 +141,4 @@ func (c CLIConfig) S3Config() S3Config {
 
 func (c CLIConfig) FileStoreEnabled() bool {
 	return c.FileStoreDirPath != ""
-}
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return nil
 }

--- a/op-batcher/batcher/batch_submitter.go
+++ b/op-batcher/batcher/batch_submitter.go
@@ -16,9 +16,6 @@ import (
 // This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed batch-submitter with.
 func Main(version string) cliapp.LifecycleAction {
 	return func(cliCtx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
-		if err := flags.CheckRequired(cliCtx); err != nil {
-			return nil, err
-		}
 		cfg := NewConfig(cliCtx)
 		if err := cfg.Check(); err != nil {
 			return nil, fmt.Errorf("invalid CLI flags: %w", err)

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -29,19 +29,22 @@ func prefixEnvVars(name string) []string {
 var (
 	// Required flags
 	L1EthRpcFlag = &cli.StringFlag{
-		Name:    "l1-eth-rpc",
-		Usage:   "HTTP provider URL for L1",
-		EnvVars: prefixEnvVars("L1_ETH_RPC"),
+		Name:     "l1-eth-rpc",
+		Usage:    "HTTP provider URL for L1",
+		EnvVars:  prefixEnvVars("L1_ETH_RPC"),
+		Required: true,
 	}
 	L2EthRpcFlag = &cli.StringFlag{
-		Name:    "l2-eth-rpc",
-		Usage:   "HTTP provider URL for L2 execution engine. A comma-separated list enables the active L2 endpoint provider. Such a list needs to match the number of rollup-rpcs provided.",
-		EnvVars: prefixEnvVars("L2_ETH_RPC"),
+		Name:     "l2-eth-rpc",
+		Usage:    "HTTP provider URL for L2 execution engine. A comma-separated list enables the active L2 endpoint provider. Such a list needs to match the number of rollup-rpcs provided.",
+		EnvVars:  prefixEnvVars("L2_ETH_RPC"),
+		Required: true,
 	}
 	RollupRpcFlag = &cli.StringFlag{
-		Name:    "rollup-rpc",
-		Usage:   "HTTP provider URL for Rollup node. A comma-separated list enables the active L2 endpoint provider. Such a list needs to match the number of l2-eth-rpcs provided.",
-		EnvVars: prefixEnvVars("ROLLUP_RPC"),
+		Name:     "rollup-rpc",
+		Usage:    "HTTP provider URL for Rollup node. A comma-separated list enables the active L2 endpoint provider. Such a list needs to match the number of l2-eth-rpcs provided.",
+		EnvVars:  prefixEnvVars("ROLLUP_RPC"),
+		Required: true,
 	}
 	// Optional flags
 	SubSafetyMarginFlag = &cli.Uint64Flag{
@@ -190,13 +193,11 @@ var (
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )
 
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	L1EthRpcFlag,
 	L2EthRpcFlag,
 	RollupRpcFlag,
-}
-
-var optionalFlags = []cli.Flag{
 	WaitNodeSyncFlag,
 	CheckRecentTxsDepthFlag,
 	SubSafetyMarginFlag,
@@ -222,24 +223,10 @@ var optionalFlags = []cli.Flag{
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, txmgr.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, altda.CLIFlags(EnvVarPrefix, "")...)
-
-	Flags = append(requiredFlags, optionalFlags...)
-}
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return nil
+	Flags = append(Flags, oprpc.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oppprof.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, txmgr.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, altda.CLIFlags(EnvVarPrefix, "")...)
 }

--- a/op-batcher/flags/flags_test.go
+++ b/op-batcher/flags/flags_test.go
@@ -9,18 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
-
-// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
-// the Required field to false.
-func TestOptionalFlagsDontSetRequired(t *testing.T) {
-	for _, flag := range optionalFlags {
-		reqFlag, ok := flag.(cli.RequiredFlag)
-		require.True(t, ok)
-		require.False(t, reqFlag.IsRequired())
-	}
-}
 
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -65,7 +65,7 @@ func TestDefaultConfigIsValid(t *testing.T) {
 
 func TestL1ETHRPCAddress(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l1-eth-rpc is required", addRequiredArgsExcept(types.TraceTypeAlphabet, "--l1-eth-rpc"))
+		verifyArgsInvalid(t, "Required flag \"l1-eth-rpc\" not set", addRequiredArgsExcept(types.TraceTypeAlphabet, "--l1-eth-rpc"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestL1ETHRPCAddress(t *testing.T) {
 
 func TestL1Beacon(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l1-beacon is required", addRequiredArgsExcept(types.TraceTypeAlphabet, "--l1-beacon"))
+		verifyArgsInvalid(t, "Required flag \"l1-beacon\" not set", addRequiredArgsExcept(types.TraceTypeAlphabet, "--l1-beacon"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -842,7 +842,7 @@ func TestDataDir(t *testing.T) {
 		traceType := traceType
 
 		t.Run(fmt.Sprintf("RequiredFor-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(t, "flag datadir is required", addRequiredArgsExcept(traceType, "--datadir"))
+			verifyArgsInvalid(t, "Required flag \"datadir\" not set", addRequiredArgsExcept(traceType, "--datadir"))
 		})
 	}
 
@@ -857,7 +857,7 @@ func TestRollupRpc(t *testing.T) {
 		traceType := traceType
 
 		t.Run(fmt.Sprintf("RequiredFor-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept(traceType, "--rollup-rpc"))
+			verifyArgsInvalid(t, "Required flag \"rollup-rpc\" not set", addRequiredArgsExcept(traceType, "--rollup-rpc"))
 		})
 	}
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -35,19 +35,22 @@ var (
 	faultDisputeVMs = []types.TraceType{types.TraceTypeCannon, types.TraceTypeAsterisc, types.TraceTypeAsteriscKona}
 	// Required Flags
 	L1EthRpcFlag = &cli.StringFlag{
-		Name:    "l1-eth-rpc",
-		Usage:   "HTTP provider URL for L1.",
-		EnvVars: prefixEnvVars("L1_ETH_RPC"),
+		Name:     "l1-eth-rpc",
+		Usage:    "HTTP provider URL for L1.",
+		EnvVars:  prefixEnvVars("L1_ETH_RPC"),
+		Required: true,
 	}
 	L1BeaconFlag = &cli.StringFlag{
-		Name:    "l1-beacon",
-		Usage:   "Address of L1 Beacon API endpoint to use",
-		EnvVars: prefixEnvVars("L1_BEACON"),
+		Name:     "l1-beacon",
+		Usage:    "Address of L1 Beacon API endpoint to use",
+		EnvVars:  prefixEnvVars("L1_BEACON"),
+		Required: true,
 	}
 	RollupRpcFlag = &cli.StringFlag{
-		Name:    "rollup-rpc",
-		Usage:   "HTTP provider URL for the rollup node",
-		EnvVars: prefixEnvVars("ROLLUP_RPC"),
+		Name:     "rollup-rpc",
+		Usage:    "HTTP provider URL for the rollup node",
+		EnvVars:  prefixEnvVars("ROLLUP_RPC"),
+		Required: true,
 	}
 	NetworkFlag        = flags.CLINetworkFlag(EnvVarPrefix, "")
 	FactoryAddressFlag = &cli.StringFlag{
@@ -68,9 +71,10 @@ var (
 		Value:   cli.NewStringSlice(types.TraceTypeCannon.String()),
 	}
 	DatadirFlag = &cli.StringFlag{
-		Name:    "datadir",
-		Usage:   "Directory to store data generated as part of responding to games",
-		EnvVars: prefixEnvVars("DATADIR"),
+		Name:     "datadir",
+		Usage:    "Directory to store data generated as part of responding to games",
+		EnvVars:  prefixEnvVars("DATADIR"),
+		Required: true,
 	}
 	// Optional Flags
 	MaxConcurrencyFlag = &cli.UintFlag{
@@ -229,16 +233,12 @@ var (
 	}
 )
 
-// requiredFlags are checked by [CheckRequired]
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	L1EthRpcFlag,
 	DatadirFlag,
 	RollupRpcFlag,
 	L1BeaconFlag,
-}
-
-// optionalFlags is a list of unchecked cli flags
-var optionalFlags = []cli.Flag{
 	NetworkFlag,
 	FactoryAddressFlag,
 	TraceTypeFlag,
@@ -273,17 +273,12 @@ var optionalFlags = []cli.Flag{
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, PreStatesURLFlag.Flags()...)
-	optionalFlags = append(optionalFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-
-	Flags = append(requiredFlags, optionalFlags...)
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, PreStatesURLFlag.Flags()...)
+	Flags = append(Flags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oppprof.CLIFlags(EnvVarPrefix)...)
 }
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
 
 func CheckCannonFlags(ctx *cli.Context) error {
 	if ctx.IsSet(CannonNetworkFlag.Name) && ctx.IsSet(flags.NetworkFlagName) {
@@ -370,11 +365,6 @@ func CheckAsteriscKonaFlags(ctx *cli.Context) error {
 }
 
 func CheckRequired(ctx *cli.Context, traceTypes []types.TraceType) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
 	// CannonL2Flag is checked because it is an alias with L2EthRpcFlag
 	if !ctx.IsSet(CannonL2Flag.Name) && !ctx.IsSet(L2EthRpcFlag.Name) {
 		return fmt.Errorf("flag %s is required", L2EthRpcFlag.Name)

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -114,10 +114,6 @@ func (c *Config) Check() error {
 
 // NewConfig parses the Config from the provided flags or environment variables.
 func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
-	if err := flags.CheckRequired(ctx); err != nil {
-		return nil, errors.Wrap(err, "missing required flags")
-	}
-
 	rollupCfg, err := opnode.NewRollupConfigFromCLI(log, ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load rollup config")

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -18,16 +17,18 @@ const EnvVarPrefix = "OP_CONDUCTOR"
 
 var (
 	ConsensusAddr = &cli.StringFlag{
-		Name:    "consensus.addr",
-		Usage:   "Address (excluding port) to listen for consensus connections.",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "CONSENSUS_ADDR"),
-		Value:   "127.0.0.1",
+		Name:     "consensus.addr",
+		Usage:    "Address (excluding port) to listen for consensus connections.",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "CONSENSUS_ADDR"),
+		Value:    "127.0.0.1",
+		Required: true,
 	}
 	ConsensusPort = &cli.IntFlag{
-		Name:    "consensus.port",
-		Usage:   "Port to listen for consensus connections. May be 0 to let the system select a port.",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "CONSENSUS_PORT"),
-		Value:   50050,
+		Name:     "consensus.port",
+		Usage:    "Port to listen for consensus connections. May be 0 to let the system select a port.",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "CONSENSUS_PORT"),
+		Value:    50050,
+		Required: true,
 	}
 	AdvertisedFullAddr = &cli.StringFlag{
 		Name:    "consensus.advertised",
@@ -42,14 +43,16 @@ var (
 		Value:   false,
 	}
 	RaftServerID = &cli.StringFlag{
-		Name:    "raft.server.id",
-		Usage:   "Unique ID for this server used by raft consensus",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_SERVER_ID"),
+		Name:     "raft.server.id",
+		Usage:    "Unique ID for this server used by raft consensus",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_SERVER_ID"),
+		Required: true,
 	}
 	RaftStorageDir = &cli.StringFlag{
-		Name:    "raft.storage.dir",
-		Usage:   "Directory to store raft data",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_STORAGE_DIR"),
+		Name:     "raft.storage.dir",
+		Usage:    "Directory to store raft data",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_STORAGE_DIR"),
+		Required: true,
 	}
 	RaftSnapshotInterval = &cli.DurationFlag{
 		Name:    "raft.snapshot-interval",
@@ -70,24 +73,28 @@ var (
 		Value:   10240,
 	}
 	NodeRPC = &cli.StringFlag{
-		Name:    "node.rpc",
-		Usage:   "HTTP provider URL for op-node",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "NODE_RPC"),
+		Name:     "node.rpc",
+		Usage:    "HTTP provider URL for op-node",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "NODE_RPC"),
+		Required: true,
 	}
 	ExecutionRPC = &cli.StringFlag{
-		Name:    "execution.rpc",
-		Usage:   "HTTP provider URL for execution layer",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "EXECUTION_RPC"),
+		Name:     "execution.rpc",
+		Usage:    "HTTP provider URL for execution layer",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "EXECUTION_RPC"),
+		Required: true,
 	}
 	HealthCheckInterval = &cli.Uint64Flag{
-		Name:    "healthcheck.interval",
-		Usage:   "Interval between health checks",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_INTERVAL"),
+		Name:     "healthcheck.interval",
+		Usage:    "Interval between health checks",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_INTERVAL"),
+		Required: true,
 	}
 	HealthCheckUnsafeInterval = &cli.Uint64Flag{
-		Name:    "healthcheck.unsafe-interval",
-		Usage:   "Interval allowed between unsafe head and now measured in seconds",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_UNSAFE_INTERVAL"),
+		Name:     "healthcheck.unsafe-interval",
+		Usage:    "Interval allowed between unsafe head and now measured in seconds",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_UNSAFE_INTERVAL"),
+		Required: true,
 	}
 	HealthCheckSafeEnabled = &cli.BoolFlag{
 		Name:    "healthcheck.safe-enabled",
@@ -102,9 +109,10 @@ var (
 		Value:   1200,
 	}
 	HealthCheckMinPeerCount = &cli.Uint64Flag{
-		Name:    "healthcheck.min-peer-count",
-		Usage:   "Minimum number of peers required to be considered healthy",
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_MIN_PEER_COUNT"),
+		Name:     "healthcheck.min-peer-count",
+		Usage:    "Minimum number of peers required to be considered healthy",
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_MIN_PEER_COUNT"),
+		Required: true,
 	}
 	Paused = &cli.BoolFlag{
 		Name:    "paused",
@@ -120,7 +128,7 @@ var (
 	}
 )
 
-var requiredFlags = []cli.Flag{
+var Flags = []cli.Flag{
 	ConsensusAddr,
 	ConsensusPort,
 	RaftServerID,
@@ -130,9 +138,6 @@ var requiredFlags = []cli.Flag{
 	HealthCheckInterval,
 	HealthCheckUnsafeInterval,
 	HealthCheckMinPeerCount,
-}
-
-var optionalFlags = []cli.Flag{
 	AdvertisedFullAddr,
 	Paused,
 	RPCEnableProxy,
@@ -145,22 +150,9 @@ var optionalFlags = []cli.Flag{
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, "")...)
-
-	Flags = append(requiredFlags, optionalFlags...)
-}
-
-var Flags []cli.Flag
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return opflags.CheckRequiredXor(ctx)
+	Flags = append(Flags, oprpc.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oppprof.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, opflags.CLIFlags(EnvVarPrefix, "")...)
 }

--- a/op-conductor/flags/flags_test.go
+++ b/op-conductor/flags/flags_test.go
@@ -4,21 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
-
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/stretchr/testify/require"
 )
-
-// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
-// the Required field to false.
-func TestOptionalFlagsDontSetRequired(t *testing.T) {
-	for _, flag := range optionalFlags {
-		reqFlag, ok := flag.(cli.RequiredFlag)
-		require.True(t, ok)
-		require.False(t, reqFlag.IsRequired())
-	}
-}
 
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -49,7 +49,7 @@ func TestDefaultConfigIsValid(t *testing.T) {
 
 func TestL1EthRpc(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l1-eth-rpc is required", addRequiredArgsExcept("--l1-eth-rpc"))
+		verifyArgsInvalid(t, "Required flag \"l1-eth-rpc\" not set", addRequiredArgsExcept("--l1-eth-rpc"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestL1EthRpc(t *testing.T) {
 
 func TestRollupRpc(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept("--rollup-rpc"))
+		verifyArgsInvalid(t, "Required flag \"rollup-rpc\" not set", addRequiredArgsExcept("--rollup-rpc"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -26,14 +26,16 @@ func prefixEnvVars(name string) []string {
 var (
 	// Required Flags
 	L1EthRpcFlag = &cli.StringFlag{
-		Name:    "l1-eth-rpc",
-		Usage:   "HTTP provider URL for L1.",
-		EnvVars: prefixEnvVars("L1_ETH_RPC"),
+		Name:     "l1-eth-rpc",
+		Usage:    "HTTP provider URL for L1.",
+		EnvVars:  prefixEnvVars("L1_ETH_RPC"),
+		Required: true,
 	}
 	RollupRpcFlag = &cli.StringFlag{
-		Name:    "rollup-rpc",
-		Usage:   "HTTP provider URL for the rollup node",
-		EnvVars: prefixEnvVars("ROLLUP_RPC"),
+		Name:     "rollup-rpc",
+		Usage:    "HTTP provider URL for the rollup node",
+		EnvVars:  prefixEnvVars("ROLLUP_RPC"),
+		Required: true,
 	}
 	// Optional Flags
 	GameFactoryAddressFlag = &cli.StringFlag{
@@ -73,14 +75,10 @@ var (
 	}
 )
 
-// requiredFlags are checked by [CheckRequired]
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	L1EthRpcFlag,
 	RollupRpcFlag,
-}
-
-// optionalFlags is a list of unchecked cli flags
-var optionalFlags = []cli.Flag{
 	GameFactoryAddressFlag,
 	NetworkFlag,
 	HonestActorsFlag,
@@ -91,30 +89,13 @@ var optionalFlags = []cli.Flag{
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(envVarPrefix)...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(envVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(envVarPrefix)...)
-
-	Flags = append(requiredFlags, optionalFlags...)
-}
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return nil
+	Flags = append(Flags, oplog.CLIFlags(envVarPrefix)...)
+	Flags = append(Flags, opmetrics.CLIFlags(envVarPrefix)...)
+	Flags = append(Flags, oppprof.CLIFlags(envVarPrefix)...)
 }
 
 // NewConfigFromCLI parses the Config from the provided flags or environment variables.
 func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
-	if err := CheckRequired(ctx); err != nil {
-		return nil, err
-	}
 	gameFactoryAddress, err := challengerFlags.FactoryAddress(ctx)
 	if err != nil {
 		return nil, err

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -51,12 +51,14 @@ var (
 		Value:    "http://127.0.0.1:8545",
 		EnvVars:  prefixEnvVars("L1_ETH_RPC"),
 		Category: RollupCategory,
+		Required: true,
 	}
 	L2EngineAddr = &cli.StringFlag{
 		Name:     "l2",
 		Usage:    "Address of L2 Engine JSON-RPC endpoints to use (engine and eth namespace required)",
 		EnvVars:  prefixEnvVars("L2_ENGINE_RPC"),
 		Category: RollupCategory,
+		Required: true,
 	}
 	L2EngineJWTSecret = &cli.StringFlag{
 		Name:        "l2.jwt-secret",
@@ -65,6 +67,7 @@ var (
 		Value:       "",
 		Destination: new(string),
 		Category:    RollupCategory,
+		Required:    true,
 	}
 	BeaconAddr = &cli.StringFlag{
 		Name:     "l1.beacon",
@@ -374,13 +377,11 @@ var (
 	}
 )
 
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	L1NodeAddr,
 	L2EngineAddr,
 	L2EngineJWTSecret,
-}
-
-var optionalFlags = []cli.Flag{
 	SupervisorAddr,
 	BeaconAddr,
 	BeaconHeader,
@@ -430,25 +431,12 @@ var DeprecatedFlags = []cli.Flag{
 	// Deprecated P2P Flags are added at the init step
 }
 
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
-
 func init() {
 	DeprecatedFlags = append(DeprecatedFlags, deprecatedP2PFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, P2PFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
-	optionalFlags = append(optionalFlags, DeprecatedFlags...)
-	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, RollupCategory)...)
-	optionalFlags = append(optionalFlags, altda.CLIFlags(EnvVarPrefix, AltDACategory)...)
-	Flags = append(requiredFlags, optionalFlags...)
-}
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return opflags.CheckRequiredXor(ctx)
+	Flags = append(Flags, P2PFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oplog.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
+	Flags = append(Flags, oppprof.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
+	Flags = append(Flags, DeprecatedFlags...)
+	Flags = append(Flags, opflags.CLIFlags(EnvVarPrefix, RollupCategory)...)
+	Flags = append(Flags, altda.CLIFlags(EnvVarPrefix, AltDACategory)...)
 }

--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -8,18 +8,7 @@ import (
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
-
-// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
-// the Required field to false.
-func TestOptionalFlagsDontSetRequired(t *testing.T) {
-	for _, flag := range optionalFlags {
-		reqFlag, ok := flag.(cli.RequiredFlag)
-		require.True(t, ok)
-		require.False(t, reqFlag.IsRequired())
-	}
-}
 
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -31,10 +31,6 @@ import (
 
 // NewConfig creates a Config from the provided flags or environment variables.
 func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
-	if err := flags.CheckRequired(ctx); err != nil {
-		return nil, err
-	}
-
 	rollupConfig, err := NewRollupConfigFromCLI(log, ctx)
 	if err != nil {
 		return nil, err
@@ -210,6 +206,9 @@ func NewDriverConfig(ctx *cli.Context) *driver.Config {
 }
 
 func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, error) {
+	if err := opflags.CheckRequiredXor(ctx); err != nil {
+		return nil, err
+	}
 	network := ctx.String(opflags.NetworkFlagName)
 	rollupConfigPath := ctx.String(opflags.RollupConfigFlagName)
 	if ctx.Bool(flags.BetaExtraNetworks.Name) {

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -162,7 +162,7 @@ func TestL2Genesis(t *testing.T) {
 
 func TestL2Head(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2.head is required", addRequiredArgsExcept("--l2.head"))
+		verifyArgsInvalid(t, "Required flag \"l2.head\" not set", addRequiredArgsExcept("--l2.head"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestL2Head(t *testing.T) {
 
 func TestL2OutputRoot(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2.outputroot is required", addRequiredArgsExcept("--l2.outputroot"))
+		verifyArgsInvalid(t, "Required flag \"l2.outputroot\" not set", addRequiredArgsExcept("--l2.outputroot"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestL2OutputRoot(t *testing.T) {
 
 func TestL1Head(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l1.head is required", addRequiredArgsExcept("--l1.head"))
+		verifyArgsInvalid(t, "Required flag \"l1.head\" not set", addRequiredArgsExcept("--l1.head"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -251,7 +251,7 @@ func TestL1RPCKind(t *testing.T) {
 
 func TestL2Claim(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2.claim is required", addRequiredArgsExcept("--l2.claim"))
+		verifyArgsInvalid(t, "Required flag \"l2.claim\" not set", addRequiredArgsExcept("--l2.claim"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -289,7 +289,7 @@ func TestL2Experimental(t *testing.T) {
 
 func TestL2BlockNumber(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2.blocknumber is required", addRequiredArgsExcept("--l2.blocknumber"))
+		verifyArgsInvalid(t, "Required flag \"l2.blocknumber\" not set", addRequiredArgsExcept("--l2.blocknumber"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -53,29 +53,34 @@ var (
 		EnvVars: prefixEnvVars("L2_RPC_EXPERIMENTAL_RPC"),
 	}
 	L1Head = &cli.StringFlag{
-		Name:    "l1.head",
-		Usage:   "Hash of the L1 head block. Derivation stops after this block is processed.",
-		EnvVars: prefixEnvVars("L1_HEAD"),
+		Name:     "l1.head",
+		Usage:    "Hash of the L1 head block. Derivation stops after this block is processed.",
+		EnvVars:  prefixEnvVars("L1_HEAD"),
+		Required: true,
 	}
 	L2Head = &cli.StringFlag{
-		Name:    "l2.head",
-		Usage:   "Hash of the L2 block at l2.outputroot",
-		EnvVars: prefixEnvVars("L2_HEAD"),
+		Name:     "l2.head",
+		Usage:    "Hash of the L2 block at l2.outputroot",
+		EnvVars:  prefixEnvVars("L2_HEAD"),
+		Required: true,
 	}
 	L2OutputRoot = &cli.StringFlag{
-		Name:    "l2.outputroot",
-		Usage:   "Agreed L2 Output Root to start derivation from",
-		EnvVars: prefixEnvVars("L2_OUTPUT_ROOT"),
+		Name:     "l2.outputroot",
+		Usage:    "Agreed L2 Output Root to start derivation from",
+		EnvVars:  prefixEnvVars("L2_OUTPUT_ROOT"),
+		Required: true,
 	}
 	L2Claim = &cli.StringFlag{
-		Name:    "l2.claim",
-		Usage:   "Claimed L2 output root to validate",
-		EnvVars: prefixEnvVars("L2_CLAIM"),
+		Name:     "l2.claim",
+		Usage:    "Claimed L2 output root to validate",
+		EnvVars:  prefixEnvVars("L2_CLAIM"),
+		Required: true,
 	}
 	L2BlockNumber = &cli.Uint64Flag{
-		Name:    "l2.blocknumber",
-		Usage:   "Number of the L2 block that the claim is from",
-		EnvVars: prefixEnvVars("L2_BLOCK_NUM"),
+		Name:     "l2.blocknumber",
+		Usage:    "Number of the L2 block that the claim is from",
+		EnvVars:  prefixEnvVars("L2_BLOCK_NUM"),
+		Required: true,
 	}
 	L2GenesisPath = &cli.StringFlag{
 		Name:    "l2.genesis",
@@ -120,17 +125,12 @@ var (
 )
 
 // Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
-
-var requiredFlags = []cli.Flag{
+var Flags = []cli.Flag{
 	L1Head,
 	L2Head,
 	L2OutputRoot,
 	L2Claim,
 	L2BlockNumber,
-}
-
-var programFlags = []cli.Flag{
 	RollupConfig,
 	Network,
 	DataDir,
@@ -148,8 +148,6 @@ var programFlags = []cli.Flag{
 
 func init() {
 	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
-	Flags = append(Flags, requiredFlags...)
-	Flags = append(Flags, programFlags...)
 }
 
 func CheckRequired(ctx *cli.Context) error {
@@ -166,11 +164,6 @@ func CheckRequired(ctx *cli.Context) error {
 	}
 	if ctx.String(L2GenesisPath.Name) != "" && network != "" {
 		return fmt.Errorf("cannot specify both %s and %s", L2GenesisPath.Name, Network.Name)
-	}
-	for _, flag := range requiredFlags {
-		if !ctx.IsSet(flag.Names()[0]) {
-			return fmt.Errorf("flag %s is required", flag.Names()[0])
-		}
 	}
 	return nil
 }

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -23,14 +22,16 @@ func prefixEnvVars(name string) []string {
 var (
 	// Required Flags
 	L1EthRpcFlag = &cli.StringFlag{
-		Name:    "l1-eth-rpc",
-		Usage:   "HTTP provider URL for L1",
-		EnvVars: prefixEnvVars("L1_ETH_RPC"),
+		Name:     "l1-eth-rpc",
+		Usage:    "HTTP provider URL for L1",
+		EnvVars:  prefixEnvVars("L1_ETH_RPC"),
+		Required: true,
 	}
 	RollupRpcFlag = &cli.StringFlag{
-		Name:    "rollup-rpc",
-		Usage:   "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
-		EnvVars: prefixEnvVars("ROLLUP_RPC"),
+		Name:     "rollup-rpc",
+		Usage:    "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
+		EnvVars:  prefixEnvVars("ROLLUP_RPC"),
+		Required: true,
 	}
 
 	// Optional flags
@@ -83,12 +84,10 @@ var (
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
 
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	L1EthRpcFlag,
 	RollupRpcFlag,
-}
-
-var optionalFlags = []cli.Flag{
 	L2OOAddressFlag,
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
@@ -101,23 +100,9 @@ var optionalFlags = []cli.Flag{
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, txmgr.CLIFlags(EnvVarPrefix)...)
-
-	Flags = append(requiredFlags, optionalFlags...)
-}
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return nil
+	Flags = append(Flags, oprpc.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oppprof.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, txmgr.CLIFlags(EnvVarPrefix)...)
 }

--- a/op-proposer/flags/flags_test.go
+++ b/op-proposer/flags/flags_test.go
@@ -9,18 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
-
-// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
-// the Required field to false.
-func TestOptionalFlagsDontSetRequired(t *testing.T) {
-	for _, flag := range optionalFlags {
-		reqFlag, ok := flag.(cli.RequiredFlag)
-		require.True(t, ok)
-		require.False(t, reqFlag.IsRequired())
-	}
-}
 
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -16,9 +16,6 @@ import (
 // This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed L2Output-submitter
 func Main(version string) cliapp.LifecycleAction {
 	return func(cliCtx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, error) {
-		if err := flags.CheckRequired(cliCtx); err != nil {
-			return nil, err
-		}
 		cfg := NewConfig(cliCtx)
 		if err := cfg.Check(); err != nil {
 			return nil, fmt.Errorf("invalid CLI flags: %w", err)

--- a/op-supervisor/cmd/main_test.go
+++ b/op-supervisor/cmd/main_test.go
@@ -46,7 +46,7 @@ func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 
 func TestL2RPCs(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2-rpcs is required", addRequiredArgsExcept("--l2-rpcs"))
+		verifyArgsInvalid(t, "Required flag \"l2-rpcs\" not set", addRequiredArgsExcept("--l2-rpcs"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestL2RPCs(t *testing.T) {
 
 func TestDatadir(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag datadir is required", addRequiredArgsExcept("--datadir"))
+		verifyArgsInvalid(t, "Required flag \"datadir\" not set", addRequiredArgsExcept("--datadir"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -1,8 +1,6 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
@@ -22,19 +20,22 @@ func prefixEnvVars(name string) []string {
 
 var (
 	L2RPCsFlag = &cli.StringSliceFlag{
-		Name:    "l2-rpcs",
-		Usage:   "L2 RPC sources.",
-		EnvVars: prefixEnvVars("L2_RPCS"),
+		Name:     "l2-rpcs",
+		Usage:    "L2 RPC sources.",
+		EnvVars:  prefixEnvVars("L2_RPCS"),
+		Required: true,
 	}
 	DataDirFlag = &cli.PathFlag{
-		Name:    "datadir",
-		Usage:   "Directory to store data generated as part of responding to games",
-		EnvVars: prefixEnvVars("DATADIR"),
+		Name:     "datadir",
+		Usage:    "Directory to store data generated as part of responding to games",
+		EnvVars:  prefixEnvVars("DATADIR"),
+		Required: true,
 	}
 	DependencySetFlag = &cli.PathFlag{
 		Name:      "dependency-set",
 		Usage:     "Dependency-set configuration, point at JSON file.",
 		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
+		Required:  true,
 		TakesFile: true,
 	}
 	MockRunFlag = &cli.BoolFlag{
@@ -45,36 +46,19 @@ var (
 	}
 )
 
-var requiredFlags = []cli.Flag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
 	L2RPCsFlag,
 	DataDirFlag,
 	DependencySetFlag,
-}
-
-var optionalFlags = []cli.Flag{
 	MockRunFlag,
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-
-	Flags = append(Flags, requiredFlags...)
-	Flags = append(Flags, optionalFlags...)
-}
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
-	}
-	return nil
+	Flags = append(Flags, oprpc.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, oppprof.CLIFlags(EnvVarPrefix)...)
 }
 
 func ConfigFromCLI(ctx *cli.Context, version string) *config.Config {

--- a/op-supervisor/flags/flags_test.go
+++ b/op-supervisor/flags/flags_test.go
@@ -4,21 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
-
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/stretchr/testify/require"
 )
-
-// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
-// the Required field to false.
-func TestOptionalFlagsDontSetRequired(t *testing.T) {
-	for _, flag := range optionalFlags {
-		reqFlag, ok := flag.(cli.RequiredFlag)
-		require.True(t, ok)
-		require.False(t, reqFlag.IsRequired())
-	}
-}
 
 // TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
 func TestUniqueFlags(t *testing.T) {

--- a/op-supervisor/supervisor/entrypoint.go
+++ b/op-supervisor/supervisor/entrypoint.go
@@ -21,9 +21,6 @@ type MainFn func(ctx context.Context, cfg *config.Config, logger log.Logger) (cl
 // This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed supervisor with.
 func Main(version string, fn MainFn) cliapp.LifecycleAction {
 	return func(cliCtx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
-		if err := flags.CheckRequired(cliCtx); err != nil {
-			return nil, err
-		}
 		cfg := flags.ConfigFromCLI(cliCtx, version)
 		if err := cfg.Check(); err != nil {
 			return nil, fmt.Errorf("invalid CLI flags: %w", err)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR simply replaces the manual `CheckRequired` functions we have scattered in our flags files with the inbuilt `Required: true` supported by the urfave library.

**Tests**

Tests have been updated.

**Additional context**

Optional cleanup. Doesn't solve any particular problem, just seems duplicative to not rely on the library's required implementation. Fine to close if there's a reason we do it the current way.

We still have some more complex required logic in the challenger flags that remains.