### PR TITLE
ci: Remove CI builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,6 @@
 version: 2.1
 
 parameters:
-  ci_builder_image:
-    type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.59.0
-  ci_builder_rust_image:
-    type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:latest
   base_image:
     type: string
     default: default
@@ -129,14 +123,6 @@ commands:
             # of the -j parameter, which speeds it up a lot.
             git submodule update --init --recursive --force -j 8
           working_directory: packages/contracts-bedrock
-      - run:
-          name: Verify mise dependencies
-          command: |
-            if command -v mise &> /dev/null; then
-              mise install
-            else
-              echo "mise not found, skipping"
-            fi
 
   notify-failures-on-develop:
     description: "Notify Slack"
@@ -172,6 +158,67 @@ commands:
           environment:
             FOUNDRY_PROFILE: ci
 
+  checkout-with-mise:
+    steps:
+      - checkout
+      - run:
+          name: Initialize mise environment
+          command: |
+            # This is used to create a per-user cache key to preserve permissions across different
+            # executor types.
+            user=$(whoami)
+            echo "$user" > .executor-user
+            echo "Set executor user to $user."
+            
+            if [[ "$user" == "root" ]]; then
+              # Self-hosted runners will persist this cache between runs. Cleaning it up means that we
+              # preserve the semantics of the cache regardless of executor type. It's also much faster
+              # to delete the cache and recreate it than it is to overwrite it in place.
+              rm -rf /data/mise-data
+              echo "Cleaned up cache data."
+            
+              mkdir -p /data/mise-data
+              echo "Created Mise data dir."
+              mkdir -p ~/.cache
+              echo "Created Mise cache dir."
+            else
+              sudo rm -rf /data/mise-data
+              echo "Cleaned up cache data."
+              sudo mkdir -p /data/mise-data
+              sudo chown -R "$user:$user" /data/mise-data
+              echo "Created Mise data dir."
+              sudo mkdir -p ~/.cache
+              sudo chown -R "$user:$user" ~/.cache
+              echo "Created Mise cache dir."
+            fi
+      - restore_cache:
+          name: Restore mise cache
+          keys:
+            - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+      - run:
+          name: Install mise
+          command: |
+            if command -v mise &> /dev/null; then
+              echo "mise already installed at $(command -v mise)"
+            else
+              curl https://mise.run | sh
+            fi
+            
+            echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
+            echo "export MISE_DATA_DIR=/data/mise-data" >> "$BASH_ENV"
+            echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"
+            echo "eval \"\$($HOME/.local/bin/mise activate --shims)\"" >> "$BASH_ENV"
+      - run:
+          name: Install mise deps
+          command: |
+            mise install -v -y
+      - save_cache:
+          name: Save mise cache
+          key: mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+          paths:
+            - /data/mise-data
+
+
 jobs:
   cannon-go-lint-and-test:
     machine: true
@@ -188,7 +235,7 @@ jobs:
         type: integer
         default: 32
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
       - attach_workspace:
@@ -257,24 +304,29 @@ jobs:
                 mentions: "@proofs-team"
 
   cannon-build-test-vectors:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: medium
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: cannon/mipsevm/tests/open_mips_tests/test
       - run:
+          name: Install dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y binutils-mips-linux-gnu
+            pip install capstone pyelftools
+      - run:
           name: Build MIPS test vectors
-          command: python3 maketests.py && git diff --exit-code
+          command: |
+            python3 maketests.py && git diff --exit-code
           working_directory: cannon/mipsevm/tests/open_mips_tests
 
   diff-asterisc-bytecode:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: medium
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Check `RISCV.sol` bytecode
           working_directory: packages/contracts-bedrock
@@ -322,7 +374,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout
+      - checkout-with-mise
       - install-contracts-dependencies
       - run:
           name: Print forge version
@@ -349,10 +401,10 @@ jobs:
 
   check-kontrol-build:
     docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+      - image: cimg/base:2024.01
     resource_class: xlarge
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -413,7 +465,7 @@ jobs:
       resource_class: "<<parameters.resource_class>>"
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace:
           at: /tmp/docker_images
       - run:
@@ -610,7 +662,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -644,7 +696,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - run:
@@ -721,7 +773,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -769,7 +821,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -833,7 +885,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -876,7 +928,7 @@ jobs:
     machine:
       image: <<pipeline.parameters.base_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Install ripgrep
           command: sudo apt-get install -y ripgrep
@@ -900,7 +952,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: "<<parameters.package_name>>"
       - attach_workspace:
@@ -925,7 +977,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: run Go linter
           command: |
@@ -964,7 +1016,7 @@ jobs:
     machine: true
     resource_class: <<parameters.resource_class>>
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace:
           at: "."
       - run:
@@ -1026,10 +1078,14 @@ jobs:
                 mentions: "<<parameters.mentions>>"
 
   sanitize-op-program:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
+      - run:
+          name: Install tools
+          command: |
+            sudo apt-get install -y binutils-mips-linux-gnu
       - run:
           name: Build cannon
           command: make cannon
@@ -1046,7 +1102,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - restore_cache:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
@@ -1069,9 +1125,9 @@ jobs:
 
   cannon-prestate:
     docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+      - image: cimg/base:2024.01
     steps:
-      - checkout
+      - checkout-with-mise
       - setup_remote_docker
       - run:
           name: Build prestates
@@ -1083,16 +1139,16 @@ jobs:
             - "op-program/bin/meta*"
 
   publish-cannon-prestates:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace:
           at: "."
       - gcp-cli/install
       - gcp-oidc-authenticate:
-          gcp_cred_config_file_path: /root/gcp_cred_config.json
-          oidc_token_file_path: /root/oidc_token.json
+          gcp_cred_config_file_path: /tmp/gcp_cred_config.json
+          oidc_token_file_path: /tmp/oidc_token.json
       - run:
           name: Upload cannon prestates
           command: |
@@ -1120,20 +1176,20 @@ jobs:
           mentions: "@proofs-team"
 
   preimage-reproducibility:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - setup_remote_docker
       - run: make -C op-program verify-reproducibility
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 
   cannon-stf-verify:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - setup_remote_docker
       - run:
           name: Build cannon
@@ -1161,7 +1217,7 @@ jobs:
       - image: returntocorp/semgrep
     resource_class: xlarge
     steps:
-      - checkout
+      - checkout # no need to use mise here since the docker image contains the only dependency
       - unless:
           condition:
             equal: ["develop", << pipeline.git.branch >>]
@@ -1203,7 +1259,7 @@ jobs:
     docker:
       - image: cimg/go:1.21
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: verify-sepolia
           command: |
@@ -1213,31 +1269,21 @@ jobs:
           mentions: "@proofs-team"
 
   op-program-compat:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
-      - restore_cache:
-          name: Restore Go modules cache
-          key: gomod-{{ checksum "go.sum" }}
-      - restore_cache:
-          key: golang-build-cache-op-program-compat-{{ checksum "go.sum" }}
+      - checkout-with-mise
       - run:
           name: compat-sepolia
           command: |
             make verify-compat
           working_directory: op-program
-      - save_cache:
-          name: Save Go build cache
-          key: golang-build-cache-op-program-compat-{{ checksum "go.sum" }}
-          paths:
-            - "/root/.cache/go-build"
 
   check-generated-mocks-op-node:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: op-node
       - run:
@@ -1245,10 +1291,10 @@ jobs:
           command: make generate-mocks-op-node && git diff --exit-code
 
   check-generated-mocks-op-service:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    machine: true
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: op-service
       - run:
@@ -1257,10 +1303,10 @@ jobs:
 
   kontrol-tests:
     docker:
-      - image: << pipeline.parameters.ci_builder_image >>
+      - image: cimg/base:2024.01
     resource_class: xlarge
     steps:
-      - checkout
+      - checkout-with-mise
       - install-contracts-dependencies
       - check-changed:
           no_go_deps: "true"
@@ -1297,7 +1343,7 @@ jobs:
           oidc_token_file_path: /tmp/oidc_token.json
           project_id: GCP_TOOLS_ARTIFACTS_PROJECT_ID
           service_account_email: GCP_CONTRACTS_PUBLISHER_SERVICE_ACCOUNT_EMAIL
-      - checkout
+      - checkout-with-mise
       - install-contracts-dependencies
       - run:
           name: Pull artifacts
@@ -1324,23 +1370,15 @@ jobs:
         default: .goreleaser.yaml
         type: string
     docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+      - image: cimg/base:2024.01
     resource_class: large
     steps:
       - setup_remote_docker
       - gcp-cli/install
       - gcp-oidc-authenticate:
-          gcp_cred_config_file_path: /root/gcp_cred_config.json
-          oidc_token_file_path: /root/oidc_token.json
-      - checkout
-      - run:
-          name: Install goreleaser pro
-          command: |
-            mkdir -p /tmp/goreleaser
-            cd /tmp/goreleaser
-            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.4.3-pro/goreleaser-pro_Linux_x86_64.tar.gz
-            tar -xzvf goreleaser.tgz
-            mv goreleaser /usr/local/bin/goreleaser
+          gcp_cred_config_file_path: /tmp/gcp_cred_config.json
+          oidc_token_file_path: /tmp/oidc_token.json
+      - checkout-with-mise
       - run:
           name: Configure Docker
           command: |

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,6 @@ direnv = "2.35.0"
 just = "1.37.0"
 
 # Cargo dependencies
-"cargo:just" = "1.37.0"
 "cargo:svm-rs" = "0.5.8"
 
 # Go dependencies
@@ -33,6 +32,10 @@ forge = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 
+# Other dependencies
+codecov-uploader = "0.8.0"
+goreleaser-pro = "2.3.2-pro"
+
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't
 # actually be managed by mise (yet). Make sure that anything you put in here is
@@ -45,6 +48,9 @@ binary_signer = "1.0.4"
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"
+just = "ubi:casey/just"
+codecov-uploader = "ubi:codecov/uploader"
+goreleaser-pro = "ubi:goreleaser/goreleaser-pro[exe=goreleaser]"
 
 [settings]
 experimental = true


### PR DESCRIPTION
We were using both Docker-based CI builder images as well as self-hosted runner images with software preinstalled. This was causing discrepancies between software versions when things were updated. Furthermore, changing `mise.toml` required a manual rebuild of the CI builder image for changes to take effect.

This PR updates the CI pipeline to use Mise to install all tool necessary to run the monorepo. Preinstalled tools have been removed from the self-hosted runners, and all Docker images in the pipeline have been replaced with a simple `cimg/base` image. Data is cached to minimize installation time between runs.

This PR has been tested with self-hosted images that have had the majority of pre-installed tools removed. To make the pipeline work while this PR is reviewed, I've put those tools back. When this is ready to merge I'll uninstall them again. Note that this PR will require a rebase of all open PRs.