### PR TITLE
op-program/prestates: Add 1.5.0-rc.1 release prestate hashes

### DIFF
--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "1.5.0-rc.1",
+    "hash": "0x03f83792f653160f3274b0888e998077a27e1f74cb35bcb20d86021e769340aa",
+    "type": "cannon64"
+  },
+  {
+    "version": "1.5.0-rc.1",
+    "hash": "0x03dfa3b3ac66e8fae9f338824237ebacff616df928cf7dada0e14be2531bc1f4"
+  },
+  {
     "version": "1.4.1-rc.3",
     "hash": "0x03d7f817d7bb1321533aeeee5e0f2031cc69d167c4a17bf2816b4cc8b1be4077",
     "type": "cannon64"


### PR DESCRIPTION
**Description**

Reviewer please verify the prestate hashes with `make reproducible-prestate` at tag `op-program/v1.5.0-rc.1`