### PR TITLE
feat: incident response improvements

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -31,9 +31,9 @@ just = "1.37.0"
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
-forge = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
-cast = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
-anvil = "nightly-59f354c179f4e7f6d7292acb3d068815c79286d1"
+forge = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+cast = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+anvil = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -71,7 +71,7 @@ func (r *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, error) 
 		Implementations: OPCMImplementationsConfig{
 			L1ContractsRelease: "dev",
 			FaultProof: SuperFaultProofConfig{
-				WithdrawalDelaySeconds:          big.NewInt(604800),
+				WithdrawalDelaySeconds:          big.NewInt(302400),
 				MinProposalSizeBytes:            big.NewInt(10000),
 				ChallengePeriodSeconds:          big.NewInt(120),
 				ProofMaturityDelaySeconds:       big.NewInt(12),

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -53,6 +53,7 @@ var (
 	methodL2BlockNumberChallenged = "l2BlockNumberChallenged"
 	methodL2BlockNumberChallenger = "l2BlockNumberChallenger"
 	methodChallengeRootL2Block    = "challengeRootL2Block"
+	methodBondDistributionMode    = "bondDistributionMode"
 )
 
 var (
@@ -455,6 +456,14 @@ func (f *FaultDisputeGameContractLatest) GetAllClaims(ctx context.Context, block
 	return claims, nil
 }
 
+func (f *FaultDisputeGameContractLatest) BondDistributionMode(ctx context.Context) (uint8, error) {
+	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodBondDistributionMode))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch bond mode: %w", err)
+	}
+	return result.GetUint8(0), nil
+}
+
 func (f *FaultDisputeGameContractLatest) IsResolved(ctx context.Context, block rpcblock.Block, claims ...types.Claim) ([]bool, error) {
 	defer f.metrics.StartContractRequest("IsResolved")()
 	calls := make([]batching.Call, 0, len(claims))
@@ -639,4 +648,5 @@ type FaultDisputeGameContract interface {
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	ResolveTx() (txmgr.TxCandidate, error)
 	Vm(ctx context.Context) (*VMContract, error)
+	BondDistributionMode(ctx context.Context) (uint8, error)
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -15,7 +15,7 @@ const (
 	GasLimit                        uint64 = 60_000_000
 	BasefeeScalar                   uint32 = 1368
 	BlobBaseFeeScalar               uint32 = 801949
-	WithdrawalDelaySeconds          uint64 = 604800
+	WithdrawalDelaySeconds          uint64 = 302400
 	MinProposalSizeBytes            uint64 = 126000
 	ChallengePeriodSeconds          uint64 = 86400
 	ProofMaturityDelaySeconds       uint64 = 604800

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -368,6 +368,18 @@ func (g *OutputGameHelper) Status(ctx context.Context) gameTypes.GameStatus {
 	return status
 }
 
+func (g *OutputGameHelper) WaitForBondModeSet(ctx context.Context) {
+	g.T.Logf("Waiting for game %v to have bond mode set", g.Addr)
+	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		bondMode, err := g.Game.BondDistributionMode(ctx)
+		g.Require.NoError(err)
+		return bondMode != 0, nil
+	})
+	g.Require.NoError(err, "Failed to wait for bond mode to be set")
+}
+
 func (g *OutputGameHelper) WaitForGameStatus(ctx context.Context, expected gameTypes.GameStatus) {
 	g.T.Logf("Waiting for game %v to have status %v", g.Addr, expected)
 	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -127,6 +127,11 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
+	// Advance the time past the finalization delay
+	// Finalization delay is the same as the credit unlock delay
+	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
 	// Wait for alice to have no available credit
 	// aka, wait for the challenger to claim its credit
 	game.WaitForNoAvailableCredit(ctx, alice)

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -121,7 +121,7 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// The actor should have no credit available because all its bonds were paid to Alice.
 	actorCredit := game.AvailableCredit(ctx, disputegame.TestAddress)
-	require.True(t, actorCredit.Cmp(big.NewInt(0)) == 0, "Expected alice available credit to be zero")
+	require.True(t, actorCredit.Cmp(big.NewInt(0)) == 0, "Expected actor available credit to be zero")
 
 	// Advance the time past the weth unlock delay
 	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -129,7 +129,8 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// Advance the time past the finalization delay
 	// Finalization delay is the same as the credit unlock delay
-	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))
+	// But just warp way into the future to be safe
+	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx) * 2)
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
 	// Wait for alice to have no available credit

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -115,6 +115,12 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 	game.WaitForGameStatus(ctx, types.GameStatusChallengerWon)
 	game.LogGameData(ctx)
 
+	// Advance the time past the finalization delay
+	// Finalization delay is the same as the credit unlock delay
+	// But just warp way into the future to be safe
+	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx) * 2)
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
 	// Wait for the game to have bond mode set
 	game.WaitForBondModeSet(ctx)
 
@@ -128,12 +134,6 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// Advance the time past the weth unlock delay
 	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	// Advance the time past the finalization delay
-	// Finalization delay is the same as the credit unlock delay
-	// But just warp way into the future to be safe
-	sys.TimeTravelClock.AdvanceTime(game.CreditUnlockDuration(ctx) * 2)
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
 	// Wait for alice to have no available credit

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -115,6 +115,9 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 	game.WaitForGameStatus(ctx, types.GameStatusChallengerWon)
 	game.LogGameData(ctx)
 
+	// Wait for the game to have bond mode set
+	game.WaitForBondModeSet(ctx)
+
 	// Expect Alice's credit to be non-zero
 	// But it can't be claimed right now since there is a delay on the weth unlock
 	require.Truef(t, game.AvailableCredit(ctx, alice).Cmp(big.NewInt(0)) > 0, "Expected alice credit to be above zero")

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -11,7 +11,7 @@ build_info_path = 'artifacts/build-info'
 snapshots = 'notarealpath' # workaround for foundry#9477
 
 optimizer = true
-optimizer_runs = 999999
+optimizer_runs = 5000
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -11,7 +11,15 @@ build_info_path = 'artifacts/build-info'
 snapshots = 'notarealpath' # workaround for foundry#9477
 
 optimizer = true
-optimizer_runs = 5000
+optimizer_runs = 999999
+
+additional_compiler_profiles = [
+  { name = "dispute", optimizer_runs = 5000 },
+]
+compilation_restrictions = [
+  { paths = "src/dispute/FaultDisputeGame.sol", optimizer_runs = 5000 },
+  { paths = "src/dispute/PermissionedDisputeGame.sol", optimizer_runs = 5000 },
+]
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -93,6 +93,7 @@ depth = 32
 
 [profile.cicoverage]
 optimizer = false
+compilation_restrictions = []
 
 [profile.cicoverage.fuzz]
 runs = 1
@@ -120,6 +121,8 @@ timeout = 300
 
 [profile.lite]
 optimizer = false
+compilation_restrictions = []
+
 
 ################################################################
 #                         PROFILE: KONTROL                     #

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -31,6 +31,7 @@ interface IOptimismPortal2 {
     error UnexpectedList();
     error UnexpectedString();
     error Unproven();
+    error LegacyGame();
 
     event DisputeGameBlacklisted(IDisputeGame indexed disputeGame);
     event Initialized(uint8 version);

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -33,6 +33,7 @@ interface IOptimismPortalInterop {
     error UnexpectedList();
     error UnexpectedString();
     error Unproven();
+    error LegacyGame();
 
     event DisputeGameBlacklisted(IDisputeGame indexed disputeGame);
     event Initialized(uint8 version);

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -29,7 +29,7 @@ interface IAnchorStateRegistry {
     )
         external;
 
-    function isGameBeyondAirgap(IDisputeGame _game) external view returns (bool);
+    function isGameAirgapped(IDisputeGame _game) external view returns (bool);
     function isGameBlacklisted(IDisputeGame _game) external view returns (bool);
     function isGameProper(IDisputeGame _game) external view returns (bool);
     function isGameRegistered(IDisputeGame _game) external view returns (bool);

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -27,13 +27,14 @@ interface IAnchorStateRegistry {
         OutputRoot memory _startingAnchorRoot
     )
         external;
-    function isGameRegistered(IDisputeGame _game) external view returns (bool);
+
+    function isGameBeyondAirgap(IDisputeGame _game) external view returns (bool);
     function isGameBlacklisted(IDisputeGame _game) external view returns (bool);
+    function isGameProper(IDisputeGame _game) external view returns (bool);
+    function isGameRegistered(IDisputeGame _game) external view returns (bool);
+    function isGameResolved(IDisputeGame _game) external view returns (bool);
     function isGameRespected(IDisputeGame _game) external view returns (bool);
     function isGameRetired(IDisputeGame _game) external view returns (bool);
-    function isGameResolved(IDisputeGame _game) external view returns (bool);
-    function isGameBeyondAirgap(IDisputeGame _game) external view returns (bool);
-    function isGameProper(IDisputeGame _game) external view returns (bool);
     function isGameFinalized(IDisputeGame _game) external view returns (bool);
     function isGameClaimValid(IDisputeGame _game) external view returns (bool);
     function portal() external view returns (IOptimismPortal2);

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -10,7 +10,6 @@ import { GameType, Hash, OutputRoot } from "src/dispute/lib/Types.sol";
 
 interface IAnchorStateRegistry {
     error AnchorStateRegistry_Unauthorized();
-    error AnchorStateRegistry_ImproperAnchorGame();
     error AnchorStateRegistry_InvalidAnchorGame();
 
     event AnchorNotUpdated(IFaultDisputeGame indexed game);
@@ -21,16 +20,26 @@ interface IAnchorStateRegistry {
     function anchors(GameType) external view returns (Hash, uint256);
     function getAnchorRoot() external view returns (Hash, uint256);
     function disputeGameFactory() external view returns (IDisputeGameFactory);
-    function initialize(ISuperchainConfig _superchainConfig, IDisputeGameFactory _disputeGameFactory, IOptimismPortal2 _portal, OutputRoot memory _startingAnchorRoot) external;
+    function initialize(
+        ISuperchainConfig _superchainConfig,
+        IDisputeGameFactory _disputeGameFactory,
+        IOptimismPortal2 _portal,
+        OutputRoot memory _startingAnchorRoot
+    )
+        external;
     function isGameRegistered(IDisputeGame _game) external view returns (bool);
     function isGameBlacklisted(IDisputeGame _game) external view returns (bool);
     function isGameRespected(IDisputeGame _game) external view returns (bool);
     function isGameRetired(IDisputeGame _game) external view returns (bool);
+    function isGameResolved(IDisputeGame _game) external view returns (bool);
+    function isGameBeyondAirgap(IDisputeGame _game) external view returns (bool);
     function isGameProper(IDisputeGame _game) external view returns (bool);
+    function isGameFinalized(IDisputeGame _game) external view returns (bool);
+    function isGameClaimValid(IDisputeGame _game) external view returns (bool);
     function portal() external view returns (IOptimismPortal2);
-    function setAnchorState(IFaultDisputeGame _game) external;
+    function respectedGameType() external view returns (GameType);
+    function setAnchorState(IDisputeGame _game) external;
     function superchainConfig() external view returns (ISuperchainConfig);
-    function tryUpdateAnchorState() external;
     function version() external view returns (string memory);
 
     function __constructor__() external;

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -11,6 +11,7 @@ import { GameType, Hash, OutputRoot } from "src/dispute/lib/Types.sol";
 interface IAnchorStateRegistry {
     error AnchorStateRegistry_Unauthorized();
     error AnchorStateRegistry_InvalidAnchorGame();
+    error AnchorStateRegistry_AnchorGameBlacklisted();
 
     event AnchorNotUpdated(IFaultDisputeGame indexed game);
     event AnchorUpdated(IFaultDisputeGame indexed game);

--- a/packages/contracts-bedrock/interfaces/dispute/IDelayedWETH.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IDelayedWETH.sol
@@ -11,13 +11,13 @@ interface IDelayedWETH {
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event Initialized(uint8 version);
-    event Unwrap(address indexed src, uint256 wad);
 
     fallback() external payable;
     receive() external payable;
 
     function config() external view returns (ISuperchainConfig);
     function delay() external view returns (uint256);
+    function hold(address _guy) external;
     function hold(address _guy, uint256 _wad) external;
     function initialize(address _owner, ISuperchainConfig _config) external;
     function owner() external view returns (address);

--- a/packages/contracts-bedrock/interfaces/dispute/IDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IDisputeGame.sol
@@ -14,7 +14,9 @@ interface IDisputeGame is IInitializable {
     function gameCreator() external pure returns (address creator_);
     function rootClaim() external pure returns (Claim rootClaim_);
     function l1Head() external pure returns (Hash l1Head_);
+    function l2BlockNumber() external pure returns (uint256 l2BlockNumber_);
     function extraData() external pure returns (bytes memory extraData_);
     function resolve() external returns (GameStatus status_);
     function gameData() external view returns (GameType gameType_, Claim rootClaim_, bytes memory extraData_);
+    function wasRespectedGameTypeWhenCreated() external view returns (bool);
 }

--- a/packages/contracts-bedrock/interfaces/dispute/IFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IFaultDisputeGame.sol
@@ -6,7 +6,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 import { Types } from "src/libraries/Types.sol";
-import { GameType, Claim, Position, Clock, Hash, Duration } from "src/dispute/lib/Types.sol";
+import { GameType, Claim, Position, Clock, Hash, Duration, BondDistributionMode } from "src/dispute/lib/Types.sol";
 
 interface IFaultDisputeGame is IDisputeGame {
     struct ClaimData {
@@ -74,13 +74,19 @@ interface IFaultDisputeGame is IDisputeGame {
     error UnexpectedRootClaim(Claim rootClaim);
     error UnexpectedString();
     error ValidStep();
+    error InvalidBondDistributionMode();
+    error GameNotFinalized(string reason);
+    error GameNotResolved();
+    error ReservedGameType();
 
     event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
+    event GameClosed(BondDistributionMode bondDistributionMode);
 
     function absolutePrestate() external view returns (Claim absolutePrestate_);
     function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external;
     function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_);
     function attack(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
+    function bondDistributionMode() external view returns (BondDistributionMode);
     function challengeRootL2Block(Types.OutputRootProof memory _outputRootProof, bytes memory _headerRLP) external;
     function claimCredit(address _recipient) external;
     function claimData(uint256)
@@ -98,11 +104,13 @@ interface IFaultDisputeGame is IDisputeGame {
     function claimDataLen() external view returns (uint256 len_);
     function claims(Hash) external view returns (bool);
     function clockExtension() external view returns (Duration clockExtension_);
+    function closeGame() external;
     function credit(address) external view returns (uint256);
     function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
     function getChallengerDuration(uint256 _claimIndex) external view returns (Duration duration_);
     function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
     function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
+    function hasUnlockedCredit(address) external view returns (bool);
     function l2BlockNumber() external pure returns (uint256 l2BlockNumber_);
     function l2BlockNumberChallenged() external view returns (bool);
     function l2BlockNumberChallenger() external view returns (address);
@@ -110,6 +118,7 @@ interface IFaultDisputeGame is IDisputeGame {
     function maxClockDuration() external view returns (Duration maxClockDuration_);
     function maxGameDepth() external view returns (uint256 maxGameDepth_);
     function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) external payable;
+    function refundModeCredit(address) external view returns (uint256);
     function resolutionCheckpoints(uint256)
         external
         view
@@ -124,6 +133,7 @@ interface IFaultDisputeGame is IDisputeGame {
     function subgames(uint256, uint256) external view returns (uint256);
     function version() external view returns (string memory);
     function vm() external view returns (IBigStepper vm_);
+    function wasRespectedGameTypeWhenCreated() external view returns (bool);
     function weth() external view returns (IDelayedWETH weth_);
 
     function __constructor__(GameConstructorParams memory _params) external;

--- a/packages/contracts-bedrock/interfaces/dispute/IFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IFaultDisputeGame.sol
@@ -105,7 +105,7 @@ interface IFaultDisputeGame is IDisputeGame {
     function claims(Hash) external view returns (bool);
     function clockExtension() external view returns (Duration clockExtension_);
     function closeGame() external;
-    function credit(address) external view returns (uint256);
+    function credit(address _recipient) external view returns (uint256 credit_);
     function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
     function getChallengerDuration(uint256 _claimIndex) external view returns (Duration duration_);
     function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
@@ -118,6 +118,7 @@ interface IFaultDisputeGame is IDisputeGame {
     function maxClockDuration() external view returns (Duration maxClockDuration_);
     function maxGameDepth() external view returns (uint256 maxGameDepth_);
     function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) external payable;
+    function normalModeCredit(address) external view returns (uint256);
     function refundModeCredit(address) external view returns (uint256);
     function resolutionCheckpoints(uint256)
         external

--- a/packages/contracts-bedrock/interfaces/dispute/IFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IFaultDisputeGame.sol
@@ -75,7 +75,7 @@ interface IFaultDisputeGame is IDisputeGame {
     error UnexpectedString();
     error ValidStep();
     error InvalidBondDistributionMode();
-    error GameNotFinalized(string reason);
+    error GameNotFinalized();
     error GameNotResolved();
     error ReservedGameType();
 

--- a/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { Types } from "src/libraries/Types.sol";
-import { Claim, Position, Clock, Hash, Duration } from "src/dispute/lib/Types.sol";
+import { Claim, Position, Clock, Hash, Duration, BondDistributionMode } from "src/dispute/lib/Types.sol";
 
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
@@ -63,13 +63,19 @@ interface IPermissionedDisputeGame is IDisputeGame {
     error UnexpectedRootClaim(Claim rootClaim);
     error UnexpectedString();
     error ValidStep();
+    error InvalidBondDistributionMode();
+    error GameNotFinalized(string reason);
+    error GameNotResolved();
+    error ReservedGameType();
 
     event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
+    event GameClosed(BondDistributionMode bondDistributionMode);
 
     function absolutePrestate() external view returns (Claim absolutePrestate_);
     function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external;
     function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_);
     function attack(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
+    function bondDistributionMode() external view returns (BondDistributionMode);
     function challengeRootL2Block(Types.OutputRootProof memory _outputRootProof, bytes memory _headerRLP) external;
     function claimCredit(address _recipient) external;
     function claimData(uint256)
@@ -87,11 +93,13 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function claimDataLen() external view returns (uint256 len_);
     function claims(Hash) external view returns (bool);
     function clockExtension() external view returns (Duration clockExtension_);
+    function closeGame() external;
     function credit(address) external view returns (uint256);
     function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
     function getChallengerDuration(uint256 _claimIndex) external view returns (Duration duration_);
     function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
     function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
+    function hasUnlockedCredit(address) external view returns (bool);
     function l2BlockNumber() external pure returns (uint256 l2BlockNumber_);
     function l2BlockNumberChallenged() external view returns (bool);
     function l2BlockNumberChallenger() external view returns (address);
@@ -99,6 +107,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function maxClockDuration() external view returns (Duration maxClockDuration_);
     function maxGameDepth() external view returns (uint256 maxGameDepth_);
     function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) external payable;
+    function refundModeCredit(address) external view returns (uint256);
     function resolutionCheckpoints(uint256)
         external
         view
@@ -113,6 +122,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function subgames(uint256, uint256) external view returns (uint256);
     function version() external view returns (string memory);
     function vm() external view returns (IBigStepper vm_);
+    function wasRespectedGameTypeWhenCreated() external view returns (bool);
     function weth() external view returns (IDelayedWETH weth_);
 
     error BadAuth();

--- a/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
@@ -94,7 +94,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function claims(Hash) external view returns (bool);
     function clockExtension() external view returns (Duration clockExtension_);
     function closeGame() external;
-    function credit(address) external view returns (uint256);
+    function credit(address _recipient) external view returns (uint256 credit_);
     function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
     function getChallengerDuration(uint256 _claimIndex) external view returns (Duration duration_);
     function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
@@ -108,6 +108,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function maxClockDuration() external view returns (Duration maxClockDuration_);
     function maxGameDepth() external view returns (uint256 maxGameDepth_);
     function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) external payable;
+    function normalModeCredit(address) external view returns (uint256);
     function refundModeCredit(address) external view returns (uint256);
     function resolutionCheckpoints(uint256)
         external

--- a/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
@@ -100,6 +100,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
     function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
     function hasUnlockedCredit(address) external view returns (bool);
+    function initialize() external payable;
     function l2BlockNumber() external pure returns (uint256 l2BlockNumber_);
     function l2BlockNumberChallenged() external view returns (bool);
     function l2BlockNumberChallenger() external view returns (address);

--- a/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IPermissionedDisputeGame.sol
@@ -64,7 +64,7 @@ interface IPermissionedDisputeGame is IDisputeGame {
     error UnexpectedString();
     error ValidStep();
     error InvalidBondDistributionMode();
-    error GameNotFinalized(string reason);
+    error GameNotFinalized();
     error GameNotResolved();
     error ReservedGameType();
 

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -73,7 +73,7 @@ test-upgrade *ARGS: build-go-ffi
   #!/bin/bash
   echo "Running upgrade tests at block $pinnedBlockNumber"
   export FORK_BLOCK_NUMBER=$pinnedBlockNumber
-  export NO_MATCH_CONTRACTS="OptimismPortal2WithMockERC20_Test|OptimismPortal2_FinalizeWithdrawal_Test|'AnchorStateRegistry_*'|FaultDisputeGame_Test|FaultDispute_1v1_Actors_Test"
+  export NO_MATCH_CONTRACTS="OptimismPortal2WithMockERC20_Test|OptimismPortal2_FinalizeWithdrawal_Test|'AnchorStateRegistry_*'|FaultDisputeGame_Test|PermissionedDisputeGame_Test|FaultDispute_1v1_Actors_Test|DelayedWETH_Hold_Test"
   export NO_MATCH_PATHS="test/dispute/AnchorStateRegistry.t.sol"
   FORK_RPC_URL=$ETH_RPC_URL \
     FORK_TEST=true \

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -120,7 +120,7 @@
         "type": "address"
       }
     ],
-    "name": "isGameBeyondAirgap",
+    "name": "isGameAirgapped",
     "outputs": [
       {
         "internalType": "bool",

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -120,12 +120,79 @@
         "type": "address"
       }
     ],
+    "name": "isGameBeyondAirgap",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "_game",
+        "type": "address"
+      }
+    ],
     "name": "isGameBlacklisted",
     "outputs": [
       {
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "_game",
+        "type": "address"
+      }
+    ],
+    "name": "isGameClaimValid",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "_game",
+        "type": "address"
+      }
+    ],
+    "name": "isGameFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
       }
     ],
     "stateMutability": "view",
@@ -159,6 +226,25 @@
       }
     ],
     "name": "isGameRegistered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "_game",
+        "type": "address"
+      }
+    ],
+    "name": "isGameResolved",
     "outputs": [
       {
         "internalType": "bool",
@@ -221,9 +307,22 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "respectedGameType",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
-        "internalType": "contract IFaultDisputeGame",
+        "internalType": "contract IDisputeGame",
         "name": "_game",
         "type": "address"
       }
@@ -244,13 +343,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "tryUpdateAnchorState",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -120,7 +120,7 @@
         "type": "address"
       }
     ],
-    "name": "isGameAirgapped",
+    "name": "isGameBeyondAirgap",
     "outputs": [
       {
         "internalType": "bool",
@@ -386,6 +386,11 @@
     ],
     "name": "Initialized",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "AnchorStateRegistry_AnchorGameBlacklisted",
+    "type": "error"
   },
   {
     "inputs": [],

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -164,11 +164,6 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
-      },
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
       }
     ],
     "stateMutability": "view",
@@ -188,11 +183,6 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
-      },
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
       }
     ],
     "stateMutability": "view",
@@ -396,11 +386,6 @@
     ],
     "name": "Initialized",
     "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "AnchorStateRegistry_ImproperAnchorGame",
-    "type": "error"
   },
   {
     "inputs": [],

--- a/packages/contracts-bedrock/snapshots/abi/DelayedWETH.json
+++ b/packages/contracts-bedrock/snapshots/abi/DelayedWETH.json
@@ -153,6 +153,19 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_guy",
+        "type": "address"
+      }
+    ],
+    "name": "hold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_owner",
         "type": "address"
       },
@@ -495,25 +508,6 @@
       }
     ],
     "name": "Transfer",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "src",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "wad",
-        "type": "uint256"
-      }
-    ],
-    "name": "Unwrap",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
@@ -135,6 +135,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "bondDistributionMode",
+    "outputs": [
+      {
+        "internalType": "enum BondDistributionMode",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [
@@ -279,6 +292,13 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "closeGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -456,6 +476,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hasUnlockedCredit",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "initialize",
     "outputs": [],
@@ -579,6 +618,25 @@
     "name": "move",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "refundModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -841,6 +899,19 @@
   },
   {
     "inputs": [],
+    "name": "wasRespectedGameTypeWhenCreated",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "weth",
     "outputs": [
       {
@@ -851,6 +922,19 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum BondDistributionMode",
+        "name": "bondDistributionMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "GameClosed",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -961,13 +1045,34 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "GameNotFinalized",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "GameNotInProgress",
     "type": "error"
   },
   {
     "inputs": [],
+    "name": "GameNotResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "IncorrectBondAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBondDistributionMode",
     "type": "error"
   },
   {
@@ -1043,6 +1148,11 @@
   {
     "inputs": [],
     "name": "OutOfOrderResolution",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReservedGameType",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
@@ -1045,13 +1045,7 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "reason",
-        "type": "string"
-      }
-    ],
+    "inputs": [],
     "name": "GameNotFinalized",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGame.json
@@ -318,7 +318,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_recipient",
         "type": "address"
       }
     ],
@@ -326,7 +326,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "credit_",
         "type": "uint256"
       }
     ],
@@ -618,6 +618,25 @@
     "name": "move",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "normalModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -814,6 +814,11 @@
   },
   {
     "inputs": [],
+    "name": "LegacyGame",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NonReentrant",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
@@ -837,6 +837,11 @@
   },
   {
     "inputs": [],
+    "name": "LegacyGame",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NonReentrant",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
@@ -145,6 +145,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "bondDistributionMode",
+    "outputs": [
+      {
+        "internalType": "enum BondDistributionMode",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [
@@ -302,6 +315,13 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "closeGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -479,6 +499,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hasUnlockedCredit",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "initialize",
     "outputs": [],
@@ -612,6 +651,25 @@
         "internalType": "address",
         "name": "proposer_",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "refundModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -877,6 +935,19 @@
   },
   {
     "inputs": [],
+    "name": "wasRespectedGameTypeWhenCreated",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "weth",
     "outputs": [
       {
@@ -887,6 +958,19 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum BondDistributionMode",
+        "name": "bondDistributionMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "GameClosed",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -1002,13 +1086,34 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "GameNotFinalized",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "GameNotInProgress",
     "type": "error"
   },
   {
     "inputs": [],
+    "name": "GameNotResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "IncorrectBondAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBondDistributionMode",
     "type": "error"
   },
   {
@@ -1084,6 +1189,11 @@
   {
     "inputs": [],
     "name": "OutOfOrderResolution",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReservedGameType",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
@@ -341,7 +341,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_recipient",
         "type": "address"
       }
     ],
@@ -349,7 +349,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "credit_",
         "type": "uint256"
       }
     ],
@@ -641,6 +641,25 @@
     "name": "move",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "normalModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGame.json
@@ -1086,13 +1086,7 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "reason",
-        "type": "string"
-      }
-    ],
+    "inputs": [],
     "name": "GameNotFinalized",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,11 +20,11 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x5121ab634e470633d965d709bb65c8ea97f8cecf84c42aa4541b5eb9a92d6cc9",
-    "sourceCodeHash": "0x889a4a53f38fa885281be58bad88c25bafec0a9fd7fb2ddfa16dcda1cecaf7d5"
+    "initCodeHash": "0x94c880ae1974be774ec956ed2d9f8d71c19ba500d47abe28856ea8a019dc9c3f",
+    "sourceCodeHash": "0x99ab9155cd18ee2bbab440431923f944a89535670546bfaa01e637eadb0342b8"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x137910751db2e7a4edc76728b8433b47911b82fe1514465f2cbc5b35daf2e53a",
+    "initCodeHash": "0x529e192525bc0f28b4402439af1defcf5407016b44a3eda2da5a6260b31779e2",
     "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,11 +20,11 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x94c880ae1974be774ec956ed2d9f8d71c19ba500d47abe28856ea8a019dc9c3f",
-    "sourceCodeHash": "0x99ab9155cd18ee2bbab440431923f944a89535670546bfaa01e637eadb0342b8"
+    "initCodeHash": "0xb906cca6c1d2ef7d783f94d502bbf8704f39488bcbe4b1633f21d5a25f39d750",
+    "sourceCodeHash": "0x2fa2648a82059eb6fc052254678d3bd2bf7952be83ab53c545c9302df3b9d1a0"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x529e192525bc0f28b4402439af1defcf5407016b44a3eda2da5a6260b31779e2",
+    "initCodeHash": "0x92e46899517ecb927a6fea35995ebf6cc534443351d1f5806a7d34c5696c0648",
     "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0x8d04e8c4185388170beabec3de6380628d5f41869e96655322685e33c3541dd9",
-    "sourceCodeHash": "0x27100c19acf49ffa999baf8f5e5dd1e8f8455e65a51c27d2e949220d0a07ac3b"
+    "initCodeHash": "0xf7b9422d4c0b175aed8fad9ac4e03054625a667cff837a9a13612ec3bb2ee936",
+    "sourceCodeHash": "0xe355003779215d2c9d8c55e84c3e8b984a2c284da6b222de0874722bc71fe598"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,11 +20,11 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0xb906cca6c1d2ef7d783f94d502bbf8704f39488bcbe4b1633f21d5a25f39d750",
-    "sourceCodeHash": "0x2fa2648a82059eb6fc052254678d3bd2bf7952be83ab53c545c9302df3b9d1a0"
+    "initCodeHash": "0x3f30480b47af0a965af7d38eff673fe1ef0e8704c1776eaef5648d242cfe376d",
+    "sourceCodeHash": "0x6241a2e1e5b8fae5e17e13abcccd3d013f66317a6d7611d844b10bbb878d38c0"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x92e46899517ecb927a6fea35995ebf6cc534443351d1f5806a7d34c5696c0648",
+    "initCodeHash": "0x9e12728cae72a1c701ddc3e09fe9e3b82aa38674ab76e6d9e74f3a384dfe25d2",
     "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x32eceffc74182357cb79f7218851e02a76200b1e57db7629c2b97b9401d71a25",
-    "sourceCodeHash": "0x95f68f577529c158070e3a23fd2da1c63581113471e1303716e387a07f3070d9"
+    "initCodeHash": "0x5121ab634e470633d965d709bb65c8ea97f8cecf84c42aa4541b5eb9a92d6cc9",
+    "sourceCodeHash": "0x889a4a53f38fa885281be58bad88c25bafec0a9fd7fb2ddfa16dcda1cecaf7d5"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x271c17198970e361cb43aff3ae788d4f726d8d1a188eeea7d0a5f0c477380a76",
-    "sourceCodeHash": "0xbb6acc3e88af9594ffcb8a2f30860511b76e09024330e70052316668fe55fd1f"
+    "initCodeHash": "0x137910751db2e7a4edc76728b8433b47911b82fe1514465f2cbc5b35daf2e53a",
+    "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x0000ec89712d8b4609873f1ba76afffd4205bf9110818995c90134dbec12e91e",
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0x751e32c8d44c5ef9b1acae2d94e07f6e91f7f59663c24e12d21298638458b272",
-    "sourceCodeHash": "0xb09dccd5bf662c42ab10afd19a2b51114df9fd3bc6e20d4d86e4ba7529036bbc"
+    "initCodeHash": "0x8d04e8c4185388170beabec3de6380628d5f41869e96655322685e33c3541dd9",
+    "sourceCodeHash": "0x27100c19acf49ffa999baf8f5e5dd1e8f8455e65a51c27d2e949220d0a07ac3b"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0xd59ffa7f487db9b0761b1fa3994c59e0d78e4546c76379a14a31dec1080b3f20",
-    "sourceCodeHash": "0xd59fd93e7332bad50714ec1abe06cebd6378d32cc4ad18434f09156ac3c97982"
+    "initCodeHash": "0x73ab839d9f77e541e0044f70fce1bd706d86f8c8ed310d96948a822b41191885",
+    "sourceCodeHash": "0x5abda30a900304e680d289be12798eda70677b54d7242499283954f98860a231"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,11 +20,11 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x3f30480b47af0a965af7d38eff673fe1ef0e8704c1776eaef5648d242cfe376d",
-    "sourceCodeHash": "0x6241a2e1e5b8fae5e17e13abcccd3d013f66317a6d7611d844b10bbb878d38c0"
+    "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",
+    "sourceCodeHash": "0xf215a31954f2ef166cfb26d20e466c62fafa235a08fc42c55131dcb81998ff01"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x9e12728cae72a1c701ddc3e09fe9e3b82aa38674ab76e6d9e74f3a384dfe25d2",
+    "initCodeHash": "0x057c56174304f3773654fed39abf5fab70d9446f531d07fdb225b738a680ad46",
     "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0xf7b9422d4c0b175aed8fad9ac4e03054625a667cff837a9a13612ec3bb2ee936",
-    "sourceCodeHash": "0xe355003779215d2c9d8c55e84c3e8b984a2c284da6b222de0874722bc71fe598"
+    "initCodeHash": "0xb2618d650808a7a335db7cc56d15ccaf432f50aa551c01be8bde8356893c0e0d",
+    "sourceCodeHash": "0x745f0e2b07b8f6492e11ca2f69b53d129177fbfd346d5ca4729d72792aff1f83"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x73ab839d9f77e541e0044f70fce1bd706d86f8c8ed310d96948a822b41191885",
-    "sourceCodeHash": "0x5abda30a900304e680d289be12798eda70677b54d7242499283954f98860a231"
+    "initCodeHash": "0x152fbb1f82488d815f56087fc464b9478f1390e3ecd67ae595344115fdd9ba91",
+    "sourceCodeHash": "0x9bfea41bd993bc1ef2ede9a5846a432ed5ea183868634fd77c4068b0a4a779b2"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x2121a97875875150106a54a71c6c4c03afe90b3364e416be047f55fdeab57204",
-    "sourceCodeHash": "0x96e3de3ef0025a6def702eeb481acd2d2d88971fd418be657472f51a98029773"
+    "initCodeHash": "0x52ddbe70f60a6f4e5c929fed417c92d99d82a85c05de8e1f0c8dfd0d634ad648",
+    "sourceCodeHash": "0xc4a66e8adacd58b961938f473b22614a520fa0bdae70381b8f56210bc34f1f32"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x09ffe45f91bf59315b9fd4a2941b819ed8b1bb0d8643a630c6193bd67acea0ed",
-    "sourceCodeHash": "0xbb6acc3e88af9594ffcb8a2f30860511b76e09024330e70052316668fe55fd1f"
+    "initCodeHash": "0x6b05d7130c019d3c46dca39dfdae3797861088a9fb7b5baa84fd4e5cb87c5883",
+    "sourceCodeHash": "0xae2fbe02c0f8685692babeed0252ae8a624dc6d3bfb082fc3807d7b84869004b"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x0000ec89712d8b4609873f1ba76afffd4205bf9110818995c90134dbec12e91e",
@@ -152,20 +152,20 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0xfbeeac40d86d13e71c7add66eef6357576a93b6a175c9cff6ec6ef587fe3acc4",
-    "sourceCodeHash": "0xbb2e08da74d470fc30dd35dc39834e19f676a45974aa2403eb97e84bc5bed0a8"
+    "initCodeHash": "0x6e94c2f4129209d2b36d6a54adaaf99b91b3df322c8c75043d29f6b0a9143738",
+    "sourceCodeHash": "0xb81181263522e939195a70b6e281fb038de2312c9682f9123723c6ae1babf559"
   },
   "src/dispute/DelayedWETH.sol": {
-    "initCodeHash": "0x759d7f9c52b7c13ce4502f39dae3a75d130c6278240cde0b60ae84616aa2bd48",
-    "sourceCodeHash": "0x4406c78e0557bedb88b4ee5977acb1ef13e7bd92b7dbf79f56f8bad95c53e229"
+    "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",
+    "sourceCodeHash": "0x0162302b9c71f184d45bee34ecfb1dfbf427f38fc5652709ab7ffef1ac816d82"
   },
   "src/dispute/DisputeGameFactory.sol": {
     "initCodeHash": "0xa728192115c5fdb08c633a0899043318289b1d413d7afeed06356008b2a5a7fa",
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x423e8488731c0b0f87b435174f412c09fbf0b17eb0b8c9a03efa37d779ec0cae",
-    "sourceCodeHash": "0xe53b970922b309ada1c59f94d5935ffca669e909c797f17ba8a3d309c487e7e8"
+    "initCodeHash": "0x734c4bce3822851f8925d3a8668630e4c503ee5a042e1234e448f4e9ea86582c",
+    "sourceCodeHash": "0x8888b471b484c3f0662dca39317aa75fbb380deea4e12f6a8ccd5dde1202e5c7"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0x2d21506cc51ebe0b60bcf89883aff5e9b1269567ce44ee779de3d3940e23fb65"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x52ddbe70f60a6f4e5c929fed417c92d99d82a85c05de8e1f0c8dfd0d634ad648",
-    "sourceCodeHash": "0xc4a66e8adacd58b961938f473b22614a520fa0bdae70381b8f56210bc34f1f32"
+    "initCodeHash": "0x32eceffc74182357cb79f7218851e02a76200b1e57db7629c2b97b9401d71a25",
+    "sourceCodeHash": "0x95f68f577529c158070e3a23fd2da1c63581113471e1303716e387a07f3070d9"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x6b05d7130c019d3c46dca39dfdae3797861088a9fb7b5baa84fd4e5cb87c5883",
-    "sourceCodeHash": "0xae2fbe02c0f8685692babeed0252ae8a624dc6d3bfb082fc3807d7b84869004b"
+    "initCodeHash": "0x271c17198970e361cb43aff3ae788d4f726d8d1a188eeea7d0a5f0c477380a76",
+    "sourceCodeHash": "0xbb6acc3e88af9594ffcb8a2f30860511b76e09024330e70052316668fe55fd1f"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x0000ec89712d8b4609873f1ba76afffd4205bf9110818995c90134dbec12e91e",
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0x6e94c2f4129209d2b36d6a54adaaf99b91b3df322c8c75043d29f6b0a9143738",
-    "sourceCodeHash": "0xb81181263522e939195a70b6e281fb038de2312c9682f9123723c6ae1babf559"
+    "initCodeHash": "0x751e32c8d44c5ef9b1acae2d94e07f6e91f7f59663c24e12d21298638458b272",
+    "sourceCodeHash": "0xb09dccd5bf662c42ab10afd19a2b51114df9fd3bc6e20d4d86e4ba7529036bbc"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x734c4bce3822851f8925d3a8668630e4c503ee5a042e1234e448f4e9ea86582c",
-    "sourceCodeHash": "0x8888b471b484c3f0662dca39317aa75fbb380deea4e12f6a8ccd5dde1202e5c7"
+    "initCodeHash": "0xd59ffa7f487db9b0761b1fa3994c59e0d78e4546c76379a14a31dec1080b3f20",
+    "sourceCodeHash": "0xd59fd93e7332bad50714ec1abe06cebd6378d32cc4ad18434f09156ac3c97982"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/storageLayout/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/FaultDisputeGame.json
@@ -89,5 +89,33 @@
     "offset": 0,
     "slot": "8",
     "type": "struct OutputRoot"
+  },
+  {
+    "bytes": "1",
+    "label": "wasRespectedGameTypeWhenCreated",
+    "offset": 0,
+    "slot": "10",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "label": "refundModeCredit",
+    "offset": 0,
+    "slot": "11",
+    "type": "mapping(address => uint256)"
+  },
+  {
+    "bytes": "32",
+    "label": "hasUnlockedCredit",
+    "offset": 0,
+    "slot": "12",
+    "type": "mapping(address => bool)"
+  },
+  {
+    "bytes": "1",
+    "label": "bondDistributionMode",
+    "offset": 0,
+    "slot": "13",
+    "type": "enum BondDistributionMode"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/FaultDisputeGame.json
@@ -50,7 +50,7 @@
   },
   {
     "bytes": "32",
-    "label": "credit",
+    "label": "normalModeCredit",
     "offset": 0,
     "slot": "3",
     "type": "mapping(address => uint256)"

--- a/packages/contracts-bedrock/snapshots/storageLayout/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PermissionedDisputeGame.json
@@ -89,5 +89,33 @@
     "offset": 0,
     "slot": "8",
     "type": "struct OutputRoot"
+  },
+  {
+    "bytes": "1",
+    "label": "wasRespectedGameTypeWhenCreated",
+    "offset": 0,
+    "slot": "10",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "label": "refundModeCredit",
+    "offset": 0,
+    "slot": "11",
+    "type": "mapping(address => uint256)"
+  },
+  {
+    "bytes": "32",
+    "label": "hasUnlockedCredit",
+    "offset": 0,
+    "slot": "12",
+    "type": "mapping(address => bool)"
+  },
+  {
+    "bytes": "1",
+    "label": "bondDistributionMode",
+    "offset": 0,
+    "slot": "13",
+    "type": "enum BondDistributionMode"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/PermissionedDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PermissionedDisputeGame.json
@@ -50,7 +50,7 @@
   },
   {
     "bytes": "32",
-    "label": "credit",
+    "label": "normalModeCredit",
     "offset": 0,
     "slot": "3",
     "type": "mapping(address => uint256)"

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -482,11 +482,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         // respectedGameTypeUpdatedAt timestamp without modifying this function's signature.
         if (_gameType.raw() == type(uint32).max) {
             respectedGameTypeUpdatedAt = uint64(block.timestamp);
-            emit RespectedGameTypeSet(respectedGameType, Timestamp.wrap(respectedGameTypeUpdatedAt));
         } else {
             respectedGameType = _gameType;
-            emit RespectedGameTypeSet(_gameType, Timestamp.wrap(respectedGameTypeUpdatedAt));
         }
+        emit RespectedGameTypeSet(respectedGameType, Timestamp.wrap(respectedGameTypeUpdatedAt));
     }
 
     /// @notice Checks if a withdrawal can be finalized. This function will revert if the withdrawal cannot be

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -308,6 +308,18 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         // The game type of the dispute game must be the respected game type.
         if (gameType.raw() != respectedGameType.raw()) revert InvalidGameType();
 
+        // The game type of the DisputeGame must have been the respected game type at creation.
+        if (!gameProxy.wasRespectedGameTypeWhenCreated()) revert InvalidGameType();
+
+        // Creation time must be greater than or equal to the respected game type updated time.
+        // Games created before this timestamp are not valid and cannot be used to finalize a
+        // withdrawal, so for user convenience we also prevent them from being used to prove a
+        // withdrawal.
+        require(
+            gameProxy.createdAt().raw() >= respectedGameTypeUpdatedAt,
+            "OptimismPortal: dispute game created before respected game type was updated"
+        );
+
         // Verify that the output root can be generated with the elements in the proof.
         if (outputRoot.raw() != Hashing.hashOutputRootProof(_outputRootProof)) revert InvalidProof();
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -176,9 +176,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.11.0-beta.11
+    /// @custom:semver 3.12.0-beta.1
     function version() public pure virtual returns (string memory) {
-        return "3.11.0-beta.11";
+        return "3.12.0-beta.1";
     }
 
     /// @notice Constructs the OptimismPortal contract.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -482,6 +482,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         // respectedGameTypeUpdatedAt timestamp without modifying this function's signature.
         if (_gameType.raw() == type(uint32).max) {
             respectedGameTypeUpdatedAt = uint64(block.timestamp);
+            emit RespectedGameTypeSet(respectedGameType, Timestamp.wrap(respectedGameTypeUpdatedAt));
         } else {
             respectedGameType = _gameType;
             emit RespectedGameTypeSet(_gameType, Timestamp.wrap(respectedGameTypeUpdatedAt));

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -28,9 +28,9 @@ contract OptimismPortalInterop is OptimismPortal2 {
         OptimismPortal2(_proofMaturityDelaySeconds, _disputeGameFinalityDelaySeconds)
     { }
 
-    /// @custom:semver +interop-beta.8
+    /// @custom:semver +interop-beta.9
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.8");
+        return string.concat(super.version(), "+interop-beta.9");
     }
 
     /// @notice Sets static configuration options for the L2 system.

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -163,7 +163,7 @@ contract AnchorStateRegistry is Initializable, ISemver {
     /// @notice Returns whether a game is beyond the airgap period.
     /// @param _game The game to check.
     /// @return Whether the game is beyond the airgap period.
-    function isGameBeyondAirgap(IDisputeGame _game) public view returns (bool) {
+    function isGameAirgapped(IDisputeGame _game) public view returns (bool) {
         return block.timestamp - _game.resolvedAt().raw() > portal.disputeGameFinalityDelaySeconds();
     }
 
@@ -215,7 +215,7 @@ contract AnchorStateRegistry is Initializable, ISemver {
         }
 
         // Game must be beyond the airgap period.
-        if (!isGameBeyondAirgap(_game)) {
+        if (!isGameAirgapped(_game)) {
             return false;
         }
 

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -55,7 +55,7 @@ contract AnchorStateRegistry is Initializable, ISemver {
     /// @notice Thrown when an invalid anchor game is provided.
     error AnchorStateRegistry_InvalidAnchorGame();
 
-    /// @notice Thrown when an anchor game is blacklisted.
+    /// @notice Thrown when the anchor root is requested, but the anchor game is blacklisted.
     error AnchorStateRegistry_AnchorGameBlacklisted();
 
     /// @notice Constructor to disable initializers.

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -23,8 +23,8 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 ///         be initialized with a more recent starting state which reduces the amount of required offchain computation.
 contract AnchorStateRegistry is Initializable, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 2.1.0-beta.1
-    string public constant version = "2.1.0-beta.1";
+    /// @custom:semver 2.2.0-beta.1
+    string public constant version = "2.2.0-beta.1";
 
     /// @notice Address of the SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -55,6 +55,9 @@ contract AnchorStateRegistry is Initializable, ISemver {
     /// @notice Thrown when an invalid anchor game is provided.
     error AnchorStateRegistry_InvalidAnchorGame();
 
+    /// @notice Thrown when an anchor game is blacklisted.
+    error AnchorStateRegistry_AnchorGameBlacklisted();
+
     /// @notice Constructor to disable initializers.
     constructor() {
         _disableInitializers();
@@ -101,6 +104,10 @@ contract AnchorStateRegistry is Initializable, ISemver {
         // Return the starting anchor root if there is no anchor game.
         if (address(anchorGame) == address(0)) {
             return (startingAnchorRoot.root, startingAnchorRoot.l2BlockNumber);
+        }
+
+        if (isGameBlacklisted(anchorGame)) {
+            revert AnchorStateRegistry_AnchorGameBlacklisted();
         }
 
         // Otherwise, return the anchor root.

--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -26,14 +26,9 @@ contract DelayedWETH is OwnableUpgradeable, WETH98, ISemver {
         uint256 timestamp;
     }
 
-    /// @notice Emitted when an unwrap is started.
-    /// @param src The address that started the unwrap.
-    /// @param wad The amount of WETH that was unwrapped.
-    event Unwrap(address indexed src, uint256 wad);
-
     /// @notice Semantic version.
-    /// @custom:semver 1.2.0-beta.5
-    string public constant version = "1.2.0-beta.5";
+    /// @custom:semver 1.3.0-beta.1
+    string public constant version = "1.3.0-beta.1";
 
     /// @notice Returns a withdrawal request for the given address.
     mapping(address => mapping(address => WithdrawalRequest)) public withdrawals;
@@ -107,12 +102,19 @@ contract DelayedWETH is OwnableUpgradeable, WETH98, ISemver {
         require(success, "DelayedWETH: recover failed");
     }
 
-    /// @notice Allows the owner to recover from error cases by pulling ETH from a specific owner.
+    /// @notice Allows the owner to recover from error cases by pulling all WETH from a specific owner.
+    /// @param _guy The address to recover the WETH from.
+    function hold(address _guy) external {
+        hold(_guy, balanceOf(_guy));
+    }
+
+    /// @notice Allows the owner to recover from error cases by pulling a specific amount of WETH from a specific owner.
     /// @param _guy The address to recover the WETH from.
     /// @param _wad The amount of WETH to recover.
-    function hold(address _guy, uint256 _wad) external {
+    function hold(address _guy, uint256 _wad) public {
         require(msg.sender == owner(), "DelayedWETH: not owner");
         _allowance[_guy][msg.sender] = _wad;
         emit Approval(_guy, msg.sender, _wad);
+        transferFrom(_guy, msg.sender, _wad);
     }
 }

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -11,6 +11,7 @@ import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 import {
     GameStatus,
     GameType,
+    BondDistributionMode,
     Claim,
     Clock,
     Duration,
@@ -51,7 +52,11 @@ import {
     BondTransferFailed,
     NoCreditToClaim,
     InvalidOutputRootProof,
-    ClaimAboveSplit
+    ClaimAboveSplit,
+    GameNotFinalized,
+    InvalidBondDistributionMode,
+    GameNotResolved,
+    ReservedGameType
 } from "src/dispute/lib/Errors.sol";
 
 // Interfaces
@@ -59,6 +64,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IBigStepper, IPreimageOracle } from "interfaces/dispute/IBigStepper.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 
 /// @title FaultDisputeGame
 /// @notice An implementation of the `IFaultDisputeGame` interface.
@@ -115,6 +121,9 @@ contract FaultDisputeGame is Clone, ISemver {
     /// @param claimant The address of the claimant
     event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
 
+    /// @notice Emitted when the game is closed.
+    event GameClosed(BondDistributionMode bondDistributionMode);
+
     ////////////////////////////////////////////////////////////////
     //                         State Vars                         //
     ////////////////////////////////////////////////////////////////
@@ -161,8 +170,8 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1-beta.9
-    string public constant version = "1.3.1-beta.9";
+    /// @custom:semver 1.4.0-beta.1
+    string public constant version = "1.4.0-beta.1";
 
     /// @notice The starting timestamp of the game
     Timestamp public createdAt;
@@ -204,6 +213,18 @@ contract FaultDisputeGame is Clone, ISemver {
     /// @notice The latest finalized output root, serving as the anchor for output bisection.
     OutputRoot public startingOutputRoot;
 
+    /// @notice A boolean for whether or not the game type was respected when the game was created.
+    bool public wasRespectedGameTypeWhenCreated;
+
+    /// @notice A mapping of each claimant's refund mode credit.
+    mapping(address => uint256) public refundModeCredit;
+
+    /// @notice A mapping of whether a claimant has unlocked their credit.
+    mapping(address => bool) public hasUnlockedCredit;
+
+    /// @notice The bond distribution mode of the game.
+    BondDistributionMode public bondDistributionMode;
+
     /// @param _params Parameters for creating a new FaultDisputeGame.
     constructor(GameConstructorParams memory _params) {
         // The max game depth may not be greater than `LibPosition.MAX_POSITION_BITLEN - 1`.
@@ -238,6 +259,10 @@ contract FaultDisputeGame is Clone, ISemver {
 
         // The maximum clock extension may not be greater than the maximum clock duration.
         if (uint64(maxClockExtension) > _params.maxClockDuration.raw()) revert InvalidClockExtension();
+
+        // Block type(uint32).max from being used as a game type so that it can be used in the
+        // OptimismPortal respected game type trick.
+        if (_params.gameType.raw() == type(uint32).max) revert ReservedGameType();
 
         // Set up initial game state.
         GAME_TYPE = _params.gameType;
@@ -320,10 +345,15 @@ contract FaultDisputeGame is Clone, ISemver {
         initialized = true;
 
         // Deposit the bond.
+        refundModeCredit[gameCreator()] += msg.value;
         WETH.deposit{ value: msg.value }();
 
         // Set the game's starting timestamp
         createdAt = Timestamp.wrap(uint64(block.timestamp));
+
+        // Set whether the game type was respected when the game was created.
+        wasRespectedGameTypeWhenCreated =
+            GameType.unwrap(ANCHOR_STATE_REGISTRY.respectedGameType()) == GameType.unwrap(GAME_TYPE);
     }
 
     ////////////////////////////////////////////////////////////////
@@ -531,6 +561,7 @@ contract FaultDisputeGame is Clone, ISemver {
         subgames[_challengeIndex].push(claimData.length - 1);
 
         // Deposit the bond.
+        refundModeCredit[msg.sender] += msg.value;
         WETH.deposit{ value: msg.value }();
 
         // Emit the appropriate event for the attack or defense.
@@ -695,9 +726,6 @@ contract FaultDisputeGame is Clone, ISemver {
 
         // Update the status and emit the resolved event, note that we're performing an assignment here.
         emit Resolved(status = status_);
-
-        // Try to update the anchor state, this should not revert.
-        ANCHOR_STATE_REGISTRY.tryUpdateAnchorState();
     }
 
     /// @notice Resolves the subgame rooted at the given claim index. `_numToResolve` specifies how many children of
@@ -913,15 +941,42 @@ contract FaultDisputeGame is Clone, ISemver {
         requiredBond_ = assumedBaseFee * requiredGas;
     }
 
-    /// @notice Claim the credit belonging to the recipient address.
+    /// @notice Claim the credit belonging to the recipient address. Reverts if the game isn't
+    ///         finalized, if the recipient has no credit to claim, or if the bond transfer
+    ///         fails. If the game is finalized but no bond has been paid out yet, this method
+    ///         will determine the bond distribution mode and also try to update anchor game.
     /// @param _recipient The owner and recipient of the credit.
     function claimCredit(address _recipient) external {
-        // Remove the credit from the recipient prior to performing the external call.
-        uint256 recipientCredit = credit[_recipient];
-        credit[_recipient] = 0;
+        // Close out the game and determine the bond distribution mode if not already set.
+        // We call this as part of claim credit to reduce the number of additional calls that a
+        // Challenger needs to make to this contract.
+        closeGame();
+
+        // Fetch the recipient's credit balance based on the bond distribution mode.
+        uint256 recipientCredit;
+        if (bondDistributionMode == BondDistributionMode.REFUND) {
+            recipientCredit = refundModeCredit[_recipient];
+        } else if (bondDistributionMode == BondDistributionMode.NORMAL) {
+            recipientCredit = credit[_recipient];
+        } else {
+            // We shouldn't get here, but sanity check just in case.
+            revert InvalidBondDistributionMode();
+        }
+
+        // If the game is in refund mode, and the recipient has not unlocked their refund mode
+        // credit, we unlock it and return early.
+        if (!hasUnlockedCredit[_recipient]) {
+            hasUnlockedCredit[_recipient] = true;
+            WETH.unlock(_recipient, recipientCredit);
+            return;
+        }
 
         // Revert if the recipient has no credit to claim.
         if (recipientCredit == 0) revert NoCreditToClaim();
+
+        // Set the recipient's credit balances to 0.
+        refundModeCredit[_recipient] = 0;
+        credit[_recipient] = 0;
 
         // Try to withdraw the WETH amount so it can be used here.
         WETH.withdraw(_recipient, recipientCredit);
@@ -929,6 +984,50 @@ contract FaultDisputeGame is Clone, ISemver {
         // Transfer the credit to the recipient.
         (bool success,) = _recipient.call{ value: recipientCredit }(hex"");
         if (!success) revert BondTransferFailed();
+    }
+
+    /// @notice Closes out the game, determines the bond distribution mode, attempts to register
+    ///         the game as the anchor game, and emits an event.
+    function closeGame() public {
+        // If the bond distribution mode has already been determined, we can return early.
+        if (bondDistributionMode == BondDistributionMode.REFUND || bondDistributionMode == BondDistributionMode.NORMAL)
+        {
+            // We can't revert or we'd break claimCredit().
+            return;
+        } else if (bondDistributionMode != BondDistributionMode.UNDECIDED) {
+            // We shouldn't get here, but sanity check just in case.
+            revert InvalidBondDistributionMode();
+        }
+
+        // Make sure that the game is resolved.
+        // AnchorStateRegistry should be checking this but we're being defensive here.
+        if (resolvedAt.raw() == 0) {
+            revert GameNotResolved();
+        }
+
+        // Game must be finalized according to the AnchorStateRegistry.
+        bool finalized = ANCHOR_STATE_REGISTRY.isGameFinalized(IDisputeGame(address(this)));
+        if (!finalized) {
+            revert GameNotFinalized();
+        }
+
+        // Try to update the anchor game first. Won't always succeed because delays can lead
+        // to situations in which this game might not be eligible to be a new anchor game.
+        try ANCHOR_STATE_REGISTRY.setAnchorState(IDisputeGame(address(this))) { } catch { }
+
+        // Check if the game is a proper game, which will determine the bond distribution mode.
+        bool properGame = ANCHOR_STATE_REGISTRY.isGameProper(IDisputeGame(address(this)));
+
+        // If the game is a proper game, the bonds should be distributed normally. Otherwise, go
+        // into refund mode and distribute bonds back to their original depositors.
+        if (properGame) {
+            bondDistributionMode = BondDistributionMode.NORMAL;
+        } else {
+            bondDistributionMode = BondDistributionMode.REFUND;
+        }
+
+        // Emit an event to signal that the game has been closed.
+        emit GameClosed(bondDistributionMode);
     }
 
     /// @notice Returns the amount of time elapsed on the potential challenger to `_claimIndex`'s chess clock. Maxes
@@ -1018,14 +1117,7 @@ contract FaultDisputeGame is Clone, ISemver {
     /// @param _recipient The recipient of the bond.
     /// @param _bonded The claim to pay out the bond of.
     function _distributeBond(address _recipient, ClaimData storage _bonded) internal {
-        // Set all bits in the bond value to indicate that the bond has been paid out.
-        uint256 bond = _bonded.bond;
-
-        // Increase the recipient's credit.
-        credit[_recipient] += bond;
-
-        // Unlock the bond.
-        WETH.unlock(_recipient, bond);
+        credit[_recipient] += _bonded.bond;
     }
 
     /// @notice Verifies the integrity of an execution bisection subgame's root claim. Reverts if the claim

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -295,7 +295,7 @@ contract FaultDisputeGame is Clone, ISemver {
         if (initialized) revert AlreadyInitialized();
 
         // Grab the latest anchor root.
-        (Hash root, uint256 rootBlockNumber) = ANCHOR_STATE_REGISTRY.anchors(GAME_TYPE);
+        (Hash root, uint256 rootBlockNumber) = ANCHOR_STATE_REGISTRY.getAnchorRoot();
 
         // Should only happen if this is a new game type that hasn't been set up yet.
         if (root.raw() == bytes32(0)) revert AnchorRootNotFound();

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -121,6 +121,18 @@ error BlockNumberMatches();
 /// @notice Thrown when the L2 block number claim has already been challenged.
 error L2BlockNumberChallenged();
 
+/// @notice Thrown when the game is not yet finalized.
+error GameNotFinalized();
+
+/// @notice Thrown when an invalid bond distribution mode is supplied.
+error InvalidBondDistributionMode();
+
+/// @notice Thrown when the game is not yet resolved.
+error GameNotResolved();
+
+/// @notice Thrown when a reserved game type is used.
+error ReservedGameType();
+
 ////////////////////////////////////////////////////////////////
 //              `PermissionedDisputeGame` Errors              //
 ////////////////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -26,6 +26,17 @@ enum GameStatus {
     DEFENDER_WINS
 }
 
+/// @notice The game's bond distribution type. Games are expected to start in the `UNDECIDED`
+///         state, and then choose either `NORMAL` or `REFUND`.
+enum BondDistributionMode {
+    // Bond distribution strategy has not been chosen.
+    UNDECIDED,
+    // Bonds should be distributed as normal.
+    NORMAL,
+    // Bonds should be refunded to claimants.
+    REFUND
+}
+
 /// @notice Represents an L2 output root and the L2 block number at which it was generated.
 /// @custom:field root The output root.
 /// @custom:field l2BlockNumber The L2 block number at which the output root was generated.

--- a/packages/contracts-bedrock/src/libraries/PortalErrors.sol
+++ b/packages/contracts-bedrock/src/libraries/PortalErrors.sol
@@ -38,3 +38,5 @@ error Unproven();
 error ProposalNotValidated();
 /// @notice Error for when a withdrawal has already been finalized.
 error AlreadyFinalized();
+/// @notice Error for when a game is a legacy game.
+error LegacyGame();

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -587,9 +587,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 
     /// @dev Tests that `proveWithdrawalTransaction` reverts if the game was not the respected game type when created.
     function test_proveWithdrawalTransaction_wasNotRespectedGameTypeWhenCreated_reverts() external {
-        vm.mockCall(
-            address(game), abi.encodeWithSelector(game.wasRespectedGameTypeWhenCreated.selector), abi.encode(false)
-        );
+        vm.mockCall(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), abi.encode(false));
         vm.expectRevert(InvalidGameType.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
@@ -602,7 +600,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     /// @dev Tests that `proveWithdrawalTransaction` reverts if the game is a legacy game that does not implement
     ///      `wasRespectedGameTypeWhenCreated`.
     function test_proveWithdrawalTransaction_legacyGame_reverts() external {
-        vm.mockCallRevert(address(game), abi.encodeWithSelector(game.wasRespectedGameTypeWhenCreated.selector), "");
+        vm.mockCallRevert(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), "");
         vm.expectRevert(LegacyGame.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
@@ -616,7 +614,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     ///      timestamp.
     function testFuzz_proveWithdrawalTransaction_createdBeforeRetirementTimestamp_reverts(uint64 _createdAt) external {
         _createdAt = uint64(bound(_createdAt, 0, optimismPortal2.respectedGameTypeUpdatedAt() - 1));
-        vm.mockCall(address(game), abi.encodeWithSelector(game.createdAt.selector), abi.encode(uint64(_createdAt)));
+        vm.mockCall(address(game), abi.encodeCall(game.createdAt, ()), abi.encode(uint64(_createdAt)));
         vm.expectRevert("OptimismPortal: dispute game created before respected game type was updated");
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
@@ -1525,7 +1523,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         // Warp past the dispute game finality delay.
         vm.warp(block.timestamp + optimismPortal2.disputeGameFinalityDelaySeconds() + 1);
 
-        vm.mockCallRevert(address(game), abi.encodeWithSelector(game.wasRespectedGameTypeWhenCreated.selector), "");
+        vm.mockCallRevert(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), "");
 
         vm.expectRevert(LegacyGame.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -672,13 +672,15 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
             _withdrawalProof: _withdrawalProof
         });
 
+        // Create a new game.
+        IDisputeGame newGame =
+            disputeGameFactory.create(GameType.wrap(0), Claim.wrap(_outputRoot), abi.encode(_proposedBlockNumber + 1));
+
         // Update the respected game type to 0xbeef.
         vm.prank(optimismPortal2.guardian());
         optimismPortal2.setRespectedGameType(GameType.wrap(0xbeef));
 
         // Create a new game and mock the game type as 0xbeef in the factory.
-        IDisputeGame newGame =
-            disputeGameFactory.create(GameType.wrap(0), Claim.wrap(_outputRoot), abi.encode(_proposedBlockNumber + 1));
         vm.mockCall(
             address(disputeGameFactory),
             abi.encodeCall(disputeGameFactory.gameAtIndex, (_proposedGameIndex + 1)),

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -338,6 +338,7 @@ contract AnchorStateRegistry_SetAnchorState_TestFail is AnchorStateRegistry_Init
         assertEq(updatedL2BlockNumber, l2BlockNumber);
         assertEq(updatedRoot.raw(), root.raw());
     }
+}
 
 contract AnchorStateRegistry_SetAnchorState_TestFail is AnchorStateRegistry_Init {
     /// @notice Tests that setAnchorState will revert if the sender is not the guardian.

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -235,7 +235,7 @@ contract AnchorStateRegistry_IsGameRetired_Test is AnchorStateRegistry_Init {
 
 contract AnchorStateRegistry_IsGameProper_Test is AnchorStateRegistry_Init {
     /// @notice Tests that isGameProper will return true if the game meets all conditions.
-    function test_isGameProper_meetsAllConditions_succeeds() public {
+    function test_isGameProper_meetsAllConditions_succeeds() public view {
         // Game will meet all conditions by default.
         assertTrue(anchorStateRegistry.isGameProper(gameProxy));
     }

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -236,9 +236,7 @@ contract AnchorStateRegistry_IsGameRetired_Test is AnchorStateRegistry_Init {
 contract AnchorStateRegistry_IsGameProper_Test is AnchorStateRegistry_Init {
     /// @notice Tests that isGameProper will return true if the game meets all conditions.
     function test_isGameProper_meetsAllConditions_succeeds() public {
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
+        // Game will meet all conditions by default.
         assertTrue(anchorStateRegistry.isGameProper(gameProxy));
     }
 
@@ -258,7 +256,7 @@ contract AnchorStateRegistry_IsGameProper_Test is AnchorStateRegistry_Init {
 
     /// @notice Tests that isGameProper will return false if the game is not the respected game type.
     /// @param _gameType The game type to use for the test.
-    function testFuzz_isGameProper_isNotRespected_succeeds(GameType _gameType) public {
+    function testFuzz_isGameProper_anyGameType_succeeds(GameType _gameType) public {
         if (_gameType.raw() == gameProxy.gameType().raw()) {
             _gameType = GameType.wrap(_gameType.raw() + 1);
         }
@@ -268,7 +266,8 @@ contract AnchorStateRegistry_IsGameProper_Test is AnchorStateRegistry_Init {
             address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(false)
         );
 
-        assertFalse(anchorStateRegistry.isGameProper(gameProxy));
+        // Still a proper game.
+        assertTrue(anchorStateRegistry.isGameProper(gameProxy));
     }
 
     /// @notice Tests that isGameProper will return false if the game is blacklisted.

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -352,26 +352,48 @@ contract DelayedWETH_Recover_Test is DelayedWETH_Init {
 
 contract DelayedWETH_Hold_Test is DelayedWETH_Init {
     /// @dev Tests that holding WETH succeeds.
-    function test_hold_succeeds() public {
+    function test_hold_byOwner_succeeds() public {
         uint256 amount = 1 ether;
 
         // Pretend to be alice and deposit some WETH.
         vm.prank(alice);
         delayedWeth.deposit{ value: amount }();
 
+        // Get our balance before.
+        uint256 initialBalance = delayedWeth.balanceOf(address(this));
+
         // Hold some WETH.
         vm.expectEmit(true, true, true, false);
         emit Approval(alice, address(this), amount);
         delayedWeth.hold(alice, amount);
 
-        // Verify the allowance.
-        assertEq(delayedWeth.allowance(alice, address(this)), amount);
-
-        // We can transfer.
-        delayedWeth.transferFrom(alice, address(this), amount);
+        // Get our balance after.
+        uint256 finalBalance = delayedWeth.balanceOf(address(this));
 
         // Verify the transfer.
-        assertEq(delayedWeth.balanceOf(address(this)), amount);
+        assertEq(finalBalance, initialBalance + amount);
+    }
+
+    function test_hold_withoutAmount_succeeds() public {
+        uint256 amount = 1 ether;
+
+        // Pretend to be alice and deposit some WETH.
+        vm.prank(alice);
+        delayedWeth.deposit{ value: amount }();
+
+        // Get our balance before.
+        uint256 initialBalance = delayedWeth.balanceOf(address(this));
+
+        // Hold some WETH.
+        vm.expectEmit(true, true, true, false);
+        emit Approval(alice, address(this), amount);
+        delayedWeth.hold(alice); // without amount parameter
+
+        // Get our balance after.
+        uint256 finalBalance = delayedWeth.balanceOf(address(this));
+
+        // Verify the transfer.
+        assertEq(finalBalance, initialBalance + amount);
     }
 
     /// @dev Tests that holding WETH by non-owner fails.

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -42,6 +42,7 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
     bytes internal extraData;
 
     event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
+    event GameClosed(BondDistributionMode bondDistributionMode);
 
     event ReceiveETH(uint256 amount);
 
@@ -967,6 +968,17 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         // Ensure the challenge was successful.
         assertEq(uint8(fdg.status()), uint8(GameStatus.CHALLENGER_WINS));
 
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        fdg.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        fdg.claimCredit(address(this));
+        fdg.claimCredit(address(0xb0b));
+        fdg.claimCredit(address(0xace));
+
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
 
@@ -1415,19 +1427,11 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
 
         vm.warp(block.timestamp + 3 days + 12 hours);
 
-        assertEq(address(this).balance, 0);
         gameProxy.resolveClaim(2, 0);
         gameProxy.resolveClaim(1, 0);
 
-        // Wait for the withdrawal delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
-
-        gameProxy.claimCredit(address(this));
-        assertEq(address(this).balance, firstBond + secondBond);
-
         vm.expectRevert(ClaimAlreadyResolved.selector);
         gameProxy.resolveClaim(1, 0);
-        assertEq(address(this).balance, firstBond + secondBond);
     }
 
     /// @dev Static unit test asserting that resolve reverts when attempting to resolve a subgame at max depth
@@ -1447,15 +1451,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
 
         vm.warp(block.timestamp + 3 days + 12 hours);
 
-        // Resolve to claim bond
-        uint256 balanceBefore = address(this).balance;
         gameProxy.resolveClaim(8, 0);
-
-        // Wait for the withdrawal delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
-
-        gameProxy.claimCredit(address(this));
-        assertEq(address(this).balance, balanceBefore + _getRequiredBond(7));
 
         vm.expectRevert(ClaimAlreadyResolved.selector);
         gameProxy.resolveClaim(8, 0);
@@ -1534,9 +1530,19 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         }
         gameProxy.resolve();
 
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
 
+        // Claim credit again to get the bond back.
         gameProxy.claimCredit(address(this));
 
         // Ensure that bonds were paid out correctly.
@@ -1622,11 +1628,24 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
             (bool success,) = address(gameProxy).call(abi.encodeCall(gameProxy.resolveClaim, (i - 1, 0)));
             assertTrue(success);
         }
+
+        // Resolve the game.
         gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+        gameProxy.claimCredit(bob);
 
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
 
+        // Claim credit again to get the bond back.
         gameProxy.claimCredit(address(this));
 
         // Bob's claim should revert since it's value is 0
@@ -1684,9 +1703,22 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         }
         gameProxy.resolve();
 
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+        gameProxy.claimCredit(alice);
+        gameProxy.claimCredit(bob);
+        gameProxy.claimCredit(charlie);
+
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
 
+        // All of these claims should work.
         gameProxy.claimCredit(address(this));
         gameProxy.claimCredit(alice);
         gameProxy.claimCredit(bob);
@@ -1720,6 +1752,12 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(0, 0);
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
 
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
         // Confirm that the anchor state is now the same as the game state.
         (root, l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
         assertEq(l2BlockNumber, gameProxy.l2BlockNumber());
@@ -1742,6 +1780,12 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(0, 0);
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
 
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
         // Confirm that the anchor state is the same as the initial anchor state.
         (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
         assertEq(updatedL2BlockNumber, l2BlockNumber);
@@ -1762,6 +1806,12 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(1, 0);
         gameProxy.resolveClaim(0, 0);
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
 
         // Confirm that the anchor state is the same as the initial anchor state.
         (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
@@ -1807,6 +1857,21 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
 
         // Ensure that the game registered the `reenter` contract's credit.
         assertEq(gameProxy.credit(address(reenter)), reenterBond);
+
+        // Resolve the root claim.
+        gameProxy.resolveClaim(0, 0);
+
+        // Resolve the game.
+        gameProxy.resolve();
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(reenter));
 
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
@@ -2113,6 +2178,90 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
 
         // Defender wins game since the root claim is uncountered
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    /// @dev Tests that closeGame reverts if the game is not resolved
+    function test_closeGame_gameNotResolved_reverts() public {
+        vm.expectRevert(GameNotResolved.selector);
+        gameProxy.closeGame();
+    }
+
+    /// @dev Tests that closeGame reverts if the game is not finalized
+    function test_closeGame_gameNotFinalized_reverts() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Don't wait the finalization delay
+        vm.expectRevert(abi.encodeWithSelector(GameNotFinalized.selector, "game not beyond airgap period"));
+        gameProxy.closeGame();
+    }
+
+    /// @dev Tests that closeGame succeeds for a proper game (normal distribution)
+    function test_closeGame_properGame_succeeds() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game and verify normal distribution mode
+        vm.expectEmit(true, true, true, true);
+        emit GameClosed(BondDistributionMode.NORMAL);
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        // Check that the anchor state was set correctly.
+        assertEq(address(gameProxy.anchorStateRegistry().anchorGame()), address(gameProxy));
+    }
+
+    /// @dev Tests that closeGame succeeds for an improper game (refund mode)
+    function test_closeGame_improperGame_succeeds() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Mock the anchor registry to return improper game
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(anchorStateRegistry.isGameProper, (IDisputeGame(address(gameProxy)))),
+            abi.encode(false, "")
+        );
+
+        // Close the game and verify refund mode
+        vm.expectEmit(true, true, true, true);
+        emit GameClosed(BondDistributionMode.REFUND);
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
+    }
+
+    /// @dev Tests that multiple calls to closeGame succeed after initial distribution mode is set
+    function test_closeGame_multipleCallsAfterSet_succeeds() public {
+        // Resolve and close the game first
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // First close sets the mode
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        // Subsequent closes should succeed without changing the mode
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
     }
 
     /// @dev Helper to generate a mock RLP encoded header (with only a real block number) & an output root proof.

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -2194,7 +2194,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolve();
 
         // Don't wait the finalization delay
-        vm.expectRevert(abi.encodeWithSelector(GameNotFinalized.selector, "game not beyond airgap period"));
+        vm.expectRevert(GameNotFinalized.selector);
         gameProxy.closeGame();
     }
 

--- a/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
@@ -45,6 +45,16 @@ contract FaultDisputeGame_Solvency_Invariant is FaultDisputeGame_Init {
         }
         gameProxy.resolve();
 
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+        gameProxy.claimCredit(address(actor));
+
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + 7 days + 1 seconds);
 

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -118,6 +118,9 @@ contract OptimismPortal2_Invariant_Harness is CommonTest {
             latestBlockhash: bytes32(uint256(0))
         });
 
+        // Warp forward in time to ensure that the game is created after the retirement timestamp.
+        vm.warp(optimismPortal2.respectedGameTypeUpdatedAt() + 1 seconds);
+
         // Create a dispute game with the output root we've proposed.
         _proposedBlockNumber = 0xFF;
         IFaultDisputeGame game = IFaultDisputeGame(

--- a/packages/contracts-bedrock/test/safe/DeputyGuardianModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/DeputyGuardianModule.t.sol
@@ -240,6 +240,11 @@ contract DeputyGuardianModule_setRespectedGameType_Test is DeputyGuardianModule_
     /// @dev Tests that `setRespectedGameType` successfully updates the respected game type when called by the deputy
     /// guardian.
     function testFuzz_setRespectedGameType_succeeds(GameType _gameType) external {
+        // Game type(uint32).max is reserved for setting the respectedGameTypeUpdatedAt timestamp.
+        // TODO(kelvin): Remove this once we've removed the hack.
+        uint32 boundedGameType = uint32(bound(_gameType.raw(), 0, type(uint32).max - 1));
+        _gameType = GameType.wrap(boundedGameType);
+
         vm.expectEmit(address(safeInstance.safe));
         emit ExecutionFromModuleSuccess(address(deputyGuardianModule));
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -23,7 +23,7 @@ import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 /// @dev Specifies common security properties of entrypoints to L1 contracts, including authorization and
 ///      pausability.
 ///      When adding new functions to the L1 system, the `setUp` function must be updated to document the security
-///      properties of the new function. The `Spec` struct reppresents this documentation. However, this contract does
+///      properties of the new function. The `Spec` struct represents this documentation. However, this contract does
 ///      not actually test to verify these properties, only that a spec is defined.
 contract Specification_Test is CommonTest {
     enum Role {
@@ -553,21 +553,25 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "MintManager", _sel: _getSel("upgrade(address)"), _auth: Role.MINTMANAGEROWNER });
 
         // AnchorStateRegistry
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("anchorGame()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("anchors(uint32)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("getAnchorRoot()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("disputeGameFactory()") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("portal()") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("anchorGame()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("initialize(address,address,address,(bytes32,uint256))") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("tryUpdateAnchorState()") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("setAnchorState(address)"), _auth: Role.GUARDIAN });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("version()") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRegistered(address)") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRespected(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameBeyondAirgap(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameBlacklisted(address)") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRetired(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameClaimValid(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameFinalized(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameProper(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRegistered(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameResolved(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRespected(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRetired(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("portal()") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("respectedGameType()") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("setAnchorState(address)"), _auth: Role.GUARDIAN });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("version()") });
 
         // PermissionedDisputeGame
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("absolutePrestate()") });
@@ -578,6 +582,7 @@ contract Specification_Test is CommonTest {
             _sel: _getSel("attack(bytes32,uint256,bytes32)"),
             _auth: Role.CHALLENGER
         });
+        _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("bondDistributionMode()") });
         _addSpec({
             _name: "PermissionedDisputeGame",
             _sel: _getSel("challengeRootL2Block((bytes32,bytes32,bytes32,bytes32),bytes)"),
@@ -589,6 +594,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("claimDataLen()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("claims(bytes32)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("clockExtension()") });
+        _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("closeGame()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("createdAt()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("credit(address)") });
         _addSpec({
@@ -603,6 +609,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("getChallengerDuration(uint256)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("getNumToResolve(uint256)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("getRequiredBond(uint128)") });
+        _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("hasUnlockedCredit(address)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("initialize()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("l1Head()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("l2BlockNumber()") });
@@ -617,6 +624,7 @@ contract Specification_Test is CommonTest {
             _auth: Role.CHALLENGER
         });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("proposer()") });
+        _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("refundModeCredit(address)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("resolutionCheckpoints(uint256)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("resolve()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("resolveClaim(uint256,uint256)") });
@@ -636,6 +644,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("subgames(uint256,uint256)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("version()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("vm()") });
+        _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("wasRespectedGameTypeWhenCreated()") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("weth()") });
 
         // FaultDisputeGame
@@ -643,6 +652,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("addLocalData(uint256,uint256,uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("anchorStateRegistry()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("attack(bytes32,uint256,bytes32)") });
+        _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("bondDistributionMode()") });
         _addSpec({
             _name: "FaultDisputeGame",
             _sel: _getSel("challengeRootL2Block((bytes32,bytes32,bytes32,bytes32),bytes)")
@@ -652,6 +662,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("claimDataLen()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("claims(bytes32)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("clockExtension()") });
+        _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("closeGame()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("createdAt()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("credit(address)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("defend(bytes32,uint256,bytes32)") });
@@ -661,6 +672,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("gameType()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("getChallengerDuration(uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("getRequiredBond(uint128)") });
+        _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("hasUnlockedCredit(address)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("initialize()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("l1Head()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("l2BlockNumber()") });
@@ -673,6 +685,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolutionCheckpoints(uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolve()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("getNumToResolve(uint256)") });
+        _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("refundModeCredit(address)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolveClaim(uint256,uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolvedAt()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolvedSubgames(uint256)") });
@@ -686,6 +699,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("subgames(uint256,uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("version()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("vm()") });
+        _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("wasRespectedGameTypeWhenCreated()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("weth()") });
 
         // DisputeGameFactory

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -948,14 +948,14 @@ contract Specification_Test is CommonTest {
 
     /// @notice Ensures that the DeputyGuardian is authorized to take all Guardian actions.
     function test_deputyGuardianAuth_works() public view {
-        // Additional 2 roles for the DeputyPauseModule.
-        assertEq(specsByRole[Role.GUARDIAN].length, 5);
-        assertEq(specsByRole[Role.DEPUTYGUARDIAN].length, specsByRole[Role.GUARDIAN].length + 2);
+        // Additional 2 roles for the DeputyPauseModule
+        // Additional role for `setAnchorState` which is in DGM but no longer role-restricted.
+        assertEq(specsByRole[Role.GUARDIAN].length, 4);
+        assertEq(specsByRole[Role.DEPUTYGUARDIAN].length, specsByRole[Role.GUARDIAN].length + 3);
 
         mapping(bytes4 => Spec) storage dgmFuncSpecs = specs["DeputyGuardianModule"];
         mapping(bytes4 => Spec) storage superchainConfigFuncSpecs = specs["SuperchainConfig"];
         mapping(bytes4 => Spec) storage portal2FuncSpecs = specs["OptimismPortal2"];
-        mapping(bytes4 => Spec) storage anchorRegFuncSpecs = specs["AnchorStateRegistry"];
 
         // Ensure that for each of the DeputyGuardianModule's methods there is a corresponding method on another
         // system contract authed to the Guardian role.
@@ -972,6 +972,5 @@ contract Specification_Test is CommonTest {
         _assertRolesEq(portal2FuncSpecs[_getSel("setRespectedGameType(uint32)")].auth, Role.GUARDIAN);
 
         _assertRolesEq(dgmFuncSpecs[_getSel("setAnchorState(address,address)")].auth, Role.DEPUTYGUARDIAN);
-        _assertRolesEq(anchorRegFuncSpecs[_getSel("setAnchorState(address)")].auth, Role.GUARDIAN);
     }
 }

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -569,7 +569,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameRetired(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("portal()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("respectedGameType()") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("setAnchorState(address)"), _auth: Role.GUARDIAN });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("setAnchorState(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("version()") });
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -558,7 +558,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("getAnchorRoot()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("disputeGameFactory()") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("initialize(address,address,address,(bytes32,uint256))") });
-        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameBeyondAirgap(address)") });
+        _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameAirgapped(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameBlacklisted(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameClaimValid(address)") });
         _addSpec({ _name: "AnchorStateRegistry", _sel: _getSel("isGameFinalized(address)") });

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -730,6 +730,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "DelayedWETH", _sel: _getSel("delay()") });
         _addSpec({ _name: "DelayedWETH", _sel: _getSel("deposit()") });
         _addSpec({ _name: "DelayedWETH", _sel: _getSel("hold(address,uint256)"), _auth: Role.DELAYEDWETHOWNER });
+        _addSpec({ _name: "DelayedWETH", _sel: _getSel("hold(address)"), _auth: Role.DELAYEDWETHOWNER });
         _addSpec({ _name: "DelayedWETH", _sel: _getSel("initialize(address,address)") });
         _addSpec({ _name: "DelayedWETH", _sel: _getSel("name()") });
         _addSpec({ _name: "DelayedWETH", _sel: _getSel("owner()") });

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -624,6 +624,7 @@ contract Specification_Test is CommonTest {
             _auth: Role.CHALLENGER
         });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("proposer()") });
+        _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("normalModeCredit(address)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("refundModeCredit(address)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("resolutionCheckpoints(uint256)") });
         _addSpec({ _name: "PermissionedDisputeGame", _sel: _getSel("resolve()") });
@@ -685,6 +686,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolutionCheckpoints(uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolve()") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("getNumToResolve(uint256)") });
+        _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("normalModeCredit(address)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("refundModeCredit(address)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolveClaim(uint256,uint256)") });
         _addSpec({ _name: "FaultDisputeGame", _sel: _getSel("resolvedAt()") });


### PR DESCRIPTION
Implements the three primary incident response improvements:

- `AnchorStateRegistry` can no longer be poisoned under normal operation
- `DelayedWETH.hold` simplifications
- `FaultDisputeGame` automated bond refunding