### PR TITLE
Apply Finality to blocks prior to L1 Finality Singal

### DIFF
--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -171,6 +171,23 @@ func (db *ChainsDB) Finalized(chainID types.ChainID) (types.BlockSeal, error) {
 	if finalizedL1 == (eth.L1BlockRef{}) {
 		return types.BlockSeal{}, fmt.Errorf("no finalized L1 signal, cannot determine L2 finality of chain %s yet", chainID)
 	}
+
+	// compare the finalized L1 block with the last derived block in the cross DB
+	xDB, ok := db.crossDBs.Get(chainID)
+	if !ok {
+		return types.BlockSeal{}, types.ErrUnknownChain
+	}
+	latestDerivedFrom, latestDerived, err := xDB.Latest()
+	if err != nil {
+		return types.BlockSeal{}, fmt.Errorf("could not get the latest derived pair for chain %s: %w", chainID, err)
+	}
+	// if the finalized L1 block is newer than the latest L1 block used to derive L2 blocks,
+	// the finality signal automatically applies to all previous blocks, including the latest derived block
+	if finalizedL1.Number > latestDerivedFrom.Number {
+		return latestDerived, nil
+	}
+
+	// otherwise, use the finalized L1 block to determine the final L2 block that was derived from it
 	derived, err := db.LastDerivedFrom(chainID, finalizedL1.ID())
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("could not find what was last derived in L2 chain %s from the finalized L1 block %s: %w", chainID, finalizedL1, err)

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -184,6 +184,11 @@ func (db *ChainsDB) Finalized(chainID types.ChainID) (types.BlockSeal, error) {
 	// if the finalized L1 block is newer than the latest L1 block used to derive L2 blocks,
 	// the finality signal automatically applies to all previous blocks, including the latest derived block
 	if finalizedL1.Number > latestDerivedFrom.Number {
+		db.logger.Warn("Finalized L1 block is newer than the latest L1 for this chain. Assuming latest L2 is finalized",
+			"chain", chainID,
+			"finalizedL1", finalizedL1.Number,
+			"latestDerivedFrom", latestDerivedFrom.Number,
+			"latestDerived", latestDerivedFrom)
 		return latestDerived, nil
 	}
 


### PR DESCRIPTION
When L1 processing on a node lags far behind the L1 processing of the Supervisor, the L1 Finality signal (which we only store the latest of) can't be used to determine L2 finality.

To fix that -- if the L1 finality signal is more recent than the L1 block the node is currently using, we can just deduce that the L2 blocks being derived currently are *already* finalized. This PR updates the `Finalized` function of ChainsDB to make such a determination.

# Testing
This issue was diagnosed via a local Kurtosis Devnet, where L2 finality was updating for a while, but stopped and never came back.

This is manually tested by observing a Kurtosis Devnet on this branch, which updates the Finalized L2 consistently.