### PR TITLE
Fix cannon e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,6 +972,13 @@ jobs:
           command: make op-program-client
           working_directory: op-program
       - run:
+          name: build op-program-host
+          command: make op-program-host
+          working_directory: op-program
+      - run:
+          name: build cannon
+          command: make cannon
+      - run:
           name: run tests
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1096,24 +1096,22 @@ jobs:
           command: |
             # Use the actual hash for tags (hash can be found by reading releases.json)
             PRESTATE_HASH=$(jq -r .pre ./op-program/bin/prestate-proof.json)
-            PRESTATE_MT_HASH=$(jq -r .pre ./op-program/bin/prestate-proof-mt.json)
+            PRESTATE_MT64_HASH=$(jq -r .pre ./op-program/bin/prestate-proof-mt64.json)
             PRESTATE_INTEROP_HASH=$(jq -r .pre ./op-program/bin/prestate-proof-interop.json)
 
             BRANCH_NAME=$(echo "<< pipeline.git.branch >>" | tr '/' '-')
-            echo "Publishing ${PRESTATE_HASH}, ${PRESTATE_MT_HASH}, ${PRESTATE_INTEROP_HASH} as ${BRANCH_NAME}"
+            echo "Publishing ${PRESTATE_HASH}, ${PRESTATE_MT64_HASH}, ${PRESTATE_INTEROP_HASH} as ${BRANCH_NAME}"
             if [[ "" != "<< pipeline.git.branch >>" ]]
             then
               # Use the branch name for branches to provide a consistent URL
               PRESTATE_HASH="${BRANCH_NAME}"
-              PRESTATE_MT_HASH="${BRANCH_NAME}"
+              PRESTATE_MT64_HASH="${BRANCH_NAME}"
               PRESTATE_INTEROP_HASH="${BRANCH_NAME}"
             fi
             gsutil cp ./op-program/bin/prestate.bin.gz \
               "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_HASH}.bin.gz"
-            gsutil cp ./op-program/bin/prestate-mt.bin.gz \
-              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_MT_HASH}-mt.bin.gz"
             gsutil cp ./op-program/bin/prestate-mt64.bin.gz \
-              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_MT_HASH}-mt64.bin.gz"
+              "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_MT64_HASH}-mt64.bin.gz"
             gsutil cp ./op-program/bin/prestate-interop.bin.gz \
               "gs://oplabs-network-data/proofs/op-program/cannon/${PRESTATE_INTEROP_HASH}-interop.bin.gz"
       - notify-failures-on-develop:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1696,7 +1696,7 @@ workflows:
           resource_class: ethereum-optimism/latitude-fps-1
           environment_overrides: |
             export OP_E2E_CANNON_ENABLED="true"
-            export PARALLEL=8
+            export PARALLEL=24
           packages: |
             op-e2e/faultproofs
           context:

--- a/Makefile
+++ b/Makefile
@@ -135,15 +135,15 @@ reproducible-prestate:   ## Builds reproducible-prestate binary
 .PHONY: reproducible-prestate
 
 # Include any files required for the devnet to build and run.
-DEVNET_CANNON_PRESTATE_FILES := op-program/bin/prestate-proof.json op-program/bin/prestate.bin.gz op-program/bin/prestate-proof-mt.json op-program/bin/prestate-mt.bin.gz op-program/bin/prestate-interop.bin.gz
+DEVNET_CANNON_PRESTATE_FILES := op-program/bin/prestate-proof.json op-program/bin/prestate.bin.gz op-program/bin/prestate-proof-mt64.json op-program/bin/prestate-mt64.bin.gz op-program/bin/prestate-interop.bin.gz
 
 
 $(DEVNET_CANNON_PRESTATE_FILES):
 	make cannon-prestate
-	make cannon-prestate-mt
+	make cannon-prestate-mt64
 	make cannon-prestate-interop
 
-cannon-prestates: cannon-prestate cannon-prestate-mt cannon-prestate-interop
+cannon-prestates: cannon-prestate cannon-prestate-mt64 cannon-prestate-interop
 .PHONY: cannon-prestates
 
 cannon-prestate: op-program cannon ## Generates prestate using cannon and op-program
@@ -152,11 +152,11 @@ cannon-prestate: op-program cannon ## Generates prestate using cannon and op-pro
 	mv op-program/bin/0.json op-program/bin/prestate-proof.json
 .PHONY: cannon-prestate
 
-cannon-prestate-mt: op-program cannon ## Generates prestate using cannon and op-program in the latest 64-bit multithreaded cannon format
-	./cannon/bin/cannon load-elf --type multithreaded64-3 --path op-program/bin/op-program-client64.elf --out op-program/bin/prestate-mt.bin.gz --meta op-program/bin/meta-mt.json
-	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate-mt.bin.gz --meta op-program/bin/meta-mt.json --proof-fmt 'op-program/bin/%d-mt.json' --output ""
-	mv op-program/bin/0-mt.json op-program/bin/prestate-proof-mt.json
-.PHONY: cannon-prestate-mt
+cannon-prestate-mt64: op-program cannon ## Generates prestate using cannon and op-program in the latest 64-bit multithreaded cannon format
+	./cannon/bin/cannon load-elf --type multithreaded64-3 --path op-program/bin/op-program-client64.elf --out op-program/bin/prestate-mt64.bin.gz --meta op-program/bin/meta-mt64.json
+	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate-mt64.bin.gz --meta op-program/bin/meta-mt64.json --proof-fmt 'op-program/bin/%d-mt64.json' --output ""
+	mv op-program/bin/0-mt64.json op-program/bin/prestate-proof-mt64.json
+.PHONY: cannon-prestate-mt64
 
 cannon-prestate-interop: op-program cannon ## Generates interop prestate using cannon and op-program in the latest 64-bit multithreaded cannon format
 	./cannon/bin/cannon load-elf --type multithreaded64-3 --path op-program/bin/op-program-client-interop.elf --out op-program/bin/prestate-interop.bin.gz --meta op-program/bin/meta-interop.json

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101412.1-rc.1
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101412.1-rc.2
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101412.1-rc.1 h1:xXsoOKpgChoUfrzml9QTKdFTDnRAGMsZoQ/FyihJAh0=
-github.com/ethereum-optimism/op-geth v1.101412.1-rc.1/go.mod h1:vgZU+rg5NYY/Dfs7oqjWxTBSrHZkHaSPd/HiZWNcw4o=
+github.com/ethereum-optimism/op-geth v1.101412.1-rc.2 h1:FNODVTV/CMOWvzV9GGPQIkxpFeHJb+3rfQc9NWbjYIY=
+github.com/ethereum-optimism/op-geth v1.101412.1-rc.2/go.mod h1:vgZU+rg5NYY/Dfs7oqjWxTBSrHZkHaSPd/HiZWNcw4o=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/kurtosis-devnet/pkg/deploy/prestate.go
+++ b/kurtosis-devnet/pkg/deploy/prestate.go
@@ -53,7 +53,6 @@ func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
 	fileToKey := map[string]string{
 		"prestate-proof.json":         "prestate",
 		"prestate-proof-mt64.json":    "prestate_mt64",
-		"prestate-proof-mt.json":      "prestate_mt",
 		"prestate-proof-interop.json": "prestate_interop",
 	}
 

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -40,8 +40,8 @@ test-fault-proofs: pre-test
 
 cannon-prestates:
 	make -C .. cannon-prestate
-	make -C .. cannon-prestate-mt
-.PHONY: cannon-prestate
+	make -C .. cannon-prestate-mt64
+.PHONY: cannon-prestates
 
 
 pre-test: pre-test-cannon

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -530,7 +530,7 @@ func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
 		once = &cannonPrestateSTOnce
 		cacheVar = &cannonPrestateST
 	} else {
-		filename = "prestate-proof-mt.json"
+		filename = "prestate-proof-mt64.json"
 		once = &cannonPrestateMTOnce
 		cacheVar = &cannonPrestateMT
 	}

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -126,8 +126,8 @@ func applyCannonConfig(c *config.Config, t *testing.T, rollupCfg *rollup.Config,
 	c.Cannon.VmBin = root + "cannon/bin/cannon"
 	c.Cannon.Server = root + "op-program/bin/op-program"
 	if allocType == e2econfig.AllocTypeMTCannon {
-		t.Log("Using MT-Cannon absolute prestate")
-		c.CannonAbsolutePreState = root + "op-program/bin/prestate-mt.bin.gz"
+		t.Log("Using Cannon64 absolute prestate")
+		c.CannonAbsolutePreState = root + "op-program/bin/prestate-mt64.bin.gz"
 	} else {
 		c.CannonAbsolutePreState = root + "op-program/bin/prestate.bin.gz"
 	}

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -34,16 +34,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-pro
 
 # Run the op-program-client.elf binary directly through cannon's load-elf subcommand.
 RUN /app/cannon/bin/cannon load-elf --type singlethreaded-2 --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate.bin.gz --meta "/app/op-program/bin/meta.json"
-RUN /app/cannon/bin/cannon load-elf --type multithreaded-2 --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate-mt.bin.gz --meta "/app/op-program/bin/meta-mt.json"
 RUN /app/cannon/bin/cannon load-elf --type multithreaded64-3 --path /app/op-program/bin/op-program-client64.elf --out /app/op-program/bin/prestate-mt64.bin.gz --meta "/app/op-program/bin/meta-mt64.json"
 RUN /app/cannon/bin/cannon load-elf --type multithreaded64-3 --path /app/op-program/bin/op-program-client-interop.elf --out /app/op-program/bin/prestate-interop.bin.gz --meta "/app/op-program/bin/meta-interop.json"
 
 # Generate the prestate proof containing the absolute pre-state hash.
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d.json' --output ""
 RUN mv /app/op-program/bin/0.json /app/op-program/bin/prestate-proof.json
-
-RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt.json' --output ""
-RUN mv /app/op-program/bin/0-mt.json /app/op-program/bin/prestate-proof-mt.json
 
 RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt64.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt64.json' --output ""
 RUN mv /app/op-program/bin/0-mt64.json /app/op-program/bin/prestate-proof-mt64.json
@@ -56,7 +52,6 @@ RUN mv /app/op-program/bin/0-interop.json /app/op-program/bin/prestate-proof-int
 # e.g. `BUILDKIT=1 docker build ...`
 FROM scratch AS export-stage-proofs
 COPY --from=builder /app/op-program/bin/prestate-proof.json .
-COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .
 COPY --from=builder /app/op-program/bin/prestate-proof-interop.json .
 
@@ -66,9 +61,6 @@ COPY --from=builder /app/op-program/bin/op-program-client64.elf .
 COPY --from=builder /app/op-program/bin/meta.json .
 COPY --from=builder /app/op-program/bin/prestate.bin.gz .
 COPY --from=builder /app/op-program/bin/prestate-proof.json .
-COPY --from=builder /app/op-program/bin/meta-mt.json .
-COPY --from=builder /app/op-program/bin/prestate-mt.bin.gz .
-COPY --from=builder /app/op-program/bin/prestate-proof-mt.json .
 COPY --from=builder /app/op-program/bin/meta-mt64.json .
 COPY --from=builder /app/op-program/bin/prestate-mt64.bin.gz .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -51,8 +51,6 @@ reproducible-prestate:
 	@docker build --output ./bin/ --progress plain -f Dockerfile.repro ../
 	@echo "Cannon Absolute prestate hash: "
 	@cat ./bin/prestate-proof.json | jq -r .pre
-	@echo "MT-Cannon Absolute prestate hash: "
-	@cat ./bin/prestate-proof-mt.json | jq -r .pre
 	@echo "Cannon64 Absolute prestate hash: "
 	@cat ./bin/prestate-proof-mt64.json | jq -r .pre
 	@echo "CannonInterop Absolute prestate hash: "

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -688,14 +688,14 @@ contract Deploy is Deployer {
         );
     }
 
-    /// @notice Loads the multithreaded mips absolute prestate from the prestate-proof-mt for devnets otherwise
+    /// @notice Loads the multithreaded mips absolute prestate from the prestate-proof-mt64 for devnets otherwise
     ///         from the config.
     function _loadDevnetMtMipsAbsolutePrestate() internal returns (Claim mipsAbsolutePrestate_) {
         // Fetch the absolute prestate dump
-        string memory filePath = string.concat(vm.projectRoot(), "/../../op-program/bin/prestate-proof-mt.json");
+        string memory filePath = string.concat(vm.projectRoot(), "/../../op-program/bin/prestate-proof-mt64.json");
         if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo \"present\""))).length == 0) {
             revert(
-                "Deploy: MT-Cannon prestate dump not found, generate it with `make cannon-prestate-mt` in the monorepo root"
+                "Deploy: MT-Cannon prestate dump not found, generate it with `make cannon-prestate-mt64` in the monorepo root"
             );
         }
         mipsAbsolutePrestate_ =


### PR DESCRIPTION
**Description**

* Builds `op-program-host` and `cannon` for go tests as `make reproducible-prestate` will not build them locally
* Stop building 32-bit multithreaded cannon prestates as they are not used and will not be shipped to production
* Consistently build 64-bit multithreaded cannon prestates with -mt64 suffix.
* Update op-geth to include https://github.com/ethereum-optimism/op-geth/pull/482 and avoid loading all genesis files

Replaces https://github.com/ethereum-optimism/optimism/pull/14016 with a cleaned up change history.