### PR TITLE
supervisor: Refactor Derivation DB Reset Functions

### DIFF
--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -209,6 +209,7 @@ const (
 
 func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.BlockID) error {
 	logger := m.log.New("unsafe", unsafe, "safe", safe, "finalized", finalized)
+	logger.Debug("Received reset request", "unsafe", unsafe, "safe", safe, "finalized", finalized)
 
 	verify := func(ref eth.BlockID, name string) (eth.L2BlockRef, error) {
 		result, err := m.l2.L2BlockRefByNumber(ctx, ref.Number)

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -567,3 +567,8 @@ func (su *SupervisorBackend) PullFinalizedL1() error {
 func (su *SupervisorBackend) SetConfDepthL1(depth uint64) {
 	su.l1Accessor.SetConfDepth(depth)
 }
+
+// Rewind rolls back the state of the supervisor for the given chain.
+func (su *SupervisorBackend) Rewind(chain eth.ChainID, block eth.BlockID) error {
+	return su.chainDBs.Rewind(chain, block)
+}

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -61,6 +61,7 @@ type LocalDerivedFromStorage interface {
 	NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error)
 	PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error)
 	PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+	RewindToL2(derived uint64) error
 }
 
 var _ LocalDerivedFromStorage = (*fromda.DB)(nil)

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -51,22 +51,6 @@ func NewFromEntryStore(logger log.Logger, m Metrics, store EntryStore) (*DB, err
 	return db, nil
 }
 
-// Rewind to the last entry that was derived from a L1 block with the given block number.
-func (db *DB) Rewind(derivedFrom uint64) error {
-	db.rwLock.Lock()
-	defer db.rwLock.Unlock()
-	index, _, err := db.lastDerivedAt(derivedFrom)
-	if err != nil {
-		return fmt.Errorf("failed to find point to rewind to: %w", err)
-	}
-	err = db.store.Truncate(index)
-	if err != nil {
-		return err
-	}
-	db.m.RecordDBDerivedEntryCount(int64(index) + 1)
-	return nil
-}
-
 // First returns the first known values, alike to Latest.
 func (db *DB) First() (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -679,17 +679,17 @@ func TestRewind(t *testing.T) {
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Rewind to the future
-		require.ErrorIs(t, db.Rewind(6), types.ErrFuture)
+		require.ErrorIs(t, db.RewindToL1(6), types.ErrFuture)
 
 		// Rewind to the exact block we're at
-		require.NoError(t, db.Rewind(l1Block5.Number))
+		require.NoError(t, db.RewindToL1(l1Block5.Number))
 		pair, err = db.Latest()
 		require.NoError(t, err)
 		require.Equal(t, l1Block5, pair.DerivedFrom)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Now rewind to L1 block 3 (inclusive).
-		require.NoError(t, db.Rewind(l1Block3.Number))
+		require.NoError(t, db.RewindToL1(l1Block3.Number))
 
 		// See if we find consistent data
 		pair, err = db.Latest()
@@ -698,14 +698,14 @@ func TestRewind(t *testing.T) {
 		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L1 block 1 (inclusive).
-		require.NoError(t, db.Rewind(l1Block1.Number))
+		require.NoError(t, db.RewindToL1(l1Block1.Number))
 		pair, err = db.Latest()
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, pair.DerivedFrom)
 		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L1 block 0 (inclusive).
-		require.NoError(t, db.Rewind(l1Block0.Number))
+		require.NoError(t, db.RewindToL1(l1Block0.Number))
 		pair, err = db.Latest()
 		require.NoError(t, err)
 		require.Equal(t, l1Block0, pair.DerivedFrom)


### PR DESCRIPTION
- Moves all Reset Functions to the `update.go` file
- Creates an collection of Reset functions
  - `RewindToL1` - resets back to a given L1, which was the original `Rewind` behavior
  - `RewindToL2` - resets back to a given L2, which is needed when pruning the ChainsDB against an L2 block
  - `Rewind` - which takes a specific L1:L2 pair to reset against
  - `RewindAndInvalidate` - which uses `Rewind` before invalidating
  - `rewindLocked` - which does the *actual* database truncation and expects that one of the above Exported functions to handle locks.

All callers to `rewindLocked` take the DB lock first so they may do things like look up the last Derived or DerivedFrom block for the requested rewind. `rewindLocked` also includes a flag to optionally trim back the target itself or not, which was a slight difference of expected behavior between the different Rewind functions (`RewindAndInvalidate` expects to remove up to *and including* the target, while `RewindToL1/L2` expects the target to remain).

Also uses `RewindToL2` in the `ChainsDB` Rewind functionality, and further exposes that function to the Backend API so it can be used (in testing at least)