### PR TITLE
op-node,op-service: Add Timeout Flag for L2 Engine

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -209,6 +209,13 @@ var (
 		}(),
 		Category: RollupCategory,
 	}
+	L2EngineRpcTimeout = &cli.DurationFlag{
+		Name:     "l2.engine-rpc-timeout",
+		Usage:    "L2 engine client rpc timeout",
+		EnvVars:  prefixEnvVars("L2_ENGINE_RPC_TIMEOUT"),
+		Value:    time.Second * 10,
+		Category: RollupCategory,
+	}
 	VerifierL1Confs = &cli.Uint64Flag{
 		Name:     "verifier.l1-confs",
 		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
@@ -459,6 +466,7 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
 	L2EngineKind,
+	L2EngineRpcTimeout,
 	InteropSupervisor,
 	InteropRPCAddr,
 	InteropRPCPort,

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -47,6 +47,10 @@ type L2EndpointConfig struct {
 	// JWT secrets for L2 Engine API authentication during HTTP or initial Websocket communication.
 	// Any value for an IPC connection.
 	L2EngineJWTSecret [32]byte
+
+	// L2EngineCallTimeout is the default timeout duration for L2 calls.
+	// Defines the maximum time a call to the L2 engine is allowed to take before timing out.
+	L2EngineCallTimeout time.Duration
 }
 
 var _ L2EndpointSetup = (*L2EndpointConfig)(nil)
@@ -67,6 +71,7 @@ func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger, rollupCf
 	opts := []client.RPCOption{
 		client.WithGethRPCOptions(auth),
 		client.WithDialAttempts(10),
+		client.WithCallTimeout(cfg.L2EngineCallTimeout),
 	}
 	l2Node, err := client.NewRPC(ctx, log, cfg.L2EngineAddr, opts...)
 	if err != nil {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -171,9 +171,11 @@ func NewL2EndpointConfig(ctx *cli.Context, logger log.Logger) (*node.L2EndpointC
 	if err != nil {
 		return nil, err
 	}
+	l2RpcTimeout := ctx.Duration(flags.L2EngineRpcTimeout.Name)
 	return &node.L2EndpointConfig{
-		L2EngineAddr:      l2Addr,
-		L2EngineJWTSecret: secret,
+		L2EngineAddr:        l2Addr,
+		L2EngineJWTSecret:   secret,
+		L2EngineCallTimeout: l2RpcTimeout,
 	}, nil
 }
 


### PR DESCRIPTION
**Description**

This PR allows the timeout duration for op-geth RPC calls from op-node to be adjusted via a flag.

During the implementation, it was discovered that a 5-second timeout is set in the engine_forkchoiceUpdatedV3 call, while the BaseRPCClient has a default 10-second timeout. These overlapping timeout settings have also been removed.

For more details: #13852 

**Tests**

**Additional context**

**Metadata**
