### PR TITLE
contracts-bedrock: default to governance being off

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -141,7 +141,7 @@ contract DeployConfig is Script {
         basefeeScalar = uint32(_readOr(_json, "$.gasPriceOracleBaseFeeScalar", 1368));
         blobbasefeeScalar = uint32(_readOr(_json, "$.gasPriceOracleBlobBaseFeeScalar", 810949));
 
-        enableGovernance = stdJson.readBool(_json, "$.enableGovernance");
+        enableGovernance = _readOr(_json, "$.enableGovernance", false);
         eip1559Denominator = stdJson.readUint(_json, "$.eip1559Denominator");
         eip1559Elasticity = stdJson.readUint(_json, "$.eip1559Elasticity");
         systemConfigStartBlock = stdJson.readUint(_json, "$.systemConfigStartBlock");


### PR DESCRIPTION
**Description**

To prevent people from accidentally deploying GovToken with the same
name as OP colliding with OP Mainnet's token, turn off by default.
`op-deployer` should be doing this already, just doing this for people
who deploy through the legacy path.

See https://github.com/celo-org/optimism/pull/280#discussion_r1882874523
for context.

