### PR TITLE
chore: cleanup devnet tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -17,12 +17,9 @@ just = "1.37.0"
 
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.10.25"
-"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.14.7"
-"go:github.com/protolambda/eth2-testnet-genesis" = "0.10.0"
 "go:gotest.tools/gotestsum" = "1.12.0"
 "go:github.com/vektra/mockery/v2" = "2.46.0"
 "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.61.0"
-"go:github.com/mikefarah/yq/v4" = "4.44.3"
 
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -314,4 +314,4 @@ while allowing regular single-chain functionality to proceed.
 
 - `op-e2e/interop`: Go interop system-tests, focused on offchain aspects of services to run end to end.
 - `op-e2e/actions/interop`: Go interop action-tests, focused on onchain aspects such as safety and state-transition.
-- `interop-devnet`: docker-compose to run interoperable chains locally.
+- `kurtosis-devnet/interop.yaml`: Kurtosis configuration to run interoperable chains locally.


### PR DESCRIPTION
**Description**

- Remove duplicate `yq`. The non-Go `yq` seems sufficient.
- Remove geth and testnet-genesis tools, we don't have the legacy devnet genesis setup anymore, so don't need these.
- Update supervisor readme to refer to kurtosis devnet instead of the old docker-compose

