### PR TITLE
always show L1BlockRef when GetBlobs failed

### DIFF
--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -289,7 +289,7 @@ func (cl *L1BeaconClient) GetBlobs(ctx context.Context, ref eth.L1BlockRef, hash
 	}
 	blobs, err := blobsFromSidecars(blobSidecars, hashes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get blob sidecars for L1BlockRef %s: %w", ref, err)
+		return nil, fmt.Errorf("failed to get blobs from sidecars for L1BlockRef %s: %w", ref, err)
 	}
 	return blobs, nil
 }

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -287,7 +287,11 @@ func (cl *L1BeaconClient) GetBlobs(ctx context.Context, ref eth.L1BlockRef, hash
 	if err != nil {
 		return nil, fmt.Errorf("failed to get blob sidecars for L1BlockRef %s: %w", ref, err)
 	}
-	return blobsFromSidecars(blobSidecars, hashes)
+	blobs, err := blobsFromSidecars(blobSidecars, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blob sidecars for L1BlockRef %s: %w", ref, err)
+	}
+	return blobs, nil
 }
 
 func blobsFromSidecars(blobSidecars []*eth.BlobSidecar, hashes []eth.IndexedBlobHash) ([]*eth.Blob, error) {


### PR DESCRIPTION
Currently when `blobsFromSidecars` fails, the error log is like this:

```bash
t=2025-01-17T04:05:13+0100 lvl=warn msg="Engine temporary error" err="derivation failed: temp: failed to fetch blobs: expected hash 0x019ea44b60c55502ddf2e001b720bdc8e5a46ba76d58439be85c3e40b3b39074 for blob at index 1 but got 0x018de41a71773642404ce2d4fa7cb15fec64d2a5a8fc7647269b2cfdccef6bf4"
```

It doesn't show `L1BlockRef` which is very useful to diagnose the problem.

This PR adds it back.