### PR TITLE
op-batcher: syncActions is aware of safe=unsafe edge case

### DIFF
--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -94,8 +94,8 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 		// This could happen if the batcher restarted.
 		// The sequencer may have derived the safe chain
 		// from channels sent by a previous batcher instance.
-		l.Warn("next safe block above newest block in state, clearing channel manager state",
-			"nextSafeBlockNum", nextSafeBlockNum,
+		l.Warn("safe head above newest block in state, clearing channel manager state",
+			"safe head", newSyncStatus.SafeL2,
 			"newestBlockInState", eth.ToBlockID(newestBlockInState),
 			"syncActions",
 			startAfresh)

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -77,7 +77,10 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 	nextSafeBlockNum := newSyncStatus.SafeL2.Number + 1
 
 	if nextSafeBlockNum < oldestBlockInStateNum {
-		l.Warn("next safe block is below oldest block in state", "syncActions", startAfresh, "oldestBlockInState", oldestBlockInState, "safeBlock", newSyncStatus.SafeL2)
+		l.Warn("next safe block is below oldest block in state",
+			"syncActions", startAfresh,
+			"oldestBlockInState", oldestBlockInState,
+			"safeL2", newSyncStatus.SafeL2)
 		return startAfresh, false
 	}
 
@@ -92,18 +95,18 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 		// The sequencer may have derived the safe chain
 		// from channels sent by a previous batcher instance.
 		l.Warn("safe head above newest block in state, clearing channel manager state",
-			"safe head", newSyncStatus.SafeL2,
+			"syncActions", startAfresh,
+			"safeL2", newSyncStatus.SafeL2,
 			"newestBlockInState", eth.ToBlockID(newestBlockInState),
-			"syncActions",
-			startAfresh)
+		)
 		return startAfresh, false
 	}
 
 	if numBlocksToDequeue > 0 && blocks[numBlocksToDequeue-1].Hash() != newSyncStatus.SafeL2.Hash {
 		l.Warn("safe chain reorg, clearing channel manager state",
+			"syncActions", startAfresh,
 			"existingBlock", eth.ToBlockID(blocks[numBlocksToDequeue-1]),
-			"newSafeBlock", newSyncStatus.SafeL2,
-			"syncActions", startAfresh)
+			"safeL2", newSyncStatus.SafeL2)
 		return startAfresh, false
 	}
 
@@ -118,9 +121,9 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 			// that the derivation pipeline may have stalled
 			// e.g. because of Holocene strict ordering rules.
 			l.Warn("sequencer did not make expected progress",
+				"syncActions", startAfresh,
 				"existingBlock", ch.LatestL2(),
-				"newSafeBlock", newSyncStatus.SafeL2,
-				"syncActions", startAfresh)
+				"safeL2", newSyncStatus.SafeL2)
 			return startAfresh, false
 		}
 	}

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -139,12 +139,14 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 		numChannelsToPrune++
 	}
 
-	start := newestBlockInStateNum + 1
-	end := newSyncStatus.UnsafeL2.Number
+	var allUnsafeBlocksAboveState *inclusiveBlockRange
+	if newSyncStatus.UnsafeL2.Number > newestBlockInStateNum {
+		allUnsafeBlocksAboveState = &inclusiveBlockRange{newestBlockInStateNum + 1, newSyncStatus.UnsafeL2.Number}
+	}
 
 	return syncActions{
 		blocksToPrune:   int(numBlocksToDequeue),
 		channelsToPrune: numChannelsToPrune,
-		blocksToLoad:    &inclusiveBlockRange{start, end},
+		blocksToLoad:    allUnsafeBlocksAboveState,
 	}, false
 }

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -286,7 +286,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				tc.newSyncStatus, tc.prevCurrentL1, tc.blocks, tc.channels, l,
 			)
 
-			require.Equal(t, tc.expected, result, "unexpected actions, %v")
+			require.Equal(t, tc.expected, result, "unexpected actions")
 			require.Equal(t, tc.expectedSeqOutOfSync, outOfSync)
 			if tc.expectedLogs == nil {
 				require.Empty(t, h.Logs, "expected no logs but found some", "logs", h.Logs)

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -161,6 +161,23 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			},
 			expectedLogs: []string{"sequencer did not make expected progress"},
 		},
+		{name: "failed to make expected progress (alt)",
+			// Edge case where unsafe = safe
+			newSyncStatus: eth.SyncStatus{
+				HeadL1:    eth.BlockRef{Number: 3},
+				CurrentL1: eth.BlockRef{Number: 2},
+				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:  eth.L2BlockRef{Number: 101},
+			},
+			prevCurrentL1: eth.BlockRef{Number: 1},
+			blocks:        queue.Queue[*types.Block]{block102, block103},
+			channels:      []channelStatuser{channel103},
+			expected: syncActions{
+				clearState:   &eth.BlockID{Number: 1},
+				blocksToLoad: &inclusiveBlockRange{102, 109},
+			},
+			expectedLogs: []string{"sequencer did not make expected progress"},
+		},
 		{name: "no progress",
 			// This can happen if we have a long channel duration
 			// and we didn't submit or have any txs confirmed since

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -105,7 +105,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				clearState:   &eth.BlockID{Number: 1},
 				blocksToLoad: &inclusiveBlockRange{101, 109},
 			},
-			expectedLogs: []string{"oldest unsafe block is below oldest block in state"},
+			expectedLogs: []string{"next safe block is below oldest block in state"},
 		},
 		{name: "unexpectedly good progress",
 			// This can happen if another batcher instance got some blocks
@@ -123,7 +123,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				clearState:   &eth.BlockID{Number: 1},
 				blocksToLoad: &inclusiveBlockRange{105, 109},
 			},
-			expectedLogs: []string{"oldest unsafe block above newest block in state"},
+			expectedLogs: []string{"next safe block above newest block in state"},
 		},
 		{name: "safe chain reorg",
 			// This can happen if there is an L1 reorg, the safe chain is at an acceptable

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -123,7 +123,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				clearState:   &eth.BlockID{Number: 1},
 				blocksToLoad: &inclusiveBlockRange{105, 109},
 			},
-			expectedLogs: []string{"next safe block above newest block in state"},
+			expectedLogs: []string{"safe head above newest block in state"},
 		},
 		{name: "safe chain reorg",
 			// This can happen if there is an L1 reorg, the safe chain is at an acceptable

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -173,8 +173,8 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			blocks:        queue.Queue[*types.Block]{block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
-				clearState:   &eth.BlockID{Number: 1},
-				blocksToLoad: &inclusiveBlockRange{102, 109},
+				clearState: &eth.BlockID{Number: 1},
+				// no blocks to load since there are no unsafe blocks
 			},
 			expectedLogs: []string{"sequencer did not make expected progress"},
 		},

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -161,7 +161,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			},
 			expectedLogs: []string{"sequencer did not make expected progress"},
 		},
-		{name: "failed to make expected progress (alt)",
+		{name: "failed to make expected progress (unsafe=safe)",
 			// Edge case where unsafe = safe
 			newSyncStatus: eth.SyncStatus{
 				HeadL1:    eth.BlockRef{Number: 3},
@@ -242,6 +242,18 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				channelsToPrune: 1,
 				blocksToLoad:    &inclusiveBlockRange{105, 109},
 			},
+		},
+		{name: "no progress + unsafe=safe",
+			newSyncStatus: eth.SyncStatus{
+				HeadL1:    eth.BlockRef{Number: 5},
+				CurrentL1: eth.BlockRef{Number: 2},
+				SafeL2:    eth.L2BlockRef{Number: 100},
+				UnsafeL2:  eth.L2BlockRef{Number: 100},
+			},
+			prevCurrentL1: eth.BlockRef{Number: 1},
+			blocks:        queue.Queue[*types.Block]{},
+			channels:      []channelStatuser{},
+			expected:      syncActions{},
 		},
 	}
 


### PR DESCRIPTION
Follow up to #13287 with some more tests and edge case awareness. 

Also avoiding use of "oldest unsafe block" in cases where there may not be any unsafe blocks. Preferring "next safe block" instead. 