### PR TITLE
fix: workaround for foundry snapshot nuking bug

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -8,6 +8,7 @@ src = 'src'
 out = 'forge-artifacts'
 script = 'scripts'
 build_info_path = 'artifacts/build-info'
+snapshots = 'notarealpath' # workaround for foundry#9477
 
 optimizer = true
 optimizer_runs = 999999
@@ -15,7 +16,7 @@ optimizer_runs = 999999
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 ast = true
-evm_version = "cancun"
+evm_version = 'cancun'
 
 remappings = [
   '@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts',


### PR DESCRIPTION
Workaround for a bug? feature? in foundry that causes it to nuke whatever snapshots directory you have configured. Since this now defaults to "snapshots" it was nuking our snapshots folder.