### PR TITLE
ci: Use ci-builder for cannon-stf-verify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,8 +947,9 @@ jobs:
           mentions: "@proofs-team"
 
   cannon-stf-verify:
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    # docker-cli is required to pull in older cannon release images
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
       - run:


### PR DESCRIPTION
We need a build environment that contains docker-cli in order to run the `cannon-stf-verify` job