### PR TITLE
maint: bump forge version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -31,9 +31,9 @@ just = "1.37.0"
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
-forge = "nightly-143abd6a768eeb52a5785240b763d72a56987b4a"
-cast = "nightly-143abd6a768eeb52a5785240b763d72a56987b4a"
-anvil = "nightly-143abd6a768eeb52a5785240b763d72a56987b4a"
+forge = "nightly-e5dbb7a320c2b871c4a4a1006ad3c15a08fcf17b"
+cast = "nightly-e5dbb7a320c2b871c4a4a1006ad3c15a08fcf17b"
+anvil = "nightly-e5dbb7a320c2b871c4a4a1006ad3c15a08fcf17b"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't


### PR DESCRIPTION
Bumps the version of forge/cast/anvil being used in the monorepo.