### PR TITLE
fix: DNS lookup for bootnodes

### DIFF
--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -53,6 +53,7 @@ const (
 )
 
 func resolveNodeDNS(n *enode.Node) (*enode.Node, error) {
+	// Adapted from https://github.com/ethereum/go-ethereum/pull/30822/files#diff-cfca27b526255b13ca472b74f49acd227e8f9cfc866d8d05093c5658db0b4eb8R444
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	foundIPs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", n.Hostname())


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Fixes DNS lookup on bootnode entries which was removed from upstream geth. Geth implements this logic in the dialer

Geth PR: https://github.com/ethereum/go-ethereum/pull/30822/files

Would love some advice on how to test this - should I expose one of the utils and test those?