### PR TITLE
feat(kurtosis-devnet): use inspect as a data source

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go
@@ -1,0 +1,45 @@
+// Package main reproduces a lightweight version of the "kurtosis enclave inspect" command
+// It can be used to sanity check the results, as writing tests against a fake
+// enclave is not practical right now.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect"
+)
+
+func main() {
+	ctx := context.Background()
+
+	flag.Parse()
+	if flag.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <enclave-id>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	enclaveID := flag.Arg(0)
+	inspector := inspect.NewInspector(enclaveID)
+
+	data, err := inspector.ExtractData(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error inspecting enclave: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("File Artifacts:")
+	for _, artifact := range data.FileArtifacts {
+		fmt.Printf("  %s\n", artifact)
+	}
+
+	fmt.Println("\nServices:")
+	for svc, ports := range data.UserServices {
+		fmt.Printf("  %s:\n", svc)
+		for portName, portNum := range ports {
+			fmt.Printf("    %s: %d\n", portName, portNum)
+		}
+	}
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
@@ -1,0 +1,77 @@
+package inspect
+
+import (
+	"context"
+
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+)
+
+type PortMap map[string]int
+
+type ServiceMap map[string]PortMap
+
+// InspectData represents a summary of the output of "kurtosis enclave inspect"
+type InspectData struct {
+	FileArtifacts []string
+	UserServices  ServiceMap
+}
+
+type Inspector struct {
+	enclaveID string
+}
+
+func NewInspector(enclaveID string) *Inspector {
+	return &Inspector{enclaveID: enclaveID}
+}
+
+func (e *Inspector) ExtractData(ctx context.Context) (*InspectData, error) {
+	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	if err != nil {
+		return nil, err
+	}
+
+	enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctx, e.enclaveID)
+	if err != nil {
+		return nil, err
+	}
+
+	services, err := enclaveCtx.GetServices()
+	if err != nil {
+		return nil, err
+	}
+
+	artifacts, err := enclaveCtx.GetAllFilesArtifactNamesAndUuids(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	data := &InspectData{
+		UserServices:  make(ServiceMap),
+		FileArtifacts: make([]string, len(artifacts)),
+	}
+
+	for i, artifact := range artifacts {
+		data.FileArtifacts[i] = artifact.GetFileName()
+	}
+
+	for svc := range services {
+		svc := string(svc)
+		svcCtx, err := enclaveCtx.GetServiceContext(svc)
+		if err != nil {
+			return nil, err
+		}
+
+		portMap := make(PortMap)
+
+		for port, portSpec := range svcCtx.GetPublicPorts() {
+			portMap[port] = int(portSpec.GetNumber())
+		}
+
+		if len(portMap) != 0 {
+			data.UserServices[svc] = portMap
+		}
+
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
**Description**

This enables us to retrieve information about artifacts and services,
for downstream consumption.


**Additional context**

gradually porting changes from
https://github.com/ethereum-optimism/optimism/tree/sigma/kurtosis-devnet-rebase/kurtosis-devnet

**Metadata**

Part of ethereum-optimism/platforms-team#519