### PR TITLE
op-challenger: Handle requesting superchain roots beyond the current unsafe head

### DIFF
--- a/op-challenger/game/fault/trace/super/prestate.go
+++ b/op-challenger/game/fault/trace/super/prestate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -32,7 +33,9 @@ func (s *SuperRootPrestateProvider) AbsolutePreStateCommitment(ctx context.Conte
 
 func (s *SuperRootPrestateProvider) AbsolutePreState(ctx context.Context) (eth.Super, error) {
 	response, err := s.provider.SuperRootAtTimestamp(ctx, hexutil.Uint64(s.timestamp))
-	if err != nil {
+	if isNotFound(err) {
+		return nil, ethereum.NotFound
+	} else if err != nil {
 		return nil, err
 	}
 	return responseToSuper(response), nil

--- a/op-challenger/game/fault/trace/super/provider.go
+++ b/op-challenger/game/fault/trace/super/provider.go
@@ -97,7 +97,6 @@ func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Pos
 	prevRoot, err := s.rootProvider.SuperRootAtTimestamp(ctx, hexutil.Uint64(timestamp))
 	if isNotFound(err) {
 		// No block at this timestamp so it must be invalid
-		fmt.Printf("error: %v\n", err)
 		return InvalidTransition, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to retrieve previous super root at timestamp %v: %w", timestamp, err)

--- a/op-challenger/game/fault/trace/super/provider.go
+++ b/op-challenger/game/fault/trace/super/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	interopTypes "github.com/ethereum-optimism/optimism/op-program/client/interop/types"
@@ -67,6 +68,11 @@ func (s *SuperTraceProvider) Get(ctx context.Context, pos types.Position) (commo
 	return crypto.Keccak256Hash(preimage), nil
 }
 
+func isNotFound(err error) bool {
+	// The RPC server wil convert the returned error to a string so we can't match on an error type here
+	return err != nil && strings.Contains(err.Error(), "not found")
+}
+
 func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Position) ([]byte, error) {
 	// Find the timestamp and step at position
 	timestamp, step, err := s.ComputeStep(pos)
@@ -76,7 +82,10 @@ func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Pos
 	s.logger.Info("Getting claim", "pos", pos.ToGIndex(), "timestamp", timestamp, "step", step)
 	if step == 0 {
 		root, err := s.rootProvider.SuperRootAtTimestamp(ctx, hexutil.Uint64(timestamp))
-		if err != nil {
+		if isNotFound(err) {
+			// No block at this timestamp so it must be invalid
+			return InvalidTransition, nil
+		} else if err != nil {
 			return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", timestamp, err)
 		}
 		if root.CrossSafeDerivedFrom.Number > s.l1Head.Number {
@@ -86,8 +95,12 @@ func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Pos
 	}
 	// Fetch the super root at the next timestamp since we are part way through the transition to it
 	prevRoot, err := s.rootProvider.SuperRootAtTimestamp(ctx, hexutil.Uint64(timestamp))
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", timestamp, err)
+	if isNotFound(err) {
+		// No block at this timestamp so it must be invalid
+		fmt.Printf("error: %v\n", err)
+		return InvalidTransition, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to retrieve previous super root at timestamp %v: %w", timestamp, err)
 	}
 	if prevRoot.CrossSafeDerivedFrom.Number > s.l1Head.Number {
 		// The previous root was not safe at the game L1 head so we must have already transitioned to the invalid hash
@@ -96,8 +109,11 @@ func (s *SuperTraceProvider) GetPreimageBytes(ctx context.Context, pos types.Pos
 	}
 	nextTimestamp := timestamp + 1
 	nextRoot, err := s.rootProvider.SuperRootAtTimestamp(ctx, hexutil.Uint64(nextTimestamp))
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve super root at timestamp %v: %w", nextTimestamp, err)
+	if isNotFound(err) {
+		// No block at this timestamp so it must be invalid
+		return InvalidTransition, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to retrieve next super root at timestamp %v: %w", nextTimestamp, err)
 	}
 
 	var safeHeads map[eth.ChainID]eth.BlockID

--- a/op-e2e/actions/interop/dsl/outputs.go
+++ b/op-e2e/actions/interop/dsl/outputs.go
@@ -1,0 +1,47 @@
+package dsl
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+type Outputs struct {
+	t               helpers.Testing
+	superRootSource *SuperRootSource
+}
+
+func (d *Outputs) SuperRoot(timestamp uint64) eth.Super {
+	ctx, cancel := context.WithTimeout(d.t.Ctx(), 30*time.Second)
+	defer cancel()
+	root, err := d.superRootSource.CreateSuperRoot(ctx, timestamp)
+	require.NoError(d.t, err)
+	return root
+}
+
+func (d *Outputs) OutputRootAtTimestamp(chain *Chain, timestamp uint64) *eth.OutputResponse {
+	ctx, cancel := context.WithTimeout(d.t.Ctx(), 30*time.Second)
+	defer cancel()
+	blockNum, err := chain.RollupCfg.TargetBlockNumber(timestamp)
+	require.NoError(d.t, err)
+	output, err := chain.Sequencer.RollupClient().OutputAtBlock(ctx, blockNum)
+	require.NoError(d.t, err)
+	return output
+}
+
+func (d *Outputs) OptimisticBlockAtTimestamp(chain *Chain, timestamp uint64) types.OptimisticBlock {
+	root := d.OutputRootAtTimestamp(chain, timestamp)
+	return types.OptimisticBlock{BlockHash: root.BlockRef.Hash, OutputRoot: root.OutputRoot}
+}
+
+func (d *Outputs) TransitionState(timestamp uint64, step uint64, pendingProgress ...types.OptimisticBlock) *types.TransitionState {
+	return &types.TransitionState{
+		SuperRoot:       d.SuperRoot(timestamp).Marshal(),
+		PendingProgress: pendingProgress,
+		Step:            step,
+	}
+}


### PR DESCRIPTION
**Description**

When the proposal timestamp for a game is after the chain's unsafe head, challenger may request super roots for timestamps beyond the unsafe head and needs to handle the not found error supervisor returns.

**Tests**

Added unit tests and expanded the action tests.  Also introduces helper methods for creating transition states.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/14077
Should improve the error handling so the superchain client detects the not found string and returns a nice typed error rather than having to do string matching in challenger (which is likely to be duplicated in dispute-mon and proposer as well).