### PR TITLE
fix typoflags.go

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -85,7 +85,7 @@ var (
 	BeaconFallbackAddrs = &cli.StringSliceFlag{
 		Name:     "l1.beacon-fallbacks",
 		Aliases:  []string{"l1.beacon-archiver"},
-		Usage:    "Addresses of L1 Beacon-API compatible HTTP fallback endpoints. Used to fetch blob sidecars not availalbe at the l1.beacon (e.g. expired blobs).",
+		Usage:    "Addresses of L1 Beacon-API compatible HTTP fallback endpoints. Used to fetch blob sidecars not available at the l1.beacon (e.g. expired blobs).",
 		EnvVars:  prefixEnvVars("L1_BEACON_FALLBACKS", "L1_BEACON_ARCHIVER"),
 		Category: L1RPCCategory,
 	}


### PR DESCRIPTION
Fixed typo: "availalbe" → "available".