### PR TITLE
op-batcher: use `pendingBlocks()` for `s.metr.RecordL2BlocksAdded`

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -328,7 +328,7 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		"max_frame_size", cfg.MaxFrameSize,
 		"use_blobs", cfg.UseBlobs,
 	)
-	s.metr.RecordChannelOpened(pc.ID(), s.blocks.Len())
+	s.metr.RecordChannelOpened(pc.ID(), s.pendingBlocks())
 
 	return nil
 }

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -380,7 +380,7 @@ func (s *channelManager) processBlocks() error {
 
 	s.metr.RecordL2BlocksAdded(latestL2ref,
 		blocksAdded,
-		s.blocks.Len(),
+		s.pendingBlocks(),
 		s.currentChannel.InputBytes(),
 		s.currentChannel.ReadyBytes())
 	s.log.Debug("Added blocks to channel",


### PR DESCRIPTION
This metric is designed to track blocks which are in the batcher's state but not yet in a channel. Since we moved to a cursor based system, the length of the block queue no longer reflects that number (since blocks hang around in the queue in case they are required again and only garbage collected when those blocks become safe or the batcher resets its state). 

This is what we are seeing on the most recent RC: 
<img width="233" alt="Screenshot 2024-12-10 at 12 13 59" src="https://github.com/user-attachments/assets/bde3d84c-31ac-45b4-91d9-91dacd2c1054">

