### PR TITLE
Update op-geth and API invocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101411.4-rc.4
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101411.5-rc.1
 
 //replace github.com/ethereum/go-ethereum => ../go-ethereum
 

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101411.4-rc.4 h1:3K7tSLwis5Z03G8Th5j5FlcyHYVSG8YybNw8Dtv+jyc=
-github.com/ethereum-optimism/op-geth v1.101411.4-rc.4/go.mod h1:n6VeI9cKFxmXCauD7Ji9lgTAg+2TYGLZu5AXgVJB4tk=
+github.com/ethereum-optimism/op-geth v1.101411.5-rc.1 h1:8fhtAycm/+xugWev5jInUxgF0Wdc29PxSODZXca6Qi8=
+github.com/ethereum-optimism/op-geth v1.101411.5-rc.1/go.mod h1:n6VeI9cKFxmXCauD7Ji9lgTAg+2TYGLZu5AXgVJB4tk=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20241213092551-33a63fce8214 h1:94dIMFDCafAQ3FCC1pryuhgfZc1jPoDwK4xSMOPshN8=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20241213092551-33a63fce8214/go.mod h1:9feO8jcL5OZ1tvRjEfNAHz4Aggvd6373l+ZxmZZAyZs=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -75,7 +75,7 @@ func newMiniL2BlockWithNumberParentAndL1Information(numTx int, l2Number *big.Int
 		Difficulty: common.Big0,
 		Number:     big.NewInt(l1Number),
 		Time:       blockTime,
-	}, nil, nil, trie.NewStackTrie(nil))
+	}, nil, nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 	l1InfoTx, err := derive.L1InfoDeposit(defaultTestRollupConfig, eth.SystemConfig{}, 0, eth.BlockToInfo(l1Block), blockTime)
 	if err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func newMiniL2BlockWithNumberParentAndL1Information(numTx int, l2Number *big.Int
 	return types.NewBlock(&types.Header{
 		Number:     l2Number,
 		ParentHash: parent,
-	}, &types.Body{Transactions: txs}, nil, trie.NewStackTrie(nil))
+	}, &types.Body{Transactions: txs}, nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 }
 
 // addTooManyBlocks adds blocks to the channel until it hits an error,

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -65,19 +65,19 @@ func ChannelManagerReturnsErrReorg(t *testing.T, batchType uint) {
 
 	a := types.NewBlock(&types.Header{
 		Number: big.NewInt(0),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 	b := types.NewBlock(&types.Header{
 		Number:     big.NewInt(1),
 		ParentHash: a.Hash(),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 	c := types.NewBlock(&types.Header{
 		Number:     big.NewInt(2),
 		ParentHash: b.Hash(),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 	x := types.NewBlock(&types.Header{
 		Number:     big.NewInt(2),
 		ParentHash: common.Hash{0xff},
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 
 	require.NoError(t, m.AddL2Block(a))
 	require.NoError(t, m.AddL2Block(b))
@@ -166,7 +166,7 @@ func ChannelManager_Clear(t *testing.T, batchType uint) {
 	b := types.NewBlock(&types.Header{
 		Number:     big.NewInt(1),
 		ParentHash: a.Hash(),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 	require.NoError(m.AddL2Block(b))
 	require.Equal(m.blockCursor, len(m.blocks)-1)
 	require.Equal(b.Hash(), m.tip)
@@ -467,15 +467,15 @@ func TestChannelManager_PruneBlocks(t *testing.T) {
 	cfg.InitNoneCompressor()
 	a := types.NewBlock(&types.Header{
 		Number: big.NewInt(0),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 	b := types.NewBlock(&types.Header{
 		Number:     big.NewInt(1),
 		ParentHash: a.Hash(),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 	c := types.NewBlock(&types.Header{
 		Number:     big.NewInt(2),
 		ParentHash: b.Hash(),
-	}, nil, nil, nil)
+	}, nil, nil, nil, types.DefaultBlockConfig)
 
 	type testCase struct {
 		name                string

--- a/op-e2e/actions/helpers/l1_miner.go
+++ b/op-e2e/actions/helpers/l1_miner.go
@@ -218,7 +218,7 @@ func (s *L1Miner) ActL1EndBlock(t Testing) *types.Block {
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
 
-	block := types.NewBlock(s.l1BuildingHeader, &types.Body{Transactions: s.L1Transactions, Withdrawals: withdrawals}, s.l1Receipts, trie.NewStackTrie(nil))
+	block := types.NewBlock(s.l1BuildingHeader, &types.Body{Transactions: s.L1Transactions, Withdrawals: withdrawals}, s.l1Receipts, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 	if s.l1Cfg.Config.IsCancun(s.l1BuildingHeader.Number, s.l1BuildingHeader.Time) {
 		parent := s.l1Chain.GetHeaderByHash(s.l1BuildingHeader.ParentHash)
 		var (

--- a/op-node/rollup/derive/test/random.go
+++ b/op-node/rollup/derive/test/random.go
@@ -17,7 +17,7 @@ import (
 // L1 Info Deposit transaction.
 func RandomL2Block(rng *rand.Rand, txCount int, t time.Time) (*types.Block, []*types.Receipt) {
 	body := types.Body{}
-	l1Block := types.NewBlock(testutils.RandomHeader(rng), &body, nil, trie.NewStackTrie(nil))
+	l1Block := types.NewBlock(testutils.RandomHeader(rng), &body, nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 	rollupCfg := rollup.Config{}
 	if testutils.RandomBool(rng) {
 		t := uint64(0)

--- a/op-program/client/l2/engine_test.go
+++ b/op-program/client/l2/engine_test.go
@@ -187,7 +187,7 @@ func createL2Block(t *testing.T, number int) *types.Block {
 	body := &types.Body{
 		Transactions: []*types.Transaction{types.NewTx(tx)},
 	}
-	return types.NewBlock(header, body, nil, trie.NewStackTrie(nil))
+	return types.NewBlock(header, body, nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 }
 
 type stubEngineBackend struct {

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -503,7 +503,7 @@ func (ea *L2EngineAPI) newPayload(_ context.Context, payload *eth.ExecutionPaylo
 		Withdrawals:   toGethWithdrawals(payload),
 		ExcessBlobGas: (*uint64)(payload.ExcessBlobGas),
 		BlobGasUsed:   (*uint64)(payload.BlobGasUsed),
-	}, hashes, root)
+	}, hashes, root, ea.backend.Config())
 	if err != nil {
 		log.Debug("Invalid NewPayload params", "params", payload, "error", err)
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalidBlockHash}, nil

--- a/op-service/testutils/random.go
+++ b/op-service/testutils/random.go
@@ -302,7 +302,7 @@ func RandomBlockPrependTxsWithTime(rng *rand.Rand, txCount int, t uint64, ptxs .
 	body := types.Body{
 		Transactions: txs,
 	}
-	block := types.NewBlock(header, &body, receipts, trie.NewStackTrie(nil))
+	block := types.NewBlock(header, &body, receipts, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 	logIndex := uint(0)
 	for i, r := range receipts {
 		r.BlockHash = block.Hash()


### PR DESCRIPTION
**Description**

* Update op-geth to pull in https://github.com/ethereum-optimism/op-geth/pull/451
* Also update API invocations per changes in the above PR

**Tests**

None

**Additional context**

Raising this PR separately from https://github.com/ethereum-optimism/optimism/pull/12847 to decouple Isthmus changes from op-geth updates, as @sebastianst is waiting on the `op-geth` changes

**Metadata**

None