### PR TITLE
fix(kurtosis-devnet): provide fake implem of localPrestate

### DIFF
--- a/kurtosis-devnet/pkg/tmpl/fake/fake.go
+++ b/kurtosis-devnet/pkg/tmpl/fake/fake.go
@@ -14,5 +14,8 @@ func NewFakeTemplateContext(enclave string) *tmpl.TemplateContext {
 		tmpl.WithFunction("localContractArtifacts", func(layer string) (string, error) {
 			return fmt.Sprintf("http://host.docker.internal:0/contracts-bundle-%s.tar.gz", enclave), nil
 		}),
+		tmpl.WithFunction("localPrestate", func() (string, error) {
+			return "http://host.docker.internal:0/proofs/op-program/cannon", nil
+		}),
 	)
 }


### PR DESCRIPTION
**Description**

This fixes the dummy expansion script to quick check kurtosis params.