### PR TITLE
node: Add `BatchQueueSize` metric

### DIFF
--- a/op-node/rollup/derive/batch_mux_test.go
+++ b/op-node/rollup/derive/batch_mux_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -22,7 +23,7 @@ func TestBatchMux_LaterHolocene(t *testing.T) {
 	cfg := &rollup.Config{
 		HoloceneTime: &l1B.Time,
 	}
-	b := NewBatchMux(log, cfg, nil, nil)
+	b := NewBatchMux(log, cfg, nil, nil, metrics.NoopMetrics)
 
 	require.Nil(t, b.SingularBatchProvider)
 
@@ -55,7 +56,7 @@ func TestBatchMux_ActiveHolocene(t *testing.T) {
 	}
 	// without the fake input, the panic check later would panic because of the Origin() call
 	prev := &fakeBatchQueueInput{origin: l1A}
-	b := NewBatchMux(log, cfg, prev, nil)
+	b := NewBatchMux(log, cfg, prev, nil, metrics.NoopMetrics)
 
 	require.Nil(t, b.SingularBatchProvider)
 

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -96,8 +96,8 @@ type BatchQueue struct {
 var _ SingularBatchProvider = (*BatchQueue)(nil)
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.
-func NewBatchQueue(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) *BatchQueue {
-	return &BatchQueue{baseBatchStage: newBaseBatchStage(log, cfg, prev, l2)}
+func NewBatchQueue(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher, metrics Metrics) *BatchQueue {
+	return &BatchQueue{baseBatchStage: newBaseBatchStage(log, cfg, prev, l2), metrics: metrics}
 }
 
 func (bs *baseBatchStage) Origin() eth.L1BlockRef {

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -170,7 +171,7 @@ type testableBatchStage interface {
 
 func TestBatchStages(t *testing.T) {
 	newBatchQueue := func(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) testableBatchStage {
-		return NewBatchQueue(log, cfg, prev, l2)
+		return NewBatchQueue(log, cfg, prev, l2, metrics.NoopMetrics)
 	}
 	newBatchStage := func(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) testableBatchStage {
 		return NewBatchStage(log, cfg, prev, l2)
@@ -579,7 +580,7 @@ func testBatchQueue_Missing(t *testing.T, batchType int) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input, nil)
+	bq := NewBatchQueue(log, cfg, input, nil, metrics.NoopMetrics)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	for i := 0; i < len(expectedOutputBatches); i++ {
@@ -797,7 +798,7 @@ func testBatchQueue_Shuffle(t *testing.T, batchType int) {
 		origin:  l1[inputOriginNumber],
 	}
 
-	bq := NewBatchQueue(log, cfg, input, nil)
+	bq := NewBatchQueue(log, cfg, input, nil, metrics.NoopMetrics)
 	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
 
 	for i := 0; i < len(expectedOutputBatches); i++ {
@@ -912,7 +913,7 @@ func TestBatchQueueOverlappingSpanBatch(t *testing.T) {
 		}
 	}
 
-	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	bq := NewBatchQueue(log, cfg, input, &l2Client, metrics.NoopMetrics)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	// Advance the origin
 	input.origin = l1[1]
@@ -1018,7 +1019,7 @@ func TestBatchQueueComplex(t *testing.T) {
 		}
 	}
 
-	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	bq := NewBatchQueue(log, cfg, input, &l2Client, metrics.NoopMetrics)
 	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
 
 	for i := 0; i < len(expectedOutputBatches); i++ {
@@ -1088,7 +1089,7 @@ func TestBatchQueueResetSpan(t *testing.T) {
 		origin:  l1[2],
 	}
 	l2Client := testutils.MockL2Client{}
-	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	bq := NewBatchQueue(log, cfg, input, &l2Client, metrics.NoopMetrics)
 	bq.l1Blocks = l1 // Set enough l1 blocks to derive span batch
 
 	// This NextBatch() will derive the span batch, return the first singular batch and save rest of batches in span.

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -25,6 +25,7 @@ type Metrics interface {
 	RecordDerivedBatches(batchType string)
 	SetDerivationIdle(idle bool)
 	RecordPipelineReset()
+	SetBatchQueueSize(int)
 }
 
 type L1Fetcher interface {

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -113,7 +113,7 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 	frameQueue := NewFrameQueue(log, rollupCfg, l1Src)
 	channelMux := NewChannelMux(log, spec, frameQueue, metrics)
 	chInReader := NewChannelInReader(rollupCfg, log, channelMux, metrics)
-	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source)
+	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source, metrics)
 	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1Fetcher, l2Source)
 	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux)
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -56,6 +56,7 @@ type Metrics interface {
 	L1FetcherMetrics
 	event.Metrics
 	sequencing.Metrics
+	derive.Metrics
 }
 
 type L1Chain interface {

--- a/op-service/testutils/metrics.go
+++ b/op-service/testutils/metrics.go
@@ -87,3 +87,6 @@ func (t *TestDerivationMetrics) SetDerivationIdle(idle bool) {}
 
 func (t *TestDerivationMetrics) RecordPipelineReset() {
 }
+
+func (t *TestDerivationMetrics) SetBatchQueueSize(int) {
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a new metric `batch_queue_size` to op-node.
This is useful especially when using AltDA to monitor the nodes progress.

