### PR TITLE
Enable AltDA unit tests in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1419,7 +1419,7 @@ workflows:
           requires: ["contracts-bedrock-build"]
       - go-tests:
           packages: |
-            op-altda
+            op-alt-da
             op-batcher
             op-chain-ops
             op-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1419,6 +1419,7 @@ workflows:
           requires: ["contracts-bedrock-build"]
       - go-tests:
           packages: |
+            op-altda
             op-batcher
             op-chain-ops
             op-node


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds op-altda package to circleci config.

**Additional context**

Currently altda unit tests are not being ran in the ci, and one of them was actually failing, so we should probably enable them to prevent this from happening.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

- Fixes #14054 

