### PR TITLE
supervisor: Refactor `Contains` ; Check Timestamps

### DIFF
--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -132,13 +132,7 @@ func isInvalidMessageError(err error) bool {
 type ConsolidateCheckDeps interface {
 	cross.UnsafeFrontierCheckDeps
 	cross.CycleCheckDeps
-	Check(
-		chain eth.ChainID,
-		blockNum uint64,
-		timestamp uint64,
-		logIdx uint32,
-		logHash common.Hash,
-	) (includedIn supervisortypes.BlockSeal, err error)
+	Contains(chain eth.ChainID, query supervisortypes.ContainsQuery) (includedIn supervisortypes.BlockSeal, err error)
 }
 
 func checkHazards(
@@ -203,15 +197,9 @@ func newConsolidateCheckDeps(transitionState *types.TransitionState, chains []et
 	}, nil
 }
 
-func (d *consolidateCheckDeps) Check(
-	chain eth.ChainID,
-	blockNum uint64,
-	timestamp uint64,
-	logIdx uint32,
-	logHash common.Hash,
-) (includedIn supervisortypes.BlockSeal, err error) {
+func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes.ContainsQuery) (includedIn supervisortypes.BlockSeal, err error) {
 	// We can assume the oracle has the block the executing message is in
-	block, err := d.BlockByNumber(d.oracle, blockNum, chain)
+	block, err := d.BlockByNumber(d.oracle, query.BlockNum, chain)
 	if err != nil {
 		return supervisortypes.BlockSeal{}, err
 	}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -394,7 +394,13 @@ func (su *SupervisorBackend) CheckMessage(identifier types.Identifier, payloadHa
 	chainID := identifier.ChainID
 	blockNum := identifier.BlockNumber
 	logIdx := identifier.LogIndex
-	_, err := su.chainDBs.Check(chainID, blockNum, identifier.Timestamp, logIdx, logHash)
+	_, err := su.chainDBs.Contains(chainID,
+		types.ContainsQuery{
+			BlockNum:  blockNum,
+			Timestamp: identifier.Timestamp,
+			LogIdx:    logIdx,
+			LogHash:   logHash,
+		})
 	if errors.Is(err, types.ErrFuture) {
 		su.logger.Debug("Future message", "identifier", identifier, "payloadHash", payloadHash, "err", err)
 		return types.LocalUnsafe, nil

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -322,7 +322,7 @@ type mockSafeStartDeps struct {
 	derivedFromFn func() (derivedFrom types.BlockSeal, err error)
 }
 
-func (m *mockSafeStartDeps) Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (m *mockSafeStartDeps) Contains(chain eth.ChainID, q types.ContainsQuery) (includedIn types.BlockSeal, err error) {
 	if m.checkFn != nil {
 		return m.checkFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -485,9 +485,9 @@ func (m *mockCrossSafeDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.Bl
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossSafeDeps) Check(chainID eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+func (m *mockCrossSafeDeps) Contains(chainID eth.ChainID, q types.ContainsQuery) (types.BlockSeal, error) {
 	if m.checkFn != nil {
-		return m.checkFn(chainID, blockNum, logIdx, logHash)
+		return m.checkFn(chainID, q.BlockNum, q.LogIdx, q.LogHash)
 	}
 	return types.BlockSeal{}, nil
 }

--- a/op-supervisor/supervisor/backend/cross/unsafe_start.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start.go
@@ -4,15 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type UnsafeStartDeps interface {
-	Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
+	Contains(chain eth.ChainID, query types.ContainsQuery) (includedIn types.BlockSeal, err error)
 
 	IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error
 
@@ -61,7 +59,13 @@ func CrossUnsafeHazards(d UnsafeStartDeps, chainID eth.ChainID,
 		if msg.Timestamp < candidate.Timestamp {
 			// If timestamp is older: invariant ensures non-cyclic ordering relative to other messages.
 			// Check that the block that they are included in is cross-safe already.
-			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.Timestamp, msg.LogIdx, msg.Hash)
+			includedIn, err := d.Contains(initChainID,
+				types.ContainsQuery{
+					Timestamp: msg.Timestamp,
+					BlockNum:  msg.BlockNum,
+					LogIdx:    msg.LogIdx,
+					LogHash:   msg.Hash,
+				})
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}
@@ -78,7 +82,13 @@ func CrossUnsafeHazards(d UnsafeStartDeps, chainID eth.ChainID,
 			// Thus check that it was included in a local-unsafe block,
 			// and then proceed with transitive block checks,
 			// to ensure the local block we depend on is becoming cross-unsafe also.
-			includedIn, err := d.Check(initChainID, msg.BlockNum, msg.Timestamp, msg.LogIdx, msg.Hash)
+			includedIn, err := d.Contains(initChainID,
+				types.ContainsQuery{
+					Timestamp: msg.Timestamp,
+					BlockNum:  msg.BlockNum,
+					LogIdx:    msg.LogIdx,
+					LogHash:   msg.Hash,
+				})
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -261,7 +261,7 @@ type mockUnsafeStartDeps struct {
 	isCrossUnsafeFn func() error
 }
 
-func (m *mockUnsafeStartDeps) Check(chain eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error) {
+func (m *mockUnsafeStartDeps) Contains(chain eth.ChainID, q types.ContainsQuery) (includedIn types.BlockSeal, err error) {
 	if m.checkFn != nil {
 		return m.checkFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
@@ -198,9 +198,9 @@ func (m *mockCrossUnsafeDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockCrossUnsafeDeps) Check(chainID eth.ChainID, blockNum uint64, timestamp uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error) {
+func (m *mockCrossUnsafeDeps) Contains(chainID eth.ChainID, q types.ContainsQuery) (types.BlockSeal, error) {
 	if m.checkFn != nil {
-		return m.checkFn(chainID, blockNum, timestamp, logIdx, logHash)
+		return m.checkFn(chainID, q.BlockNum, q.Timestamp, q.LogIdx, q.LogHash)
 	}
 	return types.BlockSeal{}, nil
 }

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -44,7 +44,7 @@ type LogStorage interface {
 	// This can be used to check the validity of cross-chain interop events.
 	// The block-seal of the blockNum block, that the log was included in, is returned.
 	// This seal may be fully zeroed, without error, if the block isn't fully known yet.
-	Contains(blockNum uint64, logIdx uint32, logHash common.Hash) (includedIn types.BlockSeal, err error)
+	Contains(types.ContainsQuery) (includedIn types.BlockSeal, err error)
 
 	// OpenBlock accumulates the ExecutingMessage events for a block and returns them
 	OpenBlock(blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -36,6 +36,15 @@ func (ci *ChainIndex) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// ContainsQuery contains all the information needed to check a message
+// against a chain's database, to determine if it is valid (ie all invariants hold).
+type ContainsQuery struct {
+	Timestamp uint64
+	BlockNum  uint64
+	LogIdx    uint32
+	LogHash   common.Hash
+}
+
 type ExecutingMessage struct {
 	Chain     ChainIndex // same as ChainID for now, but will be indirect, i.e. translated to full ID, later
 	BlockNum  uint64

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -42,7 +42,7 @@ type ContainsQuery struct {
 	Timestamp uint64
 	BlockNum  uint64
 	LogIdx    uint32
-	LogHash   common.Hash
+	LogHash   common.Hash // LogHash commits to the origin-address and the message payload-hash
 }
 
 type ExecutingMessage struct {


### PR DESCRIPTION
# What
This PR makes two major changes to `op-supervisor` and `op-program`:

## Inclusion of Timestamp Invariant in `Contains`
Flagged in https://github.com/ethereum-optimism/optimism/issues/13949, the LogDB `Contains` call was returning `ErrFuture` when the timestamp being used could upgrade the error to `ErrConflict`, in cases where the supplied timestamp falls within the database's horizon. `Contains` was not doing this because it was not handling a timestamp at all, instead allowing the outer `ChainsDB` handle that (which of course, also cannot check the database timestamp, because only an `ErrFuture` has returned).

Now, `ChainsDB` is a much simpler wrapper that passes through all query parameters as a struct. The Timestamp invariant is relocated to the `logDB` implementation, and the new check described above is included as well.

Most of this work was in updating the test signatures to use timestamps, and extending the test cases.

The changes to unit tests made up the largest volume of the updates, since tests which were previously not using timestamps when asserting on `Contains` now had to get the correct values.

## Refactor of `Contains`
In adding the timestamp, I took the suggestion of @protolambda and created a Query Structure to hold all the parameters. I wired this through all the backend components of `Contains`, and while I did so I also **Changed the name of Check to Contains** all the way up to (but not including) the Backend Interface. The BE/FE interfaces I would like to update as a batch, but this change seemed appropriate since the underlying call that is happening is `Contains`.

This affects components through the `op-supervisor` and `op-program`, by way of changing interface names from `Check` to `Contains` and replacing the arguments with `(chainID, ContainsQuery)`.

# Tests
LogDB tests updated to include appropriate timestamps for all queries (all behavior was adapted 1:1, inserting correct timestamps in all tests), and additional test cases were included to show the `Contains` behavior now respects the timestamp invariant in both ways described above.