### PR TITLE
supervisor: L1 Processor

### DIFF
--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -480,6 +480,7 @@ func (s *interopE2ESystem) prepareSupervisor() *supervisor.SupervisorService {
 			EnableAdmin: true,
 		},
 		L2RPCs:  []string{},
+		L1RPC:   s.l1.UserRPC().RPC(),
 		Datadir: path.Join(s.t.TempDir(), "supervisor"),
 	}
 	depSet := make(map[supervisortypes.ChainID]*depset.StaticConfigDependency)
@@ -536,10 +537,11 @@ func (s *interopE2ESystem) prepare(t *testing.T, w worldResourcePaths) {
 	s.hdWallet = s.prepareHDWallet()
 	s.worldDeployment, s.worldOutput = s.prepareWorld(w)
 
-	// the supervisor and client are created first so that the L2s can use the supervisor
+	// L1 first so that the Supervisor and L2s can connect to it
+	s.beacon, s.l1 = s.prepareL1()
+
 	s.supervisor = s.prepareSupervisor()
 
-	s.beacon, s.l1 = s.prepareL1()
 	s.l2s = s.prepareL2s()
 
 	s.prepareContracts()

--- a/op-supervisor/cmd/main_test.go
+++ b/op-supervisor/cmd/main_test.go
@@ -126,6 +126,7 @@ func toArgList(req map[string]string) []string {
 
 func requiredArgs() map[string]string {
 	args := map[string]string{
+		"--l1-rpc":         ValidL1RPC,
 		"--l2-rpcs":        ValidL2RPCs[0],
 		"--dependency-set": "test",
 		"--datadir":        ValidDatadir,

--- a/op-supervisor/cmd/main_test.go
+++ b/op-supervisor/cmd/main_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	ValidL1RPC   = "http://localhost:8545"
 	ValidL2RPCs  = []string{"http;//localhost:8545"}
 	ValidDatadir = "./supervisor_test_datadir"
 )
@@ -38,7 +39,7 @@ func TestLogLevel(t *testing.T) {
 func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs(t, addRequiredArgs())
 	depSet := &depset.JsonDependencySetLoader{Path: "test"}
-	defaultCfgTempl := config.NewConfig(ValidL2RPCs, depSet, ValidDatadir)
+	defaultCfgTempl := config.NewConfig(ValidL1RPC, ValidL2RPCs, depSet, ValidDatadir)
 	defaultCfg := *defaultCfgTempl
 	defaultCfg.Version = Version
 	require.Equal(t, defaultCfg, *cfg)

--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	// requiring manual triggers for the backend to process anything.
 	SynchronousProcessors bool
 
+	L1RPC string
+
 	L2RPCs  []string
 	Datadir string
 }
@@ -56,7 +58,7 @@ func (c *Config) Check() error {
 
 // NewConfig creates a new config using default values whenever possible.
 // Required options with no suitable default are passed as parameters.
-func NewConfig(l2RPCs []string, depSet depset.DependencySetSource, datadir string) *Config {
+func NewConfig(l1RPC string, l2RPCs []string, depSet depset.DependencySetSource, datadir string) *Config {
 	return &Config{
 		LogConfig:           oplog.DefaultCLIConfig(),
 		MetricsConfig:       opmetrics.DefaultCLIConfig(),
@@ -64,6 +66,7 @@ func NewConfig(l2RPCs []string, depSet depset.DependencySetSource, datadir strin
 		RPC:                 oprpc.DefaultCLIConfig(),
 		DependencySetSource: depSet,
 		MockRun:             false,
+		L1RPC:               l1RPC,
 		L2RPCs:              l2RPCs,
 		Datadir:             datadir,
 	}

--- a/op-supervisor/config/config_test.go
+++ b/op-supervisor/config/config_test.go
@@ -67,5 +67,5 @@ func validConfig() *Config {
 		panic(err)
 	}
 	// Should be valid using only the required arguments passed in via the constructor.
-	return NewConfig([]string{"http://localhost:8545"}, depSet, "./supervisor_testdir")
+	return NewConfig("http://localhost:8545", []string{"http://localhost:8545"}, depSet, "./supervisor_testdir")
 }

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -21,6 +21,11 @@ func prefixEnvVars(name string) []string {
 }
 
 var (
+	L1RPCFlag = &cli.StringFlag{
+		Name:    "l1-rpc",
+		Usage:   "L1 RPC source.",
+		EnvVars: prefixEnvVars("L1_RPC"),
+	}
 	L2RPCsFlag = &cli.StringSliceFlag{
 		Name:    "l2-rpcs",
 		Usage:   "L2 RPC sources.",
@@ -46,6 +51,7 @@ var (
 )
 
 var requiredFlags = []cli.Flag{
+	L1RPCFlag,
 	L2RPCsFlag,
 	DataDirFlag,
 	DependencySetFlag,
@@ -86,6 +92,7 @@ func ConfigFromCLI(ctx *cli.Context, version string) *config.Config {
 		RPC:                 oprpc.ReadCLIConfig(ctx),
 		DependencySetSource: &depset.JsonDependencySetLoader{Path: ctx.Path(DependencySetFlag.Name)},
 		MockRun:             ctx.Bool(MockRunFlag.Name),
+		L1RPC:               ctx.String(L1RPCFlag.Name),
 		L2RPCs:              ctx.StringSlice(L2RPCsFlag.Name),
 		Datadir:             ctx.Path(DataDirFlag.Name),
 	}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -128,12 +128,13 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 		su.chainProcessors.Set(chainID, chainProcessor)
 	}
 
-	// initialize the L1 processor
-	l1Processor, err := processors.NewL1Processor(su.logger, su.chainDBs, cfg.L1RPC)
-	if err != nil {
-		return fmt.Errorf("failed to create L1 processor: %w", err)
+	if cfg.L1RPC != "" {
+		if err := su.attachL1RPC(ctx, cfg.L1RPC); err != nil {
+			return fmt.Errorf("failed to create L1 processor: %w", err)
+		}
+	} else {
+		su.logger.Warn("No L1 RPC configured, L1 processor will not be started")
 	}
-	su.l1Processor = l1Processor
 
 	// the config has some RPC connections to attach to the chain-processors
 	for _, rpc := range cfg.L2RPCs {
@@ -240,6 +241,38 @@ func (su *SupervisorBackend) AttachProcessorSource(chainID types.ChainID, src pr
 	return nil
 }
 
+func (su *SupervisorBackend) attachL1RPC(ctx context.Context, l1RPCAddr string) error {
+	su.logger.Info("attaching L1 RPC to L1 processor", "rpc", l1RPCAddr)
+
+	logger := su.logger.New("l1-rpc", l1RPCAddr)
+	l1RPC, err := client.NewRPC(ctx, logger, l1RPCAddr)
+	if err != nil {
+		return fmt.Errorf("failed to setup L1 RPC: %w", err)
+	}
+	l1Client, err := sources.NewL1Client(
+		l1RPC,
+		su.logger,
+		nil,
+		// placeholder config for the L1
+		sources.L1ClientSimpleConfig(true, sources.RPCKindBasic, 100))
+	if err != nil {
+		return fmt.Errorf("failed to setup L1 Client: %w", err)
+	}
+	su.AttachL1Source(l1Client)
+	return nil
+}
+
+// attachL1Source attaches an L1 source to the L1 processor.
+// If the L1 processor does not exist, it is created and started.
+func (su *SupervisorBackend) AttachL1Source(source processors.L1Source) {
+	if su.l1Processor == nil {
+		su.l1Processor = processors.NewL1Processor(su.logger, su.chainDBs, source)
+		su.l1Processor.Start()
+	} else {
+		su.l1Processor.AttachClient(source)
+	}
+}
+
 func clientForL2(ctx context.Context, logger log.Logger, rpc string) (client.RPC, types.ChainID, error) {
 	ethClient, err := dial.DialEthClientWithTimeout(ctx, 10*time.Second, logger, rpc)
 	if err != nil {
@@ -264,8 +297,10 @@ func (su *SupervisorBackend) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to resume chains db: %w", err)
 	}
 
-	// start the L1 processor
-	su.l1Processor.Start()
+	// start the L1 processor if it exists
+	if su.l1Processor != nil {
+		su.l1Processor.Start()
+	}
 
 	if !su.synchronousProcessors {
 		// Make all the chain-processors run automatic background processing
@@ -293,7 +328,9 @@ func (su *SupervisorBackend) Stop(ctx context.Context) error {
 	su.logger.Info("Closing supervisor backend")
 
 	// stop the L1 processor
-	su.l1Processor.Stop()
+	if su.l1Processor != nil {
+		su.l1Processor.Stop()
+	}
 
 	// close all processors
 	su.chainProcessors.Range(func(id types.ChainID, processor *processors.ChainProcessor) bool {

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -62,6 +62,7 @@ func TestBackendLifetime(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("initialized!")
 
+	l1Src := &testutils.MockL1Source{}
 	src := &testutils.MockL1Source{}
 
 	blockX := eth.BlockRef{
@@ -77,6 +78,7 @@ func TestBackendLifetime(t *testing.T) {
 		Time:       blockX.Time + 2,
 	}
 
+	b.AttachL1Source(l1Src)
 	require.NoError(t, b.AttachProcessorSource(chainA, src))
 
 	require.FileExists(t, filepath.Join(cfg.Datadir, "900", "log.db"), "must have logs DB 900")

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -30,6 +30,32 @@ func (db *ChainsDB) LatestBlockNum(chain types.ChainID) (num uint64, ok bool) {
 	return logDB.LatestSealedBlockNum()
 }
 
+// LastCommonL1 returns the latest common L1 block between all chains in the database.
+// it only considers block numbers, not hash. That's because the L1 source is the same for all chains
+// this data can be used to determine the starting point for L1 processing
+func (db *ChainsDB) LastCommonL1() (types.BlockSeal, error) {
+	common := types.BlockSeal{}
+	for _, chain := range db.depSet.Chains() {
+		ldb, ok := db.localDBs.Get(chain)
+		if !ok {
+			return types.BlockSeal{}, types.ErrUnknownChain
+		}
+		_, derivedFrom, err := ldb.Latest()
+		if err != nil {
+			return types.BlockSeal{}, fmt.Errorf("failed to determine Last Common L1: %w", err)
+		}
+		common = derivedFrom
+		// if the common block isn't yet set,
+		// or if the new common block is older than the current common block
+		// set the common block
+		if common == (types.BlockSeal{}) ||
+			derivedFrom.Number < common.Number {
+			common = derivedFrom
+		}
+	}
+	return common, nil
+}
+
 func (db *ChainsDB) IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) error {
 	v, ok := db.crossUnsafe.Get(chainID)
 	if !ok {

--- a/op-supervisor/supervisor/backend/processors/l1_processor.go
+++ b/op-supervisor/supervisor/backend/processors/l1_processor.go
@@ -79,6 +79,7 @@ func (p *L1Processor) Stop() {
 	p.wg.Wait()
 }
 
+// worker runs a loop that checks for new L1 blocks at a regular interval
 func (p *L1Processor) worker() {
 	defer p.wg.Done()
 	delay := time.NewTicker(p.tickDuration)
@@ -96,6 +97,10 @@ func (p *L1Processor) worker() {
 	}
 }
 
+// work checks for a new L1 block and processes it if found
+// the starting point is set when Start is called, and blocks are processed searched incrementally
+// if a new block is found, it is recorded in the database and the target number is updated
+// in the future it will also kick of derivation management for the sync nodes
 func (p *L1Processor) work() error {
 	nextNumber := p.currentNumber + 1
 	ref, err := p.client.L1BlockRefByNumber(p.ctx, nextNumber)

--- a/op-supervisor/supervisor/backend/processors/l1_processor.go
+++ b/op-supervisor/supervisor/backend/processors/l1_processor.go
@@ -1,0 +1,119 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type chainsDB interface {
+	RecordNewL1(ref eth.BlockRef) error
+	LastCommonL1() (types.BlockSeal, error)
+}
+
+type l1Client interface {
+	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
+}
+
+type L1Processor struct {
+	log    log.Logger
+	client l1Client
+
+	currentNumber uint64
+	tickDuration  time.Duration
+
+	db chainsDB
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func NewL1Processor(log log.Logger, cdb chainsDB, l1RPCAddr string) (*L1Processor, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l1RPC, err := client.NewRPC(ctx, log, l1RPCAddr)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to setup L1 RPC: %w", err)
+	}
+	l1Client, err := sources.NewL1Client(
+		l1RPC,
+		log,
+		nil,
+		// placeholder config for the L1
+		sources.L1ClientSimpleConfig(true, sources.RPCKindBasic, 100))
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to setup L1 Client: %w", err)
+	}
+	return &L1Processor{
+		client:       l1Client,
+		db:           cdb,
+		log:          log.New("service", "l1-processor"),
+		tickDuration: 6 * time.Second,
+		ctx:          ctx,
+		cancel:       cancel,
+	}, nil
+}
+
+func (p *L1Processor) Start() {
+	p.currentNumber = 0
+	// if there is an issue getting the last common L1, default to starting from 0
+	// consider making this a fatal error in the future once initialization is more robust
+	if lastL1, err := p.db.LastCommonL1(); err == nil {
+		p.currentNumber = lastL1.Number
+	}
+	p.wg.Add(1)
+	go p.worker()
+}
+
+func (p *L1Processor) Stop() {
+	p.cancel()
+	p.wg.Wait()
+}
+
+func (p *L1Processor) worker() {
+	defer p.wg.Done()
+	delay := time.NewTicker(p.tickDuration)
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-delay.C:
+			p.log.Debug("Checking for new L1 block", "current", p.currentNumber)
+			err := p.work()
+			if err != nil {
+				p.log.Warn("Failed to process L1", "err", err)
+			}
+		}
+	}
+}
+
+func (p *L1Processor) work() error {
+	nextNumber := p.currentNumber + 1
+	ref, err := p.client.L1BlockRefByNumber(p.ctx, nextNumber)
+	if err != nil {
+		return err
+	}
+	// record the new L1 block
+	p.log.Debug("Processing new L1 block", "block", ref)
+	err = p.db.RecordNewL1(ref)
+	if err != nil {
+		return err
+	}
+
+	// go drive derivation on this new L1 input
+	// only possible once bidirectional RPC and new derivers are in place
+	// could do this as a function callback to a more appropriate driver
+
+	// update the target number
+	p.currentNumber = nextNumber
+	return nil
+}

--- a/op-supervisor/supervisor/backend/processors/l1_processor_test.go
+++ b/op-supervisor/supervisor/backend/processors/l1_processor_test.go
@@ -1,0 +1,104 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type mockChainsDB struct {
+	recordNewL1Fn  func(ref eth.BlockRef) error
+	lastCommonL1Fn func() (types.BlockSeal, error)
+}
+
+func (m *mockChainsDB) RecordNewL1(ref eth.BlockRef) error {
+	if m.recordNewL1Fn != nil {
+		return m.recordNewL1Fn(ref)
+	}
+	return nil
+}
+
+func (m *mockChainsDB) LastCommonL1() (types.BlockSeal, error) {
+	if m.lastCommonL1Fn != nil {
+		return m.lastCommonL1Fn()
+	}
+	return types.BlockSeal{}, nil
+}
+
+type mockL1BlockRefByNumberFetcher struct {
+	l1BlockByNumberFn func() (eth.L1BlockRef, error)
+}
+
+func (m *mockL1BlockRefByNumberFetcher) L1BlockRefByNumber(context.Context, uint64) (eth.L1BlockRef, error) {
+	if m.l1BlockByNumberFn != nil {
+		return m.l1BlockByNumberFn()
+	}
+	return eth.L1BlockRef{}, nil
+}
+
+func TestL1Processor(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	processorForTesting := func() *L1Processor {
+		proc := &L1Processor{
+			log:           testlog.Logger(t, log.LvlInfo),
+			client:        &mockL1BlockRefByNumberFetcher{},
+			currentNumber: 0,
+			tickDuration:  1,
+			db:            &mockChainsDB{},
+			ctx:           ctx,
+			cancel:        cancel,
+		}
+		return proc
+	}
+	t.Run("Initializes LastCommonL1", func(t *testing.T) {
+		proc := processorForTesting()
+		proc.db.(*mockChainsDB).lastCommonL1Fn = func() (types.BlockSeal, error) {
+			return types.BlockSeal{Number: 10}, nil
+		}
+		// before starting, the current number should be 0
+		require.Equal(t, uint64(0), proc.currentNumber)
+		proc.Start()
+		defer proc.Stop()
+		// after starting, the current number should still be 0
+		require.Equal(t, uint64(10), proc.currentNumber)
+	})
+	t.Run("Initializes LastCommonL1 at 0 if error", func(t *testing.T) {
+		proc := processorForTesting()
+		proc.db.(*mockChainsDB).lastCommonL1Fn = func() (types.BlockSeal, error) {
+			return types.BlockSeal{Number: 10}, fmt.Errorf("error")
+		}
+		// before starting, the current number should be 0
+		require.Equal(t, uint64(0), proc.currentNumber)
+		proc.Start()
+		defer proc.Stop()
+		// the error means the current number should still be 0
+		require.Equal(t, uint64(0), proc.currentNumber)
+	})
+	t.Run("Records new L1", func(t *testing.T) {
+		proc := processorForTesting()
+		proc.client.(*mockL1BlockRefByNumberFetcher).l1BlockByNumberFn = func() (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 0}, nil
+		}
+		called := 0
+		proc.db.(*mockChainsDB).recordNewL1Fn = func(ref eth.BlockRef) error {
+			require.Equal(t, uint64(0), ref.Number)
+			called++
+			return nil
+		}
+		proc.Start()
+		defer proc.Stop()
+		require.Eventually(t, func() bool {
+			return called >= 1 && proc.currentNumber >= 1
+		}, 10*time.Second, 100*time.Millisecond)
+
+	})
+
+}


### PR DESCRIPTION
# What
Introduces `L1 Processor` for Supervisor

# Why
We would like for the Supervisor to control the canonical L1 source for "Owned Nodes" in order to have better consistency and control over the data in the system.

# How
Introduces the following:
* New Required Flag and Config `L1RPC`
* Integration of `L1RPC` throughout, including in `supersystem`
* New Component `L1Processor`
* L1 Processor fully integrated to the `SupervisorBackend` to `Start` and `Stop` with the rest of the system
* New `ChainsDB` functionality to support the L1 Processor

## L1 Processor
The L1 processor spawns a worker routine which uses an L1 RPC Client to periodically check for new L1 blocks. If a new block is discovered, the `ChainsDB` is asked to Record it

## New ChainsDB Functions
### LastCommonL1
For each chain being tracked, the `latest` derivation data is checked, and the lowest L1 block height amongst them is returned. This is used to initialize the processor, so that it can start up at the first L1 block which isn't fully recorded. If an error is encountered, the processor defaults to starting at `0`. This works well when the database is uninitialized, as an `ErrFuture`. The L1 blocks should never diverge once the Supervisor is in charge of the L1 data, so only tracking heights is sufficient.

### RecordNewL1
`RecordNewL1` fetches the lastest `derived` for each chain, and extends each database with `NewL1:ExistingL2`. This happens so that the database records the new L1 row *before* any new L2 rows appear, making the `FromDA` database only ever increment *one* element at a time.

# Testing
* Basic Unit Tests for L1 Processor
* Ran the Interop Block Building E2E test with an additional 30s of waiting and observed correct operation in the logs:

```
DEBUG[12-03|17:09:40.756] Checking for new L1 block                role=supervisor service=l1-processor current=0
WARN [12-03|17:09:40.757] Failed to process L1                     role=supervisor service=l1-processor err="failed to fetch header by num 1: not found"
DEBUG[12-03|17:09:46.756] Checking for new L1 block                role=supervisor service=l1-processor current=0
DEBUG[12-03|17:09:46.758] Processing new L1 block                  role=supervisor service=l1-processor block=73c127..379a9e:1
DEBUG[12-03|17:09:52.756] Checking for new L1 block                role=supervisor service=l1-processor current=1
DEBUG[12-03|17:09:52.757] Processing new L1 block                  role=supervisor service=l1-processor block=6edeb2..f8d0fb:2
DEBUG[12-03|17:09:58.757] Checking for new L1 block                role=supervisor service=l1-processor current=2
DEBUG[12-03|17:09:58.758] Processing new L1 block                  role=supervisor service=l1-processor block=af47a7..35d078:3
DEBUG[12-03|17:10:04.756] Checking for new L1 block                role=supervisor service=l1-processor current=3
DEBUG[12-03|17:10:04.757] Processing new L1 block                  role=supervisor service=l1-processor block=eaeae3..48e4fa:4
DEBUG[12-03|17:10:10.756] Checking for new L1 block                role=supervisor service=l1-processor current=4
DEBUG[12-03|17:10:10.758] Processing new L1 block                  role=supervisor service=l1-processor block=758d60..24dbc2:5
DEBUG[12-03|17:10:16.756] Checking for new L1 block                role=supervisor service=l1-processor current=5
DEBUG[12-03|17:10:16.757] Processing new L1 block                  role=supervisor service=l1-processor block=db8d92..455792:6
DEBUG[12-03|17:10:22.756] Checking for new L1 block                role=supervisor service=l1-processor current=6
DEBUG[12-03|17:10:22.756] Processing new L1 block                  role=supervisor service=l1-processor block=66cdf3..58e9db:7
```

# Up Next
Still to come is using the detected L1 block to drive derivation of the Owned Nodes. For that we need a pathway to call down to those Owned Nodes. I may start building a PR to put OP Nodes into that mode of operation to accept the calls, but I am out tomorrow.

We can also add Finalization updating in a future PR, the existing worker can manage the last known finalization and feed it into the database when new values are noticed. I'd like to keep the scope of this initial PR tight so we can start integrating pieces (like Bidirectional RPC)