### PR TITLE
op-program: Transition to invalid state when L1Head reached before claimed block

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -157,6 +157,12 @@ func WithL2BlockNumber(num uint64) FixtureInputParam {
 	}
 }
 
+func WithL1Head(head common.Hash) FixtureInputParam {
+	return func(f *FixtureInputs) {
+		f.L1Head = head
+	}
+}
+
 func (env *L2FaultProofEnv) RunFaultProofProgram(t helpers.Testing, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
 	defaultParam := WithPreInteropDefaults(t, l2ClaimBlockNum, env.Sequencer.L2Verifier, env.Engine)
 	combinedParams := []FixtureInputParam{defaultParam}

--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -13,12 +13,17 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/tasks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
 	ErrIncorrectOutputRootType = errors.New("incorrect output root type")
+	ErrL1HeadReached           = errors.New("l1 head reached")
+
+	InvalidTransition     = []byte("invalid")
+	InvalidTransitionHash = crypto.Keccak256Hash(InvalidTransition)
 )
 
 type taskExecutor interface {
@@ -40,55 +45,33 @@ func RunInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1Prei
 func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, validateClaim bool, tasks taskExecutor) error {
 	logger.Info("Interop Program Bootstrapped", "bootInfo", bootInfo)
 
-	// For the first step in a timestamp, we would get a SuperRoot as the agreed claim - TransitionStateByRoot will
-	// automatically convert it to a TransitionState with Step: 0.
-	transitionState := l2PreimageOracle.TransitionStateByRoot(bootInfo.AgreedPrestate)
-	if transitionState.Version() != types.IntermediateTransitionVersion {
-		return fmt.Errorf("%w: %v", ErrIncorrectOutputRootType, transitionState.Version())
-	}
-
-	super, err := eth.UnmarshalSuperRoot(transitionState.SuperRoot)
+	expected, err := stateTransition(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, tasks)
 	if err != nil {
-		return fmt.Errorf("invalid super root: %w", err)
+		return err
 	}
-	if super.Version() != eth.SuperRootVersionV1 {
-		return fmt.Errorf("%w: %v", ErrIncorrectOutputRootType, super.Version())
+	if !validateClaim {
+		return nil
 	}
-	superRoot := super.(*eth.SuperV1)
+	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.Claim), eth.Bytes32(expected))
+}
 
+func stateTransition(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, tasks taskExecutor) (common.Hash, error) {
+	if bootInfo.AgreedPrestate == InvalidTransitionHash {
+		return InvalidTransitionHash, nil
+	}
+	transitionState, superRoot, err := parseAgreedState(bootInfo, l2PreimageOracle)
+	if err != nil {
+		return common.Hash{}, err
+	}
 	expectedPendingProgress := transitionState.PendingProgress
 	if transitionState.Step < uint64(len(superRoot.Chains)) {
-		chainAgreedPrestate := superRoot.Chains[transitionState.Step]
-		rollupCfg, err := bootInfo.Configs.RollupConfig(chainAgreedPrestate.ChainID)
-		if err != nil {
-			return fmt.Errorf("no rollup config available for chain ID %v: %w", chainAgreedPrestate.ChainID, err)
+		block, err := deriveOptimisticBlock(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, superRoot, transitionState, tasks)
+		if errors.Is(err, ErrL1HeadReached) {
+			return InvalidTransitionHash, nil
+		} else if err != nil {
+			return common.Hash{}, err
 		}
-		l2ChainConfig, err := bootInfo.Configs.ChainConfig(chainAgreedPrestate.ChainID)
-		if err != nil {
-			return fmt.Errorf("no chain config available for chain ID %v: %w", chainAgreedPrestate.ChainID, err)
-		}
-		claimedBlockNumber, err := rollupCfg.TargetBlockNumber(superRoot.Timestamp + 1)
-		if err != nil {
-			return err
-		}
-		derivationResult, err := tasks.RunDerivation(
-			logger,
-			rollupCfg,
-			l2ChainConfig,
-			bootInfo.L1Head,
-			chainAgreedPrestate.Output,
-			claimedBlockNumber,
-			l1PreimageOracle,
-			l2PreimageOracle,
-		)
-		if err != nil {
-			return err
-		}
-
-		expectedPendingProgress = append(expectedPendingProgress, types.OptimisticBlock{
-			BlockHash:  derivationResult.BlockHash,
-			OutputRoot: derivationResult.OutputRoot,
-		})
+		expectedPendingProgress = append(expectedPendingProgress, block)
 	}
 	finalState := &types.TransitionState{
 		SuperRoot:       transitionState.SuperRoot,
@@ -97,12 +80,66 @@ func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1Prei
 	}
 	expected, err := finalState.Hash()
 	if err != nil {
-		return err
+		return common.Hash{}, err
 	}
-	if !validateClaim {
-		return nil
+	return expected, nil
+}
+
+func parseAgreedState(bootInfo *boot.BootInfoInterop, l2PreimageOracle l2.Oracle) (*types.TransitionState, *eth.SuperV1, error) {
+	// For the first step in a timestamp, we would get a SuperRoot as the agreed claim - TransitionStateByRoot will
+	// automatically convert it to a TransitionState with Step: 0.
+	transitionState := l2PreimageOracle.TransitionStateByRoot(bootInfo.AgreedPrestate)
+	if transitionState.Version() != types.IntermediateTransitionVersion {
+		return nil, nil, fmt.Errorf("%w: %v", ErrIncorrectOutputRootType, transitionState.Version())
 	}
-	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.Claim), eth.Bytes32(expected))
+
+	super, err := eth.UnmarshalSuperRoot(transitionState.SuperRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid super root: %w", err)
+	}
+	if super.Version() != eth.SuperRootVersionV1 {
+		return nil, nil, fmt.Errorf("%w: %v", ErrIncorrectOutputRootType, super.Version())
+	}
+	superRoot := super.(*eth.SuperV1)
+	return transitionState, superRoot, nil
+}
+
+func deriveOptimisticBlock(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, superRoot *eth.SuperV1, transitionState *types.TransitionState, tasks taskExecutor) (types.OptimisticBlock, error) {
+	chainAgreedPrestate := superRoot.Chains[transitionState.Step]
+	rollupCfg, err := bootInfo.Configs.RollupConfig(chainAgreedPrestate.ChainID)
+	if err != nil {
+		return types.OptimisticBlock{}, fmt.Errorf("no rollup config available for chain ID %v: %w", chainAgreedPrestate.ChainID, err)
+	}
+	l2ChainConfig, err := bootInfo.Configs.ChainConfig(chainAgreedPrestate.ChainID)
+	if err != nil {
+		return types.OptimisticBlock{}, fmt.Errorf("no chain config available for chain ID %v: %w", chainAgreedPrestate.ChainID, err)
+	}
+	claimedBlockNumber, err := rollupCfg.TargetBlockNumber(superRoot.Timestamp + 1)
+	if err != nil {
+		return types.OptimisticBlock{}, err
+	}
+	derivationResult, err := tasks.RunDerivation(
+		logger,
+		rollupCfg,
+		l2ChainConfig,
+		bootInfo.L1Head,
+		chainAgreedPrestate.Output,
+		claimedBlockNumber,
+		l1PreimageOracle,
+		l2PreimageOracle,
+	)
+	if err != nil {
+		return types.OptimisticBlock{}, err
+	}
+	if derivationResult.Head.Number < claimedBlockNumber {
+		return types.OptimisticBlock{}, ErrL1HeadReached
+	}
+
+	block := types.OptimisticBlock{
+		BlockHash:  derivationResult.BlockHash,
+		OutputRoot: derivationResult.OutputRoot,
+	}
+	return block, nil
 }
 
 type interopTaskExecutor struct {

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -43,6 +43,7 @@ func setupTwoChains() (*staticConfigSource, *eth.SuperV1, stubTasks) {
 		chainConfigs: []*params.ChainConfig{chainCfg1, &chainCfg2},
 	}
 	tasksStub := stubTasks{
+		l2SafeHead: eth.L2BlockRef{Number: 918429823450218}, // Past the claimed block
 		blockHash:  common.Hash{0x22},
 		outputRoot: eth.Bytes32{0x66},
 	}


### PR DESCRIPTION
**Description**

If the L1 head is reached before the next block is derived for any chain, the expected claim is `keccak256("invalid")`. This avoids the need to repeat the safe head and then have the challenge l2 block number code.

**Tests**

Added action tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/13741/
