### PR TITLE
fix(kurtosis-devnet): try harder to avoid local dependency

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -1,5 +1,8 @@
 set shell := ["/bin/bash", "-c"]
 
+test:
+    go test --tags=testonly ./...
+
 _kurtosis-run PACKAGE_NAME ARG_FILE ENCLAVE:
 	kurtosis run {{PACKAGE_NAME}} --args-file {{ARG_FILE}} --enclave {{ENCLAVE}} --show-enclave-inspect=false --image-download=missing
 

--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
@@ -186,13 +186,3 @@ func (w *starlarkInfoWrapper) GetMessage() string {
 func (w *starlarkInstructionResultWrapper) GetSerializedInstructionResult() string {
 	return w.StarlarkInstructionResult.SerializedInstructionResult
 }
-
-func GetDefaultKurtosisContext() (interfaces.KurtosisContextInterface, error) {
-	kCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kurtosis context: %w", err)
-	}
-	return KurtosisContextWrapper{
-		KurtosisContext: kCtx,
-	}, nil
-}

--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers_local.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers_local.go
@@ -1,0 +1,21 @@
+//go:build !testonly
+// +build !testonly
+
+package wrappers
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+)
+
+func GetDefaultKurtosisContext() (interfaces.KurtosisContextInterface, error) {
+	kCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kurtosis context: %w", err)
+	}
+	return KurtosisContextWrapper{
+		KurtosisContext: kCtx,
+	}, nil
+}

--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers_testing.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers_testing.go
@@ -1,0 +1,14 @@
+//go:build testonly
+// +build testonly
+
+package wrappers
+
+import (
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
+)
+
+func GetDefaultKurtosisContext() (interfaces.KurtosisContextInterface, error) {
+	return nil, errors.New("attempting to use local Kurtosis context in testonly mode")
+}

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -50,7 +50,21 @@ func TestKurtosisDeployer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := NewKurtosisDeployer(tt.opts...)
+			// Create a fake Kurtosis context
+			fakeCtx := &fake.KurtosisContext{
+				EnclaveCtx: &fake.EnclaveContext{
+					Responses: []interfaces.StarlarkResponse{
+						&fake.StarlarkResponse{
+							IsSuccessful: true,
+						},
+					},
+				},
+			}
+
+			// Add the fake context to the options
+			opts := append(tt.opts, WithKurtosisKurtosisContext(fakeCtx))
+
+			d, err := NewKurtosisDeployer(opts...)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantBaseDir, d.baseDir)
 			assert.Equal(t, tt.wantPkg, d.packageName)


### PR DESCRIPTION
**Description**

It's too easy for tests to inadvertently communicate with a
locally-running kurtosis instance.

This change fixes such an instance, and adds a `just test` target that
will block similar attempts.

Unfortunately go doesn't provide a built-in flag for test-only code,
so just running `go test ./...` will still not catch these. At least
it's marginally easier to catch these issues.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
