### PR TITLE
op-supervisor: fix JWT secret loading

### DIFF
--- a/op-supervisor/supervisor/backend/syncnode/collection.go
+++ b/op-supervisor/supervisor/backend/syncnode/collection.go
@@ -41,7 +41,9 @@ func (p *CLISyncNodes) Load(ctx context.Context, logger log.Logger) ([]SyncNodeS
 	for i, endpoint := range p.Endpoints {
 		var secret eth.Bytes32
 		if i >= len(secrets) {
-			secret = secrets[0]
+			secret = secrets[0] // default to the first JWT secret (there's always at least 1)
+		} else {
+			secret = secrets[i]
 		}
 		setups = append(setups, &RPCDialSetup{
 			JWTSecret: secret,


### PR DESCRIPTION
**Description**

Fix JWT secret assignment when loading a batch of sync sources in the CLI setup.

**Tests**

TODO

**Additional context**

Bug found in local devnet / kurtosis by @sigma and @axelKingsley 

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
