### PR TITLE
op-e2e: Move interop action test helpers to a separate package

### DIFF
--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"context"

--- a/op-e2e/actions/interop/dsl/dsl_user.go
+++ b/op-e2e/actions/interop/dsl/dsl_user.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"math/big"

--- a/op-e2e/actions/interop/dsl/emitter.go
+++ b/op-e2e/actions/interop/dsl/emitter.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"

--- a/op-e2e/actions/interop/dsl/inbox.go
+++ b/op-e2e/actions/interop/dsl/inbox.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"context"
@@ -145,6 +145,10 @@ func (sa *SupervisorActor) SignalLatestL1(t helpers.Testing) {
 
 func (sa *SupervisorActor) SignalFinalizedL1(t helpers.Testing) {
 	require.NoError(t, sa.backend.PullFinalizedL1())
+}
+
+func (sa *SupervisorActor) Rewind(chain eth.ChainID, block eth.BlockID) error {
+	return sa.backend.Rewind(chain, block)
 }
 
 // worldToDepSet converts a set of chain configs into a dependency-set for the supervisor.

--- a/op-e2e/actions/interop/dsl/super_root.go
+++ b/op-e2e/actions/interop/dsl/super_root.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"context"

--- a/op-e2e/actions/interop/dsl/transactions.go
+++ b/op-e2e/actions/interop/dsl/transactions.go
@@ -1,4 +1,4 @@
-package interop
+package dsl
 
 import (
 	"math/big"

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -22,7 +23,7 @@ import (
 func TestFullInterop(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 
-	is := SetupInterop(t)
+	is := dsl.SetupInterop(t)
 	actors := is.CreateActors()
 
 	// get both sequencers set up
@@ -154,7 +155,7 @@ func TestFullInterop(gt *testing.T) {
 // affecting the way Finality would be determined.
 func TestFinality(gt *testing.T) {
 	testFinality := func(t helpers.StatefulTesting, extraBlocks int) {
-		is := SetupInterop(t)
+		is := dsl.SetupInterop(t)
 		actors := is.CreateActors()
 
 		// set up a blank ChainA
@@ -211,8 +212,8 @@ func TestFinality(gt *testing.T) {
 
 		// Process the supervisor to update the finality, and pull L1, L2 finality
 		actors.Supervisor.ProcessFull(t)
-		l1Finalized := actors.Supervisor.backend.FinalizedL1()
-		l2Finalized, err := actors.Supervisor.backend.Finalized(context.Background(), actors.ChainA.ChainID)
+		l1Finalized := actors.Supervisor.FinalizedL1()
+		l2Finalized, err := actors.Supervisor.Finalized(context.Background(), actors.ChainA.ChainID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(tip), l1Finalized.Number)
 		// the L2 finality is the latest L2 block, because L1 finality is beyond anything the L2 used to derive
@@ -235,7 +236,7 @@ func TestFinality(gt *testing.T) {
 func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 
-	is := SetupInterop(t)
+	is := dsl.SetupInterop(t)
 	actors := is.CreateActors()
 
 	// get both sequencers set up

--- a/op-e2e/actions/interop/reset_test.go
+++ b/op-e2e/actions/interop/reset_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -13,7 +14,7 @@ import (
 func TestReset(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 
-	is := SetupInterop(t)
+	is := dsl.SetupInterop(t)
 	actors := is.CreateActors()
 
 	// get both sequencers set up
@@ -131,7 +132,7 @@ func TestReset(gt *testing.T) {
 	}
 
 	// Reset the supervisor to a much earlier block
-	err := actors.Supervisor.backend.Rewind(actors.ChainA.ChainID, blocksAdded[3])
+	err := actors.Supervisor.Rewind(actors.ChainA.ChainID, blocksAdded[3])
 	require.NoError(t, err)
 	actors.Supervisor.ProcessFull(t)
 	actors.ChainA.Sequencer.ActL2PipelineFull(t)


### PR DESCRIPTION
**Description**

Moves the dsl implementation into a sub-package for interop action tests so it's easier to see the actual tests and so the dsl can choose what is exposed and what is kept internal.