### PR TITLE
fix:typos in docs and comments

### DIFF
--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -117,7 +117,7 @@ participant opnodeB as op-node B
 Note over opnodeA: on new block
 
 opnodeA ->> opgethA: engine process unsafe block
-opgethA -->> opnodeA: engine proccessed unsafe block
+opgethA -->> opnodeA: engine processed unsafe block
 opnodeA ->> opsup: update Local unsafe
 opnodeB ->> opsup: update Local unsafe (maybe)
 opsup ->> opgethA: Fetch receipts

--- a/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
@@ -145,7 +145,7 @@ contract DeployOwnership is Deploy {
     /// @param _name The name of the Safe to deploy.
     /// @param _owners The owners of the Safe.
     /// @param _threshold The threshold of the Safe.
-    /// @param _keepDeployer Wether or not the deployer address will be added as an owner of the Safe.
+    /// @param _keepDeployer Whether or not the deployer address will be added as an owner of the Safe.
     function deploySafe(
         string memory _name,
         address[] memory _owners,

--- a/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -27,7 +27,7 @@ contract GovernanceToken is ERC20Burnable, ERC20Votes, Ownable {
     /// @notice Callback called after a token transfer.
     /// @param from   The account sending tokens.
     /// @param to     The account receiving tokens.
-    /// @param amount The amount of tokens being transfered.
+    /// @param amount The amount of tokens being transferred.
     function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
         super._afterTokenTransfer(from, to, amount);
     }

--- a/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -55,8 +55,8 @@ contract Faucet {
     /// @notice Maps from id to nonces to whether or not they have been used.
     mapping(bytes32 => mapping(bytes32 => bool)) public nonces;
 
-    /// @notice Modifier that makes a function admin priviledged.
-    modifier priviledged() {
+    /// @notice Modifier that makes a function admin privileged.
+    modifier privileged() {
         require(msg.sender == ADMIN, "Faucet: function can only be called by admin");
         _;
     }
@@ -74,7 +74,7 @@ contract Faucet {
     /// @notice Allows the admin to withdraw funds.
     /// @param _recipient Address to receive the funds.
     /// @param _amount    Amount of ETH in wei to withdraw.
-    function withdraw(address payable _recipient, uint256 _amount) public priviledged {
+    function withdraw(address payable _recipient, uint256 _amount) public privileged {
         new SafeSend{ value: _amount }(_recipient);
     }
 

--- a/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
@@ -33,7 +33,7 @@ contract Burn_EthBurner is StdUtils {
         // execute a burn of _value eth
         Burn.eth(value);
 
-        // check that exactly value eth was transfered from the contract
+        // check that exactly value eth was transferred from the contract
         unchecked {
             if (address(this).balance != preBurnBalance - value) {
                 failedEthBurn = true;


### PR DESCRIPTION
This pull request fixes several typos and improves clarity in documentation comments and variable names.  
Below are the files, lines, and specific changes made:

1. **op-supervisor/README.md**  
   **Original:** `engine proccessed unsafe block`  
   **Corrected:** `engine processed unsafe block`  
   - Changed `proccessed` to `processed`.

2. **packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol**  
   **Original:** `/// @param _keepDeployer Wether or not the deployer address will be added as an owner of the Safe.`  
   **Corrected:** `/// @param _keepDeployer Whether or not the deployer address will be added as an owner of the Safe.`  
   - Changed `Wether` to `Whether`.

3. **packages/contracts-bedrock/src/governance/GovernanceToken.sol**  
   **Original:** `/// @param amount The amount of tokens being transfered.`  
   **Corrected:** `/// @param amount The amount of tokens being transferred.`  
   - Changed `transfered` to `transferred`.

4. **packages/contracts-bedrock/src/periphery/faucet/Faucet.sol**  
   **Original:** `/// @notice Modifier that makes a function admin priviledged.`  
   **Corrected:** `/// @notice Modifier that makes a function admin privileged.`  
   - Changed `priviledged` to `privileged`.

   **Original Modifier Name:** `priviledged`  
   **Corrected Modifier Name:** `privileged`  
   - Changed modifier name from `priviledged` to `privileged`.

5. **packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol**  
   **Original:** `// check that exactly value eth was transfered from the contract`  
   **Corrected:** `// check that exactly value eth was transferred from the contract`  
   - Changed `transfered` to `transferred`.
