### PR TITLE
op-supervisor: Fix chain id translation

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -147,7 +147,7 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 	// For each chain initialize a chain processor service,
 	// after cross-unsafe workers are ready to receive updates
 	for _, chainID := range chains {
-		logProcessor := processors.NewLogProcessor(chainID, su.chainDBs)
+		logProcessor := processors.NewLogProcessor(chainID, su.chainDBs, su.depSet)
 		chainProcessor := processors.NewChainProcessor(su.logger, chainID, logProcessor, su.chainDBs, su.onIndexedLocalUnsafeData)
 		su.chainProcessors.Set(chainID, chainProcessor)
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -185,11 +185,17 @@ func (m mockDependencySet) ChainIDFromIndex(index types.ChainIndex) (types.Chain
 	if m.chainIDFromIndexfn != nil {
 		return m.chainIDFromIndexfn()
 	}
-	return types.ChainID{}, nil
+	id := types.ChainIDFromUInt64(uint64(index) - 1000)
+	return id, nil
 }
 
 func (m mockDependencySet) ChainIndexFromID(chain types.ChainID) (types.ChainIndex, error) {
-	return types.ChainIndex(0), nil
+	v, err := chain.ToUInt32()
+	if err != nil {
+		return 0, err
+	}
+	// offset, so we catch improper manual conversion that doesn't apply this offset
+	return types.ChainIndex(v + 1000), nil
 }
 
 func (m mockDependencySet) Chains() []types.ChainID {

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -89,7 +89,7 @@ func scopedCrossSafeUpdate(logger log.Logger, chainID types.ChainID, d CrossSafe
 	if err := HazardSafeFrontierChecks(d, candidateScope.ID(), hazards); err != nil {
 		return candidateScope, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate, err)
 	}
-	if err := HazardCycleChecks(d, candidate.Time, hazards); err != nil {
+	if err := HazardCycleChecks(d.DependencySet(), d, candidate.Time, hazards); err != nil {
 		return candidateScope, fmt.Errorf("failed to verify block %s in cross-safe check for cycle hazards: %w", candidate, err)
 	}
 

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -60,7 +60,7 @@ func CrossUnsafeUpdate(ctx context.Context, logger log.Logger, chainID types.Cha
 	if err := HazardUnsafeFrontierChecks(d, hazards); err != nil {
 		return fmt.Errorf("failed to verify block %s in cross-unsafe frontier: %w", candidate, err)
 	}
-	if err := HazardCycleChecks(d, candidate.Timestamp, hazards); err != nil {
+	if err := HazardCycleChecks(d.DependencySet(), d, candidate.Timestamp, hazards); err != nil {
 		return fmt.Errorf("failed to verify block %s in cross-unsafe check for cycle hazards: %w", candidate, err)
 	}
 

--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -200,7 +200,7 @@ func (l *logContext) processEntry(entry Entry) error {
 			return err
 		}
 		l.execMsg = &types.ExecutingMessage{
-			Chain:     types.ChainIndex(link.chain), // TODO(#11105): translate chain ID to chain index
+			Chain:     types.ChainIndex(link.chain),
 			BlockNum:  link.blockNum,
 			LogIdx:    link.logIdx,
 			Timestamp: link.timestamp,

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -33,9 +33,18 @@ type DependencySet interface {
 	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
 	HasChain(chainID types.ChainID) bool
 
-	// ChainIndexFromID converts a ChainID to a ChainIndex.
 	ChainIndexFromID(id types.ChainID) (types.ChainIndex, error)
 
+	ChainIndexFromID
+	ChainIDFromIndex
+}
+
+type ChainIndexFromID interface {
+	// ChainIndexFromID converts a ChainID to a ChainIndex.
+	ChainIndexFromID(id types.ChainID) (types.ChainIndex, error)
+}
+
+type ChainIDFromIndex interface {
 	// ChainIDFromIndex converts a ChainIndex to a ChainID.
 	ChainIDFromIndex(index types.ChainIndex) (types.ChainID, error)
 }

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -119,7 +119,7 @@ func (ds *StaticConfigDependencySet) HasChain(chainID types.ChainID) bool {
 func (ds *StaticConfigDependencySet) ChainIndexFromID(id types.ChainID) (types.ChainIndex, error) {
 	dep, ok := ds.dependencies[id]
 	if !ok {
-		return 0, types.ErrUnknownChain
+		return 0, fmt.Errorf("failed to translate chain ID %s to chain index: %w", id, types.ErrUnknownChain)
 	}
 	return dep.ChainIndex, nil
 }
@@ -127,7 +127,7 @@ func (ds *StaticConfigDependencySet) ChainIndexFromID(id types.ChainID) (types.C
 func (ds *StaticConfigDependencySet) ChainIDFromIndex(index types.ChainIndex) (types.ChainID, error) {
 	id, ok := ds.indexToID[index]
 	if !ok {
-		return types.ChainID{}, types.ErrUnknownChain
+		return types.ChainID{}, fmt.Errorf("failed to translate chain index %s to chain ID: %w", index, types.ErrUnknownChain)
 	}
 	return id, nil
 }

--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -7,12 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-type EventDecoderFn func(*ethTypes.Log) (*types.ExecutingMessage, error)
+type EventDecoderFn func(*ethTypes.Log, depset.ChainIndexFromID) (*types.ExecutingMessage, error)
 
-func DecodeExecutingMessageLog(l *ethTypes.Log) (*types.ExecutingMessage, error) {
+func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) (*types.ExecutingMessage, error) {
 	if l.Address != params.InteropCrossL2InboxAddress {
 		return nil, nil
 	}
@@ -27,9 +28,12 @@ func DecodeExecutingMessageLog(l *ethTypes.Log) (*types.ExecutingMessage, error)
 		return nil, fmt.Errorf("invalid executing message: %w", err)
 	}
 	logHash := types.PayloadHashToLogHash(msg.PayloadHash, msg.Identifier.Origin)
+	index, err := depSet.ChainIndexFromID(types.ChainID(msg.Identifier.ChainID))
+	if err != nil {
+		return nil, err
+	}
 	return &types.ExecutingMessage{
-		// TODO(#11105): translate chain index to chain ID
-		Chain:     types.ChainIndex(msg.Identifier.ChainID.Uint64()),
+		Chain:     index,
 		BlockNum:  msg.Identifier.BlockNumber,
 		LogIdx:    msg.Identifier.LogIndex,
 		Timestamp: msg.Identifier.Timestamp,


### PR DESCRIPTION
**Description**

Fix chain ID / index translation.
The https://github.com/ethereum-optimism/optimism/issues/11105 issue was auto-closed when the dependency set was introduced, but it wasn't applied properly everywhere. This PR fixes that.

**Tests**

Updated unit tests to use chain ID mappings, so we can catch when they don't get applied properly.
