### PR TITLE
kt-devnet: improves post-deployment output for nodes/services

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -50,40 +50,84 @@ func TestFindRPCEndpoints(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		services      inspect.ServiceMap
-		findFn        func(*ServiceFinder) ([]Node, EndpointMap)
-		wantNodes     []Node
-		wantEndpoints EndpointMap
+		name         string
+		services     inspect.ServiceMap
+		findFn       func(*ServiceFinder) ([]Node, ServiceMap)
+		wantNodes    []Node
+		wantServices ServiceMap
 	}{
 		{
 			name:     "find L1 endpoints",
 			services: testServices,
-			findFn: func(f *ServiceFinder) ([]Node, EndpointMap) {
-				return f.FindL1Endpoints()
+			findFn: func(f *ServiceFinder) ([]Node, ServiceMap) {
+				return f.FindL1Services()
 			},
 			wantNodes: []Node{
 				{
-					"cl": "http://localhost:52693",
-					"el": "http://localhost:52645",
+					Services: ServiceMap{
+						"cl": Service{
+							Name: "cl-1-lighthouse-geth",
+							Endpoints: EndpointMap{
+								"metrics":       {Port: 52691},
+								"tcp-discovery": {Port: 52692},
+								"udp-discovery": {Port: 58275},
+								"http":          {Port: 52693},
+							},
+						},
+						"el": Service{
+							Name: "el-1-geth-lighthouse",
+							Endpoints: EndpointMap{
+								"metrics":       {Port: 52643},
+								"tcp-discovery": {Port: 52644},
+								"udp-discovery": {Port: 51936},
+								"engine-rpc":    {Port: 52642},
+								"rpc":           {Port: 52645},
+								"ws":            {Port: 52646},
+							},
+						},
+					},
 				},
 			},
-			wantEndpoints: EndpointMap{},
+			wantServices: ServiceMap{},
 		},
 		{
 			name:     "find op-kurtosis L2 endpoints",
 			services: testServices,
-			findFn: func(f *ServiceFinder) ([]Node, EndpointMap) {
-				return f.FindL2Endpoints("op-kurtosis")
+			findFn: func(f *ServiceFinder) ([]Node, ServiceMap) {
+				return f.FindL2Services("op-kurtosis")
 			},
 			wantNodes: []Node{
 				{
-					"cl": "http://localhost:53503",
-					"el": "http://localhost:53402",
+					Services: ServiceMap{
+						"cl": Service{
+							Name: "op-cl-1-op-node-op-geth-op-kurtosis",
+							Endpoints: EndpointMap{
+								"udp-discovery": {Port: 50990},
+								"http":          {Port: 53503},
+								"tcp-discovery": {Port: 53504},
+							},
+						},
+						"el": Service{
+							Name: "op-el-1-op-geth-op-node-op-kurtosis",
+							Endpoints: EndpointMap{
+								"udp-discovery": {Port: 53233},
+								"engine-rpc":    {Port: 53399},
+								"metrics":       {Port: 53400},
+								"tcp-discovery": {Port: 53401},
+								"rpc":           {Port: 53402},
+								"ws":            {Port: 53403},
+							},
+						},
+					},
 				},
 			},
-			wantEndpoints: EndpointMap{
-				"batcher": "http://localhost:53572",
+			wantServices: ServiceMap{
+				"batcher": Service{
+					Name: "op-batcher-op-kurtosis",
+					Endpoints: EndpointMap{
+						"http": {Port: 53572},
+					},
+				},
 			},
 		},
 		{
@@ -93,12 +137,17 @@ func TestFindRPCEndpoints(t *testing.T) {
 					"http": {Host: "custom.host", Port: 8080},
 				},
 			},
-			findFn: func(f *ServiceFinder) ([]Node, EndpointMap) {
-				return f.FindL2Endpoints("custom-host")
+			findFn: func(f *ServiceFinder) ([]Node, ServiceMap) {
+				return f.FindL2Services("custom-host")
 			},
 			wantNodes: nil,
-			wantEndpoints: EndpointMap{
-				"batcher": "http://custom.host:8080",
+			wantServices: ServiceMap{
+				"batcher": Service{
+					Name: "op-batcher-custom-host",
+					Endpoints: EndpointMap{
+						"http": {Host: "custom.host", Port: 8080},
+					},
+				},
 			},
 		},
 	}
@@ -106,9 +155,9 @@ func TestFindRPCEndpoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			finder := NewServiceFinder(tt.services)
-			gotNodes, gotEndpoints := tt.findFn(finder)
+			gotNodes, gotServices := tt.findFn(finder)
 			assert.Equal(t, tt.wantNodes, gotNodes)
-			assert.Equal(t, tt.wantEndpoints, gotEndpoints)
+			assert.Equal(t, tt.wantServices, gotServices)
 		})
 	}
 }

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
@@ -8,8 +8,8 @@ import (
 
 // PortInfo contains the host and port number for a service port
 type PortInfo struct {
-	Host string
-	Port int
+	Host string `json:"host"`
+	Port int    `json:"port"`
 }
 
 type PortMap map[string]PortInfo


### PR DESCRIPTION
* Include all ports exposed by nodes / services
* Include the service name (can tell if its a geth / reth instance, etc)
* Dont assume protocol for each endpoint (only provide hostname / port)

Realizing that it is a lot more verbose, but this output is mainly meant to be machine readable. 
We may want to just write this to file, and then do a cleanup pass to format for stdout / human readability, will follow up with that next.

pre:
```
    "nodes": [
      {
        "cl": "http://127.0.0.1:62010",
        "el": "http://127.0.0.1:61984"
      }
    ],
```

post:
```
"nodes": [
        {
          "services": {
            "cl": {
              "name": "op-cl-1-op-node-op-geth-op-kurtosis",
              "endpoints": {
                "rpc": {
                  "host": "127.0.0.1",
                  "port": 55974
                },
                "tcp-discovery": {
                  "host": "127.0.0.1",
                  "port": 55975
                },
                "udp-discovery": {
                  "host": "127.0.0.1",
                  "port": 64915
                }
              }
            },
            "el": {
              "name": "op-el-1-op-geth-op-node-op-kurtosis",
              "endpoints": {
                "engine-rpc": {
                  "host": "127.0.0.1",
                  "port": 55901
                },
                "metrics": {
                  "host": "127.0.0.1",
                  "port": 55902
                },
                "rpc": {
                  "host": "127.0.0.1",
                  "port": 55904
                },
                "tcp-discovery": {
                  "host": "127.0.0.1",
                  "port": 55903
                },
                "udp-discovery": {
                  "host": "127.0.0.1",
                  "port": 59911
                },
                "ws": {
                  "host": "127.0.0.1",
                  "port": 55905
                }
              }
            }
          }
        }
```