### PR TITLE
feat(kurtosis-devnet): cut build time for prestate

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -9,8 +9,7 @@ _contracts-build BUNDLE='contracts-bundle.tar.gz':
     tar -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
 
 _prestate-build PATH='.':
-    make -C ../op-program reproducible-prestate
-    cp ../op-program/bin/prestate-proof*.json {{PATH}}
+    docker buildx build --output {{PATH}} --target export-stage-proofs --progress plain -f ../op-program/Dockerfile.repro ../
 
 _docker_build TAG TARGET='' CONTEXT='.' DOCKERFILE='Dockerfile':
     docker buildx build -t {{TAG}} \

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -50,6 +50,11 @@ RUN mv /app/op-program/bin/0-mt64.json /app/op-program/bin/prestate-proof-mt64.j
 # Exports files to the specified output location.
 # Writing files to host requires buildkit to be enabled.
 # e.g. `BUILDKIT=1 docker build ...`
+FROM scratch AS export-stage-proofs
+COPY --from=builder /app/op-program/bin/prestate-proof.json .
+COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .
+COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .
+
 FROM scratch AS export-stage
 COPY --from=builder /app/op-program/bin/op-program-client.elf .
 COPY --from=builder /app/op-program/bin/op-program-client64.elf .


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
For the purpose of seeding op-challenger, we need only the proof files.

This change adds a separate target that outputs only these.

Unfortunately, docker outputs can be pretty slow, so avoiding dumping
the heavier binaries makes a significant differente performance-wise.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
