### PR TITLE
fix `FromAsCasing` warning for all Dockerfile

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM golang:1.22.7-alpine3.20 as builder
+FROM golang:1.22.7-alpine3.20 AS builder
 
 RUN apk add --no-cache make bash
 
@@ -25,7 +25,7 @@ ARG TARGETOS TARGETARCH
 
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.4 AS cannon-v2
 
-FROM --platform=$BUILDPLATFORM builder as cannon-verify
+FROM --platform=$BUILDPLATFORM builder AS cannon-verify
 COPY --from=cannon-v2 /usr/local/bin/cannon /usr/local/bin/cannon-v2
 # verify the latest singlethreaded VM behavior against cannon-v2
 RUN cd cannon && make diff-singlethreaded-2-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v2

--- a/op-alt-da/Dockerfile
+++ b/op-alt-da/Dockerfile
@@ -1,5 +1,5 @@
 ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
-FROM $OP_STACK_GO_BUILDER as builder
+FROM $OP_STACK_GO_BUILDER AS builder
 # See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.20

--- a/op-dispute-mon/Dockerfile
+++ b/op-dispute-mon/Dockerfile
@@ -1,5 +1,5 @@
 ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
-FROM $OP_STACK_GO_BUILDER as builder
+FROM $OP_STACK_GO_BUILDER AS builder
 # See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.20

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -4,9 +4,9 @@
 
 # This Dockerfile builds all the dependencies needed by the smart-contracts, excluding Go and Python.
 
-FROM --platform=linux/amd64 us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest as foundry
+FROM --platform=linux/amd64 us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest AS foundry
 
-FROM --platform=linux/amd64 debian:bookworm-20240812-slim as base
+FROM --platform=linux/amd64 debian:bookworm-20240812-slim AS base
 
 # Base: install deps
 RUN apt-get update && apt-get install -y \

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -81,7 +81,7 @@ ENTRYPOINT ["/bin/bash", "-c"]
 #                              CI BUILDER (RUST)                              #
 ###############################################################################
 
-FROM base-builder as rust-builder
+FROM base-builder AS rust-builder
 
 # Install clang & lld
 RUN apt-get update && apt-get install -y clang lld


### PR DESCRIPTION
This PR fixes the `FromAsCasing: 'as' and 'FROM' keywords' casing do not match` warning for all Dockerfile in the mono-repo.

Otherwise there'll be such warnings:

```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile.repro:1
```