### PR TITLE
op-challenger: Refactor super trace provider to supply preimages

### DIFF
--- a/op-challenger/game/fault/trace/super/convert.go
+++ b/op-challenger/game/fault/trace/super/convert.go
@@ -1,0 +1,12 @@
+package super
+
+import "github.com/ethereum-optimism/optimism/op-service/eth"
+
+func responseToSuper(prevRoot eth.SuperRootResponse) *eth.SuperV1 {
+	prevChainOutputs := make([]eth.ChainIDAndOutput, 0, len(prevRoot.Chains))
+	for _, chain := range prevRoot.Chains {
+		prevChainOutputs = append(prevChainOutputs, eth.ChainIDAndOutput{ChainID: chain.ChainID.ToBig().Uint64(), Output: chain.Canonical})
+	}
+	superV1 := eth.NewSuperV1(prevRoot.Timestamp, prevChainOutputs...)
+	return superV1
+}

--- a/op-challenger/game/fault/trace/super/convert_test.go
+++ b/op-challenger/game/fault/trace/super/convert_test.go
@@ -1,0 +1,60 @@
+package super
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseToSuper(t *testing.T) {
+	t.Run("SingleChain", func(t *testing.T) {
+		input := eth.SuperRootResponse{
+			Timestamp: 4978924,
+			SuperRoot: eth.Bytes32{0x65},
+			Chains: []eth.ChainRootInfo{
+				{
+					ChainID:   eth.ChainID{2987},
+					Canonical: eth.Bytes32{0x88},
+					Pending:   []byte{1, 2, 3, 4, 5},
+				},
+			},
+		}
+		expected := &eth.SuperV1{
+			Timestamp: 4978924,
+			Chains: []eth.ChainIDAndOutput{
+				{ChainID: 2987, Output: eth.Bytes32{0x88}},
+			},
+		}
+		actual := responseToSuper(input)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("SortChainsByChainID", func(t *testing.T) {
+		input := eth.SuperRootResponse{
+			Timestamp: 4978924,
+			SuperRoot: eth.Bytes32{0x65},
+			Chains: []eth.ChainRootInfo{
+				{
+					ChainID:   eth.ChainID{2987},
+					Canonical: eth.Bytes32{0x88},
+					Pending:   []byte{1, 2, 3, 4, 5},
+				},
+				{
+					ChainID:   eth.ChainID{100},
+					Canonical: eth.Bytes32{0x10},
+					Pending:   []byte{1, 2, 3, 4, 5},
+				},
+			},
+		}
+		expected := &eth.SuperV1{
+			Timestamp: 4978924,
+			Chains: []eth.ChainIDAndOutput{
+				{ChainID: 100, Output: eth.Bytes32{0x10}},
+				{ChainID: 2987, Output: eth.Bytes32{0x88}},
+			},
+		}
+		actual := responseToSuper(input)
+		require.Equal(t, expected, actual)
+	})
+}

--- a/op-challenger/game/fault/trace/super/prestate.go
+++ b/op-challenger/game/fault/trace/super/prestate.go
@@ -1,0 +1,38 @@
+package super
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type SuperRootPrestateProvider struct {
+	provider  RootProvider
+	timestamp uint64
+}
+
+var _ PreimagePrestateProvider = (*SuperRootPrestateProvider)(nil)
+
+func NewSuperRootPrestateProvider(provider RootProvider, prestateTimestamp uint64) *SuperRootPrestateProvider {
+	return &SuperRootPrestateProvider{
+		provider:  provider,
+		timestamp: prestateTimestamp,
+	}
+}
+
+func (s *SuperRootPrestateProvider) AbsolutePreStateCommitment(ctx context.Context) (common.Hash, error) {
+	prestate, err := s.AbsolutePreState(ctx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return common.Hash(eth.SuperRoot(prestate)), nil
+}
+
+func (s *SuperRootPrestateProvider) AbsolutePreState(ctx context.Context) (eth.Super, error) {
+	response, err := s.provider.SuperRootAtTimestamp(ctx, s.timestamp)
+	if err != nil {
+		return nil, err
+	}
+	return responseToSuper(response), nil
+}

--- a/op-challenger/game/fault/trace/super/prestate_test.go
+++ b/op-challenger/game/fault/trace/super/prestate_test.go
@@ -1,0 +1,58 @@
+package super
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbsolutePreState(t *testing.T) {
+	t.Run("FailedToFetchOutput", func(t *testing.T) {
+		rootProvider := &stubRootProvider{}
+		provider := NewSuperRootPrestateProvider(rootProvider, 100)
+
+		_, err := provider.AbsolutePreState(context.Background())
+		require.ErrorIs(t, err, ethereum.NotFound)
+
+		_, err = provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorIs(t, err, ethereum.NotFound)
+	})
+
+	t.Run("ReturnsSuperRootForTimestamp", func(t *testing.T) {
+		response := eth.SuperRootResponse{
+			Timestamp: 100,
+			SuperRoot: eth.Bytes32{0x11},
+			Chains: []eth.ChainRootInfo{
+				{
+					ChainID:   eth.ChainID{2987},
+					Canonical: eth.Bytes32{0x88},
+					Pending:   []byte{1, 2, 3, 4, 5},
+				},
+				{
+					ChainID:   eth.ChainID{100},
+					Canonical: eth.Bytes32{0x10},
+					Pending:   []byte{1, 2, 3, 4, 5},
+				},
+			},
+		}
+		expectedPreimage := responseToSuper(response)
+		rootProvider := &stubRootProvider{
+			rootsByTimestamp: map[uint64]eth.SuperRootResponse{
+				100: response,
+			},
+		}
+		provider := NewSuperRootPrestateProvider(rootProvider, 100)
+
+		preimage, err := provider.AbsolutePreState(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expectedPreimage, preimage)
+
+		commitment, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, common.Hash(eth.SuperRoot(expectedPreimage)), commitment)
+	})
+}

--- a/op-challenger/game/fault/trace/super/provider_test.go
+++ b/op-challenger/game/fault/trace/super/provider_test.go
@@ -26,10 +26,9 @@ var (
 func TestGet(t *testing.T) {
 	t.Run("AtPostState", func(t *testing.T) {
 		provider, stubSupervisor := createProvider(t)
-		superRoot := eth.Bytes32{0xaa}
-		stubSupervisor.Add(eth.SuperRootResponse{
+		response := eth.SuperRootResponse{
 			Timestamp: poststateTimestamp,
-			SuperRoot: superRoot,
+			SuperRoot: eth.Bytes32{0xaa},
 			Chains: []eth.ChainRootInfo{
 				{
 					ChainID:   eth.ChainIDFromUInt64(1),
@@ -37,18 +36,19 @@ func TestGet(t *testing.T) {
 					Pending:   []byte{0xcc},
 				},
 			},
-		})
+		}
+		stubSupervisor.Add(response)
 		claim, err := provider.Get(context.Background(), types.RootPosition)
 		require.NoError(t, err)
-		require.Equal(t, common.Hash(superRoot), claim)
+		expected := responseToSuper(response)
+		require.Equal(t, common.Hash(eth.SuperRoot(expected)), claim)
 	})
 
 	t.Run("AtNewTimestamp", func(t *testing.T) {
 		provider, stubSupervisor := createProvider(t)
-		superRoot := eth.Bytes32{0xaa}
-		stubSupervisor.Add(eth.SuperRootResponse{
+		response := eth.SuperRootResponse{
 			Timestamp: prestateTimestamp + 1,
-			SuperRoot: superRoot,
+			SuperRoot: eth.Bytes32{0xaa},
 			Chains: []eth.ChainRootInfo{
 				{
 					ChainID:   eth.ChainIDFromUInt64(1),
@@ -56,10 +56,12 @@ func TestGet(t *testing.T) {
 					Pending:   []byte{0xcc},
 				},
 			},
-		})
+		}
+		stubSupervisor.Add(response)
 		claim, err := provider.Get(context.Background(), types.NewPosition(gameDepth, big.NewInt(StepsPerTimestamp-1)))
 		require.NoError(t, err)
-		require.Equal(t, common.Hash(superRoot), claim)
+		expected := responseToSuper(response)
+		require.Equal(t, common.Hash(eth.SuperRoot(expected)), claim)
 	})
 
 	t.Run("FirstTimestamp", func(t *testing.T) {
@@ -240,7 +242,7 @@ func (s *stubRootProvider) Add(root eth.SuperRootResponse) {
 	s.rootsByTimestamp[root.Timestamp] = root
 }
 
-func (s *stubRootProvider) SuperRootAtTimestamp(timestamp uint64) (eth.SuperRootResponse, error) {
+func (s *stubRootProvider) SuperRootAtTimestamp(_ context.Context, timestamp uint64) (eth.SuperRootResponse, error) {
 	root, ok := s.rootsByTimestamp[timestamp]
 	if !ok {
 		return eth.SuperRootResponse{}, ethereum.NotFound


### PR DESCRIPTION
**Description**

Refactor super trace provider to supply preimages and add prestate provider for super roots that can provide preimages.

The preimages are needed for the split adapter to calculate the required game inputs for the bottom half.

**Tests**

Added/updated unit tests.