### PR TITLE
op-supervisor,op-node: introduce follow/managed interop mode

### DIFF
--- a/interop-devnet/docker-compose.yml
+++ b/interop-devnet/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       --rpc.addr="0.0.0.0"
       --rpc.port=8545
       --rpc.enable-admin
-      --l2-consensus.nodes="ws://op-node-a:8546,ws://op-node-b:8546"
+      --l2-consensus.nodes="http://op-node-a:9645,http://op-node-b:9645"
     environment:
       OP_SUPERVISOR_METRICS_ENABLED: "true"
 
@@ -156,7 +156,9 @@ services:
       --l1.http-poll-interval=6s
       --l2=http://l2-a:8551
       --l2.jwt-secret=/config/jwt-secret.txt
-      --supervisor=http://op-supervisor:8545
+      --interop.supervisor=http://op-supervisor:8545
+      --interop.rpc.addr=0.0.0.0
+      --interop.rpc.port=9645
       --sequencer.enabled
       --sequencer.l1-confs=0
       --verifier.l1-confs=0
@@ -179,6 +181,7 @@ services:
       - "9103:9003"
       - "7100:7300"
       - "6160:6060"
+      - "9645:9645"
     volumes:
       - "safedb_a_data:/db"
       - "${PWD}/../ops-bedrock/test-jwt-secret.txt:/config/jwt-secret.txt"
@@ -207,7 +210,9 @@ services:
       --l1.http-poll-interval=6s
       --l2=http://l2-b:8551
       --l2.jwt-secret=/config/jwt-secret.txt
-      --supervisor=http://op-supervisor:8545
+      --interop.supervisor=http://op-supervisor:8545
+      --interop.rpc.addr=0.0.0.0
+      --interop.rpc.port=9645
       --sequencer.enabled
       --sequencer.l1-confs=0
       --verifier.l1-confs=0
@@ -230,6 +235,7 @@ services:
       - "9203:9003"
       - "7200:7300"
       - "6260:6060"
+      - "9645:9645"
     volumes:
       - "safedb_b_data:/db"
       - "${PWD}/../ops-bedrock/test-jwt-secret.txt:/config/jwt-secret.txt"

--- a/interop-devnet/docker-compose.yml
+++ b/interop-devnet/docker-compose.yml
@@ -89,11 +89,10 @@ services:
       op-supervisor
       --datadir="/db"
       --dependency-set="/depset.json"
-      --l2-rpcs=""
       --rpc.addr="0.0.0.0"
       --rpc.port=8545
       --rpc.enable-admin
-      --l2-rpcs="ws://l2-a:8546,ws://l2-b:8546"
+      --l2-consensus.nodes="ws://op-node-a:8546,ws://op-node-b:8546"
     environment:
       OP_SUPERVISOR_METRICS_ENABLED: "true"
 

--- a/op-e2e/actions/interop/interop.go
+++ b/op-e2e/actions/interop/interop.go
@@ -109,8 +109,10 @@ func (is *InteropSetup) CreateActors() *InteropActors {
 	chainA := createL2Services(is.T, is.Log, l1Miner, is.Keys, is.Out.L2s["900200"], supervisorAPI)
 	chainB := createL2Services(is.T, is.Log, l1Miner, is.Keys, is.Out.L2s["900201"], supervisorAPI)
 	// Hook up L2 RPCs to supervisor, to fetch event data from
-	require.NoError(is.T, supervisorAPI.AddL2RPC(is.T.Ctx(), chainA.SequencerEngine.HTTPEndpoint()))
-	require.NoError(is.T, supervisorAPI.AddL2RPC(is.T.Ctx(), chainB.SequencerEngine.HTTPEndpoint()))
+	srcA := chainA.Sequencer.InteropSyncSource(is.T)
+	srcB := chainA.Sequencer.InteropSyncSource(is.T)
+	require.NoError(is.T, supervisorAPI.backend.AttachSyncSource(is.T.Ctx(), srcA))
+	require.NoError(is.T, supervisorAPI.backend.AttachSyncSource(is.T.Ctx(), srcB))
 	return &InteropActors{
 		L1Miner:    l1Miner,
 		Supervisor: supervisorAPI,

--- a/op-e2e/actions/interop/interop.go
+++ b/op-e2e/actions/interop/interop.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/metrics"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncsrc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -110,7 +111,7 @@ func (is *InteropSetup) CreateActors() *InteropActors {
 	chainB := createL2Services(is.T, is.Log, l1Miner, is.Keys, is.Out.L2s["900201"], supervisorAPI)
 	// Hook up L2 RPCs to supervisor, to fetch event data from
 	srcA := chainA.Sequencer.InteropSyncSource(is.T)
-	srcB := chainA.Sequencer.InteropSyncSource(is.T)
+	srcB := chainB.Sequencer.InteropSyncSource(is.T)
 	require.NoError(is.T, supervisorAPI.backend.AttachSyncSource(is.T.Ctx(), srcA))
 	require.NoError(is.T, supervisorAPI.backend.AttachSyncSource(is.T.Ctx(), srcB))
 	return &InteropActors{
@@ -165,6 +166,7 @@ func NewSupervisor(t helpers.Testing, logger log.Logger, depSet depset.Dependenc
 		DependencySetSource:   depSet,
 		SynchronousProcessors: true,
 		Datadir:               supervisorDataDir,
+		SyncSources:           &syncsrc.CLISyncSources{}, // sources are added dynamically afterwards
 	}
 	b, err := backend.NewSupervisorBackend(t.Ctx(),
 		logger.New("role", "supervisor"), metrics.NoopMetrics, svCfg)

--- a/op-e2e/e2eutils/opnode/opnode.go
+++ b/op-e2e/e2eutils/opnode/opnode.go
@@ -11,10 +11,15 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type Opnode struct {
 	node *rollupNode.OpNode
+}
+
+func (o *Opnode) InteropRPC() (endpoint string, jwtSecret eth.Bytes32) {
+	return o.node.InteropRPC()
 }
 
 func (o *Opnode) UserRPC() endpoint.RPC {

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	gn "github.com/ethereum/go-ethereum/node"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -21,15 +18,11 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
-
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/emit"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/systemconfig"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
@@ -39,14 +32,19 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/emit"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/systemconfig"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/services"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -56,12 +54,14 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	supervisorConfig "github.com/ethereum-optimism/optimism/op-supervisor/config"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncsrc"
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -317,8 +317,11 @@ func (s *interopE2ESystem) newNodeForL2(
 			ListenPort:  0,
 			EnableAdmin: true,
 		},
-		Supervisor: &node.SupervisorEndpointConfig{
-			SupervisorAddr: s.supervisor.RPC(),
+		InteropConfig: &interop.Config{
+			SupervisorAddr:   s.supervisor.RPC(),
+			RPCAddr:          "127.0.0.1",
+			RPCPort:          0,
+			RPCJwtSecretPath: "",
 		},
 		P2P:                         nil, // disabled P2P setup for now
 		L1EpochPollInterval:         time.Second * 2,
@@ -479,9 +482,9 @@ func (s *interopE2ESystem) prepareSupervisor() *supervisor.SupervisorService {
 			ListenPort:  0,
 			EnableAdmin: true,
 		},
-		L2RPCs:  []string{},
-		L1RPC:   s.l1.UserRPC().RPC(),
-		Datadir: path.Join(s.t.TempDir(), "supervisor"),
+		SyncSources: &syncsrc.CLISyncSources{}, // no sync-sources
+		L1RPC:       s.l1.UserRPC().RPC(),
+		Datadir:     path.Join(s.t.TempDir(), "supervisor"),
 	}
 	depSet := make(map[supervisortypes.ChainID]*depset.StaticConfigDependency)
 
@@ -549,7 +552,8 @@ func (s *interopE2ESystem) prepare(t *testing.T, w worldResourcePaths) {
 	// add the L2 RPCs to the supervisor now that the L2s are created
 	ctx := context.Background()
 	for _, l2 := range s.l2s {
-		err := s.SupervisorClient().AddL2RPC(ctx, l2.l2Geth.UserRPC().RPC())
+		rpcEndpoint, secret := l2.opNode.InteropRPC()
+		err := s.SupervisorClient().AddL2RPC(ctx, rpcEndpoint, secret)
 		require.NoError(s.t, err, "failed to add L2 RPC to supervisor")
 	}
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -28,6 +28,7 @@ const (
 	P2PCategory        = "5. PEER-TO-PEER"
 	AltDACategory      = "6. ALT-DA (EXPERIMENTAL)"
 	MiscCategory       = "7. MISC"
+	InteropCategory    = "8. INTEROP (SUPER EXPERIMENTAL)"
 )
 
 func init() {
@@ -74,13 +75,6 @@ var (
 		Category: RollupCategory,
 	}
 	/* Optional Flags */
-	SupervisorAddr = &cli.StringFlag{
-		Name: "supervisor",
-		Usage: "RPC address of interop supervisor service for cross-chain safety verification." +
-			"Applies only to Interop-enabled networks.",
-		Hidden:  true, // hidden for now during early testing.
-		EnvVars: prefixEnvVars("SUPERVISOR"),
-	}
 	BeaconHeader = &cli.StringFlag{
 		Name:     "l1.beacon-header",
 		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
@@ -372,6 +366,40 @@ var (
 		Value:    time.Second * 1,
 		Category: SequencerCategory,
 	}
+	/* Interop flags, experimental. */
+	InteropSupervisor = &cli.StringFlag{
+		Name: "interop.supervisor",
+		Usage: "Interop standard-mode: RPC address of interop supervisor to use for cross-chain safety verification." +
+			"Applies only to Interop-enabled networks.",
+		EnvVars:  prefixEnvVars("INTEROP_SUPERVISOR"),
+		Category: InteropCategory,
+	}
+	InteropRPCAddr = &cli.StringFlag{
+		Name: "interop.rpc.addr",
+		Usage: "Interop Websocket-only RPC listening address, to serve supervisor syncing." +
+			"Applies only to Interop-enabled networks. Optional, alternative to follow-mode.",
+		EnvVars:  prefixEnvVars("INTEROP_RPC_ADDR"),
+		Value:    "127.0.0.1",
+		Category: InteropCategory,
+	}
+	InteropRPCPort = &cli.IntFlag{
+		Name: "interop.rpc.port",
+		Usage: "Interop RPC listening port, to serve supervisor syncing." +
+			"Applies only to Interop-enabled networks.",
+		EnvVars:  prefixEnvVars("INTEROP_RPC_PORT"),
+		Value:    9645, // Note: op-service/rpc/cli.go uses 8545 as the default.
+		Category: InteropCategory,
+	}
+	InteropJWTSecret = &cli.StringFlag{
+		Name: "interop.jwt-secret",
+		Usage: "Interop RPC server authentication. Path to JWT secret key. Keys are 32 bytes, hex encoded in a file. " +
+			"A new key will be generated if the file is empty. " +
+			"Applies only to Interop-enabled networks.",
+		EnvVars:     prefixEnvVars("INTEROP_JWT_SECRET"),
+		Value:       "",
+		Destination: new(string),
+		Category:    InteropCategory,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -381,7 +409,6 @@ var requiredFlags = []cli.Flag{
 }
 
 var optionalFlags = []cli.Flag{
-	SupervisorAddr,
 	BeaconAddr,
 	BeaconHeader,
 	BeaconFallbackAddrs,
@@ -419,6 +446,10 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
 	L2EngineKind,
+	InteropSupervisor,
+	InteropRPCAddr,
+	InteropRPCPort,
+	InteropJWTSecret,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -230,29 +230,3 @@ func parseHTTPHeader(headerStr string) (http.Header, error) {
 	h.Add(s[0], s[1])
 	return h, nil
 }
-
-type SupervisorEndpointSetup interface {
-	SupervisorClient(ctx context.Context, log log.Logger) (*sources.SupervisorClient, error)
-	Check() error
-}
-
-type SupervisorEndpointConfig struct {
-	SupervisorAddr string
-}
-
-var _ SupervisorEndpointSetup = (*SupervisorEndpointConfig)(nil)
-
-func (cfg *SupervisorEndpointConfig) Check() error {
-	if cfg.SupervisorAddr == "" {
-		return errors.New("supervisor RPC address is not set")
-	}
-	return nil
-}
-
-func (cfg *SupervisorEndpointConfig) SupervisorClient(ctx context.Context, log log.Logger) (*sources.SupervisorClient, error) {
-	cl, err := client.NewRPC(ctx, log, cfg.SupervisorAddr, client.WithLazyDial())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create supervisor RPC: %w", err)
-	}
-	return sources.NewSupervisorClient(cl), nil
-}

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 	Beacon L1BeaconEndpointSetup
 
-	InteropConfig *interop.Config
+	InteropConfig interop.Setup
 
 	Driver driver.Config
 

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -7,14 +7,16 @@ import (
 	"math"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
+
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 type Config struct {
@@ -23,7 +25,7 @@ type Config struct {
 
 	Beacon L1BeaconEndpointSetup
 
-	Supervisor SupervisorEndpointSetup
+	InteropConfig *interop.Config
 
 	Driver driver.Config
 
@@ -142,11 +144,11 @@ func (cfg *Config) Check() error {
 		}
 	}
 	if cfg.Rollup.InteropTime != nil {
-		if cfg.Supervisor == nil {
-			return fmt.Errorf("the Interop upgrade is scheduled (timestamp = %d) but no supervisor RPC endpoint is configured", *cfg.Rollup.InteropTime)
+		if cfg.InteropConfig == nil {
+			return fmt.Errorf("the Interop upgrade is scheduled (timestamp = %d) but no interop node config is set", *cfg.Rollup.InteropTime)
 		}
-		if err := cfg.Supervisor.Check(); err != nil {
-			return fmt.Errorf("misconfigured supervisor RPC endpoint: %w", err)
+		if err := cfg.InteropConfig.Check(); err != nil {
+			return fmt.Errorf("misconfigured interop: %w", err)
 		}
 	}
 	if err := cfg.Rollup.Check(); err != nil {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -163,7 +162,7 @@ func NewDriver(
 	cfg *rollup.Config,
 	l2 L2Chain,
 	l1 L1Chain,
-	supervisor interop.InteropBackend, // may be nil pre-interop.
+	interopManager event.Deriver, // may be nil pre-interop.
 	l1Blobs derive.L1BlobsFetcher,
 	altSync AltSync,
 	network Network,
@@ -183,8 +182,7 @@ func NewDriver(
 	// It will then be ready to pick up verification work
 	// as soon as we reach the upgrade time (if the upgrade is not already active).
 	if cfg.InteropTime != nil {
-		interopDeriver := interop.NewInteropDeriver(log, cfg, driverCtx, supervisor, l2)
-		sys.Register("interop", interopDeriver, opts)
+		sys.Register("interop", interopManager, opts)
 	}
 
 	statusTracker := status.NewStatusTracker(log, metrics)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -162,7 +163,7 @@ func NewDriver(
 	cfg *rollup.Config,
 	l2 L2Chain,
 	l1 L1Chain,
-	interopManager event.Deriver, // may be nil pre-interop.
+	supervisor interop.InteropBackend, // may be nil pre-interop.
 	l1Blobs derive.L1BlobsFetcher,
 	altSync AltSync,
 	network Network,
@@ -182,7 +183,8 @@ func NewDriver(
 	// It will then be ready to pick up verification work
 	// as soon as we reach the upgrade time (if the upgrade is not already active).
 	if cfg.InteropTime != nil {
-		sys.Register("interop", interopManager, opts)
+		interopDeriver := interop.NewInteropDeriver(log, cfg, driverCtx, supervisor, l2)
+		sys.Register("interop", interopDeriver, opts)
 	}
 
 	statusTracker := status.NewStatusTracker(log, metrics)

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -1,0 +1,61 @@
+package interop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+type Config struct {
+	// SupervisorAddr to follow for cross-chain safety updates.
+	// Non-empty if running in follow-mode.
+	// Cannot be set if RPCAddr is set.
+	SupervisorAddr string
+
+	// RPCAddr address to bind RPC server to, to serve external supervisor nodes.
+	// Cannot be set if SupervisorAddr is set.
+	RPCAddr string
+	// RPCPort port to bind RPC server to, to serve external supervisor nodes.
+	// Binds to any available port if set to 0.
+	// Only applicable if RPCAddr is set.
+	RPCPort int
+	// RPCJwtSecretPath path of JWT secret file to apply authentication to the interop server address.
+	RPCJwtSecretPath string
+}
+
+func (cfg *Config) Check() error {
+	if (cfg.SupervisorAddr == "") != (cfg.RPCAddr == "") {
+		return errors.New("must have either a supervisor RPC endpoint to follow, or interop RPC address to serve from")
+	}
+	return nil
+}
+
+func (cfg *Config) Setup(ctx context.Context, logger log.Logger) (SubSystem, error) {
+	if cfg.RPCAddr != "" {
+		logger.Info("Setting up Interop RPC server to serve supervisor sync work")
+		// Load JWT secret, if any, generate one otherwise.
+		jwtSecret, err := rpc.ObtainJWTSecret(logger, cfg.RPCJwtSecretPath, true)
+		if err != nil {
+			return nil, err
+		}
+		out := &ManagedMode{}
+		out.srv = rpc.NewServer(cfg.RPCAddr, cfg.RPCPort, "v0.0.0",
+			rpc.WithWebsocketEnabled(), rpc.WithJWTSecret(jwtSecret[:]))
+		return out, nil
+	} else {
+		logger.Info("Setting up Interop RPC client to sync from read-only supervisor")
+		cl, err := client.NewRPC(ctx, logger, cfg.SupervisorAddr, client.WithLazyDial())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create supervisor RPC: %w", err)
+		}
+		out := &StandardMode{}
+		out.cl = sources.NewSupervisorClient(cl)
+		return out, nil
+	}
+}

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -30,7 +30,7 @@ type Config struct {
 }
 
 func (cfg *Config) Check() error {
-	// TODO: temporary workaround needs both to be configured.
+	// TODO(#13338): temporary workaround needs both to be configured.
 	//if (cfg.SupervisorAddr == "") != (cfg.RPCAddr == "") {
 	//	return errors.New("must have either a supervisor RPC endpoint to follow, or interop RPC address to serve from")
 	//}

--- a/op-node/rollup/interop/iface.go
+++ b/op-node/rollup/interop/iface.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
 type SubSystem interface {
@@ -17,5 +18,7 @@ type SubSystem interface {
 
 type Setup interface {
 	Setup(ctx context.Context, logger log.Logger) (SubSystem, error)
+	TemporarySetup(ctx context.Context, logger log.Logger, eng Engine) (
+		*sources.SupervisorClient, *TemporaryInteropServer, error)
 	Check() error
 }

--- a/op-node/rollup/interop/iface.go
+++ b/op-node/rollup/interop/iface.go
@@ -1,0 +1,21 @@
+package interop
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+)
+
+type SubSystem interface {
+	event.Deriver
+	event.AttachEmitter
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+}
+
+type Setup interface {
+	Setup(ctx context.Context, logger log.Logger) (SubSystem, error)
+	Check() error
+}

--- a/op-node/rollup/interop/interop.go
+++ b/op-node/rollup/interop/interop.go
@@ -228,7 +228,7 @@ func (d *InteropDeriver) onCrossSafeUpdateEvent(x engine.CrossSafeUpdateEvent) e
 	}
 	if result.Cross.Number < x.CrossSafe.Number {
 		d.log.Warn("op-supervisor is behind known cross-safe block", "supervisor", result.Cross, "known", x.CrossSafe)
-		// TODO: we may want to force set the cross-safe block in the engine,
+		// TODO(#13337): we may want to force set the cross-safe block in the engine,
 		//  and then reset derivation, so this op-node can help get the supervisor back in sync.
 		return nil
 	}

--- a/op-node/rollup/interop/managed.go
+++ b/op-node/rollup/interop/managed.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -109,12 +109,12 @@ func (ib *InteropAPI) TryDeriveNext(ctx context.Context, nextL1 eth.BlockRef) er
 	return nil
 }
 
-func (ib *InteropAPI) FetchReceipts(ctx context.Context, id eth.BlockID) (types.Receipts, error) {
+func (ib *InteropAPI) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
 	// TODO use execution engine to fetch the receipts
 	return nil, nil
 }
 
-func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num hexutil.Uint64) (eth.BlockRef, error) {
+func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
 	return eth.BlockRef{}, nil
 }
 

--- a/op-node/rollup/interop/managed.go
+++ b/op-node/rollup/interop/managed.go
@@ -37,16 +37,12 @@ func (s *ManagedMode) OnEvent(ev event.Event) bool {
 }
 
 func (s *ManagedMode) Start(ctx context.Context) error {
-
-	// TODO attach backend to server
 	interopAPI := &InteropAPI{}
 	s.srv.AddAPI(gethrpc.API{
 		Namespace:     "interop",
 		Service:       interopAPI,
 		Authenticated: true,
 	})
-
-	// TODO start RPC server, if configured as one
 	if err := s.srv.Start(); err != nil {
 		return fmt.Errorf("failed to start interop RPC server: %w", err)
 	}

--- a/op-node/rollup/interop/managed.go
+++ b/op-node/rollup/interop/managed.go
@@ -1,0 +1,127 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// ManagedMode makes the op-node managed by an op-supervisor,
+// by serving sync work and updating the canonical chain based on instructions.
+type ManagedMode struct {
+	log log.Logger
+
+	emitter event.Emitter
+
+	srv *rpc.Server
+}
+
+var _ SubSystem = (*ManagedMode)(nil)
+
+func (s *ManagedMode) AttachEmitter(em event.Emitter) {
+	s.emitter = em
+}
+
+func (s *ManagedMode) OnEvent(ev event.Event) bool {
+	// TODO: let all active subscriptions now
+	return false
+}
+
+func (s *ManagedMode) Start(ctx context.Context) error {
+
+	// TODO attach backend to server
+	interopAPI := &InteropAPI{}
+	s.srv.AddAPI(gethrpc.API{
+		Namespace:     "interop",
+		Service:       interopAPI,
+		Authenticated: true,
+	})
+
+	// TODO start RPC server, if configured as one
+	if err := s.srv.Start(); err != nil {
+		return fmt.Errorf("failed to start interop RPC server: %w", err)
+	}
+
+	return nil
+}
+
+func (s *ManagedMode) Stop(ctx context.Context) error {
+	// TODO toggle closing state
+
+	// stop RPC server
+	if err := s.srv.Stop(); err != nil {
+		return fmt.Errorf("failed to stop interop sub-system RPC server: %w", err)
+	}
+
+	s.log.Info("Interop sub-system stopped")
+	return nil
+}
+
+type InteropAPI struct {
+	// TODO event emitter handle
+	// TODO event await util
+}
+
+func (ib *InteropAPI) SubscribeUnsafeBlocks(ctx context.Context) (*gethrpc.Subscription, error) {
+	// TODO create subscription, and get new unsafe-block events to feed into it
+	return nil, nil
+}
+
+func (ib *InteropAPI) UpdateCrossUnsafe(ctx context.Context, ref eth.BlockRef) error {
+	// TODO cross-unsafe update -> fire event
+	// TODO await engine update or ctx timeout -> error maybe
+	return nil
+}
+
+func (ib *InteropAPI) UpdateCrossSafe(ctx context.Context, ref eth.BlockRef) error {
+	// TODO cross-safe update -> fire event
+	// TODO await forkchoice update or ctx timeout -> error maybe
+	return nil
+}
+
+func (ib *InteropAPI) UpdateFinalized(ctx context.Context, ref eth.BlockRef) error {
+	// TODO finalized update -> fire event
+	// TODO await forkchoice update or ctx timeout -> error maybe
+	return nil
+}
+
+func (ib *InteropAPI) AnchorPoint(ctx context.Context) (l1, l2 eth.BlockRef, err error) {
+	// TODO return genesis anchor point from rollup config
+	return
+}
+
+func (ib *InteropAPI) Reset(ctx context.Context) error {
+	// TODO fire reset event
+	// TODO await reset-confirmed event or ctx timeout
+	return nil
+}
+
+func (ib *InteropAPI) TryDeriveNext(ctx context.Context, nextL1 eth.BlockRef) error {
+	// TODO fire derivation step event
+	// TODO await deriver progress (L1 or L2 kind of progress) or ctx timeout
+	// TODO need to not auto-derive the next thing until next TryDeriveNext call: need to modify driver
+	// TODO return the L1 or L2 progress
+	return nil
+}
+
+func (ib *InteropAPI) FetchReceipts(ctx context.Context, id eth.BlockID) (types.Receipts, error) {
+	// TODO use execution engine to fetch the receipts
+	return nil, nil
+}
+
+func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num hexutil.Uint64) (eth.BlockRef, error) {
+	return eth.BlockRef{}, nil
+}
+
+func (ib *InteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
+	return supervisortypes.ChainID{}, nil
+}

--- a/op-node/rollup/interop/managed.go
+++ b/op-node/rollup/interop/managed.go
@@ -32,7 +32,7 @@ func (s *ManagedMode) AttachEmitter(em event.Emitter) {
 }
 
 func (s *ManagedMode) OnEvent(ev event.Event) bool {
-	// TODO: let all active subscriptions now
+	// TODO(#13336): let all active subscriptions now
 	return false
 }
 
@@ -51,7 +51,7 @@ func (s *ManagedMode) Start(ctx context.Context) error {
 }
 
 func (s *ManagedMode) Stop(ctx context.Context) error {
-	// TODO toggle closing state
+	// TODO(#13336): toggle closing state
 
 	// stop RPC server
 	if err := s.srv.Stop(); err != nil {
@@ -63,61 +63,63 @@ func (s *ManagedMode) Stop(ctx context.Context) error {
 }
 
 type InteropAPI struct {
-	// TODO event emitter handle
-	// TODO event await util
+	// TODO(#13336): event emitter handle
+	// TODO(#13336): event await util
 }
 
 func (ib *InteropAPI) SubscribeUnsafeBlocks(ctx context.Context) (*gethrpc.Subscription, error) {
-	// TODO create subscription, and get new unsafe-block events to feed into it
+	// TODO(#13336): create subscription, and get new unsafe-block events to feed into it
 	return nil, nil
 }
 
 func (ib *InteropAPI) UpdateCrossUnsafe(ctx context.Context, ref eth.BlockRef) error {
-	// TODO cross-unsafe update -> fire event
-	// TODO await engine update or ctx timeout -> error maybe
+	// TODO(#13336): cross-unsafe update -> fire event
+	// TODO(#13336): await engine update or ctx timeout -> error maybe
 	return nil
 }
 
 func (ib *InteropAPI) UpdateCrossSafe(ctx context.Context, ref eth.BlockRef) error {
-	// TODO cross-safe update -> fire event
-	// TODO await forkchoice update or ctx timeout -> error maybe
+	// TODO(#13336): cross-safe update -> fire event
+	// TODO(#13336): await forkchoice update or ctx timeout -> error maybe
 	return nil
 }
 
 func (ib *InteropAPI) UpdateFinalized(ctx context.Context, ref eth.BlockRef) error {
-	// TODO finalized update -> fire event
-	// TODO await forkchoice update or ctx timeout -> error maybe
+	// TODO(#13336): finalized update -> fire event
+	// TODO(#13336): await forkchoice update or ctx timeout -> error maybe
 	return nil
 }
 
 func (ib *InteropAPI) AnchorPoint(ctx context.Context) (l1, l2 eth.BlockRef, err error) {
-	// TODO return genesis anchor point from rollup config
+	// TODO(#13336): return genesis anchor point from rollup config
 	return
 }
 
 func (ib *InteropAPI) Reset(ctx context.Context) error {
-	// TODO fire reset event
-	// TODO await reset-confirmed event or ctx timeout
+	// TODO(#13336): fire reset event
+	// TODO(#13336): await reset-confirmed event or ctx timeout
 	return nil
 }
 
 func (ib *InteropAPI) TryDeriveNext(ctx context.Context, nextL1 eth.BlockRef) error {
-	// TODO fire derivation step event
-	// TODO await deriver progress (L1 or L2 kind of progress) or ctx timeout
-	// TODO need to not auto-derive the next thing until next TryDeriveNext call: need to modify driver
-	// TODO return the L1 or L2 progress
+	// TODO(#13336): fire derivation step event
+	// TODO(#13336): await deriver progress (L1 or L2 kind of progress) or ctx timeout
+	// TODO(#13336): need to not auto-derive the next thing until next TryDeriveNext call: need to modify driver
+	// TODO(#13336): return the L1 or L2 progress
 	return nil
 }
 
 func (ib *InteropAPI) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
-	// TODO use execution engine to fetch the receipts
+	// TODO(#13336): use execution engine to fetch the receipts
 	return nil, nil
 }
 
 func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
+	// (#13336): use execution engine to fetch block-ref by number
 	return eth.BlockRef{}, nil
 }
 
 func (ib *InteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
+	// (#13336): fetch chain ID
 	return supervisortypes.ChainID{}, nil
 }

--- a/op-node/rollup/interop/standard.go
+++ b/op-node/rollup/interop/standard.go
@@ -25,7 +25,7 @@ func (s *StandardMode) AttachEmitter(em event.Emitter) {
 }
 
 func (s *StandardMode) OnEvent(ev event.Event) bool {
-	// TODO: hook up to existing interop deriver
+	// TODO(#13337): hook up to existing interop deriver
 	return false
 }
 
@@ -35,7 +35,7 @@ func (s *StandardMode) Start(ctx context.Context) error {
 }
 
 func (s *StandardMode) Stop(ctx context.Context) error {
-	// TODO toggle closing state
+	// TODO(#13337) toggle closing state
 
 	s.log.Info("Interop sub-system stopped")
 	return s.cl.Stop(ctx)

--- a/op-node/rollup/interop/standard.go
+++ b/op-node/rollup/interop/standard.go
@@ -1,0 +1,42 @@
+package interop
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+// StandardMode makes the op-node follow the canonical chain based on a read-only supervisor endpoint.
+type StandardMode struct {
+	log log.Logger
+
+	emitter event.Emitter
+
+	cl *sources.SupervisorClient
+}
+
+var _ SubSystem = (*StandardMode)(nil)
+
+func (s *StandardMode) AttachEmitter(em event.Emitter) {
+	s.emitter = em
+}
+
+func (s *StandardMode) OnEvent(ev event.Event) bool {
+	// TODO: hook up to existing interop deriver
+	return false
+}
+
+func (s *StandardMode) Start(ctx context.Context) error {
+	s.log.Info("Interop sub-system started in follow-mode")
+	return nil
+}
+
+func (s *StandardMode) Stop(ctx context.Context) error {
+	// TODO toggle closing state
+
+	s.log.Info("Interop sub-system stopped")
+	return s.cl.Stop(ctx)
+}

--- a/op-node/rollup/interop/tmpapi.go
+++ b/op-node/rollup/interop/tmpapi.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
@@ -22,7 +21,7 @@ type TemporaryInteropServer struct {
 }
 
 func NewTemporaryInteropServer(host string, port int, eng Engine) *TemporaryInteropServer {
-	interopAPI := &TemporaryInteropAPI{eng: eng}
+	interopAPI := &TemporaryInteropAPI{Eng: eng}
 
 	srv := rpc.NewServer(host, port, "v0.0.1",
 		rpc.WithAPIs([]gethrpc.API{
@@ -55,20 +54,20 @@ type Engine interface {
 }
 
 type TemporaryInteropAPI struct {
-	eng Engine
+	Eng Engine
 }
 
-func (ib *TemporaryInteropAPI) FetchReceipts(ctx context.Context, id eth.BlockID) (types.Receipts, error) {
-	_, receipts, err := ib.eng.FetchReceipts(ctx, id.Hash)
+func (ib *TemporaryInteropAPI) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
+	_, receipts, err := ib.Eng.FetchReceipts(ctx, blockHash)
 	return receipts, err
 }
 
-func (ib *TemporaryInteropAPI) BlockRefByNumber(ctx context.Context, num hexutil.Uint64) (eth.BlockRef, error) {
-	return ib.eng.BlockRefByNumber(ctx, uint64(num))
+func (ib *TemporaryInteropAPI) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
+	return ib.Eng.BlockRefByNumber(ctx, num)
 }
 
 func (ib *TemporaryInteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
-	v, err := ib.eng.ChainID(ctx)
+	v, err := ib.Eng.ChainID(ctx)
 	if err != nil {
 		return supervisortypes.ChainID{}, err
 	}

--- a/op-node/rollup/interop/tmpapi.go
+++ b/op-node/rollup/interop/tmpapi.go
@@ -1,0 +1,76 @@
+package interop
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TemporaryInteropServer is a work-around to serve the "managed"-
+// mode endpoints used by the op-supervisor for data,
+// while still using the old interop deriver for syncing.
+type TemporaryInteropServer struct {
+	srv *rpc.Server
+}
+
+func NewTemporaryInteropServer(host string, port int, eng Engine) *TemporaryInteropServer {
+	interopAPI := &TemporaryInteropAPI{eng: eng}
+
+	srv := rpc.NewServer(host, port, "v0.0.1",
+		rpc.WithAPIs([]gethrpc.API{
+			{
+				Namespace:     "interop",
+				Service:       interopAPI,
+				Authenticated: false,
+			},
+		}))
+
+	return &TemporaryInteropServer{srv: srv}
+}
+
+func (s *TemporaryInteropServer) Start() error {
+	return s.srv.Start()
+}
+
+func (s *TemporaryInteropServer) Endpoint() string {
+	return s.srv.Endpoint()
+}
+
+func (s *TemporaryInteropServer) Close() error {
+	return s.srv.Stop()
+}
+
+type Engine interface {
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error)
+	ChainID(ctx context.Context) (*big.Int, error)
+}
+
+type TemporaryInteropAPI struct {
+	eng Engine
+}
+
+func (ib *TemporaryInteropAPI) FetchReceipts(ctx context.Context, id eth.BlockID) (types.Receipts, error) {
+	_, receipts, err := ib.eng.FetchReceipts(ctx, id.Hash)
+	return receipts, err
+}
+
+func (ib *TemporaryInteropAPI) BlockRefByNumber(ctx context.Context, num hexutil.Uint64) (eth.BlockRef, error) {
+	return ib.eng.BlockRefByNumber(ctx, uint64(num))
+}
+
+func (ib *TemporaryInteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
+	v, err := ib.eng.ChainID(ctx)
+	if err != nil {
+		return supervisortypes.ChainID{}, err
+	}
+	return supervisortypes.ChainIDFromBig(v), nil
+}

--- a/op-node/rollup/interop/tmpapi.go
+++ b/op-node/rollup/interop/tmpapi.go
@@ -2,6 +2,7 @@ package interop
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -40,7 +41,7 @@ func (s *TemporaryInteropServer) Start() error {
 }
 
 func (s *TemporaryInteropServer) Endpoint() string {
-	return s.srv.Endpoint()
+	return fmt.Sprintf("http://%s", s.srv.Endpoint())
 }
 
 func (s *TemporaryInteropServer) Close() error {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -2,31 +2,30 @@ package opnode
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
-	altda "github.com/ethereum-optimism/optimism/op-alt-da"
-	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
-	"github.com/ethereum-optimism/optimism/op-service/oppprof"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
 // NewConfig creates a Config from the provided flags or environment variables.
@@ -83,12 +82,12 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	}
 	conductorRPCEndpoint := ctx.String(flags.ConductorRpcFlag.Name)
 	cfg := &node.Config{
-		L1:         l1Endpoint,
-		L2:         l2Endpoint,
-		Rollup:     *rollupConfig,
-		Driver:     *driverConfig,
-		Beacon:     NewBeaconEndpointConfig(ctx),
-		Supervisor: NewSupervisorEndpointConfig(ctx),
+		L1:            l1Endpoint,
+		L2:            l2Endpoint,
+		Rollup:        *rollupConfig,
+		Driver:        *driverConfig,
+		Beacon:        NewBeaconEndpointConfig(ctx),
+		InteropConfig: NewSupervisorEndpointConfig(ctx),
 		RPC: node.RPCConfig{
 			ListenAddr:  ctx.String(flags.RPCListenAddr.Name),
 			ListenPort:  ctx.Int(flags.RPCListenPort.Name),
@@ -133,9 +132,12 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	return cfg, nil
 }
 
-func NewSupervisorEndpointConfig(ctx *cli.Context) node.SupervisorEndpointSetup {
-	return &node.SupervisorEndpointConfig{
-		SupervisorAddr: ctx.String(flags.SupervisorAddr.Name),
+func NewSupervisorEndpointConfig(ctx *cli.Context) *interop.Config {
+	return &interop.Config{
+		SupervisorAddr:   ctx.String(flags.InteropSupervisor.Name),
+		RPCAddr:          ctx.String(flags.InteropRPCAddr.Name),
+		RPCPort:          ctx.Int(flags.InteropRPCPort.Name),
+		RPCJwtSecretPath: ctx.String(flags.InteropJWTSecret.Name),
 	}
 }
 
@@ -161,30 +163,13 @@ func NewL1EndpointConfig(ctx *cli.Context) *node.L1EndpointConfig {
 	}
 }
 
-func NewL2EndpointConfig(ctx *cli.Context, log log.Logger) (*node.L2EndpointConfig, error) {
+func NewL2EndpointConfig(ctx *cli.Context, logger log.Logger) (*node.L2EndpointConfig, error) {
 	l2Addr := ctx.String(flags.L2EngineAddr.Name)
 	fileName := ctx.String(flags.L2EngineJWTSecret.Name)
-	var secret [32]byte
-	fileName = strings.TrimSpace(fileName)
-	if fileName == "" {
-		return nil, fmt.Errorf("file-name of jwt secret is empty")
+	secret, err := rpc.ObtainJWTSecret(logger, fileName, true)
+	if err != nil {
+		return nil, err
 	}
-	if data, err := os.ReadFile(fileName); err == nil {
-		jwtSecret := common.FromHex(strings.TrimSpace(string(data)))
-		if len(jwtSecret) != 32 {
-			return nil, fmt.Errorf("invalid jwt secret in path %s, not 32 hex-formatted bytes", fileName)
-		}
-		copy(secret[:], jwtSecret)
-	} else {
-		log.Warn("Failed to read JWT secret from file, generating a new one now. Configure L2 geth with --authrpc.jwt-secret=" + fmt.Sprintf("%q", fileName))
-		if _, err := io.ReadFull(rand.Reader, secret[:]); err != nil {
-			return nil, fmt.Errorf("failed to generate jwt secret: %w", err)
-		}
-		if err := os.WriteFile(fileName, []byte(hexutil.Encode(secret[:])), 0o600); err != nil {
-			return nil, err
-		}
-	}
-
 	return &node.L2EndpointConfig{
 		L2EngineAddr:      l2Addr,
 		L2EngineJWTSecret: secret,

--- a/op-service/rpc/jwt.go
+++ b/op-service/rpc/jwt.go
@@ -1,0 +1,51 @@
+package rpc
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// ObtainJWTSecret attempts to read a JWT secret, and generates one if necessary.
+// Unlike the geth rpc.ObtainJWTSecret variant, this uses local logging,
+// makes generation optional, and does not blindly overwrite a JWT secret on any read error.
+// Generally it is advised to generate a JWT secret if missing, as a server.
+// Clients should not generate a JWT secret, and use the secret of the server instead.
+func ObtainJWTSecret(logger log.Logger, jwtSecretPath string, generateMissing bool) (eth.Bytes32, error) {
+	jwtSecretPath = strings.TrimSpace(jwtSecretPath)
+	if jwtSecretPath == "" {
+		return eth.Bytes32{}, fmt.Errorf("file-name of jwt secret is empty")
+	}
+	data, err := os.ReadFile(jwtSecretPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			if !generateMissing {
+				return eth.Bytes32{}, fmt.Errorf("JWT-secret in path %q does not exist: %w", jwtSecretPath, err)
+			}
+			logger.Warn("Failed to read JWT secret from file, generating a new one now.", "path", jwtSecretPath)
+			var secret eth.Bytes32
+			if _, err := io.ReadFull(rand.Reader, secret[:]); err != nil {
+				return eth.Bytes32{}, fmt.Errorf("failed to generate jwt secret: %w", err)
+			}
+			if err := os.WriteFile(jwtSecretPath, []byte(hexutil.Encode(secret[:])), 0o600); err != nil {
+				return eth.Bytes32{}, err
+			}
+		} else {
+			return eth.Bytes32{}, fmt.Errorf("failed to read JWT secret from file path %q", jwtSecretPath)
+		}
+	}
+	jwtSecret := common.FromHex(strings.TrimSpace(string(data))) // FromHex handles optional '0x' prefix
+	if len(jwtSecret) != 32 {
+		return eth.Bytes32{}, fmt.Errorf("invalid jwt secret in path %q, not 32 hex-formatted bytes", jwtSecretPath)
+	}
+	return eth.Bytes32(jwtSecret), nil
+}

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -2,11 +2,8 @@ package sources
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -18,8 +15,6 @@ import (
 
 type L1ClientConfig struct {
 	EthClientConfig
-
-	L1BlockRefsCacheSize int
 }
 
 func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProviderKind) *L1ClientConfig {
@@ -46,9 +41,9 @@ func L1ClientSimpleConfig(trustRPC bool, kind RPCProviderKind, cacheSize int) *L
 			MustBePostMerge:       false,
 			RPCProviderKind:       kind,
 			MethodResetDuration:   time.Minute,
+			// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
+			BlockRefsCacheSize: cacheSize,
 		},
-		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
-		L1BlockRefsCacheSize: cacheSize,
 	}
 }
 
@@ -57,10 +52,6 @@ func L1ClientSimpleConfig(trustRPC bool, kind RPCProviderKind, cacheSize int) *L
 // (i.e. to verify all returned contents against corresponding block hashes).
 type L1Client struct {
 	*EthClient
-
-	// cache L1BlockRef by hash
-	// common.Hash -> eth.L1BlockRef
-	l1BlockRefsCache *caching.LRUCache[common.Hash, eth.L1BlockRef]
 }
 
 // NewL1Client wraps a RPC with bindings to fetch L1 data, while logging errors, tracking metrics (optional), and caching.
@@ -71,51 +62,24 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 	}
 
 	return &L1Client{
-		EthClient:        ethClient,
-		l1BlockRefsCache: caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.L1BlockRefsCacheSize),
+		EthClient: ethClient,
 	}, nil
 }
 
 // L1BlockRefByLabel returns the [eth.L1BlockRef] for the given block label.
 // Notice, we cannot cache a block reference by label because labels are not guaranteed to be unique.
 func (s *L1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
-	info, err := s.InfoByLabel(ctx, label)
-	if err != nil {
-		// Both geth and erigon like to serve non-standard errors for the safe and finalized heads, correct that.
-		// This happens when the chain just started and nothing is marked as safe/finalized yet.
-		if strings.Contains(err.Error(), "block not found") || strings.Contains(err.Error(), "Unknown block") {
-			err = ethereum.NotFound
-		}
-		return eth.L1BlockRef{}, fmt.Errorf("failed to fetch head header: %w", err)
-	}
-	ref := eth.InfoToL1BlockRef(info)
-	s.l1BlockRefsCache.Add(ref.Hash, ref)
-	return ref, nil
+	return s.BlockRefByLabel(ctx, label)
 }
 
 // L1BlockRefByNumber returns an [eth.L1BlockRef] for the given block number.
 // Notice, we cannot cache a block reference by number because L1 re-orgs can invalidate the cached block reference.
 func (s *L1Client) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
-	info, err := s.InfoByNumber(ctx, num)
-	if err != nil {
-		return eth.L1BlockRef{}, fmt.Errorf("failed to fetch header by num %d: %w", num, err)
-	}
-	ref := eth.InfoToL1BlockRef(info)
-	s.l1BlockRefsCache.Add(ref.Hash, ref)
-	return ref, nil
+	return s.BlockRefByNumber(ctx, num)
 }
 
 // L1BlockRefByHash returns the [eth.L1BlockRef] for the given block hash.
 // We cache the block reference by hash as it is safe to assume collision will not occur.
 func (s *L1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
-	if v, ok := s.l1BlockRefsCache.Get(hash); ok {
-		return v, nil
-	}
-	info, err := s.InfoByHash(ctx, hash)
-	if err != nil {
-		return eth.L1BlockRef{}, fmt.Errorf("failed to fetch header by hash %v: %w", hash, err)
-	}
-	ref := eth.InfoToL1BlockRef(info)
-	s.l1BlockRefsCache.Add(ref.Hash, ref)
-	return ref, nil
+	return s.BlockRefByHash(ctx, hash)
 }

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -42,13 +42,13 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 	}
 	return &L2ClientConfig{
 		EthClientConfig: EthClientConfig{
-			MaxRequestsPerBatch:   20, // TODO: tune batch param
-			MaxConcurrentRequests: 10,
 			// receipts and transactions are cached per block
 			ReceiptsCacheSize:     span,
 			TransactionsCacheSize: span,
 			HeadersCacheSize:      span,
 			PayloadsCacheSize:     span,
+			MaxRequestsPerBatch:   20, // TODO: tune batch param
+			MaxConcurrentRequests: 10,
 			BlockRefsCacheSize:    span,
 			TrustRPC:              trustRPC,
 			MustBePostMerge:       true,

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -42,13 +42,14 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 	}
 	return &L2ClientConfig{
 		EthClientConfig: EthClientConfig{
+			MaxRequestsPerBatch:   20, // TODO: tune batch param
+			MaxConcurrentRequests: 10,
 			// receipts and transactions are cached per block
 			ReceiptsCacheSize:     span,
 			TransactionsCacheSize: span,
 			HeadersCacheSize:      span,
 			PayloadsCacheSize:     span,
-			MaxRequestsPerBatch:   20, // TODO: tune batch param
-			MaxConcurrentRequests: 10,
+			BlockRefsCacheSize:    span,
 			TrustRPC:              trustRPC,
 			MustBePostMerge:       true,
 			RPCProviderKind:       RPCKindStandard,

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -44,13 +44,13 @@ func (cl *SupervisorClient) Start(ctx context.Context) error {
 	return result
 }
 
-func (cl *SupervisorClient) AddL2RPC(ctx context.Context, rpc string) error {
+func (cl *SupervisorClient) AddL2RPC(ctx context.Context, rpc string, auth eth.Bytes32) error {
 	var result error
 	err := cl.client.CallContext(
 		ctx,
 		&result,
 		"admin_addL2RPC",
-		rpc)
+		rpc, auth)
 	if err != nil {
 		return fmt.Errorf("failed to Add L2 to Supervisor (rpc: %s): %w", rpc, err)
 	}

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -103,15 +103,6 @@ func (m *MockEthClient) ExpectPayloadByLabel(label eth.BlockLabel, payload *eth.
 	m.Mock.On("PayloadByLabel", label).Once().Return(payload, err)
 }
 
-func (m *MockEthClient) FetchReceiptsOnly(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
-	out := m.Mock.Called(blockHash)
-	return out.Get(0).(types.Receipts), out.Error(1)
-}
-
-func (m *MockEthClient) ExpectFetchReceiptsOnly(hash common.Hash, receipts types.Receipts, err error) {
-	m.Mock.On("FetchReceiptsOnly", hash).Once().Return(receipts, err)
-}
-
 func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	out := m.Mock.Called(blockHash)
 	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(types.Receipts), out.Error(2)

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -103,6 +103,15 @@ func (m *MockEthClient) ExpectPayloadByLabel(label eth.BlockLabel, payload *eth.
 	m.Mock.On("PayloadByLabel", label).Once().Return(payload, err)
 }
 
+func (m *MockEthClient) FetchReceiptsOnly(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
+	out := m.Mock.Called(blockHash)
+	return out.Get(0).(types.Receipts), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectFetchReceiptsOnly(hash common.Hash, receipts types.Receipts, err error) {
+	m.Mock.On("FetchReceiptsOnly", hash).Once().Return(receipts, err)
+}
+
 func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	out := m.Mock.Called(blockHash)
 	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(types.Receipts), out.Error(2)
@@ -146,6 +155,33 @@ func (m *MockEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*ty
 
 func (m *MockEthClient) ExpectBlockByNumber(number *big.Int, block *types.Block, err error) {
 	m.Mock.On("BlockByNumber", number).Once().Return(block, err)
+}
+
+func (m *MockEthClient) BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockRef, error) {
+	out := m.Mock.Called(label)
+	return out.Get(0).(eth.BlockRef), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectBlockRefByLabel(label eth.BlockLabel, ref eth.BlockRef, err error) {
+	m.Mock.On("BlockRefByLabel", label).Once().Return(ref, err)
+}
+
+func (m *MockEthClient) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
+	out := m.Mock.Called(num)
+	return out.Get(0).(eth.BlockRef), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectBlockRefByNumber(num uint64, ref eth.BlockRef, err error) {
+	m.Mock.On("BlockRefByNumber", num).Once().Return(ref, err)
+}
+
+func (m *MockEthClient) BlockRefByHash(ctx context.Context, hash common.Hash) (eth.BlockRef, error) {
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.BlockRef), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectBlockRefByHash(hash common.Hash, ref eth.BlockRef, err error) {
+	m.Mock.On("BlockRefByHash", hash).Once().Return(ref, err)
 }
 
 func (m *MockEthClient) ExpectClose() {

--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -8,10 +8,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncsrc"
 )
 
 var (
-	ErrMissingL2RPC         = errors.New("must specify at least one L2 RPC")
+	ErrMissingSyncSources   = errors.New("must specify sync source collection")
 	ErrMissingDependencySet = errors.New("must specify a dependency set source")
 	ErrMissingDatadir       = errors.New("must specify datadir")
 )
@@ -35,7 +36,9 @@ type Config struct {
 
 	L1RPC string
 
-	L2RPCs  []string
+	// SyncSources lists the consensus nodes that help sync the supervisor
+	SyncSources syncsrc.SyncSourceCollection
+
 	Datadir string
 }
 
@@ -44,21 +47,23 @@ func (c *Config) Check() error {
 	result = errors.Join(result, c.MetricsConfig.Check())
 	result = errors.Join(result, c.PprofConfig.Check())
 	result = errors.Join(result, c.RPC.Check())
-	if len(c.L2RPCs) == 0 {
-		result = errors.Join(result, ErrMissingL2RPC)
-	}
 	if c.DependencySetSource == nil {
 		result = errors.Join(result, ErrMissingDependencySet)
 	}
 	if c.Datadir == "" {
 		result = errors.Join(result, ErrMissingDatadir)
 	}
+	if c.SyncSources == nil {
+		result = errors.Join(result, ErrMissingSyncSources)
+	} else {
+		result = errors.Join(result, c.SyncSources.Check())
+	}
 	return result
 }
 
 // NewConfig creates a new config using default values whenever possible.
 // Required options with no suitable default are passed as parameters.
-func NewConfig(l1RPC string, l2RPCs []string, depSet depset.DependencySetSource, datadir string) *Config {
+func NewConfig(l1RPC string, syncSrcs syncsrc.SyncSourceCollection, depSet depset.DependencySetSource, datadir string) *Config {
 	return &Config{
 		LogConfig:           oplog.DefaultCLIConfig(),
 		MetricsConfig:       opmetrics.DefaultCLIConfig(),
@@ -67,7 +72,7 @@ func NewConfig(l1RPC string, l2RPCs []string, depSet depset.DependencySetSource,
 		DependencySetSource: depSet,
 		MockRun:             false,
 		L1RPC:               l1RPC,
-		L2RPCs:              l2RPCs,
+		SyncSources:         syncSrcs,
 		Datadir:             datadir,
 	}
 }

--- a/op-supervisor/config/config_test.go
+++ b/op-supervisor/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncsrc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -17,10 +18,10 @@ func TestDefaultConfigIsValid(t *testing.T) {
 	require.NoError(t, cfg.Check())
 }
 
-func TestRequireL2RPC(t *testing.T) {
+func TestRequireSyncSources(t *testing.T) {
 	cfg := validConfig()
-	cfg.L2RPCs = []string{}
-	require.ErrorIs(t, cfg.Check(), ErrMissingL2RPC)
+	cfg.SyncSources = nil
+	require.ErrorIs(t, cfg.Check(), ErrMissingSyncSources)
 }
 
 func TestRequireDependencySet(t *testing.T) {
@@ -67,5 +68,5 @@ func validConfig() *Config {
 		panic(err)
 	}
 	// Should be valid using only the required arguments passed in via the constructor.
-	return NewConfig("http://localhost:8545", []string{"http://localhost:8545"}, depSet, "./supervisor_testdir")
+	return NewConfig("http://localhost:8545", &syncsrc.CLISyncSources{}, depSet, "./supervisor_testdir")
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
-	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -20,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncsrc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -136,11 +135,18 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 		su.logger.Warn("No L1 RPC configured, L1 processor will not be started")
 	}
 
-	// the config has some RPC connections to attach to the chain-processors
-	for _, rpc := range cfg.L2RPCs {
-		err := su.attachRPC(ctx, rpc)
+	setups, err := cfg.SyncSources.Load(ctx, su.logger)
+	if err != nil {
+		return fmt.Errorf("failed to load sync-source setups: %w", err)
+	}
+	// the config has some sync sources (RPC connections) to attach to the chain-processors
+	for _, srcSetup := range setups {
+		src, err := srcSetup.Setup(ctx, su.logger)
 		if err != nil {
-			return fmt.Errorf("failed to add chain monitor for rpc %v: %w", rpc, err)
+			return fmt.Errorf("failed to set up sync source: %w", err)
+		}
+		if err := su.attachSyncSource(ctx, src); err != nil {
+			return fmt.Errorf("failed to attach sync source %s: %w", src, err)
 		}
 	}
 	return nil
@@ -201,38 +207,22 @@ func (su *SupervisorBackend) openChainDBs(chainID types.ChainID) error {
 	return nil
 }
 
-func (su *SupervisorBackend) attachRPC(ctx context.Context, rpc string) error {
-	su.logger.Info("attaching RPC to chain processor", "rpc", rpc)
+func (su *SupervisorBackend) attachSyncSource(ctx context.Context, src syncsrc.SyncSource) error {
+	su.logger.Info("attaching sync source to chain processor", "source", src)
 
-	logger := su.logger.New("rpc", rpc)
-	// create the rpc client, which yields the chain id
-	rpcClient, chainID, err := clientForL2(ctx, logger, rpc)
+	chainID, err := src.ChainID(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to identify chain ID of sync source: %w", err)
 	}
 	if !su.depSet.HasChain(chainID) {
 		return fmt.Errorf("chain %s is not part of the interop dependency set: %w", chainID, types.ErrUnknownChain)
 	}
-	cm, ok := su.chainMetrics.Get(chainID)
-	if !ok {
-		return fmt.Errorf("failed to find metrics for chain %v", chainID)
-	}
-	// create an RPC client that the processor can use
-	cl, err := processors.NewEthClient(
-		ctx,
-		logger.New("chain", chainID),
-		cm,
-		rpc,
-		rpcClient, 2*time.Second,
-		false,
-		sources.RPCKindStandard)
-	if err != nil {
-		return err
-	}
-	return su.AttachProcessorSource(chainID, cl)
+	return su.AttachProcessorSource(chainID, src)
 }
 
 func (su *SupervisorBackend) AttachProcessorSource(chainID types.ChainID, src processors.Source) error {
+	// TODO: register sync sources in the backend, to trigger derivation work etc.
+
 	proc, ok := su.chainProcessors.Get(chainID)
 	if !ok {
 		return fmt.Errorf("unknown chain %s, cannot attach RPC to processor", chainID)
@@ -271,18 +261,6 @@ func (su *SupervisorBackend) AttachL1Source(source processors.L1Source) {
 	} else {
 		su.l1Processor.AttachClient(source)
 	}
-}
-
-func clientForL2(ctx context.Context, logger log.Logger, rpc string) (client.RPC, types.ChainID, error) {
-	ethClient, err := dial.DialEthClientWithTimeout(ctx, 10*time.Second, logger, rpc)
-	if err != nil {
-		return nil, types.ChainID{}, fmt.Errorf("failed to connect to rpc %v: %w", rpc, err)
-	}
-	chainID, err := ethClient.ChainID(ctx)
-	if err != nil {
-		return nil, types.ChainID{}, fmt.Errorf("failed to load chain id for rpc %v: %w", rpc, err)
-	}
-	return client.NewBaseRPCClient(ethClient.Client()), types.ChainIDFromBig(chainID), nil
 }
 
 func (su *SupervisorBackend) Start(ctx context.Context) error {
@@ -359,8 +337,16 @@ func (su *SupervisorBackend) Stop(ctx context.Context) error {
 }
 
 // AddL2RPC attaches an RPC as the RPC for the given chain, overriding the previous RPC source, if any.
-func (su *SupervisorBackend) AddL2RPC(ctx context.Context, rpc string) error {
-	return su.attachRPC(ctx, rpc)
+func (su *SupervisorBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error {
+	setupSrc := &syncsrc.RPCDialSetup{
+		JWTSecret: jwtSecret,
+		Endpoint:  rpc,
+	}
+	src, err := setupSrc.Setup(ctx, su.logger)
+	if err != nil {
+		return fmt.Errorf("failed to set up sync source from RPC: %w", err)
+	}
+	return su.attachSyncSource(ctx, src)
 }
 
 // Internal methods, for processors

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -145,7 +145,7 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 		if err != nil {
 			return fmt.Errorf("failed to set up sync source: %w", err)
 		}
-		if err := su.attachSyncSource(ctx, src); err != nil {
+		if err := su.AttachSyncSource(ctx, src); err != nil {
 			return fmt.Errorf("failed to attach sync source %s: %w", src, err)
 		}
 	}
@@ -207,7 +207,7 @@ func (su *SupervisorBackend) openChainDBs(chainID types.ChainID) error {
 	return nil
 }
 
-func (su *SupervisorBackend) attachSyncSource(ctx context.Context, src syncsrc.SyncSource) error {
+func (su *SupervisorBackend) AttachSyncSource(ctx context.Context, src syncsrc.SyncSource) error {
 	su.logger.Info("attaching sync source to chain processor", "source", src)
 
 	chainID, err := src.ChainID(ctx)
@@ -346,7 +346,7 @@ func (su *SupervisorBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret
 	if err != nil {
 		return fmt.Errorf("failed to set up sync source from RPC: %w", err)
 	}
-	return su.attachSyncSource(ctx, src)
+	return su.AttachSyncSource(ctx, src)
 }
 
 // Internal methods, for processors

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -38,7 +38,7 @@ func (m *MockBackend) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string) error {
+func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error {
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -19,8 +19,8 @@ import (
 )
 
 type Source interface {
-	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
-	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethtypes.Receipts, error)
+	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)
 }
 
 type LogProcessor interface {
@@ -199,7 +199,7 @@ func (s *ChainProcessor) rangeUpdate() (int, error) {
 
 		// fetch the block ref
 		ctx, cancel := context.WithTimeout(s.ctx, time.Second*10)
-		nextL1, err := s.client.L1BlockRefByNumber(ctx, num)
+		nextL1, err := s.client.BlockRefByNumber(ctx, num)
 		cancel()
 		if err != nil {
 			result.err = err
@@ -215,7 +215,7 @@ func (s *ChainProcessor) rangeUpdate() (int, error) {
 
 		// fetch receipts
 		ctx, cancel = context.WithTimeout(s.ctx, time.Second*10)
-		_, receipts, err := s.client.FetchReceipts(ctx, next.Hash)
+		receipts, err := s.client.FetchReceipts(ctx, next.Hash)
 		cancel()
 		if err != nil {
 			result.err = err

--- a/op-supervisor/supervisor/backend/syncsrc/collection.go
+++ b/op-supervisor/supervisor/backend/syncsrc/collection.go
@@ -1,0 +1,64 @@
+package syncsrc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+)
+
+type CLISyncSources struct {
+	Endpoints      []string
+	JWTSecretPaths []string
+}
+
+var _ SyncSourceCollection = (*CLISyncSources)(nil)
+
+func (p *CLISyncSources) Load(ctx context.Context, logger log.Logger) ([]SyncSourceSetup, error) {
+	if err := p.Check(); err != nil { // sanity-check, in case the caller did not check.
+		return nil, err
+	}
+	if len(p.Endpoints) == 0 {
+		logger.Warn("No sync sources were configured")
+		return nil, nil
+	}
+	if len(p.JWTSecretPaths) == 0 {
+		return nil, errors.New("need at least 1 JWT secret to setup sync-sources")
+	}
+	secrets := make([]eth.Bytes32, 0, len(p.JWTSecretPaths))
+	for i, secretPath := range p.JWTSecretPaths {
+		secret, err := rpc.ObtainJWTSecret(logger, secretPath, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load JWT secret %d from path %q", i, secretPath)
+		}
+		secrets = append(secrets, secret)
+	}
+	setups := make([]SyncSourceSetup, 0, len(p.Endpoints))
+	for i, endpoint := range p.Endpoints {
+		var secret eth.Bytes32
+		if i >= len(secrets) {
+			secret = secrets[0]
+		}
+		setups = append(setups, &RPCDialSetup{
+			JWTSecret: secret,
+			Endpoint:  endpoint,
+		})
+	}
+	return setups, nil
+}
+
+func (p *CLISyncSources) Check() error {
+	if len(p.Endpoints) == len(p.JWTSecretPaths) {
+		return nil
+	}
+	if len(p.JWTSecretPaths) == 1 {
+		return nil // repeating JWT secret, for any number of endpoints
+	}
+	return fmt.Errorf("expected each sync source endpoint to come with a JWT secret, "+
+		"or all share the same JWT secret, but got %d endpoints and %d secrets",
+		len(p.Endpoints), len(p.JWTSecretPaths))
+}

--- a/op-supervisor/supervisor/backend/syncsrc/collection.go
+++ b/op-supervisor/supervisor/backend/syncsrc/collection.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
+// CLISyncSources is a bundle of CLI-specified (and thus stringified) sync-source options.
+// These sources can be loaded into SyncSourceSetup instances, to retrieve the active sync sources from.
 type CLISyncSources struct {
 	Endpoints      []string
 	JWTSecretPaths []string

--- a/op-supervisor/supervisor/backend/syncsrc/dial.go
+++ b/op-supervisor/supervisor/backend/syncsrc/dial.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
+// RPCDialSetup implements SyncSourceSetup by dialing an RPC
+// and providing an RPC-client binding to sync with.
 type RPCDialSetup struct {
 	JWTSecret eth.Bytes32
 	Endpoint  string

--- a/op-supervisor/supervisor/backend/syncsrc/dial.go
+++ b/op-supervisor/supervisor/backend/syncsrc/dial.go
@@ -1,0 +1,40 @@
+package syncsrc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type RPCDialSetup struct {
+	JWTSecret eth.Bytes32
+	Endpoint  string
+}
+
+var _ SyncSourceSetup = (*RPCDialSetup)(nil)
+
+func (r *RPCDialSetup) Setup(ctx context.Context, logger log.Logger) (SyncSource, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+
+	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(r.JWTSecret))
+	opts := []client.RPCOption{
+		client.WithGethRPCOptions(auth),
+		client.WithDialAttempts(10),
+	}
+	rpcCl, err := client.NewRPC(ctx, logger, r.Endpoint, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &RPCSyncSource{
+		name: fmt.Sprintf("RPCSyncSource(%s)", r.Endpoint),
+		cl:   rpcCl,
+	}, nil
+}

--- a/op-supervisor/supervisor/backend/syncsrc/iface.go
+++ b/op-supervisor/supervisor/backend/syncsrc/iface.go
@@ -1,0 +1,29 @@
+package syncsrc
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type SyncSourceCollection interface {
+	Load(ctx context.Context, logger log.Logger) ([]SyncSourceSetup, error)
+	Check() error
+}
+
+type SyncSourceSetup interface {
+	Setup(ctx context.Context, logger log.Logger) (SyncSource, error)
+}
+
+type SyncSource interface {
+	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)
+	ChainID(ctx context.Context) (types.ChainID, error)
+	// String identifies the sync source
+	String() string
+}

--- a/op-supervisor/supervisor/backend/syncsrc/iface.go
+++ b/op-supervisor/supervisor/backend/syncsrc/iface.go
@@ -11,15 +11,19 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+// SyncSourceCollection turns a bundle of options into individual options for SyncSourceSetup.
+// This enables configurations to share properties.
 type SyncSourceCollection interface {
 	Load(ctx context.Context, logger log.Logger) ([]SyncSourceSetup, error)
 	Check() error
 }
 
+// SyncSourceSetup sets up a new active SyncSource. Setup may fail, e.g. an RPC endpoint is invalid.
 type SyncSourceSetup interface {
 	Setup(ctx context.Context, logger log.Logger) (SyncSource, error)
 }
 
+// SyncSource provides an interface to interact with a source node to e.g. sync event data.
 type SyncSource interface {
 	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)

--- a/op-supervisor/supervisor/backend/syncsrc/rpc.go
+++ b/op-supervisor/supervisor/backend/syncsrc/rpc.go
@@ -19,6 +19,13 @@ type RPCSyncSource struct {
 	cl   client.RPC
 }
 
+func NewRPCSyncSource(name string, cl client.RPC) *RPCSyncSource {
+	return &RPCSyncSource{
+		name: name,
+		cl:   cl,
+	}
+}
+
 var _ SyncSource = (*RPCSyncSource)(nil)
 
 func (rs *RPCSyncSource) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {

--- a/op-supervisor/supervisor/backend/syncsrc/rpc.go
+++ b/op-supervisor/supervisor/backend/syncsrc/rpc.go
@@ -1,0 +1,62 @@
+package syncsrc
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type RPCSyncSource struct {
+	name string
+	cl   client.RPC
+}
+
+var _ SyncSource = (*RPCSyncSource)(nil)
+
+func (rs *RPCSyncSource) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {
+	var out *eth.BlockRef
+	err := rs.cl.CallContext(ctx, &out, "interop_blockRefByNumber", number)
+	if err != nil {
+		var jsonErr rpc.Error
+		if errors.As(err, &jsonErr) {
+			if jsonErr.ErrorCode() == 0 { // TODO
+				return eth.BlockRef{}, ethereum.NotFound
+			}
+		}
+		return eth.BlockRef{}, err
+	}
+	return *out, nil
+}
+
+func (rs *RPCSyncSource) FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error) {
+	var out gethtypes.Receipts
+	err := rs.cl.CallContext(ctx, &out, "interop_fetchReceipts", blockHash)
+	if err != nil {
+		var jsonErr rpc.Error
+		if errors.As(err, &jsonErr) {
+			if jsonErr.ErrorCode() == 0 { // TODO
+				return nil, ethereum.NotFound
+			}
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+func (rs *RPCSyncSource) ChainID(ctx context.Context) (types.ChainID, error) {
+	var chainID types.ChainID
+	err := rs.cl.CallContext(ctx, &chainID, "interop_chainID")
+	return chainID, err
+}
+
+func (rs *RPCSyncSource) String() string {
+	return rs.name
+}

--- a/op-supervisor/supervisor/backend/syncsrc/rpc.go
+++ b/op-supervisor/supervisor/backend/syncsrc/rpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+// RPCSyncSource is an active RPC, wrapped with bindings, implementing the SyncSource interface.
 type RPCSyncSource struct {
 	name string
 	cl   client.RPC

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -11,7 +11,7 @@ import (
 type AdminBackend interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
-	AddL2RPC(ctx context.Context, rpc string) error
+	AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error
 }
 
 type QueryBackend interface {
@@ -88,8 +88,8 @@ func (a *AdminFrontend) Stop(ctx context.Context) error {
 }
 
 // AddL2RPC adds a new L2 chain to the supervisor backend
-func (a *AdminFrontend) AddL2RPC(ctx context.Context, rpc string) error {
-	return a.Supervisor.AddL2RPC(ctx, rpc)
+func (a *AdminFrontend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error {
+	return a.Supervisor.AddL2RPC(ctx, rpc, jwtSecret)
 }
 
 type UpdatesFrontend struct {

--- a/op-supervisor/supervisor/service.go
+++ b/op-supervisor/supervisor/service.go
@@ -72,17 +72,6 @@ func (su *SupervisorService) initBackend(ctx context.Context, cfg *config.Config
 		su.backend = backend.NewMockBackend()
 		return nil
 	}
-	// the flag is a string slice, which has the potential to have empty strings
-	filterBlank := func(in []string) []string {
-		out := make([]string, 0, len(in))
-		for _, s := range in {
-			if s != "" {
-				out = append(out, s)
-			}
-		}
-		return out
-	}
-	cfg.L2RPCs = filterBlank(cfg.L2RPCs)
 	be, err := backend.NewSupervisorBackend(ctx, su.log, su.metrics, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create supervisor backend: %w", err)


### PR DESCRIPTION
**Description**

This PR changes the op-node and op-supervisor to support two ways of interacting with each other:
- follow mode: op-node follows a read-only supervisor RPC endpoint (ideally we add proofs here later, to make this an untrusted thing)
- managed mode: op-node is actively managed by an op-supervisor, and serves an RPC server that can handle sync requests and instructions of the op-supervisor.

Changes:
- implement Websocket endpoint option for RPC server op-service util
- make obtain-JWT secret util, and de-duplicate usage, so op-node engine-API can use the same
- change interop CLI flags of op-node to have the options for these two modes
- change interop CLI flags of op-supervisor to connect to op-nodes
- change op-supervisor to have 1 kind of L2 node; a "sync source", aka a managed node used for syncing. This is where it will fetch receipts through, and instruct forkchoice / derivation work
- op-supervisor sync-source constructs:
  - a collection of endpoints, that can share a JWT secret
  - an endpoint setup, that can create a sync-source. With RPC setup as first implementation. More test-specific setups might follow.
  - an RPC based sync-source, to interact over json RPC client
- op-node generalization of interop: it's now a "sub system", so we can either instantiate it in follow-mode, or managed-mode, and simply attach it to the rest of op-node, while encapsulating the difference.
- fix op-supervisor Add-RPC functionality, so you can add an op-node interop endpoint as sync-source.
  -  `addL2RPC` now has a JWT secret arg, to connect to an authenticated RPC
- `EthClient` provides blockref fetching methods now, to not have to rely on the `L1BlockRef` methods in a L2 context.
  - `L1Client` uses these blockref methods
  - `MockEthClient` supports mocking of these methods


**Tests**

All existing op-e2e tests pass, using the new RPC and configuration functionality. Some workarounds were required, since the full standard/managed mode has not been implemented yet.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/13182
