### PR TITLE
cannon: Fix parentheses in syscall noop handling

### DIFF
--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -212,7 +212,7 @@ func (m *InstrumentedState) handleSyscall() error {
 	case arch.SysLseek:
 	default:
 		// These syscalls have the same values on 64-bit. So we use if-stmts here to avoid "duplicate case" compiler error for the cannon64 build
-		if arch.IsMips32 && syscallNum == arch.SysFstat64 || syscallNum == arch.SysStat64 || syscallNum == arch.SysLlseek {
+		if arch.IsMips32 && (syscallNum == arch.SysFstat64 || syscallNum == arch.SysStat64 || syscallNum == arch.SysLlseek) {
 			// noop
 		} else {
 			m.Traceback()


### PR DESCRIPTION
Fix grouping of conditions in syscall noop handling in mt-cannon. This does not alter the behavior of the VMs as explained below.

## Testing

Not necessary. The behavior doesn't change on cannon32.
And on cannon64, the 64-bit syscalls that are found in the 32-bit syscall table uses an undefined syscall number (`^uint64(0)`). Thus the noop codepath isn't reachable on cannon64.

## Meta

Fixes https://github.com/ethereum-optimism/optimism/issues/13427