### PR TITLE
op-deployer: Fix superchain proxy admin addr method

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/delayed_weth.go
+++ b/op-deployer/pkg/deployer/bootstrap/delayed_weth.go
@@ -145,7 +145,7 @@ func DelayedWETH(ctx context.Context, cfg DelayedWETHConfig) (opcm.DeployDelayed
 	if err != nil {
 		return dwo, fmt.Errorf("error getting superchain config: %w", err)
 	}
-	proxyAdmin, err := standard.ManagerOwnerAddrFor(chainIDU64)
+	proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(chainIDU64)
 	if err != nil {
 		return dwo, fmt.Errorf("error getting superchain proxy admin: %w", err)
 	}

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -275,7 +275,7 @@ func testApplyExistingOPCM(t *testing.T, l1ChainID uint64, forkRPCUrl string, ve
 	superchain, err := standard.SuperchainFor(l1ChainIDBig.Uint64())
 	require.NoError(t, err)
 
-	managerOwner, err := standard.ManagerOwnerAddrFor(l1ChainIDBig.Uint64())
+	managerOwner, err := standard.SuperchainProxyAdminAddrFor(l1ChainIDBig.Uint64())
 	require.NoError(t, err)
 
 	superchainTests := []struct {

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -40,7 +40,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 			return fmt.Errorf("error getting superchain config: %w", err)
 		}
 
-		proxyAdmin, err := standard.ManagerOwnerAddrFor(intent.L1ChainID)
+		proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(intent.L1ChainID)
 		if err != nil {
 			return fmt.Errorf("error getting superchain proxy admin address: %w", err)
 		}

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -216,14 +216,15 @@ func ManagerImplementationAddrFor(chainID uint64) (common.Address, error) {
 	}
 }
 
-func ManagerOwnerAddrFor(chainID uint64) (common.Address, error) {
+// SuperchainProxyAdminAddrFor returns the address of the Superchain ProxyAdmin for the given chain ID.
+// These have been verified to be the ProxyAdmin addresses on Mainnet and Sepolia.
+// DO NOT MODIFY THIS METHOD WITHOUT CLEARING IT WITH THE EVM SAFETY TEAM.
+func SuperchainProxyAdminAddrFor(chainID uint64) (common.Address, error) {
 	switch chainID {
 	case 1:
-		// Set to superchain proxy admin
 		return common.HexToAddress("0x543bA4AADBAb8f9025686Bd03993043599c6fB04"), nil
 	case 11155111:
-		// Set to development multisig
-		return common.HexToAddress("0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B"), nil
+		return common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"), nil
 	default:
 		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
 	}

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -363,7 +363,7 @@ func NewIntentStrict(deploymentStrategy DeploymentStrategy, l1ChainId uint64, l2
 	intent.ConfigType = IntentConfigTypeStrict
 
 	challenger, _ := standard.ChallengerAddressFor(l1ChainId)
-	l1ProxyAdminOwner, _ := standard.ManagerOwnerAddrFor(l1ChainId)
+	l1ProxyAdminOwner, _ := standard.L1ProxyAdminOwner(l1ChainId)
 	for chainIndex := range intent.Chains {
 		intent.Chains[chainIndex].Roles.Challenger = challenger
 		intent.Chains[chainIndex].Roles.L1ProxyAdminOwner = l1ProxyAdminOwner


### PR DESCRIPTION
Renames the ManagerOwnerAddrFor method to reflect what it actually does, and point it at the Sepolia proxy admin.
