### PR TITLE
op-chain-ops: draft of build-dev support for op-e2e

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -41,6 +41,7 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 	}
 
 	l1Host := CreateL1(logger, fa, srcFS, cfg.L1)
+	l1Host.EnforceMaxCodeSize(false) // op-e2e with dev contracts
 	if err := l1Host.EnableCheats(); err != nil {
 		return nil, nil, fmt.Errorf("failed to enable cheats in L1 state: %w", err)
 	}
@@ -85,6 +86,7 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 
 	for l2ChainID, l2Cfg := range cfg.L2s {
 		l2Host := CreateL2(logger, fa, srcFS, l2Cfg, genesisTimestamp)
+		l2Host.EnforceMaxCodeSize(false) // op-e2e with dev contracts
 		if err := l2Host.EnableCheats(); err != nil {
 			return nil, nil, fmt.Errorf("failed to enable cheats in L2 state %s: %w", l2ChainID, err)
 		}

--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -777,8 +777,11 @@ func (h *Host) ScriptBackendFn(to common.Address) CallBackendFn {
 
 // EnforceMaxCodeSize configures the EVM to enforce (if true), or not enforce (if false),
 // the maximum contract bytecode size.
-func (h *Host) EnforceMaxCodeSize(v bool) {
+// Returns the previous setting, to roll back max-code-size changes easily.
+func (h *Host) EnforceMaxCodeSize(v bool) (prev bool) {
+	prev = !h.env.Config.NoMaxCodeSize
 	h.env.Config.NoMaxCodeSize = !v
+	return prev
 }
 
 // LogCallStack is a convenience method for debugging,

--- a/op-chain-ops/script/with.go
+++ b/op-chain-ops/script/with.go
@@ -44,9 +44,10 @@ func WithScript[B any](h *Host, name string, contract string) (b *B, cleanup fun
 		return nil, nil, fmt.Errorf("failed to make bindings: %w", err)
 	}
 
-	// Scripts can be very large
-	h.EnforceMaxCodeSize(false)
-	defer h.EnforceMaxCodeSize(true)
+	// Scripts can be very large, so disable the maximum code-size.
+	// And revert back the code-size setting to what it was previously.
+	prev := h.EnforceMaxCodeSize(false)
+	defer h.EnforceMaxCodeSize(prev)
 	// deploy the script contract
 	deployedAddr, err := h.Create(deployer, artifact.Bytecode.Object)
 	if err != nil {

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -288,6 +288,13 @@ func ApplyPipeline(
 		return fmt.Errorf("invalid deployment target: '%s'", opts.DeploymentTarget)
 	}
 
+	// TODO: make this an optional thing. Behind an optional intent setting maybe.
+	// And then make the op-e2e setup that generates the allocs use the setting to disable code-size.
+	// TODO: or alternatively, maybe we can read the artifacts, and determine if they were built in dev mode? (no optimizations enabled?)
+
+	// This allows `just build-dev` contracts to be executed
+	l1Host.EnforceMaxCodeSize(false)
+
 	pEnv := &pipeline.Env{
 		StateWriter:  opts.StateWriter,
 		L1ScriptHost: l1Host,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We can support `just build-dev` (compiles contracts much faster) by disabling code-size checks during deployment. This won't work for live chain deployments, but does work for genesis deployment. After being initialized, the contract size is not checked by the ethereum protocol.

This PR aims to support this for op-e2e, such that allocs from a `just build-dev` work.

TODO: see TODO comments in the code. I am not sure what is the best way to add the option to op-deployer.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
