### PR TITLE
op-program: Support multiple types of op-program releases

### DIFF
--- a/op-program/prestates/releases.go
+++ b/op-program/prestates/releases.go
@@ -13,10 +13,15 @@ import (
 var releasesJSON []byte
 
 type Release struct {
-	Version            string `json:"version"`
-	Hash               string `json:"hash"`
-	GovernanceApproved bool   `json:"governanceApproved"`
+	Version            string      `json:"version"`
+	Hash               string      `json:"hash"`
+	GovernanceApproved bool        `json:"governanceApproved"`
+	Type               ReleaseType `json:"type"`
 }
+
+type ReleaseType string
+
+const Cannon64Type ReleaseType = "cannon64"
 
 // GetReleases reads the contents of the releases.json file
 func GetReleases() ([]Release, error) {

--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -1,11 +1,26 @@
 [
   {
     "version": "1.4.0-rc.3",
+    "hash": "0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b",
+    "type": "cannon64"
+  },
+  {
+    "version": "1.4.0-rc.3",
     "hash": "0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568"
   },
   {
     "version": "1.4.0-rc.2",
+    "hash": "0x0348ce2059f718af75729c2c56860551b46b665956a641b3cb2cd51e50b7b725",
+    "type": "cannon64"
+  },
+  {
+    "version": "1.4.0-rc.2",
     "hash": "0x0364e4e72922e7d649338f558f8a14b50ca31922a1484e73ea03987fb1516095"
+  },
+  {
+    "version": "1.4.0-rc.1",
+    "hash": "0x032e5d6119ee983cb87deae3eef16ea6086f2347433c99f1820d60f36a24a6e6",
+    "type": "cannon64"
   },
   {
     "version": "1.4.0-rc.1",

--- a/op-program/prestates/releases_test.go
+++ b/op-program/prestates/releases_test.go
@@ -11,11 +11,16 @@ func TestGetReleases(t *testing.T) {
 	require.NoError(t, err, "expected no error while parsing embedded releases.json")
 
 	foundGovernanceApproved := false
+	foundCannon64Release := false
 	for _, release := range releases {
 		if release.GovernanceApproved {
 			foundGovernanceApproved = true
 			break
 		}
+		if release.Type == Cannon64Type {
+			foundCannon64Release = true
+		}
 	}
 	require.True(t, foundGovernanceApproved, "expected to find at least one GovernanceApproved release")
+	require.True(t, foundCannon64Release, "expected to find at least one Cannon64 release")
 }

--- a/op-program/prestates/verify/verify.go
+++ b/op-program/prestates/verify/verify.go
@@ -44,11 +44,19 @@ func main() {
 		os.Exit(2)
 	}
 
+	stringCompare := func(a, b string) int {
+		if a > b {
+			return 1
+		} else if a == b {
+			return 0
+		}
+		return -1
+	}
 	sortFunc := func(a, b prestates.Release) int {
 		if a.Version > b.Version {
 			return 1
 		} else if a.Version == b.Version {
-			return 0
+			return stringCompare(string(a.Type), string(b.Type))
 		}
 		return -1
 	}
@@ -68,11 +76,12 @@ func main() {
 		expectedStr := get(expected, i)
 		actualStr := get(actual, i)
 		releaseDiffers := expectedStr != actualStr
+		releaseDiffers = releaseDiffers || (expected[i].Type != actual[i].Type)
 		marker := "✅"
 		if releaseDiffers {
 			marker = "❌"
 		}
-		report += fmt.Sprintf("%v %d\tExpected: %v\tActual: %v\n", marker, i, expectedStr, actualStr)
+		report += fmt.Sprintf("%v %d\tExpected: %v \tActual: %v \t Expected Type: %v \t Acutal Type: %v \t\n", marker, i, expectedStr, actualStr, expected[i].Type, actual[i].Type)
 		differs = differs || releaseDiffers
 	}
 	fmt.Println(report)

--- a/op-program/prestates/verify/verify.go
+++ b/op-program/prestates/verify/verify.go
@@ -76,12 +76,11 @@ func main() {
 		expectedStr := get(expected, i)
 		actualStr := get(actual, i)
 		releaseDiffers := expectedStr != actualStr
-		releaseDiffers = releaseDiffers || (expected[i].Type != actual[i].Type)
 		marker := "✅"
 		if releaseDiffers {
 			marker = "❌"
 		}
-		report += fmt.Sprintf("%v %d\tExpected: %v \tActual: %v \t Expected Type: %v \t Acutal Type: %v \t\n", marker, i, expectedStr, actualStr, expected[i].Type, actual[i].Type)
+		report += fmt.Sprintf("%v %d\tExpected: %v\tActual: %v\n", marker, i, expectedStr, actualStr)
 		differs = differs || releaseDiffers
 	}
 	fmt.Println(report)
@@ -91,5 +90,5 @@ func main() {
 }
 
 func formatRelease(release prestates.Release) string {
-	return fmt.Sprintf("%-13v %s", release.Version, release.Hash)
+	return fmt.Sprintf("%-13v %s %s", release.Version, release.Hash, release.Type)
 }

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -43,9 +43,15 @@ do
     else
       cp "${BIN_DIR}/prestate.json" "${STATES_DIR}/${HASH}.json"
     fi
-
     VERSIONS_JSON=$(echo "${VERSIONS_JSON}" | jq ". += [{\"version\": \"${SHORT_VERSION}\", \"hash\": \"${HASH}\"}]")
     echo "Built ${VERSION}: ${HASH}"
+
+    if [ -f "${BIN_DIR}/prestate-proof-mt64.json" ]; then
+      HASH=$(cat "${BIN_DIR}/prestate-proof-mt64.json" | jq -r .pre)
+      cp "${BIN_DIR}/prestate-mt64.bin.gz" "${STATES_DIR}/${HASH}.mt64.bin.gz"
+      VERSIONS_JSON=$(echo "${VERSIONS_JSON}" | jq ". += [{\"version\": \"${SHORT_VERSION}\", \"hash\": \"${HASH}\", \"type\": \"cannon64\"}]")
+      echo "Built cannon64 ${VERSION}: ${HASH}"
+    fi
 done
 echo "${VERSIONS_JSON}" > "${VERSIONS_FILE}"
 


### PR DESCRIPTION
With the upcoming MT-Cannon upgrade, we need a way to disambiguate different types of absolute prestates that may be associated with the same op-program release.

This patch updates the op-program releases.json to include the VM type used to build the prestate. An empty `type` value is used to indicate `cannon` for backwards compatibility.