### PR TITLE
fix: Fix MaxUint64 Overflow for ChainID Deployer

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -548,10 +548,10 @@ func (d *UpgradeScheduleDeployConfig) Check(log log.Logger) error {
 // L2CoreDeployConfig configures the core protocol parameters of the chain.
 type L2CoreDeployConfig struct {
 	// L1ChainID is the chain ID of the L1 chain.
-	L1ChainID uint64 `json:"l1ChainID"`
+	L1ChainID uint64 `json:"l1ChainID,string"`
 
 	// L2ChainID is the chain ID of the L2 chain.
-	L2ChainID uint64 `json:"l2ChainID"`
+	L2ChainID uint64 `json:"l2ChainID,string"`
 
 	// L2BlockTime is the number of seconds between each L2 block.
 	L2BlockTime uint64 `json:"l2BlockTime"`


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

There is currently an overflow issue when attempting to use op-program with a custom chain.

Op-program currently uses a `CustomChainIDIndicator` to boot l2ChainConfig and rollupConfig information for custom chains (e.g local networks using [Kurtosis](https://github.com/ethpandaops/optimism-package)) ([code](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/client/boot/boot.go#L15)). This value is set at `18446744073709551615` which is the highest uint64 value.

Golang JSON Un/Marshalling does not support this large number and loses precision when marshalling and unmarshalling data using this number into/from generic maps as is done by [op-service jsonutil merge](https://github.com/ethereum-optimism/optimism/blob/develop/op-service/jsonutil/merge.go#L16-L29). See [the playground code](https://go.dev/play/p/KVMEM8SoN-W).

This breaks op-deployer when attempting to deploy a custom chain because the ChainID is set to `18446744073709551615` and when this value is json merged, it loses it's precision ([code](https://github.com/ethereum-optimism/optimism/blob/develop/op-deployer/pkg/deployer/state/deploy_config.go#L165))

This fix proposes to use the `string` tag inside the `json tag` which is meant to represent numbers as strings to avoid losing precision.   

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
No tests, because it's a simple change

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
