### PR TITLE
Modify Anvil to up

### DIFF
--- a/op-service/testutils/anvil/anvil.go
+++ b/op-service/testutils/anvil/anvil.go
@@ -33,18 +33,21 @@ type Runner struct {
 }
 
 func New(l1RPCURL string, logger log.Logger) (*Runner, error) {
+	return NewWithOpts(l1RPCURL, "1000000000", logger)
+}
+
+func NewWithOpts(l1RPCURL string, baseFee string, logger log.Logger) (*Runner, error) {
 	if _, err := exec.LookPath("anvil"); err != nil {
 		return nil, fmt.Errorf("anvil not found in PATH: %w", err)
 	}
 
-	proc := exec.Command(
-		"anvil",
-		"--fork-url", l1RPCURL,
-		"--port",
-		"0",
-		"--base-fee",
-		"1000000000",
-	)
+	args := []string{"--port", "0", "--base-fee", baseFee}
+	if l1RPCURL != "" {
+		args = append([]string{"--fork-url", l1RPCURL}, args...)
+	}
+
+	proc := exec.Command("anvil", args...)
+
 	stdout, err := proc.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

I added a new way to instantiate anvil chains without using a `fork` url without monitorism 

**Tests**

We don't have existing anvil tests so I didn't add in any, but I am happy to do so, this doesn't add much new code, just opens up an existing pathway more

**Additional context**

Running into issues with my [op-monitorism](https://github.com/ethereum-optimism/monitorism/pull/100) pr because I always have to run a forked anvil instance

**Metadata**

Doesn't fix a specific PR, but I just wanted this