### PR TITLE
chore(op-challenger): Update kona executor to use subcommand

### DIFF
--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -25,6 +25,7 @@ func NewNativeKonaExecutor() *KonaExecutor {
 func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
 	args := []string{
 		cfg.Server,
+		"single",
 		"--l1-node-address", cfg.L1,
 		"--l1-beacon-address", cfg.L1Beacon,
 		"--l2-node-address", cfg.L2,

--- a/op-challenger/game/fault/trace/vm/kona_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor_test.go
@@ -31,6 +31,7 @@ func TestKonaFillHostCommand(t *testing.T) {
 	args, err := vmConfig.OracleCommand(cfg, dir, inputs)
 	require.NoError(t, err)
 
+	require.True(t, slices.Contains(args, "single"))
 	require.True(t, slices.Contains(args, "--server"))
 	require.True(t, slices.Contains(args, "--l1-node-address"))
 	require.True(t, slices.Contains(args, "--l1-beacon-address"))


### PR DESCRIPTION
## Overview

Updates the `kona` executor in the `op-challenger` to use the `single` subcommand. This keeps action tests succeeding over in our repository while we sort out the interop mode of the host.