### PR TITLE
Fix Typo in Variable Name

### DIFF
--- a/op-chain-ops/crossdomain/legacy.go
+++ b/op-chain-ops/crossdomain/legacy.go
@@ -89,7 +89,7 @@ func ReadLegacyReceipts(db ethdb.Reader, hash common.Hash, number uint64) ([]*Le
 	// Convert the receipts from their storage form to their internal representation
 	storageReceipts := []*LegacyReceipt{}
 	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
-		return nil, fmt.Errorf("error decoding legacy receiptsL: %w", err)
+		return nil, fmt.Errorf("error decoding legacy receipts: %w", err)
 	}
 	return storageReceipts, nil
 }


### PR DESCRIPTION
// Typo: receiptsL should be corrected to receipts
// Reason: The extra "L" is misleading and does not align with the variable naming convention.

receiptsL // Incorrect
receipts  // Correct
