### PR TITLE
feat(op-deployer): add support for http locator

### DIFF
--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -13,6 +13,7 @@ type schemeUnmarshaler func(string) (*Locator, error)
 var schemeUnmarshalerDispatch = map[string]schemeUnmarshaler{
 	"tag":   unmarshalTag,
 	"file":  unmarshalURL,
+	"http":  unmarshalURL,
 	"https": unmarshalURL,
 }
 

--- a/op-deployer/pkg/deployer/artifacts/locator_test.go
+++ b/op-deployer/pkg/deployer/artifacts/locator_test.go
@@ -43,6 +43,14 @@ func TestLocator_Marshaling(t *testing.T) {
 			err: false,
 		},
 		{
+			name: "valid HTTP URL",
+			in:   "http://example.com",
+			out: &Locator{
+				URL: parseUrl(t, "http://example.com"),
+			},
+			err: false,
+		},
+		{
 			name: "valid file URL",
 			in:   "file:///tmp/artifacts",
 			out: &Locator{
@@ -64,7 +72,7 @@ func TestLocator_Marshaling(t *testing.T) {
 		},
 		{
 			name: "unsupported scheme",
-			in:   "http://example.com",
+			in:   "ftp://example.com",
 			out:  nil,
 			err:  true,
 		},


### PR DESCRIPTION
**Description**

This change adds the option to use http URLs for {l1,l2}_artifacts_locator.

Given that the downloader code already supports it, we might as well offer the capability.
This is useful for pointing to local registries during development, without having to worry about SSL.

**Additional context**

This is needed in the short term for enabling local devnet with kurtosis, as we don't want to go through a proper publishing step during the dev cycles.

**Metadata**

Part of ethereum-optimism/platforms-team#518