### PR TITLE
FaultDisputeGame.sol: make code and comment consistent

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -168,8 +168,8 @@
     "sourceCodeHash": "0x155c0334f63616ed245aadf9a94f419ef7d5e2237b3b32172484fd19890a61dc"
   },
   "src/dispute/FaultDisputeGame.sol": {
-    "initCodeHash": "0x152fbb1f82488d815f56087fc464b9478f1390e3ecd67ae595344115fdd9ba91",
-    "sourceCodeHash": "0x9bfea41bd993bc1ef2ede9a5846a432ed5ea183868634fd77c4068b0a4a779b2"
+    "initCodeHash": "0x17a5cbd555969aaa591278927f25caa7e6d1f0cf492fca5286cb4bd6e6301604",
+    "sourceCodeHash": "0x9fce75799ae9687e883800d31b4e0b8eb9634a32e4a247bec653bcb6dea65548"
   },
   "src/legacy/DeployerWhitelist.sol": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -170,8 +170,8 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.0-beta.1
-    string public constant version = "1.4.0-beta.1";
+    /// @custom:semver 1.4.0-beta.2
+    string public constant version = "1.4.0-beta.2";
 
     /// @notice The starting timestamp of the game
     Timestamp public createdAt;
@@ -1151,11 +1151,16 @@ contract FaultDisputeGame is Clone, ISemver {
 
         // If the move is a defense, the disputed output could have been made by either party. In this case, we
         // need to search for the parent output to determine what the expected status byte should be.
-        Position disputedLeafPos = Position.wrap(_parentPos.raw() + 1);
-        ClaimData storage disputed = _findTraceAncestor({ _pos: disputedLeafPos, _start: _parentIdx, _global: true });
+        bool topBottomDisagreeWhenDefense = false;
+        if (!_isAttack) {
+            Position disputedLeafPos = Position.wrap(_parentPos.raw() + 1);
+            ClaimData storage disputed =
+                _findTraceAncestor({ _pos: disputedLeafPos, _start: _parentIdx, _global: true });
+            topBottomDisagreeWhenDefense = disputed.position.depth() % 2 == SPLIT_DEPTH % 2;
+        }
         uint8 vmStatus = uint8(_rootClaim.raw()[0]);
 
-        if (_isAttack || disputed.position.depth() % 2 == SPLIT_DEPTH % 2) {
+        if (_isAttack || topBottomDisagreeWhenDefense) {
             // If the move is an attack, the parent output is always deemed to be disputed. In this case, we only need
             // to check that the root claim signals that the VM panicked or resulted in an invalid transition.
             // If the move is a defense, and the disputed output and creator of the execution trace subgame disagree,

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -322,7 +322,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         // the correct anchor state and has the mips64impl.
         IPermissionedDisputeGame pdg =
             IPermissionedDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
-        assertEq(ISemver(address(pdg)).version(), "1.4.0-beta.1");
+        assertEq(ISemver(address(pdg)).version(), "1.4.0-beta.2");
         assertEq(address(pdg.anchorStateRegistry()), address(newAnchorStateRegistryProxy));
         assertEq(address(pdg.vm()), impls.mips64Impl);
 
@@ -332,7 +332,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             assertEq(impls.delayedWETHImpl, EIP1967Helper.getImplementation(address(delayedWeth)));
             // Check that the PermissionlessDisputeGame is upgraded to the expected version
             IFaultDisputeGame fdg = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
-            assertEq(ISemver(address(fdg)).version(), "1.4.0-beta.1");
+            assertEq(ISemver(address(fdg)).version(), "1.4.0-beta.2");
             assertEq(address(fdg.anchorStateRegistry()), address(newAnchorStateRegistryProxy));
             assertEq(address(fdg.vm()), impls.mips64Impl);
         }


### PR DESCRIPTION
This PR makes the code more consistent with the comment:

```solidity
// If the move is a defense, the disputed output could have been made by either party. In this case, we
// need to search for the parent output to determine what the expected status byte should be.
```

The `disputed` part is only necessary when the move is a defense.

The bytecode increases 4 bytes from:

<img width="850" alt="image" src="https://github.com/user-attachments/assets/23944dcc-7348-4661-b540-1b6792e496e5" />

to:

<img width="842" alt="image" src="https://github.com/user-attachments/assets/a2620431-7f2b-439a-a709-bb59122b89e2" />

but I think the clarity is worth it.

