### PR TITLE
op-challenger: Lazy create clients

### DIFF
--- a/op-challenger/game/fault/clients.go
+++ b/op-challenger/game/fault/clients.go
@@ -1,0 +1,68 @@
+package fault
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type clientProvider struct {
+	ctx            context.Context
+	logger         log.Logger
+	cfg            *config.Config
+	l2HeaderSource utils.L2HeaderSource
+	rollupClient   RollupClient
+	syncValidator  *syncStatusValidator
+	toClose        []CloseFunc
+}
+
+func (c *clientProvider) Close() {
+	for _, closeFunc := range c.toClose {
+		closeFunc()
+	}
+}
+
+func (c *clientProvider) SingleChainClients() (utils.L2HeaderSource, RollupClient, *syncStatusValidator, error) {
+	headers, err := c.L2HeaderSource()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	rollup, err := c.RollupClient()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return headers, rollup, c.syncValidator, nil
+}
+
+func (c *clientProvider) L2HeaderSource() (utils.L2HeaderSource, error) {
+	if c.l2HeaderSource != nil {
+		return c.l2HeaderSource, nil
+	}
+
+	l2Client, err := ethclient.DialContext(c.ctx, c.cfg.L2Rpc)
+	if err != nil {
+		return nil, fmt.Errorf("dial l2 client %v: %w", c.cfg.L2Rpc, err)
+	}
+	c.l2HeaderSource = l2Client
+	c.toClose = append(c.toClose, l2Client.Close)
+	return l2Client, nil
+}
+
+func (c *clientProvider) RollupClient() (RollupClient, error) {
+	if c.rollupClient != nil {
+		return c.rollupClient, nil
+	}
+	rollupClient, err := dial.DialRollupClientWithTimeout(c.ctx, dial.DefaultDialTimeout, c.logger, c.cfg.RollupRpc)
+	if err != nil {
+		return nil, fmt.Errorf("dial rollup client %v: %w", c.cfg.RollupRpc, err)
+	}
+	c.rollupClient = rollupClient
+	c.syncValidator = newSyncStatusValidator(rollupClient)
+	c.toClose = append(c.toClose, rollupClient.Close)
+	return rollupClient, nil
+}

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -14,10 +14,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
-	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -60,45 +58,54 @@ func RegisterGameTypes(
 	selective bool,
 	claimants []common.Address,
 ) (CloseFunc, error) {
-	l2Client, err := ethclient.DialContext(ctx, cfg.L2Rpc)
-	if err != nil {
-		return nil, fmt.Errorf("dial l2 client %v: %w", cfg.L2Rpc, err)
-	}
-	closer := l2Client.Close
-
-	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, logger, cfg.RollupRpc)
-	if err != nil {
-		return closer, fmt.Errorf("dial rollup client %v: %w", cfg.RollupRpc, err)
-	}
-	closer = func() {
-		l2Client.Close()
-		rollupClient.Close()
-	}
-	syncValidator := newSyncStatusValidator(rollupClient)
-
+	clients := &clientProvider{ctx: ctx, logger: logger, cfg: cfg}
 	var registerTasks []*RegisterTask
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeCannon) {
-		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2Client, rollupClient))
+		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
+		if err != nil {
+			return nil, err
+		}
+		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypePermissioned) {
-		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2Client, rollupClient))
+		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
+		if err != nil {
+			return nil, err
+		}
+		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsterisc) {
-		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2Client, rollupClient))
+		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
+		if err != nil {
+			return nil, err
+		}
+		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsteriscKona) {
-		registerTasks = append(registerTasks, NewAsteriscKonaRegisterTask(faultTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaExecutor(), l2Client, rollupClient))
+		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
+		if err != nil {
+			return nil, err
+		}
+		registerTasks = append(registerTasks, NewAsteriscKonaRegisterTask(faultTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeFast) {
-		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.FastGameType, l2Client, rollupClient))
+		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
+		if err != nil {
+			return nil, err
+		}
+		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.FastGameType, l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAlphabet) {
-		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.AlphabetGameType, l2Client, rollupClient))
+		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
+		if err != nil {
+			return nil, err
+		}
+		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.AlphabetGameType, l2HeaderSource, rollupClient, syncValidator))
 	}
 	for _, task := range registerTasks {
-		if err := task.Register(ctx, registry, oracles, systemClock, l1Clock, logger, m, syncValidator, txSender, gameFactory, caller, l1HeaderSource, selective, claimants); err != nil {
-			return closer, fmt.Errorf("failed to register %v game type: %w", task.gameType, err)
+		if err := task.Register(ctx, registry, oracles, systemClock, l1Clock, logger, m, txSender, gameFactory, caller, l1HeaderSource, selective, claimants); err != nil {
+			return clients.Close, fmt.Errorf("failed to register %v game type: %w", task.gameType, err)
 		}
 	}
-	return closer, nil
+	return clients.Close, nil
 }


### PR DESCRIPTION
**Description**

Only create the l2 and rollup clients when a game type actually needs them.

Make sync validator configurable per game type since we'll need a different implementation for super root games.