### PR TITLE
op-e2e: always return abs path for `BuildOpProgramClient`

### DIFF
--- a/op-e2e/system/proofs/build_helper.go
+++ b/op-e2e/system/proofs/build_helper.go
@@ -33,5 +33,10 @@ func BuildOpProgramClient(t *testing.T) string {
 	cmd.Stderr = &out
 	require.NoErrorf(t, cmd.Run(), "Failed to build op-program-client: %v", &out)
 	t.Log("Built op-program-client successfully")
-	return "../../../op-program/bin/op-program-client"
+
+	clientPath, err = filepath.Abs("../../../op-program/bin/op-program-client")
+	require.NoError(t, err)
+	_, err = os.Stat(clientPath)
+	require.NoError(t, err)
+	return clientPath
 }


### PR DESCRIPTION
The beginning part already tries to return an abs path [here](https://github.com/ethereum-optimism/optimism/blob/a1df3e127b82c4d290fd568bc7e1680145dab55c/op-e2e/system/proofs/build_helper.go#L17), this PR makes it more consistent.