### PR TITLE
op-program: Explicit interop configuration in host

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -214,11 +214,12 @@ func NewOpProgramCfg(
 		chainConfigs = append(chainConfigs, source.ChainConfig)
 	}
 
-	dfault := config.NewConfig(rollupConfigs, chainConfigs, fi.L1Head, fi.L2Head, fi.L2OutputRoot, fi.L2Claim, fi.L2BlockNumber)
-	dfault.L2ChainID = boot.CustomChainIDIndicator
+	var dfault *config.Config
 	if fi.InteropEnabled {
-		dfault.AgreedPrestate = fi.AgreedPrestate
+		dfault = config.NewInteropConfig(rollupConfigs, chainConfigs, fi.L1Head, fi.L2OutputRoot, fi.AgreedPrestate, fi.L2Claim, fi.L2BlockNumber)
+	} else {
+		dfault = config.NewConfig(rollupConfigs, chainConfigs, fi.L1Head, fi.L2Head, fi.L2OutputRoot, fi.L2Claim, fi.L2BlockNumber)
+		dfault.PreInteropInputs.L2ChainID = boot.CustomChainIDIndicator
 	}
-	dfault.InteropEnabled = fi.InteropEnabled
 	return dfault
 }

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -124,5 +124,12 @@ func CreateInprocessPrefetcher(
 	require.NoError(t, err, "failed to create L2 client")
 
 	executor := host.MakeProgramExecutor(logger, cfg)
-	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, fixtureInputs.L2ChainID, sources, kv, executor, cfg.L2Head, cfg.AgreedPrestate), nil
+	var l2Head common.Hash
+	var agreedPrestate []byte
+	if cfg.InteropEnabled() {
+		agreedPrestate = cfg.InteropInputs.AgreedPrestate
+	} else {
+		l2Head = cfg.PreInteropInputs.L2Head
+	}
+	return prefetcher.NewPrefetcher(logger, l1Cl, l1BlobFetcher, fixtureInputs.L2ChainID, sources, kv, executor, l2Head, agreedPrestate), nil
 }

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -17,6 +17,7 @@ func RunPreInteropProgram(
 	l2PreimageOracle *l2.CachingOracle,
 	db l2.KeyValueStore,
 	opts tasks.DerivationOptions,
+	validateClaim bool,
 ) error {
 	logger.Info("Program Bootstrapped", "bootInfo", bootInfo)
 	result, err := tasks.RunDerivation(
@@ -34,5 +35,8 @@ func RunPreInteropProgram(
 	if err != nil {
 		return err
 	}
-	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
+	if validateClaim {
+		return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
+	}
+	return nil
 }

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -71,5 +71,5 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	}
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
 	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData}
-	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, cfg.DB, derivationOptions)
+	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, cfg.DB, derivationOptions, !cfg.SkipValidation)
 }

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -65,6 +65,9 @@ func WithStoreBlockData(store bool) ProgramOpt {
 
 // FaultProofProgram is the programmatic entry-point for the fault proof program
 func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Config, opts ...ProgramOpt) error {
+	if err := cfg.CheckInputs(); err != nil {
+		return err
+	}
 	programConfig := &programCfg{
 		db: memorydb.New(),
 	}
@@ -138,7 +141,7 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		if programConfig.skipValidation {
 			clientCfg.SkipValidation = true
 		}
-		clientCfg.InteropEnabled = cfg.InteropEnabled
+		clientCfg.InteropEnabled = cfg.InteropEnabled()
 		clientCfg.DB = programConfig.db
 		clientCfg.StoreBlockData = programConfig.storeBlockData
 		return cl.RunProgram(logger, pClientRW, hClientRW, clientCfg)

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -3,6 +3,7 @@ package kvstore
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -28,34 +29,54 @@ var (
 	rollupKey             = boot.RollupConfigLocalIndex.PreimageKey()
 )
 
+var ErrUnexpectedLocalKey = errors.New("unexpected local key")
+
 func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 	switch [32]byte(key) {
 	case l1HeadKey:
 		return s.config.L1Head.Bytes(), nil
 	case l2OutputRootKey:
-		return s.config.L2OutputRoot.Bytes(), nil
+		if s.config.InteropEnabled() {
+			return s.config.InteropInputs.AgreedPrestateRoot.Bytes(), nil
+		} else {
+			return s.config.PreInteropInputs.L2OutputRoot.Bytes(), nil
+		}
 	case l2ClaimKey:
+		if s.config.InteropEnabled() {
+			return s.config.L2Claim.Bytes(), nil
+		}
 		return s.config.L2Claim.Bytes(), nil
 	case l2ClaimBlockNumberKey:
-		return binary.BigEndian.AppendUint64(nil, s.config.L2ClaimBlockNumber), nil
+		var value uint64
+		if s.config.InteropEnabled() {
+			value = s.config.InteropInputs.GameTimestamp
+		} else {
+			value = s.config.PreInteropInputs.L2ClaimBlockNumber
+		}
+		return binary.BigEndian.AppendUint64(nil, value), nil
 	case l2ChainIDKey:
-		return binary.BigEndian.AppendUint64(nil, eth.EvilChainIDToUInt64(s.config.L2ChainID)), nil
+		if s.config.InteropEnabled() {
+			return nil, ErrUnexpectedLocalKey
+		}
+		return binary.BigEndian.AppendUint64(nil, eth.EvilChainIDToUInt64(s.config.PreInteropInputs.L2ChainID)), nil
 	case l2ChainConfigKey:
-		if s.config.L2ChainID != boot.CustomChainIDIndicator {
-			return nil, ErrNotFound
-		}
-		if s.config.InteropEnabled {
+		if s.config.InteropEnabled() {
 			return json.Marshal(s.config.L2ChainConfigs)
+		} else {
+			if s.config.PreInteropInputs.L2ChainID != boot.CustomChainIDIndicator {
+				return nil, ErrNotFound
+			}
+			return json.Marshal(s.config.L2ChainConfigs[0])
 		}
-		return json.Marshal(s.config.L2ChainConfigs[0])
 	case rollupKey:
-		if s.config.L2ChainID != boot.CustomChainIDIndicator {
-			return nil, ErrNotFound
-		}
-		if s.config.InteropEnabled {
+		if s.config.InteropEnabled() {
 			return json.Marshal(s.config.Rollups)
+		} else {
+			if s.config.PreInteropInputs.L2ChainID != boot.CustomChainIDIndicator {
+				return nil, ErrNotFound
+			}
+			return json.Marshal(s.config.Rollups[0])
 		}
-		return json.Marshal(s.config.Rollups[0])
 	default:
 		return nil, ErrNotFound
 	}


### PR DESCRIPTION
The objective of this PR is to reduce ambiguity in the host `config.Config` struct. By requiring users to interact with specific interop or pre-interop attributes in the config, users are forced to be cognizant of which attributes are available. And by doing so, we can better reason about which interop configs need to be backwards-compatible with pre-interop. This is done by creating two separate configs for pre-interop and interop inputs. To illustrate why, let me provide an example issue that this PR solves.

The block-data hint may be served by either by an interop or pre-interop host. Prior to this PR, it's not obvious which type of host we're in just by looking at the flattened `config.Config` struct. It's very easy to accidentally use a pre-interop config value, for example, from a interop-configured host. Without a config checks that ensure interop-only and pre-interop inputs are mutually exclusive, it can be difficult to detect what type of config (and thus host) we're dealing with.
By separating the required interop and pre-interop configs into `InteropInputs` and `PreInteropInputs`, it becomes apparant that the existing block-data hint won't have all the inputs needed to run a pre-interop client _within_ an interop host.
This is because the configurator is required to be cognizant of the host variant in order to properly specify whether `InteropInputs` or `PreInteropInputs` is needed, rather than read ambiguous inputs values directly from the `config.Config` struct.