### PR TITLE
interop: Add AllSafeDerived API

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -475,6 +475,20 @@ func (su *SupervisorBackend) SafeDerivedAt(ctx context.Context, chainID eth.Chai
 	return v.ID(), nil
 }
 
+// AllSafeDerivedAt returns the last derived block for each chain, from the given L1 block
+func (su *SupervisorBackend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
+	chains := su.depSet.Chains()
+	ret := map[eth.ChainID]eth.BlockID{}
+	for _, chainID := range chains {
+		derived, err := su.SafeDerivedAt(context.Background(), chainID, derivedFrom)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get last derived block for chain %v: %w", chainID, err)
+		}
+		ret[chainID] = derived
+	}
+	return ret, nil
+}
+
 func (su *SupervisorBackend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	v, err := su.chainDBs.Finalized(chainID)
 	if err != nil {

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -480,7 +480,7 @@ func (su *SupervisorBackend) AllSafeDerivedAt(ctx context.Context, derivedFrom e
 	chains := su.depSet.Chains()
 	ret := map[eth.ChainID]eth.BlockID{}
 	for _, chainID := range chains {
-		derived, err := su.SafeDerivedAt(context.Background(), chainID, derivedFrom)
+		derived, err := su.SafeDerivedAt(ctx, chainID, derivedFrom)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get last derived block for chain %v: %w", chainID, err)
 		}

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -39,6 +39,10 @@ func (m *MockBackend) Stop(ctx context.Context) error {
 	return nil
 }
 
+func (m *MockBackend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error) {
+	return nil, nil
+}
+
 func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error {
 	return nil
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -24,6 +24,7 @@ type QueryBackend interface {
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	FinalizedL1() eth.BlockRef
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
+	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
 }
 
 type Backend interface {
@@ -73,6 +74,10 @@ func (q *QueryFrontend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainI
 
 func (q *QueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
 	return q.Supervisor.SuperRootAtTimestamp(ctx, timestamp)
+}
+
+func (q *QueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error) {
+	return q.Supervisor.AllSafeDerivedAt(ctx, derivedFrom)
 }
 
 type AdminFrontend struct {


### PR DESCRIPTION
Allows for callers to the OP Supervisor to fetch all the last known L2 block to have been derived from a given L1, for each chain in the dependency set.