### PR TITLE
feat(mise): add kurtosis to the toolchain

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
+kurtosis = "1.4.3"
 
 # Cargo dependencies
 "cargo:just" = "1.37.0"
@@ -47,6 +48,10 @@ binary_signer = "1.0.4"
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"
+# aqua backend is currently broken
+shellcheck = "ubi:koalaman/shellcheck"
+# custom asdf plugin for now
+kurtosis = "asdf:ethereum-optimism/asdf-kurtosis"
 
 [settings]
 experimental = true


### PR DESCRIPTION
**Description**

This adds kurtosis 1.4.3 to the current toolchain definition.

Unfortunately kurtosis cli is not go-installable (it uses "replace"
directives), so the "go" backend doesn't work. I added a basic asdf
recipe as a workaround for now.

Also sidestep an issue the aqua definition for shellcheck, which seems
broken at the moment.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
