### PR TITLE
fix: AnchorStateRegistry: remove blacklist check in `getAnchorRoot`

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -160,8 +160,8 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0x09ed487b605b933a2da4c87a799e2d11957a4c627efeea04aee804a9f4999bc1",
-    "sourceCodeHash": "0xafba7130f42072db2a610be8186e36669995eaf3d0a4a81f65f5c22f0c66e4c9"
+    "initCodeHash": "0xa8f56c173a44c8f2b5297210752d25ae30d0a344dc77b331a1a0032d4b3eea62",
+    "sourceCodeHash": "0xa425c001050a7002cd7387396b29bc412512270e90f216b2765a4ee02a966178"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0xdd0b5e523f3b53563fe0b6e6165fb73605b14910ffa32a7cbed855cdebab47c6",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -160,8 +160,8 @@
     "sourceCodeHash": "0xb7b0a06cd971c4647247dc19ce997d0c64a73e87c81d30731da9cf9efa1b952a"
   },
   "src/dispute/AnchorStateRegistry.sol": {
-    "initCodeHash": "0xa8f56c173a44c8f2b5297210752d25ae30d0a344dc77b331a1a0032d4b3eea62",
-    "sourceCodeHash": "0xa425c001050a7002cd7387396b29bc412512270e90f216b2765a4ee02a966178"
+    "initCodeHash": "0x08cc5a5e41eadb6c411fa6387ddc0cf12be360855599dd622cce84c0ba081e77",
+    "sourceCodeHash": "0xe0aaa79f7184724ff0fba2e92e85f652f936fecd099288edb0a0f6b0e0240f34"
   },
   "src/dispute/DelayedWETH.sol": {
     "initCodeHash": "0xdd0b5e523f3b53563fe0b6e6165fb73605b14910ffa32a7cbed855cdebab47c6",

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -106,10 +106,6 @@ contract AnchorStateRegistry is Initializable, ISemver {
             return (startingAnchorRoot.root, startingAnchorRoot.l2BlockNumber);
         }
 
-        if (isGameBlacklisted(anchorGame)) {
-            revert AnchorStateRegistry_AnchorGameBlacklisted();
-        }
-
         // Otherwise, return the anchor root.
         return (Hash.wrap(anchorGame.rootClaim().raw()), anchorGame.l2BlockNumber());
     }
@@ -248,16 +244,12 @@ contract AnchorStateRegistry is Initializable, ISemver {
         // version of IDisputeGame in the future.
         IFaultDisputeGame game = IFaultDisputeGame(address(_game));
 
-        // Check if the candidate game is valid.
-        bool valid = isGameClaimValid(game);
-        if (!valid) {
+        // Check if the candidate game claim is valid.
+        if (!isGameClaimValid(game)) {
             revert AnchorStateRegistry_InvalidAnchorGame();
         }
 
         // Must be newer than the current anchor game.
-        // Note that this WILL block/brick if getAnchorRoot() ever reverts because the current
-        // anchor game is blacklisted. A blacklisted anchor game is *very* bad and we deliberately
-        // want to force the situation to be handled manually.
         (, uint256 anchorL2BlockNumber) = getAnchorRoot();
         if (game.l2BlockNumber() <= anchorL2BlockNumber) {
             revert AnchorStateRegistry_InvalidAnchorGame();

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -23,8 +23,8 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 ///         be initialized with a more recent starting state which reduces the amount of required offchain computation.
 contract AnchorStateRegistry is Initializable, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 2.2.1
-    string public constant version = "2.2.1";
+    /// @custom:semver 2.2.2
+    string public constant version = "2.2.2";
 
     /// @notice Address of the SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -105,11 +105,9 @@ contract AnchorStateRegistry_GetAnchorRoot_Test is AnchorStateRegistry_Init {
         assertEq(root.raw(), gameProxy.rootClaim().raw());
         assertEq(l2BlockNumber, gameProxy.l2BlockNumber());
     }
-}
 
-contract AnchorStateRegistry_GetAnchorRoot_TestFail is AnchorStateRegistry_Init {
-    /// @notice Tests that getAnchorRoot will revert if the anchor game is blacklisted.
-    function test_getAnchorRoot_blacklistedGame_fails() public {
+    /// @notice Tests that getAnchorRoot returns even if the anchor game is blacklisted.
+    function test_getAnchorRoot_blacklistedGame_succeeds() public {
         // Mock the game to be resolved.
         vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
         vm.warp(block.timestamp + optimismPortal2.disputeGameFinalityDelaySeconds() + 1);
@@ -126,8 +124,11 @@ contract AnchorStateRegistry_GetAnchorRoot_TestFail is AnchorStateRegistry_Init 
             abi.encodeCall(optimismPortal2.disputeGameBlacklist, (gameProxy)),
             abi.encode(true)
         );
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_AnchorGameBlacklisted.selector);
-        anchorStateRegistry.getAnchorRoot();
+
+        // Get the anchor root.
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+        assertEq(root.raw(), gameProxy.rootClaim().raw());
+        assertEq(l2BlockNumber, gameProxy.l2BlockNumber());
     }
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Re: incident response improvements audit issue 19: [Blacklisted anchorGame in AnchorStateRegistry prevents submitting L2 root claims to L1](https://github.com/spearbit-audits/OP-Upgrade-13-review-200125/issues/19)

"Anchor game gets blacklisted" is an edge case that should never happen given our system assumptions. That said, our implementation accounted for this case by insisting on manual intervention. This broke an L2Beat stage 1 condition. So, we remove the handling of this edge case and the imposition of manual intervention, and rest instead on the assumption [aASR-004](https://github.com/ethereum-optimism/specs/blob/main/specs/fault-proof/stage-one/anchor-state-registry.md#aasr-004-incorrectly-resolving-games-will-be-invalidated-within-the-airgap-delay-period)