### PR TITLE
cannon: Expand test coverage

### DIFF
--- a/cannon/mipsevm/testutil/arch.go
+++ b/cannon/mipsevm/testutil/arch.go
@@ -70,3 +70,8 @@ func Cannon32OnlyTest(t testing.TB, msg string, args ...any) {
 		t.Skipf(msg, args...)
 	}
 }
+
+// FlipSign flips the sign of a 2's complement Word
+func FlipSign(val Word) Word {
+	return ^val + 1
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add a few more test cases.  
Also, replace literal values with the `U32Mask` constant where appropriate. 

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/14117
