### PR TITLE
ci: Add semgrep rule for broadcast/createDeterministic

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -231,3 +231,13 @@ rules:
       exclude:
         - packages/contracts-bedrock/src/L1/SystemConfig.sol
         - packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+
+  - id: sol-safety-broadcast-before-create-deterministic
+    languages: [solidity]
+    severity: ERROR
+    message: vm.broadcast() should not be used before DeployUtils.createDeterministic since it can unexpectedly broadcast incorrect calls
+    patterns:
+      - pattern: |
+          vm.broadcast(...);
+          ...
+          DeployUtils.createDeterministic(...)

--- a/.semgrep/tests/sol-rules.t.sol
+++ b/.semgrep/tests/sol-rules.t.sol
@@ -581,3 +581,28 @@ contract SemgrepTest__sol_style_enforce_require_msg {
         require(cond);
     }
 }
+
+library DeployUtils {
+    function createDeterministic(string memory _name, bytes memory _args, bytes32 _salt) internal {
+    }
+}
+
+contract SemgrepTest__sol_safety_broadast_before_create_deterministic {
+    function test() {
+        // ruleid: sol-safety-broadcast-before-create-deterministic
+        vm.broadcast();
+        DeployUtils.createDeterministic({
+            _name: "FooContract",
+            _args: abi.encode(address(0)),
+            _salt: bytes32(0)
+        });
+
+        // ruleid: sol-safety-broadcast-before-create-deterministic
+        vm.broadcast(msg.sender);
+        DeployUtils.createDeterministic({
+            _name: "FooContract",
+            _args: abi.encode(address(0)),
+            _salt: bytes32(0)
+        });
+    }
+}


### PR DESCRIPTION
Calling `vm.broadcast()` prior to `DeployUtils.createDeterministic()` can lead to incorrect calls being broadcast. This is because `createDeterministic` won't emit a contract call if there's already code at a contract's address, in which case the `vm.broadcast()` will apply to whatever call comes next. We found this while debugging nonce issues on the Interop branch.