### PR TITLE
op-challenger: Define Interop-cannon game type and required CLI args

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -596,7 +596,7 @@ func TestAlphabetRequiredArgs(t *testing.T) {
 }
 
 func TestCannonRequiredArgs(t *testing.T) {
-	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned} {
+	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeInteropCannon} {
 		traceType := traceType
 		t.Run(fmt.Sprintf("TestCannonBin-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
@@ -1004,7 +1004,6 @@ func requiredArgs(traceType types.TraceType) map[string]string {
 	args := map[string]string{
 		"--l1-eth-rpc":           l1EthRpc,
 		"--l1-beacon":            l1Beacon,
-		"--rollup-rpc":           rollupRpc,
 		"--l2-eth-rpc":           l2EthRpc,
 		"--game-factory-address": gameFactoryAddressValue,
 		"--trace-type":           traceType.String(),
@@ -1019,15 +1018,27 @@ func requiredArgs(traceType types.TraceType) map[string]string {
 		addRequiredAsteriscKonaArgs(args)
 	case types.TraceTypeInteropCannon:
 		addRequiredInteropCannonArgs(args)
+	case types.TraceTypeAlphabet, types.TraceTypeFast:
+		addRequiredOutputRootArgs(args)
 	}
 	return args
 }
 
 func addRequiredInteropCannonArgs(args map[string]string) {
+	addRequiredCannonBaseArgs(args)
 	args["--supervisor-rpc"] = supervisorRpc
 }
 
 func addRequiredCannonArgs(args map[string]string) {
+	addRequiredCannonBaseArgs(args)
+	addRequiredOutputRootArgs(args)
+}
+
+func addRequiredOutputRootArgs(args map[string]string) {
+	args["--rollup-rpc"] = rollupRpc
+}
+
+func addRequiredCannonBaseArgs(args map[string]string) {
 	args["--network"] = network
 	args["--cannon-bin"] = cannonBin
 	args["--cannon-server"] = cannonServer
@@ -1035,6 +1046,7 @@ func addRequiredCannonArgs(args map[string]string) {
 }
 
 func addRequiredAsteriscArgs(args map[string]string) {
+	addRequiredOutputRootArgs(args)
 	args["--network"] = network
 	args["--asterisc-bin"] = asteriscBin
 	args["--asterisc-server"] = asteriscServer
@@ -1042,6 +1054,7 @@ func addRequiredAsteriscArgs(args map[string]string) {
 }
 
 func addRequiredAsteriscKonaArgs(args map[string]string) {
+	addRequiredOutputRootArgs(args)
 	args["--network"] = network
 	args["--asterisc-bin"] = asteriscBin
 	args["--asterisc-kona-server"] = asteriscServer

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -831,9 +831,15 @@ func TestRollupRpc(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		traceType := traceType
 
-		t.Run(fmt.Sprintf("RequiredFor-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept(traceType, "--rollup-rpc"))
-		})
+		if traceType == types.TraceTypeInteropCannon {
+			t.Run(fmt.Sprintf("NotRequiredFor-%v", traceType), func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--rollup-rpc"))
+			})
+		} else {
+			t.Run(fmt.Sprintf("RequiredFor-%v", traceType), func(t *testing.T) {
+				verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept(traceType, "--rollup-rpc"))
+			})
+		}
 	}
 
 	t.Run("Valid", func(t *testing.T) {

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -89,13 +89,13 @@ func TestL1Beacon(t *testing.T) {
 }
 
 func TestOpSupervisor(t *testing.T) {
-	t.Run("RequiredForInteropCannon", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag supervisor-rpc is required", addRequiredArgsExcept(types.TraceTypeInteropCannon, "--supervisor-rpc"))
+	t.Run("RequiredForSuperCannon", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag supervisor-rpc is required", addRequiredArgsExcept(types.TraceTypeSuperCannon, "--supervisor-rpc"))
 	})
 
 	for _, traceType := range types.TraceTypes {
 		traceType := traceType
-		if traceType == types.TraceTypeInteropCannon {
+		if traceType == types.TraceTypeSuperCannon {
 			continue
 		}
 
@@ -106,7 +106,7 @@ func TestOpSupervisor(t *testing.T) {
 
 	t.Run("Valid", func(t *testing.T) {
 		url := "http://localhost/supervisor"
-		cfg := configForArgs(t, addRequiredArgsExcept(types.TraceTypeInteropCannon, "--supervisor-rpc", "--supervisor-rpc", url))
+		cfg := configForArgs(t, addRequiredArgsExcept(types.TraceTypeSuperCannon, "--supervisor-rpc", "--supervisor-rpc", url))
 		require.Equal(t, url, cfg.SupervisorRPC)
 	})
 }
@@ -596,7 +596,7 @@ func TestAlphabetRequiredArgs(t *testing.T) {
 }
 
 func TestCannonRequiredArgs(t *testing.T) {
-	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeInteropCannon} {
+	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeSuperCannon} {
 		traceType := traceType
 		t.Run(fmt.Sprintf("TestCannonBin-%v", traceType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
@@ -831,7 +831,7 @@ func TestRollupRpc(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		traceType := traceType
 
-		if traceType == types.TraceTypeInteropCannon {
+		if traceType == types.TraceTypeSuperCannon {
 			t.Run(fmt.Sprintf("NotRequiredFor-%v", traceType), func(t *testing.T) {
 				configForArgs(t, addRequiredArgsExcept(traceType, "--rollup-rpc"))
 			})
@@ -1016,15 +1016,15 @@ func requiredArgs(traceType types.TraceType) map[string]string {
 		addRequiredAsteriscArgs(args)
 	case types.TraceTypeAsteriscKona:
 		addRequiredAsteriscKonaArgs(args)
-	case types.TraceTypeInteropCannon:
-		addRequiredInteropCannonArgs(args)
+	case types.TraceTypeSuperCannon:
+		addRequiredSuperCannonArgs(args)
 	case types.TraceTypeAlphabet, types.TraceTypeFast:
 		addRequiredOutputRootArgs(args)
 	}
 	return args
 }
 
-func addRequiredInteropCannonArgs(args map[string]string) {
+func addRequiredSuperCannonArgs(args map[string]string) {
 	addRequiredCannonBaseArgs(args)
 	args["--supervisor-rpc"] = supervisorRpc
 }

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -74,9 +74,9 @@ type Config struct {
 
 	TraceTypes []types.TraceType // Type of traces supported
 
-	RollupRpc string // L2 Rollup RPC Url
-
-	L2Rpc string // L2 RPC Url
+	RollupRpc     string // L2 Rollup RPC Url
+	SupervisorRPC string // L2 supervisor RPC URL
+	L2Rpc         string // L2 RPC Url
 
 	// Specific to the cannon trace provider
 	Cannon                        vm.Config

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -185,7 +185,7 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
-	if c.TraceTypeEnabled(types.TraceTypeInteropCannon) {
+	if c.TraceTypeEnabled(types.TraceTypeSuperCannon) {
 		if c.SupervisorRPC == "" {
 			return ErrMissingSupervisorRpc
 		}

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -28,7 +28,8 @@ var (
 	ErrMissingCannonSnapshotFreq     = errors.New("missing cannon snapshot freq")
 	ErrMissingCannonInfoFreq         = errors.New("missing cannon info freq")
 
-	ErrMissingRollupRpc = errors.New("missing rollup rpc url")
+	ErrMissingRollupRpc     = errors.New("missing rollup rpc url")
+	ErrMissingSupervisorRpc = errors.New("missing supervisor rpc url")
 
 	ErrMissingAsteriscAbsolutePreState = errors.New("missing asterisc absolute pre-state")
 	ErrMissingAsteriscSnapshotFreq     = errors.New("missing asterisc snapshot freq")
@@ -169,9 +170,6 @@ func (c Config) Check() error {
 	if c.L1Beacon == "" {
 		return ErrMissingL1Beacon
 	}
-	if c.RollupRpc == "" {
-		return ErrMissingRollupRpc
-	}
 	if c.L2Rpc == "" {
 		return ErrMissingL2Rpc
 	}
@@ -187,21 +185,26 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
+	if c.TraceTypeEnabled(types.TraceTypeInteropCannon) {
+		if c.SupervisorRPC == "" {
+			return ErrMissingSupervisorRpc
+		}
+		if err := c.validateBaseCannonOptions(); err != nil {
+			return err
+		}
+	}
 	if c.TraceTypeEnabled(types.TraceTypeCannon) || c.TraceTypeEnabled(types.TraceTypePermissioned) {
-		if err := c.Cannon.Check(); err != nil {
-			return fmt.Errorf("cannon: %w", err)
+		if c.RollupRpc == "" {
+			return ErrMissingRollupRpc
 		}
-		if c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
-			return ErrMissingCannonAbsolutePreState
-		}
-		if c.Cannon.SnapshotFreq == 0 {
-			return ErrMissingCannonSnapshotFreq
-		}
-		if c.Cannon.InfoFreq == 0 {
-			return ErrMissingCannonInfoFreq
+		if err := c.validateBaseCannonOptions(); err != nil {
+			return err
 		}
 	}
 	if c.TraceTypeEnabled(types.TraceTypeAsterisc) {
+		if c.RollupRpc == "" {
+			return ErrMissingRollupRpc
+		}
 		if err := c.Asterisc.Check(); err != nil {
 			return fmt.Errorf("asterisc: %w", err)
 		}
@@ -216,6 +219,9 @@ func (c Config) Check() error {
 		}
 	}
 	if c.TraceTypeEnabled(types.TraceTypeAsteriscKona) {
+		if c.RollupRpc == "" {
+			return ErrMissingRollupRpc
+		}
 		if err := c.AsteriscKona.Check(); err != nil {
 			return fmt.Errorf("asterisc kona: %w", err)
 		}
@@ -229,6 +235,11 @@ func (c Config) Check() error {
 			return ErrMissingAsteriscKonaInfoFreq
 		}
 	}
+	if c.TraceTypeEnabled(types.TraceTypeAlphabet) || c.TraceTypeEnabled(types.TraceTypeFast) {
+		if c.RollupRpc == "" {
+			return ErrMissingRollupRpc
+		}
+	}
 	if err := c.TxMgrConfig.Check(); err != nil {
 		return err
 	}
@@ -237,6 +248,22 @@ func (c Config) Check() error {
 	}
 	if err := c.PprofConfig.Check(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (c Config) validateBaseCannonOptions() error {
+	if err := c.Cannon.Check(); err != nil {
+		return fmt.Errorf("cannon: %w", err)
+	}
+	if c.CannonAbsolutePreState == "" && c.CannonAbsolutePreStateBaseURL == nil {
+		return ErrMissingCannonAbsolutePreState
+	}
+	if c.Cannon.SnapshotFreq == 0 {
+		return ErrMissingCannonSnapshotFreq
+	}
+	if c.Cannon.InfoFreq == 0 {
+		return ErrMissingCannonInfoFreq
 	}
 	return nil
 }

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -44,7 +44,7 @@ var (
 	validAsteriscKonaAbsolutePreStateBaseURL, _ = url.Parse("http://localhost/bar/")
 )
 
-var cannonTraceTypes = []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeInteropCannon}
+var cannonTraceTypes = []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeSuperCannon}
 var asteriscTraceTypes = []types.TraceType{types.TraceTypeAsterisc}
 var asteriscKonaTraceTypes = []types.TraceType{types.TraceTypeAsteriscKona}
 
@@ -64,7 +64,7 @@ func ensureExists(path string) error {
 	return file.Close()
 }
 
-func applyValidConfigForInteropCannon(t *testing.T, cfg *Config) {
+func applyValidConfigForSuperCannon(t *testing.T, cfg *Config) {
 	cfg.SupervisorRPC = validSupervisorRpc
 	applyValidConfigForCannon(t, cfg)
 }
@@ -113,8 +113,8 @@ func applyValidConfigForAsteriscKona(t *testing.T, cfg *Config) {
 
 func validConfig(t *testing.T, traceType types.TraceType) Config {
 	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validRollupRpc, validL2Rpc, validDatadir, traceType)
-	if traceType == types.TraceTypeInteropCannon {
-		applyValidConfigForInteropCannon(t, &cfg)
+	if traceType == types.TraceTypeSuperCannon {
+		applyValidConfigForSuperCannon(t, &cfg)
 	}
 	if traceType == types.TraceTypeCannon || traceType == types.TraceTypePermissioned {
 		applyValidConfigForCannon(t, &cfg)
@@ -590,7 +590,7 @@ func TestHttpPollInterval(t *testing.T) {
 func TestRollupRpcRequired(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		traceType := traceType
-		if traceType == types.TraceTypeInteropCannon {
+		if traceType == types.TraceTypeSuperCannon {
 			continue
 		}
 		t.Run(traceType.String(), func(t *testing.T) {
@@ -602,7 +602,7 @@ func TestRollupRpcRequired(t *testing.T) {
 }
 
 func TestRollupRpcNotRequiredForInterop(t *testing.T) {
-	config := validConfig(t, types.TraceTypeInteropCannon)
+	config := validConfig(t, types.TraceTypeSuperCannon)
 	config.RollupRpc = ""
 	require.NoError(t, config.Check())
 }
@@ -610,7 +610,7 @@ func TestRollupRpcNotRequiredForInterop(t *testing.T) {
 func TestSupervisorRpc(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		traceType := traceType
-		if traceType == types.TraceTypeInteropCannon {
+		if traceType == types.TraceTypeSuperCannon {
 			t.Run("RequiredFor"+traceType.String(), func(t *testing.T) {
 				config := validConfig(t, traceType)
 				config.SupervisorRPC = ""

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -28,6 +28,7 @@ var (
 	validDatadir                          = "/tmp/data"
 	validL2Rpc                            = "http://localhost:9545"
 	validRollupRpc                        = "http://localhost:8555"
+	validSupervisorRpc                    = "http://localhost/supervisor"
 
 	validAsteriscBin                        = "./bin/asterisc"
 	validAsteriscOpProgramBin               = "./bin/op-program"
@@ -43,7 +44,7 @@ var (
 	validAsteriscKonaAbsolutePreStateBaseURL, _ = url.Parse("http://localhost/bar/")
 )
 
-var cannonTraceTypes = []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned}
+var cannonTraceTypes = []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeInteropCannon}
 var asteriscTraceTypes = []types.TraceType{types.TraceTypeAsterisc}
 var asteriscKonaTraceTypes = []types.TraceType{types.TraceTypeAsteriscKona}
 
@@ -63,8 +64,12 @@ func ensureExists(path string) error {
 	return file.Close()
 }
 
-func applyValidConfigForCannon(t *testing.T, cfg *Config) {
+func applyValidConfigForInteropCannon(t *testing.T, cfg *Config) {
+	cfg.SupervisorRPC = validSupervisorRpc
+	applyValidConfigForCannon(t, cfg)
+}
 
+func applyValidConfigForCannon(t *testing.T, cfg *Config) {
 	tmpDir := t.TempDir()
 	vmBin := filepath.Join(tmpDir, validCannonBin)
 	server := filepath.Join(tmpDir, validCannonOpProgramBin)
@@ -108,6 +113,9 @@ func applyValidConfigForAsteriscKona(t *testing.T, cfg *Config) {
 
 func validConfig(t *testing.T, traceType types.TraceType) Config {
 	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validRollupRpc, validL2Rpc, validDatadir, traceType)
+	if traceType == types.TraceTypeInteropCannon {
+		applyValidConfigForInteropCannon(t, &cfg)
+	}
 	if traceType == types.TraceTypeCannon || traceType == types.TraceTypePermissioned {
 		applyValidConfigForCannon(t, &cfg)
 	}
@@ -582,11 +590,39 @@ func TestHttpPollInterval(t *testing.T) {
 func TestRollupRpcRequired(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		traceType := traceType
+		if traceType == types.TraceTypeInteropCannon {
+			continue
+		}
 		t.Run(traceType.String(), func(t *testing.T) {
 			config := validConfig(t, traceType)
 			config.RollupRpc = ""
 			require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
 		})
+	}
+}
+
+func TestRollupRpcNotRequiredForInterop(t *testing.T) {
+	config := validConfig(t, types.TraceTypeInteropCannon)
+	config.RollupRpc = ""
+	require.NoError(t, config.Check())
+}
+
+func TestSupervisorRpc(t *testing.T) {
+	for _, traceType := range types.TraceTypes {
+		traceType := traceType
+		if traceType == types.TraceTypeInteropCannon {
+			t.Run("RequiredFor"+traceType.String(), func(t *testing.T) {
+				config := validConfig(t, traceType)
+				config.SupervisorRPC = ""
+				require.ErrorIs(t, config.Check(), ErrMissingSupervisorRpc)
+			})
+		} else {
+			t.Run("NotRequiredFor"+traceType.String(), func(t *testing.T) {
+				config := validConfig(t, traceType)
+				config.SupervisorRPC = ""
+				require.NoError(t, config.Check())
+			})
+		}
 	}
 }
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -32,7 +32,7 @@ func prefixEnvVars(name string) []string {
 }
 
 var (
-	faultDisputeVMs = []types.TraceType{types.TraceTypeCannon, types.TraceTypeAsterisc, types.TraceTypeAsteriscKona, types.TraceTypeInteropCannon}
+	faultDisputeVMs = []types.TraceType{types.TraceTypeCannon, types.TraceTypeAsterisc, types.TraceTypeAsteriscKona, types.TraceTypeSuperCannon}
 	// Required Flags
 	L1EthRpcFlag = &cli.StringFlag{
 		Name:    "l1-eth-rpc",
@@ -308,7 +308,7 @@ func CheckCannonBaseFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckInteropCannonFlags(ctx *cli.Context) error {
+func CheckSuperCannonFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(SupervisorRpcFlag.Name) {
 		return fmt.Errorf("flag %v is required", SupervisorRpcFlag.Name)
 	}
@@ -397,8 +397,8 @@ func CheckRequired(ctx *cli.Context, traceTypes []types.TraceType) error {
 			if err := CheckAsteriscKonaFlags(ctx); err != nil {
 				return err
 			}
-		case types.TraceTypeInteropCannon:
-			if err := CheckInteropCannonFlags(ctx); err != nil {
+		case types.TraceTypeSuperCannon:
+			if err := CheckSuperCannonFlags(ctx); err != nil {
 				return err
 			}
 		case types.TraceTypeAlphabet, types.TraceTypeFast:

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -32,7 +32,7 @@ func prefixEnvVars(name string) []string {
 }
 
 var (
-	faultDisputeVMs = []types.TraceType{types.TraceTypeCannon, types.TraceTypeAsterisc, types.TraceTypeAsteriscKona}
+	faultDisputeVMs = []types.TraceType{types.TraceTypeCannon, types.TraceTypeAsterisc, types.TraceTypeAsteriscKona, types.TraceTypeInteropCannon}
 	// Required Flags
 	L1EthRpcFlag = &cli.StringFlag{
 		Name:    "l1-eth-rpc",
@@ -361,6 +361,7 @@ func CheckRequired(ctx *cli.Context, traceTypes []types.TraceType) error {
 			if err := CheckAsteriscKonaFlags(ctx); err != nil {
 				return err
 			}
+		case types.TraceTypeInteropCannon:
 		case types.TraceTypeAlphabet, types.TraceTypeFast:
 		default:
 			return fmt.Errorf("invalid trace type %v. must be one of %v", traceType, types.TraceTypes)

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -281,17 +281,7 @@ func checkOutputProviderFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckInteropCannonFlags(ctx *cli.Context) error {
-	if !ctx.IsSet(SupervisorRpcFlag.Name) {
-		return fmt.Errorf("flag %v is required", SupervisorRpcFlag.Name)
-	}
-	return nil
-}
-
-func CheckCannonFlags(ctx *cli.Context) error {
-	if err := checkOutputProviderFlags(ctx); err != nil {
-		return err
-	}
+func CheckCannonBaseFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(flags.NetworkFlagName) &&
 		!(RollupConfigFlag.IsSet(ctx, types.TraceTypeCannon) && L2GenesisFlag.IsSet(ctx, types.TraceTypeCannon)) {
 		return fmt.Errorf("flag %v or %v and %v is required",
@@ -314,6 +304,26 @@ func CheckCannonFlags(ctx *cli.Context) error {
 	}
 	if !PreStatesURLFlag.IsSet(ctx, types.TraceTypeCannon) && !ctx.IsSet(CannonPreStateFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(types.TraceTypeCannon), CannonPreStateFlag.Name)
+	}
+	return nil
+}
+
+func CheckInteropCannonFlags(ctx *cli.Context) error {
+	if !ctx.IsSet(SupervisorRpcFlag.Name) {
+		return fmt.Errorf("flag %v is required", SupervisorRpcFlag.Name)
+	}
+	if err := CheckCannonBaseFlags(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CheckCannonFlags(ctx *cli.Context) error {
+	if err := checkOutputProviderFlags(ctx); err != nil {
+		return err
+	}
+	if err := CheckCannonBaseFlags(ctx); err != nil {
+		return err
 	}
 	return nil
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -225,12 +225,12 @@ var (
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	DatadirFlag,
-	RollupRpcFlag,
 	L1BeaconFlag,
 }
 
 // optionalFlags is a list of unchecked cli flags
 var optionalFlags = []cli.Flag{
+	RollupRpcFlag,
 	NetworkFlag,
 	FactoryAddressFlag,
 	TraceTypeFlag,
@@ -274,6 +274,13 @@ func init() {
 // Flags contains the list of configuration options available to the binary.
 var Flags []cli.Flag
 
+func checkOutputProviderFlags(ctx *cli.Context) error {
+	if !ctx.IsSet(RollupRpcFlag.Name) {
+		return fmt.Errorf("flag %v is required", RollupRpcFlag.Name)
+	}
+	return nil
+}
+
 func CheckInteropCannonFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(SupervisorRpcFlag.Name) {
 		return fmt.Errorf("flag %v is required", SupervisorRpcFlag.Name)
@@ -282,6 +289,9 @@ func CheckInteropCannonFlags(ctx *cli.Context) error {
 }
 
 func CheckCannonFlags(ctx *cli.Context) error {
+	if err := checkOutputProviderFlags(ctx); err != nil {
+		return err
+	}
 	if !ctx.IsSet(flags.NetworkFlagName) &&
 		!(RollupConfigFlag.IsSet(ctx, types.TraceTypeCannon) && L2GenesisFlag.IsSet(ctx, types.TraceTypeCannon)) {
 		return fmt.Errorf("flag %v or %v and %v is required",
@@ -309,6 +319,9 @@ func CheckCannonFlags(ctx *cli.Context) error {
 }
 
 func CheckAsteriscBaseFlags(ctx *cli.Context, traceType types.TraceType) error {
+	if err := checkOutputProviderFlags(ctx); err != nil {
+		return err
+	}
 	if !ctx.IsSet(flags.NetworkFlagName) &&
 		!(RollupConfigFlag.IsSet(ctx, traceType) && L2GenesisFlag.IsSet(ctx, traceType)) {
 		return fmt.Errorf("flag %v or %v and %v is required",
@@ -379,6 +392,9 @@ func CheckRequired(ctx *cli.Context, traceTypes []types.TraceType) error {
 				return err
 			}
 		case types.TraceTypeAlphabet, types.TraceTypeFast:
+			if err := checkOutputProviderFlags(ctx); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("invalid trace type %v. must be one of %v", traceType, types.TraceTypes)
 		}

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -24,14 +24,14 @@ var (
 type GameType uint32
 
 const (
-	CannonGameType        GameType = 0
-	PermissionedGameType  GameType = 1
-	AsteriscGameType      GameType = 2
-	AsteriscKonaGameType  GameType = 3
-	InteropCannonGameType GameType = 4
-	FastGameType          GameType = 254
-	AlphabetGameType      GameType = 255
-	UnknownGameType       GameType = math.MaxUint32
+	CannonGameType       GameType = 0
+	PermissionedGameType GameType = 1
+	AsteriscGameType     GameType = 2
+	AsteriscKonaGameType GameType = 3
+	SuperCannonGameType  GameType = 4
+	FastGameType         GameType = 254
+	AlphabetGameType     GameType = 255
+	UnknownGameType      GameType = math.MaxUint32
 )
 
 func (t GameType) MarshalText() ([]byte, error) {
@@ -60,16 +60,16 @@ func (t GameType) String() string {
 type TraceType string
 
 const (
-	TraceTypeAlphabet      TraceType = "alphabet"
-	TraceTypeFast          TraceType = "fast"
-	TraceTypeCannon        TraceType = "cannon"
-	TraceTypeAsterisc      TraceType = "asterisc"
-	TraceTypeAsteriscKona  TraceType = "asterisc-kona"
-	TraceTypePermissioned  TraceType = "permissioned"
-	TraceTypeInteropCannon TraceType = "interop-cannon"
+	TraceTypeAlphabet     TraceType = "alphabet"
+	TraceTypeFast         TraceType = "fast"
+	TraceTypeCannon       TraceType = "cannon"
+	TraceTypeAsterisc     TraceType = "asterisc"
+	TraceTypeAsteriscKona TraceType = "asterisc-kona"
+	TraceTypePermissioned TraceType = "permissioned"
+	TraceTypeSuperCannon  TraceType = "super-cannon"
 )
 
-var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned, TraceTypeAsterisc, TraceTypeAsteriscKona, TraceTypeFast, TraceTypeInteropCannon}
+var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned, TraceTypeAsterisc, TraceTypeAsteriscKona, TraceTypeFast, TraceTypeSuperCannon}
 
 func (t TraceType) String() string {
 	return string(t)
@@ -112,8 +112,8 @@ func (t TraceType) GameType() GameType {
 		return FastGameType
 	case TraceTypeAlphabet:
 		return AlphabetGameType
-	case TraceTypeInteropCannon:
-		return InteropCannonGameType
+	case TraceTypeSuperCannon:
+		return SuperCannonGameType
 	default:
 		return UnknownGameType
 	}

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -24,13 +24,14 @@ var (
 type GameType uint32
 
 const (
-	CannonGameType       GameType = 0
-	PermissionedGameType GameType = 1
-	AsteriscGameType     GameType = 2
-	AsteriscKonaGameType GameType = 3
-	FastGameType         GameType = 254
-	AlphabetGameType     GameType = 255
-	UnknownGameType      GameType = math.MaxUint32
+	CannonGameType        GameType = 0
+	PermissionedGameType  GameType = 1
+	AsteriscGameType      GameType = 2
+	AsteriscKonaGameType  GameType = 3
+	InteropCannonGameType GameType = 4
+	FastGameType          GameType = 254
+	AlphabetGameType      GameType = 255
+	UnknownGameType       GameType = math.MaxUint32
 )
 
 func (t GameType) MarshalText() ([]byte, error) {
@@ -59,15 +60,16 @@ func (t GameType) String() string {
 type TraceType string
 
 const (
-	TraceTypeAlphabet     TraceType = "alphabet"
-	TraceTypeFast         TraceType = "fast"
-	TraceTypeCannon       TraceType = "cannon"
-	TraceTypeAsterisc     TraceType = "asterisc"
-	TraceTypeAsteriscKona TraceType = "asterisc-kona"
-	TraceTypePermissioned TraceType = "permissioned"
+	TraceTypeAlphabet      TraceType = "alphabet"
+	TraceTypeFast          TraceType = "fast"
+	TraceTypeCannon        TraceType = "cannon"
+	TraceTypeAsterisc      TraceType = "asterisc"
+	TraceTypeAsteriscKona  TraceType = "asterisc-kona"
+	TraceTypePermissioned  TraceType = "permissioned"
+	TraceTypeInteropCannon TraceType = "interop-cannon"
 )
 
-var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned, TraceTypeAsterisc, TraceTypeAsteriscKona, TraceTypeFast}
+var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned, TraceTypeAsterisc, TraceTypeAsteriscKona, TraceTypeFast, TraceTypeInteropCannon}
 
 func (t TraceType) String() string {
 	return string(t)
@@ -110,6 +112,8 @@ func (t TraceType) GameType() GameType {
 		return FastGameType
 	case TraceTypeAlphabet:
 		return AlphabetGameType
+	case TraceTypeInteropCannon:
+		return InteropCannonGameType
 	default:
 		return UnknownGameType
 	}

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -60,3 +60,12 @@ func TestIsRootPosition(t *testing.T) {
 		})
 	}
 }
+
+func TestKnownGameTypeForEveryTraceType(t *testing.T) {
+	for _, traceType := range TraceTypes {
+		traceType := traceType
+		t.Run(traceType.String(), func(t *testing.T) {
+			require.NotEqual(t, UnknownGameType, traceType.GameType())
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Defines the new Interop-cannon game type and adds validation for required CLI args (requires a supervisor endpoint instead of rollup-rpc)

**Tests**

Added unit tests.

Builds on https://github.com/ethereum-optimism/optimism/pull/13777