### PR TITLE
op-supervisor: Implement supervisor_syncStatus RPC

### DIFF
--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -74,6 +74,11 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, uint64(0), status.LocalSafeL2.Number)
 	require.Equal(t, uint64(0), status.SafeL2.Number)
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
+	supervisorStatus, err := actors.Supervisor.SyncStatus()
+	require.NoError(t, err)
+	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
+	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerived.Number)
 
 	// Submit the L2 block, sync the local-safe data
 	actors.ChainA.Batcher.ActSubmitAll(t)
@@ -97,6 +102,11 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, head, status.LocalSafeL2.ID())
 	require.Equal(t, uint64(0), status.SafeL2.Number)
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
+	supervisorStatus, err = actors.Supervisor.SyncStatus()
+	require.NoError(t, err)
+	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerived.Number)
+	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
 	// Local-safe does not count as "safe" in RPC
 	n := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Number.Uint64()
 	require.Equal(t, uint64(0), n)
@@ -116,6 +126,11 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, head, status.LocalSafeL2.ID())
 	require.Equal(t, head, status.SafeL2.ID())
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
+	supervisorStatus, err = actors.Supervisor.SyncStatus()
+	require.NoError(t, err)
+	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalDerived.ID())
+	require.Equal(t, uint64(1), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
 	h := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Hash()
 	require.Equal(t, head.Hash, h)
 
@@ -141,6 +156,11 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, head, status.LocalSafeL2.ID())
 	require.Equal(t, head, status.SafeL2.ID())
 	require.Equal(t, head, status.FinalizedL2.ID())
+	supervisorStatus, err = actors.Supervisor.SyncStatus()
+	require.NoError(t, err)
+	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalDerived.ID())
+	require.Equal(t, uint64(1), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
 }
 
 // TestFinality confirms that when L1 finality is updated on the supervisor,

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -76,9 +76,8 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
 	supervisorStatus, err := actors.Supervisor.SyncStatus()
 	require.NoError(t, err)
-	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
-	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
-	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerived.Number)
+	require.Equal(t, head, supervisorStatus.Chains[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, uint64(0), supervisorStatus.MinSyncedL1.Number)
 
 	// Submit the L2 block, sync the local-safe data
 	actors.ChainA.Batcher.ActSubmitAll(t)
@@ -104,9 +103,8 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
 	supervisorStatus, err = actors.Supervisor.SyncStatus()
 	require.NoError(t, err)
-	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
-	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerived.Number)
-	require.Equal(t, uint64(0), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
+	require.Equal(t, head, supervisorStatus.Chains[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, uint64(0), supervisorStatus.MinSyncedL1.Number)
 	// Local-safe does not count as "safe" in RPC
 	n := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Number.Uint64()
 	require.Equal(t, uint64(0), n)
@@ -128,9 +126,8 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, uint64(0), status.FinalizedL2.Number)
 	supervisorStatus, err = actors.Supervisor.SyncStatus()
 	require.NoError(t, err)
-	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
-	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalDerived.ID())
-	require.Equal(t, uint64(1), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
+	require.Equal(t, head, supervisorStatus.Chains[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, uint64(1), supervisorStatus.MinSyncedL1.Number)
 	h := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Hash()
 	require.Equal(t, head.Hash, h)
 
@@ -158,9 +155,8 @@ func TestFullInterop(gt *testing.T) {
 	require.Equal(t, head, status.FinalizedL2.ID())
 	supervisorStatus, err = actors.Supervisor.SyncStatus()
 	require.NoError(t, err)
-	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalUnsafe.ID())
-	require.Equal(t, head, supervisorStatus[actors.ChainA.ChainID].LocalDerived.ID())
-	require.Equal(t, uint64(1), supervisorStatus[actors.ChainA.ChainID].LocalDerivedFrom.Number)
+	require.Equal(t, head, supervisorStatus.Chains[actors.ChainA.ChainID].LocalUnsafe.ID())
+	require.Equal(t, uint64(1), supervisorStatus.MinSyncedL1.Number)
 }
 
 // TestFinality confirms that when L1 finality is updated on the supervisor,

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -124,10 +124,16 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 		}})
 	case derive.DeriverL1StatusEvent:
 		m.log.Info("Emitting local safe update because of L1 traversal", "derivedFrom", x.Origin, "derived", x.LastL2)
-		m.events.Send(&supervisortypes.ManagedEvent{DerivationUpdate: &supervisortypes.DerivedBlockRefPair{
-			DerivedFrom: x.Origin,
-			Derived:     x.LastL2.BlockRef(),
-		}})
+		m.events.Send(&supervisortypes.ManagedEvent{
+			DerivationUpdate: &supervisortypes.DerivedBlockRefPair{
+				DerivedFrom: x.Origin,
+				Derived:     x.LastL2.BlockRef(),
+			},
+			DerivationOriginUpdate: &supervisortypes.DerivedBlockRefPair{
+				DerivedFrom: x.Origin,
+				Derived:     x.LastL2.BlockRef(),
+			},
+		})
 	case derive.ExhaustedL1Event:
 		m.log.Info("Exhausted L1 data", "derivedFrom", x.L1Ref, "derived", x.LastL2)
 		m.events.Send(&supervisortypes.ManagedEvent{ExhaustL1: &supervisortypes.DerivedBlockRefPair{

--- a/op-service/eth/supervisor_status.go
+++ b/op-service/eth/supervisor_status.go
@@ -1,11 +1,17 @@
 package eth
 
+type SupervisorStatus struct {
+	// MinSyncedL1 is the highest L1 block that has been processed by all supervisor nodes.
+	// This is not the same as the latest L1 block known to the supervisor,
+	// but rather the L1 block view of the supervisor nodes.
+	// This may not be fully derived into the L2 data of a particular node yet.
+	// The local-safe L2 blocks were produced/included fully from the L1 chain up to _but excluding_ this L1 block.
+	MinSyncedL1 L1BlockRef                         `json:"minSyncedL1"`
+	Chains      map[ChainID]*SupervisorChainStatus `json:"chains"`
+}
+
 // SupervisorChainStatus is the status of a chain as seen by the supervisor.
 type SupervisorChainStatus struct {
-	// LocalDerived is the latest L2 block that the chain was derived from.
-	LocalDerived BlockRef `json:"localDerived"`
-	// LocalDerivedFrom is the origin of LocalDerived.
-	LocalDerivedFrom L1BlockRef `json:"localDerivedFrom"`
 	// LocalUnsafe is the latest L2 block that has been processed by the supervisor.
 	LocalUnsafe BlockRef `json:"localUnsafe"`
 }

--- a/op-service/eth/supervisor_status.go
+++ b/op-service/eth/supervisor_status.go
@@ -1,0 +1,11 @@
+package eth
+
+// SupervisorChainStatus is the status of a chain as seen by the supervisor.
+type SupervisorChainStatus struct {
+	// LocalDerived is the latest L2 block that the chain was derived from.
+	LocalDerived BlockRef `json:"localDerived"`
+	// LocalDerivedFrom is the origin of LocalDerived.
+	LocalDerivedFrom L1BlockRef `json:"localDerivedFrom"`
+	// LocalUnsafe is the absolute tip of the L2 chain.
+	LocalUnsafe BlockRef `json:"localUnsafe"`
+}

--- a/op-service/eth/supervisor_status.go
+++ b/op-service/eth/supervisor_status.go
@@ -1,17 +1,16 @@
 package eth
 
-type SupervisorStatus struct {
+type SupervisorSyncStatus struct {
 	// MinSyncedL1 is the highest L1 block that has been processed by all supervisor nodes.
 	// This is not the same as the latest L1 block known to the supervisor,
 	// but rather the L1 block view of the supervisor nodes.
-	// This may not be fully derived into the L2 data of a particular node yet.
-	// The local-safe L2 blocks were produced/included fully from the L1 chain up to _but excluding_ this L1 block.
-	MinSyncedL1 L1BlockRef                         `json:"minSyncedL1"`
-	Chains      map[ChainID]*SupervisorChainStatus `json:"chains"`
+	// This L1 block may not be fully derived into L2 data on all nodes yet.
+	MinSyncedL1 L1BlockRef                             `json:"minSyncedL1"`
+	Chains      map[ChainID]*SupervisorChainSyncStatus `json:"chains"`
 }
 
 // SupervisorChainStatus is the status of a chain as seen by the supervisor.
-type SupervisorChainStatus struct {
+type SupervisorChainSyncStatus struct {
 	// LocalUnsafe is the latest L2 block that has been processed by the supervisor.
 	LocalUnsafe BlockRef `json:"localUnsafe"`
 }

--- a/op-service/eth/supervisor_status.go
+++ b/op-service/eth/supervisor_status.go
@@ -6,6 +6,6 @@ type SupervisorChainStatus struct {
 	LocalDerived BlockRef `json:"localDerived"`
 	// LocalDerivedFrom is the origin of LocalDerived.
 	LocalDerivedFrom L1BlockRef `json:"localDerivedFrom"`
-	// LocalUnsafe is the absolute tip of the L2 chain.
+	// LocalUnsafe is the latest L2 block that has been processed by the supervisor.
 	LocalUnsafe BlockRef `json:"localUnsafe"`
 }

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -174,6 +174,15 @@ func (cl *SupervisorClient) AllSafeDerivedAt(ctx context.Context, derivedFrom et
 	return result, err
 }
 
+func (cl *SupervisorClient) SyncStatus(ctx context.Context) (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
+	var result map[eth.ChainID]*eth.SupervisorChainStatus
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_syncStatus")
+	return result, err
+}
+
 func (cl *SupervisorClient) Close() {
 	cl.client.Close()
 }

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -174,8 +174,8 @@ func (cl *SupervisorClient) AllSafeDerivedAt(ctx context.Context, derivedFrom et
 	return result, err
 }
 
-func (cl *SupervisorClient) SyncStatus(ctx context.Context) (eth.SupervisorStatus, error) {
-	var result eth.SupervisorStatus
+func (cl *SupervisorClient) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
+	var result eth.SupervisorSyncStatus
 	err := cl.client.CallContext(
 		ctx,
 		&result,

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -174,8 +174,8 @@ func (cl *SupervisorClient) AllSafeDerivedAt(ctx context.Context, derivedFrom et
 	return result, err
 }
 
-func (cl *SupervisorClient) SyncStatus(ctx context.Context) (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
-	var result map[eth.ChainID]*eth.SupervisorChainStatus
+func (cl *SupervisorClient) SyncStatus(ctx context.Context) (eth.SupervisorStatus, error) {
+	var result eth.SupervisorStatus
 	err := cl.client.CallContext(
 		ctx,
 		&result,

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -584,7 +584,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 	}, nil
 }
 
-func (su *SupervisorBackend) SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
+func (su *SupervisorBackend) SyncStatus() (eth.SupervisorStatus, error) {
 	return su.statusTracker.SyncStatus(), nil
 }
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -584,7 +584,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 	}, nil
 }
 
-func (su *SupervisorBackend) SyncStatus() (eth.SupervisorStatus, error) {
+func (su *SupervisorBackend) SyncStatus() (eth.SupervisorSyncStatus, error) {
 	return su.statusTracker.SyncStatus(), nil
 }
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/l1access"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/rewinder"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/status"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
@@ -57,6 +58,9 @@ type SupervisorBackend struct {
 
 	// syncNodesController controls the derivation or reset of the sync nodes
 	syncNodesController *syncnode.SyncNodesController
+
+	// statusTracker tracks the sync status of the supervisor
+	statusTracker *status.StatusTracker
 
 	// synchronousProcessors disables background-workers,
 	// requiring manual triggers for the backend to process l2 data.
@@ -136,6 +140,10 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 	// create node controller
 	super.syncNodesController = syncnode.NewSyncNodesController(logger, depSet, eventSys, super)
 	eventSys.Register("sync-controller", super.syncNodesController, event.DefaultRegisterOpts())
+
+	// create status tracker
+	super.statusTracker = status.NewStatusTracker()
+	eventSys.Register("status", super.statusTracker, event.DefaultRegisterOpts())
 
 	// Initialize the resources of the supervisor backend.
 	// Stop the supervisor if any of the resources fails to be initialized.
@@ -574,6 +582,10 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		SuperRoot:            superRoot,
 		Chains:               chainInfos,
 	}, nil
+}
+
+func (su *SupervisorBackend) SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
+	return su.statusTracker.SyncStatus(), nil
 }
 
 // PullLatestL1 makes the supervisor aware of the latest L1 block. Exposed for testing purposes.

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -79,6 +79,10 @@ func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexuti
 	return eth.SuperRootResponse{}, nil
 }
 
+func (m *MockBackend) SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
+	return nil, nil
+}
+
 func (m *MockBackend) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -79,8 +79,8 @@ func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexuti
 	return eth.SuperRootResponse{}, nil
 }
 
-func (m *MockBackend) SyncStatus() (eth.SupervisorStatus, error) {
-	return eth.SupervisorStatus{}, nil
+func (m *MockBackend) SyncStatus() (eth.SupervisorSyncStatus, error) {
+	return eth.SupervisorSyncStatus{}, nil
 }
 
 func (m *MockBackend) Close() error {

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -79,8 +79,8 @@ func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexuti
 	return eth.SuperRootResponse{}, nil
 }
 
-func (m *MockBackend) SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
-	return nil, nil
+func (m *MockBackend) SyncStatus() (eth.SupervisorStatus, error) {
+	return eth.SupervisorStatus{}, nil
 }
 
 func (m *MockBackend) Close() error {

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -36,7 +36,7 @@ func (su *StatusTracker) OnEvent(ev event.Event) bool {
 		v.LocalDerived = x.Derived.Derived
 		v.LocalDerivedFrom = x.Derived.DerivedFrom
 		su.statuses[x.ChainID] = v
-	case superevents.LocalUnsafeReceivedEvent:
+	case superevents.LocalUnsafeUpdateEvent:
 		v := loadStatus(x.ChainID)
 		v.LocalUnsafe = x.NewLocalUnsafe
 		su.statuses[x.ChainID] = v

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -1,0 +1,59 @@
+package status
+
+import (
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+)
+
+type StatusTracker struct {
+	statuses map[eth.ChainID]*eth.SupervisorChainStatus
+	mu       sync.RWMutex
+}
+
+func NewStatusTracker() *StatusTracker {
+	return &StatusTracker{
+		statuses: make(map[eth.ChainID]*eth.SupervisorChainStatus),
+	}
+}
+
+func (su *StatusTracker) OnEvent(ev event.Event) bool {
+	su.mu.Lock()
+	defer su.mu.Unlock()
+
+	loadStatus := func(chainID eth.ChainID) *eth.SupervisorChainStatus {
+		v := su.statuses[chainID]
+		if v == nil {
+			v = &eth.SupervisorChainStatus{}
+		}
+		return v
+	}
+	switch x := ev.(type) {
+	case superevents.LocalDerivedEvent:
+		v := loadStatus(x.ChainID)
+		v.LocalDerived = x.Derived.Derived
+		v.LocalDerivedFrom = x.Derived.DerivedFrom
+		su.statuses[x.ChainID] = v
+	case superevents.LocalUnsafeReceivedEvent:
+		v := loadStatus(x.ChainID)
+		v.LocalUnsafe = x.NewLocalUnsafe
+		su.statuses[x.ChainID] = v
+	default:
+		return false
+	}
+	return true
+}
+
+func (su *StatusTracker) SyncStatus() map[eth.ChainID]*eth.SupervisorChainStatus {
+	su.mu.RLock()
+	defer su.mu.RUnlock()
+	ret := make(map[eth.ChainID]*eth.SupervisorChainStatus)
+	for chainID, status := range su.statuses {
+		clone := new(eth.SupervisorChainStatus)
+		*clone = *status
+		ret[chainID] = clone
+	}
+	return ret
+}

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -49,19 +49,19 @@ func (su *StatusTracker) OnEvent(ev event.Event) bool {
 	return true
 }
 
-func (su *StatusTracker) SyncStatus() eth.SupervisorStatus {
+func (su *StatusTracker) SyncStatus() eth.SupervisorSyncStatus {
 	su.mu.RLock()
 	defer su.mu.RUnlock()
 
-	var supervisorStatus eth.SupervisorStatus
+	var supervisorStatus eth.SupervisorSyncStatus
 	for _, nodeStatus := range su.statuses {
 		if supervisorStatus.MinSyncedL1 == (eth.L1BlockRef{}) || supervisorStatus.MinSyncedL1.Number < nodeStatus.CurrentL1.Number {
 			supervisorStatus.MinSyncedL1 = nodeStatus.CurrentL1
 		}
 	}
-	supervisorStatus.Chains = make(map[eth.ChainID]*eth.SupervisorChainStatus)
+	supervisorStatus.Chains = make(map[eth.ChainID]*eth.SupervisorChainSyncStatus)
 	for chainID, nodeStatus := range su.statuses {
-		supervisorStatus.Chains[chainID] = &eth.SupervisorChainStatus{
+		supervisorStatus.Chains[chainID] = &eth.SupervisorChainSyncStatus{
 			LocalUnsafe: nodeStatus.LocalUnsafe,
 		}
 	}

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -119,6 +119,15 @@ func (ev LocalDerivedEvent) String() string {
 	return "local-derived"
 }
 
+type LocalDerivedOriginUpdateEvent struct {
+	ChainID eth.ChainID
+	Derived types.DerivedBlockRefPair
+}
+
+func (ev LocalDerivedOriginUpdateEvent) String() string {
+	return "local-derived-origin-update"
+}
+
 type AnchorEvent struct {
 	ChainID eth.ChainID
 	Anchor  types.DerivedBlockRefPair

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -141,9 +141,10 @@ func sampleDepSet(t *testing.T) depset.DependencySet {
 }
 
 type eventMonitor struct {
-	anchorCalled        int
-	localDerived        int
-	receivedLocalUnsafe int
+	anchorCalled             int
+	localDerived             int
+	receivedLocalUnsafe      int
+	localDerivedOriginUpdate int
 }
 
 func (m *eventMonitor) OnEvent(ev event.Event) bool {
@@ -154,6 +155,8 @@ func (m *eventMonitor) OnEvent(ev event.Event) bool {
 		m.localDerived += 1
 	case superevents.LocalUnsafeReceivedEvent:
 		m.receivedLocalUnsafe += 1
+	case superevents.LocalDerivedOriginUpdateEvent:
+		m.localDerivedOriginUpdate += 1
 	default:
 		return false
 	}

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -221,6 +221,9 @@ func (m *ManagedNode) onNodeEvent(ev *types.ManagedEvent) {
 	if ev.ReplaceBlock != nil {
 		m.onReplaceBlock(*ev.ReplaceBlock)
 	}
+	if ev.DerivationOriginUpdate != nil {
+		m.onDerivationOriginUpdate(*ev.DerivationOriginUpdate)
+	}
 }
 
 func (m *ManagedNode) onResetEvent(errStr string) {
@@ -295,6 +298,14 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	//		"derived", pair.Derived, "derivedFrom", pair.DerivedFrom, "err", err)
 	//	m.resetSignal(err, pair.DerivedFrom)
 	// }
+}
+
+func (m *ManagedNode) onDerivationOriginUpdate(pair types.DerivedBlockRefPair) {
+	m.log.Info("Node derived new origin", "derived", pair.Derived, "derivedFrom", pair.DerivedFrom)
+	m.emitter.Emit(superevents.LocalDerivedOriginUpdateEvent{
+		ChainID: m.chainID,
+		Derived: pair,
+	})
 }
 
 func (m *ManagedNode) resetSignal(errSignal error, l1Ref eth.BlockRef) {

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -78,6 +78,8 @@ func TestEventResponse(t *testing.T) {
 			DerivationUpdate: &types.DerivedBlockRefPair{DerivedFrom: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
 			ExhaustL1: &types.DerivedBlockRefPair{DerivedFrom: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
+			DerivationOriginUpdate: &types.DerivedBlockRefPair{DerivedFrom: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 
 		require.NoError(t, ex.Drain())
 
@@ -86,7 +88,8 @@ func TestEventResponse(t *testing.T) {
 			finalized >= 1 &&
 			mon.receivedLocalUnsafe >= 1 &&
 			mon.localDerived >= 1 &&
-			nodeExhausted >= 1
+			nodeExhausted >= 1 &&
+			mon.localDerivedOriginUpdate >= 1
 	}, 4*time.Second, 250*time.Millisecond)
 }
 

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -24,6 +24,7 @@ type QueryBackend interface {
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	FinalizedL1() eth.BlockRef
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
+	SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error)
 	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
 }
 
@@ -78,6 +79,10 @@ func (q *QueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexu
 
 func (q *QueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error) {
 	return q.Supervisor.AllSafeDerivedAt(ctx, derivedFrom)
+}
+
+func (q *QueryFrontend) SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
+	return q.Supervisor.SyncStatus()
 }
 
 type AdminFrontend struct {

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -24,7 +24,7 @@ type QueryBackend interface {
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	FinalizedL1() eth.BlockRef
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
-	SyncStatus() (eth.SupervisorStatus, error)
+	SyncStatus() (eth.SupervisorSyncStatus, error)
 	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
 }
 
@@ -81,7 +81,7 @@ func (q *QueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.Bl
 	return q.Supervisor.AllSafeDerivedAt(ctx, derivedFrom)
 }
 
-func (q *QueryFrontend) SyncStatus() (eth.SupervisorStatus, error) {
+func (q *QueryFrontend) SyncStatus() (eth.SupervisorSyncStatus, error) {
 	return q.Supervisor.SyncStatus()
 }
 

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -24,7 +24,7 @@ type QueryBackend interface {
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	FinalizedL1() eth.BlockRef
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
-	SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error)
+	SyncStatus() (eth.SupervisorStatus, error)
 	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
 }
 
@@ -81,7 +81,7 @@ func (q *QueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.Bl
 	return q.Supervisor.AllSafeDerivedAt(ctx, derivedFrom)
 }
 
-func (q *QueryFrontend) SyncStatus() (map[eth.ChainID]*eth.SupervisorChainStatus, error) {
+func (q *QueryFrontend) SyncStatus() (eth.SupervisorStatus, error) {
 	return q.Supervisor.SyncStatus()
 }
 

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -308,9 +308,10 @@ type BlockReplacement struct {
 // ManagedEvent is an event sent by the managed node to the supervisor,
 // to share an update. One of the fields will be non-null; different kinds of updates may be sent.
 type ManagedEvent struct {
-	Reset            *string              `json:"reset,omitempty"`
-	UnsafeBlock      *eth.BlockRef        `json:"unsafeBlock,omitempty"`
-	DerivationUpdate *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
-	ExhaustL1        *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
-	ReplaceBlock     *BlockReplacement    `json:"replaceBlock,omitempty"`
+	Reset                  *string              `json:"reset,omitempty"`
+	UnsafeBlock            *eth.BlockRef        `json:"unsafeBlock,omitempty"`
+	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
+	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
+	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
+	DerivationOriginUpdate *DerivedBlockRefPair `json:"derivationOriginUpdate,omitempty"`
 }


### PR DESCRIPTION
Adds an RPC that returns the sync status of the supervisor. It will be used by the op-challenger to determine when a dispute game is safe to be disputed by comparing the game's L1 head with the local-derived reference in the status.

Although not required by the op-challenger, I've also added the `localUnsafe` head of each supervised chain to the sync status for convenience.

fixes https://github.com/ethereum-optimism/optimism/issues/13893