### PR TITLE
feat: nat; upgrade tx-fuzz.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,13 +43,12 @@ require (
 	github.com/multiformats/go-base32 v0.1.0
 	github.com/multiformats/go-multiaddr v0.14.0
 	github.com/multiformats/go-multiaddr-dns v0.4.1
-	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/protolambda/ctxlock v0.1.0
-	github.com/scharissis/tx-fuzz v0.0.0-20250110231652-a474cf246759
+	github.com/scharissis/tx-fuzz v0.0.0-20250116214814-b8b8094fac69
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/crypto v0.28.0
@@ -184,7 +183,6 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/onsi/ginkgo/v2 v2.20.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -594,10 +594,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
-github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
-github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=
-github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nwaples/rardecode v1.1.3 h1:cWCaZwfM5H7nAD6PyEdcVnczzV8i/JtotnyW/dD9lEc=
@@ -757,6 +753,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scharissis/tx-fuzz v0.0.0-20250110231652-a474cf246759 h1:yzaF8Btg3ZAcW+G4jip6br/j2a6aubcKItxDwlb4wOo=
 github.com/scharissis/tx-fuzz v0.0.0-20250110231652-a474cf246759/go.mod h1:cO3J814SQWDHqoe6xEvO5bqZCGUgr5O9v9eb4SjMjZM=
+github.com/scharissis/tx-fuzz v0.0.0-20250116214814-b8b8094fac69 h1:6n2XMGZTiKzTO76GLD4SuqFocqy/RCR25f3JLbfwOjw=
+github.com/scharissis/tx-fuzz v0.0.0-20250116214814-b8b8094fac69/go.mod h1:cO3J814SQWDHqoe6xEvO5bqZCGUgr5O9v9eb4SjMjZM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/op-nat/config.go
+++ b/op-nat/config.go
@@ -12,12 +12,13 @@ import (
 )
 
 type Config struct {
+	// Network config
 	SC         SuperchainManifest
 	L1RPCUrl   string
 	RPCURL     string
 	Validators []Validator
 
-	// tx-fuzz
+	// mix of chain config and tx-fuzz params - needs cleanup
 	SenderSecretKey     string `json:"-"`
 	ReceiverPublicKeys  []string
 	ReceiverPrivateKeys []string


### PR DESCRIPTION
**Description**

Upgrades `tx-fuzz` to a version which uses a logger instead of outputting to stdout. This de-clutters NAT output.
