### PR TITLE
op-supervisor: Refactor Database Nomenclature

### DIFF
--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -193,9 +193,9 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 			return
 		}
 		eq.emitter.Emit(engine.PromotePendingSafeEvent{
-			Ref:         ref,
-			Concluding:  attributes.Concluding,
-			DerivedFrom: attributes.DerivedFrom,
+			Ref:        ref,
+			Concluding: attributes.Concluding,
+			Source:     attributes.DerivedFrom,
 		})
 	}
 

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -299,9 +299,9 @@ func TestAttributesHandler(t *testing.T) {
 				l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
 
 				emitter.ExpectOnce(engine.PromotePendingSafeEvent{
-					Ref:         refA1,
-					Concluding:  concluding,
-					DerivedFrom: refB,
+					Ref:        refA1,
+					Concluding: concluding,
+					Source:     refB,
 				})
 				ah.OnEvent(engine.PendingSafeUpdateEvent{
 					PendingSafe: refA0,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -353,7 +353,7 @@ func (s *SyncDeriver) OnEvent(ev event.Event) bool {
 
 func (s *SyncDeriver) onSafeDerivedBlock(x engine.SafeDerivedEvent) {
 	if s.SafeHeadNotifs != nil && s.SafeHeadNotifs.Enabled() {
-		if err := s.SafeHeadNotifs.SafeHeadUpdated(x.Safe, x.DerivedFrom.ID()); err != nil {
+		if err := s.SafeHeadNotifs.SafeHeadUpdated(x.Safe, x.Source.ID()); err != nil {
 			// At this point our state is in a potentially inconsistent state as we've updated the safe head
 			// in the execution client but failed to post process it. Reset the pipeline so the safe head rolls back
 			// a little (it always rolls back at least 1 block) and then it will retry storing the entry

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -24,7 +24,7 @@ func (ev PayloadSuccessEvent) String() string {
 }
 
 func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
-	if ev.DerivedFrom == ReplaceBlockDerivedFrom {
+	if ev.DerivedFrom == ReplaceBlockSource {
 		eq.log.Warn("Successfully built replacement block, resetting chain to continue now", "replacement", ev.Ref)
 		// Change the engine state to make the replacement block the cross-safe head of the chain,
 		// And continue syncing from there.
@@ -49,9 +49,9 @@ func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
 	// If derived from L1, then it can be considered (pending) safe
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
 		eq.emitter.Emit(PromotePendingSafeEvent{
-			Ref:         ev.Ref,
-			Concluding:  ev.Concluding,
-			DerivedFrom: ev.DerivedFrom,
+			Ref:        ev.Ref,
+			Concluding: ev.Concluding,
+			Source:     ev.DerivedFrom,
 		})
 	}
 

--- a/op-node/rollup/finality/altda_test.go
+++ b/op-node/rollup/finality/altda_test.go
@@ -132,7 +132,7 @@ func TestAltDAFinalityData(t *testing.T) {
 				L1Origin:       previous.ID(), // reference previous origin, not the block the batch was included in
 				SequenceNumber: j,
 			}
-			fi.OnEvent(engine.SafeDerivedEvent{Safe: l2parent, DerivedFrom: l1parent})
+			fi.OnEvent(engine.SafeDerivedEvent{Safe: l2parent, Source: l1parent})
 			emitter.AssertExpectations(t)
 		}
 		// might trigger finalization attempt, if expired finality delay

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -142,7 +142,7 @@ func (fi *Finalizer) OnEvent(ev event.Event) bool {
 	case FinalizeL1Event:
 		fi.onL1Finalized(x.FinalizedL1)
 	case engine.SafeDerivedEvent:
-		fi.onDerivedSafeBlock(x.Safe, x.DerivedFrom)
+		fi.onDerivedSafeBlock(x.Safe, x.Source)
 	case derive.DeriverIdleEvent:
 		fi.onDerivationIdle(x.Origin)
 	case rollup.ResetEvent:

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -195,12 +195,12 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.AttachEmitter(emitter)
 
 		// now say C1 was included in D and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, Source: refD})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refD})
 		emitter.AssertExpectations(t)
 
 		// now say D0 was included in E and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD0, DerivedFrom: refE})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD0, Source: refE})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refE})
 		emitter.AssertExpectations(t)
 
@@ -230,12 +230,12 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.AttachEmitter(emitter)
 
 		// now say C1 was included in D and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, Source: refD})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refD})
 		emitter.AssertExpectations(t)
 
 		// now say D0 was included in E and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD0, DerivedFrom: refE})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD0, Source: refE})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refE})
 		emitter.AssertExpectations(t)
 
@@ -269,11 +269,11 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, l1F)
 		fi.AttachEmitter(emitter)
 
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, Source: refD})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refD})
 		emitter.AssertExpectations(t)
 
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD0, DerivedFrom: refE})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD0, Source: refE})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refE})
 		emitter.AssertExpectations(t)
 
@@ -312,11 +312,11 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refG})
 		emitter.AssertExpectations(t)
 
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD1, DerivedFrom: refH})
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refE0, DerivedFrom: refH})
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refE1, DerivedFrom: refH})
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refF0, DerivedFrom: refH})
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refF1, DerivedFrom: refH})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refD1, Source: refH})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refE0, Source: refH})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refE1, Source: refH})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refF0, Source: refH})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refF1, Source: refH})
 		emitter.AssertExpectations(t) // above updates add data, but no attempt is made until idle or L1 signal
 
 		// We recently finalized already, and there is no new L1 finality data
@@ -356,12 +356,12 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.AttachEmitter(emitter)
 
 		// now say B1 was included in C and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refB1, DerivedFrom: refC})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refB1, Source: refC})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refC})
 		emitter.AssertExpectations(t)
 
 		// now say C0 was included in E and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0, DerivedFrom: refE})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0, Source: refE})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refE})
 		emitter.AssertExpectations(t)
 
@@ -393,7 +393,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.AttachEmitter(emitter)
 
 		// now say B1 was included in C and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refB1, DerivedFrom: refC})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refB1, Source: refC})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refC})
 		emitter.AssertExpectations(t)
 
@@ -420,8 +420,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 			ParentHash: refC.Hash,
 			Time:       refC.Time + l1Time,
 		}
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0Alt, DerivedFrom: refDAlt})
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1Alt, DerivedFrom: refDAlt})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0Alt, Source: refDAlt})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1Alt, Source: refDAlt})
 
 		// We get an early finality signal for F, of the chain that did not include refC0Alt and refC1Alt,
 		// as L1 block F does not build on DAlt.
@@ -457,7 +457,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t) // no new finality
 
 		// Include C0 in E
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0, DerivedFrom: refE})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0, Source: refE})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refE})
 		// Due to the "finalityDelay" we don't repeat finality checks shortly after one another,
 		// and don't expect a finality attempt.
@@ -489,8 +489,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.AttachEmitter(emitter)
 
 		// now say C0 and C1 were included in D and became the new safe head
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0, DerivedFrom: refD})
-		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0, Source: refD})
+		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, Source: refD})
 		fi.OnEvent(derive.DeriverIdleEvent{Origin: refD})
 		emitter.AssertExpectations(t)
 

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -117,9 +117,9 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 		ref := x.Ref.BlockRef()
 		m.events.Send(&supervisortypes.ManagedEvent{UnsafeBlock: &ref})
 	case engine.LocalSafeUpdateEvent:
-		m.log.Info("Emitting local safe update because of L2 block", "derivedFrom", x.DerivedFrom, "derived", x.Ref)
+		m.log.Info("Emitting local safe update because of L2 block", "derivedFrom", x.Source, "derived", x.Ref)
 		m.events.Send(&supervisortypes.ManagedEvent{DerivationUpdate: &supervisortypes.DerivedBlockRefPair{
-			DerivedFrom: x.DerivedFrom,
+			DerivedFrom: x.Source,
 			Derived:     x.Ref.BlockRef(),
 		}})
 	case derive.DeriverL1StatusEvent:
@@ -188,8 +188,8 @@ func (m *ManagedMode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, 
 		return fmt.Errorf("failed to get L1BlockRef: %w", err)
 	}
 	m.emitter.Emit(engine.PromoteSafeEvent{
-		Ref:         l2Ref,
-		DerivedFrom: l1Ref,
+		Ref:    l2Ref,
+		Source: l1Ref,
 	})
 	// We return early: there is no point waiting for the cross-safe engine-update synchronously.
 	// All error-feedback comes to the supervisor by aborting derivation tasks with an error.
@@ -228,7 +228,7 @@ func (m *ManagedMode) InvalidateBlock(ctx context.Context, seal supervisortypes.
 		Attributes:  attributes,
 		Parent:      parentRef,
 		Concluding:  true,
-		DerivedFrom: engine.ReplaceBlockDerivedFrom,
+		DerivedFrom: engine.ReplaceBlockSource,
 	}
 
 	m.emitter.Emit(engine.InteropInvalidateBlockEvent{Invalidated: ref, Attributes: annotated})

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -129,10 +129,7 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 				Source:  x.Origin,
 				Derived: x.LastL2.BlockRef(),
 			},
-			DerivationOriginUpdate: &supervisortypes.DerivedBlockRefPair{
-				Source:  x.Origin,
-				Derived: x.LastL2.BlockRef(),
-			},
+			DerivationOriginUpdate: &x.Origin,
 		})
 	case derive.ExhaustedL1Event:
 		m.log.Info("Exhausted L1 data", "derivedFrom", x.L1Ref, "derived", x.LastL2)

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -119,26 +119,26 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 	case engine.LocalSafeUpdateEvent:
 		m.log.Info("Emitting local safe update because of L2 block", "derivedFrom", x.Source, "derived", x.Ref)
 		m.events.Send(&supervisortypes.ManagedEvent{DerivationUpdate: &supervisortypes.DerivedBlockRefPair{
-			DerivedFrom: x.Source,
-			Derived:     x.Ref.BlockRef(),
+			Source:  x.Source,
+			Derived: x.Ref.BlockRef(),
 		}})
 	case derive.DeriverL1StatusEvent:
 		m.log.Info("Emitting local safe update because of L1 traversal", "derivedFrom", x.Origin, "derived", x.LastL2)
 		m.events.Send(&supervisortypes.ManagedEvent{
 			DerivationUpdate: &supervisortypes.DerivedBlockRefPair{
-				DerivedFrom: x.Origin,
-				Derived:     x.LastL2.BlockRef(),
+				Source:  x.Origin,
+				Derived: x.LastL2.BlockRef(),
 			},
 			DerivationOriginUpdate: &supervisortypes.DerivedBlockRefPair{
-				DerivedFrom: x.Origin,
-				Derived:     x.LastL2.BlockRef(),
+				Source:  x.Origin,
+				Derived: x.LastL2.BlockRef(),
 			},
 		})
 	case derive.ExhaustedL1Event:
 		m.log.Info("Exhausted L1 data", "derivedFrom", x.L1Ref, "derived", x.LastL2)
 		m.events.Send(&supervisortypes.ManagedEvent{ExhaustL1: &supervisortypes.DerivedBlockRefPair{
-			DerivedFrom: x.L1Ref,
-			Derived:     x.LastL2.BlockRef(),
+			Source:  x.L1Ref,
+			Derived: x.LastL2.BlockRef(),
 		}})
 	case engine.InteropReplacedBlockEvent:
 		m.log.Info("Replaced block", "replacement", x.Ref)
@@ -247,8 +247,8 @@ func (m *ManagedMode) AnchorPoint(ctx context.Context) (supervisortypes.DerivedB
 		return supervisortypes.DerivedBlockRefPair{}, fmt.Errorf("failed to fetch L2 block ref: %w", err)
 	}
 	return supervisortypes.DerivedBlockRefPair{
-		DerivedFrom: l1Ref,
-		Derived:     l2Ref.BlockRef(),
+		Source:  l1Ref,
+		Derived: l2Ref.BlockRef(),
 	}, nil
 }
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -255,17 +255,17 @@ func (su *SupervisorBackend) openChainDBs(chainID eth.ChainID) error {
 	}
 	su.chainDBs.AddLogDB(chainID, logDB)
 
-	localDB, err := db.OpenLocalDerivedFromDB(su.logger, chainID, su.dataDir, cm)
+	localDB, err := db.OpenLocalDerivationDB(su.logger, chainID, su.dataDir, cm)
 	if err != nil {
 		return fmt.Errorf("failed to open local derived-from DB of chain %s: %w", chainID, err)
 	}
-	su.chainDBs.AddLocalDerivedFromDB(chainID, localDB)
+	su.chainDBs.AddLocalDerivationDB(chainID, localDB)
 
-	crossDB, err := db.OpenCrossDerivedFromDB(su.logger, chainID, su.dataDir, cm)
+	crossDB, err := db.OpenCrossDerivationDB(su.logger, chainID, su.dataDir, cm)
 	if err != nil {
 		return fmt.Errorf("failed to open cross derived-from DB of chain %s: %w", chainID, err)
 	}
-	su.chainDBs.AddCrossDerivedFromDB(chainID, crossDB)
+	su.chainDBs.AddCrossDerivationDB(chainID, crossDB)
 
 	su.chainDBs.AddCrossUnsafeTracker(chainID)
 
@@ -522,8 +522,8 @@ func (su *SupervisorBackend) FinalizedL1() eth.BlockRef {
 	return su.chainDBs.FinalizedL1()
 }
 
-func (su *SupervisorBackend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
-	v, err := su.chainDBs.CrossDerivedFromBlockRef(chainID, derived)
+func (su *SupervisorBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
+	v, err := su.chainDBs.CrossDerivedToSourceRef(chainID, derived)
 	if err != nil {
 		return eth.BlockRef{}, err
 	}
@@ -542,7 +542,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 	chainInfos := make([]eth.ChainRootInfo, len(chains))
 	superRootChains := make([]eth.ChainIDAndOutput, len(chains))
 
-	var crossSafeDerivedFrom eth.BlockID
+	var crossSafeSource eth.BlockID
 
 	for i, chainID := range chains {
 		src, ok := su.syncSources.Get(chainID)
@@ -570,12 +570,12 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		if err != nil {
 			return eth.SuperRootResponse{}, err
 		}
-		derivedFrom, err := su.chainDBs.CrossDerivedFrom(chainID, ref.ID())
+		derivedFrom, err := su.chainDBs.CrossDerivedToFirstSource(chainID, ref.ID())
 		if err != nil {
 			return eth.SuperRootResponse{}, err
 		}
-		if crossSafeDerivedFrom.Number == 0 || crossSafeDerivedFrom.Number < derivedFrom.Number {
-			crossSafeDerivedFrom = derivedFrom.ID()
+		if crossSafeSource.Number == 0 || crossSafeSource.Number < derivedFrom.Number {
+			crossSafeSource = derivedFrom.ID()
 		}
 	}
 	superRoot := eth.SuperRoot(&eth.SuperV1{
@@ -583,7 +583,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		Chains:    superRootChains,
 	})
 	return eth.SuperRootResponse{
-		CrossSafeDerivedFrom: crossSafeDerivedFrom,
+		CrossSafeDerivedFrom: crossSafeSource,
 		Timestamp:            uint64(timestamp),
 		SuperRoot:            superRoot,
 		Chains:               chainInfos,

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -570,7 +570,7 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		if err != nil {
 			return eth.SuperRootResponse{}, err
 		}
-		derivedFrom, err := su.chainDBs.CrossDerivedToFirstSource(chainID, ref.ID())
+		derivedFrom, err := su.chainDBs.CrossDerivedToSource(chainID, ref.ID())
 		if err != nil {
 			return eth.SuperRootResponse{}, err
 		}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -456,8 +456,8 @@ func (su *SupervisorBackend) CrossSafe(ctx context.Context, chainID eth.ChainID)
 		return types.DerivedIDPair{}, err
 	}
 	return types.DerivedIDPair{
-		DerivedFrom: p.DerivedFrom.ID(),
-		Derived:     p.Derived.ID(),
+		Source:  p.Source.ID(),
+		Derived: p.Derived.ID(),
 	}, nil
 }
 
@@ -467,8 +467,8 @@ func (su *SupervisorBackend) LocalSafe(ctx context.Context, chainID eth.ChainID)
 		return types.DerivedIDPair{}, err
 	}
 	return types.DerivedIDPair{
-		DerivedFrom: p.DerivedFrom.ID(),
-		Derived:     p.Derived.ID(),
+		Source:  p.Source.ID(),
+		Derived: p.Derived.ID(),
 	}, nil
 }
 

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -12,7 +12,7 @@ import (
 type SafeFrontierCheckDeps interface {
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
 
-	CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }
@@ -31,7 +31,7 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, h
 			}
 			return err
 		}
-		initSource, err := d.CrossDerivedToFirstSource(hazardChainID, hazardBlock.ID())
+		initSource, err := d.CrossDerivedToSource(hazardChainID, hazardBlock.ID())
 		if err != nil {
 			if errors.Is(err, types.ErrFuture) {
 				// If not in cross-safe scope, then check if it's the candidate cross-safe block.

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -12,7 +12,7 @@ import (
 type SafeFrontierCheckDeps interface {
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
 
-	CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }
@@ -21,7 +21,7 @@ type SafeFrontierCheckDeps interface {
 //   - already cross-safe.
 //   - the first (if not first: local blocks to verify before proceeding)
 //     local-safe block, after the cross-safe block.
-func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1DerivedFrom eth.BlockID, hazards map[types.ChainIndex]types.BlockSeal) error {
+func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, hazards map[types.ChainIndex]types.BlockSeal) error {
 	depSet := d.DependencySet()
 	for hazardChainIndex, hazardBlock := range hazards {
 		hazardChainID, err := depSet.ChainIDFromIndex(hazardChainIndex)
@@ -31,7 +31,7 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1DerivedFrom eth.Block
 			}
 			return err
 		}
-		initDerivedFrom, err := d.CrossDerivedFrom(hazardChainID, hazardBlock.ID())
+		initSource, err := d.CrossDerivedToFirstSource(hazardChainID, hazardBlock.ID())
 		if err != nil {
 			if errors.Is(err, types.ErrFuture) {
 				// If not in cross-safe scope, then check if it's the candidate cross-safe block.
@@ -43,16 +43,16 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1DerivedFrom eth.Block
 					return fmt.Errorf("expected block %s (chain %d) does not match candidate local-safe block %s: %w",
 						hazardBlock, hazardChainID, candidate.Derived, types.ErrConflict)
 				}
-				if candidate.Source.Number > inL1DerivedFrom.Number {
+				if candidate.Source.Number > inL1Source.Number {
 					return fmt.Errorf("local-safe hazard block %s derived from L1 block %s is after scope %s: %w",
-						hazardBlock.ID(), initDerivedFrom, inL1DerivedFrom, types.ErrOutOfScope)
+						hazardBlock.ID(), initSource, inL1Source, types.ErrOutOfScope)
 				}
 			} else {
 				return fmt.Errorf("failed to determine cross-derived of hazard block %s (chain %s): %w", hazardBlock, hazardChainID, err)
 			}
-		} else if initDerivedFrom.Number > inL1DerivedFrom.Number {
+		} else if initSource.Number > inL1Source.Number {
 			return fmt.Errorf("cross-safe hazard block %s derived from L1 block %s is after scope %s: %w",
-				hazardBlock.ID(), initDerivedFrom, inL1DerivedFrom, types.ErrOutOfScope)
+				hazardBlock.ID(), initSource, inL1Source, types.ErrOutOfScope)
 		}
 	}
 	return nil

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -43,7 +43,7 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1DerivedFrom eth.Block
 					return fmt.Errorf("expected block %s (chain %d) does not match candidate local-safe block %s: %w",
 						hazardBlock, hazardChainID, candidate.Derived, types.ErrConflict)
 				}
-				if candidate.DerivedFrom.Number > inL1DerivedFrom.Number {
+				if candidate.Source.Number > inL1DerivedFrom.Number {
 					return fmt.Errorf("local-safe hazard block %s derived from L1 block %s is after scope %s: %w",
 						hazardBlock.ID(), initDerivedFrom, inL1DerivedFrom, types.ErrOutOfScope)
 				}

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -14,11 +14,11 @@ import (
 func TestHazardSafeFrontierChecks(t *testing.T) {
 	t.Run("empty hazards", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		l1DerivedFrom := eth.BlockID{}
+		l1Source := eth.BlockID{}
 		hazards := map[types.ChainIndex]types.BlockSeal{}
 		// when there are no hazards,
 		// no work is done, and no error is returned
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.NoError(t, err)
 	})
 	t.Run("unknown chain", func(t *testing.T) {
@@ -29,42 +29,42 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 				},
 			},
 		}
-		l1DerivedFrom := eth.BlockID{}
+		l1Source := eth.BlockID{}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
 		// when there is one hazard, and ChainIDFromIndex returns ErrUnknownChain,
 		// an error is returned as a ErrConflict
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorIs(t, err, types.ErrConflict)
 	})
-	t.Run("initDerivedFrom in scope", func(t *testing.T) {
+	t.Run("initSource in scope", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1}, nil
 		}
-		l1DerivedFrom := eth.BlockID{Number: 2}
+		l1Source := eth.BlockID{Number: 2}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
-		// when there is one hazard, and CrossDerivedFrom returns a BlockSeal within scope
+		// when there is one hazard, and CrossSource returns a BlockSeal within scope
 		// (ie the hazard's block number is less than or equal to the derivedFrom block number),
 		// no error is returned
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.NoError(t, err)
 	})
-	t.Run("initDerivedFrom out of scope", func(t *testing.T) {
+	t.Run("initSource out of scope", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 3}, nil
 		}
-		l1DerivedFrom := eth.BlockID{Number: 2}
+		l1Source := eth.BlockID{Number: 2}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
-		// when there is one hazard, and CrossDerivedFrom returns a BlockSeal out of scope
+		// when there is one hazard, and CrossSource returns a BlockSeal out of scope
 		// (ie the hazard's block number is greater than the derivedFrom block number),
 		// an error is returned as a ErrOutOfScope
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorIs(t, err, types.ErrOutOfScope)
 	})
 	t.Run("errFuture: candidate cross safe failure", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 3}, types.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
@@ -73,17 +73,17 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 					Derived: eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})}},
 				errors.New("some error")
 		}
-		l1DerivedFrom := eth.BlockID{}
+		l1Source := eth.BlockID{}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
-		// when there is one hazard, and CrossDerivedFrom returns an ErrFuture,
+		// when there is one hazard, and CrossSource returns an ErrFuture,
 		// and CandidateCrossSafe returns an error,
 		// the error from CandidateCrossSafe is returned
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorContains(t, err, "some error")
 	})
 	t.Run("errFuture: expected block does not match candidate", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{}, types.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
@@ -92,18 +92,18 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 				Derived: eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
 			}, nil
 		}
-		l1DerivedFrom := eth.BlockID{}
+		l1Source := eth.BlockID{}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
-		// when there is one hazard, and CrossDerivedFrom returns an ErrFuture,
+		// when there is one hazard, and CrossSource returns an ErrFuture,
 		// and CandidateCrossSafe returns a candidate that does not match the hazard,
 		// (ie the candidate's block number is the same as the hazard's block number, but the hashes are different),
 		// an error is returned as a ErrConflict
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorIs(t, err, types.ErrConflict)
 	})
 	t.Run("errFuture: local-safe hazard out of scope", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{}, types.ErrFuture
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
@@ -112,17 +112,17 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 					Derived: eth.BlockRef{}},
 				nil
 		}
-		l1DerivedFrom := eth.BlockID{Number: 8}
+		l1Source := eth.BlockID{Number: 8}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
-		// when there is one hazard, and CrossDerivedFrom returns an ErrFuture,
-		// and the initDerivedFrom is out of scope,
+		// when there is one hazard, and CrossSource returns an ErrFuture,
+		// and the initSource is out of scope,
 		// an error is returned as a ErrOutOfScope
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorIs(t, err, types.ErrOutOfScope)
 	})
-	t.Run("CrossDerivedFrom Error", func(t *testing.T) {
+	t.Run("CrossSource Error", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
-		sfcd.crossDerivedFromFn = func() (types.BlockSeal, error) {
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
@@ -131,12 +131,12 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 				Derived: eth.BlockRef{},
 			}, nil
 		}
-		l1DerivedFrom := eth.BlockID{Number: 8}
+		l1Source := eth.BlockID{Number: 8}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
-		// when there is one hazard, and CrossDerivedFrom returns an ErrFuture,
-		// and the initDerivedFrom is out of scope,
+		// when there is one hazard, and CrossSource returns an ErrFuture,
+		// and the initSource is out of scope,
 		// an error is returned as a ErrOutOfScope
-		err := HazardSafeFrontierChecks(sfcd, l1DerivedFrom, hazards)
+		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorContains(t, err, "some error")
 	})
 }
@@ -144,7 +144,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 type mockSafeFrontierCheckDeps struct {
 	deps                 mockDependencySet
 	candidateCrossSafeFn func() (candidate types.DerivedBlockRefPair, err error)
-	crossDerivedFromFn   func() (derivedFrom types.BlockSeal, err error)
+	crossSourceFn        func() (derivedFrom types.BlockSeal, err error)
 }
 
 func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error) {
@@ -154,9 +154,9 @@ func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candi
 	return types.DerivedBlockRefPair{}, nil
 }
 
-func (m *mockSafeFrontierCheckDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
-	if m.crossDerivedFromFn != nil {
-		return m.crossDerivedFromFn()
+func (m *mockSafeFrontierCheckDeps) CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+	if m.crossSourceFn != nil {
+		return m.crossSourceFn()
 	}
 	return types.BlockSeal{}, nil
 }

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -154,7 +154,7 @@ func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candi
 	return types.DerivedBlockRefPair{}, nil
 }
 
-func (m *mockSafeFrontierCheckDeps) CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockSafeFrontierCheckDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	if m.crossSourceFn != nil {
 		return m.crossSourceFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -69,8 +69,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-					DerivedFrom: eth.BlockRef{},
-					Derived:     eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})}},
+					Source:  eth.BlockRef{},
+					Derived: eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})}},
 				errors.New("some error")
 		}
 		l1DerivedFrom := eth.BlockID{}
@@ -88,8 +88,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: eth.BlockRef{},
-				Derived:     eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
+				Source:  eth.BlockRef{},
+				Derived: eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
 			}, nil
 		}
 		l1DerivedFrom := eth.BlockID{}
@@ -108,8 +108,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-					DerivedFrom: eth.BlockRef{Number: 9},
-					Derived:     eth.BlockRef{}},
+					Source:  eth.BlockRef{Number: 9},
+					Derived: eth.BlockRef{}},
 				nil
 		}
 		l1DerivedFrom := eth.BlockID{Number: 8}
@@ -127,8 +127,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		}
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: eth.BlockRef{Number: 9},
-				Derived:     eth.BlockRef{},
+				Source:  eth.BlockRef{Number: 9},
+				Derived: eth.BlockRef{},
 			}, nil
 		}
 		l1DerivedFrom := eth.BlockID{Number: 8}

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -12,7 +12,7 @@ import (
 type SafeStartDeps interface {
 	Contains(chain eth.ChainID, query types.ContainsQuery) (includedIn types.BlockSeal, err error)
 
-	CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }
@@ -20,7 +20,7 @@ type SafeStartDeps interface {
 // CrossSafeHazards checks if the given messages all exist and pass invariants.
 // It returns a hazard-set: if any intra-block messaging happened,
 // these hazard blocks have to be verified.
-func CrossSafeHazards(d SafeStartDeps, chainID eth.ChainID, inL1DerivedFrom eth.BlockID,
+func CrossSafeHazards(d SafeStartDeps, chainID eth.ChainID, inL1Source eth.BlockID,
 	candidate types.BlockSeal, execMsgs []*types.ExecutingMessage) (hazards map[types.ChainIndex]types.BlockSeal, err error) {
 
 	hazards = make(map[types.ChainIndex]types.BlockSeal)
@@ -69,13 +69,13 @@ func CrossSafeHazards(d SafeStartDeps, chainID eth.ChainID, inL1DerivedFrom eth.
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}
-			initDerivedFrom, err := d.CrossDerivedFrom(initChainID, includedIn.ID())
+			initSource, err := d.CrossDerivedToFirstSource(initChainID, includedIn.ID())
 			if err != nil {
 				return nil, fmt.Errorf("msg %s included in non-cross-safe block %s: %w", msg, includedIn, err)
 			}
-			if initDerivedFrom.Number > inL1DerivedFrom.Number {
+			if initSource.Number > inL1Source.Number {
 				return nil, fmt.Errorf("msg %s was included in block %s derived from %s which is not in cross-safe scope %s: %w",
-					msg, includedIn, initDerivedFrom, inL1DerivedFrom, types.ErrOutOfScope)
+					msg, includedIn, initSource, inL1Source, types.ErrOutOfScope)
 			}
 		} else if msg.Timestamp == candidate.Timestamp {
 			// If timestamp is equal: we have to inspect ordering of individual

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -12,7 +12,7 @@ import (
 type SafeStartDeps interface {
 	Contains(chain eth.ChainID, query types.ContainsQuery) (includedIn types.BlockSeal, err error)
 
-	CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }
@@ -69,7 +69,7 @@ func CrossSafeHazards(d SafeStartDeps, chainID eth.ChainID, inL1Source eth.Block
 			if err != nil {
 				return nil, fmt.Errorf("executing msg %s failed check: %w", msg, err)
 			}
-			initSource, err := d.CrossDerivedToFirstSource(initChainID, includedIn.ID())
+			initSource, err := d.CrossDerivedToSource(initChainID, includedIn.ID())
 			if err != nil {
 				return nil, fmt.Errorf("msg %s included in non-cross-safe block %s: %w", msg, includedIn, err)
 			}

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -15,12 +15,12 @@ func TestCrossSafeHazards(t *testing.T) {
 	t.Run("empty execMsgs", func(t *testing.T) {
 		ssd := &mockSafeStartDeps{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{}
 		// when there are no execMsgs,
 		// no work is done, and no error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.NoError(t, err)
 		require.Empty(t, hazards)
 	})
@@ -32,12 +32,12 @@ func TestCrossSafeHazards(t *testing.T) {
 			},
 		}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanExecuteAt returns false,
 		// no work is done and an error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorIs(t, err, types.ErrConflict)
 		require.Empty(t, hazards)
 	})
@@ -49,12 +49,12 @@ func TestCrossSafeHazards(t *testing.T) {
 			},
 		}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanExecuteAt returns false,
 		// no work is done and an error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "some error")
 		require.Empty(t, hazards)
 	})
@@ -66,12 +66,12 @@ func TestCrossSafeHazards(t *testing.T) {
 			},
 		}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and ChainIDFromIndex returns ErrUnknownChain,
 		// an error is returned as a ErrConflict
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorIs(t, err, types.ErrConflict)
 		require.Empty(t, hazards)
 	})
@@ -83,12 +83,12 @@ func TestCrossSafeHazards(t *testing.T) {
 			},
 		}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and ChainIDFromIndex returns some other error,
 		// the error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "some error")
 		require.Empty(t, hazards)
 	})
@@ -100,12 +100,12 @@ func TestCrossSafeHazards(t *testing.T) {
 			},
 		}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanInitiateAt returns false,
 		// the error is returned as a ErrConflict
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorIs(t, err, types.ErrConflict)
 		require.Empty(t, hazards)
 	})
@@ -117,12 +117,12 @@ func TestCrossSafeHazards(t *testing.T) {
 			},
 		}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{}
 		execMsgs := []*types.ExecutingMessage{{}}
 		// when there is one execMsg, and CanInitiateAt returns an error,
 		// the error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "some error")
 		require.Empty(t, hazards)
 	})
@@ -130,13 +130,13 @@ func TestCrossSafeHazards(t *testing.T) {
 		ssd := &mockSafeStartDeps{}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 10}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is greater than the candidate,
 		// an error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "breaks timestamp invariant")
 		require.Empty(t, hazards)
 	})
@@ -147,14 +147,14 @@ func TestCrossSafeHazards(t *testing.T) {
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timetamp is equal to the candidate,
 		// and check returns an error,
 		// that error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "some error")
 		require.Empty(t, hazards)
 	})
@@ -166,7 +166,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
 		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -174,7 +174,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		// when there are two execMsgs, and both are equal time to the candidate,
 		// and check returns the same includedIn for both
 		// they load the hazards once, and return no error
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.NoError(t, err)
 		require.Equal(t, hazards, map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): sampleBlockSeal})
 	})
@@ -193,7 +193,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
 		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
@@ -201,7 +201,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		// when there are two execMsgs, and both are equal time to the candidate,
 		// and check returns different includedIn for the two,
 		// an error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "but already depend on")
 		require.Empty(t, hazards)
 	})
@@ -212,14 +212,14 @@ func TestCrossSafeHazards(t *testing.T) {
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and check returns an error,
 		// that error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "some error")
 		require.Empty(t, hazards)
 	})
@@ -234,14 +234,14 @@ func TestCrossSafeHazards(t *testing.T) {
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and CrossDerivedFrom returns aan error,
 		// that error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorContains(t, err, "some error")
 		require.Empty(t, hazards)
 	})
@@ -251,20 +251,20 @@ func TestCrossSafeHazards(t *testing.T) {
 		ssd.checkFn = func() (includedIn types.BlockSeal, err error) {
 			return sampleBlockSeal, nil
 		}
-		sampleDerivedFrom := types.BlockSeal{Number: 4, Hash: common.BytesToHash([]byte{0x03})}
+		sampleSource := types.BlockSeal{Number: 4, Hash: common.BytesToHash([]byte{0x03})}
 		ssd.derivedFromFn = func() (derivedFrom types.BlockSeal, err error) {
-			return sampleDerivedFrom, nil
+			return sampleSource, nil
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{}
+		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is less than the candidate,
-		// and CrossDerivedFrom returns a BlockSeal with a greater Number than the inL1DerivedFrom,
+		// and CrossDerivedFrom returns a BlockSeal with a greater Number than the inL1Source,
 		// an error is returned as a ErrOutOfScope
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.ErrorIs(t, err, types.ErrOutOfScope)
 		require.Empty(t, hazards)
 	})
@@ -274,20 +274,20 @@ func TestCrossSafeHazards(t *testing.T) {
 		ssd.checkFn = func() (includedIn types.BlockSeal, err error) {
 			return sampleBlockSeal, nil
 		}
-		sampleDerivedFrom := types.BlockSeal{Number: 1, Hash: common.BytesToHash([]byte{0x03})}
+		sampleSource := types.BlockSeal{Number: 1, Hash: common.BytesToHash([]byte{0x03})}
 		ssd.derivedFromFn = func() (derivedFrom types.BlockSeal, err error) {
-			return sampleDerivedFrom, nil
+			return sampleSource, nil
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{Number: 10}
+		inL1Source := eth.BlockID{Number: 10}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is less than the candidate,
-		// and CrossDerivedFrom returns a BlockSeal with a smaller Number than the inL1DerivedFrom,
+		// and CrossDerivedFrom returns a BlockSeal with a smaller Number than the inL1Source,
 		// no error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.NoError(t, err)
 		require.Empty(t, hazards)
 	})
@@ -297,20 +297,20 @@ func TestCrossSafeHazards(t *testing.T) {
 		ssd.checkFn = func() (includedIn types.BlockSeal, err error) {
 			return sampleBlockSeal, nil
 		}
-		sampleDerivedFrom := types.BlockSeal{Number: 1, Hash: common.BytesToHash([]byte{0x03})}
+		sampleSource := types.BlockSeal{Number: 1, Hash: common.BytesToHash([]byte{0x03})}
 		ssd.derivedFromFn = func() (derivedFrom types.BlockSeal, err error) {
-			return sampleDerivedFrom, nil
+			return sampleSource, nil
 		}
 		ssd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
-		inL1DerivedFrom := eth.BlockID{Number: 1}
+		inL1Source := eth.BlockID{Number: 1}
 		candidate := types.BlockSeal{Timestamp: 2}
 		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
 		execMsgs := []*types.ExecutingMessage{em1}
 		// when there is one execMsg, and the timestamp is less than the candidate,
-		// and CrossDerivedFrom returns a BlockSeal with a equal to the Number of inL1DerivedFrom,
+		// and CrossDerivedFrom returns a BlockSeal with a equal to the Number of inL1Source,
 		// no error is returned
-		hazards, err := CrossSafeHazards(ssd, chainID, inL1DerivedFrom, candidate, execMsgs)
+		hazards, err := CrossSafeHazards(ssd, chainID, inL1Source, candidate, execMsgs)
 		require.NoError(t, err)
 		require.Empty(t, hazards)
 	})
@@ -329,7 +329,7 @@ func (m *mockSafeStartDeps) Contains(chain eth.ChainID, q types.ContainsQuery) (
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockSafeStartDeps) CrossDerivedFrom(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockSafeStartDeps) CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	if m.derivedFromFn != nil {
 		return m.derivedFromFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -49,21 +49,21 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) er
 	}
 	if errors.Is(err, types.ErrConflict) {
 		logger.Warn("Found a conflicting local-safe block that cannot be promoted to cross-safe",
-			"scope", candidate.DerivedFrom, "invalidated", candidate, "err", err)
+			"scope", candidate.Source, "invalidated", candidate, "err", err)
 		return d.InvalidateLocalSafe(chainID, candidate)
 	}
 	if !errors.Is(err, types.ErrOutOfScope) {
 		return fmt.Errorf("failed to determine cross-safe update scope of chain %s: %w", chainID, err)
 	}
 	// candidate scope is expected to be set if ErrOutOfScope is returned.
-	if candidate.DerivedFrom == (eth.BlockRef{}) {
+	if candidate.Source == (eth.BlockRef{}) {
 		return fmt.Errorf("expected L1 scope to be defined with ErrOutOfScope: %w", err)
 	}
-	logger.Debug("Cross-safe updating ran out of L1 scope", "scope", candidate.DerivedFrom, "err", err)
+	logger.Debug("Cross-safe updating ran out of L1 scope", "scope", candidate.Source, "err", err)
 	// bump the L1 scope up, and repeat the prev L2 block, not the candidate
-	newScope, err := d.NextDerivedFrom(chainID, candidate.DerivedFrom.ID())
+	newScope, err := d.NextDerivedFrom(chainID, candidate.Source.ID())
 	if err != nil {
-		return fmt.Errorf("failed to identify new L1 scope to expand to after %s: %w", candidate.DerivedFrom, err)
+		return fmt.Errorf("failed to identify new L1 scope to expand to after %s: %w", candidate.Source, err)
 	}
 	currentCrossSafe, err := d.CrossSafe(chainID)
 	if err != nil {
@@ -77,7 +77,7 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) er
 	crossSafeRef := currentCrossSafe.Derived.MustWithParent(parent.ID())
 	logger.Debug("Bumping cross-safe scope", "scope", newScope, "crossSafe", crossSafeRef)
 	if err := d.UpdateCrossSafe(chainID, newScope, crossSafeRef); err != nil {
-		return fmt.Errorf("failed to update cross-safe head with L1 scope increment to %s and repeat of L2 block %s: %w", candidate.DerivedFrom, crossSafeRef, err)
+		return fmt.Errorf("failed to update cross-safe head with L1 scope increment to %s and repeat of L2 block %s: %w", candidate.Source, crossSafeRef, err)
 	}
 	return nil
 }
@@ -91,7 +91,7 @@ func scopedCrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDe
 	if err != nil {
 		return candidate, fmt.Errorf("failed to determine candidate block for cross-safe: %w", err)
 	}
-	logger.Debug("Candidate cross-safe", "scope", candidate.DerivedFrom, "candidate", candidate.Derived)
+	logger.Debug("Candidate cross-safe", "scope", candidate.Source, "candidate", candidate.Derived)
 	opened, _, execMsgs, err := d.OpenBlock(chainID, candidate.Derived.Number)
 	if err != nil {
 		return candidate, fmt.Errorf("failed to open block %s: %w", candidate.Derived, err)
@@ -99,11 +99,11 @@ func scopedCrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDe
 	if opened.ID() != candidate.Derived.ID() {
 		return candidate, fmt.Errorf("unsafe L2 DB has %s, but candidate cross-safe was %s: %w", opened, candidate.Derived, types.ErrConflict)
 	}
-	hazards, err := CrossSafeHazards(d, chainID, candidate.DerivedFrom.ID(), types.BlockSealFromRef(opened), sliceOfExecMsgs(execMsgs))
+	hazards, err := CrossSafeHazards(d, chainID, candidate.Source.ID(), types.BlockSealFromRef(opened), sliceOfExecMsgs(execMsgs))
 	if err != nil {
 		return candidate, fmt.Errorf("failed to determine dependencies of cross-safe candidate %s: %w", candidate.Derived, err)
 	}
-	if err := HazardSafeFrontierChecks(d, candidate.DerivedFrom.ID(), hazards); err != nil {
+	if err := HazardSafeFrontierChecks(d, candidate.Source.ID(), hazards); err != nil {
 		return candidate, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate.Derived, err)
 	}
 	if err := HazardCycleChecks(d.DependencySet(), d, candidate.Derived.Time, hazards); err != nil {
@@ -111,8 +111,8 @@ func scopedCrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDe
 	}
 
 	// promote the candidate block to cross-safe
-	if err := d.UpdateCrossSafe(chainID, candidate.DerivedFrom, candidate.Derived); err != nil {
-		return candidate, fmt.Errorf("failed to update cross-safe head to %s, derived from scope %s: %w", candidate.Derived, candidate.DerivedFrom, err)
+	if err := d.UpdateCrossSafe(chainID, candidate.Source, candidate.Derived); err != nil {
+		return candidate, fmt.Errorf("failed to update cross-safe head to %s, derived from scope %s: %w", candidate.Derived, candidate.Source, err)
 	}
 	return candidate, nil
 }

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -19,7 +19,7 @@ type CrossSafeDeps interface {
 	SafeStartDeps
 
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
-	NextDerivedFrom(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
+	NextSource(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
 	PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
 
 	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
@@ -61,7 +61,7 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) er
 	}
 	logger.Debug("Cross-safe updating ran out of L1 scope", "scope", candidate.Source, "err", err)
 	// bump the L1 scope up, and repeat the prev L2 block, not the candidate
-	newScope, err := d.NextDerivedFrom(chainID, candidate.Source.ID())
+	newScope, err := d.NextSource(chainID, candidate.Source.ID())
 	if err != nil {
 		return fmt.Errorf("failed to identify new L1 scope to expand to after %s: %w", candidate.Source, err)
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -22,8 +22,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
@@ -48,8 +48,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -70,8 +70,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -89,8 +89,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -100,7 +100,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd.invalidateLocalSafeFn = func(id eth.ChainID, p types.DerivedBlockRefPair) error {
 			require.Equal(t, chainID, id)
 			require.Equal(t, candidate, p.Derived)
-			require.Equal(t, candidateScope, p.DerivedFrom)
+			require.Equal(t, candidateScope, p.Source)
 			invalidated = true
 			return nil
 		}
@@ -117,8 +117,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -165,8 +165,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -190,8 +190,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -215,8 +215,8 @@ func TestCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -246,7 +246,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		// the error is returned
 		candidate, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
-		require.Equal(t, eth.BlockRef{}, candidate.DerivedFrom)
+		require.Equal(t, eth.BlockRef{}, candidate.Source)
 	})
 	t.Run("CandidateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -259,7 +259,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		// the error is returned
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
-		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
+		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("candidate does not match opened block", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -268,8 +268,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: eth.BlockRef{},
-				Derived:     candidate,
+				Source:  eth.BlockRef{},
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 2}
@@ -280,7 +280,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		// an ErrConflict is returned
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorIs(t, err, types.ErrConflict)
-		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
+		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("CrossSafeHazards returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -289,8 +289,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: eth.BlockRef{},
-				Derived:     candidate,
+				Source:  eth.BlockRef{},
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
@@ -308,7 +308,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
 		require.ErrorContains(t, err, "dependencies of cross-safe candidate")
-		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
+		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("HazardSafeFrontierChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -317,8 +317,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: eth.BlockRef{},
-				Derived:     candidate,
+				Source:  eth.BlockRef{},
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
@@ -345,7 +345,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
 		require.ErrorContains(t, err, "frontier")
-		require.Equal(t, eth.BlockRef{}, pair.DerivedFrom)
+		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("HazardCycleChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -355,8 +355,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1, Time: 1}
@@ -374,7 +374,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "cycle detected")
 		require.ErrorContains(t, err, "failed to verify block")
-		require.Equal(t, eth.BlockRef{Number: 2}, pair.DerivedFrom)
+		require.Equal(t, eth.BlockRef{Number: 2}, pair.Source)
 	})
 	t.Run("UpdateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -384,8 +384,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
@@ -405,7 +405,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
 		require.ErrorContains(t, err, "failed to update")
-		require.Equal(t, eth.BlockRef{Number: 2}, pair.DerivedFrom)
+		require.Equal(t, eth.BlockRef{Number: 2}, pair.Source)
 	})
 	t.Run("successful update", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -415,8 +415,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		candidateScope := eth.BlockRef{Number: 2}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{
-				DerivedFrom: candidateScope,
-				Derived:     candidate,
+				Source:  candidateScope,
+				Derived: candidate,
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}
@@ -444,7 +444,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		require.Equal(t, chainID, updatingChain)
 		require.Equal(t, candidateScope, updatingCandidateScope)
 		require.Equal(t, candidate, updatingCandidate)
-		require.Equal(t, candidateScope, pair.DerivedFrom)
+		require.Equal(t, candidateScope, pair.Source)
 		require.NoError(t, err)
 	})
 }

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -481,7 +481,7 @@ func (m *mockCrossSafeDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockCrossSafeDeps) CrossDerivedToFirstSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockCrossSafeDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
 

--- a/op-supervisor/supervisor/backend/db/anchor.go
+++ b/op-supervisor/supervisor/backend/db/anchor.go
@@ -13,10 +13,10 @@ func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRef
 	_, err := db.LocalSafe(id)
 	if errors.Is(err, types.ErrFuture) {
 		db.logger.Debug("initializing chain database", "chain", id)
-		if err := db.UpdateCrossSafe(id, anchor.DerivedFrom, anchor.Derived); err != nil {
+		if err := db.UpdateCrossSafe(id, anchor.Source, anchor.Derived); err != nil {
 			db.logger.Warn("failed to initialize cross safe", "chain", id, "error", err)
 		}
-		db.UpdateLocalSafe(id, anchor.DerivedFrom, anchor.Derived)
+		db.UpdateLocalSafe(id, anchor.Source, anchor.Derived)
 	} else if err != nil {
 		db.logger.Warn("failed to check if chain database is initialized", "chain", id, "error", err)
 	} else {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -166,7 +166,7 @@ func (db *ChainsDB) AddLogDB(chainID eth.ChainID, logDB LogStorage) {
 	db.logDBs.Set(chainID, logDB)
 }
 
-func (db *ChainsDB) AddLocalDerivedFromDB(chainID eth.ChainID, dfDB DerivationStorage) {
+func (db *ChainsDB) AddLocalDerivationDB(chainID eth.ChainID, dfDB DerivationStorage) {
 	if db.localDBs.Has(chainID) {
 		db.logger.Warn("overwriting existing local derived-from DB for chain", "chain", chainID)
 	}
@@ -174,7 +174,7 @@ func (db *ChainsDB) AddLocalDerivedFromDB(chainID eth.ChainID, dfDB DerivationSt
 	db.localDBs.Set(chainID, dfDB)
 }
 
-func (db *ChainsDB) AddCrossDerivedFromDB(chainID eth.ChainID, dfDB DerivationStorage) {
+func (db *ChainsDB) AddCrossDerivationDB(chainID eth.ChainID, dfDB DerivationStorage) {
 	if db.crossDBs.Has(chainID) {
 		db.logger.Warn("overwriting existing cross derived-from DB for chain", "chain", chainID)
 	}

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -69,7 +69,7 @@ type DerivationStorage interface {
 
 	// type-specific
 	Invalidated() (pair types.DerivedBlockSealPair, err error)
-	IsCanonical(derived eth.BlockID) error
+	ContainsDerived(derived eth.BlockID) error
 
 	// writing
 	AddDerived(source eth.BlockRef, derived eth.BlockRef) error

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -147,7 +147,7 @@ func (db *ChainsDB) OnEvent(ev event.Event) bool {
 		db.maybeInitEventsDB(x.ChainID, x.Anchor)
 		db.maybeInitSafeDB(x.ChainID, x.Anchor)
 	case superevents.LocalDerivedEvent:
-		db.UpdateLocalSafe(x.ChainID, x.Derived.DerivedFrom, x.Derived.Derived)
+		db.UpdateLocalSafe(x.ChainID, x.Derived.Source, x.Derived.Derived)
 	case superevents.FinalizedL1RequestEvent:
 		db.onFinalizedL1(x.FinalizedL1)
 	case superevents.ReplaceBlockEvent:

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -52,20 +52,31 @@ type LogStorage interface {
 }
 
 type LocalDerivedFromStorage interface {
+	// basic info
 	First() (pair types.DerivedBlockSealPair, err error)
-	Latest() (pair types.DerivedBlockSealPair, err error)
-	Invalidated() (pair types.DerivedBlockSealPair, err error)
-	AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error
-	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error)
-	RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error
-	LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error)
-	IsDerived(derived eth.BlockID) error
-	DerivedFrom(derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
-	FirstAfter(derivedFrom, derived eth.BlockID) (next types.DerivedBlockSealPair, err error)
-	NextDerivedFrom(derivedFrom eth.BlockID) (nextDerivedFrom types.BlockSeal, err error)
+	Last() (pair types.DerivedBlockSealPair, err error)
+
+	// mapping from source<>derived
+	DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error)
+	SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error)
+
+	// traversal
+	Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error)
+	NextSource(source eth.BlockID) (nextSource types.BlockSeal, err error)
 	NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error)
-	PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error)
+	PreviousSource(source eth.BlockID) (prevSource types.BlockSeal, err error)
 	PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+
+	// type-specific
+	Invalidated() (pair types.DerivedBlockSealPair, err error)
+	IsCanonical(derived eth.BlockID) error
+
+	// writing
+	AddDerived(source eth.BlockRef, derived eth.BlockRef) error
+	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error)
+
+	// rewining
+	RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error
 	RewindToScope(scope eth.BlockID) error
 	RewindToFirstDerived(v eth.BlockID) error
 }

--- a/op-supervisor/supervisor/backend/db/file_layout.go
+++ b/op-supervisor/supervisor/backend/db/file_layout.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func prepLocalDerivedFromDBPath(chainID eth.ChainID, datadir string) (string, error) {
+func prepLocalDerivationDBPath(chainID eth.ChainID, datadir string) (string, error) {
 	dir, err := prepChainDir(chainID, datadir)
 	if err != nil {
 		return "", err
@@ -16,7 +16,7 @@ func prepLocalDerivedFromDBPath(chainID eth.ChainID, datadir string) (string, er
 	return filepath.Join(dir, "local_safe.db"), nil
 }
 
-func prepCrossDerivedFromDBPath(chainID eth.ChainID, datadir string) (string, error) {
+func prepCrossDerivationDBPath(chainID eth.ChainID, datadir string) (string, error) {
 	dir, err := prepChainDir(chainID, datadir)
 	if err != nil {
 		return "", err

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -70,12 +70,12 @@ func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal,
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// last is always the latest view, and thus canonical.
-	_, lastCanonical, err := db.lastDerivedFrom(derived.Number)
+	_, lastCanonical, err := db.derivedNumToLastSource(derived.Number)
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("failed to find last derived %d: %w", derived.Number, err)
 	}
 	// get the first time this L2 block was seen.
-	selfIndex, self, err := db.firstDerivedFrom(derived.Number)
+	selfIndex, self, err := db.derivedNumToFirstSource(derived.Number)
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("failed to find first derived %d: %w", derived.Number, err)
 	}
@@ -98,7 +98,7 @@ func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal,
 // derivedFrom: the L1 block that the L2 block is safe for (not necessarily the first, multiple L2 blocks may be derived from the same L1 block).
 // derived: the L2 block that was derived (not necessarily the first, the L1 block may have been empty and repeated the last safe L2 block).
 // If the last entry is invalidated, this returns a types.ErrAwaitReplacementBlock error.
-func (db *DB) Latest() (pair types.DerivedBlockSealPair, err error) {
+func (db *DB) Last() (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	link, err := db.latest()
@@ -106,6 +106,19 @@ func (db *DB) Latest() (pair types.DerivedBlockSealPair, err error) {
 		return types.DerivedBlockSealPair{}, err
 	}
 	return link.sealOrErr()
+}
+
+// latest is like Latest, but without lock, for internal use.
+func (db *DB) latest() (link LinkEntry, err error) {
+	lastIndex := db.store.LastEntryIdx()
+	if lastIndex < 0 {
+		return LinkEntry{}, types.ErrFuture
+	}
+	last, err := db.readAt(lastIndex)
+	if err != nil {
+		return LinkEntry{}, fmt.Errorf("failed to read last derivation data: %w", err)
+	}
+	return last, nil
 }
 
 func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
@@ -124,31 +137,18 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 	}, nil
 }
 
-// latest is like Latest, but without lock, for internal use.
-func (db *DB) latest() (link LinkEntry, err error) {
-	lastIndex := db.store.LastEntryIdx()
-	if lastIndex < 0 {
-		return LinkEntry{}, types.ErrFuture
-	}
-	last, err := db.readAt(lastIndex)
-	if err != nil {
-		return LinkEntry{}, fmt.Errorf("failed to read last derivation data: %w", err)
-	}
-	return last, nil
-}
-
 // LastDerivedAt returns the last L2 block derived from the given L1 block.
 // This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
-func (db *DB) LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
+func (db *DB) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, link, err := db.lastDerivedAt(derivedFrom.Number)
+	_, link, err := db.sourceNumToLastDerived(source.Number)
 	if err != nil {
 		return types.BlockSeal{}, err
 	}
-	if link.derivedFrom.ID() != derivedFrom {
+	if link.derivedFrom.ID() != source {
 		return types.BlockSeal{}, fmt.Errorf("searched for last derived-from %s but found %s: %w",
-			derivedFrom, link.derivedFrom, types.ErrConflict)
+			source, link.derivedFrom, types.ErrConflict)
 	}
 	if link.invalidated {
 		return types.BlockSeal{}, types.ErrAwaitReplacementBlock
@@ -162,7 +162,7 @@ func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair,
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// get the last time this L2 block was seen.
-	selfIndex, self, err := db.lastDerivedFrom(derived.Number)
+	selfIndex, self, err := db.derivedNumToLastSource(derived.Number)
 	if err != nil {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to find derived %d: %w", derived.Number, err)
 	}
@@ -176,16 +176,16 @@ func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair,
 	return next.sealOrErr()
 }
 
-// IsDerived checks if the given block is the canonical block at the given chain.
+// IsCanonical checks if the given block is canonical for the given chain.
 // This returns an ErrFuture if the block is not known yet.
 // An ErrConflict if there is a different block.
 // Or an ErrAwaitReplacementBlock if it was invalidated.
-func (db *DB) IsDerived(derived eth.BlockID) error {
+func (db *DB) IsCanonical(derived eth.BlockID) error {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// Take the last entry: this will be the latest canonical view,
 	// if the block was previously invalidated.
-	_, link, err := db.lastDerivedFrom(derived.Number)
+	_, link, err := db.derivedNumToLastSource(derived.Number)
 	if err != nil {
 		return err
 	}
@@ -201,10 +201,10 @@ func (db *DB) IsDerived(derived eth.BlockID) error {
 
 // DerivedFrom determines where a L2 block was first derived from.
 // (a L2 block may repeat if the following L1 blocks are empty and don't produce additional L2 blocks)
-func (db *DB) DerivedFrom(derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (db *DB) DerivedToFirstSource(derived eth.BlockID) (types.BlockSeal, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, link, err := db.firstDerivedFrom(derived.Number)
+	_, link, err := db.derivedNumToFirstSource(derived.Number)
 	if err != nil {
 		return types.BlockSeal{}, err
 	}
@@ -215,20 +215,20 @@ func (db *DB) DerivedFrom(derived eth.BlockID) (derivedFrom types.BlockSeal, err
 	return link.derivedFrom, nil
 }
 
-func (db *DB) PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error) {
+func (db *DB) PreviousSource(source eth.BlockID) (types.BlockSeal, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	return db.previousDerivedFrom(derivedFrom)
+	return db.previousSource(source)
 }
 
-func (db *DB) previousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error) {
+func (db *DB) previousSource(source eth.BlockID) (types.BlockSeal, error) {
 	// get the last time this L1 block was seen.
-	selfIndex, self, err := db.firstDerivedAt(derivedFrom.Number)
+	selfIndex, self, err := db.sourceNumToFirstDerived(source.Number)
 	if err != nil {
-		return types.BlockSeal{}, fmt.Errorf("failed to find derived %d: %w", derivedFrom.Number, err)
+		return types.BlockSeal{}, fmt.Errorf("failed to find derived %d: %w", source.Number, err)
 	}
-	if self.derivedFrom.ID() != derivedFrom {
-		return types.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derivedFrom, derivedFrom, types.ErrConflict)
+	if self.derivedFrom.ID() != source {
+		return types.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derivedFrom, source, types.ErrConflict)
 	}
 	if selfIndex == 0 {
 		// genesis block has a zeroed block as parent block
@@ -236,49 +236,48 @@ func (db *DB) previousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom type
 			return types.BlockSeal{}, nil
 		} else {
 			return types.BlockSeal{},
-				fmt.Errorf("cannot find previous derived before start of database: %s (%w)", derivedFrom, types.ErrPreviousToFirst)
+				fmt.Errorf("cannot find previous derived before start of database: %s (%w)", source, types.ErrPreviousToFirst)
 		}
 	}
 	prev, err := db.readAt(selfIndex - 1)
 	if err != nil {
-		return types.BlockSeal{}, fmt.Errorf("cannot find previous derived before %s: %w", derivedFrom, err)
+		return types.BlockSeal{}, fmt.Errorf("cannot find previous derived before %s: %w", source, err)
 	}
 	return prev.derivedFrom, nil
 }
 
-// NextDerivedFrom finds the next L1 block after derivedFrom
-func (db *DB) NextDerivedFrom(derivedFrom eth.BlockID) (nextDerivedFrom types.BlockSeal, err error) {
+// NextSource finds the next source after the given source
+func (db *DB) NextSource(source eth.BlockID) (types.BlockSeal, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	selfIndex, self, err := db.lastDerivedAt(derivedFrom.Number)
+	selfIndex, self, err := db.sourceNumToLastDerived(source.Number)
 	if err != nil {
-		return types.BlockSeal{}, fmt.Errorf("failed to find derived-from %d: %w", derivedFrom.Number, err)
+		return types.BlockSeal{}, fmt.Errorf("failed to find derived-from %d: %w", source.Number, err)
 	}
-	if self.derivedFrom.ID() != derivedFrom {
-		return types.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derivedFrom, derivedFrom, types.ErrConflict)
+	if self.derivedFrom.ID() != source {
+		return types.BlockSeal{}, fmt.Errorf("found %s, but expected %s: %w", self.derivedFrom, source, types.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
-		return types.BlockSeal{}, fmt.Errorf("cannot find next derived-from after %s: %w", derivedFrom, err)
+		return types.BlockSeal{}, fmt.Errorf("cannot find next derived-from after %s: %w", source, err)
 	}
 	return next.derivedFrom, nil
 }
 
-// FirstAfter determines the next entry after the given pair of derivedFrom, derived.
-// Either one or both of the two entries will be an increment by 1.
+// Next returns the next Derived Block Pair after the given pair.
 // This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
-func (db *DB) FirstAfter(derivedFrom, derived eth.BlockID) (pair types.DerivedBlockSealPair, err error) {
+func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	selfIndex, selfLink, err := db.lookup(derivedFrom.Number, derived.Number)
+	selfIndex, selfLink, err := db.lookup(pair.DerivedFrom.Number, pair.Derived.Number)
 	if err != nil {
 		return types.DerivedBlockSealPair{}, err
 	}
-	if selfLink.derivedFrom.ID() != derivedFrom {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.derivedFrom, derivedFrom, types.ErrConflict)
+	if selfLink.derivedFrom.ID() != pair.DerivedFrom {
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.derivedFrom, pair.DerivedFrom, types.ErrConflict)
 	}
-	if selfLink.derived.ID() != derived {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, derived, types.ErrConflict)
+	if selfLink.derived.ID() != pair.Derived {
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, pair.Derived, types.ErrConflict)
 	}
 	next, err := db.readAt(selfIndex + 1)
 	if err != nil {
@@ -287,15 +286,31 @@ func (db *DB) FirstAfter(derivedFrom, derived eth.BlockID) (pair types.DerivedBl
 	return next.sealOrErr()
 }
 
-func (db *DB) lastDerivedFrom(derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
-	return db.find(true, func(link LinkEntry) int {
-		return cmp.Compare(derived, link.derived.Number)
+func (db *DB) derivedNumToFirstSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
+	// Forward: prioritize the first entry.
+	return db.find(false, func(link LinkEntry) int {
+		return cmp.Compare(link.derived.Number, derivedNum)
 	})
 }
 
-func (db *DB) firstDerivedFrom(derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
+func (db *DB) derivedNumToLastSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
+	// Reverse: prioritize the last entry.
+	return db.find(true, func(link LinkEntry) int {
+		return cmp.Compare(derivedNum, link.derived.Number)
+	})
+}
+
+func (db *DB) sourceNumToFirstDerived(sourceNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
+	// Forward: prioritize the first entry.
 	return db.find(false, func(link LinkEntry) int {
-		return cmp.Compare(link.derived.Number, derived)
+		return cmp.Compare(link.derivedFrom.Number, sourceNum)
+	})
+}
+
+func (db *DB) sourceNumToLastDerived(sourceNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
+	// Reverse: prioritize the last entry.
+	return db.find(true, func(link LinkEntry) int {
+		return cmp.Compare(sourceNum, link.derivedFrom.Number)
 	})
 }
 
@@ -306,19 +321,6 @@ func (db *DB) lookup(derivedFrom, derived uint64) (entrydb.EntryIdx, LinkEntry, 
 			return cmp.Compare(link.derivedFrom.Number, derivedFrom)
 		}
 		return res
-	})
-}
-
-func (db *DB) lastDerivedAt(derivedFrom uint64) (entrydb.EntryIdx, LinkEntry, error) {
-	// Reverse: prioritize the last entry.
-	return db.find(true, func(link LinkEntry) int {
-		return cmp.Compare(derivedFrom, link.derivedFrom.Number)
-	})
-}
-
-func (db *DB) firstDerivedAt(derivedFrom uint64) (entrydb.EntryIdx, LinkEntry, error) {
-	return db.find(false, func(link LinkEntry) int {
-		return cmp.Compare(link.derivedFrom.Number, derivedFrom)
 	})
 }
 

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -132,8 +132,8 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("last entry %s is not invalidated: %w", link, types.ErrConflict)
 	}
 	return types.DerivedBlockSealPair{
-		DerivedFrom: link.derivedFrom,
-		Derived:     link.derived,
+		Source:  link.derivedFrom,
+		Derived: link.derived,
 	}, nil
 }
 
@@ -269,12 +269,12 @@ func (db *DB) NextSource(source eth.BlockID) (types.BlockSeal, error) {
 func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	selfIndex, selfLink, err := db.lookup(pair.DerivedFrom.Number, pair.Derived.Number)
+	selfIndex, selfLink, err := db.lookup(pair.Source.Number, pair.Derived.Number)
 	if err != nil {
 		return types.DerivedBlockSealPair{}, err
 	}
-	if selfLink.derivedFrom.ID() != pair.DerivedFrom {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.derivedFrom, pair.DerivedFrom, types.ErrConflict)
+	if selfLink.derivedFrom.ID() != pair.Source {
+		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived-from %s but expected %s: %w", selfLink.derivedFrom, pair.Source, types.ErrConflict)
 	}
 	if selfLink.derived.ID() != pair.Derived {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("DB has derived %s but expected %s: %w", selfLink.derived, pair.Derived, types.ErrConflict)

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -176,11 +176,11 @@ func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair,
 	return next.sealOrErr()
 }
 
-// IsCanonical checks if the given block is canonical for the given chain.
+// ContainsDerived checks if the given block is canonical for the given chain.
 // This returns an ErrFuture if the block is not known yet.
 // An ErrConflict if there is a different block.
 // Or an ErrAwaitReplacementBlock if it was invalidated.
-func (db *DB) IsCanonical(derived eth.BlockID) error {
+func (db *DB) ContainsDerived(derived eth.BlockID) error {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// Take the last entry: this will be the latest canonical view,

--- a/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
@@ -43,7 +43,7 @@ func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
 
 	linkInvariants := []linkInvariant{
 		invariantDerivedTimestamp,
-		invariantDerivedFromTimestamp,
+		invariantSourceTimestamp,
 		invariantNumberIncrement,
 	}
 	for i, link := range links {
@@ -94,25 +94,25 @@ func invariantNumberIncrement(prev, current LinkEntry) error {
 	// derived stays the same if the new L1 block is empty.
 	derivedSame := current.derived.Number == prev.derived.Number
 	// derivedFrom stays the same if this L2 block is derived from the same L1 block as the last L2 block
-	derivedFromSame := current.derivedFrom.Number == prev.derivedFrom.Number
+	derivedFromSame := current.source.Number == prev.source.Number
 	// At least one of the two must increment, otherwise we are just repeating data in the DB.
 	if derivedSame && derivedFromSame {
 		return fmt.Errorf("expected at least either derivedFrom or derived to increment, but both have same number")
 	}
 	derivedIncrement := current.derived.Number == prev.derived.Number+1
-	derivedFromIncrement := current.derivedFrom.Number == prev.derivedFrom.Number+1
+	derivedFromIncrement := current.source.Number == prev.source.Number+1
 	if !(derivedSame || derivedIncrement) {
 		return fmt.Errorf("expected derived to either stay the same or increment, got prev %s current %s", prev.derived, current.derived)
 	}
 	if !(derivedFromSame || derivedFromIncrement) {
-		return fmt.Errorf("expected derivedFrom to either stay the same or increment, got prev %s current %s", prev.derivedFrom, current.derivedFrom)
+		return fmt.Errorf("expected derivedFrom to either stay the same or increment, got prev %s current %s", prev.source, current.source)
 	}
 	return nil
 }
 
-func invariantDerivedFromTimestamp(prev, current LinkEntry) error {
-	if current.derivedFrom.Timestamp < prev.derivedFrom.Timestamp {
-		return fmt.Errorf("derivedFrom timestamp must be >=, current: %s, prev: %s", current.derivedFrom, prev.derivedFrom)
+func invariantSourceTimestamp(prev, current LinkEntry) error {
+	if current.source.Timestamp < prev.source.Timestamp {
+		return fmt.Errorf("source timestamp must be >=, current: %s, prev: %s", current.source, prev.source)
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -96,7 +96,9 @@ func TestEmptyDB(t *testing.T) {
 			_, err = db.NextSource(eth.BlockID{})
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, err = db.Next(types.DerivedIDPair{eth.BlockID{}, eth.BlockID{}})
+			_, err = db.Next(types.DerivedIDPair{
+				Source:  eth.BlockID{},
+				Derived: eth.BlockID{}})
 			require.ErrorIs(t, err, types.ErrFuture)
 		})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -141,19 +141,19 @@ func TestSingleEntryDB(t *testing.T) {
 			// First
 			pair, err := db.First()
 			require.NoError(t, err)
-			require.Equal(t, expectedDerivedFrom, pair.DerivedFrom)
+			require.Equal(t, expectedDerivedFrom, pair.Source)
 			require.Equal(t, expectedDerived, pair.Derived)
 
 			// Last
 			pair, err = db.Last()
 			require.NoError(t, err)
-			require.Equal(t, expectedDerivedFrom, pair.DerivedFrom)
+			require.Equal(t, expectedDerivedFrom, pair.Source)
 			require.Equal(t, expectedDerived, pair.Derived)
 
 			// Next after Last
 			_, err = db.Next(types.DerivedIDPair{
-				DerivedFrom: pair.DerivedFrom.ID(),
-				Derived:     pair.Derived.ID()})
+				Source:  pair.Source.ID(),
+				Derived: pair.Derived.ID()})
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			// Last Derived
@@ -167,12 +167,12 @@ func TestSingleEntryDB(t *testing.T) {
 
 			// Next with a non-existent block (derived and derivedFrom)
 			_, err = db.Next(types.DerivedIDPair{
-				DerivedFrom: eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerivedFrom.Number},
-				Derived:     expectedDerived.ID()})
+				Source:  eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerivedFrom.Number},
+				Derived: expectedDerived.ID()})
 			require.ErrorIs(t, err, types.ErrConflict)
 			_, err = db.Next(types.DerivedIDPair{
-				DerivedFrom: expectedDerivedFrom.ID(),
-				Derived:     eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerived.Number}})
+				Source:  expectedDerivedFrom.ID(),
+				Derived: eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedDerived.Number}})
 			require.ErrorIs(t, err, types.ErrConflict)
 
 			// First Source
@@ -204,8 +204,8 @@ func TestSingleEntryDB(t *testing.T) {
 
 			// Next
 			_, err = db.Next(types.DerivedIDPair{
-				DerivedFrom: expectedDerivedFrom.ID(),
-				Derived:     expectedDerived.ID()})
+				Source:  expectedDerivedFrom.ID(),
+				Derived: expectedDerived.ID()})
 			require.ErrorIs(t, err, types.ErrFuture)
 		})
 }
@@ -245,12 +245,12 @@ func TestThreeEntryDB(t *testing.T) {
 
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, pair.DerivedFrom)
+		require.Equal(t, l1Block2, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		pair, err = db.First()
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, pair.DerivedFrom)
+		require.Equal(t, l1Block0, pair.Source)
 		require.Equal(t, l2Block0, pair.Derived)
 
 		derived, err := db.SourceToLastDerived(l1Block2.ID())
@@ -298,12 +298,12 @@ func TestThreeEntryDB(t *testing.T) {
 		next, err := db.NextDerived(l2Block0.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, next.Derived)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 
 		next, err = db.NextDerived(l2Block1.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block2, next.Derived)
-		require.Equal(t, l1Block2, next.DerivedFrom)
+		require.Equal(t, l1Block2, next.Source)
 
 		_, err = db.NextDerived(l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
@@ -332,22 +332,22 @@ func TestThreeEntryDB(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		_, err = db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block2.ID(),
-			Derived:     l2Block2.ID()})
+			Source:  l1Block2.ID(),
+			Derived: l2Block2.ID()})
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		next, err = db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block0.ID(),
-			Derived:     l2Block0.ID()})
+			Source:  l1Block0.ID(),
+			Derived: l2Block0.ID()})
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block1, next.Derived)
 
 		next, err = db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block1.ID(),
-			Derived:     l2Block1.ID()})
+			Source:  l1Block1.ID(),
+			Derived: l2Block1.ID()})
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, next.DerivedFrom)
+		require.Equal(t, l1Block2, next.Source)
 		require.Equal(t, l2Block2, next.Derived)
 	})
 }
@@ -380,7 +380,7 @@ func TestFastL2Batcher(t *testing.T) {
 
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, pair.DerivedFrom)
+		require.Equal(t, l1Block2, pair.Source)
 		require.Equal(t, l2Block5, pair.Derived)
 
 		derived, err := db.SourceToLastDerived(l1Block2.ID())
@@ -422,23 +422,23 @@ func TestFastL2Batcher(t *testing.T) {
 
 		next, err := db.NextDerived(l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block1, next.Derived)
 		next, err = db.NextDerived(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block2, next.Derived)
 		next, err = db.NextDerived(l2Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block3, next.Derived)
 		next, err = db.NextDerived(l2Block3.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block4, next.Derived)
 		next, err = db.NextDerived(l2Block4.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, next.DerivedFrom) // derived from later L1 block
+		require.Equal(t, l1Block2, next.Source) // derived from later L1 block
 		require.Equal(t, l2Block5, next.Derived)
 		_, err = db.NextDerived(l2Block5.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
@@ -460,10 +460,10 @@ func TestFastL2Batcher(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		next, err = db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block1.ID(),
-			Derived:     l2Block2.ID()})
+			Source:  l1Block1.ID(),
+			Derived: l2Block2.ID()})
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom) // no increment in L1 yet, the next after is L2 block 3
+		require.Equal(t, l1Block1, next.Source) // no increment in L1 yet, the next after is L2 block 3
 		require.Equal(t, l2Block3, next.Derived)
 	})
 }
@@ -496,7 +496,7 @@ func TestSlowL2Batcher(t *testing.T) {
 
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l1Block5, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// test what we last derived at the tip
@@ -525,11 +525,11 @@ func TestSlowL2Batcher(t *testing.T) {
 
 		next, err := db.NextDerived(l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, next.DerivedFrom)
+		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block1, next.Derived)
 		next, err = db.NextDerived(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, next.DerivedFrom)
+		require.Equal(t, l1Block5, next.Source)
 		require.Equal(t, l2Block2, next.Derived)
 		_, err = db.NextDerived(l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
@@ -566,10 +566,10 @@ func TestSlowL2Batcher(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		next, err = db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block2.ID(),
-			Derived:     l2Block1.ID()})
+			Source:  l1Block2.ID(),
+			Derived: l2Block1.ID()})
 		require.NoError(t, err)
-		require.Equal(t, l1Block3, next.DerivedFrom)
+		require.Equal(t, l1Block3, next.Source)
 		require.Equal(t, l2Block1, next.Derived) // no increment in L2 yet, the next after is L1 block 3
 	})
 }
@@ -609,18 +609,18 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 
 			switch rng.Intn(3) {
 			case 0: // bump L1
-				pair.DerivedFrom = mockL1(pair.DerivedFrom.Number + 1)
+				pair.Source = mockL1(pair.Source.Number + 1)
 			case 1: // bump L2
 				pair.Derived = mockL2(pair.Derived.Number + 1)
 			case 2: // bump both
-				pair.DerivedFrom = mockL1(pair.DerivedFrom.Number + 1)
+				pair.Source = mockL1(pair.Source.Number + 1)
 				pair.Derived = mockL2(pair.Derived.Number + 1)
 			}
-			derivedFromRef := toRef(pair.DerivedFrom, mockL1(pair.DerivedFrom.Number-1).Hash)
+			derivedFromRef := toRef(pair.Source, mockL1(pair.Source.Number-1).Hash)
 			derivedRef := toRef(pair.Derived, mockL2(pair.Derived.Number-1).Hash)
 			lastDerived[derivedFromRef.ID()] = pair.Derived
 			if _, ok := firstDerivedFrom[derivedRef.ID()]; !ok {
-				firstDerivedFrom[derivedRef.ID()] = pair.DerivedFrom
+				firstDerivedFrom[derivedRef.ID()] = pair.Source
 			}
 			require.NoError(t, db.AddDerived(derivedFromRef, derivedRef))
 		}
@@ -628,10 +628,10 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 		// Now assert we can find what they are all derived from, and match the expectations.
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.NotZero(t, pair.DerivedFrom.Number-offsetL1)
+		require.NotZero(t, pair.Source.Number-offsetL1)
 		require.NotZero(t, pair.Derived.Number-offsetL2)
 
-		for i := offsetL1; i <= pair.DerivedFrom.Number; i++ {
+		for i := offsetL1; i <= pair.Source.Number; i++ {
 			l1ID := mockL1(i).ID()
 			derived, err := db.SourceToLastDerived(l1ID)
 			require.NoError(t, err)
@@ -694,7 +694,7 @@ func TestRewindToScope(t *testing.T) {
 
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l1Block5, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Rewind to the future
@@ -704,7 +704,7 @@ func TestRewindToScope(t *testing.T) {
 		require.NoError(t, db.RewindToScope(l1Block5.ID()))
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l1Block5, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Now rewind to L1 block 3 (inclusive).
@@ -713,21 +713,21 @@ func TestRewindToScope(t *testing.T) {
 		// See if we find consistent data
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block3, pair.DerivedFrom)
+		require.Equal(t, l1Block3, pair.Source)
 		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L1 block 1 (inclusive).
 		require.NoError(t, db.RewindToScope(l1Block1.ID()))
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, pair.DerivedFrom)
+		require.Equal(t, l1Block1, pair.Source)
 		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L1 block 0 (inclusive).
 		require.NoError(t, db.RewindToScope(l1Block0.ID()))
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, pair.DerivedFrom)
+		require.Equal(t, l1Block0, pair.Source)
 		require.Equal(t, l2Block0, pair.Derived)
 	})
 }
@@ -761,7 +761,7 @@ func TestRewindToFirstDerived(t *testing.T) {
 
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l1Block5, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Rewind to the future
@@ -771,7 +771,7 @@ func TestRewindToFirstDerived(t *testing.T) {
 		require.NoError(t, db.RewindToFirstDerived(l2Block2.ID()))
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, pair.DerivedFrom)
+		require.Equal(t, l1Block5, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Now rewind to L2 block 1
@@ -780,14 +780,14 @@ func TestRewindToFirstDerived(t *testing.T) {
 		// See if we went back to the first occurrence of L2 block 1.
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, pair.DerivedFrom)
+		require.Equal(t, l1Block1, pair.Source)
 		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L2 block 0 (inclusive).
 		require.NoError(t, db.RewindToFirstDerived(l2Block0.ID()))
 		pair, err = db.Last()
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, pair.DerivedFrom)
+		require.Equal(t, l1Block0, pair.Source)
 		require.Equal(t, l2Block0, pair.Derived)
 	})
 }
@@ -819,14 +819,14 @@ func TestInvalidateAndReplace(t *testing.T) {
 		pair, err := db.Last()
 		require.NoError(t, err)
 		require.Equal(t, l2Ref3.ID(), pair.Derived.ID())
-		require.Equal(t, l1Block1.ID(), pair.DerivedFrom.ID())
+		require.Equal(t, l1Block1.ID(), pair.Source.ID())
 
 		_, err = db.Invalidated()
 		require.ErrorIs(t, err, types.ErrConflict)
 
 		invalidated := types.DerivedBlockRefPair{
-			DerivedFrom: l1Ref1,
-			Derived:     l2Ref2,
+			Source:  l1Ref1,
+			Derived: l2Ref2,
 		}
 		require.NoError(t, db.RewindAndInvalidate(invalidated))
 		_, err = db.Last()
@@ -834,7 +834,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 
 		pair, err = db.Invalidated()
 		require.NoError(t, err)
-		require.Equal(t, invalidated.DerivedFrom.ID(), pair.DerivedFrom.ID())
+		require.Equal(t, invalidated.Source.ID(), pair.Source.ID())
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
 		replacement := l2Ref2
@@ -843,12 +843,12 @@ func TestInvalidateAndReplace(t *testing.T) {
 		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
-		require.Equal(t, l1Block1.ID(), result.DerivedFrom.ID())
+		require.Equal(t, l1Block1.ID(), result.Source.ID())
 
 		pair, err = db.Last()
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), pair.Derived.ID())
-		require.Equal(t, l1Block1.ID(), pair.DerivedFrom.ID())
+		require.Equal(t, l1Block1.ID(), pair.Source.ID())
 	})
 }
 
@@ -888,14 +888,14 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		pair, err := db.Last()
 		require.NoError(t, err)
 		require.Equal(t, l2Ref4.ID(), pair.Derived.ID())
-		require.Equal(t, l1Block2.ID(), pair.DerivedFrom.ID())
+		require.Equal(t, l1Block2.ID(), pair.Source.ID())
 
 		_, err = db.Invalidated()
 		require.ErrorIs(t, err, types.ErrConflict)
 
 		invalidated := types.DerivedBlockRefPair{
-			DerivedFrom: l1Ref2,
-			Derived:     l2Ref3,
+			Source:  l1Ref2,
+			Derived: l2Ref3,
 		}
 		require.NoError(t, db.RewindAndInvalidate(invalidated))
 		_, err = db.Last()
@@ -903,7 +903,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 
 		pair, err = db.Invalidated()
 		require.NoError(t, err)
-		require.Equal(t, invalidated.DerivedFrom.ID(), pair.DerivedFrom.ID())
+		require.Equal(t, invalidated.Source.ID(), pair.Source.ID())
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
 		replacement := l2Ref3
@@ -912,12 +912,12 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
-		require.Equal(t, l1Block2.ID(), result.DerivedFrom.ID())
+		require.Equal(t, l1Block2.ID(), result.Source.ID())
 
 		pair, err = db.Last()
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), pair.Derived.ID())
-		require.Equal(t, l1Block2.ID(), pair.DerivedFrom.ID())
+		require.Equal(t, l1Block2.ID(), pair.Source.ID())
 
 		// The L2 block before the replacement should point to 2
 		prev, err := db.PreviousDerived(replacement.ID())
@@ -931,19 +931,19 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 
 		// This should point to the original, since we traverse based on L1 scope
 		entryBlock3, err := db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block1.ID(),
-			Derived:     l2Ref2.ID()})
+			Source:  l1Block1.ID(),
+			Derived: l2Ref2.ID()})
 		require.NoError(t, err)
 		require.Equal(t, l2Ref3.ID(), entryBlock3.Derived.ID())
-		require.Equal(t, l1Block1.ID(), entryBlock3.DerivedFrom.ID())
+		require.Equal(t, l1Block1.ID(), entryBlock3.Source.ID())
 
 		// And then find the replacement, once we traverse further
 		entryBlockRepl, err := db.Next(types.DerivedIDPair{
-			DerivedFrom: l1Block1.ID(),
-			Derived:     l2Ref3.ID()})
+			Source:  l1Block1.ID(),
+			Derived: l2Ref3.ID()})
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), entryBlockRepl.Derived.ID())
-		require.Equal(t, l1Block2.ID(), entryBlockRepl.DerivedFrom.ID())
+		require.Equal(t, l1Block2.ID(), entryBlockRepl.Source.ID())
 
 		// Check if canonical chain is represented accurately
 		require.NoError(t, db.IsCanonical(l2Ref2.ID()), "common block 2 is valid part of canonical chain")

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -948,8 +948,8 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, l1Block2.ID(), entryBlockRepl.Source.ID())
 
 		// Check if canonical chain is represented accurately
-		require.NoError(t, db.IsCanonical(l2Ref2.ID()), "common block 2 is valid part of canonical chain")
-		require.NoError(t, db.IsCanonical(replacement.ID()), "replacement is valid part of canonical chain")
-		require.ErrorIs(t, db.IsCanonical(l2Ref3.ID()), types.ErrConflict, "invalidated block is not valid in canonical chain")
+		require.NoError(t, db.ContainsDerived(l2Ref2.ID()), "common block 2 is valid part of canonical chain")
+		require.NoError(t, db.ContainsDerived(replacement.ID()), "replacement is valid part of canonical chain")
+		require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID()), types.ErrConflict, "invalidated block is not valid in canonical chain")
 	})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -115,7 +115,7 @@ func (d *LinkEntry) sealOrErr() (types.DerivedBlockSealPair, error) {
 		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
 	}
 	return types.DerivedBlockSealPair{
-		DerivedFrom: d.derivedFrom,
-		Derived:     d.derived,
+		Source:  d.derivedFrom,
+		Derived: d.derived,
 	}, nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -19,14 +19,14 @@ func (e Entry) Type() EntryType {
 type EntryType uint8
 
 const (
-	DerivedFromV0     EntryType = 0
+	SourceV0          EntryType = 0
 	InvalidatedFromV0 EntryType = 1
 )
 
 func (s EntryType) String() string {
 	switch s {
-	case DerivedFromV0:
-		return "derivedFromV0"
+	case SourceV0:
+		return "sourceV0"
 	case InvalidatedFromV0:
 		return "invalidatedFromV0"
 	default:
@@ -50,8 +50,8 @@ func (EntryBinary) EntrySize() int {
 
 // LinkEntry is a DerivedFromV0 or a InvalidatedFromV0 kind
 type LinkEntry struct {
-	derivedFrom types.BlockSeal
-	derived     types.BlockSeal
+	source  types.BlockSeal
+	derived types.BlockSeal
 	// when it exists as local-safe, but cannot be cross-safe.
 	// If false: this link is a DerivedFromV0
 	// If true: this link is a InvalidatedFromV0
@@ -59,11 +59,11 @@ type LinkEntry struct {
 }
 
 func (d LinkEntry) String() string {
-	return fmt.Sprintf("LinkEntry(derivedFrom: %s, derived: %s, invalidated: %v)", d.derivedFrom, d.derived, d.invalidated)
+	return fmt.Sprintf("LinkEntry(derivedFrom: %s, derived: %s, invalidated: %v)", d.source, d.derived, d.invalidated)
 }
 
 func (d *LinkEntry) decode(e Entry) error {
-	if t := e.Type(); t != DerivedFromV0 && t != InvalidatedFromV0 {
+	if t := e.Type(); t != SourceV0 && t != InvalidatedFromV0 {
 		return fmt.Errorf("%w: unexpected entry type: %s", types.ErrDataCorruption, e.Type())
 	}
 	if [3]byte(e[1:4]) != ([3]byte{}) {
@@ -74,15 +74,15 @@ func (d *LinkEntry) decode(e Entry) error {
 	// l1-number(8) l1-timestamp(8) l2-number(8) l2-timestamp(8) l1-hash(32) l2-hash(32)
 	// Note: attributes are ordered for lexical sorting to nicely match chronological sorting.
 	offset := 4
-	d.derivedFrom.Number = binary.BigEndian.Uint64(e[offset : offset+8])
+	d.source.Number = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
-	d.derivedFrom.Timestamp = binary.BigEndian.Uint64(e[offset : offset+8])
+	d.source.Timestamp = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
 	d.derived.Number = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
 	d.derived.Timestamp = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
-	copy(d.derivedFrom.Hash[:], e[offset:offset+32])
+	copy(d.source.Hash[:], e[offset:offset+32])
 	offset += 32
 	copy(d.derived.Hash[:], e[offset:offset+32])
 	return nil
@@ -93,18 +93,18 @@ func (d *LinkEntry) encode() Entry {
 	if d.invalidated {
 		out[0] = uint8(InvalidatedFromV0)
 	} else {
-		out[0] = uint8(DerivedFromV0)
+		out[0] = uint8(SourceV0)
 	}
 	offset := 4
-	binary.BigEndian.PutUint64(out[offset:offset+8], d.derivedFrom.Number)
+	binary.BigEndian.PutUint64(out[offset:offset+8], d.source.Number)
 	offset += 8
-	binary.BigEndian.PutUint64(out[offset:offset+8], d.derivedFrom.Timestamp)
+	binary.BigEndian.PutUint64(out[offset:offset+8], d.source.Timestamp)
 	offset += 8
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.derived.Number)
 	offset += 8
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.derived.Timestamp)
 	offset += 8
-	copy(out[offset:offset+32], d.derivedFrom.Hash[:])
+	copy(out[offset:offset+32], d.source.Hash[:])
 	offset += 32
 	copy(out[offset:offset+32], d.derived.Hash[:])
 	return out
@@ -115,7 +115,7 @@ func (d *LinkEntry) sealOrErr() (types.DerivedBlockSealPair, error) {
 		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
 	}
 	return types.DerivedBlockSealPair{
-		Source:  d.derivedFrom,
+		Source:  d.source,
 		Derived: d.derived,
 	}, nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/entry_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry_test.go
@@ -13,7 +13,7 @@ import (
 func FuzzRoundtripLinkEntry(f *testing.F) {
 	f.Fuzz(func(t *testing.T, aHash []byte, aNum uint64, aTimestamp uint64, bHash []byte, bNum uint64, bTimestamp uint64) {
 		x := LinkEntry{
-			derivedFrom: types.BlockSeal{
+			source: types.BlockSeal{
 				Hash:      common.BytesToHash(aHash),
 				Number:    aNum,
 				Timestamp: aTimestamp,
@@ -25,7 +25,7 @@ func FuzzRoundtripLinkEntry(f *testing.F) {
 			},
 		}
 		entry := x.encode()
-		require.Equal(t, DerivedFromV0, entry.Type())
+		require.Equal(t, SourceV0, entry.Type())
 		var y LinkEntry
 		err := y.decode(entry)
 		require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -31,7 +31,7 @@ func TestBadUpdates(t *testing.T) {
 	fDerived := mockL2(206)
 
 	noChange := assertFn(func(t *testing.T, db *DB, m *stubMetrics) {
-		pair, err := db.Latest()
+		pair, err := db.Last()
 		require.NoError(t, err)
 		require.Equal(t, dDerivedFrom, pair.DerivedFrom)
 		require.Equal(t, dDerived, pair.Derived)
@@ -69,7 +69,7 @@ func TestBadUpdates(t *testing.T) {
 				require.NoError(t, db.AddDerived(toRef(dDerivedFrom, common.Hash{0x42}), toRef(eDerived, dDerived.Hash)), types.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				pair, err := db.Latest()
+				pair, err := db.Last()
 				require.NoError(t, err)
 				require.Equal(t, dDerivedFrom, pair.DerivedFrom)
 				require.Equal(t, eDerived, pair.Derived)
@@ -120,7 +120,7 @@ func TestBadUpdates(t *testing.T) {
 				require.NoError(t, db.AddDerived(toRef(eDerivedFrom, dDerivedFrom.Hash), toRef(dDerived, common.Hash{0x42})), types.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				pair, err := db.Latest()
+				pair, err := db.Last()
 				require.NoError(t, err)
 				require.Equal(t, eDerivedFrom, pair.DerivedFrom)
 				require.Equal(t, dDerived, pair.Derived)

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -17,23 +17,23 @@ type testCase struct {
 }
 
 func TestBadUpdates(t *testing.T) {
-	aDerivedFrom := mockL1(1)
+	aSource := mockL1(1)
 	aDerived := mockL2(201)
-	bDerivedFrom := mockL1(2)
+	bSource := mockL1(2)
 	bDerived := mockL2(202)
-	cDerivedFrom := mockL1(3)
+	cSource := mockL1(3)
 	cDerived := mockL2(203)
-	dDerivedFrom := mockL1(4)
+	dSource := mockL1(4)
 	dDerived := mockL2(204)
-	eDerivedFrom := mockL1(5)
+	eSource := mockL1(5)
 	eDerived := mockL2(205)
-	fDerivedFrom := mockL1(6)
+	fSource := mockL1(6)
 	fDerived := mockL2(206)
 
 	noChange := assertFn(func(t *testing.T, db *DB, m *stubMetrics) {
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, dDerivedFrom, pair.Source)
+		require.Equal(t, dSource, pair.Source)
 		require.Equal(t, dDerived, pair.Derived)
 	})
 
@@ -41,14 +41,14 @@ func TestBadUpdates(t *testing.T) {
 		{
 			name: "add on old derivedFrom",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(bDerivedFrom, aDerivedFrom.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(bSource, aSource.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "repeat parent derivedFrom",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(cDerivedFrom, bDerivedFrom.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(cSource, bSource.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
@@ -57,56 +57,56 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, db.AddDerived(toRef(types.BlockSeal{
 					Hash:      common.Hash{0xba, 0xd},
-					Number:    dDerivedFrom.Number,
-					Timestamp: dDerivedFrom.Timestamp,
-				}, cDerivedFrom.Hash), toRef(eDerived, dDerived.Hash)), types.ErrConflict)
+					Number:    dSource.Number,
+					Timestamp: dSource.Timestamp,
+				}, cSource.Hash), toRef(eDerived, dDerived.Hash)), types.ErrConflict)
 			},
 			assertFn: noChange,
 		},
 		{
-			name: "CrossDerivedFrom with conflicting parent root, same L1 height, new L2: accepted, L1 parent-hash is used only on L1 increments.",
+			name: "CrossSource with conflicting parent root, same L1 height, new L2: accepted, L1 parent-hash is used only on L1 increments.",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddDerived(toRef(dDerivedFrom, common.Hash{0x42}), toRef(eDerived, dDerived.Hash)), types.ErrConflict)
+				require.NoError(t, db.AddDerived(toRef(dSource, common.Hash{0x42}), toRef(eDerived, dDerived.Hash)), types.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
 				require.NoError(t, err)
-				require.Equal(t, dDerivedFrom, pair.Source)
+				require.Equal(t, dSource, pair.Source)
 				require.Equal(t, eDerived, pair.Derived)
 			},
 		},
 		{
 			name: "Conflicting derivedFrom parent root, new L1 height, same L2",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(eDerivedFrom, common.Hash{0x42}), toRef(dDerived, cDerived.Hash)), types.ErrConflict)
+				require.ErrorIs(t, db.AddDerived(toRef(eSource, common.Hash{0x42}), toRef(dDerived, cDerived.Hash)), types.ErrConflict)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on too new derivedFrom (even if parent-hash looks correct)",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(fDerivedFrom, dDerivedFrom.Hash), toRef(eDerived, dDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(fSource, dSource.Hash), toRef(eDerived, dDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on old derivedFrom (even if parent-hash looks correct)",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(cDerivedFrom, bDerivedFrom.Hash), toRef(cDerived, dDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(cSource, bSource.Hash), toRef(cDerived, dDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on even older derivedFrom",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(bDerivedFrom, aDerivedFrom.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(bSource, aSource.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on conflicting derived, same L2 height, new L1 block",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(eDerivedFrom, dDerivedFrom.Hash), toRef(types.BlockSeal{
+				require.ErrorIs(t, db.AddDerived(toRef(eSource, dSource.Hash), toRef(types.BlockSeal{
 					Hash:      common.Hash{0x42},
 					Number:    dDerived.Number,
 					Timestamp: dDerived.Timestamp,
@@ -117,40 +117,40 @@ func TestBadUpdates(t *testing.T) {
 		{
 			name: "add derived with conflicting parent hash, new L1 height, same L2 height: accepted, L2 parent-hash is only checked on L2 increments.",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.NoError(t, db.AddDerived(toRef(eDerivedFrom, dDerivedFrom.Hash), toRef(dDerived, common.Hash{0x42})), types.ErrConflict)
+				require.NoError(t, db.AddDerived(toRef(eSource, dSource.Hash), toRef(dDerived, common.Hash{0x42})), types.ErrConflict)
 			},
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
 				require.NoError(t, err)
-				require.Equal(t, eDerivedFrom, pair.Source)
+				require.Equal(t, eSource, pair.Source)
 				require.Equal(t, dDerived, pair.Derived)
 			},
 		},
 		{
 			name: "add derived with conflicting parent hash, same L1 height, new L2 height",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(dDerivedFrom, cDerivedFrom.Hash), toRef(eDerived, common.Hash{0x42})), types.ErrConflict)
+				require.ErrorIs(t, db.AddDerived(toRef(dSource, cSource.Hash), toRef(eDerived, common.Hash{0x42})), types.ErrConflict)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on too new derived (even if parent-hash looks correct)",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(dDerivedFrom, cDerivedFrom.Hash), toRef(fDerived, dDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(dSource, cSource.Hash), toRef(fDerived, dDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on old derived (even if parent-hash looks correct)",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(dDerivedFrom, cDerivedFrom.Hash), toRef(cDerived, bDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(dSource, cSource.Hash), toRef(cDerived, bDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
 		{
 			name: "add on even older derived",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
-				require.ErrorIs(t, db.AddDerived(toRef(dDerivedFrom, cDerivedFrom.Hash), toRef(bDerived, aDerived.Hash)), types.ErrOutOfOrder)
+				require.ErrorIs(t, db.AddDerived(toRef(dSource, cSource.Hash), toRef(bDerived, aDerived.Hash)), types.ErrOutOfOrder)
 			},
 			assertFn: noChange,
 		},
@@ -158,7 +158,7 @@ func TestBadUpdates(t *testing.T) {
 			name: "repeat self, silent no-op",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pre := m.DBDerivedEntryCount
-				require.NoError(t, db.AddDerived(toRef(dDerivedFrom, cDerivedFrom.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
+				require.NoError(t, db.AddDerived(toRef(dSource, cSource.Hash), toRef(dDerived, cDerived.Hash)), types.ErrOutOfOrder)
 				require.Equal(t, pre, m.DBDerivedEntryCount)
 			},
 			assertFn: noChange,
@@ -170,7 +170,7 @@ func TestBadUpdates(t *testing.T) {
 			runDBTest(t,
 				func(t *testing.T, db *DB, m *stubMetrics) {
 					// Good first entry
-					require.NoError(t, db.AddDerived(toRef(dDerivedFrom, cDerivedFrom.Hash), toRef(dDerived, cDerived.Hash)))
+					require.NoError(t, db.AddDerived(toRef(dSource, cSource.Hash), toRef(dDerived, cDerived.Hash)))
 					// apply the test-case setup
 					tc.setupFn(t, db, m)
 				},

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -33,7 +33,7 @@ func TestBadUpdates(t *testing.T) {
 	noChange := assertFn(func(t *testing.T, db *DB, m *stubMetrics) {
 		pair, err := db.Last()
 		require.NoError(t, err)
-		require.Equal(t, dDerivedFrom, pair.DerivedFrom)
+		require.Equal(t, dDerivedFrom, pair.Source)
 		require.Equal(t, dDerived, pair.Derived)
 	})
 
@@ -71,7 +71,7 @@ func TestBadUpdates(t *testing.T) {
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
 				require.NoError(t, err)
-				require.Equal(t, dDerivedFrom, pair.DerivedFrom)
+				require.Equal(t, dDerivedFrom, pair.Source)
 				require.Equal(t, eDerived, pair.Derived)
 			},
 		},
@@ -122,7 +122,7 @@ func TestBadUpdates(t *testing.T) {
 			assertFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				pair, err := db.Last()
 				require.NoError(t, err)
-				require.Equal(t, eDerivedFrom, pair.DerivedFrom)
+				require.Equal(t, eDerivedFrom, pair.Source)
 				require.Equal(t, dDerived, pair.Derived)
 			},
 		},

--- a/op-supervisor/supervisor/backend/db/open.go
+++ b/op-supervisor/supervisor/backend/db/open.go
@@ -22,8 +22,8 @@ func OpenLogDB(logger log.Logger, chainID eth.ChainID, dataDir string, m logs.Me
 	return logDB, nil
 }
 
-func OpenLocalDerivedFromDB(logger log.Logger, chainID eth.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
-	path, err := prepLocalDerivedFromDBPath(chainID, dataDir)
+func OpenLocalDerivationDB(logger log.Logger, chainID eth.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
+	path, err := prepLocalDerivationDBPath(chainID, dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare datadir for chain %s: %w", chainID, err)
 	}
@@ -34,8 +34,8 @@ func OpenLocalDerivedFromDB(logger log.Logger, chainID eth.ChainID, dataDir stri
 	return db, nil
 }
 
-func OpenCrossDerivedFromDB(logger log.Logger, chainID eth.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
-	path, err := prepCrossDerivedFromDBPath(chainID, dataDir)
+func OpenCrossDerivationDB(logger log.Logger, chainID eth.ChainID, dataDir string, m fromda.ChainMetrics) (*fromda.DB, error) {
+	path, err := prepCrossDerivationDBPath(chainID, dataDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare datadir for chain %s: %w", chainID, err)
 	}

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -161,7 +161,7 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 					types.ErrAwaitReplacementBlock)
 			}
 			// If it's older, we should check if the local-safe DB matches.
-			return localDB.IsCanonical(id)
+			return localDB.ContainsDerived(id)
 		} else {
 			return fmt.Errorf("failed to read latest local-safe block: %w", err)
 		}
@@ -170,7 +170,7 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 		return nil
 	}
 	// If it's older, we should check if the local-safe DB matches.
-	return localDB.IsCanonical(id)
+	return localDB.ContainsDerived(id)
 }
 
 func (db *ChainsDB) LocalSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -236,6 +236,7 @@ func (db *ChainsDB) CrossSourceToLastDerived(chainID eth.ChainID, derivedFrom et
 }
 
 // CrossDerivedToSourceRef returns the block that the given block was derived from, if it exists in the cross derived-from storage.
+// This call requires the block to have a parent to be turned into a Ref. Use CrossDerivedToSource if the parent is not needed.
 func (db *ChainsDB) CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	xdb, ok := db.crossDBs.Get(chainID)
 	if !ok {
@@ -276,9 +277,9 @@ func (db *ChainsDB) OpenBlock(chainID eth.ChainID, blockNum uint64) (seal eth.Bl
 	return logDB.OpenBlock(blockNum)
 }
 
-// LocalDerivedToFirstSource returns the block that the given block was derived from, if it exists in the local derived-from storage.
+// LocalDerivedToSource returns the block that the given block was derived from, if it exists in the local derived-from storage.
 // it routes the request to the appropriate localDB.
-func (db *ChainsDB) LocalDerivedToFirstSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (db *ChainsDB) LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	lDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -286,9 +287,9 @@ func (db *ChainsDB) LocalDerivedToFirstSource(chain eth.ChainID, derived eth.Blo
 	return lDB.DerivedToFirstSource(derived)
 }
 
-// CrossDerivedToFirstSource returns the block that the given block was derived from, if it exists in the cross derived-from storage.
+// CrossDerivedToSource returns the block that the given block was derived from, if it exists in the cross derived-from storage.
 // it routes the request to the appropriate crossDB.
-func (db *ChainsDB) CrossDerivedToFirstSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (db *ChainsDB) CrossDerivedToSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
 	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -15,15 +15,15 @@ import (
 )
 
 type mockDerivedFromStorage struct {
-	latestFn func() (pair types.DerivedBlockSealPair, err error)
+	lastFn func() (pair types.DerivedBlockSealPair, err error)
 }
 
 func (m *mockDerivedFromStorage) First() (pair types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) Latest() (pair types.DerivedBlockSealPair, err error) {
-	if m.latestFn != nil {
-		return m.latestFn()
+func (m *mockDerivedFromStorage) Last() (pair types.DerivedBlockSealPair, err error) {
+	if m.lastFn != nil {
+		return m.lastFn()
 	}
 	return types.DerivedBlockSealPair{}, nil
 }
@@ -39,25 +39,25 @@ func (m *mockDerivedFromStorage) ReplaceInvalidatedBlock(replacementDerived eth.
 func (m *mockDerivedFromStorage) RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error {
 	return nil
 }
-func (m *mockDerivedFromStorage) LastDerivedAt(derivedFrom eth.BlockID) (derived types.BlockSeal, err error) {
+func (m *mockDerivedFromStorage) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) IsDerived(derived eth.BlockID) error {
+func (m *mockDerivedFromStorage) IsCanonical(derived eth.BlockID) error {
 	return nil
 }
-func (m *mockDerivedFromStorage) DerivedFrom(derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockDerivedFromStorage) DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) FirstAfter(derivedFrom, derived eth.BlockID) (next types.DerivedBlockSealPair, err error) {
+func (m *mockDerivedFromStorage) Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) NextDerivedFrom(derivedFrom eth.BlockID) (nextDerivedFrom types.BlockSeal, err error) {
+func (m *mockDerivedFromStorage) NextSource(source eth.BlockID) (nextSource types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
 func (m *mockDerivedFromStorage) NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) PreviousDerivedFrom(derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error) {
+func (m *mockDerivedFromStorage) PreviousSource(source eth.BlockID) (prevSource types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
 func (m *mockDerivedFromStorage) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
@@ -131,36 +131,36 @@ func TestCommonL1(t *testing.T) {
 		}
 	}
 	t.Run("pattern 1", func(t *testing.T) {
-		m1.latestFn = returnN(1)
-		m2.latestFn = returnN(2)
-		m3.latestFn = returnN(3)
+		m1.lastFn = returnN(1)
+		m2.lastFn = returnN(2)
+		m3.lastFn = returnN(3)
 
 		latest, err := chainDB.LastCommonL1()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), latest.Number)
 	})
 	t.Run("pattern 2", func(t *testing.T) {
-		m1.latestFn = returnN(3)
-		m2.latestFn = returnN(2)
-		m3.latestFn = returnN(1)
+		m1.lastFn = returnN(3)
+		m2.lastFn = returnN(2)
+		m3.lastFn = returnN(1)
 
 		latest, err := chainDB.LastCommonL1()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), latest.Number)
 	})
 	t.Run("pattern 3", func(t *testing.T) {
-		m1.latestFn = returnN(99)
-		m2.latestFn = returnN(1)
-		m3.latestFn = returnN(98)
+		m1.lastFn = returnN(99)
+		m2.lastFn = returnN(1)
+		m3.lastFn = returnN(98)
 
 		latest, err := chainDB.LastCommonL1()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), latest.Number)
 	})
 	t.Run("error", func(t *testing.T) {
-		m1.latestFn = returnN(99)
-		m2.latestFn = returnN(1)
-		m3.latestFn = func() (pair types.DerivedBlockSealPair, err error) {
+		m1.lastFn = returnN(99)
+		m2.lastFn = returnN(1)
+		m3.lastFn = func() (pair types.DerivedBlockSealPair, err error) {
 			return types.DerivedBlockSealPair{}, fmt.Errorf("error")
 		}
 		latest, err := chainDB.LastCommonL1()

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -14,59 +14,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockDerivedFromStorage struct {
+type mockDerivationStorage struct {
 	lastFn func() (pair types.DerivedBlockSealPair, err error)
 }
 
-func (m *mockDerivedFromStorage) First() (pair types.DerivedBlockSealPair, err error) {
+func (m *mockDerivationStorage) First() (pair types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) Last() (pair types.DerivedBlockSealPair, err error) {
+func (m *mockDerivationStorage) Last() (pair types.DerivedBlockSealPair, err error) {
 	if m.lastFn != nil {
 		return m.lastFn()
 	}
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) Invalidated() (pair types.DerivedBlockSealPair, err error) {
+func (m *mockDerivationStorage) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
+func (m *mockDerivationStorage) AddDerived(derivedFrom eth.BlockRef, derived eth.BlockRef) error {
 	return nil
 }
-func (m *mockDerivedFromStorage) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error) {
+func (m *mockDerivationStorage) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error {
+func (m *mockDerivationStorage) RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error {
 	return nil
 }
-func (m *mockDerivedFromStorage) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {
+func (m *mockDerivationStorage) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) ContainsDerived(derived eth.BlockID) error {
+func (m *mockDerivationStorage) ContainsDerived(derived eth.BlockID) error {
 	return nil
 }
-func (m *mockDerivedFromStorage) DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error) {
+func (m *mockDerivationStorage) DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error) {
+func (m *mockDerivationStorage) Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) NextSource(source eth.BlockID) (nextSource types.BlockSeal, err error) {
+func (m *mockDerivationStorage) NextSource(source eth.BlockID) (nextSource types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error) {
+func (m *mockDerivationStorage) NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error) {
 	return types.DerivedBlockSealPair{}, nil
 }
-func (m *mockDerivedFromStorage) PreviousSource(source eth.BlockID) (prevSource types.BlockSeal, err error) {
+func (m *mockDerivationStorage) PreviousSource(source eth.BlockID) (prevSource types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+func (m *mockDerivationStorage) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) RewindToScope(scope eth.BlockID) error {
+func (m *mockDerivationStorage) RewindToScope(scope eth.BlockID) error {
 	return nil
 }
-func (m *mockDerivedFromStorage) RewindToFirstDerived(derived eth.BlockID) error {
+func (m *mockDerivationStorage) RewindToFirstDerived(derived eth.BlockID) error {
 	return nil
 }
 
@@ -94,14 +94,14 @@ func sampleDepSet(t *testing.T) depset.DependencySet {
 }
 
 func TestCommonL1UnknownChain(t *testing.T) {
-	m1 := &mockDerivedFromStorage{}
-	m2 := &mockDerivedFromStorage{}
+	m1 := &mockDerivationStorage{}
+	m2 := &mockDerivationStorage{}
 	logger := testlog.Logger(t, log.LevelDebug)
 	chainDB := NewChainsDB(logger, sampleDepSet(t), metrics.NoopMetrics)
 
 	// add a mock local derived-from storage to drive the test
-	chainDB.AddLocalDerivedFromDB(eth.ChainIDFromUInt64(900), m1)
-	chainDB.AddLocalDerivedFromDB(eth.ChainIDFromUInt64(901), m2)
+	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(900), m1)
+	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(901), m2)
 	// don't attach a mock for chain 902
 
 	_, err := chainDB.LastCommonL1()
@@ -109,16 +109,16 @@ func TestCommonL1UnknownChain(t *testing.T) {
 }
 
 func TestCommonL1(t *testing.T) {
-	m1 := &mockDerivedFromStorage{}
-	m2 := &mockDerivedFromStorage{}
-	m3 := &mockDerivedFromStorage{}
+	m1 := &mockDerivationStorage{}
+	m2 := &mockDerivationStorage{}
+	m3 := &mockDerivationStorage{}
 	logger := testlog.Logger(t, log.LevelDebug)
 	chainDB := NewChainsDB(logger, sampleDepSet(t), metrics.NoopMetrics)
 
 	// add a mock local derived-from storage to drive the test
-	chainDB.AddLocalDerivedFromDB(eth.ChainIDFromUInt64(900), m1)
-	chainDB.AddLocalDerivedFromDB(eth.ChainIDFromUInt64(901), m2)
-	chainDB.AddLocalDerivedFromDB(eth.ChainIDFromUInt64(902), m3)
+	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(900), m1)
+	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(901), m2)
+	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(902), m3)
 
 	// returnN is a helper function which creates a Latest Function for the test
 	returnN := func(n uint64) func() (pair types.DerivedBlockSealPair, err error) {

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -124,7 +124,7 @@ func TestCommonL1(t *testing.T) {
 	returnN := func(n uint64) func() (pair types.DerivedBlockSealPair, err error) {
 		return func() (pair types.DerivedBlockSealPair, err error) {
 			return types.DerivedBlockSealPair{
-				DerivedFrom: types.BlockSeal{
+				Source: types.BlockSeal{
 					Number: n,
 				},
 			}, nil

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -42,7 +42,7 @@ func (m *mockDerivedFromStorage) RewindAndInvalidate(invalidated types.DerivedBl
 func (m *mockDerivedFromStorage) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
-func (m *mockDerivedFromStorage) IsCanonical(derived eth.BlockID) error {
+func (m *mockDerivedFromStorage) ContainsDerived(derived eth.BlockID) error {
 	return nil
 }
 func (m *mockDerivedFromStorage) DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -252,7 +252,7 @@ func (db *ChainsDB) ResetCrossUnsafeIfNewerThan(chainID eth.ChainID, number uint
 	if !ok {
 		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
 	}
-	crossSafe, err := crossSafeDB.Latest()
+	crossSafe, err := crossSafeDB.Last()
 	if err != nil {
 		return fmt.Errorf("cannot get cross-safe of chain %s: %w", chainID, err)
 	}

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -91,8 +91,8 @@ func (db *ChainsDB) UpdateLocalSafe(chain eth.ChainID, derivedFrom eth.BlockRef,
 	db.emitter.Emit(superevents.LocalSafeUpdateEvent{
 		ChainID: chain,
 		NewLocalSafe: types.DerivedBlockSealPair{
-			DerivedFrom: types.BlockSealFromRef(derivedFrom),
-			Derived:     types.BlockSealFromRef(lastDerived),
+			Source:  types.BlockSealFromRef(derivedFrom),
+			Derived: types.BlockSealFromRef(lastDerived),
 		},
 	})
 }
@@ -128,8 +128,8 @@ func (db *ChainsDB) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, last
 	db.emitter.Emit(superevents.CrossSafeUpdateEvent{
 		ChainID: chain,
 		NewCrossSafe: types.DerivedBlockSealPair{
-			DerivedFrom: types.BlockSealFromRef(l1View),
-			Derived:     types.BlockSealFromRef(lastCrossDerived),
+			Source:  types.BlockSealFromRef(l1View),
+			Derived: types.BlockSealFromRef(lastCrossDerived),
 		},
 	})
 	db.m.RecordCrossSafeRef(chain, lastCrossDerived)

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -71,7 +71,7 @@ func (m *MockBackend) FinalizedL1() eth.BlockRef {
 	return eth.BlockRef{}
 }
 
-func (m *MockBackend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+func (m *MockBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
 	return eth.BlockRef{}, nil
 }
 

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -35,7 +35,7 @@ type rewinderDB interface {
 	FindSealedBlock(eth.ChainID, uint64) (types.BlockSeal, error)
 	Finalized(eth.ChainID) (types.BlockSeal, error)
 
-	LocalDerivedToFirstSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
 }
 
 // Rewinder is responsible for handling the rewinding of databases to the latest common ancestor between
@@ -121,7 +121,7 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 			return
 		}
 
-		_, err := r.db.LocalDerivedToFirstSource(ev.ChainID, target.ID())
+		_, err := r.db.LocalDerivedToSource(ev.ChainID, target.ID())
 		if err != nil {
 			if errors.Is(err, types.ErrConflict) || errors.Is(err, types.ErrFuture) {
 				continue

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -153,7 +153,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	if err != nil {
 		return fmt.Errorf("failed to get local safe for chain %s: %w", chainID, err)
 	}
-	localSafeL1 := localSafe.DerivedFrom
+	localSafeL1 := localSafe.Source
 
 	// Get the canonical L1 block at our local head's height
 	canonicalL1, err := r.l1Node.L1BlockRefByNumber(context.Background(), localSafeL1.Number)

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -22,7 +22,7 @@ type rewinderDB interface {
 	DependencySet() depset.DependencySet
 
 	LastCrossDerivedFrom(chainID eth.ChainID, derivedFrom eth.BlockID) (derived types.BlockSeal, err error)
-	PreviousDerivedFrom(chain eth.ChainID, derivedFrom eth.BlockID) (prevDerivedFrom types.BlockSeal, err error)
+	PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource types.BlockSeal, err error)
 	CrossDerivedFromBlockRef(chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 
 	LocalSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
@@ -201,7 +201,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 		}
 
 		// Get the previous L1 block from our DB
-		prevDerivedFrom, err := r.db.PreviousDerivedFrom(chainID, currentL1)
+		prevDerivedFrom, err := r.db.PreviousSource(chainID, currentL1)
 		if err != nil {
 			// If we hit the first block, use it as common ancestor
 			if errors.Is(err, types.ErrPreviousToFirst) {

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -164,7 +164,7 @@ func TestRewindL2(t *testing.T) {
 	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
-			DerivedFrom: types.BlockSeal{
+			Source: types.BlockSeal{
 				Hash:   l1Block1.Hash,
 				Number: l1Block1.Number,
 			},
@@ -261,7 +261,7 @@ func TestNoRewindNeeded(t *testing.T) {
 	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
-			DerivedFrom: types.BlockSeal{
+			Source: types.BlockSeal{
 				Hash:   l1Block2.Hash,
 				Number: l1Block2.Number,
 			},
@@ -359,7 +359,7 @@ func TestRewindLongChain(t *testing.T) {
 	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
-			DerivedFrom: types.BlockSeal{
+			Source: types.BlockSeal{
 				Hash:   l1Blocks[96/10].Hash,
 				Number: l1Blocks[96/10].Number,
 			},
@@ -428,7 +428,7 @@ func TestRewindMultiChain(t *testing.T) {
 		i.OnEvent(superevents.LocalSafeUpdateEvent{
 			ChainID: chainID,
 			NewLocalSafe: types.DerivedBlockSealPair{
-				DerivedFrom: types.BlockSeal{
+				Source: types.BlockSeal{
 					Hash:   l1Block1.Hash,
 					Number: l1Block1.Number,
 				},
@@ -566,7 +566,7 @@ func TestRewindL2WalkBack(t *testing.T) {
 	i.OnEvent(superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
-			DerivedFrom: types.BlockSeal{
+			Source: types.BlockSeal{
 				Hash:   block4B.L1Origin.Hash,
 				Number: block4B.L1Origin.Number,
 			},

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -772,12 +772,12 @@ func setupTestChains(t *testing.T, chainIDs ...eth.ChainID) *testSetup {
 		// Create and open the local derived-from DB
 		localDB, err := fromda.NewFromFile(logger, &stubMetrics{}, filepath.Join(chainDir, "local_safe.db"))
 		require.NoError(t, err)
-		chainsDB.AddLocalDerivedFromDB(chainID, localDB)
+		chainsDB.AddLocalDerivationDB(chainID, localDB)
 
 		// Create and open the cross derived-from DB
 		crossDB, err := fromda.NewFromFile(logger, &stubMetrics{}, filepath.Join(chainDir, "cross_safe.db"))
 		require.NoError(t, err)
-		chainsDB.AddCrossDerivedFromDB(chainID, crossDB)
+		chainsDB.AddCrossDerivationDB(chainID, crossDB)
 
 		// Add cross-unsafe tracker
 		chainsDB.AddCrossUnsafeTracker(chainID)

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -39,7 +39,7 @@ func (su *StatusTracker) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
 	case superevents.LocalDerivedOriginUpdateEvent:
 		status := loadStatusRef(x.ChainID)
-		status.CurrentL1 = x.Derived.DerivedFrom
+		status.CurrentL1 = x.Derived.Source
 	case superevents.LocalUnsafeUpdateEvent:
 		status := loadStatusRef(x.ChainID)
 		status.LocalUnsafe = x.NewLocalUnsafe

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -39,7 +39,7 @@ func (su *StatusTracker) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
 	case superevents.LocalDerivedOriginUpdateEvent:
 		status := loadStatusRef(x.ChainID)
-		status.CurrentL1 = x.Derived.Source
+		status.CurrentL1 = x.Origin
 	case superevents.LocalUnsafeUpdateEvent:
 		status := loadStatusRef(x.ChainID)
 		status.LocalUnsafe = x.NewLocalUnsafe

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -121,7 +121,7 @@ func (ev LocalDerivedEvent) String() string {
 
 type LocalDerivedOriginUpdateEvent struct {
 	ChainID eth.ChainID
-	Derived types.DerivedBlockRefPair
+	Origin  eth.BlockRef
 }
 
 func (ev LocalDerivedOriginUpdateEvent) String() string {

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -183,8 +183,8 @@ func TestInitFromAnchorPoint(t *testing.T) {
 	ctrl := mockSyncControl{}
 	ctrl.anchorPointFn = func(ctx context.Context) (types.DerivedBlockRefPair, error) {
 		return types.DerivedBlockRefPair{
-			Derived:     eth.BlockRef{Number: 1},
-			DerivedFrom: eth.BlockRef{Number: 0},
+			Derived: eth.BlockRef{Number: 1},
+			Source:  eth.BlockRef{Number: 0},
 		}, nil
 	}
 

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -288,16 +288,6 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 		ChainID: m.chainID,
 		Derived: pair,
 	})
-	// TODO: keep synchronous local-safe DB update feedback?
-	// We'll still need more async ways of doing this for reorg handling.
-
-	// ctx, cancel := context.WithTimeout(m.ctx, internalTimeout)
-	// defer cancel()
-	// if err := m.backend.UpdateLocalSafe(ctx, m.chainID, pair.DerivedFrom, pair.Derived); err != nil {
-	//	m.log.Warn("Backend failed to process local-safe update",
-	//		"derived", pair.Derived, "derivedFrom", pair.DerivedFrom, "err", err)
-	//	m.resetSignal(err, pair.DerivedFrom)
-	// }
 }
 
 func (m *ManagedNode) onDerivationOriginUpdate(origin eth.BlockRef) {

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -250,11 +250,11 @@ func (m *ManagedNode) onCrossUnsafeUpdate(seal types.BlockSeal) {
 }
 
 func (m *ManagedNode) onCrossSafeUpdate(pair types.DerivedBlockSealPair) {
-	m.log.Debug("updating cross safe", "derived", pair.Derived, "derivedFrom", pair.DerivedFrom)
+	m.log.Debug("updating cross safe", "derived", pair.Derived, "derivedFrom", pair.Source)
 	ctx, cancel := context.WithTimeout(m.ctx, nodeTimeout)
 	defer cancel()
 	pairIDs := pair.IDs()
-	err := m.Node.UpdateCrossSafe(ctx, pairIDs.Derived, pairIDs.DerivedFrom)
+	err := m.Node.UpdateCrossSafe(ctx, pairIDs.Derived, pairIDs.Source)
 	if err != nil {
 		m.log.Warn("Node failed cross-safe updating", "err", err)
 		return
@@ -283,7 +283,7 @@ func (m *ManagedNode) onUnsafeBlock(unsafeRef eth.BlockRef) {
 
 func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	m.log.Info("Node derived new block", "derived", pair.Derived,
-		"derivedParent", pair.Derived.ParentID(), "derivedFrom", pair.DerivedFrom)
+		"derivedParent", pair.Derived.ParentID(), "derivedFrom", pair.Source)
 	m.emitter.Emit(superevents.LocalDerivedEvent{
 		ChainID: m.chainID,
 		Derived: pair,
@@ -301,7 +301,7 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 }
 
 func (m *ManagedNode) onDerivationOriginUpdate(pair types.DerivedBlockRefPair) {
-	m.log.Info("Node derived new origin", "derived", pair.Derived, "derivedFrom", pair.DerivedFrom)
+	m.log.Info("Node derived new origin", "derived", pair.Derived, "derivedFrom", pair.Source)
 	m.emitter.Emit(superevents.LocalDerivedOriginUpdateEvent{
 		ChainID: m.chainID,
 		Derived: pair,
@@ -448,17 +448,17 @@ func (m *ManagedNode) resolveConflict(ctx context.Context, l1Ref eth.BlockRef, u
 }
 
 func (m *ManagedNode) onExhaustL1Event(completed types.DerivedBlockRefPair) {
-	m.log.Info("Node completed syncing", "l2", completed.Derived, "l1", completed.DerivedFrom)
+	m.log.Info("Node completed syncing", "l2", completed.Derived, "l1", completed.Source)
 
 	internalCtx, cancel := context.WithTimeout(m.ctx, internalTimeout)
 	defer cancel()
-	nextL1, err := m.backend.L1BlockRefByNumber(internalCtx, completed.DerivedFrom.Number+1)
+	nextL1, err := m.backend.L1BlockRefByNumber(internalCtx, completed.Source.Number+1)
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
-			m.log.Debug("Next L1 block is not yet available", "l1Block", completed.DerivedFrom, "err", err)
+			m.log.Debug("Next L1 block is not yet available", "l1Block", completed.Source, "err", err)
 			return
 		}
-		m.log.Error("Failed to retrieve next L1 block for node", "l1Block", completed.DerivedFrom, "err", err)
+		m.log.Error("Failed to retrieve next L1 block for node", "l1Block", completed.Source, "err", err)
 		return
 	}
 
@@ -477,14 +477,14 @@ func (m *ManagedNode) onExhaustL1Event(completed types.DerivedBlockRefPair) {
 // and needs to be replaced with a deposit only block.
 func (m *ManagedNode) onInvalidateLocalSafe(invalidated types.DerivedBlockRefPair) {
 	m.log.Warn("Instructing node to replace invalidated local-safe block",
-		"invalidated", invalidated.Derived, "scope", invalidated.DerivedFrom)
+		"invalidated", invalidated.Derived, "scope", invalidated.Source)
 
 	ctx, cancel := context.WithTimeout(m.ctx, nodeTimeout)
 	defer cancel()
 	// Send instruction to the node to invalidate the block, and build a replacement block.
 	if err := m.Node.InvalidateBlock(ctx, types.BlockSealFromRef(invalidated.Derived)); err != nil {
 		m.log.Warn("Node is unable to invalidate block",
-			"invalidated", invalidated.Derived, "scope", invalidated.DerivedFrom, "err", err)
+			"invalidated", invalidated.Derived, "scope", invalidated.Source, "err", err)
 	}
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -300,11 +300,11 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	// }
 }
 
-func (m *ManagedNode) onDerivationOriginUpdate(pair types.DerivedBlockRefPair) {
-	m.log.Info("Node derived new origin", "derived", pair.Derived, "derivedFrom", pair.Source)
+func (m *ManagedNode) onDerivationOriginUpdate(origin eth.BlockRef) {
+	m.log.Info("Node derived new origin", "origin", origin)
 	m.emitter.Emit(superevents.LocalDerivedOriginUpdateEvent{
 		ChainID: m.chainID,
-		Derived: pair,
+		Origin:  origin,
 	})
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -75,11 +75,11 @@ func TestEventResponse(t *testing.T) {
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
 			UnsafeBlock: &eth.BlockRef{Number: 1}})
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
-			DerivationUpdate: &types.DerivedBlockRefPair{DerivedFrom: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+			DerivationUpdate: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
-			ExhaustL1: &types.DerivedBlockRefPair{DerivedFrom: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+			ExhaustL1: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
-			DerivationOriginUpdate: &types.DerivedBlockRefPair{DerivedFrom: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+			DerivationOriginUpdate: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 
 		require.NoError(t, ex.Drain())
 

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -79,7 +79,7 @@ func TestEventResponse(t *testing.T) {
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
 			ExhaustL1: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
-			DerivationOriginUpdate: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+			DerivationOriginUpdate: &eth.BlockRef{Number: 1}})
 
 		require.NoError(t, ex.Drain())
 

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -18,7 +18,7 @@ type AdminBackend interface {
 type QueryBackend interface {
 	CheckMessage(identifier types.Identifier, payloadHash common.Hash) (types.SafetyLevel, error)
 	CheckMessages(messages []types.Message, minSafety types.SafetyLevel) error
-	CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
+	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error)
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
@@ -69,8 +69,14 @@ func (q *QueryFrontend) FinalizedL1() eth.BlockRef {
 	return q.Supervisor.FinalizedL1()
 }
 
+// CrossDerivedFrom is deprecated, but remains for backwards compatibility to callers
+// it is equivalent to CrossDerivedToSource
 func (q *QueryFrontend) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
-	return q.Supervisor.CrossDerivedFrom(ctx, chainID, derived)
+	return q.Supervisor.CrossDerivedToSource(ctx, chainID, derived)
+}
+
+func (q *QueryFrontend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+	return q.Supervisor.CrossDerivedToSource(ctx, chainID, derived)
 }
 
 func (q *QueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -303,7 +303,7 @@ func (seals *DerivedBlockSealPair) IDs() DerivedIDPair {
 	}
 }
 
-// DerivedIDPair is a pair of block IDs, where Derived (L2) is derived from DerivedFrom (L1).
+// DerivedIDPair is a pair of block IDs, where Derived (L2) is derived from Source (L1).
 type DerivedIDPair struct {
 	Source  eth.BlockID `json:"source"`
 	Derived eth.BlockID `json:"derived"`

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -322,5 +322,5 @@ type ManagedEvent struct {
 	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
 	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
-	DerivationOriginUpdate *DerivedBlockRefPair `json:"derivationOriginUpdate,omitempty"`
+	DerivationOriginUpdate *eth.BlockRef        `json:"derivationOriginUpdate,omitempty"`
 }

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -270,43 +270,43 @@ func LogToMessagePayload(l *ethTypes.Log) []byte {
 	return msg
 }
 
-// DerivedBlockRefPair is a pair of block refs, where Derived (L2) is derived from DerivedFrom (L1).
+// DerivedBlockRefPair is a pair of block refs, where Derived (L2) is derived from Source (L1).
 type DerivedBlockRefPair struct {
-	DerivedFrom eth.BlockRef `json:"derivedFrom"`
-	Derived     eth.BlockRef `json:"derived"`
+	Source  eth.BlockRef `json:"source"`
+	Derived eth.BlockRef `json:"derived"`
 }
 
 func (refs *DerivedBlockRefPair) IDs() DerivedIDPair {
 	return DerivedIDPair{
-		DerivedFrom: refs.DerivedFrom.ID(),
-		Derived:     refs.Derived.ID(),
+		Source:  refs.Source.ID(),
+		Derived: refs.Derived.ID(),
 	}
 }
 
 func (refs *DerivedBlockRefPair) Seals() DerivedBlockSealPair {
 	return DerivedBlockSealPair{
-		DerivedFrom: BlockSealFromRef(refs.DerivedFrom),
-		Derived:     BlockSealFromRef(refs.Derived),
+		Source:  BlockSealFromRef(refs.Source),
+		Derived: BlockSealFromRef(refs.Derived),
 	}
 }
 
-// DerivedBlockSealPair is a pair of block seals, where Derived (L2) is derived from DerivedFrom (L1).
+// DerivedBlockSealPair is a pair of block seals, where Derived (L2) is derived from Source (L1).
 type DerivedBlockSealPair struct {
-	DerivedFrom BlockSeal `json:"derivedFrom"`
-	Derived     BlockSeal `json:"derived"`
+	Source  BlockSeal `json:"source"`
+	Derived BlockSeal `json:"derived"`
 }
 
 func (seals *DerivedBlockSealPair) IDs() DerivedIDPair {
 	return DerivedIDPair{
-		DerivedFrom: seals.DerivedFrom.ID(),
-		Derived:     seals.Derived.ID(),
+		Source:  seals.Source.ID(),
+		Derived: seals.Derived.ID(),
 	}
 }
 
 // DerivedIDPair is a pair of block IDs, where Derived (L2) is derived from DerivedFrom (L1).
 type DerivedIDPair struct {
-	DerivedFrom eth.BlockID `json:"derivedFrom"`
-	Derived     eth.BlockID `json:"derived"`
+	Source  eth.BlockID `json:"source"`
+	Derived eth.BlockID `json:"derived"`
 }
 
 type BlockReplacement struct {


### PR DESCRIPTION
# What

Refactors the names and interfaces of various backend and database structures in `op-supervisor`

# Why

Working on the `op-supervisor` can be confusing. We commonly field questions about the inner workings of a function, or the expected outcome given the function name. Oftentimes, answering that question requires a check of the implementation, which is a sign that our names are not sufficient. In particular, we had two fundamental types `Derived` and `DerivedFrom` which look very confusing next to each-other, and can lose meaning in larger function names.

# How

I made the following style and cleanliness decisions:
- Rename from `DerivedFrom` to `Source`. Sources can be thought of as L1 blocks where L2 data might exist. `Derived` blocks stay as they are, because they are Derived From the Source. Almost all DerivedFrom references are gone from the `op-supervisor` namespace, with those remaining being largely to handle deprecation on the Front End (I did not want to affect the external API of the supervisor)
- Explicit `Key`To`Value` format of database accessor function names. To get an L1 block using a Derived Block Number, the function is called `DerivedNumToSource`. To get the L1 block from an L2 block directly, calkl `DerivedToSource`
- I renamed some other functions like `IsDerived` to `ContainsDerived`, to fit better with logDB names and to reinforce the DB nature of these APIs
- @Inphi I also cleaned up the Origin Event structure to not use a pair
- Some functions specify `Last`, like `SourceToLastDerived`. I did not add more of these descriptors, but we could consider it if names are still confusing.
- I removed unused interfaces and some `//commented` code along the way.

# Where

The scope of this PR is **only** the `op-supervisor`, except in cases where the type changes affected other components, or the required updates for the Origin Event.

My intention with this PR is to start to clean up our Database structure to be more predictable and more usable, such that we can leverage more contributors to this codebase more quickly.