### PR TITLE
fix: resource metering use gas missing check

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,16 +24,16 @@
     "sourceCodeHash": "0x05ed7ad68e4e9bca7334314e794a1f66e5899532bb01cfa3a7716cb2688df9d5"
   },
   "src/L1/OptimismPortal.sol": {
-    "initCodeHash": "0x2f5427c78c3445cdbe38931e67274ae87a6ac7fcc1a2279f1e9fc294808b67f9",
-    "sourceCodeHash": "0x77e0f0f8caa9742896a3e7cdee15b0061e298f9c950159bb7231b8196517c9d2"
+    "initCodeHash": "0xe2901989a11d2f2d2f211332563567c07473d30d46bc416431ef6792c631071a",
+    "sourceCodeHash": "0x82206af7940f8fd7948aa91f4b4c075022c31192511d278b801b60950beade01"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0xfd14fd690752519064d6de6c3e15d69ec9146bc8714e56ac286305773dbb1533",
-    "sourceCodeHash": "0x3dbd4601c67a43c42f403f6b28e6e2d8bf4f3d2cf2f2d8f7460026e0c6c66def"
+    "initCodeHash": "0xde95a3b5ccf3acac92bdd6367ab31b7a08a1ac95e1273d02f5e8d9dc63086c9c",
+    "sourceCodeHash": "0xf02c03da42bac820f07893bb3cc59966903f6bdc89eb41887e4015db27852655"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0xc7a9282ef32425b65a647039908ea2b8d6ef231ba1b87c345c7b9f3f73acc240",
-    "sourceCodeHash": "0x85e9f10ba1884b1a45737fd35ae4c2f9a9054f81a6aba08941ab7a95e74543da"
+    "initCodeHash": "0xce696bdb464939ea61f6c575934be649931385874d566f0319ca62fe611f52b9",
+    "sourceCodeHash": "0xae2fbe02c0f8685692babeed0252ae8a624dc6d3bfb082fc3807d7b84869004b"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x0000ec89712d8b4609873f1ba76afffd4205bf9110818995c90134dbec12e91e",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -146,9 +146,9 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.8.1-beta.6
+    /// @custom:semver 2.8.1-beta.7
     function version() public pure virtual returns (string memory) {
-        return "2.8.1-beta.6";
+        return "2.8.1-beta.7";
     }
 
     /// @notice Constructs the OptimismPortal contract.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -183,9 +183,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.11.0-beta.9
+    /// @custom:semver 3.11.0-beta.10
     function version() public pure virtual returns (string memory) {
-        return "3.11.0-beta.9";
+        return "3.11.0-beta.10";
     }
 
     /// @notice Constructs the OptimismPortal contract.

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -25,9 +25,9 @@ contract OptimismPortalInterop is OptimismPortal2 {
         OptimismPortal2(_proofMaturityDelaySeconds, _disputeGameFinalityDelaySeconds)
     { }
 
-    /// @custom:semver +interop-beta.6
+    /// @custom:semver +interop-beta.7
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.6");
+        return string.concat(super.version(), "+interop-beta.7");
     }
 
     /// @notice Sets static configuration options for the L2 system.

--- a/packages/contracts-bedrock/src/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/src/L1/ResourceMetering.sol
@@ -155,6 +155,10 @@ abstract contract ResourceMetering is Initializable {
     /// @param _amount Amount of the L2 gas resource requested.
     function useGas(uint32 _amount) internal {
         params.prevBoughtGas += uint64(_amount);
+
+        if (params.prevBoughtGas > _resourceConfig().maxResourceLimit) {
+            revert OutOfGas();
+        }
     }
 
     /// @notice Virtual function that returns the resource config.


### PR DESCRIPTION
**Description**

Add a check to ensure that the gas bought on the system deposit transactions doesn't exceed the max resource limit

**Tests**

Adjust `ResourceMetering` tests

**Additional context**

This check is being done in the user deposit transactions but it was missing in the system ones
