### PR TITLE
fix(op-program): minimize docker context

### DIFF
--- a/op-program/Dockerfile.repro.dockerignore
+++ b/op-program/Dockerfile.repro.dockerignore
@@ -1,0 +1,13 @@
+# exclude everything by default to limit context size and cache miss
+*
+# module definition
+!go.*
+# internal dependencies
+!cannon/
+!op-alt-da/
+!op-node/
+!op-preimage/
+!op-program/
+op-program/bin/
+!op-service/
+!op-supervisor/


### PR DESCRIPTION
**Description**

This change minimizes the docker context needed to create the repro
artifacts.

Rationale: by default, the context is basically the entire monorepo
(minus whatever is excluded in the top-level .dockerignore file).

This is way larger than needed (and gets worse as the working
directory gets dirtier), and leads to unnecessary cache misses,
therefore rebuilds.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
