### PR TITLE
interop-managed: quick fixes

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
 	"io"
 	gosync "sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/libp2p/go-libp2p/core/peer"

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -143,10 +143,12 @@ func (db *ChainsDB) AddCrossUnsafeTracker(chainID types.ChainID) {
 
 func (db *ChainsDB) AddSubscriptions(chainID types.ChainID) {
 	if db.l2FinalitySubscription.Has(chainID) {
-		db.logger.Warn("overwriting existing L2 finality subscription for chain", "chain", chainID)
+		db.logger.Warn("a subscription for this chain already exists", "chain", chainID)
+		return
 	}
 	if db.crossSafeSubscription.Has(chainID) {
-		db.logger.Warn("overwriting existing cross-safe subscription for chain", "chain", chainID)
+		db.logger.Warn("a subscription for this chain already exists", "chain", chainID)
+		return
 	}
 	db.l2FinalitySubscription.Set(chainID, &gethevent.FeedOf[eth.BlockID]{})
 	db.crossSafeSubscription.Set(chainID, &gethevent.FeedOf[types.DerivedPair]{})

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -15,6 +15,13 @@ type L1Source interface {
 	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
 }
 
+// L1Accessor provides access to the L1 chain.
+// it wraps an L1 source in order to pass calls to the L1 chain
+// and manages the finality and latest block subscriptions.
+// The finality subscription is hooked to a finality handler function provided by the caller.
+// and the latest block subscription is used to monitor the tip height of the L1 chain.
+// L1Accessor has the concept of confirmation depth, which is used to block access to requests to blocks which are too recent.
+// When requests for blocks are more recent than the tip minus the confirmation depth, a NotFound error is returned.
 type L1Accessor struct {
 	log      log.Logger
 	client   L1Source

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -311,6 +311,8 @@ func LogToMessagePayload(l *ethTypes.Log) []byte {
 	return msg
 }
 
+// DerivedPair is a pair of block refs, where Derived (L2) is derived from DerivedFrom (L1).
+// it is used in cases where RPC can only return a single value, so the pair is returned as a struct.
 type DerivedPair struct {
 	DerivedFrom eth.BlockRef
 	Derived     eth.BlockRef


### PR DESCRIPTION
- docs on new types
  - DerivedPair
  - L1Accessor
-AddSubscriptions no longer overwrites subscriptions
- fix import lint in op-node/node
