### PR TITLE
Docs: remove version from state serialization docs

### DIFF
--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -253,7 +253,6 @@ func (s *State) ThreadCount() int {
 // The format is a simple concatenation of fields, with prefixed item count for repeating items and using big endian
 // encoding for numbers.
 //
-// StateVersion                uint8(1)
 // Memory                      As per Memory.Serialize
 // PreimageKey                 [32]byte
 // PreimageOffset              Word

--- a/cannon/mipsevm/singlethreaded/state.go
+++ b/cannon/mipsevm/singlethreaded/state.go
@@ -190,7 +190,6 @@ func (s *State) EncodeWitness() ([]byte, common.Hash) {
 // The format is a simple concatenation of fields, with prefixed item count for repeating items and using big endian
 // encoding for numbers.
 //
-// StateVersion                uint8(0)
 // Memory                      As per Memory.Serialize
 // PreimageKey                 [32]byte
 // PreimageOffset              Word


### PR DESCRIPTION
**Description**

Documentation only: remove comment that suggests a state version is serialized. In actuality, no version is serialized.