### PR TITLE
op-e2e: update `System.Cfg` when `cfg` is possibly changed

### DIFF
--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -692,7 +692,6 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	}
 
 	for _, name := range l2Nodes {
-		var ethClient services.EthInstance
 		if name != RoleSeq && !cfg.DisableTxForwarder {
 			cfg.GethOptions[name] = append(cfg.GethOptions[name], func(ethCfg *ethconfig.Config, nodeCfg *node.Config) error {
 				ethCfg.RollupSequencerHTTP = sys.EthInstances[RoleSeq].UserRPC().RPC()
@@ -708,9 +707,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 			return nil, err
 		}
 
-		ethClient = l2Geth
-
-		sys.EthInstances[name] = ethClient
+		sys.EthInstances[name] = l2Geth
 	}
 
 	// Configure connections to L1 and L2 for rollup nodes.

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -810,6 +810,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 
 		if action, ok := parsedStartOpts.Get("afterRollupNodeStart", name); ok {
 			action(&cfg, sys)
+			sys.Cfg = cfg
 		}
 	}
 
@@ -947,6 +948,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	sys.BatchSubmitter = batcher
 	if action, ok := parsedStartOpts.Get("beforeBatcherStart", ""); ok {
 		action(&cfg, sys)
+		sys.Cfg = cfg
 	}
 	if err := batcher.Start(context.Background()); err != nil {
 		return nil, errors.Join(fmt.Errorf("failed to start batch submitter: %w", err), batcher.Stop(context.Background()))

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -737,7 +737,6 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 			if err != nil {
 				return nil, fmt.Errorf("failed to init p2p host for node %s", name)
 			}
-			h.Network()
 			_, ok := cfg.Nodes[name]
 			if !ok {
 				return nil, fmt.Errorf("node %s from p2p topology not found in actual nodes map", name)


### PR DESCRIPTION
In `SystemConfig.Start` there're places that may change `cfg`(e.g., [here](https://github.com/ethereum-optimism/optimism/blob/f3b9f0c915b26c7f1ac23c15cbc1969c8b05fa1d/op-e2e/system/e2esys/setup.go#L812)).

This PR updates `System.Cfg` when `cfg` is possibly changed, and removes 2 useless statements.
