### PR TITLE
feat: Fix contract labels and make more explicit

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -136,20 +136,20 @@ contract Deploy is Deployer {
     /// @notice Returns the impl addresses, not reverting if any are unset.
     function _impls() internal view returns (Types.ContractSet memory proxies_) {
         proxies_ = Types.ContractSet({
-            L1CrossDomainMessenger: getAddress("L1CrossDomainMessenger"),
-            L1StandardBridge: getAddress("L1StandardBridge"),
-            L2OutputOracle: getAddress("L2OutputOracle"),
-            DisputeGameFactory: getAddress("DisputeGameFactory"),
-            DelayedWETH: getAddress("DelayedWETH"),
-            PermissionedDelayedWETH: getAddress("PermissionedDelayedWETH"),
-            AnchorStateRegistry: getAddress("AnchorStateRegistry"),
-            OptimismMintableERC20Factory: getAddress("OptimismMintableERC20Factory"),
-            OptimismPortal: getAddress("OptimismPortal"),
-            OptimismPortal2: getAddress("OptimismPortal2"),
-            SystemConfig: getAddress("SystemConfig"),
-            L1ERC721Bridge: getAddress("L1ERC721Bridge"),
-            ProtocolVersions: getAddress("ProtocolVersions"),
-            SuperchainConfig: getAddress("SuperchainConfig"),
+            L1CrossDomainMessenger: getAddress("L1CrossDomainMessengerImpl"),
+            L1StandardBridge: getAddress("L1StandardBridgeImpl"),
+            L2OutputOracle: getAddress("L2OutputOracleImpl"),
+            DisputeGameFactory: getAddress("DisputeGameFactoryImpl"),
+            DelayedWETH: getAddress("DelayedWETHImpl"),
+            PermissionedDelayedWETH: getAddress("PermissionedDelayedWETHImpl"),
+            AnchorStateRegistry: getAddress("AnchorStateRegistryImpl"),
+            OptimismMintableERC20Factory: getAddress("OptimismMintableERC20FactoryImpl"),
+            OptimismPortal: getAddress("OptimismPortalImpl"),
+            OptimismPortal2: getAddress("OptimismPortal2Impl"),
+            SystemConfig: getAddress("SystemConfigImpl"),
+            L1ERC721Bridge: getAddress("L1ERC721BridgeImpl"),
+            ProtocolVersions: getAddress("ProtocolVersionsImpl"),
+            SuperchainConfig: getAddress("SuperchainConfigImpl"),
             OPContractsManager: getAddress("OPContractsManager")
         });
     }
@@ -176,11 +176,11 @@ contract Deploy is Deployer {
         console.log("Deploying a fresh OP Stack with existing SuperchainConfig and ProtocolVersions");
 
         IProxy scProxy = IProxy(_superchainConfigProxy);
-        save("SuperchainConfig", scProxy.implementation());
+        save("SuperchainConfigImpl", scProxy.implementation());
         save("SuperchainConfigProxy", _superchainConfigProxy);
 
         IProxy pvProxy = IProxy(_protocolVersionsProxy);
-        save("ProtocolVersions", pvProxy.implementation());
+        save("ProtocolVersionsImpl", pvProxy.implementation());
         save("ProtocolVersionsProxy", _protocolVersionsProxy);
 
         _run({ _needsSuperchain: false });
@@ -276,9 +276,9 @@ contract Deploy is Deployer {
         ds.run(dsi, dso);
         save("SuperchainProxyAdmin", address(dso.superchainProxyAdmin()));
         save("SuperchainConfigProxy", address(dso.superchainConfigProxy()));
-        save("SuperchainConfig", address(dso.superchainConfigImpl()));
+        save("SuperchainConfigImpl", address(dso.superchainConfigImpl()));
         save("ProtocolVersionsProxy", address(dso.protocolVersionsProxy()));
-        save("ProtocolVersions", address(dso.protocolVersionsImpl()));
+        save("ProtocolVersionsImpl", address(dso.protocolVersionsImpl()));
 
         // First run assertions for the ProtocolVersions and SuperchainConfig proxy contracts.
         Types.ContractSet memory contracts = _proxies();
@@ -286,11 +286,11 @@ contract Deploy is Deployer {
         ChainAssertions.checkSuperchainConfig({ _contracts: contracts, _cfg: cfg, _isProxy: true, _isPaused: false });
 
         // Then replace the ProtocolVersions proxy with the implementation address and run assertions on it.
-        contracts.ProtocolVersions = mustGetAddress("ProtocolVersions");
+        contracts.ProtocolVersions = mustGetAddress("ProtocolVersionsImpl");
         ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: false });
 
         // Finally replace the SuperchainConfig proxy with the implementation address and run assertions on it.
-        contracts.SuperchainConfig = mustGetAddress("SuperchainConfig");
+        contracts.SuperchainConfig = mustGetAddress("SuperchainConfigImpl");
         ChainAssertions.checkSuperchainConfig({ _contracts: contracts, _cfg: cfg, _isPaused: false, _isProxy: false });
     }
 
@@ -328,18 +328,19 @@ contract Deploy is Deployer {
             deployL2OutputOracle();
         }
 
-        save("L1CrossDomainMessenger", address(dio.l1CrossDomainMessengerImpl()));
-        save("OptimismMintableERC20Factory", address(dio.optimismMintableERC20FactoryImpl()));
-        save("SystemConfig", address(dio.systemConfigImpl()));
-        save("L1StandardBridge", address(dio.l1StandardBridgeImpl()));
-        save("L1ERC721Bridge", address(dio.l1ERC721BridgeImpl()));
+        save("L1CrossDomainMessengerImpl", address(dio.l1CrossDomainMessengerImpl()));
+        save("OptimismMintableERC20FactoryImpl", address(dio.optimismMintableERC20FactoryImpl()));
+        save("SystemConfigImpl", address(dio.systemConfigImpl()));
+        save("L1StandardBridgeImpl", address(dio.l1StandardBridgeImpl()));
+        save("L1ERC721BridgeImpl", address(dio.l1ERC721BridgeImpl()));
 
         // Fault proofs
-        save("OptimismPortal2", address(dio.optimismPortalImpl()));
-        save("DisputeGameFactory", address(dio.disputeGameFactoryImpl()));
-        save("DelayedWETH", address(dio.delayedWETHImpl()));
-        save("PreimageOracle", address(dio.preimageOracleSingleton()));
-        save("Mips", address(dio.mipsSingleton()));
+        save("OptimismPortalImpl", address(dio.optimismPortalImpl()));
+        save("OptimismPortal2Impl", address(dio.optimismPortalImpl()));
+        save("DisputeGameFactoryImpl", address(dio.disputeGameFactoryImpl()));
+        save("DelayedWETHImpl", address(dio.delayedWETHImpl()));
+        save("PreimageOracleSingleton", address(dio.preimageOracleSingleton()));
+        save("MipsSingleton", address(dio.mipsSingleton()));
         save("OPContractsManager", address(dio.opcm()));
 
         Types.ContractSet memory contracts = _impls();
@@ -394,7 +395,7 @@ contract Deploy is Deployer {
         save("DisputeGameFactoryProxy", address(deployOutput.disputeGameFactoryProxy));
         save("PermissionedDelayedWETHProxy", address(deployOutput.delayedWETHPermissionedGameProxy));
         save("AnchorStateRegistryProxy", address(deployOutput.anchorStateRegistryProxy));
-        save("AnchorStateRegistry", address(deployOutput.anchorStateRegistryImpl));
+        save("AnchorStateRegistryImpl", address(deployOutput.anchorStateRegistryImpl));
         save("PermissionedDisputeGame", address(deployOutput.permissionedDisputeGame));
         save("OptimismPortalProxy", address(deployOutput.optimismPortalProxy));
 
@@ -408,7 +409,7 @@ contract Deploy is Deployer {
             permissionlessGameImpl == address(0),
             "Deploy: The PermissionlessDelayedWETH is already set by the OPCM, it is no longer necessary to deploy it separately."
         );
-        address delayedWETHImpl = mustGetAddress("DelayedWETH");
+        address delayedWETHImpl = mustGetAddress("DelayedWETHImpl");
         address delayedWETHPermissionlessGameProxy = deployERC1967ProxyWithOwner("DelayedWETHProxy", msg.sender);
         vm.broadcast(msg.sender);
         IProxy(payable(delayedWETHPermissionlessGameProxy)).upgradeToAndCall({
@@ -556,7 +557,7 @@ contract Deploy is Deployer {
     function initializeSystemConfig() public broadcast {
         console.log("Upgrading and initializing SystemConfig proxy");
         address systemConfigProxy = mustGetAddress("SystemConfigProxy");
-        address systemConfig = mustGetAddress("SystemConfig");
+        address systemConfig = mustGetAddress("SystemConfigImpl");
 
         bytes32 batcherHash = bytes32(uint256(uint160(cfg.batchSenderAddress())));
 
@@ -850,7 +851,7 @@ contract Deploy is Deployer {
                 splitDepth: cfg.faultGameSplitDepth(),
                 clockExtension: Duration.wrap(uint64(cfg.faultGameClockExtension())),
                 maxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
-                vm: IBigStepper(mustGetAddress("Mips")),
+                vm: IBigStepper(mustGetAddress("MipsSingleton")),
                 weth: weth,
                 anchorStateRegistry: IAnchorStateRegistry(mustGetAddress("AnchorStateRegistryProxy")),
                 l2ChainId: cfg.l2ChainID()

--- a/packages/contracts-bedrock/snapshots/.gas-snapshot
+++ b/packages/contracts-bedrock/snapshots/.gas-snapshot
@@ -14,4 +14,4 @@ GasBenchMark_L1StandardBridge_Finalize:test_finalizeETHWithdrawal_benchmark() (g
 GasBenchMark_L2OutputOracle:test_proposeL2Output_benchmark() (gas: 92973)
 GasBenchMark_OptimismPortal:test_depositTransaction_benchmark() (gas: 68422)
 GasBenchMark_OptimismPortal:test_depositTransaction_benchmark_1() (gas: 69008)
-GasBenchMark_OptimismPortal:test_proveWithdrawalTransaction_benchmark() (gas: 155565)
+GasBenchMark_OptimismPortal:test_proveWithdrawalTransaction_benchmark() (gas: 155557)

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -28,7 +28,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_Init {
         skipIfForkTest(
             "ProtocolVersions_Initialize_Test: cannot test initialization on forked network against hardhat config"
         );
-        IProtocolVersions protocolVersionsImpl = IProtocolVersions(deploy.mustGetAddress("ProtocolVersions"));
+        IProtocolVersions protocolVersionsImpl = IProtocolVersions(deploy.mustGetAddress("ProtocolVersionsImpl"));
         address owner = deploy.cfg().finalSystemOwner();
 
         assertEq(ProtocolVersion.unwrap(protocolVersions.required()), ProtocolVersion.unwrap(required));
@@ -42,7 +42,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_Init {
 
     /// @dev Ensures that the events are emitted during initialization.
     function test_initialize_events_succeeds() external {
-        IProtocolVersions protocolVersionsImpl = IProtocolVersions(deploy.mustGetAddress("ProtocolVersions"));
+        IProtocolVersions protocolVersionsImpl = IProtocolVersions(deploy.mustGetAddress("ProtocolVersionsImpl"));
 
         // Wipe out the initialized slot so the proxy can be initialized again
         vm.store(address(protocolVersions), bytes32(0), bytes32(0));

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -66,12 +66,12 @@ contract ForkLive is Deployer {
         // Bridge contracts
         address optimismPortal = vm.parseTomlAddress(opToml, ".addresses.OptimismPortalProxy");
         save("OptimismPortalProxy", optimismPortal);
-        save("OptimismPortal", EIP1967Helper.getImplementation(optimismPortal));
-        save("OptimismPortal2", EIP1967Helper.getImplementation(optimismPortal));
+        save("OptimismPortalImpl", EIP1967Helper.getImplementation(optimismPortal));
+        save("OptimismPortal2Impl", EIP1967Helper.getImplementation(optimismPortal));
 
         address addressManager = vm.parseTomlAddress(opToml, ".addresses.AddressManager");
         save("AddressManager", addressManager);
-        save("L1CrossDomainMessenger", IAddressManager(addressManager).getAddress("OVM_L1CrossDomainMessenger"));
+        save("L1CrossDomainMessengerImpl", IAddressManager(addressManager).getAddress("OVM_L1CrossDomainMessenger"));
         save("L1CrossDomainMessengerProxy", vm.parseTomlAddress(opToml, ".addresses.L1CrossDomainMessengerProxy"));
         saveProxyAndImpl("OptimismMintableERC20Factory", opToml, ".addresses.OptimismMintableERC20FactoryProxy");
         saveProxyAndImpl("L1StandardBridge", opToml, ".addresses.L1StandardBridgeProxy");
@@ -84,7 +84,7 @@ contract ForkLive is Deployer {
 
         // Fault proof non-proxied contracts
         save("PreimageOracle", vm.parseTomlAddress(opToml, ".addresses.PreimageOracle"));
-        save("Mips", vm.parseTomlAddress(opToml, ".addresses.MIPS"));
+        save("MipsSingleton", vm.parseTomlAddress(opToml, ".addresses.MIPS"));
         IDisputeGameFactory disputeGameFactory = IDisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy"));
         save("FaultDisputeGame", vm.parseTomlAddress(opToml, ".addresses.FaultDisputeGame"));
         // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
@@ -104,6 +104,6 @@ contract ForkLive is Deployer {
         save(string.concat(_contractName, "Proxy"), proxy);
         address impl = EIP1967Helper.getImplementation(proxy);
         require(impl != address(0), "Upgrade: Implementation address is zero");
-        save(_contractName, impl);
+        save(string.concat(_contractName, "Impl"), impl);
     }
 }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -203,42 +203,53 @@ contract Setup {
 
         optimismPortal = IOptimismPortal(deploy.mustGetAddress("OptimismPortalProxy"));
         optimismPortal2 = IOptimismPortal2(deploy.mustGetAddress("OptimismPortalProxy"));
-        disputeGameFactory = IDisputeGameFactory(deploy.mustGetAddress("DisputeGameFactoryProxy"));
-        delayedWeth = IDelayedWETH(deploy.mustGetAddress("DelayedWETHProxy"));
+        vm.label(address(optimismPortal), "OptimismPortalProxy");
+        vm.label(deploy.mustGetAddress("OptimismPortalImpl"), "OptimismPortalImpl");
+
         systemConfig = ISystemConfig(deploy.mustGetAddress("SystemConfigProxy"));
+        vm.label(address(systemConfig), "SystemConfigProxy");
+        vm.label(deploy.mustGetAddress("SystemConfigImpl"), "SystemConfigImpl");
+
         l1StandardBridge = IL1StandardBridge(deploy.mustGetAddress("L1StandardBridgeProxy"));
+        vm.label(address(l1StandardBridge), "L1StandardBridgeProxy");
+        vm.label(deploy.mustGetAddress("L1StandardBridgeImpl"), "L1StandardBridgeImpl");
+
         l1CrossDomainMessenger = IL1CrossDomainMessenger(deploy.mustGetAddress("L1CrossDomainMessengerProxy"));
+        vm.label(address(l1CrossDomainMessenger), "L1CrossDomainMessengerProxy");
+        vm.label(deploy.mustGetAddress("L1CrossDomainMessengerImpl"), "L1CrossDomainMessengerImpl");
+        vm.label(AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger)), "L1CrossDomainMessenger_aliased");
+
         addressManager = IAddressManager(deploy.mustGetAddress("AddressManager"));
+        vm.label(address(addressManager), "AddressManager");
+
         l1ERC721Bridge = IL1ERC721Bridge(deploy.mustGetAddress("L1ERC721BridgeProxy"));
+        vm.label(address(l1ERC721Bridge), "L1ERC721BridgeProxy");
+        vm.label(deploy.mustGetAddress("L1ERC721BridgeImpl"), "L1ERC721BridgeImpl");
+
         l1OptimismMintableERC20Factory =
             IOptimismMintableERC20Factory(deploy.mustGetAddress("OptimismMintableERC20FactoryProxy"));
-        protocolVersions = IProtocolVersions(deploy.mustGetAddress("ProtocolVersionsProxy"));
-        superchainConfig = ISuperchainConfig(deploy.mustGetAddress("SuperchainConfigProxy"));
-        anchorStateRegistry = IAnchorStateRegistry(deploy.mustGetAddress("AnchorStateRegistryProxy"));
+        vm.label(address(l1OptimismMintableERC20Factory), "OptimismMintableERC20FactoryProxy");
+        vm.label(deploy.mustGetAddress("OptimismMintableERC20FactoryImpl"), "OptimismMintableERC20FactoryImpl");
 
-        vm.label(address(optimismPortal), "OptimismPortal");
-        vm.label(deploy.mustGetAddress("OptimismPortalProxy"), "OptimismPortalProxy");
-        vm.label(address(disputeGameFactory), "DisputeGameFactory");
-        vm.label(deploy.mustGetAddress("DisputeGameFactoryProxy"), "DisputeGameFactoryProxy");
-        vm.label(address(delayedWeth), "DelayedWETH");
-        vm.label(deploy.mustGetAddress("DelayedWETHProxy"), "DelayedWETHProxy");
-        vm.label(address(systemConfig), "SystemConfig");
-        vm.label(deploy.mustGetAddress("SystemConfigProxy"), "SystemConfigProxy");
-        vm.label(address(l1StandardBridge), "L1StandardBridge");
-        vm.label(deploy.mustGetAddress("L1StandardBridgeProxy"), "L1StandardBridgeProxy");
-        vm.label(address(l1CrossDomainMessenger), "L1CrossDomainMessenger");
-        vm.label(deploy.mustGetAddress("L1CrossDomainMessengerProxy"), "L1CrossDomainMessengerProxy");
-        vm.label(address(addressManager), "AddressManager");
-        vm.label(address(l1ERC721Bridge), "L1ERC721Bridge");
-        vm.label(deploy.mustGetAddress("L1ERC721BridgeProxy"), "L1ERC721BridgeProxy");
-        vm.label(address(l1OptimismMintableERC20Factory), "OptimismMintableERC20Factory");
-        vm.label(deploy.mustGetAddress("OptimismMintableERC20FactoryProxy"), "OptimismMintableERC20FactoryProxy");
-        vm.label(address(protocolVersions), "ProtocolVersions");
+        protocolVersions = IProtocolVersions(deploy.mustGetAddress("ProtocolVersionsProxy"));
+        vm.label(address(protocolVersions), "ProtocolVersionsProxy");
         vm.label(deploy.mustGetAddress("ProtocolVersionsProxy"), "ProtocolVersionsProxy");
-        vm.label(address(superchainConfig), "SuperchainConfig");
-        vm.label(deploy.mustGetAddress("SuperchainConfigProxy"), "SuperchainConfigProxy");
+
+        superchainConfig = ISuperchainConfig(deploy.mustGetAddress("SuperchainConfigProxy"));
+        vm.label(address(superchainConfig), "SuperchainConfigProxy");
+        vm.label(deploy.mustGetAddress("SuperchainConfigImpl"), "SuperchainConfigImpl");
+
+        anchorStateRegistry = IAnchorStateRegistry(deploy.mustGetAddress("AnchorStateRegistryProxy"));
         vm.label(address(anchorStateRegistry), "AnchorStateRegistryProxy");
-        vm.label(AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger)), "L1CrossDomainMessenger_aliased");
+        vm.label(deploy.mustGetAddress("AnchorStateRegistryImpl"), "AnchorStateRegistryImpl");
+
+        disputeGameFactory = IDisputeGameFactory(deploy.mustGetAddress("DisputeGameFactoryProxy"));
+        vm.label(address(disputeGameFactory), "DisputeGameFactory");
+        vm.label(deploy.mustGetAddress("DisputeGameFactoryImpl"), "DisputeGameFactoryImpl");
+
+        delayedWeth = IDelayedWETH(deploy.mustGetAddress("DelayedWETHProxy"));
+        vm.label(address(delayedWeth), "DelayedWETHProxy");
+        vm.label(deploy.mustGetAddress("DelayedWETHImpl"), "DelayedWETHImpl");
 
         if (!deploy.cfg().useFaultProofs()) {
             l2OutputOracle = IL2OutputOracle(deploy.mustGetAddress("L2OutputOracleProxy"));
@@ -250,7 +261,7 @@ contract Setup {
             dataAvailabilityChallenge =
                 IDataAvailabilityChallenge(deploy.mustGetAddress("DataAvailabilityChallengeProxy"));
             vm.label(address(dataAvailabilityChallenge), "DataAvailabilityChallengeProxy");
-            vm.label(deploy.mustGetAddress("DataAvailabilityChallenge"), "DataAvailabilityChallenge");
+            vm.label(deploy.mustGetAddress("DataAvailabilityChallengeImpl"), "DataAvailabilityChallengeImpl");
         }
         console.log("Setup: registered L1 deployments");
     }

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -54,7 +54,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "SuperchainConfig",
-                target: deploy.mustGetAddress("SuperchainConfig"),
+                target: deploy.mustGetAddress("SuperchainConfigImpl"),
                 initCalldata: abi.encodeCall(superchainConfig.initialize, (address(0), false))
             })
         );
@@ -70,7 +70,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1CrossDomainMessenger",
-                target: deploy.mustGetAddress("L1CrossDomainMessenger"),
+                target: deploy.mustGetAddress("L1CrossDomainMessengerImpl"),
                 initCalldata: abi.encodeCall(
                     l1CrossDomainMessenger.initialize, (superchainConfig, optimismPortal, systemConfig)
                 )
@@ -90,7 +90,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "DisputeGameFactory",
-                target: deploy.mustGetAddress("DisputeGameFactory"),
+                target: deploy.mustGetAddress("DisputeGameFactoryImpl"),
                 initCalldata: abi.encodeCall(disputeGameFactory.initialize, (address(0)))
             })
         );
@@ -106,7 +106,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "DelayedWETH",
-                target: deploy.mustGetAddress("DelayedWETH"),
+                target: deploy.mustGetAddress("DelayedWETHImpl"),
                 initCalldata: abi.encodeCall(delayedWeth.initialize, (address(0), ISuperchainConfig(address(0))))
             })
         );
@@ -122,7 +122,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L2OutputOracle",
-                target: deploy.mustGetAddress("L2OutputOracle"),
+                target: deploy.mustGetAddress("L2OutputOracleImpl"),
                 initCalldata: abi.encodeCall(l2OutputOracle.initialize, (0, 0, 0, 0, address(0), address(0), 0))
             })
         );
@@ -138,7 +138,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "OptimismPortal",
-                target: deploy.mustGetAddress("OptimismPortal"),
+                target: deploy.mustGetAddress("OptimismPortalImpl"),
                 initCalldata: abi.encodeCall(optimismPortal.initialize, (l2OutputOracle, systemConfig, superchainConfig))
             })
         );
@@ -154,7 +154,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "OptimismPortal2",
-                target: deploy.mustGetAddress("OptimismPortal2"),
+                target: deploy.mustGetAddress("OptimismPortal2Impl"),
                 initCalldata: abi.encodeCall(
                     optimismPortal2.initialize,
                     (
@@ -170,7 +170,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "SystemConfig",
-                target: deploy.mustGetAddress("SystemConfig"),
+                target: deploy.mustGetAddress("SystemConfigImpl"),
                 initCalldata: abi.encodeCall(
                     systemConfig.initialize,
                     (
@@ -242,7 +242,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "ProtocolVersions",
-                target: deploy.mustGetAddress("ProtocolVersions"),
+                target: deploy.mustGetAddress("ProtocolVersionsImpl"),
                 initCalldata: abi.encodeCall(
                     protocolVersions.initialize, (address(0), ProtocolVersion.wrap(1), ProtocolVersion.wrap(2))
                 )
@@ -270,7 +270,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1StandardBridge",
-                target: deploy.mustGetAddress("L1StandardBridge"),
+                target: deploy.mustGetAddress("L1StandardBridgeImpl"),
                 initCalldata: abi.encodeCall(
                     l1StandardBridge.initialize, (l1CrossDomainMessenger, superchainConfig, systemConfig)
                 )
@@ -306,7 +306,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1ERC721Bridge",
-                target: deploy.mustGetAddress("L1ERC721Bridge"),
+                target: deploy.mustGetAddress("L1ERC721BridgeImpl"),
                 initCalldata: abi.encodeCall(l1ERC721Bridge.initialize, (l1CrossDomainMessenger, superchainConfig))
             })
         );
@@ -330,7 +330,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "OptimismMintableERC20Factory",
-                target: deploy.mustGetAddress("OptimismMintableERC20Factory"),
+                target: deploy.mustGetAddress("OptimismMintableERC20FactoryImpl"),
                 initCalldata: abi.encodeCall(l1OptimismMintableERC20Factory.initialize, (address(l1StandardBridge)))
             })
         );
@@ -346,7 +346,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "DataAvailabilityChallenge",
-                target: deploy.mustGetAddress("DataAvailabilityChallenge"),
+                target: deploy.mustGetAddress("DataAvailabilityChallengeImpl"),
                 initCalldata: abi.encodeCall(dataAvailabilityChallenge.initialize, (address(0), 0, 0, 0, 0))
             })
         );


### PR DESCRIPTION
Labels and contract names used in `save()`/`mustGetAddress()` now have names conforming to those used in the OPCM, ie.
- `SuperchainConfigImpl`/`SuperchainConfigProxy`
- `MipsSingleton`

Also fixes the issue described in #13391 where Proxy addresses are labelled twice and the impl address is not labelled.
