### PR TITLE
op-supervisor: fix L1-reorg handling

### DIFF
--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -65,7 +65,8 @@ type LocalDerivedFromStorage interface {
 	NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error)
 	PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error)
 	PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error)
-	RewindToL2(derived uint64) error
+	RewindToScope(scope eth.BlockID) error
+	RewindToFirstDerived(v eth.BlockID) error
 }
 
 var _ LocalDerivedFromStorage = (*fromda.DB)(nil)
@@ -128,7 +129,6 @@ func (db *ChainsDB) OnEvent(ev event.Event) bool {
 		db.maybeInitSafeDB(x.ChainID, x.Anchor)
 	case superevents.LocalDerivedEvent:
 		db.UpdateLocalSafe(x.ChainID, x.Derived.DerivedFrom, x.Derived.Derived)
-		db.emitter.Emit(superevents.LocalDerivedDoneEvent(x))
 	case superevents.FinalizedL1RequestEvent:
 		db.onFinalizedL1(x.FinalizedL1)
 	case superevents.ReplaceBlockEvent:

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -222,14 +222,14 @@ func (db *ChainsDB) Finalized(chainID eth.ChainID) (types.BlockSeal, error) {
 	}
 
 	// otherwise, use the finalized L1 block to determine the final L2 block that was derived from it
-	derived, err := db.LastDerivedFrom(chainID, finalizedL1.ID())
+	derived, err := db.LastCrossDerivedFrom(chainID, finalizedL1.ID())
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("could not find what was last derived in L2 chain %s from the finalized L1 block %s: %w", chainID, finalizedL1, err)
 	}
 	return derived, nil
 }
 
-func (db *ChainsDB) LastDerivedFrom(chainID eth.ChainID, derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
+func (db *ChainsDB) LastCrossDerivedFrom(chainID eth.ChainID, derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
 	crossDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -62,7 +62,10 @@ func (m *mockDerivedFromStorage) PreviousDerivedFrom(derivedFrom eth.BlockID) (p
 func (m *mockDerivedFromStorage) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) RewindToL2(derived uint64) error {
+func (m *mockDerivedFromStorage) RewindToScope(scope eth.BlockID) error {
+	return nil
+}
+func (m *mockDerivedFromStorage) RewindToFirstDerived(derived eth.BlockID) error {
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -55,7 +55,7 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 	if !ok {
 		return fmt.Errorf("cannot Rewind (localDB not found): %w: %s", types.ErrUnknownChain, chain)
 	}
-	if err := localDB.RewindToL2(headBlock.Number); err != nil {
+	if err := localDB.RewindToFirstDerived(headBlock); err != nil {
 		return fmt.Errorf("failed to rewind localDB to block %v: %w", headBlock, err)
 	}
 
@@ -64,7 +64,7 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 	if !ok {
 		return fmt.Errorf("cannot Rewind (crossDB not found): %w: %s", types.ErrUnknownChain, chain)
 	}
-	if err := crossDB.RewindToL2(headBlock.Number); err != nil {
+	if err := crossDB.RewindToFirstDerived(headBlock); err != nil {
 		return fmt.Errorf("failed to rewind crossDB to block %v: %w", headBlock, err)
 	}
 	return nil
@@ -196,45 +196,32 @@ func (db *ChainsDB) InvalidateLocalSafe(chainID eth.ChainID, candidate types.Der
 	return nil
 }
 
-// RewindLocalSafe removes all local-safe blocks after the given new head.
-func (db *ChainsDB) RewindLocalSafe(chainID eth.ChainID, newHead types.BlockSeal) error {
+// RewindLocalSafe removes all local-safe blocks after the given new derived-from scope.
+// Note that this drop L1 blocks that resulted in a previously invalidated local-safe block.
+// This returns ErrFuture if the block is newer than the last known block.
+// This returns ErrConflict if a different block at the given height is known.
+func (db *ChainsDB) RewindLocalSafe(chainID eth.ChainID, scope eth.BlockID) error {
 	localSafeDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
 	}
-
-	// If the new head is before the current head then rewind it
-	currentHeadPair, err := localSafeDB.Latest()
-	if err != nil {
-		return fmt.Errorf("cannot find local-safe head of chain %s: %w", chainID, err)
+	if err := localSafeDB.RewindToScope(scope); err != nil {
+		return fmt.Errorf("failed to rewind local-safe: %w", err)
 	}
-	currentHead := currentHeadPair.Derived
-	if newHead.Number <= currentHead.Number {
-		if err := localSafeDB.RewindToL2(newHead.Number); err != nil {
-			return fmt.Errorf("failed to rewind local-safe: %w", err)
-		}
-	}
-
 	return nil
 }
 
-// RewindCrossSafe removes all cross-safe blocks after the given new head.
-func (db *ChainsDB) RewindCrossSafe(chainID eth.ChainID, newHead types.BlockSeal) error {
+// RewindCrossSafe removes all cross-safe blocks after the given new derived-from scope.
+// This returns ErrFuture if the block is newer than the last known block.
+// This returns ErrConflict if a different block at the given height is known.
+func (db *ChainsDB) RewindCrossSafe(chainID eth.ChainID, scope eth.BlockID) error {
 	crossSafeDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
 		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
 	}
-
-	// If the new head is before the current head then rewind it
-	currentHeadPair, err := crossSafeDB.Latest()
-	if err != nil {
-		return fmt.Errorf("cannot find cross-safe head of chain %s: %w", chainID, err)
+	if err := crossSafeDB.RewindToScope(scope); err != nil {
+		return fmt.Errorf("failed to rewind cross-safe: %w", err)
 	}
-	currentHead := currentHeadPair.Derived
-	if newHead.Number <= currentHead.Number {
-		return crossSafeDB.RewindToL2(newHead.Number)
-	}
-
 	return nil
 }
 
@@ -243,11 +230,9 @@ func (db *ChainsDB) RewindLogs(chainID eth.ChainID, newHead types.BlockSeal) err
 	if !ok {
 		return fmt.Errorf("cannot find events DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
 	}
-
 	if err := eventsDB.Rewind(newHead.ID()); err != nil {
 		return fmt.Errorf("failed to rewind logs of chain %s: %w", chainID, err)
 	}
-
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -160,20 +160,16 @@ func TestRewindL2(t *testing.T) {
 	i.AttachEmitter(&mockEmitter{})
 
 	// Simulate receiving a LocalDerivedDoneEvent for block2B
-	i.OnEvent(superevents.LocalDerivedDoneEvent{
+	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
-		Derived: types.DerivedBlockRefPair{
-			DerivedFrom: eth.BlockRef{
-				Hash:       l1Block1.Hash,
-				Number:     l1Block1.Number,
-				Time:       l1Block1.Time,
-				ParentHash: l1Block1.ParentHash,
+		NewLocalSafe: types.DerivedBlockSealPair{
+			DerivedFrom: types.BlockSeal{
+				Hash:   l1Block1.Hash,
+				Number: l1Block1.Number,
 			},
-			Derived: eth.BlockRef{
-				Hash:       block2B.Hash,
-				Number:     block2B.Number,
-				Time:       block2B.Time,
-				ParentHash: block2B.ParentHash,
+			Derived: types.BlockSeal{
+				Hash:   block2B.Hash,
+				Number: block2B.Number,
 			},
 		},
 	})
@@ -261,20 +257,16 @@ func TestNoRewindNeeded(t *testing.T) {
 	s.verifyCrossSafe(chainID, block2A.ID(), "block2A should still be cross-safe")
 
 	// Trigger LocalDerived check with same L2 block - should not rewind
-	i.OnEvent(superevents.LocalDerivedDoneEvent{
+	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
-		Derived: types.DerivedBlockRefPair{
-			DerivedFrom: eth.BlockRef{
-				Hash:       l1Block2.Hash,
-				Number:     l1Block2.Number,
-				Time:       l1Block2.Time,
-				ParentHash: l1Block2.ParentHash,
+		NewLocalSafe: types.DerivedBlockSealPair{
+			DerivedFrom: types.BlockSeal{
+				Hash:   l1Block2.Hash,
+				Number: l1Block2.Number,
 			},
-			Derived: eth.BlockRef{
-				Hash:       block2A.Hash,
-				Number:     block2A.Number,
-				Time:       block2A.Time,
-				ParentHash: block2A.ParentHash,
+			Derived: types.BlockSeal{
+				Hash:   block2A.Hash,
+				Number: block2A.Number,
 			},
 		},
 	})
@@ -363,20 +355,16 @@ func TestRewindLongChain(t *testing.T) {
 	}
 
 	// Trigger LocalDerived event with block96B
-	i.OnEvent(superevents.LocalDerivedDoneEvent{
+	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
-		Derived: types.DerivedBlockRefPair{
-			DerivedFrom: eth.BlockRef{
-				Hash:       l1Blocks[96/10].Hash,
-				Number:     l1Blocks[96/10].Number,
-				Time:       l1Blocks[96/10].Time,
-				ParentHash: l1Blocks[96/10].ParentHash,
+		NewLocalSafe: types.DerivedBlockSealPair{
+			DerivedFrom: types.BlockSeal{
+				Hash:   l1Blocks[96/10].Hash,
+				Number: l1Blocks[96/10].Number,
 			},
-			Derived: eth.BlockRef{
-				Hash:       block96B.Hash,
-				Number:     block96B.Number,
-				Time:       block96B.Time,
-				ParentHash: block96B.ParentHash,
+			Derived: types.BlockSeal{
+				Hash:   block96B.Hash,
+				Number: block96B.Number,
 			},
 		},
 	})
@@ -436,20 +424,16 @@ func TestRewindMultiChain(t *testing.T) {
 
 	// Trigger LocalDerived events for both chains
 	for chainID := range s.chains {
-		i.OnEvent(superevents.LocalDerivedDoneEvent{
+		i.OnEvent(superevents.LocalSafeUpdateEvent{
 			ChainID: chainID,
-			Derived: types.DerivedBlockRefPair{
-				DerivedFrom: eth.BlockRef{
-					Hash:       l1Block1.Hash,
-					Number:     l1Block1.Number,
-					Time:       l1Block1.Time,
-					ParentHash: l1Block1.ParentHash,
+			NewLocalSafe: types.DerivedBlockSealPair{
+				DerivedFrom: types.BlockSeal{
+					Hash:   l1Block1.Hash,
+					Number: l1Block1.Number,
 				},
-				Derived: eth.BlockRef{
-					Hash:       block2B.Hash,
-					Number:     block2B.Number,
-					Time:       block2B.Time,
-					ParentHash: block2B.ParentHash,
+				Derived: types.BlockSeal{
+					Hash:   block2B.Hash,
+					Number: block2B.Number,
 				},
 			},
 		})
@@ -578,19 +562,16 @@ func TestRewindL2WalkBack(t *testing.T) {
 	i := New(s.logger, s.chainsDB, chain.l1Node)
 	i.AttachEmitter(&mockEmitter{})
 	// Trigger LocalDerived event with block4B
-	i.OnEvent(superevents.LocalDerivedDoneEvent{
+	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
-		Derived: types.DerivedBlockRefPair{
-			DerivedFrom: eth.BlockRef{
+		NewLocalSafe: types.DerivedBlockSealPair{
+			DerivedFrom: types.BlockSeal{
 				Hash:   block4B.L1Origin.Hash,
 				Number: block4B.L1Origin.Number,
-				Time:   1004,
 			},
-			Derived: eth.BlockRef{
-				Hash:       block4B.Hash,
-				Number:     block4B.Number,
-				Time:       block4B.Time,
-				ParentHash: block4B.ParentHash,
+			Derived: types.BlockSeal{
+				Hash:   block4B.Hash,
+				Number: block4B.Number,
 			},
 		},
 	})

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -119,15 +119,6 @@ func (ev LocalDerivedEvent) String() string {
 	return "local-derived"
 }
 
-type LocalDerivedDoneEvent struct {
-	ChainID eth.ChainID
-	Derived types.DerivedBlockRefPair
-}
-
-func (ev LocalDerivedDoneEvent) String() string {
-	return "local-derive-done"
-}
-
 type AnchorEvent struct {
 	ChainID eth.ChainID
 	Anchor  types.DerivedBlockRefPair


### PR DESCRIPTION
**Description**

- Don't introduce a new local-safe update event. Use the existing one, which is emitted inside of the function that changes the local-safe, not in the caller func.
- Replace `RewindToL2` with `RewindToFirstDerived`: explicit block ID
- Replace  `RewindToL1` with `RewindToScope`: explicit block ID
- Add new testing for `RewindToL2` (`RewindToFirstDerived` now)
- Use `RewindToScope` to avoid race-condition in `Rewinder` and remove branching logic. The DB knows about L1 blocks. We have a L1 block. Rewind to that. Don't round-trip to L2 info with unlocking.
- Always call rewinds, don't try to assume `Latest`:
  - See godoc: `Latest` will return an error if it's invalidated and needs to be replaced. That would have bricked the reorg handling. And see above w.r.t. round-trip to avoid.
- Original rewinder code was calling `LastDerivedFrom` and then calling it `localSafeDerived` even though that was loading from the cross-DB. I renamed the method to avoid future confusion.

Builds on top of #13953
