### PR TITLE
chore(kurtosis-devnet): add proper deploy package

### DIFF
--- a/kurtosis-devnet/cmd/main.go
+++ b/kurtosis-devnet/cmd/main.go
@@ -1,30 +1,17 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/build"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/deploy"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/engine"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/util"
 	"github.com/urfave/cli/v2"
 )
-
-const FILESERVER_PACKAGE = "fileserver"
-
-func fileserverURL(path ...string) string {
-	return fmt.Sprintf("http://%s/%s", FILESERVER_PACKAGE, strings.Join(path, "/"))
-}
 
 type config struct {
 	templateFile    string
@@ -57,298 +44,6 @@ func newConfig(c *cli.Context) (*config, error) {
 	return cfg, nil
 }
 
-type engineManager interface {
-	EnsureRunning() error
-}
-
-type Main struct {
-	cfg           *config
-	newDeployer   func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error)
-	engineManager engineManager
-}
-
-func (m *Main) localDockerImageOption() tmpl.TemplateContextOptions {
-	dockerBuilder := build.NewDockerBuilder(
-		build.WithDockerBaseDir(m.cfg.baseDir),
-		build.WithDockerDryRun(m.cfg.dryRun),
-	)
-
-	imageTag := func(projectName string) string {
-		return fmt.Sprintf("%s:%s", projectName, m.cfg.enclave)
-	}
-
-	return tmpl.WithFunction("localDockerImage", func(projectName string) (string, error) {
-		return dockerBuilder.Build(projectName, imageTag(projectName))
-	})
-}
-
-func (m *Main) localContractArtifactsOption(dir string) tmpl.TemplateContextOptions {
-	contractsBundle := fmt.Sprintf("contracts-bundle-%s.tar.gz", m.cfg.enclave)
-	contractsBundlePath := func(_ string) string {
-		return filepath.Join(dir, contractsBundle)
-	}
-	contractsURL := fileserverURL(contractsBundle)
-
-	contractBuilder := build.NewContractBuilder(
-		build.WithContractBaseDir(m.cfg.baseDir),
-		build.WithContractDryRun(m.cfg.dryRun),
-	)
-
-	return tmpl.WithFunction("localContractArtifacts", func(layer string) (string, error) {
-		bundlePath := contractsBundlePath(layer)
-		if err := contractBuilder.Build(layer, bundlePath); err != nil {
-			return "", err
-		}
-
-		log.Printf("%s: contract artifacts available at: %s\n", layer, contractsURL)
-		return contractsURL, nil
-	})
-}
-
-type PrestateInfo struct {
-	URL    string            `json:"url"`
-	Hashes map[string]string `json:"hashes"`
-}
-
-type localPrestateHolder struct {
-	info     *PrestateInfo
-	baseDir  string
-	buildDir string
-	dryRun   bool
-	builder  *build.PrestateBuilder
-}
-
-func newLocalPrestateHolder(baseDir string, buildDir string, dryRun bool) *localPrestateHolder {
-	return &localPrestateHolder{
-		baseDir:  baseDir,
-		buildDir: buildDir,
-		dryRun:   dryRun,
-		builder: build.NewPrestateBuilder(
-			build.WithPrestateBaseDir(baseDir),
-			build.WithPrestateDryRun(dryRun),
-		),
-	}
-}
-
-func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
-	if h.info != nil {
-		return h.info, nil
-	}
-
-	prestatePath := []string{"proofs", "op-program", "cannon"}
-	prestateURL := fileserverURL(prestatePath...)
-
-	// Create build directory with the final path structure
-	buildDir := filepath.Join(append([]string{h.buildDir}, prestatePath...)...)
-	if err := os.MkdirAll(buildDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create prestate build directory: %w", err)
-	}
-
-	info := &PrestateInfo{
-		URL:    prestateURL,
-		Hashes: make(map[string]string),
-	}
-
-	if h.dryRun {
-		h.info = info
-		return info, nil
-	}
-
-	// Map of known file prefixes to their keys
-	fileToKey := map[string]string{
-		"prestate-proof.json":         "prestate",
-		"prestate-proof-mt64.json":    "prestate_mt64",
-		"prestate-proof-mt.json":      "prestate_mt",
-		"prestate-proof-interop.json": "prestate_interop",
-	}
-
-	// Build all prestate files directly in the target directory
-	if err := h.builder.Build(buildDir); err != nil {
-		return nil, fmt.Errorf("failed to build prestates: %w", err)
-	}
-
-	// Find and process all prestate files
-	matches, err := filepath.Glob(filepath.Join(buildDir, "prestate-proof*.json"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find prestate files: %w", err)
-	}
-
-	// Process each file to rename it to its hash
-	for _, filePath := range matches {
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read prestate %s: %w", filepath.Base(filePath), err)
-		}
-
-		var data struct {
-			Pre string `json:"pre"`
-		}
-		if err := json.Unmarshal(content, &data); err != nil {
-			return nil, fmt.Errorf("failed to parse prestate %s: %w", filepath.Base(filePath), err)
-		}
-
-		// Store hash with its corresponding key
-		if key, exists := fileToKey[filepath.Base(filePath)]; exists {
-			info.Hashes[key] = data.Pre
-		}
-
-		// Rename files to hash-based names
-		newFileName := data.Pre + ".json"
-		hashedPath := filepath.Join(buildDir, newFileName)
-		if err := os.Rename(filePath, hashedPath); err != nil {
-			return nil, fmt.Errorf("failed to rename prestate %s: %w", filepath.Base(filePath), err)
-		}
-		log.Printf("%s available at: %s/%s\n", filepath.Base(filePath), prestateURL, newFileName)
-
-		// Rename the corresponding binary file
-		binFilePath := strings.Replace(strings.TrimSuffix(filePath, ".json"), "-proof", "", 1) + ".bin.gz"
-		newBinFileName := data.Pre + ".bin.gz"
-		binHashedPath := filepath.Join(buildDir, newBinFileName)
-		if err := os.Rename(binFilePath, binHashedPath); err != nil {
-			return nil, fmt.Errorf("failed to rename prestate %s: %w", filepath.Base(binFilePath), err)
-		}
-		log.Printf("%s available at: %s/%s\n", filepath.Base(binFilePath), prestateURL, newBinFileName)
-	}
-
-	h.info = info
-	return info, nil
-}
-
-func (m *Main) localPrestateOption(dir string) tmpl.TemplateContextOptions {
-	holder := newLocalPrestateHolder(m.cfg.baseDir, dir, m.cfg.dryRun)
-
-	return tmpl.WithFunction("localPrestate", func() (*PrestateInfo, error) {
-		return holder.GetPrestateInfo()
-	})
-}
-
-func (m *Main) renderTemplate(dir string) (*bytes.Buffer, error) {
-	opts := []tmpl.TemplateContextOptions{
-		m.localDockerImageOption(),
-		m.localContractArtifactsOption(dir),
-		m.localPrestateOption(dir),
-		tmpl.WithBaseDir(m.cfg.baseDir),
-	}
-
-	// Read and parse the data file if provided
-	if m.cfg.dataFile != "" {
-		data, err := os.ReadFile(m.cfg.dataFile)
-		if err != nil {
-			return nil, fmt.Errorf("error reading data file: %w", err)
-		}
-
-		var templateData map[string]interface{}
-		if err := json.Unmarshal(data, &templateData); err != nil {
-			return nil, fmt.Errorf("error parsing JSON data: %w", err)
-		}
-
-		opts = append(opts, tmpl.WithData(templateData))
-	}
-
-	// Open template file
-	tmplFile, err := os.Open(m.cfg.templateFile)
-	if err != nil {
-		return nil, fmt.Errorf("error opening template file: %w", err)
-	}
-	defer tmplFile.Close()
-
-	// Create template context
-	tmplCtx := tmpl.NewTemplateContext(opts...)
-
-	// Process template
-	buf := bytes.NewBuffer(nil)
-	if err := tmplCtx.InstantiateTemplate(tmplFile, buf); err != nil {
-		return nil, fmt.Errorf("error processing template: %w", err)
-	}
-
-	return buf, nil
-}
-
-func (m *Main) deploy(ctx context.Context, r io.Reader) error {
-	// Create a multi reader to output deployment input to stdout
-	buf := bytes.NewBuffer(nil)
-	tee := io.TeeReader(r, buf)
-
-	// Log the deployment input
-	log.Println("Deployment input:")
-	if _, err := io.Copy(os.Stdout, tee); err != nil {
-		return fmt.Errorf("error copying deployment input: %w", err)
-	}
-
-	opts := []kurtosis.KurtosisDeployerOptions{
-		kurtosis.WithKurtosisBaseDir(m.cfg.baseDir),
-		kurtosis.WithKurtosisDryRun(m.cfg.dryRun),
-		kurtosis.WithKurtosisPackageName(m.cfg.kurtosisPackage),
-		kurtosis.WithKurtosisEnclave(m.cfg.enclave),
-	}
-
-	d, err := m.newDeployer(opts...)
-	if err != nil {
-		return fmt.Errorf("error creating kurtosis deployer: %w", err)
-	}
-
-	spec, err := d.Deploy(ctx, buf)
-	if err != nil {
-		return fmt.Errorf("error deploying kurtosis package: %w", err)
-	}
-
-	env, err := d.GetEnvironmentInfo(ctx, spec)
-	if err != nil {
-		return fmt.Errorf("error getting environment: %w", err)
-	}
-
-	if err := writeEnvironment(m.cfg.environment, env); err != nil {
-		return fmt.Errorf("error writing environment: %w", err)
-	}
-
-	return nil
-}
-
-func (m *Main) deployFileserver(ctx context.Context, sourceDir string) error {
-	// Create a temp dir in the fileserver package
-	baseDir := filepath.Join(m.cfg.baseDir, FILESERVER_PACKAGE)
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		return fmt.Errorf("error creating base directory: %w", err)
-	}
-	tempDir, err := os.MkdirTemp(baseDir, "upload-content")
-	if err != nil {
-		return fmt.Errorf("error creating temporary directory: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// Copy build dir contents to tempDir
-	if err := util.CopyDir(sourceDir, tempDir); err != nil {
-		return fmt.Errorf("error copying directory: %w", err)
-	}
-
-	buf := bytes.NewBuffer(nil)
-	buf.WriteString(fmt.Sprintf("source_path: %s\n", filepath.Base(tempDir)))
-
-	opts := []kurtosis.KurtosisDeployerOptions{
-		kurtosis.WithKurtosisBaseDir(m.cfg.baseDir),
-		kurtosis.WithKurtosisDryRun(m.cfg.dryRun),
-		kurtosis.WithKurtosisPackageName(FILESERVER_PACKAGE),
-		kurtosis.WithKurtosisEnclave(m.cfg.enclave),
-	}
-
-	d, err := m.newDeployer(opts...)
-	if err != nil {
-		return fmt.Errorf("error creating kurtosis deployer: %w", err)
-	}
-
-	_, err = d.Deploy(ctx, buf)
-	if err != nil {
-		return fmt.Errorf("error deploying kurtosis package: %w", err)
-	}
-
-	return nil
-}
-
-type deployer interface {
-	Deploy(ctx context.Context, input io.Reader) (*spec.EnclaveSpec, error)
-	GetEnvironmentInfo(ctx context.Context, spec *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error)
-}
-
 func writeEnvironment(path string, env *kurtosis.KurtosisEnvironment) error {
 	out := os.Stdout
 	if path != "" {
@@ -369,49 +64,30 @@ func writeEnvironment(path string, env *kurtosis.KurtosisEnvironment) error {
 	return nil
 }
 
-func (m *Main) run() error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	if !m.cfg.dryRun {
-		if err := m.engineManager.EnsureRunning(); err != nil {
-			return fmt.Errorf("error ensuring kurtosis engine is running: %w", err)
-		}
-	}
-
-	tmpDir, err := os.MkdirTemp("", m.cfg.enclave)
-	if err != nil {
-		return fmt.Errorf("error creating temporary directory: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	buf, err := m.renderTemplate(tmpDir)
-	if err != nil {
-		return fmt.Errorf("error rendering template: %w", err)
-	}
-
-	// TODO: clean up consumers of static server and replace with fileserver
-	err = m.deployFileserver(ctx, tmpDir)
-	if err != nil {
-		return fmt.Errorf("error deploying fileserver: %w", err)
-	}
-
-	return m.deploy(ctx, buf)
-}
-
 func mainAction(c *cli.Context) error {
+	ctx := context.Background()
+
 	cfg, err := newConfig(c)
 	if err != nil {
 		return fmt.Errorf("error parsing config: %w", err)
 	}
-	m := &Main{
-		cfg: cfg,
-		newDeployer: func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
-			return kurtosis.NewKurtosisDeployer(opts...)
-		},
-		engineManager: engine.NewEngineManager(engine.WithKurtosisBinary(cfg.kurtosisBinary)),
+
+	deployer := deploy.NewDeployer(
+		deploy.WithKurtosisPackage(cfg.kurtosisPackage),
+		deploy.WithEnclave(cfg.enclave),
+		deploy.WithDryRun(cfg.dryRun),
+		deploy.WithKurtosisBinary(cfg.kurtosisBinary),
+		deploy.WithTemplateFile(cfg.templateFile),
+		deploy.WithDataFile(cfg.dataFile),
+		deploy.WithBaseDir(cfg.baseDir),
+	)
+
+	env, err := deployer.Deploy(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error deploying environment: %w", err)
 	}
-	return m.run()
+
+	return writeEnvironment(cfg.environment, env)
 }
 
 func getFlags() []cli.Flag {

--- a/kurtosis-devnet/cmd/main_test.go
+++ b/kurtosis-devnet/cmd/main_test.go
@@ -1,54 +1,15 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
-	"gopkg.in/yaml.v3"
 )
-
-type mockDeployer struct {
-	dryRun bool
-}
-
-func (m *mockDeployer) Deploy(ctx context.Context, input io.Reader) (*spec.EnclaveSpec, error) {
-	return &spec.EnclaveSpec{}, nil
-}
-
-func (m *mockDeployer) GetEnvironmentInfo(ctx context.Context, spec *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error) {
-	return &kurtosis.KurtosisEnvironment{}, nil
-}
-
-func newMockDeployer(...kurtosis.KurtosisDeployerOptions) (deployer, error) {
-	return &mockDeployer{dryRun: true}, nil
-}
-
-type mockEngineManager struct{}
-
-func (m *mockEngineManager) EnsureRunning() error {
-	return nil
-}
-
-func newTestMain(cfg *config) *Main {
-	return &Main{
-		cfg: cfg,
-		newDeployer: func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
-			return newMockDeployer(opts...)
-		},
-		engineManager: &mockEngineManager{},
-	}
-}
 
 func TestParseFlags(t *testing.T) {
 	tests := []struct {
@@ -124,100 +85,7 @@ func TestParseFlags(t *testing.T) {
 	}
 }
 
-func TestRenderTemplate(t *testing.T) {
-	// Create a temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "template-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	// Create a test template file
-	templateContent := `
-name: {{.name}}
-image: {{localDockerImage "test-project"}}
-artifacts: {{localContractArtifacts "l1"}}`
-
-	templatePath := filepath.Join(tmpDir, "template.yaml")
-	err = os.WriteFile(templatePath, []byte(templateContent), 0644)
-	require.NoError(t, err)
-
-	// Create a test data file
-	dataContent := `{"name": "test-deployment"}`
-	dataPath := filepath.Join(tmpDir, "data.json")
-	err = os.WriteFile(dataPath, []byte(dataContent), 0644)
-	require.NoError(t, err)
-
-	cfg := &config{
-		templateFile: templatePath,
-		dataFile:     dataPath,
-		enclave:      "test-enclave",
-		dryRun:       true, // Important for tests
-	}
-
-	m := newTestMain(cfg)
-
-	buf, err := m.renderTemplate(tmpDir)
-	require.NoError(t, err)
-
-	// Verify template rendering
-	assert.Contains(t, buf.String(), "test-deployment")
-	assert.Contains(t, buf.String(), "test-project:test-enclave")
-}
-
-func TestDeploy(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Create a temporary directory for the environment output
-	tmpDir, err := os.MkdirTemp("", "deploy-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	envPath := filepath.Join(tmpDir, "env.json")
-	cfg := &config{
-		environment: envPath,
-		dryRun:      true,
-	}
-
-	// Create a simple deployment configuration
-	deployConfig := bytes.NewBufferString(`{"test": "config"}`)
-
-	m := newTestMain(cfg)
-	err = m.deploy(ctx, deployConfig)
-	require.NoError(t, err)
-
-	// Verify the environment file was created
-	assert.FileExists(t, envPath)
-
-	// Read and verify the content
-	content, err := os.ReadFile(envPath)
-	require.NoError(t, err)
-
-	var env map[string]interface{}
-	err = json.Unmarshal(content, &env)
-	require.NoError(t, err)
-}
-
-func TestDeployFileserver(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	tmpDir, err := os.MkdirTemp("", "deploy-fileserver-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	envPath := filepath.Join(tmpDir, "env.json")
-	cfg := &config{
-		baseDir:     tmpDir,
-		environment: envPath,
-		dryRun:      true,
-	}
-
-	m := newTestMain(cfg)
-	err = m.deployFileserver(ctx, filepath.Join(tmpDir, "fileserver"))
-	require.NoError(t, err)
-}
-
-func TestMainFunc(t *testing.T) {
+func TestMainFuncValidatesConfig(t *testing.T) {
 	// Create a temporary directory for test files
 	tmpDir, err := os.MkdirTemp("", "main-test")
 	require.NoError(t, err)
@@ -231,111 +99,34 @@ func TestMainFunc(t *testing.T) {
 	// Create environment output path
 	envPath := filepath.Join(tmpDir, "env.json")
 
-	cfg := &config{
-		templateFile: templatePath,
-		environment:  envPath,
-		dryRun:       true,
+	app := &cli.App{
+		Flags: getFlags(),
+		Action: func(c *cli.Context) error {
+			cfg, err := newConfig(c)
+			if err != nil {
+				return err
+			}
+
+			// Verify config values
+			assert.Equal(t, templatePath, cfg.templateFile)
+			assert.Equal(t, envPath, cfg.environment)
+			assert.True(t, cfg.dryRun)
+
+			// Create an empty environment file to simulate successful deployment
+			return os.WriteFile(envPath, []byte("{}"), 0644)
+		},
 	}
 
-	m := newTestMain(cfg)
-	err = m.run()
+	args := []string{
+		"prog",
+		"--template", templatePath,
+		"--environment", envPath,
+		"--dry-run",
+	}
+
+	err = app.Run(args)
 	require.NoError(t, err)
 
 	// Verify the environment file was created
 	assert.FileExists(t, envPath)
-}
-
-func TestLocalPrestate(t *testing.T) {
-	// Create a temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "prestate-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	// Create a mock justfile
-	err = os.WriteFile(filepath.Join(tmpDir, "justfile"), []byte(`
-_prestate-build target:
-	@echo "Mock prestate build"
-`), 0644)
-	require.NoError(t, err)
-
-	tests := []struct {
-		name    string
-		dryRun  bool
-		wantErr bool
-	}{
-		{
-			name:    "dry run mode",
-			dryRun:  true,
-			wantErr: false,
-		},
-		{
-			name:    "normal mode",
-			dryRun:  false,
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config{
-				baseDir: tmpDir,
-				dryRun:  tt.dryRun,
-			}
-
-			m := newTestMain(cfg)
-
-			tmpDir, err := os.MkdirTemp("", "prestate-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(tmpDir)
-
-			// Create template context with just the prestate function
-			tmplCtx := tmpl.NewTemplateContext(m.localPrestateOption(tmpDir))
-
-			// Test template with multiple calls to localPrestate
-			template := `first:
-  url: {{(localPrestate).URL}}
-  hashes:
-    game: {{index (localPrestate).Hashes "game"}}
-    proof: {{index (localPrestate).Hashes "proof"}}
-second:
-  url: {{(localPrestate).URL}}
-  hashes:
-    game: {{index (localPrestate).Hashes "game"}}
-    proof: {{index (localPrestate).Hashes "proof"}}`
-			buf := bytes.NewBuffer(nil)
-			err = tmplCtx.InstantiateTemplate(bytes.NewBufferString(template), buf)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-
-			// Verify the output is valid YAML and contains the static path
-			output := buf.String()
-			assert.Contains(t, output, "url: http://fileserver/proofs/op-program/cannon")
-
-			// Verify both calls return the same values
-			var result struct {
-				First struct {
-					URL    string            `yaml:"url"`
-					Hashes map[string]string `yaml:"hashes"`
-				} `yaml:"first"`
-				Second struct {
-					URL    string            `yaml:"url"`
-					Hashes map[string]string `yaml:"hashes"`
-				} `yaml:"second"`
-			}
-			err = yaml.Unmarshal(buf.Bytes(), &result)
-			require.NoError(t, err)
-
-			// Check that both calls returned identical results
-			assert.Equal(t, result.First.URL, result.Second.URL, "URLs should match")
-			assert.Equal(t, result.First.Hashes, result.Second.Hashes, "Hashes should match")
-
-			// Verify the directory was created only once
-			prestateDir := filepath.Join(tmpDir, "proofs", "op-program", "cannon")
-			assert.DirExists(t, prestateDir)
-		})
-	}
 }

--- a/kurtosis-devnet/pkg/deploy/deploy.go
+++ b/kurtosis-devnet/pkg/deploy/deploy.go
@@ -1,0 +1,187 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/engine"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
+)
+
+type EngineManager interface {
+	EnsureRunning() error
+}
+
+type deployer interface {
+	Deploy(ctx context.Context, input io.Reader) (*spec.EnclaveSpec, error)
+	GetEnvironmentInfo(ctx context.Context, spec *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error)
+}
+
+type DeployerFunc func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error)
+
+type DeployerOption func(*Deployer)
+
+type Deployer struct {
+	baseDir        string
+	dryRun         bool
+	kurtosisPkg    string
+	enclave        string
+	kurtosisBinary string
+	ktDeployer     DeployerFunc
+	engineManager  EngineManager
+	templateFile   string
+	dataFile       string
+}
+
+func WithKurtosisDeployer(ktDeployer DeployerFunc) DeployerOption {
+	return func(d *Deployer) {
+		d.ktDeployer = ktDeployer
+	}
+}
+
+func WithEngineManager(engineManager EngineManager) DeployerOption {
+	return func(d *Deployer) {
+		d.engineManager = engineManager
+	}
+}
+
+func WithKurtosisBinary(kurtosisBinary string) DeployerOption {
+	return func(d *Deployer) {
+		d.kurtosisBinary = kurtosisBinary
+	}
+}
+
+func WithKurtosisPackage(kurtosisPkg string) DeployerOption {
+	return func(d *Deployer) {
+		d.kurtosisPkg = kurtosisPkg
+	}
+}
+
+func WithTemplateFile(templateFile string) DeployerOption {
+	return func(d *Deployer) {
+		d.templateFile = templateFile
+	}
+}
+
+func WithDataFile(dataFile string) DeployerOption {
+	return func(d *Deployer) {
+		d.dataFile = dataFile
+	}
+}
+
+func WithBaseDir(baseDir string) DeployerOption {
+	return func(d *Deployer) {
+		d.baseDir = baseDir
+	}
+}
+
+func WithDryRun(dryRun bool) DeployerOption {
+	return func(d *Deployer) {
+		d.dryRun = dryRun
+	}
+}
+
+func WithEnclave(enclave string) DeployerOption {
+	return func(d *Deployer) {
+		d.enclave = enclave
+	}
+}
+
+func NewDeployer(opts ...DeployerOption) *Deployer {
+	d := &Deployer{
+		kurtosisBinary: "kurtosis",
+		ktDeployer: func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
+			return kurtosis.NewKurtosisDeployer(opts...)
+		},
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	if d.engineManager == nil {
+		d.engineManager = engine.NewEngineManager(engine.WithKurtosisBinary(d.kurtosisBinary))
+	}
+	return d
+}
+
+func (d *Deployer) deployEnvironment(ctx context.Context, r io.Reader) (*kurtosis.KurtosisEnvironment, error) {
+	// Create a multi reader to output deployment input to stdout
+	buf := bytes.NewBuffer(nil)
+	tee := io.TeeReader(r, buf)
+
+	// Log the deployment input
+	log.Println("Deployment input:")
+	if _, err := io.Copy(os.Stdout, tee); err != nil {
+		return nil, fmt.Errorf("error copying deployment input: %w", err)
+	}
+
+	opts := []kurtosis.KurtosisDeployerOptions{
+		kurtosis.WithKurtosisBaseDir(d.baseDir),
+		kurtosis.WithKurtosisDryRun(d.dryRun),
+		kurtosis.WithKurtosisPackageName(d.kurtosisPkg),
+		kurtosis.WithKurtosisEnclave(d.enclave),
+	}
+
+	ktd, err := d.ktDeployer(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating kurtosis deployer: %w", err)
+	}
+
+	spec, err := ktd.Deploy(ctx, buf)
+	if err != nil {
+		return nil, fmt.Errorf("error deploying kurtosis package: %w", err)
+	}
+
+	return ktd.GetEnvironmentInfo(ctx, spec)
+}
+
+func (d *Deployer) renderTemplate(buildDir string, urlBuilder func(path ...string) string) (*bytes.Buffer, error) {
+	t := &Templater{
+		baseDir:      d.baseDir,
+		dryRun:       d.dryRun,
+		enclave:      d.enclave,
+		templateFile: d.templateFile,
+		dataFile:     d.dataFile,
+		buildDir:     buildDir,
+		urlBuilder:   urlBuilder,
+	}
+
+	return t.Render()
+}
+
+func (d *Deployer) Deploy(ctx context.Context, r io.Reader) (*kurtosis.KurtosisEnvironment, error) {
+	if !d.dryRun {
+		if err := d.engineManager.EnsureRunning(); err != nil {
+			return nil, fmt.Errorf("error ensuring kurtosis engine is running: %w", err)
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp("", d.enclave)
+	if err != nil {
+		return nil, fmt.Errorf("error creating temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srv := &FileServer{
+		baseDir:  d.baseDir,
+		dryRun:   d.dryRun,
+		enclave:  d.enclave,
+		deployer: d.ktDeployer,
+	}
+
+	buf, err := d.renderTemplate(tmpDir, srv.URL)
+	if err != nil {
+		return nil, fmt.Errorf("error rendering template: %w", err)
+	}
+
+	if err := srv.Deploy(ctx, tmpDir); err != nil {
+		return nil, fmt.Errorf("error deploying fileserver: %w", err)
+	}
+
+	return d.deployEnvironment(ctx, buf)
+}

--- a/kurtosis-devnet/pkg/deploy/deploy_test.go
+++ b/kurtosis-devnet/pkg/deploy/deploy_test.go
@@ -1,0 +1,94 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDeployerForTest implements the deployer interface for testing
+type mockDeployerForTest struct {
+	baseDir string
+}
+
+func (m *mockDeployerForTest) Deploy(ctx context.Context, input io.Reader) (*spec.EnclaveSpec, error) {
+	// Create a mock env.json file
+	envPath := filepath.Join(m.baseDir, "env.json")
+	mockEnv := map[string]interface{}{
+		"test": "value",
+	}
+	data, err := json.Marshal(mockEnv)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(envPath, data, 0644); err != nil {
+		return nil, err
+	}
+	return &spec.EnclaveSpec{}, nil
+}
+
+func (m *mockDeployerForTest) GetEnvironmentInfo(ctx context.Context, spec *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error) {
+	return &kurtosis.KurtosisEnvironment{}, nil
+}
+
+func TestDeploy(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a temporary directory for the environment output
+	tmpDir, err := os.MkdirTemp("", "deploy-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a simple template file
+	templatePath := filepath.Join(tmpDir, "template.yaml")
+	err = os.WriteFile(templatePath, []byte("test: {{ .Config }}"), 0644)
+	require.NoError(t, err)
+
+	// Create a simple data file
+	dataPath := filepath.Join(tmpDir, "data.json")
+	err = os.WriteFile(dataPath, []byte(`{"Config": "value"}`), 0644)
+	require.NoError(t, err)
+
+	envPath := filepath.Join(tmpDir, "env.json")
+	// Create a simple deployment configuration
+	deployConfig := bytes.NewBufferString(`{"test": "config"}`)
+
+	// Create a mock deployer function
+	mockDeployerFunc := func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
+		return &mockDeployerForTest{baseDir: tmpDir}, nil
+	}
+
+	d := NewDeployer(
+		WithBaseDir(tmpDir),
+		WithKurtosisDeployer(mockDeployerFunc),
+		WithDryRun(true),
+		WithTemplateFile(templatePath),
+		WithDataFile(dataPath),
+	)
+
+	env, err := d.Deploy(ctx, deployConfig)
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	// Verify the environment file was created
+	assert.FileExists(t, envPath)
+
+	// Read and verify the content
+	content, err := os.ReadFile(envPath)
+	require.NoError(t, err)
+
+	var envData map[string]interface{}
+	err = json.Unmarshal(content, &envData)
+	require.NoError(t, err)
+	assert.Equal(t, "value", envData["test"])
+}

--- a/kurtosis-devnet/pkg/deploy/fileserver.go
+++ b/kurtosis-devnet/pkg/deploy/fileserver.go
@@ -1,0 +1,66 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/util"
+)
+
+const FILESERVER_PACKAGE = "fileserver"
+
+type FileServer struct {
+	baseDir  string
+	enclave  string
+	dryRun   bool
+	deployer DeployerFunc
+}
+
+func (f *FileServer) URL(path ...string) string {
+	return fmt.Sprintf("http://%s/%s", FILESERVER_PACKAGE, strings.Join(path, "/"))
+}
+
+func (f *FileServer) Deploy(ctx context.Context, sourceDir string) error {
+	// Create a temp dir in the fileserver package
+	baseDir := filepath.Join(f.baseDir, FILESERVER_PACKAGE)
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return fmt.Errorf("error creating base directory: %w", err)
+	}
+	tempDir, err := os.MkdirTemp(baseDir, "upload-content")
+	if err != nil {
+		return fmt.Errorf("error creating temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Copy build dir contents to tempDir
+	if err := util.CopyDir(sourceDir, tempDir); err != nil {
+		return fmt.Errorf("error copying directory: %w", err)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	buf.WriteString(fmt.Sprintf("source_path: %s\n", filepath.Base(tempDir)))
+
+	opts := []kurtosis.KurtosisDeployerOptions{
+		kurtosis.WithKurtosisBaseDir(f.baseDir),
+		kurtosis.WithKurtosisDryRun(f.dryRun),
+		kurtosis.WithKurtosisPackageName(FILESERVER_PACKAGE),
+		kurtosis.WithKurtosisEnclave(f.enclave),
+	}
+
+	d, err := f.deployer(opts...)
+	if err != nil {
+		return fmt.Errorf("error creating kurtosis deployer: %w", err)
+	}
+
+	_, err = d.Deploy(ctx, buf)
+	if err != nil {
+		return fmt.Errorf("error deploying kurtosis package: %w", err)
+	}
+
+	return nil
+}

--- a/kurtosis-devnet/pkg/deploy/fileserver_test.go
+++ b/kurtosis-devnet/pkg/deploy/fileserver_test.go
@@ -1,0 +1,66 @@
+package deploy
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployFileserver(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tmpDir, err := os.MkdirTemp("", "deploy-fileserver-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a mock deployer function
+	mockDeployerFunc := func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {
+		return &mockDeployer{}, nil
+	}
+
+	testCases := []struct {
+		name        string
+		fs          *FileServer
+		shouldError bool
+	}{
+		{
+			name: "successful deployment",
+			fs: &FileServer{
+				baseDir:  tmpDir,
+				enclave:  "test-enclave",
+				dryRun:   true,
+				deployer: mockDeployerFunc,
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fs.Deploy(ctx, filepath.Join(tmpDir, "fileserver"))
+			if tc.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// mockDeployer implements the deployer interface for testing
+type mockDeployer struct{}
+
+func (m *mockDeployer) Deploy(ctx context.Context, input io.Reader) (*spec.EnclaveSpec, error) {
+	return &spec.EnclaveSpec{}, nil
+}
+
+func (m *mockDeployer) GetEnvironmentInfo(ctx context.Context, spec *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error) {
+	return &kurtosis.KurtosisEnvironment{}, nil
+}

--- a/kurtosis-devnet/pkg/deploy/prestate.go
+++ b/kurtosis-devnet/pkg/deploy/prestate.go
@@ -1,0 +1,110 @@
+package deploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/build"
+)
+
+type PrestateInfo struct {
+	URL    string            `json:"url"`
+	Hashes map[string]string `json:"hashes"`
+}
+
+type localPrestateHolder struct {
+	info       *PrestateInfo
+	baseDir    string
+	buildDir   string
+	dryRun     bool
+	builder    *build.PrestateBuilder
+	urlBuilder func(path ...string) string
+}
+
+func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
+	if h.info != nil {
+		return h.info, nil
+	}
+
+	prestatePath := []string{"proofs", "op-program", "cannon"}
+	prestateURL := h.urlBuilder(prestatePath...)
+
+	// Create build directory with the final path structure
+	buildDir := filepath.Join(append([]string{h.buildDir}, prestatePath...)...)
+	if err := os.MkdirAll(buildDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create prestate build directory: %w", err)
+	}
+
+	info := &PrestateInfo{
+		URL:    prestateURL,
+		Hashes: make(map[string]string),
+	}
+
+	if h.dryRun {
+		h.info = info
+		return info, nil
+	}
+
+	// Map of known file prefixes to their keys
+	fileToKey := map[string]string{
+		"prestate-proof.json":         "prestate",
+		"prestate-proof-mt64.json":    "prestate_mt64",
+		"prestate-proof-mt.json":      "prestate_mt",
+		"prestate-proof-interop.json": "prestate_interop",
+	}
+
+	// Build all prestate files directly in the target directory
+	if err := h.builder.Build(buildDir); err != nil {
+		return nil, fmt.Errorf("failed to build prestates: %w", err)
+	}
+
+	// Find and process all prestate files
+	matches, err := filepath.Glob(filepath.Join(buildDir, "prestate-proof*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find prestate files: %w", err)
+	}
+
+	// Process each file to rename it to its hash
+	for _, filePath := range matches {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read prestate %s: %w", filepath.Base(filePath), err)
+		}
+
+		var data struct {
+			Pre string `json:"pre"`
+		}
+		if err := json.Unmarshal(content, &data); err != nil {
+			return nil, fmt.Errorf("failed to parse prestate %s: %w", filepath.Base(filePath), err)
+		}
+
+		// Store hash with its corresponding key
+		if key, exists := fileToKey[filepath.Base(filePath)]; exists {
+			info.Hashes[key] = data.Pre
+		}
+
+		// Rename files to hash-based names
+		newFileName := data.Pre + ".json"
+		hashedPath := filepath.Join(buildDir, newFileName)
+		if err := os.Rename(filePath, hashedPath); err != nil {
+			return nil, fmt.Errorf("failed to rename prestate %s: %w", filepath.Base(filePath), err)
+		}
+		log.Printf("%s available at: %s/%s\n", filepath.Base(filePath), prestateURL, newFileName)
+
+		// Rename the corresponding binary file
+		binFilePath := strings.Replace(strings.TrimSuffix(filePath, ".json"), "-proof", "", 1) + ".bin.gz"
+		newBinFileName := data.Pre + ".bin.gz"
+		binHashedPath := filepath.Join(buildDir, newBinFileName)
+		if err := os.Rename(binFilePath, binHashedPath); err != nil {
+			return nil, fmt.Errorf("failed to rename prestate %s: %w", filepath.Base(binFilePath), err)
+		}
+		log.Printf("%s available at: %s/%s\n", filepath.Base(binFilePath), prestateURL, newBinFileName)
+	}
+
+	h.info = info
+	return info, nil
+}

--- a/kurtosis-devnet/pkg/deploy/prestate_test.go
+++ b/kurtosis-devnet/pkg/deploy/prestate_test.go
@@ -1,0 +1,106 @@
+package deploy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestLocalPrestate(t *testing.T) {
+	tests := []struct {
+		name    string
+		dryRun  bool
+		wantErr bool
+	}{
+		{
+			name:    "dry run mode",
+			dryRun:  true,
+			wantErr: false,
+		},
+		{
+			name:    "normal mode",
+			dryRun:  false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "prestate-test")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+
+			// Create a mock justfile for each test case
+			err = os.WriteFile(filepath.Join(tmpDir, "justfile"), []byte(`
+_prestate-build target:
+	@echo "Mock prestate build"
+`), 0644)
+			require.NoError(t, err)
+
+			templater := &Templater{
+				baseDir:  tmpDir,
+				dryRun:   tt.dryRun,
+				buildDir: tmpDir,
+				urlBuilder: func(path ...string) string {
+					return "http://fileserver/" + strings.Join(path, "/")
+				},
+			}
+
+			// Create template context with just the prestate function
+			tmplCtx := tmpl.NewTemplateContext(templater.localPrestateOption())
+
+			// Test template with multiple calls to localPrestate
+			template := `first:
+  url: {{(localPrestate).URL}}
+  hashes:
+    game: {{index (localPrestate).Hashes "game"}}
+    proof: {{index (localPrestate).Hashes "proof"}}
+second:
+  url: {{(localPrestate).URL}}
+  hashes:
+    game: {{index (localPrestate).Hashes "game"}}
+    proof: {{index (localPrestate).Hashes "proof"}}`
+			buf := bytes.NewBuffer(nil)
+			err = tmplCtx.InstantiateTemplate(bytes.NewBufferString(template), buf)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify the output is valid YAML and contains the static path
+			output := buf.String()
+			assert.Contains(t, output, "url: http://fileserver/proofs/op-program/cannon")
+
+			// Verify both calls return the same values
+			var result struct {
+				First struct {
+					URL    string            `yaml:"url"`
+					Hashes map[string]string `yaml:"hashes"`
+				} `yaml:"first"`
+				Second struct {
+					URL    string            `yaml:"url"`
+					Hashes map[string]string `yaml:"hashes"`
+				} `yaml:"second"`
+			}
+			err = yaml.Unmarshal(buf.Bytes(), &result)
+			require.NoError(t, err)
+
+			// Check that both calls returned identical results
+			assert.Equal(t, result.First.URL, result.Second.URL, "URLs should match")
+			assert.Equal(t, result.First.Hashes, result.Second.Hashes, "Hashes should match")
+
+			// Verify the directory was created only once
+			prestateDir := filepath.Join(tmpDir, "proofs", "op-program", "cannon")
+			assert.DirExists(t, prestateDir)
+		})
+	}
+}

--- a/kurtosis-devnet/pkg/deploy/template.go
+++ b/kurtosis-devnet/pkg/deploy/template.go
@@ -1,0 +1,120 @@
+package deploy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/build"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl"
+)
+
+type Templater struct {
+	enclave      string
+	dryRun       bool
+	baseDir      string
+	templateFile string
+	dataFile     string
+	buildDir     string
+	urlBuilder   func(path ...string) string
+}
+
+func (f *Templater) localDockerImageOption() tmpl.TemplateContextOptions {
+	dockerBuilder := build.NewDockerBuilder(
+		build.WithDockerBaseDir(f.baseDir),
+		build.WithDockerDryRun(f.dryRun),
+	)
+
+	imageTag := func(projectName string) string {
+		return fmt.Sprintf("%s:%s", projectName, f.enclave)
+	}
+
+	return tmpl.WithFunction("localDockerImage", func(projectName string) (string, error) {
+		return dockerBuilder.Build(projectName, imageTag(projectName))
+	})
+}
+
+func (f *Templater) localContractArtifactsOption() tmpl.TemplateContextOptions {
+	contractsBundle := fmt.Sprintf("contracts-bundle-%s.tar.gz", f.enclave)
+	contractsBundlePath := func(_ string) string {
+		return filepath.Join(f.buildDir, contractsBundle)
+	}
+	contractsURL := f.urlBuilder(contractsBundle)
+
+	contractBuilder := build.NewContractBuilder(
+		build.WithContractBaseDir(f.baseDir),
+		build.WithContractDryRun(f.dryRun),
+	)
+
+	return tmpl.WithFunction("localContractArtifacts", func(layer string) (string, error) {
+		bundlePath := contractsBundlePath(layer)
+		if err := contractBuilder.Build(layer, bundlePath); err != nil {
+			return "", err
+		}
+
+		log.Printf("%s: contract artifacts available at: %s\n", layer, contractsURL)
+		return contractsURL, nil
+	})
+}
+
+func (f *Templater) localPrestateOption() tmpl.TemplateContextOptions {
+	holder := &localPrestateHolder{
+		baseDir:  f.baseDir,
+		buildDir: f.buildDir,
+		dryRun:   f.dryRun,
+		builder: build.NewPrestateBuilder(
+			build.WithPrestateBaseDir(f.baseDir),
+			build.WithPrestateDryRun(f.dryRun),
+		),
+		urlBuilder: f.urlBuilder,
+	}
+
+	return tmpl.WithFunction("localPrestate", func() (*PrestateInfo, error) {
+		return holder.GetPrestateInfo()
+	})
+}
+
+func (f *Templater) Render() (*bytes.Buffer, error) {
+	opts := []tmpl.TemplateContextOptions{
+		f.localDockerImageOption(),
+		f.localContractArtifactsOption(),
+		f.localPrestateOption(),
+		tmpl.WithBaseDir(f.baseDir),
+	}
+
+	// Read and parse the data file if provided
+	if f.dataFile != "" {
+		data, err := os.ReadFile(f.dataFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading data file: %w", err)
+		}
+
+		var templateData map[string]interface{}
+		if err := json.Unmarshal(data, &templateData); err != nil {
+			return nil, fmt.Errorf("error parsing JSON data: %w", err)
+		}
+
+		opts = append(opts, tmpl.WithData(templateData))
+	}
+
+	// Open template file
+	tmplFile, err := os.Open(f.templateFile)
+	if err != nil {
+		return nil, fmt.Errorf("error opening template file: %w", err)
+	}
+	defer tmplFile.Close()
+
+	// Create template context
+	tmplCtx := tmpl.NewTemplateContext(opts...)
+
+	// Process template
+	buf := bytes.NewBuffer(nil)
+	if err := tmplCtx.InstantiateTemplate(tmplFile, buf); err != nil {
+		return nil, fmt.Errorf("error processing template: %w", err)
+	}
+
+	return buf, nil
+}

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -1,0 +1,54 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir, err := os.MkdirTemp("", "template-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a test template file
+	templateContent := `
+name: {{.name}}
+image: {{localDockerImage "test-project"}}
+artifacts: {{localContractArtifacts "l1"}}`
+
+	templatePath := filepath.Join(tmpDir, "template.yaml")
+	err = os.WriteFile(templatePath, []byte(templateContent), 0644)
+	require.NoError(t, err)
+
+	// Create a test data file
+	dataContent := `{"name": "test-deployment"}`
+	dataPath := filepath.Join(tmpDir, "data.json")
+	err = os.WriteFile(dataPath, []byte(dataContent), 0644)
+	require.NoError(t, err)
+
+	// Create a Templater instance
+	templater := &Templater{
+		enclave:      "test-enclave",
+		dryRun:       true,
+		baseDir:      tmpDir,
+		templateFile: templatePath,
+		dataFile:     dataPath,
+		buildDir:     tmpDir,
+		urlBuilder: func(path ...string) string {
+			return "http://localhost:8080/" + strings.Join(path, "/")
+		},
+	}
+
+	buf, err := templater.Render()
+	require.NoError(t, err)
+
+	// Verify template rendering
+	assert.Contains(t, buf.String(), "test-deployment")
+	assert.Contains(t, buf.String(), "test-project:test-enclave")
+}


### PR DESCRIPTION
**Description**

This change moves most of the kurtosis-devnet deployment logic out of
main, and into a separate package.

This is needed to gain the ability to use this logic as library code
on demand, for example at the start of a test scenario.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
