### PR TITLE
feat: Update foundry to support vm.skip() in setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -31,9 +31,9 @@ just = "1.37.0"
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
-forge = "nightly-e5dbb7a320c2b871c4a4a1006ad3c15a08fcf17b"
-cast = "nightly-e5dbb7a320c2b871c4a4a1006ad3c15a08fcf17b"
-anvil = "nightly-e5dbb7a320c2b871c4a4a1006ad3c15a08fcf17b"
+forge = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
+cast = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
+anvil = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't


### PR DESCRIPTION
Updates to [latest nightly](https://github.com/foundry-rs/foundry/tree/nightly-59f354c179f4e7f6d7292acb3d068815c79286d1), with improved `vm.skip()` behavior. 

Unblocks #13323. 