### PR TITLE
kt interop-devnet: enable super-cannon with interop-prestate

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -84,6 +84,7 @@ optimism_package:
         image: {{ $local_images.op_challenger }}
         cannon_prestate_path: ""
         cannon_prestates_url: {{ $urls.prestate }}
+        cannon_trace_types: ["cannon", "permissioned", "super-cannon"]
         extra_params:
         - {{ $flags.log_level }}
       proposer_params:
@@ -143,6 +144,7 @@ optimism_package:
         image: {{ $local_images.op_challenger }}
         cannon_prestate_path: ""
         cannon_prestates_url: {{ $urls.prestate }}
+        cannon_trace_types: ["cannon", "permissioned", "super-cannon"]
         extra_params:
         - {{ $flags.log_level }}
       proposer_params:
@@ -161,7 +163,7 @@ optimism_package:
     l1_artifacts_locator: {{ $urls.l1_artifacts }}
     l2_artifacts_locator: {{ $urls.l2_artifacts }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_interop }}
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []


### PR DESCRIPTION
**Description**

* Enable super-cannon in interop-devnet

**Additional context**

Requires [feat: adds support for permissionless game, challenger interop support](https://github.com/ethpandaops/optimism-package/pull/155#top)

