### PR TITLE
Documentation improvements and remove duplicate configuration

### DIFF
--- a/op-e2e/README.md
+++ b/op-e2e/README.md
@@ -23,7 +23,7 @@ make test-ws
 
 ## Overview
 
-`op-e2e` can be categorized as following:
+`op-e2e` can be categorized as follows:
 - `op-e2e/actions/`: imperative test style, more DSL-like, with a focus on the state-transition parts of services.
   Parallel processing is actively avoided, and a mock clock is used.
   - `op-e2e/actions/*`: sub-packages categorize specific domains to test.

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -62,7 +62,6 @@ make op-node
   --p2p.priv.path=opnode_p2p_priv.txt \
   --p2p.peerstore.path=opnode_peerstore_db \
   --p2p.discovery.path=opnode_discovery_db \
-  --p2p.priv.path=opnode_p2p_priv.txt
 ```
 
 ## Usage

--- a/op-wheel/README.md
+++ b/op-wheel/README.md
@@ -20,7 +20,7 @@ The `cheat` sub-command has sub-commands for interacting with the DB, making pat
 
 Note that the validity of state-changes, as applied through patches,
 does not get checked until the block is re-processed.
-This can be used ot trick the node into things like hypothetical
+This can be used to trick the node into things like hypothetical
 test-states or shadow-forks without diverging the block-hashes.
 
 To run:


### PR DESCRIPTION
Description
1. Fixed grammar: "following" → "follows"
2. Fixed typo: "ot" → "to"
3. Removed duplicate p2p.priv.path configuration line that was redundant