### PR TITLE
ctb: Fix concurrent map writes error

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/common/util_test.go
+++ b/packages/contracts-bedrock/scripts/checks/common/util_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -79,8 +80,11 @@ func TestProcessFilesGlob(t *testing.T) {
 	excludes := []string{"skip.txt"}
 
 	processedFiles := make(map[string]bool)
+	var mtx sync.Mutex
 	err := ProcessFilesGlob(includes, excludes, func(path string) []error {
+		mtx.Lock()
 		processedFiles[filepath.Base(path)] = true
+		mtx.Unlock()
 		return nil
 	})
 


### PR DESCRIPTION
`ProcessFilesGlob` calls the callback concurrently, so this test needs to lock the `processedFiles` map to prevent panics. See [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/73932/workflows/951eb7de-0611-4bea-b4de-5d3a56c9bf37/jobs/3021176) for an example of this happening.
