### PR TITLE
feat: use v4 engine APIs when Isthmus enabled

### DIFF
--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -70,6 +70,7 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 		GraniteTime:             config.GraniteTime(l1StartTime),
 		HoloceneTime:            config.HoloceneTime(l1StartTime),
 		IsthmusTime:             config.IsthmusTime(l1StartTime),
+		PragueTime:              config.IsthmusTime(l1StartTime),
 		InteropTime:             config.InteropTime(l1StartTime),
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator:       eip1559Denom,

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -168,6 +168,8 @@ func (s *ChainSpec) CheckForkActivation(log log.Logger, block eth.L2BlockRef) {
 		return
 	}
 
+	fmt.Printf("config: %+v\n", s.config)
+
 	if s.currentFork == "" {
 		// Initialize currentFork if it is not set yet
 		s.currentFork = Bedrock

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -168,8 +168,6 @@ func (s *ChainSpec) CheckForkActivation(log log.Logger, block eth.L2BlockRef) {
 		return
 	}
 
-	fmt.Printf("config: %+v\n", s.config)
-
 	if s.currentFork == "" {
 		// Initialize currentFork if it is not set yet
 		s.currentFork = Bedrock

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -559,7 +559,9 @@ func (c *Config) ForkchoiceUpdatedVersion(attr *eth.PayloadAttributes) eth.Engin
 
 // NewPayloadVersion returns the EngineAPIMethod suitable for the chain hard fork version.
 func (c *Config) NewPayloadVersion(timestamp uint64) eth.EngineAPIMethod {
-	if c.IsEcotone(timestamp) {
+	if c.IsIsthmus(timestamp) {
+		return eth.NewPayloadV4
+	} else if c.IsEcotone(timestamp) {
 		// Cancun
 		return eth.NewPayloadV3
 	} else {
@@ -569,7 +571,9 @@ func (c *Config) NewPayloadVersion(timestamp uint64) eth.EngineAPIMethod {
 
 // GetPayloadVersion returns the EngineAPIMethod suitable for the chain hard fork version.
 func (c *Config) GetPayloadVersion(timestamp uint64) eth.EngineAPIMethod {
-	if c.IsEcotone(timestamp) {
+	if c.IsIsthmus(timestamp) {
+		return eth.GetPayloadV4
+	} else if c.IsEcotone(timestamp) {
 		// Cancun
 		return eth.GetPayloadV3
 	} else {

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -693,6 +693,7 @@ func TestNewPayloadVersion(t *testing.T) {
 	tests := []struct {
 		name           string
 		ecotoneTime    uint64
+		isthmusTime    uint64
 		payloadTime    uint64
 		expectedMethod eth.EngineAPIMethod
 	}{
@@ -700,13 +701,22 @@ func TestNewPayloadVersion(t *testing.T) {
 			name:           "BeforeEcotone",
 			ecotoneTime:    10,
 			payloadTime:    5,
+			isthmusTime:    20,
 			expectedMethod: eth.NewPayloadV2,
 		},
 		{
 			name:           "Ecotone",
 			ecotoneTime:    10,
 			payloadTime:    15,
+			isthmusTime:    20,
 			expectedMethod: eth.NewPayloadV3,
+		},
+		{
+			name:           "Isthmus",
+			ecotoneTime:    10,
+			payloadTime:    25,
+			isthmusTime:    20,
+			expectedMethod: eth.NewPayloadV4,
 		},
 	}
 
@@ -725,6 +735,7 @@ func TestGetPayloadVersion(t *testing.T) {
 	config.CanyonTime = &canyonTime
 	tests := []struct {
 		name           string
+		isthmusTime    uint64
 		ecotoneTime    uint64
 		payloadTime    uint64
 		expectedMethod eth.EngineAPIMethod
@@ -733,13 +744,22 @@ func TestGetPayloadVersion(t *testing.T) {
 			name:           "BeforeEcotone",
 			ecotoneTime:    10,
 			payloadTime:    5,
+			isthmusTime:    20,
 			expectedMethod: eth.GetPayloadV2,
 		},
 		{
 			name:           "Ecotone",
 			ecotoneTime:    10,
 			payloadTime:    15,
+			isthmusTime:    20,
 			expectedMethod: eth.GetPayloadV3,
+		},
+		{
+			name:           "Isthmus",
+			ecotoneTime:    10,
+			payloadTime:    25,
+			isthmusTime:    20,
+			expectedMethod: eth.GetPayloadV4,
 		},
 	}
 

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -724,6 +724,7 @@ func TestNewPayloadVersion(t *testing.T) {
 		test := test
 		t.Run(fmt.Sprintf("TestNewPayloadVersion_%s", test.name), func(t *testing.T) {
 			config.EcotoneTime = &test.ecotoneTime
+			config.IsthmusTime = &test.isthmusTime
 			assert.Equal(t, config.NewPayloadVersion(test.payloadTime), test.expectedMethod)
 		})
 	}
@@ -767,6 +768,7 @@ func TestGetPayloadVersion(t *testing.T) {
 		test := test
 		t.Run(fmt.Sprintf("TestGetPayloadVersion_%s", test.name), func(t *testing.T) {
 			config.EcotoneTime = &test.ecotoneTime
+			config.IsthmusTime = &test.isthmusTime
 			assert.Equal(t, config.GetPayloadVersion(test.payloadTime), test.expectedMethod)
 		})
 	}

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -80,6 +81,8 @@ func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 	var res *eth.ExecutionPayloadEnvelope
 	var err error
 	switch method := o.rollupCfg.GetPayloadVersion(payloadInfo.Timestamp); method {
+	case eth.GetPayloadV4:
+		res, err = o.api.GetPayloadV4(ctx, payloadInfo.ID)
 	case eth.GetPayloadV3:
 		res, err = o.api.GetPayloadV3(ctx, payloadInfo.ID)
 	case eth.GetPayloadV2:
@@ -108,6 +111,8 @@ func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.Forkchoi
 
 func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
 	switch method := o.rollupCfg.NewPayloadVersion(uint64(payload.Timestamp)); method {
+	case eth.NewPayloadV4:
+		return o.api.NewPayloadV4(ctx, payload, []common.Hash{}, parentBeaconBlockRoot, []hexutil.Bytes{})
 	case eth.NewPayloadV3:
 		return o.api.NewPayloadV3(ctx, payload, []common.Hash{}, parentBeaconBlockRoot)
 	case eth.NewPayloadV2:

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -64,8 +64,6 @@ func NewBlockProcessorFromPayloadAttributes(provider BlockDataProvider, parent c
 	return NewBlockProcessorFromHeader(provider, header)
 }
 
-var emptyRequestsHash = types.CalcRequestsHash([][]byte{})
-
 func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*BlockProcessor, error) {
 	header := types.CopyHeader(h) // Copy to avoid mutating the original header
 
@@ -116,7 +114,7 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 		header.WithdrawalsHash = &mpHash
 
 		// set the header requests root to empty hash for Isthmus blocks
-		header.RequestsHash = &emptyRequestsHash
+		header.RequestsHash = &types.EmptyRequestsHash
 	}
 
 	return &BlockProcessor{

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -64,6 +64,8 @@ func NewBlockProcessorFromPayloadAttributes(provider BlockDataProvider, parent c
 	return NewBlockProcessorFromHeader(provider, header)
 }
 
+var emptyRequestsHash = types.CalcRequestsHash([][]byte{})
+
 func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*BlockProcessor, error) {
 	header := types.CopyHeader(h) // Copy to avoid mutating the original header
 
@@ -112,6 +114,9 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 		// set the header withdrawals root for Isthmus blocks
 		mpHash := statedb.GetStorageRoot(predeploys.L2ToL1MessagePasserAddr)
 		header.WithdrawalsHash = &mpHash
+
+		// set the header requests root to empty hash for Isthmus blocks
+		header.RequestsHash = &emptyRequestsHash
 	}
 
 	return &BlockProcessor{

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -383,8 +383,6 @@ func (ea *L2EngineAPI) NewPayloadV4(ctx context.Context, params *eth.ExecutionPa
 
 	if !ea.config().IsIsthmus(uint64(params.Timestamp)) {
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(errors.New("newPayloadV4 called pre-isthmus"))
-	} else if len(executionRequests) > 0 {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("newPayloadV4 called with non-empty execution requests"))
 	}
 
 	requests := convertRequests(executionRequests)

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -356,7 +356,7 @@ func (ea *L2EngineAPI) NewPayloadV3(ctx context.Context, params *eth.ExecutionPa
 		}
 	}
 
-	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, nil)
+	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, [][]byte{})
 }
 
 // Ported from: https://github.com/ethereum-optimism/op-geth/blob/94bb3f660f770afd407280055e7f58c0d89a01af/eth/catalyst/api.go#L646

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -553,7 +553,6 @@ func (ea *L2EngineAPI) newPayload(_ context.Context, payload *eth.ExecutionPaylo
 	}, hashes, root, requests, ea.backend.Config())
 	if err != nil {
 		log.Debug("Invalid NewPayload params", "params", payload, "error", err)
-		fmt.Printf("Invalid NewPayload params: %+v %s %+v\n", payload, err, requests)
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalidBlockHash}, nil
 	}
 	// If we already have the block locally, ignore the entire execution and just

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -356,7 +356,7 @@ func (ea *L2EngineAPI) NewPayloadV3(ctx context.Context, params *eth.ExecutionPa
 		}
 	}
 
-	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, [][]byte{})
+	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, nil)
 }
 
 // Ported from: https://github.com/ethereum-optimism/op-geth/blob/94bb3f660f770afd407280055e7f58c0d89a01af/eth/catalyst/api.go#L646
@@ -383,6 +383,8 @@ func (ea *L2EngineAPI) NewPayloadV4(ctx context.Context, params *eth.ExecutionPa
 
 	if !ea.config().IsIsthmus(uint64(params.Timestamp)) {
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(errors.New("newPayloadV4 called pre-isthmus"))
+	} else if len(executionRequests) > 0 {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("newPayloadV4 called with non-empty execution requests"))
 	}
 
 	requests := convertRequests(executionRequests)
@@ -551,6 +553,7 @@ func (ea *L2EngineAPI) newPayload(_ context.Context, payload *eth.ExecutionPaylo
 	}, hashes, root, requests, ea.backend.Config())
 	if err != nil {
 		log.Debug("Invalid NewPayload params", "params", payload, "error", err)
+		fmt.Printf("Invalid NewPayload params: %+v %s %+v\n", payload, err, requests)
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalidBlockHash}, nil
 	}
 	// If we already have the block locally, ignore the entire execution and just

--- a/op-program/client/l2/engineapi/l2_engine_api_test.go
+++ b/op-program/client/l2/engineapi/l2_engine_api_test.go
@@ -114,10 +114,10 @@ func TestCreatedBlocksAreCached(t *testing.T) {
 	require.EqualValues(t, engine.VALID, result.PayloadStatus.Status)
 	require.NotNil(t, result.PayloadID)
 
-	envelope, err := engineAPI.GetPayloadV3(context.Background(), *result.PayloadID)
+	envelope, err := engineAPI.GetPayloadV4(context.Background(), *result.PayloadID)
 	require.NoError(t, err)
 	require.NotNil(t, envelope)
-	newPayloadResult, err := engineAPI.NewPayloadV3(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot)
+	newPayloadResult, err := engineAPI.NewPayloadV4(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
 	require.NoError(t, err)
 	require.EqualValues(t, engine.VALID, newPayloadResult.Status)
 

--- a/op-program/client/l2/engineapi/l2_engine_api_test.go
+++ b/op-program/client/l2/engineapi/l2_engine_api_test.go
@@ -2,6 +2,7 @@ package engineapi
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -19,6 +21,73 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewPayloadV4(t *testing.T) {
+	cases := []struct {
+		isthmusTime   uint64
+		blockTime     uint64
+		expectedError string
+	}{
+		{6, 5, engine.UnsupportedFork.Error()}, // before isthmus
+		{6, 8, ""},                             // after isthmus
+	}
+	logger, _ := testlog.CaptureLogger(t, log.LvlTrace)
+
+	for _, c := range cases {
+		genesis := createGenesis()
+		isthmusTime := c.isthmusTime
+		genesis.Config.IsthmusTime = &isthmusTime
+		ethCfg := &ethconfig.Config{
+			NetworkId:   genesis.Config.ChainID.Uint64(),
+			Genesis:     genesis,
+			StateScheme: rawdb.HashScheme,
+			NoPruning:   true,
+		}
+		backend := newStubBackendWithConfig(t, ethCfg)
+		engineAPI := NewL2EngineAPI(logger, backend, nil)
+		require.NotNil(t, engineAPI)
+		genesisBlock := backend.GetHeaderByNumber(0)
+		genesisHash := genesisBlock.Hash()
+		eip1559Params := eth.Bytes8([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8})
+		gasLimit := eth.Uint64Quantity(4712388)
+		result, err := engineAPI.ForkchoiceUpdatedV3(context.Background(), &eth.ForkchoiceState{
+			HeadBlockHash:      genesisHash,
+			SafeBlockHash:      genesisHash,
+			FinalizedBlockHash: genesisHash,
+		}, &eth.PayloadAttributes{
+			Timestamp:             eth.Uint64Quantity(genesisBlock.Time + c.blockTime),
+			PrevRandao:            eth.Bytes32{0x11},
+			SuggestedFeeRecipient: common.Address{0x33},
+			Withdrawals:           &types.Withdrawals{},
+			ParentBeaconBlockRoot: &common.Hash{0x22},
+			NoTxPool:              false,
+			GasLimit:              &gasLimit,
+			EIP1559Params:         &eip1559Params,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, engine.VALID, result.PayloadStatus.Status)
+		require.NotNil(t, result.PayloadID)
+
+		var envelope *eth.ExecutionPayloadEnvelope
+		if c.blockTime >= c.isthmusTime {
+			envelope, err = engineAPI.GetPayloadV4(context.Background(), *result.PayloadID)
+		} else {
+			envelope, err = engineAPI.GetPayloadV3(context.Background(), *result.PayloadID)
+		}
+		require.NoError(t, err)
+		require.NotNil(t, envelope)
+
+		newPayloadResult, err := engineAPI.NewPayloadV4(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
+		fmt.Println(newPayloadResult, err)
+		if c.expectedError != "" {
+			require.ErrorContains(t, err, c.expectedError)
+			continue
+		} else {
+			require.NoError(t, err)
+		}
+		require.EqualValues(t, engine.VALID, newPayloadResult.Status)
+	}
+}
 
 func TestCreatedBlocksAreCached(t *testing.T) {
 	logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
@@ -59,14 +128,7 @@ func TestCreatedBlocksAreCached(t *testing.T) {
 	require.Equal(t, envelope.ExecutionPayload.BlockHash, foundLog.AttrValue("hash"))
 }
 
-func newStubBackend(t *testing.T) *stubCachingBackend {
-	genesis := createGenesis()
-	ethCfg := &ethconfig.Config{
-		NetworkId:   genesis.Config.ChainID.Uint64(),
-		Genesis:     genesis,
-		StateScheme: rawdb.HashScheme,
-		NoPruning:   true,
-	}
+func newStubBackendWithConfig(t *testing.T, ethCfg *ethconfig.Config) *stubCachingBackend {
 	nodeCfg := &node.Config{
 		Name: "l2-geth",
 	}
@@ -82,6 +144,17 @@ func newStubBackend(t *testing.T) *stubCachingBackend {
 	return &stubCachingBackend{EngineBackend: chain}
 }
 
+func newStubBackend(t *testing.T) *stubCachingBackend {
+	genesis := createGenesis()
+	ethCfg := &ethconfig.Config{
+		NetworkId:   genesis.Config.ChainID.Uint64(),
+		Genesis:     genesis,
+		StateScheme: rawdb.HashScheme,
+		NoPruning:   true,
+	}
+	return newStubBackendWithConfig(t, ethCfg)
+}
+
 func createGenesis() *core.Genesis {
 	config := *params.MergedTestChainConfig
 	config.PragueTime = nil
@@ -93,6 +166,7 @@ func createGenesis() *core.Genesis {
 	config.FjordTime = &zero
 	config.GraniteTime = &zero
 	config.HoloceneTime = &zero
+	config.IsthmusTime = &zero
 
 	l2Genesis := &core.Genesis{
 		Config:     &config,

--- a/op-program/client/l2/engineapi/l2_engine_api_test.go
+++ b/op-program/client/l2/engineapi/l2_engine_api_test.go
@@ -2,7 +2,6 @@ package engineapi
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestNewPayloadV4(t *testing.T) {
 		{6, 5, engine.UnsupportedFork.Error()}, // before isthmus
 		{6, 8, ""},                             // after isthmus
 	}
-	logger, _ := testlog.CaptureLogger(t, log.LvlTrace)
+	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
 
 	for _, c := range cases {
 		genesis := createGenesis()
@@ -78,7 +77,6 @@ func TestNewPayloadV4(t *testing.T) {
 		require.NotNil(t, envelope)
 
 		newPayloadResult, err := engineAPI.NewPayloadV4(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
-		fmt.Println(newPayloadResult, err)
 		if c.expectedError != "" {
 			require.ErrorContains(t, err, c.expectedError)
 			continue

--- a/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
+++ b/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -443,7 +444,7 @@ func (h *testHelper) getPayload(id *eth.PayloadID) *eth.ExecutionPayloadEnvelope
 func (h *testHelper) callNewPayload(envelope *eth.ExecutionPayloadEnvelope) (*eth.PayloadStatusV1, error) {
 	n := new(big.Int).SetUint64(uint64(envelope.ExecutionPayload.BlockNumber))
 	if h.backend.Config().IsIsthmus(uint64(envelope.ExecutionPayload.Timestamp)) {
-		return h.engine.NewPayloadV4(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, nil)
+		return h.engine.NewPayloadV4(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
 	} else if h.backend.Config().IsCancun(n, uint64(envelope.ExecutionPayload.Timestamp)) {
 		return h.engine.NewPayloadV3(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot)
 	} else {

--- a/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
+++ b/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
@@ -442,7 +442,9 @@ func (h *testHelper) getPayload(id *eth.PayloadID) *eth.ExecutionPayloadEnvelope
 
 func (h *testHelper) callNewPayload(envelope *eth.ExecutionPayloadEnvelope) (*eth.PayloadStatusV1, error) {
 	n := new(big.Int).SetUint64(uint64(envelope.ExecutionPayload.BlockNumber))
-	if h.backend.Config().IsCancun(n, uint64(envelope.ExecutionPayload.Timestamp)) {
+	if h.backend.Config().IsIsthmus(uint64(envelope.ExecutionPayload.Timestamp)) {
+		return h.engine.NewPayloadV4(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, nil)
+	} else if h.backend.Config().IsCancun(n, uint64(envelope.ExecutionPayload.Timestamp)) {
 		return h.engine.NewPayloadV3(h.ctx, envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot)
 	} else {
 		return h.engine.NewPayloadV2(h.ctx, envelope.ExecutionPayload)

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -638,9 +638,11 @@ const (
 
 	NewPayloadV2 EngineAPIMethod = "engine_newPayloadV2"
 	NewPayloadV3 EngineAPIMethod = "engine_newPayloadV3"
+	NewPayloadV4 EngineAPIMethod = "engine_newPayloadV4"
 
 	GetPayloadV2 EngineAPIMethod = "engine_getPayloadV2"
 	GetPayloadV3 EngineAPIMethod = "engine_getPayloadV3"
+	GetPayloadV4 EngineAPIMethod = "engine_getPayloadV4"
 )
 
 // StorageKey is a marshaling utility for hex-encoded storage keys, which can have leading 0s and are

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -105,7 +105,7 @@ func (s *EngineAPIClient) NewPayload(ctx context.Context, payload *eth.Execution
 	var err error
 	switch method := s.evp.NewPayloadVersion(uint64(payload.Timestamp)); method {
 	case eth.NewPayloadV4:
-		err = s.RPC.CallContext(execCtx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot, []hexutil.Bytes{})
+		err = s.RPC.CallContext(ctx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot, []hexutil.Bytes{})
 	case eth.NewPayloadV3:
 		err = s.RPC.CallContext(ctx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot)
 	case eth.NewPayloadV2:

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/eth/catalyst"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -103,6 +104,8 @@ func (s *EngineAPIClient) NewPayload(ctx context.Context, payload *eth.Execution
 
 	var err error
 	switch method := s.evp.NewPayloadVersion(uint64(payload.Timestamp)); method {
+	case eth.NewPayloadV4:
+		err = s.RPC.CallContext(execCtx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot, []hexutil.Bytes{})
 	case eth.NewPayloadV3:
 		err = s.RPC.CallContext(ctx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot)
 	case eth.NewPayloadV2:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Updates Optimism to use payload v4 methods when Isthmus is enabled.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Updates existing tests following v3 example.
