### PR TITLE
Fix typos

### DIFF
--- a/op-proposer/README.md
+++ b/op-proposer/README.md
@@ -36,7 +36,7 @@ go run ./op-proposer/cmd \
       --game-type=changeme
 ```
 
-See [Proposer Configuration docs] for customization of the transaction-managent,
+See [Proposer Configuration docs] for customization of the transaction-management,
 and usage of a remote signer to isolate the proposer secret key.
 
 On test networks, `--allow-non-finalized` may be used to make proposals sooner, to reduce test time.

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -271,7 +271,7 @@ Full support for chain reorgs (detecting them, and resolving them) is the
 next priority after the above architecture and data changes.
 
 Further background on the design-choices of op-supervisor can be found in the
-[superchain backend desgin-doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/superchain-backend.md).
+[superchain backend design-do](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/superchain-backend.md).
 
 ## Design principles
 

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -271,7 +271,7 @@ Full support for chain reorgs (detecting them, and resolving them) is the
 next priority after the above architecture and data changes.
 
 Further background on the design-choices of op-supervisor can be found in the
-[superchain backend design-do](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/superchain-backend.md).
+[superchain backend design-doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/superchain-backend.md).
 
 ## Design principles
 


### PR DESCRIPTION
### File: `op-supervisor/README.md`
1. Fixed typo in word:
   - Old: `desgin-doc`
   - New: `design-doc`

### File: `op-proposer/README.md`
2. Fixed typo in word:
   - Old: `managent`
   - New: `management`

