### PR TITLE
op-program: Build an interop prestate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,13 @@ reproducible-prestate:   ## Builds reproducible-prestate binary
 .PHONY: reproducible-prestate
 
 # Include any files required for the devnet to build and run.
-DEVNET_CANNON_PRESTATE_FILES := op-program/bin/prestate-proof.json op-program/bin/prestate.bin.gz op-program/bin/prestate-proof-mt.json op-program/bin/prestate-mt.bin.gz
+DEVNET_CANNON_PRESTATE_FILES := op-program/bin/prestate-proof.json op-program/bin/prestate.bin.gz op-program/bin/prestate-proof-mt.json op-program/bin/prestate-mt.bin.gz op-program/bin/prestate-interop.bin.gz
 
 
 $(DEVNET_CANNON_PRESTATE_FILES):
 	make cannon-prestate
 	make cannon-prestate-mt
+	make cannon-prestate-interop
 
 cannon-prestate: op-program cannon ## Generates prestate using cannon and op-program
 	./cannon/bin/cannon load-elf --type singlethreaded-2 --path op-program/bin/op-program-client.elf --out op-program/bin/prestate.bin.gz --meta op-program/bin/meta.json
@@ -153,6 +154,12 @@ cannon-prestate-mt: op-program cannon ## Generates prestate using cannon and op-
 	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate-mt.bin.gz --meta op-program/bin/meta-mt.json --proof-fmt 'op-program/bin/%d-mt.json' --output ""
 	mv op-program/bin/0-mt.json op-program/bin/prestate-proof-mt.json
 .PHONY: cannon-prestate-mt
+
+cannon-prestate-interop: op-program cannon ## Generates interop prestate using cannon and op-program in the multithreaded64-2 cannon format
+	./cannon/bin/cannon load-elf --type multithreaded64-2 --path op-program/bin/op-program-client-interop.elf --out op-program/bin/prestate-interop.bin.gz --meta op-program/bin/meta-interop.json
+	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate-interop.bin.gz --meta op-program/bin/meta-interop.json --proof-fmt 'op-program/bin/%d-interop.json' --output ""
+	mv op-program/bin/0-interop.json op-program/bin/prestate-proof-interop.json
+.PHONY: cannon-prestate-interop
 
 mod-tidy: ## Cleans up unused dependencies in Go modules
 	# Below GOPRIVATE line allows mod-tidy to be run immediately after

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -36,6 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-pro
 RUN /app/cannon/bin/cannon load-elf --type singlethreaded-2 --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate.bin.gz --meta "/app/op-program/bin/meta.json"
 RUN /app/cannon/bin/cannon load-elf --type multithreaded --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate-mt.bin.gz --meta "/app/op-program/bin/meta-mt.json"
 RUN /app/cannon/bin/cannon load-elf --type multithreaded64-2 --path /app/op-program/bin/op-program-client64.elf --out /app/op-program/bin/prestate-mt64.bin.gz --meta "/app/op-program/bin/meta-mt64.json"
+RUN /app/cannon/bin/cannon load-elf --type multithreaded64-2 --path /app/op-program/bin/op-program-client-interop.elf --out /app/op-program/bin/prestate-interop.bin.gz --meta "/app/op-program/bin/meta-interop.json"
 
 # Generate the prestate proof containing the absolute pre-state hash.
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d.json' --output ""
@@ -47,6 +48,9 @@ RUN mv /app/op-program/bin/0-mt.json /app/op-program/bin/prestate-proof-mt.json
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt64.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt64.json' --output ""
 RUN mv /app/op-program/bin/0-mt64.json /app/op-program/bin/prestate-proof-mt64.json
 
+RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-interop.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-interop.json' --output ""
+RUN mv /app/op-program/bin/0-interop.json /app/op-program/bin/prestate-proof-interop.json
+
 # Exports files to the specified output location.
 # Writing files to host requires buildkit to be enabled.
 # e.g. `BUILDKIT=1 docker build ...`
@@ -54,6 +58,7 @@ FROM scratch AS export-stage-proofs
 COPY --from=builder /app/op-program/bin/prestate-proof.json .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .
+COPY --from=builder /app/op-program/bin/prestate-proof-interop.json .
 
 FROM scratch AS export-stage
 COPY --from=builder /app/op-program/bin/op-program-client.elf .
@@ -67,3 +72,6 @@ COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .
 COPY --from=builder /app/op-program/bin/meta-mt64.json .
 COPY --from=builder /app/op-program/bin/prestate-mt64.bin.gz .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .
+COPY --from=builder /app/op-program/bin/meta-interop.json .
+COPY --from=builder /app/op-program/bin/prestate-interop.bin.gz .
+COPY --from=builder /app/op-program/bin/prestate-proof-interop.json .

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -26,7 +26,7 @@ op-program-host:
 op-program-client:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client ./client/cmd/main.go
 
-op-program-client-mips: op-program-client-mips32 op-program-client-mips64
+op-program-client-mips: op-program-client-mips32 op-program-client-mips64 op-program-client-mips64-interop
 
 op-program-client-mips32:
 	env GO111MODULE=on GOOS=linux GOARCH=mips GOMIPS=softfloat go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client.elf ./client/cmd/main.go
@@ -36,6 +36,11 @@ op-program-client-mips32:
 op-program-client-mips64:
 	env GO111MODULE=on GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client64.elf ./client/cmd/main.go
 	# verify output with: readelf -h bin/op-program-client64.elf
+	# result is mips64, big endian, R3000
+
+op-program-client-mips64-interop:
+	env GO111MODULE=on GOOS=linux GOARCH=mips64 GOMIPS64=softfloat go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client-interop.elf ./client/interopcmd/main.go
+	# verify output with: readelf -h bin/op-program-client-interop.elf
 	# result is mips64, big endian, R3000
 
 op-program-client-riscv:
@@ -49,6 +54,8 @@ reproducible-prestate:
 	@cat ./bin/prestate-proof-mt.json | jq -r .pre
 	@echo "Cannon64 Absolute prestate hash: "
 	@cat ./bin/prestate-proof-mt64.json | jq -r .pre
+	@echo "CannonInterop Absolute prestate hash: "
+	@cat ./bin/prestate-proof-interop.json | jq -r .pre
 .PHONY: reproducible-prestate
 
 verify-reproducibility:

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -25,6 +25,7 @@ op-program-host:
 
 op-program-client:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client ./client/cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client-interop ./client/interopcmd/main.go
 
 op-program-client-mips: op-program-client-mips32 op-program-client-mips64 op-program-client-mips64-interop
 

--- a/op-program/client/interopcmd/main.go
+++ b/op-program/client/interopcmd/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	client.Main(false)
+	client.Main(true)
 }

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -99,9 +99,6 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		cmd.ExtraFiles[cl.PClientWFd-3] = pClientRW.Writer()
 		cmd.Stdout = os.Stdout // for debugging
 		cmd.Stderr = os.Stderr // for debugging
-		if cfg.InteropEnabled {
-			cmd.Env = append(os.Environ(), "OP_PROGRAM_CLIENT_USE_INTEROP=true")
-		}
 
 		err := cmd.Start()
 		if err != nil {


### PR DESCRIPTION
**Description**

The bootstrap process for interop is different so introduces a separate main method to set the interop mode flag.

Previously had planned to use an env var but setting it in the cannon prestate wound up being too deep in the weeds of MIPS so going with a simpler approach.

Builds using cannon-mt64 since we're moving that way and planning to upgrade to it prior to interop anyway.