### PR TITLE
op-program: Return safe or local safe head from derivation

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -311,7 +311,6 @@ func TestInteropFaultProofs(gt *testing.T) {
 			agreedClaim:    start.Marshal(),
 			disputedClaim:  step1Expected,
 			expectValid:    true,
-			skip:           true,
 		},
 		{
 			name:           "SecondChainOptimisticBlock",

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -221,7 +221,9 @@ func NewOpProgramCfg(
 		dfault.DataDir = t.TempDir()
 		dfault.DataFormat = hostTypes.DataFormatPebble
 	}
-	dfault.AgreedPrestate = fi.AgreedPrestate
+	if fi.InteropEnabled {
+		dfault.AgreedPrestate = fi.AgreedPrestate
+	}
 	dfault.InteropEnabled = fi.InteropEnabled
 	return dfault
 }

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
@@ -17,7 +18,7 @@ import (
 
 type EndCondition interface {
 	Closing() bool
-	Result() error
+	Result() (eth.L2BlockRef, error)
 }
 
 type Driver struct {
@@ -25,8 +26,9 @@ type Driver struct {
 
 	events []event.Event
 
-	end     EndCondition
-	deriver event.Deriver
+	end         EndCondition
+	deriver     event.Deriver
+	engineDeriv *engine.EngDeriver
 }
 
 func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher,
@@ -51,7 +53,7 @@ func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher,
 		logger:         logger,
 		Emitter:        d,
 		closing:        false,
-		result:         nil,
+		result:         eth.L2BlockRef{},
 		targetBlockNum: targetBlockNum,
 	}
 
@@ -62,6 +64,7 @@ func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher,
 		engResetDeriv,
 	}
 	d.end = prog
+	d.engineDeriv = engineDeriv
 
 	return d
 }
@@ -73,7 +76,7 @@ func (d *Driver) Emit(ev event.Event) {
 	d.events = append(d.events, ev)
 }
 
-func (d *Driver) RunComplete() error {
+func (d *Driver) RunComplete() (eth.L2BlockRef, error) {
 	// Initial reset
 	d.Emit(engine.ResetEngineRequestEvent{})
 
@@ -83,7 +86,7 @@ func (d *Driver) RunComplete() error {
 			return d.end.Result()
 		}
 		if len(d.events) > 10000 { // sanity check, in case of bugs. Better than going OOM.
-			return errors.New("way too many events queued up, something is wrong")
+			return eth.L2BlockRef{}, errors.New("way too many events queued up, something is wrong")
 		}
 		ev := d.events[0]
 		d.events = d.events[1:]

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -60,15 +60,23 @@ func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
 		// and continue with the next.
 		d.Emitter.Emit(engine.PendingSafeRequestEvent{})
 	case engine.ForkchoiceUpdateEvent:
+		// Track latest head.
+		if x.SafeL2Head.Number >= d.result.Number {
+			d.result = x.SafeL2Head
+		}
+		// Stop if we have reached the target block
 		if x.SafeL2Head.Number >= d.targetBlockNum {
 			d.logger.Info("Derivation complete: reached L2 block as safe", "head", x.SafeL2Head)
 			d.closing = true
-			d.result = x.SafeL2Head
 		}
 	case engine.LocalSafeUpdateEvent:
+		// Track latest head.
+		if x.Ref.Number >= d.result.Number {
+			d.result = x.Ref
+		}
+		// Stop if we have reached the target block
 		if x.Ref.Number >= d.targetBlockNum {
 			d.logger.Info("Derivation complete: reached L2 block as local safe", "head", x.Ref)
-			d.result = x.Ref
 			d.closing = true
 		}
 	case derive.DeriverIdleEvent:

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -66,9 +66,11 @@ func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
 			d.result = x.SafeL2Head
 		}
 	case engine.LocalSafeUpdateEvent:
-		d.logger.Info("Derivation complete: reached L2 block as local safe", "head", x.Ref)
-		d.result = x.Ref
-		d.closing = true
+		if x.Ref.Number >= d.targetBlockNum {
+			d.logger.Info("Derivation complete: reached L2 block as local safe", "head", x.Ref)
+			d.result = x.Ref
+			d.closing = true
+		}
 	case derive.DeriverIdleEvent:
 		// We don't close the deriver yet, as the engine may still be processing events to reach
 		// the target. A ForkchoiceUpdateEvent will close the deriver when the target is reached.

--- a/op-program/client/driver/program.go
+++ b/op-program/client/driver/program.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -21,7 +22,8 @@ type ProgramDeriver struct {
 	Emitter event.Emitter
 
 	closing        bool
-	result         error
+	result         eth.L2BlockRef
+	resultError    error
 	targetBlockNum uint64
 }
 
@@ -29,8 +31,8 @@ func (d *ProgramDeriver) Closing() bool {
 	return d.closing
 }
 
-func (d *ProgramDeriver) Result() error {
-	return d.result
+func (d *ProgramDeriver) Result() (eth.L2BlockRef, error) {
+	return d.result, d.resultError
 }
 
 func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
@@ -59,19 +61,24 @@ func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
 		d.Emitter.Emit(engine.PendingSafeRequestEvent{})
 	case engine.ForkchoiceUpdateEvent:
 		if x.SafeL2Head.Number >= d.targetBlockNum {
-			d.logger.Info("Derivation complete: reached L2 block", "head", x.SafeL2Head)
+			d.logger.Info("Derivation complete: reached L2 block as safe", "head", x.SafeL2Head)
 			d.closing = true
+			d.result = x.SafeL2Head
 		}
+	case engine.LocalSafeUpdateEvent:
+		d.logger.Info("Derivation complete: reached L2 block as local safe", "head", x.Ref)
+		d.result = x.Ref
+		d.closing = true
 	case derive.DeriverIdleEvent:
-		// We dont't close the deriver yet, as the engine may still be processing events to reach
+		// We don't close the deriver yet, as the engine may still be processing events to reach
 		// the target. A ForkchoiceUpdateEvent will close the deriver when the target is reached.
 		d.logger.Info("Derivation complete: no further L1 data to process")
 	case rollup.ResetEvent:
 		d.closing = true
-		d.result = fmt.Errorf("unexpected reset error: %w", x.Err)
+		d.resultError = fmt.Errorf("unexpected reset error: %w", x.Err)
 	case rollup.L1TemporaryErrorEvent:
 		d.closing = true
-		d.result = fmt.Errorf("unexpected L1 error: %w", x.Err)
+		d.resultError = fmt.Errorf("unexpected L1 error: %w", x.Err)
 	case rollup.EngineTemporaryErrorEvent:
 		// (Legacy case): While most temporary errors are due to requests for external data failing which can't happen,
 		// they may also be returned due to other events like channels timing out so need to be handled
@@ -79,7 +86,7 @@ func (d *ProgramDeriver) OnEvent(ev event.Event) bool {
 		d.Emitter.Emit(engine.PendingSafeRequestEvent{})
 	case rollup.CriticalErrorEvent:
 		d.closing = true
-		d.result = x.Err
+		d.resultError = x.Err
 	default:
 		// Other events can be ignored safely.
 		// They are broadcast, but only consumed by the other derivers,

--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -64,7 +64,7 @@ func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOra
 		bootInfo.RollupConfig,
 		bootInfo.L2ChainConfig,
 		bootInfo.L1Head,
-		superRoot.Chains[0].Output,
+		superRoot.Chains[transitionState.Step].Output,
 		claimedBlockNumber,
 		l1PreimageOracle,
 		l2PreimageOracle,

--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -91,7 +91,7 @@ func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOra
 	if !validateClaim {
 		return nil
 	}
-	return claim.ValidateClaim(logger, derivationResult.SafeHead, eth.Bytes32(bootInfo.L2Claim), eth.Bytes32(expected))
+	return claim.ValidateClaim(logger, derivationResult.Head, eth.Bytes32(bootInfo.L2Claim), eth.Bytes32(expected))
 }
 
 type interopTaskExecutor struct {

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -75,7 +75,7 @@ func (t *stubTasks) RunDerivation(
 	_ l1.Oracle,
 	_ l2.Oracle) (tasks.DerivationResult, error) {
 	return tasks.DerivationResult{
-		SafeHead:   t.l2SafeHead,
+		Head:       t.l2SafeHead,
 		BlockHash:  t.blockHash,
 		OutputRoot: t.outputRoot,
 	}, t.err

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -25,5 +25,5 @@ func RunPreInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1Preimage
 	if err != nil {
 		return err
 	}
-	return claim.ValidateClaim(logger, result.SafeHead, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
+	return claim.ValidateClaim(logger, result.Head, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
 }

--- a/op-program/client/tasks/derive_test.go
+++ b/op-program/client/tasks/derive_test.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -12,81 +11,56 @@ import (
 
 func TestLoadOutputRoot(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
+		safeHead := eth.L2BlockRef{Number: 65}
 		l2 := &mockL2{
 			blockHash:  common.Hash{0x24},
 			outputRoot: eth.Bytes32{0x11},
-			safeL2:     eth.L2BlockRef{Number: 65},
 		}
-		result, err := loadOutputRoot(uint64(0), l2)
+		result, err := loadOutputRoot(uint64(0), safeHead, l2)
 		require.NoError(t, err)
-		assertDerivationResult(t, result, l2.safeL2, l2.blockHash, l2.outputRoot)
+		assertDerivationResult(t, result, safeHead, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Success-PriorToSafeHead", func(t *testing.T) {
 		expected := eth.Bytes32{0x11}
+		safeHead := eth.L2BlockRef{
+			Number: 10,
+		}
 		l2 := &mockL2{
 			blockHash:  common.Hash{0x24},
 			outputRoot: expected,
-			safeL2: eth.L2BlockRef{
-				Number: 10,
-			},
 		}
-		result, err := loadOutputRoot(uint64(20), l2)
+		result, err := loadOutputRoot(uint64(20), safeHead, l2)
 		require.NoError(t, err)
 		require.Equal(t, uint64(10), l2.requestedOutputRoot)
-		assertDerivationResult(t, result, l2.safeL2, l2.blockHash, l2.outputRoot)
-	})
-
-	t.Run("Error-SafeHead", func(t *testing.T) {
-		expectedErr := errors.New("boom")
-		l2 := &mockL2{
-			blockHash:  common.Hash{0x24},
-			outputRoot: eth.Bytes32{0x11},
-			safeL2:     eth.L2BlockRef{Number: 10},
-			safeL2Err:  expectedErr,
-		}
-		_, err := loadOutputRoot(uint64(0), l2)
-		require.ErrorIs(t, err, expectedErr)
+		assertDerivationResult(t, result, safeHead, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Error-OutputRoot", func(t *testing.T) {
 		expectedErr := errors.New("boom")
+		safeHead := eth.L2BlockRef{Number: 10}
 		l2 := &mockL2{
 			blockHash:     common.Hash{0x24},
 			outputRoot:    eth.Bytes32{0x11},
 			outputRootErr: expectedErr,
-			safeL2:        eth.L2BlockRef{Number: 10},
 		}
-		_, err := loadOutputRoot(uint64(0), l2)
+		_, err := loadOutputRoot(uint64(0), safeHead, l2)
 		require.ErrorIs(t, err, expectedErr)
 	})
 }
 
 func assertDerivationResult(t *testing.T, actual DerivationResult, safeHead eth.L2BlockRef, blockHash common.Hash, outputRoot eth.Bytes32) {
-	require.Equal(t, safeHead, actual.SafeHead)
+	require.Equal(t, safeHead, actual.Head)
 	require.Equal(t, blockHash, actual.BlockHash)
 	require.Equal(t, outputRoot, actual.OutputRoot)
 }
 
 type mockL2 struct {
-	safeL2    eth.L2BlockRef
-	safeL2Err error
-
 	blockHash     common.Hash
 	outputRoot    eth.Bytes32
 	outputRootErr error
 
 	requestedOutputRoot uint64
-}
-
-func (m *mockL2) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	if label != eth.Safe {
-		panic("unexpected usage")
-	}
-	if m.safeL2Err != nil {
-		return eth.L2BlockRef{}, m.safeL2Err
-	}
-	return m.safeL2, nil
 }
 
 func (m *mockL2) L2OutputRoot(u uint64) (common.Hash, eth.Bytes32, error) {


### PR DESCRIPTION
**Description**

Avoids relying on the safe label which won't be updated on interop chains.


**Tests**

`FirstChainOptimisticBlock` interop test now passes.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13691