### PR TITLE
op-challenger: Check chain-specific safe heads

### DIFF
--- a/op-challenger/game/fault/trace/super/rollup_configs.go
+++ b/op-challenger/game/fault/trace/super/rollup_configs.go
@@ -1,0 +1,78 @@
+package super
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var ErrDuplicateChain = errors.New("duplicate chain")
+
+type RollupConfigs struct {
+	cfgs map[eth.ChainID]*rollup.Config
+}
+
+func NewRollupConfigs(vmCfg vm.Config) (*RollupConfigs, error) {
+	cfgs := make(map[eth.ChainID]*rollup.Config)
+	for _, network := range vmCfg.Networks {
+		cfg, err := chaincfg.GetRollupConfig(network)
+		if err != nil {
+			return nil, err
+		}
+		if err := addConfig(cfgs, cfg); err != nil {
+			return nil, err
+		}
+	}
+	for _, path := range vmCfg.RollupConfigPaths {
+		cfg, err := loadRollupConfig(path)
+		if err != nil {
+			return nil, err
+		}
+		if err := addConfig(cfgs, cfg); err != nil {
+			return nil, err
+		}
+	}
+	return &RollupConfigs{
+		cfgs: cfgs,
+	}, nil
+}
+
+func NewRollupConfigsFromParsed(rollupCfgs ...*rollup.Config) (*RollupConfigs, error) {
+	cfgs := make(map[eth.ChainID]*rollup.Config)
+	for _, cfg := range rollupCfgs {
+		if err := addConfig(cfgs, cfg); err != nil {
+			return nil, err
+		}
+	}
+	return &RollupConfigs{cfgs: cfgs}, nil
+}
+
+func addConfig(cfgs map[eth.ChainID]*rollup.Config, cfg *rollup.Config) error {
+	chainID := eth.ChainIDFromBig(cfg.L2ChainID)
+	if _, ok := cfgs[chainID]; ok {
+		return fmt.Errorf("%w: %v", ErrDuplicateChain, chainID)
+	}
+	cfgs[chainID] = cfg
+	return nil
+}
+
+func (c *RollupConfigs) Get(chainID eth.ChainID) (*rollup.Config, bool) {
+	cfg, ok := c.cfgs[chainID]
+	return cfg, ok
+}
+
+func loadRollupConfig(rollupConfigPath string) (*rollup.Config, error) {
+	file, err := os.Open(rollupConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rollup config: %w", err)
+	}
+	defer file.Close()
+
+	var rollupConfig rollup.Config
+	return &rollupConfig, rollupConfig.ParseRollupConfig(file)
+}

--- a/op-challenger/game/fault/trace/super/rollup_configs_test.go
+++ b/op-challenger/game/fault/trace/super/rollup_configs_test.go
@@ -1,0 +1,128 @@
+package super
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollupConfigs(t *testing.T) {
+	t.Run("LoadNamedNetworks", func(t *testing.T) {
+		vmCfg := vm.Config{
+			Networks: []string{"op-mainnet", "op-sepolia"},
+		}
+		configs, err := NewRollupConfigs(vmCfg)
+		require.NoError(t, err)
+		require.Len(t, configs.cfgs, 2)
+		expectedMainnet, err := chaincfg.GetRollupConfig("op-mainnet")
+		require.NoError(t, err)
+		expectedSepolia, err := chaincfg.GetRollupConfig("op-sepolia")
+		require.NoError(t, err)
+		actual, ok := configs.Get(eth.ChainIDFromBig(expectedMainnet.L2ChainID))
+		require.True(t, ok, "did not load mainnet config")
+		require.EqualValues(t, expectedMainnet, actual)
+		actual, ok = configs.Get(eth.ChainIDFromBig(expectedSepolia.L2ChainID))
+		require.True(t, ok, "did not load sepolia config")
+		require.EqualValues(t, expectedSepolia, actual)
+	})
+
+	t.Run("LoadConfigFiles", func(t *testing.T) {
+		expectedMainnet, err := chaincfg.GetRollupConfig("op-mainnet")
+		require.NoError(t, err)
+		expectedSepolia, err := chaincfg.GetRollupConfig("op-sepolia")
+		require.NoError(t, err)
+
+		dir := t.TempDir()
+		writeConfig := func(cfg *rollup.Config) string {
+			data, err := json.Marshal(cfg)
+			require.NoError(t, err)
+			path := filepath.Join(dir, cfg.L2ChainID.String()+".json")
+			err = os.WriteFile(path, data, 0600)
+			require.NoError(t, err)
+			return path
+		}
+
+		mainnetFile := writeConfig(expectedMainnet)
+		sepoliaFile := writeConfig(expectedSepolia)
+
+		vmCfg := vm.Config{
+			RollupConfigPaths: []string{mainnetFile, sepoliaFile},
+		}
+		configs, err := NewRollupConfigs(vmCfg)
+		require.NoError(t, err)
+		require.Len(t, configs.cfgs, 2)
+		actual, ok := configs.Get(eth.ChainIDFromBig(expectedMainnet.L2ChainID))
+		require.True(t, ok, "did not load mainnet config")
+		require.EqualValues(t, expectedMainnet, actual)
+		actual, ok = configs.Get(eth.ChainIDFromBig(expectedSepolia.L2ChainID))
+		require.True(t, ok, "did not load sepolia config")
+		require.EqualValues(t, expectedSepolia, actual)
+	})
+
+	t.Run("CombineLoadedConfigFiles", func(t *testing.T) {
+		expectedMainnet, err := chaincfg.GetRollupConfig("op-mainnet")
+		require.NoError(t, err)
+		expectedSepolia, err := chaincfg.GetRollupConfig("op-sepolia")
+		require.NoError(t, err)
+
+		mainnetFile := writeConfig(t, expectedMainnet)
+
+		vmCfg := vm.Config{
+			RollupConfigPaths: []string{mainnetFile},
+			Networks:          []string{"op-sepolia"},
+		}
+		configs, err := NewRollupConfigs(vmCfg)
+		require.NoError(t, err)
+		require.Len(t, configs.cfgs, 2)
+		actual, ok := configs.Get(eth.ChainIDFromBig(expectedMainnet.L2ChainID))
+		require.True(t, ok, "did not load mainnet config")
+		require.EqualValues(t, expectedMainnet, actual)
+		actual, ok = configs.Get(eth.ChainIDFromBig(expectedSepolia.L2ChainID))
+		require.True(t, ok, "did not load sepolia config")
+		require.EqualValues(t, expectedSepolia, actual)
+	})
+
+	t.Run("UnknownConfig", func(t *testing.T) {
+		cfg, err := NewRollupConfigs(vm.Config{})
+		require.NoError(t, err)
+		_, ok := cfg.Get(eth.ChainIDFromUInt64(4))
+		require.False(t, ok)
+	})
+
+	t.Run("ErrorOnDuplicateConfig-Named", func(t *testing.T) {
+		_, err := NewRollupConfigs(vm.Config{Networks: []string{"op-mainnet", "op-mainnet"}})
+		require.ErrorIs(t, err, ErrDuplicateChain)
+	})
+
+	t.Run("ErrorOnDuplicateConfig-NameAndFile", func(t *testing.T) {
+		expectedMainnet, err := chaincfg.GetRollupConfig("op-mainnet")
+		require.NoError(t, err)
+		mainnetPath := writeConfig(t, expectedMainnet)
+		_, err = NewRollupConfigs(vm.Config{Networks: []string{"op-mainnet"}, RollupConfigPaths: []string{mainnetPath}})
+		require.ErrorIs(t, err, ErrDuplicateChain)
+	})
+
+	t.Run("ErrorOnDuplicateConfig-Parsed", func(t *testing.T) {
+		expectedMainnet, err := chaincfg.GetRollupConfig("op-mainnet")
+		require.NoError(t, err)
+		_, err = NewRollupConfigsFromParsed(expectedMainnet, expectedMainnet)
+		require.ErrorIs(t, err, ErrDuplicateChain)
+	})
+}
+
+func writeConfig(t *testing.T, cfg *rollup.Config) string {
+	dir := t.TempDir()
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(dir, cfg.L2ChainID.String()+".json")
+	err = os.WriteFile(path, data, 0600)
+	require.NoError(t, err)
+	return path
+}

--- a/op-challenger/game/fault/trace/super/split_adapter_test.go
+++ b/op-challenger/game/fault/trace/super/split_adapter_test.go
@@ -113,7 +113,7 @@ func setupSplitAdapterTest(t *testing.T, depth types.Depth, prestateTimestamp ui
 	creator := &capturingCreator{}
 	rootProvider := &stubRootProvider{}
 	prestateProvider := NewSuperRootPrestateProvider(rootProvider, prestateTimestamp)
-	traceProvider := NewSuperTraceProvider(testlog.Logger(t, log.LvlInfo), prestateProvider, rootProvider, eth.BlockID{}, depth, prestateTimestamp, poststateTimestamp)
+	traceProvider := NewSuperTraceProvider(testlog.Logger(t, log.LvlInfo), nil, prestateProvider, rootProvider, eth.BlockID{}, depth, prestateTimestamp, poststateTimestamp)
 	adapter := SuperRootSplitAdapter(traceProvider, creator.Create)
 	return creator, rootProvider, adapter
 }

--- a/op-challenger/game/fault/trace/super/super_cannon.go
+++ b/op-challenger/game/fault/trace/super/super_cannon.go
@@ -2,6 +2,7 @@ package super
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"path/filepath"
 
@@ -32,7 +33,11 @@ func NewSuperCannonTraceAccessor(
 	prestateBlock uint64,
 	poststateBlock uint64,
 ) (*trace.Accessor, error) {
-	outputProvider := NewSuperTraceProvider(logger, prestateProvider, rootProvider, l1Head, splitDepth, prestateBlock, poststateBlock)
+	rollupCfgs, err := NewRollupConfigs(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load rollup configs: %w", err)
+	}
+	outputProvider := NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, rootProvider, l1Head, splitDepth, prestateBlock, poststateBlock)
 	cannonCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, claimInfo ClaimInfo) (types.TraceProvider, error) {
 		logger := logger.New("agreedPrestate", claimInfo.AgreedPrestate, "claim", claimInfo.Claim, "localContext", localContext)
 		subdir := filepath.Join(dir, localContext.Hex())

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -560,9 +560,8 @@ func TestInteropFaultProofs(gt *testing.T) {
 			disputedClaim:      interop.InvalidTransition,
 			disputedTraceIndex: 0,
 			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    true,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			l1Head:      actors.L1Miner.L1Chain().Genesis().Hash(),
+			expectValid: true,
 		},
 		{
 			name:               "SecondChainReachesL1Head",
@@ -572,17 +571,16 @@ func TestInteropFaultProofs(gt *testing.T) {
 			// The derivation reaches the L1 head before the next block can be created
 			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
 			expectValid:    true,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			skipChallenger: true, // test's agreedClaim is incorrect - first chain is also invalid
 		},
 		{
 			name:               "SuperRootInvalidIfUnsupportedByL1Data",
-			agreedClaim:        step1Expected,
-			disputedClaim:      step2Expected,
-			disputedTraceIndex: 1,
+			agreedClaim:        start.Marshal(),
+			disputedClaim:      step1Expected,
+			disputedTraceIndex: 0,
 			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    false,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			l1Head:      actors.L1Miner.L1Chain().Genesis().Hash(),
+			expectValid: false,
 		},
 		{
 			name:               "FromInvalidTransitionHash",
@@ -590,9 +588,8 @@ func TestInteropFaultProofs(gt *testing.T) {
 			disputedClaim:      interop.InvalidTransition,
 			disputedTraceIndex: 2,
 			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    true,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			l1Head:      actors.L1Miner.L1Chain().Genesis().Hash(),
+			expectValid: true,
 		},
 	}
 

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -638,7 +638,9 @@ func TestInteropFaultProofs(gt *testing.T) {
 				l1Head = eth.ToBlockID(actors.L1Miner.L1Chain().GetBlockByHash(test.l1Head))
 			}
 			gameDepth := challengerTypes.Depth(30)
-			provider := super.NewSuperTraceProvider(logger, prestateProvider, &actors.Supervisor.QueryFrontend, l1Head, gameDepth, startTimestamp, endTimestamp)
+			rollupCfgs, err := super.NewRollupConfigsFromParsed(actors.ChainA.RollupCfg, actors.ChainB.RollupCfg)
+			require.NoError(t, err)
+			provider := super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, &actors.Supervisor.QueryFrontend, l1Head, gameDepth, startTimestamp, endTimestamp)
 			var agreedPrestate []byte
 			if test.disputedTraceIndex > 0 {
 				agreedPrestate, err = provider.GetPreimageBytes(ctx, challengerTypes.NewPosition(gameDepth, big.NewInt(test.disputedTraceIndex-1)))
@@ -911,7 +913,9 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 				l1Head = eth.ToBlockID(actors.L1Miner.L1Chain().GetBlockByHash(test.l1Head))
 			}
 			gameDepth := challengerTypes.Depth(30)
-			provider := super.NewSuperTraceProvider(logger, prestateProvider, &actors.Supervisor.QueryFrontend, l1Head, gameDepth, startTimestamp, endTimestamp)
+			rollupCfgs, err := super.NewRollupConfigsFromParsed(actors.ChainA.RollupCfg, actors.ChainB.RollupCfg)
+			require.NoError(t, err)
+			provider := super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, &actors.Supervisor.QueryFrontend, l1Head, gameDepth, startTimestamp, endTimestamp)
 			var agreedPrestate []byte
 			if test.disputedTraceIndex > 0 {
 				agreedPrestate, err = provider.GetPreimageBytes(ctx, challengerTypes.NewPosition(gameDepth, big.NewInt(test.disputedTraceIndex-1)))


### PR DESCRIPTION
**Description**

Updates op-challenger to check the safe head for individual chains and switch to the invalid hash at the appropriate step. The rollup configs had to be loaded to enable this so the challenger can convert from timestamp to block number for each chain.

Some action tests are able to be enabled but generally the chain setup is too simplistic (all batch data in the one and only L1 block) to test well. Will follow up with an attempt to make that chain setup more realistic and flexible.

**Tests**

Added unit tests, enabled some action tests.


**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/13903