### PR TITLE
op-node: Fix compatibility with EIP-4444 enabled L1 nodes

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -203,6 +203,11 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to validate the L1 config: %w", err)
 	}
 
+	// log error when L1 Genesis blockhash can't be retrieved (happens on EIP-4444 enabled L1 EL nodes)
+	if err := cfg.Rollup.ValidateL1Genesis(ctx, n.l1Source); err != nil {
+		n.log.Warn("failed to validate the L1 genesis block hash, might be using EIP-4444 pruned node", "err", err)
+	}
+
 	// Keep subscribed to the L1 heads, which keeps the L1 maintainer pointing to the best headers to sync
 	n.l1HeadsSub = gethevent.ResubscribeErr(time.Second*10, func(ctx context.Context, err error) (gethevent.Subscription, error) {
 		if err != nil {

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -152,6 +152,11 @@ func (cfg *Config) ValidateL1Config(ctx context.Context, client L1Client) error 
 		return err
 	}
 
+	return nil
+}
+
+// ValidateL1Genesis checks L1 Genesis blockhash exists on L1 EL node
+func  (cfg *Config) ValidateL1Genesis(ctx context.Context, client L1Client) error {
 	// Validate the Rollup L1 Genesis Blockhash
 	if err := cfg.CheckL1GenesisBlockHash(ctx, client); err != nil {
 		return err

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -105,10 +105,10 @@ func TestValidateL1ConfigInvalidGenesisHashFails(t *testing.T) {
 	config.Genesis.L1.Number = 100
 	config.Genesis.L1.Hash = [32]byte{0x00}
 	mockClient := mockL1Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL1Config(context.TODO(), &mockClient)
+	err := config.ValidateL1Genesis(context.TODO(), &mockClient)
 	assert.Error(t, err)
 	config.Genesis.L1.Hash = [32]byte{0x02}
-	err = config.ValidateL1Config(context.TODO(), &mockClient)
+	err = config.ValidateL1Genesis(context.TODO(), &mockClient)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Closes #13570

Should only log and doesn't stop op-node when the op-node fails to fetch L1 Genesis block hash from L1 EL nodes like Erigon