### PR TITLE
op-program: Fix config validation for interop

### DIFF
--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -251,6 +251,16 @@ func TestL2Head(t *testing.T) {
 		require.Equal(t, common.HexToHash(l2HeadValue), cfg.L2Head)
 	})
 
+	t.Run("NotRequiredForInterop", func(t *testing.T) {
+		req := requiredArgs()
+		delete(req, "--l2.head")
+		delete(req, "--l2.outputroot")
+		args := append(toArgList(req), "--l2.agreed-prestate", "0x1234")
+		cfg := configForArgs(t, args)
+		require.Equal(t, common.Hash{}, cfg.L2Head)
+		require.True(t, cfg.InteropEnabled)
+	})
+
 	t.Run("Invalid", func(t *testing.T) {
 		verifyArgsInvalid(t, config.ErrInvalidL2Head.Error(), replaceRequiredArg("--l2.head", "something"))
 	})

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -113,7 +113,7 @@ func (c *Config) Check() error {
 	if c.L1Head == (common.Hash{}) {
 		return ErrInvalidL1Head
 	}
-	if c.L2Head == (common.Hash{}) {
+	if !c.InteropEnabled && c.L2Head == (common.Hash{}) {
 		return ErrInvalidL2Head
 	}
 	if c.L2OutputRoot == (common.Hash{}) {
@@ -240,6 +240,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	}
 	var l2OutputRoot common.Hash
 	var agreedPrestate []byte
+	var interopEnabled bool
 	if ctx.IsSet(flags.L2OutputRoot.Name) {
 		l2OutputRoot = common.HexToHash(ctx.String(flags.L2OutputRoot.Name))
 	} else if ctx.IsSet(flags.L2AgreedPrestate.Name) {
@@ -249,6 +250,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 			return nil, ErrInvalidAgreedPrestate
 		}
 		l2OutputRoot = crypto.Keccak256Hash(agreedPrestate)
+		interopEnabled = true
 	}
 	if l2OutputRoot == (common.Hash{}) {
 		return nil, ErrInvalidL2OutputRoot
@@ -346,6 +348,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		L1RPCKind:          sources.RPCProviderKind(ctx.String(flags.L1RPCProviderKind.Name)),
 		ExecCmd:            ctx.String(flags.Exec.Name),
 		ServerMode:         ctx.Bool(flags.Server.Name),
+		InteropEnabled:     interopEnabled,
 	}, nil
 }
 

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -83,11 +83,20 @@ func TestL1HeadRequired(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidL1Head)
 }
 
-func TestL2HeadRequired(t *testing.T) {
-	config := validConfig()
-	config.L2Head = common.Hash{}
-	err := config.Check()
-	require.ErrorIs(t, err, ErrInvalidL2Head)
+func TestL2Head(t *testing.T) {
+	t.Run("RequiredPreInterop", func(t *testing.T) {
+		config := validConfig()
+		config.L2Head = common.Hash{}
+		err := config.Check()
+		require.ErrorIs(t, err, ErrInvalidL2Head)
+	})
+
+	t.Run("NotRequiredForInterop", func(t *testing.T) {
+		config := validInteropConfig()
+		config.L2Head = common.Hash{}
+		err := config.Check()
+		require.NoError(t, err)
+	})
 }
 
 func TestL2OutputRootRequired(t *testing.T) {


### PR DESCRIPTION
**Description**

Ensure InteropEnabled is set when --agreed-prestate is set.
Don't require L2 head to be set when interop enabled.

Fixes a corner case which made it impossible to run op-program from the CLI - action tests run it in-process so create the config directly.