### PR TITLE
op-service: generic tx, raw json and opaque tx types 

### DIFF
--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -194,11 +194,25 @@ func (o *OpaqueTransaction) TxHash() common.Hash {
 }
 
 func (o *OpaqueTransaction) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("cannot marshal opaque transaction to JSON")
+	tx, err := o.Transaction()
+	if err != nil {
+		return nil, err
+	}
+	return tx.MarshalJSON()
 }
 
 func (o *OpaqueTransaction) UnmarshalJSON([]byte) error {
-	return fmt.Errorf("cannot unmarshal opaque transaction from JSON")
+	var tx types.Transaction
+	if err := tx.UnmarshalJSON(o.raw); err != nil {
+		return err
+	}
+	data, err := tx.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	o.raw = data
+	o.hash = tx.Hash()
+	return nil
 }
 
 func (o *OpaqueTransaction) MarshalBinary() ([]byte, error) {

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -120,8 +120,10 @@ func CheckRecentTxs(
 	return oldestBlock.Uint64(), false, nil
 }
 
+// GenericTx is a transaction that can be represent any EIP 2718 transaction https://eips.ethereum.org/EIPS/eip-2718,
+// including transactions that are not yet explicitly supported by the derivation pipeline.
 type GenericTx interface {
-	// Transaction tries to interpret into a typed tx.
+	// Transaction tries to interpret into a supported typed tx.
 	// This will return types.ErrTxTypeNotSupported if the transaction-type is not supported.
 	Transaction() (*types.Transaction, error)
 

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -188,7 +188,7 @@ func (o *OpaqueTransaction) TxType() uint8 {
 
 func (o *OpaqueTransaction) TxHash() common.Hash {
 	if (o.hash == common.Hash{}) {
-		o.hash = crypto.Keccak256Hash(o.raw[:])
+		o.hash = crypto.Keccak256Hash(o.raw)
 	}
 	return o.hash
 }

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -131,11 +132,11 @@ type GenericTx interface {
 
 	// MarshalJSON into RPC tx definition.
 	// Block metadata may or may not be included.
-	MarshalJSON() ([]byte, error)
+	json.Marshaler
 
 	// UnmarshalJSON into RPC tx definition.
 	// Block metadata is ignored.
-	UnmarshalJSON([]byte) error
+	json.Unmarshaler
 
 	// MarshalBinary as EIP-2718 opaque tx (including version byte).
 	MarshalBinary() ([]byte, error)

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -201,9 +201,9 @@ func (o *OpaqueTransaction) MarshalJSON() ([]byte, error) {
 	return tx.MarshalJSON()
 }
 
-func (o *OpaqueTransaction) UnmarshalJSON([]byte) error {
+func (o *OpaqueTransaction) UnmarshalJSON(data []byte) error {
 	var tx types.Transaction
-	if err := tx.UnmarshalJSON(o.raw); err != nil {
+	if err := tx.UnmarshalJSON(data); err != nil {
 		return err
 	}
 	data, err := tx.MarshalBinary()
@@ -221,6 +221,7 @@ func (o *OpaqueTransaction) MarshalBinary() ([]byte, error) {
 
 func (o *OpaqueTransaction) UnmarshalBinary(b []byte) error {
 	o.raw = bytes.Clone(b)
-	o.TxType()
+	o.TxHash() // cache the hash
+	o.TxType() // panics if the tx is not an EIP2718 tx
 	return nil
 }

--- a/op-service/eth/transactions_test.go
+++ b/op-service/eth/transactions_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -124,4 +125,19 @@ func TestTransactions_checkRecentTxs(t *testing.T) {
 			l1Client.AssertExpectations(t)
 		})
 	}
+}
+
+func TestOpaqueTransaction(t *testing.T) {
+	encodedDynamicFeeTx, err := hexutil.Decode("0x02f8af017b830186a0830f4240825dc094c00e5d67c2755389aded7d8b151cbd5bcdf7ed278301e2408b68656c6c6f20776f726c64f838f7945ad5e028b664880fc7581c77547deaf776200434e1a095b358675999c4b7338ff339566349ed0ef6384876655d1b9b955e36ac165c6b80a06c33b333151b99d601320ca7f05ccb5597b9bbf1db299a63a61a780d081622f0a00ddade96dd1f0df1f67a5879b8cb06c3310818be6a2fc7d746fd73e300253b96")
+	require.NoError(t, err)
+	o := new(OpaqueTransaction)
+	o.UnmarshalBinary([]byte(encodedDynamicFeeTx))
+	require.Equal(t, uint8(2), o.TxType())
+
+	reSerialized, err := o.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, encodedDynamicFeeTx, reSerialized)
+
+	expectedHash := common.HexToHash("0x6a1d6ffccedd6b9b53e1e81fc625cdd1ad1e48993b6c6d6ee58df55245271dc3")
+	require.Equal(t, expectedHash, o.TxHash())
 }

--- a/op-service/eth/transactions_test.go
+++ b/op-service/eth/transactions_test.go
@@ -140,7 +140,8 @@ func TestOpaqueTransaction(t *testing.T) {
 
 	// Binary Unmarshal / Marshal roundtrip
 	o := new(OpaqueTransaction)
-	o.UnmarshalBinary(encodedDynamicFeeTx)
+	err = o.UnmarshalBinary(encodedDynamicFeeTx)
+	require.NoError(t, err)
 	require.Equal(t, uint8(2), o.TxType())
 
 	reSerialized, err := o.MarshalBinary()
@@ -165,7 +166,8 @@ func TestOpaqueTransaction(t *testing.T) {
 
 	// Binary Unmarshal / Marshal roundtrip
 	p := new(OpaqueTransaction)
-	p.UnmarshalBinary(hypotheticalTxBytes)
+	err = p.UnmarshalBinary(hypotheticalTxBytes)
+	require.NoError(t, err)
 	require.Equal(t, uint8(102), p.TxType())
 
 	reSerialized, err = p.MarshalBinary()

--- a/op-service/eth/transactions_test.go
+++ b/op-service/eth/transactions_test.go
@@ -131,7 +131,6 @@ func TestTransactions_checkRecentTxs(t *testing.T) {
 }
 
 func TestOpaqueTransaction(t *testing.T) {
-
 	// Prepare binary encoding of a DynamicFeeTx
 	rng := rand.New(rand.NewSource(1234))
 	tx := testutils.RandomDynamicFeeTx(rng, testutils.RandomSigner(rng))
@@ -182,4 +181,6 @@ func TestOpaqueTransaction(t *testing.T) {
 	extractedTx, err = p.Transaction()
 	require.Nil(t, extractedTx)
 	require.Error(t, err)
+
+	// TODO add coverage for JSON marshalling / unmarshalling
 }

--- a/op-service/eth/transactions_test.go
+++ b/op-service/eth/transactions_test.go
@@ -178,7 +178,7 @@ func TestOpaqueTransaction(t *testing.T) {
 
 			if !tc.eip2718 {
 				require.Panics(t, func() {
-					o.UnmarshalBinary(tc.rawTx)
+					_ = o.UnmarshalBinary(tc.rawTx)
 				})
 				return
 			}

--- a/op-service/sources/transaction.go
+++ b/op-service/sources/transaction.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,8 +18,7 @@ type RawJsonTransaction struct {
 	raw    json.RawMessage
 }
 
-var _ json.Marshaler = (*RawJsonTransaction)(nil)
-var _ json.Unmarshaler = (*RawJsonTransaction)(nil)
+var _ eth.GenericTx = (*RawJsonTransaction)(nil)
 
 // Transaction tries to interpret into a typed tx.
 // This will return types.ErrTxTypeNotSupported if the transaction-type is not supported.

--- a/op-service/sources/transaction.go
+++ b/op-service/sources/transaction.go
@@ -58,8 +58,8 @@ func (m *RawJsonTransaction) UnmarshalJSON(data []byte) error {
 	if x.Hash == (common.Hash{}) {
 		return errors.New("expected hash attribute")
 	}
-	if x.Type > 0xff {
-		return fmt.Errorf("unexpectedly large tx type: %d", uint64(x.Type))
+	if x.Type >= 0xff || (x.Type < 0xc0 && x.Type > 0x7f) {
+		return fmt.Errorf("cannot decode into an EIP-2718 transaction: TransactionType: %d", uint64(x.Type))
 	}
 	m.raw = bytes.Clone(data)
 	m.txHash = x.Hash

--- a/op-service/sources/transaction_test.go
+++ b/op-service/sources/transaction_test.go
@@ -48,7 +48,10 @@ func TestRawJsonTransaction(t *testing.T) {
 
 	// Test json round trip
 	var flexTx RawJsonTransaction
+
+	// Takes JSON encoded DynamicFeeTx and converts it to RawJsonTransaction:
 	require.NoError(t, json.Unmarshal(txJson, &flexTx))
+	// Takes RawJsonTransaction and JSON encodes it (uses cached raw JSON from the unmarshalling step):
 	reEncoded, err := json.Marshal(&flexTx)
 	require.NoError(t, err)
 	require.Equal(t, hexutil.Bytes(txJson), hexutil.Bytes(reEncoded))
@@ -57,10 +60,17 @@ func TestRawJsonTransaction(t *testing.T) {
 	require.Equal(t, tx.Type(), flexTx.TxType())
 
 	// Test binary round trip
+	// Takes RawJsonTransaction and converts it to binary, this requires the tx to be one of the supported types:
 	data, err := flexTx.MarshalBinary()
 	require.NoError(t, err)
+	t.Log(hexutil.Encode(data))
+	t.Log(tx.Hash(), flexTx.TxHash())
+
+	// Unmarshal the binary data back into a new RawJsonTransaction, again this requires it to be one of the supported types:
 	var reDecoded RawJsonTransaction
 	require.NoError(t, reDecoded.UnmarshalBinary(data))
+
+	// Re-encode the RawJsonTransaction as JSON:
 	jsonAgain, err := json.Marshal(&reDecoded)
 	require.NoError(t, err)
 	require.Equal(t, hexutil.Bytes(txJson), hexutil.Bytes(jsonAgain))

--- a/op-service/sources/transaction_test.go
+++ b/op-service/sources/transaction_test.go
@@ -2,46 +2,20 @@ package sources
 
 import (
 	"encoding/json"
-	"math/big"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 func TestRawJsonTransaction(t *testing.T) {
-
-	key := testutils.RandomKey()
-	chainID := big.NewInt(1)
-	signer := types.LatestSignerForChainID(chainID)
 	rng := rand.New(rand.NewSource(1234))
-	to := testutils.RandomAddress(rng)
-	txInner := &types.DynamicFeeTx{
-		ChainID:   chainID,
-		Nonce:     uint64(123),
-		GasTipCap: big.NewInt(100_000),
-		GasFeeCap: big.NewInt(1000_000),
-		Gas:       24_000,
-		To:        &to,
-		Value:     big.NewInt(123456),
-		Data:      []byte("hello world"),
-		AccessList: types.AccessList{
-			types.AccessTuple{
-				Address: testutils.RandomAddress(rng),
-				StorageKeys: []common.Hash{
-					testutils.RandomHash(rng),
-				},
-			},
-		},
-	}
-	tx, err := types.SignNewTx(key, signer, txInner)
-	require.NoError(t, err)
+	tx := testutils.RandomDynamicFeeTx(rng, testutils.RandomSigner(rng))
+
 	txJson, err := json.Marshal(tx)
 	require.NoError(t, err)
 	t.Log(string(txJson))

--- a/op-service/testutils/random.go
+++ b/op-service/testutils/random.go
@@ -282,9 +282,13 @@ func RandomBlock(rng *rand.Rand, txCount uint64) (*types.Block, []*types.Receipt
 	return RandomBlockPrependTxs(rng, int(txCount))
 }
 
+func RandomSigner(rng *rand.Rand) types.Signer {
+	return types.NewLondonSigner(big.NewInt(rng.Int63n(1000)))
+}
+
 func RandomBlockPrependTxsWithTime(rng *rand.Rand, txCount int, t uint64, ptxs ...*types.Transaction) (*types.Block, []*types.Receipt) {
 	header := RandomHeaderWithTime(rng, t)
-	signer := types.NewLondonSigner(big.NewInt(rng.Int63n(1000)))
+	signer := RandomSigner(rng)
 	txs := make([]*types.Transaction, 0, txCount+len(ptxs))
 	txs = append(txs, ptxs...)
 	for i := 0; i < txCount; i++ {


### PR DESCRIPTION
Replaces https://github.com/ethereum-optimism/optimism/pull/13628. Towards #13627 

(Please check base branch)

TODO 
- [x] tidy up unit tests
- [x] godoc for GenericTx interface
- [x] start experimenting with integrating into op-node derivation pipeline (see here https://github.com/ethereum-optimism/optimism/pull/13816)