### PR TITLE
chore: fix quotation mark

### DIFF
--- a/docs/handbook/pr-guidelines.md
+++ b/docs/handbook/pr-guidelines.md
@@ -17,7 +17,7 @@
 This document contains guidelines and best practices in PRs that should be enforced as much as possible. The motivations and goals behind these best practices are:
 
 - **Ensure thorough reviews**: By the time the PR is merged, at least one other person—because there is always at least one reviewer—should understand the PR’s changes just as well as the PR author. This helps improve security by reducing bugs and single points of failure (i.e. there should never be only one person who understands certain code).
-- **Reduce PR churn**: PRs should be quickly reviewable and mergeable without much churn (both in terms of code rewrites and comment cycles). This saves time by reducing the need for rebases due to conflicts. Similarly, too many review cycles are a burden for both PR authors and reviewers, and results in “review fatigue” where reviews become less careful and thorough, increasing the likelihood of bugs.
+- **Reduce PR churn**: PRs should be quickly reviewable and mergeable without much churn (both in terms of code rewrites and comment cycles). This saves time by reducing the need for rebases due to conflicts. Similarly, too many review cycles are a burden for both PR authors and reviewers, and results in "review fatigue" where reviews become less careful and thorough, increasing the likelihood of bugs.
 - **Traceability**: We should be able to look back at issues and PRs to understand why a certain decision was made or why a given approach was taken.
 
 ## PR Lifecycle Best Practices

--- a/docs/postmortems/2023-04-26-transaction-delays.md
+++ b/docs/postmortems/2023-04-26-transaction-delays.md
@@ -2,7 +2,7 @@
 
 # Incident Summary
 
-On April 26, 2023 between the hours of 1900 and 2100 UTC, OP Mainnet experienced degraded service following a ~10x increase in the rate of `eth_sendRawTransaction` requests. 
+On April 26, 2023 between the hours of 1900 and 2100 UTC, OP Mainnet experienced degraded service following a ~10x increase in the rate of `eth_sendRawTransaction` requests.
 
 While the sequencer remained online and continued to process transactions, users experienced transaction inclusion delays, rate limit errors, problems syncing nodes, and other symptoms of degraded performance.
 
@@ -15,7 +15,7 @@ OP Mainnet has not yet been upgraded to Bedrock. As a result, all OP Mainnet nod
 - The `data-transport-layer` (or DTL), which indexes transactions from L1 or another L2 node.
 - `l2geth`, which executes the transactions indexed by the DTL and maintains the L2 chain’s state.
 
-The DTL and `l2geth` retrieve new data by polling for it. The DTL polls L1 or L2 depending on how it is configured, and `l2geth` polls the DTL. The higher the transaction throughput is, the more transactions will have to be processed between each “tick” of the polling loop. When throughput is too high, it is possible for the number of transactions between each tick to exceed what can be processed in a single tick. In this case, multiple ticks are necessary to catch up to the tip of the chain.
+The DTL and `l2geth` retrieve new data by polling for it. The DTL polls L1 or L2 depending on how it is configured, and `l2geth` polls the DTL. The higher the transaction throughput is, the more transactions will have to be processed between each "tick" of the polling loop. When throughput is too high, it is possible for the number of transactions between each tick to exceed what can be processed in a single tick. In this case, multiple ticks are necessary to catch up to the tip of the chain.
 
 To protect the sequencer against traffic spikes, we route read requests - specifically `eth_getBlockRange`, which the DTL uses to sync from L2 - to a read-only replica rather than to the sequencer itself.
 


### PR DESCRIPTION
Some editors may not accurately render unexpected characters, appearing as gibberish or causing formatting problems.