### PR TITLE
docs: Fix subject-verb agreement in test description

### DIFF
--- a/docs/postmortems/2022-05-31-drop-1.md
+++ b/docs/postmortems/2022-05-31-drop-1.md
@@ -16,7 +16,7 @@ All times listed in PST.
 
 - `May 31` Optimism team deploys airdrop contract
 - `07:35` Team partially funds airdrop contract
-- `07:38` Claims frontend are tested on staging
+- `07:38` Claims frontend is tested on staging
 - `07:54` Airdrop contract is funded with full amount
 - `07:54` Team deploys claims frontend
 - `07:55` Some Discord users notice and post that claims frontend is live


### PR DESCRIPTION
**Description**

I noticed a grammatical error in the test description.
Changed "Claims frontend are tested" to "Claims frontend is tested" to correct the subject-verb agreement.
The frontend is singular, so it should be "is" instead of "are."

This is now fixed.
