### PR TITLE
op-program: Update prestate releases for op-program/v1.4.1-rc.1

### DIFF
--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "1.4.1-rc.1",
+    "hash": "0x0386cde2f2b1bde1189ac9c9b7d66774e6260eca778223def326bfe680c14ab9",
+    "type": "cannon64"
+  },
+  {
+    "version": "1.4.1-rc.1",
+    "hash": "0x03045fd433fb5391c40751939d7cb5e9dfe83cf156f9395566a311e7fe9d3aa2"
+  },
+  {
     "version": "1.4.0-rc.3",
     "hash": "0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b",
     "type": "cannon64"

--- a/op-program/prestates/verify/verify.go
+++ b/op-program/prestates/verify/verify.go
@@ -90,5 +90,5 @@ func main() {
 }
 
 func formatRelease(release prestates.Release) string {
-	return fmt.Sprintf("%-13v %s %s", release.Version, release.Hash, release.Type)
+	return fmt.Sprintf("%-13v %s %-10v", release.Version, release.Hash, release.Type)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Update  op-program `releases.json` with the latest prestates for `op-program/v1.4.1-rc.1`.

To verify the prestate hashes:
```
git checkout "op-program/v1.4.1-rc.1"
make reproducible-prestate
```

**Tests**
Tested manually with:
```
make verify-reproducibility
```
