### PR TITLE
opd: fix ProtocolVersions owner address

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -197,6 +197,17 @@ func GuardianAddressFor(chainID uint64) (common.Address, error) {
 	}
 }
 
+func ProtocolVersionsOwnerFor(chainID uint64) (common.Address, error) {
+	switch chainID {
+	case 1:
+		return common.HexToAddress("0x847B5c174615B1B7fDF770882256e2D3E95b9D92"), nil
+	case 11155111:
+		return common.HexToAddress("0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"), nil
+	default:
+		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}
+
 func ChallengerAddressFor(chainID uint64) (common.Address, error) {
 	switch chainID {
 	case 1:

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -166,11 +166,6 @@ func (c *Intent) validateStandardValues() error {
 }
 
 func getStandardSuperchainRoles(l1ChainId uint64) (*SuperchainRoles, error) {
-	superCfg, err := standard.SuperchainFor(l1ChainId)
-	if err != nil {
-		return nil, fmt.Errorf("error getting superchain config: %w", err)
-	}
-
 	proxyAdminOwner, err := standard.L1ProxyAdminOwner(l1ChainId)
 	if err != nil {
 		return nil, fmt.Errorf("error getting L1ProxyAdminOwner: %w", err)
@@ -180,9 +175,14 @@ func getStandardSuperchainRoles(l1ChainId uint64) (*SuperchainRoles, error) {
 		return nil, fmt.Errorf("error getting guardian address: %w", err)
 	}
 
+	protocolVersionsOwner, err := standard.ProtocolVersionsOwnerFor(l1ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting protocol versions owner address: %w", err)
+	}
+
 	superchainRoles := &SuperchainRoles{
 		ProxyAdminOwner:       proxyAdminOwner,
-		ProtocolVersionsOwner: superCfg.ProtocolVersionsAddr,
+		ProtocolVersionsOwner: protocolVersionsOwner,
 		Guardian:              guardian,
 	}
 


### PR DESCRIPTION
`op-deployer init` is creating an intent file with `protocolVersionsOwner` which is actually the address of the `ProtocolVersions` contract itself.

This fixes that.