### PR TITLE
kurtosis-devnet: Support the interop prestate

### DIFF
--- a/kurtosis-devnet/cmd/main.go
+++ b/kurtosis-devnet/cmd/main.go
@@ -156,9 +156,10 @@ func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
 
 	// Map of known file prefixes to their keys
 	fileToKey := map[string]string{
-		"prestate-proof.json":      "prestate",
-		"prestate-proof-mt64.json": "prestate-mt64",
-		"prestate-proof-mt.json":   "prestate-mt",
+		"prestate-proof.json":         "prestate",
+		"prestate-proof-mt64.json":    "prestate_mt64",
+		"prestate-proof-mt.json":      "prestate_mt",
+		"prestate-proof-interop.json": "prestate_interop",
 	}
 
 	// Build all prestate files directly in the target directory


### PR DESCRIPTION
**Description**

Not currently used in the interop devnet as we're not yet deploying the new game type.

Switched to `_` because yaml doesn't like `-`.
