### PR TITLE
op-service: add Delete to RWMap

### DIFF
--- a/op-service/locks/rwmap.go
+++ b/op-service/locks/rwmap.go
@@ -41,6 +41,12 @@ func (m *RWMap[K, V]) Len() int {
 	return len(m.inner)
 }
 
+func (m *RWMap[K, V]) Delete(key K) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.inner, key)
+}
+
 // Range calls f sequentially for each key and value present in the map.
 // If f returns false, range stops the iteration.
 func (m *RWMap[K, V]) Range(f func(key K, value V) bool) {

--- a/op-service/locks/rwmap_test.go
+++ b/op-service/locks/rwmap_test.go
@@ -49,4 +49,15 @@ func TestRWMap(t *testing.T) {
 		return false
 	})
 	require.Len(t, got, 1, "stop early")
+
+	// remove a value
+	require.True(t, m.Has(10))
+	m.Delete(10)
+	require.False(t, m.Has(10))
+	// and add it back, sanity check
+	m.Set(10, 123)
+	require.True(t, m.Has(10))
+
+	// remove a non-existent value
+	m.Delete(132983213)
 }


### PR DESCRIPTION
**Description**

Adding a very basic method to `RWMap` to delete entries. Was surprised it wasn't already there.

**Tests**

Tested removing existent and removing non-existent entries.

**Additional context**

Was experimenting with some things and needed this.

**Metadata**

N/A
