### PR TITLE
fix(ct): DeputyPauseModule audit fixes

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/IDeputyPauseModule.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IDeputyPauseModule.sol
@@ -8,6 +8,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 interface IDeputyPauseModule is ISemver {
     error DeputyPauseModule_InvalidDeputy();
+    error DeputyPauseModule_InvalidDeputyGuardianModule();
     error DeputyPauseModule_ExecutionFailed(string);
     error DeputyPauseModule_SuperchainNotPaused();
     error DeputyPauseModule_Unauthorized();

--- a/packages/contracts-bedrock/snapshots/abi/DeputyPauseModule.json
+++ b/packages/contracts-bedrock/snapshots/abi/DeputyPauseModule.json
@@ -301,6 +301,11 @@
   },
   {
     "inputs": [],
+    "name": "DeputyPauseModule_InvalidDeputyGuardianModule",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "DeputyPauseModule_NonceAlreadyUsed",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -184,8 +184,8 @@
     "sourceCodeHash": "0x17236a91c4171ae9525eae0e59fa65bb2dc320d62677cfc7d7eb942f182619fb"
   },
   "src/safe/DeputyPauseModule.sol": {
-    "initCodeHash": "0x55f0b6c1a102114b8c30157e7295da7058ba8d1b93f7d4070028286968611279",
-    "sourceCodeHash": "0xec92b5ccbd3ee337897464546ccb8306fca245bbb6ce4b0941d86bc82e0f4cfe"
+    "initCodeHash": "0xa3b7bf0c93b41f39ebc18a81322b90127a633d684ae9f86c2f2a1c48fe7f1372",
+    "sourceCodeHash": "0xfbe7f5733aa57de7557605e40e03e9708fbdec872bc8739c551905c4b1e1b61b"
   },
   "src/safe/LivenessGuard.sol": {
     "initCodeHash": "0xc8e29e8b12f423c8cd229a38bc731240dd815d96f1b0ab96c71494dde63f6a81",


### PR DESCRIPTION
Includes a number of low/informational fixes from the audits of the DeputyPauseModule.

- Additional validation on the DeputyGuardianModule.
- Small additional comments.
- Proper encoding of EIP-712 signature digest.