### PR TITLE
feat(kurtosis-devnet): ensure kurtosis engine is running

### DIFF
--- a/kurtosis-devnet/cmd/main_test.go
+++ b/kurtosis-devnet/cmd/main_test.go
@@ -28,6 +28,22 @@ func newMockDeployer(...kurtosis.KurtosisDeployerOptions) (deployer, error) {
 	return &mockDeployer{dryRun: true}, nil
 }
 
+type mockEngineManager struct{}
+
+func (m *mockEngineManager) EnsureRunning() error {
+	return nil
+}
+
+func newTestMain(cfg *config) *Main {
+	return &Main{
+		cfg: cfg,
+		newDeployer: func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
+			return newMockDeployer(opts...)
+		},
+		engineManager: &mockEngineManager{},
+	}
+}
+
 func TestParseFlags(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -103,15 +119,6 @@ func TestParseFlags(t *testing.T) {
 				assert.Equal(t, tt.wantCfg.dataFile, cfg.dataFile)
 			}
 		})
-	}
-}
-
-func newTestMain(cfg *config) *Main {
-	return &Main{
-		cfg: cfg,
-		newDeployer: func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
-			return newMockDeployer(opts...)
-		},
 	}
 }
 

--- a/kurtosis-devnet/pkg/kurtosis/api/engine/start.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/engine/start.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/kurtosis-tech/kurtosis/api/golang/kurtosis_version"
+)
+
+// EngineManager handles running the Kurtosis engine
+type EngineManager struct {
+	kurtosisBinary string
+	version        string
+}
+
+// Option configures an EngineManager
+type Option func(*EngineManager)
+
+// WithKurtosisBinary sets the path to the kurtosis binary
+func WithKurtosisBinary(binary string) Option {
+	return func(e *EngineManager) {
+		e.kurtosisBinary = binary
+	}
+}
+
+// WithVersion sets the engine version
+func WithVersion(version string) Option {
+	return func(e *EngineManager) {
+		e.version = version
+	}
+}
+
+// NewEngineManager creates a new EngineManager with the given options
+func NewEngineManager(opts ...Option) *EngineManager {
+	e := &EngineManager{
+		kurtosisBinary: "kurtosis",                       // Default to expecting kurtosis in PATH
+		version:        kurtosis_version.KurtosisVersion, // Default to library version
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// EnsureRunning starts the Kurtosis engine with the configured version
+func (e *EngineManager) EnsureRunning() error {
+	cmd := exec.Command(e.kurtosisBinary, "engine", "start", "--version", e.version)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to start kurtosis engine: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
**Description**

Unfortunately the logic for doing so is not present in the kurtosis
SDK, so we have to shell out to the binary.

Make sure the version we run is compatible with the client library we
use to interact with the created enclaves.
