### PR TITLE
fix: op-deployer bump to comply with latest optimism-package

### DIFF
--- a/kurtosis-devnet/mini.yaml
+++ b/kurtosis-devnet/mini.yaml
@@ -46,7 +46,7 @@ optimism_package:
         builder_port: ""
       additional_services: []
   op_contract_deployer_params:
-    image: opsigma/op-deployer:v0.0.7-http
+    image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.11"
     l1_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-9af7366a7102f51e8dbe451dcfa22971131d89e218915c91f420a164cc48be65.tar.gz
     l2_artifacts_locator: https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-9af7366a7102f51e8dbe451dcfa22971131d89e218915c91f420a164cc48be65.tar.gz
   global_log_level: "info"


### PR DESCRIPTION
**Description**

A bump in op-deployer image is needed to successfully deploy using
current optimism-package.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
