### PR TITLE
chore: Add cargo binaries folder to $PATH in ci-builder Dockerfile

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -25,6 +25,9 @@ COPY ./mise.toml ./mise.toml
 ENV PATH="/root/.local/share/mise/shims:$PATH"
 ENV PATH="/root/.local/bin:${PATH}"
 
+# Set up cargo environment
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Install dependencies
 # We do this in one mega RUN command to avoid blowing up the size of the image
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The `ci-builder` image does not add path to the `cargo` binaries folder (`~/.cargo/bin`) to `$PATH`. This adds extra clutter when trying to use this image in CI as the pipeline needs to adjust the `$PATH` when it is trying to use a binary installed by `cargo`:

```sh
# Install a cargo crate with a binary binding
cargo install mdbook

# Fails
mdbook --version
```

**Tests**

Tested locally by building the image & running the above commands in a running container.