### PR TITLE
fix(kurtosis-devnet): output padded private keys

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
@@ -7,6 +7,8 @@ import (
 	"io"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"gopkg.in/yaml.v3"
 )
 
@@ -60,10 +62,11 @@ func (d *Deployer) getKnownWallets(ctx context.Context, fs *EnclaveFS) ([]*Walle
 	for _, key := range keys {
 		addr, _ := m.Address(key)
 		sec, _ := m.Secret(key)
+
 		knownWallets = append(knownWallets, &Wallet{
 			Name:       key.String(),
 			Address:    addr.Hex(),
-			PrivateKey: fmt.Sprintf("%x", sec.D),
+			PrivateKey: hexutil.Bytes(crypto.FromECDSA(sec)).String(),
 		})
 	}
 


### PR DESCRIPTION
**Description**

We need private keys to be 64 bytes strings, including leading 0s if
need be, so that they can be read back.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
