### PR TITLE
op-challenger, op-program: Require specific opt-in to use the custom config chain ID indicator

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -765,7 +765,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestMustNotSpecifyCannonNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag cannon-network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-chain-id",
+				"flag cannon-network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
 				addRequiredArgsExcept(traceType, "--cannon-network",
 					"--cannon-network", cannonNetwork, "--cannon-rollup-config=rollup.json"))
 		})
@@ -777,10 +777,10 @@ func TestCannonRequiredArgs(t *testing.T) {
 			args["--network"] = cannonNetwork
 			args["--cannon-rollup-config"] = "rollup.json"
 			args["--cannon-l2-genesis"] = "gensis.json"
-			args["--cannon-l2-chain-id"] = "6"
+			args["--cannon-l2-custom"] = "true"
 			verifyArgsInvalid(
 				t,
-				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-chain-id",
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
 				toArgList(args))
 		})
 
@@ -818,8 +818,8 @@ func TestCannonRequiredArgs(t *testing.T) {
 			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network",
 				"--cannon-rollup-config=rollup.json",
 				"--cannon-l2-genesis=genesis.json",
-				"--cannon-l2-chain-id=9982"))
-			require.Equal(t, uint64(9982), cfg.Cannon.L2ChainID)
+				"--cannon-l2-custom"))
+			require.True(t, cfg.Cannon.L2Custom)
 		})
 
 		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -765,7 +765,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestMustNotSpecifyCannonNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag cannon-network can not be used with cannon-rollup-config and cannon-l2-genesis",
+				"flag cannon-network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-chain-id",
 				addRequiredArgsExcept(traceType, "--cannon-network",
 					"--cannon-network", cannonNetwork, "--cannon-rollup-config=rollup.json"))
 		})
@@ -777,9 +777,10 @@ func TestCannonRequiredArgs(t *testing.T) {
 			args["--network"] = cannonNetwork
 			args["--cannon-rollup-config"] = "rollup.json"
 			args["--cannon-l2-genesis"] = "gensis.json"
+			args["--cannon-l2-chain-id"] = "6"
 			verifyArgsInvalid(
 				t,
-				"flag network can not be used with cannon-rollup-config and cannon-l2-genesis",
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-chain-id",
 				toArgList(args))
 		})
 
@@ -811,6 +812,14 @@ func TestCannonRequiredArgs(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-network", testNetwork))
 				require.Equal(t, testNetwork, cfg.Cannon.Network)
 			})
+		})
+
+		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network",
+				"--cannon-rollup-config=rollup.json",
+				"--cannon-l2-genesis=genesis.json",
+				"--cannon-l2-chain-id=9982"))
+			require.Equal(t, uint64(9982), cfg.Cannon.L2ChainID)
 		})
 
 		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -41,6 +41,7 @@ type Config struct {
 	L2               string
 	Server           string // Path to the executable that provides the pre-image oracle server
 	Network          string
+	L2ChainID        uint64
 	RollupConfigPath string
 	L2GenesisPath    string
 }

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -41,7 +41,7 @@ type Config struct {
 	L2               string
 	Server           string // Path to the executable that provides the pre-image oracle server
 	Network          string
-	L2ChainID        uint64
+	L2Custom         bool
 	RollupConfigPath string
 	L2GenesisPath    string
 }

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -33,9 +33,6 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 	if cfg.Network != "" {
 		args = append(args, "--network", cfg.Network)
 	}
-	if cfg.L2Custom {
-		args = append(args, "--l2.custom", "true")
-	}
 	if cfg.RollupConfigPath != "" {
 		args = append(args, "--rollup.config", cfg.RollupConfigPath)
 	}
@@ -57,5 +54,8 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 		logLevel = "CRIT"
 	}
 	args = append(args, "--log.level", logLevel)
+	if cfg.L2Custom {
+		args = append(args, "--l2.custom")
+	}
 	return args, nil
 }

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum/go-ethereum/log"
@@ -34,8 +33,8 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 	if cfg.Network != "" {
 		args = append(args, "--network", cfg.Network)
 	}
-	if cfg.L2ChainID != 0 {
-		args = append(args, "--l2-chain-id", strconv.FormatUint(cfg.L2ChainID, 10))
+	if cfg.L2Custom {
+		args = append(args, "--l2.custom", "true")
 	}
 	if cfg.RollupConfigPath != "" {
 		args = append(args, "--rollup.config", cfg.RollupConfigPath)

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum/go-ethereum/log"
@@ -32,6 +33,9 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 	}
 	if cfg.Network != "" {
 		args = append(args, "--network", cfg.Network)
+	}
+	if cfg.L2ChainID != 0 {
+		args = append(args, "--l2-chain-id", strconv.FormatUint(cfg.L2ChainID, 10))
 	}
 	if cfg.RollupConfigPath != "" {
 		args = append(args, "--rollup.config", cfg.RollupConfigPath)

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -72,6 +72,13 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		require.Equal(t, "op-test", pairs["--network"])
 	})
 
+	t.Run("WithL2ChainID", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+			c.L2ChainID = 68284
+		})
+		require.Equal(t, "68284", pairs["--l2-chain-id"])
+	})
+
 	t.Run("WithRollupConfigPath", func(t *testing.T) {
 		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
 			c.RollupConfigPath = "rollup.config.json"

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -19,6 +19,12 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	toPairs := func(args []string) map[string]string {
 		pairs := make(map[string]string, len(args)/2)
 		for i := 0; i < len(args); i += 2 {
+			// l2.custom is a boolean flag so can't accept a value after a space
+			if args[i] == "--l2.custom" {
+				pairs[args[i]] = "true"
+				i--
+				continue
+			}
 			pairs[args[i]] = args[i+1]
 		}
 		return pairs

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -74,9 +74,9 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 
 	t.Run("WithL2ChainID", func(t *testing.T) {
 		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
-			c.L2ChainID = 68284
+			c.L2Custom = true
 		})
-		require.Equal(t, "68284", pairs["--l2-chain-id"])
+		require.Equal(t, "true", pairs["--l2.custom"])
 	})
 
 	t.Run("WithRollupConfigPath", func(t *testing.T) {

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -190,6 +190,7 @@ func NewChallengerConfig(t *testing.T, sys EndpointProvider, l2NodeName string, 
 	l1Endpoint := sys.NodeEndpoint("l1").RPC()
 	l1Beacon := sys.L1BeaconEndpoint().RestHTTP()
 	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, sys.RollupEndpoint(l2NodeName).RPC(), sys.NodeEndpoint(l2NodeName).RPC(), t.TempDir())
+	cfg.Cannon.L2Custom = true
 	// The devnet can't set the absolute prestate output root because the contracts are deployed in L1 genesis
 	// before the L2 genesis is known.
 	cfg.AllowInvalidPrestate = true

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -269,6 +269,7 @@ func runCannon(t *testing.T, ctx context.Context, sys *e2esys.System, inputs uti
 	dir := t.TempDir()
 	proofsDir := filepath.Join(dir, "cannon-proofs")
 	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, rollupEndpoint, l2Endpoint, dir)
+	cfg.Cannon.L2Custom = true
 	cannonOpts(&cfg)
 
 	logger := testlog.Logger(t, log.LevelInfo).New("role", "cannon")

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -216,6 +216,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 
 		l2ChainID = l2ChainConfig.ChainID.Uint64()
 		if ctx.Bool(flags.L2Custom.Name) {
+			log.Warn("Using custom chain configuration via preimage oracle. This is not compatible with on-chain execution.")
 			l2ChainID = client.CustomChainIDIndicator
 		}
 	}

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -37,7 +38,8 @@ var (
 )
 
 type Config struct {
-	Rollup *rollup.Config
+	L2ChainID uint64
+	Rollup    *rollup.Config
 	// DataDir is the directory to read/write pre-image data from/to.
 	// If not set, an in-memory key-value store is used and fetching data must be enabled
 	DataDir string
@@ -75,9 +77,6 @@ type Config struct {
 	// ServerMode indicates that the program should run in pre-image server mode and wait for requests.
 	// No client program is run.
 	ServerMode bool
-
-	// IsCustomChainConfig indicates that the program uses a custom chain configuration
-	IsCustomChainConfig bool
 }
 
 func (c *Config) Check() error {
@@ -131,19 +130,23 @@ func NewConfig(
 	l2Claim common.Hash,
 	l2ClaimBlockNum uint64,
 ) *Config {
-	_, err := params.LoadOPStackChainConfig(l2Genesis.ChainID.Uint64())
-	isCustomConfig := err != nil
+	l2ChainID := l2Genesis.ChainID.Uint64()
+	_, err := params.LoadOPStackChainConfig(l2ChainID)
+	if err != nil {
+		// Unknown chain ID so assume it is custom
+		l2ChainID = client.CustomChainIDIndicator
+	}
 	return &Config{
-		Rollup:              rollupCfg,
-		L2ChainConfig:       l2Genesis,
-		L1Head:              l1Head,
-		L2Head:              l2Head,
-		L2OutputRoot:        l2OutputRoot,
-		L2Claim:             l2Claim,
-		L2ClaimBlockNumber:  l2ClaimBlockNum,
-		L1RPCKind:           sources.RPCKindStandard,
-		IsCustomChainConfig: isCustomConfig,
-		DataFormat:          types.DataFormatDirectory,
+		L2ChainID:          l2ChainID,
+		Rollup:             rollupCfg,
+		L2ChainConfig:      l2Genesis,
+		L1Head:             l1Head,
+		L2Head:             l2Head,
+		L2OutputRoot:       l2OutputRoot,
+		L2Claim:            l2Claim,
+		L2ClaimBlockNumber: l2ClaimBlockNum,
+		L1RPCKind:          sources.RPCKindStandard,
+		DataFormat:         types.DataFormatDirectory,
 	}
 }
 
@@ -177,7 +180,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	var err error
 	var rollupCfg *rollup.Config
 	var l2ChainConfig *params.ChainConfig
-	var isCustomConfig bool
+	var l2ChainID uint64
 	networkName := ctx.String(flags.Network.Name)
 	if networkName != "" {
 		var chainID uint64
@@ -197,6 +200,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to load rollup config for chain %d: %w", chainID, err)
 		}
+		l2ChainID = chainID
 	} else {
 		l2GenesisPath := ctx.String(flags.L2GenesisPath.Name)
 		l2ChainConfig, err = loadChainConfigFromGenesis(l2GenesisPath)
@@ -210,7 +214,10 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 			return nil, fmt.Errorf("invalid rollup config: %w", err)
 		}
 
-		isCustomConfig = true
+		l2ChainID = l2ChainConfig.ChainID.Uint64()
+		if ctx.Bool(flags.L2Custom.Name) {
+			l2ChainID = client.CustomChainIDIndicator
+		}
 	}
 
 	dbFormat := types.DataFormat(ctx.String(flags.DataFormat.Name))
@@ -218,24 +225,24 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		return nil, fmt.Errorf("invalid %w: %v", ErrInvalidDataFormat, dbFormat)
 	}
 	return &Config{
-		Rollup:              rollupCfg,
-		DataDir:             ctx.String(flags.DataDir.Name),
-		DataFormat:          dbFormat,
-		L2URL:               ctx.String(flags.L2NodeAddr.Name),
-		L2ExperimentalURL:   ctx.String(flags.L2NodeExperimentalAddr.Name),
-		L2ChainConfig:       l2ChainConfig,
-		L2Head:              l2Head,
-		L2OutputRoot:        l2OutputRoot,
-		L2Claim:             l2Claim,
-		L2ClaimBlockNumber:  l2ClaimBlockNum,
-		L1Head:              l1Head,
-		L1URL:               ctx.String(flags.L1NodeAddr.Name),
-		L1BeaconURL:         ctx.String(flags.L1BeaconAddr.Name),
-		L1TrustRPC:          ctx.Bool(flags.L1TrustRPC.Name),
-		L1RPCKind:           sources.RPCProviderKind(ctx.String(flags.L1RPCProviderKind.Name)),
-		ExecCmd:             ctx.String(flags.Exec.Name),
-		ServerMode:          ctx.Bool(flags.Server.Name),
-		IsCustomChainConfig: isCustomConfig,
+		L2ChainID:          l2ChainID,
+		Rollup:             rollupCfg,
+		DataDir:            ctx.String(flags.DataDir.Name),
+		DataFormat:         dbFormat,
+		L2URL:              ctx.String(flags.L2NodeAddr.Name),
+		L2ExperimentalURL:  ctx.String(flags.L2NodeExperimentalAddr.Name),
+		L2ChainConfig:      l2ChainConfig,
+		L2Head:             l2Head,
+		L2OutputRoot:       l2OutputRoot,
+		L2Claim:            l2Claim,
+		L2ClaimBlockNumber: l2ClaimBlockNum,
+		L1Head:             l1Head,
+		L1URL:              ctx.String(flags.L1NodeAddr.Name),
+		L1BeaconURL:        ctx.String(flags.L1BeaconAddr.Name),
+		L1TrustRPC:         ctx.Bool(flags.L1TrustRPC.Name),
+		L1RPCKind:          sources.RPCProviderKind(ctx.String(flags.L1RPCProviderKind.Name)),
+		ExecCmd:            ctx.String(flags.Exec.Name),
+		ServerMode:         ctx.Bool(flags.Server.Name),
 	}, nil
 }
 

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -163,15 +164,15 @@ func TestRejectExecAndServerMode(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoExecInServerMode)
 }
 
-func TestIsCustomChainConfig(t *testing.T) {
+func TestCustomL2ChainID(t *testing.T) {
 	t.Run("nonCustom", func(t *testing.T) {
 		cfg := validConfig()
-		require.Equal(t, cfg.IsCustomChainConfig, false)
+		require.Equal(t, cfg.L2ChainID, validL2Genesis.ChainID.Uint64())
 	})
 	t.Run("custom", func(t *testing.T) {
 		customChainConfig := &params.ChainConfig{ChainID: big.NewInt(0x1212121212)}
 		cfg := NewConfig(validRollupConfig, customChainConfig, validL1Head, validL2Head, validL2OutputRoot, validL2Claim, validL2ClaimBlockNum)
-		require.Equal(t, cfg.IsCustomChainConfig, true)
+		require.Equal(t, cfg.L2ChainID, client.CustomChainIDIndicator)
 	})
 
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -21,6 +21,14 @@ func prefixEnvVars(name string) []string {
 }
 
 var (
+	L2Custom = &cli.BoolFlag{
+		Name: "l2.custom",
+		Usage: "Override the L2 chain ID to the custom chain indicator for custom chain configuration not present in the client program. " +
+			"WARNING: This is not compatible with on-chain execution and must only be used for testing.",
+		EnvVars: prefixEnvVars("L2_CHAINID"),
+		Value:   false,
+		Hidden:  true,
+	}
 	RollupConfig = &cli.StringFlag{
 		Name:    "rollup.config",
 		Usage:   "Rollup chain parameters",
@@ -131,6 +139,7 @@ var requiredFlags = []cli.Flag{
 }
 
 var programFlags = []cli.Flag{
+	L2Custom,
 	RollupConfig,
 	Network,
 	DataDir,
@@ -166,6 +175,9 @@ func CheckRequired(ctx *cli.Context) error {
 	}
 	if ctx.String(L2GenesisPath.Name) != "" && network != "" {
 		return fmt.Errorf("cannot specify both %s and %s", L2GenesisPath.Name, Network.Name)
+	}
+	if ctx.Bool(L2Custom.Name) && rollupConfig == "" {
+		return fmt.Errorf("flag %s cannot be used with named networks", L2Custom.Name)
 	}
 	for _, flag := range requiredFlags {
 		if !ctx.IsSet(flag.Names()[0]) {

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -38,22 +38,14 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 	case l2ClaimBlockNumberKey:
 		return binary.BigEndian.AppendUint64(nil, s.config.L2ClaimBlockNumber), nil
 	case l2ChainIDKey:
-		// The CustomChainIDIndicator informs the client to rely on the L2ChainConfigKey to
-		// read the chain config. Otherwise, it'll attempt to read a non-existent hardcoded chain config
-		var chainID uint64
-		if s.config.IsCustomChainConfig {
-			chainID = client.CustomChainIDIndicator
-		} else {
-			chainID = s.config.L2ChainConfig.ChainID.Uint64()
-		}
-		return binary.BigEndian.AppendUint64(nil, chainID), nil
+		return binary.BigEndian.AppendUint64(nil, s.config.L2ChainID), nil
 	case l2ChainConfigKey:
-		if !s.config.IsCustomChainConfig {
+		if s.config.L2ChainID != client.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
 		return json.Marshal(s.config.L2ChainConfig)
 	case rollupKey:
-		if !s.config.IsCustomChainConfig {
+		if s.config.L2ChainID != client.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
 		return json.Marshal(s.config.Rollup)

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -15,6 +16,7 @@ import (
 
 func TestLocalPreimageSource(t *testing.T) {
 	cfg := &config.Config{
+		L2ChainID:          86,
 		Rollup:             chaincfg.OPSepolia(),
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),
@@ -32,7 +34,7 @@ func TestLocalPreimageSource(t *testing.T) {
 		{"L2OutputRoot", l2OutputRootKey, cfg.L2OutputRoot.Bytes()},
 		{"L2Claim", l2ClaimKey, cfg.L2Claim.Bytes()},
 		{"L2ClaimBlockNumber", l2ClaimBlockNumberKey, binary.BigEndian.AppendUint64(nil, cfg.L2ClaimBlockNumber)},
-		{"L2ChainID", l2ChainIDKey, binary.BigEndian.AppendUint64(nil, cfg.L2ChainConfig.ChainID.Uint64())},
+		{"L2ChainID", l2ChainIDKey, binary.BigEndian.AppendUint64(nil, 86)},
 		{"Rollup", rollupKey, nil},             // Only available for custom chain configs
 		{"ChainConfig", l2ChainConfigKey, nil}, // Only available for custom chain configs
 		{"Unknown", preimage.LocalIndexKey(1000).PreimageKey(), nil},
@@ -52,13 +54,13 @@ func TestLocalPreimageSource(t *testing.T) {
 
 func TestGetCustomChainConfigPreimages(t *testing.T) {
 	cfg := &config.Config{
-		Rollup:              chaincfg.OPSepolia(),
-		IsCustomChainConfig: true,
-		L1Head:              common.HexToHash("0x1111"),
-		L2OutputRoot:        common.HexToHash("0x2222"),
-		L2Claim:             common.HexToHash("0x3333"),
-		L2ClaimBlockNumber:  1234,
-		L2ChainConfig:       params.SepoliaChainConfig,
+		Rollup:             chaincfg.OPSepolia(),
+		L2ChainID:          client.CustomChainIDIndicator,
+		L1Head:             common.HexToHash("0x1111"),
+		L2OutputRoot:       common.HexToHash("0x2222"),
+		L2Claim:            common.HexToHash("0x3333"),
+		L2ClaimBlockNumber: 1234,
+		L2ChainConfig:      params.SepoliaChainConfig,
 	}
 	source := NewLocalPreimageSource(cfg)
 	actualRollup, err := source.Get(rollupKey)


### PR DESCRIPTION
**Description**

Previously, running `op-program` with the `--rollup.config` and `--l2.genesis` options would automatically cause it to return the custom chain indicator as the L2 chain ID when requested from the preimage oracle. This made sense because if the chain wasn't in the superchain registry previously the only way to get it into the client was via this custom chain ID indication to cause the client to load the config via the preimage oracle.

However, now that custom configs can be built into the op-program client at build time, the host can't definitively know if the client will have the required chain ID or not. So the default is now changed to report the chain ID from the L2 genesis config supplied, assuming that the client will have that config built in. This ensures the default is compatible with on-chain execution where there is no way to publish the config to the preimage oracle.  For tests when a custom config really is required, a new (hidden) CLI flag is provided to send the custom chain indicator and thus use the custom config.

It is also possible to use `--network <chain-id>` but doing so requires the _host_ op-program to have the custom config built in, not just the game absolute prestate. Since op-challenger includes a generic version of op-program it is much simpler to be able to specify the chain config for the host via JSON files than to replace the version of op-program with one that has the custom config built in.

**Tests**

Updated unit tests and e2e tests.

**Additional context**

Required for https://github.com/ethereum-optimism/optimism-private/issues/339
