### PR TITLE
feat: Rename Upgrade.s.sol to ForkProd.s.sol

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -75,7 +75,7 @@ test-upgrade *ARGS: build-go-ffi
   export FORK_BLOCK_NUMBER=$pinnedBlockNumber
   export NO_MATCH_CONTRACTS="OptimismPortal2WithMockERC20_Test|OptimismPortal2_FinalizeWithdrawal_Test|AnchorStateRegistry_Initialize_Test|AnchorStateRegistry_TryUpdateAnchorState_Test|FaultDisputeGame_Test|FaultDispute_1v1_Actors_Test"
   FORK_RPC_URL=$ETH_RPC_URL \
-    UPGRADE_TEST=true \
+    FORK_TEST=true \
     forge test --match-path "test/{L1,dispute}/**" \
     --no-match-contract "$NO_MATCH_CONTRACTS" \
     {{ARGS}}
@@ -92,7 +92,7 @@ anvil-fork:
 # Helpful for debugging.
 test-upgrade-against-anvil *ARGS: build-go-ffi
   FORK_RPC_URL=http://127.0.0.1:8545 \
-    UPGRADE_TEST=true \
+    FORK_TEST=true \
     forge test {{ARGS}}
 
 # Runs standard contract tests with rerun flag.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -16,7 +16,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 
-/// @title ForkProd
+/// @title ForkLive
 /// @notice This script is called by Setup.sol as a preparation step for the foundry test suite, and is run as an
 ///         alternative to Deploy.s.sol, when `FORK_TEST=true` is set in the env.
 ///         Like Deploy.s.sol this script saves the system addresses to disk so that they can be read into memory later
@@ -25,7 +25,7 @@ import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 ///         Therefore this script can only be run against a fork of a production network which is listed in the
 ///         superchain-registry.
 ///         This contract must not have constructor logic because it is set into state using `etch`.
-contract ForkProd is Deployer {
+contract ForkLive is Deployer {
     using stdJson for string;
 
     /// @notice Returns the base chain name to use for forking

--- a/packages/contracts-bedrock/test/setup/ForkProd.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkProd.s.sol
@@ -16,28 +16,28 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 
-/// @title Upgrade
+/// @title ForkProd
 /// @notice This script is called by Setup.sol as a preparation step for the foundry test suite, and is run as an
-///         alternative to Deploy.s.sol, when `UPGRADE_TEST=true` is set in the env.
+///         alternative to Deploy.s.sol, when `FORK_TEST=true` is set in the env.
 ///         Like Deploy.s.sol this script saves the system addresses to disk so that they can be read into memory later
 ///         on, however rather than deploying new contracts from the local source code, it simply reads the addresses
 ///         from the superchain-registry.
 ///         Therefore this script can only be run against a fork of a production network which is listed in the
 ///         superchain-registry.
 ///         This contract must not have constructor logic because it is set into state using `etch`.
-contract Upgrade is Deployer {
+contract ForkProd is Deployer {
     using stdJson for string;
 
     /// @notice Returns the base chain name to use for forking
     /// @return The base chain name as a string
-    function upgradeBaseChain() internal view returns (string memory) {
-        return vm.envOr("UPGRADE_BASE_CHAIN", string("mainnet"));
+    function baseChain() internal view returns (string memory) {
+        return vm.envOr("FORK_BASE_CHAIN", string("mainnet"));
     }
 
     /// @notice Returns the OP chain name to use for forking
     /// @return The OP chain name as a string
-    function upgradeOpChain() internal view returns (string memory) {
-        return vm.envOr("UPGRADE_OP_CHAIN", string("op"));
+    function opChain() internal view returns (string memory) {
+        return vm.envOr("FORK_OP_CHAIN", string("op"));
     }
 
     /// @notice Reads a standard chains addresses from the superchain-registry and saves them to disk.
@@ -51,10 +51,8 @@ contract Upgrade is Deployer {
         // After the upgrade is complete, the superchain-registry will be updated and the contract will be present.
         // At this point, the test will need to be updated to read the new contract from the superchain-registry using
         // either the `saveProxyAndImpl` or `save` functions.
-        string memory superchainToml =
-            vm.readFile(string.concat(superchainBasePath, upgradeBaseChain(), "/superchain.toml"));
-        string memory opToml =
-            vm.readFile(string.concat(superchainBasePath, upgradeBaseChain(), "/", upgradeOpChain(), ".toml"));
+        string memory superchainToml = vm.readFile(string.concat(superchainBasePath, baseChain(), "/superchain.toml"));
+        string memory opToml = vm.readFile(string.concat(superchainBasePath, baseChain(), "/", opChain(), ".toml"));
 
         // Superchain shared contracts
         saveProxyAndImpl("SuperchainConfig", superchainToml, ".superchain_config_addr");

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -140,7 +140,7 @@ contract Setup {
                 "Setup: ETH_RPC_URL must be set to a production (Sepolia or Mainnet) RPC URL"
             );
 
-            vm.etch(address(deploy), vm.getDeployedCode("Upgrade.s.sol:Upgrade"));
+            vm.etch(address(deploy), vm.getDeployedCode("ForkProd.s.sol:ForkProd"));
         } else {
             vm.etch(address(deploy), vm.getDeployedCode("Deploy.s.sol:Deploy"));
         }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -7,7 +7,7 @@ import { Vm } from "forge-std/Vm.sol";
 
 // Scripts
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
-import { Upgrade } from "test/setup/Upgrade.s.sol";
+import { ForkProd } from "test/setup/ForkProd.s.sol";
 import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
 import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
 import { OutputMode, Fork, ForkUtils } from "scripts/libraries/Config.sol";
@@ -122,7 +122,7 @@ contract Setup {
         return _isForkTest;
     }
 
-    /// @dev Deploys either the Deploy.s.sol or Upgrade.s.sol contract, by fetching the bytecode dynamically using
+    /// @dev Deploys either the Deploy.s.sol or Fork.s.sol contract, by fetching the bytecode dynamically using
     ///      `vm.getDeployedCode()` and etching it into the state.
     ///      This enables us to avoid including the bytecode of those contracts in the bytecode of this contract.
     ///      If the bytecode of those contracts was included in this contract, then it will double
@@ -131,7 +131,7 @@ contract Setup {
     ///      This is a hack as we are pushing solidity to the edge.
     function setUp() public virtual {
         console.log("Setup: L1 setup start!");
-        if (vm.envOr("UPGRADE_TEST", false)) {
+        if (vm.envOr("FORK_TEST", false)) {
             string memory forkUrl = vm.envString("FORK_RPC_URL");
             _isForkTest = true;
             vm.createSelectFork(forkUrl, vm.envUint("FORK_BLOCK_NUMBER"));

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -7,7 +7,7 @@ import { Vm } from "forge-std/Vm.sol";
 
 // Scripts
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
-import { ForkProd } from "test/setup/ForkProd.s.sol";
+import { ForkLive } from "test/setup/ForkLive.s.sol";
 import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
 import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
 import { OutputMode, Fork, ForkUtils } from "scripts/libraries/Config.sol";
@@ -140,7 +140,7 @@ contract Setup {
                 "Setup: ETH_RPC_URL must be set to a production (Sepolia or Mainnet) RPC URL"
             );
 
-            vm.etch(address(deploy), vm.getDeployedCode("ForkProd.s.sol:ForkProd"));
+            vm.etch(address(deploy), vm.getDeployedCode("ForkLive.s.sol:ForkLive"));
         } else {
             vm.etch(address(deploy), vm.getDeployedCode("Deploy.s.sol:Deploy"));
         }


### PR DESCRIPTION
The updated name is more descriptive of what the code currently does. It also reflects more accurately the current plan of applying the upgrade outside of this script in a separate one, which may be named `Upgrade.s.sol` and  will call `OPCM.upgrade()`.
