### PR TITLE
op-chain-ops/ecotone-scalar: prefer `.FillBytes()` to `.Bytes()` and `copy`

### DIFF
--- a/op-chain-ops/cmd/ecotone-scalar/main.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"math"
@@ -9,6 +10,14 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+// These names match those used in the SystemConfig contract
+type outputTy struct {
+	BaseFee           uint     `json:"baseFeeScalar"`
+	BlobbaseFeeScalar uint     `json:"blobbaseFeeScalar"`
+	ScalarHex         string   `json:"scalarHex"`
+	Scalar            *big.Int `json:"scalar"` // post-ecotone
+}
 
 func main() {
 	var scalar, blobScalar uint
@@ -66,9 +75,14 @@ func main() {
 	}
 	i := new(big.Int).SetBytes(encoded[:])
 
-	fmt.Println("# base fee scalar     :", scalar)
-	fmt.Println("# blob base fee scalar:", blobScalar)
-	fmt.Printf("# v1 hex encoding  : 0x%x\n", encoded[:])
-	fmt.Println("# uint value for the 'scalar' parameter in SystemConfigProxy.setGasConfig():")
-	fmt.Println(i)
+	o, err := json.Marshal(outputTy{
+		BaseFee:           scalar,
+		BlobbaseFeeScalar: blobScalar,
+		ScalarHex:         fmt.Sprintf("0x%x", encoded[:]),
+		Scalar:            i,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(o))
 }

--- a/op-chain-ops/cmd/ecotone-scalar/main.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main.go
@@ -43,13 +43,13 @@ func main() {
 			flag.Usage()
 			os.Exit(2)
 		}
-		encodedSlice := uint256.Bytes()
-		if len(encodedSlice) > 32 {
+		byteLen := (uint256.BitLen() + 7) / 8
+		if byteLen > 32 {
 			fmt.Fprintln(flag.CommandLine.Output(), "post-ecotone scalar out of uint256 range")
 			flag.Usage()
 			os.Exit(2)
 		}
-		copy(encoded[:], encodedSlice)
+		uint256.FillBytes(encoded[:])
 		decoded, err := eth.DecodeScalar(encoded)
 		if err != nil {
 			fmt.Fprintln(flag.CommandLine.Output(), "post-ecotone scalar could not be decoded:", err)

--- a/op-chain-ops/cmd/ecotone-scalar/main_test.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func runMainWithArgs(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("go", "run", "main.go")
+	cmd.Args = append(cmd.Args, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := stdout.String() + stderr.String()
+	return output, err
+}
+
+func TestMain_PreEcotoneScalar(t *testing.T) {
+	output, err := runMainWithArgs(t, []string{"-decode=684000"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v, output: %s", err, output)
+	}
+	if !strings.Contains(output, "v1 hex encoding  : 0x00000000000000000000000000000000000000000000000000000000000a6fe0") {
+		t.Errorf("did not find expected output: %s", output)
+	}
+}

--- a/op-chain-ops/cmd/ecotone-scalar/main_test.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main_test.go
@@ -35,7 +35,8 @@ func TestMain_PreEcotoneScalar(t *testing.T) {
 }
 
 func TestMain_PostEcotoneScalar(t *testing.T) {
-	output, err := runMainWithArgs(t, []string{"-decode=452312848583266388373324160190187140051835877600158453279135543542576845931"})
+	longScalar := "452312848583266388373324160190187140051835877600158453279135543542576845931"
+	output, err := runMainWithArgs(t, []string{"-decode=" + longScalar})
 	require.NoError(t, err)
 
 	o := new(outputTy)
@@ -50,7 +51,8 @@ func TestMain_PostEcotoneScalar(t *testing.T) {
 		ScalarHex:         "0x010000000000000000000000000000000000000000000000000f79c50000146b",
 		Scalar:            new(big.Int),
 	}
-	_, ok := expected.Scalar.SetString("452312848583266388373324160190187140051835877600158453279135543542576845931", 0)
+	_, ok := expected.Scalar.SetString(longScalar, 0)
+
 	require.True(t, ok)
 	require.Equal(t, expected, o)
 }

--- a/op-chain-ops/cmd/ecotone-scalar/main_test.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"math/big"
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func runMainWithArgs(t *testing.T, args []string) (string, error) {
@@ -37,4 +40,31 @@ func TestMain_PreEcotoneScalar(t *testing.T) {
 	if o.ScalarHex != "0x00000000000000000000000000000000000000000000000000000000000a6fe0" {
 		t.Errorf("did not find expected output: %s", output)
 	}
+}
+
+func TestMain_PostEcotoneScalar(t *testing.T) {
+	output, err := runMainWithArgs(t, []string{"-decode=452312848583266388373324160190187140051835877600158453279135543542576845931"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v, output: %s", err, output)
+	}
+
+	o := new(outputTy)
+
+	err = json.Unmarshal([]byte(output), o)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &outputTy{
+		BaseFee:           5227,
+		BlobbaseFeeScalar: 1014213,
+		ScalarHex:         "0x010000000000000000000000000000000000000000000000000f79c50000146b",
+		Scalar:            new(big.Int),
+	}
+	_, ok := expected.Scalar.SetString("452312848583266388373324160190187140051835877600158453279135543542576845931", 0)
+
+	require.True(t, ok)
+
+	require.Equal(t, expected, o)
+
 }

--- a/op-chain-ops/cmd/ecotone-scalar/main_test.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os/exec"
-	"strings"
 	"testing"
 )
 
@@ -26,7 +26,15 @@ func TestMain_PreEcotoneScalar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v, output: %s", err, output)
 	}
-	if !strings.Contains(output, "v1 hex encoding  : 0x00000000000000000000000000000000000000000000000000000000000a6fe0") {
+
+	o := new(outputTy)
+
+	err = json.Unmarshal([]byte(output), o)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if o.ScalarHex != "0x00000000000000000000000000000000000000000000000000000000000a6fe0" {
 		t.Errorf("did not find expected output: %s", output)
 	}
 }

--- a/op-chain-ops/cmd/ecotone-scalar/main_test.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main_test.go
@@ -26,30 +26,19 @@ func runMainWithArgs(t *testing.T, args []string) (string, error) {
 
 func TestMain_PreEcotoneScalar(t *testing.T) {
 	output, err := runMainWithArgs(t, []string{"-decode=684000"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v, output: %s", err, output)
-	}
+	require.NoError(t, err)
 
 	o := new(outputTy)
-
 	err = json.Unmarshal([]byte(output), o)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if o.ScalarHex != "0x00000000000000000000000000000000000000000000000000000000000a6fe0" {
-		t.Errorf("did not find expected output: %s", output)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000a6fe0", o.ScalarHex)
 }
 
 func TestMain_PostEcotoneScalar(t *testing.T) {
 	output, err := runMainWithArgs(t, []string{"-decode=452312848583266388373324160190187140051835877600158453279135543542576845931"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v, output: %s", err, output)
-	}
+	require.NoError(t, err)
 
 	o := new(outputTy)
-
 	err = json.Unmarshal([]byte(output), o)
 	if err != nil {
 		t.Fatal(err)
@@ -62,9 +51,6 @@ func TestMain_PostEcotoneScalar(t *testing.T) {
 		Scalar:            new(big.Int),
 	}
 	_, ok := expected.Scalar.SetString("452312848583266388373324160190187140051835877600158453279135543542576845931", 0)
-
 	require.True(t, ok)
-
 	require.Equal(t, expected, o)
-
 }


### PR DESCRIPTION
The latter can result in an error if `scalar` is less than 32 bytes in length (it gets padded incorrectly). A common value in use in the wild is `scalar=684000` -- I've added a test case for this which fails with the existing implementation but passed with the fix.

After this is approved, we should cherry pick it on to https://github.com/ethereum-optimism/optimism/pull/13412.

---

TODO 
- [x] add some tests
- [x] make the util output JSON so the result is easier to parse