### PR TITLE
Fix Grammatical and Spelling Errors in Comments

### DIFF
--- a/op-service/eth/heads.go
+++ b/op-service/eth/heads.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// HeadSignalFn is used as callback function to accept head-signals
+// HeadSignalFn is used as a callback function to accept head-signals
 type HeadSignalFn func(ctx context.Context, sig L1BlockRef)
 
 type NewHeadSource interface {

--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -94,7 +94,7 @@ func (id L1BlockRef) ParentID() BlockID {
 	}
 }
 
-// BlockRef is a Block Ref indepdendent of L1 or L2
+// BlockRef is a Block Ref independent of L1 or L2
 // Because L1BlockRefs are strict subsets of L2BlockRefs, BlockRef is a direct alias of L1BlockRef
 type BlockRef = L1BlockRef
 

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -50,9 +50,9 @@ func TransactionsToHashes(elems []*types.Transaction) []common.Hash {
 	return out
 }
 
-// CheckRecentTxs checks the depth recent blocks for txs from the account with address addr
+// CheckRecentTxs checks the depth of recent blocks for txs from the account with address addr
 // and returns either:
-//   - blockNum containing the last tx and true if any was found
+//   - blockNum containing the last tx and true if any were found
 //   - the oldest block checked and false if no nonce change was found
 func CheckRecentTxs(
 	ctx context.Context,


### PR DESCRIPTION
Fix Grammatical and Spelling Errors in Comments

Reason: Added "a" for grammatical correctness.
Reason: Corrected spelling of "indepdendent" to "independent."
Reason: Added "of" for grammatical correctness.
Reason: Changed "was" to "were" for subject-verb agreement.

