### PR TITLE
feat(kurtosis-devnet): pass args in-memory

### DIFF
--- a/kurtosis-devnet/cmd/main.go
+++ b/kurtosis-devnet/cmd/main.go
@@ -259,7 +259,7 @@ func deploy(ctx context.Context, cfg *config, r io.Reader) error {
 		}
 		defer envOutput.Close()
 	} else {
-		log.Println("Environment description:")
+		log.Println("\nEnvironment description:")
 	}
 
 	enc := json.NewEncoder(envOutput)

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_run_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_run_test.go
@@ -261,7 +261,7 @@ func TestRunKurtosis(t *testing.T) {
 			d := NewKurtosisDeployer()
 			d.kurtosisCtx = fakeCtx
 
-			err := d.runKurtosis(ctx, "")
+			err := d.runKurtosis(ctx, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -56,22 +55,6 @@ func TestKurtosisDeployer(t *testing.T) {
 			assert.Equal(t, tt.wantEnclave, d.enclave)
 		})
 	}
-}
-
-func TestPrepareArgFile(t *testing.T) {
-	d := NewKurtosisDeployer()
-	input := strings.NewReader("test content")
-
-	path, err := d.prepareArgFile(input)
-	require.NoError(t, err)
-	defer func() {
-		err := os.Remove(path)
-		require.NoError(t, err)
-	}()
-
-	content, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Equal(t, "test content", string(content))
 }
 
 // fakeEnclaveInspecter implements EnclaveInspecter for testing


### PR DESCRIPTION
**Description**

This is a code cleanup.

Now that we don't use the kurtosis cli, there's no reason to go
through the filesystem to pass a configuration file.
<!--
A clear and concise description of the features you're adding in this pull request.
-->
