### PR TITLE
op-node: Fix stop sequencer deadlock in op-conductor deployments

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -680,7 +680,6 @@ func (d *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 		} else if !isLeader {
 			d.log.Info("Not leader anymore, skipping head sync wait")
 			break
-			
 		}
 
 		latestHeadSet := make(chan struct{})

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -672,6 +672,17 @@ func (d *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 
 	// ensure latestHead has been updated to the latest sealed/gossiped block before stopping the sequencer
 	for d.latestHead.Hash != d.latestSealed.Hash {
+
+		// if we are not the leader, latestSealed will never be updated and we will wait forever
+		if isLeader, err := d.conductor.Leader(ctx); err != nil {
+			d.log.Warn("Could not determine leadership while stopping. Skipping wait.", "err", err)
+			break
+		} else if !isLeader {
+			d.log.Info("Not leader anymore, skipping head sync wait")
+			break
+			
+		}
+
 		latestHeadSet := make(chan struct{})
 		d.latestHeadSet = latestHeadSet
 		d.l.Unlock()


### PR DESCRIPTION
Fix deadlock introduced by PR #11769 in `*Sequencer.Stop` method.

PR #11769 added a safety mechanism in `*Sequencer.Stop` to wait for latestHead to match latestSealed before stopping, preventing single-block reorgs. However, this introduced a deadlock when a sequencer lost leadership during the stop process:

1. A non-leader sequencer cannot commit unsafe payloads
2. Without committing payloads, blocks cannot be sealed
3. Without sealed blocks, `latestSealed` never updates
4. This caused the Stop method to hang indefinitely

The deadlock prevented proper sequencer shutdown, which could lead to multiple sequencers actively producing blocks.

This PR adds leadership checks during the stop process. If the sequencer is no longer the leader or cannot determine leadership status, it will skip waiting for head synchronization and proceed with the shutdown.