### PR TITLE
chore: Bump kona version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "REPOSITORY" {
 }
 
 variable "KONA_VERSION" {
-  default = "kona-client-v0.1.0-beta.6"
+  default = "kona-client-v0.1.0-beta.8"
 }
 
 variable "GIT_COMMIT" {


### PR DESCRIPTION
## Overview

Bumps the `kona` version to `beta.8`