### PR TITLE
op-program: Pass required block hash to OutputByRoot rather than to L2Source constructor

### DIFF
--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -78,12 +78,12 @@ func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Mi
 			// Set up in-process L2 source
 			l2ClCfg := sources.L2ClientDefaultConfig(l2.RollupCfg, true)
 			l2RPC := l2Eng.RPCClient()
-			l2Client, err := hostcommon.NewL2Client(l2RPC, logger, nil, &hostcommon.L2ClientConfig{L2ClientConfig: l2ClCfg, L2Head: cfg.L2Head})
+			l2Client, err := hostcommon.NewL2Client(l2RPC, logger, nil, &hostcommon.L2ClientConfig{L2ClientConfig: l2ClCfg})
 			require.NoError(t, err, "failed to create L2 client")
 			l2DebugCl := hostcommon.NewL2SourceWithClient(logger, l2Client, sources.NewDebugClient(l2RPC.CallContext))
 
 			executor := host.MakeProgramExecutor(logger, programCfg)
-			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2DebugCl, kv, executor, cfg.AgreedPrestate), nil
+			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2DebugCl, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
 		})
 		err = hostcommon.FaultProofProgram(t.Ctx(), logger, programCfg, withInProcessPrefetcher)
 		checkResult(t, err)

--- a/op-program/host/common/l2_client.go
+++ b/op-program/host/common/l2_client.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -30,17 +29,6 @@ func NewL2Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 	}, nil
 }
 
-func (s *L2Client) OutputByRoot(ctx context.Context, l2OutputRoot common.Hash, blockRoot common.Hash) (eth.Output, error) {
-	output, err := s.OutputV0AtBlock(ctx, blockRoot)
-	if err != nil {
-		return nil, err
-	}
-	actualOutputRoot := eth.OutputRoot(output)
-	if actualOutputRoot != eth.Bytes32(l2OutputRoot) {
-		// For fault proofs, we only reference outputs at the l2 head at boot time
-		// The caller shouldn't be requesting outputs at any other block
-		// If they are, there is no chance of recovery and we should panic to avoid retrying forever
-		panic(fmt.Errorf("output root %v from specified L2 block %v does not match requested output root %v", actualOutputRoot, blockRoot, l2OutputRoot))
-	}
-	return output, nil
+func (s *L2Client) OutputByRoot(ctx context.Context, blockRoot common.Hash) (eth.Output, error) {
+	return s.OutputV0AtBlock(ctx, blockRoot)
 }

--- a/op-program/host/common/l2_source.go
+++ b/op-program/host/common/l2_source.go
@@ -120,11 +120,11 @@ func (l *L2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) 
 }
 
 // OutputByRoot implements prefetcher.L2Source.
-func (l *L2Source) OutputByRoot(ctx context.Context, root common.Hash, blockRoot common.Hash) (eth.Output, error) {
+func (l *L2Source) OutputByRoot(ctx context.Context, blockRoot common.Hash) (eth.Output, error) {
 	if l.ExperimentalEnabled() {
-		return l.experimentalClient.OutputByRoot(ctx, root, blockRoot)
+		return l.experimentalClient.OutputByRoot(ctx, blockRoot)
 	}
-	return l.canonicalEthClient.OutputByRoot(ctx, root, blockRoot)
+	return l.canonicalEthClient.OutputByRoot(ctx, blockRoot)
 }
 
 // ExecutionWitness implements prefetcher.L2Source.

--- a/op-program/host/common/l2_source.go
+++ b/op-program/host/common/l2_source.go
@@ -59,7 +59,7 @@ func NewL2Source(ctx context.Context, logger log.Logger, config *config.Config) 
 	canonicalDebugClient := sources.NewDebugClient(canonicalL2RPC.CallContext)
 
 	canonicalL2ClientCfg := sources.L2ClientDefaultConfig(config.Rollup, true)
-	canonicalL2Client, err := NewL2Client(canonicalL2RPC, logger, nil, &L2ClientConfig{L2ClientConfig: canonicalL2ClientCfg, L2Head: config.L2Head})
+	canonicalL2Client, err := NewL2Client(canonicalL2RPC, logger, nil, &L2ClientConfig{L2ClientConfig: canonicalL2ClientCfg})
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func NewL2Source(ctx context.Context, logger log.Logger, config *config.Config) 
 		return nil, err
 	}
 	experimentalL2ClientCfg := sources.L2ClientDefaultConfig(config.Rollup, true)
-	experimentalL2Client, err := NewL2Client(experimentalRPC, logger, nil, &L2ClientConfig{L2ClientConfig: experimentalL2ClientCfg, L2Head: config.L2Head})
+	experimentalL2Client, err := NewL2Client(experimentalRPC, logger, nil, &L2ClientConfig{L2ClientConfig: experimentalL2ClientCfg})
 	if err != nil {
 		return nil, err
 	}
@@ -120,11 +120,11 @@ func (l *L2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) 
 }
 
 // OutputByRoot implements prefetcher.L2Source.
-func (l *L2Source) OutputByRoot(ctx context.Context, root common.Hash) (eth.Output, error) {
+func (l *L2Source) OutputByRoot(ctx context.Context, root common.Hash, blockRoot common.Hash) (eth.Output, error) {
 	if l.ExperimentalEnabled() {
-		return l.experimentalClient.OutputByRoot(ctx, root)
+		return l.experimentalClient.OutputByRoot(ctx, root, blockRoot)
 	}
-	return l.canonicalEthClient.OutputByRoot(ctx, root)
+	return l.canonicalEthClient.OutputByRoot(ctx, root, blockRoot)
 }
 
 // ExecutionWitness implements prefetcher.L2Source.

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -95,7 +95,7 @@ func makeDefaultPrefetcher(ctx context.Context, logger log.Logger, kv kvstore.KV
 	}
 
 	executor := MakeProgramExecutor(logger, cfg)
-	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2Client, kv, executor, cfg.AgreedPrestate), nil
+	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2Client, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
 }
 
 type programExecutor struct {

--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -55,6 +55,8 @@ type Prefetcher struct {
 	l2Fetcher     *RetryingL2Source
 	lastHint      string
 	kvStore       kvstore.KV
+	// l2Head is the L2 block hash to retrieve output root from if interop is disabled
+	l2Head common.Hash
 
 	// Used to run the program for native block execution
 	executor       ProgramExecutor
@@ -68,6 +70,7 @@ func NewPrefetcher(
 	l2Fetcher hosttypes.L2Source,
 	kvStore kvstore.KV,
 	executor ProgramExecutor,
+	l2Head common.Hash,
 	agreedPrestate []byte,
 ) *Prefetcher {
 	return &Prefetcher{
@@ -77,6 +80,7 @@ func NewPrefetcher(
 		l2Fetcher:      NewRetryingL2Source(logger, l2Fetcher),
 		kvStore:        kvStore,
 		executor:       executor,
+		l2Head:         l2Head,
 		agreedPrestate: agreedPrestate,
 	}
 }
@@ -293,7 +297,7 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 			return fmt.Errorf("invalid L2 output hint: %x", hint)
 		}
 		hash := common.Hash(hintBytes)
-		output, err := p.l2Fetcher.OutputByRoot(ctx, hash)
+		output, err := p.l2Fetcher.OutputByRoot(ctx, hash, p.l2Head)
 		if err != nil {
 			return fmt.Errorf("failed to fetch L2 output root %s: %w", hash, err)
 		}

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -646,7 +646,7 @@ func TestRetryWhenNotAvailableAfterPrefetching(t *testing.T) {
 	_, l1Source, l1BlobSource, l2Cl, kv := createPrefetcher(t)
 	putsToIgnore := 2
 	kv = &unreliableKvStore{KV: kv, putsToIgnore: putsToIgnore}
-	prefetcher := NewPrefetcher(testlog.Logger(t, log.LevelInfo), l1Source, l1BlobSource, l2Cl, kv, nil, nil)
+	prefetcher := NewPrefetcher(testlog.Logger(t, log.LevelInfo), l1Source, l1BlobSource, l2Cl, kv, nil, common.Hash{}, nil)
 
 	// Expect one call for each ignored put, plus one more request for when the put succeeds
 	for i := 0; i < putsToIgnore+1; i++ {
@@ -678,8 +678,8 @@ type l2Client struct {
 	*testutils.MockDebugClient
 }
 
-func (m *l2Client) OutputByRoot(ctx context.Context, root common.Hash) (eth.Output, error) {
-	out := m.Mock.MethodCalled("OutputByRoot", root)
+func (m *l2Client) OutputByRoot(ctx context.Context, root common.Hash, blockHash common.Hash) (eth.Output, error) {
+	out := m.Mock.MethodCalled("OutputByRoot", root, blockHash)
 	return out[0].(eth.Output), *out[1].(*error)
 }
 
@@ -701,7 +701,7 @@ func createPrefetcherWithAgreedPrestate(t *testing.T, agreedPrestate []byte) (*P
 		MockDebugClient: new(testutils.MockDebugClient),
 	}
 
-	prefetcher := NewPrefetcher(logger, l1Source, l1BlobSource, l2Source, kv, nil, agreedPrestate)
+	prefetcher := NewPrefetcher(logger, l1Source, l1BlobSource, l2Source, kv, nil, common.Hash{0xdd}, agreedPrestate)
 	return prefetcher, l1Source, l1BlobSource, l2Source, kv
 }
 

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -678,13 +678,13 @@ type l2Client struct {
 	*testutils.MockDebugClient
 }
 
-func (m *l2Client) OutputByRoot(ctx context.Context, root common.Hash, blockHash common.Hash) (eth.Output, error) {
-	out := m.Mock.MethodCalled("OutputByRoot", root, blockHash)
+func (m *l2Client) OutputByRoot(ctx context.Context, blockHash common.Hash) (eth.Output, error) {
+	out := m.Mock.MethodCalled("OutputByRoot", blockHash)
 	return out[0].(eth.Output), *out[1].(*error)
 }
 
-func (m *l2Client) ExpectOutputByRoot(root common.Hash, output eth.Output, err error) {
-	m.Mock.On("OutputByRoot", root).Once().Return(output, &err)
+func (m *l2Client) ExpectOutputByRoot(blockRoot common.Hash, output eth.Output, err error) {
+	m.Mock.On("OutputByRoot", blockRoot).Once().Return(output, &err)
 }
 
 func createPrefetcher(t *testing.T) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Client, kvstore.KV) {

--- a/op-program/host/prefetcher/retry.go
+++ b/op-program/host/prefetcher/retry.go
@@ -132,9 +132,9 @@ func (s *RetryingL2Source) CodeByHash(ctx context.Context, hash common.Hash) ([]
 	})
 }
 
-func (s *RetryingL2Source) OutputByRoot(ctx context.Context, root common.Hash) (eth.Output, error) {
+func (s *RetryingL2Source) OutputByRoot(ctx context.Context, root common.Hash, l2Head common.Hash) (eth.Output, error) {
 	return retry.Do(ctx, maxAttempts, s.strategy, func() (eth.Output, error) {
-		o, err := s.source.OutputByRoot(ctx, root)
+		o, err := s.source.OutputByRoot(ctx, root, l2Head)
 		if err != nil {
 			s.logger.Warn("Failed to fetch l2 output", "root", root, "err", err)
 			return o, err

--- a/op-program/host/prefetcher/retry.go
+++ b/op-program/host/prefetcher/retry.go
@@ -132,11 +132,11 @@ func (s *RetryingL2Source) CodeByHash(ctx context.Context, hash common.Hash) ([]
 	})
 }
 
-func (s *RetryingL2Source) OutputByRoot(ctx context.Context, root common.Hash, l2Head common.Hash) (eth.Output, error) {
+func (s *RetryingL2Source) OutputByRoot(ctx context.Context, blockRoot common.Hash) (eth.Output, error) {
 	return retry.Do(ctx, maxAttempts, s.strategy, func() (eth.Output, error) {
-		o, err := s.source.OutputByRoot(ctx, root, l2Head)
+		o, err := s.source.OutputByRoot(ctx, blockRoot)
 		if err != nil {
-			s.logger.Warn("Failed to fetch l2 output", "root", root, "err", err)
+			s.logger.Warn("Failed to fetch l2 output", "block", blockRoot, "err", err)
 			return o, err
 		}
 		return o, nil

--- a/op-program/host/prefetcher/retry_test.go
+++ b/op-program/host/prefetcher/retry_test.go
@@ -304,23 +304,25 @@ func TestRetryingL2Source(t *testing.T) {
 	})
 
 	t.Run("OutputByRoot Success", func(t *testing.T) {
+		outputHash := common.Hash{1, 2, 3}
 		source, mock := createL2Source(t)
 		defer mock.AssertExpectations(t)
-		mock.ExpectOutputByRoot(hash, output, nil)
+		mock.ExpectOutputByRoot(outputHash, hash, output, nil)
 
-		actualOutput, err := source.OutputByRoot(ctx, hash)
+		actualOutput, err := source.OutputByRoot(ctx, outputHash, hash)
 		require.NoError(t, err)
 		require.Equal(t, output, actualOutput)
 	})
 
 	t.Run("OutputByRoot Error", func(t *testing.T) {
+		outputHash := common.Hash{1, 2, 3}
 		source, mock := createL2Source(t)
 		defer mock.AssertExpectations(t)
 		expectedErr := errors.New("boom")
-		mock.ExpectOutputByRoot(hash, wrongOutput, expectedErr)
-		mock.ExpectOutputByRoot(hash, output, nil)
+		mock.ExpectOutputByRoot(outputHash, hash, wrongOutput, expectedErr)
+		mock.ExpectOutputByRoot(outputHash, hash, output, nil)
 
-		actualOutput, err := source.OutputByRoot(ctx, hash)
+		actualOutput, err := source.OutputByRoot(ctx, outputHash, hash)
 		require.NoError(t, err)
 		require.Equal(t, output, actualOutput)
 	})
@@ -354,8 +356,8 @@ func (m *MockL2Source) CodeByHash(ctx context.Context, hash common.Hash) ([]byte
 	return out[0].([]byte), *out[1].(*error)
 }
 
-func (m *MockL2Source) OutputByRoot(ctx context.Context, root common.Hash) (eth.Output, error) {
-	out := m.Mock.MethodCalled("OutputByRoot", root)
+func (m *MockL2Source) OutputByRoot(ctx context.Context, root common.Hash, blockRoot common.Hash) (eth.Output, error) {
+	out := m.Mock.MethodCalled("OutputByRoot", root, blockRoot)
 	return out[0].(eth.Output), *out[1].(*error)
 }
 
@@ -371,8 +373,8 @@ func (m *MockL2Source) ExpectCodeByHash(hash common.Hash, code []byte, err error
 	m.Mock.On("CodeByHash", hash).Once().Return(code, &err)
 }
 
-func (m *MockL2Source) ExpectOutputByRoot(root common.Hash, output eth.Output, err error) {
-	m.Mock.On("OutputByRoot", root).Once().Return(output, &err)
+func (m *MockL2Source) ExpectOutputByRoot(root common.Hash, blockHash common.Hash, output eth.Output, err error) {
+	m.Mock.On("OutputByRoot", root, blockHash).Once().Return(output, &err)
 }
 
 var _ hosttypes.L2Source = (*MockL2Source)(nil)

--- a/op-program/host/prefetcher/retry_test.go
+++ b/op-program/host/prefetcher/retry_test.go
@@ -304,25 +304,23 @@ func TestRetryingL2Source(t *testing.T) {
 	})
 
 	t.Run("OutputByRoot Success", func(t *testing.T) {
-		outputHash := common.Hash{1, 2, 3}
 		source, mock := createL2Source(t)
 		defer mock.AssertExpectations(t)
-		mock.ExpectOutputByRoot(outputHash, hash, output, nil)
+		mock.ExpectOutputByRoot(hash, output, nil)
 
-		actualOutput, err := source.OutputByRoot(ctx, outputHash, hash)
+		actualOutput, err := source.OutputByRoot(ctx, hash)
 		require.NoError(t, err)
 		require.Equal(t, output, actualOutput)
 	})
 
 	t.Run("OutputByRoot Error", func(t *testing.T) {
-		outputHash := common.Hash{1, 2, 3}
 		source, mock := createL2Source(t)
 		defer mock.AssertExpectations(t)
 		expectedErr := errors.New("boom")
-		mock.ExpectOutputByRoot(outputHash, hash, wrongOutput, expectedErr)
-		mock.ExpectOutputByRoot(outputHash, hash, output, nil)
+		mock.ExpectOutputByRoot(hash, wrongOutput, expectedErr)
+		mock.ExpectOutputByRoot(hash, output, nil)
 
-		actualOutput, err := source.OutputByRoot(ctx, outputHash, hash)
+		actualOutput, err := source.OutputByRoot(ctx, hash)
 		require.NoError(t, err)
 		require.Equal(t, output, actualOutput)
 	})
@@ -356,8 +354,8 @@ func (m *MockL2Source) CodeByHash(ctx context.Context, hash common.Hash) ([]byte
 	return out[0].([]byte), *out[1].(*error)
 }
 
-func (m *MockL2Source) OutputByRoot(ctx context.Context, root common.Hash, blockRoot common.Hash) (eth.Output, error) {
-	out := m.Mock.MethodCalled("OutputByRoot", root, blockRoot)
+func (m *MockL2Source) OutputByRoot(ctx context.Context, blockRoot common.Hash) (eth.Output, error) {
+	out := m.Mock.MethodCalled("OutputByRoot", blockRoot)
 	return out[0].(eth.Output), *out[1].(*error)
 }
 
@@ -373,8 +371,8 @@ func (m *MockL2Source) ExpectCodeByHash(hash common.Hash, code []byte, err error
 	m.Mock.On("CodeByHash", hash).Once().Return(code, &err)
 }
 
-func (m *MockL2Source) ExpectOutputByRoot(root common.Hash, blockHash common.Hash, output eth.Output, err error) {
-	m.Mock.On("OutputByRoot", root, blockHash).Once().Return(output, &err)
+func (m *MockL2Source) ExpectOutputByRoot(blockHash common.Hash, output eth.Output, err error) {
+	m.Mock.On("OutputByRoot", blockHash).Once().Return(output, &err)
 }
 
 var _ hosttypes.L2Source = (*MockL2Source)(nil)

--- a/op-program/host/types/types.go
+++ b/op-program/host/types/types.go
@@ -22,5 +22,5 @@ type L2Source interface {
 	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
 	CodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
-	OutputByRoot(ctx context.Context, root common.Hash) (eth.Output, error)
+	OutputByRoot(ctx context.Context, root common.Hash, l2Head common.Hash) (eth.Output, error)
 }

--- a/op-program/host/types/types.go
+++ b/op-program/host/types/types.go
@@ -22,5 +22,5 @@ type L2Source interface {
 	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
 	CodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
-	OutputByRoot(ctx context.Context, root common.Hash, l2Head common.Hash) (eth.Output, error)
+	OutputByRoot(ctx context.Context, blockRoot common.Hash) (eth.Output, error)
 }


### PR DESCRIPTION
**Description**

Removes the need to know the agreed block hash for each L2 chain before constructing the L2Source instance. When going multi-chain we'll calculate the L2 block number from the agreed super root prestate timestamp rather than having the L2 head hash passed in as an argument.

**Tests**

Tests continue working.
