### PR TITLE
contracts: EventLogger integration test util contract

### DIFF
--- a/packages/contracts-bedrock/src/integration/EventLogger.sol
+++ b/packages/contracts-bedrock/src/integration/EventLogger.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+/// @title EventLogger
+/// @notice EventLogger is a util contract to emit log events, primarily for integration testing.
+contract EventLogger {
+    /// @notice Emits an event log with the given number of topics and the given data.
+    /// @param _topics List of topics to emit. Can be 0 to 4 (incl.) entries. Also known as indexed event data.
+    /// @param _data   Data to emit. As much as gas allows to emit. Also known as unindexed event data.
+    function emitLog(bytes32[] calldata _topics, bytes calldata _data) external {
+        assembly {
+            let dataSize := _data.length
+            let memDataOffset := mload(0x40) // load free memory pointer
+            calldatacopy(memDataOffset, _data.offset, dataSize) // args: to, from, size
+            // after the event-logging is done, the memory is not used, so no mem pointer to update/restore.
+
+            let topicsCount := _topics.length
+            let t0 := calldataload(add(_topics.offset, mul(32, 0)))
+            let t1 := calldataload(add(_topics.offset, mul(32, 1)))
+            let t2 := calldataload(add(_topics.offset, mul(32, 2)))
+            let t3 := calldataload(add(_topics.offset, mul(32, 3)))
+
+            // Each topic-count has its own opcode for emitting an event
+            switch topicsCount
+            case 0 { log0(memDataOffset, dataSize) }
+            case 1 { log1(memDataOffset, dataSize, t0) }
+            case 2 { log2(memDataOffset, dataSize, t0, t1) }
+            case 3 { log3(memDataOffset, dataSize, t0, t1, t2) }
+            case 4 { log4(memDataOffset, dataSize, t0, t1, t2, t3) }
+            default { revert(0, 0) }
+        }
+    }
+
+    /// @notice Validates a cross chain message using the CrossL2Inbox predeploy. This emits an executing message.
+    /// @param _id      Identifier of the message.
+    /// @param _msgHash Hash of the message payload to call target with.
+    function validateMessage(Identifier calldata _id, bytes32 _msgHash) external {
+        ICrossL2Inbox(Predeploys.CROSS_L2_INBOX).validateMessage(_id, _msgHash);
+    }
+}

--- a/packages/contracts-bedrock/test/integration/EventLogger.t.sol
+++ b/packages/contracts-bedrock/test/integration/EventLogger.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import { Test } from "forge-std/Test.sol";
 
 import { Identifier as IfaceIdentifier } from "interfaces/L2/ICrossL2Inbox.sol";
-import { IL1BlockInterop } from "interfaces/L2/IL1BlockInterop.sol";
 
 import { EventLogger } from "../../src/integration/EventLogger.sol";
 
@@ -92,7 +91,7 @@ contract EventLoggerTest is EventLogger_Initializer {
     }
 
     /// @notice It should revert if called with 5 topics
-    function test_emitLog_reverts() external {
+    function test_emitLog_5topics_reverts() external {
         bytes32[] memory topics = new bytes32[](5); // 5 or more topics: not possible to log
         bytes memory empty = new bytes(0);
         vm.expectRevert(empty);

--- a/packages/contracts-bedrock/test/integration/EventLogger.t.sol
+++ b/packages/contracts-bedrock/test/integration/EventLogger.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+
+import { Identifier as IfaceIdentifier } from "interfaces/L2/ICrossL2Inbox.sol";
+import { IL1BlockInterop } from "interfaces/L2/IL1BlockInterop.sol";
+
+import { EventLogger } from "../../src/integration/EventLogger.sol";
+
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+import { CrossL2Inbox, Identifier as ImplIdentifier } from "src/L2/CrossL2Inbox.sol";
+
+// @title MockL1BlockInfo
+// @notice mock L1 block info to fake a deposit-context.
+contract MockL1BlockInfo {
+    // @notice mock deposit-context that is never active
+    // @return always false
+    function isDeposit() external pure returns (bool isDeposit_) {
+        return false;
+    }
+}
+
+contract EventLogger_Initializer is Test {
+    EventLogger eventLogger;
+
+    function setUp() public {
+        // Deploy EventLogger contract
+        eventLogger = new EventLogger();
+        vm.label(address(eventLogger), "EventLogger");
+
+        vm.etch(Predeploys.CROSS_L2_INBOX, address(new CrossL2Inbox()).code);
+        vm.label(Predeploys.CROSS_L2_INBOX, "CrossL2Inbox");
+
+        // CrossL2Inbox needs this to do the deposit-context check
+        vm.etch(Predeploys.L1_BLOCK_ATTRIBUTES, address(new MockL1BlockInfo()).code);
+        vm.label(Predeploys.L1_BLOCK_ATTRIBUTES, "L1Block");
+    }
+}
+
+contract EventLoggerTest is EventLogger_Initializer {
+    /// @notice Test logging
+    function test_emitLog_succeeds(
+        uint256 topicCount,
+        bytes32 t0,
+        bytes32 t1,
+        bytes32 t2,
+        bytes32 t3,
+        bytes memory data
+    )
+        external
+    {
+        bytes32[] memory topics = new bytes32[](topicCount % 5);
+        if (topics.length == 0) {
+            vm.expectEmitAnonymous();
+            assembly {
+                log0(add(data, 32), mload(data))
+            }
+        } else if (topics.length == 1) {
+            topics[0] = t0;
+            vm.expectEmit(false, false, false, true);
+            assembly {
+                log1(add(data, 32), mload(data), t0)
+            }
+        } else if (topics.length == 2) {
+            topics[0] = t0;
+            topics[1] = t1;
+            vm.expectEmit(true, false, false, true);
+            assembly {
+                log2(add(data, 32), mload(data), t0, t1)
+            }
+        } else if (topics.length == 3) {
+            topics[0] = t0;
+            topics[1] = t1;
+            topics[2] = t2;
+            vm.expectEmit(true, true, false, true);
+            assembly {
+                log3(add(data, 32), mload(data), t0, t1, t2)
+            }
+        } else if (topics.length == 4) {
+            topics[0] = t0;
+            topics[1] = t1;
+            topics[2] = t2;
+            topics[3] = t3;
+            vm.expectEmit(true, true, true, true);
+            assembly {
+                log4(add(data, 32), mload(data), t0, t1, t2, t3)
+            }
+        }
+        eventLogger.emitLog(topics, data);
+    }
+
+    /// @notice It should revert if called with 5 topics
+    function test_emitLog_reverts() external {
+        bytes32[] memory topics = new bytes32[](5); // 5 or more topics: not possible to log
+        bytes memory empty = new bytes(0);
+        vm.expectRevert(empty);
+        eventLogger.emitLog(topics, empty);
+    }
+
+    /// @notice It should succeed with any Identifier
+    function test_validateMessage_succeeds(
+        address _origin,
+        uint256 _blockNumber,
+        uint256 _logIndex,
+        uint256 _timestamp,
+        uint256 _chainId,
+        bytes32 _msgHash
+    )
+        external
+    {
+        IfaceIdentifier memory idIface = IfaceIdentifier({
+            origin: _origin,
+            blockNumber: _blockNumber,
+            logIndex: _logIndex,
+            timestamp: _timestamp,
+            chainId: _chainId
+        });
+        ImplIdentifier memory idImpl = ImplIdentifier({
+            origin: _origin,
+            blockNumber: _blockNumber,
+            logIndex: _logIndex,
+            timestamp: _timestamp,
+            chainId: _chainId
+        });
+        address emitter = Predeploys.CROSS_L2_INBOX;
+        vm.expectEmit(false, false, false, true, emitter);
+        emit CrossL2Inbox.ExecutingMessage(_msgHash, idImpl);
+        eventLogger.validateMessage(idIface, _msgHash);
+    }
+}


### PR DESCRIPTION
**Description**

This is a util contract for integration testing.

Specifically, to emit all the kinds of log events that we need to emit to create the interop-test-cases.
Bundling of multiple log-events we can always do through multicall, and is thus not part of this contract.

The idea is to deploy one or more dummy contracts, trigger some events between them (initiating and executing interop messages), to then assert things about in interop.

The `EmitEvent` contract (in `e2eutils` was limited to just 1-topic event log, no interop interaction) and thus insufficient for what we are trying to achieve.

I have placed the contract into a new `integration` directory, instead of the `e2eutils` foundry location, to utilize the bedrock-contracts as library. If there's a better alternative way that we can use to depend on the bedrock contracts package, please share, we can structure it differently if desired. E.g. is some relative dependency link to the local bedrock contracts package better? Or do we then break things? Or maybe with its own CI run of the tests, it won't break? Packaging together might also be useful, to have combined artifacts, and util contracts always readily available.

**Tests**

Unit-tested the new util contract with a forge test of the events functionality.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/14049

