### PR TITLE
OPCM: unify assertValidContractAddress

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0xa91b445bdc666a02ba18e3b91ba94b6d54bbe65da714002fc734814201319d57"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xe0c14a8fee7ad4c4e28a3ff6ca4e726721a6c3fea0a74ab7eac7ef07fe4da0ae",
-    "sourceCodeHash": "0xe0f5413e0a0a335016d773f02ef6bd25551416635981e83b7a4da601b9b65bc4"
+    "initCodeHash": "0x155d10984db843caff8a1d55e612e8191d9078c7c8bc073234bc07928d69164a",
+    "sourceCodeHash": "0x0f1a98ffdd55645a5120f29d0c5903db47014c6a8868e9eb46e1f966ddc22402"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x7e533474310583593c2d57d30fcd1ec11e1568dbaaf37a2dd28c5cc574068bac",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -6,6 +6,7 @@ import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Bytes } from "src/libraries/Bytes.sol";
 import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -138,8 +139,8 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.28
-    string public constant version = "1.0.0-beta.28";
+    /// @custom:semver 1.0.0-beta.29
+    string public constant version = "1.0.0-beta.29";
 
     /// @notice Represents the interface version so consumers know how to decode the DeployOutput struct
     /// that's emitted in the `Deployed` event. Whenever that struct changes, a new version should be used.
@@ -216,8 +217,8 @@ contract OPContractsManager is ISemver {
         Blueprints memory _blueprints,
         Implementations memory _implementations
     ) {
-        assertValidContractAddress(address(_superchainConfig));
-        assertValidContractAddress(address(_protocolVersions));
+        DeployUtils.assertValidContractAddress(address(_superchainConfig));
+        DeployUtils.assertValidContractAddress(address(_protocolVersions));
         superchainConfig = _superchainConfig;
         protocolVersions = _protocolVersions;
         l1ContractsRelease = _l1ContractsRelease;
@@ -754,12 +755,12 @@ contract OPContractsManager is ISemver {
             gasPayingToken: Constants.ETHER
         });
 
-        assertValidContractAddress(opChainAddrs_.l1CrossDomainMessenger);
-        assertValidContractAddress(opChainAddrs_.l1ERC721Bridge);
-        assertValidContractAddress(opChainAddrs_.l1StandardBridge);
-        assertValidContractAddress(opChainAddrs_.disputeGameFactory);
-        assertValidContractAddress(opChainAddrs_.optimismPortal);
-        assertValidContractAddress(opChainAddrs_.optimismMintableERC20Factory);
+        DeployUtils.assertValidContractAddress(opChainAddrs_.l1CrossDomainMessenger);
+        DeployUtils.assertValidContractAddress(opChainAddrs_.l1ERC721Bridge);
+        DeployUtils.assertValidContractAddress(opChainAddrs_.l1StandardBridge);
+        DeployUtils.assertValidContractAddress(opChainAddrs_.disputeGameFactory);
+        DeployUtils.assertValidContractAddress(opChainAddrs_.optimismPortal);
+        DeployUtils.assertValidContractAddress(opChainAddrs_.optimismMintableERC20Factory);
     }
 
     /// @notice Makes an external call to the target to initialize the proxy with the specified data.
@@ -772,16 +773,11 @@ contract OPContractsManager is ISemver {
     )
         internal
     {
-        assertValidContractAddress(address(_proxyAdmin));
-        assertValidContractAddress(_target);
-        assertValidContractAddress(_implementation);
+        DeployUtils.assertValidContractAddress(address(_proxyAdmin));
+        DeployUtils.assertValidContractAddress(_target);
+        DeployUtils.assertValidContractAddress(_implementation);
 
         _proxyAdmin.upgradeAndCall(payable(address(_target)), _implementation, _data);
-    }
-
-    function assertValidContractAddress(address _who) internal view {
-        if (_who == address(0)) revert AddressNotFound(_who);
-        if (_who.code.length == 0) revert AddressHasNoCode(_who);
     }
 
     /// @notice Returns the blueprint contract addresses.


### PR DESCRIPTION
This PR replaces the `OPCM.assertValidContractAddress` with `DeployUtils.assertValidContractAddress`, which makes it more consistent.

(OPCM is the only contract that defines its own `assertValidContractAddress` function) 