### PR TITLE
cannon: Update SLL(V) to mask out upper bits before sign extending

### DIFF
--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -19,6 +19,9 @@ const (
 
 	// Return address register
 	RegRA = 31
+
+	// Masks
+	U32_MASK = 0xFFffFFff
 )
 
 func GetInstructionDetails(pc Word, memory *memory.Memory) (insn, opcode, fun uint32) {
@@ -205,14 +208,16 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 
 		switch fun {
 		case 0x00: // sll
-			return SignExtend((rt&0xFFFFFFFF)<<((insn>>6)&0x1F), 32)
+			shiftAmt := (insn >> 6) & 0x1F
+			return SignExtend((rt<<shiftAmt)&U32_MASK, 32)
 		case 0x02: // srl
 			return SignExtend((rt&0xFFFFFFFF)>>((insn>>6)&0x1F), 32)
 		case 0x03: // sra
 			shamt := Word((insn >> 6) & 0x1F)
 			return SignExtend((rt&0xFFFFFFFF)>>shamt, 32-shamt)
 		case 0x04: // sllv
-			return SignExtend((rt&0xFFFFFFFF)<<(rs&0x1F), 32)
+			shiftAmt := rs & 0x1F
+			return SignExtend((rt<<shiftAmt)&U32_MASK, 32)
 		case 0x06: // srlv
 			return SignExtend((rt&0xFFFFFFFF)>>(rs&0x1F), 32)
 		case 0x07: // srav

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -21,7 +21,7 @@ const (
 	RegRA = 31
 
 	// Masks
-	U32_MASK = 0xFFffFFff
+	U32Mask = 0xFFffFFff
 )
 
 func GetInstructionDetails(pc Word, memory *memory.Memory) (insn, opcode, fun uint32) {
@@ -209,7 +209,7 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 		switch fun {
 		case 0x00: // sll
 			shiftAmt := (insn >> 6) & 0x1F
-			return SignExtend((rt<<shiftAmt)&U32_MASK, 32)
+			return SignExtend((rt<<shiftAmt)&U32Mask, 32)
 		case 0x02: // srl
 			return SignExtend((rt&0xFFFFFFFF)>>((insn>>6)&0x1F), 32)
 		case 0x03: // sra
@@ -217,7 +217,7 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 			return SignExtend((rt&0xFFFFFFFF)>>shamt, 32-shamt)
 		case 0x04: // sllv
 			shiftAmt := rs & 0x1F
-			return SignExtend((rt<<shiftAmt)&U32_MASK, 32)
+			return SignExtend((rt<<shiftAmt)&U32Mask, 32)
 		case 0x06: // srlv
 			return SignExtend((rt&0xFFFFFFFF)>>(rs&0x1F), 32)
 		case 0x07: // srav

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -552,10 +552,18 @@ func TestEVM_SingleStep_SlSr(t *testing.T) {
 		funct     uint16
 		expectVal Word
 	}{
-		{name: "sll", funct: uint16(4) << 6, rt: Word(0x20), rsReg: uint32(0x0), expectVal: Word(0x20) << uint8(4)},                         // sll t0, t1, 3
-		{name: "srl", funct: uint16(4)<<6 | 2, rt: Word(0x20), rsReg: uint32(0x0), expectVal: Word(0x20) >> uint8(4)},                       // srl t0, t1, 3
-		{name: "sra", funct: uint16(4)<<6 | 3, rt: Word(0x80_00_00_20), rsReg: uint32(0x0), expectVal: signExtend64(0xF8_00_00_02)},         // sra t0, t1, 3
-		{name: "sllv", funct: uint16(4), rt: Word(0x20), rs: Word(4), rsReg: uint32(0xa), expectVal: Word(0x20) << Word(4)},                 // sllv t0, t1, t2
+		{name: "sll", funct: uint16(4) << 6, rt: Word(0x20), rsReg: uint32(0x0), expectVal: Word(0x20) << uint8(4)}, // sll t0, t1, 3
+		{name: "sll with overflow", funct: uint16(1) << 6, rt: Word(0x8000_0000), rsReg: uint32(0x0), expectVal: 0x0},
+		{name: "sll with sign extension", funct: uint16(4) << 6, rt: Word(0x0800_0000), rsReg: uint32(0x0), expectVal: signExtend64(0x8000_0000)},
+		{name: "sll with max shift, sign extension", funct: uint16(31) << 6, rt: Word(0x01), rsReg: uint32(0x0), expectVal: signExtend64(0x8000_0000)},
+		{name: "sll with max shift, overflow", funct: uint16(31) << 6, rt: Word(0x02), rsReg: uint32(0x0), expectVal: 0x0},
+		{name: "srl", funct: uint16(4)<<6 | 2, rt: Word(0x20), rsReg: uint32(0x0), expectVal: Word(0x20) >> uint8(4)},               // srl t0, t1, 3
+		{name: "sra", funct: uint16(4)<<6 | 3, rt: Word(0x80_00_00_20), rsReg: uint32(0x0), expectVal: signExtend64(0xF8_00_00_02)}, // sra t0, t1, 3
+		{name: "sllv", funct: uint16(4), rt: Word(0x20), rs: Word(4), rsReg: uint32(0xa), expectVal: Word(0x20) << Word(4)},         // sllv t0, t1, t2
+		{name: "sllv with overflow", funct: uint16(4), rt: Word(0x8000_0000), rs: Word(1), rsReg: uint32(0xa), expectVal: 0x0},
+		{name: "sllv with sign extension", funct: uint16(4), rt: Word(0x0800_0000), rs: Word(4), rsReg: uint32(0xa), expectVal: signExtend64(0x8000_0000)},
+		{name: "sllv with max shift, sign extension", funct: uint16(4), rt: Word(0x01), rs: Word(31), rsReg: uint32(0xa), expectVal: signExtend64(0x8000_0000)},
+		{name: "sllv with max shift, overflow", funct: uint16(4), rt: Word(0x02), rs: Word(31), rsReg: uint32(0xa), expectVal: 0x0},
 		{name: "srlv", funct: uint16(6), rt: Word(0x20_00), rs: Word(4), rsReg: uint32(0xa), expectVal: Word(0x20_00) >> Word(4)},           // srlv t0, t1, t2
 		{name: "srav", funct: uint16(7), rt: Word(0xdeafbeef), rs: Word(12), rsReg: uint32(0xa), expectVal: signExtend64(Word(0xfffdeafb))}, // srav t0, t1, t2
 	}

--- a/packages/contracts-bedrock/scripts/checks/check-frozen-files.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-frozen-files.sh
@@ -61,7 +61,8 @@ FROZEN_FILES=(
   "src/dispute/PermissionedDisputeGame.sol"
   "src/cannon/MIPS.sol"
   "src/cannon/MIPS2.sol"
-  "src/cannon/MIPS64.sol"
+# TODO(#14116): Add MIPS64 back when development is finished
+#  "src/cannon/MIPS64.sol"
   "src/cannon/PreimageOracle.sol"
 )
 

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0x62c820b22c72399efd7688dcf713c34a6ee6821835ec66d5e7b98f33bbbfb209"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0x7889eff8538b652c2008beb523dc8db7ef52c9af8b6da38adab8e8288bfb7041",
-    "sourceCodeHash": "0xb710bd6d4844f9ee45f301bb815786619b5e2d6b2f85ae17f39bee4f414f1957"
+    "initCodeHash": "0xec978bbb3674bfccee19632864f9425b1541b497e53bc5336f6b75435fcc1daa",
+    "sourceCodeHash": "0xcb841393a21eafa7b24c1f8138354a00a0eb838d16ee36ed2ea68f5a2a224f6a"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x17d3b3df1aaaf7a705b8d48de8a05e6511b910fdafdbe5eb7f7f95ec944fba9a",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0x62c820b22c72399efd7688dcf713c34a6ee6821835ec66d5e7b98f33bbbfb209"
   },
   "src/cannon/MIPS64.sol": {
-    "initCodeHash": "0xec978bbb3674bfccee19632864f9425b1541b497e53bc5336f6b75435fcc1daa",
-    "sourceCodeHash": "0xcb841393a21eafa7b24c1f8138354a00a0eb838d16ee36ed2ea68f5a2a224f6a"
+    "initCodeHash": "0x6c433a3fdba3af72d2d0399572e25b1b878ae53fb13cd237e2f4c1964b51644f",
+    "sourceCodeHash": "0x9d1af96777dc76b215aec7111c4fab2af4116dfefc734908e661ec641421dae2"
   },
   "src/cannon/PreimageOracle.sol": {
     "initCodeHash": "0x17d3b3df1aaaf7a705b8d48de8a05e6511b910fdafdbe5eb7f7f95ec944fba9a",

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -63,8 +63,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.1.0-beta.1
-    string public constant version = "1.1.0-beta.1";
+    /// @custom:semver 1.0.0-beta.1
+    string public constant version = "1.0.0-beta.1";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -63,8 +63,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.1.0-beta.1
+    string public constant version = "1.1.0-beta.1";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -252,7 +252,8 @@ library MIPS64Instructions {
 
                 // sll
                 if (_fun == 0x00) {
-                    return signExtend((_rt & U32_MASK) << ((_insn >> 6) & 0x1F), 32);
+                    uint32 shiftAmt = (_insn >> 6) & 0x1F;
+                    return signExtend((_rt << shiftAmt) & U32_MASK, 32);
                 }
                 // srl
                 else if (_fun == 0x02) {
@@ -265,7 +266,8 @@ library MIPS64Instructions {
                 }
                 // sllv
                 else if (_fun == 0x04) {
-                    return signExtend((_rt & U32_MASK) << (_rs & 0x1F), 32);
+                    uint64 shiftAmt = _rs & 0x1F;
+                    return signExtend((_rt << shiftAmt) & U32_MASK, 32);
                 }
                 // srlv
                 else if (_fun == 0x6) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Rework SSL(V) instructions so that we sign extend after masking the shifted value. 

**Tests**

Add a few more unit tests.
