### PR TITLE
feat: prevent deployments of mips32 on opcm upgrade 13

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -5,10 +5,13 @@ import { Script } from "forge-std/Script.sol";
 
 import { LibString } from "@solady/utils/LibString.sol";
 
+// Libraries
+import { Chains } from "scripts/libraries/Chains.sol";
+
+// Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
-
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { IMIPS } from "interfaces/cannon/IMIPS.sol";
@@ -753,6 +756,14 @@ contract DeployImplementations is Script {
     function deployMipsSingleton(DeployImplementationsInput _dii, DeployImplementationsOutput _dio) public virtual {
         uint256 mipsVersion = _dii.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(address(_dio.preimageOracleSingleton()));
+
+        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips64 on production networks.
+        if (mipsVersion == 1) {
+            if (block.chainid == Chains.Mainnet || block.chainid == Chains.Sepolia) {
+                revert("DeployImplementations: Mips V1 should not be deployed on Mainnet or Sepolia");
+            }
+        }
+
         vm.broadcast(msg.sender);
         IMIPS singleton = IMIPS(
             DeployUtils.createDeterministic({

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -430,7 +430,7 @@ contract DeployImplementations_Test is Test {
         deployImplementations.run(dii, dio);
     }
 
-    function test_deployMipsV1OnMainnetOrSepolia_reverts() public {
+    function test_run_deployMipsV1OnMainnetOrSepolia_reverts() public {
         setDefaults();
         dii.set(dii.mipsVersion.selector, 1);
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
 import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Chains } from "scripts/libraries/Chains.sol";
+
+// Interfaces
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { IMIPS } from "interfaces/cannon/IMIPS.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
@@ -398,7 +402,7 @@ contract DeployImplementations_Test is Test {
         dio.checkOutput(dii);
     }
 
-    function testFuzz_run_largeChallengePeriodSeconds_reverts(uint256 _challengePeriodSeconds) public {
+    function setDefaults() internal {
         // Set the defaults.
         dii.set(dii.withdrawalDelaySeconds.selector, withdrawalDelaySeconds);
         dii.set(dii.minProposalSizeBytes.selector, minProposalSizeBytes);
@@ -411,7 +415,10 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.superchainConfigProxy.selector, address(superchainConfigProxy));
         dii.set(dii.protocolVersionsProxy.selector, address(protocolVersionsProxy));
         dii.set(dii.superchainProxyAdmin.selector, address(superchainProxyAdmin));
+    }
 
+    function testFuzz_run_largeChallengePeriodSeconds_reverts(uint256 _challengePeriodSeconds) public {
+        setDefaults();
         // Set the challenge period to a value that is too large, using vm.store because the setter
         // method won't allow it.
         challengePeriodSeconds = bound(_challengePeriodSeconds, uint256(type(uint64).max) + 1, type(uint256).max);
@@ -420,6 +427,19 @@ contract DeployImplementations_Test is Test {
         vm.store(address(dii), bytes32(slot), bytes32(challengePeriodSeconds));
 
         vm.expectRevert("DeployImplementationsInput: challengePeriodSeconds too large");
+        deployImplementations.run(dii, dio);
+    }
+
+    function test_deployMipsV1OnMainnetOrSepolia_reverts() public {
+        setDefaults();
+        dii.set(dii.mipsVersion.selector, 1);
+
+        vm.chainId(Chains.Mainnet);
+        vm.expectRevert("DeployImplementations: Mips V1 should not be deployed on mainnet or sepolia");
+        deployImplementations.run(dii, dio);
+
+        vm.chainId(Chains.Sepolia);
+        vm.expectRevert("DeployImplementations: Mips V1 should not be deployed on mainnet or sepolia");
         deployImplementations.run(dii, dio);
     }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -435,11 +435,11 @@ contract DeployImplementations_Test is Test {
         dii.set(dii.mipsVersion.selector, 1);
 
         vm.chainId(Chains.Mainnet);
-        vm.expectRevert("DeployImplementations: Mips V1 should not be deployed on mainnet or sepolia");
+        vm.expectRevert("DeployImplementations: Mips V1 should not be deployed on Mainnet or Sepolia");
         deployImplementations.run(dii, dio);
 
         vm.chainId(Chains.Sepolia);
-        vm.expectRevert("DeployImplementations: Mips V1 should not be deployed on mainnet or sepolia");
+        vm.expectRevert("DeployImplementations: Mips V1 should not be deployed on Mainnet or Sepolia");
         deployImplementations.run(dii, dio);
     }
 }

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -72,7 +72,10 @@ contract ForkLive is Deployer {
         } else {
             // Read the superchain registry and save the addresses to the Artifacts contract.
             _readSuperchainRegistry();
-            // Now deploy the updated OPCM and implementations of the contracts
+            // Now deploy the updated OPCM and implementations of the contracts.
+            // We need to set the USE_MT_CANNON environment variable to true to ensure that the OPCM for upgrade 13
+            // is deployed with Mips64 on production networks.
+            vm.setEnv("USE_MT_CANNON", "true");
             _deployNewImplementations();
         }
 


### PR DESCRIPTION
**Problem:** We must be sure not to perform upgrade 13 with Mips32. However the OPCM is already being audited, so we can't add constructor checks to it. We also don't want to entirely remove Mips32 from the repo, as it may prevent us from running e2e tests for the pectra upgrade.

**Proposed solution:** Add a check to ensure that Mips32 is not deployed in production (AFAIK we don't use Mainnet/sepolia chain Ids in prod).
