### PR TITLE
op-program: Update the host config to support multiple L2s

### DIFF
--- a/op-e2e/system/proofs/system_fpp_test.go
+++ b/op-e2e/system/proofs/system_fpp_test.go
@@ -287,7 +287,7 @@ func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *e2esy
 	preimageDir := t.TempDir()
 	fppConfig := oppconf.NewConfig(sys.RollupConfig, sys.L2GenesisCfg.Config, s.L1Head, s.L2Head, s.L2OutputRoot, common.Hash(s.L2Claim), s.L2ClaimBlockNumber)
 	fppConfig.L1URL = sys.NodeEndpoint("l1").RPC()
-	fppConfig.L2URL = sys.NodeEndpoint("sequencer").RPC()
+	fppConfig.L2URLs = []string{sys.NodeEndpoint("sequencer").RPC()}
 	fppConfig.L1BeaconURL = sys.L1BeaconEndpoint().RestHTTP()
 	fppConfig.DataDir = preimageDir
 	if s.Detached {
@@ -314,7 +314,7 @@ func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *e2esy
 	t.Log("Running fault proof in offline mode")
 	// Should be able to rerun in offline mode using the pre-fetched images
 	fppConfig.L1URL = ""
-	fppConfig.L2URL = ""
+	fppConfig.L2URLs = nil
 	err = opp.FaultProofProgramWithDefaultPrefecher(ctx, log, fppConfig)
 	require.NoError(t, err)
 

--- a/op-program/client/boot/boot.go
+++ b/op-program/client/boot/boot.go
@@ -6,22 +6,9 @@ import (
 	"math"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
-)
-
-const (
-	L1HeadLocalIndex preimage.LocalIndexKey = iota + 1
-	L2OutputRootLocalIndex
-	L2ClaimLocalIndex
-	L2ClaimBlockNumberLocalIndex
-	L2ChainIDLocalIndex
-
-	// These local keys are only used for custom chains
-	L2ChainConfigLocalIndex
-	RollupConfigLocalIndex
 )
 
 // CustomChainIDIndicator is used to detect when the program should load custom chain configuration
@@ -36,10 +23,6 @@ type BootInfo struct {
 
 	L2ChainConfig *params.ChainConfig
 	RollupConfig  *rollup.Config
-}
-
-type oracleClient interface {
-	Get(key preimage.Key) []byte
 }
 
 type BootstrapClient struct {

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -1,0 +1,117 @@
+package boot
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	ErrUnknownChainID = errors.New("unknown chain id")
+)
+
+type BootInfoInterop struct {
+	Configs ConfigSource
+
+	L1Head         common.Hash
+	AgreedPrestate common.Hash
+	Claim          common.Hash
+	ClaimTimestamp uint64
+}
+
+type ConfigSource interface {
+	RollupConfig(chainID uint64) (*rollup.Config, error)
+	ChainConfig(chainID uint64) (*params.ChainConfig, error)
+}
+type OracleConfigSource struct {
+	oracle oracleClient
+
+	customConfigsLoaded bool
+
+	l2ChainConfigs map[uint64]*params.ChainConfig
+	rollupConfigs  map[uint64]*rollup.Config
+}
+
+func (c *OracleConfigSource) RollupConfig(chainID uint64) (*rollup.Config, error) {
+	if cfg, ok := c.rollupConfigs[chainID]; ok {
+		return cfg, nil
+	}
+	cfg, err := chainconfig.RollupConfigByChainID(chainID)
+	if !c.customConfigsLoaded && err != nil {
+		c.loadCustomConfigs()
+		if cfg, ok := c.rollupConfigs[chainID]; !ok {
+			return nil, fmt.Errorf("%w: %v", ErrUnknownChainID, chainID)
+		} else {
+			return cfg, nil
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	c.rollupConfigs[chainID] = cfg
+	return cfg, nil
+}
+
+func (c *OracleConfigSource) ChainConfig(chainID uint64) (*params.ChainConfig, error) {
+	if cfg, ok := c.l2ChainConfigs[chainID]; ok {
+		return cfg, nil
+	}
+	cfg, err := chainconfig.ChainConfigByChainID(chainID)
+	if !c.customConfigsLoaded && err != nil {
+		c.loadCustomConfigs()
+		if cfg, ok := c.l2ChainConfigs[chainID]; !ok {
+			return nil, fmt.Errorf("%w: %v", ErrUnknownChainID, chainID)
+		} else {
+			return cfg, nil
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	c.l2ChainConfigs[chainID] = cfg
+	return cfg, nil
+}
+
+func (c *OracleConfigSource) loadCustomConfigs() {
+	var rollupConfigs []*rollup.Config
+	err := json.Unmarshal(c.oracle.Get(RollupConfigLocalIndex), &rollupConfigs)
+	if err != nil {
+		panic("failed to bootstrap rollup configs")
+	}
+	for _, config := range rollupConfigs {
+		c.rollupConfigs[config.L2ChainID.Uint64()] = config
+	}
+
+	var chainConfigs []*params.ChainConfig
+	err = json.Unmarshal(c.oracle.Get(L2ChainConfigLocalIndex), &chainConfigs)
+	if err != nil {
+		panic("failed to bootstrap chain configs")
+	}
+	for _, config := range chainConfigs {
+		c.l2ChainConfigs[config.ChainID.Uint64()] = config
+	}
+	c.customConfigsLoaded = true
+}
+
+func BootstrapInterop(r oracleClient) *BootInfoInterop {
+	l1Head := common.BytesToHash(r.Get(L1HeadLocalIndex))
+	agreedPrestate := common.BytesToHash(r.Get(L2OutputRootLocalIndex))
+	claim := common.BytesToHash(r.Get(L2ClaimLocalIndex))
+	claimTimestamp := binary.BigEndian.Uint64(r.Get(L2ClaimBlockNumberLocalIndex))
+
+	return &BootInfoInterop{
+		Configs: &OracleConfigSource{
+			oracle:         r,
+			l2ChainConfigs: make(map[uint64]*params.ChainConfig),
+			rollupConfigs:  make(map[uint64]*rollup.Config),
+		},
+		L1Head:         l1Head,
+		AgreedPrestate: agreedPrestate,
+		Claim:          claim,
+		ClaimTimestamp: claimTimestamp,
+	}
+}

--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -1,0 +1,142 @@
+package boot
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropBootstrap_SimpleValues(t *testing.T) {
+	expected := &BootInfoInterop{
+		L1Head:         common.Hash{0xaa},
+		AgreedPrestate: common.Hash{0xbb},
+		Claim:          common.Hash{0xcc},
+		ClaimTimestamp: 49829482,
+	}
+	mockOracle := newMockInteropBootstrapOracle(expected, false)
+	actual := BootstrapInterop(mockOracle)
+	require.Equal(t, expected.L1Head, actual.L1Head)
+	require.Equal(t, expected.AgreedPrestate, actual.AgreedPrestate)
+	require.Equal(t, expected.Claim, actual.Claim)
+	require.Equal(t, expected.ClaimTimestamp, actual.ClaimTimestamp)
+}
+
+func TestInteropBootstrap_RollupConfigBuiltIn(t *testing.T) {
+	expectedCfg := chaincfg.OPSepolia()
+	expected := &BootInfoInterop{
+		L1Head:         common.Hash{0xaa},
+		AgreedPrestate: common.Hash{0xbb},
+		Claim:          common.Hash{0xcc},
+		ClaimTimestamp: 49829482,
+	}
+	mockOracle := newMockInteropBootstrapOracle(expected, false)
+	actual := BootstrapInterop(mockOracle)
+	actualCfg, err := actual.Configs.RollupConfig(expectedCfg.L2ChainID.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, expectedCfg, actualCfg)
+}
+
+func TestInteropBootstrap_RollupConfigCustom(t *testing.T) {
+	config1 := &rollup.Config{L2ChainID: big.NewInt(1111)}
+	config2 := &rollup.Config{L2ChainID: big.NewInt(2222)}
+	source := &BootInfoInterop{
+		L1Head:         common.Hash{0xaa},
+		AgreedPrestate: common.Hash{0xbb},
+		Claim:          common.Hash{0xcc},
+		ClaimTimestamp: 49829482,
+	}
+	mockOracle := newMockInteropBootstrapOracle(source, true)
+	mockOracle.rollupCfgs = []*rollup.Config{config1, config2}
+	actual := BootstrapInterop(mockOracle)
+	actualCfg, err := actual.Configs.RollupConfig(config1.L2ChainID.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, config1, actualCfg)
+
+	actualCfg, err = actual.Configs.RollupConfig(config2.L2ChainID.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, config2, actualCfg)
+}
+
+func TestInteropBootstrap_ChainConfigBuiltIn(t *testing.T) {
+	expectedCfg := chainconfig.OPSepoliaChainConfig()
+	expected := &BootInfoInterop{
+		L1Head:         common.Hash{0xaa},
+		AgreedPrestate: common.Hash{0xbb},
+		Claim:          common.Hash{0xcc},
+		ClaimTimestamp: 49829482,
+	}
+	mockOracle := newMockInteropBootstrapOracle(expected, false)
+	actual := BootstrapInterop(mockOracle)
+	actualCfg, err := actual.Configs.ChainConfig(expectedCfg.ChainID.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, expectedCfg, actualCfg)
+}
+
+func TestInteropBootstrap_ChainConfigCustom(t *testing.T) {
+	config1 := &params.ChainConfig{ChainID: big.NewInt(1111)}
+	config2 := &params.ChainConfig{ChainID: big.NewInt(2222)}
+	expected := &BootInfoInterop{
+		L1Head:         common.Hash{0xaa},
+		AgreedPrestate: common.Hash{0xbb},
+		Claim:          common.Hash{0xcc},
+		ClaimTimestamp: 49829482,
+	}
+	mockOracle := newMockInteropBootstrapOracle(expected, true)
+	mockOracle.chainCfgs = []*params.ChainConfig{config1, config2}
+	actual := BootstrapInterop(mockOracle)
+
+	actualCfg, err := actual.Configs.ChainConfig(config1.ChainID.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, config1, actualCfg)
+
+	actualCfg, err = actual.Configs.ChainConfig(config2.ChainID.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, config2, actualCfg)
+}
+
+func newMockInteropBootstrapOracle(b *BootInfoInterop, custom bool) *mockInteropBootstrapOracle {
+	return &mockInteropBootstrapOracle{
+		mockBoostrapOracle: mockBoostrapOracle{
+			l1Head:             b.L1Head,
+			l2OutputRoot:       b.AgreedPrestate,
+			l2Claim:            b.Claim,
+			l2ClaimBlockNumber: b.ClaimTimestamp,
+		},
+		custom: custom,
+	}
+}
+
+type mockInteropBootstrapOracle struct {
+	mockBoostrapOracle
+	rollupCfgs []*rollup.Config
+	chainCfgs  []*params.ChainConfig
+	custom     bool
+}
+
+func (o *mockInteropBootstrapOracle) Get(key preimage.Key) []byte {
+	switch key.PreimageKey() {
+	case L2ChainConfigLocalIndex.PreimageKey():
+		if !o.custom {
+			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
+		}
+		b, _ := json.Marshal(o.chainCfgs)
+		return b
+	case RollupConfigLocalIndex.PreimageKey():
+		if !o.custom {
+			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))
+		}
+		b, _ := json.Marshal(o.rollupCfgs)
+		return b
+	default:
+		return o.mockBoostrapOracle.Get(key)
+	}
+}

--- a/op-program/client/boot/boot_test.go
+++ b/op-program/client/boot/boot_test.go
@@ -24,7 +24,7 @@ func TestBootstrapClient(t *testing.T) {
 		L2ChainConfig:      chainconfig.OPSepoliaChainConfig(),
 		RollupConfig:       rollupCfg,
 	}
-	mockOracle := &mockBoostrapOracle{bootInfo, false}
+	mockOracle := newMockPreinteropBootstrapOracle(bootInfo, false)
 	readBootInfo := NewBootstrapClient(mockOracle).BootInfo()
 	require.EqualValues(t, bootInfo, readBootInfo)
 }
@@ -39,7 +39,7 @@ func TestBootstrapClient_CustomChain(t *testing.T) {
 		L2ChainConfig:      chainconfig.OPSepoliaChainConfig(),
 		RollupConfig:       chaincfg.OPSepolia(),
 	}
-	mockOracle := &mockBoostrapOracle{bootInfo, true}
+	mockOracle := newMockPreinteropBootstrapOracle(bootInfo, true)
 	readBootInfo := NewBootstrapClient(mockOracle).BootInfo()
 	require.EqualValues(t, bootInfo, readBootInfo)
 }
@@ -52,26 +52,32 @@ func TestBootstrapClient_UnknownChainPanics(t *testing.T) {
 		L2ClaimBlockNumber: 1,
 		L2ChainID:          uint64(0xdead),
 	}
-	mockOracle := &mockBoostrapOracle{bootInfo, false}
+	mockOracle := newMockPreinteropBootstrapOracle(bootInfo, false)
 	client := NewBootstrapClient(mockOracle)
 	require.Panics(t, func() { client.BootInfo() })
 }
 
-type mockBoostrapOracle struct {
+func newMockPreinteropBootstrapOracle(info *BootInfo, custom bool) *mockPreinteropBoostrapOracle {
+	return &mockPreinteropBoostrapOracle{
+		mockBoostrapOracle: mockBoostrapOracle{
+			l1Head:             info.L1Head,
+			l2OutputRoot:       info.L2OutputRoot,
+			l2Claim:            info.L2Claim,
+			l2ClaimBlockNumber: info.L2ClaimBlockNumber,
+		},
+		b:      info,
+		custom: custom,
+	}
+}
+
+type mockPreinteropBoostrapOracle struct {
+	mockBoostrapOracle
 	b      *BootInfo
 	custom bool
 }
 
-func (o *mockBoostrapOracle) Get(key preimage.Key) []byte {
+func (o *mockPreinteropBoostrapOracle) Get(key preimage.Key) []byte {
 	switch key.PreimageKey() {
-	case L1HeadLocalIndex.PreimageKey():
-		return o.b.L1Head[:]
-	case L2OutputRootLocalIndex.PreimageKey():
-		return o.b.L2OutputRoot[:]
-	case L2ClaimLocalIndex.PreimageKey():
-		return o.b.L2Claim[:]
-	case L2ClaimBlockNumberLocalIndex.PreimageKey():
-		return binary.BigEndian.AppendUint64(nil, o.b.L2ClaimBlockNumber)
 	case L2ChainIDLocalIndex.PreimageKey():
 		return binary.BigEndian.AppendUint64(nil, o.b.L2ChainID)
 	case L2ChainConfigLocalIndex.PreimageKey():
@@ -87,6 +93,6 @@ func (o *mockBoostrapOracle) Get(key preimage.Key) []byte {
 		b, _ := json.Marshal(o.b.RollupConfig)
 		return b
 	default:
-		panic("unknown key")
+		return o.mockBoostrapOracle.Get(key)
 	}
 }

--- a/op-program/client/boot/common.go
+++ b/op-program/client/boot/common.go
@@ -1,0 +1,19 @@
+package boot
+
+import preimage "github.com/ethereum-optimism/optimism/op-preimage"
+
+const (
+	L1HeadLocalIndex preimage.LocalIndexKey = iota + 1
+	L2OutputRootLocalIndex
+	L2ClaimLocalIndex
+	L2ClaimBlockNumberLocalIndex
+	L2ChainIDLocalIndex
+
+	// These local keys are only used for custom chains
+	L2ChainConfigLocalIndex
+	RollupConfigLocalIndex
+)
+
+type oracleClient interface {
+	Get(key preimage.Key) []byte
+}

--- a/op-program/client/boot/common_test.go
+++ b/op-program/client/boot/common_test.go
@@ -1,0 +1,30 @@
+package boot
+
+import (
+	"encoding/binary"
+
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type mockBoostrapOracle struct {
+	l1Head             common.Hash
+	l2OutputRoot       common.Hash
+	l2Claim            common.Hash
+	l2ClaimBlockNumber uint64
+}
+
+func (o *mockBoostrapOracle) Get(key preimage.Key) []byte {
+	switch key.PreimageKey() {
+	case L1HeadLocalIndex.PreimageKey():
+		return o.l1Head[:]
+	case L2OutputRootLocalIndex.PreimageKey():
+		return o.l2OutputRoot[:]
+	case L2ClaimLocalIndex.PreimageKey():
+		return o.l2Claim[:]
+	case L2ClaimBlockNumberLocalIndex.PreimageKey():
+		return binary.BigEndian.AppendUint64(nil, o.l2ClaimBlockNumber)
+	default:
+		panic("unknown key")
+	}
+}

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -47,9 +47,10 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	l1PreimageOracle := l1.NewCachingOracle(l1.NewPreimageOracle(pClient, hClient))
 	l2PreimageOracle := l2.NewCachingOracle(l2.NewPreimageOracle(pClient, hClient))
 
-	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
 	if cfg.InteropEnabled {
+		bootInfo := boot.BootstrapInterop(pClient)
 		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, !cfg.SkipValidation)
 	}
+	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
 	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
 }

--- a/op-program/host/common/l2_source.go
+++ b/op-program/host/common/l2_source.go
@@ -3,10 +3,8 @@ package common
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	hosttypes "github.com/ethereum-optimism/optimism/op-program/host/types"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -47,27 +45,6 @@ func NewL2SourceWithClient(logger log.Logger, canonicalL2Client *L2Client, canon
 	}
 
 	return source
-}
-
-func NewL2Source(ctx context.Context, logger log.Logger, config *config.Config) (*L2Source, error) {
-	logger.Info("Connecting to canonical L2 source", "url", config.L2URL)
-	// eth_getProof calls are expensive and takes time, so we use a longer timeout
-	canonicalL2RPC, err := client.NewRPC(ctx, logger, config.L2URL, client.WithDialAttempts(10), client.WithCallTimeout(5*time.Minute))
-	if err != nil {
-		return nil, err
-	}
-
-	var experimentalRPC client.RPC
-
-	if len(config.L2ExperimentalURL) != 0 {
-		logger.Info("Connecting to experimental L2 source", "url", config.L2ExperimentalURL)
-		// debug_executionWitness calls are expensive and takes time, so we use a longer timeout
-		experimentalRPC, err = client.NewRPC(ctx, logger, config.L2ExperimentalURL, client.WithDialAttempts(10), client.WithCallTimeout(5*time.Minute))
-		if err != nil {
-			return nil, err
-		}
-	}
-	return NewL2SourceFromRPC(logger, config.Rollup, canonicalL2RPC, experimentalRPC)
 }
 
 func NewL2SourceFromRPC(logger log.Logger, rollupCfg *rollup.Config, canonicalL2RPC client.RPC, experimentalRPC client.RPC) (*L2Source, error) {

--- a/op-program/host/common/l2_sources.go
+++ b/op-program/host/common/l2_sources.go
@@ -1,0 +1,112 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	ErrNoSources               = errors.New("no sources specified")
+	ErrNoL2ForRollup           = errors.New("no L2 RPC available for rollup")
+	ErrNoRollupForL2           = errors.New("no rollup config available for L2 RPC")
+	ErrNoRollupForExperimental = errors.New("no rollup config available for L2 experimental RPC")
+)
+
+type L2Sources struct {
+	Sources map[uint64]*L2Source
+}
+
+func NewL2SourcesFromURLs(ctx context.Context, logger log.Logger, configs []*rollup.Config, l2URLs []string, l2ExperimentalURLs []string) (*L2Sources, error) {
+	l2Clients, err := connectRPCs(ctx, logger, l2URLs)
+	if err != nil {
+		return nil, err
+	}
+	l2ExperimentalClients, err := connectRPCs(ctx, logger, l2URLs)
+	if err != nil {
+		return nil, err
+	}
+	return NewL2Sources(ctx, logger, configs, l2Clients, l2ExperimentalClients)
+}
+
+func connectRPCs(ctx context.Context, logger log.Logger, urls []string) ([]client.RPC, error) {
+	l2Clients := make([]client.RPC, len(urls))
+	for i, url := range urls {
+		logger.Info("Connecting to L2 source", "url", url)
+		// eth_getProof calls are expensive and takes time, so we use a longer timeout
+		rpc, err := client.NewRPC(ctx, logger, url, client.WithDialAttempts(10), client.WithCallTimeout(5*time.Minute))
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to rpc URL %s: %w", url, err)
+		}
+		l2Clients[i] = rpc
+	}
+	return l2Clients, nil
+}
+
+func NewL2Sources(ctx context.Context, logger log.Logger, configs []*rollup.Config, l2Clients []client.RPC, l2ExperimentalClients []client.RPC) (*L2Sources, error) {
+	if len(configs) == 0 {
+		return nil, ErrNoSources
+	}
+	rollupConfigs := make(map[uint64]*rollup.Config)
+	for _, rollupCfg := range configs {
+		rollupConfigs[rollupCfg.L2ChainID.Uint64()] = rollupCfg
+	}
+	l2RPCs := make(map[uint64]client.RPC)
+	for _, rpc := range l2Clients {
+		chainID, err := loadChainID(ctx, rpc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load chain ID: %w", err)
+		}
+		l2RPCs[chainID] = rpc
+		if _, ok := rollupConfigs[chainID]; !ok {
+			return nil, fmt.Errorf("%w: %v", ErrNoRollupForL2, chainID)
+		}
+	}
+
+	l2ExperimentalRPCs := make(map[uint64]client.RPC)
+	for _, rpc := range l2ExperimentalClients {
+		chainID, err := loadChainID(ctx, rpc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load chain ID: %w", err)
+		}
+		l2ExperimentalRPCs[chainID] = rpc
+		if _, ok := rollupConfigs[chainID]; !ok {
+			return nil, fmt.Errorf("%w: %v", ErrNoRollupForExperimental, chainID)
+		}
+	}
+
+	sources := make(map[uint64]*L2Source)
+	for _, rollupCfg := range rollupConfigs {
+		chainID := rollupCfg.L2ChainID.Uint64()
+		l2RPC, ok := l2RPCs[chainID]
+		if !ok {
+			return nil, fmt.Errorf("%w: %v", ErrNoL2ForRollup, chainID)
+		}
+		l2ExperimentalRPC := l2ExperimentalRPCs[chainID] // Allowed to be nil
+		source, err := NewL2SourceFromRPC(logger, rollupCfg, l2RPC, l2ExperimentalRPC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create l2 source for chain ID %v: %w", chainID, err)
+		}
+		sources[chainID] = source
+	}
+
+	return &L2Sources{
+		Sources: sources,
+	}, nil
+}
+
+func loadChainID(ctx context.Context, rpc client.RPC) (uint64, error) {
+	var id hexutil.Big
+	err := rpc.CallContext(ctx, &id, "eth_chainId")
+	if err != nil {
+		return 0, err
+	}
+	return (*big.Int)(&id).Uint64(), nil
+}

--- a/op-program/host/common/l2_sources_test.go
+++ b/op-program/host/common/l2_sources_test.go
@@ -1,0 +1,131 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewL2Sources(t *testing.T) {
+	t.Run("NoSources", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelInfo)
+		_, err := NewL2Sources(context.Background(), logger, nil, nil, nil)
+		require.ErrorIs(t, err, ErrNoSources)
+	})
+
+	t.Run("SingleSource", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		config, l2Rpc, experimentalRpc := chain(4)
+		src, err := NewL2Sources(context.Background(), logger,
+			[]*rollup.Config{config},
+			[]client.RPC{l2Rpc},
+			[]client.RPC{experimentalRpc})
+		require.NoError(t, err)
+		require.Len(t, src.Sources, 1)
+		require.True(t, src.Sources[uint64(4)].ExperimentalEnabled())
+	})
+
+	t.Run("MultipleSources", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		config1, l2Rpc1, experimentalRpc1 := chain(1)
+		config2, l2Rpc2, experimentalRpc2 := chain(2)
+		src, err := NewL2Sources(context.Background(), logger,
+			[]*rollup.Config{config1, config2},
+			[]client.RPC{l2Rpc1, l2Rpc2},
+			[]client.RPC{experimentalRpc1, experimentalRpc2})
+		require.NoError(t, err)
+		require.Len(t, src.Sources, 2)
+		require.True(t, src.Sources[uint64(1)].ExperimentalEnabled())
+		require.True(t, src.Sources[uint64(2)].ExperimentalEnabled())
+	})
+
+	t.Run("ExperimentalRPCsAreOptional", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		config1, l2Rpc1, _ := chain(1)
+		config2, l2Rpc2, experimentalRpc2 := chain(2)
+		src, err := NewL2Sources(context.Background(), logger,
+			[]*rollup.Config{config1, config2},
+			[]client.RPC{l2Rpc1, l2Rpc2},
+			[]client.RPC{experimentalRpc2})
+		require.NoError(t, err)
+		require.Len(t, src.Sources, 2)
+		require.Same(t, src.Sources[uint64(1)].RollupConfig(), config1)
+		require.False(t, src.Sources[uint64(1)].ExperimentalEnabled())
+
+		require.Same(t, src.Sources[uint64(2)].RollupConfig(), config2)
+		require.True(t, src.Sources[uint64(2)].ExperimentalEnabled())
+	})
+
+	t.Run("RollupMissingL2URL", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		config1, _, _ := chain(1)
+		config2, l2Rpc2, experimentalRpc2 := chain(2)
+		_, err := NewL2Sources(context.Background(), logger,
+			[]*rollup.Config{config1, config2},
+			[]client.RPC{l2Rpc2},
+			[]client.RPC{experimentalRpc2})
+		require.ErrorIs(t, err, ErrNoL2ForRollup)
+	})
+
+	t.Run("L2URLWithoutConfig", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		_, l2Rpc1, _ := chain(1)
+		config2, l2Rpc2, experimentalRpc2 := chain(2)
+		_, err := NewL2Sources(context.Background(), logger,
+			[]*rollup.Config{config2},
+			[]client.RPC{l2Rpc1, l2Rpc2},
+			[]client.RPC{experimentalRpc2})
+		require.ErrorIs(t, err, ErrNoRollupForL2)
+	})
+
+	t.Run("ExperimentalURLWithoutConfig", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		_, _, experimentalRpc1 := chain(1)
+		config2, l2Rpc2, experimentalRpc2 := chain(2)
+		_, err := NewL2Sources(context.Background(), logger,
+			[]*rollup.Config{config2},
+			[]client.RPC{l2Rpc2},
+			[]client.RPC{experimentalRpc1, experimentalRpc2})
+		require.ErrorIs(t, err, ErrNoRollupForExperimental)
+	})
+}
+
+func chain(id uint64) (*rollup.Config, client.RPC, client.RPC) {
+	chainID := new(big.Int).SetUint64(id)
+	return &rollup.Config{L2ChainID: chainID}, &chainIDRPC{id: chainID}, &chainIDRPC{id: chainID}
+}
+
+type chainIDRPC struct {
+	id *big.Int
+}
+
+func (c *chainIDRPC) Close() {
+	panic("implement me")
+}
+
+func (c *chainIDRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
+	if method != "eth_chainId" {
+		return fmt.Errorf("invalid method: %s", method)
+	}
+	resultOut := result.(*hexutil.Big)
+	*resultOut = (hexutil.Big)(*c.id)
+	return nil
+}
+
+func (c *chainIDRPC) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	panic("implement me")
+}
+
+func (c *chainIDRPC) Subscribe(ctx context.Context, namespace string, channel any, args ...any) (ethereum.Subscription, error) {
+	panic("implement me")
+}

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -41,8 +41,8 @@ var (
 )
 
 type Config struct {
-	L2ChainID uint64
-	Rollup    *rollup.Config
+	L2ChainID uint64 // TODO: Forbid for interop
+	Rollups   []*rollup.Config
 	// DataDir is the directory to read/write pre-image data from/to.
 	// If not set, an in-memory key-value store is used and fetching data must be enabled
 	DataDir string
@@ -57,22 +57,26 @@ type Config struct {
 	L1TrustRPC  bool
 	L1RPCKind   sources.RPCProviderKind
 
-	// L2Head is the l2 block hash contained in the L2 Output referenced by the L2OutputRoot
-	L2Head common.Hash
+	// L2Head is the l2 block hash contained in the L2 Output referenced by the L2OutputRoot for pre-interop mode
+	L2Head common.Hash // TODO: Forbid for interop
 	// L2OutputRoot is the agreed L2 output root to start derivation from
 	L2OutputRoot common.Hash
-	// L2URL is the URL of the L2 node to fetch L2 data from, this is the canonical URL for L2 data
-	// This URL is used as a fallback for L2ExperimentalURL if the experimental URL fails or cannot retrieve the desired data
-	L2URL string
-	// L2ExperimentalURL is the URL of the L2 node (non hash db archival node, for example, reth archival node) to fetch L2 data from
-	L2ExperimentalURL string
+	// L2URLs are the URLs of the L2 nodes to fetch L2 data from, these are the canonical URL for L2 data
+	// These URLs are used as a fallback for L2ExperimentalURL if the experimental URL fails or cannot retrieve the desired data
+	// Must have one L2URL for each chain in Rollups
+	L2URLs []string
+	// L2ExperimentalURLs are the URLs of the L2 nodes (non hash db archival node, for example, reth archival node) to fetch L2 data from
+	// Must have one url for each chain in Rollups
+	L2ExperimentalURLs []string
 	// L2Claim is the claimed L2 output root to verify
 	L2Claim common.Hash
 	// L2ClaimBlockNumber is the block number the claimed L2 output root is from
 	// Must be above 0 and to be a valid claim needs to be above the L2Head block.
+	// For interop this is the superchain root timestamp
 	L2ClaimBlockNumber uint64
-	// L2ChainConfig is the op-geth chain config for the L2 execution engine
-	L2ChainConfig *params.ChainConfig
+	// L2ChainConfigs are the op-geth chain config for the L2 execution engines
+	// Must have one chain config for each rollup config
+	L2ChainConfigs []*params.ChainConfig
 	// ExecCmd specifies the client program to execute in a separate process.
 	// If unset, the fault proof client is run in the same process.
 	ExecCmd string
@@ -88,11 +92,13 @@ type Config struct {
 }
 
 func (c *Config) Check() error {
-	if c.Rollup == nil {
+	if len(c.Rollups) == 0 {
 		return ErrMissingRollupConfig
 	}
-	if err := c.Rollup.Check(); err != nil {
-		return err
+	for _, rollupCfg := range c.Rollups {
+		if err := rollupCfg.Check(); err != nil {
+			return fmt.Errorf("invalid rollup config for chain %v: %w", rollupCfg.L2ChainID, err)
+		}
 	}
 	if c.L1Head == (common.Hash{}) {
 		return ErrInvalidL1Head
@@ -106,10 +112,10 @@ func (c *Config) Check() error {
 	if c.L2ClaimBlockNumber == 0 {
 		return ErrInvalidL2ClaimBlock
 	}
-	if c.L2ChainConfig == nil {
+	if len(c.L2ChainConfigs) == 0 {
 		return ErrMissingL2Genesis
 	}
-	if (c.L1URL != "") != (c.L2URL != "") {
+	if (c.L1URL != "") != (len(c.L2URLs) > 0) {
 		return ErrL1AndL2Inconsistent
 	}
 	if !c.FetchingEnabled() && c.DataDir == "" {
@@ -133,7 +139,7 @@ func (c *Config) Check() error {
 }
 
 func (c *Config) FetchingEnabled() bool {
-	return c.L1URL != "" && c.L2URL != "" && c.L1BeaconURL != ""
+	return c.L1URL != "" && len(c.L2URLs) > 0 && c.L1BeaconURL != ""
 }
 
 // NewConfig creates a Config with all optional values set to the CLI default value
@@ -154,8 +160,8 @@ func NewConfig(
 	}
 	return &Config{
 		L2ChainID:          l2ChainID,
-		Rollup:             rollupCfg,
-		L2ChainConfig:      l2Genesis,
+		Rollups:            []*rollup.Config{rollupCfg},
+		L2ChainConfigs:     []*params.ChainConfig{l2Genesis},
 		L1Head:             l1Head,
 		L2Head:             l2Head,
 		L2OutputRoot:       l2OutputRoot,
@@ -252,14 +258,22 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	if !slices.Contains(types.SupportedDataFormats, dbFormat) {
 		return nil, fmt.Errorf("invalid %w: %v", ErrInvalidDataFormat, dbFormat)
 	}
+	var l2URLs []string
+	if ctx.IsSet(flags.L2NodeAddr.Name) {
+		l2URLs = append(l2URLs, ctx.String(flags.L2NodeAddr.Name))
+	}
+	var l2ExperimentalURLs []string
+	if ctx.IsSet(flags.L2NodeExperimentalAddr.Name) {
+		l2ExperimentalURLs = append(l2ExperimentalURLs, ctx.String(flags.L2NodeExperimentalAddr.Name))
+	}
 	return &Config{
 		L2ChainID:          l2ChainID,
-		Rollup:             rollupCfg,
+		Rollups:            []*rollup.Config{rollupCfg},
 		DataDir:            ctx.String(flags.DataDir.Name),
 		DataFormat:         dbFormat,
-		L2URL:              ctx.String(flags.L2NodeAddr.Name),
-		L2ExperimentalURL:  ctx.String(flags.L2NodeExperimentalAddr.Name),
-		L2ChainConfig:      l2ChainConfig,
+		L2URLs:             l2URLs,
+		L2ExperimentalURLs: l2ExperimentalURLs,
+		L2ChainConfigs:     []*params.ChainConfig{l2ChainConfig},
 		L2Head:             l2Head,
 		L2OutputRoot:       l2OutputRoot,
 		AgreedPrestate:     agreedPrestate,

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -43,12 +43,12 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
-		return json.Marshal(s.config.L2ChainConfig)
+		return json.Marshal(s.config.L2ChainConfigs)
 	case rollupKey:
 		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
-		return json.Marshal(s.config.Rollup)
+		return json.Marshal(s.config.Rollups)
 	default:
 		return nil, ErrNotFound
 	}

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -43,12 +43,18 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
-		return json.Marshal(s.config.L2ChainConfigs)
+		if s.config.InteropEnabled {
+			return json.Marshal(s.config.L2ChainConfigs)
+		}
+		return json.Marshal(s.config.L2ChainConfigs[0])
 	case rollupKey:
 		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound
 		}
-		return json.Marshal(s.config.Rollups)
+		if s.config.InteropEnabled {
+			return json.Marshal(s.config.Rollups)
+		}
+		return json.Marshal(s.config.Rollups[0])
 	default:
 		return nil, ErrNotFound
 	}

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -17,12 +18,12 @@ import (
 func TestLocalPreimageSource(t *testing.T) {
 	cfg := &config.Config{
 		L2ChainID:          86,
-		Rollup:             chaincfg.OPSepolia(),
+		Rollups:            []*rollup.Config{chaincfg.OPSepolia()},
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1234,
-		L2ChainConfig:      params.SepoliaChainConfig,
+		L2ChainConfigs:     []*params.ChainConfig{params.SepoliaChainConfig},
 	}
 	source := NewLocalPreimageSource(cfg)
 	tests := []struct {
@@ -54,21 +55,21 @@ func TestLocalPreimageSource(t *testing.T) {
 
 func TestGetCustomChainConfigPreimages(t *testing.T) {
 	cfg := &config.Config{
-		Rollup:             chaincfg.OPSepolia(),
+		Rollups:            []*rollup.Config{chaincfg.OPSepolia()},
 		L2ChainID:          boot.CustomChainIDIndicator,
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1234,
-		L2ChainConfig:      params.SepoliaChainConfig,
+		L2ChainConfigs:     []*params.ChainConfig{params.SepoliaChainConfig},
 	}
 	source := NewLocalPreimageSource(cfg)
 	actualRollup, err := source.Get(rollupKey)
 	require.NoError(t, err)
-	require.Equal(t, asJson(t, cfg.Rollup), actualRollup)
+	require.Equal(t, asJson(t, cfg.Rollups), actualRollup)
 	actualChainConfig, err := source.Get(l2ChainConfigKey)
 	require.NoError(t, err)
-	require.Equal(t, asJson(t, cfg.L2ChainConfig), actualChainConfig)
+	require.Equal(t, asJson(t, cfg.L2ChainConfigs), actualChainConfig)
 }
 
 func asJson(t *testing.T, v any) []byte {

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -3,6 +3,7 @@ package kvstore
 import (
 	"encoding/binary"
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
@@ -62,6 +63,28 @@ func TestGetCustomChainConfigPreimages(t *testing.T) {
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1234,
 		L2ChainConfigs:     []*params.ChainConfig{params.SepoliaChainConfig},
+	}
+	source := NewLocalPreimageSource(cfg)
+	actualRollup, err := source.Get(rollupKey)
+	require.NoError(t, err)
+	require.Equal(t, asJson(t, cfg.Rollups[0]), actualRollup)
+	actualChainConfig, err := source.Get(l2ChainConfigKey)
+	require.NoError(t, err)
+	require.Equal(t, asJson(t, cfg.L2ChainConfigs[0]), actualChainConfig)
+}
+
+func TestGetCustomChainConfigPreimagesInterop(t *testing.T) {
+	rollup2 := &rollup.Config{L2ChainID: big.NewInt(2498)}
+	chainCfg2 := &params.ChainConfig{ChainID: big.NewInt(2498)}
+	cfg := &config.Config{
+		Rollups:            []*rollup.Config{chaincfg.OPSepolia(), rollup2},
+		L2ChainID:          boot.CustomChainIDIndicator,
+		L1Head:             common.HexToHash("0x1111"),
+		L2OutputRoot:       common.HexToHash("0x2222"),
+		L2Claim:            common.HexToHash("0x3333"),
+		L2ClaimBlockNumber: 1234,
+		L2ChainConfigs:     []*params.ChainConfig{params.SepoliaChainConfig, chainCfg2},
+		InteropEnabled:     true,
 	}
 	source := NewLocalPreimageSource(cfg)
 	actualRollup, err := source.Get(rollupKey)

--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -216,7 +216,7 @@ func (r *Runner) run(ctx context.Context, l1Head common.Hash, agreedBlockInfo et
 		onlineCfg := *offlineCfg
 		onlineCfg.L1URL = r.l1RpcUrl
 		onlineCfg.L1BeaconURL = r.l1BeaconUrl
-		onlineCfg.L2URL = r.l2RpcUrl
+		onlineCfg.L2URLs = []string{r.l2RpcUrl}
 		if r.l1RpcKind != "" {
 			onlineCfg.L1RPCKind = sources.RPCProviderKind(r.l1RpcKind)
 		}


### PR DESCRIPTION
**Description**

The CLI flags still only support a single L2 will follow up on that.

**Tests**

Update unit tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13718