### PR TITLE
Documentation Issues

### DIFF
--- a/op-e2e/system/bridge/bridge_test.go
+++ b/op-e2e/system/bridge/bridge_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	op_e2e.RunMain(m)
 }
 
-// TestERC20BridgeDeposits tests the the L1StandardBridge bridge ERC20
+// TestERC20BridgeDeposits tests the L1StandardBridge bridge ERC20
 // functionality.
 func TestERC20BridgeDeposits(t *testing.T) {
 	op_e2e.InitParallel(t)

--- a/op-node/rollup/interop/managed.go
+++ b/op-node/rollup/interop/managed.go
@@ -32,7 +32,7 @@ func (s *ManagedMode) AttachEmitter(em event.Emitter) {
 }
 
 func (s *ManagedMode) OnEvent(ev event.Event) bool {
-	// TODO(#13336): let all active subscriptions now
+	// TODO(#13336): let all active subscriptions know
 	return false
 }
 

--- a/op-node/rollup/interop/tmpapi.go
+++ b/op-node/rollup/interop/tmpapi.go
@@ -14,7 +14,7 @@ import (
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-// TemporaryInteropServer is a work-around to serve the "managed"-
+// TemporaryInteropServer is a work-around to serve the "managed"
 // mode endpoints used by the op-supervisor for data,
 // while still using the old interop deriver for syncing.
 type TemporaryInteropServer struct {

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -306,7 +306,7 @@ func TestOriginSelectorFetchesNextOrigin(t *testing.T) {
 // The next L2 time is 24 which is before the next L1 block time. There
 // is no conf depth to stop the LOS from potentially selecting block `b`
 // but it should select block `a` because the L2 block time must be ahead
-// of the the timestamp of it's L1 origin.
+// of the timestamp of it's L1 origin.
 func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -392,7 +392,7 @@ func TestTxMgrConfirmAtMinGasPrice(t *testing.T) {
 }
 
 // TestTxMgrNeverConfirmCancel asserts that a Send can be canceled even if no
-// transaction is mined. This is done to ensure the the tx mgr can properly
+// transaction is mined. This is done to ensure the tx mgr can properly
 // abort on shutdown, even if a txn is in the process of being published.
 func TestTxMgrNeverConfirmCancel(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION


Reason: Removed duplicate article "the" to improve grammar and readability. 3x

Reason: Fixed incorrect word usage. "know" is the correct verb in this context, as it refers to informing/notifying the subscriptions, while "now" is a temporal adverb that doesn't make sense in this context.
