### PR TITLE
op-node/rollup/derive: add info logging

### DIFF
--- a/op-node/rollup/derive/channel_assembler.go
+++ b/op-node/rollup/derive/channel_assembler.go
@@ -96,6 +96,7 @@ func (ca *ChannelAssembler) NextRawChannel(ctx context.Context) ([]byte, error) 
 		if frame.FrameNumber == 0 {
 			ca.metrics.RecordHeadChannelOpened()
 			ca.channel = NewChannel(frame.ID, origin, true)
+			lgr.Info("created new channel")
 		}
 		if frame.FrameNumber > 0 && ca.channel == nil {
 			lgr.Warn("dropping non-first frame without channel",

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -105,7 +105,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		if err != nil {
 			return nil, err
 		}
-		batch.LogContext(cr.log).Debug("decoded singular batch from channel", "stage_origin", cr.Origin())
+		batch.LogContext(cr.log).Info("decoded singular batch from channel", "stage_origin", cr.Origin())
 		cr.metrics.RecordDerivedBatches("singular")
 		return batch, nil
 	case SpanBatchType:
@@ -119,7 +119,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		if err != nil {
 			return nil, err
 		}
-		batch.LogContext(cr.log).Debug("decoded span batch from channel", "stage_origin", cr.Origin())
+		batch.LogContext(cr.log).Info("decoded span batch from channel", "stage_origin", cr.Origin())
 		cr.metrics.RecordDerivedBatches("span")
 		return batch, nil
 	default:


### PR DESCRIPTION
**Description**

* adds an info log to the `ChannelAssembler` where the `ChannelBank` was previously logging
* changes two logs in the `ChannelInReader` stage from debug to info level because this is quite helpful to log even at info level.


**Additional context**

This should help debugging batching problems with logs that only log at info level, which is what most chain ops do.