### PR TITLE
docs: Fix incorrect file extension Update README.md

### DIFF
--- a/op-node/README.md
+++ b/op-node/README.md
@@ -17,7 +17,7 @@ It functions as a Consensus Layer client of an OP Stack chain.
 This builds, relays and verifies the canonical chain of blocks.
 The blocks are processed by an execution layer client, like [op-geth].
 
-[rollup-node spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/rollup-node.m
+[rollup-node spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/rollup-node.md
 [op-geth]: https://github.com/ethereum-optimism/op-geth
 
 ## Quickstart


### PR DESCRIPTION
**Description**

While working with the [rollup-node spec], I noticed the file extension was incorrect. It was listed as `.m`, but the correct extension for Markdown files is `.md`.

This update fixes the link so it correctly references the Markdown file.