### PR TITLE
op-service: fix RPC websocket support

### DIFF
--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -47,6 +47,7 @@ func (cfg *Config) Setup(ctx context.Context, logger log.Logger) (SubSystem, err
 		}
 		out := &ManagedMode{}
 		out.srv = rpc.NewServer(cfg.RPCAddr, cfg.RPCPort, "v0.0.0",
+			rpc.WithLogger(logger),
 			rpc.WithWebsocketEnabled(), rpc.WithJWTSecret(jwtSecret[:]))
 		return out, nil
 	} else {

--- a/op-service/log/http.go
+++ b/op-service/log/http.go
@@ -20,6 +20,7 @@ func NewLoggingMiddleware(lgr log.Logger, next http.Handler) http.Handler {
 			"path", r.URL.EscapedPath(),
 			"duration", time.Since(start),
 			"remote_addr", r.RemoteAddr,
+			"upgrade_attempt", ww.UpgradeAttempt,
 		)
 	})
 }

--- a/op-service/rpc/server_test.go
+++ b/op-service/rpc/server_test.go
@@ -1,15 +1,21 @@
 package rpc
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 type testAPI struct{}
@@ -20,24 +26,26 @@ func (t *testAPI) Frobnicate(n int) int {
 
 func TestBaseServer(t *testing.T) {
 	appVersion := "test"
+	logger := testlog.Logger(t, log.LevelTrace)
+	log.SetDefault(log.NewLogger(logger.Handler()))
 	server := NewServer(
 		"127.0.0.1",
 		0,
 		appVersion,
+		WithLogger(logger),
 		WithAPIs([]rpc.API{
 			{
 				Namespace: "test",
 				Service:   new(testAPI),
 			},
 		}),
+		WithWebsocketEnabled(),
 	)
-	require.NoError(t, server.Start())
-	defer func() {
-		_ = server.Stop()
-	}()
+	require.NoError(t, server.Start(), "must start")
 
 	rpcClient, err := rpc.Dial(fmt.Sprintf("http://%s", server.endpoint))
 	require.NoError(t, err)
+	t.Cleanup(rpcClient.Close)
 
 	t.Run("supports GET /healthz", func(t *testing.T) {
 		res, err := http.Get(fmt.Sprintf("http://%s/healthz", server.endpoint))
@@ -68,4 +76,19 @@ func TestBaseServer(t *testing.T) {
 		require.NoError(t, err)
 		require.Greater(t, port, 0)
 	})
+
+	t.Run("supports websocket", func(t *testing.T) {
+		endpoint := "ws://" + server.Endpoint()
+		t.Log("connecting to", endpoint)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		wsCl, err := rpc.DialContext(ctx, endpoint)
+		require.NoError(t, err)
+		defer wsCl.Close()
+		var res int
+		require.NoError(t, wsCl.Call(&res, "test_frobnicate", 42))
+		require.Equal(t, 42*2, res)
+	})
+
+	require.NoError(t, server.Stop(), "must stop")
 }


### PR DESCRIPTION
**Description**

Fix websocket support in op-service RPC server.

- logging middle-ware was interfering with the websocket connection upgrade
- allow both `/`, `/ws`, and `/ws/` paths for websocket upgrades
- clean up RPC middleware situation:
  - user middleware is always applied
  - don't use `mux`, order handlers by priority. Websockets are picked up if the upgrade headers are present. Otherwise it can continue to other handling. And the health endpoint is last.

**Tests**

Updated RPC server test with a missing websocket test case.

**Additional context**

Websockets are only a very recent feature. It was introduced without many lines, but the mux usage and logging middleware kept it from actually working. I shouldn't have ignored the unit-test need on that at the time.
