### PR TITLE
op-service: Add AllSafeDerivedAt to SupervisorClient

### DIFF
--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -164,6 +164,16 @@ func (cl *SupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp 
 	return result, err
 }
 
+func (cl *SupervisorClient) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
+	var result map[eth.ChainID]eth.BlockID
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_allSafeDerivedAt",
+		derivedFrom)
+	return result, err
+}
+
 func (cl *SupervisorClient) Close() {
 	cl.client.Close()
 }


### PR DESCRIPTION
**Description**

Adds `AllSafeDerivedAt` method to the supervisor client so it can be used by the challenger.

**Tests**

Tested manually. We don't actually have any tests for these clients currently. It will be exercised by the action and e2e tests for challenger once it's integrated there though.

fixes #13892 