### PR TITLE
fix(kurtosis-devnet): adjust build definitions

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -12,32 +12,38 @@ _prestate-build PATH='.':
     make -C ../op-program reproducible-prestate
     cp ../op-program/bin/prestate-proof*.json {{PATH}}
 
-_docker_build TAG TARGET='' CONTEXT='.' DOCKERFILE='Dockerfile':
+_docker_build TAG TARGET CONTEXT DOCKERFILE *ARGS:
     docker buildx build -t {{TAG}} \
         -f {{CONTEXT}}/{{DOCKERFILE}} \
         {{ if TARGET != '' {  "--target " + TARGET } else { "" } }} \
         --build-arg GIT_COMMIT={git_commit} \
         --build-arg GIT_DATE={git_date} \
+        {{ ARGS }} \
         {{CONTEXT}}
 
-_docker_build_stack TAG TARGET='': (_docker_build TAG TARGET "../" "ops/docker/op-stack-go/Dockerfile")
+_docker_build_stack TAG TARGET *ARGS: (_docker_build TAG TARGET "../" "ops/docker/op-stack-go/Dockerfile" ARGS)
 
 cannon-image TAG='cannon:devnet': (_docker_build_stack TAG "cannon-target")
-op-program-image TAG='op-program:devnet': (_docker_build_stack TAG "op-program-target")
-op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target")
-op-node-image TAG='op-node:devnet': (_docker_build_stack TAG "op-node-target")
-op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target")
-op-dispute-mon-image TAG='op-dispute-mon:devnet': (_docker_build_stack TAG "op-dispute-mon-target")
-op-batcher-image TAG='op-batcher:devnet': (_docker_build_stack TAG "op-batcher-target")
-op-proposer-image TAG='op-proposer:devnet': (_docker_build_stack TAG "op-proposer-target")
-op-conductor-image TAG='op-conductor:devnet': (_docker_build_stack TAG "op-conductor-target")
 da-server-image TAG='da-server:devnet': (_docker_build_stack TAG "da-server-target")
-op-supervisor-image TAG='op-supervisor:devnet': (_docker_build_stack TAG "op-supervisor-target")
+op-batcher-image TAG='op-batcher:devnet': (_docker_build_stack TAG "op-batcher-target")
+# TODO: this is a temporary hack to get the kona version right.
+# Ideally the Dockerfile should be self-sufficient (right now we depend on
+# docker-bake.hcl to do the right thing).
+op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=kona-client-v0.1.0-beta.5")
+op-conductor-image TAG='op-conductor:devnet': (_docker_build_stack TAG "op-conductor-target")
 op-deployer-image TAG='op-deployer:devnet': (_docker_build_stack TAG "op-deployer-target")
+op-dispute-mon-image TAG='op-dispute-mon:devnet': (_docker_build_stack TAG "op-dispute-mon-target")
+op-node-image TAG='op-node:devnet': (_docker_build_stack TAG "op-node-target")
+op-program-image TAG='op-program:devnet': (_docker_build_stack TAG "op-program-target")
+op-proposer-image TAG='op-proposer:devnet': (_docker_build_stack TAG "op-proposer-target")
+op-supervisor-image TAG='op-supervisor:devnet': (_docker_build_stack TAG "op-supervisor-target")
+op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target")
+
+KURTOSIS_PACKAGE := "github.com/ethpandaops/optimism-package"
 
 # Devnet template recipe
 devnet TEMPLATE_FILE DATA_FILE="":
-    go run cmd/main.go -template "{{TEMPLATE_FILE}}" -data "{{DATA_FILE}}" -enclave `basename {{TEMPLATE_FILE}} .yaml`-devnet
+    go run cmd/main.go -kurtosis-package {{KURTOSIS_PACKAGE}} -template "{{TEMPLATE_FILE}}" -data "{{DATA_FILE}}" -enclave `basename {{TEMPLATE_FILE}} .yaml`-devnet
 
 # Devnet recipes
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- fix the op-challenger image build, as currently
  ops/docker/op-stack-go/Dockerfile defaults to a non-existing tag.

- make it easier to point to an alternate kurtosis package (like a
  local for for example)
