### PR TITLE
op-e2e: Add timeouts to sequencer failover tests

### DIFF
--- a/op-e2e/system/conductor/sequencer_failover_test.go
+++ b/op-e2e/system/conductor/sequencer_failover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -28,7 +29,8 @@ func TestSequencerFailover_SetupCluster(t *testing.T) {
 // [Category: conductor rpc]
 // In this test, we test all rpcs exposed by conductor.
 func TestSequencerFailover_ConductorRPC(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 	sys, conductors, cleanup := setupSequencerFailoverTest(t)
 	defer cleanup()
 
@@ -176,7 +178,8 @@ func TestSequencerFailover_ActiveSequencerDown(t *testing.T) {
 	sys, conductors, cleanup := setupSequencerFailoverTest(t)
 	defer cleanup()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 	leaderId, leader := findLeader(t, conductors)
 	err := sys.RollupNodes[leaderId].Stop(ctx) // Stop the current leader sequencer
 	require.NoError(t, err)
@@ -205,7 +208,8 @@ func TestSequencerFailover_DisasterRecovery_OverrideLeader(t *testing.T) {
 	defer cleanup()
 
 	// randomly stop 2 nodes in the cluster to simulate a disaster.
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 	err := conductors[Sequencer1Name].service.Stop(ctx)
 	require.NoError(t, err)
 	err = conductors[Sequencer2Name].service.Stop(ctx)

--- a/op-e2e/system/gastoken/gastoken_test.go
+++ b/op-e2e/system/gastoken/gastoken_test.go
@@ -57,7 +57,7 @@ func testCustomGasToken(t *testing.T, allocType config.AllocType) {
 		uint8(18),
 	}
 
-	setup := func() gasTokenTestOpts {
+	setup := func(t *testing.T) gasTokenTestOpts {
 		cfg := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(allocType))
 		offset := hexutil.Uint64(0)
 		cfg.DeployConfig.L2GenesisRegolithTimeOffset = &offset
@@ -111,7 +111,7 @@ func testCustomGasToken(t *testing.T, allocType config.AllocType) {
 
 	t.Run("deposit", func(t *testing.T) {
 		op_e2e.InitParallel(t)
-		gto := setup()
+		gto := setup(t)
 		checkDeposit(t, gto, false)
 		setCustomGasToken(t, gto.cfg, gto.sys, gto.weth9Address)
 		checkDeposit(t, gto, true)
@@ -119,7 +119,7 @@ func testCustomGasToken(t *testing.T, allocType config.AllocType) {
 
 	t.Run("withdrawal", func(t *testing.T) {
 		op_e2e.InitParallel(t)
-		gto := setup()
+		gto := setup(t)
 		setCustomGasToken(t, gto.cfg, gto.sys, gto.weth9Address)
 		checkDeposit(t, gto, true)
 		checkWithdrawal(t, gto)
@@ -127,7 +127,7 @@ func testCustomGasToken(t *testing.T, allocType config.AllocType) {
 
 	t.Run("fee withdrawal", func(t *testing.T) {
 		op_e2e.InitParallel(t)
-		gto := setup()
+		gto := setup(t)
 		setCustomGasToken(t, gto.cfg, gto.sys, gto.weth9Address)
 		checkDeposit(t, gto, true)
 		checkFeeWithdrawal(t, gto, true)
@@ -135,7 +135,7 @@ func testCustomGasToken(t *testing.T, allocType config.AllocType) {
 
 	t.Run("token name and symbol", func(t *testing.T) {
 		op_e2e.InitParallel(t)
-		gto := setup()
+		gto := setup(t)
 		checkL1TokenNameAndSymbol(t, gto, gto.disabledExpectations)
 		checkL2TokenNameAndSymbol(t, gto, gto.disabledExpectations)
 		checkWETHTokenNameAndSymbol(t, gto, gto.disabledExpectations)


### PR DESCRIPTION
These can sometimes never return, which leads to tests timing out in CI. This PR adds timeouts so we can get feedback faster.
