### PR TITLE
op-program: Fix missing block re-exec preimages in host

### DIFF
--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -199,6 +200,7 @@ func (t *interopTaskExecutor) RunDerivation(
 		claimedBlockNumber,
 		l1Oracle,
 		l2Oracle,
+		memorydb.New(),
 	)
 }
 

--- a/op-program/client/l2/db.go
+++ b/op-program/client/l2/db.go
@@ -9,22 +9,29 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
 
 var codePrefixedKeyLength = common.HashLength + len(rawdb.CodePrefix)
 
 var ErrInvalidKeyLength = errors.New("pre-images must be identified by 32-byte hash keys")
 
+// KeyValueStore is a subset of the ethdb.KeyValueStore interface that's required for block processing.
+type KeyValueStore interface {
+	ethdb.KeyValueReader
+	ethdb.Batcher
+	// Put inserts the given value into the key-value data store.
+	Put(key []byte, value []byte) error
+}
+
 type OracleKeyValueStore struct {
-	db      ethdb.KeyValueStore
+	db      KeyValueStore
 	oracle  StateOracle
 	chainID eth.ChainID
 }
 
-func NewOracleBackedDB(oracle StateOracle, chainID eth.ChainID) *OracleKeyValueStore {
+func NewOracleBackedDB(kv KeyValueStore, oracle StateOracle, chainID eth.ChainID) *OracleKeyValueStore {
 	return &OracleKeyValueStore{
-		db:      memorydb.New(),
+		db:      kv,
 		oracle:  oracle,
 		chainID: chainID,
 	}

--- a/op-program/client/l2/db_test.go
+++ b/op-program/client/l2/db_test.go
@@ -35,7 +35,7 @@ var _ ethdb.KeyValueStore = (*OracleKeyValueStore)(nil)
 func TestGet(t *testing.T) {
 	t.Run("IncorrectLengthKey", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
+		db := NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234))
 		val, err := db.Get([]byte{1, 2, 3})
 		require.ErrorIs(t, err, ErrInvalidKeyLength)
 		require.Nil(t, val)
@@ -43,7 +43,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("KeyWithCodePrefix", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
+		db := NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234))
 		key := common.HexToHash("0x12345678")
 		prefixedKey := append(rawdb.CodePrefix, key.Bytes()...)
 
@@ -57,7 +57,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("NormalKeyThatHappensToStartWithCodePrefix", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
+		db := NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234))
 		key := make([]byte, common.HashLength)
 		copy(rawdb.CodePrefix, key)
 		fmt.Println(key[0])
@@ -74,7 +74,7 @@ func TestGet(t *testing.T) {
 		expected := []byte{2, 6, 3, 8}
 		oracle := test.NewStubStateOracle(t)
 		oracle.Data[key] = expected
-		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
+		db := NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234))
 		val, err := db.Get(key.Bytes())
 		require.NoError(t, err)
 		require.Equal(t, expected, val)
@@ -84,7 +84,7 @@ func TestGet(t *testing.T) {
 func TestPut(t *testing.T) {
 	t.Run("NewKey", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
+		db := NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234))
 		key := common.HexToHash("0xAA4488")
 		value := []byte{2, 6, 3, 8}
 		err := db.Put(key.Bytes(), value)
@@ -96,7 +96,7 @@ func TestPut(t *testing.T) {
 	})
 	t.Run("ReplaceKey", func(t *testing.T) {
 		oracle := test.NewStubStateOracle(t)
-		db := NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234))
+		db := NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234))
 		key := common.HexToHash("0xAA4488")
 		value1 := []byte{2, 6, 3, 8}
 		value2 := []byte{1, 2, 3}
@@ -118,13 +118,13 @@ func TestSupportsStateDBOperations(t *testing.T) {
 	genesisBlock := l2Genesis.MustCommit(realDb, trieDB)
 
 	loader := test.NewKvStateOracle(t, realDb)
-	assertStateDataAvailable(t, NewOracleBackedDB(loader, eth.ChainIDFromUInt64(1234)), l2Genesis, genesisBlock)
+	assertStateDataAvailable(t, NewOracleBackedDB(memorydb.New(), loader, eth.ChainIDFromUInt64(1234)), l2Genesis, genesisBlock)
 }
 
 func TestUpdateState(t *testing.T) {
 	l2Genesis := createGenesis()
 	oracle := test.NewStubStateOracle(t)
-	db := rawdb.NewDatabase(NewOracleBackedDB(oracle, eth.ChainIDFromUInt64(1234)))
+	db := rawdb.NewDatabase(NewOracleBackedDB(memorydb.New(), oracle, eth.ChainIDFromUInt64(1234)))
 
 	trieDB := triedb.NewDatabase(db, &triedb.Config{HashDB: hashdb.Defaults})
 	genesisBlock := l2Genesis.MustCommit(db, trieDB)

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -10,7 +10,13 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-func RunPreInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1PreimageOracle *l1.CachingOracle, l2PreimageOracle *l2.CachingOracle) error {
+func RunPreInteropProgram(
+	logger log.Logger,
+	bootInfo *boot.BootInfo,
+	l1PreimageOracle *l1.CachingOracle,
+	l2PreimageOracle *l2.CachingOracle,
+	db l2.KeyValueStore,
+) error {
 	logger.Info("Program Bootstrapped", "bootInfo", bootInfo)
 	result, err := tasks.RunDerivation(
 		logger,
@@ -21,6 +27,7 @@ func RunPreInteropProgram(logger log.Logger, bootInfo *boot.BootInfo, l1Preimage
 		bootInfo.L2ClaimBlockNumber,
 		l1PreimageOracle,
 		l2PreimageOracle,
+		db,
 	)
 	if err != nil {
 		return err

--- a/op-program/client/tasks/deposits_block.go
+++ b/op-program/client/tasks/deposits_block.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -32,7 +33,7 @@ func BuildDepositOnlyBlock(
 	l1Oracle l1.Oracle,
 	l2Oracle l2.Oracle,
 ) (common.Hash, eth.Bytes32, error) {
-	engineBackend, err := l2.NewOracleBackedL2Chain(logger, l2Oracle, l1Oracle, l2Cfg, common.Hash(agreedL2OutputRoot))
+	engineBackend, err := l2.NewOracleBackedL2Chain(logger, l2Oracle, l1Oracle, l2Cfg, common.Hash(agreedL2OutputRoot), memorydb.New())
 	if err != nil {
 		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("failed to create oracle-backed L2 chain: %w", err)
 	}
@@ -77,7 +78,7 @@ func BuildDepositOnlyBlock(
 }
 
 func getL2Output(logger log.Logger, cfg *rollup.Config, l2Cfg *params.ChainConfig, l2Oracle l2.Oracle, l1Oracle l1.Oracle, block *types.Block) (*eth.OutputV0, error) {
-	backend := l2.NewOracleBackedL2ChainFromHead(logger, l2Oracle, l1Oracle, l2Cfg, block)
+	backend := l2.NewOracleBackedL2ChainFromHead(logger, l2Oracle, l1Oracle, l2Cfg, block, memorydb.New())
 	engine := l2.NewOracleEngine(cfg, logger, backend)
 	output, err := engine.L2OutputAtBlockHash(block.Hash())
 	if err != nil {

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -37,10 +37,11 @@ func RunDerivation(
 	l2ClaimBlockNum uint64,
 	l1Oracle l1.Oracle,
 	l2Oracle l2.Oracle,
+	db l2.KeyValueStore,
 ) (DerivationResult, error) {
 	l1Source := l1.NewOracleL1Client(logger, l1Oracle, l1Head)
 	l1BlobsSource := l1.NewBlobFetcher(logger, l1Oracle)
-	engineBackend, err := l2.NewOracleBackedL2Chain(logger, l2Oracle, l1Oracle, l2Cfg, l2OutputRoot)
+	engineBackend, err := l2.NewOracleBackedL2Chain(logger, l2Oracle, l1Oracle, l2Cfg, l2OutputRoot, db)
 	if err != nil {
 		return DerivationResult{}, fmt.Errorf("failed to create oracle-backed L2 chain: %w", err)
 	}

--- a/op-program/host/common/l2_store.go
+++ b/op-program/host/common/l2_store.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"bytes"
+
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
+	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+type l2KeyValueStore struct {
+	kv kvstore.KV
+}
+
+var _ l2.KeyValueStore = (*l2KeyValueStore)(nil)
+
+// NewL2KeyValueStore creates a l2.KeyValueStore compatible database that's backed by a [kvstore.KV]
+func NewL2KeyValueStore(kv kvstore.KV) *l2KeyValueStore {
+	return &l2KeyValueStore{kv: kv}
+}
+
+var codePrefixedKeyLength = common.HashLength + len(rawdb.CodePrefix)
+
+func unwrapKey(key []byte) []byte {
+	if len(key) == codePrefixedKeyLength && bytes.HasPrefix(key, rawdb.CodePrefix) {
+		return key[len(rawdb.CodePrefix):]
+	}
+	return key
+}
+
+func (db *l2KeyValueStore) Get(key []byte) ([]byte, error) {
+	key = unwrapKey(key)
+	if len(key) != common.HashLength {
+		return nil, l2.ErrInvalidKeyLength
+	}
+	return db.kv.Get(common.Hash(key))
+}
+
+func (db *l2KeyValueStore) Has(key []byte) (bool, error) {
+	key = unwrapKey(key)
+	if len(key) != common.HashLength {
+		return false, l2.ErrInvalidKeyLength
+	}
+	_, err := db.kv.Get(common.Hash(key))
+	switch err {
+	case kvstore.ErrNotFound:
+		return false, nil
+	case nil:
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
+func (db *l2KeyValueStore) Put(key []byte, value []byte) error {
+	key = unwrapKey(key)
+	return db.kv.Put(common.Hash(key), value)
+}
+
+func (db *l2KeyValueStore) NewBatch() ethdb.Batch {
+	return &batch{db: db}
+}
+
+func (db *l2KeyValueStore) NewBatchWithSize(size int) ethdb.Batch {
+	return &batch{db: db}
+}
+
+// batch is similar to memorydb.batch, but adapted for kvstore.KV
+type batch struct {
+	db     *l2KeyValueStore
+	writes []keyvalue
+	size   int
+}
+
+var _ ethdb.Batch = (*batch)(nil)
+
+type keyvalue struct {
+	key   string
+	value []byte
+}
+
+func (b *batch) Put(key []byte, value []byte) error {
+	b.writes = append(b.writes, keyvalue{string(key), common.CopyBytes(value)})
+	b.size += len(key) + len(value)
+	return nil
+}
+
+func (b *batch) Delete(key []byte) error {
+	// ignore deletes
+	return nil
+}
+
+func (b *batch) ValueSize() int {
+	return b.size
+}
+
+func (b *batch) Write() error {
+	for _, keyvalue := range b.writes {
+		if err := b.db.kv.Put(common.Hash([]byte(keyvalue.key)), keyvalue.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *batch) Reset() {
+	b.writes = b.writes[:0]
+	b.size = 0
+}
+
+func (b *batch) Replay(w ethdb.KeyValueWriter) error {
+	for _, keyvalue := range b.writes {
+		if err := w.Put([]byte(keyvalue.key), keyvalue.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/op-program/host/common/l2_store_test.go
+++ b/op-program/host/common/l2_store_test.go
@@ -57,6 +57,8 @@ func TestL2KeyValueStore(t *testing.T) {
 		has, err := db.Has([]byte("invalid"))
 		require.ErrorIs(t, err, l2.ErrInvalidKeyLength)
 		require.False(t, has)
+		err = db.Put([]byte("invalid"), []byte("value"))
+		require.ErrorIs(t, err, l2.ErrInvalidKeyLength)
 	})
 	t.Run("MissingPreimage", func(t *testing.T) {
 		kv := kvstore.NewMemKV()

--- a/op-program/host/common/l2_store_test.go
+++ b/op-program/host/common/l2_store_test.go
@@ -1,0 +1,173 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
+	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestL2KeyValueStore(t *testing.T) {
+	preimageKey := common.HexToHash("0xdead")
+	codeKey := make([]byte, common.HashLength+len(rawdb.CodePrefix))
+	copy(codeKey, rawdb.CodePrefix)
+	copy(codeKey[len(rawdb.CodePrefix):], common.Hex2Bytes("0xdead"))
+	value := []byte("value")
+	codeValue := []byte("code")
+	t.Run("Preimage", func(t *testing.T) {
+		kv := kvstore.NewMemKV()
+		db := NewL2KeyValueStore(kv)
+		require.NoError(t, db.Put(preimageKey[:], value))
+
+		readValue, err := db.Get(preimageKey[:])
+		require.NoError(t, err)
+		require.Equal(t, value, readValue)
+		kvValue, err := kv.Get(preimageKey)
+		require.NoError(t, err)
+		require.Equal(t, value, kvValue)
+
+		has, err := db.Has(preimageKey[:])
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+	t.Run("Code", func(t *testing.T) {
+		kv := kvstore.NewMemKV()
+		db := NewL2KeyValueStore(kv)
+		require.NoError(t, db.Put(codeKey, codeValue))
+
+		readValue, err := db.Get(codeKey)
+		require.NoError(t, err)
+		require.Equal(t, codeValue, readValue)
+		kvValue, err := kv.Get(common.Hash(codeKey[1:]))
+		require.NoError(t, err)
+		require.Equal(t, codeValue, kvValue)
+
+		has, err := db.Has(codeKey)
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+	t.Run("InvalidKey", func(t *testing.T) {
+		kv := kvstore.NewMemKV()
+		db := NewL2KeyValueStore(kv)
+		_, err := db.Get([]byte("invalid"))
+		require.ErrorIs(t, err, l2.ErrInvalidKeyLength)
+		has, err := db.Has([]byte("invalid"))
+		require.ErrorIs(t, err, l2.ErrInvalidKeyLength)
+		require.False(t, has)
+	})
+	t.Run("MissingPreimage", func(t *testing.T) {
+		kv := kvstore.NewMemKV()
+		db := NewL2KeyValueStore(kv)
+		has, err := db.Has(preimageKey[:])
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+	t.Run("MissingCode", func(t *testing.T) {
+		kv := kvstore.NewMemKV()
+		db := NewL2KeyValueStore(kv)
+		has, err := db.Has(codeKey)
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+	t.Run("Batch", func(t *testing.T) {
+		kv := &mockKV{data: make(map[common.Hash][]byte)}
+		db := NewL2KeyValueStore(kv)
+		batch := db.NewBatch()
+		require.NoError(t, batch.Put(preimageKey[:], value))
+		expectedBatchSize := len(preimageKey) + len(value)
+		require.Equal(t, expectedBatchSize, batch.ValueSize())
+
+		require.NoError(t, batch.Put(codeKey, codeValue))
+		expectedBatchSize += len(codeKey) + len(codeValue)
+		require.Equal(t, expectedBatchSize, batch.ValueSize())
+
+		has, err := db.Has(preimageKey[:])
+		require.NoError(t, err)
+		require.True(t, has)
+		has, err = db.Has(codeKey)
+		require.NoError(t, err)
+		require.True(t, has)
+
+		require.NoError(t, batch.Write())
+
+		has, err = db.Has(preimageKey[:])
+		require.NoError(t, err)
+		require.True(t, has)
+		require.Equal(t, 2, kv.puts)
+	})
+	t.Run("Batch-Reset", func(t *testing.T) {
+		kv := &mockKV{data: make(map[common.Hash][]byte)}
+		db := NewL2KeyValueStore(kv)
+		batch := db.NewBatch()
+		require.NoError(t, batch.Put(preimageKey[:], value))
+		require.NoError(t, batch.Put(codeKey, codeValue))
+		batch.Reset()
+
+		require.NoError(t, batch.Write())
+		require.Zero(t, kv.puts)
+
+		require.Equal(t, 0, batch.ValueSize())
+		preimageKey2 := common.HexToHash("0xdead2")
+		require.NoError(t, batch.Put(preimageKey2[:], value))
+		require.NoError(t, batch.Write())
+		require.Equal(t, 1, kv.puts)
+	})
+	t.Run("Batch-Replay", func(t *testing.T) {
+		kv := &mockKV{data: make(map[common.Hash][]byte)}
+		db := NewL2KeyValueStore(kv)
+		batch := db.NewBatch()
+		require.NoError(t, batch.Put(preimageKey[:], value))
+		require.NoError(t, batch.Put(codeKey, codeValue))
+
+		writer := &mockWriter{data: make(map[common.Hash][]byte)}
+		require.NoError(t, batch.Replay(writer))
+		require.Zero(t, kv.puts)
+		require.Zero(t, kv.gets)
+		require.Equal(t, 2, writer.puts)
+		require.Equal(t, value, writer.data[preimageKey])
+		// this is the raw code key, not the code preimage key
+		require.Equal(t, codeValue, writer.data[common.Hash(codeKey)])
+	})
+}
+
+type mockKV struct {
+	puts int
+	gets int
+	data map[common.Hash][]byte
+}
+
+func (k *mockKV) Put(key common.Hash, value []byte) error {
+	k.puts++
+	k.data[key] = value
+	return nil
+}
+
+func (k *mockKV) Get(key common.Hash) ([]byte, error) {
+	k.gets++
+	return k.data[key], nil
+}
+
+func (k *mockKV) Close() error {
+	return nil
+}
+
+type mockWriter struct {
+	puts    int
+	deletes int
+	data    map[common.Hash][]byte
+}
+
+func (w *mockWriter) Put(key []byte, value []byte) error {
+	w.puts++
+	w.data[common.Hash(key)] = value
+	return nil
+}
+
+func (w *mockWriter) Delete(key []byte) error {
+	w.deletes++
+	delete(w.data, common.Hash(key))
+	return nil
+}

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-program/host/flags"
@@ -112,6 +113,7 @@ func (p *programExecutor) RunProgram(
 	prefetcher hostcommon.Prefetcher,
 	blockNum uint64,
 	chainID eth.ChainID,
+	db l2.KeyValueStore,
 ) error {
 	newCfg := *p.cfg
 	newCfg.L2ChainID = chainID
@@ -122,7 +124,7 @@ func (p *programExecutor) RunProgram(
 			// TODO(#13663): prevent recursive block execution
 			return prefetcher, nil
 		})
-	return hostcommon.FaultProofProgram(ctx, p.logger, &newCfg, withPrefetcher, hostcommon.WithSkipValidation(true))
+	return hostcommon.FaultProofProgram(ctx, p.logger, &newCfg, withPrefetcher, hostcommon.WithSkipValidation(true), hostcommon.WithDB(db))
 }
 
 func MakeProgramExecutor(logger log.Logger, cfg *config.Config) prefetcher.ProgramExecutor {

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -994,13 +994,15 @@ type mockExecutor struct {
 	invoked     bool
 	blockNumber uint64
 	chainID     eth.ChainID
+	db          l2.KeyValueStore
 }
 
 func (m *mockExecutor) RunProgram(
-	ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID) error {
+	ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID, db l2.KeyValueStore) error {
 	m.invoked = true
 	m.blockNumber = blockNumber
 	m.chainID = chainID
+	m.db = db
 	return nil
 }
 

--- a/op-program/host/prefetcher/reexec.go
+++ b/op-program/host/prefetcher/reexec.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -15,7 +16,7 @@ import (
 
 type ProgramExecutor interface {
 	// RunProgram derives the block at the specified blockNumber
-	RunProgram(ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID) error
+	RunProgram(ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID, db l2.KeyValueStore) error
 }
 
 // nativeReExecuteBlock is a helper function that re-executes a block natively.
@@ -56,7 +57,7 @@ func (p *Prefetcher) nativeReExecuteBlock(
 		return err
 	}
 	p.logger.Info("Re-executing block", "block_hash", blockHash, "block_number", header.NumberU64())
-	if err = p.executor.RunProgram(ctx, p, header.NumberU64()+1, chainID); err != nil {
+	if err = p.executor.RunProgram(ctx, p, header.NumberU64()+1, chainID, hostcommon.NewL2KeyValueStore(p.kvStore)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Make sure that the block data hint route persists all block data, including trie nodes in the host. Otherwise, the interop client won't be able to lookup, for example, receipts preimages needed for the consolidation step of the fault proof.

part of https://github.com/ethereum-optimism/optimism/issues/14020