### PR TITLE
op-supervisor: local-safe reorg support

### DIFF
--- a/op-e2e/.gitignore
+++ b/op-e2e/.gitignore
@@ -1,2 +1,2 @@
 external_*/shim
-op-e2e/interop/jwt.secret
+interop/jwt.secret

--- a/op-e2e/actions/helpers/action.go
+++ b/op-e2e/actions/helpers/action.go
@@ -64,6 +64,14 @@ func NewDefaultTesting(tb e2eutils.TestingBase) StatefulTesting {
 	}
 }
 
+func SubTest(tb e2eutils.TestingBase) StatefulTesting {
+	return &defaultTesting{
+		TestingBase: tb,
+		ctx:         context.Background(),
+		state:       ActionOK,
+	}
+}
+
 // Ctx shares a context to execute an action with, the test runner may interrupt the action without stopping the test.
 func (st *defaultTesting) Ctx() context.Context {
 	return st.ctx

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -88,6 +88,7 @@ type L2Verifier struct {
 
 type L2API interface {
 	engine.Engine
+	managed.L2Source
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 	// GetProof returns a proof of the account, it may return a nil result without error if the address was not found.

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -66,7 +66,7 @@ func (eq *AttributesHandler) OnEvent(ev event.Event) bool {
 		eq.emitter.Emit(derive.ConfirmReceivedAttributesEvent{})
 		// to make sure we have a pre-state signal to process the attributes from
 		eq.emitter.Emit(engine.PendingSafeRequestEvent{})
-	case rollup.ResetEvent:
+	case rollup.ResetEvent, rollup.ForceResetEvent:
 		eq.sentAttributes = false
 		eq.attributes = nil
 	case rollup.EngineTemporaryErrorEvent:

--- a/op-node/rollup/derive/deposit_source.go
+++ b/op-node/rollup/derive/deposit_source.go
@@ -17,6 +17,7 @@ const (
 	L1InfoDepositSourceDomain     = 1
 	UpgradeDepositSourceDomain    = 2
 	AfterForceIncludeSourceDomain = 3
+	InvalidatedBlockSourceDomain  = 4
 )
 
 func (dep *UserDepositSource) SourceHash() common.Hash {
@@ -80,5 +81,17 @@ func (dep *AfterForceIncludeSource) SourceHash() common.Hash {
 	var domainInput [32 * 2]byte
 	binary.BigEndian.PutUint64(domainInput[32-8:32], AfterForceIncludeSourceDomain)
 	copy(domainInput[32:], depositIDHash[:])
+	return crypto.Keccak256Hash(domainInput[:])
+}
+
+// InvalidatedBlockSource identifies the invalidated optimistic-block system deposit-transaction.
+type InvalidatedBlockSource struct {
+	OutputRoot common.Hash
+}
+
+func (dep *InvalidatedBlockSource) SourceHash() common.Hash {
+	var domainInput [32 * 2]byte
+	binary.BigEndian.PutUint64(domainInput[32-8:32], InvalidatedBlockSourceDomain)
+	copy(domainInput[32:], dep.OutputRoot[:])
 	return crypto.Keccak256Hash(domainInput[:])
 }

--- a/op-node/rollup/derive/deposit_source_test.go
+++ b/op-node/rollup/derive/deposit_source_test.go
@@ -65,3 +65,17 @@ func TestAfterForceIncludeSource(t *testing.T) {
 
 	assert.Equal(t, expected, actual.Hex())
 }
+
+// TestInvalidatedBlockSource
+// cast keccak $(cast concat-hex 0x0000000000000000000000000000000000000000000000000000000000000004 0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8)
+// # 0x4a62bcfa03cf778234ae28fa39c9e0748f11099997b19fef9bb3fffc154fe456
+func TestInvalidatedBlockSource(t *testing.T) {
+	source := InvalidatedBlockSource{
+		OutputRoot: common.HexToHash("0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"),
+	}
+
+	actual := source.SourceHash()
+	expected := "0x4a62bcfa03cf778234ae28fa39c9e0748f11099997b19fef9bb3fffc154fe456"
+
+	assert.Equal(t, expected, actual.Hex())
+}

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -120,7 +120,7 @@ func (d *PipelineDeriver) AttachEmitter(em event.Emitter) {
 
 func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
-	case rollup.ResetEvent:
+	case rollup.ForceResetEvent:
 		d.pipeline.Reset()
 	case PipelineStepEvent:
 		// Don't generate attributes if there are already attributes in-flight

--- a/op-node/rollup/engine/engine_reset.go
+++ b/op-node/rollup/engine/engine_reset.go
@@ -55,7 +55,7 @@ func (d *EngineResetDeriver) OnEvent(ev event.Event) bool {
 			d.emitter.Emit(rollup.ResetEvent{Err: fmt.Errorf("failed to find the L2 Heads to start from: %w", err)})
 			return true
 		}
-		d.emitter.Emit(ForceEngineResetEvent{
+		d.emitter.Emit(rollup.ForceResetEvent{
 			Unsafe:    result.Unsafe,
 			Safe:      result.Safe,
 			Finalized: result.Finalized,

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -316,6 +316,15 @@ func (ev CrossUpdateRequestEvent) String() string {
 	return "cross-update-request"
 }
 
+type InteropInvalidateBlockEvent struct {
+	Invalidated eth.BlockRef
+	Attributes  *derive.AttributesWithParent
+}
+
+func (ev InteropInvalidateBlockEvent) String() string {
+	return "interop-invalidate-block"
+}
+
 type EngDeriver struct {
 	metrics Metrics
 
@@ -526,6 +535,8 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 				LocalSafe: d.ec.LocalSafeL2Head(),
 			})
 		}
+	case InteropInvalidateBlockEvent:
+		d.emitter.Emit(BuildStartEvent{})
 	case BuildStartEvent:
 		d.onBuildStart(x)
 	case BuildStartedEvent:

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -266,14 +266,6 @@ func (ev TryUpdateEngineEvent) getBlockProcessingMetrics() []interface{} {
 	return logValues
 }
 
-type ForceEngineResetEvent struct {
-	Unsafe, Safe, Finalized eth.L2BlockRef
-}
-
-func (ev ForceEngineResetEvent) String() string {
-	return "force-engine-reset"
-}
-
 type EngineResetConfirmedEvent struct {
 	Unsafe, Safe, Finalized eth.L2BlockRef
 }
@@ -432,7 +424,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			SafeL2Head:      d.ec.SafeL2Head(),
 			FinalizedL2Head: d.ec.Finalized(),
 		})
-	case ForceEngineResetEvent:
+	case rollup.ForceResetEvent:
 		ForceEngineReset(d.ec, x)
 
 		// Time to apply the changes to the underlying engine
@@ -579,7 +571,7 @@ type ResetEngineControl interface {
 }
 
 // ForceEngineReset is not to be used. The op-program needs it for now, until event processing is adopted there.
-func ForceEngineReset(ec ResetEngineControl, x ForceEngineResetEvent) {
+func ForceEngineReset(ec ResetEngineControl, x rollup.ForceResetEvent) {
 	ec.SetUnsafeHead(x.Unsafe)
 	ec.SetLocalSafeHead(x.Safe)
 	ec.SetPendingSafeL2Head(x.Safe)

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -1,8 +1,10 @@
 package engine
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -23,6 +25,25 @@ func (ev PayloadSuccessEvent) String() string {
 }
 
 func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
+	if ev.DerivedFrom == ReplaceBlockDerivedFrom {
+		eq.log.Warn("Successfully built replacement block, resetting chain to continue now", "replacement", ev.Ref)
+		// Change the engine state to make the replacement block the cross-safe head of the chain
+		ForceEngineReset(eq.ec, ForceEngineResetEvent{
+			Unsafe:    ev.Ref,
+			Safe:      ev.Ref,
+			Finalized: eq.ec.Finalized(),
+		})
+		eq.emitter.Emit(InteropReplacedBlockEvent{
+			Envelope: ev.Envelope,
+			Ref:      ev.Ref.BlockRef(),
+		})
+		// Apply it to the execution engine
+		eq.emitter.Emit(TryUpdateEngineEvent{})
+		// Reset the rest of the system to continue from here.
+		eq.emitter.Emit(rollup.ResetEvent{Err: fmt.Errorf("replaced invalidated block with %s, chain may continue after reset", ev.Ref)})
+		return
+	}
+
 	eq.emitter.Emit(PromoteUnsafeEvent{Ref: ev.Ref})
 
 	// If derived from L1, then it can be considered (pending) safe

--- a/op-node/rollup/event.go
+++ b/op-node/rollup/event.go
@@ -1,6 +1,9 @@
 package rollup
 
-import "github.com/ethereum-optimism/optimism/op-node/rollup/event"
+import (
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 // L1TemporaryErrorEvent identifies a temporary issue with the L1 data.
 type L1TemporaryErrorEvent struct {
@@ -35,6 +38,15 @@ var _ event.Event = ResetEvent{}
 
 func (ev ResetEvent) String() string {
 	return "reset-event"
+}
+
+// ForceResetEvent forces a reset to a specific unsafe/safe/finalized starting point.
+type ForceResetEvent struct {
+	Unsafe, Safe, Finalized eth.L2BlockRef
+}
+
+func (ev ForceResetEvent) String() string {
+	return "force-reset"
 }
 
 // CriticalErrorEvent is an alias for event.CriticalErrorEvent

--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -35,6 +35,10 @@ func (ib *InteropAPI) UpdateFinalized(ctx context.Context, id eth.BlockID) error
 	return ib.backend.UpdateFinalized(ctx, id)
 }
 
+func (ib *InteropAPI) InvalidateBlock(ctx context.Context, seal supervisortypes.BlockSeal) error {
+	return ib.backend.InvalidateBlock(ctx, seal)
+}
+
 func (ib *InteropAPI) AnchorPoint(ctx context.Context) (supervisortypes.DerivedBlockRefPair, error) {
 	return ib.backend.AnchorPoint(ctx)
 }

--- a/op-node/rollup/interop/managed/attributes.go
+++ b/op-node/rollup/interop/managed/attributes.go
@@ -1,0 +1,111 @@
+package managed
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// AttributesToReplaceInvalidBlock builds the payload-attributes to replace an invalidated block.
+// See https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#replacing-invalid-blocks
+func AttributesToReplaceInvalidBlock(invalidatedBlock *eth.ExecutionPayloadEnvelope) *eth.PayloadAttributes {
+	var replaceTxs []eth.Data
+
+	// Collect all deposit transactions
+	for _, tx := range invalidatedBlock.ExecutionPayload.Transactions {
+		if len(tx) > 0 && tx[0] == types.DepositTxType {
+			replaceTxs = append(replaceTxs, tx)
+		}
+	}
+	// Add the system-tx that declares the replacement.
+	l2Output := eth.OutputV0{
+		StateRoot:                invalidatedBlock.ExecutionPayload.StateRoot,
+		MessagePasserStorageRoot: eth.Bytes32{}, // TODO: the withdrawals-root in header is needed here.
+		BlockHash:                invalidatedBlock.ExecutionPayload.BlockHash,
+	}
+	outputRootPreimage := l2Output.Marshal()
+	invalidatedBlockTx := InvalidatedBlockSourceDepositTx(outputRootPreimage)
+	invalidatedBlockOpaqueTx, err := invalidatedBlockTx.MarshalBinary()
+	if err != nil {
+		panic(fmt.Errorf("failed to encode system-deposit: %w", err))
+	}
+	replaceTxs = append(replaceTxs, invalidatedBlockOpaqueTx)
+
+	// Optional engine-API attribute, because of L1-compat, and thus we need a pointer to it.
+	gasLimit := invalidatedBlock.ExecutionPayload.GasLimit
+
+	// unfortunately, the engine API needs the inner value, not the extra-data.
+	// So we translate it here.
+	extraData := invalidatedBlock.ExecutionPayload.ExtraData
+	denominator, elasticity := eip1559.DecodeHoloceneExtraData(extraData)
+	eip1559Params := eth.Bytes8(eip1559.EncodeHolocene1559Params(denominator, elasticity))
+
+	attrs := &eth.PayloadAttributes{
+		Timestamp:             invalidatedBlock.ExecutionPayload.Timestamp,
+		PrevRandao:            invalidatedBlock.ExecutionPayload.PrevRandao,
+		SuggestedFeeRecipient: invalidatedBlock.ExecutionPayload.FeeRecipient,
+		Withdrawals:           invalidatedBlock.ExecutionPayload.Withdrawals,
+		ParentBeaconBlockRoot: invalidatedBlock.ParentBeaconBlockRoot,
+		Transactions:          replaceTxs,
+		NoTxPool:              true,
+		GasLimit:              &gasLimit,
+		EIP1559Params:         &eip1559Params,
+	}
+	return attrs
+}
+
+// TODO: spec says this is L1 Attributes Depositor Account, but that one ends with dead0001
+var invalidatedBlockSender = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0002")
+
+func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *types.Transaction {
+	outputRoot := crypto.Keccak256Hash(outputRootPreimage)
+	src := derive.InvalidatedBlockSource{OutputRoot: outputRoot}
+	return types.NewTx(&types.DepositTx{
+		SourceHash:          src.SourceHash(),
+		From:                invalidatedBlockSender,
+		To:                  &common.Address{}, // TODO 0 addr is confusing in system deposits, and pollutes the block-explorer page for 0 addr.
+		Mint:                big.NewInt(0),
+		Value:               big.NewInt(0),
+		Gas:                 36_000,
+		IsSystemTransaction: false,
+		Data:                outputRootPreimage,
+	})
+}
+
+func DecodeInvalidatedBlockTx(txs []eth.Data) (*eth.OutputV0, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("expected block-replacement tx and more")
+	}
+	var tx types.Transaction
+	if err := tx.UnmarshalBinary(txs[len(txs)-1]); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal invalidated-block system tx: %w", err)
+	}
+	if tx.Type() != types.DepositTxType {
+		return nil, fmt.Errorf("expected deposit tx type, but got %d", tx.Type())
+	}
+	signer := types.LatestSignerForChainID(tx.ChainId())
+	from, err := signer.Sender(&tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get invalidated-block deposit-tx sender addr: %w", err)
+	}
+	if from != invalidatedBlockSender {
+		return nil, fmt.Errorf("expected system tx sender, but got %s", from)
+	}
+	out, err := eth.UnmarshalOutput(tx.Data())
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal output-root preimage: %w", err)
+	}
+	outV0, ok := out.(*eth.OutputV0)
+	if !ok {
+		return nil, fmt.Errorf("expected output v0 preimage, but got %T", out)
+	}
+	return outV0, nil
+}

--- a/op-node/rollup/interop/managed/attributes.go
+++ b/op-node/rollup/interop/managed/attributes.go
@@ -77,7 +77,7 @@ func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *types.Transacti
 	})
 }
 
-func DecodeInvalidatedBlockTx(txs []eth.Data) (*eth.OutputV0, error) {
+func DecodeInvalidatedBlockTxFromReplacement(txs []eth.Data) (*eth.OutputV0, error) {
 	if len(txs) == 0 {
 		return nil, errors.New("expected block-replacement tx and more")
 	}
@@ -85,11 +85,15 @@ func DecodeInvalidatedBlockTx(txs []eth.Data) (*eth.OutputV0, error) {
 	if err := tx.UnmarshalBinary(txs[len(txs)-1]); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal invalidated-block system tx: %w", err)
 	}
+	return DecodeInvalidatedBlockTx(&tx)
+}
+
+func DecodeInvalidatedBlockTx(tx *types.Transaction) (*eth.OutputV0, error) {
 	if tx.Type() != types.DepositTxType {
 		return nil, fmt.Errorf("expected deposit tx type, but got %d", tx.Type())
 	}
 	signer := types.LatestSignerForChainID(tx.ChainId())
-	from, err := signer.Sender(&tx)
+	from, err := signer.Sender(tx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get invalidated-block deposit-tx sender addr: %w", err)
 	}

--- a/op-node/rollup/interop/managed/attributes_test.go
+++ b/op-node/rollup/interop/managed/attributes_test.go
@@ -1,0 +1,170 @@
+package managed
+
+import (
+	"math/big"
+	"math/rand" // nosemgrep
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestAttributesToReplaceInvalidBlock creates a block to invalidate,
+// and then constructs the block-attributes to build the replacement block with,
+// and tests that these accurately reference the invalidated block in the optimistic block tx.
+func TestAttributesToReplaceInvalidBlock(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+	signer := types.LatestSignerForChainID(big.NewInt(123))
+	tx := testutils.RandomDynamicFeeTx(rng, signer)
+
+	exampleDeposit := types.NewTx(&types.DepositTx{
+		SourceHash:          testutils.RandomHash(rng),
+		From:                testutils.RandomAddress(rng),
+		To:                  nil,
+		Mint:                big.NewInt(0),
+		Value:               big.NewInt(0),
+		Gas:                 30_000,
+		IsSystemTransaction: false,
+		Data:                []byte("hello"),
+	})
+	opaqueDepositTx, err := exampleDeposit.MarshalBinary()
+	require.NoError(t, err)
+
+	opaqueUserTx, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	denominator := uint64(100)
+	elasticity := uint64(42)
+	extraData := eip1559.EncodeHoloceneExtraData(denominator, elasticity)
+
+	beaconRoot := testutils.RandomHash(rng)
+	invalidatedBlock := &eth.ExecutionPayloadEnvelope{
+		ParentBeaconBlockRoot: &beaconRoot,
+		ExecutionPayload: &eth.ExecutionPayload{
+			ParentHash:    testutils.RandomHash(rng),
+			FeeRecipient:  common.Address{},
+			StateRoot:     eth.Bytes32(testutils.RandomHash(rng)),
+			ReceiptsRoot:  eth.Bytes32(testutils.RandomHash(rng)),
+			LogsBloom:     eth.Bytes256{},
+			PrevRandao:    eth.Bytes32(testutils.RandomHash(rng)),
+			BlockNumber:   eth.Uint64Quantity(rng.Uint64()),
+			GasLimit:      eth.Uint64Quantity(30_000_000),
+			GasUsed:       eth.Uint64Quantity(1_000_000),
+			Timestamp:     eth.Uint64Quantity(rng.Uint64()),
+			ExtraData:     extraData,
+			BaseFeePerGas: eth.Uint256Quantity(*uint256.NewInt(7)),
+			BlockHash:     testutils.RandomHash(rng),
+			Transactions: []eth.Data{
+				opaqueDepositTx,
+				opaqueUserTx,
+			},
+			Withdrawals:   &types.Withdrawals{},
+			BlobGasUsed:   new(eth.Uint64Quantity),
+			ExcessBlobGas: new(eth.Uint64Quantity),
+		},
+	}
+	attrs := AttributesToReplaceInvalidBlock(invalidatedBlock)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.Timestamp, attrs.Timestamp)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.PrevRandao, attrs.PrevRandao)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.FeeRecipient, attrs.SuggestedFeeRecipient)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.Withdrawals, attrs.Withdrawals)
+	require.Equal(t, invalidatedBlock.ParentBeaconBlockRoot, attrs.ParentBeaconBlockRoot)
+	require.Len(t, attrs.Transactions, 2)
+	require.Equal(t, hexutil.Bytes(opaqueDepositTx).String(), attrs.Transactions[0].String())
+	require.Equal(t, uint8(types.DepositTxType), attrs.Transactions[1][0], "remove user tx, add optimistic block system tx")
+	require.True(t, attrs.NoTxPool)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.GasLimit, *attrs.GasLimit)
+	d, e := eip1559.DecodeHolocene1559Params(attrs.EIP1559Params[:])
+	require.Equal(t, denominator, d)
+	require.Equal(t, elasticity, e)
+	result, err := DecodeInvalidatedBlockTx(attrs.Transactions)
+	require.NoError(t, err)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.BlockHash, result.BlockHash)
+	require.Equal(t, invalidatedBlock.ExecutionPayload.StateRoot, result.StateRoot)
+	// Once withdrawals-root feature lands and it is part of the execution-payload type, assert here
+	//require.Equal(t, nil, result.MessagePasserStorageRoot)
+}
+
+// TestInvalidatedBlockTx tests we can encode/decode the system tx that represents the invalidated block
+func TestInvalidatedBlockTx(t *testing.T) {
+	t.Run("nil list", func(t *testing.T) {
+		_, err := DecodeInvalidatedBlockTx(nil)
+		require.NotNil(t, err)
+	})
+	t.Run("empty list", func(t *testing.T) {
+		_, err := DecodeInvalidatedBlockTx([]eth.Data{})
+		require.NotNil(t, err)
+	})
+	t.Run("success", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		output := &eth.OutputV0{
+			StateRoot:                eth.Bytes32(testutils.RandomHash(rng)),
+			MessagePasserStorageRoot: eth.Bytes32(testutils.RandomHash(rng)),
+			BlockHash:                testutils.RandomHash(rng),
+		}
+		outputRootPreimage := output.Marshal()
+		outputRoot := crypto.Keccak256Hash(outputRootPreimage)
+		tx := InvalidatedBlockSourceDepositTx(outputRootPreimage)
+		signer := types.LatestSignerForChainID(big.NewInt(0))
+		sender, err := signer.Sender(tx)
+		require.NoError(t, err)
+		require.Equal(t, derive.L1InfoDepositerAddress, sender, "from")
+		require.Equal(t, common.Address{}, *tx.To(), "to")
+		require.Equal(t, "0", tx.Mint().String(), "mint")
+		require.Equal(t, "0", tx.Value().String(), "value")
+		require.Equal(t, uint64(36_000), tx.Gas(), "gasLimit")
+		require.False(t, tx.IsSystemTx(), "legacy isSystemTx")
+		require.Equal(t, outputRootPreimage, tx.Data(), "data")
+		domain := uint256.NewInt(4).Bytes32()
+		sourceHash := crypto.Keccak256Hash(domain[:], outputRoot[:])
+		require.Equal(t, sourceHash, tx.SourceHash(), "sourceHash")
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err, "must encode")
+		result, err := DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		require.NoError(t, err, "must decode")
+		require.Equal(t, *output, *result, "roundtrip success")
+	})
+	t.Run("other tx type", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		signer := types.LatestSignerForChainID(big.NewInt(123))
+		tx := testutils.RandomDynamicFeeTx(rng, signer)
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err, "must encode")
+		_, err = DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		require.Error(t, err, "expected deposit")
+	})
+	t.Run("bad tx sender", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		tx := types.NewTx(&types.DepositTx{
+			SourceHash:          common.Hash{},
+			From:                testutils.RandomAddress(rng),
+			To:                  &common.Address{},
+			Mint:                big.NewInt(0),
+			Value:               big.NewInt(0),
+			Gas:                 36_000,
+			IsSystemTransaction: false,
+			Data:                []byte{},
+		})
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err, "must encode")
+		_, err = DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		require.Error(t, err, "expected system tx sender")
+	})
+	t.Run("bad preimage", func(t *testing.T) {
+		tx := InvalidatedBlockSourceDepositTx([]byte("invalid output root preimage"))
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err, "must encode")
+		_, err = DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		require.Error(t, err, "failed to unmarshal")
+	})
+}

--- a/op-node/rollup/interop/managed/attributes_test.go
+++ b/op-node/rollup/interop/managed/attributes_test.go
@@ -87,7 +87,7 @@ func TestAttributesToReplaceInvalidBlock(t *testing.T) {
 	d, e := eip1559.DecodeHolocene1559Params(attrs.EIP1559Params[:])
 	require.Equal(t, denominator, d)
 	require.Equal(t, elasticity, e)
-	result, err := DecodeInvalidatedBlockTx(attrs.Transactions)
+	result, err := DecodeInvalidatedBlockTxFromReplacement(attrs.Transactions)
 	require.NoError(t, err)
 	require.Equal(t, invalidatedBlock.ExecutionPayload.BlockHash, result.BlockHash)
 	require.Equal(t, invalidatedBlock.ExecutionPayload.StateRoot, result.StateRoot)
@@ -98,11 +98,11 @@ func TestAttributesToReplaceInvalidBlock(t *testing.T) {
 // TestInvalidatedBlockTx tests we can encode/decode the system tx that represents the invalidated block
 func TestInvalidatedBlockTx(t *testing.T) {
 	t.Run("nil list", func(t *testing.T) {
-		_, err := DecodeInvalidatedBlockTx(nil)
+		_, err := DecodeInvalidatedBlockTxFromReplacement(nil)
 		require.NotNil(t, err)
 	})
 	t.Run("empty list", func(t *testing.T) {
-		_, err := DecodeInvalidatedBlockTx([]eth.Data{})
+		_, err := DecodeInvalidatedBlockTxFromReplacement([]eth.Data{})
 		require.NotNil(t, err)
 	})
 	t.Run("success", func(t *testing.T) {
@@ -130,7 +130,7 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		require.Equal(t, sourceHash, tx.SourceHash(), "sourceHash")
 		encoded, err := tx.MarshalBinary()
 		require.NoError(t, err, "must encode")
-		result, err := DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		result, err := DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.NoError(t, err, "must decode")
 		require.Equal(t, *output, *result, "roundtrip success")
 	})
@@ -140,7 +140,7 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		tx := testutils.RandomDynamicFeeTx(rng, signer)
 		encoded, err := tx.MarshalBinary()
 		require.NoError(t, err, "must encode")
-		_, err = DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		_, err = DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.Error(t, err, "expected deposit")
 	})
 	t.Run("bad tx sender", func(t *testing.T) {
@@ -157,14 +157,14 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		})
 		encoded, err := tx.MarshalBinary()
 		require.NoError(t, err, "must encode")
-		_, err = DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		_, err = DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.Error(t, err, "expected system tx sender")
 	})
 	t.Run("bad preimage", func(t *testing.T) {
 		tx := InvalidatedBlockSourceDepositTx([]byte("invalid output root preimage"))
 		encoded, err := tx.MarshalBinary()
 		require.NoError(t, err, "must encode")
-		_, err = DecodeInvalidatedBlockTx([]eth.Data{encoded})
+		_, err = DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.Error(t, err, "failed to unmarshal")
 	})
 }

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -136,7 +136,7 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 		}})
 	case engine.InteropReplacedBlockEvent:
 		m.log.Info("Replaced block", "replacement", x.Ref)
-		out, err := DecodeInvalidatedBlockTx(x.Envelope.ExecutionPayload.Transactions)
+		out, err := DecodeInvalidatedBlockTxFromReplacement(x.Envelope.ExecutionPayload.Transactions)
 		if err != nil {
 			m.log.Error("Failed to parse replacement block", "err", err)
 			return true
@@ -297,7 +297,7 @@ func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.Blo
 		return err
 	}
 
-	m.emitter.Emit(engine.ForceEngineResetEvent{
+	m.emitter.Emit(rollup.ForceResetEvent{
 		Unsafe:    unsafeRef,
 		Safe:      safeRef,
 		Finalized: finalizedRef,

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -51,7 +51,7 @@ func (los *L1OriginSelector) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
 	case engine.ForkchoiceUpdateEvent:
 		los.onForkchoiceUpdate(x.UnsafeL2Head)
-	case rollup.ResetEvent:
+	case rollup.ResetEvent, rollup.ForceResetEvent:
 		los.reset()
 	default:
 		return false

--- a/op-service/eth/output.go
+++ b/op-service/eth/output.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"errors"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )

--- a/op-service/eth/output.go
+++ b/op-service/eth/output.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -245,6 +245,15 @@ func (payload *ExecutionPayload) ParentID() BlockID {
 	return BlockID{Hash: payload.ParentHash, Number: n}
 }
 
+func (payload *ExecutionPayload) BlockRef() BlockRef {
+	return BlockRef{
+		Hash:       payload.BlockHash,
+		Number:     uint64(payload.BlockNumber),
+		ParentHash: payload.ParentHash,
+		Time:       uint64(payload.Timestamp),
+	}
+}
+
 type rawTransactions []Data
 
 func (s rawTransactions) Len() int { return len(s) }

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -67,9 +67,10 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 3}, types.ErrFuture
 		}
-		sfcd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{},
-				eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
+		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+					DerivedFrom: eth.BlockRef{},
+					Derived:     eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})}},
 				errors.New("some error")
 		}
 		l1DerivedFrom := eth.BlockID{}
@@ -85,10 +86,11 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{}, types.ErrFuture
 		}
-		sfcd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{},
-				eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
-				nil
+		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: eth.BlockRef{},
+				Derived:     eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
+			}, nil
 		}
 		l1DerivedFrom := eth.BlockID{}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
@@ -104,9 +106,10 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{}, types.ErrFuture
 		}
-		sfcd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{Number: 9},
-				eth.BlockRef{},
+		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+					DerivedFrom: eth.BlockRef{Number: 9},
+					Derived:     eth.BlockRef{}},
 				nil
 		}
 		l1DerivedFrom := eth.BlockID{Number: 8}
@@ -122,10 +125,11 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
-		sfcd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{Number: 9},
-				eth.BlockRef{},
-				nil
+		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: eth.BlockRef{Number: 9},
+				Derived:     eth.BlockRef{},
+			}, nil
 		}
 		l1DerivedFrom := eth.BlockID{Number: 8}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
@@ -139,15 +143,15 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 
 type mockSafeFrontierCheckDeps struct {
 	deps                 mockDependencySet
-	candidateCrossSafeFn func() (derivedFromScope, crossSafe eth.BlockRef, err error)
+	candidateCrossSafeFn func() (candidate types.DerivedBlockRefPair, err error)
 	crossDerivedFromFn   func() (derivedFrom types.BlockSeal, err error)
 }
 
-func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
+func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error) {
 	if m.candidateCrossSafeFn != nil {
 		return m.candidateCrossSafeFn()
 	}
-	return eth.BlockRef{}, eth.BlockRef{}, nil
+	return types.DerivedBlockRefPair{}, nil
 }
 
 func (m *mockSafeFrontierCheckDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -20,8 +20,11 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
@@ -43,8 +46,11 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, errors.New("some error")
@@ -62,8 +68,11 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
@@ -107,8 +116,11 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
@@ -129,8 +141,11 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
@@ -151,8 +166,11 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
@@ -174,14 +192,14 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{}, eth.BlockRef{}, errors.New("some error")
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{}, errors.New("some error")
 		}
 		// when CandidateCrossSafe returns an error,
 		// the error is returned
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		candidate, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
-		require.Equal(t, eth.BlockRef{}, blockRef)
+		require.Equal(t, eth.BlockRef{}, candidate.DerivedFrom)
 	})
 	t.Run("CandidateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -192,17 +210,20 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		// when OpenBlock returns an error,
 		// the error is returned
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
-		require.Equal(t, eth.BlockRef{}, blockRef)
+		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
 	})
 	t.Run("candidate does not match opened block", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{}, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: eth.BlockRef{},
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 2}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -210,17 +231,20 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		// when OpenBlock and CandidateCrossSafe return different blocks,
 		// an ErrConflict is returned
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorIs(t, err, types.ErrConflict)
-		require.Equal(t, eth.BlockRef{}, blockRef)
+		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
 	})
 	t.Run("CrossSafeHazards returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{}, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: eth.BlockRef{},
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
@@ -234,18 +258,21 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		// when CrossSafeHazards returns an error,
 		// the error is returned
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
 		require.ErrorContains(t, err, "dependencies of cross-safe candidate")
-		require.Equal(t, eth.BlockRef{}, blockRef)
+		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
 	})
 	t.Run("HazardSafeFrontierChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return eth.BlockRef{}, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: eth.BlockRef{},
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
@@ -268,10 +295,10 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		// when CrossSafeHazards returns an error,
 		// the error is returned
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
 		require.ErrorContains(t, err, "frontier")
-		require.Equal(t, eth.BlockRef{}, blockRef)
+		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
 	})
 	t.Run("HazardCycleChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -279,8 +306,11 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1, Time: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 1, Time: 1}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 2}
@@ -294,10 +324,10 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd.deps = mockDependencySet{}
 
 		// HazardCycleChecks returns an error with appropriate wrapping
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "cycle detected")
 		require.ErrorContains(t, err, "failed to verify block")
-		require.Equal(t, eth.BlockRef{Number: 2}, blockRef)
+		require.Equal(t, eth.BlockRef{Number: 2}, pair.DerivedFrom)
 	})
 	t.Run("UpdateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -305,8 +335,11 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
@@ -322,10 +355,10 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		// when UpdateCrossSafe returns an error,
 		// the error is returned
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
 		require.ErrorContains(t, err, "failed to update")
-		require.Equal(t, eth.BlockRef{Number: 2}, blockRef)
+		require.Equal(t, eth.BlockRef{Number: 2}, pair.DerivedFrom)
 	})
 	t.Run("successful update", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -333,8 +366,11 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
-		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
-			return candidateScope, candidate, nil
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				DerivedFrom: candidateScope,
+				Derived:     candidate,
+			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
@@ -357,11 +393,11 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
-		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
+		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.Equal(t, chainID, updatingChain)
 		require.Equal(t, candidateScope, updatingCandidateScope)
 		require.Equal(t, candidate, updatingCandidate)
-		require.Equal(t, candidateScope, blockRef)
+		require.Equal(t, candidateScope, pair.DerivedFrom)
 		require.NoError(t, err)
 	})
 }
@@ -369,13 +405,15 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 type mockCrossSafeDeps struct {
 	deps                 mockDependencySet
 	crossSafeFn          func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error)
-	candidateCrossSafeFn func() (derivedFromScope, crossSafe eth.BlockRef, err error)
+	candidateCrossSafeFn func() (candidate types.DerivedBlockRefPair, err error)
 	openBlockFn          func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 	updateCrossSafeFn    func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
 	nextDerivedFromFn    func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
 	previousDerivedFn    func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
 	checkFn              func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
 }
+
+var _ CrossSafeDeps = (*mockCrossSafeDeps)(nil)
 
 func (m *mockCrossSafeDeps) CrossSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 	if m.crossSafeFn != nil {
@@ -384,11 +422,11 @@ func (m *mockCrossSafeDeps) CrossSafe(chainID eth.ChainID) (pair types.DerivedBl
 	return types.DerivedBlockSealPair{}, nil
 }
 
-func (m *mockCrossSafeDeps) CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
+func (m *mockCrossSafeDeps) CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error) {
 	if m.candidateCrossSafeFn != nil {
 		return m.candidateCrossSafeFn()
 	}
-	return eth.BlockRef{}, eth.BlockRef{}, nil
+	return types.DerivedBlockRefPair{}, nil
 }
 
 func (m *mockCrossSafeDeps) DependencySet() depset.DependencySet {
@@ -431,5 +469,10 @@ func (m *mockCrossSafeDeps) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockR
 	if m.updateCrossSafeFn != nil {
 		return m.updateCrossSafeFn(chain, l1View, lastCrossDerived)
 	}
+	return nil
+}
+
+func (m *mockCrossSafeDeps) InvalidateLocalSafe(chainID eth.ChainID, candidate types.DerivedBlockRefPair) error {
+	// TODO
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -53,8 +53,12 @@ type LogStorage interface {
 type LocalDerivedFromStorage interface {
 	First() (pair types.DerivedBlockSealPair, err error)
 	Latest() (pair types.DerivedBlockSealPair, err error)
+	Invalidated() (pair types.DerivedBlockSealPair, err error)
 	AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error
+	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) error
+	RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error
 	LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error)
+	IsDerived(derived eth.BlockID) error
 	DerivedFrom(derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 	FirstAfter(derivedFrom, derived eth.BlockID) (next types.DerivedBlockSealPair, err error)
 	NextDerivedFrom(derivedFrom eth.BlockID) (nextDerivedFrom types.BlockSeal, err error)

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -130,6 +130,8 @@ func (db *ChainsDB) OnEvent(ev event.Event) bool {
 		db.UpdateLocalSafe(x.ChainID, x.Derived.DerivedFrom, x.Derived.Derived)
 	case superevents.FinalizedL1RequestEvent:
 		db.onFinalizedL1(x.FinalizedL1)
+	case superevents.ReplaceBlockEvent:
+		db.onReplaceBlock(x.ChainID, x.Replacement.Replacement, x.Replacement.Invalidated)
 	default:
 		return false
 	}

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -55,7 +55,7 @@ type LocalDerivedFromStorage interface {
 	Latest() (pair types.DerivedBlockSealPair, err error)
 	Invalidated() (pair types.DerivedBlockSealPair, err error)
 	AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error
-	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) error
+	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error)
 	RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error
 	LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error)
 	IsDerived(derived eth.BlockID) error

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -761,7 +761,10 @@ func TestInvalidateAndReplace(t *testing.T) {
 		replacement := l2Ref2
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref2.Hash, replacement.Hash) // different L2 block as replacement
-		require.NoError(t, db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash))
+		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
+		require.NoError(t, err)
+		require.Equal(t, replacement.ID(), result.Derived.ID())
+		require.Equal(t, l1Block1.ID(), result.DerivedFrom.ID())
 
 		pair, err = db.Latest()
 		require.NoError(t, err)
@@ -827,7 +830,10 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		replacement := l2Ref3
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref3.Hash, replacement.Hash) // different L2 block as replacement
-		require.NoError(t, db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash))
+		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
+		require.NoError(t, err)
+		require.Equal(t, replacement.ID(), result.Derived.ID())
+		require.Equal(t, l1Block2.ID(), result.DerivedFrom.ID())
 
 		pair, err = db.Latest()
 		require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -855,5 +855,10 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), entryBlockRepl.Derived.ID())
 		require.Equal(t, l1Block2.ID(), entryBlockRepl.DerivedFrom.ID())
+
+		// Check if canonical chain is represented accurately
+		require.NoError(t, db.IsDerived(l2Ref2.ID()), "common block 2 is valid part of canonical chain")
+		require.NoError(t, db.IsDerived(replacement.ID()), "replacement is valid part of canonical chain")
+		require.ErrorIs(t, db.IsDerived(l2Ref3.ID()), types.ErrConflict, "invalidated block is not valid in canonical chain")
 	})
 }

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -157,3 +157,82 @@ func (db *ChainsDB) onFinalizedL1(finalized eth.BlockRef) {
 		db.emitter.Emit(superevents.FinalizedL2UpdateEvent{ChainID: chain, FinalizedL2: fin})
 	}
 }
+
+func (db *ChainsDB) InvalidateLocalSafe(chainID eth.ChainID, candidate types.DerivedBlockRefPair) error {
+	// Get databases to invalidate data in.
+	eventsDB, ok := db.logDBs.Get(chainID)
+	if !ok {
+		return fmt.Errorf("cannot find events DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+	}
+	localSafeDB, ok := db.localDBs.Get(chainID)
+	if !ok {
+		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+	}
+
+	// Now invalidate the local-safe data.
+	// We insert a marker, so we don't build on top of the invalidated block, until it is replaced.
+	// And we won't index unsafe blocks, until it is replaced.
+	if err := localSafeDB.RewindAndInvalidate(candidate); err != nil {
+		return fmt.Errorf("failed to invalidate entry in local-safe DB: %w", err)
+	}
+
+	// Change cross-unsafe, if it's equal or past the invalidated block.
+	if err := db.ResetCrossUnsafeIfNewerThan(chainID, candidate.Derived.Number); err != nil {
+		return fmt.Errorf("failed to reset cross-unsafe: %w", err)
+	}
+
+	// Drop the events of the invalidated block and after,
+	// by rewinding to only keep the parent-block.
+	if err := eventsDB.Rewind(candidate.Derived.ParentID()); err != nil {
+		return fmt.Errorf("failed to rewind unsafe-chain: %w", err)
+	}
+
+	// Create an event, that subscribed sync-nodes can listen to,
+	// to start finding the replacement block.
+	db.emitter.Emit(superevents.InvalidateLocalSafeEvent{
+		ChainID:   chainID,
+		Candidate: candidate,
+	})
+	return nil
+}
+
+func (db *ChainsDB) ResetCrossUnsafeIfNewerThan(chainID eth.ChainID, number uint64) error {
+	crossUnsafe, ok := db.crossUnsafe.Get(chainID)
+	if !ok {
+		return nil
+	}
+
+	crossSafeDB, ok := db.crossDBs.Get(chainID)
+	if !ok {
+		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
+	}
+	crossSafe, err := crossSafeDB.Latest()
+	if err != nil {
+		return fmt.Errorf("cannot get cross-safe of chain %s: %w", chainID, err)
+	}
+
+	// Reset cross-unsafe if it's equal or newer than the given block number
+	crossUnsafe.Lock()
+	x := crossUnsafe.Value
+	defer crossUnsafe.Unlock()
+	if x.Number >= number {
+		db.logger.Warn("Resetting cross-unsafe to cross-safe, since prior block was invalidated",
+			"crossUnsafe", x, "crossSafe", crossSafe, "number", number)
+		crossUnsafe.Value = crossSafe.Derived
+	}
+	return nil
+}
+
+func (db *ChainsDB) ReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef, invalidated common.Hash) error {
+	localSafeDB, ok := db.localDBs.Get(chainID)
+	if !ok {
+		return fmt.Errorf("cannot find local-safe DB of chain %s for block replacement work: %w", chainID, types.ErrUnknownChain)
+	}
+
+	if err := localSafeDB.ReplaceInvalidatedBlock(replacement, invalidated); err != nil {
+		return fmt.Errorf("cannot replace invalidated block %s with %s in local-safe DB: %w", invalidated, replacement, err)
+	}
+
+	// TODO Make sure the events-DB has a matching block-hash with the replacement, roll it back otherwise.
+	return nil
+}

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -160,6 +160,7 @@ func (p *L1Accessor) onFinalized(ctx context.Context, ref eth.L1BlockRef) {
 
 func (p *L1Accessor) onLatest(ctx context.Context, ref eth.L1BlockRef) {
 	p.tipHeight = ref.Number
+	p.log.Info("Updated latest known L1 block", "ref", ref)
 }
 
 func (p *L1Accessor) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -139,7 +139,7 @@ func (ev InvalidateLocalSafeEvent) String() string {
 
 type ReplaceBlockEvent struct {
 	ChainID     eth.ChainID
-	Replacement eth.BlockRef
+	Replacement types.BlockReplacement
 }
 
 func (ev ReplaceBlockEvent) String() string {

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -127,3 +127,21 @@ type AnchorEvent struct {
 func (ev AnchorEvent) String() string {
 	return "anchor"
 }
+
+type InvalidateLocalSafeEvent struct {
+	ChainID   eth.ChainID
+	Candidate types.DerivedBlockRefPair
+}
+
+func (ev InvalidateLocalSafeEvent) String() string {
+	return "invalidate-local-safe"
+}
+
+type ReplaceBlockEvent struct {
+	ChainID     eth.ChainID
+	Replacement eth.BlockRef
+}
+
+func (ev ReplaceBlockEvent) String() string {
+	return "replace-block-event"
+}

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -30,6 +30,10 @@ type mockSyncControl struct {
 	subscribeEvents gethevent.FeedOf[*types.ManagedEvent]
 }
 
+func (m *mockSyncControl) InvalidateBlock(ctx context.Context, seal types.BlockSeal) error {
+	return nil
+}
+
 func (m *mockSyncControl) AnchorPoint(ctx context.Context) (types.DerivedBlockRefPair, error) {
 	if m.anchorPointFn != nil {
 		return m.anchorPointFn(ctx)

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -39,6 +39,8 @@ type SyncControl interface {
 	UpdateCrossSafe(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error
 	UpdateFinalized(ctx context.Context, id eth.BlockID) error
 
+	InvalidateBlock(ctx context.Context, seal types.BlockSeal) error
+
 	Reset(ctx context.Context, unsafe, safe, finalized eth.BlockID) error
 	ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error
 	AnchorPoint(ctx context.Context) (types.DerivedBlockRefPair, error)

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -424,8 +424,8 @@ func (m *ManagedNode) onExhaustL1Event(completed types.DerivedBlockRefPair) {
 	}
 }
 
-// onInvalidateLocalSafe listens for when a local-safe block is invalidated to not be possible to promote to cross-safe,
-// and when it thus has to be replaced.
+// onInvalidateLocalSafe listens for when a local-safe block is found to be invalid in the cross-safe context
+// and needs to be replaced with a deposit only block.
 func (m *ManagedNode) onInvalidateLocalSafe(invalidated types.DerivedBlockRefPair) {
 	m.log.Warn("Instructing node to replace invalidated local-safe block",
 		"invalidated", invalidated.Derived, "scope", invalidated.DerivedFrom)

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -84,6 +84,11 @@ func (m *ManagedNode) AttachEmitter(em event.Emitter) {
 
 func (m *ManagedNode) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
+	case superevents.InvalidateLocalSafeEvent:
+		if x.ChainID != m.chainID {
+			return false
+		}
+		m.onInvalidateLocalSafe(x.Candidate)
 	case superevents.CrossUnsafeUpdateEvent:
 		if x.ChainID != m.chainID {
 			return false
@@ -207,6 +212,9 @@ func (m *ManagedNode) onNodeEvent(ev *types.ManagedEvent) {
 	}
 	if ev.ExhaustL1 != nil {
 		m.onExhaustL1Event(*ev.ExhaustL1)
+	}
+	if ev.ReplaceBlock != nil {
+		m.onReplaceBlock(*ev.ReplaceBlock)
 	}
 }
 
@@ -414,6 +422,29 @@ func (m *ManagedNode) onExhaustL1Event(completed types.DerivedBlockRefPair) {
 		// but does not fit on the derivation state.
 		return
 	}
+}
+
+// onInvalidateLocalSafe listens for when a local-safe block is invalidated to not be possible to promote to cross-safe,
+// and when it thus has to be replaced.
+func (m *ManagedNode) onInvalidateLocalSafe(invalidated types.DerivedBlockRefPair) {
+	m.log.Warn("Instructing node to replace invalidated local-safe block",
+		"invalidated", invalidated.Derived, "scope", invalidated.DerivedFrom)
+
+	ctx, cancel := context.WithTimeout(m.ctx, nodeTimeout)
+	defer cancel()
+	// Send instruction to the node to invalidate the block, and build a replacement block.
+	if err := m.Node.InvalidateBlock(ctx, types.BlockSealFromRef(invalidated.Derived)); err != nil {
+		m.log.Warn("Node is unable to invalidate block",
+			"invalidated", invalidated.Derived, "scope", invalidated.DerivedFrom, "err", err)
+	}
+}
+
+func (m *ManagedNode) onReplaceBlock(ref eth.BlockRef) {
+	m.log.Info("Node provided replacement block", "ref", ref)
+	m.emitter.Emit(superevents.ReplaceBlockEvent{
+		ChainID:     m.chainID,
+		Replacement: ref,
+	})
 }
 
 func (m *ManagedNode) Close() error {

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -439,11 +439,12 @@ func (m *ManagedNode) onInvalidateLocalSafe(invalidated types.DerivedBlockRefPai
 	}
 }
 
-func (m *ManagedNode) onReplaceBlock(ref eth.BlockRef) {
-	m.log.Info("Node provided replacement block", "ref", ref)
+func (m *ManagedNode) onReplaceBlock(replacement types.BlockReplacement) {
+	m.log.Info("Node provided replacement block",
+		"ref", replacement.Replacement, "invalidated", replacement.Invalidated)
 	m.emitter.Emit(superevents.ReplaceBlockEvent{
 		ChainID:     m.chainID,
-		Replacement: ref,
+		Replacement: replacement,
 	})
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -116,6 +116,10 @@ func (rs *RPCSyncNode) UpdateFinalized(ctx context.Context, id eth.BlockID) erro
 	return rs.cl.CallContext(ctx, nil, "interop_updateFinalized", id)
 }
 
+func (rs *RPCSyncNode) InvalidateBlock(ctx context.Context, seal types.BlockSeal) error {
+	return rs.cl.CallContext(ctx, nil, "interop_invalidateBlock", seal)
+}
+
 func (rs *RPCSyncNode) Reset(ctx context.Context, unsafe, safe, finalized eth.BlockID) error {
 	return rs.cl.CallContext(ctx, nil, "interop_reset", unsafe, safe, finalized)
 }

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -274,6 +274,13 @@ func (refs *DerivedBlockRefPair) IDs() DerivedIDPair {
 	}
 }
 
+func (refs *DerivedBlockRefPair) Seals() DerivedBlockSealPair {
+	return DerivedBlockSealPair{
+		DerivedFrom: BlockSealFromRef(refs.DerivedFrom),
+		Derived:     BlockSealFromRef(refs.Derived),
+	}
+}
+
 // DerivedBlockSealPair is a pair of block seals, where Derived (L2) is derived from DerivedFrom (L1).
 type DerivedBlockSealPair struct {
 	DerivedFrom BlockSeal `json:"derivedFrom"`

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -300,4 +300,5 @@ type ManagedEvent struct {
 	UnsafeBlock      *eth.BlockRef        `json:"unsafeBlock,omitempty"`
 	DerivationUpdate *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1        *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
+	ReplaceBlock     *eth.BlockRef        `json:"replaceBlock,omitempty"`
 }

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -293,6 +293,11 @@ type DerivedIDPair struct {
 	Derived     eth.BlockID `json:"derived"`
 }
 
+type BlockReplacement struct {
+	Replacement eth.BlockRef `json:"replacement"`
+	Invalidated common.Hash  `json:"invalidated"`
+}
+
 // ManagedEvent is an event sent by the managed node to the supervisor,
 // to share an update. One of the fields will be non-null; different kinds of updates may be sent.
 type ManagedEvent struct {
@@ -300,5 +305,5 @@ type ManagedEvent struct {
 	UnsafeBlock      *eth.BlockRef        `json:"unsafeBlock,omitempty"`
 	DerivationUpdate *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1        *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
-	ReplaceBlock     *eth.BlockRef        `json:"replaceBlock,omitempty"`
+	ReplaceBlock     *BlockReplacement    `json:"replaceBlock,omitempty"`
 }


### PR DESCRIPTION
**Description**

Start of reorg support. This handles the reorg case where a local-safe block is not actually cross-safe.

When a local-safe block is detected to conflict:
1. Send update to chains-DB to roll back, and insert a replacement block entry into local/cross-safe DB.
2. Use feed to have connected sync nodes proactively follow the replacement block, rather than finding cross-safe conflicting later (at which point we then also need to handle replacement)
3. Sync nodes should insert the replacement block with a reorg, mark it as safe, and then then trigger a reset, so the nodes continues to derive on top of this cross-safe block.
4. Sync nodes should publish the replacement-block as event. Instead of a derived-from event. This can then be watched by the supervisor, and marked as cross-safe.

**Tests**

- Unit tests for block-replacement tx
- Action test for e2e block replacement example
- Updated existing test from tyler, that now reorgs out the bad tx, rather than halting cross-safe progression.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

After this we still have two types of reorgs:
- L1 reorgs, and we need to roll back the supervisor (simple, already keyed by L1 blocks)
- L2 unsafe block conflicts: we won't know what is and isn't valid. We might need some heuristics here, to choose an unsafe chain that can be recovered, and remove the rest asap, so it's not batch-submitted.


