### PR TITLE
docs: Fix formatting issue in "Production Releases" Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For contract releases, refer to the GitHub release notes for a given release whi
 
 Tags of the form `v<semver>`, such as `v1.1.4`, indicate releases of all Go code only, and **DO NOT** include smart contracts.
 This naming scheme is required by Golang.
-In the above list, this means these `v<semver` releases contain all `op-*` components and exclude all `contracts-*` components.
+In the above list, this means these `v<semver>` releases contain all `op-*` components and exclude all `contracts-*` components.
 
 `op-geth` embeds upstream geth’s version inside its own version as follows: `vMAJOR.GETH_MAJOR GETH_MINOR GETH_PATCH.PATCH`.
 Basically, geth’s version is our minor version.


### PR DESCRIPTION

<img width="848" alt="Снимок экрана 2024-12-06 в 13 08 07" src="https://github.com/user-attachments/assets/3276de62-454d-435f-87b6-7acaf862e023">


In the "Production Releases" section, there's a small formatting issue where the version tag description is missing a closing angle bracket (>).

Specifically, the text:

`v<semver releases`

should be:

`v<semver> releases`

Thanks for OP!