### PR TITLE
ci: Run mips-linux-gnu-objdump outside of the shell pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1038,7 +1038,9 @@ jobs:
           command: make op-program
       - run:
           name: Sanitize op-program client
-          command: make -f cannon/Makefile sanitize-program GUEST_PROGRAM=op-program/bin/op-program-client.elf
+          command: make sanitize-program GUEST_PROGRAM=../op-program/bin/op-program-client.elf
+          working_directory: cannon
+
 
   cannon-prestate-quick:
     machine: true

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -50,7 +50,8 @@ elf:
 	make -C ./testdata/example elf
 
 sanitize-program:
-	@if ! { mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM | awk '{print $$3}' | grep -Ew -m1 "$(UNSUPPORTED_OPCODES)"; }; then \
+	mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM > ./bin/dump.txt
+	@if ! { cat ./bin/dump.txt | awk '{print $$3}' | grep -Ew -m1 "$(UNSUPPORTED_OPCODES)"; }; then \
 		echo "guest program is sanitized for unsupported instructions"; \
 	else \
 		echo "found unsupported instructions in the guest program"; \


### PR DESCRIPTION
**Description**

Ensures the build fails if it is not available or has non-zero exit code rather than just checking for unsupported op codes in the error message.

Also run make from within `cannon` so paths are more predictable (make doesn't automatically change the working directory).