### PR TITLE
ci: Put test vectors on Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,8 +307,9 @@ jobs:
                 mentions: "@proofs-team"
 
   cannon-build-test-vectors:
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: large
     steps:
       - checkout-with-mise
       - check-changed:


### PR DESCRIPTION
This test was failing on the self-hosted executor due to lock contention in `dpkg`. Since we don't need this to run on the self-hosted runner, this PR moves the execution of the test-vectors job onto a Docker executor which is completely fresh each run.