### PR TITLE
op-service: generic tx, raw json tx types

### DIFF
--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -115,3 +115,28 @@ func CheckRecentTxs(
 	}
 	return oldestBlock.Uint64(), false, nil
 }
+
+type GenericTx interface {
+	// Transaction tries to interpret into a typed tx.
+	// This will return types.ErrTxTypeNotSupported if the transaction-type is not supported.
+	Transaction() (*types.Transaction, error)
+
+	// TxType returns the EIP-2718 type.
+	TxType() uint8
+
+	// TxHash returns the transaction hash.
+	TxHash() common.Hash
+
+	// MarshalJSON into RPC tx definition.
+	// Block metadata may or may not be included.
+	MarshalJSON() ([]byte, error)
+
+	// UnmarshalJSON into RPC tx definition.
+	// Block metadata is ignored.
+	UnmarshalJSON([]byte) error
+
+	// MarshalBinary as EIP-2718 opaque tx (including version byte).
+	MarshalBinary() ([]byte, error)
+	// UnmarshalBinary as EIP-2718 opaque tx (including version byte).
+	UnmarshalBinary(b []byte) error
+}

--- a/op-service/sources/transaction.go
+++ b/op-service/sources/transaction.go
@@ -1,0 +1,95 @@
+package sources
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type RawJsonTransaction struct {
+	txHash common.Hash
+	txType uint8
+	raw    json.RawMessage
+}
+
+var _ json.Marshaler = (*RawJsonTransaction)(nil)
+var _ json.Unmarshaler = (*RawJsonTransaction)(nil)
+
+// Transaction tries to interpret into a typed tx.
+// This will return types.ErrTxTypeNotSupported if the transaction-type is not supported.
+func (m *RawJsonTransaction) Transaction() (*types.Transaction, error) {
+	switch m.txType {
+	case types.LegacyTxType, types.AccessListTxType,
+		types.DynamicFeeTxType, types.BlobTxType,
+		types.DepositTxType:
+		var tx types.Transaction
+		// Note: this json unmarshal may still return ErrTxTypeNotSupported
+		// if the linked-in geth library doesn't support the expected tx types.
+		if err := json.Unmarshal(m.raw, &tx); err != nil {
+			return nil, err
+		}
+		return &tx, nil
+	default:
+		return nil, types.ErrTxTypeNotSupported
+	}
+}
+
+func (m *RawJsonTransaction) TxType() uint8 {
+	return m.txType
+}
+
+func (m *RawJsonTransaction) TxHash() common.Hash {
+	return m.txHash
+}
+
+func (m *RawJsonTransaction) UnmarshalJSON(data []byte) error {
+	var x struct {
+		Hash common.Hash    `json:"hash"`
+		Type hexutil.Uint64 `json:"type"`
+	}
+	if err := json.Unmarshal(data, &x); err != nil {
+		return err
+	}
+	if x.Hash == (common.Hash{}) {
+		return errors.New("expected hash attribute")
+	}
+	if x.Type > 0xff {
+		return fmt.Errorf("unexpectedly large tx type: %d", uint64(x.Type))
+	}
+	m.raw = bytes.Clone(data)
+	m.txHash = x.Hash
+	m.txType = uint8(x.Type)
+	return nil
+}
+
+func (m *RawJsonTransaction) MarshalJSON() ([]byte, error) {
+	return m.raw, nil
+}
+
+func (m *RawJsonTransaction) MarshalBinary() ([]byte, error) {
+	tx, err := m.Transaction()
+	if err != nil {
+		return nil, err
+	}
+	return tx.MarshalBinary()
+}
+
+func (m *RawJsonTransaction) UnmarshalBinary(b []byte) error {
+	var tx types.Transaction
+	if err := tx.UnmarshalBinary(b); err != nil {
+		return err
+	}
+	data, err := json.Marshal(&tx)
+	if err != nil {
+		return err
+	}
+	m.raw = data
+	m.txType = tx.Type()
+	m.txHash = tx.Hash()
+	return nil
+}

--- a/op-service/sources/transaction_test.go
+++ b/op-service/sources/transaction_test.go
@@ -1,0 +1,67 @@
+package sources
+
+import (
+	"encoding/json"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+func TestRawJsonTransaction(t *testing.T) {
+
+	key := testutils.RandomKey()
+	chainID := big.NewInt(1)
+	signer := types.LatestSignerForChainID(chainID)
+	rng := rand.New(rand.NewSource(1234))
+	to := testutils.RandomAddress(rng)
+	txInner := &types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     uint64(123),
+		GasTipCap: big.NewInt(100_000),
+		GasFeeCap: big.NewInt(1000_000),
+		Gas:       24_000,
+		To:        &to,
+		Value:     big.NewInt(123456),
+		Data:      []byte("hello world"),
+		AccessList: types.AccessList{
+			types.AccessTuple{
+				Address: testutils.RandomAddress(rng),
+				StorageKeys: []common.Hash{
+					testutils.RandomHash(rng),
+				},
+			},
+		},
+	}
+	tx, err := types.SignNewTx(key, signer, txInner)
+	require.NoError(t, err)
+	txJson, err := json.Marshal(tx)
+	require.NoError(t, err)
+	t.Log(string(txJson))
+
+	// Test json round trip
+	var flexTx RawJsonTransaction
+	require.NoError(t, json.Unmarshal(txJson, &flexTx))
+	reEncoded, err := json.Marshal(&flexTx)
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Bytes(txJson), hexutil.Bytes(reEncoded))
+
+	require.Equal(t, tx.Hash(), flexTx.TxHash())
+	require.Equal(t, tx.Type(), flexTx.TxType())
+
+	// Test binary round trip
+	data, err := flexTx.MarshalBinary()
+	require.NoError(t, err)
+	var reDecoded RawJsonTransaction
+	require.NoError(t, reDecoded.UnmarshalBinary(data))
+	jsonAgain, err := json.Marshal(&reDecoded)
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Bytes(txJson), hexutil.Bytes(jsonAgain))
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR starts to address the work described in https://github.com/ethereum-optimism/optimism/issues/13627

This implements the generic-tx interface, and json handling variant, to generalize such that the stack continues to work even if there is an unrecognized tx type.

TODO: implement `eth.OpaqueTx` (implement `eth.GenericTx` interface, on top of raw bytes)

**Tests**

- [x] Unit-tested JSON and binary round-trips of known tx type.
- [ ] Unit-test the binary opaque-tx
- [ ] Test the above, with hypothetical unknown tx type.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/13627