### PR TITLE
op-program: Implement padding steps

### DIFF
--- a/op-program/client/claim/validate.go
+++ b/op-program/client/claim/validate.go
@@ -11,8 +11,8 @@ import (
 
 var ErrClaimNotValid = errors.New("invalid claim")
 
-func ValidateClaim(log log.Logger, l2Head eth.L2BlockRef, claimedOutputRoot eth.Bytes32, outputRoot eth.Bytes32) error {
-	log.Info("Validating claim", "head", l2Head, "output", outputRoot, "claim", claimedOutputRoot)
+func ValidateClaim(log log.Logger, claimedOutputRoot eth.Bytes32, outputRoot eth.Bytes32) error {
+	log.Info("Validating claim", "output", outputRoot, "claim", claimedOutputRoot)
 	if claimedOutputRoot != outputRoot {
 		return fmt.Errorf("%w: claim: %v actual: %v", ErrClaimNotValid, claimedOutputRoot, outputRoot)
 	}

--- a/op-program/client/claim/validate_test.go
+++ b/op-program/client/claim/validate_test.go
@@ -15,18 +15,16 @@ func TestValidateClaim(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		expected := eth.Bytes32{0x11}
 		actual := eth.Bytes32{0x11}
-		l2Head := eth.L2BlockRef{Number: 42}
 		logger := testlog.Logger(t, log.LevelError)
-		err := ValidateClaim(logger, l2Head, expected, actual)
+		err := ValidateClaim(logger, expected, actual)
 		require.NoError(t, err)
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
 		expected := eth.Bytes32{0x11}
 		actual := eth.Bytes32{0x22}
-		l2Head := eth.L2BlockRef{Number: 42}
 		logger := testlog.Logger(t, log.LevelError)
-		err := ValidateClaim(logger, l2Head, expected, actual)
+		err := ValidateClaim(logger, expected, actual)
 		require.ErrorIs(t, err, ErrClaimNotValid)
 	})
 }

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -2,6 +2,7 @@ package interop
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
@@ -21,51 +22,118 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeriveBlockForFirstChainFromSuperchainRoot(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelError)
-	rollupCfg := chaincfg.OPSepolia()
-	chainCfg := chainconfig.OPSepoliaChainConfig()
-	chain1Output := &eth.OutputV0{}
+func setupTwoChains(t *testing.T) (*staticConfigSource, *eth.SuperV1, stubTasks) {
+	rollupCfg1 := chaincfg.OPSepolia()
+	chainCfg1 := chainconfig.OPSepoliaChainConfig()
+
+	rollupCfg2 := *chaincfg.OPSepolia()
+	rollupCfg2.L2ChainID = new(big.Int).SetUint64(42)
+	chainCfg2 := *chainconfig.OPSepoliaChainConfig()
+	chainCfg2.ChainID = rollupCfg2.L2ChainID
+
 	agreedSuperRoot := &eth.SuperV1{
-		Timestamp: rollupCfg.Genesis.L2Time + 1234,
-		Chains:    []eth.ChainIDAndOutput{{ChainID: rollupCfg.L2ChainID.Uint64(), Output: eth.OutputRoot(chain1Output)}},
-	}
-	outputRootHash := common.Hash(eth.SuperRoot(agreedSuperRoot))
-	l2PreimageOracle, _ := test.NewStubOracle(t)
-	l2PreimageOracle.TransitionStates[outputRootHash] = &types.TransitionState{SuperRoot: agreedSuperRoot.Marshal()}
-	tasks := stubTasks{
-		l2SafeHead: eth.L2BlockRef{
-			Number: 56,
-			Hash:   common.Hash{0x11},
+		Timestamp: rollupCfg1.Genesis.L2Time + 1234,
+		Chains: []eth.ChainIDAndOutput{
+			{ChainID: rollupCfg1.L2ChainID.Uint64(), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x11}})},
+			{ChainID: rollupCfg2.L2ChainID.Uint64(), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x22}})},
 		},
+	}
+	configSource := &staticConfigSource{
+		rollupCfgs:   []*rollup.Config{rollupCfg1, &rollupCfg2},
+		chainConfigs: []*params.ChainConfig{chainCfg1, &chainCfg2},
+	}
+	tasksStub := stubTasks{
 		blockHash:  common.Hash{0x22},
 		outputRoot: eth.Bytes32{0x66},
 	}
+	return configSource, agreedSuperRoot, tasksStub
+}
+
+func TestDeriveBlockForFirstChainFromSuperchainRoot(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	configSource, agreedSuperRoot, tasksStub := setupTwoChains(t)
+
+	outputRootHash := common.Hash(eth.SuperRoot(agreedSuperRoot))
+	l2PreimageOracle, _ := test.NewStubOracle(t)
+	l2PreimageOracle.TransitionStates[outputRootHash] = &types.TransitionState{SuperRoot: agreedSuperRoot.Marshal()}
+
 	expectedIntermediateRoot := &types.TransitionState{
 		SuperRoot: agreedSuperRoot.Marshal(),
 		PendingProgress: []types.OptimisticBlock{
-			{BlockHash: tasks.blockHash, OutputRoot: tasks.outputRoot},
+			{BlockHash: tasksStub.blockHash, OutputRoot: tasksStub.outputRoot},
 		},
 		Step: 1,
 	}
 
 	expectedClaim, err := expectedIntermediateRoot.Hash()
 	require.NoError(t, err)
+
+	verifyResult(t, logger, tasksStub, configSource, l2PreimageOracle, agreedSuperRoot, outputRootHash, expectedClaim)
+}
+
+func TestDeriveBlockForSecondChainFromTransitionState(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	configSource, agreedSuperRoot, tasksStub := setupTwoChains(t)
+	agreedTransitionState := &types.TransitionState{
+		SuperRoot: agreedSuperRoot.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: common.Hash{0xaa}, OutputRoot: eth.Bytes32{6: 22}},
+		},
+		Step: 1,
+	}
+	outputRootHash, err := agreedTransitionState.Hash()
+	require.NoError(t, err)
+	l2PreimageOracle, _ := test.NewStubOracle(t)
+	l2PreimageOracle.TransitionStates[outputRootHash] = agreedTransitionState
+	expectedIntermediateRoot := &types.TransitionState{
+		SuperRoot: agreedSuperRoot.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: common.Hash{0xaa}, OutputRoot: eth.Bytes32{6: 22}},
+			{BlockHash: tasksStub.blockHash, OutputRoot: tasksStub.outputRoot},
+		},
+		Step: 2,
+	}
+
+	expectedClaim, err := expectedIntermediateRoot.Hash()
+	require.NoError(t, err)
+	verifyResult(t, logger, tasksStub, configSource, l2PreimageOracle, agreedSuperRoot, outputRootHash, expectedClaim)
+}
+
+func TestNoOpStep(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	configSource, agreedSuperRoot, tasksStub := setupTwoChains(t)
+	agreedTransitionState := &types.TransitionState{
+		SuperRoot: agreedSuperRoot.Marshal(),
+		PendingProgress: []types.OptimisticBlock{
+			{BlockHash: common.Hash{0xaa}, OutputRoot: eth.Bytes32{6: 22}},
+			{BlockHash: tasksStub.blockHash, OutputRoot: tasksStub.outputRoot},
+		},
+		Step: 2,
+	}
+	outputRootHash, err := agreedTransitionState.Hash()
+	require.NoError(t, err)
+	l2PreimageOracle, _ := test.NewStubOracle(t)
+	l2PreimageOracle.TransitionStates[outputRootHash] = agreedTransitionState
+	expectedIntermediateRoot := *agreedTransitionState // Copy agreed state
+	expectedIntermediateRoot.Step = 3
+
+	expectedClaim, err := expectedIntermediateRoot.Hash()
+	require.NoError(t, err)
+	verifyResult(t, logger, tasksStub, configSource, l2PreimageOracle, agreedSuperRoot, outputRootHash, expectedClaim)
+}
+
+func verifyResult(t *testing.T, logger log.Logger, tasks stubTasks, configSource *staticConfigSource, l2PreimageOracle *test.StubBlockOracle, agreedSuperRoot *eth.SuperV1, agreedPrestate common.Hash, expectedClaim common.Hash) {
 	bootInfo := &boot.BootInfoInterop{
-		AgreedPrestate: outputRootHash,
+		AgreedPrestate: agreedPrestate,
 		ClaimTimestamp: agreedSuperRoot.Timestamp + 1,
 		Claim:          expectedClaim,
-		Configs: &staticConfigSource{
-			rollupCfgs:   []*rollup.Config{rollupCfg},
-			chainConfigs: []*params.ChainConfig{chainCfg},
-		},
+		Configs:        configSource,
 	}
-	err = runInteropProgram(logger, bootInfo, nil, l2PreimageOracle, true, &tasks)
+	err := runInteropProgram(logger, bootInfo, nil, l2PreimageOracle, true, &tasks)
 	require.NoError(t, err)
 }
 
 type stubTasks struct {
-	l2SafeHead eth.L2BlockRef
 	blockHash  common.Hash
 	outputRoot eth.Bytes32
 	err        error
@@ -81,7 +149,6 @@ func (t *stubTasks) RunDerivation(
 	_ l1.Oracle,
 	_ l2.Oracle) (tasks.DerivationResult, error) {
 	return tasks.DerivationResult{
-		Head:       t.l2SafeHead,
 		BlockHash:  t.blockHash,
 		OutputRoot: t.outputRoot,
 	}, t.err

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -25,5 +25,5 @@ func RunPreInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1Preimage
 	if err != nil {
 		return err
 	}
-	return claim.ValidateClaim(logger, result.Head, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
+	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
 }

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -61,6 +61,7 @@ func loadOutputRoot(l2ClaimBlockNum uint64, head eth.L2BlockRef, src L2Source) (
 		return DerivationResult{}, fmt.Errorf("calculate L2 output root: %w", err)
 	}
 	return DerivationResult{
+		Head:       head,
 		BlockHash:  blockHash,
 		OutputRoot: outputRoot,
 	}, nil

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -45,12 +45,13 @@ func RunDerivation(
 	}
 	l2Source := l2.NewOracleEngine(cfg, logger, engineBackend)
 
-	logger.Info("Starting derivation")
+	logger.Info("Starting derivation", "chainID", cfg.L2ChainID)
 	d := cldr.NewDriver(logger, cfg, l1Source, l1BlobsSource, l2Source, l2ClaimBlockNum)
 	result, err := d.RunComplete()
 	if err != nil {
 		return DerivationResult{}, fmt.Errorf("failed to run program to completion: %w", err)
 	}
+	logger.Info("Derivation complete", "head", result)
 	return loadOutputRoot(l2ClaimBlockNum, result, l2Source)
 }
 
@@ -60,7 +61,6 @@ func loadOutputRoot(l2ClaimBlockNum uint64, head eth.L2BlockRef, src L2Source) (
 		return DerivationResult{}, fmt.Errorf("calculate L2 output root: %w", err)
 	}
 	return DerivationResult{
-		Head:       head,
 		BlockHash:  blockHash,
 		OutputRoot: outputRoot,
 	}, nil

--- a/op-program/client/tasks/derive_test.go
+++ b/op-program/client/tasks/derive_test.go
@@ -18,7 +18,7 @@ func TestLoadOutputRoot(t *testing.T) {
 		}
 		result, err := loadOutputRoot(uint64(0), safeHead, l2)
 		require.NoError(t, err)
-		assertDerivationResult(t, result, l2.blockHash, l2.outputRoot)
+		assertDerivationResult(t, result, safeHead, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Success-PriorToSafeHead", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestLoadOutputRoot(t *testing.T) {
 		result, err := loadOutputRoot(uint64(20), safeHead, l2)
 		require.NoError(t, err)
 		require.Equal(t, uint64(10), l2.requestedOutputRoot)
-		assertDerivationResult(t, result, l2.blockHash, l2.outputRoot)
+		assertDerivationResult(t, result, safeHead, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Error-OutputRoot", func(t *testing.T) {
@@ -49,7 +49,8 @@ func TestLoadOutputRoot(t *testing.T) {
 	})
 }
 
-func assertDerivationResult(t *testing.T, actual DerivationResult, blockHash common.Hash, outputRoot eth.Bytes32) {
+func assertDerivationResult(t *testing.T, actual DerivationResult, safeHead eth.L2BlockRef, blockHash common.Hash, outputRoot eth.Bytes32) {
+	require.Equal(t, safeHead, actual.Head)
 	require.Equal(t, blockHash, actual.BlockHash)
 	require.Equal(t, outputRoot, actual.OutputRoot)
 }

--- a/op-program/client/tasks/derive_test.go
+++ b/op-program/client/tasks/derive_test.go
@@ -18,7 +18,7 @@ func TestLoadOutputRoot(t *testing.T) {
 		}
 		result, err := loadOutputRoot(uint64(0), safeHead, l2)
 		require.NoError(t, err)
-		assertDerivationResult(t, result, safeHead, l2.blockHash, l2.outputRoot)
+		assertDerivationResult(t, result, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Success-PriorToSafeHead", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestLoadOutputRoot(t *testing.T) {
 		result, err := loadOutputRoot(uint64(20), safeHead, l2)
 		require.NoError(t, err)
 		require.Equal(t, uint64(10), l2.requestedOutputRoot)
-		assertDerivationResult(t, result, safeHead, l2.blockHash, l2.outputRoot)
+		assertDerivationResult(t, result, l2.blockHash, l2.outputRoot)
 	})
 
 	t.Run("Error-OutputRoot", func(t *testing.T) {
@@ -49,8 +49,7 @@ func TestLoadOutputRoot(t *testing.T) {
 	})
 }
 
-func assertDerivationResult(t *testing.T, actual DerivationResult, safeHead eth.L2BlockRef, blockHash common.Hash, outputRoot eth.Bytes32) {
-	require.Equal(t, safeHead, actual.Head)
+func assertDerivationResult(t *testing.T, actual DerivationResult, blockHash common.Hash, outputRoot eth.Bytes32) {
 	require.Equal(t, blockHash, actual.BlockHash)
 	require.Equal(t, outputRoot, actual.OutputRoot)
 }


### PR DESCRIPTION
**Description**

Implements the no-op padding steps for interop fault proofs. Currently these extend forever as we haven't implemented the consolidation step yet.

**Tests**

Updated unit and action tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13735

