### PR TITLE
supervisor: Do not Filter on ChainID When Triggering Chain Processors

### DIFF
--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -132,11 +132,8 @@ type CrossSafeWorker struct {
 }
 
 func (c *CrossSafeWorker) OnEvent(ev event.Event) bool {
-	switch x := ev.(type) {
+	switch ev.(type) {
 	case superevents.UpdateCrossSafeRequestEvent:
-		if x.ChainID != c.chainID {
-			return false
-		}
 		if err := CrossSafeUpdate(c.logger, c.chainID, c.d); err != nil {
 			if errors.Is(err, types.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -79,11 +79,8 @@ type CrossUnsafeWorker struct {
 }
 
 func (c *CrossUnsafeWorker) OnEvent(ev event.Event) bool {
-	switch x := ev.(type) {
+	switch ev.(type) {
 	case superevents.UpdateCrossUnsafeRequestEvent:
-		if x.ChainID != c.chainID {
-			return false
-		}
 		if err := CrossUnsafeUpdate(c.logger, c.chainID, c.d); err != nil {
 			if errors.Is(err, types.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)


### PR DESCRIPTION
A change to any Chain DB can create a cascading update to any other Chain DB, for both Unsafe and Safe updates.

Therefore, Chain Processors in the `cross` package should not filter their work based on the ChainID of the database which was updated.

This issue was originally discovered by @Inphi during test development.