### PR TITLE
interop: Fix Step Scheduling Delay

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -343,6 +343,8 @@ func (s *SyncDeriver) OnEvent(ev event.Event) bool {
 		s.Emitter.Emit(StepReqEvent{ResetBackoff: true})
 	case engine.SafeDerivedEvent:
 		s.onSafeDerivedBlock(x)
+	case derive.ProvideL1Traversal:
+		s.Emitter.Emit(StepReqEvent{})
 	default:
 		return false
 	}


### PR DESCRIPTION
In local observation, the `op-node` derivation falls behind the L1 tip:

> Finalized L1 block is newer than the latest L1 for this chain. Assuming latest L2 

This log message indicates that the finalization known to the Supervisor exceeds the tip of the L2 validation done by the node. And over time, the difference in value between L2 tip and Finalization grows steadily.

This was due to the Step Scheduling system in the OP Node Driver, where intentional delays are used to keep the node from running hot when it processes all the L1 content it has. When connected to a Supervisor, it is the Supervisor who knows where the L1 tip truly is, and can feed more information to the OP Node readily.

The solution here is - Use the emitted `ProvideL1Traversal` in the Driver to emit a `StepReqEvent`, which allows the Driver to make immediate progress instead of waiting the scheduled time.

**Testing**:
- This issue was discovered manually by running Kurtosis locally, where the above log message would appear within 5 minutes of runtime, and steadily grow.
- The resolution is also manual - I ran the network with these fixes and observed that the message about Finalization never occurs even over a long period (30min at this point)