### PR TITLE
fix: First Time JWT Generation Bug

### DIFF
--- a/op-service/rpc/jwt.go
+++ b/op-service/rpc/jwt.go
@@ -25,27 +25,57 @@ func ObtainJWTSecret(logger log.Logger, jwtSecretPath string, generateMissing bo
 	if jwtSecretPath == "" {
 		return eth.Bytes32{}, fmt.Errorf("file-name of jwt secret is empty")
 	}
-	data, err := os.ReadFile(jwtSecretPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			if !generateMissing {
-				return eth.Bytes32{}, fmt.Errorf("JWT-secret in path %q does not exist: %w", jwtSecretPath, err)
-			}
-			logger.Warn("Failed to read JWT secret from file, generating a new one now.", "path", jwtSecretPath)
-			var secret eth.Bytes32
-			if _, err := io.ReadFull(rand.Reader, secret[:]); err != nil {
-				return eth.Bytes32{}, fmt.Errorf("failed to generate jwt secret: %w", err)
-			}
-			if err := os.WriteFile(jwtSecretPath, []byte(hexutil.Encode(secret[:])), 0o600); err != nil {
-				return eth.Bytes32{}, err
-			}
-		} else {
-			return eth.Bytes32{}, fmt.Errorf("failed to read JWT secret from file path %q", jwtSecretPath)
+	// Check if the file exists
+	_, err := os.Stat(jwtSecretPath)
+	exists := !errors.Is(err, fs.ErrNotExist)
+	if exists {
+		// If the file exists, read the JWT secret from it
+		jwtSecret, err := readJWTSecret(jwtSecretPath)
+		if err != nil {
+			return eth.Bytes32{}, fmt.Errorf("failed to read JWT secret from file path %q: %w", jwtSecretPath, err)
 		}
+		return jwtSecret, nil
+	} else if generateMissing {
+		// if the file does not exist, and generation is enabled, generate a new JWT secret
+		logger.Warn("JWT secret file not found, generating a new one now.", "path ", jwtSecretPath)
+		jwtSecret, err := generateJWTSecret(jwtSecretPath)
+		if err != nil {
+			return eth.Bytes32{}, fmt.Errorf("failed to generate JWT secret in path %q: %w", jwtSecretPath, err)
+		}
+		return jwtSecret, nil
+	} else {
+		// if the file does not exist, and generation is disabled, return an error
+		return eth.Bytes32{}, fmt.Errorf("jwt secret file not found at path %q", jwtSecretPath)
 	}
+}
+
+// generateJWTSecret generates a new JWT secret and writes it to the file at the given path.
+// Prior status of the file is not checked, and the file is always overwritten.
+// Callers should ensure the file does not exist, or that overwriting is acceptable.
+func generateJWTSecret(path string) (eth.Bytes32, error) {
+	var secret eth.Bytes32
+	if _, err := io.ReadFull(rand.Reader, secret[:]); err != nil {
+		return eth.Bytes32{}, fmt.Errorf("failed to generate jwt secret: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(hexutil.Encode(secret[:])), 0o600); err != nil {
+		return eth.Bytes32{}, err
+	}
+	return secret, nil
+}
+
+// readJWTSecret reads a JWT secret from the file at the given path.
+// Prior status of the file is not checked, and the file is always read.
+// Callers should ensure the file exists
+func readJWTSecret(path string) (eth.Bytes32, error) {
+	// Read the JWT secret from the file
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return eth.Bytes32{}, fmt.Errorf("failed to read JWT secret from file path %q: %w", path, err)
+	}
+	// Parse the JWT secret from the file
 	jwtSecret := common.FromHex(strings.TrimSpace(string(data))) // FromHex handles optional '0x' prefix
 	if len(jwtSecret) != 32 {
-		return eth.Bytes32{}, fmt.Errorf("invalid jwt secret in path %q, not 32 hex-formatted bytes", jwtSecretPath)
+		return eth.Bytes32{}, fmt.Errorf("invalid jwt secret in path %q, not 32 hex-formatted bytes", path)
 	}
 	return eth.Bytes32(jwtSecret), nil
 }

--- a/op-service/rpc/jwt_test.go
+++ b/op-service/rpc/jwt_test.go
@@ -1,0 +1,46 @@
+package rpc
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestObtainJWTSecret(t *testing.T) {
+	testPath := t.TempDir()
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	t.Run("no-generate", func(t *testing.T) {
+		secret, err := ObtainJWTSecret(logger, filepath.Join(testPath, "non_existent.txt"), false)
+		require.ErrorIs(t, err, fs.ErrNotExist, "secret does not exist")
+		require.Equal(t, eth.Bytes32{}, secret)
+
+		// Not generated, still not there
+		againSecret, err := ObtainJWTSecret(logger, filepath.Join(testPath, "non_existent.txt"), false)
+		require.ErrorIs(t, err, fs.ErrNotExist, "secret does not exist")
+		require.Equal(t, eth.Bytes32{}, againSecret)
+	})
+
+	t.Run("yes-generate", func(t *testing.T) {
+		secret, err := ObtainJWTSecret(logger, filepath.Join(testPath, "will_generate.txt"), true)
+		require.NoError(t, err)
+		require.NotEqual(t, eth.Bytes32{}, secret)
+
+		// it was generated, and should be there now
+		againSecret, err := ObtainJWTSecret(logger, filepath.Join(testPath, "will_generate.txt"), false)
+		require.NoError(t, err)
+		require.Equal(t, secret, againSecret, "read the secret that was persisted")
+
+		// now read again, but suggest generating it if missing. It's not missing, so shouldn't override
+		stillSameSecret, err := ObtainJWTSecret(logger, filepath.Join(testPath, "will_generate.txt"), true)
+		require.NoError(t, err)
+		require.Equal(t, secret, stillSameSecret)
+	})
+}


### PR DESCRIPTION
# What
Fixes an incorrect behavior where callers to `ObtainJWTSecret` would error out even when `generate` is true, on first execution.

# How
- In the previous implementation, `data` is read out of the file, and if the file does not exist, it is generated. However, the generated file is not read-from again, and so while the file is created, the function still returns an error that the file does not exist.
- In this implementation, `os.Stat` is used to check the file
  - If the file exists, a `readJWTSecret` helper is used
  - If the file does not exist, but generation is enabled, a `generateJWTSecret` helper is used
  - If neither, an error is returned