### PR TITLE
op-node: implement sequencer recover-mode

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -31,11 +31,11 @@ type MockL1OriginSelector struct {
 	originOverride eth.L1BlockRef // override which origin gets picked
 }
 
-func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
 	if m.originOverride != (eth.L1BlockRef{}) {
 		return m.originOverride, nil
 	}
-	return m.actual.FindL1Origin(ctx, l2Head)
+	return m.actual.FindL1Origin(ctx, l2Head, recoverMode)
 }
 
 // L2Sequencer is an actor that functions like a rollup node,
@@ -178,7 +178,7 @@ func (s *L2Sequencer) ActBuildToL1HeadUnsafe(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 	for {
 		s.ActL2PipelineFull(t)
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head(), false)
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.syncStatus.L1Head().Number {
 			break
@@ -191,7 +191,7 @@ func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExclUnsafe(t Testing) {
 	for {
 		// Note: the derivation pipeline does not run, we are just sequencing a block on top of the existing L2 chain.
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head(), false)
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.syncStatus.L1Head().Number {
 			break

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -245,6 +245,10 @@ func (s *l2VerifierBackend) ConductorEnabled(ctx context.Context) (bool, error) 
 	return false, nil
 }
 
+func (s *l2VerifierBackend) SetRecoverMode(ctx context.Context, mode bool) error {
+	return nil
+}
+
 func (s *L2Verifier) DerivationMetricsTracer() *testutils.TestDerivationMetrics {
 	return s.derivationMetrics
 }

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -236,6 +236,13 @@ var (
 		Value:    4,
 		Category: SequencerCategory,
 	}
+	SequencerRecoverMode = &cli.BoolFlag{
+		Name:     "sequencer.recover",
+		Usage:    "Forces the sequencer to strictly prepare the next L1 origin and create empty L2 blocks",
+		EnvVars:  prefixEnvVars("SEQUENCER_RECOVER"),
+		Value:    false,
+		Category: SequencerCategory,
+	}
 	L1EpochPollIntervalFlag = &cli.DurationFlag{
 		Name:     "l1.epoch-poll-interval",
 		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
@@ -401,6 +408,7 @@ var optionalFlags = []cli.Flag{
 	SequencerStoppedFlag,
 	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
+	SequencerRecoverMode,
 	L1EpochPollIntervalFlag,
 	RuntimeConfigReloadIntervalFlag,
 	RPCEnableAdmin,

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -35,6 +35,7 @@ type driverClient interface {
 	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
 	OverrideLeader(ctx context.Context) error
 	ConductorEnabled(ctx context.Context) (bool, error)
+	SetRecoverMode(ctx context.Context, mode bool) error
 }
 
 type SafeDBReader interface {
@@ -104,6 +105,10 @@ func (n *adminAPI) ConductorEnabled(ctx context.Context) (bool, error) {
 	recordDur := n.M.RecordRPCServerRequest("admin_conductorEnabled")
 	defer recordDur()
 	return n.dr.ConductorEnabled(ctx)
+}
+
+func (n *adminAPI) SetRecoverMode(ctx context.Context, mode bool) error {
+	return n.dr.SetRecoverMode(ctx, mode)
 }
 
 type nodeAPI struct {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -291,6 +291,11 @@ func (c *mockDriverClient) ConductorEnabled(ctx context.Context) (bool, error) {
 	return c.Mock.MethodCalled("ConductorEnabled").Get(0).(bool), nil
 }
 
+func (c *mockDriverClient) SetRecoverMode(ctx context.Context, mode bool) error {
+	c.Mock.MethodCalled("SetRecoverMode")
+	return nil
+}
+
 type mockSafeDBReader struct {
 	mock.Mock
 }

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,8 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// RecoverMode forces the sequencer to select the next L1 Origin exactly, and create an empty block,
+	// to be compatible with verifiers forcefully generating the same block.
+	RecoverMode bool `json:"recover_mode"`
 }

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -79,8 +79,9 @@ type Driver struct {
 // The loop will have been started iff err is not nil.
 func (s *Driver) Start() error {
 	log.Info("Starting driver", "sequencerEnabled", s.driverConfig.SequencerEnabled,
-		"sequencerStopped", s.driverConfig.SequencerStopped)
+		"sequencerStopped", s.driverConfig.SequencerStopped, "recoverMode", s.driverConfig.RecoverMode)
 	if s.driverConfig.SequencerEnabled {
+		s.sequencer.SetRecoverMode(s.driverConfig.RecoverMode)
 		if err := s.sequencer.SetMaxSafeLag(s.driverCtx, s.driverConfig.SequencerMaxSafeLag); err != nil {
 			return fmt.Errorf("failed to set sequencer max safe lag: %w", err)
 		}
@@ -485,6 +486,11 @@ func (s *Driver) OverrideLeader(ctx context.Context) error {
 
 func (s *Driver) ConductorEnabled(ctx context.Context) (bool, error) {
 	return s.sequencer.ConductorEnabled(ctx), nil
+}
+
+func (s *Driver) SetRecoverMode(ctx context.Context, mode bool) error {
+	s.sequencer.SetRecoverMode(mode)
+	return nil
 }
 
 // SyncStatus blocks the driver event loop and captures the syncing status.

--- a/op-node/rollup/sequencing/disabled.go
+++ b/op-node/rollup/sequencing/disabled.go
@@ -52,4 +52,6 @@ func (ds DisabledSequencer) ConductorEnabled(ctx context.Context) bool {
 	return false
 }
 
+func (ds DisabledSequencer) SetRecoverMode(mode bool) {}
+
 func (ds DisabledSequencer) Close() {}

--- a/op-node/rollup/sequencing/iface.go
+++ b/op-node/rollup/sequencing/iface.go
@@ -20,5 +20,6 @@ type SequencerIface interface {
 	SetMaxSafeLag(ctx context.Context, v uint64) error
 	OverrideLeader(ctx context.Context) error
 	ConductorEnabled(ctx context.Context) bool
+	SetRecoverMode(mode bool)
 	Close()
 }

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -554,7 +554,7 @@ func (d *Sequencer) startBuildingBlock() {
 
 	if recoverMode {
 		attrs.NoTxPool = true
-		d.log.Warn("Sequencing temporarily without user transactions, in catch-up mode")
+		d.log.Warn("Sequencing temporarily without user transactions, in recover mode")
 	}
 
 	d.log.Debug("prepared attributes for new block",

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -74,7 +74,7 @@ type FakeL1OriginSelector struct {
 	l1OriginFn func(l2Head eth.L2BlockRef) (eth.L1BlockRef, error)
 }
 
-func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
 	f.request = l2Head
 	return f.l1OriginFn(l2Head)
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -206,6 +206,7 @@ func NewDriverConfig(ctx *cli.Context) *driver.Config {
 		SequencerEnabled:    ctx.Bool(flags.SequencerEnabledFlag.Name),
 		SequencerStopped:    ctx.Bool(flags.SequencerStoppedFlag.Name),
 		SequencerMaxSafeLag: ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		RecoverMode:         ctx.Bool(flags.SequencerRecoverMode.Name),
 	}
 }
 


### PR DESCRIPTION
**Description**

E.g. on a testnet, if not batch-submitting for prolonged time, the sequencer may need to build new L2 blocks on top of actively new generated L2 blocks.

For blocks to be compatible, the L1 origin needs to be selected such that it progresses to the next L1 origin as soon as valid. And blocks need to be empty as well.

This branch is based on top of the commit of tag `op-node/v1.10.1`, to make an `op-node/v1.10.1+extra` release.

**Tests**

Updated L1 origin selector unit-tests to cover the forced next-L1-origin preparation.
