### PR TITLE
[op-node/withdrawals] Cleanup, and support multiple withdrawal events in a single receipt

### DIFF
--- a/op-e2e/system/helpers/withdrawal_helper.go
+++ b/op-e2e/system/helpers/withdrawal_helper.go
@@ -128,7 +128,7 @@ func ProveWithdrawal(t *testing.T, cfg e2esys.SystemConfig, clients ClientProvid
 	}
 
 	receiptCl := clients.NodeClient(l2NodeName)
-	blockCl := clients.NodeClient(l2NodeName)
+	headerCl := clients.NodeClient(l2NodeName)
 	proofCl := gethclient.New(receiptCl.Client())
 
 	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
@@ -146,7 +146,7 @@ func ProveWithdrawal(t *testing.T, cfg e2esys.SystemConfig, clients ClientProvid
 	portal2, err := bindingspreview.NewOptimismPortal2Caller(l1Deployments.OptimismPortalProxy, l1Client)
 	require.NoError(t, err)
 
-	params, err := ProveWithdrawalParameters(context.Background(), proofCl, receiptCl, blockCl, l2WithdrawalReceipt.TxHash, header, oracle, factory, portal2, allocType)
+	params, err := ProveWithdrawalParameters(context.Background(), proofCl, receiptCl, headerCl, l2WithdrawalReceipt.TxHash, header, oracle, factory, portal2, allocType)
 	require.NoError(t, err)
 
 	portal, err := bindings.NewOptimismPortal(l1Deployments.OptimismPortalProxy, l1Client)
@@ -179,11 +179,11 @@ func ProveWithdrawal(t *testing.T, cfg e2esys.SystemConfig, clients ClientProvid
 	return params, proveReceipt
 }
 
-func ProveWithdrawalParameters(ctx context.Context, proofCl withdrawals.ProofClient, l2ReceiptCl withdrawals.ReceiptClient, l2BlockCl withdrawals.BlockClient, txHash common.Hash, header *types.Header, l2OutputOracleContract *bindings.L2OutputOracleCaller, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller, allocType config.AllocType) (withdrawals.ProvenWithdrawalParameters, error) {
+func ProveWithdrawalParameters(ctx context.Context, proofCl withdrawals.ProofClient, l2ReceiptCl withdrawals.ReceiptClient, l2HeaderCl withdrawals.HeaderClient, txHash common.Hash, header *types.Header, l2OutputOracleContract *bindings.L2OutputOracleCaller, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller, allocType config.AllocType) (withdrawals.ProvenWithdrawalParameters, error) {
 	if allocType.UsesProofs() {
-		return withdrawals.ProveWithdrawalParametersFaultProofs(ctx, proofCl, l2ReceiptCl, l2BlockCl, txHash, disputeGameFactoryContract, optimismPortal2Contract)
+		return withdrawals.ProveWithdrawalParametersFaultProofs(ctx, proofCl, l2ReceiptCl, l2HeaderCl, txHash, disputeGameFactoryContract, optimismPortal2Contract)
 	} else {
-		return withdrawals.ProveWithdrawalParameters(ctx, proofCl, l2ReceiptCl, l2BlockCl, txHash, header, l2OutputOracleContract)
+		return withdrawals.ProveWithdrawalParameters(ctx, proofCl, l2ReceiptCl, txHash, header, l2OutputOracleContract)
 	}
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

#9366 added some unnecessary complexity to the E2E withdrawal utility. This PR cleans some of this up by:
 - reusing the header passed in for non-fault proof withdrawals (rather than requerying the block)
 - replacing the block client with a header client (only the header is needed)
 - adding a new `ParseMessagesPassed` which supports multiple withdrawal messages in a single receipt
 - split out a separate method for `ProveWithdrawalParametersForEvent`, which in combination with the above, supports generating multiple withdrawal proofs for a single L2 transaction

**Tests**

This utility is only used in E2E testing and so is already well tested. There's no logic changes here, just a cleanup.

**Additional context**

We had an audit finding for https://github.com/base-org/op-enclave that mentioned that multiple withdrawals in a single L2 transaction is not supported by the optimism code.