### PR TITLE
op-challenger: Simplify flags and validation

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -23,7 +23,7 @@ var (
 	l1EthRpc                = "http://example.com:8545"
 	l1Beacon                = "http://example.com:9000"
 	gameFactoryAddressValue = "0xbb00000000000000000000000000000000000000"
-	cannonNetwork           = "op-mainnet"
+	network                 = "op-mainnet"
 	testNetwork             = "op-sepolia"
 	l2EthRpc                = "http://example.com:9545"
 	cannonBin               = "./bin/cannon"
@@ -31,7 +31,6 @@ var (
 	cannonPreState          = "./pre.json"
 	datadir                 = "./test_data"
 	rollupRpc               = "http://example.com:8555"
-	asteriscNetwork         = "op-mainnet"
 	asteriscBin             = "./bin/asterisc"
 	asteriscServer          = "./bin/op-program"
 	asteriscPreState        = "./pre.json"
@@ -497,34 +496,33 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 			})
 		})
 
-		t.Run(fmt.Sprintf("TestRequireEitherAsteriscNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TestRequireEitherNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag asterisc-network, network or asterisc-rollup-config and asterisc-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--asterisc-network"))
+				"flag network or asterisc-rollup-config and asterisc-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network"))
 			verifyArgsInvalid(
 				t,
-				"flag asterisc-network, network or asterisc-rollup-config and asterisc-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--asterisc-network", "--asterisc-rollup-config=rollup.json"))
+				"flag network or asterisc-rollup-config and asterisc-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--asterisc-rollup-config=rollup.json"))
 			verifyArgsInvalid(
 				t,
-				"flag asterisc-network, network or asterisc-rollup-config and asterisc-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--asterisc-network", "--asterisc-l2-genesis=gensis.json"))
+				"flag network or asterisc-rollup-config and asterisc-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--asterisc-l2-genesis=gensis.json"))
 		})
 
-		t.Run(fmt.Sprintf("TestMustNotSpecifyAsteriscNetworkAndRollup-%v", traceType), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag asterisc-network can not be used with asterisc-rollup-config and asterisc-l2-genesis",
-				addRequiredArgsExcept(traceType, "--asterisc-network",
-					"--asterisc-network", asteriscNetwork, "--asterisc-rollup-config=rollup.json"))
+				"flag network can not be used with asterisc-rollup-config and asterisc-l2-genesis",
+				addRequiredArgs(traceType, "--asterisc-rollup-config=rollup.json"))
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			args := requiredArgs(traceType)
-			delete(args, "--asterisc-network")
+			delete(args, "--network")
 			delete(args, "--game-factory-address")
-			args["--network"] = asteriscNetwork
+			args["--network"] = network
 			args["--asterisc-rollup-config"] = "rollup.json"
 			args["--asterisc-l2-genesis"] = "gensis.json"
 			verifyArgsInvalid(
@@ -533,32 +531,27 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 				toArgList(args))
 		})
 
-		t.Run(fmt.Sprintf("TestAsteriscNetwork-%v", traceType), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
 				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-network"))
 			})
 
-			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-network",
+			t.Run("NotRequiredWhenRollupAndGenesisSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
 					"--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
 			})
 
 			t.Run("NotRequiredWhenNetworkSpecified", func(t *testing.T) {
 				args := requiredArgs(traceType)
-				delete(args, "--asterisc-network")
+				delete(args, "--network")
 				delete(args, "--game-factory-address")
 				args["--network"] = "op-sepolia"
 				cfg := configForArgs(t, toArgList(args))
 				require.Equal(t, "op-sepolia", cfg.Asterisc.Network)
 			})
 
-			t.Run("MustNotSpecifyNetworkAndAsteriscNetwork", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag asterisc-network can not be used with network",
-					addRequiredArgsExcept(traceType, "--game-factory-address", "--network", "op-sepolia"))
-			})
-
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-network", "--asterisc-network", testNetwork))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
 				require.Equal(t, testNetwork, cfg.Asterisc.Network)
 			})
 		})
@@ -569,7 +562,7 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-network", "--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
 				require.Equal(t, "rollup.json", cfg.Asterisc.RollupConfigPath)
 			})
 		})
@@ -580,7 +573,7 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--asterisc-network", "--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
 				require.Equal(t, "genesis.json", cfg.Asterisc.L2GenesisPath)
 			})
 		})
@@ -750,31 +743,30 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag cannon-network, network or cannon-rollup-config and cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--cannon-network"))
+				"flag network or cannon-rollup-config and cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network"))
 			verifyArgsInvalid(
 				t,
-				"flag cannon-network, network or cannon-rollup-config and cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-rollup-config=rollup.json"))
+				"flag network or cannon-rollup-config and cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
 			verifyArgsInvalid(
 				t,
-				"flag cannon-network, network or cannon-rollup-config and cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-l2-genesis=gensis.json"))
+				"flag network or cannon-rollup-config and cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
 		})
 
-		t.Run(fmt.Sprintf("TestMustNotSpecifyCannonNetworkAndRollup-%v", traceType), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag cannon-network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
-				addRequiredArgsExcept(traceType, "--cannon-network",
-					"--cannon-network", cannonNetwork, "--cannon-rollup-config=rollup.json"))
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
+				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			args := requiredArgs(traceType)
-			delete(args, "--cannon-network")
+			delete(args, "--network")
 			delete(args, "--game-factory-address")
-			args["--network"] = cannonNetwork
+			args["--network"] = network
 			args["--cannon-rollup-config"] = "rollup.json"
 			args["--cannon-l2-genesis"] = "gensis.json"
 			args["--cannon-l2-custom"] = "true"
@@ -784,38 +776,20 @@ func TestCannonRequiredArgs(t *testing.T) {
 				toArgList(args))
 		})
 
-		t.Run(fmt.Sprintf("TestCannonNetwork-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-network"))
-			})
-
+		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network",
+				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
 					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
 			})
 
-			t.Run("NotRequiredWhenNetworkSpecified", func(t *testing.T) {
-				args := requiredArgs(traceType)
-				delete(args, "--cannon-network")
-				delete(args, "--game-factory-address")
-				args["--network"] = "op-sepolia"
-				cfg := configForArgs(t, toArgList(args))
-				require.Equal(t, "op-sepolia", cfg.Cannon.Network)
-			})
-
-			t.Run("MustNotSpecifyNetworkAndCannonNetwork", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag cannon-network can not be used with network",
-					addRequiredArgsExcept(traceType, "--game-factory-address", "--network", "op-sepolia"))
-			})
-
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-network", testNetwork))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
 				require.Equal(t, testNetwork, cfg.Cannon.Network)
 			})
 		})
 
 		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network",
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
 				"--cannon-rollup-config=rollup.json",
 				"--cannon-l2-genesis=genesis.json",
 				"--cannon-l2-custom"))
@@ -828,7 +802,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
 				require.Equal(t, "rollup.json", cfg.Cannon.RollupConfigPath)
 			})
 		})
@@ -839,7 +813,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
 				require.Equal(t, "genesis.json", cfg.Cannon.L2GenesisPath)
 			})
 		})
@@ -1050,21 +1024,21 @@ func requiredArgs(traceType types.TraceType) map[string]string {
 }
 
 func addRequiredCannonArgs(args map[string]string) {
-	args["--cannon-network"] = cannonNetwork
+	args["--network"] = network
 	args["--cannon-bin"] = cannonBin
 	args["--cannon-server"] = cannonServer
 	args["--cannon-prestate"] = cannonPreState
 }
 
 func addRequiredAsteriscArgs(args map[string]string) {
-	args["--asterisc-network"] = asteriscNetwork
+	args["--network"] = network
 	args["--asterisc-bin"] = asteriscBin
 	args["--asterisc-server"] = asteriscServer
 	args["--asterisc-prestate"] = asteriscPreState
 }
 
 func addRequiredAsteriscKonaArgs(args map[string]string) {
-	args["--asterisc-network"] = asteriscNetwork
+	args["--network"] = network
 	args["--asterisc-bin"] = asteriscBin
 	args["--asterisc-kona-server"] = asteriscServer
 	args["--asterisc-kona-prestate"] = asteriscPreState

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -499,46 +499,33 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestRequireEitherNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag network or asterisc-rollup-config and asterisc-l2-genesis is required",
+				"flag network or rollup-config and l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network"))
 			verifyArgsInvalid(
 				t,
-				"flag network or asterisc-rollup-config and asterisc-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network", "--asterisc-rollup-config=rollup.json"))
+				"flag network or rollup-config and l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json"))
 			verifyArgsInvalid(
 				t,
-				"flag network or asterisc-rollup-config and asterisc-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network", "--asterisc-l2-genesis=gensis.json"))
+				"flag network or rollup-config and l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--l2-genesis=gensis.json"))
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag network can not be used with asterisc-rollup-config and asterisc-l2-genesis",
-				addRequiredArgs(traceType, "--asterisc-rollup-config=rollup.json"))
-		})
-
-		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
-			args := requiredArgs(traceType)
-			delete(args, "--network")
-			delete(args, "--game-factory-address")
-			args["--network"] = network
-			args["--asterisc-rollup-config"] = "rollup.json"
-			args["--asterisc-l2-genesis"] = "gensis.json"
-			verifyArgsInvalid(
-				t,
-				"flag network can not be used with asterisc-rollup-config and asterisc-l2-genesis",
-				toArgList(args))
+				"flag network can not be used with rollup-config and l2-genesis",
+				addRequiredArgs(traceType, "--rollup-config=rollup.json"))
 		})
 
 		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-network"))
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--network"))
 			})
 
 			t.Run("NotRequiredWhenRollupAndGenesisSpecified", func(t *testing.T) {
 				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
-					"--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
+					"--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 			})
 
 			t.Run("NotRequiredWhenNetworkSpecified", func(t *testing.T) {
@@ -562,18 +549,18 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 				require.Equal(t, "rollup.json", cfg.Asterisc.RollupConfigPath)
 			})
 		})
 
-		t.Run(fmt.Sprintf("TestAsteriscL2Genesis-%v", traceType), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TestL2Genesis-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--asterisc-l2-genesis"))
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--l2-genesis"))
 			})
 
 			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--asterisc-rollup-config=rollup.json", "--asterisc-l2-genesis=genesis.json"))
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 				require.Equal(t, "genesis.json", cfg.Asterisc.L2GenesisPath)
 			})
 		})
@@ -743,22 +730,22 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag network or cannon-rollup-config and cannon-l2-genesis is required",
+				"flag network or rollup-config and l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network"))
 			verifyArgsInvalid(
 				t,
-				"flag network or cannon-rollup-config and cannon-l2-genesis is required",
+				"flag network or rollup-config and l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
 			verifyArgsInvalid(
 				t,
-				"flag network or cannon-rollup-config and cannon-l2-genesis is required",
+				"flag network or rollup-config and l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
+				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
 				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
 		})
 

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -447,18 +447,9 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 				verifyArgsInvalid(t, "flag l2-eth-rpc is required", addRequiredArgsExcept(traceType, "--l2-eth-rpc"))
 			})
 
-			t.Run("ValidLegacy", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--l2-eth-rpc", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
-				require.Equal(t, l2EthRpc, cfg.L2Rpc)
-			})
-
 			t.Run("Valid", func(t *testing.T) {
 				cfg := configForArgs(t, addRequiredArgs(traceType))
 				require.Equal(t, l2EthRpc, cfg.L2Rpc)
-			})
-
-			t.Run("InvalidUsingBothFlags", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag cannon-l2 and l2-eth-rpc must not be both set", addRequiredArgsExcept(traceType, "", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
 			})
 		})
 
@@ -573,11 +564,6 @@ func TestAlphabetRequiredArgs(t *testing.T) {
 			verifyArgsInvalid(t, "flag l2-eth-rpc is required", addRequiredArgsExcept(types.TraceTypeAlphabet, "--l2-eth-rpc"))
 		})
 
-		t.Run("ValidLegacy", func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--l2-eth-rpc", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
-			require.Equal(t, l2EthRpc, cfg.L2Rpc)
-		})
-
 		t.Run("Valid", func(t *testing.T) {
 			cfg := configForArgs(t, addRequiredArgs(types.TraceTypeAlphabet))
 			require.Equal(t, l2EthRpc, cfg.L2Rpc)
@@ -680,11 +666,6 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestL2Rpc-%v", traceType), func(t *testing.T) {
 			t.Run("RequiredForCannonTrace", func(t *testing.T) {
 				verifyArgsInvalid(t, "flag l2-eth-rpc is required", addRequiredArgsExcept(traceType, "--l2-eth-rpc"))
-			})
-
-			t.Run("ValidLegacy", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--l2-eth-rpc", fmt.Sprintf("--cannon-l2=%s", l2EthRpc)))
-				require.Equal(t, l2EthRpc, cfg.L2Rpc)
 			})
 
 			t.Run("Valid", func(t *testing.T) {

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -293,7 +293,7 @@ func TestAsteriscOpProgramRequiredArgs(t *testing.T) {
 		})
 
 		t.Run("Required", func(t *testing.T) {
-			verifyArgsInvalid(t, "flag prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
+			verifyArgsInvalid(t, "flag prestates-url/asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
 		})
 
 		t.Run("Valid", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestAsteriscOpProgramRequiredArgs(t *testing.T) {
 		})
 
 		t.Run("RequiredIfAsteriscPrestatesBaseURLNotSet", func(t *testing.T) {
-			verifyArgsInvalid(t, "flag prestates-url or asterisc-prestate is required", addRequiredArgsExceptArr(traceType, allPrestateOptions))
+			verifyArgsInvalid(t, "flag prestates-url/asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExceptArr(traceType, allPrestateOptions))
 		})
 
 		t.Run("Invalid", func(t *testing.T) {
@@ -337,7 +337,7 @@ func TestAsteriscOpProgramRequiredArgs(t *testing.T) {
 		})
 
 		t.Run("Required", func(t *testing.T) {
-			verifyArgsInvalid(t, "flag prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
+			verifyArgsInvalid(t, "flag prestates-url/asterisc-prestates-url or asterisc-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-prestate"))
 		})
 
 		t.Run("Valid", func(t *testing.T) {
@@ -370,7 +370,7 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 		})
 
 		t.Run("Required", func(t *testing.T) {
-			verifyArgsInvalid(t, "flag prestates-url or asterisc-kona-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-kona-prestate"))
+			verifyArgsInvalid(t, "flag prestates-url/asterisc-kona-prestates-url or asterisc-kona-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-kona-prestate"))
 		})
 
 		t.Run("Valid", func(t *testing.T) {
@@ -385,7 +385,7 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 		})
 
 		t.Run("Required", func(t *testing.T) {
-			verifyArgsInvalid(t, "flag prestates-url or asterisc-kona-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-kona-prestate"))
+			verifyArgsInvalid(t, "flag prestates-url/asterisc-kona-prestates-url or asterisc-kona-prestate is required", addRequiredArgsExcept(traceType, "--asterisc-kona-prestate"))
 		})
 
 		t.Run("Valid", func(t *testing.T) {
@@ -410,7 +410,7 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 		})
 
 		t.Run("RequiredIfAsteriscKonaPrestatesBaseURLNotSet", func(t *testing.T) {
-			verifyArgsInvalid(t, "flag prestates-url or asterisc-kona-prestate is required", addRequiredArgsExceptArr(traceType, allPrestateOptions))
+			verifyArgsInvalid(t, "flag prestates-url/asterisc-kona-prestates-url or asterisc-kona-prestate is required", addRequiredArgsExceptArr(traceType, allPrestateOptions))
 		})
 
 		t.Run("Invalid", func(t *testing.T) {
@@ -490,15 +490,15 @@ func TestAsteriscBaseRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestRequireEitherNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag network or rollup-config and l2-genesis is required",
+				fmt.Sprintf("flag network or rollup-config/%s-rollup-config and l2-genesis/%s-l2-genesis is required", traceType, traceType),
 				addRequiredArgsExcept(traceType, "--network"))
 			verifyArgsInvalid(
 				t,
-				"flag network or rollup-config and l2-genesis is required",
+				fmt.Sprintf("flag network or rollup-config/%s-rollup-config and l2-genesis/%s-l2-genesis is required", traceType, traceType),
 				addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json"))
 			verifyArgsInvalid(
 				t,
-				"flag network or rollup-config and l2-genesis is required",
+				fmt.Sprintf("flag network or rollup-config/%s-rollup-config and l2-genesis/%s-l2-genesis is required", traceType, traceType),
 				addRequiredArgsExcept(traceType, "--network", "--l2-genesis=gensis.json"))
 		})
 
@@ -610,7 +610,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag prestates-url or cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
+				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
 			})
 
 			t.Run("Valid", func(t *testing.T) {
@@ -625,7 +625,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("Required", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag prestates-url or cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
+				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
 			})
 
 			t.Run("Valid", func(t *testing.T) {
@@ -650,7 +650,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			})
 
 			t.Run("RequiredIfCannonPrestatesBaseURLNotSet", func(t *testing.T) {
-				verifyArgsInvalid(t, "flag prestates-url or cannon-prestate is required", addRequiredArgsExceptArr(traceType, allPrestateOptions))
+				verifyArgsInvalid(t, "flag prestates-url/cannon-prestates-url or cannon-prestate is required", addRequiredArgsExceptArr(traceType, allPrestateOptions))
 			})
 
 			t.Run("Invalid", func(t *testing.T) {
@@ -711,15 +711,15 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
 			verifyArgsInvalid(
 				t,
-				"flag network or rollup-config and l2-genesis is required",
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network"))
 			verifyArgsInvalid(
 				t,
-				"flag network or rollup-config and l2-genesis is required",
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
 			verifyArgsInvalid(
 				t,
-				"flag network or rollup-config and l2-genesis is required",
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
 				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
 		})
 

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
@@ -175,13 +176,13 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestCannonBinRequired-%v", traceType), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.Cannon.VmBin = ""
-			require.ErrorIs(t, config.Check(), ErrMissingCannonBin)
+			require.ErrorIs(t, config.Check(), vm.ErrMissingBin)
 		})
 
 		t.Run(fmt.Sprintf("TestCannonServerRequired-%v", traceType), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.Cannon.Server = ""
-			require.ErrorIs(t, config.Check(), ErrMissingCannonServer)
+			require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
 		})
 
 		t.Run(fmt.Sprintf("TestCannonAbsolutePreStateOrBaseURLRequired-%v", traceType), func(t *testing.T) {
@@ -240,7 +241,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			cfg.Cannon.Network = ""
 			cfg.Cannon.RollupConfigPath = ""
 			cfg.Cannon.L2GenesisPath = "genesis.json"
-			require.ErrorIs(t, cfg.Check(), ErrMissingCannonRollupConfig)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingRollupConfig)
 		})
 
 		t.Run(fmt.Sprintf("TestCannonNetworkOrL2GenesisRequired-%v", traceType), func(t *testing.T) {
@@ -248,7 +249,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			cfg.Cannon.Network = ""
 			cfg.Cannon.RollupConfigPath = "foo.json"
 			cfg.Cannon.L2GenesisPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrMissingCannonL2Genesis)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingL2Genesis)
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
@@ -256,7 +257,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 			cfg.Cannon.Network = validCannonNetwork
 			cfg.Cannon.RollupConfigPath = "foo.json"
 			cfg.Cannon.L2GenesisPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkAndRollupConfig)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkAndRollupConfig)
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndL2Genesis-%v", traceType), func(t *testing.T) {
@@ -264,13 +265,13 @@ func TestCannonRequiredArgs(t *testing.T) {
 			cfg.Cannon.Network = validCannonNetwork
 			cfg.Cannon.RollupConfigPath = ""
 			cfg.Cannon.L2GenesisPath = "foo.json"
-			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkAndL2Genesis)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkAndL2Genesis)
 		})
 
 		t.Run(fmt.Sprintf("TestNetworkMustBeValid-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Cannon.Network = "unknown"
-			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkUnknown)
 		})
 
 		t.Run(fmt.Sprintf("TestNetworkMayBeAnyChainID-%v", traceType), func(t *testing.T) {
@@ -282,7 +283,7 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestNetworkInvalidWhenNotEntirelyNumeric-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Cannon.Network = "467294a"
-			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkUnknown)
 		})
 
 		t.Run(fmt.Sprintf("TestDebugInfoEnabled-%v", traceType), func(t *testing.T) {
@@ -293,13 +294,13 @@ func TestCannonRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestVMBinExists-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Cannon.VmBin = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), ErrMissingCannonBin)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingBin)
 		})
 
 		t.Run(fmt.Sprintf("TestServerExists-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Cannon.Server = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), ErrMissingCannonServer)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingServer)
 		})
 	}
 }
@@ -311,13 +312,13 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestAsteriscBinRequired-%v", traceType), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.Asterisc.VmBin = ""
-			require.ErrorIs(t, config.Check(), ErrMissingAsteriscBin)
+			require.ErrorIs(t, config.Check(), vm.ErrMissingBin)
 		})
 
 		t.Run(fmt.Sprintf("TestAsteriscServerRequired-%v", traceType), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.Asterisc.Server = ""
-			require.ErrorIs(t, config.Check(), ErrMissingAsteriscServer)
+			require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
 		})
 
 		t.Run(fmt.Sprintf("TestAsteriscAbsolutePreStateOrBaseURLRequired-%v", traceType), func(t *testing.T) {
@@ -376,7 +377,7 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			cfg.Asterisc.Network = ""
 			cfg.Asterisc.RollupConfigPath = ""
 			cfg.Asterisc.L2GenesisPath = "genesis.json"
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscRollupConfig)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingRollupConfig)
 		})
 
 		t.Run(fmt.Sprintf("TestAsteriscNetworkOrL2GenesisRequired-%v", traceType), func(t *testing.T) {
@@ -384,7 +385,7 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			cfg.Asterisc.Network = ""
 			cfg.Asterisc.RollupConfigPath = "foo.json"
 			cfg.Asterisc.L2GenesisPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscL2Genesis)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingL2Genesis)
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
@@ -392,7 +393,7 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			cfg.Asterisc.Network = validAsteriscNetwork
 			cfg.Asterisc.RollupConfigPath = "foo.json"
 			cfg.Asterisc.L2GenesisPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrAsteriscNetworkAndRollupConfig)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkAndRollupConfig)
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndL2Genesis-%v", traceType), func(t *testing.T) {
@@ -400,13 +401,13 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 			cfg.Asterisc.Network = validAsteriscNetwork
 			cfg.Asterisc.RollupConfigPath = ""
 			cfg.Asterisc.L2GenesisPath = "foo.json"
-			require.ErrorIs(t, cfg.Check(), ErrAsteriscNetworkAndL2Genesis)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkAndL2Genesis)
 		})
 
 		t.Run(fmt.Sprintf("TestNetworkMustBeValid-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Asterisc.Network = "unknown"
-			require.ErrorIs(t, cfg.Check(), ErrAsteriscNetworkUnknown)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkUnknown)
 		})
 
 		t.Run(fmt.Sprintf("TestDebugInfoDisabled-%v", traceType), func(t *testing.T) {
@@ -417,13 +418,13 @@ func TestAsteriscRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestVMBinExists-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Asterisc.VmBin = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscBin)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingBin)
 		})
 
 		t.Run(fmt.Sprintf("TestServerExists-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.Asterisc.Server = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscServer)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingServer)
 		})
 	}
 }
@@ -435,13 +436,13 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestAsteriscKonaBinRequired-%v", traceType), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.AsteriscKona.VmBin = ""
-			require.ErrorIs(t, config.Check(), ErrMissingAsteriscKonaBin)
+			require.ErrorIs(t, config.Check(), vm.ErrMissingBin)
 		})
 
 		t.Run(fmt.Sprintf("TestAsteriscKonaServerRequired-%v", traceType), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.AsteriscKona.Server = ""
-			require.ErrorIs(t, config.Check(), ErrMissingAsteriscKonaServer)
+			require.ErrorIs(t, config.Check(), vm.ErrMissingServer)
 		})
 
 		t.Run(fmt.Sprintf("TestAsteriscKonaAbsolutePreStateOrBaseURLRequired-%v", traceType), func(t *testing.T) {
@@ -500,7 +501,7 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 			cfg.AsteriscKona.Network = ""
 			cfg.AsteriscKona.RollupConfigPath = ""
 			cfg.AsteriscKona.L2GenesisPath = "genesis.json"
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscKonaRollupConfig)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingRollupConfig)
 		})
 
 		t.Run(fmt.Sprintf("TestAsteriscKonaNetworkOrL2GenesisRequired-%v", traceType), func(t *testing.T) {
@@ -508,7 +509,7 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 			cfg.AsteriscKona.Network = ""
 			cfg.AsteriscKona.RollupConfigPath = "foo.json"
 			cfg.AsteriscKona.L2GenesisPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscKonaL2Genesis)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingL2Genesis)
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
@@ -516,7 +517,7 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 			cfg.AsteriscKona.Network = validAsteriscKonaNetwork
 			cfg.AsteriscKona.RollupConfigPath = "foo.json"
 			cfg.AsteriscKona.L2GenesisPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrAsteriscKonaNetworkAndRollupConfig)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkAndRollupConfig)
 		})
 
 		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndL2Genesis-%v", traceType), func(t *testing.T) {
@@ -524,13 +525,13 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 			cfg.AsteriscKona.Network = validAsteriscKonaNetwork
 			cfg.AsteriscKona.RollupConfigPath = ""
 			cfg.AsteriscKona.L2GenesisPath = "foo.json"
-			require.ErrorIs(t, cfg.Check(), ErrAsteriscKonaNetworkAndL2Genesis)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkAndL2Genesis)
 		})
 
 		t.Run(fmt.Sprintf("TestNetworkMustBeValid-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.AsteriscKona.Network = "unknown"
-			require.ErrorIs(t, cfg.Check(), ErrAsteriscKonaNetworkUnknown)
+			require.ErrorIs(t, cfg.Check(), vm.ErrNetworkUnknown)
 		})
 
 		t.Run(fmt.Sprintf("TestDebugInfoDisabled-%v", traceType), func(t *testing.T) {
@@ -541,13 +542,13 @@ func TestAsteriscKonaRequiredArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("TestVMBinExists-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.AsteriscKona.VmBin = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscKonaBin)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingBin)
 		})
 
 		t.Run(fmt.Sprintf("TestServerExists-%v", traceType), func(t *testing.T) {
 			cfg := validConfig(t, traceType)
 			cfg.AsteriscKona.Server = nonExistingFile
-			require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscKonaServer)
+			require.ErrorIs(t, cfg.Check(), vm.ErrMissingServer)
 		})
 	}
 }
@@ -636,7 +637,7 @@ func TestRequireConfigForMultipleTraceTypesForCannonAndAsterisc(t *testing.T) {
 
 	// Require cannon specific args
 	cfg.Cannon.VmBin = ""
-	require.ErrorIs(t, cfg.Check(), ErrMissingCannonBin)
+	require.ErrorIs(t, cfg.Check(), vm.ErrMissingBin)
 	tmpDir := t.TempDir()
 	vmBin := filepath.Join(tmpDir, validCannonBin)
 	err := ensureExists(vmBin)
@@ -649,9 +650,8 @@ func TestRequireConfigForMultipleTraceTypesForCannonAndAsterisc(t *testing.T) {
 	require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscAbsolutePreState)
 	cfg.AsteriscAbsolutePreState = validAsteriscAbsolutePreState
 
-	// Require cannon specific args
 	cfg.Asterisc.Server = ""
-	require.ErrorIs(t, cfg.Check(), ErrMissingAsteriscServer)
+	require.ErrorIs(t, cfg.Check(), vm.ErrMissingServer)
 	server := filepath.Join(tmpDir, validAsteriscOpProgramBin)
 	err = ensureExists(server)
 	require.NoError(t, err)

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -320,7 +320,7 @@ func CheckAsteriscFlags(ctx *cli.Context) error {
 		return fmt.Errorf("flag %s is required", AsteriscServerFlag.Name)
 	}
 	if !PreStatesURLFlag.IsSet(ctx, types.TraceTypeAsterisc) && !ctx.IsSet(AsteriscPreStateFlag.Name) {
-		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(types.TraceTypeAsteriscKona), AsteriscPreStateFlag.Name)
+		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(types.TraceTypeAsterisc), AsteriscPreStateFlag.Name)
 	}
 	return nil
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -477,29 +477,29 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 			claimants = append(claimants, claimant)
 		}
 	}
-	var cannonPreStatesURL *url.URL
-	if PreStatesURLFlag.IsSet(ctx, types.TraceTypeCannon) {
-		val := PreStatesURLFlag.String(ctx, types.TraceTypeCannon)
-		cannonPreStatesURL, err = url.Parse(val)
-		if err != nil {
-			return nil, fmt.Errorf("invalid %v (%v): %w", PreStatesURLFlag.SourceFlagName(ctx, types.TraceTypeCannon), val, err)
+
+	getPrestatesUrl := func(traceType types.TraceType) (*url.URL, error) {
+		var preStatesURL *url.URL
+		if PreStatesURLFlag.IsSet(ctx, traceType) {
+			val := PreStatesURLFlag.String(ctx, traceType)
+			preStatesURL, err = url.Parse(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %v (%v): %w", PreStatesURLFlag.SourceFlagName(ctx, traceType), val, err)
+			}
 		}
+		return preStatesURL, nil
 	}
-	var asteriscPreStatesURL *url.URL
-	if PreStatesURLFlag.IsSet(ctx, types.TraceTypeAsterisc) {
-		val := PreStatesURLFlag.String(ctx, types.TraceTypeAsterisc)
-		asteriscPreStatesURL, err = url.Parse(val)
-		if err != nil {
-			return nil, fmt.Errorf("invalid %v (%v): %w", PreStatesURLFlag.SourceFlagName(ctx, types.TraceTypeAsterisc), val, err)
-		}
+	cannonPreStatesURL, err := getPrestatesUrl(types.TraceTypeCannon)
+	if err != nil {
+		return nil, err
 	}
-	var asteriscKonaPreStatesURL *url.URL
-	if PreStatesURLFlag.IsSet(ctx, types.TraceTypeAsteriscKona) {
-		val := PreStatesURLFlag.String(ctx, types.TraceTypeAsteriscKona)
-		asteriscKonaPreStatesURL, err = url.Parse(val)
-		if err != nil {
-			return nil, fmt.Errorf("invalid %v (%v): %w", PreStatesURLFlag.SourceFlagName(ctx, types.TraceTypeAsteriscKona), val, err)
-		}
+	asteriscPreStatesURL, err := getPrestatesUrl(types.TraceTypeAsterisc)
+	if err != nil {
+		return nil, err
+	}
+	asteriscKonaPreStatesURL, err := getPrestatesUrl(types.TraceTypeAsteriscKona)
+	if err != nil {
+		return nil, err
 	}
 	l2Rpc, err := getL2Rpc(ctx, logger)
 	if err != nil {

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -272,7 +272,7 @@ func CheckCannonFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(flags.NetworkFlagName) &&
 		!(RollupConfigFlag.IsSet(ctx, types.TraceTypeCannon) && L2GenesisFlag.IsSet(ctx, types.TraceTypeCannon)) {
 		return fmt.Errorf("flag %v or %v and %v is required",
-			flags.NetworkFlagName, RollupConfigFlag.DefaultName(), L2GenesisFlag.DefaultName())
+			flags.NetworkFlagName, RollupConfigFlag.EitherFlagName(types.TraceTypeCannon), L2GenesisFlag.EitherFlagName(types.TraceTypeCannon))
 	}
 	if ctx.IsSet(flags.NetworkFlagName) &&
 		(RollupConfigFlag.IsSet(ctx, types.TraceTypeCannon) || L2GenesisFlag.IsSet(ctx, types.TraceTypeCannon) || ctx.Bool(CannonL2CustomFlag.Name)) {
@@ -280,7 +280,8 @@ func CheckCannonFlags(ctx *cli.Context) error {
 			flags.NetworkFlagName, RollupConfigFlag.SourceFlagName(ctx, types.TraceTypeCannon), L2GenesisFlag.SourceFlagName(ctx, types.TraceTypeCannon), CannonL2CustomFlag.Name)
 	}
 	if ctx.Bool(CannonL2CustomFlag.Name) && !(RollupConfigFlag.IsSet(ctx, types.TraceTypeCannon) && L2GenesisFlag.IsSet(ctx, types.TraceTypeCannon)) {
-		return fmt.Errorf("flag %v and %v must be set when %v is true", RollupConfigFlag.DefaultName(), L2GenesisFlag.DefaultName(), CannonL2CustomFlag.Name)
+		return fmt.Errorf("flag %v and %v must be set when %v is true",
+			RollupConfigFlag.EitherFlagName(types.TraceTypeCannon), L2GenesisFlag.EitherFlagName(types.TraceTypeCannon), CannonL2CustomFlag.Name)
 	}
 	if !ctx.IsSet(CannonBinFlag.Name) {
 		return fmt.Errorf("flag %s is required", CannonBinFlag.Name)
@@ -289,7 +290,7 @@ func CheckCannonFlags(ctx *cli.Context) error {
 		return fmt.Errorf("flag %s is required", CannonServerFlag.Name)
 	}
 	if !PreStatesURLFlag.IsSet(ctx, types.TraceTypeCannon) && !ctx.IsSet(CannonPreStateFlag.Name) {
-		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.DefaultName(), CannonPreStateFlag.Name)
+		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(types.TraceTypeCannon), CannonPreStateFlag.Name)
 	}
 	return nil
 }
@@ -298,7 +299,7 @@ func CheckAsteriscBaseFlags(ctx *cli.Context, traceType types.TraceType) error {
 	if !ctx.IsSet(flags.NetworkFlagName) &&
 		!(RollupConfigFlag.IsSet(ctx, traceType) && L2GenesisFlag.IsSet(ctx, traceType)) {
 		return fmt.Errorf("flag %v or %v and %v is required",
-			flags.NetworkFlagName, RollupConfigFlag.DefaultName(), L2GenesisFlag.DefaultName())
+			flags.NetworkFlagName, RollupConfigFlag.EitherFlagName(traceType), L2GenesisFlag.EitherFlagName(traceType))
 	}
 	if ctx.IsSet(flags.NetworkFlagName) &&
 		(RollupConfigFlag.IsSet(ctx, traceType) || L2GenesisFlag.IsSet(ctx, traceType)) {
@@ -319,7 +320,7 @@ func CheckAsteriscFlags(ctx *cli.Context) error {
 		return fmt.Errorf("flag %s is required", AsteriscServerFlag.Name)
 	}
 	if !PreStatesURLFlag.IsSet(ctx, types.TraceTypeAsterisc) && !ctx.IsSet(AsteriscPreStateFlag.Name) {
-		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.DefaultName(), AsteriscPreStateFlag.Name)
+		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(types.TraceTypeAsteriscKona), AsteriscPreStateFlag.Name)
 	}
 	return nil
 }
@@ -332,7 +333,7 @@ func CheckAsteriscKonaFlags(ctx *cli.Context) error {
 		return fmt.Errorf("flag %s is required", AsteriscKonaServerFlag.Name)
 	}
 	if !PreStatesURLFlag.IsSet(ctx, types.TraceTypeAsteriscKona) && !ctx.IsSet(AsteriscKonaPreStateFlag.Name) {
-		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.DefaultName(), AsteriscKonaPreStateFlag.Name)
+		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(types.TraceTypeAsteriscKona), AsteriscKonaPreStateFlag.Name)
 	}
 	return nil
 }

--- a/op-challenger/flags/vm_flag.go
+++ b/op-challenger/flags/vm_flag.go
@@ -34,7 +34,7 @@ func (f *VMFlag) Flags() []cli.Flag {
 	defaultEnvVar := opservice.FlagNameToEnvVarName(f.name, f.envVarPrefix)
 	flags = append(flags, f.flagCreator(f.name, []string{defaultEnvVar}, ""))
 	for _, vm := range f.vms {
-		name := f.flagName(vm)
+		name := f.TraceSpecificFlagName(vm)
 		envVar := opservice.FlagNameToEnvVarName(name, f.envVarPrefix)
 		flags = append(flags, f.flagCreator(name, []string{envVar}, fmt.Sprintf("(%v trace type only)", vm)))
 	}
@@ -46,11 +46,11 @@ func (f *VMFlag) DefaultName() string {
 }
 
 func (f *VMFlag) IsSet(ctx *cli.Context, vm types.TraceType) bool {
-	return ctx.IsSet(f.flagName(vm)) || ctx.IsSet(f.name)
+	return ctx.IsSet(f.TraceSpecificFlagName(vm)) || ctx.IsSet(f.name)
 }
 
 func (f *VMFlag) String(ctx *cli.Context, vm types.TraceType) string {
-	val := ctx.String(f.flagName(vm))
+	val := ctx.String(f.TraceSpecificFlagName(vm))
 	if val == "" {
 		val = ctx.String(f.name)
 	}
@@ -58,13 +58,13 @@ func (f *VMFlag) String(ctx *cli.Context, vm types.TraceType) string {
 }
 
 func (f *VMFlag) SourceFlagName(ctx *cli.Context, vm types.TraceType) string {
-	vmFlag := f.flagName(vm)
+	vmFlag := f.TraceSpecificFlagName(vm)
 	if ctx.IsSet(vmFlag) {
 		return vmFlag
 	}
 	return f.name
 }
 
-func (f *VMFlag) flagName(vm types.TraceType) string {
+func (f *VMFlag) TraceSpecificFlagName(vm types.TraceType) string {
 	return fmt.Sprintf("%v-%v", vm, f.name)
 }

--- a/op-challenger/flags/vm_flag.go
+++ b/op-challenger/flags/vm_flag.go
@@ -65,6 +65,10 @@ func (f *VMFlag) SourceFlagName(ctx *cli.Context, vm types.TraceType) string {
 	return f.name
 }
 
+func (f *VMFlag) EitherFlagName(vm types.TraceType) string {
+	return fmt.Sprintf("%s/%s", f.DefaultName(), f.TraceSpecificFlagName(vm))
+}
+
 func (f *VMFlag) TraceSpecificFlagName(vm types.TraceType) string {
 	return fmt.Sprintf("%v-%v", vm, f.name)
 }


### PR DESCRIPTION
**Description**

Prepare for supporting multiple L2s in op-challenger by simplifying the flags and validation code to reduce duplication.

* Validation for VM settings moved to `vm.Config.Check` to remove duplication
* Remove the deprecated flags, `--cannon-network`, `--asterisc-network` and `--cannon-l2`
* Use VMFlags for rollup config and l2-genesis rather than independently defining flags for each game type.

**Tests**

Updated unit tests.
