### PR TITLE
fix(op-challenger): Clarify `op-challenger create-game` flags

### DIFF
--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -18,11 +18,11 @@ import (
 )
 
 var (
-	TraceTypeFlag = &cli.StringFlag{
-		Name:    "trace-type",
-		Usage:   "Trace types to support.",
+	GameTypeFlag = &cli.StringFlag{
+		Name:    "game-type",
+		Usage:   "Game type to create (numeric values).",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "TRACE_TYPE"),
-		Value:   types.TraceTypeCannon.String(),
+		Value:   types.CannonGameType.String(),
 	}
 	OutputRootFlag = &cli.StringFlag{
 		Name:    "output-root",
@@ -38,7 +38,7 @@ var (
 
 func CreateGame(ctx *cli.Context) error {
 	outputRoot := common.HexToHash(ctx.String(OutputRootFlag.Name))
-	traceType := ctx.Uint64(TraceTypeFlag.Name)
+	gameType := ctx.Uint64(GameTypeFlag.Name)
 	l2BlockNum := ctx.Uint64(L2BlockNumFlag.Name)
 
 	contract, txMgr, err := NewContractWithTxMgr[*contracts.DisputeGameFactoryContract](ctx, flags.FactoryAddress,
@@ -50,7 +50,7 @@ func CreateGame(ctx *cli.Context) error {
 	}
 
 	creator := tools.NewGameCreator(contract, txMgr)
-	gameAddr, err := creator.CreateGame(ctx.Context, outputRoot, traceType, l2BlockNum)
+	gameAddr, err := creator.CreateGame(ctx.Context, outputRoot, gameType, l2BlockNum)
 	if err != nil {
 		return fmt.Errorf("failed to create game: %w", err)
 	}
@@ -63,7 +63,7 @@ func createGameFlags() []cli.Flag {
 		flags.L1EthRpcFlag,
 		flags.NetworkFlag,
 		flags.FactoryAddressFlag,
-		TraceTypeFlag,
+		GameTypeFlag,
 		OutputRootFlag,
 		L2BlockNumFlag,
 	}


### PR DESCRIPTION
## Overview

Clarifies the flags in `op-challenger create-game`. It currently has `--trace-type`, which I expected to consume the string identifier. This preserves the flexibility of using any game type, but uses a more accurate `--game-type` flag with an updated help message clarifying that it is a numeric value.