### PR TITLE
undo deploy variation cgt code deletion

### DIFF
--- a/packages/contracts-bedrock/test/setup/DeployVariations.t.sol
+++ b/packages/contracts-bedrock/test/setup/DeployVariations.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 error CustomGasTokenNotSupported();
 
@@ -15,7 +16,10 @@ contract DeployVariations_Test is CommonTest {
     // Enable features which should be possible to enable or disable regardless of other options.
     function enableAddOns(bool _enableCGT, bool _enableAltDa) public {
         if (_enableCGT) {
-            revert CustomGasTokenNotSupported();
+            if (true) revert CustomGasTokenNotSupported();
+
+            ERC20 token = new ERC20("Silly", "SIL");
+            super.enableCustomGasToken(address(token));
         }
         if (_enableAltDa) {
             super.enableAltDA();


### PR DESCRIPTION
The added code here was not intended to be removed in this PR - https://github.com/ethereum-optimism/optimism/pull/13603/files#diff-2f27fb852cb32505923f0d3b81ab5cfcb4f36aaff05600ed4b10f728dc5b739f but I forgot to restore it. This pr does that.