### PR TITLE
op-supervisor: Implement supervisor_superRootAtTimestamp RPC

### DIFF
--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -55,6 +55,14 @@ func (ib *InteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, err
 	return ib.backend.ChainID(ctx)
 }
 
+func (ib *InteropAPI) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+	return ib.backend.OutputV0AtTimestamp(ctx, timestamp)
+}
+
+func (ib *InteropAPI) PendingOutputV0ATTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+	return ib.backend.PendingOutputV0AtTimestamp(ctx, timestamp)
+}
+
 func (ib *InteropAPI) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {
 	return ib.backend.ProvideL1(ctx, nextL1)
 }

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -25,6 +25,7 @@ type L2Source interface {
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error)
 }
 
 type L1Source interface {
@@ -274,4 +275,30 @@ func (m *ManagedMode) BlockRefByNumber(ctx context.Context, num uint64) (eth.Blo
 
 func (m *ManagedMode) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
 	return supervisortypes.ChainIDFromBig(m.cfg.L2ChainID), nil
+}
+
+func (m *ManagedMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+	num, err := m.cfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := m.l2.L2BlockRefByNumber(ctx, num)
+	if err != nil {
+		return nil, err
+	}
+	return m.l2.OutputV0AtBlock(ctx, ref.Hash)
+}
+
+func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+	num, err := m.cfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := m.l2.L2BlockRefByNumber(ctx, num)
+	if err != nil {
+		return nil, err
+	}
+	_ = ref
+	// TODO: return pending output in the optimistic block deposited transaction - https://github.com/ethereum-optimism/specs/pull/489
+	panic("not implemented")
 }

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -298,8 +298,8 @@ func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp 
 	if err != nil {
 		return nil, err
 	}
-	// TODO: When appropriate, replace below with the output root preimage of an actual pending block contained in
-	// the optimistic block deposited transaction. see https://github.com/ethereum-optimism/specs/pull/489
+	// TODO: Once interop reorgs are supported (see #13645), replace with the output root preimage of an actual pending
+	// block contained in the optimistic block deposited transaction - https://github.com/ethereum-optimism/specs/pull/489
 	// For now, we use the output at timestamp as-if it didn't contain invalid messages for happy path testing.
 	return m.l2.OutputV0AtBlock(ctx, ref.Hash)
 }

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -298,7 +298,8 @@ func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp 
 	if err != nil {
 		return nil, err
 	}
-	_ = ref
-	// TODO: return pending output in the optimistic block deposited transaction - https://github.com/ethereum-optimism/specs/pull/489
-	panic("not implemented")
+	// TODO: When appropriate, replace below with the output root preimage of an actual pending block contained in
+	// the optimistic block deposited transaction. see https://github.com/ethereum-optimism/specs/pull/489
+	// For now, we use the output at timestamp as-if it didn't contain invalid messages for happy path testing.
+	return m.l2.OutputV0AtBlock(ctx, ref.Hash)
 }

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type SupervisorClient struct {
@@ -151,6 +152,16 @@ func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID types.C
 		chainID,
 		derivedFrom,
 		lastDerived)
+}
+
+func (cl *SupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
+	var result types.SuperRootResponse
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_superRootAtTimestamp",
+		timestamp)
+	return result, err
 }
 
 func (cl *SupervisorClient) Close() {

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -523,7 +523,8 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 	slices.SortFunc(chains, func(a, b types.ChainID) int {
 		return a.Cmp(b)
 	})
-	for _, chainID := range chains {
+	response.Chains = make([]types.ChainRootInfo, len(chains))
+	for i, chainID := range chains {
 		src, ok := su.syncSources.Get(chainID)
 		if !ok {
 			su.logger.Error("bug: unknown chain %s, cannot get sync source", chainID)
@@ -537,8 +538,11 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		if err != nil {
 			return types.SuperRootResponse{}, err
 		}
-		response.Canonical = append(response.Canonical, eth.OutputRoot(output))
-		response.Pending = append(response.Pending, pending.Marshal())
+		response.Chains[i] = types.ChainRootInfo{
+			ChainID:   chainID,
+			Canonical: eth.OutputRoot(output),
+			Pending:   pending.Marshal(),
+		}
 	}
 	return response, nil
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -495,6 +496,15 @@ func (su *SupervisorBackend) CrossDerivedFrom(ctx context.Context, chainID types
 
 func (su *SupervisorBackend) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
 	return su.l1Accessor.L1BlockRefByNumber(ctx, number)
+}
+
+func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
+	//TODO implement me
+	panic("implement me")
+	// For each chain:
+	// * Convert timestamp to block number
+	// * Load canonical output root for block number
+
 }
 
 // Update methods

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type MockBackend struct {
@@ -68,6 +69,10 @@ func (m *MockBackend) FinalizedL1() eth.BlockRef {
 
 func (m *MockBackend) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	return eth.BlockRef{}, nil
+}
+
+func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
+	return types.SuperRootResponse{}, nil
 }
 
 func (m *MockBackend) Close() error {

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -25,6 +25,8 @@ type SyncSource interface {
 	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)
 	ChainID(ctx context.Context) (types.ChainID, error)
+	OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
+	PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
 	// String identifies the sync source
 	String() string
 }

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -69,6 +69,18 @@ func (rs *RPCSyncNode) ChainID(ctx context.Context) (types.ChainID, error) {
 	return chainID, err
 }
 
+func (rs *RPCSyncNode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+	var out *eth.OutputV0
+	err := rs.cl.CallContext(ctx, &out, "interop_outputV0AtTimestamp", timestamp)
+	return out, err
+}
+
+func (rs *RPCSyncNode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
+	var out *eth.OutputV0
+	err := rs.cl.CallContext(ctx, &out, "interop_pendingOutputV0AtTimestamp", timestamp)
+	return out, err
+}
+
 func (rs *RPCSyncNode) String() string {
 	return rs.name
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type AdminBackend interface {
@@ -22,6 +23,7 @@ type QueryBackend interface {
 	CrossSafe(ctx context.Context, chainID types.ChainID) (types.DerivedIDPair, error)
 	Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
 	FinalizedL1() eth.BlockRef
+	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error)
 }
 
 type Backend interface {
@@ -67,6 +69,10 @@ func (q *QueryFrontend) FinalizedL1() eth.BlockRef {
 
 func (q *QueryFrontend) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	return q.Supervisor.CrossDerivedFrom(ctx, chainID, derived)
+}
+
+func (q *QueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
+	return q.Supervisor.SuperRootAtTimestamp(ctx, timestamp)
 }
 
 type AdminFrontend struct {

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -366,14 +366,14 @@ type ChainRootInfo struct {
 
 type chainRootInfoMarshalling struct {
 	ChainID   ChainID       `json:"chainID"`
-	Canonical eth.Bytes32   `json:"canonical"`
+	Canonical common.Hash   `json:"canonical"`
 	Pending   hexutil.Bytes `json:"pending"`
 }
 
 func (i ChainRootInfo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&chainRootInfoMarshalling{
 		ChainID:   i.ChainID,
-		Canonical: i.Canonical,
+		Canonical: common.Hash(i.Canonical),
 		Pending:   i.Pending,
 	})
 }
@@ -384,13 +384,14 @@ func (i *ChainRootInfo) UnmarshalJSON(input []byte) error {
 		return err
 	}
 	i.ChainID = dec.ChainID
-	i.Canonical = dec.Canonical
+	i.Canonical = eth.Bytes32(dec.Canonical)
 	i.Pending = dec.Pending
 	return nil
 }
 
 type SuperRootResponse struct {
-	Timestamp uint64 `json:"timestamp"`
+	Timestamp uint64      `json:"timestamp"`
+	SuperRoot eth.Bytes32 `json:"superRoot"`
 	// Chains is the list of ChainRootInfo for each chain in the dependency set.
 	// It represents the state of the chain at or before the Timestamp.
 	Chains []ChainRootInfo `json:"chains"`
@@ -398,12 +399,14 @@ type SuperRootResponse struct {
 
 type superRootResponseMarshalling struct {
 	Timestamp hexutil.Uint64  `json:"timestamp"`
+	SuperRoot common.Hash     `json:"superRoot"`
 	Chains    []ChainRootInfo `json:"chains"`
 }
 
 func (r SuperRootResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&superRootResponseMarshalling{
 		Timestamp: hexutil.Uint64(r.Timestamp),
+		SuperRoot: common.Hash(r.SuperRoot),
 		Chains:    r.Chains,
 	})
 }
@@ -414,6 +417,7 @@ func (r *SuperRootResponse) UnmarshalJSON(input []byte) error {
 		return err
 	}
 	r.Timestamp = uint64(dec.Timestamp)
+	r.SuperRoot = eth.Bytes32(dec.SuperRoot)
 	r.Chains = dec.Chains
 	return nil
 }

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -355,11 +355,10 @@ type ManagedEvent struct {
 
 type ChainRootInfo struct {
 	ChainID ChainID `json:"chainID"`
-	// Canonical is the list of output roots of the latest canonical block at or before Timestamp on each chain in the
-	// dependency set.
+	// Canonical is the output root of the latest canonical block at a particular Timestamp.
 	Canonical eth.Bytes32 `json:"canonical"`
-	// Pending is the list of output root preimages for the latest block at or before Timestamp on each chain
-	// prior to validation of executing messages. If the original block was valid, this will be the preimage of the
+	// Pending is the output root preimage for the latest block at a particular Timestamp prior to validation of
+	// executing messages. If the original block was valid, this will be the preimage of the
 	// output root from the Canonical array. If it was invalid, it will be the output root preimage from the
 	// Optimistic Block Deposited Transaction added to the deposit-only block.
 	Pending []byte `json:"pending"`
@@ -391,8 +390,10 @@ func (i *ChainRootInfo) UnmarshalJSON(input []byte) error {
 }
 
 type SuperRootResponse struct {
-	Timestamp uint64          `json:"timestamp"`
-	Chains    []ChainRootInfo `json:"chains"`
+	Timestamp uint64 `json:"timestamp"`
+	// Chains is the list of ChainRootInfo for each chain in the dependency set.
+	// It represents the state of the chain at or before the Timestamp.
+	Chains []ChainRootInfo `json:"chains"`
 }
 
 type superRootResponseMarshalling struct {

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -352,3 +352,48 @@ type ManagedEvent struct {
 	DerivationUpdate *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1        *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
 }
+
+type SuperRootResponse struct {
+	Timestamp uint64 `json:"timestamp"`
+
+	// Canonical is the list of output roots of the latest canonical block at or before Timestamp on each chain in the
+	// dependency set, ordered by chain ID.
+	Canonical []eth.Bytes32 `json:"canonical"`
+
+	// Pending is the list of output root preimages for the latest block at or before Timestamp on each chain
+	// prior to validation of executing messages. If the original block was valid, this will be the preimage of the
+	// output root from the Canonical array. If it was invalid, it will be the output root preimage from the
+	// Optimistic Block Deposited Transaction added to the deposit-only block.
+	Pending [][]byte `json:"pending"`
+}
+
+type superRootResponseMarshalling struct {
+	Timestamp hexutil.Uint64  `json:"timestamp"`
+	Canonical []eth.Bytes32   `json:"canonical"`
+	Pending   []hexutil.Bytes `json:"pending"`
+}
+
+func (r SuperRootResponse) MarshalJSON() ([]byte, error) {
+	var enc superRootResponseMarshalling
+	enc.Timestamp = hexutil.Uint64(r.Timestamp)
+	enc.Canonical = r.Canonical
+	enc.Pending = make([]hexutil.Bytes, len(r.Pending))
+	for i := range r.Pending {
+		enc.Pending[i] = r.Pending[i]
+	}
+	return json.Marshal(&enc)
+}
+
+func (r *SuperRootResponse) UnmarshalJSON(input []byte) error {
+	var dec superRootResponseMarshalling
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	r.Timestamp = uint64(dec.Timestamp)
+	r.Canonical = dec.Canonical
+	r.Pending = make([][]byte, len(dec.Pending))
+	for i := range dec.Pending {
+		r.Pending[i] = dec.Pending[i]
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a new RPC to the supervisor to retrieve the super root at a given timestamp. This will be used by the op-challenger and op-proposer to make and check claims in dispute games.

Note that this PR only adds the plumbing for the RPC. Its implementation isn't fully complete as the op-node does not yet implement [deposit-only blocks](https://github.com/ethereum-optimism/specs/pull/489) containing pending output roots.