### PR TITLE
Test Utils

### DIFF
--- a/packages/contracts-bedrock/test/setup/testUtils/Forbiddens.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/Forbiddens.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Ephemeral contract that stores a list of forbidden addresses.
+contract ForbiddenAddresses {
+    mapping(address => bool) public forbiddenAddresses;
+
+    // chainable
+    function forbid(address _addr) public returns (ForbiddenAddresses) {
+        forbiddenAddresses[_addr] = true;
+        return this;
+    }
+}
+
+// Ephemeral contract that stores a list of forbidden uint256 values.
+contract ForbiddenUint256 {
+    mapping(uint256 => bool) public forbiddenUint256;
+
+    // chainable
+    function forbid(uint256 _value) public returns (ForbiddenUint256) {
+        forbiddenUint256[_value] = true;
+        return this;
+    }
+}

--- a/packages/contracts-bedrock/test/setup/testUtils/Forbiddens.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/Forbiddens.sol
@@ -13,12 +13,23 @@ contract ForbiddenAddresses {
 }
 
 // Ephemeral contract that stores a list of forbidden uint256 values.
-contract ForbiddenUint256 {
-    mapping(uint256 => bool) public forbiddenUint256;
+contract ForbiddenUints {
+    mapping(uint256 => bool) public forbiddenUints;
 
     // chainable
-    function forbid(uint256 _value) public returns (ForbiddenUint256) {
-        forbiddenUint256[_value] = true;
+    function forbid(uint256 _value) public returns (ForbiddenUints) {
+        forbiddenUints[_value] = true;
+        return this;
+    }
+}
+
+// Ephemeral contract that stores a list of forbidden int256 values.
+contract ForbiddenInts {
+    mapping(int256 => bool) public forbiddenInts;
+
+    // chainable
+    function forbid(int256 _value) public returns (ForbiddenInts) {
+        forbiddenInts[_value] = true;
         return this;
     }
 }

--- a/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { TestPlus } from "lib/solady/test/utils/TestPlus.sol";
+import { Vm } from "forge-std/Vm.sol";
+import {
+    IAddressCondition,
+    AddressConditionChainer,
+    AddressConditions,
+    IsPayableCondition,
+    IsNotPayableCondition,
+    IsNotPrecompileCondition,
+    IsNotForgeAddressCondition
+} from "test/setup/testUtils/conditions/AddressConditions.sol";
+import { ForbiddenAddresses, ForbiddenUint256 } from "test/setup/testUtils/Forbiddens.sol";
+
+contract TestUtils is TestPlus {
+    Vm private constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    // This function returns addr if it satisfies all given conditions and is not forbidden,
+    // otherwise it will generate a new random address that satisfies the conditions and is not
+    // forbidden.
+    // NOTE: This function will resort to vm.assume() if it does not find a valid address within
+    // the given number of attempts.
+    function _randomAddress(
+        address addr,
+        AddressConditionChainer _conditions,
+        ForbiddenAddresses _forbiddenAddresses,
+        uint256 attempts
+    )
+        internal
+        returns (address)
+    {
+        bool pass = false;
+        IAddressCondition[] memory conditions = _conditions.conditions();
+
+        for (uint256 i; i < attempts; i++) {
+            pass = true;
+            if (_forbiddenAddresses.forbiddenAddresses(addr)) continue;
+            for (uint256 j; j < conditions.length; j++) {
+                if (!conditions[j].check(addr)) {
+                    pass = false;
+                    break;
+                }
+            }
+            if (pass) break;
+            addr = _randomAddress();
+        }
+        vm.assume(pass);
+
+        return addr;
+    }
+
+    // This function returns addr if it is not forbidden by _forbiddenAddresses, otherwise it
+    // will generate a new random address that is not forbidden.
+    // NOTE: This function will resort to vm.assume() if it does not find a valid address within
+    // the given number of attempts.
+    function _randomAddress(
+        address addr,
+        ForbiddenAddresses _forbiddenAddresses,
+        uint256 attempts
+    )
+        internal
+        returns (address)
+    {
+        bool pass = false;
+
+        for (uint256 i; i < attempts; i++) {
+            if (_forbiddenAddresses.forbiddenAddresses(addr)) {
+                pass = false;
+                addr = _randomAddress();
+            } else {
+                pass = true;
+            }
+            if (pass) break;
+        }
+        vm.assume(pass);
+
+        return addr;
+    }
+
+    // This function returns addr if it satisfies all given conditions, otherwise it will generate
+    // a new random address that satisfies the conditions.
+    // NOTE: This function will resort to vm.assume() if it does not find a valid address within
+    // the given number of attempts.
+    function _randomAddress(
+        address addr,
+        AddressConditionChainer _conditions,
+        uint256 attempts
+    )
+        internal
+        returns (address)
+    {
+        bool pass = false;
+        IAddressCondition[] memory conditions = _conditions.conditions();
+
+        for (uint256 i; i < attempts; i++) {
+            pass = true;
+            for (uint256 j; j < conditions.length; j++) {
+                if (!conditions[j].check(addr)) {
+                    pass = false;
+                    break;
+                }
+            }
+            if (pass) break;
+            addr = _randomAddress();
+        }
+        vm.assume(pass);
+
+        return addr;
+    }
+
+    // This function returns _bound(_value, _min, _max) unless _bound(_value, _min, _max) is
+    // forbidden by _forbiddenUint256, in which case it will generate a new random uint256 that
+    // is not forbidden in the _forbiddenUint256 contract.
+    // NOTE: This function will resort to vm.assume() if it does not find a valid uint256 within
+    // the given number of attempts.
+    function _boundExcept(
+        uint256 _value,
+        uint256 _min,
+        uint256 _max,
+        ForbiddenUint256 _forbiddenUint256,
+        uint256 _attempts
+    )
+        internal
+        returns (uint256)
+    {
+        uint256 value_ = __bound(_value, _min, _max);
+        bool pass = false;
+        for (uint256 i; i < _attempts; i++) {
+            if (_forbiddenUint256.forbiddenUint256(value_)) {
+                pass = false;
+                value_ = __bound(_random(), _min, _max);
+            } else {
+                pass = true;
+            }
+            if (pass) break;
+        }
+        vm.assume(pass);
+        return value_;
+    }
+
+    function __bound(uint256 _value, uint256 _min, uint256 _max) private pure returns (uint256 value_) {
+        value_ = (_value % (_max - _min)) + _min;
+    }
+
+    function __randomBytes(uint256 _minLength, uint256 _maxLength) private returns (bytes memory bytes_) {
+        uint256 length = __bound(_random(), _minLength, _maxLength);
+        bytes_ = new bytes(length);
+        for (uint256 i; i < length; i++) {
+            bytes_[i] = bytes1(uint8(_random()));
+        }
+    }
+
+    uint256 private isPayableConditionCounter;
+
+    function newIsPayableCondition() internal returns (IsPayableCondition) {
+        IsPayableCondition condition = new IsPayableCondition();
+        vm.label(address(condition), string.concat("IsPayableCondition:", vm.toString(isPayableConditionCounter++)));
+        return condition;
+    }
+
+    uint256 private isNotPayableConditionCounter;
+
+    function newIsNotPayableCondition() internal returns (IsNotPayableCondition) {
+        IsNotPayableCondition condition = new IsNotPayableCondition();
+        vm.label(
+            address(condition), string.concat("IsNotPayableCondition:", vm.toString(isNotPayableConditionCounter++))
+        );
+        return condition;
+    }
+
+    uint256 private isNotPrecompileConditionCounter;
+
+    function newIsNotPrecompileCondition() internal returns (IsNotPrecompileCondition) {
+        IsNotPrecompileCondition condition = new IsNotPrecompileCondition();
+        vm.label(
+            address(condition),
+            string.concat("IsNotPrecompileCondition:", vm.toString(isNotPrecompileConditionCounter++))
+        );
+        return condition;
+    }
+
+    uint256 private isNotForgeAddressConditionCounter;
+
+    function newIsNotForgeAddressCondition() internal returns (IsNotForgeAddressCondition) {
+        IsNotForgeAddressCondition condition = new IsNotForgeAddressCondition();
+        vm.label(
+            address(condition),
+            string.concat("IsNotForgeAddressCondition:", vm.toString(isNotForgeAddressConditionCounter++))
+        );
+        return condition;
+    }
+
+    uint256 private conditionsCounter;
+
+    function newAddressConditionChainer() internal returns (AddressConditionChainer) {
+        AddressConditionChainer conditions = new AddressConditionChainer();
+        vm.label(address(conditions), string.concat("AddressConditionChainer:", vm.toString(conditionsCounter++)));
+        return conditions;
+    }
+
+    uint256 private forbiddenAddressesCounter;
+
+    function newForbiddenAddresses() internal returns (ForbiddenAddresses) {
+        ForbiddenAddresses forbiddenAddresses = new ForbiddenAddresses();
+        vm.label(
+            address(forbiddenAddresses), string.concat("ForbiddenAddresses:", vm.toString(forbiddenAddressesCounter++))
+        );
+        return forbiddenAddresses;
+    }
+
+    uint256 private forbiddenUint256Counter;
+
+    function newForbiddenUint256() internal returns (ForbiddenUint256) {
+        ForbiddenUint256 forbiddenUint256 = new ForbiddenUint256();
+        vm.label(address(forbiddenUint256), string.concat("ForbiddenUint256:", vm.toString(forbiddenUint256Counter++)));
+        return forbiddenUint256;
+    }
+}

--- a/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
 import {
     IAddressCondition,
     AddressConditionChainer,
@@ -13,19 +13,18 @@ import {
 } from "test/setup/testUtils/conditions/AddressConditions.sol";
 import { ForbiddenAddresses, ForbiddenUint256 } from "test/setup/testUtils/Forbiddens.sol";
 
-contract TestUtils {
-    Vm private constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
-
-    // This function returns addr if it satisfies all given conditions and is not forbidden,
+abstract contract TestUtils is Test {
+    // This function returns _addr if it satisfies all given conditions and is not forbidden,
+    // This function returns _addr if it satisfies all given conditions and is not forbidden,
     // otherwise it will generate a new random address that satisfies the conditions and is not
     // forbidden.
     // NOTE: This function will resort to vm.assume() if it does not find a valid address within
-    // the given number of attempts.
+    // the given number of _attempts.
     function _randomAddress(
-        address addr,
+        address _addr,
         AddressConditionChainer _conditions,
         ForbiddenAddresses _forbiddenAddresses,
-        uint256 attempts
+        uint256 _attempts
     )
         internal
         returns (address)
@@ -33,41 +32,41 @@ contract TestUtils {
         bool pass = false;
         IAddressCondition[] memory conditions = _conditions.conditions();
 
-        for (uint256 i; i < attempts; i++) {
+        for (uint256 i; i < _attempts; i++) {
             pass = true;
-            if (_forbiddenAddresses.forbiddenAddresses(addr)) continue;
+            if (_forbiddenAddresses.forbiddenAddresses(_addr)) continue;
             for (uint256 j; j < conditions.length; j++) {
-                if (!conditions[j].check(addr)) {
+                if (!conditions[j].check(_addr)) {
                     pass = false;
                     break;
                 }
             }
             if (pass) break;
-            addr = _randomAddress();
+            _addr = vm.randomAddress();
         }
         vm.assume(pass);
 
-        return addr;
+        return _addr;
     }
 
-    // This function returns addr if it is not forbidden by _forbiddenAddresses, otherwise it
+    // This function returns _addr if it is not forbidden by _forbiddenAddresses, otherwise it
     // will generate a new random address that is not forbidden.
     // NOTE: This function will resort to vm.assume() if it does not find a valid address within
-    // the given number of attempts.
+    // the given number of _attempts.
     function _randomAddress(
-        address addr,
+        address _addr,
         ForbiddenAddresses _forbiddenAddresses,
-        uint256 attempts
+        uint256 _attempts
     )
         internal
         returns (address)
     {
         bool pass = false;
 
-        for (uint256 i; i < attempts; i++) {
-            if (_forbiddenAddresses.forbiddenAddresses(addr)) {
+        for (uint256 i; i < _attempts; i++) {
+            if (_forbiddenAddresses.forbiddenAddresses(_addr)) {
                 pass = false;
-                addr = _randomAddress();
+                _addr = vm.randomAddress();
             } else {
                 pass = true;
             }
@@ -75,17 +74,17 @@ contract TestUtils {
         }
         vm.assume(pass);
 
-        return addr;
+        return _addr;
     }
 
-    // This function returns addr if it satisfies all given conditions, otherwise it will generate
+    // This function returns _addr if it satisfies all given conditions, otherwise it will generate
     // a new random address that satisfies the conditions.
     // NOTE: This function will resort to vm.assume() if it does not find a valid address within
-    // the given number of attempts.
+    // the given number of _attempts.
     function _randomAddress(
-        address addr,
+        address _addr,
         AddressConditionChainer _conditions,
-        uint256 attempts
+        uint256 _attempts
     )
         internal
         returns (address)
@@ -93,31 +92,27 @@ contract TestUtils {
         bool pass = false;
         IAddressCondition[] memory conditions = _conditions.conditions();
 
-        for (uint256 i; i < attempts; i++) {
+        for (uint256 i; i < _attempts; i++) {
             pass = true;
             for (uint256 j; j < conditions.length; j++) {
-                if (!conditions[j].check(addr)) {
+                if (!conditions[j].check(_addr)) {
                     pass = false;
                     break;
                 }
             }
             if (pass) break;
-            addr = _randomAddress();
+            _addr = vm.randomAddress();
         }
         vm.assume(pass);
 
-        return addr;
-    }
-
-    function _randomAddress() internal returns (address) {
-        return address(uint160(vm.randomUint()));
+        return _addr;
     }
 
     // This function returns _bound(_value, _min, _max) unless _bound(_value, _min, _max) is
     // forbidden by _forbiddenUint256, in which case it will generate a new random uint256 that
     // is not forbidden in the _forbiddenUint256 contract.
     // NOTE: This function will resort to vm.assume() if it does not find a valid uint256 within
-    // the given number of attempts.
+    // the given number of _attempts.
     function _boundExcept(
         uint256 _value,
         uint256 _min,
@@ -128,12 +123,12 @@ contract TestUtils {
         internal
         returns (uint256)
     {
-        uint256 value_ = __bound(_value, _min, _max);
+        uint256 value_ = _bound(_value, _min, _max);
         bool pass = false;
         for (uint256 i; i < _attempts; i++) {
             if (_forbiddenUint256.forbiddenUint256(value_)) {
                 pass = false;
-                value_ = __bound(vm.randomUint(), _min, _max);
+                value_ = vm.randomUint(_min, _max);
             } else {
                 pass = true;
             }
@@ -143,16 +138,9 @@ contract TestUtils {
         return value_;
     }
 
-    function __bound(uint256 _value, uint256 _min, uint256 _max) private pure returns (uint256 value_) {
-        value_ = (_value % (_max - _min)) + _min;
-    }
-
     function __randomBytes(uint256 _minLength, uint256 _maxLength) internal returns (bytes memory bytes_) {
-        uint256 length = __bound(vm.randomUint(), _minLength, _maxLength);
-        bytes_ = new bytes(length);
-        for (uint256 i; i < length; i++) {
-            bytes_[i] = bytes1(uint8(vm.randomUint()));
-        }
+        uint256 length = vm.randomUint(_minLength, _maxLength);
+        bytes_ = vm.randomBytes(length);
     }
 
     uint256 private isPayableConditionCounter;

--- a/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
@@ -11,7 +11,7 @@ import {
     IsNotPrecompileCondition,
     IsNotForgeAddressCondition
 } from "test/setup/testUtils/conditions/AddressConditions.sol";
-import { ForbiddenAddresses, ForbiddenUint256 } from "test/setup/testUtils/Forbiddens.sol";
+import { ForbiddenAddresses, ForbiddenUints, ForbiddenInts } from "test/setup/testUtils/Forbiddens.sol";
 
 abstract contract TestUtils is Test {
     // This function returns _addr if it satisfies all given conditions and is not forbidden,
@@ -20,7 +20,7 @@ abstract contract TestUtils is Test {
     // forbidden.
     // NOTE: This function will resort to vm.assume() if it does not find a valid address within
     // the given number of _attempts.
-    function _randomAddress(
+    function __randomAddress(
         address _addr,
         AddressConditionChainer _conditions,
         ForbiddenAddresses _forbiddenAddresses,
@@ -53,7 +53,7 @@ abstract contract TestUtils is Test {
     // will generate a new random address that is not forbidden.
     // NOTE: This function will resort to vm.assume() if it does not find a valid address within
     // the given number of _attempts.
-    function _randomAddress(
+    function __randomAddress(
         address _addr,
         ForbiddenAddresses _forbiddenAddresses,
         uint256 _attempts
@@ -81,7 +81,7 @@ abstract contract TestUtils is Test {
     // a new random address that satisfies the conditions.
     // NOTE: This function will resort to vm.assume() if it does not find a valid address within
     // the given number of _attempts.
-    function _randomAddress(
+    function __randomAddress(
         address _addr,
         AddressConditionChainer _conditions,
         uint256 _attempts
@@ -113,11 +113,11 @@ abstract contract TestUtils is Test {
     // is not forbidden in the _forbiddenUint256 contract.
     // NOTE: This function will resort to vm.assume() if it does not find a valid uint256 within
     // the given number of _attempts.
-    function _boundExcept(
+    function __boundExcept(
         uint256 _value,
         uint256 _min,
         uint256 _max,
-        ForbiddenUint256 _forbiddenUint256,
+        ForbiddenUints _forbiddenUints,
         uint256 _attempts
     )
         internal
@@ -126,9 +126,40 @@ abstract contract TestUtils is Test {
         uint256 value_ = _bound(_value, _min, _max);
         bool pass = false;
         for (uint256 i; i < _attempts; i++) {
-            if (_forbiddenUint256.forbiddenUint256(value_)) {
+            if (_forbiddenUints.forbiddenUints(value_)) {
                 pass = false;
                 value_ = vm.randomUint(_min, _max);
+            } else {
+                pass = true;
+            }
+            if (pass) break;
+        }
+        vm.assume(pass);
+        return value_;
+    }
+
+    // This function returns _bound(_value, _min, _max) unless _bound(_value, _min, _max) is
+    // forbidden by _forbiddenUint256, in which case it will generate a new random uint256 that
+    // is not forbidden in the _forbiddenUint256 contract.
+    // NOTE: This function will resort to vm.assume() if it does not find a valid uint256 within
+    // the given number of _attempts.
+    function __boundExcept(
+        int256 _value,
+        int256 _min,
+        int256 _max,
+        ForbiddenInts _forbiddenInts,
+        uint256 _attempts
+    )
+        internal
+        view
+        returns (int256)
+    {
+        int256 value_ = _bound(_value, _min, _max);
+        bool pass = false;
+        for (uint256 i; i < _attempts; i++) {
+            if (_forbiddenInts.forbiddenInts(value_)) {
+                pass = false;
+                value_ = _bound(vm.randomInt(), _min, _max); // no support for `vm.randomInt(_min, _max)` yet
             } else {
                 pass = true;
             }
@@ -203,9 +234,17 @@ abstract contract TestUtils is Test {
 
     uint256 private forbiddenUint256Counter;
 
-    function newForbiddenUint256() internal returns (ForbiddenUint256) {
-        ForbiddenUint256 forbiddenUint256 = new ForbiddenUint256();
-        vm.label(address(forbiddenUint256), string.concat("ForbiddenUint256:", vm.toString(forbiddenUint256Counter++)));
-        return forbiddenUint256;
+    function newForbiddenUints() internal returns (ForbiddenUints) {
+        ForbiddenUints forbiddenUints = new ForbiddenUints();
+        vm.label(address(forbiddenUints), string.concat("ForbiddenUints:", vm.toString(forbiddenUint256Counter++)));
+        return forbiddenUints;
+    }
+
+    uint256 private forbiddenIntsCounter;
+
+    function newForbiddenInts() internal returns (ForbiddenInts) {
+        ForbiddenInts forbiddenInts = new ForbiddenInts();
+        vm.label(address(forbiddenInts), string.concat("ForbiddenInts:", vm.toString(forbiddenIntsCounter++)));
+        return forbiddenInts;
     }
 }

--- a/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/TestUtils.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { TestPlus } from "lib/solady/test/utils/TestPlus.sol";
 import { Vm } from "forge-std/Vm.sol";
 import {
     IAddressCondition,
@@ -14,7 +13,7 @@ import {
 } from "test/setup/testUtils/conditions/AddressConditions.sol";
 import { ForbiddenAddresses, ForbiddenUint256 } from "test/setup/testUtils/Forbiddens.sol";
 
-contract TestUtils is TestPlus {
+contract TestUtils {
     Vm private constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
     // This function returns addr if it satisfies all given conditions and is not forbidden,
@@ -110,6 +109,10 @@ contract TestUtils is TestPlus {
         return addr;
     }
 
+    function _randomAddress() internal returns (address) {
+        return address(uint160(vm.randomUint()));
+    }
+
     // This function returns _bound(_value, _min, _max) unless _bound(_value, _min, _max) is
     // forbidden by _forbiddenUint256, in which case it will generate a new random uint256 that
     // is not forbidden in the _forbiddenUint256 contract.
@@ -130,7 +133,7 @@ contract TestUtils is TestPlus {
         for (uint256 i; i < _attempts; i++) {
             if (_forbiddenUint256.forbiddenUint256(value_)) {
                 pass = false;
-                value_ = __bound(_random(), _min, _max);
+                value_ = __bound(vm.randomUint(), _min, _max);
             } else {
                 pass = true;
             }
@@ -144,11 +147,11 @@ contract TestUtils is TestPlus {
         value_ = (_value % (_max - _min)) + _min;
     }
 
-    function __randomBytes(uint256 _minLength, uint256 _maxLength) private returns (bytes memory bytes_) {
-        uint256 length = __bound(_random(), _minLength, _maxLength);
+    function __randomBytes(uint256 _minLength, uint256 _maxLength) internal returns (bytes memory bytes_) {
+        uint256 length = __bound(vm.randomUint(), _minLength, _maxLength);
         bytes_ = new bytes(length);
         for (uint256 i; i < length; i++) {
-            bytes_[i] = bytes1(uint8(_random()));
+            bytes_[i] = bytes1(uint8(vm.randomUint()));
         }
     }
 

--- a/packages/contracts-bedrock/test/setup/testUtils/conditions/AddressConditions.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/conditions/AddressConditions.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { Vm } from "forge-std/Vm.sol";
+
+contract AddressConditions {
+    Vm private constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    // This function checks whether an address, `addr`, is payable. It works by sending 1 wei to
+    // `addr` and checking the `success` return value.
+    // NOTE: This function may result in state changes depending on the fallback/receive logic
+    // implemented by `addr`, which should be taken into account when this function is used.
+    function __isPayable(address addr) internal returns (bool) {
+        require(
+            addr.balance < type(uint256).max,
+            "TestUtils: Balance equals max uint256, so it cannot receive any more funds"
+        );
+        uint256 origBalanceTest = address(this).balance;
+        uint256 origBalanceAddr = address(addr).balance;
+
+        (bool success,) = payable(addr).call{ value: 1 }("");
+
+        // reset balances
+        vm.deal(address(this), origBalanceTest);
+        vm.deal(addr, origBalanceAddr);
+
+        return success;
+    }
+
+    // This function checks whether an address, `addr`, is not payable. It works by sending 1 wei to
+    // `addr` and checking the `success` return value.
+    // NOTE: This function may result in state changes depending on the fallback/receive logic
+    // implemented by `addr`, which should be taken into account when this function is used.
+    function __isNotPayable(address addr) internal returns (bool) {
+        return !__isPayable(addr);
+    }
+
+    // This function checks whether an address, `addr`, is not a precompile on OP main/test net.
+    function __isNotPrecompile(address addr) internal pure returns (bool) {
+        // Note: For some chains like Optimism these are technically predeploys (i.e. bytecode placed at a specific
+        // address), but the same rationale for excluding them applies so we include those too.
+
+        // These should be present on all EVM-compatible chains.
+        if (addr >= address(0x01) && addr <= address(0x09)) return false;
+        // forgefmt: disable-start
+        // https://github.com/ethereum-optimism/optimism/blob/eaa371a0184b56b7ca6d9eb9cb0a2b78b2ccd864/op-bindings/predeploys/addresses.go#L6-L21
+        return (addr < address(0x4200000000000000000000000000000000000000) || addr > address(0x4200000000000000000000000000000000000800));
+        // forgefmt: disable-end
+    }
+
+    // This function checks whether an address, `addr`, is not the vm, console, or Create2Deployer addresses.
+    function __isNotForgeAddress(address addr) internal pure returns (bool) {
+        // vm, console, and Create2Deployer addresses
+        return (
+            addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+                && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        );
+    }
+}
+
+interface IAddressCondition {
+    function check(address _addr) external returns (bool);
+}
+
+contract IsPayableCondition is IAddressCondition, AddressConditions {
+    function check(address _addr) external returns (bool) {
+        return __isPayable(_addr);
+    }
+}
+
+contract IsNotPayableCondition is IAddressCondition, AddressConditions {
+    function check(address _addr) external returns (bool) {
+        return __isNotPayable(_addr);
+    }
+}
+
+contract IsNotPrecompileCondition is IAddressCondition, AddressConditions {
+    function check(address _addr) external pure returns (bool) {
+        return __isNotPrecompile(_addr);
+    }
+}
+
+contract IsNotForgeAddressCondition is IAddressCondition, AddressConditions {
+    function check(address _addr) external pure returns (bool) {
+        return __isNotForgeAddress(_addr);
+    }
+}
+
+contract AddressConditionChainer {
+    IAddressCondition[] internal _conditions;
+
+    function p(IAddressCondition _condition) public returns (AddressConditionChainer) {
+        _conditions.push(_condition);
+        return this;
+    }
+
+    function conditions() public view returns (IAddressCondition[] memory) {
+        return _conditions;
+    }
+}

--- a/packages/contracts-bedrock/test/setup/testUtils/conditions/AddressConditions.sol
+++ b/packages/contracts-bedrock/test/setup/testUtils/conditions/AddressConditions.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import { Vm } from "forge-std/Vm.sol";
 
-contract AddressConditions {
+abstract contract AddressConditions {
     Vm private constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
     // This function checks whether an address, `addr`, is payable. It works by sending 1 wei to


### PR DESCRIPTION
# Test Utils

This is meant to be an alternative to scenarios where `vm.assume()` is used.
It works by utilizing `vm.randomUint()` function to be precise which generates pseudo random values at runtime.

Currently, `vm.assume()` is used to
- assume that addresses are not a particular address or set of addresses
- assume that a bytes value's length is `>`/`<` a particular value

A solution for the first use case above, would be to use `vm.random*()` function to generate new addresses via type casting if forge's fuzz input is an address we don't want it to be but in the case where we want to assume that the fuzz input is not a series of addresses, there's a slight chance that the output of `vm.randomUint()` might be one of the remaining addresses not checked yet and if that's the case, we have to start afresh again. A generic function for this might look something like this:
```solidity
function x(exceptionNum) internal returns (address) {
    address[] memory exceptions = new address[](exceptionNum);
    address addr = vm.randomAddress();
    bool found = true;
    for (uint256 i; i < _attempts; ++i) {
            for(uint256 j; j < exceptionNum; ++j) {
                    if (addr == exceptions[j]) {
                            found = false;
                    }
            }
            if (found) break;
    }
    return addr;
}
```
(the above is just an illustration, might not be perfectly correct).

This would also mean that the caller would need to fill out the array which in solidity is a very manual process.

There's no alternative solution I know for the second use case above (i.e `assume that a bytes value's length is `>`/`<` a particular value`). 

## Solution
The TestUtils file below is the proposed solution for both and more.  It:

- Supports generation of random addresses with an exception(forbidden) list support
- For addresses also, it supports adding and chaining a list of pre written (and custom) conditions the address should follow, e.g isPayable, isNotPrecompile, etc.
- For the bytes use case above, it solves it by providing a function for generating a random bytes value of a random length between any range given to the function.
- Supports generation of random uint256s with an exception(forbidden) list support
- Can be expanded to support almost anything tbh

## Example usage
```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.0;

import {TestUtils, ForbiddenAddresses, ForbiddenUints, ForbiddenInts} from "test/testUtils/TestUtils.sol";

contract T is TestUtils {
    function test_ttt(address _a) external {
        ForbiddenAddresses forbiddenAddresses = newForbiddenAddresses().forbid(address(111)).forbid(address(222));
        _a = __randomAddress(_a, forbiddenAddresses, 1_000);
        assertFalse(forbiddenAddresses.forbiddenAddresses(_a));
    }

    function test_ttt2(uint256 _a) external {
        ForbiddenUints forbiddenUints = newForbiddenUints().forbid(0).forbid(1).forbid(2).forbid(3).forbid(4);
        _a = __boundExcept(_a, 0, 10, forbiddenUints, 1_000);
        assertFalse(forbiddenUints.forbiddenUints(_a));
    }

    function test_ttt3(int256 _a) external {
        ForbiddenInts forbiddenInts = newForbiddenInts().forbid(0).forbid(1).forbid(2).forbid(3).forbid(4);
        _a = __boundExcept(_a, 0, 10, forbiddenInts, 1_000);
        assertFalse(forbiddenInts.forbiddenInts(_a));
    }

    function test_ttt4(bytes memory) external {
        bytes memory _b = __randomBytes(1, 100);
        assertTrue(_b.length <= 100);
        assertTrue(_b.length >= 0);
    }
}
```

## Benefits
- This reduces thrown-away test cases to very close to 0 instances with little downside since the use of `vm.randomUint()` function is very unlikely to generate a forbidden value except the range being bounded is slim.
- Adding forbidden values is chain-able and does not involve manually filling out an array, making DevX better.