### PR TITLE
Remove `MustRegister()` calls that do nothing

### DIFF
--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -235,7 +235,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -239,7 +239,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 

--- a/op-conductor/metrics/metrics.go
+++ b/op-conductor/metrics/metrics.go
@@ -118,7 +118,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -418,7 +418,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 

--- a/op-dripper/metrics/metrics.go
+++ b/op-dripper/metrics/metrics.go
@@ -99,7 +99,6 @@ func (m *Metrics) RecordInfo(version string) {
 }
 
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -464,7 +464,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.Up.Set(1)
 }
 

--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -100,7 +100,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -137,7 +137,6 @@ func (m *Metrics) RecordInfo(version string) {
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
-	prometheus.MustRegister()
 	m.up.Set(1)
 }
 


### PR DESCRIPTION
`MustRegister` with no arguments does nothing: https://github.com/prometheus/client_golang/blob/v1.20.5/prometheus/registry.go#L403

Every `RecordUp()`  function seems to have this.