### PR TITLE
`FaultDisputeGame`: remove redundant `createdAt` field

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x423e8488731c0b0f87b435174f412c09fbf0b17eb0b8c9a03efa37d779ec0cae",
-    "sourceCodeHash": "0xe53b970922b309ada1c59f94d5935ffca669e909c797f17ba8a3d309c487e7e8"
+    "initCodeHash": "0xa1b62e1b6c4e0bc7fec895ac62fbf7b2f795e883d78baecf1d25ed6f895232f0",
+    "sourceCodeHash": "0x127fd5b9630cd70ce008355c35d611b433487796364cbd0dc21126f517582845"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -161,11 +161,8 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1-beta.9
-    string public constant version = "1.3.1-beta.9";
-
-    /// @notice The starting timestamp of the game
-    Timestamp public createdAt;
+    /// @custom:semver 1.3.1-beta.10
+    string public constant version = "1.3.1-beta.10";
 
     /// @notice The timestamp of the game's global resolution.
     Timestamp public resolvedAt;
@@ -321,9 +318,11 @@ contract FaultDisputeGame is Clone, ISemver {
 
         // Deposit the bond.
         WETH.deposit{ value: msg.value }();
+    }
 
-        // Set the game's starting timestamp
-        createdAt = Timestamp.wrap(uint64(block.timestamp));
+    /// @notice The starting timestamp of the game
+    function createdAt() public view returns (Timestamp) {
+        return claimData[0].clock.timestamp();
     }
 
     ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `createdAt` is the same as the root claim's `clock.timestamp`(which always exists for a game, [source](https://github.com/ethereum-optimism/optimism/blob/a1df3e127b82c4d290fd568bc7e1680145dab55c/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol#L315)).