### PR TITLE
op-deployer: Holocene deployment support

### DIFF
--- a/op-chain-ops/justfile
+++ b/op-chain-ops/justfile
@@ -34,8 +34,3 @@ fuzz:
         "FuzzAliasing" \
         "FuzzVersionedNonce" \
     | parallel -j {{PARALLEL_JOBS}} {{just_executable()}} fuzz_task {}
-
-# Sync standard versions
-sync-standard-version:
-    curl -Lo ./deployer/opcm/standard-versions-mainnet.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-mainnet.toml
-    curl -Lo ./deployer/opcm/standard-versions-sepolia.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-sepolia.toml

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -8,3 +8,8 @@ calculate-artifacts-hash checksum:
     just download-artifacts {{checksum}} /tmp/artifact.tgz
     sha256sum /tmp/artifact.tgz
     rm /tmp/artifact.tgz
+
+# Sync standard versions
+sync-standard-version:
+    curl -Lo ./pkg/deployer/standard/standard-versions-mainnet.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-mainnet.toml
+    curl -Lo ./pkg/deployer/standard/standard-versions-sepolia.toml https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-sepolia.toml

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -160,15 +160,21 @@ func ApplyPipeline(
 		}
 	}()
 
-	l2ArtifactsFS, cleanupL2, err := artifacts.Download(ctx, intent.L2ContractsLocator, progressor)
-	if err != nil {
-		return fmt.Errorf("failed to download L2 artifacts: %w", err)
-	}
-	defer func() {
-		if err := cleanupL2(); err != nil {
-			opts.Logger.Warn("failed to clean up L2 artifacts", "err", err)
+	var l2ArtifactsFS foundry.StatDirFs
+	if intent.L1ContractsLocator.Equal(intent.L2ContractsLocator) {
+		l2ArtifactsFS = l1ArtifactsFS
+	} else {
+		l2Afs, cleanupL2, err := artifacts.Download(ctx, intent.L2ContractsLocator, progressor)
+		if err != nil {
+			return fmt.Errorf("failed to download L2 artifacts: %w", err)
 		}
-	}()
+		defer func() {
+			if err := cleanupL2(); err != nil {
+				opts.Logger.Warn("failed to clean up L2 artifacts", "err", err)
+			}
+		}()
+		l2ArtifactsFS = l2Afs
+	}
 
 	bundle := pipeline.ArtifactsBundle{
 		L1: l1ArtifactsFS,

--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -41,6 +41,27 @@ func MustNewLocatorFromTag(tag string) *Locator {
 	return loc
 }
 
+func MustNewLocatorFromURL(u string) *Locator {
+	if strings.HasPrefix(u, "tag://") {
+		return MustNewLocatorFromTag(strings.TrimPrefix(u, "tag://"))
+	}
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return &Locator{
+		URL: parsedURL,
+	}
+}
+
+func MustNewFileLocator(path string) *Locator {
+	loc, err := NewFileLocator(path)
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}
+
 type Locator struct {
 	URL *url.URL
 	Tag string
@@ -85,6 +106,12 @@ func (a *Locator) MarshalText() ([]byte, error) {
 
 func (a *Locator) IsTag() bool {
 	return a.Tag != ""
+}
+
+func (a *Locator) Equal(b *Locator) bool {
+	aStr, _ := a.MarshalText()
+	bStr, _ := b.MarshalText()
+	return string(aStr) == string(bStr)
 }
 
 func unmarshalTag(tag string) (*Locator, error) {

--- a/op-deployer/pkg/deployer/artifacts/locator_test.go
+++ b/op-deployer/pkg/deployer/artifacts/locator_test.go
@@ -100,3 +100,59 @@ func parseUrl(t *testing.T, u string) *url.URL {
 	require.NoError(t, err)
 	return parsed
 }
+
+func TestLocator_Equal(t *testing.T) {
+	tests := []struct {
+		a     *Locator
+		b     *Locator
+		equal bool
+	}{
+		{
+			MustNewLocatorFromTag("op-contracts/v1.6.0"),
+			MustNewLocatorFromTag("op-contracts/v1.8.0-rc.4"),
+			false,
+		},
+		{
+			MustNewLocatorFromTag("op-contracts/v1.6.0"),
+			MustNewLocatorFromTag("op-contracts/v1.6.0"),
+			true,
+		},
+		{
+			MustNewLocatorFromURL("http://www.example.com"),
+			MustNewLocatorFromTag("op-contracts/v1.6.0"),
+			false,
+		},
+		{
+			MustNewLocatorFromURL("https://www.example.com"),
+			MustNewLocatorFromURL("http://www.example.com"),
+			false,
+		},
+		{
+			MustNewLocatorFromURL("http://www.example.com"),
+			MustNewLocatorFromURL("http://www.example.com"),
+			true,
+		},
+		{
+			MustNewLocatorFromTag("op-contracts/v1.6.0"),
+			MustNewFileLocator("/foo/bar"),
+			false,
+		},
+		{
+			MustNewFileLocator("/foo/bar"),
+			MustNewFileLocator("/foo/bar"),
+			true,
+		},
+		{
+			MustNewFileLocator("/foo/bar"),
+			MustNewFileLocator("/foo/baz"),
+			false,
+		},
+	}
+	for _, test := range tests {
+		if test.equal {
+			require.True(t, test.a.Equal(test.b), "%s != %s", test.a, test.b)
+		} else {
+			require.False(t, test.a.Equal(test.b), "%s == %s", test.a, test.b)
+		}
+	}
+}

--- a/op-deployer/pkg/deployer/bootstrap/opcm.go
+++ b/op-deployer/pkg/deployer/bootstrap/opcm.go
@@ -193,12 +193,12 @@ func DeployOPCMInputForChain(release string, chainID uint64) (opcm.DeployOPCMInp
 	if err != nil {
 		return opcm.DeployOPCMInput{}, fmt.Errorf("error getting L1 versions: %w", err)
 	}
-	releases, ok := l1VersionsData.Releases[release]
+	releases, ok := l1VersionsData[release]
 	if !ok {
 		return opcm.DeployOPCMInput{}, fmt.Errorf("release not found: %s", release)
 	}
 
-	blueprints, err := standard.OPCMBlueprintsFor(chainID)
+	blueprints, err := standard.OPCMBlueprintsFor(chainID, release)
 	if err != nil {
 		return opcm.DeployOPCMInput{}, fmt.Errorf("error getting OPCM blueprints: %w", err)
 	}

--- a/op-deployer/pkg/deployer/bootstrap/opcm_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/opcm_test.go
@@ -17,14 +17,14 @@ import (
 
 var networks = []string{"mainnet", "sepolia"}
 
-var versions = []string{"v1.8.0-rc.3", "v1.6.0"}
+var versions = []string{"v1.8.0-rc.4", "v1.6.0"}
 
 func TestOPCMLiveChain(t *testing.T) {
 	for _, network := range networks {
 		for _, version := range versions {
 			t.Run(network+"-"+version, func(t *testing.T) {
-				if version == "v1.8.0-rc.3" && network == "mainnet" {
-					t.Skip("v1.8.0-rc.3 not supported on mainnet yet")
+				if version == "v1.8.0-rc.4" && network == "mainnet" {
+					t.Skip("v1.8.0-rc.4 not supported on mainnet yet")
 				}
 
 				if version == "v1.6.0" {

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -30,7 +30,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return err
 	}
 
-	opcmAddress, opcmAddrErr := standard.ManagerImplementationAddrFor(intent.L1ChainID)
+	opcmAddress, opcmAddrErr := standard.ManagerImplementationAddrFor(intent.L1ChainID, intent.L1ContractsLocator.Tag)
 	hasPredeployedOPCM := opcmAddrErr == nil
 	isTag := intent.L1ContractsLocator.IsTag()
 

--- a/op-deployer/pkg/deployer/standard/standard-versions-mainnet.toml
+++ b/op-deployer/pkg/deployer/standard/standard-versions-mainnet.toml
@@ -1,12 +1,29 @@
-[releases]
-
 # Contracts which are
 #   * unproxied singletons: specify a standard "address"
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
+# Holocene https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.4
+["op-contracts/v1.8.0-rc.4"]
+# Updated in this release
+system_config = { version = "2.3.0", implementation_address = "0xAB9d6cB7A427c0765163A7f45BB91cAfe5f2D375" } # UPDATED IN THIS RELEASE
+fault_dispute_game = { version = "1.3.1" }                                                                   # UPDATED IN THIS RELEASE
+permissioned_dispute_game = { version = "1.3.1" }                                                            # UPDATED IN THIS RELEASE
+mips = { version = "1.2.1", address = "0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C" }                         # UPDATED IN THIS RELEASE
+# Unchanged in this release
+optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
+anchor_state_registry = { version = "2.0.0" }
+delayed_weth = { version = "1.1.0", implementation_address = "0x71e966Ae981d1ce531a7b6d23DC0f27B38409087" }
+dispute_game_factory = { version = "1.0.0", implementation_address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
+preimage_oracle = { version = "1.1.2", address = "0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277" }
+l1_cross_domain_messenger = { version = "2.3.0", implementation_address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
+l1_erc721_bridge = { version = "2.1.0", implementation_address = "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d" }
+l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF" }
+# l2_output_oracle -- This contract not used in fault proofs
+optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846" }
+
 # Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
-[releases."op-contracts/v1.6.0"]
+["op-contracts/v1.6.0"]
 optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
 system_config = { version = "2.2.0", implementation_address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
 anchor_state_registry = { version = "2.0.0" }
@@ -23,7 +40,7 @@ l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64B5a5Ed26
 optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846" }
 
 # Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.4.0
-[releases."op-contracts/v1.4.0"]
+["op-contracts/v1.4.0"]
 optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
 system_config = { version = "2.2.0", implementation_address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
 anchor_state_registry = { version = "1.0.0" }
@@ -35,7 +52,7 @@ mips = { version = "1.0.1", address = "0x0f8EdFbDdD3c0256A80AD8C0F2560B1807873C9
 preimage_oracle = { version = "1.0.0", address = "0xD326E10B8186e90F4E2adc5c13a2d0C137ee8b34" }
 
 # MCP https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.3.0
-[releases."op-contracts/v1.3.0"]
+["op-contracts/v1.3.0"]
 l1_cross_domain_messenger = { version = "2.3.0", implementation_address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
 l1_erc721_bridge = { version = "2.1.0", implementation_address = "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d" }
 l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF" }

--- a/op-deployer/pkg/deployer/standard/standard-versions-sepolia.toml
+++ b/op-deployer/pkg/deployer/standard/standard-versions-sepolia.toml
@@ -1,12 +1,10 @@
-[releases]
-
 # Contracts which are
 #   * unproxied singletons: specify a standard "address"
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
-# Holocene https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.3
-[releases."op-contracts/v1.8.0-rc.3"]
+# Holocene https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.4
+["op-contracts/v1.8.0-rc.4"]
 # Updated in this release
 system_config = { version = "2.3.0", implementation_address = "0x33b83E4C305c908B2Fc181dDa36e230213058d7d" } # UPDATED IN THIS RELEASE
 fault_dispute_game = { version = "1.3.1" }                                                                   # UPDATED IN THIS RELEASE
@@ -25,7 +23,7 @@ l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64b5a5ed26
 optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xe01efbeb1089d1d1db9c6c8b135c934c0734c846" }
 
 # Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
-[releases."op-contracts/v1.6.0"]
+["op-contracts/v1.6.0"]
 optimism_portal = { version = "3.10.0", implementation_address = "0x35028bae87d71cbc192d545d38f960ba30b4b233" }
 system_config = { version = "2.2.0", implementation_address = "0xCcdd86d581e40fb5a1C77582247BC493b6c8B169" }
 anchor_state_registry = { version = "2.0.0" }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -50,9 +50,7 @@ var DefaultL1ContractsTag = ContractsV160Tag
 
 var DefaultL2ContractsTag = ContractsV170Beta1L2Tag
 
-type L1Versions struct {
-	Releases map[string]L1VersionsReleases `toml:"releases"`
-}
+type L1Versions map[string]L1VersionsReleases
 
 type L1VersionsReleases struct {
 	OptimismPortal               VersionRelease `toml:"optimism_portal"`
@@ -89,34 +87,62 @@ type OPCMBlueprints struct {
 	PermissionedDisputeGame2 common.Address
 }
 
-var sepoliaBlueprints = OPCMBlueprints{
-	AddressManager:           common.HexToAddress("0x3125a4cB2179E04203D3Eb2b5784aaef9FD64216"),
-	Proxy:                    common.HexToAddress("0xe650ADb86a0de96e2c434D0a52E7D5B70980D6f1"),
-	ProxyAdmin:               common.HexToAddress("0x3AC6b88F6bC4A5038DB7718dE47a5ab1a9609319"),
-	L1ChugSplashProxy:        common.HexToAddress("0x58770FC7ed304c43D2B70248914eb34A741cF411"),
-	ResolvedDelegateProxy:    common.HexToAddress("0x0449adB72D489a137d476aB49c6b812161754fD3"),
-	AnchorStateRegistry:      common.HexToAddress("0xB98095199437883b7661E0D58256060f3bc730a4"),
-	PermissionedDisputeGame1: common.HexToAddress("0xf72Ac5f164cC024DE09a2c249441715b69a16eAb"),
-	PermissionedDisputeGame2: common.HexToAddress("0x713dAC5A23728477547b484f9e0D751077E300a2"),
+type OPCMBlueprintsByChain struct {
+	Mainnet *OPCMBlueprints
+	Sepolia *OPCMBlueprints
 }
 
-var mainnetBlueprints = OPCMBlueprints{
-	AddressManager:           common.HexToAddress("0x29aA24714c06914d9689e933cae2293C569AfeEa"),
-	Proxy:                    common.HexToAddress("0x3626ebD458c7f34FD98789A373593fF2fc227bA0"),
-	ProxyAdmin:               common.HexToAddress("0x7170678A5CFFb6872606d251B3CcdB27De962631"),
-	L1ChugSplashProxy:        common.HexToAddress("0x538906C8B000D621fd11B7e8642f504dD8730837"),
-	ResolvedDelegateProxy:    common.HexToAddress("0xF12bD34d6a1d26d230240ECEA761f77e2013926E"),
-	AnchorStateRegistry:      common.HexToAddress("0xbA7Be2bEE016568274a4D1E6c852Bb9a99FaAB8B"),
-	PermissionedDisputeGame1: common.HexToAddress("0xb94bF6130Df8BD9a9eA45D8dD8C18957002d1986"),
-	PermissionedDisputeGame2: common.HexToAddress("0xe0a642B249CF6cbF0fF7b4dDf41443Ea7a5C8Cc8"),
+var opcmBlueprintsByVersion = map[string]OPCMBlueprintsByChain{
+	"op-contracts/v1.6.0": {
+		Mainnet: &OPCMBlueprints{
+			AddressManager:           common.HexToAddress("0x29aA24714c06914d9689e933cae2293C569AfeEa"),
+			Proxy:                    common.HexToAddress("0x3626ebD458c7f34FD98789A373593fF2fc227bA0"),
+			ProxyAdmin:               common.HexToAddress("0x7170678A5CFFb6872606d251B3CcdB27De962631"),
+			L1ChugSplashProxy:        common.HexToAddress("0x538906C8B000D621fd11B7e8642f504dD8730837"),
+			ResolvedDelegateProxy:    common.HexToAddress("0xF12bD34d6a1d26d230240ECEA761f77e2013926E"),
+			AnchorStateRegistry:      common.HexToAddress("0xbA7Be2bEE016568274a4D1E6c852Bb9a99FaAB8B"),
+			PermissionedDisputeGame1: common.HexToAddress("0xb94bF6130Df8BD9a9eA45D8dD8C18957002d1986"),
+			PermissionedDisputeGame2: common.HexToAddress("0xe0a642B249CF6cbF0fF7b4dDf41443Ea7a5C8Cc8"),
+		},
+		Sepolia: &OPCMBlueprints{
+			AddressManager:           common.HexToAddress("0x3125a4cB2179E04203D3Eb2b5784aaef9FD64216"),
+			Proxy:                    common.HexToAddress("0xe650ADb86a0de96e2c434D0a52E7D5B70980D6f1"),
+			ProxyAdmin:               common.HexToAddress("0x3AC6b88F6bC4A5038DB7718dE47a5ab1a9609319"),
+			L1ChugSplashProxy:        common.HexToAddress("0x58770FC7ed304c43D2B70248914eb34A741cF411"),
+			ResolvedDelegateProxy:    common.HexToAddress("0x0449adB72D489a137d476aB49c6b812161754fD3"),
+			AnchorStateRegistry:      common.HexToAddress("0xB98095199437883b7661E0D58256060f3bc730a4"),
+			PermissionedDisputeGame1: common.HexToAddress("0xf72Ac5f164cC024DE09a2c249441715b69a16eAb"),
+			PermissionedDisputeGame2: common.HexToAddress("0x713dAC5A23728477547b484f9e0D751077E300a2"),
+		},
+	},
+	"op-contracts/v1.8.0-rc.4": {
+		Sepolia: &OPCMBlueprints{
+			AddressManager:           common.HexToAddress("0x3125a4cB2179E04203D3Eb2b5784aaef9FD64216"),
+			Proxy:                    common.HexToAddress("0xe650ADb86a0de96e2c434D0a52E7D5B70980D6f1"),
+			ProxyAdmin:               common.HexToAddress("0x3AC6b88F6bC4A5038DB7718dE47a5ab1a9609319"),
+			L1ChugSplashProxy:        common.HexToAddress("0x58770FC7ed304c43D2B70248914eb34A741cF411"),
+			ResolvedDelegateProxy:    common.HexToAddress("0x0449adB72D489a137d476aB49c6b812161754fD3"),
+			AnchorStateRegistry:      common.HexToAddress("0xB98095199437883b7661E0D58256060f3bc730a4"),
+			PermissionedDisputeGame1: common.HexToAddress("0x596A4334a28056c7943c8bcEf220F38cA5B42dC5"), // updated
+			PermissionedDisputeGame2: common.HexToAddress("0x4E3E5C09B07AAA3fe482F5A1f82a19e91944Fffc"), // updated
+		},
+	},
 }
 
-func OPCMBlueprintsFor(chainID uint64) (OPCMBlueprints, error) {
+func OPCMBlueprintsFor(chainID uint64, version string) (OPCMBlueprints, error) {
 	switch chainID {
 	case 1:
-		return mainnetBlueprints, nil
+		bps := opcmBlueprintsByVersion[version].Mainnet
+		if bps == nil {
+			return OPCMBlueprints{}, fmt.Errorf("unsupported version: %s", version)
+		}
+		return *bps, nil
 	case 11155111:
-		return sepoliaBlueprints, nil
+		bps := opcmBlueprintsByVersion[version].Sepolia
+		if bps == nil {
+			return OPCMBlueprints{}, fmt.Errorf("unsupported version: %s", version)
+		}
+		return *bps, nil
 	default:
 		return OPCMBlueprints{}, fmt.Errorf("unsupported chain ID: %d", chainID)
 	}
@@ -199,18 +225,31 @@ func CommitForDeployTag(tag string) (string, error) {
 	}
 }
 
-func ManagerImplementationAddrFor(chainID uint64) (common.Address, error) {
+func ManagerImplementationAddrFor(chainID uint64, tag string) (common.Address, error) {
 	switch chainID {
 	case 1:
-		// Generated using the bootstrap command on 11/18/2024.
-		// Verified against compiled bytecode at:
-		// https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts-v160-artifacts-opcm-redesign-backport
-		return common.HexToAddress("0x9BC0A1eD534BFb31a6Be69e5b767Cba332f14347"), nil
+		switch tag {
+		case "op-contracts/v1.6.0":
+			// Generated using the bootstrap command on 11/18/2024.
+			// Verified against compiled bytecode at:
+			// https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts-v160-artifacts-opcm-redesign-backport
+			return common.HexToAddress("0x9BC0A1eD534BFb31a6Be69e5b767Cba332f14347"), nil
+		default:
+			return common.Address{}, fmt.Errorf("unsupported mainnet tag: %s", tag)
+		}
 	case 11155111:
-		// Generated using the bootstrap command on 11/18/2024.
-		// Verified against compiled bytecode at:
-		// https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts-v160-artifacts-opcm-redesign-backport
-		return common.HexToAddress("0x760B1d2Dc68DC51fb6E8B2b8722B8ed08903540c"), nil
+		switch tag {
+		case "op-contracts/v1.6.0":
+			// Generated using the bootstrap command on 11/18/2024.
+			// Verified against compiled bytecode at:
+			// https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts-v160-artifacts-opcm-redesign-backport
+			return common.HexToAddress("0x760B1d2Dc68DC51fb6E8B2b8722B8ed08903540c"), nil
+		case "op-contracts/v1.8.0-rc.4":
+			// Generated using the bootstrap command on 12/19/2024.
+			return common.HexToAddress("0xefb0779120d9cc3582747e5eb787d859e3a53a5c"), nil
+		default:
+			return common.Address{}, fmt.Errorf("unsupported sepolia tag: %s", tag)
+		}
 	default:
 		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
 	}
@@ -260,8 +299,8 @@ func ArtifactsURLForTag(tag string) (*url.URL, error) {
 		return url.Parse(standardArtifactsURL("e1f0c4020618c4a98972e7124c39686cab2e31d5d7846f9ce5e0d5eed0f5ff32"))
 	case "op-contracts/v1.7.0-beta.1+l2-contracts":
 		return url.Parse(standardArtifactsURL("b0fb1f6f674519d637cff39a22187a5993d7f81a6d7b7be6507a0b50a5e38597"))
-	case "op-contracts/v1.8.0-rc.3":
-		return url.Parse(standardArtifactsURL("3bcff2944953862596d5fd0125d166a04af2ba6426dc693983291d3cb86b2e2e"))
+	case "op-contracts/v1.8.0-rc.4":
+		return url.Parse(standardArtifactsURL("361ebf1f520c20d932695b00babfff6923ce2530cd05b2776eb74e07038898a6"))
 	default:
 		return nil, fmt.Errorf("unsupported tag: %s", tag)
 	}
@@ -273,8 +312,8 @@ func ArtifactsHashForTag(tag string) (common.Hash, error) {
 		return common.HexToHash("d20a930cc0ff204c2d93b7aa60755ec7859ba4f328b881f5090c6a6a2a86dcba"), nil
 	case "op-contracts/v1.7.0-beta.1+l2-contracts":
 		return common.HexToHash("9e3ad322ec9b2775d59143ce6874892f9b04781742c603ad59165159e90b00b9"), nil
-	case "op-contracts/v1.8.0-rc.3":
-		return common.HexToHash("7c133142165fbbdba28ced5d9a04af8bea68baf58b19a07cdd8ae531b01fbe9d"), nil
+	case "op-contracts/v1.8.0-rc.4":
+		return common.HexToHash("78f186df4e9a02a6421bd9c3641b281e297535140967faa428c938286923976a"), nil
 	default:
 		return common.Hash{}, fmt.Errorf("unsupported tag: %s", tag)
 	}

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -263,7 +263,7 @@ func (c *Intent) checkL1Prod() error {
 		return err
 	}
 
-	if _, ok := versions.Releases[c.L1ContractsLocator.Tag]; !ok {
+	if _, ok := versions[c.L1ContractsLocator.Tag]; !ok {
 		return fmt.Errorf("tag '%s' not found in standard versions", c.L1ContractsLocator.Tag)
 	}
 


### PR DESCRIPTION
The artifacts for v1.8.0 were generated from the tag `op-contracts-v180-artifacts-base`, which points to the branch `proposal/contracts/v1.8.0-opcm-backport`. The backport branch consists of `proposal/contracts/v1.8.0` with the non-proxied OPCM backported.

The OPCM was deployed using the `opcm bootstrap` command. The PDG blueprints were updated using a custom script which you can find at the `op-contracts-v180-blueprints-script` [tag](https://github.com/ethereum-optimism/optimism/commit/a7091185a787ea104343abafc311d65a5916e4b8).

As part of this PR, I also added a bunch of tests to assert that the semver versions of deployed contracts are correct. I'll add similar tests for mainnet once the gov vote passes.