### PR TITLE
Fix spelling errors in Various Go Files and Tests

### DIFF
--- a/cannon/mipsevm/arch/arch32.go
+++ b/cannon/mipsevm/arch/arch32.go
@@ -6,7 +6,7 @@ package arch
 import "encoding/binary"
 
 type (
-	// Word differs from the tradditional meaning in MIPS. The type represents the *maximum* architecture specific access length and value sizes.
+	// Word differs from the traditional meaning in MIPS. The type represents the *maximum* architecture specific access length and value sizes.
 	Word = uint32
 	// SignedInteger specifies the maximum signed integer type used for arithmetic.
 	SignedInteger = int32

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -44,12 +44,12 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 		expected.PrestateActiveThread().Registers[7] = 0
 		// Set expectations for new, cloned thread
 		expected.ActiveThreadId = nextThreadId
-		epxectedNewThread := expected.ExpectNewThread()
-		epxectedNewThread.PC = state.GetCpu().NextPC
-		epxectedNewThread.NextPC = state.GetCpu().NextPC + 4
-		epxectedNewThread.Registers[register.RegSyscallNum] = 0
-		epxectedNewThread.Registers[register.RegSyscallErrno] = 0
-		epxectedNewThread.Registers[register.RegSP] = stackPtr
+		expectedNewThread := expected.ExpectNewThread()
+		expectedNewThread.PC = state.GetCpu().NextPC
+		expectedNewThread.NextPC = state.GetCpu().NextPC + 4
+		expectedNewThread.Registers[register.RegSyscallNum] = 0
+		expectedNewThread.Registers[register.RegSyscallErrno] = 0
+		expectedNewThread.Registers[register.RegSP] = stackPtr
 		expected.NextThreadId = nextThreadId + 1
 		expected.StepsSinceLastContextSwitch = 0
 		if state.TraverseRight {

--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -58,7 +58,7 @@ func RandomizeWordAndSetUint32(mem *memory.Memory, addr Word, val uint32, random
 	exec.StoreSubWord(mem, addr, 4, Word(val), new(exec.NoopMemoryTracker))
 }
 
-// ToSignedInteger converts the unsigend Word to a SignedInteger.
+// ToSignedInteger converts the unsigned Word to a SignedInteger.
 // Useful for avoiding Go compiler warnings for literals that don't fit in a signed type
 func ToSignedInteger(x Word) arch.SignedInteger {
 	return arch.SignedInteger(x)

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -257,7 +257,7 @@ func TestMultipleRounds(t *testing.T) {
 			actor: incorrectAttackLastClaim,
 		},
 		{
-			name:  "LinearDefendInorrect",
+			name:  "LinearDefendIncorrect",
 			actor: incorrectDefendLastClaim,
 		},
 		{

--- a/op-node/benchmarks/batchbuilding_test.go
+++ b/op-node/benchmarks/batchbuilding_test.go
@@ -20,7 +20,7 @@ const (
 	// a really large target output size to ensure that the compressors are never full
 	targetOutput_huge = uint64(100_000_000_000)
 	// this target size was determiend by the devnet sepolia batcher's configuration
-	targetOuput_real = uint64(780120)
+	targetOutput_real = uint64(780120)
 )
 
 // compressorDetails is a helper struct to create compressors or supply the configuration for span batches
@@ -81,7 +81,7 @@ var (
 			name:         "ShadowCompressor",
 			compressorFn: compressor.NewShadowCompressor,
 			config: compressor.Config{
-				TargetOutputSize: targetOuput_real,
+				TargetOutputSize: targetOutput_real,
 				CompressionAlgo:  derive.Zlib,
 			},
 		},
@@ -240,14 +240,14 @@ func BenchmarkIncremental(b *testing.B) {
 		{derive.SpanBatchType, 5, 1, compressorDetails{
 			name: "RealThreshold",
 			config: compressor.Config{
-				TargetOutputSize: targetOuput_real,
+				TargetOutputSize: targetOutput_real,
 				CompressionAlgo:  derive.Zlib,
 			},
 		}},
 		{derive.SpanBatchType, 5, 1, compressorDetails{
 			name: "RealThreshold",
 			config: compressor.Config{
-				TargetOutputSize: targetOuput_real,
+				TargetOutputSize: targetOutput_real,
 				CompressionAlgo:  derive.Brotli10,
 			},
 		}},

--- a/op-node/rollup/clsync/clsync_test.go
+++ b/op-node/rollup/clsync/clsync_test.go
@@ -338,7 +338,7 @@ func TestCLSync(t *testing.T) {
 		// We just hold on to what payloads there are in the queue.
 		require.NotNil(t, cl.unsafePayloads.Peek(), "no pop because temporary error")
 
-		// Pretend we are still stuck on the same forkchoice. The CL-sync will retry sneding the payload.
+		// Pretend we are still stuck on the same forkchoice. The CL-sync will retry sending the payload.
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA1})
 		cl.OnEvent(engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA0,

--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -47,7 +47,7 @@ type Channel struct {
 	highestL1InclusionBlock eth.L1BlockRef
 }
 
-// NewChannel creates a new channel with the given id and openening block. If requireInOrder is
+// NewChannel creates a new channel with the given id and opening block. If requireInOrder is
 // true, frames must be added in order.
 func NewChannel(id ChannelID, openBlock eth.L1BlockRef, requireInOrder bool) *Channel {
 	return &Channel{


### PR DESCRIPTION
**Spelling corrections**:
   - In `arch32.go`, "tradditional" corrected to "traditional".
   - In `fuzz_evm_multithreaded_test.go`, multiple instances of "epxected" corrected to "expected".
   - In `arch.go`, "unsigend" corrected to "unsigned".
   - In `game_solver_test.go`, "Inorrect" corrected to "Incorrect".
   - In `batchbuilding_test.go`, "determined" corrected to "determined".
   - In `clsync_test.go`, "retry sneding" corrected to "retry sending".
   - In `channel.go`, "openening" corrected to "opening".
