### PR TITLE
supervisor: LastCommonCompleteL1 functionality and Wiring

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -522,6 +522,10 @@ func (su *SupervisorBackend) FinalizedL1() eth.BlockRef {
 	return su.chainDBs.FinalizedL1()
 }
 
+func (su *SupervisorBackend) LastCommonCompleteL1() (types.BlockSeal, error) {
+	return su.chainDBs.LastCommonL1(true)
+}
+
 func (su *SupervisorBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
 	v, err := su.chainDBs.CrossDerivedToSourceRef(chainID, derived)
 	if err != nil {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -59,6 +59,7 @@ type DerivationStorage interface {
 	// mapping from source<>derived
 	DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error)
 	SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error)
+	SourceNumToSource(sourceNum uint64) (source types.BlockSeal, err error)
 
 	// traversal
 	Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error)

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -286,6 +286,20 @@ func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error)
 	return next.sealOrErr()
 }
 
+// SourceNumToSource returns the source block for the given source number.
+// It can be used to check if multiple chains have the same source block at a given height.
+func (db *DB) SourceNumToSource(sourceNum uint64) (types.BlockSeal, error) {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	_, link, err := db.find(false, func(link LinkEntry) int {
+		return cmp.Compare(link.source.Number, sourceNum)
+	})
+	if err != nil {
+		return types.BlockSeal{}, err
+	}
+	return link.source, nil
+}
+
 func (db *DB) derivedNumToFirstSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	// Forward: prioritize the first entry.
 	return db.find(false, func(link LinkEntry) int {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -52,6 +52,11 @@ func (db *ChainsDB) LastCommonL1(completeOnly bool) (types.BlockSeal, error) {
 	}
 	// Step 2: offset to the parent block if completeOnly is true
 	if completeOnly {
+		if commonL1.Number == 0 {
+			// ErrFuture is used because we don't have enough data to determine the common *completed* L1 block yet,
+			// but will be able to once a second block is added.
+			return types.BlockSeal{}, fmt.Errorf("genesis block is known but may not be complete: %w", types.ErrFuture)
+		}
 		// we only need one chain to offset to the parent block
 		ldb, ok := db.localDBs.Get(db.depSet.Chains()[0])
 		if !ok {

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 type mockDerivationStorage struct {
-	lastFn func() (pair types.DerivedBlockSealPair, err error)
+	lastFn      func() (pair types.DerivedBlockSealPair, err error)
+	sourceNumFn func(sourceNum uint64) (source types.BlockSeal, err error)
 }
 
 func (m *mockDerivationStorage) First() (pair types.DerivedBlockSealPair, err error) {
@@ -69,6 +70,12 @@ func (m *mockDerivationStorage) RewindToScope(scope eth.BlockID) error {
 func (m *mockDerivationStorage) RewindToFirstDerived(derived eth.BlockID) error {
 	return nil
 }
+func (m *mockDerivationStorage) SourceNumToSource(sourceNum uint64) (source types.BlockSeal, err error) {
+	if m.sourceNumFn != nil {
+		return m.sourceNumFn(sourceNum)
+	}
+	return types.BlockSeal{}, nil
+}
 
 func sampleDepSet(t *testing.T) depset.DependencySet {
 	depSet, err := depset.NewStaticConfigDependencySet(
@@ -104,7 +111,7 @@ func TestCommonL1UnknownChain(t *testing.T) {
 	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(901), m2)
 	// don't attach a mock for chain 902
 
-	_, err := chainDB.LastCommonL1()
+	_, err := chainDB.LastCommonL1(false)
 	require.ErrorIs(t, err, types.ErrUnknownChain)
 }
 
@@ -120,51 +127,129 @@ func TestCommonL1(t *testing.T) {
 	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(901), m2)
 	chainDB.AddLocalDerivationDB(eth.ChainIDFromUInt64(902), m3)
 
-	// returnN is a helper function which creates a Latest Function for the test
-	returnN := func(n uint64) func() (pair types.DerivedBlockSealPair, err error) {
+	// lastN is a helper function which creates a Latest Function for the test
+	lastN := func(n uint64) func() (pair types.DerivedBlockSealPair, err error) {
 		return func() (pair types.DerivedBlockSealPair, err error) {
 			return types.DerivedBlockSealPair{
 				Source: types.BlockSeal{
 					Number: n,
+					Hash:   common.Hash{1},
 				},
 			}, nil
 		}
 	}
+	// sourceN is a helper function which creates a SourceNumToSource Function for the test
+	sourceN := func(n uint64, h common.Hash) func(sourceNum uint64) (source types.BlockSeal, err error) {
+		return func(sourceNum uint64) (source types.BlockSeal, err error) {
+			require.Equal(t, n, sourceNum)
+			return types.BlockSeal{
+				Number: n,
+				Hash:   h,
+			}, nil
+		}
+	}
 	t.Run("pattern 1", func(t *testing.T) {
-		m1.lastFn = returnN(1)
-		m2.lastFn = returnN(2)
-		m3.lastFn = returnN(3)
+		m1.lastFn = lastN(1)
+		m2.lastFn = lastN(2)
+		m3.lastFn = lastN(3)
+		m1.sourceNumFn = sourceN(1, common.Hash{1})
+		m2.sourceNumFn = sourceN(1, common.Hash{1})
+		m3.sourceNumFn = sourceN(1, common.Hash{1})
 
-		latest, err := chainDB.LastCommonL1()
+		last, err := chainDB.LastCommonL1(false)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), latest.Number)
+		require.Equal(t, uint64(1), last.Number)
+	})
+	t.Run("pattern 1 parent", func(t *testing.T) {
+		m1.lastFn = lastN(1)
+		m2.lastFn = lastN(2)
+		m3.lastFn = lastN(3)
+		m1.sourceNumFn = sourceN(0, common.Hash{1})
+		m2.sourceNumFn = sourceN(0, common.Hash{1})
+		m3.sourceNumFn = sourceN(0, common.Hash{1})
+
+		last, err := chainDB.LastCommonL1(true)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), last.Number)
 	})
 	t.Run("pattern 2", func(t *testing.T) {
-		m1.lastFn = returnN(3)
-		m2.lastFn = returnN(2)
-		m3.lastFn = returnN(1)
+		m1.lastFn = lastN(3)
+		m2.lastFn = lastN(2)
+		m3.lastFn = lastN(1)
+		m1.sourceNumFn = sourceN(1, common.Hash{1})
+		m2.sourceNumFn = sourceN(1, common.Hash{1})
+		m3.sourceNumFn = sourceN(1, common.Hash{1})
 
-		latest, err := chainDB.LastCommonL1()
+		last, err := chainDB.LastCommonL1(false)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), latest.Number)
+		require.Equal(t, uint64(1), last.Number)
+	})
+	t.Run("pattern 2 parent", func(t *testing.T) {
+		m1.lastFn = lastN(3)
+		m2.lastFn = lastN(2)
+		m3.lastFn = lastN(1)
+		m1.sourceNumFn = sourceN(0, common.Hash{1})
+		m2.sourceNumFn = sourceN(0, common.Hash{1})
+		m3.sourceNumFn = sourceN(0, common.Hash{1})
+
+		last, err := chainDB.LastCommonL1(true)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), last.Number)
 	})
 	t.Run("pattern 3", func(t *testing.T) {
-		m1.lastFn = returnN(99)
-		m2.lastFn = returnN(1)
-		m3.lastFn = returnN(98)
+		m1.lastFn = lastN(99)
+		m2.lastFn = lastN(1)
+		m3.lastFn = lastN(98)
+		m1.sourceNumFn = sourceN(1, common.Hash{1})
+		m2.sourceNumFn = sourceN(1, common.Hash{1})
+		m3.sourceNumFn = sourceN(1, common.Hash{1})
 
-		latest, err := chainDB.LastCommonL1()
+		last, err := chainDB.LastCommonL1(false)
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), latest.Number)
+		require.Equal(t, uint64(1), last.Number)
+	})
+	t.Run("pattern 3 parent", func(t *testing.T) {
+		m1.lastFn = lastN(99)
+		m2.lastFn = lastN(1)
+		m3.lastFn = lastN(98)
+		m1.sourceNumFn = sourceN(0, common.Hash{1})
+		m2.sourceNumFn = sourceN(0, common.Hash{1})
+		m3.sourceNumFn = sourceN(0, common.Hash{1})
+
+		last, err := chainDB.LastCommonL1(true)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), last.Number)
 	})
 	t.Run("error", func(t *testing.T) {
-		m1.lastFn = returnN(99)
-		m2.lastFn = returnN(1)
+		m1.lastFn = lastN(99)
+		m2.lastFn = lastN(1)
 		m3.lastFn = func() (pair types.DerivedBlockSealPair, err error) {
 			return types.DerivedBlockSealPair{}, fmt.Errorf("error")
 		}
-		latest, err := chainDB.LastCommonL1()
+		last, err := chainDB.LastCommonL1(false)
 		require.Error(t, err)
-		require.Equal(t, types.BlockSeal{}, latest)
+		require.Equal(t, types.BlockSeal{}, last)
+	})
+	t.Run("inconsistent", func(t *testing.T) {
+		m1.lastFn = lastN(99)
+		m2.lastFn = lastN(1)
+		m3.lastFn = lastN(2)
+		m1.sourceNumFn = sourceN(1, common.Hash{1})
+		m2.sourceNumFn = sourceN(1, common.Hash{2}) // m2 has a different hash
+		m3.sourceNumFn = sourceN(1, common.Hash{1})
+		last, err := chainDB.LastCommonL1(false)
+		require.Error(t, err)
+		require.Equal(t, types.BlockSeal{}, last)
+	})
+	t.Run("inconsistent parent", func(t *testing.T) {
+		m1.lastFn = lastN(99)
+		m2.lastFn = lastN(1)
+		m3.lastFn = lastN(2)
+		m1.sourceNumFn = sourceN(0, common.Hash{1})
+		m2.sourceNumFn = sourceN(0, common.Hash{2}) // m2 has a different hash
+		m3.sourceNumFn = sourceN(0, common.Hash{1})
+		last, err := chainDB.LastCommonL1(true)
+		require.Error(t, err)
+		require.Equal(t, types.BlockSeal{}, last)
 	})
 }

--- a/op-supervisor/supervisor/backend/db/query_test.go
+++ b/op-supervisor/supervisor/backend/db/query_test.go
@@ -252,4 +252,12 @@ func TestCommonL1(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, types.BlockSeal{}, last)
 	})
+	t.Run("parent to genesis", func(t *testing.T) {
+		m1.lastFn = lastN(99)
+		m2.lastFn = lastN(0)
+		m3.lastFn = lastN(2)
+		last, err := chainDB.LastCommonL1(true)
+		require.Error(t, err)
+		require.Equal(t, types.BlockSeal{}, last)
+	})
 }

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -83,6 +83,10 @@ func (m *MockBackend) SyncStatus() (eth.SupervisorSyncStatus, error) {
 	return eth.SupervisorSyncStatus{}, nil
 }
 
+func (m *MockBackend) LastCommonCompleteL1() (types.BlockSeal, error) {
+	return types.BlockSeal{}, nil
+}
+
 func (m *MockBackend) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -26,6 +26,7 @@ type QueryBackend interface {
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
 	SyncStatus() (eth.SupervisorSyncStatus, error)
 	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
+	LastCommonCompleteL1() (types.BlockSeal, error)
 }
 
 type Backend interface {
@@ -89,6 +90,10 @@ func (q *QueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.Bl
 
 func (q *QueryFrontend) SyncStatus() (eth.SupervisorSyncStatus, error) {
 	return q.Supervisor.SyncStatus()
+}
+
+func (q *QueryFrontend) LastCommonCompleteL1() (types.BlockSeal, error) {
+	return q.Supervisor.LastCommonCompleteL1()
 }
 
 type AdminFrontend struct {


### PR DESCRIPTION
# What
- Expands `LastCommonL1` to do cross-chain consistency checks
- Expands `LastCommonL1` to accept a flag which targets the *parent* of the last common L1, which is therefore guaranteed to be complete
- Expands unit testing to cover these functionalities
- Wires `LastCommonCompleteL1` from the backend through to the ChainsDB