### PR TITLE
ci: Fix uploading of prestates from op-program releases.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1520,6 +1520,7 @@ workflows:
             - slack
             - oplabs-network-optimism-io-bucket
           requires:
+            - hold
             - cannon-prestate
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,8 +947,8 @@ jobs:
                 mentions: "<<parameters.mentions>>"
 
   sanitize-op-program:
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1614,29 +1614,29 @@ workflows:
           build_args: --deny-warnings --skip test
           context:
             - slack
-      - go-tests:
-          name: op-e2e-cannon-tests
-          notify: true
-          mentions: "@proofs-team"
-          no_output_timeout: 60m
-          test_timeout: 59m
-          resource_class: ethereum-optimism/latitude-fps-1
-          environment_overrides: |
-            export OP_E2E_CANNON_ENABLED="true"
-          packages: |
-            op-e2e/faultproofs
-          context:
-            - slack
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate
+#      - go-tests:
+#          name: op-e2e-cannon-tests
+#          notify: true
+#          mentions: "@proofs-team"
+#          no_output_timeout: 60m
+#          test_timeout: 59m
+#          resource_class: ethereum-optimism/latitude-fps-1
+#          environment_overrides: |
+#            export OP_E2E_CANNON_ENABLED="true"
+#          packages: |
+#            op-e2e/faultproofs
+#          context:
+#            - slack
+#          requires:
+#            - contracts-bedrock-build
+#            - cannon-prestate
       - publish-cannon-prestates:
           context:
             - slack
             - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
-            - op-e2e-cannon-tests
+#            - op-e2e-cannon-tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -993,21 +993,26 @@ jobs:
       - run:
           name: Upload cannon prestates
           command: |
-            VERSION="<< pipeline.git.branch >>"
-            if [[ "" == "${VERSION}" ]]
+            # Use the actual hash for tags (hash can be found by reading releases.json)
+            PRESTATE_HASH=$(jq -r .pre ./op-program/bin/prestate-proof.json)
+            PRESTATE_MT_HASH=$(jq -r .pre ./op-program/bin/prestate-proof-mt.json)
+            PRESTATE_INTEROP_HASH=$(jq -r .pre ./op-program/bin/prestate-proof-interop.json)
+
+            BRANCH_NAME=$(echo "<< pipeline.git.branch >>" | tr '/' '-')
+            echo "Publishing ${PRESTATE_HASH}, ${PRESTATE_MT_HASH}, ${PRESTATE_INTEROP_HASH} as ${BRANCH_NAME}"
+            if [[ "" != "<< pipeline.git.branch >>" ]]
             then
-              VERSION = "<< pipeline.git.tag >>"
-            fi
-            if [[ "" == "${VERSION}" ]]
-            then
-              echo "Both pipeline.git.branch and pipeline.git.tag are empty"
+              # Use the branch name for branches to provide a consistent URL
+              PRESTATE_HASH="${BRANCH_NAME}"
+              PRESTATE_MT_HASH="${BRANCH_NAME}"
+              PRESTATE_INTEROP_HASH="${BRANCH_NAME}"
             fi
             gsutil cp ./op-program/bin/prestate.bin.gz \
-              "gs://oplabs-network-data/proofs/op-program/cannon/${VERSION}.bin.gz"
+              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_HASH}.bin.gz"
             gsutil cp ./op-program/bin/prestate-mt.bin.gz \
-              "gs://oplabs-network-data/proofs/op-program/cannon/${VERSION}-mt.bin.gz"
+              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_MT_HASH}-mt.bin.gz"
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
-              "gs://oplabs-network-data/proofs/op-program/cannon/${VERSION}-interop.bin.gz"
+              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_INTEROP_HASH}-interop.bin.gz"
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 
@@ -1608,6 +1613,7 @@ workflows:
             branches:
               only:
                 - develop
+                - aj/await-hold
 
   develop-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1614,34 +1614,33 @@ workflows:
           build_args: --deny-warnings --skip test
           context:
             - slack
-#      - go-tests:
-#          name: op-e2e-cannon-tests
-#          notify: true
-#          mentions: "@proofs-team"
-#          no_output_timeout: 60m
-#          test_timeout: 59m
-#          resource_class: ethereum-optimism/latitude-fps-1
-#          environment_overrides: |
-#            export OP_E2E_CANNON_ENABLED="true"
-#          packages: |
-#            op-e2e/faultproofs
-#          context:
-#            - slack
-#          requires:
-#            - contracts-bedrock-build
-#            - cannon-prestate
+      - go-tests:
+          name: op-e2e-cannon-tests
+          notify: true
+          mentions: "@proofs-team"
+          no_output_timeout: 60m
+          test_timeout: 59m
+          resource_class: ethereum-optimism/latitude-fps-1
+          environment_overrides: |
+            export OP_E2E_CANNON_ENABLED="true"
+          packages: |
+            op-e2e/faultproofs
+          context:
+            - slack
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate
       - publish-cannon-prestates:
           context:
             - slack
             - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
-#            - op-e2e-cannon-tests
+            - op-e2e-cannon-tests
           filters:
             branches:
               only:
                 - develop
-                - aj/await-hold
 
   develop-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,7 +946,7 @@ jobs:
             - notify-failures-on-develop:
                 mentions: "<<parameters.mentions>>"
 
-  cannon-prestate:
+  sanitize-op-program:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
@@ -957,14 +957,20 @@ jobs:
       - run:
           name: Build op-program
           command: make op-program
+      - run:
+          name: Sanitize op-program client
+          command: make -f cannon/Makefile sanitize-program GUEST_PROGRAM=op-program/bin/op-program-client.elf
+
+  cannon-prestate-quick:
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
+    steps:
+      - checkout
       - restore_cache:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
       - run:
-          name: Sanitize op-program guest
-          command: make -f cannon/Makefile sanitize-program GUEST_PROGRAM=op-program/bin/op-program-client.elf
-      - run:
-          name: generate cannon prestate
+          name: Build prestates
           command: make cannon-prestates
       - save_cache:
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
@@ -976,8 +982,23 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - "op-program/bin"
+            - "op-program/bin/prestate*"
+            - "op-program/bin/meta*"
             - "cannon/bin"
+
+  cannon-prestate:
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
+    steps:
+      - checkout
+      - run:
+          name: Build prestates
+          command: make reproducible-prestate
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "op-program/bin/prestate*"
+            - "op-program/bin/meta*"
 
   publish-cannon-prestates:
     docker:
@@ -1011,6 +1032,8 @@ jobs:
               "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_HASH}.bin.gz"
             gsutil cp ./op-program/bin/prestate-mt.bin.gz \
               "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_MT_HASH}-mt.bin.gz"
+            gsutil cp ./op-program/bin/prestate-mt64.bin.gz \
+              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_MT_HASH}-mt64.bin.gz"
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
               "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_INTEROP_HASH}-interop.bin.gz"
       - notify-failures-on-develop:
@@ -1360,7 +1383,7 @@ workflows:
             packages/contracts-bedrock/scripts/checks
           requires:
             - contracts-bedrock-build
-            - cannon-prestate
+            - cannon-prestate-quick
       - op-program-compat
       - bedrock-go-tests:
           requires:
@@ -1378,6 +1401,7 @@ workflows:
             - op-supervisor-docker-build
             - proofs-tools-docker-build
             - go-tests
+            - sanitize-op-program
       - docker-build:
           name: <<matrix.docker_name>>-docker-build
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
@@ -1396,7 +1420,10 @@ workflows:
                 - da-server
                 - op-supervisor
                 - cannon
-      - cannon-prestate
+      - cannon-prestate-quick
+      - sanitize-op-program:
+          requires:
+            - cannon-prestate-quick
       - check-generated-mocks-op-node
       - check-generated-mocks-op-service
       - cannon-go-lint-and-test:
@@ -1613,6 +1640,7 @@ workflows:
             branches:
               only:
                 - develop
+                - aj/await-hold
 
   develop-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -987,10 +987,11 @@ jobs:
             - "cannon/bin"
 
   cannon-prestate:
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Build prestates
           command: make reproducible-prestate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -993,12 +993,21 @@ jobs:
       - run:
           name: Upload cannon prestates
           command: |
+            VERSION="<< pipeline.git.branch >>"
+            if [[ "" == "${VERSION}" ]]
+            then
+              VERSION = "<< pipeline.git.tag >>"
+            fi
+            if [[ "" == "${VERSION}" ]]
+            then
+              echo "Both pipeline.git.branch and pipeline.git.tag are empty"
+            fi
             gsutil cp ./op-program/bin/prestate.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}.bin.gz
+              "gs://oplabs-network-data/proofs/op-program/cannon/${VERSION}.bin.gz"
             gsutil cp ./op-program/bin/prestate-mt.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-mt.bin.gz
+              "gs://oplabs-network-data/proofs/op-program/cannon/${VERSION}-mt.bin.gz"
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
-              gs://oplabs-network-data/proofs/op-program/cannon/${CIRCLE_BRANCH}-interop.bin.gz
+              "gs://oplabs-network-data/proofs/op-program/cannon/${VERSION}-interop.bin.gz"
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1613,7 +1613,6 @@ workflows:
             branches:
               only:
                 - develop
-                - aj/await-hold
 
   develop-kontrol-tests:
     when:


### PR DESCRIPTION
**Description**

The prestate upload should wait until after the `hold` step is approved.
The name of the upload needs to come from the tag param for releases, not branch.

