### PR TITLE
op-e2e: Fix Cannon tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,10 +329,6 @@ jobs:
           environment:
             FOUNDRY_PROFILE: <<parameters.profile>>
           working_directory: packages/contracts-bedrock
-      - run:
-          name: Generate allocs
-          command: |
-            make devnet-allocs
       - persist_to_workspace:
           root: "."
           paths:
@@ -341,12 +337,6 @@ jobs:
             - "packages/contracts-bedrock/forge-artifacts"
             - "packages/contracts-bedrock/deploy-config/devnetL1.json"
             - "packages/contracts-bedrock/deployments/devnetL1"
-            - ".devnet"
-            - ".devnet-standard"
-            - ".devnet-l2oo"
-            - ".devnet-alt-da"
-            - ".devnet-alt-da-generic"
-            - ".devnet-mt-cannon"
       - notify-failures-on-develop
 
   check-kontrol-build:
@@ -928,9 +918,8 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - "op-program/bin/prestate.bin.gz"
-            - "op-program/bin/meta.json"
-            - "op-program/bin/prestate-proof.json"
+            - "op-program/bin"
+            - "cannon/bin"
 
   preimage-reproducibility:
     docker:
@@ -1464,13 +1453,13 @@ workflows:
       - publish-contract-artifacts
 
   develop-fault-proofs:
-    when:
-      and:
-        - or:
-            - equal: ["develop", <<pipeline.git.branch>>]
-            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+#    when:
+#      and:
+#        - or:
+#            - equal: ["develop", <<pipeline.git.branch>>]
+#            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
+#        - not:
+#            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - cannon-prestate
       - cannon-stf-verify:
@@ -1493,6 +1482,9 @@ workflows:
             op-e2e/faultproofs
           context:
             - slack
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate
 
   develop-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1453,13 +1453,13 @@ workflows:
       - publish-contract-artifacts
 
   develop-fault-proofs:
-#    when:
-#      and:
-#        - or:
-#            - equal: ["develop", <<pipeline.git.branch>>]
-#            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
-#        - not:
-#            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    when:
+      and:
+        - or:
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - cannon-prestate
       - cannon-stf-verify:

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -115,7 +115,7 @@ func makeDCIV160(intent *state.Intent, thisIntent *state.ChainIntent, chainID co
 		for _, game := range thisIntent.AdditionalDisputeGames {
 			anchorRoots = append(anchorRoots, opcm.StartingAnchorRoot{
 				GameType:      game.DisputeGameType,
-				Root:          game.DisputeAbsolutePrestate,
+				Root:          game.StartingAnchorRoot,
 				L2BlockNumber: common.Big0,
 			})
 		}

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -33,6 +33,7 @@ type AdditionalDisputeGame struct {
 	OracleMinProposalSize        uint64
 	OracleChallengePeriodSeconds uint64
 	MakeRespected                bool
+	StartingAnchorRoot           common.Hash
 }
 
 type ChainIntent struct {

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -48,7 +48,7 @@ devnet-allocs: pre-test-cannon
 	make -C .. devnet-allocs
 .PHONY: devnet-allocs
 
-pre-test: pre-test-cannon pre-test-allocs
+pre-test: pre-test-cannon
 .PHONY: pre-test
 
 pre-test-cannon:

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -267,7 +267,7 @@ func initAllocType(root string, allocType AllocType) {
 		go func(mode genesis.L2AllocsMode) {
 			defer wg.Done()
 
-			intent := defaultIntent(root, loc, deployerAddr)
+			intent := defaultIntent(root, loc, deployerAddr, allocType)
 			if allocType == AllocTypeAltDA {
 				intent.Chains[0].DangerousAltDAConfig = genesis.AltDADeployConfig{
 					UseAltDA:                   true,
@@ -356,7 +356,9 @@ func initAllocType(root string, allocType AllocType) {
 	l2AllocsByType[allocType] = l2Alloc
 }
 
-func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address) *state.Intent {
+func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address, allocType AllocType) *state.Intent {
+	defaultPrestate := common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98")
+	genesisOutputRoot := common.HexToHash("0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
 	return &state.Intent{
 		ConfigType:         state.IntentConfigTypeCustom,
 		DeploymentStrategy: state.DeploymentStrategyGenesis,
@@ -392,12 +394,12 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address)
 			"gasPriceOracleBaseFeeScalar":              1368,
 			"gasPriceOracleBlobBaseFeeScalar":          810949,
 			"l1CancunTimeOffset":                       "0x0",
-			"faultGameAbsolutePrestate":                "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
+			"faultGameAbsolutePrestate":                defaultPrestate.Hex(),
 			"faultGameMaxDepth":                        50,
 			"faultGameClockExtension":                  0,
 			"faultGameMaxClockDuration":                1200,
 			"faultGameGenesisBlock":                    0,
-			"faultGameGenesisOutputRoot":               "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+			"faultGameGenesisOutputRoot":               genesisOutputRoot.Hex(),
 			"faultGameSplitDepth":                      14,
 			"faultGameWithdrawalDelay":                 604800,
 			"preimageOracleMinProposalSize":            10000,
@@ -429,7 +431,7 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address)
 						ChainProofParams: state.ChainProofParams{
 							// Fast game
 							DisputeGameType:         254,
-							DisputeAbsolutePrestate: common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
+							DisputeAbsolutePrestate: defaultPrestate,
 							DisputeMaxGameDepth:     14 + 3 + 1,
 							DisputeSplitDepth:       14,
 							DisputeClockExtension:   0,
@@ -440,29 +442,32 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address)
 						OracleMinProposalSize:        10000,
 						OracleChallengePeriodSeconds: 0,
 						MakeRespected:                true,
+						StartingAnchorRoot:           genesisOutputRoot,
 					},
 					{
 						ChainProofParams: state.ChainProofParams{
 							// Alphabet game
 							DisputeGameType:         255,
-							DisputeAbsolutePrestate: common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
+							DisputeAbsolutePrestate: defaultPrestate,
 							DisputeMaxGameDepth:     14 + 3 + 1,
 							DisputeSplitDepth:       14,
 							DisputeClockExtension:   0,
 							DisputeMaxClockDuration: 1200,
 						},
-						VMType: state.VMTypeAlphabet,
+						VMType:             state.VMTypeAlphabet,
+						StartingAnchorRoot: genesisOutputRoot,
 					},
 					{
 						ChainProofParams: state.ChainProofParams{
 							DisputeGameType:         0,
-							DisputeAbsolutePrestate: cannonPrestate(root),
+							DisputeAbsolutePrestate: cannonPrestate(root, allocType),
 							DisputeMaxGameDepth:     50,
 							DisputeSplitDepth:       14,
 							DisputeClockExtension:   0,
 							DisputeMaxClockDuration: 1200,
 						},
-						VMType: cannonVMType(),
+						VMType:             cannonVMType(allocType),
+						StartingAnchorRoot: genesisOutputRoot,
 					},
 				},
 			},
@@ -498,8 +503,8 @@ func decompressGzipJSON(p string, thing any) {
 	}
 }
 
-func cannonVMType() state.VMType {
-	if os.Getenv("USE_MT_CANNON") == "true" {
+func cannonVMType(allocType AllocType) state.VMType {
+	if allocType == AllocTypeMTCannon {
 		return state.VMTypeCannon2
 	}
 	return state.VMTypeCannon1
@@ -509,19 +514,27 @@ type prestateFile struct {
 	Pre string `json:"pre"`
 }
 
-var cannonPrestateCache common.Hash
-var cannonPrestateOnce sync.Once
+var cannonPrestateMT common.Hash
+var cannonPrestateST common.Hash
+var cannonPrestateMTOnce sync.Once
+var cannonPrestateSTOnce sync.Once
 
-func cannonPrestate(monorepoRoot string) common.Hash {
+func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
 	var filename string
 
-	if cannonVMType() == state.VMTypeCannon1 {
+	var once *sync.Once
+	var cacheVar *common.Hash
+	if cannonVMType(allocType) == state.VMTypeCannon1 {
 		filename = "prestate-proof-st.json"
+		once = &cannonPrestateSTOnce
+		cacheVar = &cannonPrestateST
 	} else {
 		filename = "prestate-proof-mt.json"
+		once = &cannonPrestateMTOnce
+		cacheVar = &cannonPrestateMT
 	}
 
-	cannonPrestateOnce.Do(func() {
+	once.Do(func() {
 		f, err := os.Open(path.Join(monorepoRoot, "op-program", "bin", filename))
 		if err != nil {
 			log.Warn("error opening prestate file", "err", err)
@@ -536,8 +549,8 @@ func cannonPrestate(monorepoRoot string) common.Hash {
 			return
 		}
 
-		cannonPrestateCache = common.HexToHash(prestate.Pre)
+		*cacheVar = common.HexToHash(prestate.Pre)
 	})
 
-	return cannonPrestateCache
+	return *cacheVar
 }

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -525,7 +525,7 @@ func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
 	var once *sync.Once
 	var cacheVar *common.Hash
 	if cannonVMType(allocType) == state.VMTypeCannon1 {
-		filename = "prestate-proof-st.json"
+		filename = "prestate-proof.json"
 		once = &cannonPrestateSTOnce
 		cacheVar = &cannonPrestateST
 	} else {

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -89,8 +89,7 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 			ctx := context.Background()
 			genesisTime := hexutil.Uint64(0)
-			cfg := e2esys.EcotoneSystemConfig(t, &genesisTime)
-			cfg.AllocType = allocType
+			cfg := e2esys.EcotoneSystemConfig(t, &genesisTime, e2esys.WithAllocType(allocType))
 			// We don't need a verifier - just the sequencer is enough
 			delete(cfg.Nodes, "verifier")
 
@@ -194,8 +193,7 @@ func testGranitePrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	genesisTime := hexutil.Uint64(0)
-	cfg := e2esys.GraniteSystemConfig(t, &genesisTime)
-	cfg.AllocType = allocType
+	cfg := e2esys.GraniteSystemConfig(t, &genesisTime, e2esys.WithAllocType(allocType))
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
 


### PR DESCRIPTION
Fixes the broken fault proof tests on develop by doing the following:

1. Specifying the correct `0xdead...` anchor roots in the allocs.
2. Properly archiving the Cannon prestates/binaries in CI.
3. Fixing a bug where allocs were not being properly used.

That last issue was a pre-existing bug in the FP test suite. `StartFaultDisputeGame` was modifying the `allocType` on `e2esys.SystemConfig` _after_ the allocs were already assigned. This is essentially a no-op, since `e2esys.DefaultSystemConfig` assigns the allocs upfront based on the provided alloc type. To get around this without having to refactor all of the fault proof tests, I updated `StartFaultDisputeSystem` to recalculate the allocs based on the alloc type after applying `faultDisputeConfigOpts`.