### PR TITLE
cannon: add `RegSP` constant

### DIFF
--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 )
 
 type Word = arch.Word
@@ -99,12 +100,12 @@ const (
 )
 
 func GetSyscallArgs(registers *[32]Word) (syscallNum, a0, a1, a2, a3 Word) {
-	syscallNum = registers[RegSyscallNum] // v0
+	syscallNum = registers[register.RegSyscallNum] // v0
 
-	a0 = registers[RegSyscallParam1]
-	a1 = registers[RegSyscallParam2]
-	a2 = registers[RegSyscallParam3]
-	a3 = registers[RegSyscallParam4]
+	a0 = registers[register.RegSyscallParam1]
+	a1 = registers[register.RegSyscallParam2]
+	a2 = registers[register.RegSyscallParam3]
+	a3 = registers[register.RegSyscallParam4]
 
 	return syscallNum, a0, a1, a2, a3
 }
@@ -281,8 +282,8 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 }
 
 func HandleSyscallUpdates(cpu *mipsevm.CpuScalars, registers *[32]Word, v0, v1 Word) {
-	registers[RegSyscallRet1] = v0
-	registers[RegSyscallErrno] = v1
+	registers[register.RegSyscallRet1] = v0
+	registers[register.RegSyscallErrno] = v1
 
 	cpu.PC = cpu.NextPC
 	cpu.NextPC = cpu.NextPC + 4

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 )
 
 type Word = arch.Word
@@ -57,10 +58,10 @@ func (m *InstrumentedState) handleSyscall() error {
 			Registers: thread.Registers,
 		}
 
-		newThread.Registers[29] = a1
+		newThread.Registers[register.RegSP] = a1
 		// the child will perceive a 0 value as returned value instead, and no error
-		newThread.Registers[exec.RegSyscallRet1] = 0
-		newThread.Registers[exec.RegSyscallErrno] = 0
+		newThread.Registers[register.RegSyscallRet1] = 0
+		newThread.Registers[register.RegSyscallErrno] = 0
 		m.state.NextThreadId++
 
 		// Preempt this thread for the new one. But not before updating PCs

--- a/cannon/mipsevm/program/patch.go
+++ b/cannon/mipsevm/program/patch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 )
 
 const WordSizeBytes = arch.WordSizeBytes
@@ -63,7 +64,7 @@ func PatchStack(st mipsevm.FPVMState) error {
 	if err := st.GetMemory().SetMemoryRange(sp-4*memory.PageSize, bytes.NewReader(make([]byte, 5*memory.PageSize))); err != nil {
 		return errors.New("failed to allocate page for stack content")
 	}
-	st.GetRegistersRef()[29] = sp
+	st.GetRegistersRef()[register.RegSP] = sp
 
 	storeMem := func(addr Word, v Word) {
 		var dat [WordSizeBytes]byte

--- a/cannon/mipsevm/register/calling_convention.go
+++ b/cannon/mipsevm/register/calling_convention.go
@@ -1,4 +1,4 @@
-package exec
+package register
 
 // FYI: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File
 //
@@ -12,6 +12,8 @@ const (
 	RegA2 = 6
 	// 4th syscall argument; set to 0/1 for success/error
 	RegA3 = 7
+	// Stack pointer
+	RegSP = 29
 )
 
 // FYI: https://web.archive.org/web/20231223163047/https://www.linux-mips.org/wiki/Syscall

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
@@ -327,9 +328,9 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 			expectedNewThread.PC = state.GetCpu().NextPC
 			expectedNewThread.NextPC = state.GetCpu().NextPC + 4
 			expectedNewThread.ThreadId = 1
-			expectedNewThread.Registers[2] = 0
-			expectedNewThread.Registers[7] = 0
-			expectedNewThread.Registers[29] = stackPtr
+			expectedNewThread.Registers[register.RegSyscallNum] = 0
+			expectedNewThread.Registers[register.RegSyscallErrno] = 0
+			expectedNewThread.Registers[register.RegSP] = stackPtr
 
 			var err error
 			var stepWitness *mipsevm.StepWitness

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -328,7 +328,7 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 			expectedNewThread.PC = state.GetCpu().NextPC
 			expectedNewThread.NextPC = state.GetCpu().NextPC + 4
 			expectedNewThread.ThreadId = 1
-			expectedNewThread.Registers[register.RegSyscallNum] = 0
+			expectedNewThread.Registers[register.RegSyscallRet1] = 0
 			expectedNewThread.Registers[register.RegSyscallErrno] = 0
 			expectedNewThread.Registers[register.RegSP] = stackPtr
 

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mttestutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
@@ -46,9 +47,9 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 		epxectedNewThread := expected.ExpectNewThread()
 		epxectedNewThread.PC = state.GetCpu().NextPC
 		epxectedNewThread.NextPC = state.GetCpu().NextPC + 4
-		epxectedNewThread.Registers[2] = 0
-		epxectedNewThread.Registers[7] = 0
-		epxectedNewThread.Registers[29] = stackPtr
+		epxectedNewThread.Registers[register.RegSyscallNum] = 0
+		epxectedNewThread.Registers[register.RegSyscallErrno] = 0
+		epxectedNewThread.Registers[register.RegSP] = stackPtr
 		expected.NextThreadId = nextThreadId + 1
 		expected.StepsSinceLastContextSwitch = 0
 		if state.TraverseRight {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -141,7 +141,7 @@
   },
   "src/cannon/MIPS2.sol": {
     "initCodeHash": "0x4971f62a6aecf91bd795fa44b5ce3cb77a987719af4f351d4aec5b6c3bf81387",
-    "sourceCodeHash": "0xf213cb43d633b1bc8c869f6e177b8bc6958333a63c5bcc56215d2295d7bc86c7"
+    "sourceCodeHash": "0xc047de4438015fbac77174db1a6d04c6502d85f90abcdb3fb388f4685458260a"
   },
   "src/cannon/MIPS64.sol": {
     "initCodeHash": "0x6516160f35a85abb65d8102fa71f03cb57518787f9af85bc951f27ee60e6bb8f",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -141,7 +141,7 @@
   },
   "src/cannon/MIPS2.sol": {
     "initCodeHash": "0x4971f62a6aecf91bd795fa44b5ce3cb77a987719af4f351d4aec5b6c3bf81387",
-    "sourceCodeHash": "0xc047de4438015fbac77174db1a6d04c6502d85f90abcdb3fb388f4685458260a"
+    "sourceCodeHash": "0x8da8be0b7d60af0eb11bd58653f1854d56a8f0616f3aeaeba7ab9ec340d02ac7"
   },
   "src/cannon/MIPS64.sol": {
     "initCodeHash": "0x6516160f35a85abb65d8102fa71f03cb57518787f9af85bc951f27ee60e6bb8f",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -140,8 +140,8 @@
     "sourceCodeHash": "0x6c45dd23cb0d6f9bf4f84855ad0caf70e53dee3fe6c41454f7bf8df52ec3a9af"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x7476695bb101cb45213793291124e3ec41e13a02d291837b76d8a35bfc8ec2c1",
-    "sourceCodeHash": "0xeaceb5d28bd58fca6a234d9291ca01424bf83576d191ee3046272bc4987d0b29"
+    "initCodeHash": "0x4971f62a6aecf91bd795fa44b5ce3cb77a987719af4f351d4aec5b6c3bf81387",
+    "sourceCodeHash": "0xf213cb43d633b1bc8c869f6e177b8bc6958333a63c5bcc56215d2295d7bc86c7"
   },
   "src/cannon/MIPS64.sol": {
     "initCodeHash": "0x6516160f35a85abb65d8102fa71f03cb57518787f9af85bc951f27ee60e6bb8f",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -63,7 +63,7 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.25
+    /// @custom:semver 1.0.0-beta.26
     string public constant version = "1.0.0-beta.26";
 
     /// @notice The preimage oracle contract.

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -64,7 +64,7 @@ contract MIPS2 is ISemver {
 
     /// @notice The semantic version of the MIPS2 contract.
     /// @custom:semver 1.0.0-beta.25
-    string public constant version = "1.0.0-beta.25";
+    string public constant version = "1.0.0-beta.26";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -428,10 +428,10 @@ contract MIPS2 is ISemver {
                 for (uint256 i; i < 32; i++) {
                     newThread.registers[i] = thread.registers[i];
                 }
-                newThread.registers[29] = a1; // set stack pointer
+                newThread.registers[sys.REG_SP] = a1; // set stack pointer
                 // the child will perceive a 0 value as returned value instead, and no error
-                newThread.registers[2] = 0;
-                newThread.registers[7] = 0;
+                newThread.registers[sys.REG_SYSCALL_NUM] = 0;
+                newThread.registers[sys.REG_SYSCALL_ERRNO] = 0;
                 state.nextThreadID++;
 
                 // Preempt this thread for the new one. But not before updating PCs

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -430,7 +430,7 @@ contract MIPS2 is ISemver {
                 }
                 newThread.registers[sys.REG_SP] = a1; // set stack pointer
                 // the child will perceive a 0 value as returned value instead, and no error
-                newThread.registers[sys.REG_SYSCALL_NUM] = 0;
+                newThread.registers[sys.REG_SYSCALL_RET1] = 0;
                 newThread.registers[sys.REG_SYSCALL_ERRNO] = 0;
                 state.nextThreadID++;
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSSyscalls.sol
@@ -156,6 +156,7 @@ library MIPSSyscalls {
     uint32 internal constant REG_A1 = 5;
     uint32 internal constant REG_A2 = 6;
     uint32 internal constant REG_A3 = 7;
+    uint32 internal constant REG_SP = 29;
 
     // FYI: https://web.archive.org/web/20231223163047/https://www.linux-mips.org/wiki/Syscall
     uint32 internal constant REG_SYSCALL_NUM = REG_V0;


### PR DESCRIPTION
This PR is a follow-up of [this](https://github.com/ethereum-optimism/optimism/pull/12386) one, which uses `RegSP` instead of `29`.

It also moves the constants to a separate package to avoid cyclic dependency.