### PR TITLE
op-e2e: Pass multiple chain configs through when running op-program in interop tests

### DIFF
--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -1,40 +1,21 @@
 package helpers
 
 import (
-	"encoding/json"
-	"errors"
-	"io/fs"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
-
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/naoina/toml"
-	"github.com/stretchr/testify/require"
+	"github.com/ethereum/go-ethereum/params"
 )
-
-var (
-	dumpFixtures = false
-	fixtureDir   string
-)
-
-func init() {
-	fixtureDir = os.Getenv("OP_E2E_FPP_FIXTURE_DIR")
-	if fixtureDir != "" {
-		dumpFixtures = true
-	}
-}
 
 type TestFixture struct {
 	Name           string        `toml:"name"`
 	ExpectedStatus uint8         `toml:"expected-status"`
 	Inputs         FixtureInputs `toml:"inputs"`
+}
+
+type FaultProofProgramL2Source struct {
+	Node        *helpers.L2Verifier
+	Engine      *helpers.L2Engine
+	ChainConfig *params.ChainConfig
 }
 
 type FixtureInputs struct {
@@ -46,93 +27,6 @@ type FixtureInputs struct {
 	L1Head         common.Hash `toml:"l1-head"`
 	AgreedPrestate []byte      `toml:"agreed-prestate"`
 	InteropEnabled bool        `toml:"use-interop"`
-}
 
-// Dumps a `fp-tests` test fixture to disk if the `OP_E2E_FPP_FIXTURE_DIR` environment variable is set.
-//
-// [fp-tests]: https://github.com/ethereum-optimism/fp-tests
-func tryDumpTestFixture(
-	t helpers.Testing,
-	result error,
-	name string,
-	rollupCfg *rollup.Config,
-	l2Genesis *core.Genesis,
-	inputs FixtureInputs,
-	workDir string,
-) {
-	if !dumpFixtures {
-		return
-	}
-
-	name = convertToKebabCase(name)
-
-	var expectedStatus uint8
-	if result == nil {
-		expectedStatus = 0
-	} else if errors.Is(result, claim.ErrClaimNotValid) {
-		expectedStatus = 1
-	} else {
-		expectedStatus = 2
-	}
-
-	fixture := TestFixture{
-		Name:           name,
-		ExpectedStatus: expectedStatus,
-		Inputs:         inputs,
-	}
-
-	fixturePath := filepath.Join(fixtureDir, name)
-
-	err := os.MkdirAll(filepath.Join(fixturePath), fs.ModePerm)
-	require.NoError(t, err, "failed to create fixture dir")
-
-	fixtureFilePath := filepath.Join(fixturePath, "fixture.toml")
-	serFixture, err := toml.Marshal(fixture)
-	require.NoError(t, err, "failed to serialize fixture")
-	require.NoError(t, os.WriteFile(fixtureFilePath, serFixture, fs.ModePerm), "failed to write fixture")
-
-	genesisPath := filepath.Join(fixturePath, "genesis.json")
-	serGenesis, err := l2Genesis.MarshalJSON()
-	require.NoError(t, err, "failed to serialize genesis")
-	require.NoError(t, os.WriteFile(genesisPath, serGenesis, fs.ModePerm), "failed to write genesis")
-
-	rollupPath := filepath.Join(fixturePath, "rollup.json")
-	serRollup, err := json.Marshal(rollupCfg)
-	require.NoError(t, err, "failed to serialize rollup")
-	require.NoError(t, os.WriteFile(rollupPath, serRollup, fs.ModePerm), "failed to write rollup")
-
-	// Copy the witness database into the fixture directory.
-	cmd := exec.Command("cp", "-r", workDir, filepath.Join(fixturePath, "witness-db"))
-	require.NoError(t, cmd.Run(), "Failed to copy witness DB")
-
-	// Compress the genesis file.
-	cmd = exec.Command("zstd", genesisPath)
-	_ = cmd.Run()
-	require.NoError(t, os.Remove(genesisPath), "Failed to remove uncompressed genesis file")
-
-	// Compress the witness database.
-	cmd = exec.Command(
-		"tar",
-		"--zstd",
-		"-cf",
-		filepath.Join(fixturePath, "witness-db.tar.zst"),
-		filepath.Join(fixturePath, "witness-db"),
-	)
-	cmd.Dir = filepath.Join(fixturePath)
-	require.NoError(t, cmd.Run(), "Failed to compress witness DB")
-	require.NoError(t, os.RemoveAll(filepath.Join(fixturePath, "witness-db")), "Failed to remove uncompressed witness DB")
-}
-
-// Convert to lower kebab case for strings containing `/`
-func convertToKebabCase(input string) string {
-	if !strings.Contains(input, "/") {
-		return input
-	}
-
-	// Replace non-alphanumeric characters with underscores
-	re := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	snake := re.ReplaceAllString(input, "-")
-
-	// Convert to lower case
-	return strings.ToLower(snake)
+	L2Sources []*FaultProofProgramL2Source
 }

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/host"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -14,7 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -26,33 +24,50 @@ type L2 interface {
 	RollupClient() *sources.RollupClient
 }
 
-func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Miner, l2 *helpers.L2Verifier, l2Eng *helpers.L2Engine, l2ChainConfig *core.Genesis, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
-	// Fetch the pre and post output roots for the fault proof.
-	l2PreBlockNum := l2ClaimBlockNum - 1
-	if l2ClaimBlockNum == 0 {
-		// If we are at genesis, we assert that we don't move the chain at all.
-		l2PreBlockNum = 0
+func WithPreInteropDefaults(t helpers.Testing, l2ClaimBlockNum uint64, l2 *helpers.L2Verifier, l2Eng *helpers.L2Engine) FixtureInputParam {
+	return func(f *FixtureInputs) {
+		// Fetch the pre and post output roots for the fault proof.
+		l2PreBlockNum := l2ClaimBlockNum - 1
+		if l2ClaimBlockNum == 0 {
+			// If we are at genesis, we assert that we don't move the chain at all.
+			l2PreBlockNum = 0
+		}
+		rollupClient := l2.RollupClient()
+		preRoot, err := rollupClient.OutputAtBlock(t.Ctx(), l2PreBlockNum)
+		require.NoError(t, err)
+		claimRoot, err := rollupClient.OutputAtBlock(t.Ctx(), l2ClaimBlockNum)
+		require.NoError(t, err)
+
+		f.L2BlockNumber = l2ClaimBlockNum
+		f.L2Claim = common.Hash(claimRoot.OutputRoot)
+		f.L2Head = preRoot.BlockRef.Hash
+		f.L2OutputRoot = common.Hash(preRoot.OutputRoot)
+		f.L2ChainID = l2.RollupCfg.L2ChainID.Uint64()
+
+		f.L2Sources = []*FaultProofProgramL2Source{
+			{
+				Node:        l2,
+				Engine:      l2Eng,
+				ChainConfig: l2Eng.L2Chain().Config(),
+			},
+		}
 	}
-	preRoot, err := l2.RollupClient().OutputAtBlock(t.Ctx(), l2PreBlockNum)
-	require.NoError(t, err)
-	claimRoot, err := l2.RollupClient().OutputAtBlock(t.Ctx(), l2ClaimBlockNum)
-	require.NoError(t, err)
+}
+
+func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Miner, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
 	l1Head := l1.L1Chain().CurrentBlock()
 
 	fixtureInputs := &FixtureInputs{
-		L2BlockNumber: l2ClaimBlockNum,
-		L2Claim:       common.Hash(claimRoot.OutputRoot),
-		L2Head:        preRoot.BlockRef.Hash,
-		L2OutputRoot:  common.Hash(preRoot.OutputRoot),
-		L2ChainID:     l2.RollupCfg.L2ChainID.Uint64(),
-		L1Head:        l1Head.Hash(),
+		L1Head: l1Head.Hash(),
 	}
 	for _, apply := range fixtureInputParams {
 		apply(fixtureInputs)
 	}
+	require.Greater(t, len(fixtureInputs.L2Sources), 0, "Must specify at least one L2 source")
 
 	// Run the fault proof program from the state transition from L2 block l2ClaimBlockNum - 1 -> l2ClaimBlockNum.
 	workDir := t.TempDir()
+	var err error
 	if IsKonaConfigured() {
 		fakeBeacon := fakebeacon.NewBeacon(
 			logger,
@@ -63,29 +78,28 @@ func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Mi
 		require.NoError(t, fakeBeacon.Start("127.0.0.1:0"))
 		defer fakeBeacon.Close()
 
-		err := RunKonaNative(t, workDir, l2.RollupCfg, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Eng.HTTPEndpoint(), *fixtureInputs)
+		l2Source := fixtureInputs.L2Sources[0]
+		err = RunKonaNative(t, workDir, l2Source.Node.RollupCfg, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Source.Engine.HTTPEndpoint(), *fixtureInputs)
 		checkResult(t, err)
 	} else {
-		programCfg := NewOpProgramCfg(
-			t,
-			l2.RollupCfg,
-			l2ChainConfig.Config,
-			fixtureInputs,
-		)
+		programCfg := NewOpProgramCfg(fixtureInputs)
 		withInProcessPrefetcher := hostcommon.WithPrefetcher(func(ctx context.Context, logger log.Logger, kv kvstore.KV, cfg *config.Config) (hostcommon.Prefetcher, error) {
 			// Set up in-process L1 sources
-			l1Cl := l1.L1Client(t, l2.RollupCfg)
+			l1Cl := l1.L1ClientSimple(t)
 			l1BlobFetcher := l1.BlobSource()
 
 			// Set up in-process L2 source
-			sources, err := prefetcher.NewRetryingL2Sources(ctx, logger, []*rollup.Config{l2.RollupCfg}, []client.RPC{l2Eng.RPCClient()}, nil)
+			var rpcClients []client.RPC
+			for _, source := range fixtureInputs.L2Sources {
+				rpcClients = append(rpcClients, source.Engine.RPCClient())
+			}
+			sources, err := prefetcher.NewRetryingL2Sources(ctx, logger, programCfg.Rollups, rpcClients, nil)
 			require.NoError(t, err, "failed to create L2 client")
 
 			executor := host.MakeProgramExecutor(logger, programCfg)
-			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, l2.RollupCfg.L2ChainID.Uint64(), sources, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
+			return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, fixtureInputs.L2ChainID, sources, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
 		})
 		err = hostcommon.FaultProofProgram(t.Ctx(), logger, programCfg, withInProcessPrefetcher)
 		checkResult(t, err)
 	}
-	tryDumpTestFixture(t, err, t.Name(), l2.RollupCfg, l2ChainConfig, *fixtureInputs, workDir)
 }

--- a/op-e2e/system/proofs/system_fpp_test.go
+++ b/op-e2e/system/proofs/system_fpp_test.go
@@ -285,7 +285,7 @@ type FaultProofProgramTestScenario struct {
 // testFaultProofProgramScenario runs the fault proof program in several contexts, given a test scenario.
 func testFaultProofProgramScenario(t *testing.T, ctx context.Context, sys *e2esys.System, s *FaultProofProgramTestScenario) {
 	preimageDir := t.TempDir()
-	fppConfig := oppconf.NewConfig(sys.RollupConfig, sys.L2GenesisCfg.Config, s.L1Head, s.L2Head, s.L2OutputRoot, common.Hash(s.L2Claim), s.L2ClaimBlockNumber)
+	fppConfig := oppconf.NewSingleChainConfig(sys.RollupConfig, sys.L2GenesisCfg.Config, s.L1Head, s.L2Head, s.L2OutputRoot, common.Hash(s.L2Claim), s.L2ClaimBlockNumber)
 	fppConfig.L1URL = sys.NodeEndpoint("l1").RPC()
 	fppConfig.L2URLs = []string{sys.NodeEndpoint("sequencer").RPC()}
 	fppConfig.L1BeaconURL = sys.L1BeaconEndpoint().RestHTTP()

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -74,7 +74,7 @@ func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs(t, addRequiredArgs())
 	rollupCfg, err := chaincfg.GetRollupConfig("op-sepolia")
 	require.NoError(t, err)
-	defaultCfg := config.NewConfig(
+	defaultCfg := config.NewSingleChainConfig(
 		rollupCfg,
 		chainconfig.OPSepoliaChainConfig(),
 		common.HexToHash(l1HeadValue),

--- a/op-program/host/host_test.go
+++ b/op-program/host/host_test.go
@@ -25,7 +25,7 @@ func TestServerMode(t *testing.T) {
 
 	l1Head := common.Hash{0x11}
 	l2OutputRoot := common.Hash{0x33}
-	cfg := config.NewConfig(chaincfg.OPSepolia(), chainconfig.OPSepoliaChainConfig(), l1Head, common.Hash{0x22}, l2OutputRoot, common.Hash{0x44}, 1000)
+	cfg := config.NewSingleChainConfig(chaincfg.OPSepolia(), chainconfig.OPSepoliaChainConfig(), l1Head, common.Hash{0x22}, l2OutputRoot, common.Hash{0x44}, 1000)
 	cfg.DataDir = dir
 	cfg.ServerMode = true
 

--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -320,9 +320,9 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 		if err != nil {
 			return fmt.Errorf("failed to fetch L2 output root for block %s: %w", p.l2Head, err)
 		}
-		hash := eth.OutputRoot(output)
-		if requestedHash != common.Hash(hash) {
-			return fmt.Errorf("output root %x from block %v does not match requested root: %x", hash, p.l2Head, requestedHash)
+		hash := common.Hash(eth.OutputRoot(output))
+		if requestedHash != hash {
+			return fmt.Errorf("output root %v from block %v does not match requested root: %v", hash, p.l2Head, requestedHash)
 		}
 		return p.kvStore.Put(preimage.Keccak256Key(hash).PreimageKey(), output.Marshal())
 	case l2.HintL2BlockData:

--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -209,7 +209,7 @@ func (r *Runner) run(ctx context.Context, l1Head common.Hash, agreedBlockInfo et
 	fmt.Printf("Configuration: %s\n", argsStr)
 
 	if r.runInProcess {
-		offlineCfg := config.NewConfig(
+		offlineCfg := config.NewSingleChainConfig(
 			r.rollupCfg, r.chainCfg, l1Head, agreedBlockInfo.Hash(), agreedOutputRoot, claimedOutputRoot, claimedBlockInfo.NumberU64())
 		offlineCfg.DataDir = r.dataDir
 


### PR DESCRIPTION
**Description**

Adjusts the way fault proof programs are run in actions tests so that multiple L2 sources can be passed through.  Currently only op-program uses them but the info is available for kona - just need to update its executor.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13719
