### PR TITLE
chore(ops): Bump `kona` in `proofs-tools`

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -207,7 +207,7 @@ target "proofs-tools" {
   context = "."
   args = {
     CHALLENGER_VERSION="b46bffed42db3442d7484f089278d59f51503049"
-    KONA_VERSION="kona-client-v0.1.0-beta.3"
+    KONA_VERSION="kona-client-v0.1.0-beta.4"
   }
   target="proofs-tools"
   platforms = split(",", PLATFORMS)


### PR DESCRIPTION
## Overview

Bumps the version of `kona` in `proofs-tools` to `beta.4`, which uses [`v1.2.0`](https://github.com/ethereum-optimism/asterisc/releases/tag/v1.2.0) of `asterisc` and contains several updates to critical dependencies such as `alloy`/`op-alloy`.