### PR TITLE
Add clarity on how OPCM deals with salts

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0xc3110002c722e91681e1e86c6e7de849f134ca7fa68df23e0459a9b378951942",
-    "sourceCodeHash": "0x1e9fdc13df89efd5f2bd4ce10897e38a077bb19e619e8d3bdd6048d90d030ee0"
+    "sourceCodeHash": "0xea06cdc7b94f8f411a4251dc2c29a46a0f2bb516ced4e16d94a17359324eea82"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x8aafeffb41332fddf2fb1ef4fc033bd1f323cdc5b199c6951da73e3cb86276e6"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x1eb781ca3f3609dbf13ecb9fe34063155871510b148ac63348a4947858c196ba",
-    "sourceCodeHash": "0xf1e9fe3f37414e1f1824ce18cd6164c33ca64527b419d6fa52690b6351534822"
+    "initCodeHash": "0xc3110002c722e91681e1e86c6e7de849f134ca7fa68df23e0459a9b378951942",
+    "sourceCodeHash": "0x1e9fdc13df89efd5f2bd4ce10897e38a077bb19e619e8d3bdd6048d90d030ee0"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x8aafeffb41332fddf2fb1ef4fc033bd1f323cdc5b199c6951da73e3cb86276e6"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x617989bb99e5973d4e6c6e7fb2e4c74ca66bc3cc6eb470e0bf8e5263d3b4d378",
-    "sourceCodeHash": "0xe3033efb2b53da4c0f216333f857dadb2afc491ad3bbcbbee36ec199d3c19ef3"
+    "initCodeHash": "0x0ad3652fd8f1d43f2d9799868b1dda6e0211d0f068d91e634f7b6f7c452d2995",
+    "sourceCodeHash": "0x4f86ebaaa23650029ffdf2d708ed087c706857ffd69a27cdad7c70dd49269cc6"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0xc3110002c722e91681e1e86c6e7de849f134ca7fa68df23e0459a9b378951942",
-    "sourceCodeHash": "0xea06cdc7b94f8f411a4251dc2c29a46a0f2bb516ced4e16d94a17359324eea82"
+    "sourceCodeHash": "0x99aef1a0849466df496361b79b5c7350c4f30cf341c8c236a20253661816701c"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x8aafeffb41332fddf2fb1ef4fc033bd1f323cdc5b199c6951da73e3cb86276e6"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xc3110002c722e91681e1e86c6e7de849f134ca7fa68df23e0459a9b378951942",
-    "sourceCodeHash": "0x99aef1a0849466df496361b79b5c7350c4f30cf341c8c236a20253661816701c"
+    "initCodeHash": "0x617989bb99e5973d4e6c6e7fb2e4c74ca66bc3cc6eb470e0bf8e5263d3b4d378",
+    "sourceCodeHash": "0x5e7852069ad6b328e26294dbaee90844015e530dd925fc5a49dfdd47bcfed029"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0x73dbd0af5c85a20a147a87e795526c2da31e56157d11cfc8db5445f4bd1fa13f",
-    "sourceCodeHash": "0x06660f23d989bbb6d6b5cbf89204ff75e66d18cac19604faca08520b8ae34eeb"
+    "sourceCodeHash": "0x52b2ea7508d89e51412de333950da8f5a504a214590bcb67566151c5240eaad1"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0x617989bb99e5973d4e6c6e7fb2e4c74ca66bc3cc6eb470e0bf8e5263d3b4d378",
-    "sourceCodeHash": "0x5e7852069ad6b328e26294dbaee90844015e530dd925fc5a49dfdd47bcfed029"
+    "sourceCodeHash": "0xe3033efb2b53da4c0f216333f857dadb2afc491ad3bbcbbee36ec199d3c19ef3"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x8aafeffb41332fddf2fb1ef4fc033bd1f323cdc5b199c6951da73e3cb86276e6"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x0ad3652fd8f1d43f2d9799868b1dda6e0211d0f068d91e634f7b6f7c452d2995",
-    "sourceCodeHash": "0x4f86ebaaa23650029ffdf2d708ed087c706857ffd69a27cdad7c70dd49269cc6"
+    "initCodeHash": "0x73dbd0af5c85a20a147a87e795526c2da31e56157d11cfc8db5445f4bd1fa13f",
+    "sourceCodeHash": "0x06660f23d989bbb6d6b5cbf89204ff75e66d18cac19604faca08520b8ae34eeb"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0xa8b2f8a6d1092c5e64529736462ebb35daa9ea9e67585f7de8e3e5394682ee64",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -387,19 +387,12 @@ contract OPContractsManager is ISemver {
     )
         internal
         pure
-        returns (bytes32 _salt)
+        returns (bytes32)
     {
         return keccak256(abi.encode(_l2ChainId, _saltMixer, _contractName));
     }
 
-    function computeSingleContractSalt(
-        uint256 _l2ChainId,
-        string memory _saltMixer
-    )
-        internal
-        pure
-        returns (bytes32 _salt)
-    {
+    function computeSingleContractSalt(uint256 _l2ChainId, string memory _saltMixer) internal pure returns (bytes32) {
         return keccak256(abi.encode(_l2ChainId, _saltMixer));
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -197,7 +197,7 @@ contract OPContractsManager is ISemver {
         uint256 l2ChainId = _input.l2ChainId;
         string memory saltMixer = _input.saltMixer;
         // The salt for a non-proxy contract is a function of the chain ID and the salt mixer.
-        bytes32 nonProxiedSalt = computeNonProxiedSalt(l2ChainId, saltMixer);
+        bytes32 nonProxiedSalt = computeNonProxiedContractSalt(l2ChainId, saltMixer);
         DeployOutput memory output;
 
         // -------- Deploy Chain Singletons --------
@@ -378,6 +378,7 @@ contract OPContractsManager is ISemver {
         return address(uint160(bytes20(bytes.concat(versionByte, first19Bytes))));
     }
 
+    // @notice Helper method for computing a salt for deploying proxy contracts.
     function computeProxyContractSalt(
         uint256 _l2ChainId,
         string memory _saltMixer,
@@ -390,7 +391,15 @@ contract OPContractsManager is ISemver {
         return keccak256(abi.encode(_l2ChainId, _saltMixer, _contractName));
     }
 
-    function computeNonProxiedSalt(uint256 _l2ChainId, string memory _saltMixer) internal pure returns (bytes32) {
+    // @notice Helper method for computing a salt for deploying non-proxy contracts.
+    function computeNonProxiedContractSalt(
+        uint256 _l2ChainId,
+        string memory _saltMixer
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
         return keccak256(abi.encode(_l2ChainId, _saltMixer));
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -393,8 +393,8 @@ contract OPContractsManager is ISemver {
 
     /// @notice Helper method for computing a salt that's used in CREATE2 deployments.
     /// Including the contract name ensures that the resultant address from CREATE2 is unique
-    /// across out smart conract system. For example, we deploy multiple proxy contracts
-    /// in a single deployment.
+    /// across our smart contract system. For example, we deploy multiple proxy contracts
+    /// with the same bytecode from this contract, so they need different salts to avoid an address collision
     function computeSalt(
         uint256 _l2ChainId,
         string memory _saltMixer,

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -378,10 +378,10 @@ contract OPContractsManager is ISemver {
         return address(uint160(bytes20(bytes.concat(versionByte, first19Bytes))));
     }
 
-    // @notice Helper method for computing a salt for deploying proxy contracts.
-    // Proxy contract salts are computed differently and include the name of the implementation contract.
-    // This ensures that the resultant address from CREATE2 is unique, as multiple proxy contracts are deployed
-    // in a single deployment.
+    /// @notice Helper method for computing a salt for deploying proxy contracts.
+    /// Proxy contract salts are computed differently and include the name of the implementation contract.
+    /// This ensures that the resultant address from CREATE2 is unique, as multiple proxy contracts are deployed
+    /// in a single deployment.
     function computeProxyContractSalt(
         uint256 _l2ChainId,
         string memory _saltMixer,

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -394,7 +394,7 @@ contract OPContractsManager is ISemver {
         return keccak256(abi.encode(_l2ChainId, _saltMixer, _contractName));
     }
 
-    // @notice Helper method for computing a salt for deploying non-proxy contracts.
+    /// @notice Helper method for computing a salt for deploying non-proxy contracts.
     function computeNonProxiedContractSalt(
         uint256 _l2ChainId,
         string memory _saltMixer

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -379,6 +379,9 @@ contract OPContractsManager is ISemver {
     }
 
     // @notice Helper method for computing a salt for deploying proxy contracts.
+    // Proxy contract salts are computed differently and include the name of the implementation contract.
+    // This ensures that the resultant address from CREATE2 is unique, as multiple proxy contracts are deployed
+    // in a single deployment.
     function computeProxyContractSalt(
         uint256 _l2ChainId,
         string memory _saltMixer,


### PR DESCRIPTION
This change was motivated by the discussion [here](https://discord.com/channels/1244729134312198194/1273519241076670526/1314283100536311809) on Discord. The idea is that non-proxied contracts have their salts computed slightly differently than proxied contracts. This PR is straightforward and aims to make that difference more explicit. 