### PR TITLE
Two fixes 1) Fix getBlock - it never actually pulled in transactions 2) fix nil pointer possible deref 

### DIFF
--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -324,6 +324,9 @@ func BlockAsPayload(bl *types.Block, config *params.ChainConfig) (*ExecutionPayl
 		}
 		opaqueTxs[i] = otx
 	}
+	if baseFee == nil {
+		return nil, fmt.Errorf("base fee was nil")
+	}
 
 	payload := &ExecutionPayload{
 		ParentHash:    bl.ParentHash(),

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -39,12 +39,28 @@ type RPCBlock struct {
 }
 
 func getBlock(ctx context.Context, client client.RPC, method string, tag string) (*types.Block, error) {
-	var bl *RPCBlock
-	err := client.CallContext(ctx, &bl, method, tag, true)
+	var raw json.RawMessage
+	err := client.CallContext(ctx, &raw, method, tag, true)
 	if err != nil {
 		return nil, err
 	}
-	return types.NewBlockWithHeader(&bl.Header).WithBody(types.Body{Transactions: bl.Transactions}), nil
+
+	var head *types.Header
+	if err := json.Unmarshal(raw, &head); err != nil {
+		return nil, err
+	}
+
+	type rpcBlock struct {
+		Hash         common.Hash          `json:"hash"`
+		Transactions []*types.Transaction `json:"transactions"`
+	}
+
+	var body *rpcBlock
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+
+	return types.NewBlockWithHeader(head).WithBody(types.Body{Transactions: body.Transactions}), nil
 }
 
 func getHeader(ctx context.Context, client client.RPC, method string, tag string) (*types.Header, error) {


### PR DESCRIPTION
1. was trying to use op-wheel to fix a broken geth node (`  Failed to decode block body    `) and tried out the copy-payload command. But kept getting invalid new payload params from catalyst. Dug some more and found that there was no transactions in body. 

@protolambda while your embeded struct is elegant , the transactions field doesn't get unmarshaled because the embeded struct's unmarshal method becomes the method for the whole struct, so transactions get ignored. 

2. Also playing around, hit a panic on the block payload conversion because basefee can be nil and uint256 will just give back nil which then gets blindly derefed