### PR TITLE
Code/fix

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -314,7 +314,7 @@ def wait_for_rpc_server(url):
             if response.status < 300:
                 log.info(f'RPC server at {url} ready')
                 return
-        except Exception as e:
+        except Exception :
             log.info(f'Waiting for RPC server at {url}')
             time.sleep(1)
         finally:

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -42,7 +42,7 @@ func SetMemoryUint64(t require.TestingT, mem *memory.Memory, addr Word, value ui
 	require.Equal(t, Word(value), actual)
 }
 
-// ToSignedInteger converts the unsigend Word to a SignedInteger.
+// ToSignedInteger converts the unsigned Word to a SignedInteger.
 // Useful for avoiding Go compiler warnings for literals that don't fit in a signed type
 func ToSignedInteger(x Word) arch.SignedInteger {
 	return arch.SignedInteger(x)

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -90,7 +90,8 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 FROM --platform=$BUILDPLATFORM builder AS op-challenger-builder
 ARG OP_CHALLENGER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd op-challenger && make op-challenger  \
-  GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_CHALLENGER_VERSION"
+ GOOS="$TARGETOS" GOARCH="$TARGETARCH" GITCOMMIT="$GIT_COMMIT" GITDATE="$GIT_DATE" VERSION="$OP_CHALLENGER_VERSION"
+
 
 FROM --platform=$BUILDPLATFORM builder AS op-dispute-mon-builder
 ARG OP_DISPUTE_MON_VERSION=v0.0.0


### PR DESCRIPTION
# Fix: Added double quotes to variables, removed unused local variable, and corrected typo

## Changes
1. **Surrounded variables with double quotes**:
   - `Dockerfile:93`: Wrapped shell variables with double quotes to prevent unexpected behavior.
     - **Before**:
       ```dockerfile
       GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION=$OP_CHALLENGER_VERSION
       ```
     - **After**:
       ```dockerfile
       GOOS="$TARGETOS" GOARCH="$TARGETARCH" GITCOMMIT="$GIT_COMMIT" GITDATE="$GIT_DATE" VERSION="$OP_CHALLENGER_VERSION"
       ```

2. **Removed unused local variable**:
   - `bedrock-devnet/devnet/__init__.py:317`: Removed unused exception variable `e`.
     - **Before**:
       ```python
       except Exception as e:
           pass
       ```
     - **After**:
       ```python
       except Exception:
           pass
       ```

3. **Corrected typo**:
   - `cannon/mipsevm/testutil/arch.go:45`: "unsigend" corrected to "unsigned".

## Purpose
- Ensured variables are safely quoted to avoid unexpected behavior in shell execution.
- Improved code clarity by removing unused variables.
- Enhanced code accuracy and professionalism by fixing typos.

