### PR TITLE
dispute-game: possible liveness issue caused by proposing output root with out of range l2blocknumber 

### DIFF
--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -51,7 +51,8 @@ import {
     BondTransferFailed,
     NoCreditToClaim,
     InvalidOutputRootProof,
-    ClaimAboveSplit
+    ClaimAboveSplit,
+    L2BlockNumberExceeded
 } from "src/dispute/lib/Errors.sol";
 
 // Interfaces
@@ -302,6 +303,10 @@ contract FaultDisputeGame is Clone, ISemver {
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
         if (l2BlockNumber() <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
+
+        // Do not allow the game to be initialized if the root claim corresponds to a block after the
+        // configured starting block number + 2^splitDepth.
+        if (l2BlockNumber() > rootBlockNumber + 1 << SPLIT_DEPTH) revert L2BlockNumberExceeded(l2BlockNumber());
 
         // Set the root claim
         claimData.push(

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -121,6 +121,10 @@ error BlockNumberMatches();
 /// @notice Thrown when the L2 block number claim has already been challenged.
 error L2BlockNumberChallenged();
 
+/// @notice Thrown when a game is attempted to be initialized with a l2blockNumber that is large than latest anchor
+/// root's block number + 2^splitDepth.
+error L2BlockNumberExceeded(uint256 number);
+
 ////////////////////////////////////////////////////////////////
 //              `PermissionedDisputeGame` Errors              //
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
If `splitDepth` is set too low and the proposal interval for op-proposal is slightly longer, the proposed honest output root will correspond to an L2 block number greater than the latest anchor root's block number + 2^splitDepth. In this scenario, the honest output root will always be attacked by honest op-challenger, as op-challenger can only challenge blocks within the range of [anchor root's block number, anchor root's block number + 2^splitDepth]. Consequently, the anchor state will never be updated, leading to a liveness issue for the chain.


**Tests**

set `splitDepth` to 2, `respectedGameType` to 0 in devnet and op-proposer's ` --proposal-interval` to 30 seconds
