### PR TITLE
Update CCI builder version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.55.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.56.0
   ci_builder_rust_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:latest

--- a/ops/check-changed/.gitignore
+++ b/ops/check-changed/.gitignore
@@ -1,1 +1,2 @@
-venv
+# Created by venv; see https://docs.python.org/3/library/venv.html
+*

--- a/ops/check-changed/requirements.txt
+++ b/ops/check-changed/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2024.7.4
-cffi==1.15.1
+cffi==1.17.1
 charset-normalizer==2.1.1
 Deprecated==1.2.13
 idna==3.7


### PR DESCRIPTION
Builds on https://github.com/ethereum-optimism/optimism/pull/13857, to update the versions of foundry tools running in CI.