### PR TITLE
fix: fuzz flake in CrossL2Inbox test

### DIFF
--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -157,6 +157,9 @@ contract CrossL2InboxTest is Test {
         // Ensure that the target call is payable if value is sent
         if (_value > 0) assumePayable(_target);
 
+        // Ensure target is not a forge address.
+        assumeNotForgeAddress(_target);
+
         // Ensure is not a deposit transaction
         vm.mockCall({
             callee: Predeploys.L1_BLOCK_ATTRIBUTES,
@@ -412,6 +415,9 @@ contract CrossL2InboxTest is Test {
 
         // Ensure that the target call is payable if value is sent
         if (_value > 0) assumePayable(_target);
+
+        // Ensure target is not a forge address.
+        assumeNotForgeAddress(_target);
 
         // Ensure that the target call reverts
         vm.mockCallRevert({ callee: _target, msgValue: _value, data: _message, revertData: abi.encode(false) });

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -252,6 +252,9 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure that the target call is payable if value is sent
         if (_value > 0) assumePayable(_target);
 
+        // Ensure that the target is not a forge address.
+        assumeNotForgeAddress(_target);
+
         // Ensure that the target contract does not revert
         vm.mockCall({ callee: _target, msgValue: _value, data: _message, returnData: abi.encode(true) });
 


### PR DESCRIPTION
Fixes a minor flake in CrossL2Inbox where the test can fail when the target is the vm address itself.