### PR TITLE
challenger: Transition to invalid hash at superroot boundaries

### DIFF
--- a/op-challenger/game/fault/trace/super/provider.go
+++ b/op-challenger/game/fault/trace/super/provider.go
@@ -87,7 +87,7 @@ func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Pos
 		return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", timestamp, err)
 	}
 	if prevRoot.CrossSafeDerivedFrom.Number > s.l1Head.Number {
-		// The previous root was not safe at this timestamp so we must have already transitioned to the invalid hash
+		// The previous root was not safe at the game L1 head so we must have already transitioned to the invalid hash
 		// prior to this step and it then repeats forever.
 		return InvalidTransition, nil
 	}

--- a/op-challenger/game/fault/trace/super/provider.go
+++ b/op-challenger/game/fault/trace/super/provider.go
@@ -76,12 +76,20 @@ func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Pos
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", timestamp, err)
 		}
+		if root.CrossSafeDerivedFrom.Number > s.l1Head.Number {
+			return InvalidTransition, nil
+		}
 		return responseToSuper(root).Marshal(), nil
 	}
 	// Fetch the super root at the next timestamp since we are part way through the transition to it
 	prevRoot, err := s.rootProvider.SuperRootAtTimestamp(ctx, hexutil.Uint64(timestamp))
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", timestamp, err)
+	}
+	if prevRoot.CrossSafeDerivedFrom.Number > s.l1Head.Number {
+		// The previous root was not safe at this timestamp so we must have already transitioned to the invalid hash
+		// prior to this step and it then repeats forever.
+		return InvalidTransition, nil
 	}
 	nextTimestamp := timestamp + 1
 	nextRoot, err := s.rootProvider.SuperRootAtTimestamp(ctx, hexutil.Uint64(nextTimestamp))


### PR DESCRIPTION
**Description**

Update the challenger to check the CrossSafeDerivedFrom field of super root responses to determine if the claim is unsafe. 
Doesn't yet handle transitioning at the first optimistic block that is unsafe because we will need to know what block number needs to be safe for each chain at the next timestamp to calculate that. Currently the challenger doesn't ever parse the rollup config so it doesn't have that info - will need some more plumbing to actually load rollup configs (we have them available as we pass them through to op-program).

**Tests**

Added unit tests.  This doesn't get any more action tests passing as the chains aren't actually long enough to hit these cases.  Will need to improve the action tests but avoiding conflicts with other PRs for now.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/13903