### PR TITLE
Interop: managed L1 traversal

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -164,6 +164,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		Log:            log,
 		Ctx:            ctx,
 		Drain:          executor.Drain,
+		ManagedMode:    false,
 	}, opts)
 
 	sys.Register("engine", engine.NewEngDeriver(log, ctx, cfg, metrics, ec), opts)

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -144,7 +144,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, ctx, eng), opts)
 
-	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, altDASrc, eng, metrics)
+	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, altDASrc, eng, metrics, false)
 	sys.Register("pipeline", derive.NewPipelineDeriver(ctx, pipeline), opts)
 
 	testActionEmitter := sys.Register("test-action", nil, opts)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -400,10 +400,14 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		return err
 	}
 
+	managedMode := false
 	if cfg.Rollup.InteropTime != nil {
 		sys, err := cfg.InteropConfig.Setup(ctx, n.log, &n.cfg.Rollup, n.l1Source, n.l2Source)
 		if err != nil {
 			return fmt.Errorf("failed to setup interop: %w", err)
+		}
+		if _, ok := sys.(*managed.ManagedMode); ok {
+			managedMode = ok
 		}
 		n.interopSys = sys
 		n.eventSys.Register("interop", n.interopSys, event.DefaultRegisterOpts())
@@ -431,7 +435,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		n.safeDB = safedb.Disabled
 	}
 	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source,
-		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA)
+		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, managedMode)
 	return nil
 }
 

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -29,6 +29,16 @@ func (d ExhaustedL1Event) String() string {
 	return "exhausted-l1"
 }
 
+// ProvideL1Traversal is accepted to override the next L1 block to traverse into.
+// This block must fit on the previous L1 block, or a ResetEvent may be emitted.
+type ProvideL1Traversal struct {
+	NextL1 eth.L1BlockRef
+}
+
+func (d ProvideL1Traversal) String() string {
+	return "provide-l1-traversal"
+}
+
 type DeriverL1StatusEvent struct {
 	Origin eth.L1BlockRef
 	LastL2 eth.L2BlockRef
@@ -163,6 +173,22 @@ func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 			return true
 		}
 		d.emitDerivedAttributesEvent(attrib)
+	case ProvideL1Traversal:
+		if l1t, ok := d.pipeline.traversal.(ManagedL1Traversal); ok {
+			if err := l1t.ProvideNextL1(d.ctx, x.NextL1); err != nil {
+				if err != nil && errors.Is(err, ErrReset) {
+					d.emitter.Emit(rollup.ResetEvent{Err: err})
+				} else if err != nil && errors.Is(err, ErrTemporary) {
+					d.emitter.Emit(rollup.L1TemporaryErrorEvent{Err: err})
+				} else if err != nil && errors.Is(err, ErrCritical) {
+					d.emitter.Emit(rollup.CriticalErrorEvent{Err: err})
+				} else {
+					d.emitter.Emit(rollup.L1TemporaryErrorEvent{Err: err})
+				}
+			}
+		} else {
+			d.pipeline.log.Warn("Ignoring ProvideL1Traversal event, L1 traversal derivation stage does not support it")
+		}
 	default:
 		return false
 	}

--- a/op-node/rollup/derive/l1_traversal_managed.go
+++ b/op-node/rollup/derive/l1_traversal_managed.go
@@ -1,0 +1,120 @@
+package derive
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type ManagedL1Traversal interface {
+	ProvideNextL1(ctx context.Context, nextL1 eth.L1BlockRef) error
+}
+
+type L1TraversalManagedSource interface {
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+}
+
+// L1TraversalManaged is an alternative version of L1Traversal,
+// that supports manually operated L1 traversal, as used in the Interop upgrade.
+type L1TraversalManaged struct {
+	block eth.L1BlockRef
+
+	// true = consumed by other stages
+	// false = not consumed yet
+	done bool
+
+	l1Blocks L1TraversalManagedSource
+	log      log.Logger
+	sysCfg   eth.SystemConfig
+	cfg      *rollup.Config
+}
+
+var _ l1TraversalStage = (*L1TraversalManaged)(nil)
+var _ ManagedL1Traversal = (*L1TraversalManaged)(nil)
+
+func NewL1TraversalManaged(log log.Logger, cfg *rollup.Config, l1Blocks L1TraversalManagedSource) *L1TraversalManaged {
+	return &L1TraversalManaged{
+		log:      log,
+		l1Blocks: l1Blocks,
+		cfg:      cfg,
+	}
+}
+
+func (l1t *L1TraversalManaged) Origin() eth.L1BlockRef {
+	return l1t.block
+}
+
+// NextL1Block returns the next block. It does not advance, but it can only be
+// called once before returning io.EOF
+func (l1t *L1TraversalManaged) NextL1Block(_ context.Context) (eth.L1BlockRef, error) {
+	if !l1t.done {
+		l1t.done = true
+		return l1t.block, nil
+	} else {
+		return eth.L1BlockRef{}, io.EOF
+	}
+}
+
+// AdvanceL1Block advances the internal state of L1 Traversal
+func (l1t *L1TraversalManaged) AdvanceL1Block(ctx context.Context) error {
+	if !l1t.done {
+		return fmt.Errorf("L1TraversalManaged should not advance to next L1 block before reading the current L1 block")
+	}
+	// At this point we consumed the L1 block, i.e. exhausted available data.
+	// The next L1 block will not be available until a manual ProvideNextL1 call.
+	return nil
+}
+
+// Reset sets the internal L1 block to the supplied base.
+func (l1t *L1TraversalManaged) Reset(ctx context.Context, base eth.L1BlockRef, cfg eth.SystemConfig) error {
+	l1t.block = base
+	l1t.done = false
+	l1t.sysCfg = cfg
+	l1t.log.Info("completed reset of derivation pipeline", "origin", base)
+	return io.EOF
+}
+
+func (l1c *L1TraversalManaged) SystemConfig() eth.SystemConfig {
+	return l1c.sysCfg
+}
+
+// ProvideNextL1 is an override to traverse to the next L1 block.
+func (l1t *L1TraversalManaged) ProvideNextL1(ctx context.Context, nextL1 eth.L1BlockRef) error {
+	logger := l1t.log.New("current", l1t.block, "next", nextL1)
+	if !l1t.done {
+		logger.Debug("Not ready for next L1 block yet")
+		return nil
+	}
+	if l1t.block.Number+1 != nextL1.Number {
+		logger.Warn("Received signal for L1 block, but needed different block")
+		return nil // safe to ignore; we'll signal an exhaust-L1 event, and get the correct next L1 block.
+	}
+	if l1t.block.Hash != nextL1.ParentHash {
+		logger.Warn("Provided next L1 block does not build on last processed L1 block")
+		return NewResetError(fmt.Errorf("provided next L1 block %s does not build on last processed L1 block %s", nextL1, l1t.block))
+	}
+
+	// Parse L1 receipts of the given block and update the L1 system configuration.
+	// If this fails, the caller will just have to ProvideNextL1 again (triggered by revisiting the exhausted-L1 signal).
+	_, receipts, err := l1t.l1Blocks.FetchReceipts(ctx, nextL1.Hash)
+	if err != nil {
+		return NewTemporaryError(fmt.Errorf("failed to fetch receipts of L1 block %s (parent: %s) for L1 sysCfg update: %w",
+			nextL1, nextL1.ParentID(), err))
+	}
+	if err := UpdateSystemConfigWithL1Receipts(&l1t.sysCfg, receipts, l1t.cfg, nextL1.Time); err != nil {
+		// the sysCfg changes should always be formatted correctly.
+		return NewCriticalError(fmt.Errorf("failed to update L1 sysCfg with receipts from block %s: %w", nextL1, err))
+	}
+
+	logger.Info("Derivation continued with next L1 block")
+	l1t.block = nextL1
+	l1t.done = false
+	return nil
+}

--- a/op-node/rollup/derive/l1_traversal_managed_test.go
+++ b/op-node/rollup/derive/l1_traversal_managed_test.go
@@ -1,0 +1,87 @@
+package derive
+
+import (
+	"context"
+	"io"
+	"math/big"
+	"math/rand" // nosemgrep
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+func TestL1TraversalManaged(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+	a := testutils.RandomBlockRef(rng)
+	// Load up the initial state with a reset
+	l1Cfg := eth.SystemConfig{
+		BatcherAddr: testutils.RandomAddress(rng),
+		Overhead:    [32]byte{42},
+		Scalar:      [32]byte{69},
+	}
+	sysCfgAddr := testutils.RandomAddress(rng)
+	cfg := &rollup.Config{
+		Genesis:               rollup.Genesis{SystemConfig: l1Cfg},
+		L1SystemConfigAddress: sysCfgAddr,
+	}
+	l1F := &testutils.MockL1Source{}
+	tr := NewL1TraversalManaged(testlog.Logger(t, log.LevelError), cfg, l1F)
+
+	_ = tr.Reset(context.Background(), a, l1Cfg)
+
+	// First call should always succeed
+	ref, err := tr.NextL1Block(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, a, ref)
+
+	// Subsequent calls should return io.EOF
+	ref, err = tr.NextL1Block(context.Background())
+	require.Equal(t, eth.L1BlockRef{}, ref)
+	require.Equal(t, io.EOF, err)
+	// again
+	ref, err = tr.NextL1Block(context.Background())
+	require.Equal(t, eth.L1BlockRef{}, ref)
+	require.Equal(t, io.EOF, err)
+
+	// Now provide the next L1 block
+	b := testutils.NextRandomRef(rng, a)
+
+	// L1 block info and receipts are fetched to update the system config.
+	l1F.ExpectFetchReceipts(b.Hash, &testutils.MockBlockInfo{
+		InfoHash:             b.Hash,
+		InfoParentHash:       b.ParentHash,
+		InfoCoinbase:         common.Address{},
+		InfoRoot:             common.Hash{},
+		InfoNum:              b.Number,
+		InfoTime:             b.Time,
+		InfoMixDigest:        [32]byte{},
+		InfoBaseFee:          big.NewInt(10),
+		InfoBlobBaseFee:      big.NewInt(10),
+		InfoReceiptRoot:      common.Hash{},
+		InfoGasUsed:          0,
+		InfoGasLimit:         30_000_000,
+		InfoHeaderRLP:        nil,
+		InfoParentBeaconRoot: nil,
+	}, nil, nil)
+	require.NoError(t, tr.ProvideNextL1(context.Background(), b))
+	l1F.AssertExpectations(t)
+
+	// It should provide B now
+	ref, err = tr.NextL1Block(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, b, ref)
+
+	// And EOF again after traversing
+	ref, err = tr.NextL1Block(context.Background())
+	require.Equal(t, eth.L1BlockRef{}, ref)
+	require.Equal(t, io.EOF, err)
+
+}

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -58,6 +58,12 @@ type L2Source interface {
 	SystemConfigL2Fetcher
 }
 
+type l1TraversalStage interface {
+	NextBlockProvider
+	ResettableStage
+	AdvanceL1Block(ctx context.Context) error
+}
+
 // DerivationPipeline is updated with new L1 data, and the Step() function can be iterated on to generate attributes
 type DerivationPipeline struct {
 	log       log.Logger
@@ -73,7 +79,7 @@ type DerivationPipeline struct {
 	stages    []ResettableStage
 
 	// Special stages to keep track of
-	traversal *L1Traversal
+	traversal l1TraversalStage
 
 	attrib *AttributesQueue
 
@@ -88,11 +94,17 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
 func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
-	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics,
+	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedMode bool,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
-	// Pull stages
-	l1Traversal := NewL1Traversal(log, rollupCfg, l1Fetcher)
+	// Stages are strung together into a pipeline,
+	// results are pulled from the stage closed to the L2 engine, which pulls from the previous stage, and so on.
+	var l1Traversal l1TraversalStage
+	if managedMode {
+		l1Traversal = NewL1TraversalManaged(log, rollupCfg, l1Fetcher)
+	} else {
+		l1Traversal = NewL1Traversal(log, rollupCfg, l1Fetcher)
+	}
 	dataSrc := NewDataSourceFactory(log, rollupCfg, l1Fetcher, l1Blobs, altDA) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, rollupCfg, l1Src)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -172,6 +172,7 @@ func NewDriver(
 	syncCfg *sync.Config,
 	sequencerConductor conductor.SequencerConductor,
 	altDA AltDAIface,
+	managedMode bool,
 ) *Driver {
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 
@@ -206,7 +207,7 @@ func NewDriver(
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, driverCtx, l2), opts)
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode)
 
 	sys.Register("pipeline",
 		derive.NewPipelineDeriver(driverCtx, derivationPipeline), opts)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -224,6 +224,7 @@ func NewDriver(
 		Log:            log,
 		Ctx:            driverCtx,
 		Drain:          drain.Drain,
+		ManagedMode:    managedMode,
 	}
 	sys.Register("sync", syncDeriver, opts)
 

--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -62,3 +62,7 @@ func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num uint64) (eth.Blo
 func (ib *InteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
 	return ib.backend.ChainID(ctx)
 }
+
+func (ib *InteropAPI) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {
+	return ib.backend.ProvideL1(ctx, nextL1)
+}

--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -15,6 +15,10 @@ type InteropAPI struct {
 	backend *ManagedMode
 }
 
+func (ib *InteropAPI) ResetEvents(ctx context.Context) (*gethrpc.Subscription, error) {
+	return ib.backend.ResetEvents(ctx)
+}
+
 func (ib *InteropAPI) UnsafeBlocks(ctx context.Context) (*gethrpc.Subscription, error) {
 	return ib.backend.UnsafeBlocks(ctx)
 }

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -223,7 +223,7 @@ func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.Blo
 				return eth.L2BlockRef{}, &gethrpc.JsonError{
 					Code:    BlockNotFoundRPCErrCode,
 					Message: "Block not found",
-					Data:    nil,
+					Data:    nil, // TODO communicate the latest block that we do have.
 				}
 			}
 			logger.Warn("unable to find reference", "refName", name)

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -36,7 +36,7 @@ func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher,
 		logger: logger,
 	}
 
-	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, altda.Disabled, l2Source, metrics.NoopMetrics)
+	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, altda.Disabled, l2Source, metrics.NoopMetrics, false)
 	pipelineDeriver := derive.NewPipelineDeriver(context.Background(), pipeline)
 	pipelineDeriver.AttachEmitter(d)
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -488,6 +488,10 @@ func (su *SupervisorBackend) CrossDerivedFrom(ctx context.Context, chainID types
 	return v, nil
 }
 
+func (su *SupervisorBackend) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+	return su.l1Accessor.L1BlockRefByNumber(ctx, number)
+}
+
 // Update methods
 // ----------------------------
 

--- a/op-supervisor/supervisor/backend/syncnode/controller.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller.go
@@ -214,6 +214,13 @@ func (m *ManagedNode) resetSignal(errSignal error, l1Ref eth.BlockRef) {
 	if err != nil {
 		m.log.Warn("Node failed to reset", "err", err)
 	}
+
+	// fix finalized to point to a L2 block that the L2 node knows about
+	// Conceptually: track the last known block by the node (based on unsafe block updates), as upper bound for resets.
+	// Then when reset fails, lower the last known block
+	// (and prevent it from changing by subscription, until success with reset), and rinse and repeat.
+
+	// TODO: errors.As switch
 	switch errSignal {
 	case types.ErrConflict:
 		s, err := m.backend.SafeDerivedAt(ctx, m.chainID, l1Ref.ID())

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -30,6 +30,7 @@ type SyncSource interface {
 }
 
 type SyncControl interface {
+	SubscribeResetEvents(ctx context.Context, c chan string) (ethereum.Subscription, error)
 	SubscribeUnsafeBlocks(ctx context.Context, dest chan eth.BlockRef) (ethereum.Subscription, error)
 	SubscribeDerivationUpdates(ctx context.Context, dest chan types.DerivedPair) (ethereum.Subscription, error)
 	SubscribeExhaustL1Events(ctx context.Context, dest chan types.DerivedPair) (ethereum.Subscription, error)

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -70,6 +70,10 @@ func (rs *RPCSyncNode) String() string {
 	return rs.name
 }
 
+func (rs *RPCSyncNode) SubscribeResetEvents(ctx context.Context, dest chan string) (ethereum.Subscription, error) {
+	return rs.cl.Subscribe(ctx, "interop", dest, "resetEvents")
+}
+
 func (rs *RPCSyncNode) SubscribeUnsafeBlocks(ctx context.Context, dest chan eth.BlockRef) (ethereum.Subscription, error) {
 	return rs.cl.Subscribe(ctx, "interop", dest, "unsafeBlocks")
 }


### PR DESCRIPTION
**Description**

- Add `L1TraversalManaged` stage to derivation, and swap that in if the node is initialized in interop managed-mode.
- Emit reset-events to RPC subscription, for op-supervisor to know when op-node is stuck
- Provide next L1 block to op-node, when op-supervisor receives an event that requests the next block.

Targets `interop-managed` feature branch

**Tests**

- Added test of `L1TraversalManaged`
- Fixed sync-controller tests to not error upon missing setup of mock subscriptions
