### PR TITLE
Ensure vm-runner metrics are initialized to 0

### DIFF
--- a/op-challenger/runner/metrics.go
+++ b/op-challenger/runner/metrics.go
@@ -31,11 +31,11 @@ var _ Metricer = (*Metrics)(nil)
 // Metrics implementation must implement RegistryMetricer to allow the metrics server to work.
 var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
 
-func NewMetrics() *Metrics {
+func NewMetrics(runConfigs []RunConfig) *Metrics {
 	registry := opmetrics.NewRegistry()
 	factory := opmetrics.With(registry)
 
-	return &Metrics{
+	metrics := &Metrics{
 		ns:       Namespace,
 		registry: registry,
 		factory:  factory,
@@ -69,6 +69,14 @@ func NewMetrics() *Metrics {
 			Help:      "Number of runs that determined the output root was invalid",
 		}, []string{"type"}),
 	}
+
+	for _, runConfig := range runConfigs {
+		metrics.successTotal.WithLabelValues(runConfig.Name).Add(0)
+		metrics.failuresTotal.WithLabelValues(runConfig.Name).Add(0)
+		metrics.invalidTotal.WithLabelValues(runConfig.Name).Add(0)
+	}
+
+	return metrics
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -68,7 +68,7 @@ func NewRunner(logger log.Logger, cfg *config.Config, runConfigs []RunConfig) *R
 		log:        logger,
 		cfg:        cfg,
 		runConfigs: runConfigs,
-		m:          NewMetrics(),
+		m:          NewMetrics(runConfigs),
 	}
 }
 


### PR DESCRIPTION
This is because alerts use `increase()` to detect changes in the metrics, and the first instance of a metric is not considered a change.

There is still an edge case where the alert fails to fire which is a failure on the first run (since the metric hasn't already been initialized to 0 by a previous run).
