### PR TITLE
fix: OptimismPortal was deleted, so removing it from kontrol

### DIFF
--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -113,7 +113,7 @@ on_failure() {
 # empty assignment to activate/deactivate the corresponding flag
 lemmas=test/kontrol/pausability-lemmas.md
 base_module=PAUSABILITY-LEMMAS
-module=OptimismPortalKontrol:$base_module
+module=OptimismPortal2Kontrol:$base_module
 rekompile=--rekompile
 # rekompile=
 regen=--regen
@@ -122,19 +122,6 @@ regen=--regen
 #################################
 # Tests to symbolically execute #
 #################################
-# Temporarily unexecuted tests
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused0" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused1(" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused2" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused3" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused4" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused5" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused6" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused7" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused8" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused9" \
-# "OptimismPortalKontrol.prove_proveWithdrawalTransaction_paused10" \
-
 test_list=()
 if [ "$SCRIPT_TESTS" == true ]; then
   test_list=(


### PR DESCRIPTION
Per @JuanCoRo 
> Because of how new modules are imported in K, to add the lemmas in Kontrol we need do it by specifying a contract in [this line](https://github.com/ethereum-optimism/optimism/blob/56d336e95467b850e07ca5ec1f26d3f809fb7aae/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh#L116). In this case it is `OptimismPortalKontrol`, but that one was removed, so Kontrol is not finding it. We need to change it to `OptimismPortal2Kontrol`