### PR TITLE
OPCM upgrade: Add MTCannon to OPCM

### DIFF
--- a/op-deployer/pkg/deployer/opcm/implementations.go
+++ b/op-deployer/pkg/deployer/opcm/implementations.go
@@ -20,6 +20,7 @@ type DeployImplementationsInput struct {
 	L1ContractsRelease    string
 	SuperchainConfigProxy common.Address
 	ProtocolVersionsProxy common.Address
+	SuperchainProxyAdmin  common.Address
 	UpgradeController     common.Address
 	UseInterop            bool // if true, deploy Interop implementations
 }

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -56,6 +56,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			L1ContractsRelease:              contractsRelease,
 			SuperchainConfigProxy:           st.SuperchainDeployment.SuperchainConfigProxyAddress,
 			ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxyAddress,
+			SuperchainProxyAdmin:            st.SuperchainDeployment.ProxyAdminAddress,
 			UpgradeController:               intent.SuperchainRoles.ProxyAdminOwner,
 			UseInterop:                      intent.UseInterop,
 		},

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -105,13 +105,15 @@ interface IOPContractsManager {
         address disputeGameFactoryImpl;
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
-        address mipsImpl;
+        address mips64Impl;
     }
 
     /// @notice The input required to identify a chain for upgrading.
-    struct OpChain {
+    struct OpChainConfig {
         ISystemConfig systemConfigProxy;
         IProxyAdmin proxyAdmin;
+        Claim permissionedDisputeGamePrestateHash;
+        Claim permissionlessDisputeGamePrestateHash;
     }
 
     struct AddGameInput {
@@ -222,8 +224,8 @@ interface IOPContractsManager {
 
     /// @notice Upgrades the implementation of all proxies in the specified chains
     /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
-    /// @param _opChains The chains to upgrade
-    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external;
+    /// @param _opChainConfigs The chains to upgrade
+    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChainConfig[] memory _opChainConfigs) external;
 
     /// @notice addGameType deploys a new dispute game and links it to the DisputeGameFactory. The inputted _gameConfigs
     /// must be added in ascending GameType order.

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -112,8 +112,7 @@ interface IOPContractsManager {
     struct OpChainConfig {
         ISystemConfig systemConfigProxy;
         IProxyAdmin proxyAdmin;
-        Claim permissionedDisputeGamePrestateHash;
-        Claim permissionlessDisputeGamePrestateHash;
+        Claim absolutePrestate;
     }
 
     struct AddGameInput {
@@ -208,7 +207,7 @@ interface IOPContractsManager {
 
     error SuperchainProxyAdminMismatch();
 
-    error PrestateNotSet(GameType gameType);
+    error PrestateNotSet();
 
     // -------- Methods --------
 

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -146,6 +146,9 @@ interface IOPContractsManager {
     /// @notice Address of the ProtocolVersions contract shared by all chains.
     function protocolVersions() external view returns (IProtocolVersions);
 
+    /// @notice Address of the ProxyAdmin contract shared by all chains.
+    function superchainProxyAdmin() external view returns (IProxyAdmin);
+
     /// @notice L1 smart contracts release deployed by this version of OPCM. This is used in opcm to signal which
     /// version of the L1 smart contracts is deployed. It takes the format of `op-contracts/vX.Y.Z`.
     function l1ContractsRelease() external view returns (string memory);
@@ -214,6 +217,7 @@ interface IOPContractsManager {
     function __constructor__(
         ISuperchainConfig _superchainConfig,
         IProtocolVersions _protocolVersions,
+        IProxyAdmin _superchainProxyAdmin,
         string memory _l1ContractsRelease,
         Blueprints memory _blueprints,
         Implementations memory _implementations,
@@ -224,9 +228,8 @@ interface IOPContractsManager {
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory);
 
     /// @notice Upgrades the implementation of all proxies in the specified chains
-    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
     /// @param _opChainConfigs The chains to upgrade
-    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChainConfig[] memory _opChainConfigs) external;
+    function upgrade(OpChainConfig[] memory _opChainConfigs) external;
 
     /// @notice addGameType deploys a new dispute game and links it to the DisputeGameFactory. The inputted _gameConfigs
     /// must be added in ascending GameType order.

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -208,6 +208,8 @@ interface IOPContractsManager {
 
     error SuperchainProxyAdminMismatch();
 
+    error PrestateNotSet(GameType gameType);
+
     // -------- Methods --------
 
     function __constructor__(

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerInterop.sol
@@ -3,12 +3,14 @@ pragma solidity ^0.8.0;
 
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 
 interface IOPContractsManagerInterop is IOPContractsManager {
     function __constructor__(
         ISuperchainConfig _superchainConfig,
         IProtocolVersions _protocolVersions,
+        IProxyAdmin _superchainProxyAdmin,
         string memory _l1ContractsRelease,
         Blueprints memory _blueprints,
         Implementations memory _implementations,

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -501,7 +501,7 @@ library ChainAssertions {
         require(impls.l1StandardBridgeImpl == _contracts.L1StandardBridge, "CHECK-OPCM-100");
         require(impls.disputeGameFactoryImpl == _contracts.DisputeGameFactory, "CHECK-OPCM-110");
         require(impls.delayedWETHImpl == _contracts.DelayedWETH, "CHECK-OPCM-120");
-        require(impls.mipsImpl == address(_mips), "CHECK-OPCM-130");
+        require(impls.mips64Impl == address(_mips), "CHECK-OPCM-130");
 
         // Verify that initCode is correctly set into the blueprints
         IOPContractsManager.Blueprints memory blueprints = _opcm.blueprints();

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 // Testing
 import { Vm } from "forge-std/Vm.sol";
 import { console2 as console } from "forge-std/console2.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -32,6 +32,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { IMIPS } from "interfaces/cannon/IMIPS.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 library ChainAssertions {
     Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
@@ -469,9 +470,11 @@ library ChainAssertions {
 
     /// @notice Asserts that the OPContractsManager is setup correctly
     function checkOPContractsManager(
-        Types.ContractSet memory _contracts,
+        Types.ContractSet memory _impls,
+        Types.ContractSet memory _proxies,
         IOPContractsManager _opcm,
-        IMIPS _mips
+        IMIPS _mips,
+        IProxyAdmin _superchainProxyAdmin
     )
         internal
         view
@@ -479,13 +482,19 @@ library ChainAssertions {
         console.log("Running chain assertions on the OPContractsManager at %s", address(_opcm));
         require(address(_opcm) != address(0), "CHECK-OPCM-10");
 
+        require(bytes(_opcm.version()).length > 0, "CHECK-OPCM-15");
+        require(bytes(_opcm.l1ContractsRelease()).length > 0, "CHECK-OPCM-16");
+        require(address(_opcm.protocolVersions()) == _proxies.ProtocolVersions, "CHECK-OPCM-17");
+        require(address(_opcm.superchainProxyAdmin()) == address(_superchainProxyAdmin), "CHECK-OPCM-18");
+        require(address(_opcm.superchainConfig()) == _proxies.SuperchainConfig, "CHECK-OPCM-19");
+
         require(
             address(EIP1967Helper.getImplementation(address(_opcm.superchainConfig())))
-                == address(_contracts.SuperchainConfig),
+                == address(_impls.SuperchainConfig),
             "CHECK-OPCM-20"
         );
         require(
-            EIP1967Helper.getImplementation(address(_opcm.protocolVersions())) == address(_contracts.ProtocolVersions),
+            EIP1967Helper.getImplementation(address(_opcm.protocolVersions())) == address(_impls.ProtocolVersions),
             "CHECK-OPCM-30"
         );
 
@@ -493,14 +502,14 @@ library ChainAssertions {
 
         // Ensure that the OPCM impls are correctly saved
         IOPContractsManager.Implementations memory impls = _opcm.implementations();
-        require(impls.l1ERC721BridgeImpl == _contracts.L1ERC721Bridge, "CHECK-OPCM-50");
-        require(impls.optimismPortalImpl == _contracts.OptimismPortal, "CHECK-OPCM-60");
-        require(impls.systemConfigImpl == _contracts.SystemConfig, "CHECK-OPCM-70");
-        require(impls.optimismMintableERC20FactoryImpl == _contracts.OptimismMintableERC20Factory, "CHECK-OPCM-80");
-        require(impls.l1CrossDomainMessengerImpl == _contracts.L1CrossDomainMessenger, "CHECK-OPCM-90");
-        require(impls.l1StandardBridgeImpl == _contracts.L1StandardBridge, "CHECK-OPCM-100");
-        require(impls.disputeGameFactoryImpl == _contracts.DisputeGameFactory, "CHECK-OPCM-110");
-        require(impls.delayedWETHImpl == _contracts.DelayedWETH, "CHECK-OPCM-120");
+        require(impls.l1ERC721BridgeImpl == _impls.L1ERC721Bridge, "CHECK-OPCM-50");
+        require(impls.optimismPortalImpl == _impls.OptimismPortal, "CHECK-OPCM-60");
+        require(impls.systemConfigImpl == _impls.SystemConfig, "CHECK-OPCM-70");
+        require(impls.optimismMintableERC20FactoryImpl == _impls.OptimismMintableERC20Factory, "CHECK-OPCM-80");
+        require(impls.l1CrossDomainMessengerImpl == _impls.L1CrossDomainMessenger, "CHECK-OPCM-90");
+        require(impls.l1StandardBridgeImpl == _impls.L1StandardBridge, "CHECK-OPCM-100");
+        require(impls.disputeGameFactoryImpl == _impls.DisputeGameFactory, "CHECK-OPCM-110");
+        require(impls.delayedWETHImpl == _impls.DelayedWETH, "CHECK-OPCM-120");
         require(impls.mips64Impl == address(_mips), "CHECK-OPCM-130");
 
         // Verify that initCode is correctly set into the blueprints

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -488,16 +488,6 @@ library ChainAssertions {
         require(address(_opcm.superchainProxyAdmin()) == address(_superchainProxyAdmin), "CHECK-OPCM-18");
         require(address(_opcm.superchainConfig()) == _proxies.SuperchainConfig, "CHECK-OPCM-19");
 
-        require(
-            address(EIP1967Helper.getImplementation(address(_opcm.superchainConfig())))
-                == address(_impls.SuperchainConfig),
-            "CHECK-OPCM-20"
-        );
-        require(
-            EIP1967Helper.getImplementation(address(_opcm.protocolVersions())) == address(_impls.ProtocolVersions),
-            "CHECK-OPCM-30"
-        );
-
         require(bytes(_opcm.l1ContractsRelease()).length > 0, "CHECK-OPCM-40");
 
         // Ensure that the OPCM impls are correctly saved
@@ -511,6 +501,8 @@ library ChainAssertions {
         require(impls.disputeGameFactoryImpl == _impls.DisputeGameFactory, "CHECK-OPCM-110");
         require(impls.delayedWETHImpl == _impls.DelayedWETH, "CHECK-OPCM-120");
         require(impls.mips64Impl == address(_mips), "CHECK-OPCM-130");
+        require(impls.superchainConfigImpl == _impls.SuperchainConfig, "CHECK-OPCM-140");
+        require(impls.protocolVersionsImpl == _impls.ProtocolVersions, "CHECK-OPCM-150");
 
         // Verify that initCode is correctly set into the blueprints
         IOPContractsManager.Blueprints memory blueprints = _opcm.blueprints();

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -329,12 +329,7 @@ contract Deploy is Deployer {
         ChainAssertions.checkOptimismPortal2({ _contracts: impls, _cfg: cfg, _isProxy: false });
         ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: impls, _isProxy: false });
         ChainAssertions.checkDisputeGameFactory({ _contracts: impls, _expectedOwner: address(0), _isProxy: false });
-        ChainAssertions.checkDelayedWETH({
-            _contracts: impls,
-            _cfg: cfg,
-            _isProxy: false,
-            _expectedOwner: address(0)
-        });
+        ChainAssertions.checkDelayedWETH({ _contracts: impls, _cfg: cfg, _isProxy: false, _expectedOwner: address(0) });
         ChainAssertions.checkPreimageOracle({
             _oracle: IPreimageOracle(address(dio.preimageOracleSingleton())),
             _cfg: cfg

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -284,12 +284,16 @@ contract Deploy is Deployer {
         dii.set(dii.mipsVersion.selector, Config.useMultithreadedCannon() ? 2 : 1);
         string memory release = "dev";
         dii.set(dii.l1ContractsRelease.selector, release);
-        dii.set(dii.superchainConfigProxy.selector, artifacts.mustGetAddress("SuperchainConfigProxy"));
         dii.set(dii.protocolVersionsProxy.selector, artifacts.mustGetAddress("ProtocolVersionsProxy"));
-        dii.set(
-            dii.upgradeController.selector,
-            IProxyAdmin(EIP1967Helper.getAdmin(artifacts.mustGetAddress("SuperchainConfigProxy"))).owner()
-        );
+
+        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
+        dii.set(dii.superchainConfigProxy.selector, artifacts.mustGetAddress("SuperchainConfigProxy"));
+
+        address superchainProxyAdmin = EIP1967Helper.getAdmin(address(superchainConfig));
+        dii.set(dii.superchainProxyAdmin.selector, superchainProxyAdmin);
+
+        // I think this was a bug
+        dii.set(dii.upgradeController.selector, IProxyAdmin(superchainProxyAdmin).owner());
 
         if (_isInterop) {
             di = DeployImplementations(new DeployImplementationsInterop());

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -287,7 +287,7 @@ contract Deploy is Deployer {
         dii.set(dii.protocolVersionsProxy.selector, artifacts.mustGetAddress("ProtocolVersionsProxy"));
 
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
-        dii.set(dii.superchainConfigProxy.selector, artifacts.mustGetAddress("SuperchainConfigProxy"));
+        dii.set(dii.superchainConfigProxy.selector, address(superchainConfig));
 
         address superchainProxyAdmin = EIP1967Helper.getAdmin(address(superchainConfig));
         dii.set(dii.superchainProxyAdmin.selector, superchainProxyAdmin);

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -24,7 +24,7 @@ import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IOptimismPortalInterop } from "interfaces/L1/IOptimismPortalInterop.sol";
 import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
-
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
@@ -45,6 +45,7 @@ contract DeployImplementationsInput is BaseDeployIO {
     // Outputs from DeploySuperchain.s.sol.
     ISuperchainConfig internal _superchainConfigProxy;
     IProtocolVersions internal _protocolVersionsProxy;
+    IProxyAdmin internal _superchainProxyAdmin;
     address internal _upgradeController;
 
     function set(bytes4 _sel, uint256 _value) public {
@@ -78,6 +79,7 @@ contract DeployImplementationsInput is BaseDeployIO {
         require(_addr != address(0), "DeployImplementationsInput: cannot set zero address");
         if (_sel == this.superchainConfigProxy.selector) _superchainConfigProxy = ISuperchainConfig(_addr);
         else if (_sel == this.protocolVersionsProxy.selector) _protocolVersionsProxy = IProtocolVersions(_addr);
+        else if (_sel == this.superchainProxyAdmin.selector) _superchainProxyAdmin = IProxyAdmin(_addr);
         else if (_sel == this.upgradeController.selector) _upgradeController = _addr;
         else revert("DeployImplementationsInput: unknown selector");
     }
@@ -128,6 +130,11 @@ contract DeployImplementationsInput is BaseDeployIO {
     function protocolVersionsProxy() public view returns (IProtocolVersions) {
         require(address(_protocolVersionsProxy) != address(0), "DeployImplementationsInput: not set");
         return _protocolVersionsProxy;
+    }
+
+    function superchainProxyAdmin() public view returns (IProxyAdmin) {
+        require(address(_superchainProxyAdmin) != address(0), "DeployImplementationsInput: not set");
+        return _superchainProxyAdmin;
     }
 
     function upgradeController() public view returns (address) {
@@ -470,6 +477,7 @@ contract DeployImplementations is Script {
     {
         ISuperchainConfig superchainConfigProxy = _dii.superchainConfigProxy();
         IProtocolVersions protocolVersionsProxy = _dii.protocolVersionsProxy();
+        IProxyAdmin superchainProxyAdmin = _dii.superchainProxyAdmin();
         address upgradeController = _dii.upgradeController();
 
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
@@ -497,6 +505,7 @@ contract DeployImplementations is Script {
                         (
                             superchainConfigProxy,
                             protocolVersionsProxy,
+                            superchainProxyAdmin,
                             _l1ContractsRelease,
                             _blueprints,
                             implementations,
@@ -852,6 +861,7 @@ contract DeployImplementationsInterop is DeployImplementations {
     {
         ISuperchainConfig superchainConfigProxy = _dii.superchainConfigProxy();
         IProtocolVersions protocolVersionsProxy = _dii.protocolVersionsProxy();
+        IProxyAdmin superchainProxyAdmin = _dii.superchainProxyAdmin();
         address upgradeController = _dii.upgradeController();
 
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
@@ -879,6 +889,7 @@ contract DeployImplementationsInterop is DeployImplementations {
                         (
                             superchainConfigProxy,
                             protocolVersionsProxy,
+                            superchainProxyAdmin,
                             _l1ContractsRelease,
                             _blueprints,
                             implementations,

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -484,7 +484,7 @@ contract DeployImplementations is Script {
             disputeGameFactoryImpl: address(_dio.disputeGameFactoryImpl()),
             anchorStateRegistryImpl: address(_dio.anchorStateRegistryImpl()),
             delayedWETHImpl: address(_dio.delayedWETHImpl()),
-            mipsImpl: address(_dio.mipsSingleton())
+            mips64Impl: address(_dio.mipsSingleton())
         });
 
         vm.broadcast(msg.sender);
@@ -866,7 +866,7 @@ contract DeployImplementationsInterop is DeployImplementations {
             disputeGameFactoryImpl: address(_dio.disputeGameFactoryImpl()),
             anchorStateRegistryImpl: address(_dio.anchorStateRegistryImpl()),
             delayedWETHImpl: address(_dio.delayedWETHImpl()),
-            mipsImpl: address(_dio.mipsSingleton())
+            mips64Impl: address(_dio.mipsSingleton())
         });
 
         vm.broadcast(msg.sender);

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -11,10 +11,12 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 contract DeployOPCMInput is BaseDeployIO {
     ISuperchainConfig internal _superchainConfig;
     IProtocolVersions internal _protocolVersions;
+    IProxyAdmin internal _superchainProxyAdmin;
     string internal _l1ContractsRelease;
     address internal _upgradeController;
 
@@ -45,6 +47,7 @@ contract DeployOPCMInput is BaseDeployIO {
 
         if (_sel == this.superchainConfig.selector) _superchainConfig = ISuperchainConfig(_addr);
         else if (_sel == this.protocolVersions.selector) _protocolVersions = IProtocolVersions(_addr);
+        else if (_sel == this.superchainProxyAdmin.selector) _superchainProxyAdmin = IProxyAdmin(_addr);
         else if (_sel == this.superchainConfigImpl.selector) _superchainConfigImpl = _addr;
         else if (_sel == this.protocolVersionsImpl.selector) _protocolVersionsImpl = _addr;
         else if (_sel == this.upgradeController.selector) _upgradeController = _addr;
@@ -84,6 +87,11 @@ contract DeployOPCMInput is BaseDeployIO {
     function protocolVersions() public view returns (IProtocolVersions) {
         require(address(_protocolVersions) != address(0), "DeployOPCMInput: not set");
         return _protocolVersions;
+    }
+
+    function superchainProxyAdmin() public view returns (IProxyAdmin) {
+        require(address(_superchainProxyAdmin) != address(0), "DeployOPCMInput: not set");
+        return _superchainProxyAdmin;
     }
 
     function l1ContractsRelease() public view returns (string memory) {
@@ -240,6 +248,7 @@ contract DeployOPCM is Script {
         IOPContractsManager opcm_ = deployOPCM(
             _doi.superchainConfig(),
             _doi.protocolVersions(),
+            _doi.superchainProxyAdmin(),
             blueprints,
             implementations,
             _doi.l1ContractsRelease(),
@@ -253,6 +262,7 @@ contract DeployOPCM is Script {
     function deployOPCM(
         ISuperchainConfig _superchainConfig,
         IProtocolVersions _protocolVersions,
+        IProxyAdmin _superchainProxyAdmin,
         IOPContractsManager.Blueprints memory _blueprints,
         IOPContractsManager.Implementations memory _implementations,
         string memory _l1ContractsRelease,
@@ -271,6 +281,7 @@ contract DeployOPCM is Script {
                         (
                             _superchainConfig,
                             _protocolVersions,
+                            _superchainProxyAdmin,
                             _l1ContractsRelease,
                             _blueprints,
                             _implementations,

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -37,7 +37,7 @@ contract DeployOPCMInput is BaseDeployIO {
     address internal _disputeGameFactoryImpl;
     address internal _anchorStateRegistryImpl;
     address internal _delayedWETHImpl;
-    address internal _mipsImpl;
+    address internal _mips64Impl;
 
     // Setter for address type
     function set(bytes4 _sel, address _addr) public {
@@ -64,7 +64,7 @@ contract DeployOPCMInput is BaseDeployIO {
         else if (_sel == this.disputeGameFactoryImpl.selector) _disputeGameFactoryImpl = _addr;
         else if (_sel == this.anchorStateRegistryImpl.selector) _anchorStateRegistryImpl = _addr;
         else if (_sel == this.delayedWETHImpl.selector) _delayedWETHImpl = _addr;
-        else if (_sel == this.mipsImpl.selector) _mipsImpl = _addr;
+        else if (_sel == this.mips64Impl.selector) _mips64Impl = _addr;
         else revert("DeployOPCMInput: unknown selector");
     }
 
@@ -186,9 +186,9 @@ contract DeployOPCMInput is BaseDeployIO {
         return _delayedWETHImpl;
     }
 
-    function mipsImpl() public view returns (address) {
-        require(_mipsImpl != address(0), "DeployOPCMInput: not set");
-        return _mipsImpl;
+    function mips64Impl() public view returns (address) {
+        require(_mips64Impl != address(0), "DeployOPCMInput: not set");
+        return _mips64Impl;
     }
 }
 
@@ -234,7 +234,7 @@ contract DeployOPCM is Script {
             disputeGameFactoryImpl: address(_doi.disputeGameFactoryImpl()),
             anchorStateRegistryImpl: address(_doi.anchorStateRegistryImpl()),
             delayedWETHImpl: address(_doi.delayedWETHImpl()),
-            mipsImpl: address(_doi.mipsImpl())
+            mips64Impl: address(_doi.mips64Impl())
         });
 
         IOPContractsManager opcm_ = deployOPCM(
@@ -313,7 +313,7 @@ contract DeployOPCM is Script {
         require(implementations.disputeGameFactoryImpl == _doi.disputeGameFactoryImpl(), "OPCMI-180");
         require(implementations.anchorStateRegistryImpl == _doi.anchorStateRegistryImpl(), "OPCMI-190");
         require(implementations.delayedWETHImpl == _doi.delayedWETHImpl(), "OPCMI-200");
-        require(implementations.mipsImpl == _doi.mipsImpl(), "OPCMI-210");
+        require(implementations.mips64Impl == _doi.mips64Impl(), "OPCMI-210");
     }
 
     function etchIOContracts() public returns (DeployOPCMInput doi_, DeployOPCMOutput doo_) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -468,8 +468,8 @@ contract DeployOPChain is Script {
         );
 
         IOPContractsManager opcm = _doi.opcm();
-        address mipsImpl = opcm.implementations().mipsImpl;
-        require(game.vm() == IBigStepper(mipsImpl), "DPG-30");
+        address mips64Impl = opcm.implementations().mips64Impl;
+        require(game.vm() == IBigStepper(mips64Impl), "DPG-30");
 
         require(address(game.weth()) == address(_doo.delayedWETHPermissionedGameProxy()), "DPG-40");
         require(address(game.anchorStateRegistry()) == address(_doo.anchorStateRegistryProxy()), "DPG-50");

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -143,7 +143,7 @@ contract ReadImplementationAddresses is Script {
         vm.prank(address(0));
         _rio.set(_rio.l1StandardBridge.selector, l1SBImpl);
 
-        address mipsLogic = _rii.opcm().implementations().mipsImpl;
+        address mipsLogic = _rii.opcm().implementations().mips64Impl;
         _rio.set(_rio.mipsSingleton.selector, mipsLogic);
 
         address delayedWETH = _rii.opcm().implementations().delayedWETHImpl;

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -672,12 +672,7 @@
           },
           {
             "internalType": "Claim",
-            "name": "permissionedDisputeGamePrestateHash",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "Claim",
-            "name": "permissionlessDisputeGamePrestateHash",
+            "name": "absolutePrestate",
             "type": "bytes32"
           }
         ],
@@ -861,13 +856,7 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "GameType",
-        "name": "gameType",
-        "type": "uint32"
-      }
-    ],
+    "inputs": [],
     "name": "PrestateNotSet",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -12,6 +12,11 @@
         "type": "address"
       },
       {
+        "internalType": "contract IProxyAdmin",
+        "name": "_superchainProxyAdmin",
+        "type": "address"
+      },
+      {
         "internalType": "string",
         "name": "_l1ContractsRelease",
         "type": "string"
@@ -652,12 +657,20 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [],
+    "name": "superchainProxyAdmin",
+    "outputs": [
       {
         "internalType": "contract IProxyAdmin",
-        "name": "_superchainProxyAdmin",
+        "name": "",
         "type": "address"
-      },
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
         "components": [
           {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -127,7 +127,7 @@
           },
           {
             "internalType": "address",
-            "name": "mipsImpl",
+            "name": "mips64Impl",
             "type": "address"
           }
         ],
@@ -574,7 +574,7 @@
           },
           {
             "internalType": "address",
-            "name": "mipsImpl",
+            "name": "mips64Impl",
             "type": "address"
           }
         ],
@@ -669,10 +669,20 @@
             "internalType": "contract IProxyAdmin",
             "name": "proxyAdmin",
             "type": "address"
+          },
+          {
+            "internalType": "Claim",
+            "name": "permissionedDisputeGamePrestateHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "Claim",
+            "name": "permissionlessDisputeGamePrestateHash",
+            "type": "bytes32"
           }
         ],
-        "internalType": "struct OPContractsManager.OpChain[]",
-        "name": "_opChains",
+        "internalType": "struct OPContractsManager.OpChainConfig[]",
+        "name": "_opChainConfigs",
         "type": "tuple[]"
       }
     ],
@@ -848,6 +858,17 @@
   {
     "inputs": [],
     "name": "OnlyUpgradeController",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      }
+    ],
+    "name": "PrestateNotSet",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -672,12 +672,7 @@
           },
           {
             "internalType": "Claim",
-            "name": "permissionedDisputeGamePrestateHash",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "Claim",
-            "name": "permissionlessDisputeGamePrestateHash",
+            "name": "absolutePrestate",
             "type": "bytes32"
           }
         ],
@@ -861,13 +856,7 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "GameType",
-        "name": "gameType",
-        "type": "uint32"
-      }
-    ],
+    "inputs": [],
     "name": "PrestateNotSet",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -12,6 +12,11 @@
         "type": "address"
       },
       {
+        "internalType": "contract IProxyAdmin",
+        "name": "_superchainProxyAdmin",
+        "type": "address"
+      },
+      {
         "internalType": "string",
         "name": "_l1ContractsRelease",
         "type": "string"
@@ -652,12 +657,20 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [],
+    "name": "superchainProxyAdmin",
+    "outputs": [
       {
         "internalType": "contract IProxyAdmin",
-        "name": "_superchainProxyAdmin",
+        "name": "",
         "type": "address"
-      },
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
         "components": [
           {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -127,7 +127,7 @@
           },
           {
             "internalType": "address",
-            "name": "mipsImpl",
+            "name": "mips64Impl",
             "type": "address"
           }
         ],
@@ -574,7 +574,7 @@
           },
           {
             "internalType": "address",
-            "name": "mipsImpl",
+            "name": "mips64Impl",
             "type": "address"
           }
         ],
@@ -669,10 +669,20 @@
             "internalType": "contract IProxyAdmin",
             "name": "proxyAdmin",
             "type": "address"
+          },
+          {
+            "internalType": "Claim",
+            "name": "permissionedDisputeGamePrestateHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "Claim",
+            "name": "permissionlessDisputeGamePrestateHash",
+            "type": "bytes32"
           }
         ],
-        "internalType": "struct OPContractsManager.OpChain[]",
-        "name": "_opChains",
+        "internalType": "struct OPContractsManager.OpChainConfig[]",
+        "name": "_opChainConfigs",
         "type": "tuple[]"
       }
     ],
@@ -848,6 +858,17 @@
   {
     "inputs": [],
     "name": "OnlyUpgradeController",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      }
+    ],
+    "name": "PrestateNotSet",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,12 +16,12 @@
     "sourceCodeHash": "0x2dd7bf6cbce655b1023a3ad071523bf455aa13fad5d02e1e434af71728cd794c"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xb89013d252e41d3ef3ed60aed873e88061cebc811d5958cdbebf04cf3cb7b116",
-    "sourceCodeHash": "0x0194f77b66c45cbf7dcb4b29d1bfecf9da2c0b689d16f06dda04c2181867ac30"
+    "initCodeHash": "0x5b2d0d8d6d478ce44c577e14f8fb8c332632f7cdd8af867e7e1a2afb0ab6ebe9",
+    "sourceCodeHash": "0x806d231d8c9ccfba9bb3fbdfb64bccbfb5af20c70d96a762705e98729881bbaa"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0x8629628786da626db58b9b971dfa5498caffedcdbb948fe3913eb87b3953ecd7",
-    "sourceCodeHash": "0x526ff72544d404377ea58b5ed476f4cdd3d4338acec9909ce12d1778bffb298e"
+    "initCodeHash": "0xf9dc573b52c1f2c1e3b6a1c61a5dd84294244f759bf86f86310540d8852913da",
+    "sourceCodeHash": "0x5427e7251a4a9ef3cb3378301ae0d23ab8d2083a93a662268d01392443aba280"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,11 +16,11 @@
     "sourceCodeHash": "0x2dd7bf6cbce655b1023a3ad071523bf455aa13fad5d02e1e434af71728cd794c"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0xe0324c986d2e8dee0c20d325631ed8fc68cad79a52555790c25cdc13dd8ef5fc",
-    "sourceCodeHash": "0x811a20610e91be43f8bde8621476803513ed301ebf15df79885930e5ac28c78f"
+    "initCodeHash": "0xb89013d252e41d3ef3ed60aed873e88061cebc811d5958cdbebf04cf3cb7b116",
+    "sourceCodeHash": "0x0194f77b66c45cbf7dcb4b29d1bfecf9da2c0b689d16f06dda04c2181867ac30"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0x52391efa9a5093b253b5a61f8b81f41ae735733a73a2862ff8ed31a450601c1b",
+    "initCodeHash": "0x8629628786da626db58b9b971dfa5498caffedcdbb948fe3913eb87b3953ecd7",
     "sourceCodeHash": "0x526ff72544d404377ea58b5ed476f4cdd3d4338acec9909ce12d1778bffb298e"
   },
   "src/L1/OptimismPortal2.sol": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,12 +16,12 @@
     "sourceCodeHash": "0x2dd7bf6cbce655b1023a3ad071523bf455aa13fad5d02e1e434af71728cd794c"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x181f685035a334401db2c145689e6b1bfcee8e9422e5850fc0de7937e009e965",
-    "sourceCodeHash": "0xd3f173b2dba1f23cbe6510737b583069035a015781ee4735836ef3620a9abd2a"
+    "initCodeHash": "0xe0324c986d2e8dee0c20d325631ed8fc68cad79a52555790c25cdc13dd8ef5fc",
+    "sourceCodeHash": "0x811a20610e91be43f8bde8621476803513ed301ebf15df79885930e5ac28c78f"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0xb9e066b13039ea0b0dfa956991551f1cebc6e2ba6be8d00531c198817ede383f",
-    "sourceCodeHash": "0x5d69aed02dcb5d87cb12c84139c551acced73363965c4bbfff9413e72aaa1173"
+    "initCodeHash": "0x52391efa9a5093b253b5a61f8b81f41ae735733a73a2862ff8ed31a450601c1b",
+    "sourceCodeHash": "0x526ff72544d404377ea58b5ed476f4cdd3d4338acec9909ce12d1778bffb298e"
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -111,7 +111,7 @@ contract OPContractsManager is ISemver {
         address disputeGameFactoryImpl;
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
-        address mipsImpl; // this should be updated to mips64
+        address mips64Impl;
     }
 
     /// @notice The input required to identify a chain for upgrading.
@@ -172,6 +172,9 @@ contract OPContractsManager is ISemver {
 
     /// @notice The address of the upgrade controller.
     address public immutable upgradeController;
+
+    /// @notice The prestate hash to be used for the upgrade.
+    bytes32 public immutable prestateHash;
 
     /// @notice Whether this is a release candidate.
     bool public isRC = true;
@@ -240,7 +243,8 @@ contract OPContractsManager is ISemver {
         string memory _l1ContractsRelease,
         Blueprints memory _blueprints,
         Implementations memory _implementations,
-        address _upgradeController
+        address _upgradeController,
+        bytes32 _prestateHash
     ) {
         assertValidContractAddress(address(_superchainConfig));
         assertValidContractAddress(address(_protocolVersions));
@@ -252,6 +256,7 @@ contract OPContractsManager is ISemver {
         implementation = _implementations;
         thisOPCM = this;
         upgradeController = _upgradeController;
+        prestateHash = _prestateHash;
     }
 
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory) {
@@ -1074,8 +1079,7 @@ contract OPContractsManager is ISemver {
         IFaultDisputeGame.GameConstructorParams memory params =
             getGameConstructorParams(IFaultDisputeGame(address(_currentGame)));
         params.anchorStateRegistry = IAnchorStateRegistry(address(_newAnchorStateRegistryProxy));
-        // TODO: also override with the new prestate hash
-        // params.absolutePrestate = (comes from input)
+        params.absolutePrestate = prestateHash;
         params.vm = IBigStepper(mips64);
 
         IDisputeGame newGame;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -345,7 +345,7 @@ contract OPContractsManager is ISemver {
                         splitDepth: _input.disputeSplitDepth,
                         clockExtension: _input.disputeClockExtension,
                         maxClockDuration: _input.disputeMaxClockDuration,
-                        vm: IBigStepper(implementation.mipsImpl),
+                        vm: IBigStepper(implementation.mips64Impl),
                         weth: IDelayedWETH(payable(address(output.delayedWETHPermissionedGameProxy))),
                         anchorStateRegistry: IAnchorStateRegistry(address(output.anchorStateRegistryProxy)),
                         l2ChainId: _input.l2ChainId

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -146,9 +146,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.37
+    /// @custom:semver 1.0.0-beta.38
     function version() public pure virtual returns (string memory) {
-        return "1.0.0-beta.37";
+        return "1.0.0-beta.38";
     }
 
     /// @notice Address of the SuperchainConfig contract shared by all chains.

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -550,7 +550,7 @@ contract OPContractsManager is ISemver {
 
                 deployAndSetNewGameImpl({
                     _proxyAdmin: _opChains[i].proxyAdmin,
-                    _currentGame: IDisputeGame(address(permissionedDisputeGame)),
+                    _disputeGame: IDisputeGame(address(permissionedDisputeGame)),
                     _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
                     _gameType: GameTypes.PERMISSIONED_CANNON,
                     _implementations: impls,
@@ -567,7 +567,7 @@ contract OPContractsManager is ISemver {
             if (address(permissionlessDisputeGame) != address(0)) {
                 deployAndSetNewGameImpl({
                     _proxyAdmin: _opChains[i].proxyAdmin,
-                    _currentGame: IDisputeGame(address(permissionlessDisputeGame)),
+                    _disputeGame: IDisputeGame(address(permissionlessDisputeGame)),
                     _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
                     _gameType: GameTypes.CANNON,
                     _implementations: impls,
@@ -1061,7 +1061,7 @@ contract OPContractsManager is ISemver {
     /// 3. Set the new game as the implementation on the OptimismPortal
     function deployAndSetNewGameImpl(
         IProxyAdmin _proxyAdmin,
-        IDisputeGame _currentGame,
+        IDisputeGame _disputeGame,
         IAnchorStateRegistry _newAnchorStateRegistryProxy,
         GameType _gameType,
         Blueprints memory _blueprints,
@@ -1072,20 +1072,20 @@ contract OPContractsManager is ISemver {
         internal
     {
         // Get and upgrade the WETH proxy
-        IDelayedWETH delayedWethProxy = getWETH(IFaultDisputeGame(address(_currentGame)));
+        IDelayedWETH delayedWethProxy = getWETH(IFaultDisputeGame(address(_disputeGame)));
         upgradeTo(_proxyAdmin, address(delayedWethProxy), _implementations.delayedWETHImpl);
 
         // Get the constructor params for the game
         IFaultDisputeGame.GameConstructorParams memory params =
-            getGameConstructorParams(IFaultDisputeGame(address(_currentGame)));
+            getGameConstructorParams(IFaultDisputeGame(address(_disputeGame)));
         params.anchorStateRegistry = IAnchorStateRegistry(address(_newAnchorStateRegistryProxy));
         params.absolutePrestate = prestateHash;
         params.vm = IBigStepper(mips64);
 
         IDisputeGame newGame;
         if (GameType.unwrap(_gameType) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON)) {
-            address proposer = getProposer(IPermissionedDisputeGame(address(_currentGame)));
-            address challenger = getChallenger(IPermissionedDisputeGame(address(_currentGame)));
+            address proposer = getProposer(IPermissionedDisputeGame(address(_disputeGame)));
+            address challenger = getChallenger(IPermissionedDisputeGame(address(_disputeGame)));
             newGame = IDisputeGame(
                 Blueprint.deployFrom(
                     _blueprints.permissionedDisputeGame1,

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -234,6 +234,9 @@ contract OPContractsManager is ISemver {
     /// @notice Thrown when the SuperchainProxyAdmin does not match the SuperchainConfig's admin.
     error SuperchainProxyAdminMismatch();
 
+    /// @notice Thrown when a prestate is not set for a game.
+    error PrestateNotSet(GameType gameType);
+
     // -------- Methods --------
 
     constructor(
@@ -1091,11 +1094,9 @@ contract OPContractsManager is ISemver {
 
         IDisputeGame newGame;
         if (GameType.unwrap(_gameType) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON)) {
-            // TODO: custom error
-            require(
-                Claim.unwrap(_opChain.permissionedDisputeGamePrestateHash) != bytes32(0),
-                "No absolutePrestate for permissioned game"
-            );
+            if (Claim.unwrap(_opChain.permissionedDisputeGamePrestateHash) == bytes32(0)) {
+                revert PrestateNotSet(GameTypes.PERMISSIONED_CANNON);
+            }
 
             // modify the params to set the permissioned game specific absolutePrestate
             params.absolutePrestate = _opChain.permissionedDisputeGamePrestateHash;
@@ -1111,11 +1112,9 @@ contract OPContractsManager is ISemver {
                 )
             );
         } else {
-            // TODO: custom error
-            require(
-                Claim.unwrap(_opChain.permissionlessDisputeGamePrestateHash) != bytes32(0),
-                "No absolutePrestate for permissionless game"
-            );
+            if (Claim.unwrap(_opChain.permissionlessDisputeGamePrestateHash) == bytes32(0)) {
+                revert PrestateNotSet(GameTypes.CANNON);
+            }
 
             // modify the params to set the permissionless game specific absolutePrestate
             params.absolutePrestate = _opChain.permissionlessDisputeGamePrestateHash;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -111,7 +111,7 @@ contract OPContractsManager is ISemver {
         address disputeGameFactoryImpl;
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
-        address mipsImpl;
+        address mipsImpl; // this should be updated to mips64
     }
 
     /// @notice The input required to identify a chain for upgrading.
@@ -1074,6 +1074,9 @@ contract OPContractsManager is ISemver {
         IFaultDisputeGame.GameConstructorParams memory params =
             getGameConstructorParams(IFaultDisputeGame(address(_currentGame)));
         params.anchorStateRegistry = IAnchorStateRegistry(address(_newAnchorStateRegistryProxy));
+        // TODO: also override with the new prestate hash
+        // params.absolutePrestate = (comes from input)
+        params.vm = IBigStepper(mips64);
 
         IDisputeGame newGame;
         if (GameType.unwrap(_gameType) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON)) {

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -115,8 +115,7 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice The input required to identify a chain for upgrading, along with new prestate hashes
-    // TODO: rename to OpChainConfig
-    struct OpChain {
+    struct OpChainConfig {
         ISystemConfig systemConfigProxy;
         IProxyAdmin proxyAdmin;
         Claim permissionedDisputeGamePrestateHash;
@@ -441,7 +440,7 @@ contract OPContractsManager is ISemver {
     /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
     /// @param _opChains Array of OpChain structs, one per chain to upgrade
     /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
-    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external {
+    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChainConfig[] memory _opChains) external {
         if (address(this) == address(thisOPCM)) revert OnlyDelegatecall();
 
         // If this is delegatecalled by the upgrade controller, set isRC to false first, else, continue execution.
@@ -1054,13 +1053,21 @@ contract OPContractsManager is ISemver {
         return thisOPCM.blueprints();
     }
 
-    /// @notice TODO: write me.
+    /// @notice Deploys and sets a new dispute game implementation
+    /// @param _l2ChainId The L2 chain ID
+    /// @param _disputeGame The current dispute game implementation
+    /// @param _newAnchorStateRegistryProxy The new anchor state registry proxy
+    /// @param _gameType The type of game to deploy
+    /// @param _opChain The OP chain configuration
+    /// @param _blueprints The blueprint addresses
+    /// @param _implementations The implementation addresses
+    /// @param _opChainAddrs The OP chain addresses
     function deployAndSetNewGameImpl(
         uint256 _l2ChainId,
         IDisputeGame _disputeGame,
         IAnchorStateRegistry _newAnchorStateRegistryProxy,
         GameType _gameType,
-        OpChain memory _opChain,
+        OpChainConfig memory _opChain,
         Blueprints memory _blueprints,
         Implementations memory _implementations,
         ISystemConfig.Addresses memory _opChainAddrs
@@ -1085,7 +1092,10 @@ contract OPContractsManager is ISemver {
         IDisputeGame newGame;
         if (GameType.unwrap(_gameType) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON)) {
             // TODO: custom error
-            require(Claim.unwrap(_opChain.permissionedDisputeGamePrestateHash) != bytes32(0), "No absolutePrestate for permissioned game");
+            require(
+                Claim.unwrap(_opChain.permissionedDisputeGamePrestateHash) != bytes32(0),
+                "No absolutePrestate for permissioned game"
+            );
 
             // modify the params to set the permissioned game specific absolutePrestate
             params.absolutePrestate = _opChain.permissionedDisputeGamePrestateHash;
@@ -1102,7 +1112,10 @@ contract OPContractsManager is ISemver {
             );
         } else {
             // TODO: custom error
-            require(Claim.unwrap(_opChain.permissionlessDisputeGamePrestateHash) != bytes32(0), "No absolutePrestate for permissionless game");
+            require(
+                Claim.unwrap(_opChain.permissionlessDisputeGamePrestateHash) != bytes32(0),
+                "No absolutePrestate for permissionless game"
+            );
 
             // modify the params to set the permissionless game specific absolutePrestate
             params.absolutePrestate = _opChain.permissionlessDisputeGamePrestateHash;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
@@ -10,16 +10,18 @@ import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 contract OPContractsManagerInterop is OPContractsManager {
-    /// @custom:semver +interop-beta.6
+    /// @custom:semver +interop-beta.7
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.6");
+        return string.concat(super.version(), "+interop-beta.7");
     }
 
     constructor(
         ISuperchainConfig _superchainConfig,
         IProtocolVersions _protocolVersions,
+        IProxyAdmin _superchainProxyAdmin,
         string memory _l1ContractsRelease,
         Blueprints memory _blueprints,
         Implementations memory _implementations,
@@ -28,6 +30,7 @@ contract OPContractsManagerInterop is OPContractsManager {
         OPContractsManager(
             _superchainConfig,
             _protocolVersions,
+            _superchainProxyAdmin,
             _l1ContractsRelease,
             _blueprints,
             _implementations,

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerInterop.sol
@@ -12,9 +12,9 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
 
 contract OPContractsManagerInterop is OPContractsManager {
-    /// @custom:semver +interop-beta.5
+    /// @custom:semver +interop-beta.6
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.5");
+        return string.concat(super.version(), "+interop-beta.6");
     }
 
     constructor(

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -546,7 +546,7 @@ contract OPContractsManager_AddGameType_Test is Test {
             disputeGameFactoryImpl: DeployUtils.create1("DisputeGameFactory"),
             anchorStateRegistryImpl: DeployUtils.create1("AnchorStateRegistry"),
             delayedWETHImpl: DeployUtils.create1("DelayedWETH", abi.encode(3)),
-            mips64Impl: DeployUtils.create1("MIPS", abi.encode(oracle))
+            mips64Impl: DeployUtils.create1("MIPS64", abi.encode(oracle))
         });
 
         vm.etch(address(superchainConfigProxy), hex"01");

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -454,6 +454,32 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
             address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (proxyAdmin, opChainConfigs))
         );
     }
+
+    function test_permissionedPrestateNotSet_reverts() public {
+        opChainConfigs[0].permissionedDisputeGamePrestateHash = Claim.wrap(bytes32(0));
+        address delegateCaller = makeAddr("delegateCaller");
+        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.PERMISSIONED_CANNON))
+        );
+        DelegateCaller(delegateCaller).dcForward(
+            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (proxyAdmin, opChainConfigs))
+        );
+    }
+
+    function test_permissionlessPrestateNotSet_reverts() public {
+        opChainConfigs[0].permissionlessDisputeGamePrestateHash = Claim.wrap(bytes32(0));
+        address delegateCaller = makeAddr("delegateCaller");
+        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.CANNON))
+        );
+        DelegateCaller(delegateCaller).dcForward(
+            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (proxyAdmin, opChainConfigs))
+        );
+    }
 }
 
 contract OPContractsManager_SetRC_Test is OPContractsManager_Upgrade_Harness {

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -317,10 +317,9 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Check that the PermissionedDisputeGame is upgraded to the expected version, references
         // the correct anchor state and has the mips64impl.
-        IPermissionedDisputeGame pdg = IPermissionedDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
-        assertEq(
-            ISemver(address(pdg)).version(), "1.4.0-beta.1"
-        );
+        IPermissionedDisputeGame pdg =
+            IPermissionedDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
+        assertEq(ISemver(address(pdg)).version(), "1.4.0-beta.1");
         assertEq(address(pdg.anchorStateRegistry()), address(newAnchorStateRegistryProxy));
         assertEq(address(pdg.vm()), impls.mips64Impl);
 
@@ -330,9 +329,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             assertEq(impls.delayedWETHImpl, EIP1967Helper.getImplementation(address(delayedWeth)));
             // Check that the PermissionlessDisputeGame is upgraded to the expected version
             IFaultDisputeGame fdg = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
-            assertEq(
-                ISemver(address(fdg)).version(), "1.4.0-beta.1"
-            );
+            assertEq(ISemver(address(fdg)).version(), "1.4.0-beta.1");
             assertEq(address(fdg.anchorStateRegistry()), address(newAnchorStateRegistryProxy));
             assertEq(address(fdg.vm()), impls.mips64Impl);
             assertEq(ISemver(address(fdg)).version(), "1.4.0-beta.1");
@@ -455,27 +452,22 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
         );
     }
 
-    function test_permissionedPrestateNotSet_reverts() public {
-        opChainConfigs[0].permissionedDisputeGamePrestateHash = Claim.wrap(bytes32(0));
-        address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+    function test_upgrade_permissionedPrestateNotSet_reverts() public {
+        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         vm.expectRevert(
             abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.PERMISSIONED_CANNON))
         );
-        DelegateCaller(delegateCaller).dcForward(
+        DelegateCaller(upgrader).dcForward(
             address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (proxyAdmin, opChainConfigs))
         );
     }
 
-    function test_permissionlessPrestateNotSet_reverts() public {
-        opChainConfigs[0].permissionlessDisputeGamePrestateHash = Claim.wrap(bytes32(0));
+    function test_upgrade_permissionlessPrestateNotSet_reverts() public {
         address delegateCaller = makeAddr("delegateCaller");
         vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.CANNON))
-        );
+        vm.expectRevert(abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.CANNON)));
         DelegateCaller(delegateCaller).dcForward(
             address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (proxyAdmin, opChainConfigs))
         );

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -455,6 +455,7 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
     function test_upgrade_permissionedPrestateNotSet_reverts() public {
         vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
+        opChainConfigs[0].permissionedDisputeGamePrestateHash = Claim.wrap(bytes32(0));
         vm.expectRevert(
             abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.PERMISSIONED_CANNON))
         );
@@ -464,11 +465,11 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
     }
 
     function test_upgrade_permissionlessPrestateNotSet_reverts() public {
-        address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+        opChainConfigs[0].permissionlessDisputeGamePrestateHash = Claim.wrap(bytes32(0));
 
         vm.expectRevert(abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.CANNON)));
-        DelegateCaller(delegateCaller).dcForward(
+        DelegateCaller(upgrader).dcForward(
             address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (proxyAdmin, opChainConfigs))
         );
     }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -227,6 +227,9 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
+        // Set the upgrader to be a DelegateCaller so we can test the upgrade
+        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+
         opChainConfigs.push(
             IOPContractsManager.OpChainConfig({
                 systemConfigProxy: systemConfig,
@@ -332,8 +335,6 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             assertEq(ISemver(address(fdg)).version(), "1.4.0-beta.1");
             assertEq(address(fdg.anchorStateRegistry()), address(newAnchorStateRegistryProxy));
             assertEq(address(fdg.vm()), impls.mips64Impl);
-            assertEq(ISemver(address(fdg)).version(), "1.4.0-beta.1");
-            assertEq(address(fdg.vm()), impls.mips64Impl);
         }
     }
 }
@@ -410,7 +411,6 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
 
     function test_upgrade_superchainConfigMismatch_reverts() public {
         upgrader = proxyAdmin.owner();
-        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
         // Set the superchainConfig to a different address in the OptimismPortal2 contract.
         vm.store(
             address(optimismPortal2),
@@ -453,7 +453,6 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
     }
 
     function test_upgrade_permissionedPrestateNotSet_reverts() public {
-        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         opChainConfigs[0].permissionedDisputeGamePrestateHash = Claim.wrap(bytes32(0));
         vm.expectRevert(
@@ -465,7 +464,6 @@ contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harn
     }
 
     function test_upgrade_permissionlessPrestateNotSet_reverts() public {
-        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
         opChainConfigs[0].permissionlessDisputeGamePrestateHash = Claim.wrap(bytes32(0));
 
         vm.expectRevert(abi.encodeWithSelector(IOPContractsManager.PrestateNotSet.selector, (GameTypes.CANNON)));

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -231,6 +231,7 @@ contract DeployImplementations_Test is Test {
     uint256 disputeGameFinalityDelaySeconds = 500;
     ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
     IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+    IProxyAdmin superchainProxyAdmin = IProxyAdmin(makeAddr("superchainProxyAdmin"));
     address upgradeController = makeAddr("upgradeController");
 
     function setUp() public virtual {
@@ -267,6 +268,7 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.mipsVersion.selector, 1);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
+        dii.set(dii.superchainProxyAdmin.selector, address(superchainProxyAdmin));
         dii.set(dii.upgradeController.selector, upgradeController);
 
         // Perform the initial deployment.
@@ -338,7 +340,7 @@ contract DeployImplementations_Test is Test {
         protocolVersionsProxy = IProtocolVersions(address(uint160(uint256(hash(_seed, 7)))));
 
         // Must configure the ProxyAdmin contract.
-        IProxyAdmin superchainProxyAdmin = IProxyAdmin(
+        superchainProxyAdmin = IProxyAdmin(
             DeployUtils.create1({
                 _name: "ProxyAdmin",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (msg.sender)))
@@ -370,6 +372,7 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
+        dii.set(dii.superchainProxyAdmin.selector, address(superchainProxyAdmin));
         dii.set(dii.upgradeController.selector, upgradeController);
 
         deployImplementations.run(dii, dio);
@@ -384,7 +387,8 @@ contract DeployImplementations_Test is Test {
         assertEq(release, dii.l1ContractsRelease(), "525");
         assertEq(address(superchainConfigProxy), address(dii.superchainConfigProxy()), "550");
         assertEq(address(protocolVersionsProxy), address(dii.protocolVersionsProxy()), "575");
-        assertEq(upgradeController, dii.upgradeController(), "600");
+        assertEq(address(superchainProxyAdmin), address(dii.superchainProxyAdmin()), "600");
+        assertEq(upgradeController, dii.upgradeController(), "625");
 
         // Architecture assertions.
         assertEq(address(dio.mipsSingleton().oracle()), address(dio.preimageOracleSingleton()), "600");
@@ -406,6 +410,7 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
+        dii.set(dii.superchainProxyAdmin.selector, address(superchainProxyAdmin));
 
         // Set the challenge period to a value that is too large, using vm.store because the setter
         // method won't allow it.

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -6,6 +6,7 @@ import { DeployOPCM, DeployOPCMInput, DeployOPCMOutput } from "scripts/deploy/De
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 contract DeployOPCMInput_Test is Test {
     DeployOPCMInput dii;
@@ -214,6 +215,7 @@ contract DeployOPCMTest is Test {
 
     ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
     IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+    IProxyAdmin superchainProxyAdmin = IProxyAdmin(makeAddr("superchainProxyAdmin"));
     address superchainConfigImpl = makeAddr("superchainConfigImpl");
     address protocolVersionsImpl = makeAddr("protocolVersionsImpl");
     address upgradeController = makeAddr("upgradeController");
@@ -226,6 +228,7 @@ contract DeployOPCMTest is Test {
     function test_run_succeeds() public {
         doi.set(doi.superchainConfig.selector, address(superchainConfigProxy));
         doi.set(doi.protocolVersions.selector, address(protocolVersionsProxy));
+        doi.set(doi.superchainProxyAdmin.selector, address(superchainProxyAdmin));
         doi.set(doi.superchainConfigImpl.selector, address(superchainConfigImpl));
         doi.set(doi.protocolVersionsImpl.selector, address(protocolVersionsImpl));
         doi.set(doi.l1ContractsRelease.selector, "1.0.0");

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -74,7 +74,7 @@ contract DeployOPCMInput_Test is Test {
         dii.delayedWETHImpl();
 
         vm.expectRevert("DeployOPCMInput: not set");
-        dii.mipsImpl();
+        dii.mips64Impl();
     }
 
     // Below setter tests are split into two parts to avoid stack too deep errors
@@ -130,7 +130,7 @@ contract DeployOPCMInput_Test is Test {
         address disputeGameFactoryImpl = makeAddr("disputeGameFactoryImpl");
         address anchorStateRegistryImpl = makeAddr("anchorStateRegistryImpl");
         address delayedWETHImpl = makeAddr("delayedWETHImpl");
-        address mipsImpl = makeAddr("mipsImpl");
+        address mips64Impl = makeAddr("mips64Impl");
 
         dii.set(dii.l1ERC721BridgeImpl.selector, l1ERC721BridgeImpl);
         dii.set(dii.optimismPortalImpl.selector, optimismPortalImpl);
@@ -141,7 +141,7 @@ contract DeployOPCMInput_Test is Test {
         dii.set(dii.disputeGameFactoryImpl.selector, disputeGameFactoryImpl);
         dii.set(dii.anchorStateRegistryImpl.selector, anchorStateRegistryImpl);
         dii.set(dii.delayedWETHImpl.selector, delayedWETHImpl);
-        dii.set(dii.mipsImpl.selector, mipsImpl);
+        dii.set(dii.mips64Impl.selector, mips64Impl);
 
         assertEq(dii.l1ERC721BridgeImpl(), l1ERC721BridgeImpl, "600");
         assertEq(dii.optimismPortalImpl(), optimismPortalImpl, "650");
@@ -151,7 +151,7 @@ contract DeployOPCMInput_Test is Test {
         assertEq(dii.l1StandardBridgeImpl(), l1StandardBridgeImpl, "850");
         assertEq(dii.disputeGameFactoryImpl(), disputeGameFactoryImpl, "900");
         assertEq(dii.delayedWETHImpl(), delayedWETHImpl, "950");
-        assertEq(dii.mipsImpl(), mipsImpl, "1000");
+        assertEq(dii.mips64Impl(), mips64Impl, "1000");
     }
 
     function test_set_withZeroAddress_reverts() public {
@@ -250,7 +250,7 @@ contract DeployOPCMTest is Test {
         doi.set(doi.disputeGameFactoryImpl.selector, makeAddr("disputeGameFactoryImpl"));
         doi.set(doi.anchorStateRegistryImpl.selector, makeAddr("anchorStateRegistryImpl"));
         doi.set(doi.delayedWETHImpl.selector, makeAddr("delayedWETHImpl"));
-        doi.set(doi.mipsImpl.selector, makeAddr("mipsImpl"));
+        doi.set(doi.mips64Impl.selector, makeAddr("mips64Impl"));
 
         // Etch all addresses with dummy bytecode
         vm.etch(address(doi.superchainConfig()), hex"01");
@@ -273,7 +273,7 @@ contract DeployOPCMTest is Test {
         vm.etch(doi.l1StandardBridgeImpl(), hex"01");
         vm.etch(doi.disputeGameFactoryImpl(), hex"01");
         vm.etch(doi.delayedWETHImpl(), hex"01");
-        vm.etch(doi.mipsImpl(), hex"01");
+        vm.etch(doi.mips64Impl(), hex"01");
 
         deployOPCM.run(doi, doo);
 

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -315,6 +315,7 @@ contract DeployOPChain_TestBase is Test {
     string release = "dev-release"; // this means implementation contracts will be deployed
     ISuperchainConfig superchainConfigProxy;
     IProtocolVersions protocolVersionsProxy;
+    IProxyAdmin superchainProxyAdmin;
     address upgradeController;
     // Define default inputs for DeployOPChain.
     // `opcm` is set during `setUp` since it is an output of the previous step.
@@ -356,7 +357,8 @@ contract DeployOPChain_TestBase is Test {
         // Populate the inputs for DeployImplementations based on the output of DeploySuperchain.
         superchainConfigProxy = dso.superchainConfigProxy();
         protocolVersionsProxy = dso.protocolVersionsProxy();
-        upgradeController = dso.superchainProxyAdmin().owner();
+        superchainProxyAdmin = dso.superchainProxyAdmin();
+        upgradeController = superchainProxyAdmin.owner();
 
         // Configure and deploy Implementation contracts
         DeployImplementations deployImplementations = createDeployImplementationsContract();
@@ -371,6 +373,7 @@ contract DeployOPChain_TestBase is Test {
         dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
+        dii.set(dii.superchainProxyAdmin.selector, address(superchainProxyAdmin));
         dii.set(dii.upgradeController.selector, upgradeController);
 
         deployImplementations.run(dii, dio);

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -12,7 +12,7 @@ import { Deployer } from "scripts/deploy/Deployer.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
 
 // Libraries
-import { GameTypes } from "src/dispute/lib/Types.sol";
+import { GameTypes, Claim } from "src/dispute/lib/Types.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
@@ -155,8 +155,13 @@ contract ForkLive is Deployer {
         address upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
-        IOPContractsManager.OpChain[] memory opChains = new IOPContractsManager.OpChain[](1);
-        opChains[0] = IOPContractsManager.OpChain({ systemConfigProxy: systemConfig, proxyAdmin: proxyAdmin });
+        IOPContractsManager.OpChainConfig[] memory opChains = new IOPContractsManager.OpChainConfig[](1);
+        opChains[0] = IOPContractsManager.OpChainConfig({
+            systemConfigProxy: systemConfig,
+            proxyAdmin: proxyAdmin,
+            permissionedDisputeGamePrestateHash: Claim.wrap(bytes32(keccak256("permissionedPrestate"))),
+            permissionlessDisputeGamePrestateHash: Claim.wrap(bytes32(keccak256("permissionlessPrestate")))
+        });
 
         // TODO Migrate from DelegateCaller to a Safe to reduce risk of mocks not properly
         // reflecting the production system.

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -21,7 +21,6 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
@@ -149,9 +148,6 @@ contract ForkLive is Deployer {
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         IProxyAdmin proxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(systemConfig)));
 
-        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
-        IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
-
         address upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
@@ -165,9 +161,7 @@ contract ForkLive is Deployer {
         // TODO Migrate from DelegateCaller to a Safe to reduce risk of mocks not properly
         // reflecting the production system.
         vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-        DelegateCaller(upgrader).dcForward(
-            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (superchainProxyAdmin, opChains))
-        );
+        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
 
         console.log("ForkLive: Saving newly deployed contracts");
         // A new ASR and new dispute games were deployed, so we need to update them

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -159,8 +159,7 @@ contract ForkLive is Deployer {
         opChains[0] = IOPContractsManager.OpChainConfig({
             systemConfigProxy: systemConfig,
             proxyAdmin: proxyAdmin,
-            permissionedDisputeGamePrestateHash: Claim.wrap(bytes32(keccak256("permissionedPrestate"))),
-            permissionlessDisputeGamePrestateHash: Claim.wrap(bytes32(keccak256("permissionlessPrestate")))
+            absolutePrestate: Claim.wrap(bytes32(keccak256("absolutePrestate")))
         });
 
         // TODO Migrate from DelegateCaller to a Safe to reduce risk of mocks not properly

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -778,6 +778,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("version()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("protocolVersions()") });
+        _addSpec({ _name: "OPContractsManager", _sel: _getSel("superchainProxyAdmin()") });
         _addSpec({ _name: "OPContractsManager", _sel: _getSel("l1ContractsRelease()") });
         _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.deploy.selector });
         _addSpec({ _name: "OPContractsManager", _sel: IOPContractsManager.blueprints.selector });
@@ -793,6 +794,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("version()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("protocolVersions()") });
+        _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("superchainProxyAdmin()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: _getSel("l1ContractsRelease()") });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.deploy.selector });
         _addSpec({ _name: "OPContractsManagerInterop", _sel: IOPContractsManager.blueprints.selector });


### PR DESCRIPTION
- Renames `mipsImpl` to `mips64Impl` in the Implementations struct
- Adds a new prestateHash input value for each new game.
