### PR TITLE
`pos.IndexAtDepth()` always equals `pos.TraceIndex(pos.Depth())`

### DIFF
--- a/op-challenger/game/fault/trace/split/split.go
+++ b/op-challenger/game/fault/trace/split/split.go
@@ -34,7 +34,7 @@ func NewSplitProviderSelector(topProvider types.TraceProvider, topDepth types.De
 		var pre, post types.Claim
 		// If pos is to the right of the leaf from the top game, we must be defending that output root
 		// otherwise, we're attacking it.
-		if pos.TraceIndex(pos.Depth()).Cmp(topLeaf.TraceIndex(pos.Depth())) > 0 {
+		if pos.IndexAtDepth().Cmp(topLeaf.TraceIndex(pos.Depth())) > 0 {
 			// Defending the top leaf claim, so use it as the pre-claim and find the post
 			pre = topLeaf
 			postTraceIdx := new(big.Int).Add(pre.TraceIndex(topDepth), big.NewInt(1))

--- a/op-challenger/game/fault/types/position_test.go
+++ b/op-challenger/game/fault/types/position_test.go
@@ -152,7 +152,9 @@ func TestTraceIndex(t *testing.T) {
 		{depth: 63, indexAtDepth: bi(9223372036854775806), maxDepth: 64, traceIndexExpected: bi(0).Sub(bi(0).Mul(bi(math.MaxInt64), bi(2)), bi(1))},
 	}
 	for _, test := range tests {
-		require.Equal(t, test.traceIndexExpected, NewPosition(test.depth, test.indexAtDepth).TraceIndex(test.maxDepth))
+		pos := NewPosition(test.depth, test.indexAtDepth)
+		require.Equal(t, test.traceIndexExpected, pos.TraceIndex(test.maxDepth))
+		require.Equal(t, pos.IndexAtDepth(), pos.TraceIndex(pos.Depth()))
 	}
 }
 


### PR DESCRIPTION
Simplify the code a bit by the invariant that `pos.IndexAtDepth() == pos.TraceIndex(pos.Depth())` always holds.