### PR TITLE
make interfaces for opcm contracts and use them in tests and scripts

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Libraries
+import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
+
+// Interfaces
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+
+interface IOPContractsManager {
+    // -------- Structs --------
+
+    /// @notice Represents the roles that can be set when deploying a standard OP Stack chain.
+    struct Roles {
+        address opChainProxyAdminOwner;
+        address systemConfigOwner;
+        address batcher;
+        address unsafeBlockSigner;
+        address proposer;
+        address challenger;
+    }
+
+    /// @notice The full set of inputs to deploy a new OP Stack chain.
+    struct DeployInput {
+        Roles roles;
+        uint32 basefeeScalar;
+        uint32 blobBasefeeScalar;
+        uint256 l2ChainId;
+        // The correct type is OutputRoot memory but OP Deployer does not yet support structs.
+        bytes startingAnchorRoot;
+        // The salt mixer is used as part of making the resulting salt unique.
+        string saltMixer;
+        uint64 gasLimit;
+        // Configurable dispute game parameters.
+        GameType disputeGameType;
+        Claim disputeAbsolutePrestate;
+        uint256 disputeMaxGameDepth;
+        uint256 disputeSplitDepth;
+        Duration disputeClockExtension;
+        Duration disputeMaxClockDuration;
+    }
+
+    /// @notice The full set of outputs from deploying a new OP Stack chain.
+    struct DeployOutput {
+        IProxyAdmin opChainProxyAdmin;
+        IAddressManager addressManager;
+        IL1ERC721Bridge l1ERC721BridgeProxy;
+        ISystemConfig systemConfigProxy;
+        IOptimismMintableERC20Factory optimismMintableERC20FactoryProxy;
+        IL1StandardBridge l1StandardBridgeProxy;
+        IL1CrossDomainMessenger l1CrossDomainMessengerProxy;
+        // Fault proof contracts below.
+        IOptimismPortal2 optimismPortalProxy;
+        IDisputeGameFactory disputeGameFactoryProxy;
+        IAnchorStateRegistry anchorStateRegistryProxy;
+        IFaultDisputeGame faultDisputeGame;
+        IPermissionedDisputeGame permissionedDisputeGame;
+        IDelayedWETH delayedWETHPermissionedGameProxy;
+        IDelayedWETH delayedWETHPermissionlessGameProxy;
+    }
+
+    /// @notice Addresses of ERC-5202 Blueprint contracts. There are used for deploying full size
+    /// contracts, to reduce the code size of this factory contract. If it deployed full contracts
+    /// using the `new Proxy()` syntax, the code size would get large fast, since this contract would
+    /// contain the bytecode of every contract it deploys. Therefore we instead use Blueprints to
+    /// reduce the code size of this contract.
+    struct Blueprints {
+        address addressManager;
+        address proxy;
+        address proxyAdmin;
+        address l1ChugSplashProxy;
+        address resolvedDelegateProxy;
+        address permissionedDisputeGame1;
+        address permissionedDisputeGame2;
+        address permissionlessDisputeGame1;
+        address permissionlessDisputeGame2;
+    }
+
+    /// @notice The latest implementation contracts for the OP Stack.
+    struct Implementations {
+        address l1ERC721BridgeImpl;
+        address optimismPortalImpl;
+        address systemConfigImpl;
+        address optimismMintableERC20FactoryImpl;
+        address l1CrossDomainMessengerImpl;
+        address l1StandardBridgeImpl;
+        address disputeGameFactoryImpl;
+        address anchorStateRegistryImpl;
+        address delayedWETHImpl;
+        address mipsImpl;
+    }
+
+    /// @notice The input required to identify a chain for upgrading.
+    struct OpChain {
+        ISystemConfig systemConfigProxy;
+        IProxyAdmin proxyAdmin;
+    }
+
+    struct AddGameInput {
+        string saltMixer;
+        ISystemConfig systemConfig;
+        IProxyAdmin proxyAdmin;
+        IDelayedWETH delayedWETH;
+        GameType disputeGameType;
+        Claim disputeAbsolutePrestate;
+        uint256 disputeMaxGameDepth;
+        uint256 disputeSplitDepth;
+        Duration disputeClockExtension;
+        Duration disputeMaxClockDuration;
+        uint256 initialBond;
+        IBigStepper vm;
+        bool permissioned;
+    }
+
+    struct AddGameOutput {
+        IDelayedWETH delayedWETH;
+        IFaultDisputeGame faultDisputeGame;
+    }
+
+    // -------- Constants and Variables --------
+
+    function version() external pure returns (string memory);
+
+    /// @notice Address of the SuperchainConfig contract shared by all chains.
+    function superchainConfig() external view returns (ISuperchainConfig);
+
+    /// @notice Address of the ProtocolVersions contract shared by all chains.
+    function protocolVersions() external view returns (IProtocolVersions);
+
+    /// @notice L1 smart contracts release deployed by this version of OPCM. This is used in opcm to signal which
+    /// version of the L1 smart contracts is deployed. It takes the format of `op-contracts/vX.Y.Z`.
+    function l1ContractsRelease() external view returns (string memory);
+
+    // -------- Events --------
+
+    /// @notice Emitted when a new OP Stack chain is deployed.
+    /// @param l2ChainId Chain ID of the new chain.
+    /// @param deployer Address that deployed the chain.
+    /// @param deployOutput ABI-encoded output of the deployment.
+    event Deployed(uint256 indexed l2ChainId, address indexed deployer, bytes deployOutput);
+
+    /// @notice Emitted when a chain is upgraded
+    /// @param systemConfig Address of the chain's SystemConfig contract
+    /// @param upgrader Address that initiated the upgrade
+    event Upgraded(uint256 indexed l2ChainId, ISystemConfig indexed systemConfig, address indexed upgrader);
+
+    // -------- Errors --------
+
+    error BytesArrayTooLong();
+    error DeploymentFailed();
+    error EmptyInitcode();
+    error IdentityPrecompileCallFailed();
+    error NotABlueprint();
+    error ReservedBitsSet();
+    error UnexpectedPreambleData(bytes data);
+    error UnsupportedERCVersion(uint8 version);
+
+    /// @notice Thrown when an address is the zero address.
+    error AddressNotFound(address who);
+
+    /// @notice Throw when a contract address has no code.
+    error AddressHasNoCode(address who);
+
+    /// @notice Thrown when a release version is already set.
+    error AlreadyReleased();
+
+    /// @notice Thrown when an invalid `l2ChainId` is provided to `deploy`.
+    error InvalidChainId();
+
+    /// @notice Thrown when a role's address is not valid.
+    error InvalidRoleAddress(string role);
+
+    /// @notice Thrown when the latest release is not set upon initialization.
+    error LatestReleaseNotSet();
+
+    /// @notice Thrown when the starting anchor root is not provided.
+    error InvalidStartingAnchorRoot();
+
+    /// @notice Thrown when certain methods are called outside of a DELEGATECALL.
+    error OnlyDelegatecall();
+
+    /// @notice Thrown when game configs passed to addGameType are invalid.
+    error InvalidGameConfigs();
+
+    /// @notice Thrown when the SuperchainConfig of the chain does not match the SuperchainConfig of this OPCM.
+    error SuperchainConfigMismatch(ISystemConfig systemConfig);
+
+    // -------- Methods --------
+
+    function __constructor__(
+        ISuperchainConfig _superchainConfig,
+        IProtocolVersions _protocolVersions,
+        string memory _l1ContractsRelease,
+        Blueprints memory _blueprints,
+        Implementations memory _implementations
+    )
+        external;
+
+    function deploy(DeployInput calldata _input) external returns (DeployOutput memory);
+
+    /// @notice Upgrades a set of chains to the latest implementation contracts
+    /// @param _opChains Array of OpChain structs, one per chain to upgrade
+    /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
+    function upgrade(OpChain[] memory _opChains) external;
+
+    /// @notice addGameType deploys a new dispute game and links it to the DisputeGameFactory. The inputted _gameConfigs
+    /// must be added in ascending GameType order.
+    function addGameType(AddGameInput[] memory _gameConfigs) external returns (AddGameOutput[] memory);
+
+    /// @notice Maps an L2 chain ID to an L1 batch inbox address as defined by the standard
+    /// configuration's convention. This convention is `versionByte || keccak256(bytes32(chainId))[:19]`,
+    /// where || denotes concatenation`, versionByte is 0x00, and chainId is a uint256.
+    /// https://specs.optimism.io/protocol/configurability.html#consensus-parameters
+    function chainIdToBatchInboxAddress(uint256 _l2ChainId) external pure returns (address);
+
+    /// @notice Returns the blueprint contract addresses.
+    function blueprints() external view returns (Blueprints memory);
+
+    /// @notice Returns the implementation contract addresses.
+    function implementations() external view returns (Implementations memory);
+}

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerInterop.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+
+interface IOPContractsManagerInterop is IOPContractsManager {
+    function __constructor__(
+        ISuperchainConfig _superchainConfig,
+        IProtocolVersions _protocolVersions,
+        string memory _l1ContractsRelease,
+        Blueprints memory _blueprints,
+        Implementations memory _implementations
+    )
+        external;
+}

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -17,10 +17,8 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Types } from "scripts/libraries/Types.sol";
 import { Blueprint } from "src/libraries/Blueprint.sol";
 
-// Contracts
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
-
 // Interfaces
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -472,7 +470,7 @@ library ChainAssertions {
     /// @notice Asserts that the OPContractsManager is setup correctly
     function checkOPContractsManager(
         Types.ContractSet memory _contracts,
-        OPContractsManager _opcm,
+        IOPContractsManager _opcm,
         IMIPS _mips
     )
         internal
@@ -494,7 +492,7 @@ library ChainAssertions {
         require(bytes(_opcm.l1ContractsRelease()).length > 0, "CHECK-OPCM-40");
 
         // Ensure that the OPCM impls are correctly saved
-        OPContractsManager.Implementations memory impls = _opcm.implementations();
+        IOPContractsManager.Implementations memory impls = _opcm.implementations();
         require(impls.l1ERC721BridgeImpl == _contracts.L1ERC721Bridge, "CHECK-OPCM-50");
         require(impls.optimismPortalImpl == _contracts.OptimismPortal, "CHECK-OPCM-60");
         require(impls.systemConfigImpl == _contracts.SystemConfig, "CHECK-OPCM-70");
@@ -506,7 +504,7 @@ library ChainAssertions {
         require(impls.mipsImpl == address(_mips), "CHECK-OPCM-130");
 
         // Verify that initCode is correctly set into the blueprints
-        OPContractsManager.Blueprints memory blueprints = _opcm.blueprints();
+        IOPContractsManager.Blueprints memory blueprints = _opcm.blueprints();
         Blueprint.Preamble memory addressManagerPreamble =
             Blueprint.parseBlueprintPreamble(address(blueprints.addressManager).code);
         require(keccak256(addressManagerPreamble.initcode) == keccak256(vm.getCode("AddressManager")), "CHECK-OPCM-140");

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -24,9 +24,6 @@ import {
     DeployImplementationsOutput
 } from "scripts/deploy/DeployImplementations.s.sol";
 
-// Contracts
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
-
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 import { Types } from "scripts/libraries/Types.sol";
@@ -35,6 +32,7 @@ import { StorageSlot, ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.so
 import { GameType, Claim, GameTypes, OutputRoot, Hash } from "src/dispute/lib/Types.sol";
 
 // Interfaces
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
@@ -346,7 +344,7 @@ contract Deploy is Deployer {
         });
         ChainAssertions.checkOPContractsManager({
             _contracts: contracts,
-            _opcm: OPContractsManager(address(dio.opcm())),
+            _opcm: IOPContractsManager(address(dio.opcm())),
             _mips: IMIPS(address(dio.mipsSingleton()))
         });
         if (_isInterop) {
@@ -362,10 +360,10 @@ contract Deploy is Deployer {
 
         // Ensure that the requisite contracts are deployed
         address superchainConfigProxy = artifacts.mustGetAddress("SuperchainConfigProxy");
-        OPContractsManager opcm = OPContractsManager(artifacts.mustGetAddress("OPContractsManager"));
+        IOPContractsManager opcm = IOPContractsManager(artifacts.mustGetAddress("OPContractsManager"));
 
-        OPContractsManager.DeployInput memory deployInput = getDeployInput();
-        OPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
+        IOPContractsManager.DeployInput memory deployInput = getDeployInput();
+        IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
 
         // Save all deploy outputs from the OPCM, in the order they are declared in the DeployOutput struct
         artifacts.save("ProxyAdmin", address(deployOutput.opChainProxyAdmin));
@@ -854,10 +852,10 @@ contract Deploy is Deployer {
     }
 
     /// @notice Get the DeployInput struct to use for testing
-    function getDeployInput() public view returns (OPContractsManager.DeployInput memory) {
+    function getDeployInput() public view returns (IOPContractsManager.DeployInput memory) {
         string memory saltMixer = "salt mixer";
-        return OPContractsManager.DeployInput({
-            roles: OPContractsManager.Roles({
+        return IOPContractsManager.DeployInput({
+            roles: IOPContractsManager.Roles({
                 opChainProxyAdminOwner: msg.sender,
                 systemConfigOwner: cfg.finalSystemOwner(),
                 batcher: cfg.batchSenderAddress(),

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -805,12 +805,14 @@ contract DeployImplementationsInterop is DeployImplementations {
         });
 
         vm.broadcast(msg.sender);
-        opcm_ = IOPContractsManagerInterop(
+        opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManagerInterop",
-                _args: abi.encodeCall(
-                    IOPContractsManagerInterop.__constructor__,
-                    (superchainConfigProxy, protocolVersionsProxy, _l1ContractsRelease, _blueprints, implementations)
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IOPContractsManagerInterop.__constructor__,
+                        (superchainConfigProxy, protocolVersionsProxy, _l1ContractsRelease, _blueprints, implementations)
+                    )
                 ),
                 _salt: _salt
             })

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -14,15 +14,14 @@ import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { IMIPS } from "interfaces/cannon/IMIPS.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { IOPContractsManagerInterop } from "interfaces/L1/IOPContractsManagerInterop.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
-
-import { OPContractsManagerInterop } from "src/L1/OPContractsManagerInterop.sol";
 import { IOptimismPortalInterop } from "interfaces/L1/IOptimismPortalInterop.sol";
 import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
 
@@ -131,7 +130,7 @@ contract DeployImplementationsInput is BaseDeployIO {
 }
 
 contract DeployImplementationsOutput is BaseDeployIO {
-    OPContractsManager internal _opcm;
+    IOPContractsManager internal _opcm;
     IDelayedWETH internal _delayedWETHImpl;
     IOptimismPortal2 internal _optimismPortalImpl;
     IPreimageOracle internal _preimageOracleSingleton;
@@ -148,7 +147,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
         require(_addr != address(0), "DeployImplementationsOutput: cannot set zero address");
 
         // forgefmt: disable-start
-        if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
+        if (_sel == this.opcm.selector) _opcm = IOPContractsManager(_addr);
         else if (_sel == this.optimismPortalImpl.selector) _optimismPortalImpl = IOptimismPortal2(payable(_addr));
         else if (_sel == this.delayedWETHImpl.selector) _delayedWETHImpl = IDelayedWETH(payable(_addr));
         else if (_sel == this.preimageOracleSingleton.selector) _preimageOracleSingleton = IPreimageOracle(_addr);
@@ -190,7 +189,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
         assertValidDeploy(_dii);
     }
 
-    function opcm() public view returns (OPContractsManager) {
+    function opcm() public view returns (IOPContractsManager) {
         DeployUtils.assertValidContractAddress(address(_opcm));
         return _opcm;
     }
@@ -267,7 +266,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
     }
 
     function assertValidOpcm(DeployImplementationsInput _dii) internal view {
-        OPContractsManager impl = OPContractsManager(address(opcm()));
+        IOPContractsManager impl = IOPContractsManager(address(opcm()));
         require(address(impl.superchainConfig()) == address(_dii.superchainConfigProxy()), "OPCMI-10");
         require(address(impl.protocolVersions()) == address(_dii.protocolVersionsProxy()), "OPCMI-20");
     }
@@ -436,17 +435,17 @@ contract DeployImplementations is Script {
     function createOPCMContract(
         DeployImplementationsInput _dii,
         DeployImplementationsOutput _dio,
-        OPContractsManager.Blueprints memory _blueprints,
+        IOPContractsManager.Blueprints memory _blueprints,
         string memory _l1ContractsRelease
     )
         internal
         virtual
-        returns (OPContractsManager opcm_)
+        returns (IOPContractsManager opcm_)
     {
         ISuperchainConfig superchainConfigProxy = _dii.superchainConfigProxy();
         IProtocolVersions protocolVersionsProxy = _dii.protocolVersionsProxy();
 
-        OPContractsManager.Implementations memory implementations = OPContractsManager.Implementations({
+        IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),
@@ -460,11 +459,14 @@ contract DeployImplementations is Script {
         });
 
         vm.broadcast(msg.sender);
-        opcm_ = OPContractsManager(
+        opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManager",
-                _args: abi.encode(
-                    superchainConfigProxy, protocolVersionsProxy, _l1ContractsRelease, _blueprints, implementations
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IOPContractsManager.__constructor__,
+                        (superchainConfigProxy, protocolVersionsProxy, _l1ContractsRelease, _blueprints, implementations)
+                    )
                 ),
                 _salt: _salt
             })
@@ -485,7 +487,7 @@ contract DeployImplementations is Script {
 
         // First we deploy the blueprints for the singletons deployed by OPCM.
         // forgefmt: disable-start
-        OPContractsManager.Blueprints memory blueprints;
+        IOPContractsManager.Blueprints memory blueprints;
         vm.startBroadcast(msg.sender);
         address checkAddress;
         (blueprints.addressManager, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("AddressManager"), _salt);
@@ -505,7 +507,7 @@ contract DeployImplementations is Script {
         // forgefmt: disable-end
         vm.stopBroadcast();
 
-        OPContractsManager opcm = createOPCMContract(_dii, _dio, blueprints, l1ContractsRelease);
+        IOPContractsManager opcm = createOPCMContract(_dii, _dio, blueprints, l1ContractsRelease);
 
         vm.label(address(opcm), "OPContractsManager");
         _dio.set(_dio.opcm.selector, address(opcm));
@@ -778,18 +780,18 @@ contract DeployImplementationsInterop is DeployImplementations {
     function createOPCMContract(
         DeployImplementationsInput _dii,
         DeployImplementationsOutput _dio,
-        OPContractsManager.Blueprints memory _blueprints,
+        IOPContractsManager.Blueprints memory _blueprints,
         string memory _l1ContractsRelease
     )
         internal
         virtual
         override
-        returns (OPContractsManager opcm_)
+        returns (IOPContractsManager opcm_)
     {
         ISuperchainConfig superchainConfigProxy = _dii.superchainConfigProxy();
         IProtocolVersions protocolVersionsProxy = _dii.protocolVersionsProxy();
 
-        OPContractsManager.Implementations memory implementations = OPContractsManager.Implementations({
+        IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),
@@ -803,11 +805,12 @@ contract DeployImplementationsInterop is DeployImplementations {
         });
 
         vm.broadcast(msg.sender);
-        opcm_ = OPContractsManagerInterop(
+        opcm_ = IOPContractsManagerInterop(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManagerInterop",
-                _args: abi.encode(
-                    superchainConfigProxy, protocolVersionsProxy, _l1ContractsRelease, _blueprints, implementations
+                _args: abi.encodeCall(
+                    IOPContractsManagerInterop.__constructor__,
+                    (superchainConfigProxy, protocolVersionsProxy, _l1ContractsRelease, _blueprints, implementations)
                 ),
                 _salt: _salt
             })

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -18,7 +18,7 @@ import { Constants as ScriptConstants } from "scripts/libraries/Constants.sol";
 
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -27,7 +27,6 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 import { Claim, Duration, GameType, GameTypes, Hash } from "src/dispute/lib/Types.sol";
 
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -47,7 +46,7 @@ contract DeployOPChainInput is BaseDeployIO {
     uint32 internal _basefeeScalar;
     uint32 internal _blobBaseFeeScalar;
     uint256 internal _l2ChainId;
-    OPContractsManager internal _opcm;
+    IOPContractsManager internal _opcm;
     string internal _saltMixer;
     uint64 internal _gasLimit;
 
@@ -68,7 +67,7 @@ contract DeployOPChainInput is BaseDeployIO {
         else if (_sel == this.unsafeBlockSigner.selector) _unsafeBlockSigner = _addr;
         else if (_sel == this.proposer.selector) _proposer = _addr;
         else if (_sel == this.challenger.selector) _challenger = _addr;
-        else if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
+        else if (_sel == this.opcm.selector) _opcm = IOPContractsManager(_addr);
         else revert("DeployOPChainInput: unknown selector");
     }
 
@@ -174,7 +173,7 @@ contract DeployOPChainInput is BaseDeployIO {
         return abi.encode(ScriptConstants.DEFAULT_OUTPUT_ROOT());
     }
 
-    function opcm() public view returns (OPContractsManager) {
+    function opcm() public view returns (IOPContractsManager) {
         require(address(_opcm) != address(0), "DeployOPChainInput: not set");
         DeployUtils.assertValidContractAddress(address(_opcm));
         return _opcm;
@@ -339,9 +338,9 @@ contract DeployOPChain is Script {
     // -------- Core Deployment Methods --------
 
     function run(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
-        OPContractsManager opcm = _doi.opcm();
+        IOPContractsManager opcm = _doi.opcm();
 
-        OPContractsManager.Roles memory roles = OPContractsManager.Roles({
+        IOPContractsManager.Roles memory roles = IOPContractsManager.Roles({
             opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
             systemConfigOwner: _doi.systemConfigOwner(),
             batcher: _doi.batcher(),
@@ -349,7 +348,7 @@ contract DeployOPChain is Script {
             proposer: _doi.proposer(),
             challenger: _doi.challenger()
         });
-        OPContractsManager.DeployInput memory deployInput = OPContractsManager.DeployInput({
+        IOPContractsManager.DeployInput memory deployInput = IOPContractsManager.DeployInput({
             roles: roles,
             basefeeScalar: _doi.basefeeScalar(),
             blobBasefeeScalar: _doi.blobBaseFeeScalar(),
@@ -366,7 +365,7 @@ contract DeployOPChain is Script {
         });
 
         vm.broadcast(msg.sender);
-        OPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
+        IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
 
         vm.label(address(deployOutput.opChainProxyAdmin), "opChainProxyAdmin");
         vm.label(address(deployOutput.addressManager), "addressManager");
@@ -468,7 +467,7 @@ contract DeployOPChain is Script {
             "DPG-20"
         );
 
-        OPContractsManager opcm = _doi.opcm();
+        IOPContractsManager opcm = _doi.opcm();
         address mipsImpl = opcm.implementations().mipsImpl;
         require(game.vm() == IBigStepper(mipsImpl), "DPG-30");
 

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -7,21 +7,21 @@ import { Script } from "forge-std/Script.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { DeployOPChainOutput } from "scripts/deploy/DeployOPChain.s.sol";
 import { IMIPS } from "interfaces/cannon/IMIPS.sol";
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IStaticL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
 
 contract ReadImplementationAddressesInput is DeployOPChainOutput {
-    OPContractsManager internal _opcm;
+    IOPContractsManager internal _opcm;
 
     function set(bytes4 _sel, address _addr) public override {
         require(_addr != address(0), "ReadImplementationAddressesInput: cannot set zero address");
-        if (_sel == this.opcm.selector) _opcm = OPContractsManager(_addr);
+        if (_sel == this.opcm.selector) _opcm = IOPContractsManager(_addr);
         else if (_sel == this.addressManager.selector) _addressManager = IAddressManager(_addr);
         else super.set(_sel, _addr);
     }
 
-    function opcm() public view returns (OPContractsManager) {
+    function opcm() public view returns (IOPContractsManager) {
         DeployUtils.assertValidContractAddress(address(_opcm));
         return _opcm;
     }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -9,6 +9,7 @@ import { DelegateCaller } from "test/mocks/Callers.sol";
 
 // Scripts
 import { DeployOPChainInput } from "scripts/deploy/DeployOPChain.s.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
@@ -24,6 +25,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 
 // Contracts
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
@@ -97,9 +99,13 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
 
     // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol
     // to the input struct type defined in OPContractsManager.sol.
-    function toOPCMDeployInput(DeployOPChainInput _doi) internal view returns (OPContractsManager.DeployInput memory) {
-        return OPContractsManager.DeployInput({
-            roles: OPContractsManager.Roles({
+    function toOPCMDeployInput(DeployOPChainInput _doi)
+        internal
+        view
+        returns (IOPContractsManager.DeployInput memory)
+    {
+        return IOPContractsManager.DeployInput({
+            roles: IOPContractsManager.Roles({
                 opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
                 systemConfigOwner: _doi.systemConfigOwner(),
                 batcher: _doi.batcher(),
@@ -123,17 +129,17 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
     }
 
     function test_deploy_l2ChainIdEqualsZero_reverts() public {
-        OPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
+        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
         deployInput.l2ChainId = 0;
-        vm.expectRevert(OPContractsManager.InvalidChainId.selector);
+        vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
         opcm.deploy(deployInput);
     }
 
     function test_deploy_l2ChainIdEqualsCurrentChainId_reverts() public {
-        OPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
+        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
         deployInput.l2ChainId = block.chainid;
 
-        vm.expectRevert(OPContractsManager.InvalidChainId.selector);
+        vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
         opcm.deploy(deployInput);
     }
 
@@ -194,7 +200,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
     uint256 l2ChainId;
     IProxyAdmin proxyAdmin;
     address upgrader;
-    OPContractsManager.OpChain[] opChains;
+    IOPContractsManager.OpChain[] opChains;
 
     function setUp() public virtual override {
         super.disableUpgradedFork();
@@ -208,7 +214,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
-        opChains.push(OPContractsManager.OpChain({ systemConfigProxy: systemConfig, proxyAdmin: proxyAdmin }));
+        opChains.push(IOPContractsManager.OpChain({ systemConfigProxy: systemConfig, proxyAdmin: proxyAdmin }));
 
         // Retrieve the l2ChainId, which was read from the superchain-registry, and saved in Artifacts
         // encoded as an address.
@@ -225,7 +231,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     function test_upgrade_succeeds() public {
         vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-        OPContractsManager.Implementations memory impls = opcm.implementations();
+        IOPContractsManager.Implementations memory impls = opcm.implementations();
         address oldL1CrossDomainMessenger = addressManager.getAddress("OVM_L1CrossDomainMessenger");
 
         expectEmitUpgraded(impls.systemConfigImpl, address(systemConfig));
@@ -244,7 +250,7 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
         }
         vm.expectEmit(true, true, true, true, address(upgrader));
         emit Upgraded(l2ChainId, opChains[0].systemConfigProxy, address(upgrader));
-        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(OPContractsManager.upgrade, (opChains)));
+        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
 
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(impls.l1ERC721BridgeImpl, EIP1967Helper.getImplementation(address(l1ERC721Bridge)));
@@ -275,7 +281,7 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
 contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harness {
     function test_upgrade_notDelegateCalled_reverts() public {
         vm.prank(upgrader);
-        vm.expectRevert(OPContractsManager.OnlyDelegatecall.selector);
+        vm.expectRevert(IOPContractsManager.OnlyDelegatecall.selector);
         opcm.upgrade(opChains);
     }
 
@@ -289,22 +295,22 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
         );
 
         vm.expectRevert(
-            abi.encodeWithSelector(OPContractsManager.SuperchainConfigMismatch.selector, address(systemConfig))
+            abi.encodeWithSelector(IOPContractsManager.SuperchainConfigMismatch.selector, address(systemConfig))
         );
-        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(OPContractsManager.upgrade, (opChains)));
+        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
     }
 }
 
 contract OPContractsManager_AddGameType_Test is Test {
-    OPContractsManager internal opcm;
+    IOPContractsManager internal opcm;
 
-    OPContractsManager.DeployOutput internal chainDeployOutput;
+    IOPContractsManager.DeployOutput internal chainDeployOutput;
 
     function setUp() public {
         ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfig"));
         IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersions"));
         bytes32 salt = hex"01";
-        OPContractsManager.Blueprints memory blueprints;
+        IOPContractsManager.Blueprints memory blueprints;
         (blueprints.addressManager,) = Blueprint.create(vm.getCode("AddressManager"), salt);
         (blueprints.proxy,) = Blueprint.create(vm.getCode("Proxy"), salt);
         (blueprints.proxyAdmin,) = Blueprint.create(vm.getCode("ProxyAdmin"), salt);
@@ -317,7 +323,7 @@ contract OPContractsManager_AddGameType_Test is Test {
 
         IPreimageOracle oracle = IPreimageOracle(address(new PreimageOracle(126000, 86400)));
 
-        OPContractsManager.Implementations memory impls = OPContractsManager.Implementations({
+        IOPContractsManager.Implementations memory impls = IOPContractsManager.Implementations({
             l1ERC721BridgeImpl: address(new L1ERC721Bridge()),
             optimismPortalImpl: address(new OptimismPortal2(1, 1)),
             systemConfigImpl: address(new SystemConfig()),
@@ -333,11 +339,22 @@ contract OPContractsManager_AddGameType_Test is Test {
         vm.etch(address(superchainConfigProxy), hex"01");
         vm.etch(address(protocolVersionsProxy), hex"01");
 
-        opcm = new OPContractsManager(superchainConfigProxy, protocolVersionsProxy, "dev", blueprints, impls);
+        opcm = IOPContractsManager(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IOPContractsManager.__constructor__,
+                        (superchainConfigProxy, protocolVersionsProxy, "dev", blueprints, impls)
+                    )
+                ),
+                _salt: DeployUtils.DEFAULT_SALT
+            })
+        );
 
         chainDeployOutput = opcm.deploy(
-            OPContractsManager.DeployInput({
-                roles: OPContractsManager.Roles({
+            IOPContractsManager.DeployInput({
+                roles: IOPContractsManager.Roles({
                     opChainProxyAdminOwner: address(this),
                     systemConfigOwner: address(this),
                     batcher: address(this),
@@ -364,8 +381,8 @@ contract OPContractsManager_AddGameType_Test is Test {
     }
 
     function test_addGameType_permissioned_succeeds() public {
-        OPContractsManager.AddGameInput memory input = newGameInputFactory(true);
-        OPContractsManager.AddGameOutput memory output = addGameType(input);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        IOPContractsManager.AddGameOutput memory output = addGameType(input);
         assertValidGameType(input, output);
         IPermissionedDisputeGame newPDG = IPermissionedDisputeGame(address(output.faultDisputeGame));
         IPermissionedDisputeGame oldPDG = chainDeployOutput.permissionedDisputeGame;
@@ -374,8 +391,8 @@ contract OPContractsManager_AddGameType_Test is Test {
     }
 
     function test_addGameType_permissionless_succeeds() public {
-        OPContractsManager.AddGameInput memory input = newGameInputFactory(false);
-        OPContractsManager.AddGameOutput memory output = addGameType(input);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        IOPContractsManager.AddGameOutput memory output = addGameType(input);
         assertValidGameType(input, output);
         IPermissionedDisputeGame notPDG = IPermissionedDisputeGame(address(output.faultDisputeGame));
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
@@ -385,76 +402,76 @@ contract OPContractsManager_AddGameType_Test is Test {
     function test_addGameType_reusedDelayedWETH_succeeds() public {
         IDelayedWETH delayedWETH = IDelayedWETH(payable(address(new DelayedWETH(1))));
         vm.etch(address(delayedWETH), hex"01");
-        OPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
         input.delayedWETH = delayedWETH;
-        OPContractsManager.AddGameOutput memory output = addGameType(input);
+        IOPContractsManager.AddGameOutput memory output = addGameType(input);
         assertValidGameType(input, output);
         assertEq(address(output.delayedWETH), address(delayedWETH), "delayedWETH address mismatch");
     }
 
     function test_addGameType_outOfOrderInputs_reverts() public {
-        OPContractsManager.AddGameInput memory input1 = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput memory input1 = newGameInputFactory(false);
         input1.disputeGameType = GameType.wrap(2);
-        OPContractsManager.AddGameInput memory input2 = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput memory input2 = newGameInputFactory(false);
         input2.disputeGameType = GameType.wrap(1);
-        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](2);
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](2);
         inputs[0] = input1;
         inputs[1] = input2;
 
         // For the sake of completeness, we run the call again to validate the success behavior.
-        (bool success,) = address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+        (bool success,) = address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.addGameType, (inputs)));
         assertFalse(success, "addGameType should have failed");
     }
 
     function test_addGameType_duplicateGameType_reverts() public {
-        OPContractsManager.AddGameInput memory input = newGameInputFactory(false);
-        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](2);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](2);
         inputs[0] = input;
         inputs[1] = input;
 
         // See test above for why we run the call twice.
         (bool success, bytes memory revertData) =
-            address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+            address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.addGameType, (inputs)));
         assertFalse(success, "addGameType should have failed");
-        assertEq(bytes4(revertData), OPContractsManager.InvalidGameConfigs.selector, "revertData mismatch");
+        assertEq(bytes4(revertData), IOPContractsManager.InvalidGameConfigs.selector, "revertData mismatch");
     }
 
     function test_addGameType_zeroLengthInput_reverts() public {
-        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](0);
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](0);
 
         (bool success, bytes memory revertData) =
-            address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+            address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.addGameType, (inputs)));
         assertFalse(success, "addGameType should have failed");
-        assertEq(bytes4(revertData), OPContractsManager.InvalidGameConfigs.selector, "revertData mismatch");
+        assertEq(bytes4(revertData), IOPContractsManager.InvalidGameConfigs.selector, "revertData mismatch");
     }
 
     function test_addGameType_notDelegateCall_reverts() public {
-        OPContractsManager.AddGameInput memory input = newGameInputFactory(true);
-        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](1);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
         inputs[0] = input;
 
-        vm.expectRevert(OPContractsManager.OnlyDelegatecall.selector);
+        vm.expectRevert(IOPContractsManager.OnlyDelegatecall.selector);
         opcm.addGameType(inputs);
     }
 
-    function addGameType(OPContractsManager.AddGameInput memory input)
+    function addGameType(IOPContractsManager.AddGameInput memory input)
         internal
-        returns (OPContractsManager.AddGameOutput memory)
+        returns (IOPContractsManager.AddGameOutput memory)
     {
-        OPContractsManager.AddGameInput[] memory inputs = new OPContractsManager.AddGameInput[](1);
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
         inputs[0] = input;
 
         (bool success, bytes memory rawGameOut) =
-            address(opcm).delegatecall(abi.encodeCall(OPContractsManager.addGameType, (inputs)));
+            address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.addGameType, (inputs)));
         assertTrue(success, "addGameType failed");
 
-        OPContractsManager.AddGameOutput[] memory addGameOutAll =
-            abi.decode(rawGameOut, (OPContractsManager.AddGameOutput[]));
+        IOPContractsManager.AddGameOutput[] memory addGameOutAll =
+            abi.decode(rawGameOut, (IOPContractsManager.AddGameOutput[]));
         return addGameOutAll[0];
     }
 
-    function newGameInputFactory(bool permissioned) internal view returns (OPContractsManager.AddGameInput memory) {
-        return OPContractsManager.AddGameInput({
+    function newGameInputFactory(bool permissioned) internal view returns (IOPContractsManager.AddGameInput memory) {
+        return IOPContractsManager.AddGameInput({
             saltMixer: "hello",
             systemConfig: chainDeployOutput.systemConfigProxy,
             proxyAdmin: chainDeployOutput.opChainProxyAdmin,
@@ -472,8 +489,8 @@ contract OPContractsManager_AddGameType_Test is Test {
     }
 
     function assertValidGameType(
-        OPContractsManager.AddGameInput memory agi,
-        OPContractsManager.AddGameOutput memory ago
+        IOPContractsManager.AddGameInput memory agi,
+        IOPContractsManager.AddGameOutput memory ago
     )
         internal
         view

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -12,7 +12,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -80,7 +80,7 @@ contract DeployImplementationsOutput_Test is Test {
     }
 
     function test_set_succeeds() public {
-        OPContractsManager opcm = OPContractsManager(address(makeAddr("opcm")));
+        IOPContractsManager opcm = IOPContractsManager(address(makeAddr("opcm")));
         IOptimismPortal2 optimismPortalImpl = IOptimismPortal2(payable(makeAddr("optimismPortalImpl")));
         IDelayedWETH delayedWETHImpl = IDelayedWETH(payable(makeAddr("delayedWETHImpl")));
         IPreimageOracle preimageOracleSingleton = IPreimageOracle(makeAddr("preimageOracleSingleton"));

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { DeployOPCM, DeployOPCMInput, DeployOPCMOutput } from "scripts/deploy/DeployOPCM.s.sol";
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 
@@ -181,7 +181,7 @@ contract DeployOPCMOutput_Test is Test {
     }
 
     function test_set_succeeds() public {
-        OPContractsManager opcm = OPContractsManager(makeAddr("opcm"));
+        IOPContractsManager opcm = IOPContractsManager(makeAddr("opcm"));
         vm.etch(address(opcm), hex"01");
 
         doo.set(doo.opcm.selector, address(opcm));

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -24,7 +24,7 @@ import { IResolvedDelegateProxy } from "interfaces/legacy/IResolvedDelegateProxy
 
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 
 import { Claim, Duration, GameType, GameTypes, Hash, OutputRoot } from "src/dispute/lib/Types.sol";
@@ -328,7 +328,7 @@ contract DeployOPChain_TestBase is Test {
     uint32 blobBaseFeeScalar = 200;
     uint256 l2ChainId = 300;
     OutputRoot startingAnchorRoot = OutputRoot({ root: Hash.wrap(keccak256("defaultOutputRoot")), l2BlockNumber: 400 });
-    OPContractsManager opcm = OPContractsManager(address(0));
+    IOPContractsManager opcm = IOPContractsManager(address(0));
     string saltMixer = "defaultSaltMixer";
     uint64 gasLimit = 60_000_000;
     // Configurable dispute game parameters.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -21,7 +21,7 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 
 /// @title ForkLive
 /// @notice This script is called by Setup.sol as a preparation step for the foundry test suite, and is run as an
@@ -141,7 +141,7 @@ contract ForkLive is Deployer {
 
     /// @notice Upgrades the contracts using the OPCM.
     function _upgrade() internal {
-        OPContractsManager opcm = OPContractsManager(artifacts.mustGetAddress("OPContractsManager"));
+        IOPContractsManager opcm = IOPContractsManager(artifacts.mustGetAddress("OPContractsManager"));
 
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         IProxyAdmin proxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(systemConfig)));
@@ -149,13 +149,13 @@ contract ForkLive is Deployer {
         address upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
-        OPContractsManager.OpChain[] memory opChains = new OPContractsManager.OpChain[](1);
-        opChains[0] = OPContractsManager.OpChain({ systemConfigProxy: systemConfig, proxyAdmin: proxyAdmin });
+        IOPContractsManager.OpChain[] memory opChains = new IOPContractsManager.OpChain[](1);
+        opChains[0] = IOPContractsManager.OpChain({ systemConfigProxy: systemConfig, proxyAdmin: proxyAdmin });
 
         // TODO Migrate from DelegateCaller to a Safe to reduce risk of mocks not properly
         // reflecting the production system.
         vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(OPContractsManager.upgrade, (opChains)));
+        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
     }
 
     /// @notice Saves the proxy and implementation addresses for a contract name

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -20,10 +20,8 @@ import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Chains } from "scripts/libraries/Chains.sol";
 
-// Contracts (TODO: move to interfaces)
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
-
 // Interfaces
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -107,7 +105,7 @@ contract Setup {
     IProtocolVersions protocolVersions;
     ISuperchainConfig superchainConfig;
     IDataAvailabilityChallenge dataAvailabilityChallenge;
-    OPContractsManager opcm;
+    IOPContractsManager opcm;
 
     // L2 contracts
     IL2CrossDomainMessenger l2CrossDomainMessenger =
@@ -229,7 +227,7 @@ contract Setup {
         anchorStateRegistry = IAnchorStateRegistry(artifacts.mustGetAddress("AnchorStateRegistryProxy"));
         disputeGameFactory = IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
         delayedWeth = IDelayedWETH(artifacts.mustGetAddress("DelayedWETHProxy"));
-        opcm = OPContractsManager(artifacts.mustGetAddress("OPContractsManager"));
+        opcm = IOPContractsManager(artifacts.mustGetAddress("OPContractsManager"));
 
         if (deploy.cfg().useAltDA()) {
             dataAvailabilityChallenge =

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -8,10 +8,8 @@ import { console2 as console } from "forge-std/console2.sol";
 // Scripts
 import { ForgeArtifacts, Abi, AbiEntry } from "scripts/libraries/ForgeArtifacts.sol";
 
-// Contracts
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
-
 // Interfaces
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IOptimismPortalInterop } from "interfaces/L1/IOptimismPortalInterop.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -781,24 +779,24 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("protocolVersions()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("l1ContractsRelease()") });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.deploy.selector });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.blueprints.selector });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.chainIdToBatchInboxAddress.selector });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.implementations.selector });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.upgrade.selector });
-        _addSpec({ _name: "OPContractsManager", _sel: OPContractsManager.addGameType.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.deploy.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.blueprints.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.chainIdToBatchInboxAddress.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.implementations.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.upgrade.selector });
+        _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.addGameType.selector });
 
         // OPContractsManagerInterop
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("version()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("protocolVersions()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("l1ContractsRelease()") });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.deploy.selector });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.blueprints.selector });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.chainIdToBatchInboxAddress.selector });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.implementations.selector });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.upgrade.selector });
-        _addSpec({ _name: "OPContractsManagerInterop", _sel: OPContractsManager.addGameType.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.deploy.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.blueprints.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.chainIdToBatchInboxAddress.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.implementations.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.upgrade.selector });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.addGameType.selector });
 
         // DeputyGuardianModule
         _addSpec({


### PR DESCRIPTION
- make interfaces for opcm contracts
- use them in tests and scripts to boost compilation times and ensure type safety when encoding it's constructor arguments