### PR TITLE
fix docker warning

### DIFF
--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -1,4 +1,4 @@
-FROM golang:1.22.7-alpine3.20 as builder
+FROM golang:1.22.7-alpine3.20 AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 


### PR DESCRIPTION
This PR fixes this warning when running `make reproducible-prestate`:

<img width="506" alt="image" src="https://github.com/user-attachments/assets/c511b991-5c4d-4514-9830-1a102620d3c6" />
