### PR TITLE
op-node: update interop optimistic block system deposit tx sender address

### DIFF
--- a/op-node/rollup/interop/managed/attributes.go
+++ b/op-node/rollup/interop/managed/attributes.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
+var OptimisticBlockDepositSenderAddress = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0002")
+
 // AttributesToReplaceInvalidBlock builds the payload-attributes to replace an invalidated block.
 // See https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#replacing-invalid-blocks
 func AttributesToReplaceInvalidBlock(invalidatedBlock *eth.ExecutionPayloadEnvelope) *eth.PayloadAttributes {
@@ -67,7 +69,7 @@ func InvalidatedBlockSourceDepositTx(outputRootPreimage []byte) *types.Transacti
 	src := derive.InvalidatedBlockSource{OutputRoot: outputRoot}
 	return types.NewTx(&types.DepositTx{
 		SourceHash:          src.SourceHash(),
-		From:                derive.L1InfoDepositerAddress,
+		From:                OptimisticBlockDepositSenderAddress,
 		To:                  &common.Address{}, // to the zero address, no EVM execution.
 		Mint:                big.NewInt(0),
 		Value:               big.NewInt(0),
@@ -97,7 +99,7 @@ func DecodeInvalidatedBlockTx(tx *types.Transaction) (*eth.OutputV0, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get invalidated-block deposit-tx sender addr: %w", err)
 	}
-	if from != derive.L1InfoDepositerAddress {
+	if from != OptimisticBlockDepositSenderAddress {
 		return nil, fmt.Errorf("expected system tx sender, but got %s", from)
 	}
 	out, err := eth.UnmarshalOutput(tx.Data())

--- a/op-node/rollup/interop/managed/attributes_test.go
+++ b/op-node/rollup/interop/managed/attributes_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
@@ -118,7 +117,7 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		signer := types.LatestSignerForChainID(big.NewInt(0))
 		sender, err := signer.Sender(tx)
 		require.NoError(t, err)
-		require.Equal(t, derive.L1InfoDepositerAddress, sender, "from")
+		require.Equal(t, OptimisticBlockDepositSenderAddress, sender, "from")
 		require.Equal(t, common.Address{}, *tx.To(), "to")
 		require.Equal(t, "0", tx.Mint().String(), "mint")
 		require.Equal(t, "0", tx.Value().String(), "value")


### PR DESCRIPTION
**Description**

Small interop code update, to match https://github.com/ethereum-optimism/specs/pull/536
