### PR TITLE
ci: print the diff in contracts-checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ commands:
           command: |
             git reset --hard
             just <<parameters.command>>
-            git diff --quiet --exit-code
+            git diff --exit-code
           working_directory: packages/contracts-bedrock
           when: always
           environment:


### PR DESCRIPTION
**Description**

When a git diff check fails in CI, we should just print the diff to make it easier to debug. 