### PR TITLE
fix: standard address parsing in holocene upgrade scripts

### DIFF
--- a/packages/contracts-bedrock/scripts/upgrades/holocene/scripts/common.sh
+++ b/packages/contracts-bedrock/scripts/upgrades/holocene/scripts/common.sh
@@ -91,7 +91,7 @@ fetch_standard_address() {
     fi
   fi
 
-  local contract_path=".releases.\"op-contracts/${release_version}\".$contract_name"
+  local contract_path=".\"op-contracts/${release_version}\".$contract_name"
   local contract_address
   contract_address=$(yq "${contract_path}.address // ${contract_path}.implementation_address // \"\"" "${toml_path}")
   if [[ -z "$contract_address" ]]; then


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
After the PR https://github.com/ethereum-optimism/superchain-registry/pull/768 removed the "releases" prefix from standard address file in SCR, it broke the address parsing in holocene scripts, this small PR fix it
