### PR TITLE
op-proposer: add stopped flag

### DIFF
--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -82,6 +82,7 @@ var (
 	StoppedFlag = &cli.BoolFlag{
 		Name:    "stopped",
 		Usage:   "Initialize the proposer in a stopped state. The proposer can be started using the admin_startProposer RPC",
+		Value:   false,
 		EnvVars: prefixEnvVars("STOPPED"),
 	}
 

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -79,6 +79,12 @@ var (
 		Value:   false,
 		EnvVars: prefixEnvVars("WAIT_NODE_SYNC"),
 	}
+	StoppedFlag = &cli.BoolFlag{
+		Name:    "stopped",
+		Usage:   "Initialize the proposer in a stopped state. The proposer can be started using the admin_startProposer RPC",
+		EnvVars: prefixEnvVars("STOPPED"),
+	}
+
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
@@ -98,6 +104,7 @@ var optionalFlags = []cli.Flag{
 	DisputeGameTypeFlag,
 	ActiveSequencerCheckDurationFlag,
 	WaitNodeSyncFlag,
+	StoppedFlag,
 }
 
 func init() {

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -116,6 +116,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ProposalInterval:             ctx.Duration(flags.ProposalIntervalFlag.Name),
 		DisputeGameType:              uint32(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
 		ActiveSequencerCheckDuration: ctx.Duration(flags.ActiveSequencerCheckDurationFlag.Name),
+		Stopped:                      ctx.Bool(flags.StoppedFlag.Name),
 		WaitNodeSync:                 ctx.Bool(flags.WaitNodeSyncFlag.Name),
 	}
 }

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -59,6 +59,10 @@ type CLIConfig struct {
 	// ActiveSequencerCheckDuration is the duration between checks to determine the active sequencer endpoint.
 	ActiveSequencerCheckDuration time.Duration
 
+	// If Stopped is true, the proposer starts stopped and won't start proposing right away.
+	// Proposing needs to be started via an admin RPC.
+	Stopped bool
+
 	// Whether to wait for the sequencer to sync to a recent block at startup.
 	WaitNodeSync bool
 }

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -212,6 +212,10 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 	return nil
 }
 
+func (l *L2OutputSubmitter) Stopped() bool {
+	return !l.running
+}
+
 // FetchL2OOOutput gets the next output proposal for the L2OO.
 // It queries the L2OO for the earliest next block number that should be proposed.
 // It returns the output to propose, and whether the proposal should be submitted at all.

--- a/op-proposer/proposer/rpc/api.go
+++ b/op-proposer/proposer/rpc/api.go
@@ -13,6 +13,7 @@ import (
 type ProposerDriver interface {
 	StartL2OutputSubmitting() error
 	StopL2OutputSubmitting() error
+	Stopped() bool
 }
 
 type adminAPI struct {
@@ -40,4 +41,8 @@ func (a *adminAPI) StartProposer(_ context.Context) error {
 
 func (a *adminAPI) StopProposer(ctx context.Context) error {
 	return a.b.StopL2OutputSubmitting()
+}
+
+func (a *adminAPI) Stopped() bool {
+	return a.b.Stopped()
 }

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -267,8 +267,6 @@ func (ps *ProposerService) initRPCServer(cfg *CLIConfig) error {
 // Start runs once upon start of the proposer lifecycle,
 // and starts L2Output-submission work if the proposer is configured to start submit data on startup.
 func (ps *ProposerService) Start(_ context.Context) error {
-	ps.Log.Info("Starting Proposer")
-
 	if !ps.NotSubmittingOnStart {
 		return ps.driver.StartL2OutputSubmitting()
 	}

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -69,7 +69,8 @@ type ProposerService struct {
 
 	balanceMetricer io.Closer
 
-	stopped atomic.Bool
+	stopped              atomic.Bool
+	NotSubmittingOnStart bool
 }
 
 // ProposerServiceFromCLIConfig creates a new ProposerService from a CLIConfig.
@@ -86,6 +87,7 @@ func ProposerServiceFromCLIConfig(ctx context.Context, version string, cfg *CLIC
 func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string, cfg *CLIConfig, log log.Logger) error {
 	ps.Version = version
 	ps.Log = log
+	ps.NotSubmittingOnStart = cfg.Stopped
 
 	ps.initMetrics(cfg)
 
@@ -266,7 +268,11 @@ func (ps *ProposerService) initRPCServer(cfg *CLIConfig) error {
 // and starts L2Output-submission work if the proposer is configured to start submit data on startup.
 func (ps *ProposerService) Start(_ context.Context) error {
 	ps.Log.Info("Starting Proposer")
-	return ps.driver.StartL2OutputSubmitting()
+
+	if !ps.NotSubmittingOnStart {
+		return ps.driver.StartL2OutputSubmitting()
+	}
+	return nil
 }
 
 func (ps *ProposerService) Stopped() bool {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Add `--stopped` flag to `op-proposer` to be able to start op-proposer inactive state like.
Similar feature is already supported on `op-batcher`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Updated code seems covered by `op-proposer/flags_test.go`

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

This feature is required to prepare *standby* proposer.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

- close #13220