### PR TITLE
docs: fix typo Update README.md

### DIFF
--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -290,7 +290,7 @@ such that a chain which does not take on new interop dependencies, can continue 
 
 I.e. safety must be guaranteed at all times,
 but a minimal level of liveness can be maintained by holding off on cross-chain message acceptance
-while allowing regular single-chain functionaltiy to proceed.
+while allowing regular single-chain functionality to proceed.
 
 ## Testing
 


### PR DESCRIPTION
**Description**

<img width="768" alt="Снимок экрана 2024-12-07 в 18 18 25" src="https://github.com/user-attachments/assets/1b07ad36-e9ce-44e1-a4e4-fb32eab43ea6">

The word "functionaltiy" has been corrected to the proper spelling: "**functionality**".

Thanks!
