### PR TITLE
op-program: Move towards using eth.ChainID instead of uint64

### DIFF
--- a/op-challenger/game/fault/trace/super/convert.go
+++ b/op-challenger/game/fault/trace/super/convert.go
@@ -5,7 +5,7 @@ import "github.com/ethereum-optimism/optimism/op-service/eth"
 func responseToSuper(prevRoot eth.SuperRootResponse) *eth.SuperV1 {
 	prevChainOutputs := make([]eth.ChainIDAndOutput, 0, len(prevRoot.Chains))
 	for _, chain := range prevRoot.Chains {
-		prevChainOutputs = append(prevChainOutputs, eth.ChainIDAndOutput{ChainID: chain.ChainID.ToBig().Uint64(), Output: chain.Canonical})
+		prevChainOutputs = append(prevChainOutputs, eth.ChainIDAndOutput{ChainID: chain.ChainID, Output: chain.Canonical})
 	}
 	superV1 := eth.NewSuperV1(prevRoot.Timestamp, prevChainOutputs...)
 	return superV1

--- a/op-challenger/game/fault/trace/super/convert_test.go
+++ b/op-challenger/game/fault/trace/super/convert_test.go
@@ -23,7 +23,7 @@ func TestResponseToSuper(t *testing.T) {
 		expected := &eth.SuperV1{
 			Timestamp: 4978924,
 			Chains: []eth.ChainIDAndOutput{
-				{ChainID: 2987, Output: eth.Bytes32{0x88}},
+				{ChainID: eth.ChainIDFromUInt64(2987), Output: eth.Bytes32{0x88}},
 			},
 		}
 		actual := responseToSuper(input)
@@ -50,8 +50,8 @@ func TestResponseToSuper(t *testing.T) {
 		expected := &eth.SuperV1{
 			Timestamp: 4978924,
 			Chains: []eth.ChainIDAndOutput{
-				{ChainID: 100, Output: eth.Bytes32{0x10}},
-				{ChainID: 2987, Output: eth.Bytes32{0x88}},
+				{ChainID: eth.ChainIDFromUInt64(100), Output: eth.Bytes32{0x10}},
+				{ChainID: eth.ChainIDFromUInt64(2987), Output: eth.Bytes32{0x88}},
 			},
 		}
 		actual := responseToSuper(input)

--- a/op-challenger/game/fault/trace/super/provider_test.go
+++ b/op-challenger/game/fault/trace/super/provider_test.go
@@ -75,11 +75,11 @@ func TestGet(t *testing.T) {
 		outputB2 := testutils.RandomOutputV0(rng)
 		superRoot1 := eth.NewSuperV1(
 			prestateTimestamp,
-			eth.ChainIDAndOutput{ChainID: 1, Output: eth.OutputRoot(outputA1)},
-			eth.ChainIDAndOutput{ChainID: 2, Output: eth.OutputRoot(outputB1)})
+			eth.ChainIDAndOutput{ChainID: eth.ChainIDFromUInt64(1), Output: eth.OutputRoot(outputA1)},
+			eth.ChainIDAndOutput{ChainID: eth.ChainIDFromUInt64(2), Output: eth.OutputRoot(outputB1)})
 		superRoot2 := eth.NewSuperV1(prestateTimestamp+1,
-			eth.ChainIDAndOutput{ChainID: 1, Output: eth.OutputRoot(outputA2)},
-			eth.ChainIDAndOutput{ChainID: 2, Output: eth.OutputRoot(outputB2)})
+			eth.ChainIDAndOutput{ChainID: eth.ChainIDFromUInt64(1), Output: eth.OutputRoot(outputA2)},
+			eth.ChainIDAndOutput{ChainID: eth.ChainIDFromUInt64(2), Output: eth.OutputRoot(outputB2)})
 		stubSupervisor.Add(eth.SuperRootResponse{
 			Timestamp: prestateTimestamp,
 			SuperRoot: eth.SuperRoot(superRoot1),

--- a/op-e2e/actions/interop/super_root.go
+++ b/op-e2e/actions/interop/super_root.go
@@ -3,7 +3,6 @@ package interop
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -16,7 +15,7 @@ type OutputRootSource interface {
 }
 
 type chainInfo struct {
-	chainID *big.Int
+	chainID eth.ChainID
 	source  OutputRootSource
 	config  *rollup.Config
 }
@@ -33,7 +32,7 @@ func NewSuperRootSource(ctx context.Context, sources ...OutputRootSource) (*Supe
 		if err != nil {
 			return nil, fmt.Errorf("failed to load rollup config: %w", err)
 		}
-		chainID := config.L2ChainID
+		chainID := eth.ChainIDFromBig(config.L2ChainID)
 		chains = append(chains, &chainInfo{
 			chainID: chainID,
 			source:  source,
@@ -57,7 +56,7 @@ func (s *SuperRootSource) CreateSuperRoot(ctx context.Context, timestamp uint64)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load output root for chain %v at block %v: %w", chain.chainID, blockNum, err)
 		}
-		chains[i] = eth.ChainIDAndOutput{ChainID: chain.chainID.Uint64(), Output: output.OutputRoot}
+		chains[i] = eth.ChainIDAndOutput{ChainID: chain.chainID, Output: output.OutputRoot}
 	}
 	output := eth.SuperV1{
 		Timestamp: timestamp,

--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -23,7 +24,7 @@ type FixtureInputs struct {
 	L2Claim        common.Hash `toml:"l2-claim"`
 	L2Head         common.Hash `toml:"l2-head"`
 	L2OutputRoot   common.Hash `toml:"l2-output-root"`
-	L2ChainID      uint64      `toml:"l2-chain-id"`
+	L2ChainID      eth.ChainID `toml:"l2-chain-id"`
 	L1Head         common.Hash `toml:"l1-head"`
 	AgreedPrestate []byte      `toml:"agreed-prestate"`
 	InteropEnabled bool        `toml:"use-interop"`

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
 	"github.com/ethereum-optimism/optimism/op-program/host/prefetcher"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -44,7 +45,7 @@ func WithPreInteropDefaults(t helpers.Testing, l2ClaimBlockNum uint64, l2 *helpe
 		f.L2Claim = common.Hash(claimRoot.OutputRoot)
 		f.L2Head = preRoot.BlockRef.Hash
 		f.L2OutputRoot = common.Hash(preRoot.OutputRoot)
-		f.L2ChainID = l2.RollupCfg.L2ChainID.Uint64()
+		f.L2ChainID = eth.ChainIDFromBig(l2.RollupCfg.L2ChainID)
 
 		f.L2Sources = []*FaultProofProgramL2Source{
 			{

--- a/op-program/chainconfig/chaincfg_test.go
+++ b/op-program/chainconfig/chaincfg_test.go
@@ -4,26 +4,27 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig/test"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
 
 // TestGetCustomRollupConfig tests loading the custom rollup configs from test embed FS.
 func TestGetCustomRollupConfig(t *testing.T) {
-	config, err := rollupConfigByChainID(901, test.TestCustomChainConfigFS)
+	config, err := rollupConfigByChainID(eth.ChainIDFromUInt64(901), test.TestCustomChainConfigFS)
 	require.NoError(t, err)
 	require.Equal(t, config.L1ChainID.Uint64(), uint64(900))
 	require.Equal(t, config.L2ChainID.Uint64(), uint64(901))
 
-	_, err = rollupConfigByChainID(900, test.TestCustomChainConfigFS)
+	_, err = rollupConfigByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.Error(t, err)
 }
 
 // TestGetCustomChainConfig tests loading the custom chain configs from test embed FS.
 func TestGetCustomChainConfig(t *testing.T) {
-	config, err := chainConfigByChainID(901, test.TestCustomChainConfigFS)
+	config, err := chainConfigByChainID(eth.ChainIDFromUInt64(901), test.TestCustomChainConfigFS)
 	require.NoError(t, err)
 	require.Equal(t, config.ChainID.Uint64(), uint64(901))
 
-	_, err = chainConfigByChainID(900, test.TestCustomChainConfigFS)
+	_, err = chainConfigByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.Error(t, err)
 }

--- a/op-program/client/boot/boot.go
+++ b/op-program/client/boot/boot.go
@@ -7,19 +7,20 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
 
 // CustomChainIDIndicator is used to detect when the program should load custom chain configuration
-const CustomChainIDIndicator = uint64(math.MaxUint64)
+var CustomChainIDIndicator = eth.ChainIDFromUInt64(uint64(math.MaxUint64))
 
 type BootInfo struct {
 	L1Head             common.Hash
 	L2OutputRoot       common.Hash
 	L2Claim            common.Hash
 	L2ClaimBlockNumber uint64
-	L2ChainID          uint64
+	L2ChainID          eth.ChainID
 
 	L2ChainConfig *params.ChainConfig
 	RollupConfig  *rollup.Config
@@ -38,7 +39,7 @@ func (br *BootstrapClient) BootInfo() *BootInfo {
 	l2OutputRoot := common.BytesToHash(br.r.Get(L2OutputRootLocalIndex))
 	l2Claim := common.BytesToHash(br.r.Get(L2ClaimLocalIndex))
 	l2ClaimBlockNumber := binary.BigEndian.Uint64(br.r.Get(L2ClaimBlockNumberLocalIndex))
-	l2ChainID := binary.BigEndian.Uint64(br.r.Get(L2ChainIDLocalIndex))
+	l2ChainID := eth.ChainIDFromUInt64(binary.BigEndian.Uint64(br.r.Get(L2ChainIDLocalIndex)))
 
 	var l2ChainConfig *params.ChainConfig
 	var rollupConfig *rollup.Config

--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func TestInteropBootstrap_RollupConfigBuiltIn(t *testing.T) {
 	}
 	mockOracle := newMockInteropBootstrapOracle(expected, false)
 	actual := BootstrapInterop(mockOracle)
-	actualCfg, err := actual.Configs.RollupConfig(expectedCfg.L2ChainID.Uint64())
+	actualCfg, err := actual.Configs.RollupConfig(eth.ChainIDFromBig(expectedCfg.L2ChainID))
 	require.NoError(t, err)
 	require.Equal(t, expectedCfg, actualCfg)
 }
@@ -57,11 +58,11 @@ func TestInteropBootstrap_RollupConfigCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(source, true)
 	mockOracle.rollupCfgs = []*rollup.Config{config1, config2}
 	actual := BootstrapInterop(mockOracle)
-	actualCfg, err := actual.Configs.RollupConfig(config1.L2ChainID.Uint64())
+	actualCfg, err := actual.Configs.RollupConfig(eth.ChainIDFromBig(config1.L2ChainID))
 	require.NoError(t, err)
 	require.Equal(t, config1, actualCfg)
 
-	actualCfg, err = actual.Configs.RollupConfig(config2.L2ChainID.Uint64())
+	actualCfg, err = actual.Configs.RollupConfig(eth.ChainIDFromBig(config2.L2ChainID))
 	require.NoError(t, err)
 	require.Equal(t, config2, actualCfg)
 }
@@ -76,7 +77,7 @@ func TestInteropBootstrap_ChainConfigBuiltIn(t *testing.T) {
 	}
 	mockOracle := newMockInteropBootstrapOracle(expected, false)
 	actual := BootstrapInterop(mockOracle)
-	actualCfg, err := actual.Configs.ChainConfig(expectedCfg.ChainID.Uint64())
+	actualCfg, err := actual.Configs.ChainConfig(eth.ChainIDFromBig(expectedCfg.ChainID))
 	require.NoError(t, err)
 	require.Equal(t, expectedCfg, actualCfg)
 }
@@ -94,11 +95,11 @@ func TestInteropBootstrap_ChainConfigCustom(t *testing.T) {
 	mockOracle.chainCfgs = []*params.ChainConfig{config1, config2}
 	actual := BootstrapInterop(mockOracle)
 
-	actualCfg, err := actual.Configs.ChainConfig(config1.ChainID.Uint64())
+	actualCfg, err := actual.Configs.ChainConfig(eth.ChainIDFromBig(config1.ChainID))
 	require.NoError(t, err)
 	require.Equal(t, config1, actualCfg)
 
-	actualCfg, err = actual.Configs.ChainConfig(config2.ChainID.Uint64())
+	actualCfg, err = actual.Configs.ChainConfig(eth.ChainIDFromBig(config2.ChainID))
 	require.NoError(t, err)
 	require.Equal(t, config2, actualCfg)
 }

--- a/op-program/client/boot/boot_test.go
+++ b/op-program/client/boot/boot_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +21,7 @@ func TestBootstrapClient(t *testing.T) {
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1,
-		L2ChainID:          rollupCfg.L2ChainID.Uint64(),
+		L2ChainID:          eth.ChainIDFromBig(rollupCfg.L2ChainID),
 		L2ChainConfig:      chainconfig.OPSepoliaChainConfig(),
 		RollupConfig:       rollupCfg,
 	}
@@ -50,7 +51,7 @@ func TestBootstrapClient_UnknownChainPanics(t *testing.T) {
 		L2OutputRoot:       common.HexToHash("0x2222"),
 		L2Claim:            common.HexToHash("0x3333"),
 		L2ClaimBlockNumber: 1,
-		L2ChainID:          uint64(0xdead),
+		L2ChainID:          eth.ChainID{0xdead},
 	}
 	mockOracle := newMockPreinteropBootstrapOracle(bootInfo, false)
 	client := NewBootstrapClient(mockOracle)
@@ -79,7 +80,7 @@ type mockPreinteropBoostrapOracle struct {
 func (o *mockPreinteropBoostrapOracle) Get(key preimage.Key) []byte {
 	switch key.PreimageKey() {
 	case L2ChainIDLocalIndex.PreimageKey():
-		return binary.BigEndian.AppendUint64(nil, o.b.L2ChainID)
+		return binary.BigEndian.AppendUint64(nil, eth.EvilChainIDToUInt64(o.b.L2ChainID))
 	case L2ChainConfigLocalIndex.PreimageKey():
 		if !o.custom {
 			panic(fmt.Sprintf("unexpected oracle request for preimage key %x", key.PreimageKey()))

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -36,8 +36,8 @@ func setupTwoChains() (*staticConfigSource, *eth.SuperV1, stubTasks) {
 	agreedSuperRoot := &eth.SuperV1{
 		Timestamp: rollupCfg1.Genesis.L2Time + 1234,
 		Chains: []eth.ChainIDAndOutput{
-			{ChainID: rollupCfg1.L2ChainID.Uint64(), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x11}})},
-			{ChainID: rollupCfg2.L2ChainID.Uint64(), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x22}})},
+			{ChainID: eth.ChainIDFromBig(rollupCfg1.L2ChainID), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x11}})},
+			{ChainID: eth.ChainIDFromBig(rollupCfg2.L2ChainID), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x22}})},
 		},
 	}
 	configSource := &staticConfigSource{
@@ -152,11 +152,11 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 		Timestamp: agreedSuperRoot.Timestamp + 1,
 		Chains: []eth.ChainIDAndOutput{
 			{
-				ChainID: configSource.rollupCfgs[0].L2ChainID.Uint64(),
+				ChainID: eth.ChainIDFromBig(configSource.rollupCfgs[0].L2ChainID),
 				Output:  agreedTransitionState.PendingProgress[0].OutputRoot,
 			},
 			{
-				ChainID: configSource.rollupCfgs[1].L2ChainID.Uint64(),
+				ChainID: eth.ChainIDFromBig(configSource.rollupCfgs[1].L2ChainID),
 				Output:  agreedTransitionState.PendingProgress[1].OutputRoot,
 			},
 		},
@@ -248,18 +248,18 @@ type staticConfigSource struct {
 	chainConfigs []*params.ChainConfig
 }
 
-func (s *staticConfigSource) RollupConfig(chainID uint64) (*rollup.Config, error) {
+func (s *staticConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, error) {
 	for _, cfg := range s.rollupCfgs {
-		if cfg.L2ChainID.Uint64() == chainID {
+		if eth.ChainIDFromBig(cfg.L2ChainID) == chainID {
 			return cfg, nil
 		}
 	}
 	return nil, fmt.Errorf("no rollup config found for chain %d", chainID)
 }
 
-func (s *staticConfigSource) ChainConfig(chainID uint64) (*params.ChainConfig, error) {
+func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConfig, error) {
 	for _, cfg := range s.chainConfigs {
-		if cfg.ChainID.Uint64() == chainID {
+		if eth.ChainIDFromBig(cfg.ChainID) == chainID {
 			return cfg, nil
 		}
 	}

--- a/op-program/client/interop/types/roots_test.go
+++ b/op-program/client/interop/types/roots_test.go
@@ -13,8 +13,8 @@ func TestTransitionStateCodec(t *testing.T) {
 		superRoot := &eth.SuperV1{
 			Timestamp: 9842494,
 			Chains: []eth.ChainIDAndOutput{
-				{ChainID: 34, Output: eth.Bytes32{0x01}},
-				{ChainID: 35, Output: eth.Bytes32{0x02}},
+				{ChainID: eth.ChainIDFromUInt64(34), Output: eth.Bytes32{0x01}},
+				{ChainID: eth.ChainIDFromUInt64(35), Output: eth.Bytes32{0x02}},
 			},
 		}
 		state := &TransitionState{
@@ -35,8 +35,8 @@ func TestTransitionStateCodec(t *testing.T) {
 		superRoot := &eth.SuperV1{
 			Timestamp: 9842494,
 			Chains: []eth.ChainIDAndOutput{
-				{ChainID: 34, Output: eth.Bytes32{0x01}},
-				{ChainID: 35, Output: eth.Bytes32{0x02}},
+				{ChainID: eth.ChainIDFromUInt64(34), Output: eth.Bytes32{0x01}},
+				{ChainID: eth.ChainIDFromUInt64(35), Output: eth.Bytes32{0x02}},
 			},
 		}
 		expected := &TransitionState{

--- a/op-program/client/l2/cache.go
+++ b/op-program/client/l2/cache.go
@@ -40,7 +40,7 @@ func NewCachingOracle(oracle Oracle) *CachingOracle {
 	}
 }
 
-func (o *CachingOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte {
+func (o *CachingOracle) NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte {
 	node, ok := o.nodes.Get(nodeHash)
 	if ok {
 		return node
@@ -50,7 +50,7 @@ func (o *CachingOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte 
 	return node
 }
 
-func (o *CachingOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID uint64) (*types.Block, types.Receipts) {
+func (o *CachingOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.ChainID) (*types.Block, types.Receipts) {
 	rcpts, ok := o.rcpts.Get(blockHash)
 	if ok {
 		return o.BlockByHash(blockHash, chainID), rcpts
@@ -61,7 +61,7 @@ func (o *CachingOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID uint6
 	return block, rcpts
 }
 
-func (o *CachingOracle) CodeByHash(codeHash common.Hash, chainID uint64) []byte {
+func (o *CachingOracle) CodeByHash(codeHash common.Hash, chainID eth.ChainID) []byte {
 	code, ok := o.codes.Get(codeHash)
 	if ok {
 		return code
@@ -71,7 +71,7 @@ func (o *CachingOracle) CodeByHash(codeHash common.Hash, chainID uint64) []byte 
 	return code
 }
 
-func (o *CachingOracle) BlockByHash(blockHash common.Hash, chainID uint64) *types.Block {
+func (o *CachingOracle) BlockByHash(blockHash common.Hash, chainID eth.ChainID) *types.Block {
 	block, ok := o.blocks.Get(blockHash)
 	if ok {
 		return block
@@ -81,7 +81,7 @@ func (o *CachingOracle) BlockByHash(blockHash common.Hash, chainID uint64) *type
 	return block
 }
 
-func (o *CachingOracle) OutputByRoot(root common.Hash, chainID uint64) eth.Output {
+func (o *CachingOracle) OutputByRoot(root common.Hash, chainID eth.ChainID) eth.Output {
 	output, ok := o.outputs.Get(root)
 	if ok {
 		return output
@@ -91,7 +91,7 @@ func (o *CachingOracle) OutputByRoot(root common.Hash, chainID uint64) eth.Outpu
 	return output
 }
 
-func (o *CachingOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID uint64) *types.Block {
+func (o *CachingOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID eth.ChainID) *types.Block {
 	// Always request from the oracle even on cache hit. as we want the effects of the host oracle hinting
 	block := o.oracle.BlockDataByHash(agreedBlockHash, blockHash, chainID)
 	o.blocks.Add(blockHash, block)

--- a/op-program/client/l2/cache_test.go
+++ b/op-program/client/l2/cache_test.go
@@ -24,12 +24,12 @@ func TestBlockByHash(t *testing.T) {
 
 	// Initial call retrieves from the stub
 	stub.Blocks[block.Hash()] = block
-	actual := oracle.BlockByHash(block.Hash(), chainID)
+	actual := oracle.BlockByHash(block.Hash(), eth.ChainIDFromUInt64(chainID))
 	require.Equal(t, block, actual)
 
 	// Later calls should retrieve from cache (even if chain ID is different)
 	delete(stub.Blocks, block.Hash())
-	actual = oracle.BlockByHash(block.Hash(), 9982)
+	actual = oracle.BlockByHash(block.Hash(), eth.ChainIDFromUInt64(9982))
 	require.Equal(t, block, actual)
 }
 
@@ -42,17 +42,17 @@ func TestNodeByHash(t *testing.T) {
 
 	// Initial call retrieves from the stub
 	stateStub.Data[hash] = node
-	actual := oracle.NodeByHash(hash, 1234)
+	actual := oracle.NodeByHash(hash, eth.ChainIDFromUInt64(1234))
 	require.Equal(t, node, actual)
 
 	// Later calls should retrieve from cache (even if chain ID is different)
 	delete(stateStub.Data, hash)
-	actual = oracle.NodeByHash(hash, 997845)
+	actual = oracle.NodeByHash(hash, eth.ChainIDFromUInt64(997845))
 	require.Equal(t, node, actual)
 }
 
 func TestReceiptsByBlockHash(t *testing.T) {
-	chainID := uint64(48294)
+	chainID := eth.ChainIDFromUInt64(48294)
 	stub, _ := test.NewStubOracle(t)
 	oracle := NewCachingOracle(stub)
 
@@ -69,7 +69,7 @@ func TestReceiptsByBlockHash(t *testing.T) {
 	// Later calls should retrieve from cache (even if chain ID is different)
 	delete(stub.Blocks, block.Hash())
 	delete(stub.Receipts, block.Hash())
-	actualBlock, actualRcpts = oracle.ReceiptsByBlockHash(block.Hash(), 9982)
+	actualBlock, actualRcpts = oracle.ReceiptsByBlockHash(block.Hash(), eth.ChainIDFromUInt64(9982))
 	require.EqualValues(t, block, actualBlock)
 	require.EqualValues(t, rcpts, actualRcpts)
 }
@@ -83,12 +83,12 @@ func TestCodeByHash(t *testing.T) {
 
 	// Initial call retrieves from the stub
 	stateStub.Code[hash] = node
-	actual := oracle.CodeByHash(hash, 342)
+	actual := oracle.CodeByHash(hash, eth.ChainIDFromUInt64(342))
 	require.Equal(t, node, actual)
 
 	// Later calls should retrieve from cache (even if the chain ID is different)
 	delete(stateStub.Code, hash)
-	actual = oracle.CodeByHash(hash, 986776)
+	actual = oracle.CodeByHash(hash, eth.ChainIDFromUInt64(986776))
 	require.Equal(t, node, actual)
 }
 
@@ -102,11 +102,11 @@ func TestOutputByRoot(t *testing.T) {
 	// Initial call retrieves from the stub
 	root := common.Hash(eth.OutputRoot(output))
 	stub.Outputs[root] = output
-	actual := oracle.OutputByRoot(root, 59284)
+	actual := oracle.OutputByRoot(root, eth.ChainIDFromUInt64(59284))
 	require.Equal(t, output, actual)
 
 	// Later calls should retrieve from cache (even if the chain ID is different)
 	delete(stub.Outputs, root)
-	actual = oracle.OutputByRoot(root, 9193)
+	actual = oracle.OutputByRoot(root, eth.ChainIDFromUInt64(9193))
 	require.Equal(t, output, actual)
 }

--- a/op-program/client/l2/canon_test.go
+++ b/op-program/client/l2/canon_test.go
@@ -3,6 +3,7 @@ package l2
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func TestCanonicalBlockNumberOracle_GetHeaderByNumber(t *testing.T) {
 			t.Fatalf("Requested duplicate block: %v", hash)
 		}
 		requestedBlocks[hash] = true
-		return oracle.BlockByHash(hash, chainCfg.ChainID.Uint64())
+		return oracle.BlockByHash(hash, eth.ChainIDFromBig(chainCfg.ChainID))
 	}
 	canon := NewCanonicalBlockHeaderOracle(head, blockByHash)
 	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
@@ -63,7 +64,7 @@ func TestCanonicalBlockNumberOracle_SetCanonical(t *testing.T) {
 		blockRequestCount := 0
 		blockByHash := func(hash common.Hash) *types.Block {
 			blockRequestCount++
-			return oracle.BlockByHash(hash, chainCfg.ChainID.Uint64())
+			return oracle.BlockByHash(hash, eth.ChainIDFromBig(chainCfg.ChainID))
 		}
 		canon := NewCanonicalBlockHeaderOracle(head, blockByHash)
 		oracle.Blocks[blocks[2].Hash()] = blocks[2]
@@ -100,7 +101,7 @@ func TestCanonicalBlockNumberOracle_SetCanonical(t *testing.T) {
 		head := blocks[headBlockNumber].Header()
 
 		blockByHash := func(hash common.Hash) *types.Block {
-			return oracle.BlockByHash(hash, chainCfg.ChainID.Uint64())
+			return oracle.BlockByHash(hash, eth.ChainIDFromBig(chainCfg.ChainID))
 		}
 		canon := NewCanonicalBlockHeaderOracle(head, blockByHash)
 		oracle.Blocks[blocks[2].Hash()] = blocks[2]

--- a/op-program/client/l2/db.go
+++ b/op-program/client/l2/db.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -18,10 +19,10 @@ var ErrInvalidKeyLength = errors.New("pre-images must be identified by 32-byte h
 type OracleKeyValueStore struct {
 	db      ethdb.KeyValueStore
 	oracle  StateOracle
-	chainID uint64
+	chainID eth.ChainID
 }
 
-func NewOracleBackedDB(oracle StateOracle, chainID uint64) *OracleKeyValueStore {
+func NewOracleBackedDB(oracle StateOracle, chainID eth.ChainID) *OracleKeyValueStore {
 	return &OracleKeyValueStore{
 		db:      memorydb.New(),
 		oracle:  oracle,

--- a/op-program/client/l2/db_test.go
+++ b/op-program/client/l2/db_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/test"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -34,7 +35,7 @@ var _ ethdb.KeyValueStore = (*OracleKeyValueStore)(nil)
 func TestGet(t *testing.T) {
 	t.Run("IncorrectLengthKey", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, 1234)
+		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
 		val, err := db.Get([]byte{1, 2, 3})
 		require.ErrorIs(t, err, ErrInvalidKeyLength)
 		require.Nil(t, val)
@@ -42,7 +43,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("KeyWithCodePrefix", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, 1234)
+		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
 		key := common.HexToHash("0x12345678")
 		prefixedKey := append(rawdb.CodePrefix, key.Bytes()...)
 
@@ -56,7 +57,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("NormalKeyThatHappensToStartWithCodePrefix", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, 1234)
+		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
 		key := make([]byte, common.HashLength)
 		copy(rawdb.CodePrefix, key)
 		fmt.Println(key[0])
@@ -73,7 +74,7 @@ func TestGet(t *testing.T) {
 		expected := []byte{2, 6, 3, 8}
 		oracle := test.NewStubStateOracle(t)
 		oracle.Data[key] = expected
-		db := NewOracleBackedDB(oracle, 1234)
+		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
 		val, err := db.Get(key.Bytes())
 		require.NoError(t, err)
 		require.Equal(t, expected, val)
@@ -83,7 +84,7 @@ func TestGet(t *testing.T) {
 func TestPut(t *testing.T) {
 	t.Run("NewKey", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, 1234)
+		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
 		key := common.HexToHash("0xAA4488")
 		value := []byte{2, 6, 3, 8}
 		err := db.Put(key.Bytes(), value)
@@ -95,7 +96,7 @@ func TestPut(t *testing.T) {
 	})
 	t.Run("ReplaceKey", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, 1234)
+		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
 		key := common.HexToHash("0xAA4488")
 		value1 := []byte{2, 6, 3, 8}
 		value2 := []byte{1, 2, 3}
@@ -117,13 +118,13 @@ func TestSupportsStateDBOperations(t *testing.T) {
 	genesisBlock := l2Genesis.MustCommit(realDb, trieDB)
 
 	loader := test.NewKvStateOracle(t, realDb)
-	assertStateDataAvailable(t, NewOracleBackedDB(loader, 1234), l2Genesis, genesisBlock)
+	assertStateDataAvailable(t, NewOracleBackedDB(loader, eth.ChainIDFromUInt64(1234)), l2Genesis, genesisBlock)
 }
 
 func TestUpdateState(t *testing.T) {
 	l2Genesis := createGenesis()
 	oracle := test.NewStubStateOracle(t)
-	db := rawdb.NewDatabase(NewOracleBackedDB(oracle, 1234))
+	db := rawdb.NewDatabase(NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234)))
 
 	trieDB := triedb.NewDatabase(db, &triedb.Config{HashDB: hashdb.Defaults})
 	genesisBlock := l2Genesis.MustCommit(db, trieDB)

--- a/op-program/client/l2/engine_backend.go
+++ b/op-program/client/l2/engine_backend.go
@@ -42,7 +42,7 @@ type OracleBackedL2Chain struct {
 var _ engineapi.CachingEngineBackend = (*OracleBackedL2Chain)(nil)
 
 func NewOracleBackedL2Chain(logger log.Logger, oracle Oracle, precompileOracle engineapi.PrecompileOracle, chainCfg *params.ChainConfig, l2OutputRoot common.Hash) (*OracleBackedL2Chain, error) {
-	chainID := chainCfg.ChainID.Uint64()
+	chainID := eth.ChainIDFromBig(chainCfg.ChainID)
 	output := oracle.OutputByRoot(l2OutputRoot, chainID)
 	outputV0, ok := output.(*eth.OutputV0)
 	if !ok {
@@ -107,7 +107,7 @@ func (o *OracleBackedL2Chain) GetBlockByHash(hash common.Hash) *types.Block {
 		return block
 	}
 	// Retrieve from the oracle
-	return o.oracle.BlockByHash(hash, o.chainCfg.ChainID.Uint64())
+	return o.oracle.BlockByHash(hash, eth.ChainIDFromBig(o.chainCfg.ChainID))
 }
 
 func (o *OracleBackedL2Chain) GetBlock(hash common.Hash, number uint64) *types.Block {

--- a/op-program/client/l2/engine_backend_test.go
+++ b/op-program/client/l2/engine_backend_test.go
@@ -378,7 +378,7 @@ func createBlock(t *testing.T, chain *OracleBackedL2Chain, opts ...blockCreateOp
 	require.NoError(t, err)
 	nonce := parentDB.GetNonce(fundedAddress)
 	config := chain.Config()
-	db := rawdb.NewDatabase(NewOracleBackedDB(chain.oracle, config.ChainID.Uint64()))
+	db := rawdb.NewDatabase(NewOracleBackedDB(chain.oracle, eth.ChainIDFromBig(config.ChainID)))
 	blocks, _ := core.GenerateChain(config, parent, chain.Engine(), db, 1, func(i int, gen *core.BlockGen) {
 		rawTx := &types.DynamicFeeTx{
 			ChainID:   config.ChainID,

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -32,13 +32,13 @@ func (l LegacyBlockHeaderHint) Hint() string {
 
 type HashAndChainID struct {
 	Hash    common.Hash
-	ChainID uint64
+	ChainID eth.ChainID
 }
 
 func (h HashAndChainID) Marshal() []byte {
 	d := make([]byte, 32+8)
 	copy(d[:32], h.Hash[:])
-	binary.BigEndian.PutUint64(d[32:], h.ChainID)
+	binary.BigEndian.PutUint64(d[32:], eth.EvilChainIDToUInt64(h.ChainID))
 	return d
 }
 

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -124,7 +125,7 @@ func (l LegacyL2OutputHint) Hint() string {
 type L2BlockDataHint struct {
 	AgreedBlockHash common.Hash
 	BlockHash       common.Hash
-	ChainID         uint64
+	ChainID         eth.ChainID
 }
 
 var _ preimage.Hint = L2BlockDataHint{}
@@ -133,7 +134,7 @@ func (l L2BlockDataHint) Hint() string {
 	hintBytes := make([]byte, 32+32+8)
 	copy(hintBytes[:32], (common.Hash)(l.AgreedBlockHash).Bytes())
 	copy(hintBytes[32:64], (common.Hash)(l.BlockHash).Bytes())
-	binary.BigEndian.PutUint64(hintBytes[64:], l.ChainID)
+	binary.BigEndian.PutUint64(hintBytes[64:], eth.EvilChainIDToUInt64(l.ChainID))
 	return fmt.Sprintf("%s 0x%s", HintL2BlockData, common.Bytes2Hex(hintBytes))
 }
 

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -19,11 +19,11 @@ type StateOracle interface {
 	// NodeByHash retrieves the merkle-patricia trie node pre-image for a given hash.
 	// Trie nodes may be from the world state trie or any account storage trie.
 	// Contract code is not stored as part of the trie and must be retrieved via CodeByHash
-	NodeByHash(nodeHash common.Hash, chainID uint64) []byte
+	NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte
 
 	// CodeByHash retrieves the contract code pre-image for a given hash.
 	// codeHash should be retrieved from the world state account for a contract.
-	CodeByHash(codeHash common.Hash, chainID uint64) []byte
+	CodeByHash(codeHash common.Hash, chainID eth.ChainID) []byte
 }
 
 // Oracle defines the high-level API used to retrieve L2 data.
@@ -32,16 +32,16 @@ type Oracle interface {
 	StateOracle
 
 	// BlockByHash retrieves the block with the given hash.
-	BlockByHash(blockHash common.Hash, chainID uint64) *types.Block
+	BlockByHash(blockHash common.Hash, chainID eth.ChainID) *types.Block
 
-	OutputByRoot(root common.Hash, chainID uint64) eth.Output
+	OutputByRoot(root common.Hash, chainID eth.ChainID) eth.Output
 
 	// BlockDataByHash retrieves the block, including all data used to construct it.
-	BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID uint64) *types.Block
+	BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID eth.ChainID) *types.Block
 
 	TransitionStateByRoot(root common.Hash) *interopTypes.TransitionState
 
-	ReceiptsByBlockHash(blockHash common.Hash, chainID uint64) (*types.Block, types.Receipts)
+	ReceiptsByBlockHash(blockHash common.Hash, chainID eth.ChainID) (*types.Block, types.Receipts)
 }
 
 // PreimageOracle implements Oracle using by interfacing with the pure preimage.Oracle
@@ -62,7 +62,7 @@ func NewPreimageOracle(raw preimage.Oracle, hint preimage.Hinter, hintL2ChainIDs
 	}
 }
 
-func (p *PreimageOracle) headerByBlockHash(blockHash common.Hash, chainID uint64) *types.Header {
+func (p *PreimageOracle) headerByBlockHash(blockHash common.Hash, chainID eth.ChainID) *types.Header {
 	if p.hintL2ChainIDs {
 		p.hint.Hint(BlockHeaderHint{Hash: blockHash, ChainID: chainID})
 	} else {
@@ -76,14 +76,14 @@ func (p *PreimageOracle) headerByBlockHash(blockHash common.Hash, chainID uint64
 	return &header
 }
 
-func (p *PreimageOracle) BlockByHash(blockHash common.Hash, chainID uint64) *types.Block {
+func (p *PreimageOracle) BlockByHash(blockHash common.Hash, chainID eth.ChainID) *types.Block {
 	header := p.headerByBlockHash(blockHash, chainID)
 	txs := p.LoadTransactions(blockHash, header.TxHash, chainID)
 
 	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs})
 }
 
-func (p *PreimageOracle) LoadTransactions(blockHash common.Hash, txHash common.Hash, chainID uint64) []*types.Transaction {
+func (p *PreimageOracle) LoadTransactions(blockHash common.Hash, txHash common.Hash, chainID eth.ChainID) []*types.Transaction {
 	if p.hintL2ChainIDs {
 		p.hint.Hint(TransactionsHint{Hash: blockHash, ChainID: chainID})
 	} else {
@@ -101,7 +101,7 @@ func (p *PreimageOracle) LoadTransactions(blockHash common.Hash, txHash common.H
 	return txs
 }
 
-func (p *PreimageOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte {
+func (p *PreimageOracle) NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte {
 	if p.hintL2ChainIDs {
 		p.hint.Hint(StateNodeHint{Hash: nodeHash, ChainID: chainID})
 	} else {
@@ -110,7 +110,7 @@ func (p *PreimageOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte
 	return p.oracle.Get(preimage.Keccak256Key(nodeHash))
 }
 
-func (p *PreimageOracle) CodeByHash(codeHash common.Hash, chainID uint64) []byte {
+func (p *PreimageOracle) CodeByHash(codeHash common.Hash, chainID eth.ChainID) []byte {
 	if p.hintL2ChainIDs {
 		p.hint.Hint(CodeHint{Hash: codeHash, ChainID: chainID})
 	} else {
@@ -119,7 +119,7 @@ func (p *PreimageOracle) CodeByHash(codeHash common.Hash, chainID uint64) []byte
 	return p.oracle.Get(preimage.Keccak256Key(codeHash))
 }
 
-func (p *PreimageOracle) OutputByRoot(l2OutputRoot common.Hash, chainID uint64) eth.Output {
+func (p *PreimageOracle) OutputByRoot(l2OutputRoot common.Hash, chainID eth.ChainID) eth.Output {
 	if p.hintL2ChainIDs {
 		p.hint.Hint(L2OutputHint{Hash: l2OutputRoot, ChainID: chainID})
 	} else {
@@ -133,11 +133,11 @@ func (p *PreimageOracle) OutputByRoot(l2OutputRoot common.Hash, chainID uint64) 
 	return output
 }
 
-func (p *PreimageOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID uint64) *types.Block {
+func (p *PreimageOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID eth.ChainID) *types.Block {
 	hint := L2BlockDataHint{
 		AgreedBlockHash: agreedBlockHash,
 		BlockHash:       blockHash,
-		ChainID:         eth.ChainIDFromUInt64(chainID),
+		ChainID:         chainID,
 	}
 	p.hint.Hint(hint)
 	header := p.headerByBlockHash(blockHash, chainID)
@@ -155,7 +155,7 @@ func (p *PreimageOracle) TransitionStateByRoot(root common.Hash) *interopTypes.T
 	return output
 }
 
-func (p *PreimageOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID uint64) (*types.Block, types.Receipts) {
+func (p *PreimageOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.ChainID) (*types.Block, types.Receipts) {
 	block := p.BlockByHash(blockHash, chainID)
 	p.hint.Hint(ReceiptsHint{Hash: blockHash, ChainID: chainID})
 	opaqueReceipts := mpt.ReadTrie(block.ReceiptHash(), func(key common.Hash) []byte {

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -137,7 +137,7 @@ func (p *PreimageOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash,
 	hint := L2BlockDataHint{
 		AgreedBlockHash: agreedBlockHash,
 		BlockHash:       blockHash,
-		ChainID:         chainID,
+		ChainID:         eth.ChainIDFromUInt64(chainID),
 	}
 	p.hint.Hint(hint)
 	header := p.headerByBlockHash(blockHash, chainID)

--- a/op-program/client/l2/oracle_test.go
+++ b/op-program/client/l2/oracle_test.go
@@ -52,7 +52,7 @@ func testBlock(t *testing.T, block *types.Block, hintL2ChainIDs bool) {
 		preimages[preimage.Keccak256Key(crypto.Keccak256Hash(p)).PreimageKey()] = p
 	}
 
-	chainID := uint64(4924)
+	chainID := eth.ChainIDFromUInt64(4924)
 
 	// Prepare a raw mock pre-image oracle that will serve the pre-image data and handle hints
 
@@ -94,7 +94,7 @@ func TestPreimageOracleNodeByHash(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
 
 	for i := 0; i < 10; i++ {
-		chainID := rng.Uint64()
+		chainID := eth.ChainIDFromUInt64(rng.Uint64())
 		t.Run(fmt.Sprintf("legacy_node_%d", i), func(t *testing.T) {
 			po, hints, preimages := mockPreimageOracle(t, false)
 
@@ -131,7 +131,7 @@ func TestPreimageOracleCodeByHash(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
 
 	for i := 0; i < 10; i++ {
-		chainID := rng.Uint64()
+		chainID := eth.ChainIDFromUInt64(rng.Uint64())
 		t.Run(fmt.Sprintf("legacy_code_%d", i), func(t *testing.T) {
 			po, hints, preimages := mockPreimageOracle(t, false)
 
@@ -168,7 +168,7 @@ func TestPreimageOracleOutputByRoot(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
 
 	for i := 0; i < 10; i++ {
-		chainID := rng.Uint64()
+		chainID := eth.ChainIDFromUInt64(rng.Uint64())
 		t.Run(fmt.Sprintf("legacy_output_%d", i), func(t *testing.T) {
 			po, hints, preimages := mockPreimageOracle(t, false)
 			output := testutils.RandomOutputV0(rng)

--- a/op-program/client/l2/test/stub_oracle.go
+++ b/op-program/client/l2/test/stub_oracle.go
@@ -15,8 +15,8 @@ import (
 
 // Same as l2.StateOracle but need to use our own copy to avoid dependency loops
 type stateOracle interface {
-	NodeByHash(nodeHash common.Hash, chainID uint64) []byte
-	CodeByHash(codeHash common.Hash, chainID uint64) []byte
+	NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte
+	CodeByHash(codeHash common.Hash, chainID eth.ChainID) []byte
 }
 
 type StubBlockOracle struct {
@@ -58,7 +58,7 @@ func NewStubOracleWithBlocks(t *testing.T, chain []*gethTypes.Block, outputs []e
 	}
 }
 
-func (o StubBlockOracle) BlockByHash(blockHash common.Hash, chainID uint64) *gethTypes.Block {
+func (o StubBlockOracle) BlockByHash(blockHash common.Hash, chainID eth.ChainID) *gethTypes.Block {
 	block, ok := o.Blocks[blockHash]
 	if !ok {
 		o.t.Fatalf("requested unknown block %s", blockHash)
@@ -66,7 +66,7 @@ func (o StubBlockOracle) BlockByHash(blockHash common.Hash, chainID uint64) *get
 	return block
 }
 
-func (o StubBlockOracle) OutputByRoot(root common.Hash, chainID uint64) eth.Output {
+func (o StubBlockOracle) OutputByRoot(root common.Hash, chainID eth.ChainID) eth.Output {
 	output, ok := o.Outputs[root]
 	if !ok {
 		o.t.Fatalf("requested unknown output root %s", root)
@@ -81,7 +81,7 @@ func (o StubBlockOracle) TransitionStateByRoot(root common.Hash) *interopTypes.T
 	return output
 }
 
-func (o StubBlockOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID uint64) *gethTypes.Block {
+func (o StubBlockOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID eth.ChainID) *gethTypes.Block {
 	block, ok := o.Blocks[blockHash]
 	if !ok {
 		o.t.Fatalf("requested unknown block %s", blockHash)
@@ -89,7 +89,7 @@ func (o StubBlockOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash,
 	return block
 }
 
-func (o StubBlockOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID uint64) (*gethTypes.Block, gethTypes.Receipts) {
+func (o StubBlockOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.ChainID) (*gethTypes.Block, gethTypes.Receipts) {
 	receipts, ok := o.Receipts[blockHash]
 	if !ok {
 		o.t.Fatalf("requested unknown receipts for block %s", blockHash)
@@ -110,7 +110,7 @@ func NewKvStateOracle(t *testing.T, db ethdb.KeyValueStore) *KvStateOracle {
 	}
 }
 
-func (o *KvStateOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte {
+func (o *KvStateOracle) NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte {
 	val, err := o.Source.Get(nodeHash.Bytes())
 	if err != nil {
 		o.t.Fatalf("error retrieving node %v: %v", nodeHash, err)
@@ -118,7 +118,7 @@ func (o *KvStateOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte 
 	return val
 }
 
-func (o *KvStateOracle) CodeByHash(hash common.Hash, chainID uint64) []byte {
+func (o *KvStateOracle) CodeByHash(hash common.Hash, chainID eth.ChainID) []byte {
 	return rawdb.ReadCode(o.Source, hash)
 }
 
@@ -137,7 +137,7 @@ type StubStateOracle struct {
 	Code map[common.Hash][]byte
 }
 
-func (o *StubStateOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byte {
+func (o *StubStateOracle) NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte {
 	data, ok := o.Data[nodeHash]
 	if !ok {
 		o.t.Fatalf("no value for node %v", nodeHash)
@@ -145,7 +145,7 @@ func (o *StubStateOracle) NodeByHash(nodeHash common.Hash, chainID uint64) []byt
 	return data
 }
 
-func (o *StubStateOracle) CodeByHash(hash common.Hash, chainID uint64) []byte {
+func (o *StubStateOracle) CodeByHash(hash common.Hash, chainID eth.ChainID) []byte {
 	data, ok := o.Code[hash]
 	if !ok {
 		o.t.Fatalf("no value for code %v", hash)

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -206,14 +207,14 @@ func TestMultipleNetworkConfigs(t *testing.T) {
 func TestL2ChainID(t *testing.T) {
 	t.Run("DefaultToNetworkChainID", func(t *testing.T) {
 		cfg := configForArgs(t, replaceRequiredArg("--network", "op-mainnet"))
-		require.Equal(t, uint64(10), cfg.L2ChainID)
+		require.Equal(t, eth.ChainIDFromUInt64(10), cfg.L2ChainID)
 	})
 
 	t.Run("DefaultToGenesisChainID", func(t *testing.T) {
 		rollupCfgFile := writeValidRollupConfig(t)
 		genesisFile := writeValidGenesis(t)
 		cfg := configForArgs(t, addRequiredArgsExcept("--network", "--rollup.config", rollupCfgFile, "--l2.genesis", genesisFile))
-		require.Equal(t, l2GenesisConfig.ChainID.Uint64(), cfg.L2ChainID)
+		require.Equal(t, eth.ChainIDFromBig(l2GenesisConfig.ChainID), cfg.L2ChainID)
 	})
 
 	t.Run("OverrideToCustomIndicator", func(t *testing.T) {

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -97,7 +97,7 @@ type Config struct {
 }
 
 func (c *Config) Check() error {
-	if !c.InteropEnabled && c.L2ChainID == eth.ChainIDFromUInt64(0) {
+	if !c.InteropEnabled && c.L2ChainID == (eth.ChainID{}) {
 		return ErrMissingL2ChainID
 	}
 	if len(c.Rollups) == 0 {
@@ -317,7 +317,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		l2ChainID = boot.CustomChainIDIndicator
 	} else if len(rollupCfgs) > 1 {
 		// L2ChainID is not applicable when multiple L2 sources are used and not using custom configs
-		l2ChainID = eth.ChainIDFromUInt64(0)
+		l2ChainID = eth.ChainID{}
 	}
 
 	dbFormat := types.DataFormat(ctx.String(flags.DataFormat.Name))

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"strconv"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -46,7 +46,7 @@ var (
 )
 
 type Config struct {
-	L2ChainID uint64 // TODO: Forbid for interop
+	L2ChainID eth.ChainID // TODO: Forbid for interop
 	Rollups   []*rollup.Config
 	// DataDir is the directory to read/write pre-image data from/to.
 	// If not set, an in-memory key-value store is used and fetching data must be enabled
@@ -97,7 +97,7 @@ type Config struct {
 }
 
 func (c *Config) Check() error {
-	if !c.InteropEnabled && c.L2ChainID == 0 {
+	if !c.InteropEnabled && c.L2ChainID == eth.ChainIDFromUInt64(0) {
 		return ErrMissingL2ChainID
 	}
 	if len(c.Rollups) == 0 {
@@ -183,8 +183,8 @@ func NewSingleChainConfig(
 	l2Claim common.Hash,
 	l2ClaimBlockNum uint64,
 ) *Config {
-	l2ChainID := l2ChainConfig.ChainID.Uint64()
-	_, err := params.LoadOPStackChainConfig(l2ChainID)
+	l2ChainID := eth.ChainIDFromBig(l2ChainConfig.ChainID)
+	_, err := params.LoadOPStackChainConfig(eth.EvilChainIDToUInt64(l2ChainID))
 	if err != nil {
 		// Unknown chain ID so assume it is custom
 		l2ChainID = boot.CustomChainIDIndicator
@@ -268,16 +268,16 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	var err error
 	var rollupCfgs []*rollup.Config
 	var l2ChainConfigs []*params.ChainConfig
-	var l2ChainID uint64
+	var l2ChainID eth.ChainID
 	networkNames := ctx.StringSlice(flags.Network.Name)
 	for _, networkName := range networkNames {
-		var chainID uint64
-		if chainID, err = strconv.ParseUint(networkName, 10, 64); err != nil {
+		var chainID eth.ChainID
+		if chainID, err = eth.ParseDecimalChainID(networkName); err != nil {
 			ch := chaincfg.ChainByName(networkName)
 			if ch == nil {
 				return nil, fmt.Errorf("invalid network: %q", networkName)
 			}
-			chainID = ch.ChainID
+			chainID = eth.ChainIDFromUInt64(ch.ChainID)
 		}
 
 		l2ChainConfig, err := chainconfig.ChainConfigByChainID(chainID)
@@ -300,7 +300,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 			return nil, fmt.Errorf("invalid genesis: %w", err)
 		}
 		l2ChainConfigs = append(l2ChainConfigs, l2ChainConfig)
-		l2ChainID = l2ChainConfig.ChainID.Uint64()
+		l2ChainID = eth.ChainIDFromBig(l2ChainConfig.ChainID)
 	}
 
 	rollupPaths := ctx.StringSlice(flags.RollupConfig.Name)
@@ -317,7 +317,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		l2ChainID = boot.CustomChainIDIndicator
 	} else if len(rollupCfgs) > 1 {
 		// L2ChainID is not applicable when multiple L2 sources are used and not using custom configs
-		l2ChainID = 0
+		l2ChainID = eth.ChainIDFromUInt64(0)
 	}
 
 	dbFormat := types.DataFormat(ctx.String(flags.DataFormat.Name))

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -42,13 +43,13 @@ func TestValidInteropConfigIsValid(t *testing.T) {
 func TestL2BlockNum(t *testing.T) {
 	t.Run("RequiredForPreInterop", func(t *testing.T) {
 		cfg := validConfig()
-		cfg.L2ChainID = 0
+		cfg.L2ChainID = eth.ChainID{}
 		require.ErrorIs(t, cfg.Check(), ErrMissingL2ChainID)
 	})
 
 	t.Run("NotRequiredForInterop", func(t *testing.T) {
 		cfg := validInteropConfig()
-		cfg.L2ChainID = 0
+		cfg.L2ChainID = eth.ChainID{}
 		require.NoError(t, cfg.Check())
 	})
 }
@@ -221,7 +222,7 @@ func TestRejectExecAndServerMode(t *testing.T) {
 func TestCustomL2ChainID(t *testing.T) {
 	t.Run("nonCustom", func(t *testing.T) {
 		cfg := validConfig()
-		require.Equal(t, cfg.L2ChainID, validL2Genesis.ChainID.Uint64())
+		require.Equal(t, cfg.L2ChainID, eth.ChainIDFromBig(validL2Genesis.ChainID))
 	})
 	t.Run("custom", func(t *testing.T) {
 		customChainConfig := &params.ChainConfig{ChainID: big.NewInt(0x1212121212)}

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -14,6 +14,7 @@ import (
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -98,7 +99,7 @@ func makeDefaultPrefetcher(ctx context.Context, logger log.Logger, kv kvstore.KV
 	}
 
 	executor := MakeProgramExecutor(logger, cfg)
-	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, cfg.Rollups[0].L2ChainID.Uint64(), sources, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
+	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, eth.ChainIDFromBig(cfg.Rollups[0].L2ChainID), sources, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
 }
 
 type programExecutor struct {
@@ -110,7 +111,7 @@ func (p *programExecutor) RunProgram(
 	ctx context.Context,
 	prefetcher hostcommon.Prefetcher,
 	blockNum uint64,
-	chainID uint64,
+	chainID eth.ChainID,
 ) error {
 	newCfg := *p.cfg
 	newCfg.L2ChainID = chainID

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -38,7 +39,7 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 	case l2ClaimBlockNumberKey:
 		return binary.BigEndian.AppendUint64(nil, s.config.L2ClaimBlockNumber), nil
 	case l2ChainIDKey:
-		return binary.BigEndian.AppendUint64(nil, s.config.L2ChainID), nil
+		return binary.BigEndian.AppendUint64(nil, eth.EvilChainIDToUInt64(s.config.L2ChainID)), nil
 	case l2ChainConfigKey:
 		if s.config.L2ChainID != boot.CustomChainIDIndicator {
 			return nil, ErrNotFound

--- a/op-program/host/kvstore/local_test.go
+++ b/op-program/host/kvstore/local_test.go
@@ -11,6 +11,7 @@ import (
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ import (
 
 func TestLocalPreimageSource(t *testing.T) {
 	cfg := &config.Config{
-		L2ChainID:          86,
+		L2ChainID:          eth.ChainIDFromUInt64(86),
 		Rollups:            []*rollup.Config{chaincfg.OPSepolia()},
 		L1Head:             common.HexToHash("0x1111"),
 		L2OutputRoot:       common.HexToHash("0x2222"),

--- a/op-program/host/prefetcher/l2_sources_test.go
+++ b/op-program/host/prefetcher/l2_sources_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -32,7 +33,7 @@ func TestNewL2Sources(t *testing.T) {
 			[]client.RPC{experimentalRpc})
 		require.NoError(t, err)
 		require.Len(t, src.Sources, 1)
-		require.True(t, src.Sources[uint64(4)].ExperimentalEnabled())
+		require.True(t, src.Sources[eth.ChainIDFromUInt64(4)].ExperimentalEnabled())
 	})
 
 	t.Run("MultipleSources", func(t *testing.T) {
@@ -45,8 +46,8 @@ func TestNewL2Sources(t *testing.T) {
 			[]client.RPC{experimentalRpc1, experimentalRpc2})
 		require.NoError(t, err)
 		require.Len(t, src.Sources, 2)
-		require.True(t, src.Sources[uint64(1)].ExperimentalEnabled())
-		require.True(t, src.Sources[uint64(2)].ExperimentalEnabled())
+		require.True(t, src.Sources[eth.ChainIDFromUInt64(1)].ExperimentalEnabled())
+		require.True(t, src.Sources[eth.ChainIDFromUInt64(2)].ExperimentalEnabled())
 	})
 
 	t.Run("ExperimentalRPCsAreOptional", func(t *testing.T) {
@@ -59,11 +60,11 @@ func TestNewL2Sources(t *testing.T) {
 			[]client.RPC{experimentalRpc2})
 		require.NoError(t, err)
 		require.Len(t, src.Sources, 2)
-		require.Same(t, src.Sources[uint64(1)].RollupConfig(), config1)
-		require.False(t, src.Sources[uint64(1)].ExperimentalEnabled())
+		require.Same(t, src.Sources[eth.ChainIDFromUInt64(1)].RollupConfig(), config1)
+		require.False(t, src.Sources[eth.ChainIDFromUInt64(1)].ExperimentalEnabled())
 
-		require.Same(t, src.Sources[uint64(2)].RollupConfig(), config2)
-		require.True(t, src.Sources[uint64(2)].ExperimentalEnabled())
+		require.Same(t, src.Sources[eth.ChainIDFromUInt64(2)].RollupConfig(), config2)
+		require.True(t, src.Sources[eth.ChainIDFromUInt64(2)].ExperimentalEnabled())
 	})
 
 	t.Run("RollupMissingL2URL", func(t *testing.T) {

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -416,7 +416,7 @@ func TestRestrictedPrecompileContracts(t *testing.T) {
 
 func TestFetchL2Block(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
-	chainID := uint64(482948)
+	chainID := eth.ChainIDFromUInt64(482948)
 	block, rcpts := testutils.RandomBlock(rng, 10)
 	hash := block.Hash()
 
@@ -449,7 +449,7 @@ func TestFetchL2Block(t *testing.T) {
 		defer assertAllClientExpectations(t, l2Cls)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
-		result := oracle.BlockByHash(hash, 7)
+		result := oracle.BlockByHash(hash, eth.ChainIDFromUInt64(7))
 		require.EqualValues(t, block.Header(), result.Header())
 		assertTransactionsEqual(t, block.Transactions(), result.Transactions())
 	})
@@ -459,7 +459,7 @@ func TestFetchL2Transactions(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
 	block, rcpts := testutils.RandomBlock(rng, 10)
 	hash := block.Hash()
-	chainID := rng.Uint64()
+	chainID := eth.ChainIDFromUInt64(rng.Uint64())
 
 	t.Run("AlreadyKnown", func(t *testing.T) {
 		prefetcher, _, _, _, kv := createPrefetcher(t)
@@ -488,7 +488,7 @@ func TestFetchL2Transactions(t *testing.T) {
 		defer assertAllClientExpectations(t, l2Cls)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
-		result := oracle.LoadTransactions(hash, block.TxHash(), 7)
+		result := oracle.LoadTransactions(hash, block.TxHash(), eth.ChainIDFromUInt64(7))
 		assertTransactionsEqual(t, block.Transactions(), result)
 	})
 }
@@ -498,7 +498,7 @@ func TestFetchL2Node(t *testing.T) {
 	node := testutils.RandomData(rng, 30)
 	hash := crypto.Keccak256Hash(node)
 	key := preimage.Keccak256Key(hash).PreimageKey()
-	chainID := rng.Uint64()
+	chainID := eth.ChainIDFromUInt64(rng.Uint64())
 
 	t.Run("AlreadyKnown", func(t *testing.T) {
 		prefetcher, _, _, _, kv := createPrefetcher(t)
@@ -527,7 +527,7 @@ func TestFetchL2Node(t *testing.T) {
 		defer assertAllClientExpectations(t, l2Cls)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
-		result := oracle.NodeByHash(hash, 9)
+		result := oracle.NodeByHash(hash, eth.ChainIDFromUInt64(9))
 		require.EqualValues(t, node, result)
 	})
 }
@@ -537,7 +537,7 @@ func TestFetchL2Code(t *testing.T) {
 	code := testutils.RandomData(rng, 30)
 	hash := crypto.Keccak256Hash(code)
 	key := preimage.Keccak256Key(hash).PreimageKey()
-	chainID := rng.Uint64()
+	chainID := eth.ChainIDFromUInt64(rng.Uint64())
 
 	t.Run("AlreadyKnown", func(t *testing.T) {
 		prefetcher, _, _, _, kv := createPrefetcher(t)
@@ -566,7 +566,7 @@ func TestFetchL2Code(t *testing.T) {
 		defer assertAllClientExpectations(t, l2Cls)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
-		result := oracle.CodeByHash(hash, 98)
+		result := oracle.CodeByHash(hash, eth.ChainIDFromUInt64(98))
 		require.EqualValues(t, code, result)
 	})
 }
@@ -581,7 +581,7 @@ func TestFetchL2Output(t *testing.T) {
 		require.NoError(t, kv.Put(key, output.Marshal()))
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), false)
-		result := oracle.OutputByRoot(hash, rng.Uint64())
+		result := oracle.OutputByRoot(hash, eth.ChainIDFromUInt64(rng.Uint64()))
 		require.EqualValues(t, output, result)
 	})
 
@@ -592,7 +592,7 @@ func TestFetchL2Output(t *testing.T) {
 		l2Cl.ExpectOutputByRoot(prefetcher.l2Head, output, nil)
 		defer assertAllClientExpectations(t, l2Cls)
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), false)
-		result := oracle.OutputByRoot(hash, rng.Uint64())
+		result := oracle.OutputByRoot(hash, eth.ChainIDFromUInt64(rng.Uint64()))
 		require.EqualValues(t, output, result)
 	})
 
@@ -616,7 +616,7 @@ func TestFetchL2Output(t *testing.T) {
 		l2Cl.ExpectOutputByNumber(blockNum, output, nil)
 		defer assertAllClientExpectations(t, l2Cls)
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
-		result := oracle.OutputByRoot(hash, 78)
+		result := oracle.OutputByRoot(hash, eth.ChainIDFromUInt64(78))
 		require.EqualValues(t, output, result)
 	})
 }
@@ -767,7 +767,7 @@ func TestRetryWhenNotAvailableAfterPrefetching(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
 	node := testutils.RandomData(rng, 30)
 	hash := crypto.Keccak256Hash(node)
-	chainID := rng.Uint64()
+	chainID := eth.ChainIDFromUInt64(rng.Uint64())
 
 	_, l1Source, l1BlobSource, l2Cls, kv := createPrefetcher(t)
 	putsToIgnore := 2

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	ecRecoverInput    = common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549")
 	kzgPointEvalInput = common.FromHex("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a")
-	defaultChainID    = uint64(14)
+	defaultChainID    = eth.ChainIDFromUInt64(14)
 )
 
 func TestNoHint(t *testing.T) {
@@ -443,8 +443,8 @@ func TestFetchL2Block(t *testing.T) {
 	})
 
 	t.Run("WithChainID", func(t *testing.T) {
-		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, 5, 7, 10)
-		l2Cl := l2Cls.sources[7]
+		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, eth.ChainIDFromUInt64(5), eth.ChainIDFromUInt64(7), eth.ChainIDFromUInt64(10))
+		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(7)]
 		l2Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
 		defer assertAllClientExpectations(t, l2Cls)
 
@@ -482,8 +482,8 @@ func TestFetchL2Transactions(t *testing.T) {
 	})
 
 	t.Run("WithChainID", func(t *testing.T) {
-		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, 5, 7, 10)
-		l2Cl := l2Cls.sources[7]
+		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, eth.ChainIDFromUInt64(5), eth.ChainIDFromUInt64(7), eth.ChainIDFromUInt64(10))
+		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(7)]
 		l2Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
 		defer assertAllClientExpectations(t, l2Cls)
 
@@ -521,8 +521,8 @@ func TestFetchL2Node(t *testing.T) {
 	})
 
 	t.Run("WithChainID", func(t *testing.T) {
-		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, 5, 9, 99)
-		l2Cl := l2Cls.sources[9]
+		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, eth.ChainIDFromUInt64(5), eth.ChainIDFromUInt64(9), eth.ChainIDFromUInt64(99))
+		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(9)]
 		l2Cl.ExpectNodeByHash(hash, node, nil)
 		defer assertAllClientExpectations(t, l2Cls)
 
@@ -560,8 +560,8 @@ func TestFetchL2Code(t *testing.T) {
 	})
 
 	t.Run("WithChainID", func(t *testing.T) {
-		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, 8, 45, 98, 55)
-		l2Cl := l2Cls.sources[98]
+		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, eth.ChainIDFromUInt64(8), eth.ChainIDFromUInt64(45), eth.ChainIDFromUInt64(98), eth.ChainIDFromUInt64(55))
+		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(98)]
 		l2Cl.ExpectCodeByHash(hash, code, nil)
 		defer assertAllClientExpectations(t, l2Cls)
 
@@ -603,15 +603,15 @@ func TestFetchL2Output(t *testing.T) {
 		superV1 := eth.SuperV1{
 			Timestamp: timestamp,
 			Chains: []eth.ChainIDAndOutput{
-				{ChainID: 6, Output: eth.OutputRoot(chain6Output)},
-				{ChainID: 78, Output: eth.OutputRoot(output)},
-				{ChainID: 99, Output: eth.OutputRoot(chain99Output)},
+				{ChainID: eth.ChainIDFromUInt64(6), Output: eth.OutputRoot(chain6Output)},
+				{ChainID: eth.ChainIDFromUInt64(78), Output: eth.OutputRoot(output)},
+				{ChainID: eth.ChainIDFromUInt64(99), Output: eth.OutputRoot(chain99Output)},
 			},
 		}
-		prefetcher, _, _, l2Cls, _ := createPrefetcherWithAgreedPrestate(t, superV1.Marshal(), 6, 78, 99)
+		prefetcher, _, _, l2Cls, _ := createPrefetcherWithAgreedPrestate(t, superV1.Marshal(), eth.ChainIDFromUInt64(6), eth.ChainIDFromUInt64(78), eth.ChainIDFromUInt64(99))
 
-		l2Cl := l2Cls.sources[78]
-		blockNum, err := l2Cls.sources[78].RollupConfig().TargetBlockNumber(timestamp)
+		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(78)]
+		blockNum, err := l2Cls.sources[eth.ChainIDFromUInt64(78)].RollupConfig().TargetBlockNumber(timestamp)
 		require.NoError(t, err)
 		l2Cl.ExpectOutputByNumber(blockNum, output, nil)
 		defer assertAllClientExpectations(t, l2Cls)
@@ -622,7 +622,7 @@ func TestFetchL2Output(t *testing.T) {
 }
 
 func TestFetchL2BlockData(t *testing.T) {
-	chainID := uint64(14)
+	chainID := eth.ChainIDFromUInt64(14)
 
 	testBlockExec := func(t *testing.T, clientErrs []error) {
 		require.NotEmpty(t, clientErrs)
@@ -772,10 +772,10 @@ func TestRetryWhenNotAvailableAfterPrefetching(t *testing.T) {
 	_, l1Source, l1BlobSource, l2Cls, kv := createPrefetcher(t)
 	putsToIgnore := 2
 	kv = &unreliableKvStore{KV: kv, putsToIgnore: putsToIgnore}
-	sources := &l2Clients{sources: map[uint64]*l2Client{6: l2Cls.sources[defaultChainID]}}
-	prefetcher := NewPrefetcher(testlog.Logger(t, log.LevelInfo), l1Source, l1BlobSource, 6, sources, kv, nil, common.Hash{}, nil)
+	sources := &l2Clients{sources: map[eth.ChainID]*l2Client{eth.ChainIDFromUInt64(6): l2Cls.sources[defaultChainID]}}
+	prefetcher := NewPrefetcher(testlog.Logger(t, log.LevelInfo), l1Source, l1BlobSource, eth.ChainIDFromUInt64(6), sources, kv, nil, common.Hash{}, nil)
 
-	l2Cl := sources.sources[6]
+	l2Cl := sources.sources[eth.ChainIDFromUInt64(6)]
 	// Expect one call for each ignored put, plus one more request for when the put succeeds
 	for i := 0; i < putsToIgnore+1; i++ {
 		l2Cl.ExpectNodeByHash(hash, node, nil)
@@ -802,10 +802,10 @@ func (s *unreliableKvStore) Put(k common.Hash, v []byte) error {
 }
 
 type l2Clients struct {
-	sources map[uint64]*l2Client
+	sources map[eth.ChainID]*l2Client
 }
 
-func (l *l2Clients) ForChainID(id uint64) (hostTypes.L2Source, error) {
+func (l *l2Clients) ForChainID(id eth.ChainID) (hostTypes.L2Source, error) {
 	source, ok := l.sources[id]
 	if !ok {
 		return nil, fmt.Errorf("no such source for chain %d", id)
@@ -813,7 +813,7 @@ func (l *l2Clients) ForChainID(id uint64) (hostTypes.L2Source, error) {
 	return source, nil
 }
 
-func (l *l2Clients) ForChainIDWithoutRetries(id uint64) (hostTypes.L2Source, error) {
+func (l *l2Clients) ForChainIDWithoutRetries(id eth.ChainID) (hostTypes.L2Source, error) {
 	return l.ForChainID(id)
 }
 
@@ -849,11 +849,11 @@ func (m *l2Client) ExpectOutputByNumber(blockNum uint64, output eth.Output, err 
 	m.Mock.On("OutputByNumber", blockNum).Once().Return(output, &err)
 }
 
-func createPrefetcher(t *testing.T, chainIDs ...uint64) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Clients, kvstore.KV) {
+func createPrefetcher(t *testing.T, chainIDs ...eth.ChainID) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Clients, kvstore.KV) {
 	return createPrefetcherWithAgreedPrestate(t, nil, chainIDs...)
 }
 
-func createPrefetcherWithAgreedPrestate(t *testing.T, agreedPrestate []byte, chainIDs ...uint64) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Clients, kvstore.KV) {
+func createPrefetcherWithAgreedPrestate(t *testing.T, agreedPrestate []byte, chainIDs ...eth.ChainID) (*Prefetcher, *testutils.MockL1Source, *testutils.MockBlobsFetcher, *l2Clients, kvstore.KV) {
 	logger := testlog.Logger(t, log.LevelDebug)
 	kv := kvstore.NewMemKV()
 
@@ -862,10 +862,10 @@ func createPrefetcherWithAgreedPrestate(t *testing.T, agreedPrestate []byte, cha
 
 	// Provide a default chain if none specified.
 	if len(chainIDs) == 0 {
-		chainIDs = []uint64{defaultChainID}
+		chainIDs = []eth.ChainID{defaultChainID}
 	}
 
-	l2Sources := &l2Clients{sources: make(map[uint64]*l2Client)}
+	l2Sources := &l2Clients{sources: make(map[eth.ChainID]*l2Client)}
 	for i, chainID := range chainIDs {
 		l2Source := &l2Client{
 			rollupCfg: &rollup.Config{
@@ -985,11 +985,11 @@ func (o *legacyPrecompileOracle) Precompile(address common.Address, input []byte
 type mockExecutor struct {
 	invoked     bool
 	blockNumber uint64
-	chainID     uint64
+	chainID     eth.ChainID
 }
 
 func (m *mockExecutor) RunProgram(
-	ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID uint64) error {
+	ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID) error {
 	m.invoked = true
 	m.blockNumber = blockNumber
 	m.chainID = chainID

--- a/op-program/host/prefetcher/reexec.go
+++ b/op-program/host/prefetcher/reexec.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -12,14 +13,14 @@ import (
 
 type ProgramExecutor interface {
 	// RunProgram derives the block at the specified blockNumber
-	RunProgram(ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID uint64) error
+	RunProgram(ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID) error
 }
 
 // nativeReExecuteBlock is a helper function that re-executes a block natively.
 // It is used to populate the kv store with the data needed for the program to
 // re-derive the block.
 func (p *Prefetcher) nativeReExecuteBlock(
-	ctx context.Context, agreedBlockHash, blockHash common.Hash, chainID uint64) error {
+	ctx context.Context, agreedBlockHash, blockHash common.Hash, chainID eth.ChainID) error {
 	// Avoid using the retrying source to prevent indefinite retries as the block may not be canonical and unavailable
 	source, err := p.l2Sources.ForChainIDWithoutRetries(chainID)
 	if err != nil {

--- a/op-program/host/types/types.go
+++ b/op-program/host/types/types.go
@@ -31,6 +31,6 @@ type L2Source interface {
 }
 
 type L2Sources interface {
-	ForChainID(chainID uint64) (L2Source, error)
-	ForChainIDWithoutRetries(chainID uint64) (L2Source, error)
+	ForChainID(chainID eth.ChainID) (L2Source, error)
+	ForChainIDWithoutRetries(chainID eth.ChainID) (L2Source, error)
 }

--- a/op-program/verify/devnet/cmd/devnet.go
+++ b/op-program/verify/devnet/cmd/devnet.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/ethereum-optimism/optimism/op-program/verify"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -44,7 +45,7 @@ func main() {
 	}
 
 	// Apply the custom configs by running op-program
-	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "901", 901, false)
+	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "901", eth.ChainIDFromUInt64(901), false)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())
 		os.Exit(1)

--- a/op-program/verify/mainnet/cmd/mainnet.go
+++ b/op-program/verify/mainnet/cmd/mainnet.go
@@ -7,10 +7,11 @@ import (
 	"os"
 
 	"github.com/ethereum-optimism/optimism/op-program/verify"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const opMainnetChainID = 10
+var opMainnetChainID = eth.ChainIDFromUInt64(10)
 
 func main() {
 	var l1RpcUrl string

--- a/op-program/verify/sepolia/cmd/sepolia.go
+++ b/op-program/verify/sepolia/cmd/sepolia.go
@@ -7,10 +7,11 @@ import (
 	"os"
 
 	"github.com/ethereum-optimism/optimism/op-program/verify"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const opSepoliaChainID = 11155420
+var opSepoliaChainID = eth.ChainIDFromUInt64(11155420)
 
 func main() {
 	var l1RpcUrl string

--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -43,7 +43,7 @@ type Runner struct {
 	runInProcess bool
 }
 
-func NewRunner(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string, dataDir string, network string, chainID uint64, runInProcess bool) (*Runner, error) {
+func NewRunner(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl string, dataDir string, network string, chainID eth.ChainID, runInProcess bool) (*Runner, error) {
 	ctx := context.Background()
 	logCfg := oplog.DefaultCLIConfig()
 	logCfg.Level = log.LevelDebug

--- a/op-service/eth/chain_id.go
+++ b/op-service/eth/chain_id.go
@@ -18,6 +18,19 @@ func ChainIDFromUInt64(i uint64) ChainID {
 	return ChainID(*uint256.NewInt(i))
 }
 
+func ChainIDFromBytes32(b [32]byte) ChainID {
+	val := new(uint256.Int).SetBytes(b[:])
+	return ChainID(*val)
+}
+
+func ParseDecimalChainID(chainID string) (ChainID, error) {
+	v, err := uint256.FromDecimal(chainID)
+	if err != nil {
+		return ChainID{}, err
+	}
+	return ChainID(*v), nil
+}
+
 func (id ChainID) String() string {
 	return ((*uint256.Int)(&id)).Dec()
 }
@@ -32,6 +45,22 @@ func (id ChainID) ToUInt32() (uint32, error) {
 		return 0, fmt.Errorf("ChainID too large for uint32: %v", id)
 	}
 	return uint32(v64), nil
+}
+
+func (id ChainID) Bytes32() [32]byte {
+	return (*uint256.Int)(&id).Bytes32()
+}
+
+// EvilChainIDToUInt64 converts a ChainID to a uint64 and panic's if the ChainID is too large for a UInt64
+// It is "evil" because 32 byte ChainIDs should be universally supported which this method breaks. It is provided
+// for legacy purposes to facilitate a transition to full 32 byte chain ID support and should not be used in new code.
+// Existing calls should be replaced with full 32 byte support whenever possible.
+func EvilChainIDToUInt64(id ChainID) uint64 {
+	v := (*uint256.Int)(&id)
+	if !v.IsUint64() {
+		panic(fmt.Errorf("ChainID too large for uint64: %v", id))
+	}
+	return v.Uint64()
 }
 
 func (id *ChainID) ToBig() *big.Int {

--- a/op-service/eth/super_root.go
+++ b/op-service/eth/super_root.go
@@ -1,7 +1,6 @@
 package eth
 
 import (
-	"cmp"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -35,20 +34,21 @@ func SuperRoot(super Super) Bytes32 {
 }
 
 type ChainIDAndOutput struct {
-	ChainID uint64
+	ChainID ChainID
 	Output  Bytes32
 }
 
 func (c *ChainIDAndOutput) Marshal() []byte {
 	d := make([]byte, 64)
-	binary.BigEndian.PutUint64(d[24:32], c.ChainID)
+	chainID := c.ChainID.Bytes32()
+	copy(d[0:32], chainID[:])
 	copy(d[32:], c.Output[:])
 	return d
 }
 
 func NewSuperV1(timestamp uint64, chains ...ChainIDAndOutput) *SuperV1 {
 	slices.SortFunc(chains, func(a, b ChainIDAndOutput) int {
-		return cmp.Compare(a.ChainID, b.ChainID)
+		return a.ChainID.Cmp(b.ChainID)
 	})
 	return &SuperV1{
 		Timestamp: timestamp,
@@ -103,7 +103,7 @@ func unmarshalSuperRootV1(data []byte) (*SuperV1, error) {
 	output.Timestamp = binary.BigEndian.Uint64(data[1:9])
 	for i := 9; i < len(data); i += 64 {
 		chainOutput := ChainIDAndOutput{
-			ChainID: binary.BigEndian.Uint64(data[i+24 : i+32]),
+			ChainID: ChainIDFromBytes32([32]byte(data[i : i+32])),
 			Output:  Bytes32(data[i+32 : i+64]),
 		}
 		output.Chains = append(output.Chains, chainOutput)

--- a/op-service/eth/super_root_test.go
+++ b/op-service/eth/super_root_test.go
@@ -19,9 +19,9 @@ func TestUnmarshalSuperRoot_TooShortForVersion(t *testing.T) {
 
 func TestSuperRootV1Codec(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		chainA := ChainIDAndOutput{ChainID: 11, Output: Bytes32{0x01}}
-		chainB := ChainIDAndOutput{ChainID: 12, Output: Bytes32{0x02}}
-		chainC := ChainIDAndOutput{ChainID: 13, Output: Bytes32{0x03}}
+		chainA := ChainIDAndOutput{ChainID: ChainIDFromUInt64(11), Output: Bytes32{0x01}}
+		chainB := ChainIDAndOutput{ChainID: ChainIDFromUInt64(12), Output: Bytes32{0x02}}
+		chainC := ChainIDAndOutput{ChainID: ChainIDFromUInt64(13), Output: Bytes32{0x03}}
 		superRoot := SuperV1{
 			Timestamp: 7000,
 			Chains:    []ChainIDAndOutput{chainA, chainB, chainC},

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -540,7 +540,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 			Canonical: canonicalRoot,
 			Pending:   pending.Marshal(),
 		}
-		superRootChains[i] = eth.ChainIDAndOutput{ChainID: chainID.ToBig().Uint64(), Output: canonicalRoot}
+		superRootChains[i] = eth.ChainIDAndOutput{ChainID: chainID, Output: canonicalRoot}
 	}
 	superRoot := eth.SuperRoot(&eth.SuperV1{
 		Timestamp: uint64(timestamp),


### PR DESCRIPTION
**Description**

Start moving op-program over to using `eth.ChainID` instead of `uint64` for chain IDs.

Introduces `EvilChainIDToUInt64` to facilitate migrating in parts rather than having to support 32 byte chain IDs everywhere immediately.  The `Evil` prefix makes it clear this is not a method we want to be using and we can search for usages of it to continue making progress towards removing 64bit limitations.  And after that we can start looking at `ChainIDFromUInt64 though that's also useful for making ChainID instances from constants for testing.

Key starting points for conversion were the op-program boot info and the new super root type.

**Tests**

Should be no change in functionality.
