### PR TITLE
txmgr: Disable default batcher tx send timeout

### DIFF
--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -79,7 +79,7 @@ var (
 		MinBaseFeeGwei:            1.0,
 		ResubmissionTimeout:       48 * time.Second,
 		NetworkTimeout:            10 * time.Second,
-		TxSendTimeout:             10 * time.Minute,
+		TxSendTimeout:             0, // Try sending txs indefinitely, to preserve tx ordering for Holocene
 		TxNotInMempoolTimeout:     2 * time.Minute,
 		ReceiptQueryInterval:      12 * time.Second,
 	}


### PR DESCRIPTION
With Holocene, batcher transaction ordering has to be strictly preserved, so trying to send a transaction candidate should just never timeout. Note that the txmgr will still bump fees to get a transaction for the same nonce submitted.
