### PR TITLE
fix: test filtering in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1256,7 +1256,7 @@ workflows:
       - contracts-bedrock-tests:
           # Test everything except PreimageOracle.t.sol since it's slow.
           name: contracts-bedrock-tests
-          test_list: find test -name "PreimageOracle.t.sol"
+          test_list: find test -name "*.t.sol" -not -name "PreimageOracle.t.sol"
       - contracts-bedrock-tests:
           # PreimageOracle test is slow, run it separately to unblock CI.
           name: contracts-bedrock-tests-preimage-oracle


### PR DESCRIPTION
I introduced a bug [here](https://github.com/ethereum-optimism/optimism/pull/13323/files#r1896111128) which skipped the majority of the foundry test suite. 

This fixes it.

Here's a [run with the bug](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/75659/workflows/1e4a1d50-d8ff-48b7-946f-df1cc6935911/jobs/3074943) in it (43 total tests). Compare that to the [test run](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/75662/workflows/9ef87787-c805-4147-a4a2-f6c51c3e1591/jobs/3075029) on this P (1779 total tests).

Fortunately they are all passing. I also looked at the PRs merged since the issue was introduced and am not concerned about them. 