### PR TITLE
fix: AltDA commitment test

### DIFF
--- a/op-alt-da/commitment_test.go
+++ b/op-alt-da/commitment_test.go
@@ -81,4 +81,3 @@ func TestCommitmentData(t *testing.T) {
 		})
 	}
 }
-

--- a/op-alt-da/commitment_test.go
+++ b/op-alt-da/commitment_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive/params"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
+
+func encodeCommitmentData(commitmentType CommitmentType, data []byte) []byte {
+	return append([]byte{byte(commitmentType)}, data...)
+}
 
 // TestCommitmentData tests the CommitmentData type and its implementations,
 // by encoding and decoding the commitment data and verifying the input data.
@@ -14,39 +19,48 @@ func TestCommitmentData(t *testing.T) {
 	type tcase struct {
 		name        string
 		commType    CommitmentType
+		commInput   []byte
 		commData    []byte
 		expectedErr error
 	}
+
+	input := []byte{0}
+	hash := crypto.Keccak256(input)
 
 	testCases := []tcase{
 		{
 			name:        "valid keccak256 commitment",
 			commType:    Keccak256CommitmentType,
-			commData:    []byte("abcdefghijklmnopqrstuvwxyz012345"),
-			expectedErr: ErrInvalidCommitment,
+			commInput:   input,
+			commData:    encodeCommitmentData(Keccak256CommitmentType, hash),
+			expectedErr: nil,
 		},
 		{
 			name:        "invalid keccak256 commitment",
 			commType:    Keccak256CommitmentType,
-			commData:    []byte("ab_baddata_yz012345"),
+			commInput:   input,
+			commData:    encodeCommitmentData(Keccak256CommitmentType, []byte("ab_baddata_yz012345")),
 			expectedErr: ErrInvalidCommitment,
 		},
 		{
 			name:        "valid generic commitment",
 			commType:    GenericCommitmentType,
-			commData:    []byte("any length of data! wow, that's so generic!"),
-			expectedErr: ErrInvalidCommitment,
+			commInput:   []byte("any input works"),
+			commData:    encodeCommitmentData(GenericCommitmentType, []byte("any length of data! wow, that's so generic!")),
+			expectedErr: nil, // This should actually be valid now
 		},
 		{
 			name:        "invalid commitment type",
 			commType:    9,
-			commData:    []byte("abcdefghijklmnopqrstuvwxyz012345"),
+			commInput:   []byte("some input"),
+			commData:    encodeCommitmentData(CommitmentType(9), []byte("abcdefghijklmnopqrstuvwxyz012345")),
 			expectedErr: ErrInvalidCommitment,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Log(tc.commData)
 			comm, err := DecodeCommitmentData(tc.commData)
 			require.ErrorIs(t, err, tc.expectedErr)
 			if err == nil {
@@ -58,7 +72,7 @@ func TestCommitmentData(t *testing.T) {
 				require.Equal(t, append([]byte{params.DerivationVersion1}, tc.commData...), comm.TxData())
 
 				// Test that Verify() returns no error for the correct data
-				require.NoError(t, comm.Verify(tc.commData))
+				require.NoError(t, comm.Verify(tc.commInput))
 				// Test that Verify() returns error for the incorrect data
 				// don't do this for GenericCommitmentType, which does not do any verification
 				if tc.commType != GenericCommitmentType {
@@ -68,3 +82,4 @@ func TestCommitmentData(t *testing.T) {
 		})
 	}
 }
+

--- a/op-alt-da/commitment_test.go
+++ b/op-alt-da/commitment_test.go
@@ -60,7 +60,6 @@ func TestCommitmentData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Log(tc.commData)
 			comm, err := DecodeCommitmentData(tc.commData)
 			require.ErrorIs(t, err, tc.expectedErr)
 			if err == nil {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes the test in `commitment_test.go`. Before, it wasn't really testing anything.

**Tests**

Only modified the existing `TestCommitmentData` test to now correctly encode commitments and check against real inputs.

