### PR TITLE
op-program: Add new prestate

### DIFF
--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -12,6 +12,10 @@
     "hash": "0x03925193e3e89f87835bbdf3a813f60b2aa818a36bbe71cd5d8fd7e79f5e8afe"
   },
   {
+    "version": "v1.3.1-ink",
+    "hash": "0x03c50b9fd04bdadc228205f340767bbf2d01a030aec39903120d3559d94bb8cc"
+  },
+  {
     "version": "1.3.1",
     "hash": "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c",
     "governanceApproved": true


### PR DESCRIPTION
Update the list of op-program prestates.
To verify:

- git checkout op-program/v1.3.1-ink
- Run `make reproducible-prestate`
- Confirm that the prestate hash matches the new addition.