### PR TITLE
op-service: Fix failing SSZ fuzz test

### DIFF
--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -412,6 +412,9 @@ func unmarshalTransactions(in []byte) (txs []Data, err error) {
 		return nil, fmt.Errorf("invalid first tx offset: %d, out of scope %d", firstTxOffset, scope)
 	}
 	txCount := firstTxOffset / 4
+	if txCount == 0 && scope > 0 {
+		return nil, fmt.Errorf("invalid first tx offset: %d, no transactions in scope %d", firstTxOffset, scope)
+	}
 	if txCount > maxTransactionsPerPayload {
 		return nil, fmt.Errorf("too many transactions: %d > %d", txCount, maxTransactionsPerPayload)
 	}


### PR DESCRIPTION
The SSZ fuzz tests were not erroring when the `edOffset` was 508 and the `txOffset` was 514. This is because the transaction unmarshaler was reading the number of transactions in the payload as zero, but not checking to see if there was additional data left over. This should never be the case for a valid payload.

To verify, I ran the fuzz suite for 5 minutes:

```
fuzz: elapsed: 5m1s, execs: 12910962 (42267/sec), new interesting: 9 (total: 41)
```
