### PR TITLE
fix: remove proxy implementation for OPCM contract

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -360,7 +360,7 @@ contract Deploy is Deployer {
 
         // Ensure that the requisite contracts are deployed
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
-        OPContractsManager opcm = OPContractsManager(mustGetAddress("OPContractsManager"));
+        OPContractsManager opcm = new OPContractsManager();
 
         OPContractsManager.DeployInput memory deployInput = getDeployInput();
         OPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);


### PR DESCRIPTION
## Description

This pull request removes the proxy implementation for the `OPContractsManager` (OPCM) contract in the Bedrock deployment script. The changes replace the reference to a previously deployed `OPContractsManager` with the creation of a new instance of the contract directly within the deployment process.

## Tests

No specific tests were added for this change as it directly updates the deployment script. However, deployment processes should be revalidated to ensure that the removal of the proxy does not introduce regressions or disrupt existing deployment workflows.

## Additional Context

- The updated logic ensures that the `OPContractsManager` is deployed afresh with each invocation of the script, aligning with deployment requirements for Bedrock.
- This change simplifies the deployment flow by removing an additional dependency on the proxy.

## Metadata

- Fixes: #13473 

---

### Notes for Maintainers

Allow edits by maintainers: ✅  
This change follows the contributing guidelines and aims to streamline the Bedrock contract deployment process.

