### PR TITLE
op-node: change default L1 cache size to 900

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -182,8 +182,13 @@ var (
 	L1CacheSize = &cli.UintFlag{
 		Name: "l1.cache-size",
 		Usage: "Cache size for blocks, receipts and transactions. " +
-			"It's optional and a sane default of 3/2 the sequencing window size is used if this field is set to 0.",
+			"If this flag is set to 0, 2/3 of the sequencing window size is used (usually 2400). " +
+			"The default value of 900 (~3h of L1 blocks) is good for (high-throughput) networks that see frequent safe head increments. " +
+			"On (low-throughput) networks with infrequent safe head increments, it is recommended to set this value to 0, " +
+			"or a value that well covers the typical span between safe head increments. " +
+			"Note that higher values will cause significantly increased memory usage.",
 		EnvVars:  prefixEnvVars("L1_CACHE_SIZE"),
+		Value:    900, // ~3h of L1 blocks
 		Category: L1RPCCategory,
 	}
 	L1HTTPPollInterval = &cli.DurationFlag{


### PR DESCRIPTION
In #13772, the L1 cache size was made configurable and the cap of 1000 was removed. This implied that the old default value (before applying the cap) of 2/3 the sequencing window was now active.

However, high-throughput chains don't need such a high cache size under normal conditions, so memory usage unexpectedly jumped for most node operators.

This PR adds back a lower default value of 900, which is a better default for most nodes. Only low-throughput chains with infrequent safe head increments can now use this flag to set a higher value.
