### PR TITLE
op-deployer: Improve default hardfork choice

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
+
 	"github.com/BurntSushi/toml"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
@@ -333,6 +337,27 @@ func ArtifactsHashForTag(tag string) (common.Hash, error) {
 	default:
 		return common.Hash{}, fmt.Errorf("unsupported tag: %s", tag)
 	}
+}
+
+// DefaultHardforkScheduleForTag is used to determine which hardforks should be activated by default given a
+// contract tag. For example, passing in v1.6.0 will return all hardforks up to and including Granite. This allows
+// OP Deployer to set sane defaults for hardforks. This is not an ideal solution, but it will have to work until we get
+// to MCP L2.
+func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployConfig {
+	sched := &genesis.UpgradeScheduleDeployConfig{
+		L2GenesisRegolithTimeOffset: op_service.U64UtilPtr(0),
+		L2GenesisCanyonTimeOffset:   op_service.U64UtilPtr(0),
+		L2GenesisDeltaTimeOffset:    op_service.U64UtilPtr(0),
+		L2GenesisEcotoneTimeOffset:  op_service.U64UtilPtr(0),
+		L2GenesisFjordTimeOffset:    op_service.U64UtilPtr(0),
+		L2GenesisGraniteTimeOffset:  op_service.U64UtilPtr(0),
+	}
+
+	if tag == "op-contracts/v1.8.0-rc.4" {
+		sched.ActivateForkAtGenesis(rollup.Holocene)
+	}
+
+	return sched
 }
 
 func standardArtifactsURL(checksum string) string {

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -353,7 +353,10 @@ func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployCon
 		L2GenesisGraniteTimeOffset:  op_service.U64UtilPtr(0),
 	}
 
-	if tag == "op-contracts/v1.8.0-rc.4" {
+	switch tag {
+	case ContractsV160Tag, ContractsV170Beta1L2Tag:
+		return sched
+	default:
 		sched.ActivateForkAtGenesis(rollup.Holocene)
 	}
 

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -1,0 +1,15 @@
+package standard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultHardforkScheduleForTag(t *testing.T) {
+	sched := DefaultHardforkScheduleForTag(ContractsV160Tag)
+	require.Nil(t, sched.HoloceneTime(0))
+
+	sched = DefaultHardforkScheduleForTag(ContractsV180Tag)
+	require.NotNil(t, sched.HoloceneTime(0))
+}

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
@@ -25,6 +27,11 @@ var (
 )
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
+	upgradeSchedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
+	if intent.UseInterop {
+		upgradeSchedule.UseInterop = true
+	}
+
 	cfg := genesis.DeployConfig{
 		L1DependenciesConfig: genesis.L1DependenciesConfig{
 			L1StandardBridgeProxy:       chainState.L1StandardBridgeProxyAddress,
@@ -73,16 +80,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 			// Any upgrades you enable here will be enabled for all new deployments.
 			// In-development hardforks should never be activated here. Instead, they
 			// should be specified as overrides.
-			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
-				L2GenesisRegolithTimeOffset: op_service.U64UtilPtr(0),
-				L2GenesisCanyonTimeOffset:   op_service.U64UtilPtr(0),
-				L2GenesisDeltaTimeOffset:    op_service.U64UtilPtr(0),
-				L2GenesisEcotoneTimeOffset:  op_service.U64UtilPtr(0),
-				L2GenesisFjordTimeOffset:    op_service.U64UtilPtr(0),
-				L2GenesisGraniteTimeOffset:  op_service.U64UtilPtr(0),
-				L2GenesisHoloceneTimeOffset: op_service.U64UtilPtr(0),
-				UseInterop:                  intent.UseInterop,
-			},
+			UpgradeScheduleDeployConfig: *upgradeSchedule,
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
 				L1ChainID:                 intent.L1ChainID,
 				L2ChainID:                 chainState.ID.Big().Uint64(),

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -3,6 +3,9 @@ package state
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
@@ -10,7 +13,8 @@ import (
 
 func TestCombineDeployConfig(t *testing.T) {
 	intent := Intent{
-		L1ChainID: 1,
+		L1ChainID:          1,
+		L1ContractsLocator: artifacts.MustNewLocatorFromTag(standard.ContractsV170Beta1L2Tag),
 	}
 	chainState := ChainState{
 		ID: common.HexToHash("0x123"),


### PR DESCRIPTION
The deploy config was previously created with Holocene activated by default. This PR updates the hardfork selection logic to choose default hardforks based on the contracts version.
