### PR TITLE
fix: typos in documentation files

### DIFF
--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -117,7 +117,7 @@ participant opnodeB as op-node B
 Note over opnodeA: on new block
 
 opnodeA ->> opgethA: engine process unsafe block
-opgethA -->> opnodeA: engine proccessed unsafe block
+opgethA -->> opnodeA: engine processed unsafe block
 opnodeA ->> opsup: update Local unsafe
 opnodeB ->> opsup: update Local unsafe (maybe)
 opsup ->> opgethA: Fetch receipts

--- a/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -27,7 +27,7 @@ contract GovernanceToken is ERC20Burnable, ERC20Votes, Ownable {
     /// @notice Callback called after a token transfer.
     /// @param from   The account sending tokens.
     /// @param to     The account receiving tokens.
-    /// @param amount The amount of tokens being transfered.
+    /// @param amount The amount of tokens being transferred.
     function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
         super._afterTokenTransfer(from, to, amount);
     }

--- a/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
@@ -33,7 +33,7 @@ contract Burn_EthBurner is StdUtils {
         // execute a burn of _value eth
         Burn.eth(value);
 
-        // check that exactly value eth was transfered from the contract
+        // check that exactly value eth was transferred from the contract
         unchecked {
             if (address(this).balance != preBurnBalance - value) {
                 failedEthBurn = true;

--- a/packages/contracts-bedrock/test/invariants/OptimismSuperchainERC20/PROPERTIES.md
+++ b/packages/contracts-bedrock/test/invariants/OptimismSuperchainERC20/PROPERTIES.md
@@ -16,7 +16,7 @@ Considering only the supertoken contract is merged into the `develop` branch, an
 
 ## Definitions
 
-- _legacy token:_ an OptimismMintableERC20 or L2StandardERC20 token on the suprechain that has either been deployed by the factory after the liquidity migration upgrade to the latter, or has been deployed before it **but** added to factory’s `deployments` mapping as part of the upgrade. This testing campaign is not concerned with tokens on L1 or not listed in the factory’s `deployments` mapping.
+- _legacy token:_ an OptimismMintableERC20 or L2StandardERC20 token on the superchain that has either been deployed by the factory after the liquidity migration upgrade to the latter, or has been deployed before it **but** added to factory’s `deployments` mapping as part of the upgrade. This testing campaign is not concerned with tokens on L1 or not listed in the factory’s `deployments` mapping.
 - _supertoken:_ a SuperchainERC20 contract deployed by the `OptimismSuperchainERC20Factory`
 
 # Ecosystem properties


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `proccessed` to `processed`
Corrected `transfered` to `transferred` x2.
Corrected `suprechain` to `superchain`.

Please review the changes and let me know if any additional changes are needed.