### PR TITLE
chore: bump kontrol version, and make output checks more robust

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ anvil = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
 # actually be managed by mise (yet). Make sure that anything you put in here is
 # also found inside of disabled_tools or mise will try to install it.
 asterisc = "1.2.0"
-kontrol = "1.0.53"
+kontrol = "1.0.90"
 binary_signer = "1.0.4"
 
 [alias]

--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -202,20 +202,4 @@ fi
 
 get_log_results
 echo "Kontrol Passed"
-
-# Now you can use ${results[0]} and ${results[1]}
-# to check the results of kontrol_build and kontrol_prove, respectively
-if [ "${results[0]}" -ne 0 ] && [ "${results[1]}" -ne 0 ]; then
-  echo "Kontrol Build and Prove Failed"
-  exit 1
-elif [ "${results[0]}" -ne 0 ]; then
-  echo "Kontrol Build Failed"
-  exit 1
-elif [ "${results[1]}" -ne 0 ]; then
-  echo "Kontrol Prove Failed"
-  exit 2
-else
-  echo "Kontrol Passed"
-fi
-
 notif "DONE"

--- a/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/scripts/run-kontrol.sh
@@ -183,15 +183,25 @@ trap clean_docker EXIT
 conditionally_start_docker
 
 results=()
+
 # Run kontrol_build and store the result
 kontrol_build
 results[0]=$?
+if [ "${results[0]}" -ne 0 ]; then
+  echo "Kontrol Build Failed"
+  exit 1
+fi
 
 # Run kontrol_prove and store the result
 kontrol_prove
 results[1]=$?
+if [ "${results[1]}" -ne 0 ]; then
+  echo "Kontrol Prove Failed"
+  exit 2
+fi
 
 get_log_results
+echo "Kontrol Passed"
 
 # Now you can use ${results[0]} and ${results[1]}
 # to check the results of kontrol_build and kontrol_prove, respectively


### PR DESCRIPTION
Some CI failures occurred due to silent failure of `kontrol build` (so CI should have failed earlier than it did). The newest version of kontrol has a fix for this, and we also update `run-kontrl.sh` to check for failure explicitly