### PR TITLE
feat: nat; per-validator configuration.

### DIFF
--- a/op-nat/gate.go
+++ b/op-nat/gate.go
@@ -12,24 +12,34 @@ var _ Validator = &Gate{}
 // A Gate is a collection of suites and/or tests.
 type Gate struct {
 	ID         string
-	Validators []Validator
+	Validators []Validator // Validators can be Suites or Tests
+	Params     map[string]interface{}
 }
 
 // Run runs all the tests in the gate.
 // Returns the overall result of the gate and an error if any of the tests failed.
-func (g Gate) Run(ctx context.Context, log log.Logger, cfg Config) (ValidatorResult, error) {
+// Gate-specific params are passed in as `_` because we haven't implemented them yet.
+func (g Gate) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{}) (ValidatorResult, error) {
 	log.Info("", "type", g.Type(), "id", g.Name())
 	allPassed := true
 	results := []ValidatorResult{}
 	var allErrors error
 	for _, validator := range g.Validators {
-		res, err := validator.Run(ctx, log, cfg)
+		// We don't want Gates to have Gates
+		if validator == nil || validator.Type() == "Gate" {
+			continue
+		}
+		// Get params
+		params := g.Params[validator.Name()]
+
+		res, err := validator.Run(ctx, log, cfg, params)
 		if err != nil || !res.Passed {
 			allPassed = false
 			allErrors = errors.Join(allErrors, err)
 		}
 		results = append(results, res)
 	}
+	log.Info("", "type", g.Type(), "id", g.Name(), "passed", allPassed, "error", allErrors)
 	return ValidatorResult{
 		ID:         g.ID,
 		Type:       g.Type(),

--- a/op-nat/gate_test.go
+++ b/op-nat/gate_test.go
@@ -1,0 +1,96 @@
+package nat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGate(t *testing.T) {
+	t.Run("passes when all validators pass", func(t *testing.T) {
+		gate := &Gate{
+			Validators: []Validator{
+				&Test{
+					ID: "test1",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return true, nil
+					},
+				},
+				&Test{
+					ID: "test2",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return true, nil
+					},
+				},
+			},
+		}
+
+		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
+
+		require.NoError(t, err)
+		assert.True(t, result.Passed)
+	})
+
+	t.Run("fails if any validator fails", func(t *testing.T) {
+		gate := &Gate{
+			Validators: []Validator{
+				&Test{
+					ID: "test1",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return true, nil
+					},
+				},
+				&Test{
+					ID: "test2",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return false, nil
+					},
+				},
+			},
+		}
+
+		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
+
+		require.NoError(t, err)
+		assert.False(t, result.Passed)
+	})
+
+	t.Run("doesnt stop on validator failure", func(t *testing.T) {
+		executionOrder := []string{}
+
+		gate := &Gate{
+			Validators: []Validator{
+				&Test{
+					ID: "test1",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						executionOrder = append(executionOrder, "test1")
+						return true, nil
+					},
+				},
+				&Test{
+					ID: "test2",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						executionOrder = append(executionOrder, "test2")
+						return false, nil
+					},
+				},
+				&Test{
+					ID: "test3",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						executionOrder = append(executionOrder, "test3")
+						return true, nil
+					},
+				},
+			},
+		}
+
+		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
+
+		require.NoError(t, err)
+		assert.False(t, result.Passed)
+		assert.Equal(t, []string{"test1", "test2", "test3"}, executionOrder, "shouldnt stop on validator failure")
+	})
+}

--- a/op-nat/nat.go
+++ b/op-nat/nat.go
@@ -19,6 +19,7 @@ type nat struct {
 	ctx     context.Context
 	log     log.Logger
 	config  *Config
+	params  map[string]interface{}
 	version string
 	results []ValidatorResult
 
@@ -36,6 +37,7 @@ func New(ctx context.Context, config *Config, log log.Logger, version string) (*
 	return &nat{
 		ctx:     ctx,
 		config:  config,
+		params:  map[string]interface{}{},
 		log:     log,
 		version: version,
 	}, nil
@@ -48,7 +50,11 @@ func (n *nat) Start(ctx context.Context) error {
 	n.running.Store(true)
 	for _, validator := range n.config.Validators {
 		n.log.Info("Running acceptance tests...")
-		result, err := validator.Run(ctx, n.log, *n.config)
+
+		// Get test-specific parameters if they exist
+		params := n.params[validator.Name()]
+
+		result, err := validator.Run(ctx, n.log, *n.config, params)
 		n.log.Info("Completed validator", "validator", validator.Name(), "type", validator.Type(), "passed", result.Passed, "error", err)
 		if err != nil {
 			n.log.Error("Error running validator", "validator", validator.Name(), "error", err)

--- a/op-nat/nat_test.go
+++ b/op-nat/nat_test.go
@@ -1,0 +1,117 @@
+package nat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNATParameterization(t *testing.T) {
+	// Create a test that records its received parameters
+	var receivedParams interface{}
+	testFn := func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+		receivedParams = params
+		return true, nil
+	}
+
+	test := &Test{
+		ID:            "test-with-params",
+		DefaultParams: map[string]string{"value": "default"},
+		Fn:            testFn,
+	}
+
+	// Create a basic config with our test
+	cfg := &Config{
+		Validators:          []Validator{test},
+		SenderSecretKey:     "0x0",
+		ReceiverPublicKeys:  []string{"0x0"},
+		ReceiverPrivateKeys: []string{"0x0"},
+	}
+	logger := log.New()
+
+	t.Run("uses default parameters when none provided", func(t *testing.T) {
+		nat, err := New(context.Background(), cfg, logger, "test")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := nat.Stop(context.Background())
+			require.NoError(t, err)
+		})
+
+		err = nat.Start(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, test.DefaultParams, receivedParams)
+	})
+
+	t.Run("uses custom parameters when provided", func(t *testing.T) {
+		nat, err := New(context.Background(), cfg, logger, "test")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := nat.Stop(context.Background())
+			require.NoError(t, err)
+		})
+
+		customParams := map[string]string{"value": "custom"}
+		nat.params = map[string]interface{}{
+			test.ID: customParams,
+		}
+
+		err = nat.Start(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, customParams, receivedParams)
+	})
+
+	t.Run("different test instances can have different parameters", func(t *testing.T) {
+		// Create two instances with different parameters
+		nat1, err := New(context.Background(), cfg, logger, "test1")
+		require.NoError(t, err)
+		nat1.params = map[string]interface{}{
+			test.ID: map[string]string{"value": "instance1"},
+		}
+
+		nat2, err := New(context.Background(), cfg, logger, "test2")
+		require.NoError(t, err)
+		nat2.params = map[string]interface{}{
+			test.ID: map[string]string{"value": "instance2"},
+		}
+
+		t.Cleanup(func() {
+			err := nat1.Stop(context.Background())
+			require.NoError(t, err)
+			err = nat2.Stop(context.Background())
+			require.NoError(t, err)
+		})
+
+		// Run first instance
+		err = nat1.Start(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"value": "instance1"}, receivedParams)
+
+		// Run second instance
+		err = nat2.Start(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"value": "instance2"}, receivedParams)
+	})
+
+	t.Run("results are properly recorded", func(t *testing.T) {
+		nat, err := New(context.Background(), cfg, logger, "test")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := nat.Stop(context.Background())
+			require.NoError(t, err)
+		})
+		nat.params = make(map[string]interface{})
+
+		err = nat.Start(context.Background())
+		require.NoError(t, err)
+
+		require.Len(t, nat.results, 1)
+		assert.Equal(t, "test-with-params", nat.results[0].ID)
+		assert.Equal(t, "Test", nat.results[0].Type)
+		assert.True(t, nat.results[0].Passed)
+	})
+}

--- a/op-nat/suite_test.go
+++ b/op-nat/suite_test.go
@@ -1,0 +1,65 @@
+package nat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuite(t *testing.T) {
+	t.Run("runs all tests in order", func(t *testing.T) {
+		executionOrder := []string{}
+
+		suite := &Suite{
+			Tests: []Test{
+				{
+					ID: "test1",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						executionOrder = append(executionOrder, "test1")
+						return true, nil
+					},
+				},
+				{
+					ID: "test2",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						executionOrder = append(executionOrder, "test2")
+						return true, nil
+					},
+				},
+			},
+		}
+
+		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
+
+		require.NoError(t, err)
+		assert.True(t, result.Passed)
+		assert.Equal(t, []string{"test1", "test2"}, executionOrder)
+	})
+
+	t.Run("fails if any test fails", func(t *testing.T) {
+		suite := &Suite{
+			Tests: []Test{
+				{
+					ID: "test1",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return true, nil
+					},
+				},
+				{
+					ID: "test2",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return false, nil
+					},
+				},
+			},
+		}
+
+		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
+
+		require.NoError(t, err)
+		assert.False(t, result.Passed)
+	})
+}

--- a/op-nat/test.go
+++ b/op-nat/test.go
@@ -10,18 +10,27 @@ import (
 var _ Validator = &Test{}
 
 type Test struct {
-	ID string
-	Fn func(ctx context.Context, log log.Logger, cfg Config) (bool, error)
+	ID            string
+	DefaultParams interface{}
+	Fn            func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error)
 }
 
-func (t Test) Run(ctx context.Context, log log.Logger, cfg Config) (ValidatorResult, error) {
+func (t Test) Run(ctx context.Context, log log.Logger, cfg Config, params interface{}) (ValidatorResult, error) {
 	if t.Fn == nil {
 		return ValidatorResult{
 			Passed: false,
 		}, fmt.Errorf("test function is nil")
 	}
-	log.Info("", "type", t.Type(), "id", t.Name())
-	passed, err := t.Fn(ctx, log, cfg)
+
+	// Use default params if none provided
+	testParams := t.DefaultParams
+	if params != nil {
+		testParams = params
+	}
+
+	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams)
+	passed, err := t.Fn(ctx, log, cfg, testParams)
+	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams, "passed", passed, "error", err)
 	return ValidatorResult{
 		ID:     t.ID,
 		Type:   t.Type(),

--- a/op-nat/test_test.go
+++ b/op-nat/test_test.go
@@ -1,0 +1,103 @@
+package nat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTest(t *testing.T) {
+	t.Run("uses default parameters", func(t *testing.T) {
+		defaultParams := map[string]string{"key": "value"}
+		var receivedParams interface{}
+
+		test := &Test{
+			ID:            "test-default-params",
+			DefaultParams: defaultParams,
+			Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+				receivedParams = params
+				return true, nil
+			},
+		}
+
+		result, err := test.Run(context.Background(), log.New(), Config{}, nil)
+
+		require.NoError(t, err)
+		assert.True(t, result.Passed)
+		assert.Equal(t, defaultParams, receivedParams)
+	})
+
+	t.Run("uses provided parameters", func(t *testing.T) {
+		customParams := map[string]string{"custom": "param"}
+		var receivedParams interface{}
+
+		test := &Test{
+			ID: "test-custom-params",
+			Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+				receivedParams = params
+				return true, nil
+			},
+		}
+
+		result, err := test.Run(context.Background(), log.New(), Config{}, customParams)
+
+		require.NoError(t, err)
+		assert.True(t, result.Passed)
+		assert.Equal(t, customParams, receivedParams)
+	})
+
+	t.Run("returns correct result based on Fn return value", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			fnReturn     bool
+			fnErr        error
+			expectPassed bool
+			expectErr    error
+		}{
+			{
+				name:         "returns true when Fn returns true",
+				fnReturn:     true,
+				fnErr:        nil,
+				expectPassed: true,
+				expectErr:    nil,
+			},
+			{
+				name:         "returns false when Fn returns false",
+				fnReturn:     false,
+				fnErr:        nil,
+				expectPassed: false,
+				expectErr:    nil,
+			},
+			{
+				name:         "propagates error from Fn",
+				fnReturn:     false,
+				fnErr:        assert.AnError,
+				expectPassed: false,
+				expectErr:    assert.AnError,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				test := &Test{
+					ID: "test-return-values",
+					Fn: func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error) {
+						return tc.fnReturn, tc.fnErr
+					},
+				}
+
+				result, err := test.Run(context.Background(), log.New(), Config{}, nil)
+
+				if tc.expectErr != nil {
+					assert.Equal(t, tc.expectErr, err)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, tc.expectPassed, result.Passed)
+				}
+			})
+		}
+	})
+}

--- a/op-nat/validator.go
+++ b/op-nat/validator.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Validator interface {
-	Run(ctx context.Context, log log.Logger, cfg Config) (ValidatorResult, error)
+	Run(ctx context.Context, log log.Logger, cfg Config, params interface{}) (ValidatorResult, error)
 	Name() string
 	Type() string
 }

--- a/op-nat/validators/suites/deposit.go
+++ b/op-nat/validators/suites/deposit.go
@@ -10,4 +10,9 @@ var DepositSuite = nat.Suite{
 	Tests: []nat.Test{
 		tests.SimpleDeposit,
 	},
+	TestsParams: map[string]interface{}{
+		tests.SimpleDeposit.ID: tests.SimpleDepositParams{
+			MaxBalanceChecks: 24,
+		},
+	},
 }

--- a/op-nat/validators/suites/load-test.go
+++ b/op-nat/validators/suites/load-test.go
@@ -10,4 +10,11 @@ var LoadTest = nat.Suite{
 	Tests: []nat.Test{
 		tests.TxFuzz,
 	},
+	TestsParams: map[string]interface{}{
+		"tx-fuzz": tests.TxFuzzParams{
+			NSlotsToRunFor:     1,
+			TxPerAccount:       2,
+			GenerateAccessList: false,
+		},
+	},
 }

--- a/op-nat/validators/suites/simple-transfer.go
+++ b/op-nat/validators/suites/simple-transfer.go
@@ -10,4 +10,5 @@ var SimpleTransfer = nat.Suite{
 	Tests: []nat.Test{
 		tests.SimpleTransfer,
 	},
+	TestsParams: map[string]interface{}{},
 }

--- a/op-nat/validators/tests/network-get-blocknumber.go
+++ b/op-nat/validators/tests/network-get-blocknumber.go
@@ -12,7 +12,7 @@ import (
 // NetworkGetBlockNumber is a test that checks if RPC call `BlockNumber` is working.
 var NetworkGetBlockNumber = nat.Test{
 	ID: "network-get-block-number",
-	Fn: func(ctx context.Context, log log.Logger, config nat.Config) (bool, error) {
+	Fn: func(ctx context.Context, log log.Logger, config nat.Config, _ interface{}) (bool, error) {
 		network, err := network.NewNetwork(ctx, log, config.RPCURL, "kurtosis-l2")
 		if err != nil {
 			return false, fmt.Errorf("failed to setup network")

--- a/op-nat/validators/tests/network-get-chainid.go
+++ b/op-nat/validators/tests/network-get-chainid.go
@@ -13,7 +13,7 @@ import (
 // NetworkGetChainID is a test that checks if the RPC call `ChainID` is working.
 var NetworkGetChainID = nat.Test{
 	ID: "network-get-chainid",
-	Fn: func(ctx context.Context, log log.Logger, config nat.Config) (bool, error) {
+	Fn: func(ctx context.Context, log log.Logger, config nat.Config, _ interface{}) (bool, error) {
 		network, err := network.NewNetwork(ctx, log, config.RPCURL, "kurtosis-l2")
 		if err != nil {
 			return false, fmt.Errorf("failed to setup network")

--- a/op-nat/validators/tests/simple-transfer.go
+++ b/op-nat/validators/tests/simple-transfer.go
@@ -15,7 +15,7 @@ import (
 // SimpleTransfer is a test that runs a transfer on a network
 var SimpleTransfer = nat.Test{
 	ID: "simple-transfer",
-	Fn: func(ctx context.Context, log log.Logger, cfg nat.Config) (bool, error) {
+	Fn: func(ctx context.Context, log log.Logger, cfg nat.Config, _ interface{}) (bool, error) {
 		network, walletA, walletB, err := SetupSimpleTransferTest(ctx, log, cfg)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
**Description**

* Introduces a way to add per-validator configuration (just tests for now)
* Introduces some tests, which check the above and more
* Note that there is not yet support for reading these values from a file (or elsewhere)

**Repercussions**

1. Each can now define its own config struct and also default values 

(tx_fuzz.go as an example)
```
type TxFuzzParams struct {
	NSlotsToRunFor     int
	TxPerAccount       uint64
	GenerateAccessList bool
}

var TxFuzz = nat.Test{
	ID: "tx-fuzz",
	DefaultParams: TxFuzzParams{
		NSlotsToRunFor:     120, // Duration of the fuzzing
		TxPerAccount:       3,
		GenerateAccessList: false,
	},
	Fn: func(ctx context.Context, log log.Logger, cfg nat.Config, params interface{}) (bool, error) {
		p := params.(TxFuzzParams)
		err := runBasicSpam(cfg, p)
		if err != nil {
			return false, err
		}
		return true, nil
	},
}
```

2. This can be specified, for example, when defining our suite:

```
var LoadTest = nat.Suite{
	ID: "load-test",
	Tests: []nat.Test{
		tests.TxFuzz,
	},
	TestsParams: map[string]interface{}{
		"tx-fuzz": tests.TxFuzzParams{
			NSlotsToRunFor:     2400,
			TxPerAccount:       9,
			GenerateAccessList: false,
		},
	},
}
```

**Pros**
* Each test (and validator, although for now we've just implemented support for tests) can have variable config/params
* The params are somewhat typed (runtime checks) [could potentially be improved with generics but would complicate things]
* The params have support for defaults so they don't need to be specified everywhere or everytime
* Quite easy and intuitive 

**Cons**
* If you wish to change just a single param of a test you must nonetheless provide ALL params (we could 'fix' this, but would likely make the code much messier; full of pointers to distinguish the difference between a zero value and a missing value. perhaps something to explore in the future if we like this approach)
* We aren't validating params (we could fix this by forcing the testParam structs to satisfy an interface with a `Validate` function, but then EVERY test would need to implement this)
