### PR TITLE
chore: add predeploy details comments

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0x9bbfabb19b7f572dadae797786c2f87d892693650151bd8de6eadee3e03fc559"
   },
   "src/L2/ETHLiquidity.sol": {
-    "initCodeHash": "0xbb16de6a3f678db7301694a000f315154f25f9660c8dcec4b0bef20bc7cfdebd",
-    "sourceCodeHash": "0x0576b189811bd343c2cdafcb512ece2c2ea20077bef8754a3dc3e3c80210b225"
+    "initCodeHash": "0xdc7075deb7e7c407e6ec3be33ce352ee4a9ca0e82f4bffeb360c93b395a2452f",
+    "sourceCodeHash": "0x92bf6a7a13d1331cbfed35e22130b54b00576bd31de5feb309dfadef2a0b7dd9"
   },
   "src/L2/GasPriceOracle.sol": {
     "initCodeHash": "0x83d50e3b34cd1b4de32f1cced28796b07aefc526cc17ceb1903ad55f4abc90b7",

--- a/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
+++ b/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
@@ -12,6 +12,8 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 
+/// @custom:proxied true
+/// @custom:predeploy 0x4200000000000000000000000000000000000025
 /// @title ETHLiquidity
 /// @notice The ETHLiquidity contract allows other contracts to access ETH liquidity without
 ///         needing to modify the EVM to generate new ETH.
@@ -23,8 +25,8 @@ contract ETHLiquidity is ISemver {
     event LiquidityMinted(address indexed caller, uint256 value);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.4
-    string public constant version = "1.0.0-beta.4";
+    /// @custom:semver 1.0.0-beta.5
+    string public constant version = "1.0.0-beta.5";
 
     /// @notice Allows an address to lock ETH liquidity into this contract.
     function burn() external payable {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`ETHLiquidity.sol` is a predeploy contract and is proxied, this should be reflected in the NATSPEC.


