### PR TITLE
`eip4844_test.go`: avoid nil pointer error for `requireEventualBatcherTxType`

### DIFF
--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -307,7 +307,7 @@ func TestBatcherAutoDA(t *testing.T) {
 			b, err := l1Client.BlockByNumber(ctx, nil)
 			require.NoError(t, err)
 			for _, tx := range b.Transactions() {
-				if tx.To().Cmp(cfg.DeployConfig.BatchInboxAddress) != 0 {
+				if tx.To() == nil || tx.To().Cmp(cfg.DeployConfig.BatchInboxAddress) != 0 {
 					continue
 				}
 				if typ := tx.Type(); typ == txType {


### PR DESCRIPTION
This PR fixes a potential nil-pointer error in `requireEventualBatcherTxType`, in general we need to ensure the pointer is not nil before calling the `Cmp` method.