### PR TITLE
fix: load state from allocs logic

### DIFF
--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -77,12 +77,11 @@ contract ForkLive is Deployer {
         }
 
         // Now upgrade the contracts (if the config is set to do so)
-        if (cfg.useUpgradedFork()) {
-            require(!useOpsRepo, "ForkLive: cannot upgrade and use ops repo");
+        if (useOpsRepo) {
+            console.log("ForkLive: using ops repo to upgrade");
+        } else if (cfg.useUpgradedFork()) {
             console.log("ForkLive: upgrading");
             _upgrade();
-        } else if (useOpsRepo) {
-            console.log("ForkLive: using ops repo to upgrade");
         }
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
When useOpsRepo is set to true `ForkLive:run()` reverted with `ForkLive: cannot upgrade and use ops repo`. This PR fixes this issue.
<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
