### PR TITLE
fix: add `--remove-old-proofs` to remove old KCFGs from the cache

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -45,7 +45,8 @@ kontrol_prove() {
     --no-log-rewrites \
     --smt-timeout 16000 \
     --smt-retry-limit 0 \
-    --no-stack-checks
+    --no-stack-checks \
+    --remove-old-proofs
   return $?
 }
 


### PR DESCRIPTION
Recently we have seen a few flakes in the kontrol CI runs:

- https://github.com/runtimeverification/optimism-ci/actions/runs/12697439604
- https://github.com/runtimeverification/optimism-ci/actions/runs/12701047980
- https://github.com/runtimeverification/optimism-ci/actions/runs/12697588708
- https://github.com/runtimeverification/optimism-ci/actions/runs/12705067302

Some of these are due to running out of disk space, so this reduces disk space by removing old, outdated KCFGs from the cache (h/t @JuanCoRo)