### PR TITLE
Fix version format in `releases.json` to fix `make verify-reproducibility` 

### DIFF
--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -12,7 +12,7 @@
     "hash": "0x03925193e3e89f87835bbdf3a813f60b2aa818a36bbe71cd5d8fd7e79f5e8afe"
   },
   {
-    "version": "v1.3.1-ink",
+    "version": "1.3.1-ink",
     "hash": "0x03c50b9fd04bdadc228205f340767bbf2d01a030aec39903120d3559d94bb8cc"
   },
   {


### PR DESCRIPTION
This fixes `make verify-reproducibility` due to a sorting bug.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
