### PR TITLE
OPCMs state should be checked after a deploy

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -594,6 +594,7 @@ library ChainAssertions {
 
         require(bytes(_opcm.l1ContractsRelease()).length > 0, "CHECK-OPCM-40");
 
+		// Ensure that the OPCM impls are correctly saved
         OPContractsManager.Implementations memory impls = _opcm.implementations();
         require(impls.l1ERC721BridgeImpl == _contracts.L1ERC721Bridge, "CHECK-OPCM-50");
         require(impls.optimismPortalImpl == _contracts.OptimismPortal2, "CHECK-OPCM-60");

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -581,7 +581,6 @@ library ChainAssertions {
         console.log("Running chain assertions on the OPContractsManager at %s", address(_opcm));
         require(address(_opcm) != address(0), "CHECK-OPCM-10");
 
-        // immutables
         require(
             address(EIP1967Helper.getImplementation(address(_opcm.superchainConfig())))
                 == address(_contracts.SuperchainConfig),
@@ -594,7 +593,7 @@ library ChainAssertions {
 
         require(bytes(_opcm.l1ContractsRelease()).length > 0, "CHECK-OPCM-40");
 
-		// Ensure that the OPCM impls are correctly saved
+        // Ensure that the OPCM impls are correctly saved
         OPContractsManager.Implementations memory impls = _opcm.implementations();
         require(impls.l1ERC721BridgeImpl == _contracts.L1ERC721Bridge, "CHECK-OPCM-50");
         require(impls.optimismPortalImpl == _contracts.OptimismPortal2, "CHECK-OPCM-60");
@@ -606,7 +605,7 @@ library ChainAssertions {
         require(impls.delayedWETHImpl == _contracts.DelayedWETH, "CHECK-OPCM-120");
         require(impls.mipsImpl == address(_mips), "CHECK-OPCM-130");
 
-		// Verify that initCode is correctly set into the blueprints
+        // Verify that initCode is correctly set into the blueprints
         OPContractsManager.Blueprints memory blueprints = _opcm.blueprints();
         Blueprint.Preamble memory addressManagerPreamble =
             Blueprint.parseBlueprintPreamble(address(blueprints.addressManager).code);

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 // Testing
 import { Vm } from "forge-std/Vm.sol";
 import { console2 as console } from "forge-std/console2.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
@@ -14,6 +15,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Types } from "scripts/libraries/Types.sol";
+import { Blueprint } from "src/libraries/Blueprint.sol";
 
 // Contracts
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
@@ -567,23 +569,79 @@ library ChainAssertions {
         }
     }
 
-    /// @notice Asserts that the SuperchainConfig is setup correctly
-    function checkOPContractsManager(Types.ContractSet memory _contracts, bool _isProxy) internal view {
-        OPContractsManager opcm = OPContractsManager(_contracts.OPContractsManager);
-        console.log(
-            "Running chain assertions on the OPContractsManager %s at %s",
-            _isProxy ? "proxy" : "implementation",
-            address(opcm)
+    /// @notice Asserts that the OPContractsManager is setup correctly
+    function checkOPContractsManager(
+        Types.ContractSet memory _contracts,
+        OPContractsManager _opcm,
+        IMIPS _mips
+    )
+        internal
+        view
+    {
+        console.log("Running chain assertions on the OPContractsManager at %s", address(_opcm));
+        require(address(_opcm) != address(0), "CHECK-OPCM-10");
+
+        // immutables
+        require(
+            address(EIP1967Helper.getImplementation(address(_opcm.superchainConfig())))
+                == address(_contracts.SuperchainConfig),
+            "CHECK-OPCM-20"
         );
-        require(address(opcm) != address(0), "CHECK-OPCM-10");
+        require(
+            EIP1967Helper.getImplementation(address(_opcm.protocolVersions())) == address(_contracts.ProtocolVersions),
+            "CHECK-OPCM-30"
+        );
 
-        // Check that the contract is initialized
-        DeployUtils.assertInitialized({ _contractAddress: address(opcm), _isProxy: _isProxy, _slot: 0, _offset: 0 });
+        require(bytes(_opcm.l1ContractsRelease()).length > 0, "CHECK-OPCM-40");
 
-        // These values are immutable so are shared by the proxy and implementation
-        require(address(opcm.superchainConfig()) == address(_contracts.SuperchainConfig), "CHECK-OPCM-30");
-        require(address(opcm.protocolVersions()) == address(_contracts.ProtocolVersions), "CHECK-OPCM-40");
+        OPContractsManager.Implementations memory impls = _opcm.implementations();
+        require(impls.l1ERC721BridgeImpl == _contracts.L1ERC721Bridge, "CHECK-OPCM-50");
+        require(impls.optimismPortalImpl == _contracts.OptimismPortal2, "CHECK-OPCM-60");
+        require(impls.systemConfigImpl == _contracts.SystemConfig, "CHECK-OPCM-70");
+        require(impls.optimismMintableERC20FactoryImpl == _contracts.OptimismMintableERC20Factory, "CHECK-OPCM-80");
+        require(impls.l1CrossDomainMessengerImpl == _contracts.L1CrossDomainMessenger, "CHECK-OPCM-90");
+        require(impls.l1StandardBridgeImpl == _contracts.L1StandardBridge, "CHECK-OPCM-100");
+        require(impls.disputeGameFactoryImpl == _contracts.DisputeGameFactory, "CHECK-OPCM-110");
+        require(impls.delayedWETHImpl == _contracts.DelayedWETH, "CHECK-OPCM-120");
+        require(impls.mipsImpl == address(_mips), "CHECK-OPCM-130");
 
-        // TODO: Add assertions for blueprints and setters?
+        OPContractsManager.Blueprints memory blueprints = _opcm.blueprints();
+        Blueprint.Preamble memory addressManagerPreamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.addressManager).code);
+        require(keccak256(addressManagerPreamble.initcode) == keccak256(vm.getCode("AddressManager")), "CHECK-OPCM-140");
+
+        Blueprint.Preamble memory proxyPreamble = Blueprint.parseBlueprintPreamble(address(blueprints.proxy).code);
+        require(keccak256(proxyPreamble.initcode) == keccak256(vm.getCode("Proxy")), "CHECK-OPCM-150");
+
+        Blueprint.Preamble memory proxyAdminPreamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.proxyAdmin).code);
+        require(keccak256(proxyAdminPreamble.initcode) == keccak256(vm.getCode("ProxyAdmin")), "CHECK-OPCM-160");
+
+        Blueprint.Preamble memory l1ChugSplashProxyPreamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.l1ChugSplashProxy).code);
+        require(
+            keccak256(l1ChugSplashProxyPreamble.initcode) == keccak256(vm.getCode("L1ChugSplashProxy")),
+            "CHECK-OPCM-170"
+        );
+
+        Blueprint.Preamble memory rdProxyPreamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.resolvedDelegateProxy).code);
+        require(keccak256(rdProxyPreamble.initcode) == keccak256(vm.getCode("ResolvedDelegateProxy")), "CHECK-OPCM-180");
+
+        Blueprint.Preamble memory asrPreamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.anchorStateRegistry).code);
+        require(keccak256(asrPreamble.initcode) == keccak256(vm.getCode("AnchorStateRegistry")), "CHECK-OPCM-190");
+
+        Blueprint.Preamble memory pdg1Preamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.permissionedDisputeGame1).code);
+        Blueprint.Preamble memory pdg2Preamble =
+            Blueprint.parseBlueprintPreamble(address(blueprints.permissionedDisputeGame2).code);
+        // combine pdg1 and pdg2 initcodes
+        bytes memory fullPermissionedDisputeGameInitcode =
+            abi.encodePacked(pdg1Preamble.initcode, pdg2Preamble.initcode);
+        require(
+            keccak256(fullPermissionedDisputeGameInitcode) == keccak256(vm.getCode("PermissionedDisputeGame")),
+            "CHECK-OPCM-200"
+        );
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -606,6 +606,7 @@ library ChainAssertions {
         require(impls.delayedWETHImpl == _contracts.DelayedWETH, "CHECK-OPCM-120");
         require(impls.mipsImpl == address(_mips), "CHECK-OPCM-130");
 
+		// Verify that initCode is correctly set into the blueprints
         OPContractsManager.Blueprints memory blueprints = _opcm.blueprints();
         Blueprint.Preamble memory addressManagerPreamble =
             Blueprint.parseBlueprintPreamble(address(blueprints.addressManager).code);

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -128,8 +128,7 @@ contract Deploy is Deployer {
             SystemConfig: getAddress("SystemConfigProxy"),
             L1ERC721Bridge: getAddress("L1ERC721BridgeProxy"),
             ProtocolVersions: getAddress("ProtocolVersionsProxy"),
-            SuperchainConfig: getAddress("SuperchainConfigProxy"),
-            OPContractsManager: getAddress("OPContractsManager")
+            SuperchainConfig: getAddress("SuperchainConfigProxy")
         });
     }
 
@@ -149,8 +148,7 @@ contract Deploy is Deployer {
             SystemConfig: getAddress("SystemConfig"),
             L1ERC721Bridge: getAddress("L1ERC721Bridge"),
             ProtocolVersions: getAddress("ProtocolVersions"),
-            SuperchainConfig: getAddress("SuperchainConfig"),
-            OPContractsManager: getAddress("OPContractsManager")
+            SuperchainConfig: getAddress("SuperchainConfig")
         });
     }
 
@@ -362,6 +360,11 @@ contract Deploy is Deployer {
         ChainAssertions.checkMIPS({
             _mips: IMIPS(address(dio.mipsSingleton())),
             _oracle: IPreimageOracle(address(dio.preimageOracleSingleton()))
+        });
+        ChainAssertions.checkOPContractsManager({
+            _contracts: contracts,
+            _opcm: OPContractsManager(mustGetAddress("OPContractsManager")),
+            _mips: IMIPS(mustGetAddress("Mips"))
         });
         if (_isInterop) {
             ChainAssertions.checkSystemConfigInterop({ _contracts: contracts, _cfg: cfg, _isProxy: false });

--- a/packages/contracts-bedrock/scripts/libraries/Types.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Types.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 library Types {
     /// @notice Represents a set of L1 contracts. Used to represent a set of proxies.
+    /// This is not an exhaustive list of all contracts on L1, but rather a subset.
     struct ContractSet {
         address L1CrossDomainMessenger;
         address L1StandardBridge;
@@ -18,6 +19,5 @@ library Types {
         address L1ERC721Bridge;
         address ProtocolVersions;
         address SuperchainConfig;
-        address OPContractsManager;
     }
 }


### PR DESCRIPTION
When deploying OPCM through `Deploy.s.sol`, its state should be checked to be consistent with what we expect it should be. As we move away from `Deploy.s.sol`, we will still want to perform chain assertions (`ChainAssertions.sol`). 

OPContractsManager was included as part of two functions `_impls` and `_proxies`. Neither made sense so I removed OPCM from this abstraction.