### PR TITLE
op-program: Support agreed prestate hint in host

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 
@@ -239,8 +240,8 @@ func TestInteropFaultProofs(gt *testing.T) {
 	chainBClient := actors.ChainB.Sequencer.RollupClient()
 
 	ctx := context.Background()
-	startTimestamp := actors.ChainA.RollupCfg.Genesis.L2Time
-	endTimestamp := startTimestamp + actors.ChainA.RollupCfg.BlockTime
+	endTimestamp := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime
+	startTimestamp := endTimestamp - 1
 	source, err := NewSuperRootSource(ctx, chainAClient, chainBClient)
 	require.NoError(t, err)
 	start, err := source.CreateSuperRoot(ctx, startTimestamp)
@@ -254,14 +255,14 @@ func TestInteropFaultProofs(gt *testing.T) {
 		return data
 	}
 
-	num, err := actors.ChainA.RollupCfg.TargetBlockNumber(endTimestamp)
+	endBlockNumA, err := actors.ChainA.RollupCfg.TargetBlockNumber(endTimestamp)
 	require.NoError(t, err)
-	chain1End, err := chainAClient.OutputAtBlock(ctx, num)
+	chain1End, err := chainAClient.OutputAtBlock(ctx, endBlockNumA)
 	require.NoError(t, err)
 
-	num, err = actors.ChainB.RollupCfg.TargetBlockNumber(endTimestamp)
+	endBlockNumB, err := actors.ChainB.RollupCfg.TargetBlockNumber(endTimestamp)
 	require.NoError(t, err)
-	chain2End, err := chainBClient.OutputAtBlock(ctx, num)
+	chain2End, err := chainBClient.OutputAtBlock(ctx, endBlockNumB)
 	require.NoError(t, err)
 
 	step1Expected := serializeIntermediateRoot(&types.TransitionState{
@@ -297,7 +298,6 @@ func TestInteropFaultProofs(gt *testing.T) {
 			agreedClaim:    start.Marshal(),
 			disputedClaim:  start.Marshal(),
 			expectValid:    false,
-			skip:           true,
 		},
 		{
 			name:           "ClaimDirectToNextTimestamp",
@@ -305,7 +305,6 @@ func TestInteropFaultProofs(gt *testing.T) {
 			agreedClaim:    start.Marshal(),
 			disputedClaim:  end.Marshal(),
 			expectValid:    false,
-			skip:           true,
 		},
 		{
 			name:           "FirstChainOptimisticBlock",
@@ -364,6 +363,9 @@ func TestInteropFaultProofs(gt *testing.T) {
 				chain1End.BlockRef.Number,
 				checkResult,
 				fpHelpers.WithInteropEnabled(),
+				fpHelpers.WithAgreedPrestate(test.agreedClaim),
+				fpHelpers.WithL2Claim(crypto.Keccak256Hash(test.disputedClaim)),
+				fpHelpers.WithL2BlockNumber(endBlockNumA),
 			)
 		})
 	}

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
@@ -250,7 +249,7 @@ func TestInteropFaultProofs(gt *testing.T) {
 	require.NoError(t, err)
 
 	serializeIntermediateRoot := func(root *types.TransitionState) []byte {
-		data, err := rlp.EncodeToBytes(root)
+		data, err := root.Marshal()
 		require.NoError(t, err)
 		return data
 	}

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	e2ecfg "github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
@@ -151,6 +152,13 @@ func WithL2Claim(claim common.Hash) FixtureInputParam {
 	}
 }
 
+func WithAgreedPrestate(prestate []byte) FixtureInputParam {
+	return func(f *FixtureInputs) {
+		f.AgreedPrestate = prestate
+		f.L2OutputRoot = crypto.Keccak256Hash(prestate)
+	}
+}
+
 func WithL2BlockNumber(num uint64) FixtureInputParam {
 	return func(f *FixtureInputs) {
 		f.L2BlockNumber = num
@@ -213,6 +221,7 @@ func NewOpProgramCfg(
 		dfault.DataDir = t.TempDir()
 		dfault.DataFormat = hostTypes.DataFormatPebble
 	}
+	dfault.AgreedPrestate = fi.AgreedPrestate
 	dfault.InteropEnabled = fi.InteropEnabled
 	return dfault
 }

--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -44,6 +44,7 @@ type FixtureInputs struct {
 	L2OutputRoot   common.Hash `toml:"l2-output-root"`
 	L2ChainID      uint64      `toml:"l2-chain-id"`
 	L1Head         common.Hash `toml:"l1-head"`
+	AgreedPrestate []byte      `toml:"agreed-prestate"`
 	InteropEnabled bool        `toml:"use-interop"`
 }
 

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -83,7 +83,7 @@ func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Mi
 			l2DebugCl := hostcommon.NewL2SourceWithClient(logger, l2Client, sources.NewDebugClient(l2RPC.CallContext))
 
 			executor := host.MakeProgramExecutor(logger, programCfg)
-			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2DebugCl, kv, l2ChainConfig.Config, executor), nil
+			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2DebugCl, kv, executor, cfg.AgreedPrestate), nil
 		})
 		err = hostcommon.FaultProofProgram(t.Ctx(), logger, programCfg, withInProcessPrefetcher)
 		checkResult(t, err)

--- a/op-program/client/interop/types/roots.go
+++ b/op-program/client/interop/types/roots.go
@@ -48,7 +48,7 @@ func (i *TransitionState) Hash() (common.Hash, error) {
 	return crypto.Keccak256Hash(data), nil
 }
 
-func UnmarshalProofsState(data []byte) (*TransitionState, error) {
+func UnmarshalTransitionState(data []byte) (*TransitionState, error) {
 	if len(data) == 0 {
 		return nil, eth.ErrInvalidSuperRoot
 	}

--- a/op-program/client/interop/types/roots_test.go
+++ b/op-program/client/interop/types/roots_test.go
@@ -27,7 +27,7 @@ func TestTransitionStateCodec(t *testing.T) {
 		}
 		data, err := state.Marshal()
 		require.NoError(t, err)
-		actual, err := UnmarshalProofsState(data)
+		actual, err := UnmarshalTransitionState(data)
 		require.NoError(t, err)
 		require.Equal(t, state, actual)
 	})
@@ -44,7 +44,7 @@ func TestTransitionStateCodec(t *testing.T) {
 			SuperRoot: superRoot.Marshal(),
 		}
 		data := superRoot.Marshal()
-		actual, err := UnmarshalProofsState(data)
+		actual, err := UnmarshalTransitionState(data)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	})

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -124,7 +124,7 @@ func (p *PreimageOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash,
 func (p *PreimageOracle) TransitionStateByRoot(root common.Hash) *interopTypes.TransitionState {
 	p.hint.Hint(AgreedPrestateHint(root))
 	data := p.oracle.Get(preimage.Keccak256Key(root))
-	output, err := interopTypes.UnmarshalProofsState(data)
+	output, err := interopTypes.UnmarshalTransitionState(data)
 	if err != nil {
 		panic(fmt.Errorf("invalid agreed prestate data for root %s: %w", root, err))
 	}

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -202,7 +203,11 @@ func TestL2Head(t *testing.T) {
 
 func TestL2OutputRoot(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2.outputroot is required", addRequiredArgsExcept("--l2.outputroot"))
+		verifyArgsInvalid(t, "flag l2.outputroot or l2.agreed-prestate is required", addRequiredArgsExcept("--l2.outputroot"))
+	})
+
+	t.Run("NotRequiredWhenAgreedPrestateProvided", func(t *testing.T) {
+		configForArgs(t, addRequiredArgsExcept("--l2.outputroot", "--l2.agreed-prestate", "0x1234"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -212,6 +217,29 @@ func TestL2OutputRoot(t *testing.T) {
 
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, config.ErrInvalidL2OutputRoot.Error(), replaceRequiredArg("--l2.outputroot", "something"))
+	})
+}
+
+func TestL2AgreedPrestate(t *testing.T) {
+	t.Run("NotRequiredWhenL2OutputRootProvided", func(t *testing.T) {
+		configForArgs(t, addRequiredArgsExcept("--l2.outputroot", "--l2.outputroot", "0x1234"))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		prestate := "0x1234"
+		prestateBytes := common.FromHex(prestate)
+		expectedOutputRoot := crypto.Keccak256Hash(prestateBytes)
+		cfg := configForArgs(t, addRequiredArgsExcept("--l2.outputroot", "--l2.agreed-prestate", prestate))
+		require.Equal(t, expectedOutputRoot, cfg.L2OutputRoot)
+		require.Equal(t, prestateBytes, cfg.AgreedPrestate)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(t, config.ErrInvalidAgreedPrestate.Error(), addRequiredArgsExcept("--l2.outputroot", "--l2.agreed-prestate", "something"))
+	})
+
+	t.Run("ZeroLength", func(t *testing.T) {
+		verifyArgsInvalid(t, config.ErrInvalidAgreedPrestate.Error(), addRequiredArgsExcept("--l2.outputroot", "--l2.agreed-prestate", "0x"))
 	})
 }
 

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -234,6 +234,10 @@ func TestL2AgreedPrestate(t *testing.T) {
 		require.Equal(t, prestateBytes, cfg.AgreedPrestate)
 	})
 
+	t.Run("MustNotSpecifyWithL2OutputRoot", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag l2.outputroot and l2.agreed-prestate must not be specified together", addRequiredArgs("--l2.agreed-prestate", "0x1234"))
+	})
+
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, config.ErrInvalidAgreedPrestate.Error(), addRequiredArgsExcept("--l2.outputroot", "--l2.agreed-prestate", "something"))
 	})

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -121,8 +121,13 @@ func (c *Config) Check() error {
 	if c.DataDir != "" && !slices.Contains(types.SupportedDataFormats, c.DataFormat) {
 		return ErrInvalidDataFormat
 	}
-	if c.InteropEnabled && len(c.AgreedPrestate) == 0 {
-		return ErrMissingAgreedPrestate
+	if c.InteropEnabled {
+		if len(c.AgreedPrestate) == 0 {
+			return ErrMissingAgreedPrestate
+		}
+		if crypto.Keccak256Hash(c.AgreedPrestate) != c.L2OutputRoot {
+			return fmt.Errorf("%w: must be preimage of L2 output root", ErrInvalidAgreedPrestate)
+		}
 	}
 	return nil
 }

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/host/flags"
@@ -24,17 +25,19 @@ import (
 )
 
 var (
-	ErrMissingRollupConfig = errors.New("missing rollup config")
-	ErrMissingL2Genesis    = errors.New("missing l2 genesis")
-	ErrInvalidL1Head       = errors.New("invalid l1 head")
-	ErrInvalidL2Head       = errors.New("invalid l2 head")
-	ErrInvalidL2OutputRoot = errors.New("invalid l2 output root")
-	ErrL1AndL2Inconsistent = errors.New("l1 and l2 options must be specified together or both omitted")
-	ErrInvalidL2Claim      = errors.New("invalid l2 claim")
-	ErrInvalidL2ClaimBlock = errors.New("invalid l2 claim block number")
-	ErrDataDirRequired     = errors.New("datadir must be specified when in non-fetching mode")
-	ErrNoExecInServerMode  = errors.New("exec command must not be set when in server mode")
-	ErrInvalidDataFormat   = errors.New("invalid data format")
+	ErrMissingRollupConfig   = errors.New("missing rollup config")
+	ErrMissingL2Genesis      = errors.New("missing l2 genesis")
+	ErrInvalidL1Head         = errors.New("invalid l1 head")
+	ErrInvalidL2Head         = errors.New("invalid l2 head")
+	ErrInvalidL2OutputRoot   = errors.New("invalid l2 output root")
+	ErrInvalidAgreedPrestate = errors.New("invalid l2 agreed prestate")
+	ErrL1AndL2Inconsistent   = errors.New("l1 and l2 options must be specified together or both omitted")
+	ErrInvalidL2Claim        = errors.New("invalid l2 claim")
+	ErrInvalidL2ClaimBlock   = errors.New("invalid l2 claim block number")
+	ErrDataDirRequired       = errors.New("datadir must be specified when in non-fetching mode")
+	ErrNoExecInServerMode    = errors.New("exec command must not be set when in server mode")
+	ErrInvalidDataFormat     = errors.New("invalid data format")
+	ErrMissingAgreedPrestate = errors.New("missing agreed prestate")
 )
 
 type Config struct {
@@ -80,6 +83,8 @@ type Config struct {
 
 	// InteropEnabled enables interop fault proof rules when running the client in-process
 	InteropEnabled bool
+	// AgreedPrestate is the preimage of the agreed prestate claim. Required for interop.
+	AgreedPrestate []byte
 }
 
 func (c *Config) Check() error {
@@ -115,6 +120,9 @@ func (c *Config) Check() error {
 	}
 	if c.DataDir != "" && !slices.Contains(types.SupportedDataFormats, c.DataFormat) {
 		return ErrInvalidDataFormat
+	}
+	if c.InteropEnabled && len(c.AgreedPrestate) == 0 {
+		return ErrMissingAgreedPrestate
 	}
 	return nil
 }
@@ -162,7 +170,18 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	if l2Head == (common.Hash{}) {
 		return nil, ErrInvalidL2Head
 	}
-	l2OutputRoot := common.HexToHash(ctx.String(flags.L2OutputRoot.Name))
+	var l2OutputRoot common.Hash
+	var agreedPrestate []byte
+	if ctx.IsSet(flags.L2OutputRoot.Name) {
+		l2OutputRoot = common.HexToHash(ctx.String(flags.L2OutputRoot.Name))
+	} else if ctx.IsSet(flags.L2AgreedPrestate.Name) {
+		prestateStr := ctx.String(flags.L2AgreedPrestate.Name)
+		agreedPrestate = common.FromHex(prestateStr)
+		if len(agreedPrestate) == 0 {
+			return nil, ErrInvalidAgreedPrestate
+		}
+		l2OutputRoot = crypto.Keccak256Hash(agreedPrestate)
+	}
 	if l2OutputRoot == (common.Hash{}) {
 		return nil, ErrInvalidL2OutputRoot
 	}
@@ -238,6 +257,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		L2ChainConfig:      l2ChainConfig,
 		L2Head:             l2Head,
 		L2OutputRoot:       l2OutputRoot,
+		AgreedPrestate:     agreedPrestate,
 		L2Claim:            l2Claim,
 		L2ClaimBlockNumber: l2ClaimBlockNum,
 		L1Head:             l1Head,

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
@@ -202,7 +203,16 @@ func TestAgreedPrestate(t *testing.T) {
 		cfg := validConfig()
 		cfg.InteropEnabled = true
 		cfg.AgreedPrestate = []byte{1}
+		cfg.L2OutputRoot = crypto.Keccak256Hash(cfg.AgreedPrestate)
 		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("mustMatchL2OutputRoot", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.InteropEnabled = true
+		cfg.AgreedPrestate = []byte{1}
+		cfg.L2OutputRoot = common.Hash{0xaa}
+		require.ErrorIs(t, cfg.Check(), ErrInvalidAgreedPrestate)
 	})
 }
 

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -174,7 +174,36 @@ func TestCustomL2ChainID(t *testing.T) {
 		cfg := NewConfig(validRollupConfig, customChainConfig, validL1Head, validL2Head, validL2OutputRoot, validL2Claim, validL2ClaimBlockNum)
 		require.Equal(t, cfg.L2ChainID, boot.CustomChainIDIndicator)
 	})
+}
 
+func TestAgreedPrestate(t *testing.T) {
+	t.Run("requiredWithInterop-nil", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.InteropEnabled = true
+		cfg.AgreedPrestate = nil
+		err := cfg.Check()
+		require.ErrorIs(t, err, ErrMissingAgreedPrestate)
+	})
+	t.Run("requiredWithInterop-empty", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.InteropEnabled = true
+		cfg.AgreedPrestate = []byte{}
+		err := cfg.Check()
+		require.ErrorIs(t, err, ErrMissingAgreedPrestate)
+	})
+
+	t.Run("notRequiredWithoutInterop", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.AgreedPrestate = nil
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.InteropEnabled = true
+		cfg.AgreedPrestate = []byte{1}
+		require.NoError(t, cfg.Check())
+	})
 }
 
 func TestDBFormat(t *testing.T) {

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -194,5 +194,8 @@ func CheckRequired(ctx *cli.Context) error {
 	if !ctx.IsSet(L2OutputRoot.Name) && !ctx.IsSet(L2AgreedPrestate.Name) {
 		return fmt.Errorf("flag %s or %s is required", L2OutputRoot.Name, L2AgreedPrestate.Name)
 	}
+	if ctx.IsSet(L2OutputRoot.Name) && ctx.IsSet(L2AgreedPrestate.Name) {
+		return fmt.Errorf("flag %s and %s must not be specified together", L2OutputRoot.Name, L2AgreedPrestate.Name)
+	}
 	return nil
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -72,8 +72,14 @@ var (
 	}
 	L2OutputRoot = &cli.StringFlag{
 		Name:    "l2.outputroot",
-		Usage:   "Agreed L2 Output Root to start derivation from",
+		Usage:   "Agreed L2 Output Root to start derivation from. Used for non-interop games.",
 		EnvVars: prefixEnvVars("L2_OUTPUT_ROOT"),
+	}
+	L2AgreedPrestate = &cli.StringFlag{
+		Name: "l2.agreed-prestate",
+		Usage: "Agreed L2 pre state pre-image to start derivation from. " +
+			"l2.outputroot will be automatically set to the hash of the prestate. Used for interop-enabled games.",
+		EnvVars: prefixEnvVars("L2_AGREED_PRESTATE"),
 	}
 	L2Claim = &cli.StringFlag{
 		Name:    "l2.claim",
@@ -133,12 +139,13 @@ var Flags []cli.Flag
 var requiredFlags = []cli.Flag{
 	L1Head,
 	L2Head,
-	L2OutputRoot,
 	L2Claim,
 	L2BlockNumber,
 }
 
 var programFlags = []cli.Flag{
+	L2OutputRoot,
+	L2AgreedPrestate,
 	L2Custom,
 	RollupConfig,
 	Network,
@@ -183,6 +190,9 @@ func CheckRequired(ctx *cli.Context) error {
 		if !ctx.IsSet(flag.Names()[0]) {
 			return fmt.Errorf("flag %s is required", flag.Names()[0])
 		}
+	}
+	if !ctx.IsSet(L2OutputRoot.Name) && !ctx.IsSet(L2AgreedPrestate.Name) {
+		return fmt.Errorf("flag %s or %s is required", L2OutputRoot.Name, L2AgreedPrestate.Name)
 	}
 	return nil
 }

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -95,7 +95,7 @@ func makeDefaultPrefetcher(ctx context.Context, logger log.Logger, kv kvstore.KV
 	}
 
 	executor := MakeProgramExecutor(logger, cfg)
-	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2Client, kv, cfg.L2ChainConfig, executor), nil
+	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2Client, kv, executor, cfg.AgreedPrestate), nil
 }
 
 type programExecutor struct {

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -567,6 +567,28 @@ func TestFetchL2BlockData(t *testing.T) {
 	})
 }
 
+func TestFetchAgreedPrestate(t *testing.T) {
+	t.Run("unavailable", func(t *testing.T) {
+		prefetcher, _, _, _, _ := createPrefetcher(t)
+		hash := common.Hash{0xaa}
+		hint := l2.AgreedPrestateHint(hash).Hint()
+		require.NoError(t, prefetcher.Hint(hint))
+		_, err := prefetcher.GetPreimage(context.Background(), hash)
+		require.ErrorIs(t, err, ErrAgreedPrestateUnavailable)
+	})
+
+	t.Run("available", func(t *testing.T) {
+		prestate := []byte{1, 2, 3, 6}
+		prefetcher, _, _, _, _ := createPrefetcherWithAgreedPrestate(t, prestate)
+		hash := crypto.Keccak256Hash(prestate)
+		hint := l2.AgreedPrestateHint(hash).Hint()
+		require.NoError(t, prefetcher.Hint(hint))
+		actual, err := prefetcher.GetPreimage(context.Background(), hash)
+		require.NoError(t, err)
+		require.Equal(t, prestate, actual)
+	})
+}
+
 func TestBadHints(t *testing.T) {
 	prefetcher, _, _, _, kv := createPrefetcher(t)
 	hash := common.Hash{0xad}
@@ -666,6 +688,9 @@ func (m *l2Client) ExpectOutputByRoot(root common.Hash, output eth.Output, err e
 }
 
 func createPrefetcher(t *testing.T) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Client, kvstore.KV) {
+	return createPrefetcherWithAgreedPrestate(t, nil)
+}
+func createPrefetcherWithAgreedPrestate(t *testing.T, agreedPrestate []byte) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Client, kvstore.KV) {
 	logger := testlog.Logger(t, log.LevelDebug)
 	kv := kvstore.NewMemKV()
 
@@ -676,7 +701,7 @@ func createPrefetcher(t *testing.T) (*Prefetcher, *testutils.MockL1Source, *test
 		MockDebugClient: new(testutils.MockDebugClient),
 	}
 
-	prefetcher := NewPrefetcher(logger, l1Source, l1BlobSource, l2Source, kv, nil, nil)
+	prefetcher := NewPrefetcher(logger, l1Source, l1BlobSource, l2Source, kv, nil, agreedPrestate)
 	return prefetcher, l1Source, l1BlobSource, l2Source, kv
 }
 

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -583,7 +583,7 @@ func TestFetchAgreedPrestate(t *testing.T) {
 		hash := crypto.Keccak256Hash(prestate)
 		hint := l2.AgreedPrestateHint(hash).Hint()
 		require.NoError(t, prefetcher.Hint(hint))
-		actual, err := prefetcher.GetPreimage(context.Background(), hash)
+		actual, err := prefetcher.GetPreimage(context.Background(), preimage.Keccak256Key(hash).PreimageKey())
 		require.NoError(t, err)
 		require.Equal(t, prestate, actual)
 	})


### PR DESCRIPTION
**Description**

Adds a cli flag and config option to set the agree prestate preimage and use it for the agree-prestate hash.

**Tests**

Added some.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13677