### PR TITLE
feat(kurtosis-devnet): add small cli tool to expand template

### DIFF
--- a/kurtosis-devnet/pkg/tmpl/cmd/main.go
+++ b/kurtosis-devnet/pkg/tmpl/cmd/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl/fake"
+)
+
+func main() {
+
+	// Parse command line flags
+	templateFile := flag.String("template", "", "Path to template file")
+	flag.Parse()
+
+	if *templateFile == "" {
+		fmt.Fprintln(os.Stderr, "Error: --template flag is required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Open template file
+	f, err := os.Open(*templateFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening template file: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	// Get basename of template file without extension
+	base := *templateFile
+	if lastSlash := strings.LastIndex(base, "/"); lastSlash >= 0 {
+		base = base[lastSlash+1:]
+	}
+	if lastDot := strings.LastIndex(base, "."); lastDot >= 0 {
+		base = base[:lastDot]
+	}
+	enclave := base + "-devnet"
+
+	// Create template context
+	ctx := fake.NewFakeTemplateContext(enclave)
+
+	// Process template and write to stdout
+	if err := ctx.InstantiateTemplate(f, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "Error processing template: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/kurtosis-devnet/pkg/tmpl/fake/fake.go
+++ b/kurtosis-devnet/pkg/tmpl/fake/fake.go
@@ -1,0 +1,18 @@
+package fake
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl"
+)
+
+func NewFakeTemplateContext(enclave string) *tmpl.TemplateContext {
+	return tmpl.NewTemplateContext(
+		tmpl.WithFunction("localDockerImage", func(image string) (string, error) {
+			return fmt.Sprintf("%s:%s", image, enclave), nil
+		}),
+		tmpl.WithFunction("localContractArtifacts", func(layer string) (string, error) {
+			return fmt.Sprintf("http://host.docker.internal:0/contracts-bundle-%s.tar.gz", enclave), nil
+		}),
+	)
+}


### PR DESCRIPTION
**Description**

This can be used in isolation to sanity check that a kurtosis-devnet
template expands properly, without having to run the entire workflow
(although it would fail early anyway).

**Additional context**

gradually porting changes from
https://github.com/ethereum-optimism/optimism/tree/sigma/kurtosis-devnet-rebase/kurtosis-devnet

**Metadata**

Part of
- ethereum-optimism/platforms-team#517
- ethereum-optimism/platforms-team#518