### PR TITLE
op-supervisor: return typed pairs of L1/L2 blocks, and support invalidation of fromda entries

### DIFF
--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -53,6 +53,8 @@ func NewFromEntryStore(logger log.Logger, m Metrics, store EntryStore) (*DB, err
 
 // Rewind to the last entry that was derived from a L1 block with the given block number.
 func (db *DB) Rewind(derivedFrom uint64) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
 	index, _, err := db.lastDerivedAt(derivedFrom)
 	if err != nil {
 		return fmt.Errorf("failed to find point to rewind to: %w", err)
@@ -66,18 +68,24 @@ func (db *DB) Rewind(derivedFrom uint64) error {
 }
 
 // First returns the first known values, alike to Latest.
-func (db *DB) First() (derivedFrom types.BlockSeal, derived types.BlockSeal, err error) {
+func (db *DB) First() (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return types.BlockSeal{}, types.BlockSeal{}, types.ErrFuture
+		return types.DerivedBlockSealPair{}, types.ErrFuture
 	}
 	last, err := db.readAt(0)
 	if err != nil {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("failed to read first derivation data: %w", err)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to read first derivation data: %w", err)
 	}
-	return last.derivedFrom, last.derived, nil
+	if last.invalidated {
+		return types.DerivedBlockSealPair{}, fmt.Errorf("first DB entry cannot be invalidated: %w", types.ErrDataCorruption)
+	}
+	return types.DerivedBlockSealPair{
+		DerivedFrom: last.derivedFrom,
+		Derived:     last.derived,
+	}, nil
 }
 
 func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
@@ -104,26 +112,38 @@ func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal,
 // Latest returns the last known values:
 // derivedFrom: the L1 block that the L2 block is safe for (not necessarily the first, multiple L2 blocks may be derived from the same L1 block).
 // derived: the L2 block that was derived (not necessarily the first, the L1 block may have been empty and repeated the last safe L2 block).
-func (db *DB) Latest() (derivedFrom types.BlockSeal, derived types.BlockSeal, err error) {
+// If the last entry is invalidated, this returns a types.ErrAwaitReplacementBlock error.
+func (db *DB) Latest() (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	return db.latest()
+	link, err := db.latest()
+	if err != nil {
+		return types.DerivedBlockSealPair{}, err
+	}
+	if link.invalidated {
+		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
+	}
+	return types.DerivedBlockSealPair{
+		DerivedFrom: link.derivedFrom,
+		Derived:     link.derived,
+	}, nil
 }
 
 // latest is like Latest, but without lock, for internal use.
-func (db *DB) latest() (derivedFrom types.BlockSeal, derived types.BlockSeal, err error) {
+func (db *DB) latest() (link LinkEntry, err error) {
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return types.BlockSeal{}, types.BlockSeal{}, types.ErrFuture
+		return LinkEntry{}, types.ErrFuture
 	}
 	last, err := db.readAt(lastIndex)
 	if err != nil {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("failed to read last derivation data: %w", err)
+		return LinkEntry{}, fmt.Errorf("failed to read last derivation data: %w", err)
 	}
-	return last.derivedFrom, last.derived, nil
+	return last, nil
 }
 
 // LastDerivedAt returns the last L2 block derived from the given L1 block.
+// This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 func (db *DB) LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -135,26 +155,36 @@ func (db *DB) LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, e
 		return types.BlockSeal{}, fmt.Errorf("searched for last derived-from %s but found %s: %w",
 			derivedFrom, link.derivedFrom, types.ErrConflict)
 	}
+	if link.invalidated {
+		return types.BlockSeal{}, types.ErrAwaitReplacementBlock
+	}
 	return link.derived, nil
 }
 
-// NextDerived finds the next L2 block after derived, and what it was derived from
-func (db *DB) NextDerived(derived eth.BlockID) (derivedFrom types.BlockSeal, nextDerived types.BlockSeal, err error) {
+// NextDerived finds the next L2 block after derived, and what it was derived from.
+// This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
+func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// get the last time this L2 block was seen.
 	selfIndex, self, err := db.lastDerivedFrom(derived.Number)
 	if err != nil {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("failed to find derived %d: %w", derived.Number, err)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to find derived %d: %w", derived.Number, err)
 	}
 	if self.derived.ID() != derived {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derived, derived, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("found %s, but expected %s: %w", self.derived, derived, types.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("cannot find next derived after %s: %w", derived, err)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("cannot find next derived after %s: %w", derived, err)
 	}
-	return next.derivedFrom, next.derived, nil
+	if next.invalidated {
+		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
+	}
+	return types.DerivedBlockSealPair{
+		DerivedFrom: next.derivedFrom,
+		Derived:     next.derived,
+	}, nil
 }
 
 // DerivedFrom determines where a L2 block was first derived from.
@@ -219,25 +249,32 @@ func (db *DB) NextDerivedFrom(derivedFrom eth.BlockID) (nextDerivedFrom types.Bl
 }
 
 // FirstAfter determines the next entry after the given pair of derivedFrom, derived.
-// Either one or both of the two entries will be an increment by 1
-func (db *DB) FirstAfter(derivedFrom, derived eth.BlockID) (nextDerivedFrom, nextDerived types.BlockSeal, err error) {
+// Either one or both of the two entries will be an increment by 1.
+// This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
+func (db *DB) FirstAfter(derivedFrom, derived eth.BlockID) (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	selfIndex, selfLink, err := db.lookup(derivedFrom.Number, derived.Number)
 	if err != nil {
-		return types.BlockSeal{}, types.BlockSeal{}, err
+		return types.DerivedBlockSealPair{}, err
 	}
 	if selfLink.derivedFrom.ID() != derivedFrom {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.derivedFrom, derivedFrom, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.derivedFrom, derivedFrom, types.ErrConflict)
 	}
 	if selfLink.derived.ID() != derived {
-		return types.BlockSeal{}, types.BlockSeal{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, derived, types.ErrConflict)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, derived, types.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
-		return types.BlockSeal{}, types.BlockSeal{}, err
+		return types.DerivedBlockSealPair{}, err
 	}
-	return next.derivedFrom, next.derived, nil
+	if next.invalidated {
+		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
+	}
+	return types.DerivedBlockSealPair{
+		DerivedFrom: next.derivedFrom,
+		Derived:     next.derived,
+	}, nil
 }
 
 func (db *DB) lastDerivedFrom(derived uint64) (entrydb.EntryIdx, LinkEntry, error) {

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -72,10 +72,10 @@ func TestEmptyDB(t *testing.T) {
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			_, _, err := db.Latest()
+			_, err := db.Latest()
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, _, err = db.First()
+			_, err = db.First()
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			_, err = db.LastDerivedAt(eth.BlockID{})
@@ -87,7 +87,7 @@ func TestEmptyDB(t *testing.T) {
 			_, err = db.PreviousDerived(eth.BlockID{})
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, _, err = db.NextDerived(eth.BlockID{})
+			_, err = db.NextDerived(eth.BlockID{})
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			_, err = db.PreviousDerivedFrom(eth.BlockID{})
@@ -96,7 +96,7 @@ func TestEmptyDB(t *testing.T) {
 			_, err = db.NextDerivedFrom(eth.BlockID{})
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, _, err = db.FirstAfter(eth.BlockID{}, eth.BlockID{})
+			_, err = db.FirstAfter(eth.BlockID{}, eth.BlockID{})
 			require.ErrorIs(t, err, types.ErrFuture)
 		})
 }
@@ -139,23 +139,23 @@ func TestSingleEntryDB(t *testing.T) {
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// First
-			derivedFrom, derived, err := db.First()
+			pair, err := db.First()
 			require.NoError(t, err)
-			require.Equal(t, expectedDerivedFrom, derivedFrom)
-			require.Equal(t, expectedDerived, derived)
+			require.Equal(t, expectedDerivedFrom, pair.DerivedFrom)
+			require.Equal(t, expectedDerived, pair.Derived)
 
 			// Latest
-			derivedFrom, derived, err = db.Latest()
+			pair, err = db.Latest()
 			require.NoError(t, err)
-			require.Equal(t, expectedDerivedFrom, derivedFrom)
-			require.Equal(t, expectedDerived, derived)
+			require.Equal(t, expectedDerivedFrom, pair.DerivedFrom)
+			require.Equal(t, expectedDerived, pair.Derived)
 
 			// FirstAfter Latest
-			_, _, err = db.FirstAfter(derivedFrom.ID(), derived.ID())
+			_, err = db.FirstAfter(pair.DerivedFrom.ID(), pair.Derived.ID())
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			// LastDerivedAt
-			derived, err = db.LastDerivedAt(expectedDerivedFrom.ID())
+			derived, err := db.LastDerivedAt(expectedDerivedFrom.ID())
 			require.NoError(t, err)
 			require.Equal(t, expectedDerived, derived)
 
@@ -164,13 +164,13 @@ func TestSingleEntryDB(t *testing.T) {
 			require.ErrorIs(t, err, types.ErrConflict)
 
 			// FirstAfter with a non-existent block (derived and derivedFrom)
-			_, _, err = db.FirstAfter(eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerivedFrom.Number}, expectedDerived.ID())
+			_, err = db.FirstAfter(eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerivedFrom.Number}, expectedDerived.ID())
 			require.ErrorIs(t, err, types.ErrConflict)
-			_, _, err = db.FirstAfter(expectedDerivedFrom.ID(), eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerived.Number})
+			_, err = db.FirstAfter(expectedDerivedFrom.ID(), eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerived.Number})
 			require.ErrorIs(t, err, types.ErrConflict)
 
 			// DerivedFrom
-			derivedFrom, err = db.DerivedFrom(expectedDerived.ID())
+			derivedFrom, err := db.DerivedFrom(expectedDerived.ID())
 			require.NoError(t, err)
 			require.Equal(t, expectedDerivedFrom, derivedFrom)
 
@@ -189,7 +189,7 @@ func TestSingleEntryDB(t *testing.T) {
 			require.Equal(t, types.BlockSeal{}, prev, "zeroed seal before first entry")
 
 			// NextDerived
-			_, _, err = db.NextDerived(expectedDerived.ID())
+			_, err = db.NextDerived(expectedDerived.ID())
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			// NextDerivedFrom
@@ -197,7 +197,7 @@ func TestSingleEntryDB(t *testing.T) {
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			// FirstAfter
-			_, _, err = db.FirstAfter(expectedDerivedFrom.ID(), expectedDerived.ID())
+			_, err = db.FirstAfter(expectedDerivedFrom.ID(), expectedDerived.ID())
 			require.ErrorIs(t, err, types.ErrFuture)
 		})
 }
@@ -212,7 +212,7 @@ func TestGap(t *testing.T) {
 			require.NoError(t, db.AddDerived(toRef(expectedDerivedFrom, mockL1(0).Hash), toRef(expectedDerived, mockL2(0).Hash)))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			_, _, err := db.NextDerived(mockL2(0).ID())
+			_, err := db.NextDerived(mockL2(0).ID())
 			require.ErrorIs(t, err, types.ErrSkipped)
 
 			_, err = db.NextDerivedFrom(mockL1(0).ID())
@@ -235,24 +235,24 @@ func TestThreeEntryDB(t *testing.T) {
 		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
-		derivedFrom, derived, err := db.Latest()
+		pair, err := db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
-		require.Equal(t, l2Block2, derived)
+		require.Equal(t, l1Block2, pair.DerivedFrom)
+		require.Equal(t, l2Block2, pair.Derived)
 
-		derivedFrom, derived, err = db.First()
+		pair, err = db.First()
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, derivedFrom)
-		require.Equal(t, l2Block0, derived)
+		require.Equal(t, l1Block0, pair.DerivedFrom)
+		require.Equal(t, l2Block0, pair.Derived)
 
-		derived, err = db.LastDerivedAt(l1Block2.ID())
+		derived, err := db.LastDerivedAt(l1Block2.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block2, derived)
 
 		_, err = db.LastDerivedAt(eth.BlockID{Hash: common.Hash{0xaa}, Number: l1Block2.Number})
 		require.ErrorIs(t, err, types.ErrConflict)
 
-		derivedFrom, err = db.DerivedFrom(l2Block2.ID())
+		derivedFrom, err := db.DerivedFrom(l2Block2.ID())
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, derivedFrom)
 
@@ -287,17 +287,17 @@ func TestThreeEntryDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, derived)
 
-		derivedFrom, derived, err = db.NextDerived(l2Block0.ID())
+		next, err := db.NextDerived(l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l2Block1, derived)
-		require.Equal(t, l1Block1, derivedFrom)
+		require.Equal(t, l2Block1, next.Derived)
+		require.Equal(t, l1Block1, next.DerivedFrom)
 
-		derivedFrom, derived, err = db.NextDerived(l2Block1.ID())
+		next, err = db.NextDerived(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l2Block2, derived)
-		require.Equal(t, l1Block2, derivedFrom)
+		require.Equal(t, l2Block2, next.Derived)
+		require.Equal(t, l1Block2, next.DerivedFrom)
 
-		_, _, err = db.NextDerived(l2Block2.ID())
+		_, err = db.NextDerived(l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		derivedFrom, err = db.PreviousDerivedFrom(l1Block0.ID())
@@ -323,18 +323,18 @@ func TestThreeEntryDB(t *testing.T) {
 		_, err = db.NextDerivedFrom(l1Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		_, _, err = db.FirstAfter(l1Block2.ID(), l2Block2.ID())
+		_, err = db.FirstAfter(l1Block2.ID(), l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		derivedFrom, derived, err = db.FirstAfter(l1Block0.ID(), l2Block0.ID())
+		next, err = db.FirstAfter(l1Block0.ID(), l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block1, derived)
+		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l2Block1, next.Derived)
 
-		derivedFrom, derived, err = db.FirstAfter(l1Block1.ID(), l2Block1.ID())
+		next, err = db.FirstAfter(l1Block1.ID(), l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
-		require.Equal(t, l2Block2, derived)
+		require.Equal(t, l1Block2, next.DerivedFrom)
+		require.Equal(t, l2Block2, next.Derived)
 	})
 }
 
@@ -364,17 +364,17 @@ func TestFastL2Batcher(t *testing.T) {
 		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), toRef(l2Block5, l2Block4.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
-		derivedFrom, derived, err := db.Latest()
+		pair, err := db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
-		require.Equal(t, l2Block5, derived)
+		require.Equal(t, l1Block2, pair.DerivedFrom)
+		require.Equal(t, l2Block5, pair.Derived)
 
-		derived, err = db.LastDerivedAt(l1Block2.ID())
+		derived, err := db.LastDerivedAt(l1Block2.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block5, derived)
 
 		// test what tip was derived from
-		derivedFrom, err = db.DerivedFrom(l2Block5.ID())
+		derivedFrom, err := db.DerivedFrom(l2Block5.ID())
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, derivedFrom)
 
@@ -406,27 +406,27 @@ func TestFastL2Batcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		derivedFrom, derived, err = db.NextDerived(l2Block0.ID())
+		next, err := db.NextDerived(l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block1, derived)
-		derivedFrom, derived, err = db.NextDerived(l2Block1.ID())
+		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l2Block1, next.Derived)
+		next, err = db.NextDerived(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block2, derived)
-		derivedFrom, derived, err = db.NextDerived(l2Block2.ID())
+		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l2Block2, next.Derived)
+		next, err = db.NextDerived(l2Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block3, derived)
-		derivedFrom, derived, err = db.NextDerived(l2Block3.ID())
+		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l2Block3, next.Derived)
+		next, err = db.NextDerived(l2Block3.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block4, derived)
-		derivedFrom, derived, err = db.NextDerived(l2Block4.ID())
+		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l2Block4, next.Derived)
+		next, err = db.NextDerived(l2Block4.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom) // derived from later L1 block
-		require.Equal(t, l2Block5, derived)
-		_, _, err = db.NextDerived(l2Block5.ID())
+		require.Equal(t, l1Block2, next.DerivedFrom) // derived from later L1 block
+		require.Equal(t, l2Block5, next.Derived)
+		_, err = db.NextDerived(l2Block5.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		derivedFrom, err = db.PreviousDerivedFrom(l1Block2.ID())
@@ -445,10 +445,10 @@ func TestFastL2Batcher(t *testing.T) {
 		_, err = db.NextDerivedFrom(l1Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		derivedFrom, derived, err = db.FirstAfter(l1Block1.ID(), l2Block2.ID())
+		next, err = db.FirstAfter(l1Block1.ID(), l2Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom) // no increment in L1 yet, the next after is L2 block 3
-		require.Equal(t, l2Block3, derived)
+		require.Equal(t, l1Block1, next.DerivedFrom) // no increment in L1 yet, the next after is L2 block 3
+		require.Equal(t, l2Block3, next.Derived)
 	})
 }
 
@@ -478,13 +478,13 @@ func TestSlowL2Batcher(t *testing.T) {
 		require.NoError(t, db.AddDerived(toRef(l1Block5, l1Block4.Hash), toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
-		derivedFrom, derived, err := db.Latest()
+		pair, err := db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, derivedFrom)
-		require.Equal(t, l2Block2, derived)
+		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l2Block2, pair.Derived)
 
 		// test what we last derived at the tip
-		derived, err = db.LastDerivedAt(l1Block5.ID())
+		derived, err := db.LastDerivedAt(l1Block5.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block2, derived)
 
@@ -496,7 +496,7 @@ func TestSlowL2Batcher(t *testing.T) {
 		}
 
 		// test that the first L1 counts, not the ones that repeat the L2 info
-		derivedFrom, err = db.DerivedFrom(l2Block1.ID())
+		derivedFrom, err := db.DerivedFrom(l2Block1.ID())
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, derivedFrom)
 
@@ -507,15 +507,15 @@ func TestSlowL2Batcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		derivedFrom, derived, err = db.NextDerived(l2Block0.ID())
+		next, err := db.NextDerived(l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block1, derived)
-		derivedFrom, derived, err = db.NextDerived(l2Block1.ID())
+		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l2Block1, next.Derived)
+		next, err = db.NextDerived(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, derivedFrom)
-		require.Equal(t, l2Block2, derived)
-		_, _, err = db.NextDerived(l2Block2.ID())
+		require.Equal(t, l1Block5, next.DerivedFrom)
+		require.Equal(t, l2Block2, next.Derived)
+		_, err = db.NextDerived(l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		derivedFrom, err = db.PreviousDerivedFrom(l1Block5.ID())
@@ -549,10 +549,10 @@ func TestSlowL2Batcher(t *testing.T) {
 		_, err = db.NextDerivedFrom(l1Block5.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		derivedFrom, derived, err = db.FirstAfter(l1Block2.ID(), l2Block1.ID())
+		next, err = db.FirstAfter(l1Block2.ID(), l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block3, derivedFrom)
-		require.Equal(t, l2Block1, derived) // no increment in L2 yet, the next after is L1 block 3
+		require.Equal(t, l1Block3, next.DerivedFrom)
+		require.Equal(t, l2Block1, next.Derived) // no increment in L2 yet, the next after is L1 block 3
 	})
 }
 
@@ -586,34 +586,34 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 		rng := rand.New(rand.NewSource(1234))
 		// Insert 1000 randomly generated entries, derived at random bumps in L1
 		for i := uint64(0); i < 1000; i++ {
-			derivedFrom, derived, err := db.Latest()
+			pair, err := db.Latest()
 			require.NoError(t, err)
 
 			switch rng.Intn(3) {
 			case 0: // bump L1
-				derivedFrom = mockL1(derivedFrom.Number + 1)
+				pair.DerivedFrom = mockL1(pair.DerivedFrom.Number + 1)
 			case 1: // bump L2
-				derived = mockL2(derived.Number + 1)
+				pair.Derived = mockL2(pair.Derived.Number + 1)
 			case 2: // bump both
-				derivedFrom = mockL1(derivedFrom.Number + 1)
-				derived = mockL2(derived.Number + 1)
+				pair.DerivedFrom = mockL1(pair.DerivedFrom.Number + 1)
+				pair.Derived = mockL2(pair.Derived.Number + 1)
 			}
-			derivedFromRef := toRef(derivedFrom, mockL1(derivedFrom.Number-1).Hash)
-			derivedRef := toRef(derived, mockL2(derived.Number-1).Hash)
-			lastDerived[derivedFromRef.ID()] = derived
+			derivedFromRef := toRef(pair.DerivedFrom, mockL1(pair.DerivedFrom.Number-1).Hash)
+			derivedRef := toRef(pair.Derived, mockL2(pair.Derived.Number-1).Hash)
+			lastDerived[derivedFromRef.ID()] = pair.Derived
 			if _, ok := firstDerivedFrom[derivedRef.ID()]; !ok {
-				firstDerivedFrom[derivedRef.ID()] = derivedFrom
+				firstDerivedFrom[derivedRef.ID()] = pair.DerivedFrom
 			}
 			require.NoError(t, db.AddDerived(derivedFromRef, derivedRef))
 		}
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 		// Now assert we can find what they are all derived from, and match the expectations.
-		derivedFrom, derived, err := db.Latest()
+		pair, err := db.Latest()
 		require.NoError(t, err)
-		require.NotZero(t, derivedFrom.Number-offsetL1)
-		require.NotZero(t, derived.Number-offsetL2)
+		require.NotZero(t, pair.DerivedFrom.Number-offsetL1)
+		require.NotZero(t, pair.Derived.Number-offsetL2)
 
-		for i := offsetL1; i <= derivedFrom.Number; i++ {
+		for i := offsetL1; i <= pair.DerivedFrom.Number; i++ {
 			l1ID := mockL1(i).ID()
 			derived, err := db.LastDerivedAt(l1ID)
 			require.NoError(t, err)
@@ -621,7 +621,7 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 			require.Equal(t, lastDerived[l1ID], derived)
 		}
 
-		for i := offsetL2; i <= derived.Number; i++ {
+		for i := offsetL2; i <= pair.Derived.Number; i++ {
 			l2ID := mockL2(i).ID()
 			derivedFrom, err := db.DerivedFrom(l2ID)
 			require.NoError(t, err)
@@ -673,42 +673,42 @@ func TestRewind(t *testing.T) {
 		require.NoError(t, db.AddDerived(toRef(l1Block5, l1Block4.Hash), toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
-		derivedFrom, derived, err := db.Latest()
+		pair, err := db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, derivedFrom)
-		require.Equal(t, l2Block2, derived)
+		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l2Block2, pair.Derived)
 
 		// Rewind to the future
 		require.ErrorIs(t, db.Rewind(6), types.ErrFuture)
 
 		// Rewind to the exact block we're at
 		require.NoError(t, db.Rewind(l1Block5.Number))
-		derivedFrom, derived, err = db.Latest()
+		pair, err = db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, derivedFrom)
-		require.Equal(t, l2Block2, derived)
+		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l2Block2, pair.Derived)
 
 		// Now rewind to L1 block 3 (inclusive).
 		require.NoError(t, db.Rewind(l1Block3.Number))
 
 		// See if we find consistent data
-		derivedFrom, derived, err = db.Latest()
+		pair, err = db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block3, derivedFrom)
-		require.Equal(t, l2Block1, derived)
+		require.Equal(t, l1Block3, pair.DerivedFrom)
+		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L1 block 1 (inclusive).
 		require.NoError(t, db.Rewind(l1Block1.Number))
-		derivedFrom, derived, err = db.Latest()
+		pair, err = db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		require.Equal(t, l2Block1, derived)
+		require.Equal(t, l1Block1, pair.DerivedFrom)
+		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L1 block 0 (inclusive).
 		require.NoError(t, db.Rewind(l1Block0.Number))
-		derivedFrom, derived, err = db.Latest()
+		pair, err = db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, derivedFrom)
-		require.Equal(t, l2Block0, derived)
+		require.Equal(t, l1Block0, pair.DerivedFrom)
+		require.Equal(t, l2Block0, pair.Derived)
 	})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -19,13 +19,16 @@ func (e Entry) Type() EntryType {
 type EntryType uint8
 
 const (
-	DerivedFromV0 EntryType = 0
+	DerivedFromV0     EntryType = 0
+	InvalidatedFromV0 EntryType = 1
 )
 
 func (s EntryType) String() string {
 	switch s {
 	case DerivedFromV0:
-		return "v0"
+		return "derivedFromV0"
+	case InvalidatedFromV0:
+		return "invalidatedFromV0"
 	default:
 		return fmt.Sprintf("unknown(%d)", uint8(s))
 	}
@@ -45,22 +48,30 @@ func (EntryBinary) EntrySize() int {
 	return EntrySize
 }
 
+// LinkEntry is a DerivedFromV0 or a InvalidatedFromV0 kind
 type LinkEntry struct {
 	derivedFrom types.BlockSeal
 	derived     types.BlockSeal
+	// when it exists as local-safe, but cannot be cross-safe.
+	// If false: this link is a DerivedFromV0
+	// If true: this link is a InvalidatedFromV0
+	invalidated bool
 }
 
 func (d LinkEntry) String() string {
-	return fmt.Sprintf("LinkEntry(derivedFrom: %s, derived: %s)", d.derivedFrom, d.derived)
+	return fmt.Sprintf("LinkEntry(derivedFrom: %s, derived: %s, invalidated: %v)", d.derivedFrom, d.derived, d.invalidated)
 }
 
 func (d *LinkEntry) decode(e Entry) error {
-	if e.Type() != DerivedFromV0 {
+	if t := e.Type(); t != DerivedFromV0 && t != InvalidatedFromV0 {
 		return fmt.Errorf("%w: unexpected entry type: %s", types.ErrDataCorruption, e.Type())
 	}
 	if [3]byte(e[1:4]) != ([3]byte{}) {
 		return fmt.Errorf("%w: expected empty data, to pad entry size to round number: %x", types.ErrDataCorruption, e[1:4])
 	}
+	// Format:
+	// l1-number(8) l1-timestamp(8) l2-number(8) l2-timestamp(8) l1-hash(32) l2-hash(32)
+	// Note: attributes are ordered for lexical sorting to nicely match chronological sorting.
 	offset := 4
 	d.derivedFrom.Number = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
@@ -78,7 +89,11 @@ func (d *LinkEntry) decode(e Entry) error {
 
 func (d *LinkEntry) encode() Entry {
 	var out Entry
-	out[0] = uint8(DerivedFromV0)
+	if d.invalidated {
+		out[0] = uint8(InvalidatedFromV0)
+	} else {
+		out[0] = uint8(DerivedFromV0)
+	}
 	offset := 4
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.derivedFrom.Number)
 	offset += 8

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -37,15 +37,15 @@ func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidat
 	if last.derived.Hash != invalidated {
 		return fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
 	}
-	// Remove the invalidated placeholder and everything after
-	err = db.store.Truncate(lastIndex - 1)
-	if err != nil {
-		return err
-	}
 	// Find the parent-block of derived-from.
 	// We need this to build a block-ref, so the DB can be consistency-checked when the next entry is added.
 	// There is always one, since the first entry in the DB should never be an invalidated one.
 	prevDerivedFrom, err := db.previousDerivedFrom(last.derivedFrom.ID())
+	if err != nil {
+		return err
+	}
+	// Remove the invalidated placeholder and everything after
+	err = db.store.Truncate(lastIndex - 1)
 	if err != nil {
 		return err
 	}

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -3,6 +3,8 @@ package fromda
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -10,20 +12,30 @@ import (
 func (db *DB) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
+	return db.addLink(derivedFrom, derived, common.Hash{})
+}
 
+// addLink adds a L1/L2 derivation link, with strong consistency checks.
+// if the link invalidates a prior L2 block, that was valid in a prior L1,
+// the invalidated hash needs to match it, even if a new derived block replaces it.
+func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidated common.Hash) error {
+	link := LinkEntry{
+		derivedFrom: types.BlockSeal{
+			Hash:      derivedFrom.Hash,
+			Number:    derivedFrom.Number,
+			Timestamp: derivedFrom.Time,
+		},
+		derived: types.BlockSeal{
+			Hash:      derived.Hash,
+			Number:    derived.Number,
+			Timestamp: derived.Time,
+		},
+		invalidated: (invalidated != common.Hash{}) && derived.Hash == invalidated,
+	}
 	// If we don't have any entries yet, allow any block to start things off
 	if db.store.Size() == 0 {
-		link := LinkEntry{
-			derivedFrom: types.BlockSeal{
-				Hash:      derivedFrom.Hash,
-				Number:    derivedFrom.Number,
-				Timestamp: derivedFrom.Time,
-			},
-			derived: types.BlockSeal{
-				Hash:      derived.Hash,
-				Number:    derived.Number,
-				Timestamp: derived.Time,
-			},
+		if link.invalidated {
+			return fmt.Errorf("first DB entry %s cannot be an invalidated entry: %w", link, types.ErrConflict)
 		}
 		e := link.encode()
 		if err := db.store.Append(e); err != nil {
@@ -33,10 +45,15 @@ func (db *DB) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
 		return nil
 	}
 
-	lastDerivedFrom, lastDerived, err := db.latest()
+	last, err := db.latest()
 	if err != nil {
 		return err
 	}
+	if last.invalidated {
+		return fmt.Errorf("cannot build %s on top of invalidated entry %s: %w", link, last, types.ErrConflict)
+	}
+	lastDerivedFrom := last.derivedFrom
+	lastDerived := last.derived
 
 	if lastDerived.ID() == derived.ID() && lastDerivedFrom.ID() == derivedFrom.ID() {
 		// it shouldn't be possible, but the ID component of a block ref doesn't include the timestamp
@@ -57,9 +74,15 @@ func (db *DB) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
 	if lastDerived.Number == derived.Number {
 		// Same block height? Then it must be the same block.
 		// I.e. we encountered an empty L1 block, and the same L2 block continues to be the last block that was derived from it.
-		if lastDerived.Hash != derived.Hash {
-			return fmt.Errorf("derived block %s conflicts with known derived block %s at same height: %w",
-				derived, lastDerived, types.ErrConflict)
+		if invalidated != (common.Hash{}) {
+			if lastDerived.Hash != invalidated {
+				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s", derived.Hash, invalidated, lastDerived.Number, lastDerived.Hash)
+			}
+		} else {
+			if lastDerived.Hash != derived.Hash {
+				return fmt.Errorf("derived block %s conflicts with known derived block %s at same height: %w",
+					derived, lastDerived, types.ErrConflict)
+			}
 		}
 	} else if lastDerived.Number+1 == derived.Number {
 		if lastDerived.Hash != derived.ParentHash {
@@ -101,18 +124,6 @@ func (db *DB) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
 			derived, derivedFrom, lastDerivedFrom, types.ErrOutOfOrder)
 	}
 
-	link := LinkEntry{
-		derivedFrom: types.BlockSeal{
-			Hash:      derivedFrom.Hash,
-			Number:    derivedFrom.Number,
-			Timestamp: derivedFrom.Time,
-		},
-		derived: types.BlockSeal{
-			Hash:      derived.Hash,
-			Number:    derived.Number,
-			Timestamp: derived.Time,
-		},
-	}
 	e := link.encode()
 	if err := db.store.Append(e); err != nil {
 		return err

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -15,6 +15,79 @@ func (db *DB) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
 	return db.addLink(derivedFrom, derived, common.Hash{})
 }
 
+// ReplaceInvalidatedBlock replaces the current Invalidated block with the given replacement.
+// The to-be invalidated hash must be provided for consistency checks.
+func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+
+	// We take the last occurrence. This is where it started to be considered invalid,
+	// and where we thus stopped building additional entries for it.
+	lastIndex := db.store.LastEntryIdx()
+	if lastIndex < 0 {
+		return types.ErrFuture
+	}
+	last, err := db.readAt(lastIndex)
+	if err != nil {
+		return fmt.Errorf("failed to read last derivation data: %w", err)
+	}
+	if !last.invalidated {
+		return fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
+	}
+	if last.derived.Hash != invalidated {
+		return fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
+	}
+	// Remove the invalidated placeholder and everything after
+	err = db.store.Truncate(lastIndex - 1)
+	if err != nil {
+		return err
+	}
+	// Find the parent-block of derived-from.
+	// We need this to build a block-ref, so the DB can be consistency-checked when the next entry is added.
+	// There is always one, since the first entry in the DB should never be an invalidated one.
+	prevDerivedFrom, err := db.previousDerivedFrom(last.derivedFrom.ID())
+	if err != nil {
+		return err
+	}
+	replacement := types.DerivedBlockRefPair{
+		DerivedFrom: last.derivedFrom.ForceWithParent(prevDerivedFrom.ID()),
+		Derived:     replacementDerived,
+	}
+	// Insert the replacement
+	if err := db.addLink(replacement.DerivedFrom, replacement.Derived, invalidated); err != nil {
+		return fmt.Errorf("failed to add %s as replacement at %s: %w", replacement.Derived, replacement.DerivedFrom, err)
+	}
+	return nil
+}
+
+// RewindAndInvalidate rolls back the database to just before the invalidated block,
+// and then marks the block as invalidated, so that no new data can be added to the DB
+// until a Rewind or ReplaceInvalidatedBlock.
+func (db *DB) RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+	i, link, err := db.lookup(invalidated.DerivedFrom.Number, invalidated.Derived.Number)
+	if err != nil {
+		return err
+	}
+	if link.derivedFrom.Hash != invalidated.DerivedFrom.Hash {
+		return fmt.Errorf("found derived-from %s, but expected %s: %w",
+			link.derivedFrom, invalidated.DerivedFrom, types.ErrConflict)
+	}
+	if link.derived.Hash != invalidated.Derived.Hash {
+		return fmt.Errorf("found derived %s, but expected %s: %w",
+			link.derived, invalidated.Derived, types.ErrConflict)
+	}
+	if err := db.store.Truncate(i - 1); err != nil {
+		return fmt.Errorf("failed to rewind upon block invalidation of %s: %w", invalidated, err)
+	}
+	db.m.RecordDBDerivedEntryCount(int64(i))
+	if err := db.addLink(invalidated.DerivedFrom, invalidated.Derived, invalidated.Derived.Hash); err != nil {
+		return fmt.Errorf("failed to add invalidation entry %s: %w", invalidated, err)
+	}
+	return nil
+}
+
 // addLink adds a L1/L2 derivation link, with strong consistency checks.
 // if the link invalidates a prior L2 block, that was valid in a prior L1,
 // the invalidated hash needs to match it, even if a new derived block replaces it.

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -31,10 +31,10 @@ func TestBadUpdates(t *testing.T) {
 	fDerived := mockL2(206)
 
 	noChange := assertFn(func(t *testing.T, db *DB, m *stubMetrics) {
-		derivedFrom, derived, err := db.Latest()
+		pair, err := db.Latest()
 		require.NoError(t, err)
-		require.Equal(t, dDerivedFrom, derivedFrom)
-		require.Equal(t, dDerived, derived)
+		require.Equal(t, dDerivedFrom, pair.DerivedFrom)
+		require.Equal(t, dDerived, pair.Derived)
 	})
 
 	testCases := []testCase{
@@ -69,10 +69,10 @@ func TestBadUpdates(t *testing.T) {
 				require.NoError(t, db.AddDerived(toRef(dDerivedFrom, common.Hash{0x42}), toRef(eDerived, dDerived.Hash)), types.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				derivedFrom, derived, err := db.Latest()
+				pair, err := db.Latest()
 				require.NoError(t, err)
-				require.Equal(t, dDerivedFrom, derivedFrom)
-				require.Equal(t, eDerived, derived)
+				require.Equal(t, dDerivedFrom, pair.DerivedFrom)
+				require.Equal(t, eDerived, pair.Derived)
 			},
 		},
 		{
@@ -120,10 +120,10 @@ func TestBadUpdates(t *testing.T) {
 				require.NoError(t, db.AddDerived(toRef(eDerivedFrom, dDerivedFrom.Hash), toRef(dDerived, common.Hash{0x42})), types.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				derivedFrom, derived, err := db.Latest()
+				pair, err := db.Latest()
 				require.NoError(t, err)
-				require.Equal(t, eDerivedFrom, derivedFrom)
-				require.Equal(t, dDerived, derived)
+				require.Equal(t, eDerivedFrom, pair.DerivedFrom)
+				require.Equal(t, dDerived, pair.Derived)
 			},
 		},
 		{

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -40,12 +40,12 @@ func (db *ChainsDB) SealBlock(chain eth.ChainID, block eth.BlockRef) error {
 	return nil
 }
 
-func (db *ChainsDB) Rewind(chain eth.ChainID, headBlockNum uint64) error {
+func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot Rewind: %w: %s", types.ErrUnknownChain, chain)
 	}
-	return logDB.Rewind(headBlockNum)
+	return logDB.Rewind(headBlock)
 }
 
 func (db *ChainsDB) UpdateLocalSafe(chain eth.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -29,7 +29,7 @@ type LogProcessor interface {
 }
 
 type DatabaseRewinder interface {
-	Rewind(chain eth.ChainID, headBlockNum uint64) error
+	Rewind(chain eth.ChainID, headBlock eth.BlockID) error
 	LatestBlockNum(chain eth.ChainID) (num uint64, ok bool)
 }
 
@@ -247,7 +247,7 @@ func (s *ChainProcessor) process(ctx context.Context, next eth.BlockRef, receipt
 		}
 
 		// Try to rewind the database to the previous block to remove any logs from this block that were written
-		if err := s.rewinder.Rewind(s.chain, next.Number-1); err != nil {
+		if err := s.rewinder.Rewind(s.chain, next.ParentID()); err != nil {
 			// If any logs were written, our next attempt to write will fail and we'll retry this rewind.
 			// If no logs were written successfully then the rewind wouldn't have done anything anyway.
 			s.log.Error("Failed to rewind after error processing block", "block", next, "err", err)

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -15,6 +15,8 @@ var (
 	ErrFuture = errors.New("future data")
 	// ErrConflict happens when we know for sure that there is different canonical data
 	ErrConflict = errors.New("conflicting data")
+	// ErrAwaitReplacementBlock happens when we know for sure that a replacement block is needed before progress can be made.
+	ErrAwaitReplacementBlock = errors.New("awaiting replacement block")
 	// ErrStop can be used in iterators to indicate iteration has to stop
 	ErrStop = errors.New("iter stop")
 	// ErrOutOfScope is when data is accessed, but access is not allowed, because of a limited scope.

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -263,8 +263,8 @@ func LogToMessagePayload(l *ethTypes.Log) []byte {
 
 // DerivedBlockRefPair is a pair of block refs, where Derived (L2) is derived from DerivedFrom (L1).
 type DerivedBlockRefPair struct {
-	DerivedFrom eth.BlockRef
-	Derived     eth.BlockRef
+	DerivedFrom eth.BlockRef `json:"derivedFrom"`
+	Derived     eth.BlockRef `json:"derived"`
 }
 
 func (refs *DerivedBlockRefPair) IDs() DerivedIDPair {
@@ -276,8 +276,8 @@ func (refs *DerivedBlockRefPair) IDs() DerivedIDPair {
 
 // DerivedBlockSealPair is a pair of block seals, where Derived (L2) is derived from DerivedFrom (L1).
 type DerivedBlockSealPair struct {
-	DerivedFrom BlockSeal
-	Derived     BlockSeal
+	DerivedFrom BlockSeal `json:"derivedFrom"`
+	Derived     BlockSeal `json:"derived"`
 }
 
 func (seals *DerivedBlockSealPair) IDs() DerivedIDPair {
@@ -289,8 +289,8 @@ func (seals *DerivedBlockSealPair) IDs() DerivedIDPair {
 
 // DerivedIDPair is a pair of block IDs, where Derived (L2) is derived from DerivedFrom (L1).
 type DerivedIDPair struct {
-	DerivedFrom eth.BlockID
-	Derived     eth.BlockID
+	DerivedFrom eth.BlockID `json:"derivedFrom"`
+	Derived     eth.BlockID `json:"derived"`
 }
 
 // ManagedEvent is an event sent by the managed node to the supervisor,


### PR DESCRIPTION
**Description**

This PR is split out of #13645, to prepare for local-safe reorg handling:
- Adds support to invalidate local-safe DB entries. After an invalidated entry, you cannot add to the DB, until you have replaced the bad block.
- Changes interfaces to use the typed block-seal pair, so the derived-from and derived kinds don't get mixed up as easily.

This PR changes things a little more on top of  #13645, to return an await-replacement error when an invalidated entry is read by the from-DA. We can add methods later to access data without error, but this way we never accidentally read and assume things about the data until the replacement is applied.

**Tests**

- [x] updated existing tests
- [x] add test for the invalidated-entry and non-first occurrence replacement

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
