### PR TITLE
feat: NAT; comprehensive results

### DIFF
--- a/op-nat/cmd/main.go
+++ b/op-nat/cmd/main.go
@@ -49,7 +49,7 @@ func run(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, 
 
 	// TODO: map validators from flags
 	var validators = []nat.Validator{
-		&gates.Alphanet,
+		gates.Alphanet,
 	}
 
 	cfg, err := nat.NewConfig(ctx, validators)

--- a/op-nat/test.go
+++ b/op-nat/test.go
@@ -14,12 +14,20 @@ type Test struct {
 	Fn func(ctx context.Context, log log.Logger, cfg Config) (bool, error)
 }
 
-func (t Test) Run(ctx context.Context, log log.Logger, cfg Config) (bool, error) {
+func (t Test) Run(ctx context.Context, log log.Logger, cfg Config) (ValidatorResult, error) {
 	if t.Fn == nil {
-		return false, fmt.Errorf("test function is nil")
+		return ValidatorResult{
+			Passed: false,
+		}, fmt.Errorf("test function is nil")
 	}
 	log.Info("", "type", t.Type(), "id", t.Name())
-	return t.Fn(ctx, log, cfg)
+	passed, err := t.Fn(ctx, log, cfg)
+	return ValidatorResult{
+		ID:     t.ID,
+		Type:   t.Type(),
+		Error:  err,
+		Passed: passed,
+	}, err
 }
 
 // Name returns the id of the test.

--- a/op-nat/validator.go
+++ b/op-nat/validator.go
@@ -7,7 +7,15 @@ import (
 )
 
 type Validator interface {
-	Run(ctx context.Context, log log.Logger, cfg Config) (bool, error)
+	Run(ctx context.Context, log log.Logger, cfg Config) (ValidatorResult, error)
 	Name() string
 	Type() string
+}
+
+type ValidatorResult struct {
+	ID         string
+	Type       string
+	Passed     bool
+	Error      error
+	SubResults []ValidatorResult
 }


### PR DESCRIPTION
**Description**

- Bubbles up the validator results
- Prints a nice table (green for success, red for fail)

SUCCESS:
<img width="1237" alt="Screenshot 2025-01-15 at 14 26 20" src="https://github.com/user-attachments/assets/eeb4de95-1171-4e0e-8de4-5966270f92a9" />

FAIL:
<img width="1356" alt="Screenshot 2025-01-15 at 14 27 04" src="https://github.com/user-attachments/assets/91c75711-5c20-4166-942c-be8c73ac9d3f" />
