### PR TITLE
feat: return the returned data from the target call on l2 to l2 relay message

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -104,7 +104,14 @@ interface IL2ToL2CrossDomainMessenger {
     ///         already received once and is currently being replayed.
     /// @param _id          Identifier of the SentMessage event to be relayed
     /// @param _sentMessage Message payload of the `SentMessage` event
-    function relayMessage(Identifier calldata _id, bytes calldata _sentMessage) external payable;
+    /// @return returnData_ Return data from the target contract call.
+    function relayMessage(
+        Identifier calldata _id,
+        bytes calldata _sentMessage
+    )
+        external
+        payable
+        returns (bytes memory returnData_);
 
     function messageVersion() external view returns (uint16);
 

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -110,7 +110,13 @@
       }
     ],
     "name": "relayMessage",
-    "outputs": [],
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "returnData_",
+        "type": "bytes"
+      }
+    ],
     "stateMutability": "payable",
     "type": "function"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -100,8 +100,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0x45564b97c63419cc12eadc60425c6d001857a3eea688ecaf1439ae7ede6aa9aa",
-    "sourceCodeHash": "0xed64736338b43a42f6bc6a88cca734403e1bb9ceafa55e4738605dfdedd1a99f"
+    "initCodeHash": "0xc56db8cb569efa0467fd53ab3fa218af3051e54f5517d7fafb7b5831b4350618",
+    "sourceCodeHash": "0x72062343a044e9c56f4143dcfc71706286eb205902006c2afcf6a4cd90c3e9f8"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
     "initCodeHash": "0xdac32a1057a6bc8a8d2ffdce1db8f34950cd0ffd1454d2133865736d21869192",

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -159,7 +159,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     ///         currently being replayed.
     /// @param _id          Identifier of the SentMessage event to be relayed
     /// @param _sentMessage Message payload of the `SentMessage` event
-    function relayMessage(Identifier calldata _id, bytes calldata _sentMessage) external payable nonReentrant {
+    /// @return returnData_ Return data from the target contract call.
+    function relayMessage(Identifier calldata _id, bytes calldata _sentMessage) external payable nonReentrant returns (bytes memory returnData_) {
         // Ensure the log came from the messenger. Since the log origin is the CDM, there isn't a scenario where
         // this can be invoked from the CrossL2Inbox as the SentMessage log is not calldata for this function
         if (_id.origin != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER) {
@@ -194,7 +195,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
 
         _storeMessageMetadata(source, sender);
 
-        bool success = SafeCall.call(target, msg.value, message);
+        bool success;
+        (success, returnData_) = target.call{value: msg.value}(message);
 
         if (!success) {
             revert TargetCallFailed();

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.25;
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { SafeCall } from "src/libraries/SafeCall.sol";
 import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
 
 // Interfaces
@@ -72,8 +71,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.13
-    string public constant version = "1.0.0-beta.13";
+    /// @custom:semver 1.0.0-beta.14
+    string public constant version = "1.0.0-beta.14";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -160,7 +159,15 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param _id          Identifier of the SentMessage event to be relayed
     /// @param _sentMessage Message payload of the `SentMessage` event
     /// @return returnData_ Return data from the target contract call.
-    function relayMessage(Identifier calldata _id, bytes calldata _sentMessage) external payable nonReentrant returns (bytes memory returnData_) {
+    function relayMessage(
+        Identifier calldata _id,
+        bytes calldata _sentMessage
+    )
+        external
+        payable
+        nonReentrant
+        returns (bytes memory returnData_)
+    {
         // Ensure the log came from the messenger. Since the log origin is the CDM, there isn't a scenario where
         // this can be invoked from the CrossL2Inbox as the SentMessage log is not calldata for this function
         if (_id.origin != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER) {
@@ -196,7 +203,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
         _storeMessageMetadata(source, sender);
 
         bool success;
-        (success, returnData_) = target.call{value: msg.value}(message);
+        (success, returnData_) = target.call{ value: msg.value }(message);
 
         if (!success) {
             revert TargetCallFailed();

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -393,7 +393,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(l2ToL2CrossDomainMessenger.crossDomainMessageSender(), address(0));
     }
 
-    /// @dev Tests the `relayMessage` function returns the expected return data of the call to the target contract.
+    /// @dev Tests the `relayMessage` function returns the expected return data from the call to the target contract.
     function testFuzz_relayMessage_returnData_succeeds(
         uint256 _source,
         uint256 _nonce,

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -411,7 +411,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         vm.deal(_target, 0);
 
         // Declare a random call to be made over the target
-        bytes memory message = abi.encodeWithSignature("randomCall()");
+        bytes memory message = abi.encodePacked("randomCall()");
 
         // Construct the message
         Identifier memory id =

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -402,11 +402,14 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         uint256 _blockNum,
         uint256 _logIndex,
         uint256 _time,
-        address _target,
         bytes memory _mockedReturnData
     )
         public
     {
+        // Declare target and ensure it has 0 balance to avoid an overflow
+        address _target = makeAddr("target");
+        vm.deal(_target, 0);
+
         // Declare a random call to be made over the target
         bytes memory message = abi.encodeWithSignature("randomCall()");
 

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -67,6 +67,8 @@ contract L2ToL2CrossDomainMessengerWithModifiableTransientStorage is L2ToL2Cross
 /// @title L2ToL2CrossDomainMessengerTest
 /// @dev Contract for testing the L2ToL2CrossDomainMessenger contract.
 contract L2ToL2CrossDomainMessengerTest is Test {
+    address internal foundryVMAddress = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+
     /// @dev L2ToL2CrossDomainMessenger contract instance with modifiable transient storage.
     L2ToL2CrossDomainMessengerWithModifiableTransientStorage l2ToL2CrossDomainMessenger;
 
@@ -246,8 +248,11 @@ contract L2ToL2CrossDomainMessengerTest is Test {
     )
         external
     {
-        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger
-        vm.assume(_target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger or the foundry VM
+        vm.assume(
+            _target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
+                && _target != foundryVMAddress
+        );
 
         // Ensure that the target call is payable if value is sent
         if (_value > 0) assumePayable(_target);
@@ -402,12 +407,18 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         uint256 _blockNum,
         uint256 _logIndex,
         uint256 _time,
+        address _target,
         bytes memory _mockedReturnData
     )
         public
     {
-        // Declare target and ensure it has 0 balance to avoid an overflow
-        address _target = makeAddr("target");
+        // Ensure the target is not CrossL2Inbox or L2ToL2CrossDomainMessenger or the foundry VM
+        vm.assume(
+            _target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
+                && _target != foundryVMAddress
+        );
+
+        // ensure the target has 0 balance to avoid an overflow
         vm.deal(_target, 0);
 
         // Declare a random call to be made over the target
@@ -690,8 +701,11 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Ensure that the target call is payable if value is sent
         if (_value > 0) assumePayable(_target);
 
-        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger
-        vm.assume(_target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger or the foundry VM
+        vm.assume(
+            _target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
+                && _target != foundryVMAddress
+        );
 
         // Ensure that the target contract does not revert
         vm.mockCall({ callee: _target, msgValue: _value, data: _message, returnData: abi.encode(true) });


### PR DESCRIPTION
**Description**

Return the returned data from the call made to target on `L2ToL2CrossDomainMessenger#relayMessage()`.

**Tests**

Add one test checking that the function always returns the exact same data than the one returned on the target low-level call.

**Metadata**

* First draft: https://github.com/ethereum-optimism/optimism/pull/13358#issuecomment-2539985771
* Spec: https://github.com/ethereum-optimism/specs/pull/481
