### PR TITLE
op-program,op-service: dedup BlockInfo header wrapper, always cache hash, avoid recomputing hash

### DIFF
--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -59,7 +59,7 @@ func (p *PreimageOracle) headerByBlockHash(blockHash common.Hash) *types.Header 
 }
 
 func (p *PreimageOracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
-	return eth.HeaderBlockInfo(p.headerByBlockHash(blockHash))
+	return eth.HeaderBlockInfoTrusted(blockHash, p.headerByBlockHash(blockHash))
 }
 
 func (p *PreimageOracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
@@ -75,7 +75,7 @@ func (p *PreimageOracle) TransactionsByBlockHash(blockHash common.Hash) (eth.Blo
 		panic(fmt.Errorf("failed to decode list of txs: %w", err))
 	}
 
-	return eth.HeaderBlockInfo(header), txs
+	return eth.HeaderBlockInfoTrusted(blockHash, header), txs
 }
 
 func (p *PreimageOracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {


### PR DESCRIPTION
**Description**

The header hash was not being cached in op-program. This costs a lot of compute, as `BlockInfo.Hash()` was being called repeatedly.

**Tests**

No new logic, same tests run over the header. Work in progress performance testing outside of this PR.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
