### PR TITLE
op-program: Implement initial block derivation step for interop fault proofs

### DIFF
--- a/op-e2e/actions/interop/interop.go
+++ b/op-e2e/actions/interop/interop.go
@@ -5,12 +5,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/params"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
@@ -30,6 +27,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -42,7 +41,7 @@ type Chain struct {
 	ChainID types.ChainID
 
 	RollupCfg   *rollup.Config
-	ChainCfg    *params.ChainConfig
+	L2Genesis   *core.Genesis
 	BatcherAddr common.Address
 
 	Sequencer       *helpers.L2Sequencer
@@ -242,7 +241,7 @@ func createL2Services(
 	return &Chain{
 		ChainID:         types.ChainIDFromBig(output.Genesis.Config.ChainID),
 		RollupCfg:       output.RollupCfg,
-		ChainCfg:        output.Genesis.Config,
+		L2Genesis:       output.Genesis,
 		BatcherAddr:     crypto.PubkeyToAddress(batcherKey.PublicKey),
 		Sequencer:       seq,
 		SequencerEngine: eng,

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -1,8 +1,15 @@
 package interop
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
+	fpHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
@@ -126,4 +133,244 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, head, status.LocalSafeL2.ID())
 	require.Equal(t, head, status.SafeL2.ID())
 	require.Equal(t, head, status.FinalizedL2.ID())
+}
+
+func TestInteropFaultProofs(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+
+	is := SetupInterop(t)
+	actors := is.CreateActors()
+
+	// get both sequencers set up
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
+	// sync the supervisor, handle initial events emitted by the nodes
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+
+	// No blocks yet
+	status := actors.ChainA.Sequencer.SyncStatus()
+	require.Equal(t, uint64(0), status.UnsafeL2.Number)
+
+	// sync chain A
+	actors.Supervisor.SyncEvents(t, actors.ChainA.ChainID)
+	actors.Supervisor.SyncCrossUnsafe(t, actors.ChainA.ChainID)
+	actors.Supervisor.SyncCrossSafe(t, actors.ChainA.ChainID)
+
+	// sync chain B
+	actors.Supervisor.SyncEvents(t, actors.ChainB.ChainID)
+	actors.Supervisor.SyncCrossUnsafe(t, actors.ChainB.ChainID)
+	actors.Supervisor.SyncCrossSafe(t, actors.ChainB.ChainID)
+
+	// Build L2 block on chain A
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	actors.ChainA.Sequencer.ActL2EndBlock(t)
+	require.Equal(t, uint64(1), actors.ChainA.Sequencer.L2Unsafe().Number)
+
+	// Build L2 block on chain B
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+	actors.ChainB.Sequencer.ActL2EndBlock(t)
+	require.Equal(t, uint64(1), actors.ChainB.Sequencer.L2Unsafe().Number)
+
+	// Ingest the new unsafe-block events
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+
+	// Verify as cross-unsafe with supervisor
+	actors.Supervisor.SyncEvents(t, actors.ChainA.ChainID)
+	actors.Supervisor.SyncEvents(t, actors.ChainB.ChainID)
+	actors.Supervisor.SyncCrossUnsafe(t, actors.ChainA.ChainID)
+	actors.Supervisor.SyncCrossUnsafe(t, actors.ChainB.ChainID)
+	actors.ChainA.Sequencer.AwaitSentCrossUnsafeUpdate(t, 1)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainA.Sequencer.SyncStatus()
+	require.Equal(gt, uint64(1), status.UnsafeL2.Number)
+	require.Equal(gt, uint64(1), status.CrossUnsafeL2.Number)
+	actors.ChainB.Sequencer.AwaitSentCrossUnsafeUpdate(t, 1)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainB.Sequencer.SyncStatus()
+	require.Equal(gt, uint64(1), status.UnsafeL2.Number)
+	require.Equal(gt, uint64(1), status.CrossUnsafeL2.Number)
+
+	// Submit the L2 blocks, sync the local-safe data
+	actors.ChainA.Batcher.ActSubmitAll(t)
+	actors.ChainB.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+	// The node will exhaust L1 data,
+	// it needs the supervisor to see the L1 block first, and provide it to the node.
+	actors.ChainA.Sequencer.ActL2EventsUntil(t, event.Is[derive.ExhaustedL1Event], 100, false)
+	actors.ChainB.Sequencer.ActL2EventsUntil(t, event.Is[derive.ExhaustedL1Event], 100, false)
+	actors.ChainA.Sequencer.SyncSupervisor(t)    // supervisor to react to exhaust-L1
+	actors.ChainB.Sequencer.SyncSupervisor(t)    // supervisor to react to exhaust-L1
+	actors.ChainA.Sequencer.ActL2PipelineFull(t) // node to complete syncing to L1 head.
+	actors.ChainB.Sequencer.ActL2PipelineFull(t) // node to complete syncing to L1 head.
+
+	actors.ChainA.Sequencer.ActL1HeadSignal(t)
+	status = actors.ChainA.Sequencer.SyncStatus()
+	require.Equal(gt, uint64(1), status.LocalSafeL2.Number)
+	actors.ChainB.Sequencer.ActL1HeadSignal(t)
+	status = actors.ChainB.Sequencer.SyncStatus()
+	require.Equal(gt, uint64(1), status.LocalSafeL2.Number)
+
+	// Ingest the new local-safe event
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+
+	// Cross-safe verify it
+	actors.Supervisor.SyncCrossSafe(t, actors.ChainA.ChainID)
+	actors.Supervisor.SyncCrossSafe(t, actors.ChainB.ChainID)
+	actors.ChainA.Sequencer.AwaitSentCrossSafeUpdate(t, 1)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainA.Sequencer.SyncStatus()
+	require.Equal(gt, uint64(1), status.SafeL2.Number)
+	actors.ChainB.Sequencer.AwaitSentCrossSafeUpdate(t, 1)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainB.Sequencer.SyncStatus()
+	require.Equal(gt, uint64(1), status.SafeL2.Number)
+
+	require.Equal(gt, uint64(1), actors.ChainA.Sequencer.L2Safe().Number)
+	require.Equal(gt, uint64(1), actors.ChainB.Sequencer.L2Safe().Number)
+
+	chainAClient := actors.ChainA.Sequencer.RollupClient()
+	chainBClient := actors.ChainB.Sequencer.RollupClient()
+
+	ctx := context.Background()
+	startTimestamp := actors.ChainA.RollupCfg.Genesis.L2Time
+	endTimestamp := startTimestamp + actors.ChainA.RollupCfg.BlockTime
+	source, err := NewSuperRootSource(ctx, chainAClient, chainBClient)
+	require.NoError(t, err)
+	start, err := source.CreateSuperRoot(ctx, startTimestamp)
+	require.NoError(t, err)
+	end, err := source.CreateSuperRoot(ctx, endTimestamp)
+	require.NoError(t, err)
+
+	serializeIntermediateRoot := func(root *types.TransitionState) []byte {
+		data, err := rlp.EncodeToBytes(root)
+		require.NoError(t, err)
+		return data
+	}
+
+	num, err := actors.ChainA.RollupCfg.TargetBlockNumber(endTimestamp)
+	require.NoError(t, err)
+	chain1End, err := chainAClient.OutputAtBlock(ctx, num)
+	require.NoError(t, err)
+
+	num, err = actors.ChainB.RollupCfg.TargetBlockNumber(endTimestamp)
+	require.NoError(t, err)
+	chain2End, err := chainBClient.OutputAtBlock(ctx, num)
+	require.NoError(t, err)
+
+	step1Expected := serializeIntermediateRoot(&types.TransitionState{
+		SuperRoot: start.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: chain1End.BlockRef.Hash, OutputRoot: chain1End.OutputRoot},
+		},
+		Step: 1,
+	})
+
+	step2Expected := serializeIntermediateRoot(&types.TransitionState{
+		SuperRoot: start.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: chain1End.BlockRef.Hash, OutputRoot: chain1End.OutputRoot},
+			{BlockHash: chain2End.BlockRef.Hash, OutputRoot: chain2End.OutputRoot},
+		},
+		Step: 2,
+	})
+
+	step3Expected := serializeIntermediateRoot(&types.TransitionState{
+		SuperRoot: start.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: chain1End.BlockRef.Hash, OutputRoot: chain1End.OutputRoot},
+			{BlockHash: chain2End.BlockRef.Hash, OutputRoot: chain2End.OutputRoot},
+		},
+		Step: 3,
+	})
+
+	tests := []*transitionTest{
+		{
+			name:           "ClaimNoChange",
+			startTimestamp: startTimestamp,
+			agreedClaim:    start.Marshal(),
+			disputedClaim:  start.Marshal(),
+			expectValid:    false,
+		},
+		{
+			name:           "ClaimDirectToNextTimestamp",
+			startTimestamp: startTimestamp,
+			agreedClaim:    start.Marshal(),
+			disputedClaim:  end.Marshal(),
+			expectValid:    false,
+		},
+		{
+			name:           "FirstChainOptimisticBlock",
+			startTimestamp: startTimestamp,
+			agreedClaim:    start.Marshal(),
+			disputedClaim:  step1Expected,
+			expectValid:    true,
+			skip:           true,
+		},
+		{
+			name:           "SecondChainOptimisticBlock",
+			startTimestamp: startTimestamp,
+			agreedClaim:    step1Expected,
+			disputedClaim:  step2Expected,
+			expectValid:    true,
+			skip:           true,
+		},
+		{
+			name:           "PaddingStep",
+			startTimestamp: startTimestamp,
+			agreedClaim:    step2Expected,
+			disputedClaim:  step3Expected,
+			expectValid:    true,
+			skip:           true,
+		},
+		{
+			name:           "Consolidate",
+			startTimestamp: startTimestamp,
+			agreedClaim:    step3Expected,
+			disputedClaim:  end.Marshal(),
+			expectValid:    true,
+			skip:           true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		gt.Run(test.name, func(gt *testing.T) {
+			t := helpers.NewDefaultTesting(gt)
+			if test.skip {
+				t.Skip("Not yet implemented")
+				return
+			}
+			logger := testlog.Logger(t, slog.LevelInfo)
+			checkResult := fpHelpers.ExpectNoError()
+			if !test.expectValid {
+				checkResult = fpHelpers.ExpectError(claim.ErrClaimNotValid)
+			}
+			fpHelpers.RunFaultProofProgram(
+				t,
+				logger,
+				actors.L1Miner,
+				actors.ChainA.Sequencer.L2Verifier,
+				actors.ChainA.SequencerEngine,
+				actors.ChainA.L2Genesis,
+				chain1End.BlockRef.Number,
+				checkResult,
+			)
+		})
+	}
+}
+
+type transitionTest struct {
+	name           string
+	startTimestamp uint64
+	agreedClaim    []byte
+	disputedClaim  []byte
+	expectValid    bool
+	skip           bool
 }

--- a/op-e2e/actions/interop/super_root.go
+++ b/op-e2e/actions/interop/super_root.go
@@ -47,7 +47,7 @@ func NewSuperRootSource(ctx context.Context, sources ...OutputRootSource) (*Supe
 }
 
 func (s *SuperRootSource) CreateSuperRoot(ctx context.Context, timestamp uint64) (*eth.SuperV1, error) {
-	chainOutputs := make([]eth.Bytes32, len(s.chains))
+	chains := make([]eth.ChainIDAndOutput, len(s.chains))
 	for i, chain := range s.chains {
 		blockNum, err := chain.config.TargetBlockNumber(timestamp)
 		if err != nil {
@@ -57,11 +57,11 @@ func (s *SuperRootSource) CreateSuperRoot(ctx context.Context, timestamp uint64)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load output root for chain %v at block %v: %w", chain.chainID, blockNum, err)
 		}
-		chainOutputs[i] = output.OutputRoot
+		chains[i] = eth.ChainIDAndOutput{ChainID: chain.chainID.Uint64(), Output: output.OutputRoot}
 	}
 	output := eth.SuperV1{
 		Timestamp: timestamp,
-		Outputs:   chainOutputs,
+		Chains:    chains,
 	}
 	return &output, nil
 }

--- a/op-e2e/actions/interop/super_root.go
+++ b/op-e2e/actions/interop/super_root.go
@@ -1,0 +1,67 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"slices"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type OutputRootSource interface {
+	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
+	RollupConfig(ctx context.Context) (*rollup.Config, error)
+}
+
+type chainInfo struct {
+	chainID *big.Int
+	source  OutputRootSource
+	config  *rollup.Config
+}
+
+// SuperRootSource is a testing helper to create a Super Root from a set of rollup clients
+type SuperRootSource struct {
+	chains []*chainInfo
+}
+
+func NewSuperRootSource(ctx context.Context, sources ...OutputRootSource) (*SuperRootSource, error) {
+	chains := make([]*chainInfo, 0, len(sources))
+	for _, source := range sources {
+		config, err := source.RollupConfig(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load rollup config: %w", err)
+		}
+		chainID := config.L2ChainID
+		chains = append(chains, &chainInfo{
+			chainID: chainID,
+			source:  source,
+			config:  config,
+		})
+	}
+	slices.SortFunc(chains, func(a, b *chainInfo) int {
+		return a.chainID.Cmp(b.chainID)
+	})
+	return &SuperRootSource{chains: chains}, nil
+}
+
+func (s *SuperRootSource) CreateSuperRoot(ctx context.Context, timestamp uint64) (*eth.SuperV1, error) {
+	chainOutputs := make([]eth.Bytes32, len(s.chains))
+	for i, chain := range s.chains {
+		blockNum, err := chain.config.TargetBlockNumber(timestamp)
+		if err != nil {
+			return nil, err
+		}
+		output, err := chain.source.OutputAtBlock(ctx, blockNum)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load output root for chain %v at block %v: %w", chain.chainID, blockNum, err)
+		}
+		chainOutputs[i] = output.OutputRoot
+	}
+	output := eth.SuperV1{
+		Timestamp: timestamp,
+		Outputs:   chainOutputs,
+	}
+	return &output, nil
+}

--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/naoina/toml"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +53,8 @@ func tryDumpTestFixture(
 	t helpers.Testing,
 	result error,
 	name string,
-	env *L2FaultProofEnv,
+	rollupCfg *rollup.Config,
+	l2Genesis *core.Genesis,
 	inputs FixtureInputs,
 	workDir string,
 ) {
@@ -60,8 +63,6 @@ func tryDumpTestFixture(
 	}
 
 	name = convertToKebabCase(name)
-	rollupCfg := env.Sd.RollupCfg
-	l2Genesis := env.Sd.L2Cfg
 
 	var expectedStatus uint8
 	if result == nil {

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func IsKonaConfigured() bool {
 func RunKonaNative(
 	t helpers.Testing,
 	workDir string,
-	env *L2FaultProofEnv,
+	rollupCfg *rollup.Config,
 	l1Rpc string,
 	l1BeaconRpc string,
 	l2Rpc string,
@@ -37,7 +38,7 @@ func RunKonaNative(
 ) error {
 	// Write rollup config to tempdir.
 	rollupConfigPath := filepath.Join(workDir, "rollup.json")
-	ser, err := json.Marshal(env.Sd.RollupCfg)
+	ser, err := json.Marshal(rollupCfg)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(rollupConfigPath, ser, fs.ModePerm))
 

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -1,0 +1,92 @@
+package helpers
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
+	"github.com/ethereum-optimism/optimism/op-program/host"
+	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
+	"github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum-optimism/optimism/op-program/host/prefetcher"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type L1 interface {
+}
+
+type L2 interface {
+	RollupClient() *sources.RollupClient
+}
+
+func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Miner, l2 *helpers.L2Verifier, l2Eng *helpers.L2Engine, l2ChainConfig *core.Genesis, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
+	// Fetch the pre and post output roots for the fault proof.
+	l2PreBlockNum := l2ClaimBlockNum - 1
+	if l2ClaimBlockNum == 0 {
+		// If we are at genesis, we assert that we don't move the chain at all.
+		l2PreBlockNum = 0
+	}
+	preRoot, err := l2.RollupClient().OutputAtBlock(t.Ctx(), l2PreBlockNum)
+	require.NoError(t, err)
+	claimRoot, err := l2.RollupClient().OutputAtBlock(t.Ctx(), l2ClaimBlockNum)
+	require.NoError(t, err)
+	l1Head := l1.L1Chain().CurrentBlock()
+
+	fixtureInputs := &FixtureInputs{
+		L2BlockNumber: l2ClaimBlockNum,
+		L2Claim:       common.Hash(claimRoot.OutputRoot),
+		L2Head:        preRoot.BlockRef.Hash,
+		L2OutputRoot:  common.Hash(preRoot.OutputRoot),
+		L2ChainID:     l2.RollupCfg.L2ChainID.Uint64(),
+		L1Head:        l1Head.Hash(),
+	}
+	for _, apply := range fixtureInputParams {
+		apply(fixtureInputs)
+	}
+
+	// Run the fault proof program from the state transition from L2 block l2ClaimBlockNum - 1 -> l2ClaimBlockNum.
+	workDir := t.TempDir()
+	if IsKonaConfigured() {
+		fakeBeacon := fakebeacon.NewBeacon(
+			logger,
+			l1.BlobStore(),
+			l1.L1Chain().Genesis().Time(),
+			12,
+		)
+		require.NoError(t, fakeBeacon.Start("127.0.0.1:0"))
+		defer fakeBeacon.Close()
+
+		err := RunKonaNative(t, workDir, l2.RollupCfg, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Eng.HTTPEndpoint(), *fixtureInputs)
+		checkResult(t, err)
+	} else {
+		programCfg := NewOpProgramCfg(
+			t,
+			l2.RollupCfg,
+			l2ChainConfig.Config,
+			fixtureInputs,
+		)
+		withInProcessPrefetcher := hostcommon.WithPrefetcher(func(ctx context.Context, logger log.Logger, kv kvstore.KV, cfg *config.Config) (hostcommon.Prefetcher, error) {
+			// Set up in-process L1 sources
+			l1Cl := l1.L1Client(t, l2.RollupCfg)
+			l1BlobFetcher := l1.BlobSource()
+
+			// Set up in-process L2 source
+			l2ClCfg := sources.L2ClientDefaultConfig(l2.RollupCfg, true)
+			l2RPC := l2Eng.RPCClient()
+			l2Client, err := hostcommon.NewL2Client(l2RPC, logger, nil, &hostcommon.L2ClientConfig{L2ClientConfig: l2ClCfg, L2Head: cfg.L2Head})
+			require.NoError(t, err, "failed to create L2 client")
+			l2DebugCl := hostcommon.NewL2SourceWithClient(logger, l2Client, sources.NewDebugClient(l2RPC.CallContext))
+
+			executor := host.MakeProgramExecutor(logger, programCfg)
+			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2DebugCl, kv, l2ChainConfig.Config, executor), nil
+		})
+		err = hostcommon.FaultProofProgram(t.Ctx(), logger, programCfg, withInProcessPrefetcher)
+		checkResult(t, err)
+	}
+	tryDumpTestFixture(t, err, t.Name(), l2.RollupCfg, l2ChainConfig, *fixtureInputs, workDir)
+}

--- a/op-e2e/faultproofs/preimages_test.go
+++ b/op-e2e/faultproofs/preimages_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
-	"github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -19,10 +19,10 @@ func TestLocalPreimages(t *testing.T) {
 	tests := []struct {
 		key preimage.Key
 	}{
-		{key: client.L1HeadLocalIndex},
-		{key: client.L2OutputRootLocalIndex},
-		{key: client.L2ClaimLocalIndex},
-		{key: client.L2ClaimBlockNumberLocalIndex},
+		{key: boot.L1HeadLocalIndex},
+		{key: boot.L2OutputRootLocalIndex},
+		{key: boot.L2ClaimLocalIndex},
+		{key: boot.L2ClaimBlockNumberLocalIndex},
 		// We don't check client.L2ChainIDLocalIndex because e2e tests use a custom chain configuration
 		// which requires using a custom chain ID indicator so op-program will load the full rollup config and
 		// genesis from the preimage oracle

--- a/op-program/client/boot/boot.go
+++ b/op-program/client/boot/boot.go
@@ -1,4 +1,4 @@
-package client
+package boot
 
 import (
 	"encoding/binary"

--- a/op-program/client/boot/boot_test.go
+++ b/op-program/client/boot/boot_test.go
@@ -1,4 +1,4 @@
-package client
+package boot
 
 import (
 	"encoding/binary"

--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -1,0 +1,115 @@
+package interop
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-program/client/l1"
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
+	"github.com/ethereum-optimism/optimism/op-program/client/tasks"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	ErrIncorrectOutputRootType = errors.New("incorrect output root type")
+)
+
+type taskExecutor interface {
+	RunDerivation(
+		logger log.Logger,
+		rollupCfg *rollup.Config,
+		l2ChainConfig *params.ChainConfig,
+		l1Head common.Hash,
+		agreedOutputRoot eth.Bytes32,
+		claimedBlockNumber uint64,
+		l1Oracle l1.Oracle,
+		l2Oracle l2.Oracle) (tasks.DerivationResult, error)
+}
+
+func RunInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle) error {
+	return runInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, &interopTaskExecutor{})
+}
+
+func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, tasks taskExecutor) error {
+	logger.Info("Interop Program Bootstrapped", "bootInfo", bootInfo)
+
+	// For the first step in a timestamp, we would get a SuperRoot as the agreed claim - TransitionStateByRoot will
+	// automatically convert it to a TransitionState with Step: 0.
+	transitionState := l2PreimageOracle.TransitionStateByRoot(bootInfo.L2OutputRoot)
+	if transitionState.Version() != types.IntermediateTransitionVersion {
+		return fmt.Errorf("%w: %v", ErrIncorrectOutputRootType, transitionState.Version())
+	}
+
+	super, err := eth.UnmarshalSuperRoot(transitionState.SuperRoot)
+	if err != nil {
+		return fmt.Errorf("invalid super root: %w", err)
+	}
+	if super.Version() != eth.SuperRootVersionV1 {
+		return fmt.Errorf("%w: %v", ErrIncorrectOutputRootType, super.Version())
+	}
+	superRoot := super.(*eth.SuperV1)
+	claimedBlockNumber, err := bootInfo.RollupConfig.TargetBlockNumber(superRoot.Timestamp + 1)
+	if err != nil {
+		return err
+	}
+	derivationResult, err := tasks.RunDerivation(
+		logger,
+		bootInfo.RollupConfig,
+		bootInfo.L2ChainConfig,
+		bootInfo.L1Head,
+		superRoot.Outputs[0],
+		claimedBlockNumber,
+		l1PreimageOracle,
+		l2PreimageOracle,
+	)
+	if err != nil {
+		return err
+	}
+
+	newPendingProgress := make([]types.OptimisticBlock, len(transitionState.PendingProgress)+1)
+	copy(newPendingProgress, transitionState.PendingProgress)
+	newPendingProgress[len(newPendingProgress)-1] = types.OptimisticBlock{
+		BlockHash:  derivationResult.BlockHash,
+		OutputRoot: derivationResult.OutputRoot,
+	}
+	finalState := &types.TransitionState{
+		SuperRoot:       transitionState.SuperRoot,
+		PendingProgress: newPendingProgress,
+		Step:            transitionState.Step + 1,
+	}
+	expected, err := finalState.Hash()
+	if err != nil {
+		return err
+	}
+	return claim.ValidateClaim(logger, derivationResult.SafeHead, eth.Bytes32(bootInfo.L2Claim), eth.Bytes32(expected))
+}
+
+type interopTaskExecutor struct {
+}
+
+func (t *interopTaskExecutor) RunDerivation(
+	logger log.Logger,
+	rollupCfg *rollup.Config,
+	l2ChainConfig *params.ChainConfig,
+	l1Head common.Hash,
+	agreedOutputRoot eth.Bytes32,
+	claimedBlockNumber uint64,
+	l1Oracle l1.Oracle,
+	l2Oracle l2.Oracle) (tasks.DerivationResult, error) {
+	return tasks.RunDerivation(
+		logger,
+		rollupCfg,
+		l2ChainConfig,
+		l1Head,
+		common.Hash(agreedOutputRoot),
+		claimedBlockNumber,
+		l1Oracle,
+		l2Oracle)
+}

--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -33,11 +33,11 @@ type taskExecutor interface {
 		l2Oracle l2.Oracle) (tasks.DerivationResult, error)
 }
 
-func RunInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle) error {
-	return runInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, &interopTaskExecutor{})
+func RunInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, validate bool) error {
+	return runInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, validate, &interopTaskExecutor{})
 }
 
-func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, tasks taskExecutor) error {
+func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, validate bool, tasks taskExecutor) error {
 	logger.Info("Interop Program Bootstrapped", "bootInfo", bootInfo)
 
 	// For the first step in a timestamp, we would get a SuperRoot as the agreed claim - TransitionStateByRoot will
@@ -87,6 +87,9 @@ func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOra
 	expected, err := finalState.Hash()
 	if err != nil {
 		return err
+	}
+	if !validate {
+		return nil
 	}
 	return claim.ValidateClaim(logger, derivationResult.SafeHead, eth.Bytes32(bootInfo.L2Claim), eth.Bytes32(expected))
 }

--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -64,7 +64,7 @@ func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOra
 		bootInfo.RollupConfig,
 		bootInfo.L2ChainConfig,
 		bootInfo.L1Head,
-		superRoot.Outputs[0],
+		superRoot.Chains[0].Output,
 		claimedBlockNumber,
 		l1PreimageOracle,
 		l2PreimageOracle,

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -54,7 +54,7 @@ func TestDeriveBlockForFirstChainFromSuperchainRoot(t *testing.T) {
 		L2ClaimBlockNumber: agreedSuperRoot.Timestamp + 1,
 		L2Claim:            expectedClaim,
 	}
-	err = runInteropProgram(logger, bootInfo, nil, l2PreimageOracle, &tasks)
+	err = runInteropProgram(logger, bootInfo, nil, l2PreimageOracle, true, &tasks)
 	require.NoError(t, err)
 }
 

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -25,7 +25,7 @@ func TestDeriveBlockForFirstChainFromSuperchainRoot(t *testing.T) {
 	chain1Output := &eth.OutputV0{}
 	agreedSuperRoot := &eth.SuperV1{
 		Timestamp: rollupCfg.Genesis.L2Time + 1234,
-		Outputs:   []eth.Bytes32{eth.OutputRoot(chain1Output)},
+		Chains:    []eth.ChainIDAndOutput{{ChainID: rollupCfg.L2ChainID.Uint64(), Output: eth.OutputRoot(chain1Output)}},
 	}
 	outputRootHash := common.Hash(eth.SuperRoot(agreedSuperRoot))
 	l2PreimageOracle, _ := test.NewStubOracle(t)

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -1,0 +1,82 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
+	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-program/client/l1"
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
+	"github.com/ethereum-optimism/optimism/op-program/client/l2/test"
+	"github.com/ethereum-optimism/optimism/op-program/client/tasks"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveBlockForFirstChainFromSuperchainRoot(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	rollupCfg := chaincfg.OPSepolia()
+	chain1Output := &eth.OutputV0{}
+	agreedSuperRoot := &eth.SuperV1{
+		Timestamp: rollupCfg.Genesis.L2Time + 1234,
+		Outputs:   []eth.Bytes32{eth.OutputRoot(chain1Output)},
+	}
+	outputRootHash := common.Hash(eth.SuperRoot(agreedSuperRoot))
+	l2PreimageOracle, _ := test.NewStubOracle(t)
+	l2PreimageOracle.TransitionStates[outputRootHash] = &types.TransitionState{SuperRoot: agreedSuperRoot.Marshal()}
+	tasks := stubTasks{
+		l2SafeHead: eth.L2BlockRef{
+			Number: 56,
+			Hash:   common.Hash{0x11},
+		},
+		blockHash:  common.Hash{0x22},
+		outputRoot: eth.Bytes32{0x66},
+	}
+	expectedIntermediateRoot := &types.TransitionState{
+		SuperRoot: agreedSuperRoot.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: tasks.blockHash, OutputRoot: tasks.outputRoot},
+		},
+		Step: 1,
+	}
+
+	expectedClaim, err := expectedIntermediateRoot.Hash()
+	require.NoError(t, err)
+	bootInfo := &boot.BootInfo{
+		L2OutputRoot:       outputRootHash,
+		RollupConfig:       rollupCfg,
+		L2ClaimBlockNumber: agreedSuperRoot.Timestamp + 1,
+		L2Claim:            expectedClaim,
+	}
+	err = runInteropProgram(logger, bootInfo, nil, l2PreimageOracle, &tasks)
+	require.NoError(t, err)
+}
+
+type stubTasks struct {
+	l2SafeHead eth.L2BlockRef
+	blockHash  common.Hash
+	outputRoot eth.Bytes32
+	err        error
+}
+
+func (t *stubTasks) RunDerivation(
+	_ log.Logger,
+	_ *rollup.Config,
+	_ *params.ChainConfig,
+	_ common.Hash,
+	_ eth.Bytes32,
+	_ uint64,
+	_ l1.Oracle,
+	_ l2.Oracle) (tasks.DerivationResult, error) {
+	return tasks.DerivationResult{
+		SafeHead:   t.l2SafeHead,
+		BlockHash:  t.blockHash,
+		OutputRoot: t.outputRoot,
+	}, t.err
+}

--- a/op-program/client/interop/types/roots.go
+++ b/op-program/client/interop/types/roots.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+var (
+	IntermediateTransitionVersion = byte(255)
+)
+
+type OptimisticBlock struct {
+	BlockHash  common.Hash
+	OutputRoot eth.Bytes32
+}
+
+type TransitionState struct {
+	SuperRoot       []byte
+	PendingProgress []OptimisticBlock
+	Step            uint64
+}
+
+func (t *TransitionState) String() string {
+	return fmt.Sprintf("{SuperRoot: %x, PendingProgress: %v, Step: %d}", t.SuperRoot, t.PendingProgress, t.Step)
+}
+
+func (i *TransitionState) Version() byte {
+	return IntermediateTransitionVersion
+}
+
+func (i *TransitionState) Marshal() ([]byte, error) {
+	rlpData, err := rlp.EncodeToBytes(i)
+	if err != nil {
+		panic(err)
+	}
+	return append([]byte{IntermediateTransitionVersion}, rlpData...), nil
+}
+
+func (i *TransitionState) Hash() (common.Hash, error) {
+	data, err := i.Marshal()
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return crypto.Keccak256Hash(data), nil
+}
+
+func UnmarshalProofsState(data []byte) (*TransitionState, error) {
+	if len(data) == 0 {
+		return nil, eth.ErrInvalidSuperRoot
+	}
+	switch data[0] {
+	case IntermediateTransitionVersion:
+		return unmarshalTransitionSate(data)
+	case eth.SuperRootVersionV1:
+		return &TransitionState{SuperRoot: data}, nil
+	default:
+		return nil, eth.ErrInvalidSuperRootVersion
+	}
+}
+
+func unmarshalTransitionSate(data []byte) (*TransitionState, error) {
+	if len(data) == 0 {
+		return nil, eth.ErrInvalidSuperRoot
+	}
+	var state TransitionState
+	if err := rlp.DecodeBytes(data[1:], &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}

--- a/op-program/client/interop/types/roots_test.go
+++ b/op-program/client/interop/types/roots_test.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransitionStateCodec(t *testing.T) {
+	t.Run("TransitionState", func(t *testing.T) {
+		superRoot := &eth.SuperV1{
+			Timestamp: 9842494,
+			Outputs:   []eth.Bytes32{{0x01}, {0x02}},
+		}
+		state := &TransitionState{
+			SuperRoot: superRoot.Marshal(),
+			PendingProgress: []OptimisticBlock{
+				{BlockHash: common.Hash{0x05}, OutputRoot: eth.Bytes32{0x03}},
+				{BlockHash: common.Hash{0x06}, OutputRoot: eth.Bytes32{0x04}},
+			},
+			Step: 2,
+		}
+		data, err := state.Marshal()
+		require.NoError(t, err)
+		actual, err := UnmarshalProofsState(data)
+		require.NoError(t, err)
+		require.Equal(t, state, actual)
+	})
+
+	t.Run("SuperRoot", func(t *testing.T) {
+		superRoot := &eth.SuperV1{
+			Timestamp: 9842494,
+			Outputs:   []eth.Bytes32{{0x01}, {0x02}},
+		}
+		expected := &TransitionState{
+			SuperRoot: superRoot.Marshal(),
+		}
+		data := superRoot.Marshal()
+		actual, err := UnmarshalProofsState(data)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}

--- a/op-program/client/interop/types/roots_test.go
+++ b/op-program/client/interop/types/roots_test.go
@@ -12,7 +12,10 @@ func TestTransitionStateCodec(t *testing.T) {
 	t.Run("TransitionState", func(t *testing.T) {
 		superRoot := &eth.SuperV1{
 			Timestamp: 9842494,
-			Outputs:   []eth.Bytes32{{0x01}, {0x02}},
+			Chains: []eth.ChainIDAndOutput{
+				{ChainID: 34, Output: eth.Bytes32{0x01}},
+				{ChainID: 35, Output: eth.Bytes32{0x02}},
+			},
 		}
 		state := &TransitionState{
 			SuperRoot: superRoot.Marshal(),
@@ -32,7 +35,10 @@ func TestTransitionStateCodec(t *testing.T) {
 	t.Run("SuperRoot", func(t *testing.T) {
 		superRoot := &eth.SuperV1{
 			Timestamp: 9842494,
-			Outputs:   []eth.Bytes32{{0x01}, {0x02}},
+			Chains: []eth.ChainIDAndOutput{
+				{ChainID: 34, Output: eth.Bytes32{0x01}},
+				{ChainID: 35, Output: eth.Bytes32{0x02}},
+			},
 		}
 		expected := &TransitionState{
 			SuperRoot: superRoot.Marshal(),

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -36,20 +36,25 @@ func NewOracleEngine(rollupCfg *rollup.Config, logger log.Logger, backend engine
 	}
 }
 
-func (o *OracleEngine) L2OutputRoot(l2ClaimBlockNum uint64) (eth.Bytes32, error) {
+// L2OutputRoot returns the block hash and output root at the specified block number
+func (o *OracleEngine) L2OutputRoot(l2ClaimBlockNum uint64) (common.Hash, eth.Bytes32, error) {
 	outBlock := o.backend.GetHeaderByNumber(l2ClaimBlockNum)
 	if outBlock == nil {
-		return eth.Bytes32{}, fmt.Errorf("failed to get L2 block at %d", l2ClaimBlockNum)
+		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("failed to get L2 block at %d", l2ClaimBlockNum)
 	}
 	stateDB, err := o.backend.StateAt(outBlock.Root)
 	if err != nil {
-		return eth.Bytes32{}, fmt.Errorf("failed to open L2 state db at block %s: %w", outBlock.Hash(), err)
+		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("failed to open L2 state db at block %s: %w", outBlock.Hash(), err)
 	}
 	withdrawalsTrie, err := stateDB.OpenStorageTrie(predeploys.L2ToL1MessagePasserAddr)
 	if err != nil {
-		return eth.Bytes32{}, fmt.Errorf("withdrawals trie unavailable at block %v: %w", outBlock.Hash(), err)
+		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("withdrawals trie unavailable at block %v: %w", outBlock.Hash(), err)
 	}
-	return rollup.ComputeL2OutputRootV0(eth.HeaderBlockInfo(outBlock), withdrawalsTrie.Hash())
+	output, err := rollup.ComputeL2OutputRootV0(eth.HeaderBlockInfo(outBlock), withdrawalsTrie.Hash())
+	if err != nil {
+		return common.Hash{}, eth.Bytes32{}, err
+	}
+	return outBlock.Hash(), output, nil
 }
 
 func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -16,6 +16,7 @@ const (
 	HintL2StateNode    = "l2-state-node"
 	HintL2Output       = "l2-output"
 	HintL2BlockData    = "l2-block-data"
+	HintAgreedPrestate = "agreed-pre-state"
 )
 
 type BlockHeaderHint common.Hash
@@ -72,4 +73,12 @@ func (l L2BlockDataHint) Hint() string {
 	copy(hintBytes[32:64], (common.Hash)(l.BlockHash).Bytes())
 	binary.BigEndian.PutUint64(hintBytes[64:], l.ChainID)
 	return fmt.Sprintf("%s 0x%s", HintL2BlockData, common.Bytes2Hex(hintBytes))
+}
+
+type AgreedPrestateHint common.Hash
+
+var _ preimage.Hint = AgreedPrestateHint{}
+
+func (l AgreedPrestateHint) Hint() string {
+	return HintAgreedPrestate + " " + (common.Hash)(l).String()
 }

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-program/client/l1"
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
+	"github.com/ethereum-optimism/optimism/op-program/client/tasks"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func RunPreInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle *l1.CachingOracle, l2PreimageOracle *l2.CachingOracle) error {
+	logger.Info("Program Bootstrapped", "bootInfo", bootInfo)
+	result, err := tasks.RunDerivation(
+		logger,
+		bootInfo.RollupConfig,
+		bootInfo.L2ChainConfig,
+		bootInfo.L1Head,
+		bootInfo.L2OutputRoot,
+		bootInfo.L2ClaimBlockNumber,
+		l1PreimageOracle,
+		l2PreimageOracle,
+	)
+	if err != nil {
+		return err
+	}
+	return claim.ValidateClaim(logger, result.SafeHead, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
+}

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -6,11 +6,11 @@ import (
 	"os"
 
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-program/client/interop"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
-	"github.com/ethereum-optimism/optimism/op-program/client/tasks"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -46,23 +46,12 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	l1PreimageOracle := l1.NewCachingOracle(l1.NewPreimageOracle(pClient, hClient))
 	l2PreimageOracle := l2.NewCachingOracle(l2.NewPreimageOracle(pClient, hClient))
 
-	bootInfo := NewBootstrapClient(pClient).BootInfo()
-	logger.Info("Program Bootstrapped", "bootInfo", bootInfo)
-	safeHead, outputRoot, err := tasks.RunDerivation(
-		logger,
-		bootInfo.RollupConfig,
-		bootInfo.L2ChainConfig,
-		bootInfo.L1Head,
-		bootInfo.L2OutputRoot,
-		bootInfo.L2ClaimBlockNumber,
-		l1PreimageOracle,
-		l2PreimageOracle,
-	)
-	if err != nil {
-		return err
+	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
+	if os.Getenv("USE_INTEROP") == "true" {
+		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
 	}
 	if flags == RunProgramFlagValidate {
-		return claim.ValidateClaim(logger, safeHead, eth.Bytes32(bootInfo.L2Claim), outputRoot)
+		return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
 	}
 	return nil
 }

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -47,11 +47,8 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	l2PreimageOracle := l2.NewCachingOracle(l2.NewPreimageOracle(pClient, hClient))
 
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
-	if os.Getenv("USE_INTEROP") == "true" {
-		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
+	if os.Getenv("OP_PROGRAM_USE_INTEROP") == "true" {
+		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, flags == RunProgramFlagValidate)
 	}
-	if flags == RunProgramFlagValidate {
-		return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
-	}
-	return nil
+	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
 }

--- a/op-program/client/tasks/derive_test.go
+++ b/op-program/client/tasks/derive_test.go
@@ -6,64 +6,73 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoadOutputRoot(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		expected := eth.Bytes32{0x11}
 		l2 := &mockL2{
-			outputRoot: expected,
+			blockHash:  common.Hash{0x24},
+			outputRoot: eth.Bytes32{0x11},
 			safeL2:     eth.L2BlockRef{Number: 65},
 		}
-		safeHead, outputRoot, err := loadOutputRoot(uint64(0), l2)
+		result, err := loadOutputRoot(uint64(0), l2)
 		require.NoError(t, err)
-		require.Equal(t, l2.safeL2, safeHead)
-		require.Equal(t, expected, outputRoot)
+		assertDerivationResult(t, result, l2.safeL2, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Success-PriorToSafeHead", func(t *testing.T) {
 		expected := eth.Bytes32{0x11}
 		l2 := &mockL2{
+			blockHash:  common.Hash{0x24},
 			outputRoot: expected,
 			safeL2: eth.L2BlockRef{
 				Number: 10,
 			},
 		}
-		safeHead, outputRoot, err := loadOutputRoot(uint64(20), l2)
+		result, err := loadOutputRoot(uint64(20), l2)
 		require.NoError(t, err)
 		require.Equal(t, uint64(10), l2.requestedOutputRoot)
-		require.Equal(t, l2.safeL2, safeHead)
-		require.Equal(t, expected, outputRoot)
+		assertDerivationResult(t, result, l2.safeL2, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Error-SafeHead", func(t *testing.T) {
 		expectedErr := errors.New("boom")
 		l2 := &mockL2{
+			blockHash:  common.Hash{0x24},
 			outputRoot: eth.Bytes32{0x11},
 			safeL2:     eth.L2BlockRef{Number: 10},
 			safeL2Err:  expectedErr,
 		}
-		_, _, err := loadOutputRoot(uint64(0), l2)
+		_, err := loadOutputRoot(uint64(0), l2)
 		require.ErrorIs(t, err, expectedErr)
 	})
 
 	t.Run("Error-OutputRoot", func(t *testing.T) {
 		expectedErr := errors.New("boom")
 		l2 := &mockL2{
+			blockHash:     common.Hash{0x24},
 			outputRoot:    eth.Bytes32{0x11},
 			outputRootErr: expectedErr,
 			safeL2:        eth.L2BlockRef{Number: 10},
 		}
-		_, _, err := loadOutputRoot(uint64(0), l2)
+		_, err := loadOutputRoot(uint64(0), l2)
 		require.ErrorIs(t, err, expectedErr)
 	})
+}
+
+func assertDerivationResult(t *testing.T, actual DerivationResult, safeHead eth.L2BlockRef, blockHash common.Hash, outputRoot eth.Bytes32) {
+	require.Equal(t, safeHead, actual.SafeHead)
+	require.Equal(t, blockHash, actual.BlockHash)
+	require.Equal(t, outputRoot, actual.OutputRoot)
 }
 
 type mockL2 struct {
 	safeL2    eth.L2BlockRef
 	safeL2Err error
 
+	blockHash     common.Hash
 	outputRoot    eth.Bytes32
 	outputRootErr error
 
@@ -80,12 +89,12 @@ func (m *mockL2) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (e
 	return m.safeL2, nil
 }
 
-func (m *mockL2) L2OutputRoot(u uint64) (eth.Bytes32, error) {
+func (m *mockL2) L2OutputRoot(u uint64) (common.Hash, eth.Bytes32, error) {
 	m.requestedOutputRoot = u
 	if m.outputRootErr != nil {
-		return eth.Bytes32{}, m.outputRootErr
+		return common.Hash{}, eth.Bytes32{}, m.outputRootErr
 	}
-	return m.outputRoot, nil
+	return m.blockHash, m.outputRoot, nil
 }
 
 var _ L2Source = (*mockL2)(nil)

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
-	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -181,7 +181,7 @@ func TestL2ChainID(t *testing.T) {
 			"--rollup.config", rollupCfgFile,
 			"--l2.genesis", genesisFile,
 			"--l2.custom"))
-		require.Equal(t, client.CustomChainIDIndicator, cfg.L2ChainID)
+		require.Equal(t, boot.CustomChainIDIndicator, cfg.L2ChainID)
 	})
 }
 

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
-	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -134,7 +134,7 @@ func NewConfig(
 	_, err := params.LoadOPStackChainConfig(l2ChainID)
 	if err != nil {
 		// Unknown chain ID so assume it is custom
-		l2ChainID = client.CustomChainIDIndicator
+		l2ChainID = boot.CustomChainIDIndicator
 	}
 	return &Config{
 		L2ChainID:          l2ChainID,
@@ -217,7 +217,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		l2ChainID = l2ChainConfig.ChainID.Uint64()
 		if ctx.Bool(flags.L2Custom.Name) {
 			log.Warn("Using custom chain configuration via preimage oracle. This is not compatible with on-chain execution.")
-			l2ChainID = client.CustomChainIDIndicator
+			l2ChainID = boot.CustomChainIDIndicator
 		}
 	}
 

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
-	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -172,7 +172,7 @@ func TestCustomL2ChainID(t *testing.T) {
 	t.Run("custom", func(t *testing.T) {
 		customChainConfig := &params.ChainConfig{ChainID: big.NewInt(0x1212121212)}
 		cfg := NewConfig(validRollupConfig, customChainConfig, validL1Head, validL2Head, validL2OutputRoot, validL2Claim, validL2ClaimBlockNum)
-		require.Equal(t, cfg.L2ChainID, client.CustomChainIDIndicator)
+		require.Equal(t, cfg.L2ChainID, boot.CustomChainIDIndicator)
 	})
 
 }

--- a/op-program/host/host_test.go
+++ b/op-program/host/host_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
-	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -45,8 +45,8 @@ func TestServerMode(t *testing.T) {
 	hClient := preimage.NewHintWriter(hintClient)
 	l1PreimageOracle := l1.NewPreimageOracle(pClient, hClient)
 
-	require.Equal(t, l1Head.Bytes(), pClient.Get(client.L1HeadLocalIndex), "Should get l1 head preimages")
-	require.Equal(t, l2OutputRoot.Bytes(), pClient.Get(client.L2OutputRootLocalIndex), "Should get l2 output root preimages")
+	require.Equal(t, l1Head.Bytes(), pClient.Get(boot.L1HeadLocalIndex), "Should get l1 head preimages")
+	require.Equal(t, l2OutputRoot.Bytes(), pClient.Get(boot.L2OutputRootLocalIndex), "Should get l2 output root preimages")
 
 	// Should exit when a preimage is unavailable
 	require.Panics(t, func() {

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 
-	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -18,13 +18,13 @@ func NewLocalPreimageSource(config *config.Config) *LocalPreimageSource {
 }
 
 var (
-	l1HeadKey             = client.L1HeadLocalIndex.PreimageKey()
-	l2OutputRootKey       = client.L2OutputRootLocalIndex.PreimageKey()
-	l2ClaimKey            = client.L2ClaimLocalIndex.PreimageKey()
-	l2ClaimBlockNumberKey = client.L2ClaimBlockNumberLocalIndex.PreimageKey()
-	l2ChainIDKey          = client.L2ChainIDLocalIndex.PreimageKey()
-	l2ChainConfigKey      = client.L2ChainConfigLocalIndex.PreimageKey()
-	rollupKey             = client.RollupConfigLocalIndex.PreimageKey()
+	l1HeadKey             = boot.L1HeadLocalIndex.PreimageKey()
+	l2OutputRootKey       = boot.L2OutputRootLocalIndex.PreimageKey()
+	l2ClaimKey            = boot.L2ClaimLocalIndex.PreimageKey()
+	l2ClaimBlockNumberKey = boot.L2ClaimBlockNumberLocalIndex.PreimageKey()
+	l2ChainIDKey          = boot.L2ChainIDLocalIndex.PreimageKey()
+	l2ChainConfigKey      = boot.L2ChainConfigLocalIndex.PreimageKey()
+	rollupKey             = boot.RollupConfigLocalIndex.PreimageKey()
 )
 
 func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
@@ -40,12 +40,12 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 	case l2ChainIDKey:
 		return binary.BigEndian.AppendUint64(nil, s.config.L2ChainID), nil
 	case l2ChainConfigKey:
-		if s.config.L2ChainID != client.CustomChainIDIndicator {
+		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
 		return json.Marshal(s.config.L2ChainConfig)
 	case rollupKey:
-		if s.config.L2ChainID != client.CustomChainIDIndicator {
+		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
 		return json.Marshal(s.config.Rollup)

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
-	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -55,7 +55,7 @@ func TestLocalPreimageSource(t *testing.T) {
 func TestGetCustomChainConfigPreimages(t *testing.T) {
 	cfg := &config.Config{
 		Rollup:             chaincfg.OPSepolia(),
-		L2ChainID:          client.CustomChainIDIndicator,
+		L2ChainID:          boot.CustomChainIDIndicator,
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),

--- a/op-service/eth/output_test.go
+++ b/op-service/eth/output_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUnmarshalOutput_UnknownVersion(t *testing.T) {
+	_, err := UnmarshalOutput([]byte{0: 0xA, 32: 0xA})
+	require.ErrorIs(t, err, ErrInvalidOutputVersion)
+}
+
+func TestUnmarshalOutput_TooShortForVersion(t *testing.T) {
+	_, err := UnmarshalOutput([]byte{0xA})
+	require.ErrorIs(t, err, ErrInvalidOutput)
+}
+
 func TestOutputV0Codec(t *testing.T) {
 	output := OutputV0{
 		StateRoot:                Bytes32{1, 2, 3},
@@ -19,8 +29,6 @@ func TestOutputV0Codec(t *testing.T) {
 	unmarshaledV0 := unmarshaled.(*OutputV0)
 	require.Equal(t, output, *unmarshaledV0)
 
-	_, err = UnmarshalOutput([]byte{0: 0xA, 32: 0xA})
-	require.ErrorIs(t, err, ErrInvalidOutputVersion)
 	_, err = UnmarshalOutput([]byte{64: 0xA})
 	require.ErrorIs(t, err, ErrInvalidOutput)
 }

--- a/op-service/eth/super_root.go
+++ b/op-service/eth/super_root.go
@@ -29,12 +29,12 @@ func SuperRoot(super Super) Bytes32 {
 	return Bytes32(crypto.Keccak256Hash(marshaled))
 }
 
-type ChainIdOutputPair struct {
+type ChainIDAndOutput struct {
 	ChainID uint64
 	Output  Bytes32
 }
 
-func (c *ChainIdOutputPair) Marshal() []byte {
+func (c *ChainIDAndOutput) Marshal() []byte {
 	d := make([]byte, 64)
 	binary.BigEndian.PutUint64(d[24:32], c.ChainID)
 	copy(d[32:], c.Output[:])
@@ -43,7 +43,7 @@ func (c *ChainIdOutputPair) Marshal() []byte {
 
 type SuperV1 struct {
 	Timestamp uint64
-	Chains    []ChainIdOutputPair
+	Chains    []ChainIDAndOutput
 }
 
 func (o *SuperV1) Version() byte {
@@ -87,7 +87,7 @@ func unmarshalSuperRootV1(data []byte) (*SuperV1, error) {
 	// data[:1] is the version
 	output.Timestamp = binary.BigEndian.Uint64(data[1:9])
 	for i := 9; i < len(data); i += 64 {
-		chainOutput := ChainIdOutputPair{
+		chainOutput := ChainIDAndOutput{
 			ChainID: binary.BigEndian.Uint64(data[i+24 : i+32]),
 			Output:  Bytes32(data[i+32 : i+64]),
 		}

--- a/op-service/eth/super_root.go
+++ b/op-service/eth/super_root.go
@@ -1,0 +1,83 @@
+package eth
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	ErrInvalidSuperRoot        = errors.New("invalid super root")
+	ErrInvalidSuperRootVersion = errors.New("invalid super root version")
+	SuperRootVersionV1         = byte(1)
+)
+
+const (
+	// SuperRootVersionV1MinLen is the minimum length of a V1 super root prior to hashing
+	// Must contain a 1 byte version, uint64 timestamp and at least one chain's output root hash
+	SuperRootVersionV1MinLen = 1 + 8 + 32
+)
+
+type Super interface {
+	Version() byte
+	Marshal() []byte
+}
+
+func SuperRoot(super Super) Bytes32 {
+	marshaled := super.Marshal()
+	return Bytes32(crypto.Keccak256Hash(marshaled))
+}
+
+type SuperV1 struct {
+	Timestamp uint64
+	Outputs   []Bytes32
+}
+
+func (o *SuperV1) Version() byte {
+	return SuperRootVersionV1
+}
+
+func (o *SuperV1) Marshal() []byte {
+	buf := make([]byte, 0, 9+len(o.Outputs)*32)
+	version := o.Version()
+	buf = append(buf, version)
+	buf = binary.BigEndian.AppendUint64(buf, o.Timestamp)
+	for _, o := range o.Outputs {
+		buf = append(buf, o[:]...)
+	}
+	return buf
+}
+
+func UnmarshalSuperRoot(data []byte) (Super, error) {
+	if len(data) < 1 {
+		return nil, ErrInvalidSuperRoot
+	}
+	ver := data[0]
+	switch ver {
+	case SuperRootVersionV1:
+		return unmarshalSuperRootV1(data)
+	default:
+		return nil, ErrInvalidSuperRootVersion
+	}
+}
+
+func unmarshalSuperRootV1(data []byte) (*SuperV1, error) {
+	// Must contain the version, timestamp and at least one output root.
+	if len(data) < SuperRootVersionV1MinLen {
+		return nil, ErrInvalidSuperRoot
+	}
+	// Must contain complete chain output roots
+	if (len(data)-9)%32 != 0 {
+		return nil, ErrInvalidSuperRoot
+	}
+	var output SuperV1
+	// data[:32] is the version
+	output.Timestamp = binary.BigEndian.Uint64(data[1:9])
+	for i := 9; i < len(data); i += 32 {
+		chainOutput := Bytes32{}
+		copy(chainOutput[:], data[i:i+32])
+		output.Outputs = append(output.Outputs, chainOutput)
+	}
+	return &output, nil
+}

--- a/op-service/eth/super_root_test.go
+++ b/op-service/eth/super_root_test.go
@@ -1,0 +1,52 @@
+package eth
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalSuperRoot_UnknownVersion(t *testing.T) {
+	_, err := UnmarshalSuperRoot([]byte{0: 0xA, 32: 0xA})
+	require.ErrorIs(t, err, ErrInvalidSuperRootVersion)
+}
+
+func TestUnmarshalSuperRoot_TooShortForVersion(t *testing.T) {
+	_, err := UnmarshalSuperRoot([]byte{})
+	require.ErrorIs(t, err, ErrInvalidSuperRoot)
+}
+
+func TestSuperRootV1Codec(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		chainA := Bytes32{0x01}
+		chainB := Bytes32{0x02}
+		chainC := Bytes32{0x03}
+		superRoot := SuperV1{
+			Timestamp: 7000,
+			Outputs:   []Bytes32{chainA, chainB, chainC},
+		}
+		marshaled := superRoot.Marshal()
+		unmarshaled, err := UnmarshalSuperRoot(marshaled)
+		require.NoError(t, err)
+		unmarshaledV1 := unmarshaled.(*SuperV1)
+		require.Equal(t, superRoot, *unmarshaledV1)
+	})
+
+	t.Run("BelowMinLength", func(t *testing.T) {
+		_, err := UnmarshalSuperRoot(append([]byte{SuperRootVersionV1}, 0x01))
+		require.ErrorIs(t, err, ErrInvalidSuperRoot)
+	})
+
+	t.Run("NoChainsIncluded", func(t *testing.T) {
+		_, err := UnmarshalSuperRoot(binary.BigEndian.AppendUint64([]byte{SuperRootVersionV1}, 134058))
+		require.ErrorIs(t, err, ErrInvalidSuperRoot)
+	})
+
+	t.Run("PartialChainSuperRoot", func(t *testing.T) {
+		input := binary.BigEndian.AppendUint64([]byte{SuperRootVersionV1}, 134058)
+		input = append(input, 0x01, 0x02, 0x03)
+		_, err := UnmarshalSuperRoot(input)
+		require.ErrorIs(t, err, ErrInvalidSuperRoot)
+	})
+}

--- a/op-service/eth/super_root_test.go
+++ b/op-service/eth/super_root_test.go
@@ -19,12 +19,12 @@ func TestUnmarshalSuperRoot_TooShortForVersion(t *testing.T) {
 
 func TestSuperRootV1Codec(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		chainA := ChainIdOutputPair{ChainID: 11, Output: Bytes32{0x01}}
-		chainB := ChainIdOutputPair{ChainID: 12, Output: Bytes32{0x02}}
-		chainC := ChainIdOutputPair{ChainID: 13, Output: Bytes32{0x03}}
+		chainA := ChainIDAndOutput{ChainID: 11, Output: Bytes32{0x01}}
+		chainB := ChainIDAndOutput{ChainID: 12, Output: Bytes32{0x02}}
+		chainC := ChainIDAndOutput{ChainID: 13, Output: Bytes32{0x03}}
 		superRoot := SuperV1{
 			Timestamp: 7000,
-			Chains:    []ChainIdOutputPair{chainA, chainB, chainC},
+			Chains:    []ChainIDAndOutput{chainA, chainB, chainC},
 		}
 		marshaled := superRoot.Marshal()
 		unmarshaled, err := UnmarshalSuperRoot(marshaled)

--- a/op-service/eth/super_root_test.go
+++ b/op-service/eth/super_root_test.go
@@ -19,12 +19,12 @@ func TestUnmarshalSuperRoot_TooShortForVersion(t *testing.T) {
 
 func TestSuperRootV1Codec(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		chainA := Bytes32{0x01}
-		chainB := Bytes32{0x02}
-		chainC := Bytes32{0x03}
+		chainA := ChainIdOutputPair{ChainID: 11, Output: Bytes32{0x01}}
+		chainB := ChainIdOutputPair{ChainID: 12, Output: Bytes32{0x02}}
+		chainC := ChainIdOutputPair{ChainID: 13, Output: Bytes32{0x03}}
 		superRoot := SuperV1{
 			Timestamp: 7000,
-			Outputs:   []Bytes32{chainA, chainB, chainC},
+			Chains:    []ChainIdOutputPair{chainA, chainB, chainC},
 		}
 		marshaled := superRoot.Marshal()
 		unmarshaled, err := UnmarshalSuperRoot(marshaled)


### PR DESCRIPTION
**Description**

Implements the first step of derivation for interop fault proofs in op-program client.

The host doesn't yet support the new hint that's required - will follow up with that.


**Tests**

Unit tests added.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13672
Final piece of https://github.com/ethereum-optimism/optimism/pull/13669
