### PR TITLE
op-challenger: Add super-cannon to GameType strings

### DIFF
--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -48,6 +48,8 @@ func (t GameType) String() string {
 		return "asterisc"
 	case AsteriscKonaGameType:
 		return "asterisc-kona"
+	case SuperCannonGameType:
+		return "super-cannon"
 	case FastGameType:
 		return "fast"
 	case AlphabetGameType:

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -69,3 +69,12 @@ func TestKnownGameTypeForEveryTraceType(t *testing.T) {
 		})
 	}
 }
+
+func TestKnownStringForUtilisedGameType(t *testing.T) {
+	for _, traceType := range TraceTypes {
+		traceType := traceType
+		t.Run(traceType.String(), func(t *testing.T) {
+			require.NotContains(t, traceType.GameType().String(), "invalid")
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Define a proper string serialisation for the super-cannon game type.  Add a test to make sure all game types used by trace types have a name defined.