### PR TITLE
Fix typos 

### DIFF
--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -82,7 +82,7 @@ block builder to instead impose a (tighter) block level limit of OP_BATCHER_THRO
 transaction limit of OP_BATCHER_THROTTLE_TRANSACTION_SIZE.
 
 ### Max Channel Duration
-The batcher tries to ensure that batches are posted at a minimum frequency specified by `MAX_CHANNEL_DURATION`. To achiveve this, it caches the l1 origin of the last submitted channel, and will force close a channel if the timestamp of the l1 head moves beyond the timestamp of that l1 origin plus `MAX_CHANNEL_DURATION`. When clearing its state, e.g. following the detection of a reorg, the batcher will not clear the cached l1 origin: this way, the regular posting of batches will not be disturbed by events like reorgs.
+The batcher tries to ensure that batches are posted at a minimum frequency specified by `MAX_CHANNEL_DURATION`. To achieve this, it caches the l1 origin of the last submitted channel, and will force close a channel if the timestamp of the l1 head moves beyond the timestamp of that l1 origin plus `MAX_CHANNEL_DURATION`. When clearing its state, e.g. following the detection of a reorg, the batcher will not clear the cached l1 origin: this way, the regular posting of batches will not be disturbed by events like reorgs.
 
 ## Known issues and future work
 

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -54,7 +54,7 @@ make op-node
   --rpc.port=7000 \
   --syncmode=execution-layer
 
-# If running inside docker, ake sure to mount the below persistent data as (host) volume,
+# If running inside docker, make sure to mount the below persistent data as (host) volume,
 # it may be lost on restart otherwise:
 # - P2P private key: auto-generated when missing, used to maintain a stable peer identity.
 # - Peerstore DB: remember peer records to connect with, used to not wait for peer discovery.

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -159,7 +159,7 @@ interfaces-check-no-build:
 
 # Checks that all interfaces are appropriately named and accurately reflect the corresponding
 # contract that they're meant to represent. We run "clean" before building because leftover
-# artifacts can cause the script to detect issues incorrectly.2
+# artifacts can cause the script to detect issues incorrectly.
 interfaces-check: clean build interfaces-check-no-build
 
 # Checks that the size of the contracts is within the limit.


### PR DESCRIPTION


Changes Made:

1. op-batcher/readme.md
- Fixed typo: "achiveve" → "achieve"

2. op-node/README.md
- Changed: "ake" → "make" in docker mounting instructions

Rationale:
These documentation-only updates improve readability and fix potential confusion in technical instructions. No code changes or testing required.