### PR TITLE
supervisor: Correct log message L1->L2

### DIFF
--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -125,7 +125,7 @@ func (db *ChainsDB) NotifyL2Finalized() {
 	for _, chain := range db.depSet.Chains() {
 		f, err := db.Finalized(chain)
 		if err != nil {
-			db.logger.Error("Failed to get finalized L1 block", "chain", chain, "err", err)
+			db.logger.Error("Failed to get finalized L2 block", "chain", chain, "err", err)
 			continue
 		}
 		sub, ok := db.l2FinalityFeeds.Get(chain)


### PR DESCRIPTION
The log incorrectly says it failed to get the L1 block, when it means the L2 block.