### PR TITLE
feat(op-challenger): Kona interop executor

### DIFF
--- a/op-challenger/game/fault/trace/utils/local.go
+++ b/op-challenger/game/fault/trace/utils/local.go
@@ -10,11 +10,12 @@ import (
 )
 
 type LocalGameInputs struct {
-	L1Head        common.Hash
-	L2Head        common.Hash
-	L2OutputRoot  common.Hash
-	L2Claim       common.Hash
-	L2BlockNumber *big.Int
+	L1Head         common.Hash
+	L2Head         common.Hash
+	L2OutputRoot   common.Hash
+	AgreedPreState *[]byte
+	L2Claim        common.Hash
+	L2BlockNumber  *big.Int
 }
 
 type L2HeaderSource interface {

--- a/op-challenger/game/fault/trace/vm/kona_interop_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_interop_server_executor.go
@@ -8,7 +8,7 @@ import (
 )
 
 type KonaSuperExecutor struct {
-	nativeMode     bool
+	nativeMode bool
 }
 
 var _ OracleServerExecutor = (*KonaSuperExecutor)(nil)

--- a/op-challenger/game/fault/trace/vm/kona_interop_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_interop_server_executor.go
@@ -1,0 +1,48 @@
+package vm
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type KonaInteropExecutor struct {
+	nativeMode     bool
+	agreedPreState []byte
+}
+
+var _ OracleServerExecutor = (*KonaInteropExecutor)(nil)
+
+func NewKonaInteropExecutor(agreedPreState []byte) *KonaInteropExecutor {
+	return &KonaInteropExecutor{nativeMode: false, agreedPreState: agreedPreState}
+}
+
+func NewNativeKonaInteropExecutor(agreedPreState []byte) *KonaInteropExecutor {
+	return &KonaInteropExecutor{nativeMode: true, agreedPreState: agreedPreState}
+}
+
+func (s *KonaInteropExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
+	args := []string{
+		cfg.Server,
+		"super",
+		"--l1-node-address", cfg.L1,
+		"--l1-beacon-address", cfg.L1Beacon,
+		"--l2-node-addresses", cfg.L2,
+		"--l1-head", inputs.L1Head.Hex(),
+		"--agreed-l2-pre-state", common.Bytes2Hex(s.agreedPreState),
+		"--claimed-l2-post-state", inputs.L2Claim.Hex(),
+		"--claimed-l2-timestamp", inputs.L2BlockNumber.Text(10),
+	}
+
+	if s.nativeMode {
+		args = append(args, "--native")
+	} else {
+		args = append(args, "--server")
+		args = append(args, "--data-dir", dataDir)
+	}
+
+	if cfg.RollupConfigPath != "" {
+		args = append(args, "--rollup-config-paths", cfg.RollupConfigPath)
+	}
+
+	return args, nil
+}

--- a/op-challenger/game/fault/trace/vm/kona_interop_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_interop_server_executor.go
@@ -7,21 +7,21 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type KonaInteropExecutor struct {
+type KonaSuperExecutor struct {
 	nativeMode     bool
 }
 
-var _ OracleServerExecutor = (*KonaInteropExecutor)(nil)
+var _ OracleServerExecutor = (*KonaSuperExecutor)(nil)
 
-func NewKonaInteropExecutor() *KonaInteropExecutor {
-	return &KonaInteropExecutor{nativeMode: false}
+func NewKonaSuperExecutor() *KonaSuperExecutor {
+	return &KonaSuperExecutor{nativeMode: false}
 }
 
-func NewNativeKonaInteropExecutor() *KonaInteropExecutor {
-	return &KonaInteropExecutor{nativeMode: true}
+func NewNativeKonaSuperExecutor() *KonaSuperExecutor {
+	return &KonaSuperExecutor{nativeMode: true}
 }
 
-func (s *KonaInteropExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
+func (s *KonaSuperExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
 	if inputs.AgreedPreState == nil {
 		return nil, errors.New("agreed pre-state is not defined")
 	}

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
@@ -30,24 +31,32 @@ func IsKonaConfigured() bool {
 func RunKonaNative(
 	t helpers.Testing,
 	workDir string,
-	rollupCfg *rollup.Config,
+	rollupCfgs []*rollup.Config,
 	l1Rpc string,
 	l1BeaconRpc string,
-	l2Rpc string,
+	l2Rpcs []string,
 	fixtureInputs FixtureInputs,
 ) error {
 	// Write rollup config to tempdir.
-	rollupConfigPath := filepath.Join(workDir, "rollup.json")
-	ser, err := json.Marshal(rollupCfg)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(rollupConfigPath, ser, fs.ModePerm))
+	rollupCfgPaths := make([]string, len(rollupCfgs))
+	for i, cfg := range rollupCfgs {
+		rollupConfigPath := filepath.Join(workDir, fmt.Sprintf("rollup_%d.json", i))
+		ser, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(rollupConfigPath, ser, fs.ModePerm))
+
+		rollupCfgPaths[i] = rollupConfigPath
+	}
+
+	joinedRollupCfgPaths := strings.Join(rollupCfgPaths, ",")
+	joinedL2Rpcs := strings.Join(l2Rpcs, ",")
 
 	// Run the fault proof program from the state transition from L2 block L2Blocknumber - 1 -> L2BlockNumber.
 	vmCfg := vm.Config{
 		L1:               l1Rpc,
 		L1Beacon:         l1BeaconRpc,
-		L2:               l2Rpc,
-		RollupConfigPath: rollupConfigPath,
+		L2:               joinedL2Rpcs,
+		RollupConfigPath: joinedRollupCfgPaths,
 		Server:           konaHostPath,
 	}
 	inputs := utils.LocalGameInputs{
@@ -57,7 +66,14 @@ func RunKonaNative(
 		L2Claim:       fixtureInputs.L2Claim,
 		L2BlockNumber: big.NewInt(int64(fixtureInputs.L2BlockNumber)),
 	}
-	hostCmd, err := vm.NewNativeKonaExecutor().OracleCommand(vmCfg, workDir, inputs)
+
+	var hostCmd []string
+	var err error
+	if fixtureInputs.InteropEnabled {
+		hostCmd, err = vm.NewNativeKonaInteropExecutor(fixtureInputs.AgreedPrestate).OracleCommand(vmCfg, workDir, inputs)
+	} else {
+		hostCmd, err = vm.NewNativeKonaExecutor().OracleCommand(vmCfg, workDir, inputs)
+	}
 	require.NoError(t, err)
 
 	cmd := exec.Command(hostCmd[0], hostCmd[1:]...)

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -70,7 +70,8 @@ func RunKonaNative(
 	var hostCmd []string
 	var err error
 	if fixtureInputs.InteropEnabled {
-		hostCmd, err = vm.NewNativeKonaInteropExecutor(fixtureInputs.AgreedPrestate).OracleCommand(vmCfg, workDir, inputs)
+		inputs.AgreedPreState = &fixtureInputs.AgreedPrestate
+		hostCmd, err = vm.NewNativeKonaInteropExecutor().OracleCommand(vmCfg, workDir, inputs)
 	} else {
 		hostCmd, err = vm.NewNativeKonaExecutor().OracleCommand(vmCfg, workDir, inputs)
 	}

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -71,7 +71,7 @@ func RunKonaNative(
 	var err error
 	if fixtureInputs.InteropEnabled {
 		inputs.AgreedPreState = &fixtureInputs.AgreedPrestate
-		hostCmd, err = vm.NewNativeKonaInteropExecutor().OracleCommand(vmCfg, workDir, inputs)
+		hostCmd, err = vm.NewNativeKonaSuperExecutor().OracleCommand(vmCfg, workDir, inputs)
 	} else {
 		hostCmd, err = vm.NewNativeKonaExecutor().OracleCommand(vmCfg, workDir, inputs)
 	}

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/host"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -79,8 +80,14 @@ func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Mi
 		require.NoError(t, fakeBeacon.Start("127.0.0.1:0"))
 		defer fakeBeacon.Close()
 
-		l2Source := fixtureInputs.L2Sources[0]
-		err = RunKonaNative(t, workDir, l2Source.Node.RollupCfg, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Source.Engine.HTTPEndpoint(), *fixtureInputs)
+		rollupCfgs := make([]*rollup.Config, 0, len(fixtureInputs.L2Sources))
+		l2Endpoints := make([]string, 0, len(fixtureInputs.L2Sources))
+		for _, source := range fixtureInputs.L2Sources {
+			rollupCfgs = append(rollupCfgs, source.Node.RollupCfg)
+			l2Endpoints = append(l2Endpoints, source.Engine.HTTPEndpoint())
+		}
+
+		err = RunKonaNative(t, workDir, rollupCfgs, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Endpoints, *fixtureInputs)
 		checkResult(t, err)
 	} else {
 		programCfg := NewOpProgramCfg(fixtureInputs)


### PR DESCRIPTION
## Overview

Adds a new server executor to the `op-challenger` for `kona`'s interop mode. This mode is a different subcommand with a different set of flags than `single` mode, so it warranted a split.

Also hooks this executor up to the action tests, using it if `InteropEnabled` is set on the FPP test case.