### PR TITLE
op-supervisor: Move ChainID and SuperRootResponse to op-service eth package

### DIFF
--- a/op-e2e/actions/interop/interop.go
+++ b/op-e2e/actions/interop/interop.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,7 @@ const (
 
 // Chain holds the most common per-chain action-test data and actors
 type Chain struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 
 	RollupCfg   *rollup.Config
 	L2Genesis   *core.Genesis
@@ -148,9 +149,9 @@ func (sa *SupervisorActor) SignalFinalizedL1(t helpers.Testing) {
 
 // worldToDepSet converts a set of chain configs into a dependency-set for the supervisor.
 func worldToDepSet(t helpers.Testing, worldOutput *interopgen.WorldOutput) *depset.StaticConfigDependencySet {
-	depSetCfg := make(map[types.ChainID]*depset.StaticConfigDependency)
+	depSetCfg := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for _, out := range worldOutput.L2s {
-		depSetCfg[types.ChainIDFromBig(out.Genesis.Config.ChainID)] = &depset.StaticConfigDependency{
+		depSetCfg[eth.ChainIDFromBig(out.Genesis.Config.ChainID)] = &depset.StaticConfigDependency{
 			ChainIndex:     types.ChainIndex(out.Genesis.Config.ChainID.Uint64()),
 			ActivationTime: 0,
 			HistoryMinTime: 0,
@@ -231,7 +232,7 @@ func createL2Services(
 		eng.EthClient(), eng.EngineClient(t, output.RollupCfg))
 
 	return &Chain{
-		ChainID:         types.ChainIDFromBig(output.Genesis.Config.ChainID),
+		ChainID:         eth.ChainIDFromBig(output.Genesis.Config.ChainID),
 		RollupCfg:       output.RollupCfg,
 		L2Genesis:       output.Genesis,
 		BatcherAddr:     crypto.PubkeyToAddress(batcherKey.PublicKey),

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
@@ -198,7 +199,7 @@ func TestInterop_EmitLogs(t *testing.T) {
 				BlockNumber: log.BlockNumber,
 				LogIndex:    uint32(log.Index),
 				Timestamp:   block.Time(),
-				ChainID:     types.ChainIDFromBig(s2.ChainID(chainID)),
+				ChainID:     eth.ChainIDFromBig(s2.ChainID(chainID)),
 			}
 			return identifier, expectedHash
 		}
@@ -290,7 +291,7 @@ func TestInteropBlockBuilding(t *testing.T) {
 			BlockNumber: ev.BlockNumber,
 			LogIndex:    uint32(ev.Index),
 			Timestamp:   header.Time,
-			ChainID:     types.ChainIDFromBig(s2.ChainID(chainA)),
+			ChainID:     eth.ChainIDFromBig(s2.ChainID(chainA)),
 		}
 
 		msgPayload := types.LogToMessagePayload(ev)

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -485,11 +486,11 @@ func (s *interopE2ESystem) prepareSupervisor() *supervisor.SupervisorService {
 		L1RPC:       s.l1.UserRPC().RPC(),
 		Datadir:     path.Join(s.t.TempDir(), "supervisor"),
 	}
-	depSet := make(map[supervisortypes.ChainID]*depset.StaticConfigDependency)
+	depSet := make(map[eth.ChainID]*depset.StaticConfigDependency)
 
 	// Iterate over the L2 chain configs. The L2 nodes don't exist yet.
 	for _, l2Out := range s.worldOutput.L2s {
-		chainID := supervisortypes.ChainIDFromBig(l2Out.Genesis.Config.ChainID)
+		chainID := eth.ChainIDFromBig(l2Out.Genesis.Config.ChainID)
 		index, err := chainID.ToUInt32()
 		require.NoError(s.t, err)
 		depSet[chainID] = &depset.StaticConfigDependency{

--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -51,7 +51,7 @@ func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num uint64) (eth.Blo
 	return ib.backend.BlockRefByNumber(ctx, num)
 }
 
-func (ib *InteropAPI) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
+func (ib *InteropAPI) ChainID(ctx context.Context) (eth.ChainID, error) {
 	return ib.backend.ChainID(ctx)
 }
 

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -276,8 +276,8 @@ func (m *ManagedMode) BlockRefByNumber(ctx context.Context, num uint64) (eth.Blo
 	return m.l2.BlockRefByNumber(ctx, num)
 }
 
-func (m *ManagedMode) ChainID(ctx context.Context) (supervisortypes.ChainID, error) {
-	return supervisortypes.ChainIDFromBig(m.cfg.L2ChainID), nil
+func (m *ManagedMode) ChainID(ctx context.Context) (eth.ChainID, error) {
+	return eth.ChainIDFromBig(m.cfg.L2ChainID), nil
 }
 
 func (m *ManagedMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {

--- a/op-service/eth/chain_id.go
+++ b/op-service/eth/chain_id.go
@@ -1,0 +1,57 @@
+package eth
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/holiman/uint256"
+)
+
+type ChainID uint256.Int
+
+func ChainIDFromBig(chainID *big.Int) ChainID {
+	return ChainID(*uint256.MustFromBig(chainID))
+}
+
+func ChainIDFromUInt64(i uint64) ChainID {
+	return ChainID(*uint256.NewInt(i))
+}
+
+func (id ChainID) String() string {
+	return ((*uint256.Int)(&id)).Dec()
+}
+
+func (id ChainID) ToUInt32() (uint32, error) {
+	v := (*uint256.Int)(&id)
+	if !v.IsUint64() {
+		return 0, fmt.Errorf("ChainID too large for uint32: %v", id)
+	}
+	v64 := v.Uint64()
+	if v64 > math.MaxUint32 {
+		return 0, fmt.Errorf("ChainID too large for uint32: %v", id)
+	}
+	return uint32(v64), nil
+}
+
+func (id *ChainID) ToBig() *big.Int {
+	return (*uint256.Int)(id).ToBig()
+}
+
+func (id ChainID) MarshalText() ([]byte, error) {
+	return []byte(id.String()), nil
+}
+
+func (id *ChainID) UnmarshalText(data []byte) error {
+	var x uint256.Int
+	err := x.UnmarshalText(data)
+	if err != nil {
+		return err
+	}
+	*id = ChainID(x)
+	return nil
+}
+
+func (id ChainID) Cmp(other ChainID) int {
+	return (*uint256.Int)(&id).Cmp((*uint256.Int)(&other))
+}

--- a/op-service/eth/chain_id_test.go
+++ b/op-service/eth/chain_id_test.go
@@ -1,0 +1,41 @@
+package eth
+
+import (
+	"math"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainID_String(t *testing.T) {
+	tests := []struct {
+		input    ChainID
+		expected string
+	}{
+		{ChainIDFromUInt64(0), "0"},
+		{ChainIDFromUInt64(1), "1"},
+		{ChainIDFromUInt64(871975192374), "871975192374"},
+		{ChainIDFromUInt64(math.MaxInt64), "9223372036854775807"},
+		{ChainID(*uint256.NewInt(math.MaxUint64)), "18446744073709551615"},
+		{ChainID(*uint256.MustFromDecimal("1844674407370955161618446744073709551616")), "1844674407370955161618446744073709551616"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.expected, func(t *testing.T) {
+			t.Run("String", func(t *testing.T) {
+				require.Equal(t, test.expected, test.input.String())
+			})
+			t.Run("MarshalText", func(t *testing.T) {
+				data, err := test.input.MarshalText()
+				require.NoError(t, err)
+				require.Equal(t, test.expected, string(data))
+			})
+			t.Run("UnmarshalText", func(t *testing.T) {
+				var id ChainID
+				require.NoError(t, id.UnmarshalText([]byte(test.expected)))
+				require.Equal(t, test.input, id)
+			})
+		})
+	}
+}

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -77,7 +77,7 @@ func (cl *SupervisorClient) CheckMessage(ctx context.Context, identifier types.I
 	return result, nil
 }
 
-func (cl *SupervisorClient) UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
+func (cl *SupervisorClient) UnsafeView(ctx context.Context, chainID eth.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
 	var result types.ReferenceView
 	err := cl.client.CallContext(
 		ctx,
@@ -91,7 +91,7 @@ func (cl *SupervisorClient) UnsafeView(ctx context.Context, chainID types.ChainI
 	return result, nil
 }
 
-func (cl *SupervisorClient) SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
+func (cl *SupervisorClient) SafeView(ctx context.Context, chainID eth.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
 	var result types.ReferenceView
 	err := cl.client.CallContext(
 		ctx,
@@ -105,7 +105,7 @@ func (cl *SupervisorClient) SafeView(ctx context.Context, chainID types.ChainID,
 	return result, nil
 }
 
-func (cl *SupervisorClient) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (cl *SupervisorClient) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	var result eth.BlockID
 	err := cl.client.CallContext(
 		ctx,
@@ -124,7 +124,7 @@ func (cl *SupervisorClient) FinalizedL1(ctx context.Context) (eth.BlockRef, erro
 	return result, err
 }
 
-func (cl *SupervisorClient) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.BlockRef, error) {
+func (cl *SupervisorClient) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (eth.BlockRef, error) {
 	var result eth.BlockRef
 	err := cl.client.CallContext(
 		ctx,
@@ -135,7 +135,7 @@ func (cl *SupervisorClient) CrossDerivedFrom(ctx context.Context, chainID types.
 	return result, err
 }
 
-func (cl *SupervisorClient) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
+func (cl *SupervisorClient) UpdateLocalUnsafe(ctx context.Context, chainID eth.ChainID, head eth.BlockRef) error {
 	return cl.client.CallContext(
 		ctx,
 		nil,
@@ -144,7 +144,7 @@ func (cl *SupervisorClient) UpdateLocalUnsafe(ctx context.Context, chainID types
 		head)
 }
 
-func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
+func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID eth.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 	return cl.client.CallContext(
 		ctx,
 		nil,
@@ -154,8 +154,8 @@ func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID types.C
 		lastDerived)
 }
 
-func (cl *SupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
-	var result types.SuperRootResponse
+func (cl *SupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
+	var result eth.SuperRootResponse
 	err := cl.client.CallContext(
 		ctx,
 		&result,

--- a/op-service/testutils/fake_interop_backend.go
+++ b/op-service/testutils/fake_interop_backend.go
@@ -8,39 +8,39 @@ import (
 )
 
 type FakeInteropBackend struct {
-	UnsafeViewFn        func(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error)
-	SafeViewFn          func(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error)
-	FinalizedFn         func(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
-	DerivedFromFn       func(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error)
-	UpdateLocalUnsafeFn func(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error
-	UpdateLocalSafeFn   func(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error
-	UpdateFinalizedL1Fn func(ctx context.Context, chainID types.ChainID, finalized eth.L1BlockRef) error
+	UnsafeViewFn        func(ctx context.Context, chainID eth.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error)
+	SafeViewFn          func(ctx context.Context, chainID eth.ChainID, safe types.ReferenceView) (types.ReferenceView, error)
+	FinalizedFn         func(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
+	DerivedFromFn       func(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (eth.L1BlockRef, error)
+	UpdateLocalUnsafeFn func(ctx context.Context, chainID eth.ChainID, head eth.BlockRef) error
+	UpdateLocalSafeFn   func(ctx context.Context, chainID eth.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error
+	UpdateFinalizedL1Fn func(ctx context.Context, chainID eth.ChainID, finalized eth.L1BlockRef) error
 }
 
-func (m *FakeInteropBackend) UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
+func (m *FakeInteropBackend) UnsafeView(ctx context.Context, chainID eth.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
 	return m.UnsafeViewFn(ctx, chainID, unsafe)
 }
 
-func (m *FakeInteropBackend) SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
+func (m *FakeInteropBackend) SafeView(ctx context.Context, chainID eth.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
 	return m.SafeViewFn(ctx, chainID, safe)
 }
 
-func (m *FakeInteropBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (m *FakeInteropBackend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return m.FinalizedFn(ctx, chainID)
 }
 
-func (m *FakeInteropBackend) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
+func (m *FakeInteropBackend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
 	return m.DerivedFromFn(ctx, chainID, derived)
 }
 
-func (m *FakeInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
+func (m *FakeInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID eth.ChainID, head eth.BlockRef) error {
 	return m.UpdateLocalUnsafeFn(ctx, chainID, head)
 }
 
-func (m *FakeInteropBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
+func (m *FakeInteropBackend) UpdateLocalSafe(ctx context.Context, chainID eth.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 	return m.UpdateLocalSafeFn(ctx, chainID, derivedFrom, lastDerived)
 }
 
-func (m *FakeInteropBackend) UpdateFinalizedL1(ctx context.Context, chainID types.ChainID, finalized eth.L1BlockRef) error {
+func (m *FakeInteropBackend) UpdateFinalizedL1(ctx context.Context, chainID eth.ChainID, finalized eth.L1BlockRef) error {
 	return m.UpdateFinalizedL1Fn(ctx, chainID, finalized)
 }

--- a/op-service/testutils/mock_interop_backend.go
+++ b/op-service/testutils/mock_interop_backend.go
@@ -13,16 +13,16 @@ type MockInteropBackend struct {
 	Mock mock.Mock
 }
 
-func (m *MockInteropBackend) UnsafeView(ctx context.Context, chainID types.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
+func (m *MockInteropBackend) UnsafeView(ctx context.Context, chainID eth.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
 	result := m.Mock.MethodCalled("UnsafeView", chainID, unsafe)
 	return result.Get(0).(types.ReferenceView), *result.Get(1).(*error)
 }
 
-func (m *MockInteropBackend) ExpectUnsafeView(chainID types.ChainID, unsafe types.ReferenceView, result types.ReferenceView, err error) {
+func (m *MockInteropBackend) ExpectUnsafeView(chainID eth.ChainID, unsafe types.ReferenceView, result types.ReferenceView, err error) {
 	m.Mock.On("UnsafeView", chainID, unsafe).Once().Return(result, &err)
 }
 
-func (m *MockInteropBackend) OnUnsafeView(chainID types.ChainID, fn func(request types.ReferenceView) (result types.ReferenceView, err error)) {
+func (m *MockInteropBackend) OnUnsafeView(chainID eth.ChainID, fn func(request types.ReferenceView) (result types.ReferenceView, err error)) {
 	var result types.ReferenceView
 	var err error
 	m.Mock.On("UnsafeView", chainID, mock.Anything).Run(func(args mock.Arguments) {
@@ -31,16 +31,16 @@ func (m *MockInteropBackend) OnUnsafeView(chainID types.ChainID, fn func(request
 	}).Return(result, &err)
 }
 
-func (m *MockInteropBackend) SafeView(ctx context.Context, chainID types.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
+func (m *MockInteropBackend) SafeView(ctx context.Context, chainID eth.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
 	result := m.Mock.MethodCalled("SafeView", chainID, safe)
 	return result.Get(0).(types.ReferenceView), *result.Get(1).(*error)
 }
 
-func (m *MockInteropBackend) ExpectSafeView(chainID types.ChainID, safe types.ReferenceView, result types.ReferenceView, err error) {
+func (m *MockInteropBackend) ExpectSafeView(chainID eth.ChainID, safe types.ReferenceView, result types.ReferenceView, err error) {
 	m.Mock.On("SafeView", chainID, safe).Once().Return(result, &err)
 }
 
-func (m *MockInteropBackend) OnSafeView(chainID types.ChainID, fn func(request types.ReferenceView) (result types.ReferenceView, err error)) {
+func (m *MockInteropBackend) OnSafeView(chainID eth.ChainID, fn func(request types.ReferenceView) (result types.ReferenceView, err error)) {
 	var result types.ReferenceView
 	var err error
 	m.Mock.On("SafeView", chainID, mock.Anything).Run(func(args mock.Arguments) {
@@ -49,47 +49,47 @@ func (m *MockInteropBackend) OnSafeView(chainID types.ChainID, fn func(request t
 	}).Return(result, &err)
 }
 
-func (m *MockInteropBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (m *MockInteropBackend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	result := m.Mock.MethodCalled("Finalized", chainID)
 	return result.Get(0).(eth.BlockID), *result.Get(1).(*error)
 }
 
-func (m *MockInteropBackend) ExpectFinalized(chainID types.ChainID, result eth.BlockID, err error) {
+func (m *MockInteropBackend) ExpectFinalized(chainID eth.ChainID, result eth.BlockID, err error) {
 	m.Mock.On("Finalized", chainID).Once().Return(result, &err)
 }
 
-func (m *MockInteropBackend) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
+func (m *MockInteropBackend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (eth.L1BlockRef, error) {
 	result := m.Mock.MethodCalled("CrossDerivedFrom", chainID, derived)
 	return result.Get(0).(eth.L1BlockRef), *result.Get(1).(*error)
 }
 
-func (m *MockInteropBackend) ExpectDerivedFrom(chainID types.ChainID, derived eth.BlockID, result eth.L1BlockRef, err error) {
+func (m *MockInteropBackend) ExpectDerivedFrom(chainID eth.ChainID, derived eth.BlockID, result eth.L1BlockRef, err error) {
 	m.Mock.On("CrossDerivedFrom", chainID, derived).Once().Return(result, &err)
 }
 
-func (m *MockInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID types.ChainID, head eth.BlockRef) error {
+func (m *MockInteropBackend) UpdateLocalUnsafe(ctx context.Context, chainID eth.ChainID, head eth.BlockRef) error {
 	result := m.Mock.MethodCalled("UpdateLocalUnsafe", chainID, head)
 	return *result.Get(0).(*error)
 }
 
-func (m *MockInteropBackend) ExpectUpdateLocalUnsafe(chainID types.ChainID, head eth.BlockRef, err error) {
+func (m *MockInteropBackend) ExpectUpdateLocalUnsafe(chainID eth.ChainID, head eth.BlockRef, err error) {
 	m.Mock.On("UpdateLocalUnsafe", chainID, head).Once().Return(&err)
 }
 
-func (m *MockInteropBackend) ExpectAnyUpdateLocalUnsafe(chainID types.ChainID, err error) {
+func (m *MockInteropBackend) ExpectAnyUpdateLocalUnsafe(chainID eth.ChainID, err error) {
 	m.Mock.On("UpdateLocalUnsafe", chainID, mock.Anything).Once().Return(&err)
 }
 
-func (m *MockInteropBackend) UpdateLocalSafe(ctx context.Context, chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
+func (m *MockInteropBackend) UpdateLocalSafe(ctx context.Context, chainID eth.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
 	result := m.Mock.MethodCalled("UpdateLocalSafe", chainID, derivedFrom, lastDerived)
 	return *result.Get(0).(*error)
 }
 
-func (m *MockInteropBackend) ExpectUpdateLocalSafe(chainID types.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef, err error) {
+func (m *MockInteropBackend) ExpectUpdateLocalSafe(chainID eth.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef, err error) {
 	m.Mock.On("UpdateLocalSafe", chainID, derivedFrom, lastDerived).Once().Return(&err)
 }
 
-func (m *MockInteropBackend) UpdateFinalizedL1(ctx context.Context, chainID types.ChainID, finalized eth.L1BlockRef) error {
+func (m *MockInteropBackend) UpdateFinalizedL1(ctx context.Context, chainID eth.ChainID, finalized eth.L1BlockRef) error {
 	result := m.Mock.MethodCalled("UpdateFinalizedL1", chainID, finalized)
 	return *result.Get(0).(*error)
 }

--- a/op-supervisor/config/config_test.go
+++ b/op-supervisor/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -10,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestDefaultConfigIsValid(t *testing.T) {
@@ -57,8 +57,8 @@ func TestValidateRPCConfig(t *testing.T) {
 }
 
 func validConfig() *Config {
-	depSet, err := depset.NewStaticConfigDependencySet(map[types.ChainID]*depset.StaticConfigDependency{
-		types.ChainIDFromUInt64(900): &depset.StaticConfigDependency{
+	depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+		eth.ChainIDFromUInt64(900): &depset.StaticConfigDependency{
 			ChainIndex:     900,
 			ActivationTime: 0,
 			HistoryMinTime: 0,

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -1,10 +1,10 @@
 package metrics
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/prometheus/client_golang/prometheus"
 
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 const Namespace = "op_supervisor"
@@ -15,11 +15,11 @@ type Metricer interface {
 
 	opmetrics.RPCMetricer
 
-	CacheAdd(chainID types.ChainID, label string, cacheSize int, evicted bool)
-	CacheGet(chainID types.ChainID, label string, hit bool)
+	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
+	CacheGet(chainID eth.ChainID, label string, hit bool)
 
-	RecordDBEntryCount(chainID types.ChainID, kind string, count int64)
-	RecordDBSearchEntriesRead(chainID types.ChainID, count int64)
+	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
+	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
 
 	Document() []opmetrics.DocumentedMetric
 }
@@ -141,7 +141,7 @@ func (m *Metrics) RecordUp() {
 	m.up.Set(1)
 }
 
-func (m *Metrics) CacheAdd(chainID types.ChainID, label string, cacheSize int, evicted bool) {
+func (m *Metrics) CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool) {
 	chain := chainIDLabel(chainID)
 	m.CacheSizeVec.WithLabelValues(chain, label).Set(float64(cacheSize))
 	if evicted {
@@ -151,7 +151,7 @@ func (m *Metrics) CacheAdd(chainID types.ChainID, label string, cacheSize int, e
 	}
 }
 
-func (m *Metrics) CacheGet(chainID types.ChainID, label string, hit bool) {
+func (m *Metrics) CacheGet(chainID eth.ChainID, label string, hit bool) {
 	chain := chainIDLabel(chainID)
 	if hit {
 		m.CacheGetVec.WithLabelValues(chain, label, "true").Inc()
@@ -160,14 +160,14 @@ func (m *Metrics) CacheGet(chainID types.ChainID, label string, hit bool) {
 	}
 }
 
-func (m *Metrics) RecordDBEntryCount(chainID types.ChainID, kind string, count int64) {
+func (m *Metrics) RecordDBEntryCount(chainID eth.ChainID, kind string, count int64) {
 	m.DBEntryCountVec.WithLabelValues(chainIDLabel(chainID), kind).Set(float64(count))
 }
 
-func (m *Metrics) RecordDBSearchEntriesRead(chainID types.ChainID, count int64) {
+func (m *Metrics) RecordDBSearchEntriesRead(chainID eth.ChainID, count int64) {
 	m.DBSearchEntriesReadVec.WithLabelValues(chainIDLabel(chainID)).Observe(float64(count))
 }
 
-func chainIDLabel(chainID types.ChainID) string {
+func chainIDLabel(chainID eth.ChainID) string {
 	return chainID.String()
 }

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type noopMetrics struct {
@@ -16,8 +16,8 @@ func (*noopMetrics) Document() []opmetrics.DocumentedMetric { return nil }
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
-func (m *noopMetrics) CacheAdd(_ types.ChainID, _ string, _ int, _ bool) {}
-func (m *noopMetrics) CacheGet(_ types.ChainID, _ string, _ bool)        {}
+func (m *noopMetrics) CacheAdd(_ eth.ChainID, _ string, _ int, _ bool) {}
+func (m *noopMetrics) CacheGet(_ eth.ChainID, _ string, _ bool)        {}
 
-func (m *noopMetrics) RecordDBEntryCount(_ types.ChainID, _ string, _ int64) {}
-func (m *noopMetrics) RecordDBSearchEntriesRead(_ types.ChainID, _ int64)    {}
+func (m *noopMetrics) RecordDBEntryCount(_ eth.ChainID, _ string, _ int64) {}
+func (m *noopMetrics) RecordDBSearchEntriesRead(_ eth.ChainID, _ int64)    {}

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -34,10 +34,10 @@ func TestBackendLifetime(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	m := metrics.NoopMetrics
 	dataDir := t.TempDir()
-	chainA := types.ChainIDFromUInt64(900)
-	chainB := types.ChainIDFromUInt64(901)
+	chainA := eth.ChainIDFromUInt64(900)
+	chainB := eth.ChainIDFromUInt64(901)
 	depSet, err := depset.NewStaticConfigDependencySet(
-		map[types.ChainID]*depset.StaticConfigDependency{
+		map[eth.ChainID]*depset.StaticConfigDependency{
 			chainA: {
 				ChainIndex:     900,
 				ActivationTime: 42,

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -1,27 +1,27 @@
 package backend
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type Metrics interface {
-	CacheAdd(chainID types.ChainID, label string, cacheSize int, evicted bool)
-	CacheGet(chainID types.ChainID, label string, hit bool)
+	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
+	CacheGet(chainID eth.ChainID, label string, hit bool)
 
-	RecordDBEntryCount(chainID types.ChainID, kind string, count int64)
-	RecordDBSearchEntriesRead(chainID types.ChainID, count int64)
+	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
+	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
 }
 
 // chainMetrics is an adapter between the metrics API expected by clients that assume there's only a single chain
 // and the actual metrics implementation which requires a chain ID to identify the source chain.
 type chainMetrics struct {
-	chainID  types.ChainID
+	chainID  eth.ChainID
 	delegate Metrics
 }
 
-func newChainMetrics(chainID types.ChainID, delegate Metrics) *chainMetrics {
+func newChainMetrics(chainID eth.ChainID, delegate Metrics) *chainMetrics {
 	return &chainMetrics{
 		chainID:  chainID,
 		delegate: delegate,

--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -19,7 +19,7 @@ var (
 // CycleCheckDeps is an interface for checking cyclical dependencies between logs.
 type CycleCheckDeps interface {
 	// OpenBlock returns log data for the requested block, to be used for cycle checking.
-	OpenBlock(chainID types.ChainID, blockNum uint64) (block eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
+	OpenBlock(chainID eth.ChainID, blockNum uint64) (block eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 }
 
 // node represents a log entry in the dependency graph.

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -10,9 +10,9 @@ import (
 )
 
 type SafeFrontierCheckDeps interface {
-	CandidateCrossSafe(chain types.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error)
+	CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error)
 
-	CrossDerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -24,8 +24,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 	t.Run("unknown chain", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{
 			deps: mockDependencySet{
-				chainIDFromIndexfn: func() (types.ChainID, error) {
-					return types.ChainID{}, types.ErrUnknownChain
+				chainIDFromIndexfn: func() (eth.ChainID, error) {
+					return eth.ChainID{}, types.ErrUnknownChain
 				},
 			},
 		}
@@ -143,14 +143,14 @@ type mockSafeFrontierCheckDeps struct {
 	crossDerivedFromFn   func() (derivedFrom types.BlockSeal, err error)
 }
 
-func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain types.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
+func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
 	if m.candidateCrossSafeFn != nil {
 		return m.candidateCrossSafeFn()
 	}
 	return eth.BlockRef{}, eth.BlockRef{}, nil
 }
 
-func (m *mockSafeFrontierCheckDeps) CrossDerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockSafeFrontierCheckDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	if m.crossDerivedFromFn != nil {
 		return m.crossDerivedFromFn()
 	}
@@ -162,34 +162,34 @@ func (m *mockSafeFrontierCheckDeps) DependencySet() depset.DependencySet {
 }
 
 type mockDependencySet struct {
-	chainIDFromIndexfn func() (types.ChainID, error)
+	chainIDFromIndexfn func() (eth.ChainID, error)
 	canExecuteAtfn     func() (bool, error)
 	canInitiateAtfn    func() (bool, error)
 }
 
-func (m mockDependencySet) CanExecuteAt(chain types.ChainID, timestamp uint64) (bool, error) {
+func (m mockDependencySet) CanExecuteAt(chain eth.ChainID, timestamp uint64) (bool, error) {
 	if m.canExecuteAtfn != nil {
 		return m.canExecuteAtfn()
 	}
 	return true, nil
 }
 
-func (m mockDependencySet) CanInitiateAt(chain types.ChainID, timestamp uint64) (bool, error) {
+func (m mockDependencySet) CanInitiateAt(chain eth.ChainID, timestamp uint64) (bool, error) {
 	if m.canInitiateAtfn != nil {
 		return m.canInitiateAtfn()
 	}
 	return true, nil
 }
 
-func (m mockDependencySet) ChainIDFromIndex(index types.ChainIndex) (types.ChainID, error) {
+func (m mockDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
 	if m.chainIDFromIndexfn != nil {
 		return m.chainIDFromIndexfn()
 	}
-	id := types.ChainIDFromUInt64(uint64(index) - 1000)
+	id := eth.ChainIDFromUInt64(uint64(index) - 1000)
 	return id, nil
 }
 
-func (m mockDependencySet) ChainIndexFromID(chain types.ChainID) (types.ChainIndex, error) {
+func (m mockDependencySet) ChainIndexFromID(chain eth.ChainID) (types.ChainIndex, error) {
 	v, err := chain.ToUInt32()
 	if err != nil {
 		return 0, err
@@ -198,10 +198,10 @@ func (m mockDependencySet) ChainIndexFromID(chain types.ChainID) (types.ChainInd
 	return types.ChainIndex(v + 1000), nil
 }
 
-func (m mockDependencySet) Chains() []types.ChainID {
+func (m mockDependencySet) Chains() []eth.ChainID {
 	return nil
 }
 
-func (m mockDependencySet) HasChain(chain types.ChainID) bool {
+func (m mockDependencySet) HasChain(chain eth.ChainID) bool {
 	return true
 }

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -12,9 +12,9 @@ import (
 )
 
 type SafeStartDeps interface {
-	Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
+	Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
 
-	CrossDerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }
@@ -22,7 +22,7 @@ type SafeStartDeps interface {
 // CrossSafeHazards checks if the given messages all exist and pass invariants.
 // It returns a hazard-set: if any intra-block messaging happened,
 // these hazard blocks have to be verified.
-func CrossSafeHazards(d SafeStartDeps, chainID types.ChainID, inL1DerivedFrom eth.BlockID,
+func CrossSafeHazards(d SafeStartDeps, chainID eth.ChainID, inL1DerivedFrom eth.BlockID,
 	candidate types.BlockSeal, execMsgs []*types.ExecutingMessage) (hazards map[types.ChainIndex]types.BlockSeal, err error) {
 
 	hazards = make(map[types.ChainIndex]types.BlockSeal)

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -14,7 +14,7 @@ import (
 func TestCrossSafeHazards(t *testing.T) {
 	t.Run("empty execMsgs", func(t *testing.T) {
 		ssd := &mockSafeStartDeps{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{}
@@ -31,7 +31,7 @@ func TestCrossSafeHazards(t *testing.T) {
 				return false, nil
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
@@ -48,7 +48,7 @@ func TestCrossSafeHazards(t *testing.T) {
 				return false, errors.New("some error")
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
@@ -61,11 +61,11 @@ func TestCrossSafeHazards(t *testing.T) {
 	t.Run("unknown chain", func(t *testing.T) {
 		ssd := &mockSafeStartDeps{}
 		ssd.deps = mockDependencySet{
-			chainIDFromIndexfn: func() (types.ChainID, error) {
-				return types.ChainID{}, types.ErrUnknownChain
+			chainIDFromIndexfn: func() (eth.ChainID, error) {
+				return eth.ChainID{}, types.ErrUnknownChain
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
@@ -78,11 +78,11 @@ func TestCrossSafeHazards(t *testing.T) {
 	t.Run("ChainIDFromUInt64 returns error", func(t *testing.T) {
 		ssd := &mockSafeStartDeps{}
 		ssd.deps = mockDependencySet{
-			chainIDFromIndexfn: func() (types.ChainID, error) {
-				return types.ChainID{}, errors.New("some error")
+			chainIDFromIndexfn: func() (eth.ChainID, error) {
+				return eth.ChainID{}, errors.New("some error")
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
@@ -99,7 +99,7 @@ func TestCrossSafeHazards(t *testing.T) {
 				return false, nil
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
@@ -116,7 +116,7 @@ func TestCrossSafeHazards(t *testing.T) {
 				return false, errors.New("some error")
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
@@ -129,7 +129,7 @@ func TestCrossSafeHazards(t *testing.T) {
 	t.Run("timestamp is greater than candidate", func(t *testing.T) {
 		ssd := &mockSafeStartDeps{}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 10}
@@ -146,7 +146,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -165,7 +165,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleBlockSeal, nil
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -192,7 +192,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleBlockSeal2, nil
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -211,7 +211,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
@@ -233,7 +233,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
@@ -256,7 +256,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleDerivedFrom, nil
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
@@ -279,7 +279,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleDerivedFrom, nil
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{Number: 10}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
@@ -302,7 +302,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleDerivedFrom, nil
 		}
 		ssd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		inL1DerivedFrom := eth.BlockID{Number: 1}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
@@ -322,14 +322,14 @@ type mockSafeStartDeps struct {
 	derivedFromFn func() (derivedFrom types.BlockSeal, err error)
 }
 
-func (m *mockSafeStartDeps) Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (m *mockSafeStartDeps) Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
 	if m.checkFn != nil {
 		return m.checkFn()
 	}
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockSafeStartDeps) CrossDerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockSafeStartDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	if m.derivedFromFn != nil {
 		return m.derivedFromFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -13,21 +13,21 @@ import (
 )
 
 type CrossSafeDeps interface {
-	CrossSafe(chainID types.ChainID) (pair types.DerivedBlockSealPair, err error)
+	CrossSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error)
 
 	SafeFrontierCheckDeps
 	SafeStartDeps
 
-	CandidateCrossSafe(chain types.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error)
-	NextDerivedFrom(chain types.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
-	PreviousDerived(chain types.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+	CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error)
+	NextDerivedFrom(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
+	PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
 
-	OpenBlock(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
+	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 
-	UpdateCrossSafe(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
+	UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
 }
 
-func CrossSafeUpdate(logger log.Logger, chainID types.ChainID, d CrossSafeDeps) error {
+func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) error {
 	logger.Debug("Cross-safe update call")
 	// TODO(#11693): establish L1 reorg-lock of scopeDerivedFrom
 	// defer unlock once we are done checking the chain
@@ -70,7 +70,7 @@ func CrossSafeUpdate(logger log.Logger, chainID types.ChainID, d CrossSafeDeps) 
 // If no L2 cross-safe progress can be made without additional L1 input data,
 // then a types.ErrOutOfScope error is returned,
 // with the current scope that will need to be expanded for further progress.
-func scopedCrossSafeUpdate(logger log.Logger, chainID types.ChainID, d CrossSafeDeps) (scope eth.BlockRef, err error) {
+func scopedCrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) (scope eth.BlockRef, err error) {
 	candidateScope, candidate, err := d.CandidateCrossSafe(chainID)
 	if err != nil {
 		return candidateScope, fmt.Errorf("failed to determine candidate block for cross-safe: %w", err)
@@ -111,7 +111,7 @@ func sliceOfExecMsgs(execMsgs map[uint32]*types.ExecutingMessage) []*types.Execu
 
 type CrossSafeWorker struct {
 	logger  log.Logger
-	chainID types.ChainID
+	chainID eth.ChainID
 	d       CrossSafeDeps
 }
 
@@ -136,7 +136,7 @@ func (c *CrossSafeWorker) OnEvent(ev event.Event) bool {
 
 var _ event.Deriver = (*CrossUnsafeWorker)(nil)
 
-func NewCrossSafeWorker(logger log.Logger, chainID types.ChainID, d CrossSafeDeps) *CrossSafeWorker {
+func NewCrossSafeWorker(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) *CrossSafeWorker {
 	logger = logger.New("chain", chainID)
 	return &CrossSafeWorker{
 		logger:  logger,

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -16,7 +16,7 @@ import (
 func TestCrossSafeUpdate(t *testing.T) {
 	t.Run("scopedCrossSafeUpdate passes", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -25,10 +25,10 @@ func TestCrossSafeUpdate(t *testing.T) {
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 10, execs, nil
 		}
-		csd.checkFn = func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		csd.deps = mockDependencySet{}
@@ -39,14 +39,14 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return candidateScope, candidate, nil
 		}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, errors.New("some error")
 		}
 		csd.deps = mockDependencySet{}
@@ -58,33 +58,33 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns ErrOutOfScope", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return candidateScope, candidate, nil
 		}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
 		}
 		newScope := eth.BlockRef{Number: 3}
-		csd.nextDerivedFromFn = func(chain types.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+		csd.nextDerivedFromFn = func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
 			return newScope, nil
 		}
 		currentCrossSafe := types.BlockSeal{Number: 5}
-		csd.crossSafeFn = func(chainID types.ChainID) (pair types.DerivedBlockSealPair, err error) {
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 			return types.DerivedBlockSealPair{Derived: currentCrossSafe}, nil
 		}
 		parent := types.BlockSeal{Number: 4}
-		csd.previousDerivedFn = func(chain types.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+		csd.previousDerivedFn = func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 			return parent, nil
 		}
 		csd.deps = mockDependencySet{}
-		var updatingChain types.ChainID
+		var updatingChain eth.ChainID
 		var updatingCandidateScope eth.BlockRef
 		var updatingCandidate eth.BlockRef
-		csd.updateCrossSafeFn = func(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+		csd.updateCrossSafeFn = func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 			updatingChain = chain
 			updatingCandidateScope = l1View
 			updatingCandidate = lastCrossDerived
@@ -103,17 +103,17 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("NextDerivedFrom returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return candidateScope, candidate, nil
 		}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
 		}
-		csd.nextDerivedFromFn = func(chain types.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+		csd.nextDerivedFromFn = func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
 			return eth.BlockRef{}, errors.New("some error")
 		}
 		csd.deps = mockDependencySet{}
@@ -125,17 +125,17 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("PreviousDerived returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return candidateScope, candidate, nil
 		}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
 		}
-		csd.previousDerivedFn = func(chain types.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+		csd.previousDerivedFn = func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		csd.deps = mockDependencySet{}
@@ -147,17 +147,17 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("UpdateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return candidateScope, candidate, nil
 		}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
 		}
-		csd.updateCrossSafeFn = func(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+		csd.updateCrossSafeFn = func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 			return errors.New("some error")
 		}
 		csd.deps = mockDependencySet{}
@@ -172,7 +172,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 func TestScopedCrossSafeUpdate(t *testing.T) {
 	t.Run("CandidateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return eth.BlockRef{}, eth.BlockRef{}, errors.New("some error")
@@ -185,9 +185,9 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("CandidateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, errors.New("some error")
 		}
 		// when OpenBlock returns an error,
@@ -198,14 +198,14 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("candidate does not match opened block", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
 			return eth.BlockRef{}, candidate, nil
 		}
 		opened := eth.BlockRef{Number: 2}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 0, nil, nil
 		}
 		// when OpenBlock and CandidateCrossSafe return different blocks,
@@ -216,7 +216,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("CrossSafeHazards returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
@@ -224,13 +224,13 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 10, execs, nil
 		}
 		// cause CrossSafeHazards to return an error by making ChainIDFromIndex return an error
 		csd.deps = mockDependencySet{}
-		csd.deps.chainIDFromIndexfn = func() (types.ChainID, error) {
-			return types.ChainID{}, errors.New("some error")
+		csd.deps.chainIDFromIndexfn = func() (eth.ChainID, error) {
+			return eth.ChainID{}, errors.New("some error")
 		}
 		// when CrossSafeHazards returns an error,
 		// the error is returned
@@ -241,7 +241,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("HazardSafeFrontierChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (derivedFromScope, crossSafe eth.BlockRef, err error) {
@@ -249,22 +249,22 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 10, execs, nil
 		}
-		csd.checkFn = func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		count := 0
 		csd.deps = mockDependencySet{}
 		// cause CrossSafeHazards to return an error by making ChainIDFromIndex return an error
 		// but only on the second call (which will be used by HazardSafeFrontierChecks)
-		csd.deps.chainIDFromIndexfn = func() (types.ChainID, error) {
+		csd.deps.chainIDFromIndexfn = func() (eth.ChainID, error) {
 			defer func() { count++ }()
 			if count == 0 {
-				return types.ChainID{}, nil
+				return eth.ChainID{}, nil
 			}
-			return types.ChainID{}, errors.New("some error")
+			return eth.ChainID{}, errors.New("some error")
 		}
 		// when CrossSafeHazards returns an error,
 		// the error is returned
@@ -275,7 +275,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("HazardCycleChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1, Time: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -285,10 +285,10 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		opened := eth.BlockRef{Number: 1, Time: 1}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 2}
 		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 1}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 3, map[uint32]*types.ExecutingMessage{1: em1, 2: em2}, nil
 		}
-		csd.checkFn = func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		csd.deps = mockDependencySet{}
@@ -301,7 +301,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("UpdateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -310,14 +310,14 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 10, execs, nil
 		}
-		csd.checkFn = func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		csd.deps = mockDependencySet{}
-		csd.updateCrossSafeFn = func(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+		csd.updateCrossSafeFn = func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 			return errors.New("some error")
 		}
 		// when UpdateCrossSafe returns an error,
@@ -329,7 +329,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("successful update", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -338,14 +338,14 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
-		csd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 10, execs, nil
 		}
 		csd.deps = mockDependencySet{}
-		var updatingChain types.ChainID
+		var updatingChain eth.ChainID
 		var updatingCandidateScope eth.BlockRef
 		var updatingCandidate eth.BlockRef
-		csd.updateCrossSafeFn = func(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+		csd.updateCrossSafeFn = func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 			updatingChain = chain
 			updatingCandidateScope = l1View
 			updatingCandidate = lastCrossDerived
@@ -354,7 +354,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		// when no errors occur, the update is carried out
 		// the used candidate and scope are from CandidateCrossSafe
 		// the candidateScope is returned
-		csd.checkFn = func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		blockRef, err := scopedCrossSafeUpdate(logger, chainID, csd)
@@ -368,23 +368,23 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 
 type mockCrossSafeDeps struct {
 	deps                 mockDependencySet
-	crossSafeFn          func(chainID types.ChainID) (pair types.DerivedBlockSealPair, err error)
+	crossSafeFn          func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error)
 	candidateCrossSafeFn func() (derivedFromScope, crossSafe eth.BlockRef, err error)
-	openBlockFn          func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
-	updateCrossSafeFn    func(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
-	nextDerivedFromFn    func(chain types.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
-	previousDerivedFn    func(chain types.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
-	checkFn              func(chainID types.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
+	openBlockFn          func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
+	updateCrossSafeFn    func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
+	nextDerivedFromFn    func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
+	previousDerivedFn    func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+	checkFn              func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
 }
 
-func (m *mockCrossSafeDeps) CrossSafe(chainID types.ChainID) (pair types.DerivedBlockSealPair, err error) {
+func (m *mockCrossSafeDeps) CrossSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 	if m.crossSafeFn != nil {
 		return m.crossSafeFn(chainID)
 	}
 	return types.DerivedBlockSealPair{}, nil
 }
 
-func (m *mockCrossSafeDeps) CandidateCrossSafe(chain types.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
+func (m *mockCrossSafeDeps) CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
 	if m.candidateCrossSafeFn != nil {
 		return m.candidateCrossSafeFn()
 	}
@@ -395,39 +395,39 @@ func (m *mockCrossSafeDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockCrossSafeDeps) CrossDerivedFrom(chainID types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockCrossSafeDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossSafeDeps) Check(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+func (m *mockCrossSafeDeps) Check(chainID eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 	if m.checkFn != nil {
 		return m.checkFn(chainID, blockNum, logIdx, logHash)
 	}
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossSafeDeps) NextDerivedFrom(chain types.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+func (m *mockCrossSafeDeps) NextDerivedFrom(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
 	if m.nextDerivedFromFn != nil {
 		return m.nextDerivedFromFn(chain, derivedFrom)
 	}
 	return eth.BlockRef{}, nil
 }
 
-func (m *mockCrossSafeDeps) PreviousDerived(chain types.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+func (m *mockCrossSafeDeps) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 	if m.previousDerivedFn != nil {
 		return m.previousDerivedFn(chain, derived)
 	}
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossSafeDeps) OpenBlock(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+func (m *mockCrossSafeDeps) OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 	if m.openBlockFn != nil {
 		return m.openBlockFn(chainID, blockNum)
 	}
 	return eth.BlockRef{}, 0, nil, nil
 }
 
-func (m *mockCrossSafeDeps) UpdateCrossSafe(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+func (m *mockCrossSafeDeps) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 	if m.updateCrossSafeFn != nil {
 		return m.updateCrossSafeFn(chain, l1View, lastCrossDerived)
 	}

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
@@ -10,10 +10,10 @@ import (
 )
 
 type UnsafeFrontierCheckDeps interface {
-	ParentBlock(chainID types.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error)
+	ParentBlock(chainID eth.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error)
 
-	IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) error
-	IsLocalUnsafe(chainID types.ChainID, block eth.BlockID) error
+	IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error
+	IsLocalUnsafe(chainID eth.ChainID, block eth.BlockID) error
 
 	DependencySet() depset.DependencySet
 }

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
@@ -23,8 +23,8 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	t.Run("unknown chain", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{
 			deps: mockDependencySet{
-				chainIDFromIndexfn: func() (types.ChainID, error) {
-					return types.ChainID{}, types.ErrUnknownChain
+				chainIDFromIndexfn: func() (eth.ChainID, error) {
+					return eth.ChainID{}, types.ErrUnknownChain
 				},
 			},
 		}
@@ -114,17 +114,17 @@ func (m *mockUnsafeFrontierCheckDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockUnsafeFrontierCheckDeps) ParentBlock(chainID types.ChainID, block eth.BlockID) (parent eth.BlockID, err error) {
+func (m *mockUnsafeFrontierCheckDeps) ParentBlock(chainID eth.ChainID, block eth.BlockID) (parent eth.BlockID, err error) {
 	if m.parentBlockFn != nil {
 		return m.parentBlockFn()
 	}
 	return eth.BlockID{}, nil
 }
 
-func (m *mockUnsafeFrontierCheckDeps) IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) error {
+func (m *mockUnsafeFrontierCheckDeps) IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error {
 	return m.isCrossUnsafe
 }
 
-func (m *mockUnsafeFrontierCheckDeps) IsLocalUnsafe(chainID types.ChainID, block eth.BlockID) error {
+func (m *mockUnsafeFrontierCheckDeps) IsLocalUnsafe(chainID eth.ChainID, block eth.BlockID) error {
 	return m.isLocalUnsafe
 }

--- a/op-supervisor/supervisor/backend/cross/unsafe_start.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start.go
@@ -12,9 +12,9 @@ import (
 )
 
 type UnsafeStartDeps interface {
-	Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
+	Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
 
-	IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) error
+	IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error
 
 	DependencySet() depset.DependencySet
 }
@@ -22,7 +22,7 @@ type UnsafeStartDeps interface {
 // CrossUnsafeHazards checks if the given messages all exist and pass invariants.
 // It returns a hazard-set: if any intra-block messaging happened,
 // these hazard blocks have to be verified.
-func CrossUnsafeHazards(d UnsafeStartDeps, chainID types.ChainID,
+func CrossUnsafeHazards(d UnsafeStartDeps, chainID eth.ChainID,
 	candidate types.BlockSeal, execMsgs []*types.ExecutingMessage) (hazards map[types.ChainIndex]types.BlockSeal, err error) {
 
 	hazards = make(map[types.ChainIndex]types.BlockSeal)

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -14,7 +14,7 @@ import (
 func TestCrossUnsafeHazards(t *testing.T) {
 	t.Run("empty execMsgs", func(t *testing.T) {
 		usd := &mockUnsafeStartDeps{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{}
 		// when there are no execMsgs,
@@ -30,7 +30,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 				return false, nil
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanExecuteAt returns false,
@@ -46,7 +46,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 				return false, errors.New("some error")
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanExecuteAt returns false,
@@ -58,11 +58,11 @@ func TestCrossUnsafeHazards(t *testing.T) {
 	t.Run("unknown chain", func(t *testing.T) {
 		usd := &mockUnsafeStartDeps{}
 		usd.deps = mockDependencySet{
-			chainIDFromIndexfn: func() (types.ChainID, error) {
-				return types.ChainID{}, types.ErrUnknownChain
+			chainIDFromIndexfn: func() (eth.ChainID, error) {
+				return eth.ChainID{}, types.ErrUnknownChain
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and ChainIDFromIndex returns ErrUnknownChain,
@@ -74,11 +74,11 @@ func TestCrossUnsafeHazards(t *testing.T) {
 	t.Run("ChainIDFromUInt64 returns error", func(t *testing.T) {
 		usd := &mockUnsafeStartDeps{}
 		usd.deps = mockDependencySet{
-			chainIDFromIndexfn: func() (types.ChainID, error) {
-				return types.ChainID{}, errors.New("some error")
+			chainIDFromIndexfn: func() (eth.ChainID, error) {
+				return eth.ChainID{}, errors.New("some error")
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and ChainIDFromIndex returns some other error,
@@ -94,7 +94,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 				return false, nil
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanInitiateAt returns false,
@@ -110,7 +110,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 				return false, errors.New("some error")
 			},
 		}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanInitiateAt returns an error,
@@ -122,7 +122,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 	t.Run("timestamp is greater than candidate", func(t *testing.T) {
 		usd := &mockUnsafeStartDeps{}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 10}
 		execMsgs := []*types.ExecutingMessage{em1}
@@ -138,7 +138,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
 		execMsgs := []*types.ExecutingMessage{em1}
@@ -156,7 +156,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 			return sampleBlockSeal, nil
 		}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
 		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -182,7 +182,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 			return sampleBlockSeal2, nil
 		}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
 		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -200,7 +200,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
@@ -221,7 +221,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 			return errors.New("some error")
 		}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
@@ -242,7 +242,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 			return nil
 		}
 		usd.deps = mockDependencySet{}
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 0}
 		execMsgs := []*types.ExecutingMessage{em1}
@@ -261,14 +261,14 @@ type mockUnsafeStartDeps struct {
 	isCrossUnsafeFn func() error
 }
 
-func (m *mockUnsafeStartDeps) Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (m *mockUnsafeStartDeps) Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
 	if m.checkFn != nil {
 		return m.checkFn()
 	}
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockUnsafeStartDeps) IsCrossUnsafe(chainID types.ChainID, derived eth.BlockID) error {
+func (m *mockUnsafeStartDeps) IsCrossUnsafe(chainID eth.ChainID, derived eth.BlockID) error {
 	if m.isCrossUnsafeFn != nil {
 		return m.isCrossUnsafeFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -13,17 +13,17 @@ import (
 )
 
 type CrossUnsafeDeps interface {
-	CrossUnsafe(chainID types.ChainID) (types.BlockSeal, error)
+	CrossUnsafe(chainID eth.ChainID) (types.BlockSeal, error)
 
 	UnsafeStartDeps
 	UnsafeFrontierCheckDeps
 
-	OpenBlock(chainID types.ChainID, blockNum uint64) (block eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
+	OpenBlock(chainID eth.ChainID, blockNum uint64) (block eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 
-	UpdateCrossUnsafe(chain types.ChainID, crossUnsafe types.BlockSeal) error
+	UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.BlockSeal) error
 }
 
-func CrossUnsafeUpdate(logger log.Logger, chainID types.ChainID, d CrossUnsafeDeps) error {
+func CrossUnsafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps) error {
 	var candidate types.BlockSeal
 	var execMsgs []*types.ExecutingMessage
 
@@ -74,7 +74,7 @@ func CrossUnsafeUpdate(logger log.Logger, chainID types.ChainID, d CrossUnsafeDe
 
 type CrossUnsafeWorker struct {
 	logger  log.Logger
-	chainID types.ChainID
+	chainID eth.ChainID
 	d       CrossUnsafeDeps
 }
 
@@ -99,7 +99,7 @@ func (c *CrossUnsafeWorker) OnEvent(ev event.Event) bool {
 
 var _ event.Deriver = (*CrossUnsafeWorker)(nil)
 
-func NewCrossUnsafeWorker(logger log.Logger, chainID types.ChainID, d CrossUnsafeDeps) *CrossUnsafeWorker {
+func NewCrossUnsafeWorker(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps) *CrossUnsafeWorker {
 	logger = logger.New("chain", chainID)
 	return &CrossUnsafeWorker{
 		logger:  logger,

--- a/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
@@ -16,9 +16,9 @@ import (
 func TestCrossUnsafeUpdate(t *testing.T) {
 	t.Run("CrossUnsafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		usd.deps = mockDependencySet{}
@@ -29,9 +29,9 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("CrossUnsafe returns ErrFuture", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return types.BlockSeal{}, types.ErrFuture
 		}
 		usd.deps = mockDependencySet{}
@@ -42,9 +42,9 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("OpenBlock returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
-		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, errors.New("some error")
 		}
 		usd.deps = mockDependencySet{}
@@ -55,14 +55,14 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("opened block parent hash does not match", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
 		crossUnsafe := types.BlockSeal{Hash: common.Hash{0x11}}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return crossUnsafe, nil
 		}
 		bl := eth.BlockRef{ParentHash: common.Hash{0x01}}
-		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return bl, 0, nil, nil
 		}
 		usd.deps = mockDependencySet{}
@@ -73,14 +73,14 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("CrossSafeHazards returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
 		crossUnsafe := types.BlockSeal{Hash: common.Hash{0x01}}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return crossUnsafe, nil
 		}
 		bl := eth.BlockRef{ParentHash: common.Hash{0x01}}
-		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			// include one executing message to trigger the CanExecuteAt check
 			return bl, 0, map[uint32]*types.ExecutingMessage{1: {}}, nil
 		}
@@ -96,15 +96,15 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("HazardUnsafeFrontierChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
 		crossUnsafe := types.BlockSeal{Hash: common.Hash{0x01}}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return crossUnsafe, nil
 		}
 		bl := eth.BlockRef{ParentHash: common.Hash{0x01}, Time: 1}
 		em1 := &types.ExecutingMessage{Timestamp: 1}
-		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			// include one executing message to ensure one hazard is returned
 			return bl, 0, map[uint32]*types.ExecutingMessage{1: em1}, nil
 		}
@@ -112,12 +112,12 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 		count := 0
 		// make HazardUnsafeFrontierChecks return an error by failing the second ChainIDFromIndex call
 		// (the first one is in CrossSafeHazards)
-		usd.deps.chainIDFromIndexfn = func() (types.ChainID, error) {
+		usd.deps.chainIDFromIndexfn = func() (eth.ChainID, error) {
 			defer func() { count++ }()
 			if count == 1 {
-				return types.ChainID{}, errors.New("some error")
+				return eth.ChainID{}, errors.New("some error")
 			}
-			return types.ChainID{}, nil
+			return eth.ChainID{}, nil
 		}
 		// when HazardUnsafeFrontierChecks returns an error,
 		// the error is returned
@@ -126,19 +126,19 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("HazardCycleChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
 		crossUnsafe := types.BlockSeal{Hash: common.Hash{0x01}}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return crossUnsafe, nil
 		}
 		bl := eth.BlockRef{ParentHash: common.Hash{0x01}, Number: 1, Time: 1}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 2}
 		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 1}
-		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return bl, 3, map[uint32]*types.ExecutingMessage{1: em1, 2: em2}, nil
 		}
-		usd.checkFn = func(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+		usd.checkFn = func(chainID eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
 		usd.deps = mockDependencySet{}
@@ -150,22 +150,22 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 	})
 	t.Run("successful update", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := types.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(0)
 		usd := &mockCrossUnsafeDeps{}
 		crossUnsafe := types.BlockSeal{Hash: common.Hash{0x01}}
-		usd.crossUnsafeFn = func(chainID types.ChainID) (types.BlockSeal, error) {
+		usd.crossUnsafeFn = func(chainID eth.ChainID) (types.BlockSeal, error) {
 			return crossUnsafe, nil
 		}
 		bl := eth.BlockRef{ParentHash: common.Hash{0x01}, Time: 1}
 		em1 := &types.ExecutingMessage{Timestamp: 1}
-		usd.openBlockFn = func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			// include one executing message to ensure one hazard is returned
 			return bl, 2, map[uint32]*types.ExecutingMessage{1: em1}, nil
 		}
 		usd.deps = mockDependencySet{}
-		var updatingChainID types.ChainID
+		var updatingChainID eth.ChainID
 		var updatingBlock types.BlockSeal
-		usd.updateCrossUnsafeFn = func(chain types.ChainID, crossUnsafe types.BlockSeal) error {
+		usd.updateCrossUnsafeFn = func(chain eth.ChainID, crossUnsafe types.BlockSeal) error {
 			updatingChainID = chain
 			updatingBlock = crossUnsafe
 			return nil
@@ -181,13 +181,13 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 
 type mockCrossUnsafeDeps struct {
 	deps                mockDependencySet
-	crossUnsafeFn       func(chainID types.ChainID) (types.BlockSeal, error)
-	openBlockFn         func(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
-	updateCrossUnsafeFn func(chain types.ChainID, crossUnsafe types.BlockSeal) error
-	checkFn             func(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
+	crossUnsafeFn       func(chainID eth.ChainID) (types.BlockSeal, error)
+	openBlockFn         func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
+	updateCrossUnsafeFn func(chain eth.ChainID, crossUnsafe types.BlockSeal) error
+	checkFn             func(chainID eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
 }
 
-func (m *mockCrossUnsafeDeps) CrossUnsafe(chainID types.ChainID) (derived types.BlockSeal, err error) {
+func (m *mockCrossUnsafeDeps) CrossUnsafe(chainID eth.ChainID) (derived types.BlockSeal, err error) {
 	if m.crossUnsafeFn != nil {
 		return m.crossUnsafeFn(chainID)
 	}
@@ -198,35 +198,35 @@ func (m *mockCrossUnsafeDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockCrossUnsafeDeps) Check(chainID types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+func (m *mockCrossUnsafeDeps) Check(chainID eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
 	if m.checkFn != nil {
 		return m.checkFn(chainID, blockNum, timestamp, logIdx, logHash)
 	}
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossUnsafeDeps) OpenBlock(chainID types.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+func (m *mockCrossUnsafeDeps) OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 	if m.openBlockFn != nil {
 		return m.openBlockFn(chainID, blockNum)
 	}
 	return eth.BlockRef{}, 0, nil, nil
 }
 
-func (m *mockCrossUnsafeDeps) UpdateCrossUnsafe(chain types.ChainID, block types.BlockSeal) error {
+func (m *mockCrossUnsafeDeps) UpdateCrossUnsafe(chain eth.ChainID, block types.BlockSeal) error {
 	if m.updateCrossUnsafeFn != nil {
 		return m.updateCrossUnsafeFn(chain, block)
 	}
 	return nil
 }
 
-func (m *mockCrossUnsafeDeps) IsCrossUnsafe(chainID types.ChainID, blockNum eth.BlockID) error {
+func (m *mockCrossUnsafeDeps) IsCrossUnsafe(chainID eth.ChainID, blockNum eth.BlockID) error {
 	return nil
 }
 
-func (m *mockCrossUnsafeDeps) IsLocalUnsafe(chainID types.ChainID, blockNum eth.BlockID) error {
+func (m *mockCrossUnsafeDeps) IsLocalUnsafe(chainID eth.ChainID, blockNum eth.BlockID) error {
 	return nil
 }
 
-func (m *mockCrossUnsafeDeps) ParentBlock(chainID types.ChainID, blockNum eth.BlockID) (eth.BlockID, error) {
+func (m *mockCrossUnsafeDeps) ParentBlock(chainID eth.ChainID, blockNum eth.BlockID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }

--- a/op-supervisor/supervisor/backend/db/anchor.go
+++ b/op-supervisor/supervisor/backend/db/anchor.go
@@ -3,12 +3,13 @@ package db
 import (
 	"errors"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // maybeInitSafeDB initializes the chain database if it is not already initialized
 // it checks if the Local Safe database is empty, and loads it with the Anchor Point if so
-func (db *ChainsDB) maybeInitSafeDB(id types.ChainID, anchor types.DerivedBlockRefPair) {
+func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRefPair) {
 	_, err := db.LocalSafe(id)
 	if errors.Is(err, types.ErrFuture) {
 		db.logger.Debug("initializing chain database", "chain", id)
@@ -23,7 +24,7 @@ func (db *ChainsDB) maybeInitSafeDB(id types.ChainID, anchor types.DerivedBlockR
 	}
 }
 
-func (db *ChainsDB) maybeInitEventsDB(id types.ChainID, anchor types.DerivedBlockRefPair) {
+func (db *ChainsDB) maybeInitEventsDB(id eth.ChainID, anchor types.DerivedBlockRefPair) {
 	_, _, _, err := db.OpenBlock(id, 0)
 	if errors.Is(err, types.ErrFuture) {
 		db.logger.Debug("initializing events database", "chain", id)

--- a/op-supervisor/supervisor/backend/db/file_layout.go
+++ b/op-supervisor/supervisor/backend/db/file_layout.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func prepLocalDerivedFromDBPath(chainID types.ChainID, datadir string) (string, error) {
+func prepLocalDerivedFromDBPath(chainID eth.ChainID, datadir string) (string, error) {
 	dir, err := prepChainDir(chainID, datadir)
 	if err != nil {
 		return "", err
@@ -16,7 +16,7 @@ func prepLocalDerivedFromDBPath(chainID types.ChainID, datadir string) (string, 
 	return filepath.Join(dir, "local_safe.db"), nil
 }
 
-func prepCrossDerivedFromDBPath(chainID types.ChainID, datadir string) (string, error) {
+func prepCrossDerivedFromDBPath(chainID eth.ChainID, datadir string) (string, error) {
 	dir, err := prepChainDir(chainID, datadir)
 	if err != nil {
 		return "", err
@@ -24,7 +24,7 @@ func prepCrossDerivedFromDBPath(chainID types.ChainID, datadir string) (string, 
 	return filepath.Join(dir, "cross_safe.db"), nil
 }
 
-func prepLogDBPath(chainID types.ChainID, datadir string) (string, error) {
+func prepLogDBPath(chainID eth.ChainID, datadir string) (string, error) {
 	dir, err := prepChainDir(chainID, datadir)
 	if err != nil {
 		return "", err
@@ -32,7 +32,7 @@ func prepLogDBPath(chainID types.ChainID, datadir string) (string, error) {
 	return filepath.Join(dir, "log.db"), nil
 }
 
-func prepChainDir(chainID types.ChainID, datadir string) (string, error) {
+func prepChainDir(chainID eth.ChainID, datadir string) (string, error) {
 	dir := filepath.Join(datadir, chainID.String())
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create chain directory %v: %w", dir, err)

--- a/op-supervisor/supervisor/backend/db/file_layout_test.go
+++ b/op-supervisor/supervisor/backend/db/file_layout_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +15,7 @@ func TestLogDBPath(t *testing.T) {
 	chainIDStr := "42984928492928428424243444"
 	chainIDBig, ok := new(big.Int).SetString(chainIDStr, 10)
 	require.True(t, ok)
-	chainID := types.ChainIDFromBig(chainIDBig)
+	chainID := eth.ChainIDFromBig(chainIDBig)
 	expected := filepath.Join(base, "subdir", chainIDStr, "log.db")
 	path, err := prepLogDBPath(chainID, filepath.Join(base, "subdir"))
 	require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/db/open.go
+++ b/op-supervisor/supervisor/backend/db/open.go
@@ -3,14 +3,14 @@ package db
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/fromda"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-func OpenLogDB(logger log.Logger, chainID types.ChainID, dataDir string, m logs.Metrics) (*logs.DB, error) {
+func OpenLogDB(logger log.Logger, chainID eth.ChainID, dataDir string, m logs.Metrics) (*logs.DB, error) {
 	path, err := prepLogDBPath(chainID, dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create datadir for chain %s: %w", chainID, err)
@@ -22,7 +22,7 @@ func OpenLogDB(logger log.Logger, chainID types.ChainID, dataDir string, m logs.
 	return logDB, nil
 }
 
-func OpenLocalDerivedFromDB(logger log.Logger, chainID types.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
+func OpenLocalDerivedFromDB(logger log.Logger, chainID eth.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
 	path, err := prepLocalDerivedFromDBPath(chainID, dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare datadir for chain %s: %w", chainID, err)
@@ -34,7 +34,7 @@ func OpenLocalDerivedFromDB(logger log.Logger, chainID types.ChainID, dataDir st
 	return db, nil
 }
 
-func OpenCrossDerivedFromDB(logger log.Logger, chainID types.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
+func OpenCrossDerivedFromDB(logger log.Logger, chainID eth.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
 	path, err := prepCrossDerivedFromDBPath(chainID, dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare datadir for chain %s: %w", chainID, err)

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-func (db *ChainsDB) FindSealedBlock(chain types.ChainID, number uint64) (seal types.BlockSeal, err error) {
+func (db *ChainsDB) FindSealedBlock(chain eth.ChainID, number uint64) (seal types.BlockSeal, err error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
@@ -22,7 +22,7 @@ func (db *ChainsDB) FindSealedBlock(chain types.ChainID, number uint64) (seal ty
 // LatestBlockNum returns the latest fully-sealed block number that has been recorded to the logs db
 // for the given chain. It does not contain safety guarantees.
 // The block number might not be available (empty database, or non-existent chain).
-func (db *ChainsDB) LatestBlockNum(chain types.ChainID) (num uint64, ok bool) {
+func (db *ChainsDB) LatestBlockNum(chain eth.ChainID) (num uint64, ok bool) {
 	logDB, knownChain := db.logDBs.Get(chain)
 	if !knownChain {
 		return 0, false
@@ -56,7 +56,7 @@ func (db *ChainsDB) LastCommonL1() (types.BlockSeal, error) {
 	return common, nil
 }
 
-func (db *ChainsDB) IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) error {
+func (db *ChainsDB) IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error {
 	v, ok := db.crossUnsafe.Get(chainID)
 	if !ok {
 		return types.ErrUnknownChain
@@ -72,7 +72,7 @@ func (db *ChainsDB) IsCrossUnsafe(chainID types.ChainID, block eth.BlockID) erro
 	return nil
 }
 
-func (db *ChainsDB) ParentBlock(chainID types.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error) {
+func (db *ChainsDB) ParentBlock(chainID eth.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error) {
 	logDB, ok := db.logDBs.Get(chainID)
 	if !ok {
 		return eth.BlockID{}, types.ErrUnknownChain
@@ -88,7 +88,7 @@ func (db *ChainsDB) ParentBlock(chainID types.ChainID, parentOf eth.BlockID) (pa
 	return got.ID(), nil
 }
 
-func (db *ChainsDB) IsLocalUnsafe(chainID types.ChainID, block eth.BlockID) error {
+func (db *ChainsDB) IsLocalUnsafe(chainID eth.ChainID, block eth.BlockID) error {
 	logDB, ok := db.logDBs.Get(chainID)
 	if !ok {
 		return types.ErrUnknownChain
@@ -103,7 +103,7 @@ func (db *ChainsDB) IsLocalUnsafe(chainID types.ChainID, block eth.BlockID) erro
 	return nil
 }
 
-func (db *ChainsDB) SafeDerivedAt(chainID types.ChainID, derivedFrom eth.BlockID) (types.BlockSeal, error) {
+func (db *ChainsDB) SafeDerivedAt(chainID eth.ChainID, derivedFrom eth.BlockID) (types.BlockSeal, error) {
 	lDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -115,7 +115,7 @@ func (db *ChainsDB) SafeDerivedAt(chainID types.ChainID, derivedFrom eth.BlockID
 	return derived, nil
 }
 
-func (db *ChainsDB) LocalUnsafe(chainID types.ChainID) (types.BlockSeal, error) {
+func (db *ChainsDB) LocalUnsafe(chainID eth.ChainID) (types.BlockSeal, error) {
 	eventsDB, ok := db.logDBs.Get(chainID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -127,7 +127,7 @@ func (db *ChainsDB) LocalUnsafe(chainID types.ChainID) (types.BlockSeal, error) 
 	return eventsDB.FindSealedBlock(n)
 }
 
-func (db *ChainsDB) CrossUnsafe(chainID types.ChainID) (types.BlockSeal, error) {
+func (db *ChainsDB) CrossUnsafe(chainID eth.ChainID) (types.BlockSeal, error) {
 	result, ok := db.crossUnsafe.Get(chainID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -144,7 +144,7 @@ func (db *ChainsDB) CrossUnsafe(chainID types.ChainID) (types.BlockSeal, error) 
 	return crossUnsafe, nil
 }
 
-func (db *ChainsDB) LocalSafe(chainID types.ChainID) (pair types.DerivedBlockSealPair, err error) {
+func (db *ChainsDB) LocalSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 	localDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
@@ -153,7 +153,7 @@ func (db *ChainsDB) LocalSafe(chainID types.ChainID) (pair types.DerivedBlockSea
 	return types.DerivedBlockSealPair{DerivedFrom: df, Derived: d}, err
 }
 
-func (db *ChainsDB) CrossSafe(chainID types.ChainID) (pair types.DerivedBlockSealPair, err error) {
+func (db *ChainsDB) CrossSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
 	crossDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
 		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
@@ -166,7 +166,7 @@ func (db *ChainsDB) FinalizedL1() eth.BlockRef {
 	return db.finalizedL1.Get()
 }
 
-func (db *ChainsDB) Finalized(chainID types.ChainID) (types.BlockSeal, error) {
+func (db *ChainsDB) Finalized(chainID eth.ChainID) (types.BlockSeal, error) {
 	finalizedL1 := db.finalizedL1.Get()
 	if finalizedL1 == (eth.L1BlockRef{}) {
 		return types.BlockSeal{}, fmt.Errorf("no finalized L1 signal, cannot determine L2 finality of chain %s yet", chainID)
@@ -200,7 +200,7 @@ func (db *ChainsDB) Finalized(chainID types.ChainID) (types.BlockSeal, error) {
 	return derived, nil
 }
 
-func (db *ChainsDB) LastDerivedFrom(chainID types.ChainID, derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
+func (db *ChainsDB) LastDerivedFrom(chainID eth.ChainID, derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
 	crossDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -210,7 +210,7 @@ func (db *ChainsDB) LastDerivedFrom(chainID types.ChainID, derivedFrom eth.Block
 
 // CrossDerivedFromBlockRef returns the block that the given block was derived from, if it exists in the cross derived-from storage.
 // This includes the parent-block lookup. Use CrossDerivedFrom if no parent-block info is needed.
-func (db *ChainsDB) CrossDerivedFromBlockRef(chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+func (db *ChainsDB) CrossDerivedFromBlockRef(chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	xdb, ok := db.crossDBs.Get(chainID)
 	if !ok {
 		return eth.BlockRef{}, types.ErrUnknownChain
@@ -232,7 +232,7 @@ func (db *ChainsDB) CrossDerivedFromBlockRef(chainID types.ChainID, derived eth.
 
 // Check calls the underlying logDB to determine if the given log entry exists at the given location.
 // If the block-seal of the block that includes the log is known, it is returned. It is fully zeroed otherwise, if the block is in-progress.
-func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (db *ChainsDB) Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)
@@ -254,7 +254,7 @@ func (db *ChainsDB) Check(chain types.ChainID, blockNum uint64, timestamp uint64
 
 // OpenBlock returns the Executing Messages for the block at the given number on the given chain.
 // it routes the request to the appropriate logDB.
-func (db *ChainsDB) OpenBlock(chainID types.ChainID, blockNum uint64) (seal eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+func (db *ChainsDB) OpenBlock(chainID eth.ChainID, blockNum uint64) (seal eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 	logDB, ok := db.logDBs.Get(chainID)
 	if !ok {
 		return eth.BlockRef{}, 0, nil, types.ErrUnknownChain
@@ -264,7 +264,7 @@ func (db *ChainsDB) OpenBlock(chainID types.ChainID, blockNum uint64) (seal eth.
 
 // LocalDerivedFrom returns the block that the given block was derived from, if it exists in the local derived-from storage.
 // it routes the request to the appropriate localDB.
-func (db *ChainsDB) LocalDerivedFrom(chain types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (db *ChainsDB) LocalDerivedFrom(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -274,7 +274,7 @@ func (db *ChainsDB) LocalDerivedFrom(chain types.ChainID, derived eth.BlockID) (
 
 // CrossDerivedFrom returns the block that the given block was derived from, if it exists in the cross derived-from storage.
 // it routes the request to the appropriate crossDB.
-func (db *ChainsDB) CrossDerivedFrom(chain types.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (db *ChainsDB) CrossDerivedFrom(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -290,7 +290,7 @@ func (db *ChainsDB) CrossDerivedFrom(chain types.ChainID, derived eth.BlockID) (
 //
 // Or ErrOutOfScope, with non-zero derivedFromScope,
 // if additional L1 data is needed to cross-verify the candidate L2 block.
-func (db *ChainsDB) CandidateCrossSafe(chain types.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
+func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (derivedFromScope, crossSafe eth.BlockRef, err error) {
 	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return eth.BlockRef{}, eth.BlockRef{}, types.ErrUnknownChain
@@ -380,7 +380,7 @@ func (db *ChainsDB) CandidateCrossSafe(chain types.ChainID) (derivedFromScope, c
 	return candidateFromRef, candidateRef, nil
 }
 
-func (db *ChainsDB) PreviousDerived(chain types.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+func (db *ChainsDB) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -388,7 +388,7 @@ func (db *ChainsDB) PreviousDerived(chain types.ChainID, derived eth.BlockID) (p
 	return lDB.PreviousDerived(derived)
 }
 
-func (db *ChainsDB) PreviousDerivedFrom(chain types.ChainID, derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error) {
+func (db *ChainsDB) PreviousDerivedFrom(chain eth.ChainID, derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -396,7 +396,7 @@ func (db *ChainsDB) PreviousDerivedFrom(chain types.ChainID, derivedFrom eth.Blo
 	return lDB.PreviousDerivedFrom(derivedFrom)
 }
 
-func (db *ChainsDB) NextDerivedFrom(chain types.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+func (db *ChainsDB) NextDerivedFrom(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		return eth.BlockRef{}, types.ErrUnknownChain
@@ -411,7 +411,7 @@ func (db *ChainsDB) NextDerivedFrom(chain types.ChainID, derivedFrom eth.BlockID
 // Safest returns the strongest safety level that can be guaranteed for the given log entry.
 // it assumes the log entry has already been checked and is valid, this function only checks safety levels.
 // Safety levels are assumed to graduate from LocalUnsafe to LocalSafe to CrossUnsafe to CrossSafe, with Finalized as the strongest.
-func (db *ChainsDB) Safest(chainID types.ChainID, blockNum uint64, index uint32) (safest types.SafetyLevel, err error) {
+func (db *ChainsDB) Safest(chainID eth.ChainID, blockNum uint64, index uint32) (safest types.SafetyLevel, err error) {
 	if finalized, err := db.Finalized(chainID); err == nil {
 		if finalized.Number >= blockNum {
 			return types.Finalized, nil
@@ -443,7 +443,7 @@ func (db *ChainsDB) Safest(chainID types.ChainID, blockNum uint64, index uint32)
 	return types.LocalUnsafe, nil
 }
 
-func (db *ChainsDB) IteratorStartingAt(chain types.ChainID, sealedNum uint64, logIndex uint32) (logs.Iterator, error) {
+func (db *ChainsDB) IteratorStartingAt(chain eth.ChainID, sealedNum uint64, logIndex uint32) (logs.Iterator, error) {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return nil, fmt.Errorf("%w: %v", types.ErrUnknownChain, chain)

--- a/op-supervisor/supervisor/backend/db/sync/client.go
+++ b/op-supervisor/supervisor/backend/db/sync/client.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 var (
@@ -57,7 +57,7 @@ func NewClient(config Config, serverURL string) (*Client, error) {
 }
 
 // SyncAll syncs all known databases for the given chains.
-func (c *Client) SyncAll(ctx context.Context, chains []types.ChainID, resume bool) error {
+func (c *Client) SyncAll(ctx context.Context, chains []eth.ChainID, resume bool) error {
 	for _, chain := range chains {
 		for fileAlias := range Databases {
 			if err := c.SyncDatabase(ctx, chain, fileAlias, resume); err != nil {
@@ -70,7 +70,7 @@ func (c *Client) SyncAll(ctx context.Context, chains []types.ChainID, resume boo
 
 // SyncDatabase downloads the named file from the server.
 // If the local file exists, it will attempt to resume the download if resume is true.
-func (c *Client) SyncDatabase(ctx context.Context, chainID types.ChainID, database Database, resume bool) error {
+func (c *Client) SyncDatabase(ctx context.Context, chainID eth.ChainID, database Database, resume bool) error {
 	// Validate file alias
 	filePath, exists := Databases[database]
 	if !exists {
@@ -111,7 +111,7 @@ func (c *Client) SyncDatabase(ctx context.Context, chainID types.ChainID, databa
 }
 
 // attemptSync makes a single attempt to sync the file
-func (c *Client) attemptSync(ctx context.Context, chainID types.ChainID, database Database, absPath string, initialSize int64) error {
+func (c *Client) attemptSync(ctx context.Context, chainID eth.ChainID, database Database, absPath string, initialSize int64) error {
 	// First do a HEAD request to get the file size
 	path := c.buildURLPath(chainID, database)
 	resp, err := c.httpClient.Get(ctx, path, nil, http.Header{"X-HTTP-Method-Override": []string{"HEAD"}})
@@ -178,7 +178,7 @@ func (c *Client) attemptSync(ctx context.Context, chainID types.ChainID, databas
 }
 
 // buildURLPath creates the URL path for a given database download request
-func (c *Client) buildURLPath(chainID types.ChainID, database Database) string {
+func (c *Client) buildURLPath(chainID eth.ChainID, database Database) string {
 	return fmt.Sprintf("dbsync/%s/%s", chainID.String(), database)
 }
 

--- a/op-supervisor/supervisor/backend/db/sync/server.go
+++ b/op-supervisor/supervisor/backend/db/sync/server.go
@@ -7,17 +7,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // Server handles sync requests
 type Server struct {
 	config      Config
-	validChains map[types.ChainID]struct{}
+	validChains map[eth.ChainID]struct{}
 }
 
 // NewServer creates a new Server with the given config.
-func NewServer(config Config, chains []types.ChainID) (*Server, error) {
+func NewServer(config Config, chains []eth.ChainID) (*Server, error) {
 	// Convert root to absolute path for security
 	root, err := filepath.Abs(config.DataDir)
 	if err != nil {
@@ -34,7 +34,7 @@ func NewServer(config Config, chains []types.ChainID) (*Server, error) {
 	}
 
 	// Build map of valid chains for efficient lookup
-	validChains := make(map[types.ChainID]struct{}, len(chains))
+	validChains := make(map[eth.ChainID]struct{}, len(chains))
 	for _, chain := range chains {
 		validChains[chain] = struct{}{}
 	}
@@ -45,9 +45,9 @@ func NewServer(config Config, chains []types.ChainID) (*Server, error) {
 	}, nil
 }
 
-func parsePath(path string) (types.ChainID, string, error) {
+func parsePath(path string) (eth.ChainID, string, error) {
 	var (
-		chainID   types.ChainID
+		chainID   eth.ChainID
 		fileAlias string
 	)
 

--- a/op-supervisor/supervisor/backend/db/sync/sync_test.go
+++ b/op-supervisor/supervisor/backend/db/sync/sync_test.go
@@ -9,14 +9,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestSyncBasic(t *testing.T) {
 	serverRoot, clientRoot := setupTest(t)
-	chainID := types.ChainID{1}
+	chainID := eth.ChainID{1}
 
 	// Create a test file on the server
 	serverFile := filepath.Join(serverRoot, chainID.String(), DBLocalSafe.File())
@@ -26,7 +25,7 @@ func TestSyncBasic(t *testing.T) {
 	serverCfg := Config{
 		DataDir: serverRoot,
 	}
-	server, err := NewServer(serverCfg, []types.ChainID{chainID})
+	server, err := NewServer(serverCfg, []eth.ChainID{chainID})
 	require.NoError(t, err)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -46,7 +45,7 @@ func TestSyncBasic(t *testing.T) {
 
 func TestSyncResume(t *testing.T) {
 	serverRoot, clientRoot := setupTest(t)
-	chainID := types.ChainID{1} // Use chain ID 1 for testing
+	chainID := eth.ChainID{1} // Use chain ID 1 for testing
 
 	// Create a test file on the server and partial file on the client
 	serverFile := filepath.Join(serverRoot, chainID.String(), DBLocalSafe.File())
@@ -59,7 +58,7 @@ func TestSyncResume(t *testing.T) {
 	serverCfg := Config{
 		DataDir: serverRoot,
 	}
-	server, err := NewServer(serverCfg, []types.ChainID{chainID})
+	server, err := NewServer(serverCfg, []eth.ChainID{chainID})
 	require.NoError(t, err)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -78,7 +77,7 @@ func TestSyncResume(t *testing.T) {
 
 func TestSyncRetry(t *testing.T) {
 	serverRoot, clientRoot := setupTest(t)
-	chainID := types.ChainID{1}
+	chainID := eth.ChainID{1}
 
 	// Create a test file
 	serverFile := filepath.Join(serverRoot, chainID.String(), DBLocalSafe.File())
@@ -88,7 +87,7 @@ func TestSyncRetry(t *testing.T) {
 	serverCfg := Config{
 		DataDir: serverRoot,
 	}
-	server, err := NewServer(serverCfg, []types.ChainID{chainID})
+	server, err := NewServer(serverCfg, []eth.ChainID{chainID})
 	require.NoError(t, err)
 
 	failureCount := 0
@@ -118,12 +117,12 @@ func TestSyncRetry(t *testing.T) {
 
 func TestSyncErrors(t *testing.T) {
 	serverRoot, clientRoot := setupTest(t)
-	chainID := types.ChainID{1}
+	chainID := eth.ChainID{1}
 
 	serverCfg := Config{
 		DataDir: serverRoot,
 	}
-	server, err := NewServer(serverCfg, []types.ChainID{chainID})
+	server, err := NewServer(serverCfg, []eth.ChainID{chainID})
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(server)

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (db *ChainsDB) AddLog(
-	chain types.ChainID,
+	chain eth.ChainID,
 	logHash common.Hash,
 	parentBlock eth.BlockID,
 	logIdx uint32,
@@ -23,7 +23,7 @@ func (db *ChainsDB) AddLog(
 	return logDB.AddLog(logHash, parentBlock, logIdx, execMsg)
 }
 
-func (db *ChainsDB) SealBlock(chain types.ChainID, block eth.BlockRef) error {
+func (db *ChainsDB) SealBlock(chain eth.ChainID, block eth.BlockRef) error {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot SealBlock: %w: %v", types.ErrUnknownChain, chain)
@@ -40,7 +40,7 @@ func (db *ChainsDB) SealBlock(chain types.ChainID, block eth.BlockRef) error {
 	return nil
 }
 
-func (db *ChainsDB) Rewind(chain types.ChainID, headBlockNum uint64) error {
+func (db *ChainsDB) Rewind(chain eth.ChainID, headBlockNum uint64) error {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot Rewind: %w: %s", types.ErrUnknownChain, chain)
@@ -48,7 +48,7 @@ func (db *ChainsDB) Rewind(chain types.ChainID, headBlockNum uint64) error {
 	return logDB.Rewind(headBlockNum)
 }
 
-func (db *ChainsDB) UpdateLocalSafe(chain types.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
+func (db *ChainsDB) UpdateLocalSafe(chain eth.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
 	logger := db.logger.New("chain", chain, "derivedFrom", derivedFrom, "lastDerived", lastDerived)
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
@@ -75,7 +75,7 @@ func (db *ChainsDB) UpdateLocalSafe(chain types.ChainID, derivedFrom eth.BlockRe
 	})
 }
 
-func (db *ChainsDB) UpdateCrossUnsafe(chain types.ChainID, crossUnsafe types.BlockSeal) error {
+func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.BlockSeal) error {
 	v, ok := db.crossUnsafe.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot UpdateCrossUnsafe: %w: %s", types.ErrUnknownChain, chain)
@@ -89,7 +89,7 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain types.ChainID, crossUnsafe types.Blo
 	return nil
 }
 
-func (db *ChainsDB) UpdateCrossSafe(chain types.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+func (db *ChainsDB) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 	crossDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot UpdateCrossSafe: %w: %s", types.ErrUnknownChain, chain)

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -3,6 +3,7 @@ package depset
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -18,22 +19,22 @@ type DependencySet interface {
 	// I.e. if the chain may be executing messages at the given timestamp.
 	// This may return an error if the query temporarily cannot be answered.
 	// E.g. if the DependencySet is syncing new changes.
-	CanExecuteAt(chainID types.ChainID, execTimestamp uint64) (bool, error)
+	CanExecuteAt(chainID eth.ChainID, execTimestamp uint64) (bool, error)
 
 	// CanInitiateAt determines if an initiating message is valid to pull in.
 	// I.e. if the message of the given chain is readable or not.
 	// This may return an error if the query temporarily cannot be answered.
 	// E.g. if the DependencySet is syncing new changes.
-	CanInitiateAt(chainID types.ChainID, initTimestamp uint64) (bool, error)
+	CanInitiateAt(chainID eth.ChainID, initTimestamp uint64) (bool, error)
 
 	// Chains returns the list of chains that are part of the dependency set.
-	Chains() []types.ChainID
+	Chains() []eth.ChainID
 
 	// HasChain determines if a chain is being tracked for interop purposes.
 	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
-	HasChain(chainID types.ChainID) bool
+	HasChain(chainID eth.ChainID) bool
 
-	ChainIndexFromID(id types.ChainID) (types.ChainIndex, error)
+	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
 
 	ChainIndexFromID
 	ChainIDFromIndex
@@ -41,10 +42,10 @@ type DependencySet interface {
 
 type ChainIndexFromID interface {
 	// ChainIndexFromID converts a ChainID to a ChainIndex.
-	ChainIndexFromID(id types.ChainID) (types.ChainIndex, error)
+	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
 }
 
 type ChainIDFromIndex interface {
 	// ChainIDFromIndex converts a ChainIndex to a ChainID.
-	ChainIDFromIndex(index types.ChainIndex) (types.ChainID, error)
+	ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error)
 }

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -7,22 +7,21 @@ import (
 	"path"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestDependencySet(t *testing.T) {
 	d := path.Join(t.TempDir(), "tmp_dep_set.json")
 
 	depSet, err := NewStaticConfigDependencySet(
-		map[types.ChainID]*StaticConfigDependency{
-			types.ChainIDFromUInt64(900): {
+		map[eth.ChainID]*StaticConfigDependency{
+			eth.ChainIDFromUInt64(900): {
 				ChainIndex:     900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
-			types.ChainIDFromUInt64(901): {
+			eth.ChainIDFromUInt64(901): {
 				ChainIndex:     901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
@@ -39,41 +38,41 @@ func TestDependencySet(t *testing.T) {
 	require.NoError(t, err)
 
 	chainIDs := result.Chains()
-	require.Equal(t, []types.ChainID{
-		types.ChainIDFromUInt64(900),
-		types.ChainIDFromUInt64(901),
+	require.Equal(t, []eth.ChainID{
+		eth.ChainIDFromUInt64(900),
+		eth.ChainIDFromUInt64(901),
 	}, chainIDs)
 
-	v, err := result.CanExecuteAt(types.ChainIDFromUInt64(900), 42)
+	v, err := result.CanExecuteAt(eth.ChainIDFromUInt64(900), 42)
 	require.NoError(t, err)
 	require.True(t, v)
-	v, err = result.CanExecuteAt(types.ChainIDFromUInt64(900), 41)
+	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(900), 41)
 	require.NoError(t, err)
 	require.False(t, v)
-	v, err = result.CanInitiateAt(types.ChainIDFromUInt64(900), 100)
+	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(900), 100)
 	require.NoError(t, err)
 	require.True(t, v)
-	v, err = result.CanInitiateAt(types.ChainIDFromUInt64(900), 99)
-	require.NoError(t, err)
-	require.False(t, v)
-
-	v, err = result.CanExecuteAt(types.ChainIDFromUInt64(901), 30)
-	require.NoError(t, err)
-	require.True(t, v)
-	v, err = result.CanExecuteAt(types.ChainIDFromUInt64(901), 29)
-	require.NoError(t, err)
-	require.False(t, v)
-	v, err = result.CanInitiateAt(types.ChainIDFromUInt64(901), 20)
-	require.NoError(t, err)
-	require.True(t, v)
-	v, err = result.CanInitiateAt(types.ChainIDFromUInt64(901), 19)
+	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(900), 99)
 	require.NoError(t, err)
 	require.False(t, v)
 
-	v, err = result.CanExecuteAt(types.ChainIDFromUInt64(902), 100000)
+	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(901), 30)
+	require.NoError(t, err)
+	require.True(t, v)
+	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(901), 29)
+	require.NoError(t, err)
+	require.False(t, v)
+	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(901), 20)
+	require.NoError(t, err)
+	require.True(t, v)
+	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(901), 19)
+	require.NoError(t, err)
+	require.False(t, v)
+
+	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(902), 100000)
 	require.NoError(t, err)
 	require.False(t, v, "902 not a dependency")
-	v, err = result.CanInitiateAt(types.ChainIDFromUInt64(902), 100000)
+	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(902), 100000)
 	require.NoError(t, err)
 	require.False(t, v, "902 not a dependency")
 }

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -28,14 +29,14 @@ type StaticConfigDependency struct {
 // It can be used as a DependencySetSource itself, by simply returning the itself when loading the set.
 type StaticConfigDependencySet struct {
 	// dependency info per chain
-	dependencies map[types.ChainID]*StaticConfigDependency
+	dependencies map[eth.ChainID]*StaticConfigDependency
 	// cached mapping of chain index to chain ID
-	indexToID map[types.ChainIndex]types.ChainID
+	indexToID map[types.ChainIndex]eth.ChainID
 	// cached list of chain IDs, sorted by ID value
-	chainIDs []types.ChainID
+	chainIDs []eth.ChainID
 }
 
-func NewStaticConfigDependencySet(dependencies map[types.ChainID]*StaticConfigDependency) (*StaticConfigDependencySet, error) {
+func NewStaticConfigDependencySet(dependencies map[eth.ChainID]*StaticConfigDependency) (*StaticConfigDependencySet, error) {
 	out := &StaticConfigDependencySet{dependencies: dependencies}
 	if err := out.hydrate(); err != nil {
 		return nil, err
@@ -47,7 +48,7 @@ func NewStaticConfigDependencySet(dependencies map[types.ChainID]*StaticConfigDe
 // to encode/decode just the attributes that matter,
 // while wrapping the decoding functionality with additional hydration step.
 type jsonStaticConfigDependencySet struct {
-	Dependencies map[types.ChainID]*StaticConfigDependency `json:"dependencies"`
+	Dependencies map[eth.ChainID]*StaticConfigDependency `json:"dependencies"`
 }
 
 func (ds *StaticConfigDependencySet) MarshalJSON() ([]byte, error) {
@@ -68,8 +69,8 @@ func (ds *StaticConfigDependencySet) UnmarshalJSON(data []byte) error {
 
 // hydrate sets all the cached values, based on the dependencies attribute
 func (ds *StaticConfigDependencySet) hydrate() error {
-	ds.indexToID = make(map[types.ChainIndex]types.ChainID)
-	ds.chainIDs = make([]types.ChainID, 0, len(ds.dependencies))
+	ds.indexToID = make(map[types.ChainIndex]eth.ChainID)
+	ds.chainIDs = make([]eth.ChainID, 0, len(ds.dependencies))
 	for id, dep := range ds.dependencies {
 		if existing, ok := ds.indexToID[dep.ChainIndex]; ok {
 			return fmt.Errorf("chain %s cannot have the same index (%d) as chain %s", id, dep.ChainIndex, existing)
@@ -91,7 +92,7 @@ func (ds *StaticConfigDependencySet) LoadDependencySet(ctx context.Context) (Dep
 	return ds, nil
 }
 
-func (ds *StaticConfigDependencySet) CanExecuteAt(chainID types.ChainID, execTimestamp uint64) (bool, error) {
+func (ds *StaticConfigDependencySet) CanExecuteAt(chainID eth.ChainID, execTimestamp uint64) (bool, error) {
 	dep, ok := ds.dependencies[chainID]
 	if !ok {
 		return false, nil
@@ -99,7 +100,7 @@ func (ds *StaticConfigDependencySet) CanExecuteAt(chainID types.ChainID, execTim
 	return execTimestamp >= dep.ActivationTime, nil
 }
 
-func (ds *StaticConfigDependencySet) CanInitiateAt(chainID types.ChainID, initTimestamp uint64) (bool, error) {
+func (ds *StaticConfigDependencySet) CanInitiateAt(chainID eth.ChainID, initTimestamp uint64) (bool, error) {
 	dep, ok := ds.dependencies[chainID]
 	if !ok {
 		return false, nil
@@ -107,16 +108,16 @@ func (ds *StaticConfigDependencySet) CanInitiateAt(chainID types.ChainID, initTi
 	return initTimestamp >= dep.HistoryMinTime, nil
 }
 
-func (ds *StaticConfigDependencySet) Chains() []types.ChainID {
+func (ds *StaticConfigDependencySet) Chains() []eth.ChainID {
 	return slices.Clone(ds.chainIDs)
 }
 
-func (ds *StaticConfigDependencySet) HasChain(chainID types.ChainID) bool {
+func (ds *StaticConfigDependencySet) HasChain(chainID eth.ChainID) bool {
 	_, ok := ds.dependencies[chainID]
 	return ok
 }
 
-func (ds *StaticConfigDependencySet) ChainIndexFromID(id types.ChainID) (types.ChainIndex, error) {
+func (ds *StaticConfigDependencySet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
 	dep, ok := ds.dependencies[id]
 	if !ok {
 		return 0, fmt.Errorf("failed to translate chain ID %s to chain index: %w", id, types.ErrUnknownChain)
@@ -124,10 +125,10 @@ func (ds *StaticConfigDependencySet) ChainIndexFromID(id types.ChainID) (types.C
 	return dep.ChainIndex, nil
 }
 
-func (ds *StaticConfigDependencySet) ChainIDFromIndex(index types.ChainIndex) (types.ChainID, error) {
+func (ds *StaticConfigDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
 	id, ok := ds.indexToID[index]
 	if !ok {
-		return types.ChainID{}, fmt.Errorf("failed to translate chain index %s to chain ID: %w", index, types.ErrUnknownChain)
+		return eth.ChainID{}, fmt.Errorf("failed to translate chain index %s to chain ID: %w", index, types.ErrUnknownChain)
 	}
 	return id, nil
 }

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -51,15 +51,15 @@ func (m *MockBackend) CheckMessages(messages []types.Message, minSafety types.Sa
 	return nil
 }
 
-func (m *MockBackend) LocalUnsafe(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (m *MockBackend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
 
-func (m *MockBackend) CrossSafe(ctx context.Context, chainID types.ChainID) (types.DerivedIDPair, error) {
+func (m *MockBackend) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
 	return types.DerivedIDPair{}, nil
 }
 
-func (m *MockBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (m *MockBackend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
 
@@ -67,12 +67,12 @@ func (m *MockBackend) FinalizedL1() eth.BlockRef {
 	return eth.BlockRef{}
 }
 
-func (m *MockBackend) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+func (m *MockBackend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	return eth.BlockRef{}, nil
 }
 
-func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
-	return types.SuperRootResponse{}, nil
+func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
+	return eth.SuperRootResponse{}, nil
 }
 
 func (m *MockBackend) Close() error {

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -29,8 +29,8 @@ type LogProcessor interface {
 }
 
 type DatabaseRewinder interface {
-	Rewind(chain types.ChainID, headBlockNum uint64) error
-	LatestBlockNum(chain types.ChainID) (num uint64, ok bool)
+	Rewind(chain eth.ChainID, headBlockNum uint64) error
+	LatestBlockNum(chain eth.ChainID) (num uint64, ok bool)
 }
 
 type BlockProcessorFn func(ctx context.Context, block eth.BlockRef) error
@@ -47,7 +47,7 @@ type ChainProcessor struct {
 	client     Source
 	clientLock sync.Mutex
 
-	chain types.ChainID
+	chain eth.ChainID
 
 	systemContext context.Context
 
@@ -62,7 +62,7 @@ type ChainProcessor struct {
 var _ event.AttachEmitter = (*ChainProcessor)(nil)
 var _ event.Deriver = (*ChainProcessor)(nil)
 
-func NewChainProcessor(systemContext context.Context, log log.Logger, chain types.ChainID, processor LogProcessor, rewinder DatabaseRewinder) *ChainProcessor {
+func NewChainProcessor(systemContext context.Context, log log.Logger, chain eth.ChainID, processor LogProcessor, rewinder DatabaseRewinder) *ChainProcessor {
 	out := &ChainProcessor{
 		systemContext:     systemContext,
 		log:               log.New("chain", chain),

--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/params"
@@ -28,7 +29,7 @@ func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) 
 		return nil, fmt.Errorf("invalid executing message: %w", err)
 	}
 	logHash := types.PayloadHashToLogHash(msg.PayloadHash, msg.Identifier.Origin)
-	index, err := depSet.ChainIndexFromID(types.ChainID(msg.Identifier.ChainID))
+	index, err := depSet.ChainIndexFromID(eth.ChainID(msg.Identifier.ChainID))
 	if err != nil {
 		return nil, err
 	}

--- a/op-supervisor/supervisor/backend/processors/executing_message_test.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -14,10 +15,10 @@ import (
 )
 
 type testDepSet struct {
-	mapping map[types.ChainID]types.ChainIndex
+	mapping map[eth.ChainID]types.ChainIndex
 }
 
-func (t *testDepSet) ChainIndexFromID(id types.ChainID) (types.ChainIndex, error) {
+func (t *testDepSet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
 	v, ok := t.mapping[id]
 	if !ok {
 		return 0, types.ErrUnknownChain
@@ -48,8 +49,8 @@ func TestDecodeExecutingMessageLog(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(data), &logEvent))
 
 	msg, err := DecodeExecutingMessageLog(&logEvent, &testDepSet{
-		mapping: map[types.ChainID]types.ChainIndex{
-			types.ChainIDFromUInt64(900200): types.ChainIndex(123),
+		mapping: map[eth.ChainID]types.ChainIndex{
+			eth.ChainIDFromUInt64(900200): types.ChainIndex(123),
 		},
 	})
 	require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/processors/log_processor.go
+++ b/op-supervisor/supervisor/backend/processors/log_processor.go
@@ -14,18 +14,18 @@ import (
 )
 
 type LogStorage interface {
-	SealBlock(chain types.ChainID, block eth.BlockRef) error
-	AddLog(chain types.ChainID, logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error
+	SealBlock(chain eth.ChainID, block eth.BlockRef) error
+	AddLog(chain eth.ChainID, logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error
 }
 
 type logProcessor struct {
-	chain        types.ChainID
+	chain        eth.ChainID
 	logStore     LogStorage
 	eventDecoder EventDecoderFn
 	depSet       depset.ChainIndexFromID
 }
 
-func NewLogProcessor(chain types.ChainID, logStore LogStorage, depSet depset.ChainIndexFromID) LogProcessor {
+func NewLogProcessor(chain eth.ChainID, logStore LogStorage, depSet depset.ChainIndexFromID) LogProcessor {
 	return &logProcessor{
 		chain:        chain,
 		logStore:     logStore,

--- a/op-supervisor/supervisor/backend/processors/log_processor_test.go
+++ b/op-supervisor/supervisor/backend/processors/log_processor_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-var logProcessorChainID = types.ChainIDFromUInt64(4)
+var logProcessorChainID = eth.ChainIDFromUInt64(4)
 
 func TestLogProcessor(t *testing.T) {
 	ctx := context.Background()
@@ -27,8 +27,8 @@ func TestLogProcessor(t *testing.T) {
 		Time:       1111,
 	}
 	depSet := &testDepSet{
-		mapping: map[types.ChainID]types.ChainIndex{
-			types.ChainIDFromUInt64(100): 4,
+		mapping: map[eth.ChainID]types.ChainIndex{
+			eth.ChainIDFromUInt64(100): 4,
 		},
 	}
 
@@ -124,7 +124,7 @@ func TestLogProcessor(t *testing.T) {
 			Hash:      common.Hash{0xaa},
 		}
 		store := &stubLogStorage{}
-		processor := NewLogProcessor(types.ChainID{4}, store, depSet).(*logProcessor)
+		processor := NewLogProcessor(eth.ChainID{4}, store, depSet).(*logProcessor)
 		processor.eventDecoder = func(l *ethTypes.Log, translator depset.ChainIndexFromID) (*types.ExecutingMessage, error) {
 			require.Equal(t, rcpts[0].Logs[0], l)
 			return execMsg, nil
@@ -214,7 +214,7 @@ type stubLogStorage struct {
 	seals []storedSeal
 }
 
-func (s *stubLogStorage) SealBlock(chainID types.ChainID, block eth.BlockRef) error {
+func (s *stubLogStorage) SealBlock(chainID eth.ChainID, block eth.BlockRef) error {
 	if logProcessorChainID != chainID {
 		return fmt.Errorf("chain id mismatch, expected %v but got %v", logProcessorChainID, chainID)
 	}
@@ -226,7 +226,7 @@ func (s *stubLogStorage) SealBlock(chainID types.ChainID, block eth.BlockRef) er
 	return nil
 }
 
-func (s *stubLogStorage) AddLog(chainID types.ChainID, logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error {
+func (s *stubLogStorage) AddLog(chainID eth.ChainID, logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error {
 	if logProcessorChainID != chainID {
 		return fmt.Errorf("chain id mismatch, expected %v but got %v", logProcessorChainID, chainID)
 	}

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ChainProcessEvent struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 	Target  uint64
 }
 
@@ -15,7 +15,7 @@ func (ev ChainProcessEvent) String() string {
 }
 
 type UpdateCrossUnsafeRequestEvent struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 }
 
 func (ev UpdateCrossUnsafeRequestEvent) String() string {
@@ -23,7 +23,7 @@ func (ev UpdateCrossUnsafeRequestEvent) String() string {
 }
 
 type UpdateCrossSafeRequestEvent struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 }
 
 func (ev UpdateCrossSafeRequestEvent) String() string {
@@ -31,7 +31,7 @@ func (ev UpdateCrossSafeRequestEvent) String() string {
 }
 
 type LocalUnsafeUpdateEvent struct {
-	ChainID        types.ChainID
+	ChainID        eth.ChainID
 	NewLocalUnsafe eth.BlockRef
 }
 
@@ -40,7 +40,7 @@ func (ev LocalUnsafeUpdateEvent) String() string {
 }
 
 type LocalSafeUpdateEvent struct {
-	ChainID      types.ChainID
+	ChainID      eth.ChainID
 	NewLocalSafe types.DerivedBlockSealPair
 }
 
@@ -49,7 +49,7 @@ func (ev LocalSafeUpdateEvent) String() string {
 }
 
 type CrossUnsafeUpdateEvent struct {
-	ChainID        types.ChainID
+	ChainID        eth.ChainID
 	NewCrossUnsafe types.BlockSeal
 }
 
@@ -58,7 +58,7 @@ func (ev CrossUnsafeUpdateEvent) String() string {
 }
 
 type CrossSafeUpdateEvent struct {
-	ChainID      types.ChainID
+	ChainID      eth.ChainID
 	NewCrossSafe types.DerivedBlockSealPair
 }
 
@@ -83,7 +83,7 @@ func (ev FinalizedL1UpdateEvent) String() string {
 }
 
 type FinalizedL2UpdateEvent struct {
-	ChainID     types.ChainID
+	ChainID     eth.ChainID
 	FinalizedL2 types.BlockSeal
 }
 
@@ -92,7 +92,7 @@ func (ev FinalizedL2UpdateEvent) String() string {
 }
 
 type LocalSafeOutOfSyncEvent struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 	L1Ref   eth.BlockRef
 	Err     error
 }
@@ -102,7 +102,7 @@ func (ev LocalSafeOutOfSyncEvent) String() string {
 }
 
 type LocalUnsafeReceivedEvent struct {
-	ChainID        types.ChainID
+	ChainID        eth.ChainID
 	NewLocalUnsafe eth.BlockRef
 }
 
@@ -111,7 +111,7 @@ func (ev LocalUnsafeReceivedEvent) String() string {
 }
 
 type LocalDerivedEvent struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 	Derived types.DerivedBlockRefPair
 }
 
@@ -120,7 +120,7 @@ func (ev LocalDerivedEvent) String() string {
 }
 
 type AnchorEvent struct {
-	ChainID types.ChainID
+	ChainID eth.ChainID
 	Anchor  types.DerivedBlockRefPair
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -87,19 +87,19 @@ var _ SyncControl = (*mockSyncControl)(nil)
 
 type mockBackend struct{}
 
-func (m *mockBackend) LocalSafe(ctx context.Context, chainID types.ChainID) (pair types.DerivedIDPair, err error) {
+func (m *mockBackend) LocalSafe(ctx context.Context, chainID eth.ChainID) (pair types.DerivedIDPair, err error) {
 	return types.DerivedIDPair{}, nil
 }
 
-func (m *mockBackend) LocalUnsafe(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (m *mockBackend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
 
-func (m *mockBackend) SafeDerivedAt(ctx context.Context, chainID types.ChainID, derivedFrom eth.BlockID) (derived eth.BlockID, err error) {
+func (m *mockBackend) SafeDerivedAt(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (derived eth.BlockID, err error) {
 	return eth.BlockID{}, nil
 }
 
-func (m *mockBackend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (m *mockBackend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }
 
@@ -111,13 +111,13 @@ var _ backend = (*mockBackend)(nil)
 
 func sampleDepSet(t *testing.T) depset.DependencySet {
 	depSet, err := depset.NewStaticConfigDependencySet(
-		map[types.ChainID]*depset.StaticConfigDependency{
-			types.ChainIDFromUInt64(900): {
+		map[eth.ChainID]*depset.StaticConfigDependency{
+			eth.ChainIDFromUInt64(900): {
 				ChainIndex:     900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
-			types.ChainIDFromUInt64(901): {
+			eth.ChainIDFromUInt64(901): {
 				ChainIndex:     901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
@@ -173,14 +173,14 @@ func TestInitFromAnchorPoint(t *testing.T) {
 	}
 
 	// after the first attach, both databases are called for update
-	_, err := controller.AttachNodeController(types.ChainIDFromUInt64(900), &ctrl, false)
+	_, err := controller.AttachNodeController(eth.ChainIDFromUInt64(900), &ctrl, false)
 	require.NoError(t, err)
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 1, mon.anchorCalled, "an anchor point should be received")
 
 	// on second attach we send the anchor again; it's up to the DB to use it or not.
 	ctrl2 := mockSyncControl{}
-	_, err = controller.AttachNodeController(types.ChainIDFromUInt64(901), &ctrl2, false)
+	_, err = controller.AttachNodeController(eth.ChainIDFromUInt64(901), &ctrl2, false)
 	require.NoError(t, err)
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 2, mon.anchorCalled, "anchor point again")
@@ -199,21 +199,21 @@ func TestAttachNodeController(t *testing.T) {
 
 	// Attach a controller for chain 900
 	ctrl := mockSyncControl{}
-	_, err := controller.AttachNodeController(types.ChainIDFromUInt64(900), &ctrl, false)
+	_, err := controller.AttachNodeController(eth.ChainIDFromUInt64(900), &ctrl, false)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, controller.controllers.Len(), "controllers should have 1 entry")
 
 	// Attach a controller for chain 901
 	ctrl2 := mockSyncControl{}
-	_, err = controller.AttachNodeController(types.ChainIDFromUInt64(901), &ctrl2, false)
+	_, err = controller.AttachNodeController(eth.ChainIDFromUInt64(901), &ctrl2, false)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, controller.controllers.Len(), "controllers should have 2 entries")
 
 	// Attach a controller for chain 902 (which is not in the dependency set)
 	ctrl3 := mockSyncControl{}
-	_, err = controller.AttachNodeController(types.ChainIDFromUInt64(902), &ctrl3, false)
+	_, err = controller.AttachNodeController(eth.ChainIDFromUInt64(902), &ctrl3, false)
 	require.Error(t, err)
 	require.Equal(t, 2, controller.controllers.Len(), "controllers should still have 2 entries")
 }

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -24,7 +24,7 @@ type SyncNodeSetup interface {
 type SyncSource interface {
 	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)
-	ChainID(ctx context.Context) (types.ChainID, error)
+	ChainID(ctx context.Context) (eth.ChainID, error)
 	OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
 	PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
 	// String identifies the sync source

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -22,10 +22,10 @@ import (
 )
 
 type backend interface {
-	LocalSafe(ctx context.Context, chainID types.ChainID) (pair types.DerivedIDPair, err error)
-	LocalUnsafe(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
-	SafeDerivedAt(ctx context.Context, chainID types.ChainID, derivedFrom eth.BlockID) (derived eth.BlockID, err error)
-	Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
+	LocalSafe(ctx context.Context, chainID eth.ChainID) (pair types.DerivedIDPair, err error)
+	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
+	SafeDerivedAt(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (derived eth.BlockID, err error)
+	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
 }
 
@@ -37,7 +37,7 @@ const (
 type ManagedNode struct {
 	log     log.Logger
 	Node    SyncControl
-	chainID types.ChainID
+	chainID eth.ChainID
 
 	backend backend
 
@@ -57,7 +57,7 @@ type ManagedNode struct {
 var _ event.AttachEmitter = (*ManagedNode)(nil)
 var _ event.Deriver = (*ManagedNode)(nil)
 
-func NewManagedNode(log log.Logger, id types.ChainID, node SyncControl, backend backend, noSubscribe bool) *ManagedNode {
+func NewManagedNode(log log.Logger, id eth.ChainID, node SyncControl, backend backend, noSubscribe bool) *ManagedNode {
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &ManagedNode{
 		log:     log.New("chain", id),

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestEventResponse(t *testing.T) {
-	chainID := types.ChainIDFromUInt64(1)
+	chainID := eth.ChainIDFromUInt64(1)
 	logger := testlog.Logger(t, log.LvlInfo)
 	syncCtrl := &mockSyncControl{}
 	backend := &mockBackend{}

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -63,8 +63,8 @@ func (rs *RPCSyncNode) FetchReceipts(ctx context.Context, blockHash common.Hash)
 	return out, nil
 }
 
-func (rs *RPCSyncNode) ChainID(ctx context.Context) (types.ChainID, error) {
-	var chainID types.ChainID
+func (rs *RPCSyncNode) ChainID(ctx context.Context) (eth.ChainID, error) {
+	var chainID eth.ChainID
 	err := rs.cl.CallContext(ctx, &chainID, "interop_chainID")
 	return chainID, err
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -18,12 +18,12 @@ type AdminBackend interface {
 type QueryBackend interface {
 	CheckMessage(identifier types.Identifier, payloadHash common.Hash) (types.SafetyLevel, error)
 	CheckMessages(messages []types.Message, minSafety types.SafetyLevel) error
-	CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
-	LocalUnsafe(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
-	CrossSafe(ctx context.Context, chainID types.ChainID) (types.DerivedIDPair, error)
-	Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error)
+	CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
+	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
+	CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error)
+	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	FinalizedL1() eth.BlockRef
-	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error)
+	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
 }
 
 type Backend interface {
@@ -51,15 +51,15 @@ func (q *QueryFrontend) CheckMessages(
 	return q.Supervisor.CheckMessages(messages, minSafety)
 }
 
-func (q *QueryFrontend) LocalUnsafe(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (q *QueryFrontend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return q.Supervisor.LocalUnsafe(ctx, chainID)
 }
 
-func (q *QueryFrontend) CrossSafe(ctx context.Context, chainID types.ChainID) (types.DerivedIDPair, error) {
+func (q *QueryFrontend) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
 	return q.Supervisor.CrossSafe(ctx, chainID)
 }
 
-func (q *QueryFrontend) Finalized(ctx context.Context, chainID types.ChainID) (eth.BlockID, error) {
+func (q *QueryFrontend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	return q.Supervisor.Finalized(ctx, chainID)
 }
 
@@ -67,11 +67,11 @@ func (q *QueryFrontend) FinalizedL1() eth.BlockRef {
 	return q.Supervisor.FinalizedL1()
 }
 
-func (q *QueryFrontend) CrossDerivedFrom(ctx context.Context, chainID types.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+func (q *QueryFrontend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	return q.Supervisor.CrossDerivedFrom(ctx, chainID, derived)
 }
 
-func (q *QueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (types.SuperRootResponse, error) {
+func (q *QueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
 	return q.Supervisor.SuperRootAtTimestamp(ctx, timestamp)
 }
 

--- a/op-supervisor/supervisor/service_test.go
+++ b/op-supervisor/supervisor/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -22,7 +23,7 @@ import (
 )
 
 func TestSupervisorService(t *testing.T) {
-	depSet, err := depset.NewStaticConfigDependencySet(make(map[types.ChainID]*depset.StaticConfigDependency))
+	depSet, err := depset.NewStaticConfigDependencySet(make(map[eth.ChainID]*depset.StaticConfigDependency))
 	require.NoError(t, err)
 
 	cfg := &config.Config{
@@ -71,7 +72,7 @@ func TestSupervisorService(t *testing.T) {
 				BlockNumber: 123,
 				LogIndex:    42,
 				Timestamp:   1234567,
-				ChainID:     types.ChainID{0xbb},
+				ChainID:     eth.ChainID{0xbb},
 			}, common.Hash{0xcc})
 		cancel()
 		require.NoError(t, err)

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -2,14 +2,13 @@ package types
 
 import (
 	"encoding/json"
-	"math"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
 )
 
 func FuzzRoundtripIdentifierJSONMarshal(f *testing.F) {
@@ -23,7 +22,7 @@ func FuzzRoundtripIdentifierJSONMarshal(f *testing.F) {
 			BlockNumber: blockNumber,
 			LogIndex:    logIndex,
 			Timestamp:   timestamp,
-			ChainID:     ChainIDFromBig(new(big.Int).SetBytes(chainID)),
+			ChainID:     eth.ChainIDFromBig(new(big.Int).SetBytes(chainID)),
 		}
 
 		raw, err := json.Marshal(&id)
@@ -38,36 +37,4 @@ func FuzzRoundtripIdentifierJSONMarshal(f *testing.F) {
 		require.Equal(t, id.Timestamp, dec.Timestamp)
 		require.Equal(t, id.ChainID, dec.ChainID)
 	})
-}
-
-func TestChainID_String(t *testing.T) {
-	tests := []struct {
-		input    ChainID
-		expected string
-	}{
-		{ChainIDFromUInt64(0), "0"},
-		{ChainIDFromUInt64(1), "1"},
-		{ChainIDFromUInt64(871975192374), "871975192374"},
-		{ChainIDFromUInt64(math.MaxInt64), "9223372036854775807"},
-		{ChainID(*uint256.NewInt(math.MaxUint64)), "18446744073709551615"},
-		{ChainID(*uint256.MustFromDecimal("1844674407370955161618446744073709551616")), "1844674407370955161618446744073709551616"},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.expected, func(t *testing.T) {
-			t.Run("String", func(t *testing.T) {
-				require.Equal(t, test.expected, test.input.String())
-			})
-			t.Run("MarshalText", func(t *testing.T) {
-				data, err := test.input.MarshalText()
-				require.NoError(t, err)
-				require.Equal(t, test.expected, string(data))
-			})
-			t.Run("UnmarshalText", func(t *testing.T) {
-				var id ChainID
-				require.NoError(t, id.UnmarshalText([]byte(test.expected)))
-				require.Equal(t, test.input, id)
-			})
-		})
-	}
 }


### PR DESCRIPTION
**Description**

Moves `ChainID` and `SuperRootResponse` to the op-service eth package so they can be shared between op-supervisor, op-challenger and op-program.

**Tests**

No change in functionality - moved the unit tests as well.
