### PR TITLE
feat: Add upgrade of superchain singletons

### DIFF
--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -21,6 +21,8 @@ type Implementations struct {
 	OptimismMintableERC20FactoryImpl common.Address `json:"OptimismMintableERC20FactoryImpl"`
 	DisputeGameFactoryImpl           common.Address `json:"DisputeGameFactoryImpl"`
 	AnchorStateRegistryImpl          common.Address `json:"AnchorStateRegistryImpl"`
+	SuperchainConfigImpl			 common.Address `json:"SuperchainConfigImpl"`
+	ProtocolVersionsImpl			 common.Address `json:"ProtocolVersionsImpl"`
 }
 
 type SuperchainDeployment struct {

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -21,8 +21,8 @@ type Implementations struct {
 	OptimismMintableERC20FactoryImpl common.Address `json:"OptimismMintableERC20FactoryImpl"`
 	DisputeGameFactoryImpl           common.Address `json:"DisputeGameFactoryImpl"`
 	AnchorStateRegistryImpl          common.Address `json:"AnchorStateRegistryImpl"`
-	SuperchainConfigImpl			 common.Address `json:"SuperchainConfigImpl"`
-	ProtocolVersionsImpl			 common.Address `json:"ProtocolVersionsImpl"`
+	SuperchainConfigImpl             common.Address `json:"SuperchainConfigImpl"`
+	ProtocolVersionsImpl             common.Address `json:"ProtocolVersionsImpl"`
 }
 
 type SuperchainDeployment struct {

--- a/op-deployer/pkg/deployer/opcm/implementations.go
+++ b/op-deployer/pkg/deployer/opcm/implementations.go
@@ -41,6 +41,8 @@ type DeployImplementationsOutput struct {
 	OptimismMintableERC20FactoryImpl common.Address
 	DisputeGameFactoryImpl           common.Address
 	AnchorStateRegistryImpl          common.Address
+	SuperchainConfigImpl             common.Address
+	ProtocolVersionsImpl             common.Address
 }
 
 func (output *DeployImplementationsOutput) CheckOutput(input common.Address) error {

--- a/op-deployer/pkg/deployer/opcm/opcm.go
+++ b/op-deployer/pkg/deployer/opcm/opcm.go
@@ -21,6 +21,8 @@ type DeployOPCMInput struct {
 	PermissionedDisputeGame1Blueprint common.Address
 	PermissionedDisputeGame2Blueprint common.Address
 
+	SuperchainConfigImpl             common.Address
+	ProtocolVersionsImpl             common.Address
 	L1ERC721BridgeImpl               common.Address
 	OptimismPortalImpl               common.Address
 	SystemConfigImpl                 common.Address

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -204,6 +204,8 @@ interface IOPContractsManager {
     /// @notice Thrown when the SuperchainConfig of the chain does not match the SuperchainConfig of this OPCM.
     error SuperchainConfigMismatch(ISystemConfig systemConfig);
 
+    error SuperchainProxyAdminMismatch();
+
     // -------- Methods --------
 
     function __constructor__(

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -94,6 +94,8 @@ interface IOPContractsManager {
 
     /// @notice The latest implementation contracts for the OP Stack.
     struct Implementations {
+        address superchainConfigImpl;
+        address protocolVersionsImpl;
         address l1ERC721BridgeImpl;
         address optimismPortalImpl;
         address systemConfigImpl;
@@ -216,10 +218,10 @@ interface IOPContractsManager {
 
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory);
 
-    /// @notice Upgrades a set of chains to the latest implementation contracts
-    /// @param _opChains Array of OpChain structs, one per chain to upgrade
-    /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
-    function upgrade(OpChain[] memory _opChains) external;
+    /// @notice Upgrades the implementation of all proxies in the specified chains
+    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
+    /// @param _opChains The chains to upgrade
+    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external;
 
     /// @notice addGameType deploys a new dispute game and links it to the DisputeGameFactory. The inputted _gameConfigs
     /// must be added in ascending GameType order.

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -471,6 +471,8 @@ contract DeployImplementations is Script {
         address upgradeController = _dii.upgradeController();
 
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
+            superchainConfigImpl: address(_dio.superchainConfigImpl()),
+            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),
@@ -479,8 +481,6 @@ contract DeployImplementations is Script {
             l1StandardBridgeImpl: address(_dio.l1StandardBridgeImpl()),
             disputeGameFactoryImpl: address(_dio.disputeGameFactoryImpl()),
             anchorStateRegistryImpl: address(_dio.anchorStateRegistryImpl()),
-            superchainConfigImpl: address(_dio.superchainConfigImpl()),
-            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             delayedWETHImpl: address(_dio.delayedWETHImpl()),
             mipsImpl: address(_dio.mipsSingleton())
         });

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -831,8 +831,8 @@ contract DeployImplementationsInterop is DeployImplementations {
 
         // moose here (next call fails)
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
-            superchainConfigImpl: address(_dii.superchainConfigImpl()),
-            protocolVersionsImpl: address(_dii.protocolVersionsImpl()),
+            superchainConfigImpl: address(_dio.superchainConfigImpl()),
+            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -29,7 +29,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 import { DeploySuperchainImplementations, DeploySuperchainOutput } from "scripts/deploy/DeploySuperchain.s.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // See DeploySuperchain.s.sol for detailed comments on the script architecture used here.
 contract DeployImplementationsInput is BaseDeployIO {
@@ -130,18 +129,6 @@ contract DeployImplementationsInput is BaseDeployIO {
     function protocolVersionsProxy() public view returns (IProtocolVersions) {
         require(address(_protocolVersionsProxy) != address(0), "DeployImplementationsInput: not set");
         return _protocolVersionsProxy;
-    }
-
-    function superchainConfigImpl() public view returns (ISuperchainConfig) {
-        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfigProxy)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
-    }
-
-    function protocolVersionsImpl() public view returns (IProtocolVersions) {
-        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersionsProxy)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
     }
 
     function upgradeController() public view returns (address) {
@@ -487,8 +474,8 @@ contract DeployImplementations is Script {
 
         // moose here (next call fails)
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
-            superchainConfigImpl: address(_dii.superchainConfigImpl()),
-            protocolVersionsImpl: address(_dii.protocolVersionsImpl()),
+            superchainConfigImpl: address(_dio.superchainConfigImpl()),
+            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -11,7 +11,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract DeployOPCMInput is BaseDeployIO {
     ISuperchainConfig internal _superchainConfig;

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -26,6 +26,8 @@ contract DeployOPCMInput is BaseDeployIO {
     address internal _permissionedDisputeGame1Blueprint;
     address internal _permissionedDisputeGame2Blueprint;
 
+    address internal _superchainConfigImpl;
+    address internal _protocolVersionsImpl;
     address internal _l1ERC721BridgeImpl;
     address internal _optimismPortalImpl;
     address internal _systemConfigImpl;
@@ -167,6 +169,16 @@ contract DeployOPCMInput is BaseDeployIO {
         return _anchorStateRegistryImpl;
     }
 
+    function superchainConfigImpl() public view returns (address) {
+        require(_superchainConfigImpl != address(0), "DeployOPCMInput: not set");
+        return _superchainConfigImpl;
+    }
+
+    function protocolVersionsImpl() public view returns (address) {
+        require(_protocolVersionsImpl != address(0), "DeployOPCMInput: not set");
+        return _protocolVersionsImpl;
+    }
+
     function delayedWETHImpl() public view returns (address) {
         require(_delayedWETHImpl != address(0), "DeployOPCMInput: not set");
         return _delayedWETHImpl;
@@ -209,6 +221,8 @@ contract DeployOPCM is Script {
             permissionlessDisputeGame2: address(0)
         });
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
+            superchainConfigImpl: address(_doi.superchainConfigImpl()),
+            protocolVersionsImpl: address(_doi.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_doi.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_doi.optimismPortalImpl()),
             systemConfigImpl: address(_doi.systemConfigImpl()),

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -46,6 +46,8 @@ contract DeployOPCMInput is BaseDeployIO {
 
         if (_sel == this.superchainConfig.selector) _superchainConfig = ISuperchainConfig(_addr);
         else if (_sel == this.protocolVersions.selector) _protocolVersions = IProtocolVersions(_addr);
+        else if (_sel == this.superchainConfigImpl.selector) _superchainConfigImpl = _addr;
+        else if (_sel == this.protocolVersionsImpl.selector) _protocolVersionsImpl = _addr;
         else if (_sel == this.upgradeController.selector) _upgradeController = _addr;
         else if (_sel == this.addressManagerBlueprint.selector) _addressManagerBlueprint = _addr;
         else if (_sel == this.proxyBlueprint.selector) _proxyBlueprint = _addr;
@@ -170,16 +172,14 @@ contract DeployOPCMInput is BaseDeployIO {
         return _anchorStateRegistryImpl;
     }
 
-    function superchainConfigImpl() public view returns (ISuperchainConfig) {
-        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfig)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
+    function superchainConfigImpl() public view returns (address) {
+        require(_superchainConfigImpl != address(0), "DeployOPCMInput: not set");
+        return _superchainConfigImpl;
     }
 
-    function protocolVersionsImpl() public view returns (IProtocolVersions) {
-        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersions)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
+    function protocolVersionsImpl() public view returns (address) {
+        require(_protocolVersionsImpl != address(0), "DeployOPCMInput: not set");
+        return _protocolVersionsImpl;
     }
 
     function delayedWETHImpl() public view returns (address) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -171,13 +171,13 @@ contract DeployOPCMInput is BaseDeployIO {
     }
 
     function superchainConfigImpl() public view returns (ISuperchainConfig) {
-        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfigProxy)));
+        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfig)));
         DeployUtils.assertValidContractAddress(address(impl));
         return impl;
     }
 
     function protocolVersionsImpl() public view returns (IProtocolVersions) {
-        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersionsProxy)));
+        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersions)));
         DeployUtils.assertValidContractAddress(address(impl));
         return impl;
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -11,6 +11,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract DeployOPCMInput is BaseDeployIO {
     ISuperchainConfig internal _superchainConfig;
@@ -169,14 +170,16 @@ contract DeployOPCMInput is BaseDeployIO {
         return _anchorStateRegistryImpl;
     }
 
-    function superchainConfigImpl() public view returns (address) {
-        require(_superchainConfigImpl != address(0), "DeployOPCMInput: not set");
-        return _superchainConfigImpl;
+    function superchainConfigImpl() public view returns (ISuperchainConfig) {
+        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfigProxy)));
+        DeployUtils.assertValidContractAddress(address(impl));
+        return impl;
     }
 
-    function protocolVersionsImpl() public view returns (address) {
-        require(_protocolVersionsImpl != address(0), "DeployOPCMInput: not set");
-        return _protocolVersionsImpl;
+    function protocolVersionsImpl() public view returns (IProtocolVersions) {
+        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersionsProxy)));
+        DeployUtils.assertValidContractAddress(address(impl));
+        return impl;
     }
 
     function delayedWETHImpl() public view returns (address) {

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -441,7 +441,7 @@ library DeploySuperchainImplementations {
     bytes32 internal constant _salt = keccak256("op-stack-contract-impls-salt-v0");
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function deploySuperchainImplementationContracts(DeploySuperchainOutput _dso) public {
+    function deploySuperchainImplementationContracts(DeploySuperchainOutput _dso) internal {
         // Deploy implementation contracts.
         vm.startBroadcast(msg.sender);
         ISuperchainConfig superchainConfigImpl = ISuperchainConfig(

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
 import { stdToml } from "forge-std/StdToml.sol";
-
+import { Vm } from "forge-std/Vm.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
@@ -310,7 +310,7 @@ contract DeploySuperchain is Script {
         deploySuperchainProxyAdmin(_dsi, _dso);
 
         // Deploy and initialize the superchain contracts.
-        deploySuperchainImplementationContracts(_dsi, _dso);
+        DeploySuperchainImplementations.deploySuperchainImplementationContracts(_dso);
         deployAndInitializeSuperchainConfig(_dsi, _dso);
         deployAndInitializeProtocolVersions(_dsi, _dso);
 
@@ -341,29 +341,7 @@ contract DeploySuperchain is Script {
     }
 
     function deploySuperchainImplementationContracts(DeploySuperchainInput, DeploySuperchainOutput _dso) public {
-        // Deploy implementation contracts.
-        vm.startBroadcast(msg.sender);
-        ISuperchainConfig superchainConfigImpl = ISuperchainConfig(
-            DeployUtils.createDeterministic({
-                _name: "SuperchainConfig",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperchainConfig.__constructor__, ())),
-                _salt: _salt
-            })
-        );
-        IProtocolVersions protocolVersionsImpl = IProtocolVersions(
-            DeployUtils.createDeterministic({
-                _name: "ProtocolVersions",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProtocolVersions.__constructor__, ())),
-                _salt: _salt
-            })
-        );
-        vm.stopBroadcast();
-
-        vm.label(address(superchainConfigImpl), "SuperchainConfigImpl");
-        vm.label(address(protocolVersionsImpl), "ProtocolVersionsImpl");
-
-        _dso.set(_dso.superchainConfigImpl.selector, address(superchainConfigImpl));
-        _dso.set(_dso.protocolVersionsImpl.selector, address(protocolVersionsImpl));
+        DeploySuperchainImplementations.deploySuperchainImplementationContracts(_dso);
     }
 
     function deployAndInitializeSuperchainConfig(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
@@ -456,5 +434,36 @@ contract DeploySuperchain is Script {
     function getIOContracts() public view returns (DeploySuperchainInput dsi_, DeploySuperchainOutput dso_) {
         dsi_ = DeploySuperchainInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeploySuperchainInput"));
         dso_ = DeploySuperchainOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeploySuperchainOutput"));
+    }
+}
+
+library DeploySuperchainImplementations {
+    bytes32 internal constant _salt = keccak256("op-stack-contract-impls-salt-v0");
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function deploySuperchainImplementationContracts(DeploySuperchainOutput _dso) public {
+        // Deploy implementation contracts.
+        vm.startBroadcast(msg.sender);
+        ISuperchainConfig superchainConfigImpl = ISuperchainConfig(
+            DeployUtils.createDeterministic({
+                _name: "SuperchainConfig",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperchainConfig.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        IProtocolVersions protocolVersionsImpl = IProtocolVersions(
+            DeployUtils.createDeterministic({
+                _name: "ProtocolVersions",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProtocolVersions.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.stopBroadcast();
+
+        vm.label(address(superchainConfigImpl), "SuperchainConfigImpl");
+        vm.label(address(protocolVersionsImpl), "ProtocolVersionsImpl");
+
+        _dso.set(_dso.superchainConfigImpl.selector, address(superchainConfigImpl));
+        _dso.set(_dso.protocolVersionsImpl.selector, address(protocolVersionsImpl));
     }
 }

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -72,6 +72,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -509,6 +519,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -633,6 +653,11 @@
   },
   {
     "inputs": [
+      {
+        "internalType": "contract IProxyAdmin",
+        "name": "_superchainProxyAdmin",
+        "type": "address"
+      },
       {
         "components": [
           {
@@ -839,6 +864,11 @@
       }
     ],
     "name": "SuperchainConfigMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SuperchainProxyAdminMismatch",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -72,6 +72,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -509,6 +519,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -633,6 +653,11 @@
   },
   {
     "inputs": [
+      {
+        "internalType": "contract IProxyAdmin",
+        "name": "_superchainProxyAdmin",
+        "type": "address"
+      },
       {
         "components": [
           {
@@ -839,6 +864,11 @@
       }
     ],
     "name": "SuperchainConfigMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SuperchainProxyAdminMismatch",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x2b46015fc16f0562f1c902faa91a39dcdeaba9d282493c31f2870541b5d028df"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0xfafa73cc636c5ba92c7e0ca26324bd1f7c514acba7977b6c9df4b445c3242dc2",
-    "sourceCodeHash": "0xc2ec936877c5e85425fe261c8394bec43cc7f32fe415c0c7a9acff716e3de599"
+    "initCodeHash": "0xd0fb3c6319cacaec7200f4bce681876f63b1e5203428cbdbe1ba01af71b14c87",
+    "sourceCodeHash": "0xf592701695e8383cc6a86e752108f733228e56a3027fa0bf55440c367bd4dc0d"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,11 +16,11 @@
     "sourceCodeHash": "0x2dd7bf6cbce655b1023a3ad071523bf455aa13fad5d02e1e434af71728cd794c"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x91a3194df65af1604004fc0cae535a664f4320b8c3d043b4e220e5f41058eb0b",
-    "sourceCodeHash": "0x2c54078dadc80e2a9c8b313acc01b753051206fc0c5d90a5188a88eb3b60c69f"
+    "initCodeHash": "0x88b7de58e1e57402b4497c4fdad5fe940d0879133bb9dab87365a3cc1ec27282",
+    "sourceCodeHash": "0x2b46015fc16f0562f1c902faa91a39dcdeaba9d282493c31f2870541b5d028df"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0xff07c5f0ae28bfe45c696127dea07481a5a58acda12614b354c7b04479c46bb5",
+    "initCodeHash": "0xfafa73cc636c5ba92c7e0ca26324bd1f7c514acba7977b6c9df4b445c3242dc2",
     "sourceCodeHash": "0xc2ec936877c5e85425fe261c8394bec43cc7f32fe415c0c7a9acff716e3de599"
   },
   "src/L1/OptimismPortal2.sol": {

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
@@ -24,7 +24,7 @@
     "bytes": "1",
     "label": "isRC",
     "offset": 0,
-    "slot": "20",
+    "slot": "22",
     "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
@@ -14,7 +14,7 @@
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "320",
+    "bytes": "384",
     "label": "implementation",
     "offset": 0,
     "slot": "10",

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
@@ -24,7 +24,7 @@
     "bytes": "1",
     "label": "isRC",
     "offset": 0,
-    "slot": "20",
+    "slot": "22",
     "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
@@ -14,7 +14,7 @@
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "320",
+    "bytes": "384",
     "label": "implementation",
     "offset": 0,
     "slot": "10",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -432,6 +432,7 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice Upgrades a set of chains to the latest implementation contracts
+    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
     /// @param _opChains Array of OpChain structs, one per chain to upgrade
     /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
     function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external {

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -519,7 +519,8 @@ contract OPContractsManager is ISemver {
                 // 3. getting the anchor root for the respected game type from the Anchor State Registry.
                 {
                     GameType gameType = IOptimismPortal2(payable(opChainAddrs.optimismPortal)).respectedGameType();
-                    (Hash root, uint256 l2BlockNumber) = permissionedDisputeGame.anchorStateRegistry().anchors(gameType);
+                    (Hash root, uint256 l2BlockNumber) =
+                        getAnchorStateRegistry(IFaultDisputeGame(address(permissionedDisputeGame))).anchors(gameType);
                     OutputRoot memory startingAnchorRoot = OutputRoot({ root: root, l2BlockNumber: l2BlockNumber });
 
                     upgradeToAndCall(
@@ -643,7 +644,7 @@ contract OPContractsManager is ISemver {
                                 gameConfig.disputeMaxClockDuration,
                                 gameConfig.vm,
                                 outputs[i].delayedWETH,
-                                pdg.anchorStateRegistry(),
+                                getAnchorStateRegistry(IFaultDisputeGame(address(pdg))),
                                 l2ChainId
                             ),
                             pdg.proposer(),
@@ -667,7 +668,7 @@ contract OPContractsManager is ISemver {
                                 gameConfig.disputeMaxClockDuration,
                                 gameConfig.vm,
                                 outputs[i].delayedWETH,
-                                fdg.anchorStateRegistry(),
+                                getAnchorStateRegistry(fdg),
                                 l2ChainId
                             )
                         )
@@ -975,6 +976,7 @@ contract OPContractsManager is ISemver {
         isRC = _isRC;
     }
 
+    /// @notice Retrieves the constructor params for a given game.
     function getGameConstructorParams(IFaultDisputeGame _disputeGame)
         internal
         view
@@ -993,6 +995,11 @@ contract OPContractsManager is ISemver {
             l2ChainId: _disputeGame.l2ChainId()
         });
         return params;
+    }
+
+    /// @notice Retrieves the Anchor State Registry for a given game
+    function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal returns (IAnchorStateRegistry) {
+        return _disputeGame.anchorStateRegistry();
     }
 
     /// @notice For a given game type, does the following:

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -999,7 +999,7 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice Retrieves the Anchor State Registry for a given game
-    function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal returns (IAnchorStateRegistry) {
+    function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal view returns (IAnchorStateRegistry) {
         return _disputeGame.anchorStateRegistry();
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -143,9 +143,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.35
+    /// @custom:semver 1.0.0-beta.36
     function version() public pure virtual returns (string memory) {
-        return "1.0.0-beta.35";
+        return "1.0.0-beta.36";
     }
 
     /// @notice Address of the SuperchainConfig contract shared by all chains.

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
@@ -12,9 +12,9 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
 
 contract OPContractsManagerInterop is OPContractsManager {
-    /// @custom:semver +interop-beta.3
+    /// @custom:semver +interop-beta.4
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.3");
+        return string.concat(super.version(), "+interop-beta.4");
     }
 
     constructor(

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -342,12 +342,12 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
 
         assertFalse(opcm.isRC(), "isRC should be false");
         releaseBytes = bytes(opcm.l1ContractsRelease());
-        assertNotEq(
-            Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should not end with '-rc'"
-        );
+        assertNotEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should not end with '-rc'");
     }
 
-    function testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works(address _nonUpgradeController)
+    function testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works(
+        address _nonUpgradeController
+    )
         public
     {
         if (

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -296,6 +296,8 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
         }
 
         // Check the implementations of the core addresses
+        assertEq(impls.superchainConfigImpl, EIP1967Helper.getImplementation(address(superchainConfig)));
+        assertEq(impls.protocolVersionsImpl, EIP1967Helper.getImplementation(address(protocolVersions)));
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(impls.l1ERC721BridgeImpl, EIP1967Helper.getImplementation(address(l1ERC721Bridge)));
         assertEq(impls.disputeGameFactoryImpl, EIP1967Helper.getImplementation(address(disputeGameFactory)));

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -238,11 +238,12 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
 contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     function runUpgradeTestAndChecks(address delegateCaller) public {
+        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+
         assertTrue(opcm.isRC(), "isRC should be true");
         bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
         assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
 
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
         IOPContractsManager.Implementations memory impls = opcm.implementations();
 
         // Cache the old L1xDM address so we can look for it in the AddressManager's event
@@ -283,7 +284,7 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
         }
         vm.expectEmit(address(delegateCaller));
         emit Upgraded(l2ChainId, opChains[0].systemConfigProxy, address(delegateCaller));
-        DelegateCaller(upgrader).dcForward(
+        DelegateCaller(delegateCaller).dcForward(
             address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (superchainProxyAdmin, opChains))
         );
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -270,6 +270,8 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.upgradeController.selector, upgradeController);
 
         // Perform the initial deployment.
+        deployImplementations.deploySuperchainConfigImpl(dio);
+        deployImplementations.deployProtocolVersionsImpl(dio);
         deployImplementations.deploySystemConfigImpl(dio);
         deployImplementations.deployL1CrossDomainMessengerImpl(dio);
         deployImplementations.deployL1ERC721BridgeImpl(dio);

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -82,6 +82,8 @@ contract DeployOPCMInput_Test is Test {
     function test_set_part1_succeeds() public {
         ISuperchainConfig superchainConfig = ISuperchainConfig(makeAddr("superchainConfig"));
         IProtocolVersions protocolVersions = IProtocolVersions(makeAddr("protocolVersions"));
+        address superchainConfigImpl = makeAddr("superchainConfigImpl");
+        address protocolVersionsImpl = makeAddr("protocolVersionsImpl");
         address upgradeController = makeAddr("upgradeController");
         address addressManagerBlueprint = makeAddr("addressManagerBlueprint");
         address proxyBlueprint = makeAddr("proxyBlueprint");
@@ -93,6 +95,8 @@ contract DeployOPCMInput_Test is Test {
 
         dii.set(dii.superchainConfig.selector, address(superchainConfig));
         dii.set(dii.protocolVersions.selector, address(protocolVersions));
+        dii.set(dii.superchainConfigImpl.selector, superchainConfigImpl);
+        dii.set(dii.protocolVersionsImpl.selector, protocolVersionsImpl);
         dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.upgradeController.selector, upgradeController);
         dii.set(dii.addressManagerBlueprint.selector, addressManagerBlueprint);
@@ -210,6 +214,8 @@ contract DeployOPCMTest is Test {
 
     ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
     IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+    address superchainConfigImpl = makeAddr("superchainConfigImpl");
+    address protocolVersionsImpl = makeAddr("protocolVersionsImpl");
     address upgradeController = makeAddr("upgradeController");
 
     function setUp() public virtual {
@@ -220,6 +226,8 @@ contract DeployOPCMTest is Test {
     function test_run_succeeds() public {
         doi.set(doi.superchainConfig.selector, address(superchainConfigProxy));
         doi.set(doi.protocolVersions.selector, address(protocolVersionsProxy));
+        doi.set(doi.superchainConfigImpl.selector, address(superchainConfigImpl));
+        doi.set(doi.protocolVersionsImpl.selector, address(protocolVersionsImpl));
         doi.set(doi.l1ContractsRelease.selector, "1.0.0");
         doi.set(doi.upgradeController.selector, upgradeController);
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -149,7 +149,7 @@ contract ForkLive is Deployer {
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         IProxyAdmin proxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(systemConfig)));
 
-        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfig"));
+        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
         IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
 
         address upgrader = proxyAdmin.owner();

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -21,6 +21,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
@@ -148,6 +149,9 @@ contract ForkLive is Deployer {
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         IProxyAdmin proxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(systemConfig)));
 
+        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfig"));
+        IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
+
         address upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
@@ -157,7 +161,9 @@ contract ForkLive is Deployer {
         // TODO Migrate from DelegateCaller to a Safe to reduce risk of mocks not properly
         // reflecting the production system.
         vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
+        DelegateCaller(upgrader).dcForward(
+            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (superchainProxyAdmin, opChains))
+        );
 
         console.log("ForkLive: Saving newly deployed contracts");
         // A new ASR and new dispute games were deployed, so we need to update them


### PR DESCRIPTION
### TL;DR
Added support for upgrading `SuperchainConfig` and `ProtocolVersions` contracts through the OPContractsManager.

### What changed?

- Added `superchainConfigImpl` and `protocolVersionsImpl` to the OPContractsManager's Implementations struct. This also requires adding those values to `DeploySuperchain`, `DeployImplementations` and `DeployOPCM`.
- Modified the `upgrade` function in OPContractsManager to handle upgrading superchain contracts.


