### PR TITLE
chore: Upgrade `kona-client` version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "REPOSITORY" {
 }
 
 variable "KONA_VERSION" {
-  default = "kona-client-v0.1.0-beta.5"
+  default = "kona-client-v0.1.0-beta.6"
 }
 
 variable "GIT_COMMIT" {


### PR DESCRIPTION
## Overview

Upgrades the `kona-client` version to [`beta.6`](https://github.com/anton-rs/kona/releases/tag/kona-client-v0.1.0-beta.6)