### PR TITLE
op-supervisor: Add cross-safe L1 block to SuperRootResponse

### DIFF
--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -63,6 +63,10 @@ func (ib *InteropAPI) PendingOutputV0AtTimestamp(ctx context.Context, timestamp 
 	return ib.backend.PendingOutputV0AtTimestamp(ctx, timestamp)
 }
 
+func (ib *InteropAPI) L2BlockRefByTimestamp(ctx context.Context, timestamp uint64) (eth.L2BlockRef, error) {
+	return ib.backend.L2BlockRefByTimestamp(ctx, timestamp)
+}
+
 func (ib *InteropAPI) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {
 	return ib.backend.ProvideL1(ctx, nextL1)
 }

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -282,11 +282,7 @@ func (m *ManagedMode) ChainID(ctx context.Context) (eth.ChainID, error) {
 }
 
 func (m *ManagedMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
-	num, err := m.cfg.TargetBlockNumber(timestamp)
-	if err != nil {
-		return nil, err
-	}
-	ref, err := m.l2.L2BlockRefByNumber(ctx, num)
+	ref, err := m.L2BlockRefByTimestamp(ctx, timestamp)
 	if err != nil {
 		return nil, err
 	}
@@ -294,11 +290,7 @@ func (m *ManagedMode) OutputV0AtTimestamp(ctx context.Context, timestamp uint64)
 }
 
 func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error) {
-	num, err := m.cfg.TargetBlockNumber(timestamp)
-	if err != nil {
-		return nil, err
-	}
-	ref, err := m.l2.L2BlockRefByNumber(ctx, num)
+	ref, err := m.L2BlockRefByTimestamp(ctx, timestamp)
 	if err != nil {
 		return nil, err
 	}
@@ -306,4 +298,12 @@ func (m *ManagedMode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp 
 	// block contained in the optimistic block deposited transaction - https://github.com/ethereum-optimism/specs/pull/489
 	// For now, we use the output at timestamp as-if it didn't contain invalid messages for happy path testing.
 	return m.l2.OutputV0AtBlock(ctx, ref.Hash)
+}
+
+func (m *ManagedMode) L2BlockRefByTimestamp(ctx context.Context, timestamp uint64) (eth.L2BlockRef, error) {
+	num, err := m.cfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		return eth.L2BlockRef{}, err
+	}
+	return m.l2.L2BlockRefByNumber(ctx, num)
 }

--- a/op-service/eth/super_root.go
+++ b/op-service/eth/super_root.go
@@ -148,24 +148,27 @@ func (i *ChainRootInfo) UnmarshalJSON(input []byte) error {
 }
 
 type SuperRootResponse struct {
-	Timestamp uint64  `json:"timestamp"`
-	SuperRoot Bytes32 `json:"superRoot"`
+	CrossSafeDerivedFrom BlockID `json:"crossSafeDerivedFrom"`
+	Timestamp            uint64  `json:"timestamp"`
+	SuperRoot            Bytes32 `json:"superRoot"`
 	// Chains is the list of ChainRootInfo for each chain in the dependency set.
 	// It represents the state of the chain at or before the Timestamp.
 	Chains []ChainRootInfo `json:"chains"`
 }
 
 type superRootResponseMarshalling struct {
-	Timestamp hexutil.Uint64  `json:"timestamp"`
-	SuperRoot common.Hash     `json:"superRoot"`
-	Chains    []ChainRootInfo `json:"chains"`
+	CrossSafeDerivedFrom BlockID         `json:"crossSafeDerivedFrom"`
+	Timestamp            hexutil.Uint64  `json:"timestamp"`
+	SuperRoot            common.Hash     `json:"superRoot"`
+	Chains               []ChainRootInfo `json:"chains"`
 }
 
 func (r SuperRootResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&superRootResponseMarshalling{
-		Timestamp: hexutil.Uint64(r.Timestamp),
-		SuperRoot: common.Hash(r.SuperRoot),
-		Chains:    r.Chains,
+		CrossSafeDerivedFrom: r.CrossSafeDerivedFrom,
+		Timestamp:            hexutil.Uint64(r.Timestamp),
+		SuperRoot:            common.Hash(r.SuperRoot),
+		Chains:               r.Chains,
 	})
 }
 
@@ -174,6 +177,7 @@ func (r *SuperRootResponse) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
+	r.CrossSafeDerivedFrom = dec.CrossSafeDerivedFrom
 	r.Timestamp = uint64(dec.Timestamp)
 	r.SuperRoot = Bytes32(dec.SuperRoot)
 	r.Chains = dec.Chains

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -27,6 +27,7 @@ type SyncSource interface {
 	ChainID(ctx context.Context) (eth.ChainID, error)
 	OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
 	PendingOutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
+	L2BlockRefByTimestamp(ctx context.Context, timestamp uint64) (eth.L2BlockRef, error)
 	// String identifies the sync source
 	String() string
 }

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -81,6 +81,12 @@ func (rs *RPCSyncNode) PendingOutputV0AtTimestamp(ctx context.Context, timestamp
 	return out, err
 }
 
+func (rs *RPCSyncNode) L2BlockRefByTimestamp(ctx context.Context, timestamp uint64) (eth.L2BlockRef, error) {
+	var out eth.L2BlockRef
+	err := rs.cl.CallContext(ctx, &out, "interop_l2BlockRefByTimestamp", timestamp)
+	return out, err
+}
+
 func (rs *RPCSyncNode) String() string {
 	return rs.name
 }


### PR DESCRIPTION
Add the L1 block that a super root can be considered cross-safe. This is the earliest block that indicates cross-safety in the super root.

It'll be used later by the challenger to determine when its view of the chain is synchronized enough to participate in dispute games.

Fixes https://github.com/ethereum-optimism/optimism/issues/13890