### PR TITLE
interop: Initialize ChainsDB from Anchor Point

### DIFF
--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -31,7 +31,7 @@ func (ib *InteropAPI) UpdateFinalized(ctx context.Context, ref eth.BlockRef) err
 	return ib.backend.UpdateFinalized(ctx, ref)
 }
 
-func (ib *InteropAPI) AnchorPoint(ctx context.Context) (l1, l2 eth.BlockRef, err error) {
+func (ib *InteropAPI) AnchorPoint(ctx context.Context) (supervisortypes.DerivedPair, error) {
 	return ib.backend.AnchorPoint(ctx)
 }
 

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -176,16 +177,19 @@ func (m *ManagedMode) UpdateFinalized(ctx context.Context, ref eth.BlockRef) err
 	return nil
 }
 
-func (m *ManagedMode) AnchorPoint(ctx context.Context) (l1, l2 eth.BlockRef, err error) {
+func (m *ManagedMode) AnchorPoint(ctx context.Context) (supervisortypes.DerivedPair, error) {
 	l1Ref, err := m.l1.L1BlockRefByHash(ctx, m.cfg.Genesis.L1.Hash)
 	if err != nil {
-		return eth.BlockRef{}, eth.BlockRef{}, fmt.Errorf("failed to fetch L1 block ref: %w", err)
+		return supervisortypes.DerivedPair{}, fmt.Errorf("failed to fetch L1 block ref: %w", err)
 	}
 	l2Ref, err := m.l2.L2BlockRefByHash(ctx, m.cfg.Genesis.L2.Hash)
 	if err != nil {
-		return eth.BlockRef{}, eth.BlockRef{}, fmt.Errorf("failed to fetch L2 block ref: %w", err)
+		return supervisortypes.DerivedPair{}, fmt.Errorf("failed to fetch L2 block ref: %w", err)
 	}
-	return l1Ref, l2Ref.BlockRef(), nil
+	return supervisortypes.DerivedPair{
+		DerivedFrom: l1Ref,
+		Derived:     l2Ref.BlockRef(),
+	}, nil
 }
 
 func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.BlockRef) error {

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -30,6 +30,7 @@ type SyncSource interface {
 
 type SyncControl interface {
 	TryDeriveNext(ctx context.Context, ref eth.BlockRef) (eth.BlockRef, error)
+	AnchorPoint(ctx context.Context) (types.DerivedPair, error)
 }
 
 type SyncNode interface {

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -75,3 +75,9 @@ func (rs *RPCSyncNode) TryDeriveNext(ctx context.Context, ref eth.BlockRef) (eth
 	// the node only returns an error currently
 	return eth.BlockRef{}, err
 }
+
+func (rs *RPCSyncNode) AnchorPoint(ctx context.Context) (types.DerivedPair, error) {
+	var out types.DerivedPair
+	err := rs.cl.CallContext(ctx, &out, "interop_anchorPoint")
+	return out, err
+}

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -310,3 +310,8 @@ func LogToMessagePayload(l *ethTypes.Log) []byte {
 	msg = append(msg, l.Data...)
 	return msg
 }
+
+type DerivedPair struct {
+	DerivedFrom eth.BlockRef
+	Derived     eth.BlockRef
+}


### PR DESCRIPTION
This PR is against the `interop-managed` feature branch

# What
Uses `AnchorPoint` to initialize ChainsDB if the given chain's database is empty

# How
The Node Controller, when a new individual controller is attached, will trigger a `maybeInit` function which will:
- check if the database is empty for that chain
- calls the AnchorPoint API on the controller
- writes the anchor to the Cross and Local databases

Also introduces "DerivationPair", a struct for returning two Refs at once over RPC.

# Tests
New unit tests to show that the DB is initialized when it returns `ErrFuture` (empty), and does not do initialization otherwise.