### PR TITLE
op-e2e/actions: Accelerated precompile tests

### DIFF
--- a/op-e2e/actions/proofs/block_data_hint_test.go
+++ b/op-e2e/actions/proofs/block_data_hint_test.go
@@ -32,7 +32,7 @@ func Test_OPProgramAction_BlockDataHint(gt *testing.T) {
 
 	// Build a block on L2 with 1 tx.
 	env.Alice.L2.ActResetTxOpts(t)
-	env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+	env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
 	env.Alice.L2.ActMakeTx(t)
 
 	env.Sequencer.ActL2StartBlock(t)

--- a/op-e2e/actions/proofs/fixtures.go
+++ b/op-e2e/actions/proofs/fixtures.go
@@ -1,0 +1,49 @@
+package proofs
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type PrecompileTestFixture struct {
+	Name        string
+	Address     common.Address
+	Input       []byte
+	Accelerated bool
+}
+
+// precompile test vectors copied from go-ethereum
+var PrecompileTestFixtures = []PrecompileTestFixture{
+	{
+		Name:        "ecrecover",
+		Address:     common.BytesToAddress([]byte{0x01}),
+		Input:       common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549"),
+		Accelerated: true,
+	},
+	{
+		Name:    "sha256",
+		Address: common.BytesToAddress([]byte{0x02}),
+		Input:   common.FromHex("68656c6c6f20776f726c64"),
+	},
+	{
+		Name:    "ripemd160",
+		Address: common.BytesToAddress([]byte{0x03}),
+		Input:   common.FromHex("68656c6c6f20776f726c64"),
+	},
+	{
+		Name:        "bn256Pairing",
+		Address:     common.BytesToAddress([]byte{0x08}),
+		Input:       common.FromHex("1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa"),
+		Accelerated: true,
+	},
+	{
+		Name:    "blake2F",
+		Address: common.BytesToAddress([]byte{0x09}),
+		Input:   common.FromHex("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001"),
+	},
+	{
+		Name:        "kzgPointEvaluation",
+		Address:     common.BytesToAddress([]byte{0x0a}),
+		Input:       common.FromHex("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a"),
+		Accelerated: true,
+	},
+}

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -185,7 +185,7 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			if !testCfg.Custom.breachMaxSequencerDrift {
 				// Send an L2 tx
 				env.Alice.L2.ActResetTxOpts(t)
-				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
 				env.Alice.L2.ActMakeTx(t)
 				env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
 			}
@@ -196,7 +196,7 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 				parentNum == 1801 {
 				// Send an L2 tx and force sequencer to include it
 				env.Alice.L2.ActResetTxOpts(t)
-				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+				env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
 				env.Alice.L2.ActMakeTx(t)
 				env.Engine.ActL2IncludeTxIgnoreForcedEmpty(env.Alice.Address())(t)
 			}

--- a/op-e2e/actions/proofs/precompile_test.go
+++ b/op-e2e/actions/proofs/precompile_test.go
@@ -1,0 +1,157 @@
+package proofs
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
+	hostconfig "github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OPProgramAction_Precompiles(gt *testing.T) {
+	tests := []precompileTestCase{
+		{
+			name:        "ecrecover",
+			address:     common.BytesToAddress([]byte{0x01}),
+			input:       common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549"),
+			gas:         params.EcrecoverGas,
+			accelerated: true,
+		},
+		{
+			name:    "sha256",
+			address: common.BytesToAddress([]byte{0x02}),
+			input:   common.FromHex("68656c6c6f20776f726c64"),
+		},
+		{
+			name:    "ripemd160",
+			address: common.BytesToAddress([]byte{0x03}),
+			input:   common.FromHex("68656c6c6f20776f726c64"),
+		},
+		{
+			name:        "bn256Pairing",
+			address:     common.BytesToAddress([]byte{0x08}),
+			input:       common.FromHex("1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa"),
+			accelerated: true,
+		},
+		{
+			name:    "blake2F",
+			address: common.BytesToAddress([]byte{0x09}),
+			input:   common.FromHex("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001"),
+		},
+		{
+			name:        "kzgPointEvaluation",
+			address:     common.BytesToAddress([]byte{0x0a}),
+			input:       common.FromHex("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a"),
+			accelerated: true,
+		},
+	}
+
+	for _, test := range tests {
+		gt.Run(test.name, func(t *testing.T) {
+			runPrecompileTest(t, test)
+		})
+	}
+}
+
+type precompileTestCase struct {
+	name        string
+	address     common.Address
+	input       []byte
+	gas         uint64
+	accelerated bool
+}
+
+func runPrecompileTest(gt *testing.T, testCase precompileTestCase) {
+	testCfg := &helpers.TestCfg[any]{
+		Hardfork:    helpers.LatestFork,
+		CheckResult: helpers.ExpectNoError(),
+	}
+	t := actionsHelpers.NewDefaultTesting(gt)
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+	// Build a block on L2 with 1 tx.
+	env.Alice.L2.ActResetTxOpts(t)
+	env.Alice.L2.ActSetTxToAddr(&testCase.address)(t)
+	env.Alice.L2.ActSetTxCalldata(testCase.input)(t)
+	env.Alice.L2.ActMakeTx(t)
+
+	env.Sequencer.ActL2StartBlock(t)
+	env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+	env.Sequencer.ActL2EndBlock(t)
+	env.Alice.L2.ActCheckReceiptStatusOfLastTx(true)(t)
+
+	// Instruct the batcher to submit the block to L1, and include the transaction.
+	env.Batcher.ActSubmitAll(t)
+	env.Miner.ActL1StartBlock(12)(t)
+	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+	env.Miner.ActL1EndBlock(t)
+
+	// Finalize the block with the batch on L1.
+	env.Miner.ActL1SafeNext(t)
+	env.Miner.ActL1FinalizeNext(t)
+
+	// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+	env.Sequencer.ActL1HeadSignal(t)
+	env.Sequencer.ActL2PipelineFull(t)
+
+	l1Head := env.Miner.L1Chain().CurrentBlock()
+	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
+
+	// Ensure there is only 1 block on L1.
+	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	// Ensure the block is marked as safe before we attempt to fault prove it.
+	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+
+	defaultParam := helpers.WithPreInteropDefaults(t, l2SafeHead.Number.Uint64(), env.Sequencer.L2Verifier, env.Engine)
+	fixtureInputParams := []helpers.FixtureInputParam{defaultParam, helpers.WithL1Head(l1Head.Hash())}
+	var fixtureInputs helpers.FixtureInputs
+	for _, apply := range fixtureInputParams {
+		apply(&fixtureInputs)
+	}
+	programCfg := helpers.NewOpProgramCfg(&fixtureInputs)
+	// Create an external in-memory kv store so we can inspect the precompile results.
+	kv := kvstore.NewMemKV()
+	withInProcessPrefetcher := hostcommon.WithPrefetcher(func(ctx context.Context, logger log.Logger, _kv kvstore.KV, cfg *hostconfig.Config) (hostcommon.Prefetcher, error) {
+		return helpers.CreateInprocessPrefetcher(t, ctx, logger, env.Miner, kv, cfg, &fixtureInputs)
+	})
+	ctx, cancel := context.WithTimeout(t.Ctx(), 2*time.Minute)
+	defer cancel()
+	require.NoError(t, hostcommon.FaultProofProgram(ctx, testlog.Logger(t, log.LevelDebug).New("role", "program"), programCfg, withInProcessPrefetcher))
+
+	rules := env.Engine.L2Chain().Config().Rules(l2SafeHead.Number, true, l2SafeHead.Time)
+	precompile := vm.ActivePrecompiledContracts(rules)[testCase.address]
+	gas := precompile.RequiredGas(testCase.input)
+	precompileKey := createPrecompileKey(testCase.address, testCase.input, gas)
+	// If accelerated, make sure that the precompile was fetched from the host.
+	if testCase.accelerated {
+		programResult, err := kv.Get(precompileKey)
+		require.NoError(t, err)
+
+		precompileSuccess := [1]byte{1}
+		expected, err := precompile.Run(testCase.input)
+		expected = append(precompileSuccess[:], expected...)
+		require.NoError(t, err)
+		require.EqualValues(t, expected, programResult)
+	} else {
+		_, err := kv.Get(precompileKey)
+		require.ErrorIs(t, kvstore.ErrNotFound, err)
+	}
+}
+
+func createPrecompileKey(precompileAddress common.Address, input []byte, gas uint64) common.Hash {
+	hintBytes := append(precompileAddress.Bytes(), binary.BigEndian.AppendUint64(nil, gas)...)
+	return preimage.PrecompileKey(crypto.Keccak256Hash(append(hintBytes, input...))).PreimageKey()
+}

--- a/op-e2e/actions/proofs/precompile_test.go
+++ b/op-e2e/actions/proofs/precompile_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +26,6 @@ func Test_OPProgramAction_Precompiles(gt *testing.T) {
 			name:        "ecrecover",
 			address:     common.BytesToAddress([]byte{0x01}),
 			input:       common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549"),
-			gas:         params.EcrecoverGas,
 			accelerated: true,
 		},
 		{
@@ -70,7 +68,6 @@ type precompileTestCase struct {
 	name        string
 	address     common.Address
 	input       []byte
-	gas         uint64
 	accelerated bool
 }
 

--- a/op-e2e/actions/proofs/precompile_test.go
+++ b/op-e2e/actions/proofs/precompile_test.go
@@ -21,57 +21,14 @@ import (
 )
 
 func Test_OPProgramAction_Precompiles(gt *testing.T) {
-	tests := []precompileTestCase{
-		{
-			name:        "ecrecover",
-			address:     common.BytesToAddress([]byte{0x01}),
-			input:       common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549"),
-			accelerated: true,
-		},
-		{
-			name:    "sha256",
-			address: common.BytesToAddress([]byte{0x02}),
-			input:   common.FromHex("68656c6c6f20776f726c64"),
-		},
-		{
-			name:    "ripemd160",
-			address: common.BytesToAddress([]byte{0x03}),
-			input:   common.FromHex("68656c6c6f20776f726c64"),
-		},
-		{
-			name:        "bn256Pairing",
-			address:     common.BytesToAddress([]byte{0x08}),
-			input:       common.FromHex("1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa"),
-			accelerated: true,
-		},
-		{
-			name:    "blake2F",
-			address: common.BytesToAddress([]byte{0x09}),
-			input:   common.FromHex("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001"),
-		},
-		{
-			name:        "kzgPointEvaluation",
-			address:     common.BytesToAddress([]byte{0x0a}),
-			input:       common.FromHex("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a"),
-			accelerated: true,
-		},
-	}
-
-	for _, test := range tests {
-		gt.Run(test.name, func(t *testing.T) {
+	for _, test := range PrecompileTestFixtures {
+		gt.Run(test.Name, func(t *testing.T) {
 			runPrecompileTest(t, test)
 		})
 	}
 }
 
-type precompileTestCase struct {
-	name        string
-	address     common.Address
-	input       []byte
-	accelerated bool
-}
-
-func runPrecompileTest(gt *testing.T, testCase precompileTestCase) {
+func runPrecompileTest(gt *testing.T, testCase PrecompileTestFixture) {
 	testCfg := &helpers.TestCfg[any]{
 		Hardfork:    helpers.LatestFork,
 		CheckResult: helpers.ExpectNoError(),
@@ -81,8 +38,8 @@ func runPrecompileTest(gt *testing.T, testCase precompileTestCase) {
 
 	// Build a block on L2 with 1 tx.
 	env.Alice.L2.ActResetTxOpts(t)
-	env.Alice.L2.ActSetTxToAddr(&testCase.address)(t)
-	env.Alice.L2.ActSetTxCalldata(testCase.input)(t)
+	env.Alice.L2.ActSetTxToAddr(&testCase.Address)(t)
+	env.Alice.L2.ActSetTxCalldata(testCase.Input)(t)
 	env.Alice.L2.ActMakeTx(t)
 
 	env.Sequencer.ActL2StartBlock(t)
@@ -129,16 +86,16 @@ func runPrecompileTest(gt *testing.T, testCase precompileTestCase) {
 	require.NoError(t, hostcommon.FaultProofProgram(ctx, testlog.Logger(t, log.LevelDebug).New("role", "program"), programCfg, withInProcessPrefetcher))
 
 	rules := env.Engine.L2Chain().Config().Rules(l2SafeHead.Number, true, l2SafeHead.Time)
-	precompile := vm.ActivePrecompiledContracts(rules)[testCase.address]
-	gas := precompile.RequiredGas(testCase.input)
-	precompileKey := createPrecompileKey(testCase.address, testCase.input, gas)
+	precompile := vm.ActivePrecompiledContracts(rules)[testCase.Address]
+	gas := precompile.RequiredGas(testCase.Input)
+	precompileKey := createPrecompileKey(testCase.Address, testCase.Input, gas)
 	// If accelerated, make sure that the precompile was fetched from the host.
-	if testCase.accelerated {
+	if testCase.Accelerated {
 		programResult, err := kv.Get(precompileKey)
 		require.NoError(t, err)
 
 		precompileSuccess := [1]byte{1}
-		expected, err := precompile.Run(testCase.input)
+		expected, err := precompile.Run(testCase.Input)
 		expected = append(precompileSuccess[:], expected...)
 		require.NoError(t, err)
 		require.EqualValues(t, expected, programResult)

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs"
 	e2e_config "github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
@@ -42,50 +43,9 @@ func TestPrecompiles_Multithreaded(t *testing.T) {
 
 func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
-	// precompile test vectors copied from go-ethereum
-	tests := []struct {
-		name        string
-		address     common.Address
-		input       []byte
-		accelerated bool
-	}{
-		{
-			name:        "ecrecover",
-			address:     common.BytesToAddress([]byte{0x01}),
-			input:       common.FromHex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549"),
-			accelerated: true,
-		},
-		{
-			name:    "sha256",
-			address: common.BytesToAddress([]byte{0x02}),
-			input:   common.FromHex("68656c6c6f20776f726c64"),
-		},
-		{
-			name:    "ripemd160",
-			address: common.BytesToAddress([]byte{0x03}),
-			input:   common.FromHex("68656c6c6f20776f726c64"),
-		},
-		{
-			name:        "bn256Pairing",
-			address:     common.BytesToAddress([]byte{0x08}),
-			input:       common.FromHex("1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f593034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf704bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a416782bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c21800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa"),
-			accelerated: true,
-		},
-		{
-			name:    "blake2F",
-			address: common.BytesToAddress([]byte{0x09}),
-			input:   common.FromHex("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001"),
-		},
-		{
-			name:        "kzgPointEvaluation",
-			address:     common.BytesToAddress([]byte{0x0a}),
-			input:       common.FromHex("01e798154708fe7789429634053cbf9f99b619f9f084048927333fce637f549b564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d3630624d25032e67a7e6a4910df5834b8fe70e6bcfeeac0352434196bdf4b2485d5a18f59a8d2a1a625a17f3fea0fe5eb8c896db3764f3185481bc22f91b4aaffcca25f26936857bc3a7c2539ea8ec3a952b7873033e038326e87ed3e1276fd140253fa08e9fc25fb2d9a98527fc22a2c9612fbeafdad446cbc7bcdbdcd780af2c16a"),
-			accelerated: true,
-		},
-	}
-	for _, test := range tests {
+	for _, test := range proofs.PrecompileTestFixtures {
 		test := test
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.Name, func(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 			ctx := context.Background()
 			genesisTime := hexutil.Uint64(0)
@@ -114,9 +74,9 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 
 			receipt := helpers.SendL2Tx(t, cfg, l2Seq, aliceKey, func(opts *helpers.TxOpts) {
 				opts.Gas = 1_000_000
-				opts.ToAddr = &test.address
+				opts.ToAddr = &test.Address
 				opts.Nonce = 0
-				opts.Data = test.input
+				opts.Data = test.Input
 			})
 
 			t.Log("Determine L2 claim")
@@ -141,10 +101,10 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 			runCannon(t, ctx, sys, inputs)
 		})
 
-		t.Run("DisputePrecompile-"+test.name, func(t *testing.T) {
+		t.Run("DisputePrecompile-"+test.Name, func(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
-			if !test.accelerated {
-				t.Skipf("%v is not accelerated so no preimgae to upload", test.name)
+			if !test.Accelerated {
+				t.Skipf("%v is not accelerated so no preimgae to upload", test.Name)
 			}
 			ctx := context.Background()
 			sys, _ := StartFaultDisputeSystem(t, WithBlobBatches(), WithAllocType(allocType))
@@ -153,9 +113,9 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 			aliceKey := sys.Cfg.Secrets.Alice
 			receipt := helpers.SendL2Tx(t, sys.Cfg, l2Seq, aliceKey, func(opts *helpers.TxOpts) {
 				opts.Gas = 1_000_000
-				opts.ToAddr = &test.address
+				opts.ToAddr = &test.Address
 				opts.Nonce = 0
-				opts.Data = test.input
+				opts.Data = test.Input
 			})
 
 			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)


### PR DESCRIPTION
There are e2e [tests](https://github.com/ethereum-optimism/optimism/blob/ab6283fe7b45c68e667cd9fb32758dee7606f32a/op-e2e/faultproofs/precompile_test.go) in op-e2e that cover the precompile execution code path of the op-program and the op-challenger.
These tests however do not assert that precompiles are actually accelerated. The only way to notice if a precompile wasn't accelerated is if one were to carefully note how long the tests take to run.

To address this gap in testing, this PR introduces an action test asserting that the host oracle is used appropriately for accelerated precompiles.