### PR TITLE
op-challenger: Implement SyncValidator for super games

### DIFF
--- a/op-challenger/game/fault/clients.go
+++ b/op-challenger/game/fault/clients.go
@@ -74,13 +74,13 @@ func (c *clientProvider) RollupClient() (RollupClient, error) {
 	return rollupClient, nil
 }
 
-func (c *clientProvider) SuperRootProvider() (super.RootProvider, error) {
+func (c *clientProvider) SuperchainClients() (super.RootProvider, *super.SyncValidator, error) {
 	cl, err := client.NewRPC(context.Background(), c.logger, c.cfg.SupervisorRPC)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial supervisor: %w", err)
+		return nil, nil, fmt.Errorf("failed to dial supervisor: %w", err)
 	}
 	supervisorClient := sources.NewSupervisorClient(cl)
 	c.rootProvider = supervisorClient
 	c.toClose = append(c.toClose, supervisorClient.Close)
-	return supervisorClient, nil
+	return supervisorClient, super.NewSyncValidator(supervisorClient), nil
 }

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -29,6 +29,8 @@ type GameInfo interface {
 }
 
 type SyncValidator interface {
+	// ValidateNodeSynced checks that the local node is sufficiently up to date to play the game.
+	// It returns types.ErrNotInSync if the node is too far behind.
 	ValidateNodeSynced(ctx context.Context, gameL1Head eth.BlockID) error
 }
 
@@ -179,7 +181,7 @@ func (g *GamePlayer) ProgressGame(ctx context.Context) gameTypes.GameStatus {
 		g.logger.Trace("Skipping completed game")
 		return g.status
 	}
-	if err := g.syncValidator.ValidateNodeSynced(ctx, g.gameL1Head); errors.Is(err, ErrNotInSync) {
+	if err := g.syncValidator.ValidateNodeSynced(ctx, g.gameL1Head); errors.Is(err, types.ErrNotInSync) {
 		g.logger.Warn("Local node not sufficiently up to date", "err", err)
 		return g.status
 	} else if err != nil {

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -68,11 +68,11 @@ func RegisterGameTypes(
 		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeSuperCannon) {
-		rootProvider, err := clients.SuperRootProvider()
+		rootProvider, syncValidator, err := clients.SuperchainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(faultTypes.SuperCannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider))
+		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(faultTypes.SuperCannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypePermissioned) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -50,11 +50,11 @@ type RegisterTask struct {
 		poststateBlock uint64) (*trace.Accessor, error)
 }
 
-func NewSuperCannonRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider) *RegisterTask {
+func NewSuperCannonRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
 	stateConverter := cannon.NewStateConverter(cfg.Cannon)
 	return &RegisterTask{
 		gameType:      gameType,
-		syncValidator: super.NewSyncValidator(),
+		syncValidator: syncValidator,
 		getTopPrestateProvider: func(ctx context.Context, prestateTimestamp uint64) (faultTypes.PrestateProvider, error) {
 			return super.NewSuperRootPrestateProvider(rootProvider, prestateTimestamp), nil
 		},

--- a/op-challenger/game/fault/sync.go
+++ b/op-challenger/game/fault/sync.go
@@ -2,13 +2,11 @@ package fault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
-
-var ErrNotInSync = errors.New("local node too far behind")
 
 type SyncStatusProvider interface {
 	SyncStatus(context.Context) (*eth.SyncStatus, error)
@@ -30,7 +28,7 @@ func (s *syncStatusValidator) ValidateNodeSynced(ctx context.Context, gameL1Head
 		return fmt.Errorf("failed to retrieve local node sync status: %w", err)
 	}
 	if syncStatus.CurrentL1.Number <= gameL1Head.Number {
-		return fmt.Errorf("%w require L1 block above %v but at %v", ErrNotInSync, gameL1Head.Number, syncStatus.CurrentL1.Number)
+		return fmt.Errorf("%w require L1 block above %v but at %v", types.ErrNotInSync, gameL1Head.Number, syncStatus.CurrentL1.Number)
 	}
 	return nil
 }

--- a/op-challenger/game/fault/sync_test.go
+++ b/op-challenger/game/fault/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +35,7 @@ func TestSyncStatusProvider(t *testing.T) {
 				},
 			},
 			statusReqErr: nil,
-			expected:     ErrNotInSync,
+			expected:     types.ErrNotInSync,
 		},
 		{
 			name:       "CurrentL1EqualToGameL1Head",
@@ -45,7 +46,7 @@ func TestSyncStatusProvider(t *testing.T) {
 				},
 			},
 			statusReqErr: nil,
-			expected:     ErrNotInSync,
+			expected:     types.ErrNotInSync,
 		},
 		{
 			name:       "CurrentL1AboveGameL1Head",

--- a/op-challenger/game/fault/trace/super/sync.go
+++ b/op-challenger/game/fault/trace/super/sync.go
@@ -2,18 +2,33 @@ package super
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type SyncValidator struct {
+	syncStatusProvider SyncStatusProvider
 }
 
-func NewSyncValidator() *SyncValidator {
-	return &SyncValidator{}
+type SyncStatusProvider interface {
+	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
+}
+
+func NewSyncValidator(syncStatusProvider SyncStatusProvider) *SyncValidator {
+	return &SyncValidator{
+		syncStatusProvider: syncStatusProvider,
+	}
 }
 
 func (s SyncValidator) ValidateNodeSynced(ctx context.Context, gameL1Head eth.BlockID) error {
-	// TODO: Check sync status of supervisor
+	syncStatus, err := s.syncStatusProvider.SyncStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve sync status: %w", err)
+	}
+	if syncStatus.MinSyncedL1.Number <= gameL1Head.Number {
+		return fmt.Errorf("%w require L1 block above %v but at %v", types.ErrNotInSync, gameL1Head.Number, syncStatus.MinSyncedL1.Number)
+	}
 	return nil
 }

--- a/op-challenger/game/fault/trace/super/sync_test.go
+++ b/op-challenger/game/fault/trace/super/sync_test.go
@@ -1,0 +1,75 @@
+package super
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncStatusProvider(t *testing.T) {
+	requestErr := errors.New("boom")
+	tests := []struct {
+		name          string
+		gameL1Head    uint64
+		syncStatus    eth.SupervisorSyncStatus
+		statusReqErr  error
+		expectedError error
+	}{
+		{
+			name:          "ErrorFetchingStatus",
+			gameL1Head:    100,
+			statusReqErr:  requestErr,
+			expectedError: requestErr,
+		},
+		{
+			name:       "MinSyncedL1BehindGameHead",
+			gameL1Head: 100,
+			syncStatus: eth.SupervisorSyncStatus{
+				MinSyncedL1: eth.L1BlockRef{Number: 99},
+			},
+			expectedError: types.ErrNotInSync,
+		},
+		{
+			name:       "MinSyncedL1EqualToGameHead",
+			gameL1Head: 100,
+			syncStatus: eth.SupervisorSyncStatus{
+				MinSyncedL1: eth.L1BlockRef{Number: 100},
+			},
+			expectedError: types.ErrNotInSync,
+		},
+		{
+			name:       "InSync",
+			gameL1Head: 100,
+			syncStatus: eth.SupervisorSyncStatus{
+				MinSyncedL1: eth.L1BlockRef{Number: 101},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test // capture range variable
+		t.Run(test.name, func(t *testing.T) {
+			stubProvider := &stubSyncStatusProvider{
+				status: test.syncStatus,
+				err:    test.statusReqErr,
+			}
+			validator := NewSyncValidator(stubProvider)
+			err := validator.ValidateNodeSynced(context.Background(), eth.BlockID{Number: test.gameL1Head})
+			require.ErrorIs(t, err, test.expectedError, "expected error to be %v, got %v", test.expectedError, err)
+		})
+	}
+}
+
+type stubSyncStatusProvider struct {
+	status eth.SupervisorSyncStatus
+	err    error
+}
+
+func (f *stubSyncStatusProvider) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
+	return f.status, f.err
+}

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -19,6 +19,7 @@ import (
 var (
 	ErrGameDepthReached   = errors.New("game depth reached")
 	ErrL2BlockNumberValid = errors.New("l2 block number is valid")
+	ErrNotInSync          = errors.New("local node too far behind")
 )
 
 type GameType uint32

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -342,7 +342,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      step1Expected,
 			disputedTraceIndex: 0,
 			expectValid:        true,
-			skipChallenger:     true,
 		},
 		{
 			name:               "SecondChainOptimisticBlock",
@@ -350,7 +349,8 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      step2Expected,
 			disputedTraceIndex: 1,
 			expectValid:        true,
-			skipChallenger:     true,
+			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
+			skipChallenger: true,
 		},
 		{
 			name:               "FirstPaddingStep",
@@ -358,7 +358,8 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      paddingStep(3),
 			disputedTraceIndex: 2,
 			expectValid:        true,
-			skipChallenger:     true,
+			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
+			skipChallenger: true,
 		},
 		{
 			name:               "SecondPaddingStep",
@@ -366,7 +367,8 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      paddingStep(4),
 			disputedTraceIndex: 3,
 			expectValid:        true,
-			skipChallenger:     true,
+			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
+			skipChallenger: true,
 		},
 		{
 			name:               "LastPaddingStep",
@@ -374,7 +376,8 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      paddingStep(1023),
 			disputedTraceIndex: 1022,
 			expectValid:        true,
-			skipChallenger:     true,
+			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
+			skipChallenger: true,
 		},
 		{
 			name:               "Consolidate-ExpectInvalidPendingBlock",
@@ -416,9 +419,8 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      interop.InvalidTransition,
 			disputedTraceIndex: 0,
 			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    true,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			l1Head:      actors.L1Miner.L1Chain().Genesis().Hash(),
+			expectValid: true,
 		},
 		{
 			name:               "SecondChainReachesL1Head",
@@ -446,9 +448,8 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      interop.InvalidTransition,
 			disputedTraceIndex: 2,
 			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    true,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			l1Head:      actors.L1Miner.L1Chain().Genesis().Hash(),
+			expectValid: true,
 		},
 	}
 
@@ -506,7 +507,7 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 				require.NoError(t, err)
 				agreedPrestate = superRoot.Marshal()
 			}
-			require.Equal(t, test.agreedClaim, agreedPrestate)
+			require.Equal(t, test.agreedClaim, agreedPrestate, "agreed prestate mismatch")
 
 			disputedClaim, err := provider.GetPreimageBytes(t.Ctx(), challengerTypes.NewPosition(gameDepth, big.NewInt(test.disputedTraceIndex)))
 			require.NoError(t, err)

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -423,24 +423,13 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			expectValid: true,
 		},
 		{
-			name:               "SecondChainReachesL1Head",
-			agreedClaim:        step1Expected,
-			disputedClaim:      interop.InvalidTransition,
-			disputedTraceIndex: 1,
-			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    true,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
-		},
-		{
 			name:               "SuperRootInvalidIfUnsupportedByL1Data",
-			agreedClaim:        step1Expected,
-			disputedClaim:      step2Expected,
-			disputedTraceIndex: 1,
+			agreedClaim:        start.Marshal(),
+			disputedClaim:      step1Expected,
+			disputedTraceIndex: 0,
 			// The derivation reaches the L1 head before the next block can be created
-			l1Head:         actors.L1Miner.L1Chain().Genesis().Hash(),
-			expectValid:    false,
-			skipChallenger: true, // Challenger doesn't yet check if blocks were safe
+			l1Head:      actors.L1Miner.L1Chain().Genesis().Hash(),
+			expectValid: false,
 		},
 		{
 			name:               "FromInvalidTransitionHash",


### PR DESCRIPTION
Grant the challenger the ability to determine when its local node is synchronized enough to play a super fault proof game.
The semantics of sync status checking in the supervisor is identical to the rollup node. Where the challenger only participates once all managed nodes have processed the L1 head a game was created at.

fixes https://github.com/ethereum-optimism/optimism/issues/13902