### PR TITLE
Update foundry versions and update ci-builder

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -28,9 +28,9 @@ just = "1.37.0"
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
-forge = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
-cast = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
-anvil = "nightly-017c59d6806ce11f1dc131f8607178efad79d84a"
+forge = "nightly-a038646cde347afaae67cc955c1e99c22dc23875"
+cast = "nightly-a038646cde347afaae67cc955c1e99c22dc23875"
+anvil = "nightly-a038646cde347afaae67cc955c1e99c22dc23875"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't


### PR DESCRIPTION
This PR contains 2 commits: 

1. Bumps the foundry versions. This commit is tagged with [ci-builder/v0.56.0](https://github.com/ethereum-optimism/optimism/releases/tag/ci-builder/v0.56.0)
2. Bumps the ci-builder version in the CCI config.