### PR TITLE
chore: Specify package manager version for corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,6 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.27.1"
-  }
+  },
+  "packageManager": "pnpm@8.15.9"
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

When following the [OP Stack tutorial](https://docs.optimism.io/builders/chain-operators/tutorials/create-l2-rollup#build-the-optimism-monorepo), I got a warning coming from node (with `corepack` enabled) about `packageManager` field missing from `package.json`.

The dependency version checking script requires `pnpm` version 8 so I added this to the `package.json`. This field only supports exact versions (`corepack` handles the version management) so version `8.15.9` was specified.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

Running `pnpm i` without error is sufficient