### PR TITLE
interop: Fix Managed Mode Reset  ; Add Reset Action Test

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -83,7 +83,8 @@ func TestFullInterop(gt *testing.T) {
 	actors.ChainA.Sequencer.SyncSupervisor(t)    // supervisor to react to exhaust-L1
 	actors.ChainA.Sequencer.ActL2PipelineFull(t) // node to complete syncing to L1 head.
 
-	actors.ChainA.Sequencer.ActL1HeadSignal(t) // TODO: two sources of L1 head
+	// TODO(#13972): two sources of L1 head
+	actors.ChainA.Sequencer.ActL1HeadSignal(t)
 	status = actors.ChainA.Sequencer.SyncStatus()
 	require.Equal(t, head, status.UnsafeL2.ID())
 	require.Equal(t, head, status.CrossUnsafeL2.ID())

--- a/op-e2e/actions/interop/reset_test.go
+++ b/op-e2e/actions/interop/reset_test.go
@@ -73,8 +73,8 @@ func TestReset(gt *testing.T) {
 		actors.Supervisor.SignalLatestL1(t)          // supervisor will be aware of latest L1
 		actors.ChainA.Sequencer.SyncSupervisor(t)    // supervisor to react to exhaust-L1
 		actors.ChainA.Sequencer.ActL2PipelineFull(t) // node to complete syncing to L1 head.
-
-		actors.ChainA.Sequencer.ActL1HeadSignal(t) // TODO: two sources of L1 head
+		// TODO(#13972): two sources of L1 head
+		actors.ChainA.Sequencer.ActL1HeadSignal(t)
 		status = actors.ChainA.Sequencer.SyncStatus()
 		if expect {
 			require.Equal(t, head, status.UnsafeL2.ID())

--- a/op-e2e/actions/interop/reset_test.go
+++ b/op-e2e/actions/interop/reset_test.go
@@ -1,0 +1,146 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReset(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+
+	is := SetupInterop(t)
+	actors := is.CreateActors()
+
+	// get both sequencers set up
+	// sync the supervisor, handle initial events emitted by the nodes
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+
+	// No blocks yet
+	status := actors.ChainA.Sequencer.SyncStatus()
+	require.Equal(t, uint64(0), status.UnsafeL2.Number)
+
+	// Sync initial Supervisor state
+	actors.Supervisor.ProcessFull(t)
+
+	// Advance the chain by one block, and step through the sync process
+	// until the block is cross safe.
+	currentBlockNum := 0
+	advanceChainA := func(expect bool) (head eth.BlockID) {
+		currentBlockNum++
+		prevBlockNum := currentBlockNum - 1
+		// Build L2 block on chain A
+		actors.ChainA.Sequencer.ActL2StartBlock(t)
+		actors.ChainA.Sequencer.ActL2EndBlock(t)
+		status = actors.ChainA.Sequencer.SyncStatus()
+		head = status.UnsafeL2.ID()
+		if expect {
+			require.Equal(t, uint64(currentBlockNum), head.Number)
+			require.Equal(t, uint64(prevBlockNum), status.CrossUnsafeL2.Number)
+			require.Equal(t, uint64(prevBlockNum), status.LocalSafeL2.Number)
+			require.Equal(t, uint64(prevBlockNum), status.SafeL2.Number)
+		}
+
+		// Ingest the new unsafe-block event
+		actors.ChainA.Sequencer.SyncSupervisor(t)
+
+		// Verify as cross-unsafe with supervisor
+		actors.Supervisor.ProcessFull(t)
+		actors.ChainA.Sequencer.ActL2PipelineFull(t)
+		status = actors.ChainA.Sequencer.SyncStatus()
+		if expect {
+			require.Equal(t, head, status.UnsafeL2.ID())
+			require.Equal(t, head, status.CrossUnsafeL2.ID())
+			require.Equal(t, uint64(prevBlockNum), status.LocalSafeL2.Number)
+			require.Equal(t, uint64(prevBlockNum), status.SafeL2.Number)
+		}
+
+		// Submit the L2 block, sync the local-safe data
+		actors.ChainA.Batcher.ActSubmitAll(t)
+		actors.L1Miner.ActL1StartBlock(12)(t)
+		actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
+		actors.L1Miner.ActL1EndBlock(t)
+
+		// The node will exhaust L1 data,
+		// it needs the supervisor to see the L1 block first,
+		// and provide it to the node.
+		actors.ChainA.Sequencer.ActL2EventsUntil(t, event.Is[derive.ExhaustedL1Event], 100, false)
+		actors.Supervisor.SignalLatestL1(t)          // supervisor will be aware of latest L1
+		actors.ChainA.Sequencer.SyncSupervisor(t)    // supervisor to react to exhaust-L1
+		actors.ChainA.Sequencer.ActL2PipelineFull(t) // node to complete syncing to L1 head.
+
+		actors.ChainA.Sequencer.ActL1HeadSignal(t) // TODO: two sources of L1 head
+		status = actors.ChainA.Sequencer.SyncStatus()
+		if expect {
+			require.Equal(t, head, status.UnsafeL2.ID())
+			require.Equal(t, head, status.CrossUnsafeL2.ID())
+			require.Equal(t, head, status.LocalSafeL2.ID())
+			require.Equal(t, uint64(prevBlockNum), status.SafeL2.Number)
+			// Local-safe does not count as "safe" in RPC
+			n := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Number.Uint64()
+			require.Equal(t, uint64(prevBlockNum), n)
+		}
+
+		// Make the supervisor aware of the new L1 block
+		actors.Supervisor.SignalLatestL1(t)
+
+		// Ingest the new local-safe event
+		actors.ChainA.Sequencer.SyncSupervisor(t)
+
+		// Cross-safe verify it
+		actors.Supervisor.ProcessFull(t)
+		actors.ChainA.Sequencer.ActL2PipelineFull(t)
+		status = actors.ChainA.Sequencer.SyncStatus()
+		if expect {
+			require.Equal(t, head, status.UnsafeL2.ID())
+			require.Equal(t, head, status.CrossUnsafeL2.ID())
+			require.Equal(t, head, status.LocalSafeL2.ID())
+			require.Equal(t, head, status.SafeL2.ID())
+			h := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Hash()
+			require.Equal(t, head.Hash, h)
+		}
+
+		return head
+	}
+
+	numBlocks := 10
+	blocksAdded := []eth.BlockID{}
+	// Advance through multiple blocks
+	for i := 0; i < numBlocks; i++ {
+		blocksAdded = append(blocksAdded, advanceChainA(true))
+		// finalize just the first block
+		if i == 0 {
+			actors.L1Miner.ActL1SafeNext(t)
+			actors.L1Miner.ActL1FinalizeNext(t)
+			actors.ChainA.Sequencer.ActL1SafeSignal(t) // TODO old source of finality
+			actors.ChainA.Sequencer.ActL1FinalizedSignal(t)
+			actors.Supervisor.SignalFinalizedL1(t)
+			actors.Supervisor.ProcessFull(t)
+			actors.ChainA.Sequencer.ActL2PipelineFull(t)
+			finalizedL2BlockID, err := actors.Supervisor.Finalized(t.Ctx(), actors.ChainA.ChainID)
+			require.NoError(t, err)
+			require.Equal(t, blocksAdded[0], finalizedL2BlockID)
+		}
+	}
+
+	// Reset the supervisor to a much earlier block
+	actors.Supervisor.backend.Rewind(actors.ChainA.ChainID, blocksAdded[3])
+	actors.Supervisor.ProcessFull(t)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+
+	// add another block, this will be the numBlocks+1 block
+	advanceChainA(false)
+	// the supervisor should detect an our of order error and instruct the node to reset
+	actors.Supervisor.ProcessFull(t)
+	// let the node and supervisor sync to this new state
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainA.Sequencer.SyncStatus()
+
+	// The supervisor should have reset to the block before the reset block
+	require.Equal(t, blocksAdded[3].Number, status.LocalSafeL2.Number)
+}

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -229,7 +229,7 @@ func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.Blo
 				Data:    name,
 			}
 		}
-		if result.Hash != unsafe.Hash {
+		if result.Hash != ref.Hash {
 			return eth.L2BlockRef{}, &gethrpc.JsonError{
 				Code:    ConflictingBlockRPCErrCode,
 				Message: "Conflicting block",
@@ -243,11 +243,11 @@ func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.Blo
 	if err != nil {
 		return err
 	}
-	safeRef, err := verify(unsafe, "safe")
+	safeRef, err := verify(safe, "safe")
 	if err != nil {
 		return err
 	}
-	finalizedRef, err := verify(unsafe, "finalized")
+	finalizedRef, err := verify(finalized, "finalized")
 	if err != nil {
 		return err
 	}

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -94,7 +94,7 @@ func (db *DB) RewindToL2(derived uint64) error {
 	defer db.rwLock.Unlock()
 	_, link, err := db.firstDerivedFrom(derived)
 	if err != nil {
-		return fmt.Errorf("failed to find last derived-from %d: %w", derived, err)
+		return fmt.Errorf("failed to find first derived-from %d: %w", derived, err)
 	}
 	return db.rewindLocked(types.DerivedBlockSealPair{
 		DerivedFrom: link.derivedFrom,
@@ -108,7 +108,7 @@ func (db *DB) RewindToL1(derivedFrom uint64) error {
 	defer db.rwLock.Unlock()
 	_, link, err := db.lastDerivedAt(derivedFrom)
 	if err != nil {
-		return fmt.Errorf("failed to find last derived-from %d: %w", derivedFrom, err)
+		return fmt.Errorf("failed to find last derived %d: %w", derivedFrom, err)
 	}
 	return db.rewindLocked(types.DerivedBlockSealPair{
 		DerivedFrom: link.derivedFrom,

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -288,6 +288,7 @@ func (m *ManagedNode) resetSignal(errSignal error, l1Ref eth.BlockRef) {
 	// if conflict error -> send reset to drop
 	// if future error -> send reset to rewind
 	// if out of order -> warn, just old data
+	// TODO(#13971): When there are errors getting these blocks, we shouldn't always exit early.
 	ctx, cancel := context.WithTimeout(m.ctx, internalTimeout)
 	defer cancel()
 	u, err := m.backend.LocalUnsafe(ctx, m.chainID)
@@ -323,6 +324,7 @@ func (m *ManagedNode) resetSignal(errSignal error, l1Ref eth.BlockRef) {
 		s, err := m.backend.LocalSafe(ctx, m.chainID)
 		if err != nil {
 			m.log.Warn("Failed to retrieve local-safe", "err", err)
+			return
 		}
 		m.log.Warn("Node detected out of order block", "unsafe", u, "finalized", f)
 		err = m.Node.Reset(ctx, u, s.Derived, f)

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -301,22 +301,15 @@ func (m *ManagedNode) resetSignal(errSignal error, l1Ref eth.BlockRef) {
 		return
 	}
 
-	// fix finalized to point to a L2 block that the L2 node knows about
-	// Conceptually: track the last known block by the node (based on unsafe block updates), as upper bound for resets.
-	// Then when reset fails, lower the last known block
-	// (and prevent it from changing by subscription, until success with reset), and rinse and repeat.
-
-	// TODO: this is very very broken
-
-	// TODO: errors.As switch
-	switch errSignal {
-	case types.ErrConflict:
+	// TODO: Lots of changes needed here
+	// Reset walkback exists via resolveConflict, so this error-type handling should be reconsidered.
+	switch {
+	case errors.Is(errSignal, types.ErrConflict):
 		if err := m.resolveConflict(ctx, l1Ref, u, f); err != nil {
 			m.log.Warn("Failed to resolve conflict", "unsafe", u, "finalized", f)
 			return
 		}
-
-	case types.ErrFuture:
+	case errors.Is(errSignal, types.ErrFuture):
 		s, err := m.backend.LocalSafe(ctx, m.chainID)
 		if err != nil {
 			m.log.Warn("Failed to retrieve local-safe", "err", err)
@@ -326,8 +319,16 @@ func (m *ManagedNode) resetSignal(errSignal error, l1Ref eth.BlockRef) {
 		if err != nil {
 			m.log.Warn("Node failed to reset", "err", err)
 		}
-	case types.ErrOutOfOrder:
+	case errors.Is(errSignal, types.ErrOutOfOrder):
+		s, err := m.backend.LocalSafe(ctx, m.chainID)
+		if err != nil {
+			m.log.Warn("Failed to retrieve local-safe", "err", err)
+		}
 		m.log.Warn("Node detected out of order block", "unsafe", u, "finalized", f)
+		err = m.Node.Reset(ctx, u, s.Derived, f)
+		if err != nil {
+			m.log.Warn("Node failed to reset", "err", err)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes Managed Mode Reset Handling, and introduces an Action Test demonstrating functionality.

Significant Changes:
- The Reset Handler was previously validating `unsafe` 3 times, when it should have been validating `unsafe`, `safe`, `finalized`, leading to the unsafe head being used for all new heads when resetting the Engine Controller.
- `ErrOutOfOrder` in the Supervisor was previously assumed to be an ignorable error, but it actually needs to trigger a reset, because it indicates that we have a gap in the Derivation DBs (event DB is always indexed in order since the indexer controls the fetch and insert of all events). That gap in the Derivation DB *must* be solved by rewinding the node to recreate the derivation events.
- The `resetSignal` function was improved to use `errors.Is`. Likely this whole function should be collapsed into some `Invalidator` component we are looking to build shortly.