### PR TITLE
op-batcher: Lower default active seq check duration to 5s

### DIFF
--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -138,8 +138,8 @@ var (
 	}
 	ActiveSequencerCheckDurationFlag = &cli.DurationFlag{
 		Name:    "active-sequencer-check-duration",
-		Usage:   "The duration between checks to determine the active sequencer endpoint. ",
-		Value:   2 * time.Minute,
+		Usage:   "The duration between checks to determine the active sequencer endpoint.",
+		Value:   5 * time.Second,
 		EnvVars: prefixEnvVars("ACTIVE_SEQUENCER_CHECK_DURATION"),
 	}
 	CheckRecentTxsDepthFlag = &cli.IntFlag{


### PR DESCRIPTION
Throttling depends on the batcher always being pointed at the active sequencer. So the check should happen much more frequently.