### PR TITLE
Fix typos in error messages and comments

### DIFF
--- a/cannon/mipsevm/arch/arch32.go
+++ b/cannon/mipsevm/arch/arch32.go
@@ -6,7 +6,7 @@ package arch
 import "encoding/binary"
 
 type (
-	// Word differs from the tradditional meaning in MIPS. The type represents the *maximum* architecture specific access length and value sizes.
+	// Word differs from the traditional meaning in MIPS. The type represents the *maximum* architecture specific access length and value sizes.
 	Word = uint32
 	// SignedInteger specifies the maximum signed integer type used for arithmetic.
 	SignedInteger = int32

--- a/cannon/mipsevm/memory/page.go
+++ b/cannon/mipsevm/memory/page.go
@@ -46,7 +46,7 @@ func (p *Page) UnmarshalJSON(dat []byte) error {
 	}
 	defer r.Close()
 	if n, err := r.Read(p[:]); n != PageSize {
-		return fmt.Errorf("epxeted %d bytes, but got %d", PageSize, n)
+		return fmt.Errorf("expected %d bytes, but got %d", PageSize, n)
 	} else if err == io.EOF {
 		return nil
 	} else {

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -28,13 +28,13 @@ func TestEVM_SingleStep_Operators64(t *testing.T) {
 
 		{name: "daddu. both 32", funct: 0x2d, isImm: false, rs: Word(0x12), rt: Word(0x20), expectRes: Word(0x32)},                                                    // daddu t0, s1, s2
 		{name: "daddu. 32-bit. expect doubleword-sized", funct: 0x2d, isImm: false, rs: Word(0x12), rt: Word(^uint32(0)), expectRes: Word(0x1_00_00_00_11)},           // daddu t0, s1, s2
-		{name: "daddu. 32-bit. expect double-word sized x", funct: 0x2d, isImm: false, rs: Word(^uint32(0)), rt: Word(0x12), expectRes: Word(0x1_00_00_00_11)},        // dadu t0, s1, s2
-		{name: "daddu. doubleword-sized, word-sized", funct: 0x2d, isImm: false, rs: Word(0x0FFFFFFF_00000012), rt: Word(0x20), expectRes: Word(0x0FFFFFFF_00000032)}, // dadu t0, s1, s2
-		{name: "daddu. overflow. rt sign bit set", funct: 0x2d, isImm: false, rs: Word(12), rt: ^Word(0), expectRes: Word(11)},                                        // dadu t0, s1, s2
-		{name: "daddu. overflow. rs sign bit set", funct: 0x2d, isImm: false, rs: ^Word(0), rt: Word(12), expectRes: Word(11)},                                        // dadu t0, s1, s2
-		{name: "daddu. doubleword-sized and word-sized", funct: 0x2d, isImm: false, rs: ^Word(20), rt: Word(4), expectRes: ^Word(16)},                                 // dadu t0, s1, s2
-		{name: "daddu. word-sized and doubleword-sized", funct: 0x2d, isImm: false, rs: Word(4), rt: ^Word(20), expectRes: ^Word(16)},                                 // dadu t0, s1, s2
-		{name: "daddu. both doubleword-sized. expect overflow", funct: 0x2d, isImm: false, rs: ^Word(10), rt: ^Word(4), expectRes: ^Word(15)},                         // dadu t0, s1, s2
+		{name: "daddu. 32-bit. expect double-word sized x", funct: 0x2d, isImm: false, rs: Word(^uint32(0)), rt: Word(0x12), expectRes: Word(0x1_00_00_00_11)},        // daddu t0, s1, s2
+		{name: "daddu. doubleword-sized, word-sized", funct: 0x2d, isImm: false, rs: Word(0x0FFFFFFF_00000012), rt: Word(0x20), expectRes: Word(0x0FFFFFFF_00000032)}, // daddu t0, s1, s2
+		{name: "daddu. overflow. rt sign bit set", funct: 0x2d, isImm: false, rs: Word(12), rt: ^Word(0), expectRes: Word(11)},                                        // daddu t0, s1, s2
+		{name: "daddu. overflow. rs sign bit set", funct: 0x2d, isImm: false, rs: ^Word(0), rt: Word(12), expectRes: Word(11)},                                        // daddu t0, s1, s2
+		{name: "daddu. doubleword-sized and word-sized", funct: 0x2d, isImm: false, rs: ^Word(20), rt: Word(4), expectRes: ^Word(16)},                                 // daddu t0, s1, s2
+		{name: "daddu. word-sized and doubleword-sized", funct: 0x2d, isImm: false, rs: Word(4), rt: ^Word(20), expectRes: ^Word(16)},                                 // daddu t0, s1, s2
+		{name: "daddu. both doubleword-sized. expect overflow", funct: 0x2d, isImm: false, rs: ^Word(10), rt: ^Word(4), expectRes: ^Word(15)},                         // daddu t0, s1, s2
 
 		{name: "daddi word-sized", opcode: 0x18, isImm: true, rs: Word(12), rt: ^Word(0), imm: uint16(20), expectRes: Word(32)},                                           // daddi t0, s1, s2
 		{name: "daddi doubleword-sized", opcode: 0x18, isImm: true, rs: Word(0x00000010_00000000), rt: ^Word(0), imm: uint16(0x20), expectRes: Word(0x00000010_00000020)}, // daddi t0, s1, s2

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,4 @@ The `docs/` directory contains Optimism documentation closely tied to the implem
 The directory layout is divided into the following sub-directories.
 
 - [`postmortems/`](./postmortems/): Timestamped post-mortem documents.
-- [`security-reviews`](./security-reviews/): Audit summaries and other security review documents.
+- [`security-reviews/`](./security-reviews/): Audit summaries and other security review documents.

--- a/docs/security-reviews/2024_10-Cannon-FGETFD-3DocSecurity.md
+++ b/docs/security-reviews/2024_10-Cannon-FGETFD-3DocSecurity.md
@@ -111,4 +111,4 @@ Consider extending the current e2e test suite to cover execution from Docker ima
 [acknowledged]: https://img.shields.io/badge/-ACKNOWLEDGED-blue "ACKNOWLEDGED"
 [disputed]: https://img.shields.io/badge/-DISPUTED-lightgrey "DISPUTED"
 [reported]: https://img.shields.io/badge/-REPORTED-lightblue "REPORTED"
-[partiallyfixed]: https://img.shields.io/badge/-PARTIALLY_FIXED-lightgreen "PARTIALLTY FIXED"
+[partiallyfixed]: https://img.shields.io/badge/-PARTIALLY_FIXED-lightgreen "PARTIALLY FIXED"


### PR DESCRIPTION


Changes Made:

1. cannon/mipsevm/arch/arch32.go:
- "tradditional" -> "traditional" (removed extra 'd' in comment)

2. cannon/mipsevm/memory/page.go:
- "epxeted" -> "expected" (fixed error message spelling)

3. Badge text:
- "PARTIALLTY" -> "PARTIALLY" (removed extra 'T')

4.evm_common64_test.go
- "dadu" -> "daddu"
Rationale:
These changes improve code readability and maintain professional quality by fixing spelling errors in comments, error messages and status badges. No functional changes were made - all tests should continue to pass.
