### PR TITLE
Add deployImplementations to ForkLive flow

### DIFF
--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -158,8 +158,10 @@ contract Artifacts {
         if (bytes(_name).length == 0) {
             revert InvalidDeployment("EmptyName");
         }
-        if (bytes(_namedDeployments[_name].name).length > 0) {
-            revert InvalidDeployment("AlreadyExists");
+        Deployment memory existing = _namedDeployments[_name];
+        if (bytes(existing.name).length > 0) {
+            console.log("Warning: Deployment already exists for %s.", _name);
+            console.log("Overwriting %s with %s", existing.addr, _deployed);
         }
 
         Deployment memory deployment = Deployment({ name: _name, addr: payable(_deployed) });

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -200,8 +200,6 @@ contract Deploy is Deployer {
             deploySuperchain();
         }
 
-        // Deploy the implementations, with no suffix. The suffix is only used when deploying a new set of
-        // implementations to test upgrades.
         deployImplementations({ _isInterop: cfg.useInterop() });
 
         // Deploy Current OPChain Contracts

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -326,21 +326,23 @@ contract Deploy is Deployer {
 
         // Get a contract set from the implementation addresses which were just deployed.
         Types.ContractSet memory contracts = Types.ContractSet({
-            L1CrossDomainMessenger: mustGetAddress(string.concat("L1CrossDomainMessengerImpl", _suffix)),
-            L1StandardBridge: mustGetAddress(string.concat("L1StandardBridgeImpl", _suffix)),
+            L1CrossDomainMessenger: artifacts.mustGetAddress(string.concat("L1CrossDomainMessengerImpl", _suffix)),
+            L1StandardBridge: artifacts.mustGetAddress(string.concat("L1StandardBridgeImpl", _suffix)),
             L2OutputOracle: address(0),
-            DisputeGameFactory: mustGetAddress(string.concat("DisputeGameFactoryImpl", _suffix)),
-            DelayedWETH: mustGetAddress(string.concat("DelayedWETHImpl", _suffix)),
-            PermissionedDelayedWETH: mustGetAddress(string.concat("DelayedWETHImpl", _suffix)),
+            DisputeGameFactory: artifacts.mustGetAddress(string.concat("DisputeGameFactoryImpl", _suffix)),
+            DelayedWETH: artifacts.mustGetAddress(string.concat("DelayedWETHImpl", _suffix)),
+            PermissionedDelayedWETH: artifacts.mustGetAddress(string.concat("DelayedWETHImpl", _suffix)),
             AnchorStateRegistry: address(0),
-            OptimismMintableERC20Factory: mustGetAddress(string.concat("OptimismMintableERC20FactoryImpl", _suffix)),
-            OptimismPortal: mustGetAddress(string.concat("OptimismPortal2Impl", _suffix)),
-            SystemConfig: mustGetAddress(string.concat("SystemConfigImpl", _suffix)),
-            L1ERC721Bridge: mustGetAddress(string.concat("L1ERC721BridgeImpl", _suffix)),
+            OptimismMintableERC20Factory: artifacts.mustGetAddress(
+                string.concat("OptimismMintableERC20FactoryImpl", _suffix)
+            ),
+            OptimismPortal: artifacts.mustGetAddress(string.concat("OptimismPortal2Impl", _suffix)),
+            SystemConfig: artifacts.mustGetAddress(string.concat("SystemConfigImpl", _suffix)),
+            L1ERC721Bridge: artifacts.mustGetAddress(string.concat("L1ERC721BridgeImpl", _suffix)),
             // We didn't deploy a new version of these so we don't append a suffix
             // We didn't deploy these in this function so we don't need to append a suffix.
-            ProtocolVersions: mustGetAddress("ProtocolVersionsImpl"),
-            SuperchainConfig: mustGetAddress("SuperchainConfigImpl")
+            ProtocolVersions: artifacts.mustGetAddress("ProtocolVersionsImpl"),
+            SuperchainConfig: artifacts.mustGetAddress("SuperchainConfigImpl")
         });
 
         ChainAssertions.checkL1CrossDomainMessenger({ _contracts: contracts, _vm: vm, _isProxy: false });

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -339,8 +339,8 @@ contract Deploy is Deployer {
             OptimismPortal: artifacts.mustGetAddress(string.concat("OptimismPortal2Impl", _suffix)),
             SystemConfig: artifacts.mustGetAddress(string.concat("SystemConfigImpl", _suffix)),
             L1ERC721Bridge: artifacts.mustGetAddress(string.concat("L1ERC721BridgeImpl", _suffix)),
-            // We didn't deploy a new version of these so we don't append a suffix
-            // We didn't deploy these in this function so we don't need to append a suffix.
+
+            // We didn't deploy new versions of these in this function so we don't need to append a suffix.
             ProtocolVersions: artifacts.mustGetAddress("ProtocolVersionsImpl"),
             SuperchainConfig: artifacts.mustGetAddress("SuperchainConfigImpl")
         });

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -306,13 +306,11 @@ contract Deploy is Deployer {
         }
         di.run(dii, dio);
 
-        // Fault proofs
+        // Save the implementation addresses which are needed outside of this function or script.
         // When called in a fork test, this will overwrite the existing implementations.
-        // TODO: Deploy implementations using create2 to avoid replacing existing identical implementations
-        // (https://github.com/ethereum-optimism/optimism/issues/13644)
-        artifacts.save("PreimageOracleSingleton", address(dio.preimageOracleSingleton()));
         artifacts.save("MipsSingleton", address(dio.mipsSingleton()));
         artifacts.save("OPContractsManager", address(dio.opcm()));
+        artifacts.save("DelayedWETHImpl", address(dio.delayedWETHImpl()));
 
         // Get a contract set from the implementation addresses which were just deployed.
         Types.ContractSet memory contracts = Types.ContractSet({
@@ -354,8 +352,8 @@ contract Deploy is Deployer {
         });
         ChainAssertions.checkOPContractsManager({
             _contracts: contracts,
-            _opcm: OPContractsManager(artifacts.mustGetAddress("OPContractsManager")),
-            _mips: IMIPS(artifacts.mustGetAddress("MipsSingleton"))
+            _opcm: OPContractsManager(address(dio.opcm())),
+            _mips: IMIPS(address(dio.mipsSingleton()))
         });
         if (_isInterop) {
             ChainAssertions.checkSystemConfigInterop({ _contracts: contracts, _cfg: cfg, _isProxy: false });

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -200,6 +200,8 @@ contract Deploy is Deployer {
             deploySuperchain();
         }
 
+        // Deploy the implementations, with no suffix. The suffix is only used when deploying a new set of
+        // implementations to test upgrades.
         deployImplementations({ _isInterop: cfg.useInterop(), _suffix: "" });
 
         // Deploy Current OPChain Contracts
@@ -276,7 +278,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy all of the implementations
     /// @param _isInterop Whether to use interop
-    /// @param _suffix    An optional suffix to append to the implementation names. Used in the ForkLives script to
+    /// @param _suffix    An optional suffix to append to the implementation names. Used in the ForkLive script to
     ///                   distinguish between implementations already in production and new implementations deployed by
     ///                   this script.
     function deployImplementations(bool _isInterop, string memory _suffix) public {
@@ -323,6 +325,7 @@ contract Deploy is Deployer {
         artifacts.save(string.concat("OPContractsManager", _suffix), address(dio.opcm()));
 
         // Get a contract set from the implementation addresses with the suffix.
+        // Get a contract set from the implementation addresses just deployed
         Types.ContractSet memory contracts = Types.ContractSet({
             L1CrossDomainMessenger: mustGetAddress(string.concat("L1CrossDomainMessengerImpl", _suffix)),
             L1StandardBridge: mustGetAddress(string.concat("L1StandardBridgeImpl", _suffix)),
@@ -336,6 +339,7 @@ contract Deploy is Deployer {
             SystemConfig: mustGetAddress(string.concat("SystemConfigImpl", _suffix)),
             L1ERC721Bridge: mustGetAddress(string.concat("L1ERC721BridgeImpl", _suffix)),
             // We didn't deploy a new version of these so we don't append a suffix
+            // We didn't deploy these in this function so we don't need to append a suffix.
             ProtocolVersions: mustGetAddress("ProtocolVersionsImpl"),
             SuperchainConfig: mustGetAddress("SuperchainConfigImpl")
         });

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -325,7 +325,7 @@ contract Deploy is Deployer {
             OptimismPortal: address(dio.optimismPortalImpl()),
             SystemConfig: address(dio.systemConfigImpl()),
             L1ERC721Bridge: address(dio.l1ERC721BridgeImpl()),
-            // We didn't deploy new versions of these in this function so we don't need to append a suffix.
+            // We didn't deploy new versions of these in this function, so just read the existing ones.
             ProtocolVersions: artifacts.mustGetAddress("ProtocolVersionsImpl"),
             SuperchainConfig: artifacts.mustGetAddress("SuperchainConfigImpl")
         });

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -324,8 +324,7 @@ contract Deploy is Deployer {
         artifacts.save(string.concat("MipsSingleton", _suffix), address(dio.mipsSingleton()));
         artifacts.save(string.concat("OPContractsManager", _suffix), address(dio.opcm()));
 
-        // Get a contract set from the implementation addresses with the suffix.
-        // Get a contract set from the implementation addresses just deployed
+        // Get a contract set from the implementation addresses which were just deployed.
         Types.ContractSet memory contracts = Types.ContractSet({
             L1CrossDomainMessenger: mustGetAddress(string.concat("L1CrossDomainMessengerImpl", _suffix)),
             L1StandardBridge: mustGetAddress(string.concat("L1StandardBridgeImpl", _suffix)),

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -283,8 +283,6 @@ contract Deploy is Deployer {
 
         console.log("Deploying implementations");
 
-        // TODO: Deploy implementations using create2 to avoid replacing existing identical implementations
-        // (https://github.com/ethereum-optimism/optimism/issues/13644)
         DeployImplementations di = new DeployImplementations();
         (DeployImplementationsInput dii, DeployImplementationsOutput dio) = di.etchIOContracts();
 
@@ -309,7 +307,9 @@ contract Deploy is Deployer {
         di.run(dii, dio);
 
         // Fault proofs
-        // When called in a fork test, this will
+        // When called in a fork test, this will overwrite the existing implementations.
+        // TODO: Deploy implementations using create2 to avoid replacing existing identical implementations
+        // (https://github.com/ethereum-optimism/optimism/issues/13644)
         artifacts.save("PreimageOracleSingleton", address(dio.preimageOracleSingleton()));
         artifacts.save("MipsSingleton", address(dio.mipsSingleton()));
         artifacts.save("OPContractsManager", address(dio.opcm()));

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -339,7 +339,6 @@ contract Deploy is Deployer {
             OptimismPortal: artifacts.mustGetAddress(string.concat("OptimismPortal2Impl", _suffix)),
             SystemConfig: artifacts.mustGetAddress(string.concat("SystemConfigImpl", _suffix)),
             L1ERC721Bridge: artifacts.mustGetAddress(string.concat("L1ERC721BridgeImpl", _suffix)),
-
             // We didn't deploy new versions of these in this function so we don't need to append a suffix.
             ProtocolVersions: artifacts.mustGetAddress("ProtocolVersionsImpl"),
             SuperchainConfig: artifacts.mustGetAddress("SuperchainConfigImpl")

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -11,6 +11,7 @@ import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Target contract dependencies
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -29,7 +30,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
-        IL1CrossDomainMessenger impl = IL1CrossDomainMessenger(artifacts.mustGetAddress("L1CrossDomainMessengerImpl"));
+        IL1CrossDomainMessenger impl =
+            IL1CrossDomainMessenger(payable(EIP1967Helper.getImplementation(address(l1CrossDomainMessenger))));
         assertEq(address(impl.superchainConfig()), address(0));
         assertEq(address(impl.PORTAL()), address(0));
         assertEq(address(impl.portal()), address(0));

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -11,7 +11,6 @@ import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Target contract dependencies
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -31,7 +30,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
         IL1CrossDomainMessenger impl =
-            IL1CrossDomainMessenger(payable(EIP1967Helper.getImplementation(address(l1CrossDomainMessenger))));
+            IL1CrossDomainMessenger(addressManager.getAddress("OVM_L1CrossDomainMessenger"));
         assertEq(address(impl.superchainConfig()), address(0));
         assertEq(address(impl.PORTAL()), address(0));
         assertEq(address(impl.portal()), address(0));

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -29,8 +29,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
-        IL1CrossDomainMessenger impl =
-            IL1CrossDomainMessenger(addressManager.getAddress("OVM_L1CrossDomainMessenger"));
+        IL1CrossDomainMessenger impl = IL1CrossDomainMessenger(addressManager.getAddress("OVM_L1CrossDomainMessenger"));
         assertEq(address(impl.superchainConfig()), address(0));
         assertEq(address(impl.PORTAL()), address(0));
         assertEq(address(impl.portal()), address(0));

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -9,6 +9,7 @@ import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -69,7 +70,7 @@ contract L1ERC721Bridge_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() public virtual {
-        IL1ERC721Bridge impl = IL1ERC721Bridge(artifacts.mustGetAddress("L1ERC721BridgeImpl"));
+        IL1ERC721Bridge impl = IL1ERC721Bridge(EIP1967Helper.getImplementation(address(l1ERC721Bridge)));
         assertEq(address(impl.MESSENGER()), address(0));
         assertEq(address(impl.messenger()), address(0));
         assertEq(address(impl.superchainConfig()), address(0));

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -12,6 +12,7 @@ import { StandardBridge } from "src/universal/StandardBridge.sol";
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
@@ -38,7 +39,7 @@ contract L1StandardBridge_Initialize_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
-        IL1StandardBridge impl = IL1StandardBridge(artifacts.mustGetAddress("L1StandardBridgeImpl"));
+        IL1StandardBridge impl = IL1StandardBridge(payable(EIP1967Helper.getImplementation(address(l1StandardBridge))));
         assertEq(address(impl.superchainConfig()), address(0));
 
         // The constructor now uses _disableInitializers, whereas OP Mainnet has these values in storage

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -19,6 +19,7 @@ import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import "src/dispute/lib/Types.sol";
 import "src/libraries/PortalErrors.sol";
 
@@ -42,7 +43,7 @@ contract OptimismPortal2_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
-        IOptimismPortal2 opImpl = IOptimismPortal2(payable(artifacts.mustGetAddress("OptimismPortal2Impl")));
+        IOptimismPortal2 opImpl = IOptimismPortal2(payable(EIP1967Helper.getImplementation(address(optimismPortal2))));
         assertEq(address(opImpl.disputeGameFactory()), address(0));
         assertEq(address(opImpl.systemConfig()), address(0));
         assertEq(address(opImpl.superchainConfig()), address(0));

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -11,6 +11,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
@@ -42,7 +43,7 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         batcherHash = bytes32(uint256(uint160(deploy.cfg().batchSenderAddress())));
         gasLimit = uint64(deploy.cfg().l2GenesisBlockGasLimit());
         unsafeBlockSigner = deploy.cfg().p2pSequencerAddress();
-        systemConfigImpl = artifacts.mustGetAddress("SystemConfigImpl");
+        systemConfigImpl = EIP1967Helper.getImplementation(address(systemConfig));
         optimismMintableERC20Factory = artifacts.mustGetAddress("OptimismMintableERC20FactoryProxy");
     }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -111,7 +111,6 @@ contract ForkLive is Deployer {
         vm.etch(address(deployNew), vm.getDeployedCode("Deploy.s.sol:Deploy"));
         vm.label(address(deployNew), "DeployNew");
         vm.allowCheatcodes(address(deployNew));
-        vm.setEnv("CONTRACT_ADDRESSES_PATH", string.concat(vm.projectRoot(), "/deployments/1-deploy.json"));
 
         deployNew.setUp();
         deployNew.deployImplementations({ _isInterop: false, _suffix: "_NextVersion" });

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -111,7 +111,6 @@ contract ForkLive is Deployer {
         vm.setEnv("CONTRACT_ADDRESSES_PATH", string.concat(vm.projectRoot(), "/deployments/1-deploy.json"));
 
         deployNew.setUp();
-        deployNew.cfg().setUseFaultProofs(true);
         deployNew.deployImplementations({ _isInterop: false, _suffix: "_NextVersion" });
     }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -7,6 +7,7 @@ import { stdJson } from "forge-std/StdJson.sol";
 // Scripts
 import { Deployer } from "scripts/deploy/Deployer.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { GameTypes } from "src/dispute/lib/Types.sol";
@@ -20,9 +21,9 @@ import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 /// @title ForkLive
 /// @notice This script is called by Setup.sol as a preparation step for the foundry test suite, and is run as an
 ///         alternative to Deploy.s.sol, when `FORK_TEST=true` is set in the env.
-///         Like Deploy.s.sol this script saves the system addresses to disk so that they can be read into memory later
-///         on, however rather than deploying new contracts from the local source code, it simply reads the addresses
-///         from the superchain-registry.
+///         Like Deploy.s.sol this script saves the system addresses to the Artifacts contract so that they can be
+///         read by other contracts. However, rather than deploying new contracts from the local source code, it
+///         simply reads the addresses from the superchain-registry.
 ///         Therefore this script can only be run against a fork of a production network which is listed in the
 ///         superchain-registry.
 ///         This contract must not have constructor logic because it is set into state using `etch`.
@@ -41,17 +42,29 @@ contract ForkLive is Deployer {
         return vm.envOr("FORK_OP_CHAIN", string("op"));
     }
 
-    /// @notice Reads a standard chains addresses from the superchain-registry and saves them to disk.
+    /// @notice Forks, upgrades and tests a production network.
+    /// @dev This function sets up the system to test by:
+    ///      1. reading the superchain-registry to get the contract addresses we wish to test from that network.
+    ///      2. deploying the updated OPCM and implementations of the contracts.
+    ///      3. upgrading the system using the OPCM.upgrade() function.
     function run() public {
+        // Read the superchain registry and save the addresses to the Artifacts contract.
+        _readSuperchainRegistry();
+
+        // Now deploy the updated OPCM and implementations of the contracts
+        _deployNewImplementations();
+    }
+
+    /// @notice Reads the superchain config files and saves the addresses to disk.
+    /// @dev During development of an upgrade which adds a new contract, the contract will not yet be present in the
+    ///      superchain-registry. In this case, the contract will be deployed by the upgrade process, and will need to
+    ///      be stored by artifacts.save() after the call to opcm.upgrade().
+    ///      After the upgrade is complete, the superchain-registry will be updated and the contract will be present. At
+    ///      that point, this function will need to be updated to read the new contract from the superchain-registry
+    ///      using either the `saveProxyAndImpl` or `artifacts.save()` functions.
+    function _readSuperchainRegistry() internal {
         string memory superchainBasePath = "./lib/superchain-registry/superchain/configs/";
 
-        // Read the superchain config files
-        // During development of an upgrade which adds a new contract, the contract will not yet be present in the
-        // superchain-registry. In this case, the contract will be deployed by the upgrade process, and will need to
-        // be saved by after the call to opcm.upgrade().
-        // After the upgrade is complete, the superchain-registry will be updated and the contract will be present.
-        // At this point, the test will need to be updated to read the new contract from the superchain-registry using
-        // either the `saveProxyAndImpl` or `save` functions.
         string memory superchainToml = vm.readFile(string.concat(superchainBasePath, baseChain(), "/superchain.toml"));
         string memory opToml = vm.readFile(string.concat(superchainBasePath, baseChain(), "/", opChain(), ".toml"));
 
@@ -98,9 +111,6 @@ contract ForkLive is Deployer {
             IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
         artifacts.save("PermissionedDisputeGame", address(permissionedDisputeGame));
         artifacts.save("PermissionedDelayedWETHProxy", address(permissionedDisputeGame.weth()));
-
-        // Now deploy the updated OPCM and implementations of the contracts
-        _deployNewImplementations();
     }
 
     /// @notice Etches a new Deploy.s.sol contract at a deterministic address, sets up the environment,

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -7,7 +7,6 @@ import { stdJson } from "forge-std/StdJson.sol";
 // Scripts
 import { Deployer } from "scripts/deploy/Deployer.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { GameTypes } from "src/dispute/lib/Types.sol";

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -117,11 +117,8 @@ contract ForkLive is Deployer {
     ///         and deploys new implementations with a "_NextVersion" suffix. This suffix is necessary to avoid
     ///         naming collisions with the implementations saved above.
     function _deployNewImplementations() internal {
-        Deploy deployNew = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy.new"))))));
-        DeployUtils.etchLabelAndAllowCheatcodes({ _etchTo: address(deployNew), _cname: "DeployNew" });
-
-        deployNew.setUp();
-        deployNew.deployImplementations({ _isInterop: false, _suffix: "_NextVersion" });
+        Deploy deploy = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
+        deploy.deployImplementations({ _isInterop: false, _suffix: "_NextVersion" });
     }
 
     /// @notice Saves the proxy and implementation addresses for a contract name

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -112,12 +112,11 @@ contract ForkLive is Deployer {
         artifacts.save("PermissionedDelayedWETHProxy", address(permissionedDisputeGame.weth()));
     }
 
-    /// @notice Etches a new Deploy.s.sol contract at a deterministic address, sets up the environment,
-    ///         and deploys new implementations with a "_NextVersion" suffix. This suffix is necessary to avoid
-    ///         naming collisions with the implementations saved above.
+    /// @notice Calls to the Deploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the
+    /// environment, and deploys new implementations.
     function _deployNewImplementations() internal {
         Deploy deploy = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
-        deploy.deployImplementations({ _isInterop: false, _suffix: "_NextVersion" });
+        deploy.deployImplementations({ _isInterop: false });
     }
 
     /// @notice Saves the proxy and implementation addresses for a contract name

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -103,6 +103,9 @@ contract ForkLive is Deployer {
         _deployNewImplementations();
     }
 
+    /// @notice Etches a new Deploy.s.sol contract at a deterministic address, sets up the environment,
+    ///         and deploys new implementations with a "_NextVersion" suffix. This suffix is necessary to avoid
+    ///         naming collisions with the implementations saved above.
     function _deployNewImplementations() internal {
         Deploy deployNew = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy.new"))))));
         vm.etch(address(deployNew), vm.getDeployedCode("Deploy.s.sol:Deploy"));

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -108,9 +108,7 @@ contract ForkLive is Deployer {
     ///         naming collisions with the implementations saved above.
     function _deployNewImplementations() internal {
         Deploy deployNew = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy.new"))))));
-        vm.etch(address(deployNew), vm.getDeployedCode("Deploy.s.sol:Deploy"));
-        vm.label(address(deployNew), "DeployNew");
-        vm.allowCheatcodes(address(deployNew));
+        DeployUtils.etchLabelAndAllowCheatcodes({ _etchTo: address(deployNew), _cname: "DeployNew" });
 
         deployNew.setUp();
         deployNew.deployImplementations({ _isInterop: false, _suffix: "_NextVersion" });

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -12,6 +12,7 @@ import { Process } from "scripts/libraries/Process.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GameType } from "src/dispute/lib/Types.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -57,7 +58,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "SuperchainConfigImpl",
-                target: artifacts.mustGetAddress("SuperchainConfigImpl"),
+                target: EIP1967Helper.getImplementation(address(superchainConfig)),
                 initCalldata: abi.encodeCall(superchainConfig.initialize, (address(0), false))
             })
         );
@@ -73,7 +74,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1CrossDomainMessengerImpl",
-                target: artifacts.mustGetAddress("L1CrossDomainMessengerImpl"),
+                target: EIP1967Helper.getImplementation(address(l1CrossDomainMessenger)),
                 initCalldata: abi.encodeCall(
                     l1CrossDomainMessenger.initialize, (superchainConfig, optimismPortal2, systemConfig)
                 )
@@ -93,7 +94,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "DisputeGameFactoryImpl",
-                target: artifacts.mustGetAddress("DisputeGameFactoryImpl"),
+                target: EIP1967Helper.getImplementation(address(disputeGameFactory)),
                 initCalldata: abi.encodeCall(disputeGameFactory.initialize, (address(0)))
             })
         );
@@ -109,7 +110,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "DelayedWETHImpl",
-                target: artifacts.mustGetAddress("DelayedWETHImpl"),
+                target: EIP1967Helper.getImplementation(address(delayedWeth)),
                 initCalldata: abi.encodeCall(delayedWeth.initialize, (address(0), ISuperchainConfig(address(0))))
             })
         );
@@ -125,7 +126,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "OptimismPortal2Impl",
-                target: artifacts.mustGetAddress("OptimismPortal2Impl"),
+                target: EIP1967Helper.getImplementation(address(optimismPortal2)),
                 initCalldata: abi.encodeCall(
                     optimismPortal2.initialize,
                     (
@@ -157,7 +158,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "SystemConfigImpl",
-                target: artifacts.mustGetAddress("SystemConfigImpl"),
+                target: EIP1967Helper.getImplementation(address(systemConfig)),
                 initCalldata: abi.encodeCall(
                     systemConfig.initialize,
                     (
@@ -229,7 +230,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "ProtocolVersionsImpl",
-                target: artifacts.mustGetAddress("ProtocolVersionsImpl"),
+                target: EIP1967Helper.getImplementation(address(protocolVersions)),
                 initCalldata: abi.encodeCall(
                     protocolVersions.initialize, (address(0), ProtocolVersion.wrap(1), ProtocolVersion.wrap(2))
                 )
@@ -249,7 +250,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1StandardBridgeImpl",
-                target: artifacts.mustGetAddress("L1StandardBridgeImpl"),
+                target: EIP1967Helper.getImplementation(address(l1StandardBridge)),
                 initCalldata: abi.encodeCall(
                     l1StandardBridge.initialize, (l1CrossDomainMessenger, superchainConfig, systemConfig)
                 )
@@ -269,7 +270,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1ERC721BridgeImpl",
-                target: artifacts.mustGetAddress("L1ERC721BridgeImpl"),
+                target: EIP1967Helper.getImplementation(address(l1ERC721Bridge)),
                 initCalldata: abi.encodeCall(l1ERC721Bridge.initialize, (l1CrossDomainMessenger, superchainConfig))
             })
         );
@@ -285,7 +286,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "OptimismMintableERC20FactoryImpl",
-                target: artifacts.mustGetAddress("OptimismMintableERC20FactoryImpl"),
+                target: EIP1967Helper.getImplementation(address(l1OptimismMintableERC20Factory)),
                 initCalldata: abi.encodeCall(l1OptimismMintableERC20Factory.initialize, (address(l1StandardBridge)))
             })
         );
@@ -301,7 +302,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "DataAvailabilityChallengeImpl",
-                target: artifacts.mustGetAddress("DataAvailabilityChallengeImpl"),
+                target: EIP1967Helper.getImplementation(address(dataAvailabilityChallenge)),
                 initCalldata: abi.encodeCall(dataAvailabilityChallenge.initialize, (address(0), 0, 0, 0, 0))
             })
         );
@@ -317,7 +318,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "AnchorStateRegistryImpl",
-                target: address(anchorStateRegistry),
+                target: EIP1967Helper.getImplementation(address(anchorStateRegistry)),
                 initCalldata: abi.encodeCall(
                     anchorStateRegistry.initialize,
                     (new IAnchorStateRegistry.StartingAnchorRoot[](1), ISuperchainConfig(address(0)))

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -12,6 +12,7 @@ import { Process } from "scripts/libraries/Process.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GameType } from "src/dispute/lib/Types.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -12,7 +12,6 @@ import { Process } from "scripts/libraries/Process.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GameType } from "src/dispute/lib/Types.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -74,7 +73,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "L1CrossDomainMessengerImpl",
-                target: EIP1967Helper.getImplementation(address(l1CrossDomainMessenger)),
+                target: addressManager.getAddress("OVM_L1CrossDomainMessenger"),
                 initCalldata: abi.encodeCall(
                     l1CrossDomainMessenger.initialize, (superchainConfig, optimismPortal2, systemConfig)
                 )


### PR DESCRIPTION
### TL;DR

Added support for deploying the `develop` versions of contract implementations alongside implementations from the forked network.

This is necessary because the `ForkLive` script currently only loads the pre-existing contracts from the production network. So we are now deploying the current implementation contracts so that the Proxies can be upgraded to them.

### What changed?

- Modified `Deploy.deployImplementations` to:
  - not save implementations of most contracts
  - allow overwriting saved addresses
- ForkLive: 
  - Calls to `deploy.deployImplementations()` to deploy the current impls in preparation for the upgrade.
