### PR TITLE
fix: Incorrect oldest L1 origin block tracking in channel builder

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -193,7 +193,7 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 			Number: l1info.Number,
 		}
 	}
-	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.oldestL1Origin.Number {
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Incorrect tracking of oldest L1 block in ChannelBuilder causes the "oldest" block to be updated with newer blocks,

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
