### PR TITLE
cannon: Use 32-bit futex values

### DIFF
--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -120,8 +120,7 @@ func (m *InstrumentedState) handleSyscall() error {
 				v1 = exec.MipsEAGAIN
 			} else {
 				thread.FutexAddr = effFutexAddr
-				// TODO: Change FutexVal field to 32-bit
-				thread.FutexVal = Word(targetVal)
+				thread.FutexVal = targetVal
 				if a3 == 0 {
 					thread.FutexTimeoutStep = exec.FutexNoTimeout
 				} else {
@@ -286,8 +285,7 @@ func (m *InstrumentedState) doMipsStep() error {
 			return nil
 		} else {
 			futexVal := m.getFutexValue(thread.FutexAddr)
-			// TODO: Change FutexVal field to 32-bit
-			if uint32(thread.FutexVal) == futexVal {
+			if thread.FutexVal == futexVal {
 				// still got expected value, continue sleeping, try next thread.
 				m.preemptThread(thread)
 				m.statsTracker.trackWakeupFail()

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -109,7 +109,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		return nil
 	case arch.SysFutex:
 		// args: a0 = addr, a1 = op, a2 = val, a3 = timeout
-		// Futex value is 32-bit, so mask out the lower 2 bits
+		// Futex value is 32-bit, so clear the lower 2 bits to get an effective address targeting a 4-byte value
 		effFutexAddr := a0 & ^Word(0x3)
 		switch a1 {
 		case exec.FutexWaitPrivate:

--- a/cannon/mipsevm/multithreaded/state_test.go
+++ b/cannon/mipsevm/multithreaded/state_test.go
@@ -399,7 +399,7 @@ func TestStateWitnessSize(t *testing.T) {
 func TestThreadStateWitnessSize(t *testing.T) {
 	expectedWitnessSize := 166
 	if !arch.IsMips32 {
-		expectedWitnessSize = 322
+		expectedWitnessSize = 318
 	}
 	require.Equal(t, expectedWitnessSize, SERIALIZED_THREAD_SIZE)
 }

--- a/cannon/mipsevm/multithreaded/testutil/expectations.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations.go
@@ -48,7 +48,7 @@ type ExpectedThreadState struct {
 	ExitCode         uint8
 	Exited           bool
 	FutexAddr        arch.Word
-	FutexVal         arch.Word
+	FutexVal         uint32
 	FutexTimeoutStep uint64
 	PC               arch.Word
 	NextPC           arch.Word

--- a/cannon/mipsevm/multithreaded/thread.go
+++ b/cannon/mipsevm/multithreaded/thread.go
@@ -18,12 +18,12 @@ const (
 	THREAD_EXITED_WITNESS_OFFSET             = THREAD_EXIT_CODE_WITNESS_OFFSET + 1
 	THREAD_FUTEX_ADDR_WITNESS_OFFSET         = THREAD_EXITED_WITNESS_OFFSET + 1
 	THREAD_FUTEX_VAL_WITNESS_OFFSET          = THREAD_FUTEX_ADDR_WITNESS_OFFSET + arch.WordSizeBytes
-	THREAD_FUTEX_TIMEOUT_STEP_WITNESS_OFFSET = THREAD_FUTEX_VAL_WITNESS_OFFSET + arch.WordSizeBytes
+	THREAD_FUTEX_TIMEOUT_STEP_WITNESS_OFFSET = THREAD_FUTEX_VAL_WITNESS_OFFSET + 4
 	THREAD_FUTEX_CPU_WITNESS_OFFSET          = THREAD_FUTEX_TIMEOUT_STEP_WITNESS_OFFSET + 8
 	THREAD_REGISTERS_WITNESS_OFFSET          = THREAD_FUTEX_CPU_WITNESS_OFFSET + (4 * arch.WordSizeBytes)
 
 	// SERIALIZED_THREAD_SIZE is the size of a serialized ThreadState object
-	// 166 and 322 bytes for 32 and 64-bit respectively
+	// 166 and 318 bytes for 32 and 64-bit respectively
 	SERIALIZED_THREAD_SIZE = THREAD_REGISTERS_WITNESS_OFFSET + (32 * arch.WordSizeBytes)
 
 	// THREAD_WITNESS_SIZE is the size of a thread witness encoded in bytes.
@@ -41,7 +41,7 @@ type ThreadState struct {
 	ExitCode         uint8              `json:"exit"`
 	Exited           bool               `json:"exited"`
 	FutexAddr        Word               `json:"futexAddr"`
-	FutexVal         Word               `json:"futexVal"`
+	FutexVal         uint32             `json:"futexVal"`
 	FutexTimeoutStep uint64             `json:"futexTimeoutStep"`
 	Cpu              mipsevm.CpuScalars `json:"cpu"`
 	Registers        [32]Word           `json:"registers"`
@@ -73,7 +73,7 @@ func (t *ThreadState) serializeThread() []byte {
 	out = append(out, t.ExitCode)
 	out = mipsevm.AppendBoolToWitness(out, t.Exited)
 	out = arch.ByteOrderWord.AppendWord(out, t.FutexAddr)
-	out = arch.ByteOrderWord.AppendWord(out, t.FutexVal)
+	out = binary.BigEndian.AppendUint32(out, t.FutexVal)
 	out = binary.BigEndian.AppendUint64(out, t.FutexTimeoutStep)
 
 	out = arch.ByteOrderWord.AppendWord(out, t.Cpu.PC)

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -509,6 +509,7 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 	}
 	for i, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			rand := testutil.NewRandHelper(int64(i * 33))
 			goVm, state, contracts := setup(t, i*1234, nil, testutil.WithPCAndNextPC(0x04))
 			step := state.GetStep()
 
@@ -517,7 +518,8 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = Word(c.addressParam)
 			state.GetRegistersRef()[5] = exec.FutexWaitPrivate
-			state.GetRegistersRef()[6] = Word(c.targetValue)
+			// Randomize upper bytes of futex target
+			state.GetRegistersRef()[6] = (rand.Word() & ^Word(0xFF_FF_FF_FF)) | Word(c.targetValue)
 			state.GetRegistersRef()[7] = Word(c.timeout)
 
 			// Setup expectations

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -514,7 +514,7 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 			step := state.GetStep()
 
 			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			testutil.SetMemoryUint32(state.GetMemory(), Word(c.effAddr), c.actualValue, int64(i+22))
+			testutil.RandomizeWordAndSetUint32(state.GetMemory(), Word(c.effAddr), c.actualValue, int64(i+22))
 			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = Word(c.addressParam)
 			state.GetRegistersRef()[5] = exec.FutexWaitPrivate
@@ -1065,7 +1065,7 @@ func TestEVM_NormalTraversalStep_HandleWaitingThread(t *testing.T) {
 				activeThread.FutexAddr = c.futexAddr
 				activeThread.FutexVal = c.targetValue
 				activeThread.FutexTimeoutStep = c.timeoutStep
-				testutil.SetMemoryUint32(state.GetMemory(), c.effAddr, c.actualValue, int64(i+11))
+				testutil.RandomizeWordAndSetUint32(state.GetMemory(), c.effAddr, c.actualValue, int64(i+11))
 
 				// Set up post-state expectations
 				expected := mttestutil.NewExpectedMTState(state)
@@ -1203,7 +1203,7 @@ func TestEVM_WakeupTraversalStep(t *testing.T) {
 
 			state.Wakeup = c.wakeupAddr
 			effWakeupAddr := ^Word(3) & c.wakeupAddr
-			testutil.SetMemoryUint32(state.GetMemory(), effWakeupAddr, wakeupVal, int64(i+1000))
+			testutil.RandomizeWordAndSetUint32(state.GetMemory(), effWakeupAddr, wakeupVal, int64(i+1000))
 			activeThread := state.GetCurrentThread()
 			activeThread.FutexAddr = c.futexAddr
 			activeThread.FutexVal = c.targetVal
@@ -1317,7 +1317,7 @@ func TestEVM_WakeupTraversal_WithExitedThreads(t *testing.T) {
 
 			state.Wakeup = c.wakeupAddr
 			effWakeupAddr := ^Word(3) & c.wakeupAddr
-			testutil.SetMemoryUint32(state.GetMemory(), effWakeupAddr, wakeupVal, int64(i+1111))
+			testutil.RandomizeWordAndSetUint32(state.GetMemory(), effWakeupAddr, wakeupVal, int64(i+1111))
 
 			threads := mttestutil.GetAllThreads(state)
 			for idx, thread := range threads {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -489,28 +489,31 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 		name             string
 		addressParam     uint64
 		effAddr          uint64
-		targetValue      uint64
-		actualValue      uint64
+		targetValue      uint32
+		actualValue      uint32
 		timeout          uint64
 		shouldFail       bool
 		shouldSetTimeout bool
 	}{
-		{name: "successful wait, no timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_38, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_01},
-		{name: "successful wait, no timeout, unaligned addr", addressParam: 0xFF_FF_FF_FF_FF_FF_12_39, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_01},
-		{name: "memory mismatch, no timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_00, effAddr: 0xFF_FF_FF_FF_FF_FF_12_00, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_02, shouldFail: true},
-		{name: "memory mismatch, no timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_03, effAddr: 0xFF_FF_FF_FF_FF_FF_12_00, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_02, shouldFail: true},
-		{name: "successful wait w timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_38, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_01, timeout: 1000000, shouldSetTimeout: true},
-		{name: "successful wait w timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_32, effAddr: 0xFF_FF_FF_FF_FF_FF_12_30, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_01, timeout: 1000000, shouldSetTimeout: true},
-		{name: "memory mismatch w timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_00, effAddr: 0xFF_FF_FF_FF_FF_FF_12_00, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_02, timeout: 2000000, shouldFail: true},
-		{name: "memory mismatch w timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_0F, effAddr: 0xFF_FF_FF_FF_FF_FF_12_10, targetValue: 0xFF_FF_FF_FF_FF_FF_FF_01, actualValue: 0xFF_FF_FF_FF_FF_FF_FF_02, timeout: 2000000, shouldFail: true},
+		{name: "successful wait, no timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_38, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_01},
+		{name: "successful wait, no timeout, unaligned addr #1", addressParam: 0xFF_FF_FF_FF_FF_FF_12_33, effAddr: 0xFF_FF_FF_FF_FF_FF_12_30, targetValue: 0x01, actualValue: 0x01},
+		{name: "successful wait, no timeout, unaligned addr #2", addressParam: 0xFF_FF_FF_FF_FF_FF_12_37, effAddr: 0xFF_FF_FF_FF_FF_FF_12_34, targetValue: 0x01, actualValue: 0x01},
+		{name: "successful wait, no timeout, unaligned addr #3", addressParam: 0xFF_FF_FF_FF_FF_FF_12_3A, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0x01, actualValue: 0x01},
+		{name: "successful wait, no timeout, unaligned addr #4", addressParam: 0xFF_FF_FF_FF_FF_FF_12_3F, effAddr: 0xFF_FF_FF_FF_FF_FF_12_3C, targetValue: 0x01, actualValue: 0x01},
+		{name: "memory mismatch, no timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_00, effAddr: 0xFF_FF_FF_FF_FF_FF_12_00, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_02, shouldFail: true},
+		{name: "memory mismatch, no timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_05, effAddr: 0xFF_FF_FF_FF_FF_FF_12_04, targetValue: 0x01, actualValue: 0x02, shouldFail: true},
+		{name: "successful wait w timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_38, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_01, timeout: 1000000, shouldSetTimeout: true},
+		{name: "successful wait w timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_37, effAddr: 0xFF_FF_FF_FF_FF_FF_12_34, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_01, timeout: 1000000, shouldSetTimeout: true},
+		{name: "memory mismatch w timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_00, effAddr: 0xFF_FF_FF_FF_FF_FF_12_00, targetValue: 0xFF_FF_FF_F8, actualValue: 0xF8, timeout: 2000000, shouldFail: true},
+		{name: "memory mismatch w timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_0F, effAddr: 0xFF_FF_FF_FF_FF_FF_12_0C, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_02, timeout: 2000000, shouldFail: true},
 	}
 	for i, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			goVm, state, contracts := setup(t, i*1234, nil)
+			goVm, state, contracts := setup(t, i*1234, nil, testutil.WithPCAndNextPC(0x04))
 			step := state.GetStep()
 
 			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			state.Memory.SetWord(Word(c.effAddr), Word(c.actualValue))
+			testutil.SetMemoryUint32(state.GetMemory(), Word(c.effAddr), c.actualValue, int64(i+22))
 			state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
 			state.GetRegistersRef()[4] = Word(c.addressParam)
 			state.GetRegistersRef()[5] = exec.FutexWaitPrivate
@@ -559,7 +562,10 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 		expectTraverseRight bool
 	}{
 		{name: "Traverse right", addressParam: 0xFF_FF_FF_FF_FF_FF_67_00, effAddr: 0xFF_FF_FF_FF_FF_FF_67_00, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
-		{name: "Traverse right, unaligned addr", addressParam: 0xFF_FF_FF_FF_FF_FF_67_89, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
+		{name: "Traverse right, unaligned addr #1", addressParam: 0xFF_FF_FF_FF_FF_FF_67_83, effAddr: 0xFF_FF_FF_FF_FF_FF_67_80, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
+		{name: "Traverse right, unaligned addr #2", addressParam: 0xFF_FF_FF_FF_FF_FF_67_87, effAddr: 0xFF_FF_FF_FF_FF_FF_67_84, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
+		{name: "Traverse right, unaligned addr #3", addressParam: 0xFF_FF_FF_FF_FF_FF_67_89, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
+		{name: "Traverse right, unaligned addr #4", addressParam: 0xFF_FF_FF_FF_FF_FF_67_8F, effAddr: 0xFF_FF_FF_FF_FF_FF_67_8C, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
 		{name: "Traverse right, no left threads", addressParam: 0xFF_FF_FF_FF_FF_FF_67_84, effAddr: 0xFF_FF_FF_FF_FF_FF_67_84, activeThreadCount: 2, inactiveThreadCount: 0, traverseRight: true},
 		{name: "Traverse right, no left threads, unaligned addr", addressParam: 0xFF_FF_FF_FF_FF_FF_67_8E, effAddr: 0xFF_FF_FF_FF_FF_FF_67_8C, activeThreadCount: 2, inactiveThreadCount: 0, traverseRight: true},
 		{name: "Traverse right, single thread", addressParam: 0xFF_FF_FF_FF_FF_FF_67_88, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 0, traverseRight: true},
@@ -567,7 +573,7 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 		{name: "Traverse left", addressParam: 0xFF_FF_FF_FF_FF_FF_67_88, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: false},
 		{name: "Traverse left, unaliagned", addressParam: 0xFF_FF_FF_FF_FF_FF_67_89, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: false},
 		{name: "Traverse left, switch directions", addressParam: 0xFF_FF_FF_FF_FF_FF_67_88, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 1, traverseRight: false, expectTraverseRight: true},
-		{name: "Traverse left, switch directions, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_67_89, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 1, traverseRight: false, expectTraverseRight: true},
+		{name: "Traverse left, switch directions, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_67_8F, effAddr: 0xFF_FF_FF_FF_FF_FF_67_8C, activeThreadCount: 1, inactiveThreadCount: 1, traverseRight: false, expectTraverseRight: true},
 		{name: "Traverse left, single thread", addressParam: 0xFF_FF_FF_FF_FF_FF_67_88, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 0, traverseRight: false, expectTraverseRight: true},
 		{name: "Traverse left, single thread, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_67_89, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 0, traverseRight: false, expectTraverseRight: true},
 	}
@@ -587,7 +593,7 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = 0
 			expected.ActiveThread().Registers[7] = 0
-			expected.Wakeup = Word(c.effAddr) & arch.AddressMask // aligned for 32 and 64-bit compatibility
+			expected.Wakeup = Word(c.effAddr)
 			expected.ExpectPreemption(state)
 			expected.TraverseRight = c.expectTraverseRight
 			if c.traverseRight != c.expectTraverseRight {
@@ -1012,26 +1018,33 @@ func TestEVM_NormalTraversalStep_HandleWaitingThread(t *testing.T) {
 		activeStackSize int
 		otherStackSize  int
 		futexAddr       Word
-		targetValue     Word
-		actualValue     Word
+		effAddr         Word
+		targetValue     uint32
+		actualValue     uint32
 		timeoutStep     uint64
 		shouldWakeup    bool
 		shouldTimeout   bool
 	}{
-		{name: "Preempt, no timeout #1", step: 100, activeStackSize: 1, otherStackSize: 0, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
-		{name: "Preempt, no timeout #2", step: 100, activeStackSize: 1, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
-		{name: "Preempt, no timeout #3", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
-		{name: "Preempt, no timeout, unaligned", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x101, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
-		{name: "Preempt, with timeout #1", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: 101},
-		{name: "Preempt, with timeout #2", step: 100, activeStackSize: 1, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: 150},
-		{name: "Preempt, with timeout, unaligned", step: 100, activeStackSize: 1, otherStackSize: 1, futexAddr: 0x101, targetValue: 0x01, actualValue: 0x01, timeoutStep: 150},
-		{name: "Wakeup, no timeout #1", step: 100, activeStackSize: 1, otherStackSize: 0, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
-		{name: "Wakeup, no timeout #2", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
-		{name: "Wakeup, no timeout, unaligned", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x102, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
-		{name: "Wakeup with timeout #1", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: 100, shouldWakeup: true, shouldTimeout: true},
-		{name: "Wakeup with timeout #2", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x02, actualValue: 0x02, timeoutStep: 100, shouldWakeup: true, shouldTimeout: true},
-		{name: "Wakeup with timeout #3", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, targetValue: 0x02, actualValue: 0x02, timeoutStep: 50, shouldWakeup: true, shouldTimeout: true},
-		{name: "Wakeup with timeout, unaligned", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x103, targetValue: 0x02, actualValue: 0x02, timeoutStep: 50, shouldWakeup: true, shouldTimeout: true},
+		{name: "Preempt, no timeout #1", step: 100, activeStackSize: 1, otherStackSize: 0, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, no timeout #2", step: 100, activeStackSize: 1, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, no timeout #3", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, no timeout, unaligned #1", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x101, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, no timeout, unaligned #2", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x107, effAddr: 0x104, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, no timeout, unaligned #3", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x109, effAddr: 0x108, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, no timeout, unaligned #4", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x10F, effAddr: 0x10C, targetValue: 0x01, actualValue: 0x01, timeoutStep: exec.FutexNoTimeout},
+		{name: "Preempt, with timeout #1", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: 101},
+		{name: "Preempt, with timeout #2", step: 100, activeStackSize: 1, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: 150},
+		{name: "Preempt, with timeout, unaligned", step: 100, activeStackSize: 1, otherStackSize: 1, futexAddr: 0x101, effAddr: 0x100, targetValue: 0x01, actualValue: 0x01, timeoutStep: 150},
+		{name: "Wakeup, no timeout #1", step: 100, activeStackSize: 1, otherStackSize: 0, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
+		{name: "Wakeup, no timeout #2", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
+		{name: "Wakeup, no timeout, unaligned #1", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x102, effAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
+		{name: "Wakeup, no timeout, unaligned #2", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x105, effAddr: 0x104, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
+		{name: "Wakeup, no timeout, unaligned #3", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x10B, effAddr: 0x108, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
+		{name: "Wakeup, no timeout, unaligned #4", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x10E, effAddr: 0x10C, targetValue: 0x01, actualValue: 0x02, timeoutStep: exec.FutexNoTimeout, shouldWakeup: true},
+		{name: "Wakeup with timeout #1", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x01, actualValue: 0x02, timeoutStep: 100, shouldWakeup: true, shouldTimeout: true},
+		{name: "Wakeup with timeout #2", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x02, actualValue: 0x02, timeoutStep: 100, shouldWakeup: true, shouldTimeout: true},
+		{name: "Wakeup with timeout #3", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x100, effAddr: 0x100, targetValue: 0x02, actualValue: 0x02, timeoutStep: 50, shouldWakeup: true, shouldTimeout: true},
+		{name: "Wakeup with timeout, unaligned", step: 100, activeStackSize: 2, otherStackSize: 1, futexAddr: 0x103, effAddr: 0x100, targetValue: 0x02, actualValue: 0x02, timeoutStep: 50, shouldWakeup: true, shouldTimeout: true},
 	}
 
 	for _, c := range cases {
@@ -1042,16 +1055,15 @@ func TestEVM_NormalTraversalStep_HandleWaitingThread(t *testing.T) {
 				if !c.shouldWakeup && c.shouldTimeout {
 					require.Fail(t, "Invalid test case - cannot expect a timeout with no wakeup")
 				}
-				effAddr := c.futexAddr & arch.AddressMask
 				goVm, state, contracts := setup(t, i, nil)
 				mttestutil.SetupThreads(int64(i*101), state, traverseRight, c.activeStackSize, c.otherStackSize)
 				state.Step = c.step
 
 				activeThread := state.GetCurrentThread()
 				activeThread.FutexAddr = c.futexAddr
-				activeThread.FutexVal = c.targetValue
+				activeThread.FutexVal = Word(c.targetValue)
 				activeThread.FutexTimeoutStep = c.timeoutStep
-				state.GetMemory().SetWord(effAddr, c.actualValue)
+				testutil.SetMemoryUint32(state.GetMemory(), c.effAddr, c.actualValue, int64(i+11))
 
 				// Set up post-state expectations
 				expected := mttestutil.NewExpectedMTState(state)

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -44,9 +44,8 @@ func SetMemoryUint64(t require.TestingT, mem *memory.Memory, addr Word, value ui
 	require.Equal(t, Word(value), actual)
 }
 
-// SetMemoryUint32 writes a 4-byte value to memory.
-// Also, randomizes the rest of the Word containing the uint32
-func SetMemoryUint32(mem *memory.Memory, addr Word, val uint32, randomizeWordSeed int64) {
+// RandomizeWordAndSetUint32 writes a uint32 value and randomizes the rest of the Word containing the uint32 in memory
+func RandomizeWordAndSetUint32(mem *memory.Memory, addr Word, val uint32, randomizeWordSeed int64) {
 	if addr&0x3 != 0 {
 		panic(fmt.Errorf("unaligned memory access: %x", addr))
 	}

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -4,11 +4,13 @@ package testutil
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
 )
 
@@ -40,6 +42,21 @@ func SetMemoryUint64(t require.TestingT, mem *memory.Memory, addr Word, value ui
 	effAddr := addr & arch.AddressMask
 	actual := mem.GetWord(effAddr)
 	require.Equal(t, Word(value), actual)
+}
+
+// SetMemoryUint32 writes a 4-byte value to memory.
+// Also, randomizes the rest of the Word containing the uint32
+func SetMemoryUint32(mem *memory.Memory, addr Word, val uint32, randomizeWordSeed int64) {
+	if addr&0x3 != 0 {
+		panic(fmt.Errorf("unaligned memory access: %x", addr))
+	}
+
+	// Randomize the Word containing the target uint32 - only makes a difference for 64-bit architectures
+	rand := NewRandHelper(randomizeWordSeed)
+	wordAddr := addr & arch.AddressMask
+	mem.SetWord(wordAddr, rand.Word())
+
+	exec.StoreSubWord(mem, addr, 4, Word(val), new(exec.NoopMemoryTracker))
 }
 
 // ToSignedInteger converts the unsigend Word to a SignedInteger.

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x6c45dd23cb0d6f9bf4f84855ad0caf70e53dee3fe6c41454f7bf8df52ec3a9af"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x4971f62a6aecf91bd795fa44b5ce3cb77a987719af4f351d4aec5b6c3bf81387",
-    "sourceCodeHash": "0x8da8be0b7d60af0eb11bd58653f1854d56a8f0616f3aeaeba7ab9ec340d02ac7"
+    "initCodeHash": "0x5e04e69321f1081869de8d0e4625dc491bec118651f7cfa7b2449878923ee81e",
+    "sourceCodeHash": "0x550bbd4478ba42ce4fe6b7f8fc72da828d9ff01bb3880beefe5f580e44dd4a54"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0xdef0bd64af2541644e1fba56cb443650749dee201a38053c02464584f2e806a9",
-    "sourceCodeHash": "0x16b46d17dff5b772675bdd280dddea482e85c707a8779694f10cc78b05de871d"
+    "initCodeHash": "0xfb8a13523ce94e1ef002b255bf41d7ececfd6d2e9091422f0abaae5e4b3eac8f",
+    "sourceCodeHash": "0x724ef465479c6ed3bb1c34768305947cc36b6e29eaa1522b8c649d56523d0874"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xf08736a5af9277a4f3498dfee84a40c9b05f1a2ba3177459bebe2b0b54f99343",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -140,12 +140,12 @@
     "sourceCodeHash": "0x6c45dd23cb0d6f9bf4f84855ad0caf70e53dee3fe6c41454f7bf8df52ec3a9af"
   },
   "src/cannon/MIPS2.sol": {
-    "initCodeHash": "0x5e04e69321f1081869de8d0e4625dc491bec118651f7cfa7b2449878923ee81e",
-    "sourceCodeHash": "0xd23a120e56758aae04f8ca991c988e98ffe433b342106a0cb82fb449c9d637fb"
+    "initCodeHash": "0x70ecbb2327fadd6205312aa93279a6340242dfeb44a00b98caa7b56688c46bdc",
+    "sourceCodeHash": "0x84506539c40b72b1d40c9d07418650b30c27d2b219b40e55f61edcd31365157f"
   },
   "src/cannon/MIPS64.sol": {
     "initCodeHash": "0xa2a42c50d2fac71d93e44ad4871e5d838f1c630b9d1abc4c89971d36b0ae44bb",
-    "sourceCodeHash": "0xa8f07e709c60ad6c917d4e1d09b670a7d16fd9fdb183a546e6d87f952774d080"
+    "sourceCodeHash": "0xdb771f1b92c7612b120e0bce31967f0c8a7ce332dbb426bc9cfc52b47be21c4d"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xf08736a5af9277a4f3498dfee84a40c9b05f1a2ba3177459bebe2b0b54f99343",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -144,8 +144,8 @@
     "sourceCodeHash": "0xd23a120e56758aae04f8ca991c988e98ffe433b342106a0cb82fb449c9d637fb"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0xfb8a13523ce94e1ef002b255bf41d7ececfd6d2e9091422f0abaae5e4b3eac8f",
-    "sourceCodeHash": "0x6f571737f0980e47e52399a398bc62e912319f846ce10c5e313d482de95a45c3"
+    "initCodeHash": "0xa2a42c50d2fac71d93e44ad4871e5d838f1c630b9d1abc4c89971d36b0ae44bb",
+    "sourceCodeHash": "0xa8f07e709c60ad6c917d4e1d09b670a7d16fd9fdb183a546e6d87f952774d080"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xf08736a5af9277a4f3498dfee84a40c9b05f1a2ba3177459bebe2b0b54f99343",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -141,11 +141,11 @@
   },
   "src/cannon/MIPS2.sol": {
     "initCodeHash": "0x5e04e69321f1081869de8d0e4625dc491bec118651f7cfa7b2449878923ee81e",
-    "sourceCodeHash": "0x550bbd4478ba42ce4fe6b7f8fc72da828d9ff01bb3880beefe5f580e44dd4a54"
+    "sourceCodeHash": "0xd23a120e56758aae04f8ca991c988e98ffe433b342106a0cb82fb449c9d637fb"
   },
   "src/cannon/MIPS64.sol": {
     "initCodeHash": "0xfb8a13523ce94e1ef002b255bf41d7ececfd6d2e9091422f0abaae5e4b3eac8f",
-    "sourceCodeHash": "0x724ef465479c6ed3bb1c34768305947cc36b6e29eaa1522b8c649d56523d0874"
+    "sourceCodeHash": "0x6f571737f0980e47e52399a398bc62e912319f846ce10c5e313d482de95a45c3"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0xf08736a5af9277a4f3498dfee84a40c9b05f1a2ba3177459bebe2b0b54f99343",

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -63,7 +63,7 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.26
+    /// @custom:semver 1.0.0-beta.27
     string public constant version = "1.0.0-beta.27";
 
     /// @notice The preimage oracle contract.

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -245,10 +245,8 @@ contract MIPS2 is ISemver {
                     // timeout! Allow execution
                     return onWaitComplete(thread, true);
                 } else {
-                    uint32 mem = MIPSMemory.readMem(
-                        state.memRoot, thread.futexAddr & 0xFFffFFfc, MIPSMemory.memoryProofOffset(MEM_PROOF_OFFSET, 1)
-                    );
-                    if (thread.futexVal == mem) {
+                    uint32 futexVal = getFutexValue(thread.futexAddr);
+                    if (thread.futexVal == futexVal) {
                         // still got expected value, continue sleeping, try next thread.
                         preemptThread(state, thread);
                         return outputState();
@@ -488,15 +486,14 @@ contract MIPS2 is ISemver {
                 return outputState();
             } else if (syscall_no == sys.SYS_FUTEX) {
                 // args: a0 = addr, a1 = op, a2 = val, a3 = timeout
-                uint32 effAddr = a0 & 0xFFffFFfc;
+                uint32 effFutexAddr = a0 & 0xFFffFFfc;
                 if (a1 == sys.FUTEX_WAIT_PRIVATE) {
-                    uint32 mem =
-                        MIPSMemory.readMem(state.memRoot, effAddr, MIPSMemory.memoryProofOffset(MEM_PROOF_OFFSET, 1));
-                    if (mem != a2) {
+                    uint32 futexVal = getFutexValue(effFutexAddr);
+                    if (futexVal != a2) {
                         v0 = sys.SYS_ERROR_SIGNAL;
                         v1 = sys.EAGAIN;
                     } else {
-                        thread.futexAddr = effAddr;
+                        thread.futexAddr = effFutexAddr;
                         thread.futexVal = a2;
                         thread.futexTimeoutStep = a3 == 0 ? sys.FUTEX_NO_TIMEOUT : state.step + sys.FUTEX_TIMEOUT_STEPS;
                         // Leave cpu scalars as-is. This instruction will be completed by `onWaitComplete`
@@ -506,7 +503,7 @@ contract MIPS2 is ISemver {
                 } else if (a1 == sys.FUTEX_WAKE_PRIVATE) {
                     // Trigger thread traversal starting from the left stack until we find one waiting on the wakeup
                     // address
-                    state.wakeup = effAddr;
+                    state.wakeup = effFutexAddr;
                     // Don't indicate to the program that we've woken up a waiting thread, as there are no guarantees.
                     // The woken up thread should indicate this in userspace.
                     v0 = 0;
@@ -941,5 +938,17 @@ contract MIPS2 is ISemver {
         }
         // verify we have enough calldata
         require(s >= (THREAD_PROOF_OFFSET + 198), "insufficient calldata for thread witness"); // 166 + 32
+    }
+
+    /// @notice Loads a 32-bit futex value at _vAddr
+    function getFutexValue(uint32 _vAddr) internal pure returns (uint32 out_) {
+        State memory state;
+        assembly {
+            state := STATE_MEM_OFFSET
+        }
+
+        uint32 effAddr = _vAddr & 0xFFffFFfc;
+        uint256 memProofOffset = MIPSMemory.memoryProofOffset(MEM_PROOF_OFFSET, 1);
+        return MIPSMemory.readMem(state.memRoot, effAddr, memProofOffset);
     }
 }

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -489,12 +489,13 @@ contract MIPS2 is ISemver {
                 uint32 effFutexAddr = a0 & 0xFFffFFfc;
                 if (a1 == sys.FUTEX_WAIT_PRIVATE) {
                     uint32 futexVal = getFutexValue(effFutexAddr);
-                    if (futexVal != a2) {
+                    uint32 targetValue = a2;
+                    if (futexVal != targetValue) {
                         v0 = sys.SYS_ERROR_SIGNAL;
                         v1 = sys.EAGAIN;
                     } else {
                         thread.futexAddr = effFutexAddr;
-                        thread.futexVal = a2;
+                        thread.futexVal = targetValue;
                         thread.futexTimeoutStep = a3 == 0 ? sys.FUTEX_NO_TIMEOUT : state.step + sys.FUTEX_TIMEOUT_STEPS;
                         // Leave cpu scalars as-is. This instruction will be completed by `onWaitComplete`
                         updateCurrentThreadRoot();

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -64,7 +64,7 @@ contract MIPS2 is ISemver {
 
     /// @notice The semantic version of the MIPS2 contract.
     /// @custom:semver 1.0.0-beta.26
-    string public constant version = "1.0.0-beta.26";
+    string public constant version = "1.0.0-beta.27";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -67,7 +67,7 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.0.0-beta.8
+    /// @custom:semver 1.0.0-beta.9
     string public constant version = "1.0.0-beta.9";
 
     /// @notice The preimage oracle contract.

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -526,7 +526,7 @@ contract MIPS64 is ISemver {
                 return outputState();
             } else if (syscall_no == sys.SYS_FUTEX) {
                 // args: a0 = addr, a1 = op, a2 = val, a3 = timeout
-                // Futex value is 32-bit, so mask out the lower 2 bits
+                // Futex value is 32-bit, so clear the lower 2 bits to get an effective address targeting a 4-byte value
                 uint64 effFutexAddr = a0 & 0xFFFFFFFFFFFFFFFC;
                 if (a1 == sys.FUTEX_WAIT_PRIVATE) {
                     uint32 futexVal = getFutexValue(effFutexAddr);

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -68,7 +68,7 @@ contract MIPS64 is ISemver {
 
     /// @notice The semantic version of the MIPS64 contract.
     /// @custom:semver 1.0.0-beta.8
-    string public constant version = "1.0.0-beta.8";
+    string public constant version = "1.0.0-beta.9";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

When loading futex values on  64-bit MTCannon, treat futexes as 32-bit rather than 64-bit values.  Make `ThreadState.futexVal` field 32-bit.  Update the 32- and 64-bit MTCannon implementations to keep the code consistent across all implementations.  

**Tests**

Updated futex operation tests to target futexes at various memory offsets.  Also added randomization around the uint32 futex value in memory and in the register holding the futex value.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/13425
