### PR TITLE
fix(kurtosis-devnet): point to HEAD op-deployer

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -133,7 +133,7 @@ optimism_package:
         builder_port: ""
       additional_services: []
   op_contract_deployer_params:
-    image: opsigma/op-deployer:v0.0.7-http
+    image: {{ localDockerImage "op-deployer" }}
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
   global_log_level: "info"


### PR DESCRIPTION
**Description**

This adjusts the sample interop configuration to use op-deployer at
HEAD, now that it's working in optimism-package.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- followup to ethpandaops/optimism-package#121
