### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
@@ -145,7 +145,7 @@ contract DeployOwnership is Deploy {
     /// @param _name The name of the Safe to deploy.
     /// @param _owners The owners of the Safe.
     /// @param _threshold The threshold of the Safe.
-    /// @param _keepDeployer Wether or not the deployer address will be added as an owner of the Safe.
+    /// @param _keepDeployer Whether or not the deployer address will be added as an owner of the Safe.
     function deploySafe(
         string memory _name,
         address[] memory _owners,

--- a/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -55,8 +55,8 @@ contract Faucet {
     /// @notice Maps from id to nonces to whether or not they have been used.
     mapping(bytes32 => mapping(bytes32 => bool)) public nonces;
 
-    /// @notice Modifier that makes a function admin priviledged.
-    modifier priviledged() {
+    /// @notice Modifier that makes a function admin privileged.
+    modifier privileged() {
         require(msg.sender == ADMIN, "Faucet: function can only be called by admin");
         _;
     }
@@ -74,14 +74,14 @@ contract Faucet {
     /// @notice Allows the admin to withdraw funds.
     /// @param _recipient Address to receive the funds.
     /// @param _amount    Amount of ETH in wei to withdraw.
-    function withdraw(address payable _recipient, uint256 _amount) public priviledged {
+    function withdraw(address payable _recipient, uint256 _amount) public privileged {
         new SafeSend{ value: _amount }(_recipient);
     }
 
     /// @notice Allows the admin to configure an authentication module.
     /// @param _module Authentication module to configure.
     /// @param _config Configuration to set for the module.
-    function configure(IFaucetAuthModule _module, ModuleConfig memory _config) public priviledged {
+    function configure(IFaucetAuthModule _module, ModuleConfig memory _config) public privileged {
         modules[_module] = _config;
     }
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `Wether` to `Whether`
Corrected `priviledged` to `privileged`

Please review the changes and let me know if any additional changes are needed.