### PR TITLE
op-supervisor: bugfix timestamp Check

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -385,7 +385,7 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	chainID := identifier.ChainID
 	blockNum := identifier.BlockNumber
 	logIdx := identifier.LogIndex
-	_, err := su.chainDBs.Check(chainID, blockNum, logIdx, logHash)
+	_, err := su.chainDBs.Check(chainID, blockNum, identifier.Timestamp, logIdx, logHash)
 	if errors.Is(err, types.ErrFuture) {
 		su.logger.Debug("Future message", "identifier", identifier, "payloadHash", payloadHash, "err", err)
 		return types.LocalUnsafe, nil

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SafeStartDeps interface {
-	Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
+	Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
 
 	CrossDerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
@@ -61,7 +61,7 @@ func CrossSafeHazards(d SafeStartDeps, chainID types.ChainID, inL1DerivedFrom et
 		if msg.Timestamp < candidate.Timestamp {
 			// If timestamp is older: invariant ensures non-cyclic ordering relative to other messages.
 			// Check that the block that they are included in is cross-safe already.
-			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.LogIdx, msg.Hash)
+			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.Timestamp, msg.LogIdx, msg.Hash)
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}
@@ -80,7 +80,7 @@ func CrossSafeHazards(d SafeStartDeps, chainID types.ChainID, inL1DerivedFrom et
 			// Thus check that it was included in a local-safe block,
 			// and then proceed with transitive block checks,
 			// to ensure the local block we depend on is becoming cross-safe also.
-			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.LogIdx, msg.Hash)
+			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.Timestamp, msg.LogIdx, msg.Hash)
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -322,7 +322,7 @@ type mockSafeStartDeps struct {
 	derivedFromFn func() (derivedFrom types.BlockSeal, err error)
 }
 
-func (m *mockSafeStartDeps) Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (m *mockSafeStartDeps) Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
 	if m.checkFn != nil {
 		return m.checkFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -406,7 +406,7 @@ func (m *mockCrossSafeDeps) CrossDerivedFrom(chainID types.ChainID, derived eth.
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossSafeDeps) Check(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+func (m *mockCrossSafeDeps) Check(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 	if m.checkFn != nil {
 		return m.checkFn(chainID, blockNum, logIdx, logHash)
 	}

--- a/op-supervisor/supervisor/backend/cross/unsafe_start.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start.go
@@ -12,7 +12,7 @@ import (
 )
 
 type UnsafeStartDeps interface {
-	Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
+	Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
 
 	IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) error
 
@@ -61,12 +61,15 @@ func CrossUnsafeHazards(d UnsafeStartDeps, chainID types.ChainID,
 		if msg.Timestamp < candidate.Timestamp {
 			// If timestamp is older: invariant ensures non-cyclic ordering relative to other messages.
 			// Check that the block that they are included in is cross-safe already.
-			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.LogIdx, msg.Hash)
+			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.Timestamp, msg.LogIdx, msg.Hash)
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}
 			if err := d.IsCrossUnsafe(initChainID, includedIn.ID()); err != nil {
 				return nil, fmt.Errorf("msg %s included in non-cross-unsafe block %s: %w", msg, includedIn, err)
+			}
+			if includedIn.Timestamp != msg.Timestamp {
+				return nil, fmt.Errorf("executing msg %s exists, but has different timestamp than block %s: %w", msg, includedIn, types.ErrConflict)
 			}
 		} else if msg.Timestamp == candidate.Timestamp {
 			// If timestamp is equal: we have to inspect ordering of individual
@@ -75,7 +78,7 @@ func CrossUnsafeHazards(d UnsafeStartDeps, chainID types.ChainID,
 			// Thus check that it was included in a local-unsafe block,
 			// and then proceed with transitive block checks,
 			// to ensure the local block we depend on is becoming cross-unsafe also.
-			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.LogIdx, msg.Hash)
+			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.Timestamp, msg.LogIdx, msg.Hash)
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -244,7 +244,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := types.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 0}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and IsCrossUnsafe returns no error,

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -261,7 +261,7 @@ type mockUnsafeStartDeps struct {
 	isCrossUnsafeFn func() error
 }
 
-func (m *mockUnsafeStartDeps) Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (m *mockUnsafeStartDeps) Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
 	if m.checkFn != nil {
 		return m.checkFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
@@ -146,7 +146,7 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return bl, 3, map[uint32]*types.ExecutingMessage{1: em1, 2: em2}, nil
 		}
-		usd.checkFn = func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		usd.checkFn = func(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		usd.deps = mockDependencySet{}
@@ -193,7 +193,7 @@ type mockCrossUnsafeDeps struct {
 	crossUnsafeFn       func(chainID types.ChainID) (types.BlockSeal, error)
 	openBlockFn         func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 	updateCrossUnsafeFn func(chain types.ChainID, crossUnsafe types.BlockSeal) error
-	checkFn             func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
+	checkFn             func(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
 }
 
 func (m *mockCrossUnsafeDeps) CrossUnsafe(chainID types.ChainID) (derived types.BlockSeal, err error) {
@@ -207,9 +207,9 @@ func (m *mockCrossUnsafeDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockCrossUnsafeDeps) Check(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+func (m *mockCrossUnsafeDeps) Check(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 	if m.checkFn != nil {
-		return m.checkFn(chainID, blockNum, logIdx, logHash)
+		return m.checkFn(chainID, blockNum, timestamp, logIdx, logHash)
 	}
 	return types.BlockSeal{}, nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -315,7 +315,10 @@ func (db *DB) Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (typ
 		panic("expected iterator to stop with error")
 	}
 	if errors.Is(err, types.ErrStop) {
-		h, n, _ := iter.SealedBlock()
+		h, n, ok := iter.SealedBlock()
+		if !ok {
+			return types.BlockSeal{}, fmt.Errorf("iterator stopped but no sealed block found")
+		}
 		timestamp, _ := iter.SealedTimestamp()
 		return types.BlockSeal{
 			Hash:      h,

--- a/op-supervisor/supervisor/backend/db/logs/iterator.go
+++ b/op-supervisor/supervisor/backend/db/logs/iterator.go
@@ -121,6 +121,10 @@ func (i *iterator) TraverseConditional(fn traverseConditionalFn) error {
 			continue
 		}
 		if err := fn(&i.current); err != nil {
+			// don't rewind to the snapshot if the error is ErrStop
+			if errors.Is(err, types.ErrStop) {
+				return err
+			}
 			i.current = snapshot
 			return err
 		}

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -210,12 +210,19 @@ func (db *ChainsDB) CrossDerivedFromBlockRef(chainID types.ChainID, derived eth.
 
 // Check calls the underlying logDB to determine if the given log entry exists at the given location.
 // If the block-seal of the block that includes the log is known, it is returned. It is fully zeroed otherwise, if the block is in-progress.
-func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
 	}
-	return logDB.Contains(blockNum, logIdx, logHash)
+	includedIn, err = logDB.Contains(blockNum, logIdx, logHash)
+	if err != nil {
+		return types.BlockSeal{}, err
+	}
+	if includedIn.Timestamp != timestamp {
+		return types.BlockSeal{}, fmt.Errorf("identified block %s, but have timestamp %d: %w", includedIn, timestamp, types.ErrConflict)
+	}
+	return includedIn, nil
 }
 
 // OpenBlock returns the Executing Messages for the block at the given number on the given chain.

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -105,9 +105,10 @@ func (lvl SafetyLevel) String() string {
 	return string(lvl)
 }
 
-func (lvl SafetyLevel) Valid() bool {
+// Validate returns true if the SafetyLevel is one of the recognized levels
+func (lvl SafetyLevel) Validate() bool {
 	switch lvl {
-	case Finalized, CrossSafe, LocalSafe, CrossUnsafe, LocalUnsafe:
+	case Invalid, Finalized, CrossSafe, LocalSafe, CrossUnsafe, LocalUnsafe:
 		return true
 	default:
 		return false
@@ -123,7 +124,7 @@ func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
 		return errors.New("cannot unmarshal into nil SafetyLevel")
 	}
 	x := SafetyLevel(text)
-	if !x.Valid() {
+	if !x.Validate() {
 		return fmt.Errorf("unrecognized safety level: %q", text)
 	}
 	*lvl = x


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

A 3-pack of bugfixes discovered when @skeletor-spaceman and @agusduha called out that the Supervisor does not check the timestamp when checking a message:

- Timestamps are now checked by the ChainsDB after retrieving a log entry from the database. This was the original issue found by the Wonderland team and fixed by @protolambda.
- `Invalid` safety levels are now recognized. They had been excluded from `SafetyLevel.Valid()`, I think due to the semantic assumption that Invalid != Valid. I renamed the function `Validate` for that reason.
- `TraverseConditional` no longer rewinds to the `snapshot` if the traversal function returns `ErrStop`. Previously, it would rewind on any error. This meant that when looking for a `SealedBlock` in the` Check` function, the `TraverseConditional` would find the `SealedBlock` and emit a `ErrStop`, and then the outer code couldn't use the `SealedBlock` we had just traversed to, as it was rewound behind it.

**Tests**

- Existing E2E `TestInterop_EmitLogs` is expanded to include a check that when the timestamp is incorrect, the `Check` function catches this and returns an `Invalid` safety level.

**Additional context**

Found by Wonderland team. Ty @skeletor-spaceman and @agusduha 