### PR TITLE
feat(kurtosis-devnet): build/serve prestate proofs

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -8,6 +8,10 @@ _contracts-build BUNDLE='contracts-bundle.tar.gz':
     just ../packages/contracts-bedrock/forge-build
     tar -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
 
+_prestate-build PATH='.':
+    make -C ../op-program reproducible-prestate
+    cp ../op-program/bin/prestate-proof*.json {{PATH}}
+
 _docker_build TAG TARGET='' CONTEXT='.' DOCKERFILE='Dockerfile':
     docker buildx build -t {{TAG}} \
         -f {{CONTEXT}}/{{DOCKERFILE}} \

--- a/kurtosis-devnet/pkg/build/prestate.go
+++ b/kurtosis-devnet/pkg/build/prestate.go
@@ -1,0 +1,95 @@
+package build
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os/exec"
+	"text/template"
+)
+
+// PrestateBuilder handles building prestates using just commands
+type PrestateBuilder struct {
+	baseDir     string
+	cmdTemplate *template.Template
+	dryRun      bool
+}
+
+const (
+	prestateCmdTemplateStr = "just _prestate-build {{.Path}}"
+)
+
+var defaultPrestateTemplate *template.Template
+
+func init() {
+	defaultPrestateTemplate = template.Must(template.New("prestate_build_cmd").Parse(prestateCmdTemplateStr))
+}
+
+type PrestateBuilderOptions func(*PrestateBuilder)
+
+func WithPrestateBaseDir(baseDir string) PrestateBuilderOptions {
+	return func(b *PrestateBuilder) {
+		b.baseDir = baseDir
+	}
+}
+
+func WithPrestateTemplate(cmdTemplate *template.Template) PrestateBuilderOptions {
+	return func(b *PrestateBuilder) {
+		b.cmdTemplate = cmdTemplate
+	}
+}
+
+func WithPrestateDryRun(dryRun bool) PrestateBuilderOptions {
+	return func(b *PrestateBuilder) {
+		b.dryRun = dryRun
+	}
+}
+
+// NewPrestateBuilder creates a new PrestateBuilder instance
+func NewPrestateBuilder(opts ...PrestateBuilderOptions) *PrestateBuilder {
+	b := &PrestateBuilder{
+		baseDir:     ".",
+		cmdTemplate: defaultPrestateTemplate,
+		dryRun:      false,
+	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
+	return b
+}
+
+// templateData holds the data for the command template
+type prestateTemplateData struct {
+	Path string
+}
+
+// Build executes the prestate build command
+func (b *PrestateBuilder) Build(path string) error {
+	log.Printf("Building prestate: %s", path)
+
+	// Prepare template data
+	data := prestateTemplateData{
+		Path: path,
+	}
+
+	// Execute template to get command string
+	var cmdBuf bytes.Buffer
+	if err := b.cmdTemplate.Execute(&cmdBuf, data); err != nil {
+		return fmt.Errorf("failed to execute command template: %w", err)
+	}
+
+	// Create command
+	cmd := exec.Command("sh", "-c", cmdBuf.String())
+	cmd.Dir = b.baseDir
+
+	if !b.dryRun {
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("prestate build command failed: %w\nOutput: %s", err, string(output))
+		}
+	}
+
+	return nil
+}

--- a/kurtosis-devnet/pkg/tmpl/tmpl.go
+++ b/kurtosis-devnet/pkg/tmpl/tmpl.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TemplateFunc represents a function that can be used in templates
-type TemplateFunc func(string) (string, error)
+type TemplateFunc any
 
 // TemplateContext contains data and functions to be passed to templates
 type TemplateContext struct {


### PR DESCRIPTION
**Description**

This prepares the ground for op-challenger needing a URL locator
serving prestate proof files.

A {{localPrestate}} placeholder will expand to a URL that's usable by
op-challenger.

**Additional context**

This will integrate with corresponding support code on the
optimism-package side.
