### PR TITLE
op-deployer: Use deterministic deployments for MIPS/DGs

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
@@ -290,18 +290,20 @@ contract DeployDisputeGame is Script {
         IPermissionedDisputeGame impl;
         if (LibString.eq(_dgi.gameKind(), "FaultDisputeGame")) {
             impl = IPermissionedDisputeGame(
-                DeployUtils.create1({
+                DeployUtils.createDeterministic({
                     _name: "FaultDisputeGame",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IFaultDisputeGame.__constructor__, (args)))
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IFaultDisputeGame.__constructor__, (args))),
+                    _salt: DeployUtils.DEFAULT_SALT
                 })
             );
         } else {
             impl = IPermissionedDisputeGame(
-                DeployUtils.create1({
+                DeployUtils.createDeterministic({
                     _name: "PermissionedDisputeGame",
                     _args: DeployUtils.encodeConstructor(
                         abi.encodeCall(IPermissionedDisputeGame.__constructor__, (args, _dgi.proposer(), _dgi.challenger()))
-                    )
+                    ),
+                    _salt: DeployUtils.DEFAULT_SALT
                 })
             );
         }

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
@@ -82,9 +82,10 @@ contract DeployMIPS is Script {
         IPreimageOracle preimageOracle = IPreimageOracle(_mi.preimageOracle());
         vm.broadcast(msg.sender);
         singleton = IMIPS(
-            DeployUtils.create1({
+            DeployUtils.createDeterministic({
                 _name: mipsVersion == 1 ? "MIPS" : "MIPS64",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS.__constructor__, (preimageOracle)))
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS.__constructor__, (preimageOracle))),
+                _salt: DeployUtils.DEFAULT_SALT
             })
         );
 


### PR DESCRIPTION
There's a nonce bug in the VM somewhere. This PR works around it and update these deployments to be deterministic. I'll investigate the bug separately.
