### PR TITLE
op-service: Directly Register APIs in RPC Server

### DIFF
--- a/op-service/rpc/server.go
+++ b/op-service/rpc/server.go
@@ -166,8 +166,12 @@ func (b *Server) AddAPI(api rpc.API) {
 
 func (b *Server) Start() error {
 	srv := rpc.NewServer()
-	if err := node.RegisterApis(b.apis, nil, srv); err != nil {
-		return fmt.Errorf("error registering APIs: %w", err)
+
+	for _, api := range b.apis {
+		if err := srv.RegisterName(api.Namespace, api.Service); err != nil {
+			return fmt.Errorf("failed to register API %s: %w", api.Namespace, err)
+		}
+		b.log.Info("registered API", "namespace", api.Namespace)
 	}
 
 	// rpc middleware


### PR DESCRIPTION
# What

Rather than send the APIs to the Node for Registration, directly loop over the apis known to the server and direct register them.

# Why

When attaching additional APIs (like Interop), if the APIs aren't part of the original set, they won't be allow-listed, and you can't ever register them. Direct registration allows for services to register more APIs later.