### PR TITLE
Protocol versions

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IProtocolVersions.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IProtocolVersions.sol
@@ -19,10 +19,10 @@ interface IProtocolVersions {
     function initialize(address _owner, ProtocolVersion _required, ProtocolVersion _recommended) external;
     function owner() external view returns (address);
     function recommended() external view returns (ProtocolVersion out_);
-    function recommendedVersion() external view returns (string memory);
+    function recommendedVersion() external view returns (string memory out_);
     function renounceOwnership() external;
     function required() external view returns (ProtocolVersion out_);
-    function requiredVersion() external view returns (string memory);
+    function requiredVersion() external view returns (string memory out_);
     function setRecommended(ProtocolVersion _recommended) external;
     function setRequired(ProtocolVersion _required) external;
     function transferOwnership(address newOwner) external; // nosemgrep

--- a/packages/contracts-bedrock/interfaces/L1/IProtocolVersions.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IProtocolVersions.sol
@@ -19,8 +19,10 @@ interface IProtocolVersions {
     function initialize(address _owner, ProtocolVersion _required, ProtocolVersion _recommended) external;
     function owner() external view returns (address);
     function recommended() external view returns (ProtocolVersion out_);
+    function recommendedVersion() external view returns (string memory);
     function renounceOwnership() external;
     function required() external view returns (ProtocolVersion out_);
+    function requiredVersion() external view returns (string memory);
     function setRecommended(ProtocolVersion _recommended) external;
     function setRequired(ProtocolVersion _required) external;
     function transferOwnership(address newOwner) external; // nosemgrep

--- a/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
@@ -572,21 +572,19 @@ func DiffTestUtils() {
 			panic("decodeProtocolVersion requires 1 argument: version")
 		}
 		versionBytes := common.FromHex(args[1])
-		fmt.Fprintf(os.Stderr, "Input bytes: %x\n", versionBytes)
+		fmt.Fprintf(os.Stderr, "Input version bytes: %x\n", versionBytes)
 		decoded := params.ProtocolVersionV0{}
 		var version big.Int
 		version.SetBytes(versionBytes)
 
-		// Decode components
-		var tmp big.Int
-		tmp.Set(&version)
 		// Get build (first 8 bytes)
 		var buildInt big.Int
 		buildInt.Rsh(&version, 192)
 		buildBytes := buildInt.Bytes()
 		decoded.Build = [8]byte{}
-		copy(decoded.Build[8-len(buildBytes):], buildBytes) // Right-align the bytes
+		copy(decoded.Build[8-len(buildBytes):], buildBytes)
 
+		var tmp big.Int
 		// Get remaining components
 		tmp.Set(&version)
 		decoded.Major = uint32(new(big.Int).Rsh(&tmp, 96).Uint64())
@@ -597,7 +595,7 @@ func DiffTestUtils() {
 		tmp.Set(&version)
 		decoded.PreRelease = uint32(tmp.Uint64())
 
-		// Format string
+		fmt.Fprintf(os.Stderr, "Decoded build: %x\n", decoded.Build[:])
 		result := fmt.Sprintf("%s.%d.%d.%d-%d",
 			hex.EncodeToString(decoded.Build[:]),
 			decoded.Major,

--- a/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/differential-testing.go
@@ -557,7 +557,7 @@ func DiffTestUtils() {
 		// Create a 32-byte array with the build ID at the start
 		var encoded [32]byte
 		// First 8 bytes are zeros
-		copy(encoded[8:16], build[:])  // build after zeros
+		copy(encoded[8:16], build[:]) // build after zeros
 		binary.BigEndian.PutUint32(encoded[16:20], major)
 		binary.BigEndian.PutUint32(encoded[20:24], minor)
 		binary.BigEndian.PutUint32(encoded[24:28], patch)

--- a/packages/contracts-bedrock/snapshots/abi/ProtocolVersions.json
+++ b/packages/contracts-bedrock/snapshots/abi/ProtocolVersions.json
@@ -94,6 +94,19 @@
   },
   {
     "inputs": [],
+    "name": "recommendedVersion",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "out_",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "renounceOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -107,6 +120,19 @@
         "internalType": "ProtocolVersion",
         "name": "out_",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "requiredVersion",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "out_",
+        "type": "string"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -6,7 +6,7 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 
 // Libraries
 import { Storage } from "src/libraries/Storage.sol";
-
+import { Encoding } from "src/libraries/Encoding.sol";
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -66,6 +66,12 @@ contract ProtocolVersions is OwnableUpgradeable, ISemver {
         out_ = ProtocolVersion.wrap(Storage.getUint(REQUIRED_SLOT));
     }
 
+    /// @notice High level getter for the required protocol version.
+    /// @return out_ Required protocol version to sync to the head of the chain as a string.
+    function requiredVersion() external view returns (string memory out_) {
+        out_ = Encoding.decodeProtocolVersion(bytes32(Storage.getUint(REQUIRED_SLOT)));
+    }
+
     /// @notice Updates the required protocol version. Can only be called by the owner.
     /// @param _required New required protocol version.
     function setRequired(ProtocolVersion _required) external onlyOwner {
@@ -85,6 +91,12 @@ contract ProtocolVersions is OwnableUpgradeable, ISemver {
     /// @return out_ Recommended protocol version to sync to the head of the chain.
     function recommended() external view returns (ProtocolVersion out_) {
         out_ = ProtocolVersion.wrap(Storage.getUint(RECOMMENDED_SLOT));
+    }
+
+    /// @notice High level getter for the recommended protocol version.
+    /// @return out_ Recommended protocol version to sync to the head of the chain as a string.
+    function recommendedVersion() external view returns (string memory out_) {
+        out_ = Encoding.decodeProtocolVersion(bytes32(Storage.getUint(RECOMMENDED_SLOT)));
     }
 
     /// @notice Updates the recommended protocol version. Can only be called by the owner.

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -269,11 +269,11 @@ library Encoding {
         return result;
     }
 
-    function bytes2hex(bytes8 data) internal pure returns (bytes memory) {
+    function bytes2hex(bytes8 _data) internal pure returns (bytes memory) {
         bytes memory alphabet = "0123456789abcdef";
         bytes memory str = new bytes(16);
         for (uint256 i = 0; i < 8; i++) {
-            uint8 b = uint8(data[i]);
+            uint8 b = uint8(_data[i]);
             str[i * 2] = alphabet[b >> 4];
             str[i * 2 + 1] = alphabet[b & 0x0f];
         }

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -236,7 +236,8 @@ library Encoding {
         returns (bytes32)
     {
         return bytes32(
-            (uint256(uint64(_build)) << 128) | (uint256(_major) << 96) | (uint256(_minor) << 64) | (uint256(_patch) << 32) | uint256(_preRelease)
+            (uint256(uint64(_build)) << 128) | (uint256(_major) << 96) | (uint256(_minor) << 64)
+                | (uint256(_patch) << 32) | uint256(_preRelease)
         );
     }
 
@@ -252,13 +253,8 @@ library Encoding {
         uint32 preRelease = uint32(version);
 
         // Base version string
-        string memory result = string(
-            abi.encodePacked(
-                "v", uint2str(major),
-                ".", uint2str(minor),
-                ".", uint2str(patch)
-            )
-        );
+        string memory result =
+            string(abi.encodePacked("v", uint2str(major), ".", uint2str(minor), ".", uint2str(patch)));
 
         // Add prerelease if non-zero
         if (preRelease != 0) {

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -216,4 +216,48 @@ library Encoding {
             _batcherHash
         );
     }
+
+    /// @notice Encodes a protocol version into bytes32
+    /// @param _build The build identifier (8 bytes)
+    /// @param _major The major version
+    /// @param _minor The minor version
+    /// @param _patch The patch version
+    /// @param _preRelease The pre-release version
+    /// @return The encoded protocol version
+    function encodeProtocolVersion(
+        bytes8 _build,
+        uint32 _major,
+        uint32 _minor,
+        uint32 _patch,
+        uint32 _preRelease
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        return bytes32(
+            (uint256(uint64(_build)) << 192) | (uint256(_major) << 96) | (uint256(_minor) << 64)
+                | (uint256(_patch) << 32) | uint256(_preRelease)
+        );
+    }
+
+    /// @notice Decodes a protocol version from bytes32
+    /// @param _versionBytes The protocol version to decode
+    /// @return build The build identifier (8 bytes)
+    /// @return major The major version
+    /// @return minor The minor version
+    /// @return patch The patch version
+    /// @return preRelease The pre-release version
+    function decodeProtocolVersion(bytes32 _versionBytes)
+        internal
+        pure
+        returns (bytes8 build, uint32 major, uint32 minor, uint32 patch, uint32 preRelease)
+    {
+        uint256 version = uint256(_versionBytes);
+        build = bytes8(uint64(version >> 192));
+        major = uint32(version >> 96);
+        minor = uint32(version >> 64);
+        patch = uint32(version >> 32);
+        preRelease = uint32(version);
+    }
 }

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -243,21 +243,57 @@ library Encoding {
 
     /// @notice Decodes a protocol version from bytes32
     /// @param _versionBytes The protocol version to decode
-    /// @return build The build identifier (8 bytes)
-    /// @return major The major version
-    /// @return minor The minor version
-    /// @return patch The patch version
-    /// @return preRelease The pre-release version
+    /// @return The decoded protocol version as a string
     function decodeProtocolVersion(bytes32 _versionBytes)
         internal
         pure
-        returns (bytes8 build, uint32 major, uint32 minor, uint32 patch, uint32 preRelease)
+        returns (string memory)
     {
         uint256 version = uint256(_versionBytes);
-        build = bytes8(uint64(version >> 192));
-        major = uint32(version >> 96);
-        minor = uint32(version >> 64);
-        patch = uint32(version >> 32);
-        preRelease = uint32(version);
+        bytes8 build = bytes8(uint64(version >> 192));
+        uint32 major = uint32(version >> 96);
+        uint32 minor = uint32(version >> 64);
+        uint32 patch = uint32(version >> 32);
+        uint32 preRelease = uint32(version);
+        
+        // Format string like Go implementation
+        return string(abi.encodePacked(
+            bytes2hex(build),
+            ".",
+            uint2str(major),
+            ".",
+            uint2str(minor),
+            ".",
+            uint2str(patch),
+            "-",
+            uint2str(preRelease)
+        ));
+    }
+
+    function bytes2hex(bytes8 data) internal pure returns (bytes memory) {
+        bytes memory alphabet = "0123456789abcdef";
+        bytes memory str = new bytes(16);
+        for (uint256 i = 0; i < 8; i++) {
+            str[i*2] = alphabet[uint8(data[i] >> 4)];
+            str[i*2+1] = alphabet[uint8(data[i] & 0x0f)];
+        }
+        return str;
+    }
+
+    function uint2str(uint32 _i) internal pure returns (string memory) {
+        if (_i == 0) return "0";
+        uint j = _i;
+        uint len;
+        while (j != 0) {
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        while (_i != 0) {
+            len -= 1;
+            bstr[len] = bytes1(uint8(48 + _i % 10));
+            _i /= 10;
+        }
+        return string(bstr);
     }
 }

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -244,46 +244,44 @@ library Encoding {
     /// @notice Decodes a protocol version from bytes32
     /// @param _versionBytes The protocol version to decode
     /// @return The decoded protocol version as a string
-    function decodeProtocolVersion(bytes32 _versionBytes)
-        internal
-        pure
-        returns (string memory)
-    {
+    function decodeProtocolVersion(bytes32 _versionBytes) internal pure returns (string memory) {
         uint256 version = uint256(_versionBytes);
         bytes8 build = bytes8(uint64(version >> 192));
         uint32 major = uint32(version >> 96);
         uint32 minor = uint32(version >> 64);
         uint32 patch = uint32(version >> 32);
         uint32 preRelease = uint32(version);
-        
+
         // Format string like Go implementation
-        return string(abi.encodePacked(
-            bytes2hex(build),
-            ".",
-            uint2str(major),
-            ".",
-            uint2str(minor),
-            ".",
-            uint2str(patch),
-            "-",
-            uint2str(preRelease)
-        ));
+        return string(
+            abi.encodePacked(
+                bytes2hex(build),
+                ".",
+                uint2str(major),
+                ".",
+                uint2str(minor),
+                ".",
+                uint2str(patch),
+                "-",
+                uint2str(preRelease)
+            )
+        );
     }
 
     function bytes2hex(bytes8 data) internal pure returns (bytes memory) {
         bytes memory alphabet = "0123456789abcdef";
         bytes memory str = new bytes(16);
         for (uint256 i = 0; i < 8; i++) {
-            str[i*2] = alphabet[uint8(data[i] >> 4)];
-            str[i*2+1] = alphabet[uint8(data[i] & 0x0f)];
+            str[i * 2] = alphabet[uint8(data[i] >> 4)];
+            str[i * 2 + 1] = alphabet[uint8(data[i] & 0x0f)];
         }
         return str;
     }
 
     function uint2str(uint32 _i) internal pure returns (string memory) {
         if (_i == 0) return "0";
-        uint j = _i;
-        uint len;
+        uint256 j = _i;
+        uint256 len;
         while (j != 0) {
             len++;
             j /= 10;

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -272,8 +272,9 @@ library Encoding {
         bytes memory alphabet = "0123456789abcdef";
         bytes memory str = new bytes(16);
         for (uint256 i = 0; i < 8; i++) {
-            str[i * 2] = alphabet[uint8(data[i] >> 4)];
-            str[i * 2 + 1] = alphabet[uint8(data[i] & 0x0f)];
+            uint8 b = uint8(data[i]);
+            str[i * 2] = alphabet[b >> 4];
+            str[i * 2 + 1] = alphabet[b & 0x0f];
         }
         return str;
     }

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -9,6 +9,9 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 
+// Libraries
+import { Encoding } from "src/libraries/Encoding.sol";
+
 contract ProtocolVersions_Init is CommonTest {
     event ConfigUpdate(uint256 indexed version, IProtocolVersions.UpdateType indexed updateType, bytes data);
 
@@ -101,5 +104,123 @@ contract ProtocolVersions_Setters_Test is ProtocolVersions_Init {
         vm.prank(protocolVersions.owner());
         protocolVersions.setRecommended(ProtocolVersion.wrap(_version));
         assertEq(ProtocolVersion.unwrap(protocolVersions.recommended()), _version);
+    }
+
+    /// @dev Tests that `requiredVersion` returns the correct string representation
+    function test_requiredVersion_succeeds() external {
+        // Set a known protocol version
+        ProtocolVersion version = ProtocolVersion.wrap(
+            uint256(bytes32(hex"00000000000000000123456789abcdef00000001000000020000000300000004"))
+        );
+
+        vm.prank(protocolVersions.owner());
+        protocolVersions.setRequired(version);
+
+        // Check the string representation
+        assertEq(protocolVersions.requiredVersion(), "v1.2.3-4+0x0123456789abcdef");
+    }
+
+    /// @dev Tests that `recommendedVersion` returns the correct string representation
+    function test_recommendedVersion_succeeds() external {
+        // Set a known protocol version
+        ProtocolVersion version = ProtocolVersion.wrap(
+            uint256(bytes32(hex"00000000000000000123456789abcdef00000001000000020000000300000004"))
+        );
+
+        vm.prank(protocolVersions.owner());
+        protocolVersions.setRecommended(version);
+
+        // Check the string representation
+        assertEq(protocolVersions.recommendedVersion(), "v1.2.3-4+0x0123456789abcdef");
+    }
+
+    /// @dev Tests that version strings are correct for versions without build/prerelease
+    function test_versionStrings_minimal_succeeds() external {
+        // Version with no build ID or prerelease
+        ProtocolVersion version = ProtocolVersion.wrap(
+            uint256(bytes32(hex"0000000000000000000000000000000000000001000000020000000300000000"))
+        );
+
+        vm.startPrank(protocolVersions.owner());
+        protocolVersions.setRequired(version);
+        protocolVersions.setRecommended(version);
+        vm.stopPrank();
+
+        assertEq(protocolVersions.requiredVersion(), "v1.2.3");
+        assertEq(protocolVersions.recommendedVersion(), "v1.2.3");
+    }
+
+    /// @dev Fuzz test that required version string encoding/decoding is consistent
+    function testFuzz_requiredVersion_succeeds(
+        bytes8 _build,
+        uint32 _major,
+        uint32 _minor,
+        uint32 _patch,
+        uint32 _preRelease
+    )
+        external
+    {
+        ProtocolVersion version =
+            ProtocolVersion.wrap(uint256(Encoding.encodeProtocolVersion(_build, _major, _minor, _patch, _preRelease)));
+
+        vm.prank(protocolVersions.owner());
+        protocolVersions.setRequired(version);
+
+        // Get version string from contract
+        string memory versionString = protocolVersions.requiredVersion();
+
+        // Build expected string
+        string memory expected = string(
+            abi.encodePacked(
+                "v", Encoding.uint2str(_major), ".", Encoding.uint2str(_minor), ".", Encoding.uint2str(_patch)
+            )
+        );
+
+        if (_preRelease != 0) {
+            expected = string(abi.encodePacked(expected, "-", Encoding.uint2str(_preRelease)));
+        }
+
+        if (uint64(_build) != 0) {
+            expected = string(abi.encodePacked(expected, "+0x", Encoding.bytes2hex(_build)));
+        }
+
+        assertEq(versionString, expected);
+    }
+
+    /// @dev Fuzz test that recommended version string encoding/decoding is consistent
+    function testFuzz_recommendedVersion_succeeds(
+        bytes8 _build,
+        uint32 _major,
+        uint32 _minor,
+        uint32 _patch,
+        uint32 _preRelease
+    )
+        external
+    {
+        ProtocolVersion version =
+            ProtocolVersion.wrap(uint256(Encoding.encodeProtocolVersion(_build, _major, _minor, _patch, _preRelease)));
+
+        vm.prank(protocolVersions.owner());
+        protocolVersions.setRecommended(version);
+
+        // Get version string from contract
+        string memory versionString = protocolVersions.recommendedVersion();
+
+        // Build expected string
+        string memory expected = string(
+            abi.encodePacked(
+                "v", Encoding.uint2str(_major), ".", Encoding.uint2str(_minor), ".", Encoding.uint2str(_patch)
+            )
+        );
+
+        if (_preRelease != 0) {
+            expected = string(abi.encodePacked(expected, "-", Encoding.uint2str(_preRelease)));
+        }
+
+        if (uint64(_build) != 0) {
+            expected = string(abi.encodePacked(expected, "+0x", Encoding.bytes2hex(_build)));
+        }
+
+        assertEq(versionString, expected);
     }
 }

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -107,7 +107,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test that decoding and re-encoding preserves all components
-    function testFuzz_encodeDecodeProtocolVersion(
+    function testFuzz_encodeDecode_protocolVersion_succeeds(
         bytes8 _build,
         uint32 _major,
         uint32 _minor,
@@ -137,7 +137,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test specific known values for verification
-    function test_protocolVersion_specific() public pure {
+    function test_protocolVersion_specific_succeeds() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0123456789abcdef"), 1, 2, 3, 4);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v1.2.3-4+0x0123456789abcdef";
@@ -145,14 +145,14 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test encoding with no prerelease version
-    function test_protocolVersion_noPrerelease() public pure {
+    function test_protocolVersion_noPrerelease_succeeds() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0123456789abcdef"), 1, 2, 3, 0);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v1.2.3+0x0123456789abcdef";
         assertEq(decoded, expected);
     }
 
-    function test_protocolVersion_allZeros() public pure {
+    function test_protocolVersion_allZeros_succeeds() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(0), 0, 0, 0, 0);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v0.0.0"; // No prerelease or build
@@ -160,7 +160,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test specific known values for verification with Go implementation
-    function testDiff_encodeProtocolVersion_matchesGo() public {
+    function testDiff_encodeProtocolVersion_matchesGo_succeeds() public {
         bytes32 encoded = Encoding.encodeProtocolVersion(
             bytes8(hex"0123456789abcdef"), // build
             1, // major
@@ -183,7 +183,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test that Go and Solidity implementations match for decoding
-    function testDiff_decodeProtocolVersion_matchesGo() public {
+    function testDiff_decodeProtocolVersion_matchesGo_succeeds() public {
         bytes32 version = bytes32(hex"00000000000000000123456789abcdef00000001000000020000000300000004");
 
         string memory solString = Encoding.decodeProtocolVersion(version);
@@ -193,7 +193,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test maximum values for all fields
-    function test_protocolVersion_maxValues() public pure {
+    function test_protocolVersion_maxValues_succeeds() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(
             bytes8(hex"ffffffffffffffff"),
             type(uint32).max, // 4294967295
@@ -207,7 +207,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test minimal non-zero build ID
-    function test_protocolVersion_minimalBuild() public pure {
+    function test_protocolVersion_minimalBuild_succeeds() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0000000000000001"), 1, 0, 0, 0);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v1.0.0+0x0000000000000001";
@@ -215,7 +215,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test prerelease without build
-    function test_protocolVersion_onlyPrerelease() public pure {
+    function test_protocolVersion_onlyPrerelease_succeeds() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(0), 1, 0, 0, 1);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v1.0.0-1";

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -122,7 +122,8 @@ contract Encoding_Test is CommonTest {
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = string(
             abi.encodePacked(
-                _build, ".", uint2str(_major), ".", uint2str(_minor), ".", uint2str(_patch), "-", uint2str(_preRelease)
+                Encoding.bytes2hex(_build),
+                ".", uint2str(_major), ".", uint2str(_minor), ".", uint2str(_patch), "-", uint2str(_preRelease)
             )
         );
         assertEq(decoded, expected);
@@ -133,7 +134,7 @@ contract Encoding_Test is CommonTest {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0123456789abcdef"), 1, 2, 3, 4);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected =
-            string(abi.encodePacked(bytes8(hex"0123456789abcdef"), ".", "1", ".", "2", ".", "3", "-", "4"));
+            string(abi.encodePacked(Encoding.bytes2hex(bytes8(hex"0123456789abcdef")), ".", "1", ".", "2", ".", "3", "-", "4"));
         assertEq(decoded, expected);
     }
 
@@ -142,7 +143,7 @@ contract Encoding_Test is CommonTest {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0123456789abcdef"), 1, 2, 3, 0);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected =
-            string(abi.encodePacked(bytes8(hex"0123456789abcdef"), ".", "1", ".", "2", ".", "3", "-", "0"));
+            string(abi.encodePacked(Encoding.bytes2hex(bytes8(hex"0123456789abcdef")), ".", "1", ".", "2", ".", "3", "-", "0"));
         assertEq(decoded, expected);
     }
 

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -158,7 +158,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test specific known values for verification with Go implementation
-    function testDiff_protocolVersion_specific() public {
+    function testDiff_encodeProtocolVersion_matchesGo() public {
         bytes32 encoded = Encoding.encodeProtocolVersion(
             bytes8(hex"0123456789abcdef"),  // build
             1,                               // major
@@ -179,7 +179,7 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test protocol version decoding matches Go implementation
-    function testDiff_decodeProtocolVersion() public {
+    function testDiff_decodeProtocolVersion_matchesGo() public {
         bytes32 version = bytes32(hex"0123456789abcdef0000000100000002000000030000000400000000");
 
         (

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -113,13 +113,18 @@ contract Encoding_Test is CommonTest {
         uint32 _minor,
         uint32 _patch,
         uint32 _preRelease
-    ) public pure {
+    )
+        public
+        pure
+    {
         bytes32 encoded = Encoding.encodeProtocolVersion(_build, _major, _minor, _patch, _preRelease);
 
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
-        string memory expected = string(abi.encodePacked(
-            _build, ".", uint2str(_major), ".", uint2str(_minor), ".", uint2str(_patch), "-", uint2str(_preRelease)
-        ));
+        string memory expected = string(
+            abi.encodePacked(
+                _build, ".", uint2str(_major), ".", uint2str(_minor), ".", uint2str(_patch), "-", uint2str(_preRelease)
+            )
+        );
         assertEq(decoded, expected);
     }
 
@@ -127,9 +132,8 @@ contract Encoding_Test is CommonTest {
     function test_protocolVersion_specific() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0123456789abcdef"), 1, 2, 3, 4);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
-        string memory expected = string(abi.encodePacked(
-            bytes8(hex"0123456789abcdef"), ".", "1", ".", "2", ".", "3", "-", "4"
-        ));
+        string memory expected =
+            string(abi.encodePacked(bytes8(hex"0123456789abcdef"), ".", "1", ".", "2", ".", "3", "-", "4"));
         assertEq(decoded, expected);
     }
 
@@ -137,28 +141,27 @@ contract Encoding_Test is CommonTest {
     function test_protocolVersion_noPrerelease() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0123456789abcdef"), 1, 2, 3, 0);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
-        string memory expected = string(abi.encodePacked(
-            bytes8(hex"0123456789abcdef"), ".", "1", ".", "2", ".", "3", "-", "0"
-        ));
+        string memory expected =
+            string(abi.encodePacked(bytes8(hex"0123456789abcdef"), ".", "1", ".", "2", ".", "3", "-", "0"));
         assertEq(decoded, expected);
     }
 
     /// @notice Test specific known values for verification with Go implementation
     function testDiff_encodeProtocolVersion_matchesGo() public {
         bytes32 encoded = Encoding.encodeProtocolVersion(
-            bytes8(hex"0123456789abcdef"),  // build
-            1,                               // major
-            2,                               // minor
-            3,                               // patch
-            4                                // prerelease
+            bytes8(hex"0123456789abcdef"), // build
+            1, // major
+            2, // minor
+            3, // patch
+            4 // prerelease
         );
 
         bytes memory goEncoded = ffi.encodeProtocolVersion(
-            hex"0123456789abcdef",  // build
-            1,                      // major
-            2,                      // minor
-            3,                      // patch
-            4                       // prerelease
+            hex"0123456789abcdef", // build
+            1, // major
+            2, // minor
+            3, // patch
+            4 // prerelease
         );
 
         assertEq(encoded, bytes32(goEncoded));
@@ -176,8 +179,8 @@ contract Encoding_Test is CommonTest {
 
     function uint2str(uint32 _i) internal pure returns (string memory) {
         if (_i == 0) return "0";
-        uint j = _i;
-        uint len;
+        uint256 j = _i;
+        uint256 len;
         while (j != 0) {
             len++;
             j /= 10;

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -107,15 +107,22 @@ contract Encoding_Test is CommonTest {
     }
 
     /// @notice Test that decoding and re-encoding preserves all components
-    function testFuzz_encodeDecodeProtocolVersion(bytes8 _build, uint32 _major, uint32 _minor, uint32 _patch, uint32 _preRelease) public pure {
+    function testFuzz_encodeDecodeProtocolVersion(
+        bytes8 _build,
+        uint32 _major,
+        uint32 _minor,
+        uint32 _patch,
+        uint32 _preRelease
+    )
+        public
+        pure
+    {
         bytes32 encoded = Encoding.encodeProtocolVersion(_build, _major, _minor, _patch, _preRelease);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         // Base version string
         string memory expected = string(
             abi.encodePacked(
-                "v", Encoding.uint2str(_major),
-                ".", Encoding.uint2str(_minor),
-                ".", Encoding.uint2str(_patch)
+                "v", Encoding.uint2str(_major), ".", Encoding.uint2str(_minor), ".", Encoding.uint2str(_patch)
             )
         );
         // Add prerelease if non-zero
@@ -189,7 +196,7 @@ contract Encoding_Test is CommonTest {
     function test_protocolVersion_maxValues() public pure {
         bytes32 encoded = Encoding.encodeProtocolVersion(
             bytes8(hex"ffffffffffffffff"),
-            type(uint32).max,  // 4294967295
+            type(uint32).max, // 4294967295
             type(uint32).max,
             type(uint32).max,
             type(uint32).max
@@ -201,13 +208,7 @@ contract Encoding_Test is CommonTest {
 
     /// @notice Test minimal non-zero build ID
     function test_protocolVersion_minimalBuild() public pure {
-        bytes32 encoded = Encoding.encodeProtocolVersion(
-            bytes8(hex"0000000000000001"),
-            1,
-            0,
-            0,
-            0
-        );
+        bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(hex"0000000000000001"), 1, 0, 0, 0);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v1.0.0+0x0000000000000001";
         assertEq(decoded, expected);
@@ -215,13 +216,7 @@ contract Encoding_Test is CommonTest {
 
     /// @notice Test prerelease without build
     function test_protocolVersion_onlyPrerelease() public pure {
-        bytes32 encoded = Encoding.encodeProtocolVersion(
-            bytes8(0),
-            1,
-            0,
-            0,
-            1
-        );
+        bytes32 encoded = Encoding.encodeProtocolVersion(bytes8(0), 1, 0, 0, 1);
         string memory decoded = Encoding.decodeProtocolVersion(encoded);
         string memory expected = "v1.0.0-1";
         assertEq(decoded, expected);

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -454,4 +454,44 @@ contract FFIInterface {
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes));
     }
+
+    /// @notice Encodes a protocol version using the Go implementation
+    function encodeProtocolVersion(
+        bytes memory build,
+        uint32 major,
+        uint32 minor,
+        uint32 patch,
+        uint32 preRelease
+    ) external returns (bytes memory) {
+        string[] memory cmds = new string[](8);
+        cmds[0] = "scripts/go-ffi/go-ffi";
+        cmds[1] = "diff";
+        cmds[2] = "encodeProtocolVersion";
+        cmds[3] = vm.toString(build);
+        cmds[4] = vm.toString(major);
+        cmds[5] = vm.toString(minor);
+        cmds[6] = vm.toString(patch);
+        cmds[7] = vm.toString(preRelease);
+
+        bytes memory result = Process.run(cmds);
+        return abi.decode(result, (bytes));
+    }
+
+    /// @notice Decodes a protocol version using the Go implementation
+    function decodeProtocolVersion(bytes32 version) external returns (
+        bytes8 build,
+        uint32 major,
+        uint32 minor,
+        uint32 patch,
+        uint32 preRelease
+    ) {
+        string[] memory cmds = new string[](4);
+        cmds[0] = "scripts/go-ffi/go-ffi";
+        cmds[1] = "diff";
+        cmds[2] = "decodeProtocolVersion";
+        cmds[3] = vm.toString(version);
+
+        bytes memory result = Process.run(cmds);
+        return abi.decode(result, (bytes8, uint32, uint32, uint32, uint32));
+    }
 }

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -478,13 +478,7 @@ contract FFIInterface {
     }
 
     /// @notice Decodes a protocol version using the Go implementation
-    function decodeProtocolVersion(bytes32 version) external returns (
-        bytes8 build,
-        uint32 major,
-        uint32 minor,
-        uint32 patch,
-        uint32 preRelease
-    ) {
+    function decodeProtocolVersion(bytes32 version) external returns (string memory) {
         string[] memory cmds = new string[](4);
         cmds[0] = "scripts/go-ffi/go-ffi";
         cmds[1] = "diff";
@@ -494,15 +488,7 @@ contract FFIInterface {
         bytes memory result = Process.run(cmds);
         require(result.length > 0, "FFI call returned empty result");
         
-        // The Go implementation returns the values in a different format
-        // We need to decode them properly
-        (bytes memory buildBytes, uint32 maj, uint32 min, uint32 pat, uint32 pre) = 
-            abi.decode(result, (bytes, uint32, uint32, uint32, uint32));
-        
-        build = bytes8(buildBytes);
-        major = maj;
-        minor = min;
-        patch = pat;
-        preRelease = pre;
+        string memory decoded = abi.decode(result, (string));
+        return decoded;
     }
 }

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -489,7 +489,9 @@ contract FFIInterface {
         cmds[3] = Strings.toHexString(uint256(version));
 
         bytes memory result = Process.run(cmds);
-        require(result.length > 0, "FFI call returned empty result");
+        if (result.length == 0) {
+            revert("FFI call returned empty result");
+        }
 
         string memory decoded = abi.decode(result, (string));
         return decoded;

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -489,9 +489,20 @@ contract FFIInterface {
         cmds[0] = "scripts/go-ffi/go-ffi";
         cmds[1] = "diff";
         cmds[2] = "decodeProtocolVersion";
-        cmds[3] = vm.toString(version);
+        cmds[3] = Strings.toHexString(uint256(version));
 
         bytes memory result = Process.run(cmds);
-        return abi.decode(result, (bytes8, uint32, uint32, uint32, uint32));
+        require(result.length > 0, "FFI call returned empty result");
+        
+        // The Go implementation returns the values in a different format
+        // We need to decode them properly
+        (bytes memory buildBytes, uint32 maj, uint32 min, uint32 pat, uint32 pre) = 
+            abi.decode(result, (bytes, uint32, uint32, uint32, uint32));
+        
+        build = bytes8(buildBytes);
+        major = maj;
+        minor = min;
+        patch = pat;
+        preRelease = pre;
     }
 }

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -462,7 +462,10 @@ contract FFIInterface {
         uint32 minor,
         uint32 patch,
         uint32 preRelease
-    ) external returns (bytes memory) {
+    )
+        external
+        returns (bytes memory)
+    {
         string[] memory cmds = new string[](8);
         cmds[0] = "scripts/go-ffi/go-ffi";
         cmds[1] = "diff";
@@ -487,7 +490,7 @@ contract FFIInterface {
 
         bytes memory result = Process.run(cmds);
         require(result.length > 0, "FFI call returned empty result");
-        
+
         string memory decoded = abi.decode(result, (string));
         return decoded;
     }

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -322,7 +322,9 @@ contract Specification_Test is CommonTest {
 
         // ProtocolVersions
         _addSpec({ _name: "ProtocolVersions", _sel: _getSel("RECOMMENDED_SLOT()") });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("recommendedVersion()") });
         _addSpec({ _name: "ProtocolVersions", _sel: _getSel("REQUIRED_SLOT()") });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("requiredVersion()") });
         _addSpec({ _name: "ProtocolVersions", _sel: _getSel("VERSION()") });
         _addSpec({ _name: "ProtocolVersions", _sel: IProtocolVersions.initialize.selector });
         _addSpec({ _name: "ProtocolVersions", _sel: _getSel("owner()") });


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds protocol version string support to the ProtocolVersions contract, aligning with the official implementation in `op-chain-ops/cmd/protocol-version/main.go`.

Key changes:
- Add protocol version encoding/decoding to `Encoding.sol` library
  - Standardized byte layout: `8 zeros | 8 build | 4 major | 4 minor | 4 patch | 4 prerelease`
  - String format: `v<major>.<minor>.<patch>-<prerelease>+0x<build>`
- Add `requiredVersion()` and `recommendedVersion()` to `ProtocolVersions.sol`
- Add Go FFI integration for differential testing
- Update interfaces and add comprehensive test coverage

**Tests**

Added extensive test coverage across multiple files:

`Encoding.t.sol`:
- Fuzz tests for encoding/decoding consistency
- Specific test cases for known values
- Edge cases (all zeros, minimal build, max values)
- Differential tests against Go implementation

`ProtocolVersions.t.sol`:
- Tests for string representation functions
- Fuzz tests for version components
- Tests for versions with/without build and prerelease

`differential-testing.go`:
- Go implementation matching official byte layout
- String formatting matching official tool

**Additional context**

This standardization ensures consistent version handling across the entire system, from contract storage to string representation, matching the official protocol-version tool's format.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
