### PR TITLE
docs: Clarify directory reference Update README.md

### DIFF
--- a/bedrock-devnet/README.md
+++ b/bedrock-devnet/README.md
@@ -2,4 +2,4 @@
 
 This is a utility for running a local Bedrock devnet. It is designed to replace the legacy Bash-based devnet runner as part of a progressive migration away from Bash automation.
 
-The easiest way to invoke this script is to run `make devnet-up` from the root of this repository. Otherwise, to use this script run `python3 main.py --monorepo-dir=<path to the monorepo>`. You may need to set `PYTHONPATH` to this directory if you are invoking the script from somewhere other than `bedrock-devnet`.
+The easiest way to invoke this script is to run `make devnet-up` from the root of this repository. Otherwise, to use this script run `python3 main.py --monorepo-dir=<path to the monorepo>`. You may need to set `PYTHONPATH` to this directory if you invoke the script from somewhere other than the `bedrock-devnet` directory.


### PR DESCRIPTION
**Description:**  

Issue in the `bedrock-devnet` documentation. The original phrasing:  
> "if you are invoking the script from somewhere other than `bedrock-devnet`"  

has been updated to:  
> "if you invoke the script from somewhere other than the `bedrock-devnet` directory"  

The revised version explicitly refers to the directory, avoiding potential confusion about whether `bedrock-devnet` refers to the directory or the script itself.  

**Love OP L2**