### PR TITLE
ci: Upload cannon prestates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1591,12 +1591,11 @@ workflows:
             - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
-          #            - op-e2e-cannon-tests
+            - op-e2e-cannon-tests
           filters:
             branches:
               only:
                 - develop
-                - aj-upload-prestates
 
   develop-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1005,11 +1005,11 @@ jobs:
           name: Upload cannon prestates
           command: |
             gsutil cp ./op-program/bin/prestate.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/,<<pipeline.git.branch>>.bin.gz
+              gs://oplabs-network-data/proofs/op-program/cannon/<<pipeline.git.branch>>.bin.gz
             gsutil cp ./op-program/bin/prestate-mt64.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/,<<pipeline.git.branch>>-mt64.bin.gz
+              gs://oplabs-network-data/proofs/op-program/cannon/<<pipeline.git.branch>>-mt64.bin.gz
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/,<<pipeline.git.branch>>-interop.bin.gz
+              gs://oplabs-network-data/proofs/op-program/cannon/<<pipeline.git.branch>>-interop.bin.gz
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -990,6 +990,29 @@ jobs:
             - "op-program/bin"
             - "cannon/bin"
 
+  publish-cannon-prestates:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - attach_workspace:
+          at: "."
+      - gcp-cli/install
+      - gcp-oidc-authenticate:
+          gcp_cred_config_file_path: /root/gcp_cred_config.json
+          oidc_token_file_path: /root/oidc_token.json
+      - run:
+          name: Upload cannon prestates
+          command: |
+            gsutil cp ./op-program/bin/prestate.bin.gz \
+              gs://oplabs-network-data/proofs/op-program/cannon/,<<pipeline.git.branch>>.bin.gz
+            gsutil cp ./op-program/bin/prestate-mt64.bin.gz \
+              gs://oplabs-network-data/proofs/op-program/cannon/,<<pipeline.git.branch>>-mt64.bin.gz
+            gsutil cp ./op-program/bin/prestate-interop.bin.gz \
+              gs://oplabs-network-data/proofs/op-program/cannon/,<<pipeline.git.branch>>-interop.bin.gz
+      - notify-failures-on-develop:
+          mentions: "@proofs-team"
+
   preimage-reproducibility:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -1495,6 +1518,24 @@ workflows:
             - oplabs-gcr-release
           requires:
             - hold
+      - cannon-prestate:
+          filters:
+            tags:
+              only: /^op-program\/v.*/
+            branches:
+              ignore: /.*/
+      - publish-cannon-prestates:
+          context:
+            - slack
+            - oplabs-gcr
+          requires:
+            - cannon-prestate
+          filters:
+            tags:
+              only: /^op-program\/v.*/
+            branches:
+              ignore: /.*/
+
 
   scheduled-todo-issues:
     when:
@@ -1556,6 +1597,18 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
+      - publish-cannon-prestates:
+          context:
+            - slack
+            - oplabs-gcr
+          requires:
+            - cannon-prestate
+#            - op-e2e-cannon-tests
+          filters:
+            branches:
+              only:
+                - develop
+                - aj-upload-prestates
 
   develop-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1527,7 +1527,7 @@ workflows:
       - publish-cannon-prestates:
           context:
             - slack
-            - oplabs-gcr
+            - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
           filters:
@@ -1600,7 +1600,7 @@ workflows:
       - publish-cannon-prestates:
           context:
             - slack
-            - oplabs-gcr
+            - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
 #            - op-e2e-cannon-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -698,7 +698,6 @@ jobs:
             - "/root/.cache/go-build"
       - notify-failures-on-develop
 
-
   contracts-bedrock-tests-upgrade:
     machine: true
     resource_class: ethereum-optimism/latitude-1
@@ -1005,11 +1004,11 @@ jobs:
           name: Upload cannon prestates
           command: |
             gsutil cp ./op-program/bin/prestate.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/<<pipeline.git.branch>>.bin.gz
+              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}.bin.gz
             gsutil cp ./op-program/bin/prestate-mt64.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/<<pipeline.git.branch>>-mt64.bin.gz
+              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-mt64.bin.gz
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/<<pipeline.git.branch>>-interop.bin.gz
+              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-interop.bin.gz
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 
@@ -1536,7 +1535,6 @@ workflows:
             branches:
               ignore: /.*/
 
-
   scheduled-todo-issues:
     when:
       equal: [build_four_hours, <<pipeline.schedule.name>>]
@@ -1603,7 +1601,7 @@ workflows:
             - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
-#            - op-e2e-cannon-tests
+          #            - op-e2e-cannon-tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -995,8 +995,8 @@ jobs:
           command: |
             gsutil cp ./op-program/bin/prestate.bin.gz \
               gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}.bin.gz
-            gsutil cp ./op-program/bin/prestate-mt64.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-mt64.bin.gz
+            gsutil cp ./op-program/bin/prestate-mt.bin.gz \
+              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-mt.bin.gz
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
               gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-interop.bin.gz
       - notify-failures-on-develop:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -965,24 +965,14 @@ jobs:
           command: make -f cannon/Makefile sanitize-program GUEST_PROGRAM=op-program/bin/op-program-client.elf
       - run:
           name: generate cannon prestate
-          command: make cannon-prestate
+          command: make cannon-prestates
       - save_cache:
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
           name: Save Cannon prestate to cache
           paths:
-            - "op-program/bin/prestate.bin.gz"
-            - "op-program/bin/meta.json"
-            - "op-program/bin/prestate-proof.json"
-      - run:
-          name: generate cannon-mt prestate
-          command: make cannon-prestate-mt
-      - save_cache:
-          key: cannon-prestate-mt-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
-          name: Save MT-Cannon prestate to cache
-          paths:
-            - "op-program/bin/prestate-mt.json"
-            - "op-program/bin/meta-mt.json"
-            - "op-program/bin/prestate-proof-mt.json"
+            - "op-program/bin/prestate*.bin.gz"
+            - "op-program/bin/meta*.json"
+            - "op-program/bin/prestate-proof*.json"
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
**Description**

Uploads cannon prestates from develop branch (if cannon e2e tests pass) and on op-program release tags so they are accessible to vm runner for further testing.
