### PR TITLE
fix(kurtosis-devnet): handle out of order services

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -83,9 +83,12 @@ func (f *ServiceFinder) findRPCEndpoints(matchService func(string) (string, int,
 			for _, service := range f.nodeServices {
 				if serviceIdentifier == service {
 					if num > len(nodes) {
-						nodes = append(nodes, Node{
-							Services: make(ServiceMap),
-						})
+						// Extend the slice to accommodate the required index
+						for i := len(nodes); i < num; i++ {
+							nodes = append(nodes, Node{
+								Services: make(ServiceMap),
+							})
+						}
 					}
 					endpoints := make(EndpointMap)
 					for portName, portInfo := range ports {


### PR DESCRIPTION
**Description**

We can't assume that the redundant services will come sorted by index.
So we need to make room for lower-index instances coming later.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
