### PR TITLE
chore(op-deployer): Accept existing impl in `DelayedWETH` bootstrap task

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -26,13 +26,14 @@ const (
 	SplitDepthFlagName                      = "split-depth"
 	ClockExtensionFlagName                  = "clock-extension"
 	MaxClockDurationFlagName                = "max-clock-duration"
-	DelayedWethProxyFlagName                = "delayed-weth-proxy"
 	AnchorStateRegistryProxyFlagName        = "anchor-state-registry-proxy"
 	L2ChainIdFlagName                       = "l2-chain-id"
 	ProposerFlagName                        = "proposer"
 	ChallengerFlagName                      = "challenger"
 	PreimageOracleFlagName                  = "preimage-oracle"
 	ReleaseFlagName                         = "release"
+	DelayedWethProxyFlagName                = "delayed-weth-proxy"
+	DelayedWethImplFlagName                 = "delayed-weth-impl"
 )
 
 var (
@@ -128,6 +129,12 @@ var (
 		Usage:   "Delayed WETH proxy.",
 		EnvVars: deployer.PrefixEnvVar("DELAYED_WETH_PROXY"),
 	}
+	DelayedWethImplFlag = &cli.StringFlag{
+		Name:    DelayedWethImplFlagName,
+		Usage:   "Delayed WETH implementation.",
+		EnvVars: deployer.PrefixEnvVar("DELAYED_WETH_IMPL"),
+		Value:   common.Address{}.Hex(),
+	}
 	AnchorStateRegistryProxyFlag = &cli.StringFlag{
 		Name:    AnchorStateRegistryProxyFlagName,
 		Usage:   "Anchor state registry proxy.",
@@ -182,6 +189,7 @@ var DelayedWETHFlags = []cli.Flag{
 	deployer.L1RPCURLFlag,
 	deployer.PrivateKeyFlag,
 	ArtifactsLocatorFlag,
+	DelayedWethImplFlag,
 }
 
 var DisputeGameFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/opcm/delayed_weth.go
+++ b/op-deployer/pkg/deployer/opcm/delayed_weth.go
@@ -11,9 +11,9 @@ import (
 
 type DeployDelayedWETHInput struct {
 	Release               string
-	StandardVersionsToml  string
 	ProxyAdmin            common.Address
 	SuperchainConfigProxy common.Address
+	DelayedWethImpl       common.Address
 	DelayedWethOwner      common.Address
 	DelayedWethDelay      *big.Int
 }

--- a/op-deployer/pkg/deployer/opcm/delayed_weth_test.go
+++ b/op-deployer/pkg/deployer/opcm/delayed_weth_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -17,29 +16,44 @@ import (
 func TestDeployDelayedWETH(t *testing.T) {
 	_, artifacts := testutil.LocalArtifacts(t)
 
-	host, err := env.DefaultScriptHost(
-		broadcaster.NoopBroadcaster(),
-		testlog.Logger(t, log.LevelInfo),
-		common.Address{'D'},
-		artifacts,
-	)
-	require.NoError(t, err)
-
-	standardVersionsTOML, err := standard.L1VersionsDataFor(11155111)
-	require.NoError(t, err)
-
-	input := DeployDelayedWETHInput{
-		Release:               "dev",
-		StandardVersionsToml:  standardVersionsTOML,
-		ProxyAdmin:            common.Address{'P'},
-		SuperchainConfigProxy: common.Address{'S'},
-		DelayedWethOwner:      common.Address{'O'},
-		DelayedWethDelay:      big.NewInt(100),
+	testCases := []struct {
+		TestName string
+		Impl     common.Address
+	}{
+		{
+			TestName: "ExistingImpl",
+			Impl:     common.Address{'I'},
+		},
+		{
+			TestName: "NoExistingImpl",
+			Impl:     common.Address{},
+		},
 	}
 
-	output, err := DeployDelayedWETH(host, input)
-	require.NoError(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			host, err := env.DefaultScriptHost(
+				broadcaster.NoopBroadcaster(),
+				testlog.Logger(t, log.LevelInfo),
+				common.Address{'D'},
+				artifacts,
+			)
+			require.NoError(t, err)
 
-	require.NotEmpty(t, output.DelayedWethImpl)
-	require.NotEmpty(t, output.DelayedWethProxy)
+			input := DeployDelayedWETHInput{
+				Release:               "dev",
+				ProxyAdmin:            common.Address{'P'},
+				SuperchainConfigProxy: common.Address{'S'},
+				DelayedWethImpl:       testCase.Impl,
+				DelayedWethOwner:      common.Address{'O'},
+				DelayedWethDelay:      big.NewInt(100),
+			}
+
+			output, err := DeployDelayedWETH(host, input)
+			require.NoError(t, err)
+
+			require.NotEmpty(t, output.DelayedWethImpl)
+			require.NotEmpty(t, output.DelayedWethProxy)
+		})
+	}
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployDelayedWETH.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDelayedWETH.s.sol
@@ -20,9 +20,9 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 contract DeployDelayedWETHInput is BaseDeployIO {
     /// Required inputs.
     string internal _release;
-    string internal _standardVersionsToml;
     address public _proxyAdmin;
     ISuperchainConfig public _superchainConfigProxy;
+    address public _delayedWethImpl;
     address public _delayedWethOwner;
     uint256 public _delayedWethDelay;
 
@@ -45,6 +45,9 @@ contract DeployDelayedWETHInput is BaseDeployIO {
         } else if (_sel == this.delayedWethOwner.selector) {
             require(_value != address(0), "DeployDelayedWETH: delayedWethOwner cannot be zero address");
             _delayedWethOwner = _value;
+        } else if (_sel == this.delayedWethImpl.selector) {
+            require(_value != address(0), "DeployDelayedWETH: delayedWethImpl cannot be zero address");
+            _delayedWethImpl = _value;
         } else {
             revert("DeployDelayedWETH: unknown selector");
         }
@@ -54,9 +57,6 @@ contract DeployDelayedWETHInput is BaseDeployIO {
         if (_sel == this.release.selector) {
             require(!LibString.eq(_value, ""), "DeployDelayedWETH: release cannot be empty");
             _release = _value;
-        } else if (_sel == this.standardVersionsToml.selector) {
-            require(!LibString.eq(_value, ""), "DeployDelayedWETH: standardVersionsToml cannot be empty");
-            _standardVersionsToml = _value;
         } else {
             revert("DeployDelayedWETH: unknown selector");
         }
@@ -67,11 +67,6 @@ contract DeployDelayedWETHInput is BaseDeployIO {
         return _release;
     }
 
-    function standardVersionsToml() public view returns (string memory) {
-        require(!LibString.eq(_standardVersionsToml, ""), "DeployDelayedWETH: standardVersionsToml not set");
-        return _standardVersionsToml;
-    }
-
     function proxyAdmin() public view returns (address) {
         require(_proxyAdmin != address(0), "DeployDelayedWETH: proxyAdmin not set");
         return _proxyAdmin;
@@ -80,6 +75,11 @@ contract DeployDelayedWETHInput is BaseDeployIO {
     function superchainConfigProxy() public view returns (ISuperchainConfig) {
         require(address(_superchainConfigProxy) != address(0), "DeployDisputeGame: superchainConfigProxy not set");
         return _superchainConfigProxy;
+    }
+
+    function delayedWethImpl() public view returns (address) {
+        require(_delayedWethImpl != address(0), "DeployDelayedWETH: delayedWethImpl not set");
+        return _delayedWethImpl;
     }
 
     function delayedWethOwner() public view returns (address) {
@@ -166,11 +166,9 @@ contract DeployDelayedWETH is Script {
 
     function deployDelayedWethImpl(DeployDelayedWETHInput _dwi, DeployDelayedWETHOutput _dwo) internal {
         string memory release = _dwi.release();
-        string memory stdVerToml = _dwi.standardVersionsToml();
-        string memory contractName = "delayed_weth";
         IDelayedWETH impl;
 
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
+        address existingImplementation = _dwi.delayedWethImpl();
         if (existingImplementation != address(0)) {
             impl = IDelayedWETH(payable(existingImplementation));
         } else if (isDevelopRelease(release)) {
@@ -212,30 +210,6 @@ contract DeployDelayedWETH is Script {
 
         vm.label(address(proxy), "DelayedWETHProxy");
         _dwo.set(_dwo.delayedWethProxy.selector, address(proxy));
-    }
-
-    // Zero address is returned if the address is not found in '_standardVersionsToml'.
-    function getReleaseAddress(
-        string memory _version,
-        string memory _contractName,
-        string memory _standardVersionsToml
-    )
-        internal
-        pure
-        returns (address addr_)
-    {
-        string memory baseKey = string.concat('.releases["', _version, '"].', _contractName);
-        string memory implAddressKey = string.concat(baseKey, ".implementation_address");
-        string memory addressKey = string.concat(baseKey, ".address");
-        try vm.parseTomlAddress(_standardVersionsToml, implAddressKey) returns (address parsedAddr_) {
-            addr_ = parsedAddr_;
-        } catch {
-            try vm.parseTomlAddress(_standardVersionsToml, addressKey) returns (address parsedAddr_) {
-                addr_ = parsedAddr_;
-            } catch {
-                addr_ = address(0);
-            }
-        }
     }
 
     // A release is considered a 'develop' release if it does not start with 'op-contracts'.

--- a/packages/contracts-bedrock/scripts/deploy/DeployDelayedWETH.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDelayedWETH.s.sol
@@ -46,7 +46,6 @@ contract DeployDelayedWETHInput is BaseDeployIO {
             require(_value != address(0), "DeployDelayedWETH: delayedWethOwner cannot be zero address");
             _delayedWethOwner = _value;
         } else if (_sel == this.delayedWethImpl.selector) {
-            require(_value != address(0), "DeployDelayedWETH: delayedWethImpl cannot be zero address");
             _delayedWethImpl = _value;
         } else {
             revert("DeployDelayedWETH: unknown selector");


### PR DESCRIPTION
## Overview

Alters the `delayedweth` bootstrap task to take the existing implementation as an input, rather than pulling it from the standard versions toml.