### PR TITLE
feat: Add ForgeArtifacts.getSlot()

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -11,6 +11,7 @@ import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
+import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Target contract dependencies
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -23,7 +24,12 @@ contract L1CrossDomainMessenger_Test is CommonTest {
     address recipient = address(0xabbaacdc);
 
     /// @dev The storage slot of the l2Sender
-    uint256 constant senderSlotIndex = 50;
+    uint256 senderSlotIndex;
+
+    function setUp() public override {
+        super.setUp();
+        senderSlotIndex = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender").slot;
+    }
 
     /// @dev Tests that the implementation is initialized correctly.
     /// @notice Marked virtual to be overridden in

--- a/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
@@ -10,10 +10,11 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
+import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 
 contract RelayActor is StdUtils {
     // Storage slot of the l2Sender
-    uint256 constant senderSlotIndex = 50;
+    uint256 senderSlotIndex;
 
     uint256 public numHashes;
     bytes32[] public hashes;
@@ -29,6 +30,7 @@ contract RelayActor is StdUtils {
         xdm = _xdm;
         vm = _vm;
         doFail = _doFail;
+        senderSlotIndex = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender").slot;
     }
 
     /// @notice Relays a message to the `L1CrossDomainMessenger` with a random `version`,


### PR DESCRIPTION
Added a new `getSlot` function to `ForgeArtifacts` library and updated the `CrossDomainMessenger` tests to validate the usage.

While this duplicates functionality provided by `StdStorage` it IMO has a more intuitive syntax, and does not requiring adding a `using ... for ...` statement.


