### PR TITLE
proposal/op contracts/v1.8.0 opcm backport

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -162,7 +162,7 @@ contract Deploy is Deployer {
             L1ERC721Bridge: getAddress("L1ERC721BridgeProxy"),
             ProtocolVersions: getAddress("ProtocolVersionsProxy"),
             SuperchainConfig: getAddress("SuperchainConfigProxy"),
-            OPContractsManager: getAddress("OPContractsManagerProxy")
+            OPContractsManager: getAddress("OPContractsManager")
         });
     }
 
@@ -378,13 +378,12 @@ contract Deploy is Deployer {
         dii.set(dii.disputeGameFinalityDelaySeconds.selector, cfg.disputeGameFinalityDelaySeconds());
         dii.set(dii.mipsVersion.selector, Config.useMultithreadedCannon() ? 2 : 1);
         string memory release = "dev";
-        dii.set(dii.release.selector, release);
+        dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(
             dii.standardVersionsToml.selector, string.concat(vm.projectRoot(), "/test/fixtures/standard-versions.toml")
         );
         dii.set(dii.superchainConfigProxy.selector, mustGetAddress("SuperchainConfigProxy"));
         dii.set(dii.protocolVersionsProxy.selector, mustGetAddress("ProtocolVersionsProxy"));
-        dii.set(dii.opcmProxyOwner.selector, cfg.finalSystemOwner());
 
         if (_isInterop) {
             di = DeployImplementations(new DeployImplementationsInterop());
@@ -409,8 +408,7 @@ contract Deploy is Deployer {
         save("DelayedWETH", address(dio.delayedWETHImpl()));
         save("PreimageOracle", address(dio.preimageOracleSingleton()));
         save("Mips", address(dio.mipsSingleton()));
-        save("OPContractsManagerProxy", address(dio.opcmProxy()));
-        save("OPContractsManager", address(dio.opcmImpl()));
+        save("OPContractsManager", address(dio.opcm()));
 
         Types.ContractSet memory contracts = _impls();
         ChainAssertions.checkL1CrossDomainMessenger({ _contracts: contracts, _vm: vm, _isProxy: false });
@@ -446,7 +444,7 @@ contract Deploy is Deployer {
 
         // Ensure that the requisite contracts are deployed
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
-        OPContractsManager opcm = OPContractsManager(mustGetAddress("OPContractsManagerProxy"));
+        OPContractsManager opcm = OPContractsManager(mustGetAddress("OPContractsManager"));
 
         OPContractsManager.DeployInput memory deployInput = getDeployInput();
         OPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { LibString } from "@solady/utils/LibString.sol";
+
+import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
+import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+
+contract DeployOPCMInput is BaseDeployIO {
+    ISuperchainConfig internal _superchainConfig;
+    IProtocolVersions internal _protocolVersions;
+    string internal _l1ContractsRelease;
+
+    address internal _addressManagerBlueprint;
+    address internal _proxyBlueprint;
+    address internal _proxyAdminBlueprint;
+    address internal _l1ChugSplashProxyBlueprint;
+    address internal _resolvedDelegateProxyBlueprint;
+    address internal _anchorStateRegistryBlueprint;
+    address internal _permissionedDisputeGame1Blueprint;
+    address internal _permissionedDisputeGame2Blueprint;
+
+    address internal _l1ERC721BridgeImpl;
+    address internal _optimismPortalImpl;
+    address internal _systemConfigImpl;
+    address internal _optimismMintableERC20FactoryImpl;
+    address internal _l1CrossDomainMessengerImpl;
+    address internal _l1StandardBridgeImpl;
+    address internal _disputeGameFactoryImpl;
+    address internal _delayedWETHImpl;
+    address internal _mipsImpl;
+
+    // Setter for address type
+    function set(bytes4 _sel, address _addr) public {
+        require(_addr != address(0), "DeployOPCMInput: cannot set zero address");
+
+        if (_sel == this.superchainConfig.selector) _superchainConfig = ISuperchainConfig(_addr);
+        else if (_sel == this.protocolVersions.selector) _protocolVersions = IProtocolVersions(_addr);
+        else if (_sel == this.addressManagerBlueprint.selector) _addressManagerBlueprint = _addr;
+        else if (_sel == this.proxyBlueprint.selector) _proxyBlueprint = _addr;
+        else if (_sel == this.proxyAdminBlueprint.selector) _proxyAdminBlueprint = _addr;
+        else if (_sel == this.l1ChugSplashProxyBlueprint.selector) _l1ChugSplashProxyBlueprint = _addr;
+        else if (_sel == this.resolvedDelegateProxyBlueprint.selector) _resolvedDelegateProxyBlueprint = _addr;
+        else if (_sel == this.anchorStateRegistryBlueprint.selector) _anchorStateRegistryBlueprint = _addr;
+        else if (_sel == this.permissionedDisputeGame1Blueprint.selector) _permissionedDisputeGame1Blueprint = _addr;
+        else if (_sel == this.permissionedDisputeGame2Blueprint.selector) _permissionedDisputeGame2Blueprint = _addr;
+        else if (_sel == this.l1ERC721BridgeImpl.selector) _l1ERC721BridgeImpl = _addr;
+        else if (_sel == this.optimismPortalImpl.selector) _optimismPortalImpl = _addr;
+        else if (_sel == this.systemConfigImpl.selector) _systemConfigImpl = _addr;
+        else if (_sel == this.optimismMintableERC20FactoryImpl.selector) _optimismMintableERC20FactoryImpl = _addr;
+        else if (_sel == this.l1CrossDomainMessengerImpl.selector) _l1CrossDomainMessengerImpl = _addr;
+        else if (_sel == this.l1StandardBridgeImpl.selector) _l1StandardBridgeImpl = _addr;
+        else if (_sel == this.disputeGameFactoryImpl.selector) _disputeGameFactoryImpl = _addr;
+        else if (_sel == this.delayedWETHImpl.selector) _delayedWETHImpl = _addr;
+        else if (_sel == this.mipsImpl.selector) _mipsImpl = _addr;
+        else revert("DeployOPCMInput: unknown selector");
+    }
+
+    // Setter for string type
+    function set(bytes4 _sel, string memory _value) public {
+        require(!LibString.eq(_value, ""), "DeployOPCMInput: cannot set empty string");
+        if (_sel == this.l1ContractsRelease.selector) _l1ContractsRelease = _value;
+        else revert("DeployOPCMInput: unknown selector");
+    }
+
+    // Getters
+    function superchainConfig() public view returns (ISuperchainConfig) {
+        require(address(_superchainConfig) != address(0), "DeployOPCMInput: not set");
+        return _superchainConfig;
+    }
+
+    function protocolVersions() public view returns (IProtocolVersions) {
+        require(address(_protocolVersions) != address(0), "DeployOPCMInput: not set");
+        return _protocolVersions;
+    }
+
+    function l1ContractsRelease() public view returns (string memory) {
+        require(!LibString.eq(_l1ContractsRelease, ""), "DeployOPCMInput: not set");
+        return _l1ContractsRelease;
+    }
+
+    function addressManagerBlueprint() public view returns (address) {
+        require(_addressManagerBlueprint != address(0), "DeployOPCMInput: not set");
+        return _addressManagerBlueprint;
+    }
+
+    function proxyBlueprint() public view returns (address) {
+        require(_proxyBlueprint != address(0), "DeployOPCMInput: not set");
+        return _proxyBlueprint;
+    }
+
+    function proxyAdminBlueprint() public view returns (address) {
+        require(_proxyAdminBlueprint != address(0), "DeployOPCMInput: not set");
+        return _proxyAdminBlueprint;
+    }
+
+    function l1ChugSplashProxyBlueprint() public view returns (address) {
+        require(_l1ChugSplashProxyBlueprint != address(0), "DeployOPCMInput: not set");
+        return _l1ChugSplashProxyBlueprint;
+    }
+
+    function resolvedDelegateProxyBlueprint() public view returns (address) {
+        require(_resolvedDelegateProxyBlueprint != address(0), "DeployOPCMInput: not set");
+        return _resolvedDelegateProxyBlueprint;
+    }
+
+    function anchorStateRegistryBlueprint() public view returns (address) {
+        require(_anchorStateRegistryBlueprint != address(0), "DeployOPCMInput: not set");
+        return _anchorStateRegistryBlueprint;
+    }
+
+    function permissionedDisputeGame1Blueprint() public view returns (address) {
+        require(_permissionedDisputeGame1Blueprint != address(0), "DeployOPCMInput: not set");
+        return _permissionedDisputeGame1Blueprint;
+    }
+
+    function permissionedDisputeGame2Blueprint() public view returns (address) {
+        require(_permissionedDisputeGame2Blueprint != address(0), "DeployOPCMInput: not set");
+        return _permissionedDisputeGame2Blueprint;
+    }
+
+    function l1ERC721BridgeImpl() public view returns (address) {
+        require(_l1ERC721BridgeImpl != address(0), "DeployOPCMInput: not set");
+        return _l1ERC721BridgeImpl;
+    }
+
+    function optimismPortalImpl() public view returns (address) {
+        require(_optimismPortalImpl != address(0), "DeployOPCMInput: not set");
+        return _optimismPortalImpl;
+    }
+
+    function systemConfigImpl() public view returns (address) {
+        require(_systemConfigImpl != address(0), "DeployOPCMInput: not set");
+        return _systemConfigImpl;
+    }
+
+    function optimismMintableERC20FactoryImpl() public view returns (address) {
+        require(_optimismMintableERC20FactoryImpl != address(0), "DeployOPCMInput: not set");
+        return _optimismMintableERC20FactoryImpl;
+    }
+
+    function l1CrossDomainMessengerImpl() public view returns (address) {
+        require(_l1CrossDomainMessengerImpl != address(0), "DeployOPCMInput: not set");
+        return _l1CrossDomainMessengerImpl;
+    }
+
+    function l1StandardBridgeImpl() public view returns (address) {
+        require(_l1StandardBridgeImpl != address(0), "DeployOPCMInput: not set");
+        return _l1StandardBridgeImpl;
+    }
+
+    function disputeGameFactoryImpl() public view returns (address) {
+        require(_disputeGameFactoryImpl != address(0), "DeployOPCMInput: not set");
+        return _disputeGameFactoryImpl;
+    }
+
+    function delayedWETHImpl() public view returns (address) {
+        require(_delayedWETHImpl != address(0), "DeployOPCMInput: not set");
+        return _delayedWETHImpl;
+    }
+
+    function mipsImpl() public view returns (address) {
+        require(_mipsImpl != address(0), "DeployOPCMInput: not set");
+        return _mipsImpl;
+    }
+}
+
+contract DeployOPCMOutput is BaseDeployIO {
+    OPContractsManager internal _opcm;
+
+    // Setter for address type
+    function set(bytes4 _sel, address _addr) public {
+        require(_addr != address(0), "DeployOPCMOutput: cannot set zero address");
+        if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
+        else revert("DeployOPCMOutput: unknown selector");
+    }
+
+    // Getter
+    function opcm() public view returns (OPContractsManager) {
+        require(address(_opcm) != address(0), "DeployOPCMOutput: not set");
+        return _opcm;
+    }
+}
+
+contract DeployOPCM is Script {
+    function run(DeployOPCMInput _doi, DeployOPCMOutput _doo) public {
+        OPContractsManager.Blueprints memory blueprints = OPContractsManager.Blueprints({
+            addressManager: _doi.addressManagerBlueprint(),
+            proxy: _doi.proxyBlueprint(),
+            proxyAdmin: _doi.proxyAdminBlueprint(),
+            l1ChugSplashProxy: _doi.l1ChugSplashProxyBlueprint(),
+            resolvedDelegateProxy: _doi.resolvedDelegateProxyBlueprint(),
+            anchorStateRegistry: _doi.anchorStateRegistryBlueprint(),
+            permissionedDisputeGame1: _doi.permissionedDisputeGame1Blueprint(),
+            permissionedDisputeGame2: _doi.permissionedDisputeGame2Blueprint()
+        });
+        OPContractsManager.Implementations memory implementations = OPContractsManager.Implementations({
+            l1ERC721BridgeImpl: address(_doi.l1ERC721BridgeImpl()),
+            optimismPortalImpl: address(_doi.optimismPortalImpl()),
+            systemConfigImpl: address(_doi.systemConfigImpl()),
+            optimismMintableERC20FactoryImpl: address(_doi.optimismMintableERC20FactoryImpl()),
+            l1CrossDomainMessengerImpl: address(_doi.l1CrossDomainMessengerImpl()),
+            l1StandardBridgeImpl: address(_doi.l1StandardBridgeImpl()),
+            disputeGameFactoryImpl: address(_doi.disputeGameFactoryImpl()),
+            delayedWETHImpl: address(_doi.delayedWETHImpl()),
+            mipsImpl: address(_doi.mipsImpl())
+        });
+
+        OPContractsManager opcm_ = deployOPCM(
+            _doi.superchainConfig(), _doi.protocolVersions(), blueprints, implementations, _doi.l1ContractsRelease()
+        );
+        _doo.set(_doo.opcm.selector, address(opcm_));
+
+        assertValidOpcm(_doi, _doo);
+    }
+
+    function deployOPCM(
+        ISuperchainConfig _superchainConfig,
+        IProtocolVersions _protocolVersions,
+        OPContractsManager.Blueprints memory _blueprints,
+        OPContractsManager.Implementations memory _implementations,
+        string memory _l1ContractsRelease
+    )
+        public
+        returns (OPContractsManager opcm_)
+    {
+        vm.broadcast(msg.sender);
+        opcm_ = new OPContractsManager(
+            _superchainConfig, _protocolVersions, _l1ContractsRelease, _blueprints, _implementations
+        );
+        vm.label(address(opcm_), "OPContractsManager");
+    }
+
+    function assertValidOpcm(DeployOPCMInput _doi, DeployOPCMOutput _doo) public view {
+        OPContractsManager impl = OPContractsManager(address(_doo.opcm()));
+        require(address(impl.superchainConfig()) == address(_doi.superchainConfig()), "OPCMI-10");
+        require(address(impl.protocolVersions()) == address(_doi.protocolVersions()), "OPCMI-20");
+        require(LibString.eq(impl.l1ContractsRelease(), _doi.l1ContractsRelease()));
+
+        OPContractsManager.Blueprints memory blueprints = impl.blueprints();
+        require(blueprints.addressManager == _doi.addressManagerBlueprint(), "OPCMI-40");
+        require(blueprints.proxy == _doi.proxyBlueprint(), "OPCMI-50");
+        require(blueprints.proxyAdmin == _doi.proxyAdminBlueprint(), "OPCMI-60");
+        require(blueprints.l1ChugSplashProxy == _doi.l1ChugSplashProxyBlueprint(), "OPCMI-70");
+        require(blueprints.resolvedDelegateProxy == _doi.resolvedDelegateProxyBlueprint(), "OPCMI-80");
+        require(blueprints.anchorStateRegistry == _doi.anchorStateRegistryBlueprint(), "OPCMI-90");
+        require(blueprints.permissionedDisputeGame1 == _doi.permissionedDisputeGame1Blueprint(), "OPCMI-100");
+        require(blueprints.permissionedDisputeGame2 == _doi.permissionedDisputeGame2Blueprint(), "OPCMI-110");
+
+        OPContractsManager.Implementations memory implementations = impl.implementations();
+        require(implementations.l1ERC721BridgeImpl == _doi.l1ERC721BridgeImpl(), "OPCMI-120");
+        require(implementations.optimismPortalImpl == _doi.optimismPortalImpl(), "OPCMI-130");
+        require(implementations.systemConfigImpl == _doi.systemConfigImpl(), "OPCMI-140");
+        require(
+            implementations.optimismMintableERC20FactoryImpl == _doi.optimismMintableERC20FactoryImpl(), "OPCMI-150"
+        );
+        require(implementations.l1CrossDomainMessengerImpl == _doi.l1CrossDomainMessengerImpl(), "OPCMI-160");
+        require(implementations.l1StandardBridgeImpl == _doi.l1StandardBridgeImpl(), "OPCMI-170");
+        require(implementations.disputeGameFactoryImpl == _doi.disputeGameFactoryImpl(), "OPCMI-180");
+        require(implementations.delayedWETHImpl == _doi.delayedWETHImpl(), "OPCMI-190");
+        require(implementations.mipsImpl == _doi.mipsImpl(), "OPCMI-200");
+    }
+
+    function etchIOContracts() public returns (DeployOPCMInput doi_, DeployOPCMOutput doo_) {
+        (doi_, doo_) = getIOContracts();
+        vm.etch(address(doi_), type(DeployOPCMInput).runtimeCode);
+        vm.etch(address(doo_), type(DeployOPCMOutput).runtimeCode);
+    }
+
+    function getIOContracts() public view returns (DeployOPCMInput doi_, DeployOPCMOutput doo_) {
+        doi_ = DeployOPCMInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPCMInput"));
+        doo_ = DeployOPCMOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPCMOutput"));
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -47,7 +47,7 @@ contract DeployOPChainInput is BaseDeployIO {
     uint32 internal _basefeeScalar;
     uint32 internal _blobBaseFeeScalar;
     uint256 internal _l2ChainId;
-    OPContractsManager internal _opcmProxy;
+    OPContractsManager internal _opcm;
     string internal _saltMixer;
     uint64 internal _gasLimit;
 
@@ -68,7 +68,7 @@ contract DeployOPChainInput is BaseDeployIO {
         else if (_sel == this.unsafeBlockSigner.selector) _unsafeBlockSigner = _addr;
         else if (_sel == this.proposer.selector) _proposer = _addr;
         else if (_sel == this.challenger.selector) _challenger = _addr;
-        else if (_sel == this.opcmProxy.selector) _opcmProxy = OPContractsManager(_addr);
+        else if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
         else revert("DeployOPChainInput: unknown selector");
     }
 
@@ -174,11 +174,10 @@ contract DeployOPChainInput is BaseDeployIO {
         return abi.encode(ScriptConstants.DEFAULT_STARTING_ANCHOR_ROOTS());
     }
 
-    function opcmProxy() public returns (OPContractsManager) {
-        require(address(_opcmProxy) != address(0), "DeployOPChainInput: not set");
-        DeployUtils.assertValidContractAddress(address(_opcmProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_opcmProxy));
-        return _opcmProxy;
+    function opcm() public view returns (OPContractsManager) {
+        require(address(_opcm) != address(0), "DeployOPChainInput: not set");
+        DeployUtils.assertValidContractAddress(address(_opcm));
+        return _opcm;
     }
 
     function saltMixer() public view returns (string memory) {
@@ -235,7 +234,7 @@ contract DeployOPChainOutput is BaseDeployIO {
     IDelayedWETH internal _delayedWETHPermissionedGameProxy;
     IDelayedWETH internal _delayedWETHPermissionlessGameProxy;
 
-    function set(bytes4 _sel, address _addr) public {
+    function set(bytes4 _sel, address _addr) public virtual {
         require(_addr != address(0), "DeployOPChainOutput: cannot set zero address");
         // forgefmt: disable-start
         if (_sel == this.opChainProxyAdmin.selector) _opChainProxyAdmin = IProxyAdmin(_addr) ;
@@ -347,7 +346,7 @@ contract DeployOPChain is Script {
     // -------- Core Deployment Methods --------
 
     function run(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
-        OPContractsManager opcmProxy = _doi.opcmProxy();
+        OPContractsManager opcm = _doi.opcm();
 
         OPContractsManager.Roles memory roles = OPContractsManager.Roles({
             opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
@@ -374,7 +373,7 @@ contract DeployOPChain is Script {
         });
 
         vm.broadcast(msg.sender);
-        OPContractsManager.DeployOutput memory deployOutput = opcmProxy.deploy(deployInput);
+        OPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
 
         vm.label(address(deployOutput.opChainProxyAdmin), "opChainProxyAdmin");
         vm.label(address(deployOutput.addressManager), "addressManager");
@@ -480,9 +479,9 @@ contract DeployOPChain is Script {
             "DPG-20"
         );
 
-        OPContractsManager opcm = _doi.opcmProxy();
-        (address mips,) = opcm.implementations(opcm.latestRelease(), "MIPS");
-        require(game.vm() == IBigStepper(mips), "DPG-30");
+        OPContractsManager opcm = _doi.opcm();
+        address mipsImpl = opcm.implementations().mipsImpl;
+        require(game.vm() == IBigStepper(mipsImpl), "DPG-30");
 
         require(address(game.weth()) == address(_doo.delayedWETHPermissionedGameProxy()), "DPG-40");
         require(address(game.anchorStateRegistry()) == address(_doo.anchorStateRegistryProxy()), "DPG-50");
@@ -552,9 +551,7 @@ contract DeployOPChain is Script {
         require(outputConfig.maximumBaseFee == rConfig.maximumBaseFee, "SYSCON-130");
 
         require(systemConfig.startBlock() == block.number, "SYSCON-140");
-        require(
-            systemConfig.batchInbox() == _doi.opcmProxy().chainIdToBatchInboxAddress(_doi.l2ChainId()), "SYSCON-150"
-        );
+        require(systemConfig.batchInbox() == _doi.opcm().chainIdToBatchInboxAddress(_doi.l2ChainId()), "SYSCON-150");
 
         require(systemConfig.l1CrossDomainMessenger() == address(_doo.l1CrossDomainMessengerProxy()), "SYSCON-160");
         require(systemConfig.l1ERC721Bridge() == address(_doo.l1ERC721BridgeProxy()), "SYSCON-170");
@@ -579,7 +576,7 @@ contract DeployOPChain is Script {
 
         require(address(messenger.PORTAL()) == address(_doo.optimismPortalProxy()), "L1xDM-30");
         require(address(messenger.portal()) == address(_doo.optimismPortalProxy()), "L1xDM-40");
-        require(address(messenger.superchainConfig()) == address(_doi.opcmProxy().superchainConfig()), "L1xDM-50");
+        require(address(messenger.superchainConfig()) == address(_doi.opcm().superchainConfig()), "L1xDM-50");
 
         bytes32 xdmSenderSlot = vm.load(address(messenger), bytes32(uint256(204)));
         require(address(uint160(uint256(xdmSenderSlot))) == Constants.DEFAULT_L2_SENDER, "L1xDM-60");
@@ -595,7 +592,7 @@ contract DeployOPChain is Script {
         require(address(bridge.messenger()) == address(messenger), "L1SB-20");
         require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_STANDARD_BRIDGE, "L1SB-30");
         require(address(bridge.otherBridge()) == Predeploys.L2_STANDARD_BRIDGE, "L1SB-40");
-        require(address(bridge.superchainConfig()) == address(_doi.opcmProxy().superchainConfig()), "L1SB-50");
+        require(address(bridge.superchainConfig()) == address(_doi.opcm().superchainConfig()), "L1SB-50");
     }
 
     function assertValidOptimismMintableERC20Factory(DeployOPChainInput, DeployOPChainOutput _doo) internal {
@@ -617,12 +614,12 @@ contract DeployOPChain is Script {
 
         require(address(bridge.MESSENGER()) == address(_doo.l1CrossDomainMessengerProxy()), "L721B-30");
         require(address(bridge.messenger()) == address(_doo.l1CrossDomainMessengerProxy()), "L721B-40");
-        require(address(bridge.superchainConfig()) == address(_doi.opcmProxy().superchainConfig()), "L721B-50");
+        require(address(bridge.superchainConfig()) == address(_doi.opcm().superchainConfig()), "L721B-50");
     }
 
     function assertValidOptimismPortal(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {
         IOptimismPortal2 portal = _doo.optimismPortalProxy();
-        ISuperchainConfig superchainConfig = ISuperchainConfig(address(_doi.opcmProxy().superchainConfig()));
+        ISuperchainConfig superchainConfig = ISuperchainConfig(address(_doi.opcm().superchainConfig()));
 
         require(address(portal.disputeGameFactory()) == address(_doo.disputeGameFactoryProxy()), "PORTAL-10");
         require(address(portal.systemConfig()) == address(_doo.systemConfigProxy()), "PORTAL-20");

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
+import { IProxy } from "src/universal/interfaces/IProxy.sol";
+import { Script } from "forge-std/Script.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { DeployOPChainOutput } from "scripts/deploy/DeployOPChain.s.sol";
+import { IMIPS } from "src/cannon/interfaces/IMIPS.sol";
+import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IAddressManager } from "src/legacy/interfaces/IAddressManager.sol";
+import { IStaticL1ChugSplashProxy } from "src/legacy/interfaces/IL1ChugSplashProxy.sol";
+
+contract ReadImplementationAddressesInput is DeployOPChainOutput {
+    OPContractsManager internal _opcm;
+
+    function set(bytes4 _sel, address _addr) public override {
+        require(_addr != address(0), "ReadImplementationAddressesInput: cannot set zero address");
+        if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
+        else if (_sel == this.addressManager.selector) _addressManager = IAddressManager(_addr);
+        else super.set(_sel, _addr);
+    }
+
+    function opcm() public view returns (OPContractsManager) {
+        DeployUtils.assertValidContractAddress(address(_opcm));
+        return _opcm;
+    }
+}
+
+contract ReadImplementationAddressesOutput is BaseDeployIO {
+    address internal _delayedWETH;
+    address internal _optimismPortal;
+    address internal _systemConfig;
+    address internal _l1CrossDomainMessenger;
+    address internal _l1ERC721Bridge;
+    address internal _l1StandardBridge;
+    address internal _optimismMintableERC20Factory;
+    address internal _disputeGameFactory;
+    address internal _mipsSingleton;
+    address internal _preimageOracleSingleton;
+
+    function set(bytes4 _sel, address _addr) public {
+        require(_addr != address(0), "ReadImplementationAddressesOutput: cannot set zero address");
+        if (_sel == this.delayedWETH.selector) _delayedWETH = _addr;
+        else if (_sel == this.optimismPortal.selector) _optimismPortal = _addr;
+        else if (_sel == this.systemConfig.selector) _systemConfig = _addr;
+        else if (_sel == this.l1CrossDomainMessenger.selector) _l1CrossDomainMessenger = _addr;
+        else if (_sel == this.l1ERC721Bridge.selector) _l1ERC721Bridge = _addr;
+        else if (_sel == this.l1StandardBridge.selector) _l1StandardBridge = _addr;
+        else if (_sel == this.optimismMintableERC20Factory.selector) _optimismMintableERC20Factory = _addr;
+        else if (_sel == this.disputeGameFactory.selector) _disputeGameFactory = _addr;
+        else if (_sel == this.mipsSingleton.selector) _mipsSingleton = _addr;
+        else if (_sel == this.preimageOracleSingleton.selector) _preimageOracleSingleton = _addr;
+        else revert("ReadImplementationAddressesOutput: unknown selector");
+    }
+
+    function delayedWETH() public view returns (address) {
+        require(_delayedWETH != address(0), "ReadImplementationAddressesOutput: delayedWETH not set");
+        return _delayedWETH;
+    }
+
+    function optimismPortal() public view returns (address) {
+        require(_optimismPortal != address(0), "ReadImplementationAddressesOutput: optimismPortal not set");
+        return _optimismPortal;
+    }
+
+    function systemConfig() public view returns (address) {
+        require(_systemConfig != address(0), "ReadImplementationAddressesOutput: systemConfig not set");
+        return _systemConfig;
+    }
+
+    function l1CrossDomainMessenger() public view returns (address) {
+        require(
+            _l1CrossDomainMessenger != address(0), "ReadImplementationAddressesOutput: l1CrossDomainMessenger not set"
+        );
+        return _l1CrossDomainMessenger;
+    }
+
+    function l1ERC721Bridge() public view returns (address) {
+        require(_l1ERC721Bridge != address(0), "ReadImplementationAddressesOutput: l1ERC721Bridge not set");
+        return _l1ERC721Bridge;
+    }
+
+    function l1StandardBridge() public view returns (address) {
+        require(_l1StandardBridge != address(0), "ReadImplementationAddressesOutput: l1StandardBridge not set");
+        return _l1StandardBridge;
+    }
+
+    function optimismMintableERC20Factory() public view returns (address) {
+        require(
+            _optimismMintableERC20Factory != address(0),
+            "ReadImplementationAddressesOutput: optimismMintableERC20Factory not set"
+        );
+        return _optimismMintableERC20Factory;
+    }
+
+    function disputeGameFactory() public view returns (address) {
+        require(_disputeGameFactory != address(0), "ReadImplementationAddressesOutput: disputeGameFactory not set");
+        return _disputeGameFactory;
+    }
+
+    function mipsSingleton() public view returns (address) {
+        require(_mipsSingleton != address(0), "ReadImplementationAddressesOutput: mipsSingleton not set");
+        return _mipsSingleton;
+    }
+
+    function preimageOracleSingleton() public view returns (address) {
+        require(
+            _preimageOracleSingleton != address(0), "ReadImplementationAddressesOutput: preimageOracleSingleton not set"
+        );
+        return _preimageOracleSingleton;
+    }
+}
+
+contract ReadImplementationAddresses is Script {
+    function run(ReadImplementationAddressesInput _rii, ReadImplementationAddressesOutput _rio) public {
+        address[6] memory eip1967Proxies = [
+            address(_rii.delayedWETHPermissionedGameProxy()),
+            address(_rii.optimismPortalProxy()),
+            address(_rii.systemConfigProxy()),
+            address(_rii.l1ERC721BridgeProxy()),
+            address(_rii.optimismMintableERC20FactoryProxy()),
+            address(_rii.disputeGameFactoryProxy())
+        ];
+
+        bytes4[6] memory sels = [
+            _rio.delayedWETH.selector,
+            _rio.optimismPortal.selector,
+            _rio.systemConfig.selector,
+            _rio.l1ERC721Bridge.selector,
+            _rio.optimismMintableERC20Factory.selector,
+            _rio.disputeGameFactory.selector
+        ];
+
+        for (uint256 i = 0; i < eip1967Proxies.length; i++) {
+            IProxy proxy = IProxy(payable(eip1967Proxies[i]));
+            vm.prank(address(0));
+            _rio.set(sels[i], proxy.implementation());
+        }
+
+        vm.prank(address(0));
+        address l1SBImpl = IStaticL1ChugSplashProxy(address(_rii.l1StandardBridgeProxy())).getImplementation();
+        vm.prank(address(0));
+        _rio.set(_rio.l1StandardBridge.selector, l1SBImpl);
+
+        address mipsLogic = _rii.opcm().implementations().mipsImpl;
+        _rio.set(_rio.mipsSingleton.selector, mipsLogic);
+
+        address delayedWETH = _rii.opcm().implementations().delayedWETHImpl;
+        _rio.set(_rio.delayedWETH.selector, delayedWETH);
+
+        IAddressManager am = _rii.addressManager();
+        _rio.set(_rio.l1CrossDomainMessenger.selector, am.getAddress("OVM_L1CrossDomainMessenger"));
+
+        address preimageOracle = address(IMIPS(mipsLogic).oracle());
+        _rio.set(_rio.preimageOracleSingleton.selector, preimageOracle);
+    }
+}

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0x4132ff37d267cb12224b75ea806c0aa7d25407b0d66ce526d7fcda8f7d223882"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xd58cb3978affc5c1457cdd498ff8420c90aef804d4c3b62cf42ab2691986d6d2",
-    "sourceCodeHash": "0x7bfa6eff76176649fe600303cd60009a0f6e282cbaec55836b5ea1f8875cbeb5"
+    "initCodeHash": "0xd038cc35325d023499151264232d75fa4ecc81f04a8c8353e6b50c43af224d6e",
+    "sourceCodeHash": "0xa13f3ab2b8744015290dbabe5f20fdd44774607e6a7ad3e5e016303fc4aa8c12"
   },
   "src/L1/OptimismPortal.sol": {
     "initCodeHash": "0x152167cfa18635ae4918a6eb3371a599cfa084418c0a652799cdb48bfc0ee0cc",
@@ -152,7 +152,7 @@
     "sourceCodeHash": "0x171d66c651fdad2ac9c287da92689815a5b09589945ada092179508ad2326306"
   },
   "src/cannon/PreimageOracle.sol": {
-    "initCodeHash": "0x5d7e8ae64f802bd9d760e3d52c0a620bd02405dc2c8795818db9183792ffe81c",
+    "initCodeHash": "0x2d25bb2b1cb536ec7d72e7b3f977e335b6ba4d0ed0b08f2394fa9f62e86d7c7a",
     "sourceCodeHash": "0x979d8595d925c70a123e72c062fa58c9ef94777c2e93b6bc3231d6679e2e9055"
   },
   "src/dispute/AnchorStateRegistry.sol": {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -10,6 +10,110 @@
         "internalType": "contract IProtocolVersions",
         "name": "_protocolVersions",
         "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_l1ContractsRelease",
+        "type": "string"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addressManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "proxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "proxyAdmin",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1ChugSplashProxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "resolvedDelegateProxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "anchorStateRegistry",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGame1",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGame2",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.Blueprints",
+        "name": "_blueprints",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "l1ERC721BridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismPortalImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "systemConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC20FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1CrossDomainMessengerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1StandardBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "disputeGameFactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "delayedWETHImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "mipsImpl",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.Implementations",
+        "name": "_implementations",
+        "type": "tuple"
       }
     ],
     "stateMutability": "nonpayable",
@@ -298,138 +402,68 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
+    "inputs": [],
     "name": "implementations",
     "outputs": [
       {
-        "internalType": "address",
-        "name": "logic",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "initializer",
-        "type": "bytes4"
+        "components": [
+          {
+            "internalType": "address",
+            "name": "l1ERC721BridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismPortalImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "systemConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC20FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1CrossDomainMessengerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1StandardBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "disputeGameFactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "delayedWETHImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "mipsImpl",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.Implementations",
+        "name": "",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "addressManager",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "proxy",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "proxyAdmin",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "l1ChugSplashProxy",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "resolvedDelegateProxy",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "anchorStateRegistry",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "permissionedDisputeGame1",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "permissionedDisputeGame2",
-                "type": "address"
-              }
-            ],
-            "internalType": "struct OPContractsManager.Blueprints",
-            "name": "blueprints",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              {
-                "internalType": "string",
-                "name": "name",
-                "type": "string"
-              },
-              {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "logic",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "bytes4",
-                    "name": "initializer",
-                    "type": "bytes4"
-                  }
-                ],
-                "internalType": "struct OPContractsManager.Implementation",
-                "name": "info",
-                "type": "tuple"
-              }
-            ],
-            "internalType": "struct OPContractsManager.ImplementationSetter[]",
-            "name": "setters",
-            "type": "tuple[]"
-          },
-          {
-            "internalType": "string",
-            "name": "release",
-            "type": "string"
-          },
-          {
-            "internalType": "bool",
-            "name": "isLatest",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct OPContractsManager.InitializerInputs",
-        "name": "_initializerInputs",
-        "type": "tuple"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
-    "name": "latestRelease",
+    "name": "l1ContractsRelease",
     "outputs": [
       {
         "internalType": "string",
@@ -527,19 +561,6 @@
       }
     ],
     "name": "Deployed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "version",
-        "type": "uint8"
-      }
-    ],
-    "name": "Initialized",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -10,6 +10,110 @@
         "internalType": "contract IProtocolVersions",
         "name": "_protocolVersions",
         "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_l1ContractsRelease",
+        "type": "string"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addressManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "proxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "proxyAdmin",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1ChugSplashProxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "resolvedDelegateProxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "anchorStateRegistry",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGame1",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGame2",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.Blueprints",
+        "name": "_blueprints",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "l1ERC721BridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismPortalImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "systemConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC20FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1CrossDomainMessengerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1StandardBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "disputeGameFactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "delayedWETHImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "mipsImpl",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.Implementations",
+        "name": "_implementations",
+        "type": "tuple"
       }
     ],
     "stateMutability": "nonpayable",
@@ -298,138 +402,68 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
+    "inputs": [],
     "name": "implementations",
     "outputs": [
       {
-        "internalType": "address",
-        "name": "logic",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "initializer",
-        "type": "bytes4"
+        "components": [
+          {
+            "internalType": "address",
+            "name": "l1ERC721BridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismPortalImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "systemConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC20FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1CrossDomainMessengerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1StandardBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "disputeGameFactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "delayedWETHImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "mipsImpl",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.Implementations",
+        "name": "",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "addressManager",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "proxy",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "proxyAdmin",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "l1ChugSplashProxy",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "resolvedDelegateProxy",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "anchorStateRegistry",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "permissionedDisputeGame1",
-                "type": "address"
-              },
-              {
-                "internalType": "address",
-                "name": "permissionedDisputeGame2",
-                "type": "address"
-              }
-            ],
-            "internalType": "struct OPContractsManager.Blueprints",
-            "name": "blueprints",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              {
-                "internalType": "string",
-                "name": "name",
-                "type": "string"
-              },
-              {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "logic",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "bytes4",
-                    "name": "initializer",
-                    "type": "bytes4"
-                  }
-                ],
-                "internalType": "struct OPContractsManager.Implementation",
-                "name": "info",
-                "type": "tuple"
-              }
-            ],
-            "internalType": "struct OPContractsManager.ImplementationSetter[]",
-            "name": "setters",
-            "type": "tuple[]"
-          },
-          {
-            "internalType": "string",
-            "name": "release",
-            "type": "string"
-          },
-          {
-            "internalType": "bool",
-            "name": "isLatest",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct OPContractsManager.InitializerInputs",
-        "name": "_initializerInputs",
-        "type": "tuple"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
-    "name": "latestRelease",
+    "name": "l1ContractsRelease",
     "outputs": [
       {
         "internalType": "string",
@@ -527,19 +561,6 @@
       }
     ],
     "name": "Deployed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "version",
-        "type": "uint8"
-      }
-    ],
-    "name": "Initialized",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
@@ -1,51 +1,30 @@
 [
   {
-    "bytes": "1",
-    "label": "_initialized",
-    "offset": 0,
-    "slot": "0",
-    "type": "uint8"
-  },
-  {
-    "bytes": "1",
-    "label": "_initializing",
-    "offset": 1,
-    "slot": "0",
-    "type": "bool"
-  },
-  {
     "bytes": "32",
-    "label": "latestRelease",
+    "label": "l1ContractsRelease",
     "offset": 0,
-    "slot": "1",
+    "slot": "0",
     "type": "string"
-  },
-  {
-    "bytes": "32",
-    "label": "implementations",
-    "offset": 0,
-    "slot": "2",
-    "type": "mapping(string => mapping(string => struct OPContractsManager.Implementation))"
   },
   {
     "bytes": "32",
     "label": "systemConfigs",
     "offset": 0,
-    "slot": "3",
+    "slot": "1",
     "type": "mapping(uint256 => contract ISystemConfig)"
   },
   {
     "bytes": "256",
     "label": "blueprint",
     "offset": 0,
-    "slot": "4",
+    "slot": "2",
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "1600",
-    "label": "__gap",
+    "bytes": "288",
+    "label": "implementation",
     "offset": 0,
-    "slot": "12",
-    "type": "uint256[50]"
+    "slot": "10",
+    "type": "struct OPContractsManager.Implementations"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
@@ -1,51 +1,30 @@
 [
   {
-    "bytes": "1",
-    "label": "_initialized",
-    "offset": 0,
-    "slot": "0",
-    "type": "uint8"
-  },
-  {
-    "bytes": "1",
-    "label": "_initializing",
-    "offset": 1,
-    "slot": "0",
-    "type": "bool"
-  },
-  {
     "bytes": "32",
-    "label": "latestRelease",
+    "label": "l1ContractsRelease",
     "offset": 0,
-    "slot": "1",
+    "slot": "0",
     "type": "string"
-  },
-  {
-    "bytes": "32",
-    "label": "implementations",
-    "offset": 0,
-    "slot": "2",
-    "type": "mapping(string => mapping(string => struct OPContractsManager.Implementation))"
   },
   {
     "bytes": "32",
     "label": "systemConfigs",
     "offset": 0,
-    "slot": "3",
+    "slot": "1",
     "type": "mapping(uint256 => contract ISystemConfig)"
   },
   {
     "bytes": "256",
     "label": "blueprint",
     "offset": 0,
-    "slot": "4",
+    "slot": "2",
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "1600",
-    "label": "__gap",
+    "bytes": "288",
+    "label": "implementation",
     "offset": 0,
-    "slot": "12",
-    "type": "uint256[50]"
+    "slot": "10",
+    "type": "struct OPContractsManager.Implementations"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
@@ -6,20 +6,22 @@ import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
 import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
+import { ISystemConfigInterop } from "src/L1/interfaces/ISystemConfigInterop.sol";
 
-/// @custom:proxied true
 contract OPContractsManagerInterop is OPContractsManager {
     constructor(
         ISuperchainConfig _superchainConfig,
-        IProtocolVersions _protocolVersions
+        IProtocolVersions _protocolVersions,
+        string memory _l1ContractsRelease,
+        Blueprints memory _blueprints,
+        Implementations memory _implementations
     )
-        OPContractsManager(_superchainConfig, _protocolVersions)
+        OPContractsManager(_superchainConfig, _protocolVersions, _l1ContractsRelease, _blueprints, _implementations)
     { }
 
     // The `SystemConfigInterop` contract has an extra `address _dependencyManager` argument
     // that we must account for.
     function encodeSystemConfigInitializer(
-        bytes4 _selector,
         DeployInput memory _input,
         DeployOutput memory _output
     )
@@ -29,8 +31,9 @@ contract OPContractsManagerInterop is OPContractsManager {
         override
         returns (bytes memory)
     {
+        bytes4 selector = ISystemConfigInterop.initialize.selector;
         (IResourceMetering.ResourceConfig memory referenceResourceConfig, ISystemConfig.Addresses memory opChainAddrs) =
-            defaultSystemConfigParams(_selector, _input, _output);
+            defaultSystemConfigParams(selector, _input, _output);
 
         // TODO For now we assume that the dependency manager is the same as system config owner.
         // This is currently undefined since it's not part of the standard config, so we may need
@@ -40,7 +43,7 @@ contract OPContractsManagerInterop is OPContractsManager {
         address dependencyManager = address(_input.roles.systemConfigOwner);
 
         return abi.encodeWithSelector(
-            _selector,
+            selector,
             _input.roles.systemConfigOwner,
             _input.basefeeScalar,
             _input.blobBasefeeScalar,

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -14,9 +14,12 @@ import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
 contract OPContractsManager_Harness is OPContractsManager {
     constructor(
         ISuperchainConfig _superchainConfig,
-        IProtocolVersions _protocolVersions
+        IProtocolVersions _protocolVersions,
+        string memory _l1ContractsRelease,
+        Blueprints memory _blueprints,
+        Implementations memory _implementations
     )
-        OPContractsManager(_superchainConfig, _protocolVersions)
+        OPContractsManager(_superchainConfig, _protocolVersions, _l1ContractsRelease, _blueprints, _implementations)
     { }
 
     function chainIdToBatchInboxAddress_exposed(uint256 l2ChainId) public pure returns (address) {
@@ -49,7 +52,7 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcmProxy.selector, address(opcm));
+        doi.set(doi.opcm.selector, address(opcm));
         doi.set(doi.gasLimit.selector, gasLimit);
 
         doi.set(doi.disputeGameType.selector, disputeGameType);
@@ -116,12 +119,17 @@ contract OPContractsManager_InternalMethods_Test is Test {
     function setUp() public {
         ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfig"));
         IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersions"));
+        OPContractsManager.Blueprints memory emptyBlueprints;
+        OPContractsManager.Implementations memory emptyImpls;
         vm.etch(address(superchainConfigProxy), hex"01");
         vm.etch(address(protocolVersionsProxy), hex"01");
 
         opcmHarness = new OPContractsManager_Harness({
             _superchainConfig: superchainConfigProxy,
-            _protocolVersions: protocolVersionsProxy
+            _protocolVersions: protocolVersionsProxy,
+            _l1ContractsRelease: "dev",
+            _blueprints: emptyBlueprints,
+            _implementations: emptyImpls
         });
     }
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -44,7 +44,7 @@ contract DeployImplementationsInput_Test is Test {
         dii = new DeployImplementationsInput();
     }
 
-    function test_getters_whenNotSet_revert() public {
+    function test_getters_whenNotSet_reverts() public {
         vm.expectRevert("DeployImplementationsInput: not set");
         dii.withdrawalDelaySeconds();
 
@@ -61,7 +61,7 @@ contract DeployImplementationsInput_Test is Test {
         dii.disputeGameFinalityDelaySeconds();
 
         vm.expectRevert("DeployImplementationsInput: not set");
-        dii.release();
+        dii.l1ContractsRelease();
 
         vm.expectRevert("DeployImplementationsInput: not set");
         dii.superchainConfigProxy();
@@ -70,21 +70,7 @@ contract DeployImplementationsInput_Test is Test {
         dii.protocolVersionsProxy();
 
         vm.expectRevert("DeployImplementationsInput: not set");
-        dii.opcmProxyOwner();
-
-        vm.expectRevert("DeployImplementationsInput: not set");
         dii.standardVersionsToml();
-    }
-
-    function test_opcmProxyOwner_whenNotSet_reverts() public {
-        vm.expectRevert("DeployImplementationsInput: not set");
-        dii.opcmProxyOwner();
-    }
-
-    function test_opcmProxyOwner_succeeds() public {
-        dii.set(dii.opcmProxyOwner.selector, address(msg.sender));
-        address opcmProxyOwner = dii.opcmProxyOwner();
-        assertEq(address(msg.sender), address(opcmProxyOwner), "100");
     }
 }
 
@@ -96,17 +82,7 @@ contract DeployImplementationsOutput_Test is Test {
     }
 
     function test_set_succeeds() public {
-        IProxy proxy = IProxy(
-            DeployUtils.create1({
-                _name: "Proxy",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (address(0))))
-            })
-        );
-        address opcmImpl = address(makeAddr("opcmImpl"));
-        vm.prank(address(0));
-        proxy.upgradeTo(opcmImpl);
-
-        OPContractsManager opcmProxy = OPContractsManager(address(proxy));
+        OPContractsManager opcm = OPContractsManager(address(makeAddr("opcm")));
         IOptimismPortal2 optimismPortalImpl = IOptimismPortal2(payable(makeAddr("optimismPortalImpl")));
         IDelayedWETH delayedWETHImpl = IDelayedWETH(payable(makeAddr("delayedWETHImpl")));
         IPreimageOracle preimageOracleSingleton = IPreimageOracle(makeAddr("preimageOracleSingleton"));
@@ -120,8 +96,7 @@ contract DeployImplementationsOutput_Test is Test {
             IOptimismMintableERC20Factory(makeAddr("optimismMintableERC20FactoryImpl"));
         IDisputeGameFactory disputeGameFactoryImpl = IDisputeGameFactory(makeAddr("disputeGameFactoryImpl"));
 
-        vm.etch(address(opcmProxy), address(opcmProxy).code);
-        vm.etch(address(opcmImpl), hex"01");
+        vm.etch(address(opcm), hex"01");
         vm.etch(address(optimismPortalImpl), hex"01");
         vm.etch(address(delayedWETHImpl), hex"01");
         vm.etch(address(preimageOracleSingleton), hex"01");
@@ -132,7 +107,7 @@ contract DeployImplementationsOutput_Test is Test {
         vm.etch(address(l1StandardBridgeImpl), hex"01");
         vm.etch(address(optimismMintableERC20FactoryImpl), hex"01");
         vm.etch(address(disputeGameFactoryImpl), hex"01");
-        dio.set(dio.opcmProxy.selector, address(opcmProxy));
+        dio.set(dio.opcm.selector, address(opcm));
         dio.set(dio.optimismPortalImpl.selector, address(optimismPortalImpl));
         dio.set(dio.delayedWETHImpl.selector, address(delayedWETHImpl));
         dio.set(dio.preimageOracleSingleton.selector, address(preimageOracleSingleton));
@@ -144,7 +119,7 @@ contract DeployImplementationsOutput_Test is Test {
         dio.set(dio.optimismMintableERC20FactoryImpl.selector, address(optimismMintableERC20FactoryImpl));
         dio.set(dio.disputeGameFactoryImpl.selector, address(disputeGameFactoryImpl));
 
-        assertEq(address(opcmProxy), address(dio.opcmProxy()), "50");
+        assertEq(address(opcm), address(dio.opcm()), "50");
         assertEq(address(optimismPortalImpl), address(dio.optimismPortalImpl()), "100");
         assertEq(address(delayedWETHImpl), address(dio.delayedWETHImpl()), "200");
         assertEq(address(preimageOracleSingleton), address(dio.preimageOracleSingleton()), "300");
@@ -157,7 +132,7 @@ contract DeployImplementationsOutput_Test is Test {
         assertEq(address(disputeGameFactoryImpl), address(dio.disputeGameFactoryImpl()), "950");
     }
 
-    function test_getters_whenNotSet_revert() public {
+    function test_getters_whenNotSet_reverts() public {
         bytes memory expectedErr = "DeployUtils: zero address";
 
         vm.expectRevert(expectedErr);
@@ -273,7 +248,7 @@ contract DeployImplementations_Test is Test {
 
     function test_deployImplementation_succeeds() public {
         string memory deployContractsRelease = "dev-release";
-        dii.set(dii.release.selector, deployContractsRelease);
+        dii.set(dii.l1ContractsRelease.selector, deployContractsRelease);
         deployImplementations.deploySystemConfigImpl(dii, dio);
         assertTrue(address(0) != address(dio.systemConfigImpl()));
     }
@@ -282,7 +257,7 @@ contract DeployImplementations_Test is Test {
         // All hardcoded addresses below are taken from the superchain-registry config:
         // https://github.com/ethereum-optimism/superchain-registry/blob/be65d22f8128cf0c4e5b4e1f677daf86843426bf/validation/standard/standard-versions.toml#L11
         string memory testRelease = "op-contracts/v1.6.0";
-        dii.set(dii.release.selector, testRelease);
+        dii.set(dii.l1ContractsRelease.selector, testRelease);
 
         deployImplementations.deploySystemConfigImpl(dii, dio);
         address srSystemConfigImpl = address(0xF56D96B2535B932656d3c04Ebf51baBff241D886);
@@ -335,71 +310,6 @@ contract DeployImplementations_Test is Test {
         assertEq(srDisputeGameFactoryImpl, address(dio.disputeGameFactoryImpl()));
     }
 
-    function test_deployAtNonExistentRelease_reverts() public {
-        string memory unknownRelease = "op-contracts/v0.0.0";
-        dii.set(dii.release.selector, unknownRelease);
-
-        bytes memory expectedErr =
-            bytes(string.concat("DeployImplementations: failed to deploy release ", unknownRelease));
-
-        vm.expectRevert(expectedErr);
-        deployImplementations.deploySystemConfigImpl(dii, dio);
-
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployL1CrossDomainMessengerImpl(dii, dio);
-
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployL1ERC721BridgeImpl(dii, dio);
-
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployL1StandardBridgeImpl(dii, dio);
-
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployOptimismMintableERC20FactoryImpl(dii, dio);
-
-        // TODO: Uncomment the code below when OPContractsManager is deployed based on release. Superchain-registry
-        // doesn't contain OPContractsManager yet.
-        // dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
-        // dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
-        // vm.etch(address(superchainConfigProxy), hex"01");
-        // vm.etch(address(protocolVersionsProxy), hex"01");
-        // vm.expectRevert(expectedErr);
-        // deployImplementations.deployOPContractsManagerImpl(dii, dio);
-
-        dii.set(dii.proofMaturityDelaySeconds.selector, 1);
-        dii.set(dii.disputeGameFinalityDelaySeconds.selector, 2);
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployOptimismPortalImpl(dii, dio);
-
-        dii.set(dii.withdrawalDelaySeconds.selector, 1);
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployDelayedWETHImpl(dii, dio);
-
-        dii.set(dii.minProposalSizeBytes.selector, 1);
-        dii.set(dii.challengePeriodSeconds.selector, 2);
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployPreimageOracleSingleton(dii, dio);
-
-        address preImageOracleSingleton = makeAddr("preImageOracleSingleton");
-        vm.etch(address(preImageOracleSingleton), hex"01");
-        dio.set(dio.preimageOracleSingleton.selector, preImageOracleSingleton);
-        vm.expectRevert(expectedErr);
-        deployImplementations.deployMipsSingleton(dii, dio);
-
-        vm.expectRevert(expectedErr); // fault proof contracts don't exist at this release
-        deployImplementations.deployDisputeGameFactoryImpl(dii, dio);
-    }
-
-    function test_noContractExistsAtRelease_reverts() public {
-        string memory unknownRelease = "op-contracts/v1.3.0";
-        dii.set(dii.release.selector, unknownRelease);
-        bytes memory expectedErr =
-            bytes(string.concat("DeployImplementations: failed to deploy release ", unknownRelease));
-
-        vm.expectRevert(expectedErr); // fault proof contracts don't exist at this release
-        deployImplementations.deployDisputeGameFactoryImpl(dii, dio);
-    }
-
     function testFuzz_run_memory_succeeds(bytes32 _seed) public {
         withdrawalDelaySeconds = uint256(hash(_seed, 0));
         minProposalSizeBytes = uint256(hash(_seed, 1));
@@ -409,7 +319,7 @@ contract DeployImplementations_Test is Test {
         string memory release = string(bytes.concat(hash(_seed, 5)));
         protocolVersionsProxy = IProtocolVersions(address(uint160(uint256(hash(_seed, 7)))));
 
-        // Must configure the ProxyAdmin contract which is used to upgrade the OPCM's proxy contract.
+        // Must configure the ProxyAdmin contract.
         IProxyAdmin superchainProxyAdmin = IProxyAdmin(
             DeployUtils.create1({
                 _name: "ProxyAdmin",
@@ -439,10 +349,9 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.proofMaturityDelaySeconds.selector, proofMaturityDelaySeconds);
         dii.set(dii.disputeGameFinalityDelaySeconds.selector, disputeGameFinalityDelaySeconds);
         dii.set(dii.mipsVersion.selector, 1);
-        dii.set(dii.release.selector, release);
+        dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
-        dii.set(dii.opcmProxyOwner.selector, msg.sender);
 
         deployImplementations.run(dii, dio);
 
@@ -453,10 +362,9 @@ contract DeployImplementations_Test is Test {
         assertEq(proofMaturityDelaySeconds, dii.proofMaturityDelaySeconds(), "400");
         assertEq(disputeGameFinalityDelaySeconds, dii.disputeGameFinalityDelaySeconds(), "500");
         assertEq(1, dii.mipsVersion(), "512");
-        assertEq(release, dii.release(), "525");
+        assertEq(release, dii.l1ContractsRelease(), "525");
         assertEq(address(superchainConfigProxy), address(dii.superchainConfigProxy()), "550");
         assertEq(address(protocolVersionsProxy), address(dii.protocolVersionsProxy()), "575");
-        assertEq(msg.sender, dii.opcmProxyOwner(), "580");
 
         // Architecture assertions.
         assertEq(address(dio.mipsSingleton().oracle()), address(dio.preimageOracleSingleton()), "600");
@@ -475,7 +383,7 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.disputeGameFinalityDelaySeconds.selector, disputeGameFinalityDelaySeconds);
         dii.set(dii.mipsVersion.selector, 1);
         string memory release = "dev-release";
-        dii.set(dii.release.selector, release);
+        dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
 

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { DeployOPCM, DeployOPCMInput, DeployOPCMOutput } from "scripts/deploy/DeployOPCM.s.sol";
+import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { IProtocolVersions } from "src/L1/interfaces/IProtocolVersions.sol";
+
+contract DeployOPCMInput_Test is Test {
+    DeployOPCMInput dii;
+    string release = "1.0.0";
+
+    function setUp() public {
+        dii = new DeployOPCMInput();
+    }
+
+    function test_getters_whenNotSet_reverts() public {
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.superchainConfig();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.protocolVersions();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1ContractsRelease();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.addressManagerBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.proxyBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.proxyAdminBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1ChugSplashProxyBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.resolvedDelegateProxyBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.anchorStateRegistryBlueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.permissionedDisputeGame1Blueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.permissionedDisputeGame2Blueprint();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1ERC721BridgeImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.optimismPortalImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.systemConfigImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.optimismMintableERC20FactoryImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1CrossDomainMessengerImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.l1StandardBridgeImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.disputeGameFactoryImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.delayedWETHImpl();
+
+        vm.expectRevert("DeployOPCMInput: not set");
+        dii.mipsImpl();
+    }
+
+    // Below setter tests are split into two parts to avoid stack too deep errors
+
+    function test_set_part1_succeeds() public {
+        ISuperchainConfig superchainConfig = ISuperchainConfig(makeAddr("superchainConfig"));
+        IProtocolVersions protocolVersions = IProtocolVersions(makeAddr("protocolVersions"));
+        address addressManagerBlueprint = makeAddr("addressManagerBlueprint");
+        address proxyBlueprint = makeAddr("proxyBlueprint");
+        address proxyAdminBlueprint = makeAddr("proxyAdminBlueprint");
+        address l1ChugSplashProxyBlueprint = makeAddr("l1ChugSplashProxyBlueprint");
+        address resolvedDelegateProxyBlueprint = makeAddr("resolvedDelegateProxyBlueprint");
+        address anchorStateRegistryBlueprint = makeAddr("anchorStateRegistryBlueprint");
+        address permissionedDisputeGame1Blueprint = makeAddr("permissionedDisputeGame1Blueprint");
+        address permissionedDisputeGame2Blueprint = makeAddr("permissionedDisputeGame2Blueprint");
+
+        dii.set(dii.superchainConfig.selector, address(superchainConfig));
+        dii.set(dii.protocolVersions.selector, address(protocolVersions));
+        dii.set(dii.l1ContractsRelease.selector, release);
+        dii.set(dii.addressManagerBlueprint.selector, addressManagerBlueprint);
+        dii.set(dii.proxyBlueprint.selector, proxyBlueprint);
+        dii.set(dii.proxyAdminBlueprint.selector, proxyAdminBlueprint);
+        dii.set(dii.l1ChugSplashProxyBlueprint.selector, l1ChugSplashProxyBlueprint);
+        dii.set(dii.resolvedDelegateProxyBlueprint.selector, resolvedDelegateProxyBlueprint);
+        dii.set(dii.anchorStateRegistryBlueprint.selector, anchorStateRegistryBlueprint);
+        dii.set(dii.permissionedDisputeGame1Blueprint.selector, permissionedDisputeGame1Blueprint);
+        dii.set(dii.permissionedDisputeGame2Blueprint.selector, permissionedDisputeGame2Blueprint);
+
+        assertEq(address(dii.superchainConfig()), address(superchainConfig), "50");
+        assertEq(address(dii.protocolVersions()), address(protocolVersions), "100");
+        assertEq(dii.l1ContractsRelease(), release, "150");
+        assertEq(dii.addressManagerBlueprint(), addressManagerBlueprint, "200");
+        assertEq(dii.proxyBlueprint(), proxyBlueprint, "250");
+        assertEq(dii.proxyAdminBlueprint(), proxyAdminBlueprint, "300");
+        assertEq(dii.l1ChugSplashProxyBlueprint(), l1ChugSplashProxyBlueprint, "350");
+        assertEq(dii.resolvedDelegateProxyBlueprint(), resolvedDelegateProxyBlueprint, "400");
+        assertEq(dii.anchorStateRegistryBlueprint(), anchorStateRegistryBlueprint, "450");
+        assertEq(dii.permissionedDisputeGame1Blueprint(), permissionedDisputeGame1Blueprint, "500");
+        assertEq(dii.permissionedDisputeGame2Blueprint(), permissionedDisputeGame2Blueprint, "550");
+    }
+
+    function test_set_part2_succeeds() public {
+        address l1ERC721BridgeImpl = makeAddr("l1ERC721BridgeImpl");
+        address optimismPortalImpl = makeAddr("optimismPortalImpl");
+        address systemConfigImpl = makeAddr("systemConfigImpl");
+        address optimismMintableERC20FactoryImpl = makeAddr("optimismMintableERC20FactoryImpl");
+        address l1CrossDomainMessengerImpl = makeAddr("l1CrossDomainMessengerImpl");
+        address l1StandardBridgeImpl = makeAddr("l1StandardBridgeImpl");
+        address disputeGameFactoryImpl = makeAddr("disputeGameFactoryImpl");
+        address delayedWETHImpl = makeAddr("delayedWETHImpl");
+        address mipsImpl = makeAddr("mipsImpl");
+
+        dii.set(dii.l1ERC721BridgeImpl.selector, l1ERC721BridgeImpl);
+        dii.set(dii.optimismPortalImpl.selector, optimismPortalImpl);
+        dii.set(dii.systemConfigImpl.selector, systemConfigImpl);
+        dii.set(dii.optimismMintableERC20FactoryImpl.selector, optimismMintableERC20FactoryImpl);
+        dii.set(dii.l1CrossDomainMessengerImpl.selector, l1CrossDomainMessengerImpl);
+        dii.set(dii.l1StandardBridgeImpl.selector, l1StandardBridgeImpl);
+        dii.set(dii.disputeGameFactoryImpl.selector, disputeGameFactoryImpl);
+        dii.set(dii.delayedWETHImpl.selector, delayedWETHImpl);
+        dii.set(dii.mipsImpl.selector, mipsImpl);
+
+        assertEq(dii.l1ERC721BridgeImpl(), l1ERC721BridgeImpl, "600");
+        assertEq(dii.optimismPortalImpl(), optimismPortalImpl, "650");
+        assertEq(dii.systemConfigImpl(), systemConfigImpl, "700");
+        assertEq(dii.optimismMintableERC20FactoryImpl(), optimismMintableERC20FactoryImpl, "750");
+        assertEq(dii.l1CrossDomainMessengerImpl(), l1CrossDomainMessengerImpl, "800");
+        assertEq(dii.l1StandardBridgeImpl(), l1StandardBridgeImpl, "850");
+        assertEq(dii.disputeGameFactoryImpl(), disputeGameFactoryImpl, "900");
+        assertEq(dii.delayedWETHImpl(), delayedWETHImpl, "950");
+        assertEq(dii.mipsImpl(), mipsImpl, "1000");
+    }
+
+    function test_set_withZeroAddress_reverts() public {
+        vm.expectRevert("DeployOPCMInput: cannot set zero address");
+        dii.set(dii.superchainConfig.selector, address(0));
+    }
+
+    function test_set_withEmptyString_reverts() public {
+        vm.expectRevert("DeployOPCMInput: cannot set empty string");
+        dii.set(dii.l1ContractsRelease.selector, "");
+    }
+
+    function test_set_withInvalidSelector_reverts() public {
+        vm.expectRevert("DeployOPCMInput: unknown selector");
+        dii.set(bytes4(0xdeadbeef), address(1));
+    }
+
+    function test_set_withInvalidStringSelector_reverts() public {
+        vm.expectRevert("DeployOPCMInput: unknown selector");
+        dii.set(bytes4(0xdeadbeef), "test");
+    }
+}
+
+contract DeployOPCMOutput_Test is Test {
+    DeployOPCMOutput doo;
+
+    function setUp() public {
+        doo = new DeployOPCMOutput();
+    }
+
+    function test_getters_whenNotSet_reverts() public {
+        vm.expectRevert("DeployOPCMOutput: not set");
+        doo.opcm();
+    }
+
+    function test_set_succeeds() public {
+        OPContractsManager opcm = OPContractsManager(makeAddr("opcm"));
+        vm.etch(address(opcm), hex"01");
+
+        doo.set(doo.opcm.selector, address(opcm));
+
+        assertEq(address(doo.opcm()), address(opcm), "50");
+    }
+
+    function test_set_withZeroAddress_reverts() public {
+        vm.expectRevert("DeployOPCMOutput: cannot set zero address");
+        doo.set(doo.opcm.selector, address(0));
+    }
+
+    function test_set_withInvalidSelector_reverts() public {
+        vm.expectRevert("DeployOPCMOutput: unknown selector");
+        doo.set(bytes4(0xdeadbeef), makeAddr("test"));
+    }
+}
+
+contract DeployOPCMTest is Test {
+    DeployOPCM deployOPCM;
+    DeployOPCMInput doi;
+    DeployOPCMOutput doo;
+
+    ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
+    IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+
+    function setUp() public virtual {
+        deployOPCM = new DeployOPCM();
+        (doi, doo) = deployOPCM.etchIOContracts();
+    }
+
+    function test_run_succeeds() public {
+        doi.set(doi.superchainConfig.selector, address(superchainConfigProxy));
+        doi.set(doi.protocolVersions.selector, address(protocolVersionsProxy));
+        doi.set(doi.l1ContractsRelease.selector, "1.0.0");
+
+        // Set and etch blueprints
+        doi.set(doi.addressManagerBlueprint.selector, makeAddr("addressManagerBlueprint"));
+        doi.set(doi.proxyBlueprint.selector, makeAddr("proxyBlueprint"));
+        doi.set(doi.proxyAdminBlueprint.selector, makeAddr("proxyAdminBlueprint"));
+        doi.set(doi.l1ChugSplashProxyBlueprint.selector, makeAddr("l1ChugSplashProxyBlueprint"));
+        doi.set(doi.resolvedDelegateProxyBlueprint.selector, makeAddr("resolvedDelegateProxyBlueprint"));
+        doi.set(doi.anchorStateRegistryBlueprint.selector, makeAddr("anchorStateRegistryBlueprint"));
+        doi.set(doi.permissionedDisputeGame1Blueprint.selector, makeAddr("permissionedDisputeGame1Blueprint"));
+        doi.set(doi.permissionedDisputeGame2Blueprint.selector, makeAddr("permissionedDisputeGame2Blueprint"));
+
+        // Set and etch implementations
+        doi.set(doi.l1ERC721BridgeImpl.selector, makeAddr("l1ERC721BridgeImpl"));
+        doi.set(doi.optimismPortalImpl.selector, makeAddr("optimismPortalImpl"));
+        doi.set(doi.systemConfigImpl.selector, makeAddr("systemConfigImpl"));
+        doi.set(doi.optimismMintableERC20FactoryImpl.selector, makeAddr("optimismMintableERC20FactoryImpl"));
+        doi.set(doi.l1CrossDomainMessengerImpl.selector, makeAddr("l1CrossDomainMessengerImpl"));
+        doi.set(doi.l1StandardBridgeImpl.selector, makeAddr("l1StandardBridgeImpl"));
+        doi.set(doi.disputeGameFactoryImpl.selector, makeAddr("disputeGameFactoryImpl"));
+        doi.set(doi.delayedWETHImpl.selector, makeAddr("delayedWETHImpl"));
+        doi.set(doi.mipsImpl.selector, makeAddr("mipsImpl"));
+
+        // Etch all addresses with dummy bytecode
+        vm.etch(address(doi.superchainConfig()), hex"01");
+        vm.etch(address(doi.protocolVersions()), hex"01");
+
+        vm.etch(doi.addressManagerBlueprint(), hex"01");
+        vm.etch(doi.proxyBlueprint(), hex"01");
+        vm.etch(doi.proxyAdminBlueprint(), hex"01");
+        vm.etch(doi.l1ChugSplashProxyBlueprint(), hex"01");
+        vm.etch(doi.resolvedDelegateProxyBlueprint(), hex"01");
+        vm.etch(doi.anchorStateRegistryBlueprint(), hex"01");
+        vm.etch(doi.permissionedDisputeGame1Blueprint(), hex"01");
+        vm.etch(doi.permissionedDisputeGame2Blueprint(), hex"01");
+
+        vm.etch(doi.l1ERC721BridgeImpl(), hex"01");
+        vm.etch(doi.optimismPortalImpl(), hex"01");
+        vm.etch(doi.systemConfigImpl(), hex"01");
+        vm.etch(doi.optimismMintableERC20FactoryImpl(), hex"01");
+        vm.etch(doi.l1CrossDomainMessengerImpl(), hex"01");
+        vm.etch(doi.l1StandardBridgeImpl(), hex"01");
+        vm.etch(doi.disputeGameFactoryImpl(), hex"01");
+        vm.etch(doi.delayedWETHImpl(), hex"01");
+        vm.etch(doi.mipsImpl(), hex"01");
+
+        deployOPCM.run(doi, doo);
+
+        assertNotEq(address(doo.opcm()), address(0));
+
+        // sanity check to ensure that the OPCM is validated
+        deployOPCM.assertValidOpcm(doi, doo);
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -39,10 +39,10 @@ contract DeployOPChainInput_Test is Test {
     address unsafeBlockSigner = makeAddr("unsafeBlockSigner");
     address proposer = makeAddr("proposer");
     address challenger = makeAddr("challenger");
+    address opcm = makeAddr("opcm");
     uint32 basefeeScalar = 100;
     uint32 blobBaseFeeScalar = 200;
     uint256 l2ChainId = 300;
-    OPContractsManager opcm = OPContractsManager(makeAddr("opcm"));
     string saltMixer = "saltMixer";
 
     function setUp() public {
@@ -60,9 +60,8 @@ contract DeployOPChainInput_Test is Test {
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
         doi.set(doi.allowCustomDisputeParameters.selector, true);
-
-        (IProxy opcmProxy) = DeployUtils.buildERC1967ProxyWithImpl("opcmProxy");
-        doi.set(doi.opcmProxy.selector, address(opcmProxy));
+        doi.set(doi.opcm.selector, opcm);
+        vm.etch(opcm, hex"01");
 
         // Compare the default inputs to the getter methods.
         assertEq(opChainProxyAdminOwner, doi.opChainProxyAdminOwner(), "200");
@@ -74,11 +73,11 @@ contract DeployOPChainInput_Test is Test {
         assertEq(basefeeScalar, doi.basefeeScalar(), "800");
         assertEq(blobBaseFeeScalar, doi.blobBaseFeeScalar(), "900");
         assertEq(l2ChainId, doi.l2ChainId(), "1000");
-        assertEq(address(opcmProxy), address(doi.opcmProxy()), "1100");
+        assertEq(opcm, address(doi.opcm()), "1100");
         assertEq(true, doi.allowCustomDisputeParameters(), "1200");
     }
 
-    function test_getters_whenNotSet_revert() public {
+    function test_getters_whenNotSet_reverts() public {
         bytes memory expectedErr = "DeployOPChainInput: not set";
 
         vm.expectRevert(expectedErr);
@@ -182,7 +181,7 @@ contract DeployOPChainOutput_Test is Test {
         // "1600");
     }
 
-    function test_getters_whenNotSet_revert() public {
+    function test_getters_whenNotSet_reverts() public {
         bytes memory expectedErr = "DeployUtils: zero address";
 
         vm.expectRevert(expectedErr);
@@ -396,7 +395,7 @@ contract DeployOPChain_TestBase is Test {
         dii.set(dii.proofMaturityDelaySeconds.selector, proofMaturityDelaySeconds);
         dii.set(dii.disputeGameFinalityDelaySeconds.selector, disputeGameFinalityDelaySeconds);
         dii.set(dii.mipsVersion.selector, 1);
-        dii.set(dii.release.selector, release);
+        dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
         // End users of the DeployImplementations contract will need to set the `standardVersionsToml`.
@@ -404,7 +403,7 @@ contract DeployOPChain_TestBase is Test {
             string.concat(vm.projectRoot(), "/test/fixtures/standard-versions.toml");
         string memory standardVersionsToml = vm.readFile(standardVersionsTomlPath);
         dii.set(dii.standardVersionsToml.selector, standardVersionsToml);
-        dii.set(dii.opcmProxyOwner.selector, address(1));
+
         deployImplementations.run(dii, dio);
 
         // Deploy DeployOpChain, but defer populating the input values to the test suites inheriting this contract.
@@ -412,7 +411,7 @@ contract DeployOPChain_TestBase is Test {
         (doi, doo) = deployOPChain.etchIOContracts();
 
         // Set the OPContractsManager input for DeployOPChain.
-        opcm = dio.opcmProxy();
+        opcm = dio.opcm();
     }
 
     // See the function of the same name in the `DeployImplementations_Test` contract of
@@ -427,7 +426,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         return keccak256(abi.encode(_seed, _i));
     }
 
-    function testFuzz_run_memory_succeed(bytes32 _seed) public {
+    function testFuzz_run_memory_succeeds(bytes32 _seed) public {
         opChainProxyAdminOwner = address(uint160(uint256(hash(_seed, 0))));
         systemConfigOwner = address(uint160(uint256(hash(_seed, 1))));
         batcher = address(uint160(uint256(hash(_seed, 2))));
@@ -466,7 +465,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcmProxy.selector, address(opcm)); // Not fuzzed since it must be an actual instance.
+        doi.set(doi.opcm.selector, address(opcm));
         doi.set(doi.saltMixer.selector, saltMixer);
         doi.set(doi.gasLimit.selector, gasLimit);
         doi.set(doi.disputeGameType.selector, disputeGameType);
@@ -541,7 +540,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         deployOPChain.run(doi, doo);
     }
 
-    function test_customDisputeGame_customEnabled_doesNotRevert() public {
+    function test_customDisputeGame_customEnabled_succeeds() public {
         setDOI();
         doi.set(doi.allowCustomDisputeParameters.selector, true);
         doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth + 1);
@@ -559,7 +558,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
         doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcmProxy.selector, address(opcm));
+        doi.set(doi.opcm.selector, address(opcm));
         doi.set(doi.saltMixer.selector, saltMixer);
         doi.set(doi.gasLimit.selector, gasLimit);
         doi.set(doi.disputeGameType.selector, disputeGameType);

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -849,27 +849,25 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("version()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("protocolVersions()") });
-        _addSpec({ _name: "OPContractsManager", _sel: _getSel("latestRelease()") });
-        _addSpec({ _name: "OPContractsManager", _sel: _getSel("implementations(string,string)") });
+        _addSpec({ _name: "OPContractsManager", _sel: _getSel("l1ContractsRelease()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("systemConfigs(uint256)") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("OUTPUT_VERSION()") });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.initialize.selector });
         _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.deploy.selector });
         _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.blueprints.selector });
         _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.chainIdToBatchInboxAddress.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.implementations.selector });
 
         // OPContractsManagerInterop
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("version()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("protocolVersions()") });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("latestRelease()") });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("implementations(string,string)") });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("l1ContractsRelease()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("systemConfigs(uint256)") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("OUTPUT_VERSION()") });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.initialize.selector });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.deploy.selector });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.blueprints.selector });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.chainIdToBatchInboxAddress.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.implementations.selector });
 
         // DeputyGuardianModule
         _addSpec({


### PR DESCRIPTION
- contracts: v1.8.0
- contracts: finalize release
- ci: fix
- feat(ctb): Holocene upgrade package (#12878)
- downgrade `SystemConfigInterop` back to proper version from `origin/develop`
- remove `-beta` from `FaultDisputeGame`
- ctb: Fix Holocene upgrade script (#13015)
- ctb: Holocene upgrade script: make contract release tag configurable
- more script fixes
- fix contract address fetcher
- make shellcheck happy
- improve readme and .env.example
- more fixes & shallow cloning
- clarify readme
- bump op-contracts release to rc.4 in .env.example
- op-deployer/ctb: Add DeployOPCM script (#13187)
- ctb: Backport deployment changes
- snapshots
- semver
