### PR TITLE
Fix tests on forked networks

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -745,6 +745,9 @@ contract L1CrossDomainMessenger_Test is CommonTest {
 
     /// @dev Tests that the sendMessage reverts when call value is non-zero with custom gas token.
     function test_sendMessage_customGasTokenWithValue_reverts() external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1CrossDomainMessenger_Test: gas paying token functionality DNE on op mainnet");
+
         // Mock the gasPayingToken function to return a custom gas token
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))
@@ -756,6 +759,9 @@ contract L1CrossDomainMessenger_Test is CommonTest {
 
     /// @dev Tests that the relayMessage succeeds with a custom gas token when the call value is zero.
     function test_relayMessage_customGasTokenAndNoValue_succeeds() external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1CrossDomainMessenger_Test: gas paying token functionality DNE on op mainnet");
+
         // Mock the gasPayingToken function to return a custom gas token
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -168,7 +168,7 @@ contract L1StandardBridge_Initialize_TestFail is CommonTest { }
 contract L1StandardBridge_Receive_Test is CommonTest {
     /// @dev Tests receive bridges ETH successfully.
     function test_receive_succeeds() external {
-        assertEq(address(optimismPortal).balance, 0);
+        uint256 balanceBefore = address(optimismPortal).balance;
 
         // The legacy event must be emitted for backwards compatibility
         vm.expectEmit(address(l1StandardBridge));
@@ -192,13 +192,16 @@ contract L1StandardBridge_Receive_Test is CommonTest {
         vm.prank(alice, alice);
         (bool success,) = address(l1StandardBridge).call{ value: 100 }(hex"");
         assertEq(success, true);
-        assertEq(address(optimismPortal).balance, 100);
+        assertEq(address(optimismPortal).balance, balanceBefore + 100);
     }
 }
 
 contract L1StandardBridge_Receive_TestFail is CommonTest {
     /// @dev Tests receive function reverts with custom gas token.
     function testFuzz_receive_customGasToken_reverts(uint256 _value) external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1StandardBridge_Receive_TestFail: gas paying token functionality DNE on op mainnet");
+
         vm.prank(alice, alice);
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(18))
@@ -305,6 +308,9 @@ contract L1StandardBridge_DepositETH_TestFail is CommonTest {
 
     /// @dev Tests that depositing reverts with custom gas token.
     function test_depositETH_customGasToken_reverts() external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1StandardBridge_DepositETH_TestFail: gas paying token functionality DNE on op mainnet");
+
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))
         );
@@ -331,6 +337,9 @@ contract L1StandardBridge_BridgeETH_Test is PreBridgeETH {
 contract L1StandardBridge_BridgeETH_TestFail is PreBridgeETH {
     /// @dev Tests that bridging eth reverts with custom gas token.
     function test_bridgeETH_customGasToken_reverts() external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1StandardBridge_BridgeETH_TestFail: gas paying token functionality DNE on op mainnet");
+
         vm.prank(alice, alice);
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))
@@ -431,6 +440,9 @@ contract L1StandardBridge_DepositETHTo_TestFail is CommonTest {
     )
         external
     {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1StandardBridge_DepositETHTo_TestFail: gas paying token functionality DNE on op mainnet");
+
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))
         );
@@ -464,6 +476,9 @@ contract L1StandardBridge_BridgeETHTo_TestFail is PreBridgeETHTo {
     )
         external
     {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1StandardBridge_BridgeETHTo_TestFail: gas paying token functionality DNE on op mainnet");
+
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))
         );
@@ -673,6 +688,11 @@ contract L1StandardBridge_FinalizeETHWithdrawal_TestFail is CommonTest {
     )
         external
     {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest(
+            "L1StandardBridge_FinalizeETHWithdrawal_TestFail: gas paying token functionality DNE on op mainnet"
+        );
+
         vm.mockCall(
             address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(1), uint8(2))
         );
@@ -776,6 +796,9 @@ contract L1StandardBridge_FinalizeBridgeETH_Test is CommonTest {
 contract L1StandardBridge_FinalizeBridgeETH_TestFail is CommonTest {
     /// @dev Tests that finalizing bridged reverts with custom gas token.
     function testFuzz_finalizeBridgeETH_customGasToken_reverts(uint256 _value, bytes calldata _extraData) external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("L1StandardBridge_FinalizeBridgeETH_TestFail: gas paying token functionality DNE on op mainnet");
+
         vm.mockCall(
             address(l1StandardBridge.messenger()),
             abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -543,6 +543,8 @@ contract OptimismPortal_Test is CommonTest {
     }
 
     function test_depositERC20Transaction_balanceOverflow_reverts() external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
+        skipIfForkTest("OptimismPortal_Test: custom gas token DNE on op mainnet");
         vm.mockCall(address(systemConfig), abi.encodeCall(systemConfig.gasPayingToken, ()), abi.encode(address(42), 18));
 
         // The balance slot
@@ -1341,6 +1343,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is CommonTest {
 contract OptimismPortalUpgradeable_Test is CommonTest {
     /// @dev Tests that the proxy is initialized correctly.
     function test_params_initValuesOnProxy_succeeds() external {
+        // TODO(opcm upgrades): remove skip once upgrade path is implemented
         skipIfForkTest("OptimismPortal_Test: resource config varies on mainnet");
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = optimismPortal.params();
         IResourceMetering.ResourceConfig memory rcfg = systemConfig.resourceConfig();

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -461,6 +461,7 @@ contract OptimismPortal2_Test is CommonTest {
         vm.deal(alice, _amount);
 
         uint256 preBalance = address(optimismPortal2).balance;
+        _amount = bound(_amount, 0, type(uint256).max - preBalance);
 
         vm.startStateDiffRecording();
         optimismPortal2.donateETH{ value: _amount }();

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -67,7 +67,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
         assertEq(Timestamp.unwrap(timestamp), block.timestamp);
         assertEq(disputeGameFactory.gameCount(), gameCountBefore + 1);
 
-        (, Timestamp timestamp2, IDisputeGame game2) = disputeGameFactory.gameAtIndex(0);
+        (, Timestamp timestamp2, IDisputeGame game2) = disputeGameFactory.gameAtIndex(gameCountBefore);
         assertEq(address(game2), address(proxy));
         assertEq(Timestamp.unwrap(timestamp2), block.timestamp);
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -54,6 +54,8 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
 
         vm.deal(address(this), _value);
 
+        uint256 gameCountBefore = disputeGameFactory.gameCount();
+
         vm.expectEmit(false, true, true, false);
         emit DisputeGameCreated(address(0), gt, rootClaim);
         IDisputeGame proxy = disputeGameFactory.create{ value: _value }(gt, rootClaim, extraData);
@@ -63,7 +65,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
         // Ensure that the dispute game was assigned to the `disputeGames` mapping.
         assertEq(address(game), address(proxy));
         assertEq(Timestamp.unwrap(timestamp), block.timestamp);
-        assertEq(disputeGameFactory.gameCount(), 1);
+        assertEq(disputeGameFactory.gameCount(), gameCountBefore + 1);
 
         (, Timestamp timestamp2, IDisputeGame game2) = disputeGameFactory.gameAtIndex(0);
         assertEq(address(game2), address(proxy));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -275,22 +275,25 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_Init {
 
         uint256 start = gameCount - 1;
 
+        // Find type 1 games.
         games = disputeGameFactory.findLatestGames(GameType.wrap(1), start, 1);
         assertEq(games.length, 1);
         // The type 1 game should be the last one added.
         assertEq(games[0].index, start);
-        (gameType, createdAt, game) = games[0].metadata.unpack();
+        (GameType gameType, Timestamp createdAt, address game) = games[0].metadata.unpack();
         assertEq(gameType.raw(), 1);
         assertEq(createdAt.raw(), block.timestamp);
 
+        // Find type 0 games.
         games = disputeGameFactory.findLatestGames(GameType.wrap(0), start, 1);
         assertEq(games.length, 1);
         // The type 0 game should be the second to last one added.
         assertEq(games[0].index, start - 1);
-        (GameType gameType, Timestamp createdAt, address game) = games[0].metadata.unpack();
+        (gameType, createdAt, game) = games[0].metadata.unpack();
         assertEq(gameType.raw(), 0);
         assertEq(createdAt.raw(), block.timestamp);
 
+        // Find type 2 games.
         games = disputeGameFactory.findLatestGames(GameType.wrap(2), start, 1);
         assertEq(games.length, 1);
         // The type 2 game should be the third to last one added.
@@ -317,10 +320,13 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_Init {
         games = disputeGameFactory.findLatestGames(GameType.wrap(2), gameCount - 1, 5);
         assertEq(games.length, 0);
 
-        games = disputeGameFactory.findLatestGames(GameType.wrap(1), gameCount - 1, 5);
-        assertEq(games.length, 2);
-        assertEq(games[0].index, 1);
-        assertEq(games[1].index, 0);
+        // Forked network will have an indefinite, but very large number of games, so we skip this test when forking.
+        if (!isForkTest) {
+            games = disputeGameFactory.findLatestGames(GameType.wrap(1), gameCount - 1, 5);
+            assertEq(games.length, 2);
+            assertEq(games[0].index, 1);
+            assertEq(games[1].index, 0);
+        }
     }
 
     /// @dev Tests that the expected number of games are returned when `findLatestGames` is called.

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -124,10 +124,12 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
             disputeGameFactory.setImplementation(GameType.wrap(i), IDisputeGame(address(fakeClone)));
         }
 
+        uint256 bondAmount = disputeGameFactory.initBonds(gt);
+
         // Create our first dispute game - this should succeed.
         vm.expectEmit(false, true, true, false);
         emit DisputeGameCreated(address(0), gt, rootClaim);
-        IDisputeGame proxy = disputeGameFactory.create(gt, rootClaim, extraData);
+        IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
 
         (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(gt, rootClaim, extraData);
         // Ensure that the dispute game was assigned to the `disputeGames` mapping.
@@ -138,7 +140,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
         vm.expectRevert(
             abi.encodeWithSelector(GameAlreadyExists.selector, disputeGameFactory.getGameUUID(gt, rootClaim, extraData))
         );
-        disputeGameFactory.create(gt, rootClaim, extraData);
+        disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
     }
 
     function changeClaimStatus(Claim _claim, VMStatus _status) public pure returns (Claim out_) {

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -325,7 +325,7 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_Init {
         assertEq(games.length, 0);
 
         // Forked network will have an indefinite, but very large number of games, so we skip this test when forking.
-        if (!isForkTest) {
+        if (!isForkTest()) {
             games = disputeGameFactory.findLatestGames(GameType.wrap(1), gameCount - 1, 5);
             assertEq(games.length, 2);
             assertEq(games[0].index, 1);

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import { console2 as console } from "forge-std/console2.sol";
-
 // Testing
 import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
@@ -97,7 +95,6 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         disputeGameFactory.setImplementation(GAME_TYPE, gameImpl);
         // Create a new game.
         uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
-        console.log("bondAmount", bondAmount);
         vm.prank(PROPOSER, PROPOSER);
         gameProxy = IPermissionedDisputeGame(
             payable(address(disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, rootClaim, extraData)))

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -226,6 +226,7 @@ contract Setup {
         vm.label(deploy.mustGetAddress("ProtocolVersionsProxy"), "ProtocolVersionsProxy");
         vm.label(address(superchainConfig), "SuperchainConfig");
         vm.label(deploy.mustGetAddress("SuperchainConfigProxy"), "SuperchainConfigProxy");
+        vm.label(address(anchorStateRegistry), "AnchorStateRegistryProxy");
         vm.label(AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger)), "L1CrossDomainMessenger_aliased");
 
         if (!deploy.cfg().useFaultProofs()) {

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -174,7 +174,9 @@ contract Setup {
     function returnIfForkTest(string memory message) public view {
         if (_isForkTest) {
             console.log(string.concat("Returning early from fork test: ", message));
-            return;
+            assembly {
+                return(0, 0)
+            }
         }
     }
 

--- a/packages/contracts-bedrock/test/setup/Upgrade.s.sol
+++ b/packages/contracts-bedrock/test/setup/Upgrade.s.sol
@@ -8,7 +8,6 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { Deployer } from "scripts/deploy/Deployer.sol";
 
 // Libraries
-import { Constants } from "src/libraries/Constants.sol";
 import { GameTypes } from "src/dispute/lib/Types.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 

--- a/packages/contracts-bedrock/test/setup/Upgrade.s.sol
+++ b/packages/contracts-bedrock/test/setup/Upgrade.s.sol
@@ -69,10 +69,9 @@ contract Upgrade is Deployer {
         // Bridge contracts
         address optimismPortal = vm.parseTomlAddress(opToml, ".addresses.OptimismPortalProxy");
         save("OptimismPortalProxy", optimismPortal);
-        save(
-            "OptimismPortal", address(uint160(uint256(vm.load(optimismPortal, Constants.PROXY_IMPLEMENTATION_ADDRESS))))
-        );
-        save("OptimismPortal2", optimismPortal);
+        save("OptimismPortal", EIP1967Helper.getImplementation(optimismPortal));
+        save("OptimismPortal2", EIP1967Helper.getImplementation(optimismPortal));
+
         address addressManager = vm.parseTomlAddress(opToml, ".addresses.AddressManager");
         save("AddressManager", addressManager);
         save("L1CrossDomainMessenger", IAddressManager(addressManager).getAddress("OVM_L1CrossDomainMessenger"));


### PR DESCRIPTION
Builds on #13323. 

Changes made here either: 
1. skip tests which cannot pass on OP Mainnet due to incompatible functionality
2. make the test more generic in some way so that it does not make assumptions based on the system being freshly deployed with hardhat.json as the deploy config.

The upgrade tests job should not be expected to pass in this PR. They will pass when the [stack](https://github.com/ethereum-optimism/optimism/pull/13424#issuecomment-2546638232) is collapsed.