### PR TITLE
feat: remove redundant loadInitializeSlot func

### DIFF
--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -210,20 +210,4 @@ contract Artifacts {
         _namedDeployments[_name] = deployment;
     }
 
-    /// @notice Returns the value of the internal `_initialized` storage slot for a given contract.
-    /// @param _sourceName The name of the contract in the source code
-    /// @param _deploymentName The name used to save() the deployed contract
-    function loadInitializedSlot(
-        string memory _sourceName,
-        string memory _deploymentName
-    )
-        public
-        returns (uint8 initialized_)
-    {
-        address contractAddress = mustGetAddress(_deploymentName);
-
-        StorageSlot memory slot = ForgeArtifacts.getInitializedSlot(_sourceName);
-        bytes32 slotVal = vm.load(contractAddress, bytes32(slot.slot));
-        initialized_ = uint8((uint256(slotVal) >> (slot.offset * 8)) & 0xFF);
-    }
 }

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -6,7 +6,7 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Config } from "scripts/libraries/Config.sol";
-import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
+import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 import { Process } from "scripts/libraries/Process.sol";
 
 /// @notice Represents a deployment. Is serialized to JSON as a key/value

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -197,17 +197,4 @@ contract Artifacts {
     function _appendDeployment(string memory _name, address _deployed) internal {
         vm.writeJson({ json: stdJson.serialize("", _name, _deployed), path: deploymentOutfile });
     }
-
-    /// @notice Stubs a deployment retrieved through `get`.
-    /// @param _name The name of the deployment.
-    /// @param _addr The mock address of the deployment.
-    function prankDeployment(string memory _name, address _addr) public {
-        if (bytes(_name).length == 0) {
-            revert InvalidDeployment("EmptyName");
-        }
-
-        Deployment memory deployment = Deployment({ name: _name, addr: payable(_addr) });
-        _namedDeployments[_name] = deployment;
-    }
-
 }

--- a/packages/contracts-bedrock/test/L2/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/L2/Predeploys.t.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+
+// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 
 /// @title PredeploysTest
 contract PredeploysBaseTest is CommonTest {
@@ -106,7 +110,8 @@ contract PredeploysBaseTest is CommonTest {
             }
 
             if (_isInitializable(addr)) {
-                assertEq(artifacts.loadInitializedSlot({ _sourceName: cname, _deploymentName: cname }), uint8(1));
+                assertTrue(ForgeArtifacts.isInitialized({ _name: cname, _address: addr }));
+                assertTrue(ForgeArtifacts.isInitialized({ _name: cname, _address: implAddr }));
             }
         }
     }

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -417,16 +417,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract memory _contract = contracts[i];
             string memory deploymentName = _getRealContractName(_contract.name);
 
-            // Grab the value of the "initialized" storage slot.
-            uint8 initializedSlotVal = artifacts.loadInitializedSlot({
-                _sourceName: _removeSuffix(deploymentName),
-                _deploymentName: deploymentName
-            });
-
             // Assert that the contract is already initialized.
             assertTrue(
-                // Either 1 for initialized or type(uint8).max for initializer disabled.
-                initializedSlotVal == 1 || initializedSlotVal == type(uint8).max,
+                ForgeArtifacts.isInitialized({ _name: _removeSuffix(deploymentName), _address: _contract.target }),
                 "Initializable: contract is not initialized"
             );
 


### PR DESCRIPTION
1. remove redundant `loadInitializeSlot` func (can use `ForgeArtifacts.isInitialized()` instead.
2. remove unused `prankDeployment` func.