### PR TITLE
op-node: Use withdrawals-root for replacement block attrs

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -266,6 +266,8 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	originalBlock := actors.ChainB.Sequencer.SyncStatus().UnsafeL2
 	require.Equal(t, uint64(1), originalBlock.Number)
+	originalOutput, err := actors.ChainB.Sequencer.RollupClient().OutputAtBlock(t.Ctx(), originalBlock.Number)
+	require.NoError(t, err)
 
 	// build another empty L2 block, that will get reorged out
 	actors.ChainB.Sequencer.ActL2StartBlock(t)
@@ -328,7 +330,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	txs := replacementBlock.Transactions()
 	out, err := managed.DecodeInvalidatedBlockTx(txs[len(txs)-1])
 	require.NoError(t, err)
-	require.Equal(t, originalBlock.Hash, out.BlockHash)
+	require.Equal(t, originalOutput.OutputRoot, eth.OutputRoot(out))
 
 	// Now check if we can continue to build L2 blocks on top of the new chain.
 	// Build a new L2 block

--- a/op-node/rollup/interop/managed/attributes.go
+++ b/op-node/rollup/interop/managed/attributes.go
@@ -28,9 +28,12 @@ func AttributesToReplaceInvalidBlock(invalidatedBlock *eth.ExecutionPayloadEnvel
 		}
 	}
 	// Add the system-tx that declares the replacement.
+	if invalidatedBlock.ExecutionPayload.WithdrawalsRoot == nil {
+		panic("withdrawals-root is nil")
+	}
 	l2Output := eth.OutputV0{
 		StateRoot:                invalidatedBlock.ExecutionPayload.StateRoot,
-		MessagePasserStorageRoot: eth.Bytes32{}, // TODO: the withdrawals-root in header is needed here.
+		MessagePasserStorageRoot: eth.Bytes32(*invalidatedBlock.ExecutionPayload.WithdrawalsRoot),
 		BlockHash:                invalidatedBlock.ExecutionPayload.BlockHash,
 	}
 	outputRootPreimage := l2Output.Marshal()

--- a/op-node/rollup/interop/managed/attributes_test.go
+++ b/op-node/rollup/interop/managed/attributes_test.go
@@ -45,6 +45,7 @@ func TestAttributesToReplaceInvalidBlock(t *testing.T) {
 	denominator := uint64(100)
 	elasticity := uint64(42)
 	extraData := eip1559.EncodeHoloceneExtraData(denominator, elasticity)
+	withdrawalsRoot := testutils.RandomHash(rng)
 
 	beaconRoot := testutils.RandomHash(rng)
 	invalidatedBlock := &eth.ExecutionPayloadEnvelope{
@@ -67,9 +68,10 @@ func TestAttributesToReplaceInvalidBlock(t *testing.T) {
 				opaqueDepositTx,
 				opaqueUserTx,
 			},
-			Withdrawals:   &types.Withdrawals{},
-			BlobGasUsed:   new(eth.Uint64Quantity),
-			ExcessBlobGas: new(eth.Uint64Quantity),
+			Withdrawals:     &types.Withdrawals{},
+			BlobGasUsed:     new(eth.Uint64Quantity),
+			ExcessBlobGas:   new(eth.Uint64Quantity),
+			WithdrawalsRoot: &withdrawalsRoot,
 		},
 	}
 	attrs := AttributesToReplaceInvalidBlock(invalidatedBlock)
@@ -90,8 +92,7 @@ func TestAttributesToReplaceInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, invalidatedBlock.ExecutionPayload.BlockHash, result.BlockHash)
 	require.Equal(t, invalidatedBlock.ExecutionPayload.StateRoot, result.StateRoot)
-	// Once withdrawals-root feature lands and it is part of the execution-payload type, assert here
-	//require.Equal(t, nil, result.MessagePasserStorageRoot)
+	require.Equal(t, withdrawalsRoot[:], result.MessagePasserStorageRoot[:])
 }
 
 // TestInvalidatedBlockTx tests we can encode/decode the system tx that represents the invalidated block


### PR DESCRIPTION
This patch properly sets up the L2 output root in the deposited transaction data.