### PR TITLE
generate semver-lock with no changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ commands:
           command: |
             git reset --hard
             just <<parameters.command>>
-            git diff --quiet --exit-code
+            git diff --exit-code
           working_directory: packages/contracts-bedrock
           when: always
           environment:

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -19,6 +19,7 @@ additional_compiler_profiles = [
 compilation_restrictions = [
   { paths = "src/dispute/FaultDisputeGame.sol", optimizer_runs = 5000 },
   { paths = "src/dispute/PermissionedDisputeGame.sol", optimizer_runs = 5000 },
+  { paths = "src/L1/OPContractsManager.sol", optimizer_runs = 5000 },
 ]
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -12,19 +12,19 @@
     "sourceCodeHash": "0xe12b9e6c4e4ac2e2c9a03f07c7689f6bf2231922536072812cf1f37a5a276e73"
   },
   "src/L1/L1StandardBridge.sol": {
-    "initCodeHash": "0xe69e972e18930d3feaaad20b8e0e15625df9a71ad8304ee7d89c17d32644e152",
+    "initCodeHash": "0x3b7d0cffe4f4bc8c7a2cefe5657c8147656ecdbf387fe70a39ee74fdfaa172c9",
     "sourceCodeHash": "0xc6613d35d1ad95cbef26a503a10b5dd8663ceb80426f8c528835d39f79e4b4cf"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xa277d25e1aae34f68e9e8a0814c34f6adada5248992dc5e62831ef0082f130fb",
+    "initCodeHash": "0x788930c28625a3332128d3ccc4a25200cc95bf05b2ea8d37aaf94a2bdc9efca5",
     "sourceCodeHash": "0xaa2c1ae210bf8c53b21e8fe3280bf17040118530eafd1f33e8ed64bc17ee4a17"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0x5cbfb22cb4ca0465a0bc8d87034763f9a103384ff60ac88af8a4c2ced7c96b7d",
+    "initCodeHash": "0x68f6fec897c673b6bf67562b55900c6eec18a165d3cb97c8f317a5f5680afbd2",
     "sourceCodeHash": "0x1bbe8f918f1d5b1cc75924cdf23b10664b890fd306c2aa5d195a7b4177670431"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",
+    "initCodeHash": "0x7befd717b511a9207f6042de50d8e65d84ef7d8d42afff41c25d6528f46d14de",
     "sourceCodeHash": "0xf215a31954f2ef166cfb26d20e466c62fafa235a08fc42c55131dcb81998ff01"
   },
   "src/L1/OptimismPortalInterop.sol": {
@@ -104,7 +104,7 @@
     "sourceCodeHash": "0xb67b91f28c8666fee26c40375f835c61629e0f14054bfaf78bc3c61175bbf136"
   },
   "src/L2/OptimismMintableERC721Factory.sol": {
-    "initCodeHash": "0x9ccba9a5db77356c361fe4aea0e93498a56bda9fdac8d5e654d6f7abc4553028",
+    "initCodeHash": "0x174f9ece897365a31525cee030d6ea71864f832ab7dc1c2a56b657fa56122087",
     "sourceCodeHash": "0x2e4b8535b1f7749a0479b2c1de86b3ff79ee4ff6122c6f87c52d66cd301f3f97"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
@@ -136,11 +136,11 @@
     "sourceCodeHash": "0x11d711704a5afcae6076d017ee001b25bc705728973b1ad2e6a32274a8475f50"
   },
   "src/L2/WETH.sol": {
-    "initCodeHash": "0x480d4f8dbec1b0d3211bccbbdfb69796f3e90c784f724b1bbfd4703b0aafdeba",
+    "initCodeHash": "0x4ae485c1327118ac9c1a492fb687502a0eb6079a93b57912ab0d3af201754c74",
     "sourceCodeHash": "0xe9964aa66db1dfc86772958b4c9276697e67f7055529a43e6a49a055009bc995"
   },
   "src/cannon/MIPS.sol": {
-    "initCodeHash": "0xc10654f0e6498f424f7a5095bac36005dc7062d3813cc8f805a15005fc37406b",
+    "initCodeHash": "0x66478c040c82be2c383b4c9616f92eed4849939461aea0dd24606502da29dce6",
     "sourceCodeHash": "0x6c45dd23cb0d6f9bf4f84855ad0caf70e53dee3fe6c41454f7bf8df52ec3a9af"
   },
   "src/cannon/MIPS2.sol": {
@@ -164,7 +164,7 @@
     "sourceCodeHash": "0x0162302b9c71f184d45bee34ecfb1dfbf427f38fc5652709ab7ffef1ac816d82"
   },
   "src/dispute/DisputeGameFactory.sol": {
-    "initCodeHash": "0xa728192115c5fdb08c633a0899043318289b1d413d7afeed06356008b2a5a7fa",
+    "initCodeHash": "0x4179eeaa24838490be82aa5059fa9078ab84b020fe2eddb72aeea1bb44ea8775",
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
@@ -184,7 +184,7 @@
     "sourceCodeHash": "0x62c9a6182d82692fb9c173ddb0d7978bcff2d1d4dc8cd2f10625e1e65bda6888"
   },
   "src/safe/DeputyGuardianModule.sol": {
-    "initCodeHash": "0x5eaf823d81995ce1f703f26e31049c54c1d4902dd9873a0b4645d470f2f459a2",
+    "initCodeHash": "0xf170ba8120f9e83cf9933958892edcf1a0d4e19bd1cfe73de9de94fb28325f4c",
     "sourceCodeHash": "0x17236a91c4171ae9525eae0e59fa65bb2dc320d62677cfc7d7eb942f182619fb"
   },
   "src/safe/DeputyPauseModule.sol": {
@@ -196,11 +196,11 @@
     "sourceCodeHash": "0x72b8d8d855e7af8beee29330f6cb9b9069acb32e23ce940002ec9a41aa012a16"
   },
   "src/safe/LivenessModule.sol": {
-    "initCodeHash": "0xde3b3273aa37604048b5fa228b90f3b05997db613dfcda45061545a669b2476a",
+    "initCodeHash": "0xb710b33ee83412b7e210de0cd623e911952351711d5c84a99dd03b00066cf66f",
     "sourceCodeHash": "0x918965e52bbd358ac827ebe35998f5d8fa5ca77d8eb9ab8986b44181b9aaa48a"
   },
   "src/universal/OptimismMintableERC20.sol": {
-    "initCodeHash": "0xc3289416829b252c830ad7d389a430986a7404df4fe0be37cb19e1c40907f047",
+    "initCodeHash": "0x144f8ed06e2086f9dbfc805f277bef3b5a65badf6c467f0a89177b8fe995e980",
     "sourceCodeHash": "0xf5e29dd5c750ea935c7281ec916ba5277f5610a0a9e984e53ae5d5245b3cf2f4"
   },
   "src/universal/OptimismMintableERC20Factory.sol": {


### PR DESCRIPTION
The diff here is generated just by running `just semver-lock` without changing source code.

The semver-lock diff check should pass, demonstrating that the recent update to the forge version is causing some kind of compilation diff.

There are 3 commits: 
1. changes CI config to print the diff between the current semver lock and what is generated in CI. Note that CI passes. (https://github.com/ethereum-optimism/optimism/pull/13919/commits/44ba64a7508683b9258a4b4e1a9071cae5a4130b)
2. Adds a `compiler_restriction` for `OPContractsManager`. Note that this causes a diff in the `initCodeHash` for multiple unrelated contracts. (https://github.com/ethereum-optimism/optimism/pull/13919/commits/a9796b0a5680bf3b269dc0589ff6c81a5997bba3)
3. Commits a locally regenerated semver-lock, on a slightly newer version of foundry. This does cause an `initCodeHash` change, but it does not match the one generated in CI. 😡 (https://github.com/ethereum-optimism/optimism/pull/13919/commits/3c23a8da21f0630b2baeb358f5e873dd51f41f80)