### PR TITLE
ctb: Implement addGameType method on OPCM

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -198,7 +198,9 @@ contract DeployOPCM is Script {
             resolvedDelegateProxy: _doi.resolvedDelegateProxyBlueprint(),
             anchorStateRegistry: _doi.anchorStateRegistryBlueprint(),
             permissionedDisputeGame1: _doi.permissionedDisputeGame1Blueprint(),
-            permissionedDisputeGame2: _doi.permissionedDisputeGame2Blueprint()
+            permissionedDisputeGame2: _doi.permissionedDisputeGame2Blueprint(),
+            permissionlessDisputeGame1: address(0),
+            permissionlessDisputeGame2: address(0)
         });
         OPContractsManager.Implementations memory implementations = OPContractsManager.Implementations({
             l1ERC721BridgeImpl: address(_doi.l1ERC721BridgeImpl()),

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -57,6 +57,16 @@
             "internalType": "address",
             "name": "permissionedDisputeGame2",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame1",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame2",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Blueprints",
@@ -133,6 +143,104 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "saltMixer",
+            "type": "string"
+          },
+          {
+            "internalType": "contract ISystemConfig",
+            "name": "systemConfig",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IProxyAdmin",
+            "name": "proxyAdmin",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IDelayedWETH",
+            "name": "delayedWETH",
+            "type": "address"
+          },
+          {
+            "internalType": "GameType",
+            "name": "disputeGameType",
+            "type": "uint32"
+          },
+          {
+            "internalType": "Claim",
+            "name": "disputeAbsolutePrestate",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "disputeMaxGameDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "disputeSplitDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "Duration",
+            "name": "disputeClockExtension",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Duration",
+            "name": "disputeMaxClockDuration",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialBond",
+            "type": "uint256"
+          },
+          {
+            "internalType": "contract IBigStepper",
+            "name": "vm",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "permissioned",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct OPContractsManager.AddGameInput[]",
+        "name": "_gameConfigs",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "addGameType",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IDelayedWETH",
+            "name": "delayedWETH",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IFaultDisputeGame",
+            "name": "faultDisputeGame",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.AddGameOutput[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "blueprints",
     "outputs": [
@@ -176,6 +284,16 @@
           {
             "internalType": "address",
             "name": "permissionedDisputeGame2",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame1",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame2",
             "type": "address"
           }
         ],
@@ -597,6 +715,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "InvalidGameConfigs",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",
@@ -620,6 +743,11 @@
   {
     "inputs": [],
     "name": "NotABlueprint",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyDelegatecall",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -57,6 +57,16 @@
             "internalType": "address",
             "name": "permissionedDisputeGame2",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame1",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame2",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Blueprints",
@@ -133,6 +143,104 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "saltMixer",
+            "type": "string"
+          },
+          {
+            "internalType": "contract ISystemConfig",
+            "name": "systemConfig",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IProxyAdmin",
+            "name": "proxyAdmin",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IDelayedWETH",
+            "name": "delayedWETH",
+            "type": "address"
+          },
+          {
+            "internalType": "GameType",
+            "name": "disputeGameType",
+            "type": "uint32"
+          },
+          {
+            "internalType": "Claim",
+            "name": "disputeAbsolutePrestate",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "disputeMaxGameDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "disputeSplitDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "Duration",
+            "name": "disputeClockExtension",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Duration",
+            "name": "disputeMaxClockDuration",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialBond",
+            "type": "uint256"
+          },
+          {
+            "internalType": "contract IBigStepper",
+            "name": "vm",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "permissioned",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct OPContractsManager.AddGameInput[]",
+        "name": "_gameConfigs",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "addGameType",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IDelayedWETH",
+            "name": "delayedWETH",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IFaultDisputeGame",
+            "name": "faultDisputeGame",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct OPContractsManager.AddGameOutput[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "blueprints",
     "outputs": [
@@ -176,6 +284,16 @@
           {
             "internalType": "address",
             "name": "permissionedDisputeGame2",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame1",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionlessDisputeGame2",
             "type": "address"
           }
         ],
@@ -597,6 +715,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "InvalidGameConfigs",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",
@@ -620,6 +743,11 @@
   {
     "inputs": [],
     "name": "NotABlueprint",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyDelegatecall",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0xa91b445bdc666a02ba18e3b91ba94b6d54bbe65da714002fc734814201319d57"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x4b413cbe79bd10d41d8f3e9f0408e773dd49ced823d457b9f9aa92f446828105",
-    "sourceCodeHash": "0xe5179a20ae40d4e4773c52df98bac67e73e04044bec9e8750073b4e2f14fe81b"
+    "initCodeHash": "0xe0c14a8fee7ad4c4e28a3ff6ca4e726721a6c3fea0a74ab7eac7ef07fe4da0ae",
+    "sourceCodeHash": "0xe0f5413e0a0a335016d773f02ef6bd25551416635981e83b7a4da601b9b65bc4"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x7e533474310583593c2d57d30fcd1ec11e1568dbaaf37a2dd28c5cc574068bac",

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
@@ -7,7 +7,7 @@
     "type": "string"
   },
   {
-    "bytes": "256",
+    "bytes": "320",
     "label": "blueprint",
     "offset": 0,
     "slot": "1",
@@ -17,7 +17,7 @@
     "bytes": "288",
     "label": "implementation",
     "offset": 0,
-    "slot": "9",
+    "slot": "11",
     "type": "struct OPContractsManager.Implementations"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
@@ -7,7 +7,7 @@
     "type": "string"
   },
   {
-    "bytes": "256",
+    "bytes": "320",
     "label": "blueprint",
     "offset": 0,
     "slot": "1",
@@ -17,7 +17,7 @@
     "bytes": "288",
     "label": "implementation",
     "offset": 0,
-    "slot": "9",
+    "slot": "11",
     "type": "struct OPContractsManager.Implementations"
   }
 ]

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -9,6 +9,26 @@ import { DeployOPChain_TestBase } from "test/opcm/DeployOPChain.t.sol";
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+
+import { Blueprint } from "src/libraries/Blueprint.sol";
+import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
+import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
+import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
+import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
+import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
+import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { DelayedWETH } from "src/dispute/DelayedWETH.sol";
+import { MIPS } from "src/cannon/MIPS.sol";
+import { GameType, Duration, Hash, Claim } from "src/dispute/lib/LibUDT.sol";
+import { OutputRoot } from "src/dispute/lib/Types.sol";
+import { AnchorStateRegistry } from "src/dispute/AnchorStateRegistry.sol";
+import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 
 // Exposes internal functions for testing.
 contract OPContractsManager_Harness is OPContractsManager {
@@ -146,5 +166,237 @@ contract OPContractsManager_InternalMethods_Test is Test {
         expected = 0x00a9C584056064687E149968cBaB758a3376D22A;
         actual = opcmHarness.chainIdToBatchInboxAddress_exposed(chainId);
         vm.assertEq(expected, actual);
+    }
+}
+
+contract OPContractsManager_AddGameType_Test is Test {
+    OPContractsManager internal opcm;
+
+    OPContractsManager.DeployOutput internal chainDeployOutput;
+
+    function setUp() public {
+        ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfig"));
+        IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersions"));
+        bytes32 salt = hex"01";
+        OPContractsManager.Blueprints memory blueprints;
+        (blueprints.addressManager,) = Blueprint.create(vm.getCode("AddressManager"), salt);
+        (blueprints.proxy,) = Blueprint.create(vm.getCode("Proxy"), salt);
+        (blueprints.proxyAdmin,) = Blueprint.create(vm.getCode("ProxyAdmin"), salt);
+        (blueprints.l1ChugSplashProxy,) = Blueprint.create(vm.getCode("L1ChugSplashProxy"), salt);
+        (blueprints.resolvedDelegateProxy,) = Blueprint.create(vm.getCode("ResolvedDelegateProxy"), salt);
+        (blueprints.anchorStateRegistry,) = Blueprint.create(vm.getCode("AnchorStateRegistry"), salt);
+        (blueprints.permissionedDisputeGame1, blueprints.permissionedDisputeGame2) =
+            Blueprint.create(vm.getCode("PermissionedDisputeGame"), salt);
+        (blueprints.permissionlessDisputeGame1, blueprints.permissionlessDisputeGame2) =
+            Blueprint.create(vm.getCode("FaultDisputeGame"), salt);
+
+        IPreimageOracle oracle = IPreimageOracle(address(new PreimageOracle(126000, 86400)));
+
+        OPContractsManager.Implementations memory impls = OPContractsManager.Implementations({
+            l1ERC721BridgeImpl: address(new L1ERC721Bridge()),
+            optimismPortalImpl: address(new OptimismPortal2(1, 1)),
+            systemConfigImpl: address(new SystemConfig()),
+            optimismMintableERC20FactoryImpl: address(new OptimismMintableERC20Factory()),
+            l1CrossDomainMessengerImpl: address(new L1CrossDomainMessenger()),
+            l1StandardBridgeImpl: address(new L1StandardBridge()),
+            disputeGameFactoryImpl: address(new DisputeGameFactory()),
+            delayedWETHImpl: address(new DelayedWETH(3)),
+            mipsImpl: address(new MIPS(oracle))
+        });
+
+        vm.etch(address(superchainConfigProxy), hex"01");
+        vm.etch(address(protocolVersionsProxy), hex"01");
+
+        opcm = new OPContractsManager(superchainConfigProxy, protocolVersionsProxy, "dev", blueprints, impls);
+
+        AnchorStateRegistry.StartingAnchorRoot[] memory roots = new AnchorStateRegistry.StartingAnchorRoot[](1);
+        roots[0] = AnchorStateRegistry.StartingAnchorRoot({
+            outputRoot: OutputRoot({ root: Hash.wrap(hex"dead"), l2BlockNumber: 0 }),
+            gameType: GameType.wrap(1)
+        });
+
+        chainDeployOutput = opcm.deploy(
+            OPContractsManager.DeployInput({
+                roles: OPContractsManager.Roles({
+                    opChainProxyAdminOwner: address(this),
+                    systemConfigOwner: address(this),
+                    batcher: address(this),
+                    unsafeBlockSigner: address(this),
+                    proposer: address(this),
+                    challenger: address(this)
+                }),
+                basefeeScalar: 1,
+                blobBasefeeScalar: 1,
+                startingAnchorRoots: abi.encode(roots),
+                l2ChainId: 100,
+                saltMixer: "hello",
+                gasLimit: 30_000_000,
+                disputeGameType: GameType.wrap(1),
+                disputeAbsolutePrestate: Claim.wrap(
+                    bytes32(hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
+                ),
+                disputeMaxGameDepth: 73,
+                disputeSplitDepth: 30,
+                disputeClockExtension: Duration.wrap(10800),
+                disputeMaxClockDuration: Duration.wrap(302400)
+            })
+        );
+    }
+
+    function test_addGameType_permissioned_succeeds() public {
+        OPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        OPContractsManager.AddGameOutput memory output = addGameType(input);
+        assertValidGameType(input, output);
+        IPermissionedDisputeGame newPDG = IPermissionedDisputeGame(address(output.faultDisputeGame));
+        IPermissionedDisputeGame oldPDG = chainDeployOutput.permissionedDisputeGame;
+        assertEq(newPDG.proposer(), oldPDG.proposer(), "proposer mismatch");
+        assertEq(newPDG.challenger(), oldPDG.challenger(), "challenger mismatch");
+    }
+
+    function test_addGameType_permissionless_succeeds() public {
+        OPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        OPContractsManager.AddGameOutput memory output = addGameType(input);
+        assertValidGameType(input, output);
+        IPermissionedDisputeGame notPDG = IPermissionedDisputeGame(address(output.faultDisputeGame));
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        notPDG.proposer();
+    }
+
+    function test_addGameType_reusedDelayedWETH_succeeds() public {
+        IDelayedWETH delayedWETH = IDelayedWETH(payable(address(new DelayedWETH(1))));
+        vm.etch(address(delayedWETH), hex"01");
+        OPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        input.delayedWETH = delayedWETH;
+        OPContractsManager.AddGameOutput memory output = addGameType(input);
+        assertValidGameType(input, output);
+        assertEq(address(output.delayedWETH), address(delayedWETH), "delayedWETH address mismatch");
+    }
+
+    function test_addGameType_outOfOrderInputs_reverts() public {
+        OPContractsManager.AddGameInput memory input1 = newGameInputFactory(false);
+        input1.disputeGameType = GameType.wrap(2);
+        OPContractsManager.AddGameInput memory input2 = newGameInputFactory(false);
+        input2.disputeGameType = GameType.wrap(1);
+        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](2);
+        inputs[0] = input1;
+        inputs[1] = input2;
+
+        // For the sake of completeness, we run the call again to validate the success behavior.
+        (bool success,) = address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+        assertFalse(success, "addGameType should have failed");
+    }
+
+    function test_addGameType_duplicateGameType_reverts() public {
+        OPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](2);
+        inputs[0] = input;
+        inputs[1] = input;
+
+        // See test above for why we run the call twice.
+        (bool success, bytes memory revertData) =
+            address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+        assertFalse(success, "addGameType should have failed");
+        assertEq(bytes4(revertData), OPContractsManager.InvalidGameConfigs.selector, "revertData mismatch");
+    }
+
+    function test_addGameType_zeroLengthInput_reverts() public {
+        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](0);
+
+        (bool success, bytes memory revertData) =
+            address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+        assertFalse(success, "addGameType should have failed");
+        assertEq(bytes4(revertData), OPContractsManager.InvalidGameConfigs.selector, "revertData mismatch");
+    }
+
+    function test_addGameType_notDelegateCall_reverts() public {
+        OPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](1);
+        inputs[0] = input;
+
+        vm.expectRevert(OPContractsManager.OnlyDelegatecall.selector);
+        opcm.addGameType(inputs);
+    }
+
+    function addGameType(OPContractsManager.AddGameInput memory input)
+        internal
+        returns (OPContractsManager.AddGameOutput memory)
+    {
+        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](1);
+        inputs[0] = input;
+
+        (bool success, bytes memory rawGameOut) =
+            address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+        assertTrue(success, "addGameType failed");
+
+        OPContractsManager.AddGameOutput[] memory addGameOutAll =
+            abi.decode(rawGameOut, (OPContractsManager.AddGameOutput[]));
+        return addGameOutAll[0];
+    }
+
+    function newGameInputFactory(bool permissioned) internal view returns (OPContractsManager.AddGameInput memory) {
+        return OPContractsManager.AddGameInput({
+            saltMixer: "hello",
+            systemConfig: chainDeployOutput.systemConfigProxy,
+            proxyAdmin: chainDeployOutput.opChainProxyAdmin,
+            delayedWETH: IDelayedWETH(payable(address(0))),
+            disputeGameType: GameType.wrap(2000),
+            disputeAbsolutePrestate: Claim.wrap(bytes32(hex"deadbeef1234")),
+            disputeMaxGameDepth: 73,
+            disputeSplitDepth: 30,
+            disputeClockExtension: Duration.wrap(10800),
+            disputeMaxClockDuration: Duration.wrap(302400),
+            initialBond: 1 ether,
+            vm: IBigStepper(address(opcm.implementations().mipsImpl)),
+            permissioned: permissioned
+        });
+    }
+
+    function assertValidGameType(
+        OPContractsManager.AddGameInput memory agi,
+        OPContractsManager.AddGameOutput memory ago
+    )
+        internal
+        view
+    {
+        // Check the config for the game itself
+        assertEq(ago.faultDisputeGame.gameType().raw(), agi.disputeGameType.raw(), "gameType mismatch");
+        assertEq(
+            ago.faultDisputeGame.absolutePrestate().raw(),
+            agi.disputeAbsolutePrestate.raw(),
+            "absolutePrestate mismatch"
+        );
+        assertEq(ago.faultDisputeGame.maxGameDepth(), agi.disputeMaxGameDepth, "maxGameDepth mismatch");
+        assertEq(ago.faultDisputeGame.splitDepth(), agi.disputeSplitDepth, "splitDepth mismatch");
+        assertEq(
+            ago.faultDisputeGame.clockExtension().raw(), agi.disputeClockExtension.raw(), "clockExtension mismatch"
+        );
+        assertEq(
+            ago.faultDisputeGame.maxClockDuration().raw(),
+            agi.disputeMaxClockDuration.raw(),
+            "maxClockDuration mismatch"
+        );
+        assertEq(address(ago.faultDisputeGame.vm()), address(agi.vm), "vm address mismatch");
+        assertEq(address(ago.faultDisputeGame.weth()), address(ago.delayedWETH), "delayedWETH address mismatch");
+        assertEq(
+            address(ago.faultDisputeGame.anchorStateRegistry()),
+            address(chainDeployOutput.anchorStateRegistryProxy),
+            "ASR address mismatch"
+        );
+
+        // Check the DGF
+        assertEq(
+            chainDeployOutput.disputeGameFactoryProxy.gameImpls(agi.disputeGameType).gameType().raw(),
+            agi.disputeGameType.raw(),
+            "gameType mismatch"
+        );
+        assertEq(
+            address(chainDeployOutput.disputeGameFactoryProxy.gameImpls(agi.disputeGameType)),
+            address(ago.faultDisputeGame),
+            "gameImpl address mismatch"
+        );
+        assertEq(address(ago.faultDisputeGame.weth()), address(ago.delayedWETH), "weth address mismatch");
+        assertEq(
+            chainDeployOutput.disputeGameFactoryProxy.initBonds(agi.disputeGameType), agi.initialBond, "bond mismatch"
+        );
     }
 }

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -8,6 +8,8 @@ import { FaultDisputeGame_Init, _changeClaimStatus } from "test/dispute/FaultDis
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";
 
+import { Hash } from "src/dispute/lib/Types.sol";
+
 contract AnchorStateRegistry_Init is FaultDisputeGame_Init {
     function setUp() public virtual override {
         // Duplicating the initialization/setup logic of FaultDisputeGame_Test.

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -781,6 +781,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.blueprints.selector });
         _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.chainIdToBatchInboxAddress.selector });
         _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.implementations.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.addGameType.selector });
 
         // OPContractsManagerInterop
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("version()") });
@@ -792,6 +793,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.blueprints.selector });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.chainIdToBatchInboxAddress.selector });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.implementations.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.addGameType.selector });
 
         // DeputyGuardianModule
         _addSpec({


### PR DESCRIPTION
Adds `addGameType` to the OPCM. I deviated from the [spec](https://github.com/ethereum-optimism/specs/blob/4e8f5343a266e9eb714594f36b4909110ee1285e/specs/experimental/op-contracts-manager.md?plain=1#290) a bit here. Rather than inferring most of the dispute parameters from the permissioned game, I instead expose all the parameters on the game config struct. This lets us deploy dispute games that use different parameters if necessary. If there's strong pushback against this I can revert back to what's in the spec.

Closes https://github.com/ethereum-optimism/optimism/issues/13070.