### PR TITLE
[Superchain Ops] Integration Testing Fork Test

### DIFF
--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -49,7 +49,8 @@ contract ForkLive is Deployer {
 
     /// @notice Forks, upgrades and tests a production network.
     /// @dev This function sets up the system to test by:
-    ///      0. reading the environment variable to determine the base and OP chain names, read the STATE_PATH data
+    ///      0. reading the environment variable to determine the base and OP chain names, read the
+    /// SUPERCHAIN_OPS_ALLOCS_PATH data
     /// created from superchain ops.
     ///      1. if the environment variable is set, load the state from the given path.
     ///      2. read the superchain-registry to get the contract addresses we wish to test from that network.
@@ -57,10 +58,10 @@ contract ForkLive is Deployer {
     ///      4. upgrading the system using the OPCM.upgrade() function if not using the applied state from superchain
     /// ops.
     function run() public {
-        bool useOpsRepo = bytes(vm.envOr("STATE_PATH", string(""))).length > 0;
+        bool useOpsRepo = bytes(vm.envOr("SUPERCHAIN_OPS_ALLOCS_PATH", string(""))).length > 0;
         if (useOpsRepo) {
-            console.log("ForkLive: loading state from %s", vm.envString("STATE_PATH"));
-            vm.loadAllocs(vm.envString("STATE_PATH"));
+            console.log("ForkLive: loading state from %s", vm.envString("SUPERCHAIN_OPS_ALLOCS_PATH"));
+            vm.loadAllocs(vm.envString("SUPERCHAIN_OPS_ALLOCS_PATH"));
             _readSuperchainRegistry();
         } else {
             // Read the superchain registry and save the addresses to the Artifacts contract.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -49,8 +49,8 @@ contract ForkLive is Deployer {
 
     /// @notice Forks, upgrades and tests a production network.
     /// @dev This function sets up the system to test by:
-    ///      0. reading the environment variable to determine the base and OP chain names, read the
-    ///         SUPERCHAIN_OPS_ALLOCS_PATH data created from superchain ops.
+    ///      0. read the environment variable to determine the
+    ///         SUPERCHAIN_OPS_ALLOCS_PATH environment variable set from superchain ops.
     ///      1. if the environment variable is set, load the state from the given path.
     ///      2. read the superchain-registry to get the contract addresses we wish to test from that network.
     ///      3. deploying the updated OPCM and implementations of the contracts.
@@ -62,7 +62,11 @@ contract ForkLive is Deployer {
         bool useOpsRepo = bytes(superchainOpsAllocsPath).length > 0;
         if (useOpsRepo) {
             console.log("ForkLive: loading state from %s", superchainOpsAllocsPath);
+            /// run the upgrades from the ops repo first
             vm.loadAllocs(superchainOpsAllocsPath);
+            /// then fetch the addresses from the superchain registry after the upgrade
+            /// as this function will read the logic contract addresses which may have
+            /// changed from the upgrade.
             _readSuperchainRegistry();
         } else {
             // Read the superchain registry and save the addresses to the Artifacts contract.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -58,10 +58,12 @@ contract ForkLive is Deployer {
     ///      4. upgrading the system using the OPCM.upgrade() function if not using the applied state from superchain
     /// ops.
     function run() public {
-        bool useOpsRepo = bytes(vm.envOr("SUPERCHAIN_OPS_ALLOCS_PATH", string(""))).length > 0;
+        string memory superchainOpsAllocsPath = vm.envOr("SUPERCHAIN_OPS_ALLOCS_PATH", string(""));
+
+        bool useOpsRepo = bytes(superchainOpsAllocsPath).length > 0;
         if (useOpsRepo) {
-            console.log("ForkLive: loading state from %s", vm.envString("SUPERCHAIN_OPS_ALLOCS_PATH"));
-            vm.loadAllocs(vm.envString("SUPERCHAIN_OPS_ALLOCS_PATH"));
+            console.log("ForkLive: loading state from %s", superchainOpsAllocsPath);
+            vm.loadAllocs(superchainOpsAllocsPath);
             _readSuperchainRegistry();
         } else {
             // Read the superchain registry and save the addresses to the Artifacts contract.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -53,6 +53,10 @@ contract ForkLive is Deployer {
     ///      2. deploying the updated OPCM and implementations of the contracts.
     ///      3. upgrading the system using the OPCM.upgrade() function.
     function run() public {
+        if (bytes(vm.envString("LOAD_STATE_PATH")).length > 0) {
+            console.log("ForkLive: loading state from %s", vm.envString("LOAD_STATE_PATH"));
+            vm.loadAllocs(vm.envString("LOAD_STATE_PATH"));
+        }
         // Read the superchain registry and save the addresses to the Artifacts contract.
         _readSuperchainRegistry();
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -49,18 +49,20 @@ contract ForkLive is Deployer {
 
     /// @notice Forks, upgrades and tests a production network.
     /// @dev This function sets up the system to test by:
-    ///      0. reading the environment variable to determine the base and OP chain names, read the STATE_PATH data created from superchain ops.
+    ///      0. reading the environment variable to determine the base and OP chain names, read the STATE_PATH data
+    /// created from superchain ops.
     ///      1. if the environment variable is set, load the state from the given path.
     ///      2. read the superchain-registry to get the contract addresses we wish to test from that network.
     ///      3. deploying the updated OPCM and implementations of the contracts.
-    ///      4. upgrading the system using the OPCM.upgrade() function if not using the applied state from superchain ops.
+    ///      4. upgrading the system using the OPCM.upgrade() function if not using the applied state from superchain
+    /// ops.
     function run() public {
         bool useOpsRepo = bytes(vm.envOr("STATE_PATH", string(""))).length > 0;
         if (useOpsRepo) {
             console.log("ForkLive: loading state from %s", vm.envString("STATE_PATH"));
             vm.loadAllocs(vm.envString("STATE_PATH"));
             _readSuperchainRegistry();
-        } else{
+        } else {
             // Read the superchain registry and save the addresses to the Artifacts contract.
             _readSuperchainRegistry();
             // Now deploy the updated OPCM and implementations of the contracts

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -50,8 +50,7 @@ contract ForkLive is Deployer {
     /// @notice Forks, upgrades and tests a production network.
     /// @dev This function sets up the system to test by:
     ///      0. reading the environment variable to determine the base and OP chain names, read the
-    /// SUPERCHAIN_OPS_ALLOCS_PATH data
-    /// created from superchain ops.
+    ///         SUPERCHAIN_OPS_ALLOCS_PATH data created from superchain ops.
     ///      1. if the environment variable is set, load the state from the given path.
     ///      2. read the superchain-registry to get the contract addresses we wish to test from that network.
     ///      3. deploying the updated OPCM and implementations of the contracts.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -49,24 +49,31 @@ contract ForkLive is Deployer {
 
     /// @notice Forks, upgrades and tests a production network.
     /// @dev This function sets up the system to test by:
-    ///      1. reading the superchain-registry to get the contract addresses we wish to test from that network.
-    ///      2. deploying the updated OPCM and implementations of the contracts.
-    ///      3. upgrading the system using the OPCM.upgrade() function.
+    ///      0. reading the environment variable to determine the base and OP chain names, read the STATE_PATH data created from superchain ops.
+    ///      1. if the environment variable is set, load the state from the given path.
+    ///      2. read the superchain-registry to get the contract addresses we wish to test from that network.
+    ///      3. deploying the updated OPCM and implementations of the contracts.
+    ///      4. upgrading the system using the OPCM.upgrade() function if not using the applied state from superchain ops.
     function run() public {
-        if (bytes(vm.envString("LOAD_STATE_PATH")).length > 0) {
-            console.log("ForkLive: loading state from %s", vm.envString("LOAD_STATE_PATH"));
-            vm.loadAllocs(vm.envString("LOAD_STATE_PATH"));
+        bool useOpsRepo = bytes(vm.envOr("STATE_PATH", string(""))).length > 0;
+        if (useOpsRepo) {
+            console.log("ForkLive: loading state from %s", vm.envString("STATE_PATH"));
+            vm.loadAllocs(vm.envString("STATE_PATH"));
+            _readSuperchainRegistry();
+        } else{
+            // Read the superchain registry and save the addresses to the Artifacts contract.
+            _readSuperchainRegistry();
+            // Now deploy the updated OPCM and implementations of the contracts
+            _deployNewImplementations();
         }
-        // Read the superchain registry and save the addresses to the Artifacts contract.
-        _readSuperchainRegistry();
-
-        // Now deploy the updated OPCM and implementations of the contracts
-        _deployNewImplementations();
 
         // Now upgrade the contracts (if the config is set to do so)
         if (cfg.useUpgradedFork()) {
+            require(!useOpsRepo, "ForkLive: cannot upgrade and use ops repo");
             console.log("ForkLive: upgrading");
             _upgrade();
+        } else if (useOpsRepo) {
+            console.log("ForkLive: using ops repo to upgrade");
         }
     }
 


### PR DESCRIPTION
**Description**

This PR paves the way for fork testing using the state diff result of a task from superchain ops.

**Additional context**

Superchain ops integration testing will allow us to run the integration tests after the superchain ops task state changes are applied.

**Metadata**

Include a link to any github issues that this may close in the following form:
- Start of implementing issue https://github.com/ethereum-optimism/superchain-ops/issues/343
