### PR TITLE
feat: remove contractAddressesPath and disk reading

### DIFF
--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -50,28 +50,6 @@ contract Artifacts {
 
         uint256 chainId = Config.chainID();
         console.log("Connected to network with chainid %s", chainId);
-
-        // Load addresses from a JSON file if the CONTRACT_ADDRESSES_PATH environment variable
-        // is set. Great for loading addresses from `superchain-registry`.
-        string memory addresses = Config.contractAddressesPath();
-        if (bytes(addresses).length > 0) {
-            console.log("Loading addresses from %s", addresses);
-            _loadAddresses(addresses);
-        }
-    }
-
-    /// @notice Populates the addresses to be used in a script based on a JSON file.
-    ///         The format of the JSON file is the same that it output by this script
-    ///         as well as the JSON files that contain addresses in the `superchain-registry`
-    ///         repo. The JSON key is the name of the contract and the value is an address.
-    function _loadAddresses(string memory _path) internal {
-        string memory json = Process.bash(string.concat("jq -cr < ", _path));
-        string[] memory keys = vm.parseJsonKeys(json, "");
-        for (uint256 i; i < keys.length; i++) {
-            string memory key = keys[i];
-            address addr = stdJson.readAddress(json, string.concat("$.", key));
-            save(key, addr);
-        }
     }
 
     /// @notice Returns all of the deployments done in the current context.

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -7,7 +7,6 @@ import { Vm } from "forge-std/Vm.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Config } from "scripts/libraries/Config.sol";
 import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
-import { Process } from "scripts/libraries/Process.sol";
 
 /// @notice Represents a deployment. Is serialized to JSON as a key/value
 ///         pair. Can be accessed from within scripts.

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -56,8 +56,6 @@ import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 ///         To add a new contract to the system, add a public function that deploys that individual contract.
 ///         Then add a call to that function inside of `run`. Be sure to call the `save` function after each
 ///         deployment so that hardhat-deploy style artifacts can be generated using a call to `sync()`.
-///         The `CONTRACT_ADDRESSES_PATH` environment variable can be set to a path that contains a JSON file full of
-///         contract name to address pairs. That enables this script to be much more flexible in the way it is used.
 ///         This contract must not have constructor logic because it is set into state using `etch`.
 contract Deploy is Deployer {
     using stdJson for string;

--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -94,13 +94,6 @@ library Config {
         env_ = vm.envOr("CHAIN_ID", block.chainid);
     }
 
-    /// @notice Returns the value of the env var CONTRACT_ADDRESSES_PATH which is a JSON key/value
-    ///         pair of contract names and their addresses. Each key/value pair is passed to `save`
-    ///         which then backs the `getAddress` function.
-    function contractAddressesPath() internal view returns (string memory env_) {
-        env_ = vm.envOr("CONTRACT_ADDRESSES_PATH", string(""));
-    }
-
     /// @notice The CREATE2 salt to be used when deploying the implementations.
     function implSalt() internal view returns (string memory env_) {
         env_ = vm.envOr("IMPL_SALT", string("ethers phoenix"));


### PR DESCRIPTION
### TL;DR
Removed the ability to load contract addresses from external JSON files during deployment

### What changed?
- Removed the `CONTRACT_ADDRESSES_PATH` environment variable and related functionality
- Eliminated the `_loadAddresses` function from `Artifacts.s.sol` (_tests now write, but do not read from disk_).
- Removed the `contractAddressesPath` function from `Config.sol`

Although small, this PR was separated from the previous in case it causes failures in CI.