### PR TITLE
semver lock changes demo

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -80,6 +80,23 @@ wrap_comments=true
 #                         PROFILE: CI                          #
 ################################################################
 
+[profile.ci]
+optimizer = true
+optimizer_runs = 999999
+
+additional_compiler_profiles = [
+  { name = "dispute", optimizer_runs = 5000 },
+]
+compilation_restrictions = [
+  { paths = "src/dispute/FaultDisputeGame.sol", optimizer_runs = 5000 },
+  { paths = "src/dispute/PermissionedDisputeGame.sol", optimizer_runs = 5000 },
+]
+
+extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
+bytecode_hash = 'none'
+ast = true
+evm_version = 'cancun'
+
 [profile.ci.fuzz]
 runs = 128
 

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -8,11 +8,11 @@
     "sourceCodeHash": "0x9726b6f646269f4288ff8dc1b8228dedbdf960e90df1d11793bc534297328e96"
   },
   "src/L1/L1ERC721Bridge.sol": {
-    "initCodeHash": "0x280488bce8b4fb364740c59de14c423851902088f384e077bccc79b9df48528a",
+    "initCodeHash": "0x61a509ace719c19ce6e288d2c37ff4671ade678bbd9148e6c10ffe32675eee9c",
     "sourceCodeHash": "0xe12b9e6c4e4ac2e2c9a03f07c7689f6bf2231922536072812cf1f37a5a276e73"
   },
   "src/L1/L1StandardBridge.sol": {
-    "initCodeHash": "0xe69e972e18930d3feaaad20b8e0e15625df9a71ad8304ee7d89c17d32644e152",
+    "initCodeHash": "0x3b7d0cffe4f4bc8c7a2cefe5657c8147656ecdbf387fe70a39ee74fdfaa172c9",
     "sourceCodeHash": "0xc6613d35d1ad95cbef26a503a10b5dd8663ceb80426f8c528835d39f79e4b4cf"
   },
   "src/L1/OPContractsManager.sol": {
@@ -36,7 +36,7 @@
     "sourceCodeHash": "0xd4284db247fc1e686bd4b57755c7ac9a073a173d6df4f93448eb7fb5518882f7"
   },
   "src/L1/SuperchainConfig.sol": {
-    "initCodeHash": "0xcc35362cfd686d2f50e1db8c4a864cbc1eb847eaf58007d8ce7295ae9e101102",
+    "initCodeHash": "0x91410b22e52e82d89a5ee65b00dc3ddc6aa14b86386c8a55c4ebae32208d980b",
     "sourceCodeHash": "0xafa784ea78818a382ff3a61e2d84be58c7978110c06b9273db68c0213ead02d3"
   },
   "src/L1/SystemConfig.sol": {
@@ -104,7 +104,7 @@
     "sourceCodeHash": "0xb67b91f28c8666fee26c40375f835c61629e0f14054bfaf78bc3c61175bbf136"
   },
   "src/L2/OptimismMintableERC721Factory.sol": {
-    "initCodeHash": "0x9ccba9a5db77356c361fe4aea0e93498a56bda9fdac8d5e654d6f7abc4553028",
+    "initCodeHash": "0x174f9ece897365a31525cee030d6ea71864f832ab7dc1c2a56b657fa56122087",
     "sourceCodeHash": "0x2e4b8535b1f7749a0479b2c1de86b3ff79ee4ff6122c6f87c52d66cd301f3f97"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
@@ -136,7 +136,7 @@
     "sourceCodeHash": "0x11d711704a5afcae6076d017ee001b25bc705728973b1ad2e6a32274a8475f50"
   },
   "src/L2/WETH.sol": {
-    "initCodeHash": "0x480d4f8dbec1b0d3211bccbbdfb69796f3e90c784f724b1bbfd4703b0aafdeba",
+    "initCodeHash": "0x4ae485c1327118ac9c1a492fb687502a0eb6079a93b57912ab0d3af201754c74",
     "sourceCodeHash": "0xe9964aa66db1dfc86772958b4c9276697e67f7055529a43e6a49a055009bc995"
   },
   "src/cannon/MIPS.sol": {
@@ -160,11 +160,11 @@
     "sourceCodeHash": "0x745f0e2b07b8f6492e11ca2f69b53d129177fbfd346d5ca4729d72792aff1f83"
   },
   "src/dispute/DelayedWETH.sol": {
-    "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",
+    "initCodeHash": "0x7f523e229213a4c5c52ddac40a03b9eafc8c420444807ea6a9149a627919f81b",
     "sourceCodeHash": "0x0162302b9c71f184d45bee34ecfb1dfbf427f38fc5652709ab7ffef1ac816d82"
   },
   "src/dispute/DisputeGameFactory.sol": {
-    "initCodeHash": "0xa728192115c5fdb08c633a0899043318289b1d413d7afeed06356008b2a5a7fa",
+    "initCodeHash": "0x4179eeaa24838490be82aa5059fa9078ab84b020fe2eddb72aeea1bb44ea8775",
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
@@ -192,7 +192,7 @@
     "sourceCodeHash": "0xfbe7f5733aa57de7557605e40e03e9708fbdec872bc8739c551905c4b1e1b61b"
   },
   "src/safe/LivenessGuard.sol": {
-    "initCodeHash": "0xc8e29e8b12f423c8cd229a38bc731240dd815d96f1b0ab96c71494dde63f6a81",
+    "initCodeHash": "0xb9c1318f86bfc429abfe43b4f051a639aa0707563ff7ca371e72385b218f1f50",
     "sourceCodeHash": "0x72b8d8d855e7af8beee29330f6cb9b9069acb32e23ce940002ec9a41aa012a16"
   },
   "src/safe/LivenessModule.sol": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -4,15 +4,15 @@
     "sourceCodeHash": "0xae49c741c8cd546981ab59b85b88e9fc1055c4fae085e7078d601b42464f86e6"
   },
   "src/L1/L1CrossDomainMessenger.sol": {
-    "initCodeHash": "0xcff231ee7465984e853572c5050e761f746575d78f709eba65c982178de3e718",
+    "initCodeHash": "0x149d67ed4524a89d7554e88c8652c1748fa6f8870b1ce276b73456b746b3b43a",
     "sourceCodeHash": "0x9726b6f646269f4288ff8dc1b8228dedbdf960e90df1d11793bc534297328e96"
   },
   "src/L1/L1ERC721Bridge.sol": {
-    "initCodeHash": "0x61a509ace719c19ce6e288d2c37ff4671ade678bbd9148e6c10ffe32675eee9c",
+    "initCodeHash": "0x280488bce8b4fb364740c59de14c423851902088f384e077bccc79b9df48528a",
     "sourceCodeHash": "0xe12b9e6c4e4ac2e2c9a03f07c7689f6bf2231922536072812cf1f37a5a276e73"
   },
   "src/L1/L1StandardBridge.sol": {
-    "initCodeHash": "0x3b7d0cffe4f4bc8c7a2cefe5657c8147656ecdbf387fe70a39ee74fdfaa172c9",
+    "initCodeHash": "0xe69e972e18930d3feaaad20b8e0e15625df9a71ad8304ee7d89c17d32644e152",
     "sourceCodeHash": "0xc6613d35d1ad95cbef26a503a10b5dd8663ceb80426f8c528835d39f79e4b4cf"
   },
   "src/L1/OPContractsManager.sol": {
@@ -24,7 +24,7 @@
     "sourceCodeHash": "0x1bbe8f918f1d5b1cc75924cdf23b10664b890fd306c2aa5d195a7b4177670431"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",
+    "initCodeHash": "0x7befd717b511a9207f6042de50d8e65d84ef7d8d42afff41c25d6528f46d14de",
     "sourceCodeHash": "0xf215a31954f2ef166cfb26d20e466c62fafa235a08fc42c55131dcb81998ff01"
   },
   "src/L1/OptimismPortalInterop.sol": {
@@ -32,7 +32,7 @@
     "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {
-    "initCodeHash": "0x0000ec89712d8b4609873f1ba76afffd4205bf9110818995c90134dbec12e91e",
+    "initCodeHash": "0x6ca9c0a0622ba74ac6bfef1e7f922adc7c4b815a34689fdf01b4a00acdb4a63d",
     "sourceCodeHash": "0xd4284db247fc1e686bd4b57755c7ac9a073a173d6df4f93448eb7fb5518882f7"
   },
   "src/L1/SuperchainConfig.sol": {
@@ -136,11 +136,11 @@
     "sourceCodeHash": "0x11d711704a5afcae6076d017ee001b25bc705728973b1ad2e6a32274a8475f50"
   },
   "src/L2/WETH.sol": {
-    "initCodeHash": "0x4ae485c1327118ac9c1a492fb687502a0eb6079a93b57912ab0d3af201754c74",
+    "initCodeHash": "0x480d4f8dbec1b0d3211bccbbdfb69796f3e90c784f724b1bbfd4703b0aafdeba",
     "sourceCodeHash": "0xe9964aa66db1dfc86772958b4c9276697e67f7055529a43e6a49a055009bc995"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0xc10654f0e6498f424f7a5095bac36005dc7062d3813cc8f805a15005fc37406b",
+    "initCodeHash": "0x66478c040c82be2c383b4c9616f92eed4849939461aea0dd24606502da29dce6",
     "sourceCodeHash": "0x6c45dd23cb0d6f9bf4f84855ad0caf70e53dee3fe6c41454f7bf8df52ec3a9af"
   },
   "src/cannon/MIPS2.sol": {
@@ -152,15 +152,15 @@
     "sourceCodeHash": "0xdb771f1b92c7612b120e0bce31967f0c8a7ce332dbb426bc9cfc52b47be21c4d"
   },
   "src/cannon/PreimageOracle.sol": {
-    "initCodeHash": "0x17d3b3df1aaaf7a705b8d48de8a05e6511b910fdafdbe5eb7f7f95ec944fba9a",
+    "initCodeHash": "0x8412f8a8397ff8706fb58b2ddb8952cd093f9e5c70231816852466ac52b567d1",
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0xb2618d650808a7a335db7cc56d15ccaf432f50aa551c01be8bde8356893c0e0d",
+    "initCodeHash": "0x3c940e43218ae4e83019acafe9fe5201194da7d0f7a9b4d09ada4cc705fb3aa3",
     "sourceCodeHash": "0x745f0e2b07b8f6492e11ca2f69b53d129177fbfd346d5ca4729d72792aff1f83"
   },
   "src/dispute/DelayedWETH.sol": {
-    "initCodeHash": "0x7f523e229213a4c5c52ddac40a03b9eafc8c420444807ea6a9149a627919f81b",
+    "initCodeHash": "0xb1f04c9ee86984a157b92a18754c84104e9d4df7a3838633301ca7f557d0220a",
     "sourceCodeHash": "0x0162302b9c71f184d45bee34ecfb1dfbf427f38fc5652709ab7ffef1ac816d82"
   },
   "src/dispute/DisputeGameFactory.sol": {
@@ -200,7 +200,7 @@
     "sourceCodeHash": "0x918965e52bbd358ac827ebe35998f5d8fa5ca77d8eb9ab8986b44181b9aaa48a"
   },
   "src/universal/OptimismMintableERC20.sol": {
-    "initCodeHash": "0xc3289416829b252c830ad7d389a430986a7404df4fe0be37cb19e1c40907f047",
+    "initCodeHash": "0x144f8ed06e2086f9dbfc805f277bef3b5a65badf6c467f0a89177b8fe995e980",
     "sourceCodeHash": "0xf5e29dd5c750ea935c7281ec916ba5277f5610a0a9e984e53ae5d5245b3cf2f4"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -8,11 +8,11 @@
     "sourceCodeHash": "0x9726b6f646269f4288ff8dc1b8228dedbdf960e90df1d11793bc534297328e96"
   },
   "src/L1/L1ERC721Bridge.sol": {
-    "initCodeHash": "0x280488bce8b4fb364740c59de14c423851902088f384e077bccc79b9df48528a",
+    "initCodeHash": "0x61a509ace719c19ce6e288d2c37ff4671ade678bbd9148e6c10ffe32675eee9c",
     "sourceCodeHash": "0xe12b9e6c4e4ac2e2c9a03f07c7689f6bf2231922536072812cf1f37a5a276e73"
   },
   "src/L1/L1StandardBridge.sol": {
-    "initCodeHash": "0xe69e972e18930d3feaaad20b8e0e15625df9a71ad8304ee7d89c17d32644e152",
+    "initCodeHash": "0x3b7d0cffe4f4bc8c7a2cefe5657c8147656ecdbf387fe70a39ee74fdfaa172c9",
     "sourceCodeHash": "0xc6613d35d1ad95cbef26a503a10b5dd8663ceb80426f8c528835d39f79e4b4cf"
   },
   "src/L1/OPContractsManager.sol": {
@@ -32,11 +32,11 @@
     "sourceCodeHash": "0xc04a7f9c14a13ec3587f5cc351c8e9f27fbbe9f1291a1aba07de29edbeef418a"
   },
   "src/L1/ProtocolVersions.sol": {
-    "initCodeHash": "0x6ca9c0a0622ba74ac6bfef1e7f922adc7c4b815a34689fdf01b4a00acdb4a63d",
+    "initCodeHash": "0x0000ec89712d8b4609873f1ba76afffd4205bf9110818995c90134dbec12e91e",
     "sourceCodeHash": "0xd4284db247fc1e686bd4b57755c7ac9a073a173d6df4f93448eb7fb5518882f7"
   },
   "src/L1/SuperchainConfig.sol": {
-    "initCodeHash": "0x91410b22e52e82d89a5ee65b00dc3ddc6aa14b86386c8a55c4ebae32208d980b",
+    "initCodeHash": "0xcc35362cfd686d2f50e1db8c4a864cbc1eb847eaf58007d8ce7295ae9e101102",
     "sourceCodeHash": "0xafa784ea78818a382ff3a61e2d84be58c7978110c06b9273db68c0213ead02d3"
   },
   "src/L1/SystemConfig.sol": {
@@ -152,7 +152,7 @@
     "sourceCodeHash": "0xdb771f1b92c7612b120e0bce31967f0c8a7ce332dbb426bc9cfc52b47be21c4d"
   },
   "src/cannon/PreimageOracle.sol": {
-    "initCodeHash": "0x8412f8a8397ff8706fb58b2ddb8952cd093f9e5c70231816852466ac52b567d1",
+    "initCodeHash": "0x17d3b3df1aaaf7a705b8d48de8a05e6511b910fdafdbe5eb7f7f95ec944fba9a",
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
@@ -200,7 +200,7 @@
     "sourceCodeHash": "0x918965e52bbd358ac827ebe35998f5d8fa5ca77d8eb9ab8986b44181b9aaa48a"
   },
   "src/universal/OptimismMintableERC20.sol": {
-    "initCodeHash": "0x144f8ed06e2086f9dbfc805f277bef3b5a65badf6c467f0a89177b8fe995e980",
+    "initCodeHash": "0xc3289416829b252c830ad7d389a430986a7404df4fe0be37cb19e1c40907f047",
     "sourceCodeHash": "0xf5e29dd5c750ea935c7281ec916ba5277f5610a0a9e984e53ae5d5245b3cf2f4"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {


### PR DESCRIPTION
This PR demonstrates that initCode changes are occurring in the build process. Though the pattern is not yet clear to me. 

For context, in the `packages/contracts-bedrock` directory, running `just semver-lock` will build the contracts and write hashes of the bytecode to `semver-lock.json`.

I have included 3 commits here: 

1. 679dca351243c78dd0a0e5a6d28f1db019afe53d is generated by running `just semver-lock` on the `develop` branch. It results in unexpected changes to several contract's initcode.
2. d3847146cf47419736dc9421287ee33978c9f66b is generated by running `FOUNDRY_PROFILE=ci just semver-lock`, which results in further changes, even though the [`ci` profile has no additional compiler settings](https://github.com/ethereum-optimism/optimism/blob/maur/initcode-updates/packages/contracts-bedrock/foundry.toml#L84).
3. 88d9e8d45a7241b4cd48ce4f2d22d69c33dcf968  is generated by copying compiler settings into the `ci` profile then running `FOUNDRY_PROFILE=ci just semver-lock` once again.

