### PR TITLE
feat(kurtosis-devnet): add spec data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/sync v0.10.0
 	golang.org/x/term v0.25.0
 	golang.org/x/time v0.7.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -247,7 +248,6 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go
@@ -1,0 +1,75 @@
+package spec
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ChainSpec represents the network parameters for a chain
+type ChainSpec struct {
+	Name      string
+	NetworkID string
+}
+
+// EnclaveSpec represents the parsed chain specifications from the YAML
+type EnclaveSpec struct {
+	Chains []ChainSpec
+}
+
+// NetworkParams represents the network parameters section in the YAML
+type NetworkParams struct {
+	Name      string `yaml:"name"`
+	NetworkID string `yaml:"network_id"`
+}
+
+// ChainConfig represents a chain configuration in the YAML
+type ChainConfig struct {
+	NetworkParams NetworkParams `yaml:"network_params"`
+}
+
+// OptimismPackage represents the optimism_package section in the YAML
+type OptimismPackage struct {
+	Chains []ChainConfig `yaml:"chains"`
+}
+
+// YAMLSpec represents the root of the YAML document
+type YAMLSpec struct {
+	OptimismPackage OptimismPackage `yaml:"optimism_package"`
+}
+
+type Spec struct{}
+
+type SpecOption func(*Spec)
+
+func NewSpec(opts ...SpecOption) *Spec {
+	s := &Spec{}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// ExtractData parses a YAML document and returns the chain specifications
+func (s *Spec) ExtractData(r io.Reader) (*EnclaveSpec, error) {
+	var yamlSpec YAMLSpec
+	decoder := yaml.NewDecoder(r)
+	if err := decoder.Decode(&yamlSpec); err != nil {
+		return nil, fmt.Errorf("failed to decode YAML: %w", err)
+	}
+
+	result := &EnclaveSpec{
+		Chains: make([]ChainSpec, 0, len(yamlSpec.OptimismPackage.Chains)),
+	}
+
+	// Extract chain specifications
+	for _, chain := range yamlSpec.OptimismPackage.Chains {
+		result.Chains = append(result.Chains, ChainSpec{
+			Name:      chain.NetworkParams.Name,
+			NetworkID: chain.NetworkParams.NetworkID,
+		})
+	}
+
+	return result, nil
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -1,0 +1,104 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSpec(t *testing.T) {
+	yamlContent := `
+optimism_package:
+  chains:
+    - participants:
+        - el_type: op-geth
+      network_params:
+        name: op-rollup-one
+        network_id: "3151909"
+      additional_services:
+        - blockscout
+    - participants:
+        - el_type: op-geth
+      network_params:
+        name: op-rollup-two
+        network_id: "3151910"
+      additional_services:
+        - blockscout
+ethereum_package:
+  participants:
+    - el_type: geth
+    - el_type: reth
+  network_params:
+    preset: minimal
+    genesis_delay: 5
+`
+
+	result, err := NewSpec().ExtractData(strings.NewReader(yamlContent))
+	require.NoError(t, err)
+
+	expectedChains := []ChainSpec{
+		{
+			Name:      "op-rollup-one",
+			NetworkID: "3151909",
+		},
+		{
+			Name:      "op-rollup-two",
+			NetworkID: "3151910",
+		},
+	}
+
+	require.Len(t, result.Chains, len(expectedChains))
+
+	for i, expected := range expectedChains {
+		actual := result.Chains[i]
+		require.Equal(t, expected.Name, actual.Name, "Chain %d: name mismatch", i)
+		require.Equal(t, expected.NetworkID, actual.NetworkID, "Chain %d: network ID mismatch", i)
+	}
+}
+
+func TestParseSpecErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name:    "empty yaml",
+			yaml:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid yaml",
+			yaml:    "invalid: [yaml: content",
+			wantErr: true,
+		},
+		{
+			name: "missing network params",
+			yaml: `
+optimism_package:
+  chains:
+    - participants:
+        - el_type: op-geth
+      additional_services:
+        - blockscout`,
+		},
+		{
+			name: "missing chains",
+			yaml: `
+optimism_package:
+  other_field: value`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSpec().ExtractData(strings.NewReader(tt.yaml))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

This enables us to parse the input provided to kurtosis for the
enclave creation, and retrieve some basic information to organize the
dynamic information we'll get from the enclave directly.

Namely, the name and network ID for each chain created.

**Additional context**

gradually porting changes from
https://github.com/ethereum-optimism/optimism/tree/sigma/kurtosis-devnet-rebase/kurtosis-devnet

**Metadata**

Part of ethereum-optimism/platforms-team#519
