### PR TITLE
txmgr: Add custom publish error message handling

### DIFF
--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -27,17 +27,18 @@ const (
 	HDPathFlagName     = "hd-path"
 	PrivateKeyFlagName = "private-key"
 	// TxMgr Flags (new + legacy + some shared flags)
-	NumConfirmationsFlagName          = "num-confirmations"
-	SafeAbortNonceTooLowCountFlagName = "safe-abort-nonce-too-low-count"
-	FeeLimitMultiplierFlagName        = "fee-limit-multiplier"
-	FeeLimitThresholdFlagName         = "txmgr.fee-limit-threshold"
-	MinBaseFeeFlagName                = "txmgr.min-basefee"
-	MinTipCapFlagName                 = "txmgr.min-tip-cap"
-	ResubmissionTimeoutFlagName       = "resubmission-timeout"
-	NetworkTimeoutFlagName            = "network-timeout"
-	TxSendTimeoutFlagName             = "txmgr.send-timeout"
-	TxNotInMempoolTimeoutFlagName     = "txmgr.not-in-mempool-timeout"
-	ReceiptQueryIntervalFlagName      = "txmgr.receipt-query-interval"
+	NumConfirmationsFlagName           = "num-confirmations"
+	SafeAbortNonceTooLowCountFlagName  = "safe-abort-nonce-too-low-count"
+	FeeLimitMultiplierFlagName         = "fee-limit-multiplier"
+	FeeLimitThresholdFlagName          = "txmgr.fee-limit-threshold"
+	MinBaseFeeFlagName                 = "txmgr.min-basefee"
+	MinTipCapFlagName                  = "txmgr.min-tip-cap"
+	ResubmissionTimeoutFlagName        = "resubmission-timeout"
+	NetworkTimeoutFlagName             = "network-timeout"
+	TxSendTimeoutFlagName              = "txmgr.send-timeout"
+	TxNotInMempoolTimeoutFlagName      = "txmgr.not-in-mempool-timeout"
+	ReceiptQueryIntervalFlagName       = "txmgr.receipt-query-interval"
+	AlreadyPublishedCustomErrsFlagName = "txmgr.already-published-custom-errs"
 )
 
 var (
@@ -191,28 +192,34 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 			Value:   defaults.ReceiptQueryInterval,
 			EnvVars: prefixEnvVars("TXMGR_RECEIPT_QUERY_INTERVAL"),
 		},
+		&cli.StringSliceFlag{
+			Name:    AlreadyPublishedCustomErrsFlagName,
+			Usage:   "List of custom RPC error messages that indicate that a transaction has already been published.",
+			EnvVars: prefixEnvVars("ALREADY_PUBLISHED_CUSTOM_ERRS"),
+		},
 	}, opsigner.CLIFlags(envPrefix, "")...)
 }
 
 type CLIConfig struct {
-	L1RPCURL                  string
-	Mnemonic                  string
-	HDPath                    string
-	SequencerHDPath           string
-	L2OutputHDPath            string
-	PrivateKey                string
-	SignerCLIConfig           opsigner.CLIConfig
-	NumConfirmations          uint64
-	SafeAbortNonceTooLowCount uint64
-	FeeLimitMultiplier        uint64
-	FeeLimitThresholdGwei     float64
-	MinBaseFeeGwei            float64
-	MinTipCapGwei             float64
-	ResubmissionTimeout       time.Duration
-	ReceiptQueryInterval      time.Duration
-	NetworkTimeout            time.Duration
-	TxSendTimeout             time.Duration
-	TxNotInMempoolTimeout     time.Duration
+	L1RPCURL                   string
+	Mnemonic                   string
+	HDPath                     string
+	SequencerHDPath            string
+	L2OutputHDPath             string
+	PrivateKey                 string
+	SignerCLIConfig            opsigner.CLIConfig
+	NumConfirmations           uint64
+	SafeAbortNonceTooLowCount  uint64
+	FeeLimitMultiplier         uint64
+	FeeLimitThresholdGwei      float64
+	MinBaseFeeGwei             float64
+	MinTipCapGwei              float64
+	ResubmissionTimeout        time.Duration
+	ReceiptQueryInterval       time.Duration
+	NetworkTimeout             time.Duration
+	TxSendTimeout              time.Duration
+	TxNotInMempoolTimeout      time.Duration
+	AlreadyPublishedCustomErrs []string
 }
 
 func NewCLIConfig(l1RPCURL string, defaults DefaultFlagValues) CLIConfig {
@@ -270,24 +277,25 @@ func (m CLIConfig) Check() error {
 
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	return CLIConfig{
-		L1RPCURL:                  ctx.String(L1RPCFlagName),
-		Mnemonic:                  ctx.String(MnemonicFlagName),
-		HDPath:                    ctx.String(HDPathFlagName),
-		SequencerHDPath:           ctx.String(SequencerHDPathFlag.Name),
-		L2OutputHDPath:            ctx.String(L2OutputHDPathFlag.Name),
-		PrivateKey:                ctx.String(PrivateKeyFlagName),
-		SignerCLIConfig:           opsigner.ReadCLIConfig(ctx),
-		NumConfirmations:          ctx.Uint64(NumConfirmationsFlagName),
-		SafeAbortNonceTooLowCount: ctx.Uint64(SafeAbortNonceTooLowCountFlagName),
-		FeeLimitMultiplier:        ctx.Uint64(FeeLimitMultiplierFlagName),
-		FeeLimitThresholdGwei:     ctx.Float64(FeeLimitThresholdFlagName),
-		MinBaseFeeGwei:            ctx.Float64(MinBaseFeeFlagName),
-		MinTipCapGwei:             ctx.Float64(MinTipCapFlagName),
-		ResubmissionTimeout:       ctx.Duration(ResubmissionTimeoutFlagName),
-		ReceiptQueryInterval:      ctx.Duration(ReceiptQueryIntervalFlagName),
-		NetworkTimeout:            ctx.Duration(NetworkTimeoutFlagName),
-		TxSendTimeout:             ctx.Duration(TxSendTimeoutFlagName),
-		TxNotInMempoolTimeout:     ctx.Duration(TxNotInMempoolTimeoutFlagName),
+		L1RPCURL:                   ctx.String(L1RPCFlagName),
+		Mnemonic:                   ctx.String(MnemonicFlagName),
+		HDPath:                     ctx.String(HDPathFlagName),
+		SequencerHDPath:            ctx.String(SequencerHDPathFlag.Name),
+		L2OutputHDPath:             ctx.String(L2OutputHDPathFlag.Name),
+		PrivateKey:                 ctx.String(PrivateKeyFlagName),
+		SignerCLIConfig:            opsigner.ReadCLIConfig(ctx),
+		NumConfirmations:           ctx.Uint64(NumConfirmationsFlagName),
+		SafeAbortNonceTooLowCount:  ctx.Uint64(SafeAbortNonceTooLowCountFlagName),
+		FeeLimitMultiplier:         ctx.Uint64(FeeLimitMultiplierFlagName),
+		FeeLimitThresholdGwei:      ctx.Float64(FeeLimitThresholdFlagName),
+		MinBaseFeeGwei:             ctx.Float64(MinBaseFeeFlagName),
+		MinTipCapGwei:              ctx.Float64(MinTipCapFlagName),
+		ResubmissionTimeout:        ctx.Duration(ResubmissionTimeoutFlagName),
+		ReceiptQueryInterval:       ctx.Duration(ReceiptQueryIntervalFlagName),
+		NetworkTimeout:             ctx.Duration(NetworkTimeoutFlagName),
+		TxSendTimeout:              ctx.Duration(TxSendTimeoutFlagName),
+		TxNotInMempoolTimeout:      ctx.Duration(TxNotInMempoolTimeoutFlagName),
+		AlreadyPublishedCustomErrs: ctx.StringSlice(AlreadyPublishedCustomErrsFlagName),
 	}
 }
 
@@ -339,16 +347,18 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	}
 
 	res := Config{
-		Backend:                   l1,
-		ChainID:                   chainID,
-		TxSendTimeout:             cfg.TxSendTimeout,
-		TxNotInMempoolTimeout:     cfg.TxNotInMempoolTimeout,
-		NetworkTimeout:            cfg.NetworkTimeout,
-		ReceiptQueryInterval:      cfg.ReceiptQueryInterval,
-		NumConfirmations:          cfg.NumConfirmations,
-		SafeAbortNonceTooLowCount: cfg.SafeAbortNonceTooLowCount,
-		Signer:                    signerFactory(chainID),
-		From:                      from,
+		Backend: l1,
+		ChainID: chainID,
+		Signer:  signerFactory(chainID),
+		From:    from,
+
+		TxSendTimeout:              cfg.TxSendTimeout,
+		TxNotInMempoolTimeout:      cfg.TxNotInMempoolTimeout,
+		NetworkTimeout:             cfg.NetworkTimeout,
+		ReceiptQueryInterval:       cfg.ReceiptQueryInterval,
+		NumConfirmations:           cfg.NumConfirmations,
+		SafeAbortNonceTooLowCount:  cfg.SafeAbortNonceTooLowCount,
+		AlreadyPublishedCustomErrs: cfg.AlreadyPublishedCustomErrs,
 	}
 
 	res.ResubmissionTimeout.Store(int64(cfg.ResubmissionTimeout))
@@ -422,6 +432,10 @@ type Config struct {
 	// GasPriceEstimatorFn is used to estimate the gas price for a transaction.
 	// If nil, DefaultGasPriceEstimatorFn is used.
 	GasPriceEstimatorFn GasPriceEstimatorFn
+
+	// List of custom RPC error messages that indicate that a transaction has
+	// already been published.
+	AlreadyPublishedCustomErrs []string
 }
 
 func (m *Config) Check() error {

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -195,7 +195,7 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 		&cli.StringSliceFlag{
 			Name:    AlreadyPublishedCustomErrsFlagName,
 			Usage:   "List of custom RPC error messages that indicate that a transaction has already been published.",
-			EnvVars: prefixEnvVars("ALREADY_PUBLISHED_CUSTOM_ERRS"),
+			EnvVars: prefixEnvVars("TXMGR_ALREADY_PUBLISHED_CUSTOM_ERRS"),
 		},
 	}, opsigner.CLIFlags(envPrefix, "")...)
 }


### PR DESCRIPTION
**Description**

This PR adds the ability to configure a "List of custom RPC error messages that indicate that a transaction has already been published."
Some (proprietary) RPC providers respond with custom errors when a transaction got already published or even mined, see #13739. This would let the txmgr enter a publishing loop repeatedly hitting the same error that should be interpreted as a signal that a transaction actually already got published. 

**Tests**

Added a test that a custom rpc error returned from a transaction publication is interpreted as a successful send.

**Metadata**

Fixes #13739
