### PR TITLE
OPCM(perf): reduce bytecode size

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -204,6 +204,9 @@ interface IOPContractsManager {
     /// @notice Thrown when the SuperchainConfig of the chain does not match the SuperchainConfig of this OPCM.
     error SuperchainConfigMismatch(ISystemConfig systemConfig);
 
+    /// @notice Thrown when the SuperchainProxyAdmin does not match the SuperchainConfig's admin.
+    error SuperchainProxyAdminMismatch();
+
     // -------- Methods --------
 
     function __constructor__(

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -94,6 +94,8 @@ interface IOPContractsManager {
 
     /// @notice The latest implementation contracts for the OP Stack.
     struct Implementations {
+        address superchainConfigImpl;
+        address protocolVersionsImpl;
         address l1ERC721BridgeImpl;
         address optimismPortalImpl;
         address systemConfigImpl;
@@ -216,10 +218,10 @@ interface IOPContractsManager {
 
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory);
 
-    /// @notice Upgrades a set of chains to the latest implementation contracts
-    /// @param _opChains Array of OpChain structs, one per chain to upgrade
-    /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
-    function upgrade(OpChain[] memory _opChains) external;
+    /// @notice Upgrades the implementation of all proxies in the specified chains
+    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
+    /// @param _opChains The chains to upgrade
+    function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external;
 
     /// @notice addGameType deploys a new dispute game and links it to the DisputeGameFactory. The inputted _gameConfigs
     /// must be added in ascending GameType order.

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -219,7 +219,7 @@ interface IOPContractsManager {
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory);
 
     /// @notice Upgrades the implementation of all proxies in the specified chains
-    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
+    /// @param _superchainProxyAdmin The proxy admin that owns the superchain contract proxies
     /// @param _opChains The chains to upgrade
     function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external;
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -471,6 +471,8 @@ contract DeployImplementations is Script {
         address upgradeController = _dii.upgradeController();
 
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
+            superchainConfigImpl: address(_dio.superchainConfigImpl()),
+            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),
@@ -479,8 +481,6 @@ contract DeployImplementations is Script {
             l1StandardBridgeImpl: address(_dio.l1StandardBridgeImpl()),
             disputeGameFactoryImpl: address(_dio.disputeGameFactoryImpl()),
             anchorStateRegistryImpl: address(_dio.anchorStateRegistryImpl()),
-            superchainConfigImpl: address(_dio.superchainConfigImpl()),
-            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             delayedWETHImpl: address(_dio.delayedWETHImpl()),
             mipsImpl: address(_dio.mipsSingleton())
         });

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -831,8 +831,8 @@ contract DeployImplementationsInterop is DeployImplementations {
 
         // moose here (next call fails)
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
-            superchainConfigImpl: address(_dii.superchainConfigImpl()),
-            protocolVersionsImpl: address(_dii.protocolVersionsImpl()),
+            superchainConfigImpl: address(_dio.superchainConfigImpl()),
+            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -29,7 +29,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 import { DeploySuperchainImplementations, DeploySuperchainOutput } from "scripts/deploy/DeploySuperchain.s.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // See DeploySuperchain.s.sol for detailed comments on the script architecture used here.
 contract DeployImplementationsInput is BaseDeployIO {
@@ -130,18 +129,6 @@ contract DeployImplementationsInput is BaseDeployIO {
     function protocolVersionsProxy() public view returns (IProtocolVersions) {
         require(address(_protocolVersionsProxy) != address(0), "DeployImplementationsInput: not set");
         return _protocolVersionsProxy;
-    }
-
-    function superchainConfigImpl() public view returns (ISuperchainConfig) {
-        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfigProxy)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
-    }
-
-    function protocolVersionsImpl() public view returns (IProtocolVersions) {
-        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersionsProxy)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
     }
 
     function upgradeController() public view returns (address) {
@@ -487,8 +474,8 @@ contract DeployImplementations is Script {
 
         // moose here (next call fails)
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
-            superchainConfigImpl: address(_dii.superchainConfigImpl()),
-            protocolVersionsImpl: address(_dii.protocolVersionsImpl()),
+            superchainConfigImpl: address(_dio.superchainConfigImpl()),
+            protocolVersionsImpl: address(_dio.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_dio.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_dio.optimismPortalImpl()),
             systemConfigImpl: address(_dio.systemConfigImpl()),

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -11,7 +11,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract DeployOPCMInput is BaseDeployIO {
     ISuperchainConfig internal _superchainConfig;

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -26,6 +26,8 @@ contract DeployOPCMInput is BaseDeployIO {
     address internal _permissionedDisputeGame1Blueprint;
     address internal _permissionedDisputeGame2Blueprint;
 
+    address internal _superchainConfigImpl;
+    address internal _protocolVersionsImpl;
     address internal _l1ERC721BridgeImpl;
     address internal _optimismPortalImpl;
     address internal _systemConfigImpl;
@@ -167,6 +169,16 @@ contract DeployOPCMInput is BaseDeployIO {
         return _anchorStateRegistryImpl;
     }
 
+    function superchainConfigImpl() public view returns (address) {
+        require(_superchainConfigImpl != address(0), "DeployOPCMInput: not set");
+        return _superchainConfigImpl;
+    }
+
+    function protocolVersionsImpl() public view returns (address) {
+        require(_protocolVersionsImpl != address(0), "DeployOPCMInput: not set");
+        return _protocolVersionsImpl;
+    }
+
     function delayedWETHImpl() public view returns (address) {
         require(_delayedWETHImpl != address(0), "DeployOPCMInput: not set");
         return _delayedWETHImpl;
@@ -209,6 +221,8 @@ contract DeployOPCM is Script {
             permissionlessDisputeGame2: address(0)
         });
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
+            superchainConfigImpl: address(_doi.superchainConfigImpl()),
+            protocolVersionsImpl: address(_doi.protocolVersionsImpl()),
             l1ERC721BridgeImpl: address(_doi.l1ERC721BridgeImpl()),
             optimismPortalImpl: address(_doi.optimismPortalImpl()),
             systemConfigImpl: address(_doi.systemConfigImpl()),

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -46,6 +46,8 @@ contract DeployOPCMInput is BaseDeployIO {
 
         if (_sel == this.superchainConfig.selector) _superchainConfig = ISuperchainConfig(_addr);
         else if (_sel == this.protocolVersions.selector) _protocolVersions = IProtocolVersions(_addr);
+        else if (_sel == this.superchainConfigImpl.selector) _superchainConfigImpl = _addr;
+        else if (_sel == this.protocolVersionsImpl.selector) _protocolVersionsImpl = _addr;
         else if (_sel == this.upgradeController.selector) _upgradeController = _addr;
         else if (_sel == this.addressManagerBlueprint.selector) _addressManagerBlueprint = _addr;
         else if (_sel == this.proxyBlueprint.selector) _proxyBlueprint = _addr;
@@ -170,16 +172,14 @@ contract DeployOPCMInput is BaseDeployIO {
         return _anchorStateRegistryImpl;
     }
 
-    function superchainConfigImpl() public view returns (ISuperchainConfig) {
-        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfig)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
+    function superchainConfigImpl() public view returns (address) {
+        require(_superchainConfigImpl != address(0), "DeployOPCMInput: not set");
+        return _superchainConfigImpl;
     }
 
-    function protocolVersionsImpl() public view returns (IProtocolVersions) {
-        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersions)));
-        DeployUtils.assertValidContractAddress(address(impl));
-        return impl;
+    function protocolVersionsImpl() public view returns (address) {
+        require(_protocolVersionsImpl != address(0), "DeployOPCMInput: not set");
+        return _protocolVersionsImpl;
     }
 
     function delayedWETHImpl() public view returns (address) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -171,13 +171,13 @@ contract DeployOPCMInput is BaseDeployIO {
     }
 
     function superchainConfigImpl() public view returns (ISuperchainConfig) {
-        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfigProxy)));
+        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfig)));
         DeployUtils.assertValidContractAddress(address(impl));
         return impl;
     }
 
     function protocolVersionsImpl() public view returns (IProtocolVersions) {
-        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersionsProxy)));
+        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersions)));
         DeployUtils.assertValidContractAddress(address(impl));
         return impl;
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -11,6 +11,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract DeployOPCMInput is BaseDeployIO {
     ISuperchainConfig internal _superchainConfig;
@@ -169,14 +170,16 @@ contract DeployOPCMInput is BaseDeployIO {
         return _anchorStateRegistryImpl;
     }
 
-    function superchainConfigImpl() public view returns (address) {
-        require(_superchainConfigImpl != address(0), "DeployOPCMInput: not set");
-        return _superchainConfigImpl;
+    function superchainConfigImpl() public view returns (ISuperchainConfig) {
+        ISuperchainConfig impl = ISuperchainConfig(EIP1967Helper.getImplementation(address(_superchainConfigProxy)));
+        DeployUtils.assertValidContractAddress(address(impl));
+        return impl;
     }
 
-    function protocolVersionsImpl() public view returns (address) {
-        require(_protocolVersionsImpl != address(0), "DeployOPCMInput: not set");
-        return _protocolVersionsImpl;
+    function protocolVersionsImpl() public view returns (IProtocolVersions) {
+        IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(_protocolVersionsProxy)));
+        DeployUtils.assertValidContractAddress(address(impl));
+        return impl;
     }
 
     function delayedWETHImpl() public view returns (address) {

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -441,7 +441,7 @@ library DeploySuperchainImplementations {
     bytes32 internal constant _salt = keccak256("op-stack-contract-impls-salt-v0");
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function deploySuperchainImplementationContracts(DeploySuperchainOutput _dso) public {
+    function deploySuperchainImplementationContracts(DeploySuperchainOutput _dso) internal {
         // Deploy implementation contracts.
         vm.startBroadcast(msg.sender);
         ISuperchainConfig superchainConfigImpl = ISuperchainConfig(

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
 import { stdToml } from "forge-std/StdToml.sol";
-
+import { Vm } from "forge-std/Vm.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
@@ -310,7 +310,7 @@ contract DeploySuperchain is Script {
         deploySuperchainProxyAdmin(_dsi, _dso);
 
         // Deploy and initialize the superchain contracts.
-        deploySuperchainImplementationContracts(_dsi, _dso);
+        DeploySuperchainImplementations.deploySuperchainImplementationContracts(_dso);
         deployAndInitializeSuperchainConfig(_dsi, _dso);
         deployAndInitializeProtocolVersions(_dsi, _dso);
 
@@ -341,29 +341,7 @@ contract DeploySuperchain is Script {
     }
 
     function deploySuperchainImplementationContracts(DeploySuperchainInput, DeploySuperchainOutput _dso) public {
-        // Deploy implementation contracts.
-        vm.startBroadcast(msg.sender);
-        ISuperchainConfig superchainConfigImpl = ISuperchainConfig(
-            DeployUtils.createDeterministic({
-                _name: "SuperchainConfig",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperchainConfig.__constructor__, ())),
-                _salt: _salt
-            })
-        );
-        IProtocolVersions protocolVersionsImpl = IProtocolVersions(
-            DeployUtils.createDeterministic({
-                _name: "ProtocolVersions",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProtocolVersions.__constructor__, ())),
-                _salt: _salt
-            })
-        );
-        vm.stopBroadcast();
-
-        vm.label(address(superchainConfigImpl), "SuperchainConfigImpl");
-        vm.label(address(protocolVersionsImpl), "ProtocolVersionsImpl");
-
-        _dso.set(_dso.superchainConfigImpl.selector, address(superchainConfigImpl));
-        _dso.set(_dso.protocolVersionsImpl.selector, address(protocolVersionsImpl));
+        DeploySuperchainImplementations.deploySuperchainImplementationContracts(_dso);
     }
 
     function deployAndInitializeSuperchainConfig(DeploySuperchainInput _dsi, DeploySuperchainOutput _dso) public {
@@ -456,5 +434,36 @@ contract DeploySuperchain is Script {
     function getIOContracts() public view returns (DeploySuperchainInput dsi_, DeploySuperchainOutput dso_) {
         dsi_ = DeploySuperchainInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeploySuperchainInput"));
         dso_ = DeploySuperchainOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeploySuperchainOutput"));
+    }
+}
+
+library DeploySuperchainImplementations {
+    bytes32 internal constant _salt = keccak256("op-stack-contract-impls-salt-v0");
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function deploySuperchainImplementationContracts(DeploySuperchainOutput _dso) public {
+        // Deploy implementation contracts.
+        vm.startBroadcast(msg.sender);
+        ISuperchainConfig superchainConfigImpl = ISuperchainConfig(
+            DeployUtils.createDeterministic({
+                _name: "SuperchainConfig",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperchainConfig.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        IProtocolVersions protocolVersionsImpl = IProtocolVersions(
+            DeployUtils.createDeterministic({
+                _name: "ProtocolVersions",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProtocolVersions.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.stopBroadcast();
+
+        vm.label(address(superchainConfigImpl), "SuperchainConfigImpl");
+        vm.label(address(protocolVersionsImpl), "ProtocolVersionsImpl");
+
+        _dso.set(_dso.superchainConfigImpl.selector, address(superchainConfigImpl));
+        _dso.set(_dso.protocolVersionsImpl.selector, address(protocolVersionsImpl));
     }
 }

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -72,6 +72,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -509,6 +519,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -633,6 +653,11 @@
   },
   {
     "inputs": [
+      {
+        "internalType": "contract IProxyAdmin",
+        "name": "_superchainProxyAdmin",
+        "type": "address"
+      },
       {
         "components": [
           {
@@ -839,6 +864,11 @@
       }
     ],
     "name": "SuperchainConfigMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SuperchainProxyAdminMismatch",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInterop.json
@@ -72,6 +72,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -509,6 +519,16 @@
         "components": [
           {
             "internalType": "address",
+            "name": "superchainConfigImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "protocolVersionsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
             "name": "l1ERC721BridgeImpl",
             "type": "address"
           },
@@ -633,6 +653,11 @@
   },
   {
     "inputs": [
+      {
+        "internalType": "contract IProxyAdmin",
+        "name": "_superchainProxyAdmin",
+        "type": "address"
+      },
       {
         "components": [
           {
@@ -839,6 +864,11 @@
       }
     ],
     "name": "SuperchainConfigMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SuperchainProxyAdminMismatch",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -16,11 +16,11 @@
     "sourceCodeHash": "0x2dd7bf6cbce655b1023a3ad071523bf455aa13fad5d02e1e434af71728cd794c"
   },
   "src/L1/OPContractsManager.sol": {
-    "initCodeHash": "0x91a3194df65af1604004fc0cae535a664f4320b8c3d043b4e220e5f41058eb0b",
-    "sourceCodeHash": "0x2c54078dadc80e2a9c8b313acc01b753051206fc0c5d90a5188a88eb3b60c69f"
+    "initCodeHash": "0x88b7de58e1e57402b4497c4fdad5fe940d0879133bb9dab87365a3cc1ec27282",
+    "sourceCodeHash": "0xe9738b76ac4c7a9704e62082bdc7ea984c7810ea9b5200f56e9349e0e7f764d4"
   },
   "src/L1/OPContractsManagerInterop.sol": {
-    "initCodeHash": "0xff07c5f0ae28bfe45c696127dea07481a5a58acda12614b354c7b04479c46bb5",
+    "initCodeHash": "0xfafa73cc636c5ba92c7e0ca26324bd1f7c514acba7977b6c9df4b445c3242dc2",
     "sourceCodeHash": "0xc2ec936877c5e85425fe261c8394bec43cc7f32fe415c0c7a9acff716e3de599"
   },
   "src/L1/OptimismPortal2.sol": {

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
@@ -24,7 +24,7 @@
     "bytes": "1",
     "label": "isRC",
     "offset": 0,
-    "slot": "20",
+    "slot": "22",
     "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManager.json
@@ -14,7 +14,7 @@
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "320",
+    "bytes": "384",
     "label": "implementation",
     "offset": 0,
     "slot": "10",

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
@@ -24,7 +24,7 @@
     "bytes": "1",
     "label": "isRC",
     "offset": 0,
-    "slot": "20",
+    "slot": "22",
     "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerInterop.json
@@ -14,7 +14,7 @@
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "320",
+    "bytes": "384",
     "label": "implementation",
     "offset": 0,
     "slot": "10",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -726,13 +726,13 @@ contract OPContractsManager is ISemver {
     function computeSalt(
         uint256 _l2ChainId,
         bytes32 _saltMixer,
-        string memory _contractName
+        bytes32 _contractName
     )
         internal
         pure
         returns (bytes32)
     {
-        return keccak256(abi.encode(_l2ChainId, _saltMixer, _contractName));
+        return keccak256(bytes.concat(bytes32(_l2ChainId), _saltMixer, _contractName));
     }
 
     /// @notice Deterministically deploys a new proxy contract owned by the provided ProxyAdmin.
@@ -742,7 +742,7 @@ contract OPContractsManager is ISemver {
         uint256 _l2ChainId,
         IProxyAdmin _proxyAdmin,
         bytes32 _saltMixer,
-        string memory _contractName
+        bytes32 _contractName
     )
         internal
         returns (address)

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -319,7 +319,7 @@ contract OPContractsManager is ISemver {
         );
         output.opChainProxyAdmin.setImplementationName(address(output.l1CrossDomainMessengerProxy), contractName);
         // Now that all proxies are deployed, we can transfer ownership of the AddressManager to the ProxyAdmin.
-        output.addressManager.transferOwnership(address(output.opChainProxyAdmin));
+        transferOwnership(address(output.addressManager), address(output.opChainProxyAdmin));
 
         // Eventually we will switch from DelayedWETHPermissionedGameProxy to DelayedWETHPermissionlessGameProxy.
         output.delayedWETHPermissionedGameProxy = IDelayedWETH(
@@ -410,10 +410,13 @@ contract OPContractsManager is ISemver {
             implementation.disputeGameFactoryImpl,
             data
         );
-        output.disputeGameFactoryProxy.setImplementation(
-            GameTypes.PERMISSIONED_CANNON, IDisputeGame(address(output.permissionedDisputeGame))
+        setDGFImplementation(
+            output.disputeGameFactoryProxy,
+            GameTypes.PERMISSIONED_CANNON,
+            IDisputeGame(address(output.permissionedDisputeGame))
         );
-        output.disputeGameFactoryProxy.transferOwnership(address(_input.roles.opChainProxyAdminOwner));
+
+        transferOwnership(address(output.disputeGameFactoryProxy), address(_input.roles.opChainProxyAdminOwner));
 
         data = encodeAnchorStateRegistryInitializer(_input, output);
         upgradeToAndCall(
@@ -425,7 +428,7 @@ contract OPContractsManager is ISemver {
 
         // -------- Finalize Deployment --------
         // Transfer ownership of the ProxyAdmin from this contract to the specified owner.
-        output.opChainProxyAdmin.transferOwnership(_input.roles.opChainProxyAdminOwner);
+        transferOwnership(address(output.opChainProxyAdmin), _input.roles.opChainProxyAdminOwner);
 
         emit Deployed(l2ChainId, msg.sender, abi.encode(output));
         return output;
@@ -445,8 +448,8 @@ contract OPContractsManager is ISemver {
             thisOPCM.setRC(false);
         }
 
-        Implementations memory impls = thisOPCM.implementations();
-        Blueprints memory bps = thisOPCM.blueprints();
+        Implementations memory impls = getImplementations();
+        Blueprints memory bps = getBlueprints();
 
         if (address(_superchainProxyAdmin) != address(0)) {
             // Attempt to upgrade. If the ProxyAdmin is not the SuperchainConfig's admin, this will revert.
@@ -460,7 +463,7 @@ contract OPContractsManager is ISemver {
                 l1CrossDomainMessenger: _opChains[i].systemConfigProxy.l1CrossDomainMessenger(),
                 l1ERC721Bridge: _opChains[i].systemConfigProxy.l1ERC721Bridge(),
                 l1StandardBridge: _opChains[i].systemConfigProxy.l1StandardBridge(),
-                disputeGameFactory: _opChains[i].systemConfigProxy.disputeGameFactory(),
+                disputeGameFactory: address(getDisputeGameFactory(_opChains[i].systemConfigProxy)),
                 optimismPortal: _opChains[i].systemConfigProxy.optimismPortal(),
                 optimismMintableERC20Factory: _opChains[i].systemConfigProxy.optimismMintableERC20Factory()
             });
@@ -495,7 +498,7 @@ contract OPContractsManager is ISemver {
                 )
             );
             // We're also going to need the l2ChainId below, so we cache it in the outer scope.
-            uint256 l2ChainId = permissionedDisputeGame.l2ChainId();
+            uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
 
             // Replace the Anchor State Registry Proxy with a new Proxy and Implementation
             // For this upgrade, we are replacing the previous Anchor State Registry, thus we:
@@ -582,7 +585,7 @@ contract OPContractsManager is ISemver {
         if (_gameConfigs.length == 0) revert InvalidGameConfigs();
 
         AddGameOutput[] memory outputs = new AddGameOutput[](_gameConfigs.length);
-        Blueprints memory bps = thisOPCM.blueprints();
+        Blueprints memory bps = getBlueprints();
 
         // Store last game config as an int256 so that we can ensure that the same game config is not added twice.
         // Using int256 generates cheaper, simpler bytecode.
@@ -600,13 +603,11 @@ contract OPContractsManager is ISemver {
             // Grab the FDG from the SystemConfig.
             IFaultDisputeGame fdg = IFaultDisputeGame(
                 address(
-                    getGameImplementation(
-                        IDisputeGameFactory(gameConfig.systemConfig.disputeGameFactory()), GameTypes.PERMISSIONED_CANNON
-                    )
+                    getGameImplementation(getDisputeGameFactory(gameConfig.systemConfig), GameTypes.PERMISSIONED_CANNON)
                 )
             );
             // Pull out the chain ID.
-            uint256 l2ChainId = fdg.l2ChainId();
+            uint256 l2ChainId = getL2ChainId(fdg);
 
             // Deploy a new DelayedWETH proxy for this game if one hasn't already been specified. Leaving
             /// gameConfig.delayedWETH as the zero address will cause a new DelayedWETH to be deployed for this game.
@@ -619,7 +620,7 @@ contract OPContractsManager is ISemver {
                 upgradeToAndCall(
                     gameConfig.proxyAdmin,
                     address(outputs[i].delayedWETH),
-                    thisOPCM.implementations().delayedWETHImpl,
+                    getImplementations().delayedWETHImpl,
                     bytes.concat(
                         IDelayedWETH.initialize.selector,
                         bytes32(uint256(uint160(address(gameConfig.proxyAdmin.owner())))),
@@ -652,8 +653,8 @@ contract OPContractsManager is ISemver {
                                 getAnchorStateRegistry(IFaultDisputeGame(address(pdg))),
                                 l2ChainId
                             ),
-                            pdg.proposer(),
-                            pdg.challenger()
+                            getProposer(pdg),
+                            getChallenger(pdg)
                         )
                     )
                 );
@@ -683,8 +684,8 @@ contract OPContractsManager is ISemver {
 
             // As a last step, register the new game type with the DisputeGameFactory. If the game type already exists,
             // then its implementation will be overwritten.
-            IDisputeGameFactory dgf = IDisputeGameFactory(gameConfig.systemConfig.disputeGameFactory());
-            dgf.setImplementation(gameConfig.disputeGameType, IDisputeGame(address(outputs[i].faultDisputeGame)));
+            IDisputeGameFactory dgf = getDisputeGameFactory(gameConfig.systemConfig);
+            setDGFImplementation(dgf, gameConfig.disputeGameType, IDisputeGame(address(outputs[i].faultDisputeGame)));
             dgf.setInitBond(gameConfig.disputeGameType, gameConfig.initialBond);
         }
 
@@ -749,7 +750,7 @@ contract OPContractsManager is ISemver {
     {
         bytes32 salt = computeSalt(_l2ChainId, _saltMixer, _contractName);
         return Blueprint.deployFrom(
-            thisOPCM.blueprints().proxy, salt, bytes.concat(bytes32(uint256(uint160(address((_proxyAdmin))))))
+            getBlueprints().proxy, salt, bytes.concat(bytes32(uint256(uint160(address((_proxyAdmin))))))
         );
     }
 
@@ -1000,6 +1001,17 @@ contract OPContractsManager is ISemver {
         isRC = _isRC;
     }
 
+    /// @notice Sets a game implementation on the dispute game factory
+    function setDGFImplementation(IDisputeGameFactory _dgf, GameType _gameType, IDisputeGame _newGame) internal {
+        _dgf.setImplementation(_gameType, _newGame);
+    }
+
+    /// @notice Transfers ownership
+    function transferOwnership(address _target, address _newOwner) internal {
+        // All transferOwnership targets have the same selector, so we just use IAddressManager
+        IAddressManager(_target).transferOwnership(_newOwner);
+    }
+
     /// @notice Retrieves the constructor params for a given game.
     function getGameConstructorParams(IFaultDisputeGame _disputeGame)
         internal
@@ -1014,9 +1026,9 @@ contract OPContractsManager is ISemver {
             clockExtension: _disputeGame.clockExtension(),
             maxClockDuration: _disputeGame.maxClockDuration(),
             vm: _disputeGame.vm(),
-            weth: _disputeGame.weth(),
-            anchorStateRegistry: _disputeGame.anchorStateRegistry(),
-            l2ChainId: _disputeGame.l2ChainId()
+            weth: getWETH(_disputeGame),
+            anchorStateRegistry: getAnchorStateRegistry(_disputeGame),
+            l2ChainId: getL2ChainId(_disputeGame)
         });
         return params;
     }
@@ -1024,6 +1036,41 @@ contract OPContractsManager is ISemver {
     /// @notice Retrieves the Anchor State Registry for a given game
     function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal view returns (IAnchorStateRegistry) {
         return _disputeGame.anchorStateRegistry();
+    }
+
+    /// @notice Retrieves the DelayedWETH address for a given game
+    function getWETH(IFaultDisputeGame _disputeGame) internal view returns (IDelayedWETH) {
+        return _disputeGame.weth();
+    }
+
+    /// @notice Retrieves the L2 chain ID for a given game
+    function getL2ChainId(IFaultDisputeGame _disputeGame) internal view returns (uint256) {
+        return _disputeGame.l2ChainId();
+    }
+
+    /// @notice Retrieves the proposer address for a given game
+    function getProposer(IPermissionedDisputeGame _disputeGame) internal view returns (address) {
+        return _disputeGame.proposer();
+    }
+
+    /// @notice Retrieves the challenger address for a given game
+    function getChallenger(IPermissionedDisputeGame _disputeGame) internal view returns (address) {
+        return _disputeGame.challenger();
+    }
+
+    /// @notice Retrieves the DisputeGameFactory address for a given SystemConfig
+    function getDisputeGameFactory(ISystemConfig _systemConfig) internal view returns (IDisputeGameFactory) {
+        return IDisputeGameFactory(_systemConfig.disputeGameFactory());
+    }
+
+    /// @notice Retrieves the implementation addresses stored in this OPCM contract
+    function getImplementations() internal view returns (Implementations memory) {
+        return thisOPCM.implementations();
+    }
+
+    /// @notice Retrieves the blueprint addresses stored in this OPCM contract
+    function getBlueprints() internal view returns (Blueprints memory) {
+        return thisOPCM.blueprints();
     }
 
     /// @notice For a given game type, does the following:
@@ -1043,7 +1090,7 @@ contract OPContractsManager is ISemver {
         internal
     {
         // Get and upgrade the WETH proxy
-        IDelayedWETH delayedWethProxy = IFaultDisputeGame(address(_currentGame)).weth();
+        IDelayedWETH delayedWethProxy = getWETH(IFaultDisputeGame(address(_currentGame)));
         upgradeTo(_proxyAdmin, address(delayedWethProxy), _implementations.delayedWETHImpl);
 
         // Get the constructor params for the game
@@ -1053,8 +1100,8 @@ contract OPContractsManager is ISemver {
 
         IDisputeGame newGame;
         if (GameType.unwrap(_gameType) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON)) {
-            address proposer = IPermissionedDisputeGame(address(_currentGame)).proposer();
-            address challenger = IPermissionedDisputeGame(address(_currentGame)).challenger();
+            address proposer = getProposer(IPermissionedDisputeGame(address(_currentGame)));
+            address challenger = getChallenger(IPermissionedDisputeGame(address(_currentGame)));
             newGame = IDisputeGame(
                 Blueprint.deployFrom(
                     _blueprints.permissionedDisputeGame1,
@@ -1073,6 +1120,6 @@ contract OPContractsManager is ISemver {
                 )
             );
         }
-        IDisputeGameFactory(_opChainAddrs.disputeGameFactory).setImplementation(_gameType, IDisputeGame(newGame));
+        setDGFImplementation(IDisputeGameFactory(_opChainAddrs.disputeGameFactory), _gameType, IDisputeGame(newGame));
     }
 }

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -432,6 +432,7 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice Upgrades a set of chains to the latest implementation contracts
+    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
     /// @param _opChains Array of OpChain structs, one per chain to upgrade
     /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
     function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external {

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -432,7 +432,7 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice Upgrades a set of chains to the latest implementation contracts
-    /// @param _superchainProxyAdmin The proxy admin that owns all of the proxies
+    /// @param _superchainProxyAdmin The proxy admin that owns the superchain contract proxies
     /// @param _opChains Array of OpChain structs, one per chain to upgrade
     /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
     function upgrade(IProxyAdmin _superchainProxyAdmin, OpChain[] memory _opChains) external {

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -51,7 +51,7 @@ contract OPContractsManager is ISemver {
         // The correct type is OutputRoot memory but OP Deployer does not yet support structs.
         bytes startingAnchorRoot;
         // The salt mixer is used as part of making the resulting salt unique.
-        string saltMixer;
+        bytes32 saltMixer;
         uint64 gasLimit;
         // Configurable dispute game parameters.
         GameType disputeGameType;
@@ -121,7 +121,7 @@ contract OPContractsManager is ISemver {
     }
 
     struct AddGameInput {
-        string saltMixer;
+        bytes32 saltMixer;
         ISystemConfig systemConfig;
         IProxyAdmin proxyAdmin;
         IDelayedWETH delayedWETH;
@@ -257,7 +257,7 @@ contract OPContractsManager is ISemver {
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory) {
         assertValidInputs(_input);
         uint256 l2ChainId = _input.l2ChainId;
-        string memory saltMixer = _input.saltMixer;
+        bytes32 saltMixer = _input.saltMixer;
         DeployOutput memory output;
 
         // -------- Deploy Chain Singletons --------
@@ -725,7 +725,7 @@ contract OPContractsManager is ISemver {
     /// with the same bytecode from this contract, so they each require a unique salt for determinism.
     function computeSalt(
         uint256 _l2ChainId,
-        string memory _saltMixer,
+        bytes32 _saltMixer,
         string memory _contractName
     )
         internal
@@ -741,7 +741,7 @@ contract OPContractsManager is ISemver {
     function deployProxy(
         uint256 _l2ChainId,
         IProxyAdmin _proxyAdmin,
-        string memory _saltMixer,
+        bytes32 _saltMixer,
         string memory _contractName
     )
         internal

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -519,7 +519,8 @@ contract OPContractsManager is ISemver {
                 // 3. getting the anchor root for the respected game type from the Anchor State Registry.
                 {
                     GameType gameType = IOptimismPortal2(payable(opChainAddrs.optimismPortal)).respectedGameType();
-                    (Hash root, uint256 l2BlockNumber) = permissionedDisputeGame.anchorStateRegistry().anchors(gameType);
+                    (Hash root, uint256 l2BlockNumber) =
+                        getAnchorStateRegistry(IFaultDisputeGame(address(permissionedDisputeGame))).anchors(gameType);
                     OutputRoot memory startingAnchorRoot = OutputRoot({ root: root, l2BlockNumber: l2BlockNumber });
 
                     upgradeToAndCall(
@@ -643,7 +644,7 @@ contract OPContractsManager is ISemver {
                                 gameConfig.disputeMaxClockDuration,
                                 gameConfig.vm,
                                 outputs[i].delayedWETH,
-                                pdg.anchorStateRegistry(),
+                                getAnchorStateRegistry(IFaultDisputeGame(address(pdg))),
                                 l2ChainId
                             ),
                             pdg.proposer(),
@@ -667,7 +668,7 @@ contract OPContractsManager is ISemver {
                                 gameConfig.disputeMaxClockDuration,
                                 gameConfig.vm,
                                 outputs[i].delayedWETH,
-                                fdg.anchorStateRegistry(),
+                                getAnchorStateRegistry(fdg),
                                 l2ChainId
                             )
                         )
@@ -975,6 +976,7 @@ contract OPContractsManager is ISemver {
         isRC = _isRC;
     }
 
+    /// @notice Retrieves the constructor params for a given game.
     function getGameConstructorParams(IFaultDisputeGame _disputeGame)
         internal
         view
@@ -993,6 +995,11 @@ contract OPContractsManager is ISemver {
             l2ChainId: _disputeGame.l2ChainId()
         });
         return params;
+    }
+
+    /// @notice Retrieves the Anchor State Registry for a given game
+    function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal returns (IAnchorStateRegistry) {
+        return _disputeGame.anchorStateRegistry();
     }
 
     /// @notice For a given game type, does the following:

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -999,7 +999,7 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice Retrieves the Anchor State Registry for a given game
-    function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal returns (IAnchorStateRegistry) {
+    function getAnchorStateRegistry(IFaultDisputeGame _disputeGame) internal view returns (IAnchorStateRegistry) {
         return _disputeGame.anchorStateRegistry();
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -143,9 +143,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.0.0-beta.35
+    /// @custom:semver 1.0.0-beta.36
     function version() public pure virtual returns (string memory) {
-        return "1.0.0-beta.35";
+        return "1.0.0-beta.36";
     }
 
     /// @notice Address of the SuperchainConfig contract shared by all chains.

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -296,6 +296,8 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
         }
 
         // Check the implementations of the core addresses
+        assertEq(impls.superchainConfigImpl, EIP1967Helper.getImplementation(address(superchainConfig)));
+        assertEq(impls.protocolVersionsImpl, EIP1967Helper.getImplementation(address(protocolVersions)));
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(impls.l1ERC721BridgeImpl, EIP1967Helper.getImplementation(address(l1ERC721Bridge)));
         assertEq(impls.disputeGameFactoryImpl, EIP1967Helper.getImplementation(address(disputeGameFactory)));

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -238,11 +238,12 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
 contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     function runUpgradeTestAndChecks(address delegateCaller) public {
+        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+
         assertTrue(opcm.isRC(), "isRC should be true");
         bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
         assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
 
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
         IOPContractsManager.Implementations memory impls = opcm.implementations();
 
         // Cache the old L1xDM address so we can look for it in the AddressManager's event
@@ -283,7 +284,7 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
         }
         vm.expectEmit(address(delegateCaller));
         emit Upgraded(l2ChainId, opChains[0].systemConfigProxy, address(delegateCaller));
-        DelegateCaller(upgrader).dcForward(
+        DelegateCaller(delegateCaller).dcForward(
             address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (superchainProxyAdmin, opChains))
         );
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -270,6 +270,8 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.upgradeController.selector, upgradeController);
 
         // Perform the initial deployment.
+        deployImplementations.deploySuperchainConfigImpl(dio);
+        deployImplementations.deployProtocolVersionsImpl(dio);
         deployImplementations.deploySystemConfigImpl(dio);
         deployImplementations.deployL1CrossDomainMessengerImpl(dio);
         deployImplementations.deployL1ERC721BridgeImpl(dio);

--- a/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPCM.t.sol
@@ -82,6 +82,8 @@ contract DeployOPCMInput_Test is Test {
     function test_set_part1_succeeds() public {
         ISuperchainConfig superchainConfig = ISuperchainConfig(makeAddr("superchainConfig"));
         IProtocolVersions protocolVersions = IProtocolVersions(makeAddr("protocolVersions"));
+        address superchainConfigImpl = makeAddr("superchainConfigImpl");
+        address protocolVersionsImpl = makeAddr("protocolVersionsImpl");
         address upgradeController = makeAddr("upgradeController");
         address addressManagerBlueprint = makeAddr("addressManagerBlueprint");
         address proxyBlueprint = makeAddr("proxyBlueprint");
@@ -93,6 +95,8 @@ contract DeployOPCMInput_Test is Test {
 
         dii.set(dii.superchainConfig.selector, address(superchainConfig));
         dii.set(dii.protocolVersions.selector, address(protocolVersions));
+        dii.set(dii.superchainConfigImpl.selector, superchainConfigImpl);
+        dii.set(dii.protocolVersionsImpl.selector, protocolVersionsImpl);
         dii.set(dii.l1ContractsRelease.selector, release);
         dii.set(dii.upgradeController.selector, upgradeController);
         dii.set(dii.addressManagerBlueprint.selector, addressManagerBlueprint);
@@ -210,6 +214,8 @@ contract DeployOPCMTest is Test {
 
     ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
     IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+    address superchainConfigImpl = makeAddr("superchainConfigImpl");
+    address protocolVersionsImpl = makeAddr("protocolVersionsImpl");
     address upgradeController = makeAddr("upgradeController");
 
     function setUp() public virtual {
@@ -220,6 +226,8 @@ contract DeployOPCMTest is Test {
     function test_run_succeeds() public {
         doi.set(doi.superchainConfig.selector, address(superchainConfigProxy));
         doi.set(doi.protocolVersions.selector, address(protocolVersionsProxy));
+        doi.set(doi.superchainConfigImpl.selector, address(superchainConfigImpl));
+        doi.set(doi.protocolVersionsImpl.selector, address(protocolVersionsImpl));
         doi.set(doi.l1ContractsRelease.selector, "1.0.0");
         doi.set(doi.upgradeController.selector, upgradeController);
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -149,7 +149,7 @@ contract ForkLive is Deployer {
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         IProxyAdmin proxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(systemConfig)));
 
-        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfig"));
+        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
         IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
 
         address upgrader = proxyAdmin.owner();

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -21,6 +21,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
@@ -148,6 +149,9 @@ contract ForkLive is Deployer {
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         IProxyAdmin proxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(systemConfig)));
 
+        ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfig"));
+        IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
+
         address upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
@@ -157,7 +161,9 @@ contract ForkLive is Deployer {
         // TODO Migrate from DelegateCaller to a Safe to reduce risk of mocks not properly
         // reflecting the production system.
         vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
+        DelegateCaller(upgrader).dcForward(
+            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (superchainProxyAdmin, opChains))
+        );
 
         console.log("ForkLive: Saving newly deployed contracts");
         // A new ASR and new dispute games were deployed, so we need to update them


### PR DESCRIPTION
Each row in the table corresponds to a commit. Looks like the branch I based off of, `opcm-up/superchain-singleton`, changed since I branched off hence all the @maurelian commits. I'd ignore the overall diff of this PR and just look at the individual commits and their savings. I only built src, and didn't run any tests, so some of these might result in e.g. Go test failures by changing types

```
| Contract            | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| OPContractsManager  | 24,328           | 26,449            | 248                | 22,703              | initial
| OPContractsManager  | 24,207           | 26,328            | 369                | 22,824              | save 121 bytes, remove simple abi.encode* usages
| OPContractsManager  | 23,953           | 26,074            | 623                | 23,078              | save 254 bytes, change saltMixer from string to bytes32
| OPContractsManager  | 23,876           | 25,997            | 700                | 23,155              | save 77 bytes, change contractName from string to bytes32
| OPContractsManager  | 22,404           | 24,504            | 2,172              | 24,648              | save 1472 bytes, dedupe external calls
```