### PR TITLE
ctb: move vm.broadcast into createDeterministic

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
@@ -286,7 +286,7 @@ contract DeployDisputeGame is Script {
         // PermissionedDisputeGame is used as the type here because it is a superset of
         // FaultDisputeGame. If the user requests to deploy a FaultDisputeGame, the user will get a
         // FaultDisputeGame (and not a PermissionedDisputeGame).
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IPermissionedDisputeGame impl;
         if (LibString.eq(_dgi.gameKind(), "FaultDisputeGame")) {
             impl = IPermissionedDisputeGame(
@@ -307,6 +307,7 @@ contract DeployDisputeGame is Script {
                 })
             );
         }
+        vm.stopBroadcast();
 
         vm.label(address(impl), string.concat(_dgi.gameKind(), "Impl"));
         _dgo.set(_dgo.disputeGameImpl.selector, address(impl));

--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
@@ -286,7 +286,6 @@ contract DeployDisputeGame is Script {
         // PermissionedDisputeGame is used as the type here because it is a superset of
         // FaultDisputeGame. If the user requests to deploy a FaultDisputeGame, the user will get a
         // FaultDisputeGame (and not a PermissionedDisputeGame).
-        vm.startBroadcast(msg.sender);
         IPermissionedDisputeGame impl;
         if (LibString.eq(_dgi.gameKind(), "FaultDisputeGame")) {
             impl = IPermissionedDisputeGame(
@@ -307,7 +306,6 @@ contract DeployDisputeGame is Script {
                 })
             );
         }
-        vm.stopBroadcast();
 
         vm.label(address(impl), string.concat(_dgi.gameKind(), "Impl"));
         _dgo.set(_dgo.disputeGameImpl.selector, address(impl));

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -498,7 +498,6 @@ contract DeployImplementations is Script {
             mipsImpl: address(_dio.mipsSingleton())
         });
 
-        vm.startBroadcast(msg.sender);
         opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManager",
@@ -519,7 +518,6 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
 
         vm.label(address(opcm_), "OPContractsManager");
         _dio.set(_dio.opcm.selector, address(opcm_));
@@ -565,7 +563,6 @@ contract DeployImplementations is Script {
     // --- Core Contracts ---
 
     function deploySuperchainConfigImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         ISuperchainConfig impl = ISuperchainConfig(
             DeployUtils.createDeterministic({
                 _name: "SuperchainConfig",
@@ -573,13 +570,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "SuperchainConfigImpl");
         _dio.set(_dio.superchainConfigImpl.selector, address(impl));
     }
 
     function deployProtocolVersionsImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IProtocolVersions impl = IProtocolVersions(
             DeployUtils.createDeterministic({
                 _name: "ProtocolVersions",
@@ -587,13 +582,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "ProtocolVersionsImpl");
         _dio.set(_dio.protocolVersionsImpl.selector, address(impl));
     }
 
     function deploySystemConfigImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         ISystemConfig impl = ISystemConfig(
             DeployUtils.createDeterministic({
                 _name: "SystemConfig",
@@ -601,13 +594,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "SystemConfigImpl");
         _dio.set(_dio.systemConfigImpl.selector, address(impl));
     }
 
     function deployL1CrossDomainMessengerImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IL1CrossDomainMessenger impl = IL1CrossDomainMessenger(
             DeployUtils.createDeterministic({
                 _name: "L1CrossDomainMessenger",
@@ -615,13 +606,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "L1CrossDomainMessengerImpl");
         _dio.set(_dio.l1CrossDomainMessengerImpl.selector, address(impl));
     }
 
     function deployL1ERC721BridgeImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IL1ERC721Bridge impl = IL1ERC721Bridge(
             DeployUtils.createDeterministic({
                 _name: "L1ERC721Bridge",
@@ -629,13 +618,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "L1ERC721BridgeImpl");
         _dio.set(_dio.l1ERC721BridgeImpl.selector, address(impl));
     }
 
     function deployL1StandardBridgeImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IL1StandardBridge impl = IL1StandardBridge(
             DeployUtils.createDeterministic({
                 _name: "L1StandardBridge",
@@ -643,13 +630,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "L1StandardBridgeImpl");
         _dio.set(_dio.l1StandardBridgeImpl.selector, address(impl));
     }
 
     function deployOptimismMintableERC20FactoryImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IOptimismMintableERC20Factory impl = IOptimismMintableERC20Factory(
             DeployUtils.createDeterministic({
                 _name: "OptimismMintableERC20Factory",
@@ -657,7 +642,6 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "OptimismMintableERC20FactoryImpl");
         _dio.set(_dio.optimismMintableERC20FactoryImpl.selector, address(impl));
     }
@@ -708,7 +692,6 @@ contract DeployImplementations is Script {
     {
         uint256 proofMaturityDelaySeconds = _dii.proofMaturityDelaySeconds();
         uint256 disputeGameFinalityDelaySeconds = _dii.disputeGameFinalityDelaySeconds();
-        vm.startBroadcast(msg.sender);
         IOptimismPortal2 impl = IOptimismPortal2(
             DeployUtils.createDeterministic({
                 _name: "OptimismPortal2",
@@ -720,14 +703,12 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "OptimismPortalImpl");
         _dio.set(_dio.optimismPortalImpl.selector, address(impl));
     }
 
     function deployDelayedWETHImpl(DeployImplementationsInput _dii, DeployImplementationsOutput _dio) public virtual {
         uint256 withdrawalDelaySeconds = _dii.withdrawalDelaySeconds();
-        vm.startBroadcast(msg.sender);
         IDelayedWETH impl = IDelayedWETH(
             DeployUtils.createDeterministic({
                 _name: "DelayedWETH",
@@ -735,7 +716,6 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "DelayedWETHImpl");
         _dio.set(_dio.delayedWETHImpl.selector, address(impl));
     }
@@ -749,7 +729,6 @@ contract DeployImplementations is Script {
     {
         uint256 minProposalSizeBytes = _dii.minProposalSizeBytes();
         uint256 challengePeriodSeconds = _dii.challengePeriodSeconds();
-        vm.startBroadcast(msg.sender);
         IPreimageOracle singleton = IPreimageOracle(
             DeployUtils.createDeterministic({
                 _name: "PreimageOracle",
@@ -759,7 +738,6 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(singleton), "PreimageOracleSingleton");
         _dio.set(_dio.preimageOracleSingleton.selector, address(singleton));
     }
@@ -775,7 +753,6 @@ contract DeployImplementations is Script {
             }
         }
 
-        vm.startBroadcast(msg.sender);
         IMIPS singleton = IMIPS(
             DeployUtils.createDeterministic({
                 _name: mipsVersion == 1 ? "MIPS" : "MIPS64",
@@ -783,13 +760,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(singleton), "MIPSSingleton");
         _dio.set(_dio.mipsSingleton.selector, address(singleton));
     }
 
     function deployDisputeGameFactoryImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IDisputeGameFactory impl = IDisputeGameFactory(
             DeployUtils.createDeterministic({
                 _name: "DisputeGameFactory",
@@ -797,13 +772,11 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "DisputeGameFactoryImpl");
         _dio.set(_dio.disputeGameFactoryImpl.selector, address(impl));
     }
 
     function deployAnchorStateRegistryImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.startBroadcast(msg.sender);
         IAnchorStateRegistry impl = IAnchorStateRegistry(
             DeployUtils.createDeterministic({
                 _name: "AnchorStateRegistry",
@@ -811,7 +784,6 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "AnchorStateRegistryImpl");
         _dio.set(_dio.anchorStateRegistryImpl.selector, address(impl));
     }
@@ -904,7 +876,6 @@ contract DeployImplementationsInterop is DeployImplementations {
             mipsImpl: address(_dio.mipsSingleton())
         });
 
-        vm.startBroadcast(msg.sender);
         opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManagerInterop",
@@ -925,7 +896,6 @@ contract DeployImplementationsInterop is DeployImplementations {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
 
         vm.label(address(opcm_), "OPContractsManager");
         _dio.set(_dio.opcm.selector, address(opcm_));
@@ -940,7 +910,6 @@ contract DeployImplementationsInterop is DeployImplementations {
     {
         uint256 proofMaturityDelaySeconds = _dii.proofMaturityDelaySeconds();
         uint256 disputeGameFinalityDelaySeconds = _dii.disputeGameFinalityDelaySeconds();
-        vm.startBroadcast(msg.sender);
         IOptimismPortalInterop impl = IOptimismPortalInterop(
             DeployUtils.createDeterministic({
                 _name: "OptimismPortalInterop",
@@ -952,14 +921,12 @@ contract DeployImplementationsInterop is DeployImplementations {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
 
         vm.label(address(impl), "OptimismPortalImpl");
         _dio.set(_dio.optimismPortalImpl.selector, address(impl));
     }
 
     function deploySystemConfigImpl(DeployImplementationsOutput _dio) public override {
-        vm.startBroadcast(msg.sender);
         ISystemConfigInterop impl = ISystemConfigInterop(
             DeployUtils.createDeterministic({
                 _name: "SystemConfigInterop",
@@ -967,7 +934,6 @@ contract DeployImplementationsInterop is DeployImplementations {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
         vm.label(address(impl), "SystemConfigImpl");
         _dio.set(_dio.systemConfigImpl.selector, address(impl));
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -498,7 +498,7 @@ contract DeployImplementations is Script {
             mipsImpl: address(_dio.mipsSingleton())
         });
 
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManager",
@@ -519,6 +519,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
 
         vm.label(address(opcm_), "OPContractsManager");
         _dio.set(_dio.opcm.selector, address(opcm_));
@@ -564,7 +565,7 @@ contract DeployImplementations is Script {
     // --- Core Contracts ---
 
     function deploySuperchainConfigImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         ISuperchainConfig impl = ISuperchainConfig(
             DeployUtils.createDeterministic({
                 _name: "SuperchainConfig",
@@ -572,12 +573,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "SuperchainConfigImpl");
         _dio.set(_dio.superchainConfigImpl.selector, address(impl));
     }
 
     function deployProtocolVersionsImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IProtocolVersions impl = IProtocolVersions(
             DeployUtils.createDeterministic({
                 _name: "ProtocolVersions",
@@ -585,12 +587,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "ProtocolVersionsImpl");
         _dio.set(_dio.protocolVersionsImpl.selector, address(impl));
     }
 
     function deploySystemConfigImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         ISystemConfig impl = ISystemConfig(
             DeployUtils.createDeterministic({
                 _name: "SystemConfig",
@@ -598,12 +601,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "SystemConfigImpl");
         _dio.set(_dio.systemConfigImpl.selector, address(impl));
     }
 
     function deployL1CrossDomainMessengerImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IL1CrossDomainMessenger impl = IL1CrossDomainMessenger(
             DeployUtils.createDeterministic({
                 _name: "L1CrossDomainMessenger",
@@ -611,12 +615,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "L1CrossDomainMessengerImpl");
         _dio.set(_dio.l1CrossDomainMessengerImpl.selector, address(impl));
     }
 
     function deployL1ERC721BridgeImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IL1ERC721Bridge impl = IL1ERC721Bridge(
             DeployUtils.createDeterministic({
                 _name: "L1ERC721Bridge",
@@ -624,12 +629,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "L1ERC721BridgeImpl");
         _dio.set(_dio.l1ERC721BridgeImpl.selector, address(impl));
     }
 
     function deployL1StandardBridgeImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IL1StandardBridge impl = IL1StandardBridge(
             DeployUtils.createDeterministic({
                 _name: "L1StandardBridge",
@@ -637,12 +643,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "L1StandardBridgeImpl");
         _dio.set(_dio.l1StandardBridgeImpl.selector, address(impl));
     }
 
     function deployOptimismMintableERC20FactoryImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IOptimismMintableERC20Factory impl = IOptimismMintableERC20Factory(
             DeployUtils.createDeterministic({
                 _name: "OptimismMintableERC20Factory",
@@ -650,6 +657,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "OptimismMintableERC20FactoryImpl");
         _dio.set(_dio.optimismMintableERC20FactoryImpl.selector, address(impl));
     }
@@ -700,7 +708,7 @@ contract DeployImplementations is Script {
     {
         uint256 proofMaturityDelaySeconds = _dii.proofMaturityDelaySeconds();
         uint256 disputeGameFinalityDelaySeconds = _dii.disputeGameFinalityDelaySeconds();
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IOptimismPortal2 impl = IOptimismPortal2(
             DeployUtils.createDeterministic({
                 _name: "OptimismPortal2",
@@ -712,13 +720,14 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "OptimismPortalImpl");
         _dio.set(_dio.optimismPortalImpl.selector, address(impl));
     }
 
     function deployDelayedWETHImpl(DeployImplementationsInput _dii, DeployImplementationsOutput _dio) public virtual {
         uint256 withdrawalDelaySeconds = _dii.withdrawalDelaySeconds();
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IDelayedWETH impl = IDelayedWETH(
             DeployUtils.createDeterministic({
                 _name: "DelayedWETH",
@@ -726,6 +735,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "DelayedWETHImpl");
         _dio.set(_dio.delayedWETHImpl.selector, address(impl));
     }
@@ -739,7 +749,7 @@ contract DeployImplementations is Script {
     {
         uint256 minProposalSizeBytes = _dii.minProposalSizeBytes();
         uint256 challengePeriodSeconds = _dii.challengePeriodSeconds();
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IPreimageOracle singleton = IPreimageOracle(
             DeployUtils.createDeterministic({
                 _name: "PreimageOracle",
@@ -749,6 +759,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(singleton), "PreimageOracleSingleton");
         _dio.set(_dio.preimageOracleSingleton.selector, address(singleton));
     }
@@ -764,7 +775,7 @@ contract DeployImplementations is Script {
             }
         }
 
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IMIPS singleton = IMIPS(
             DeployUtils.createDeterministic({
                 _name: mipsVersion == 1 ? "MIPS" : "MIPS64",
@@ -772,12 +783,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(singleton), "MIPSSingleton");
         _dio.set(_dio.mipsSingleton.selector, address(singleton));
     }
 
     function deployDisputeGameFactoryImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IDisputeGameFactory impl = IDisputeGameFactory(
             DeployUtils.createDeterministic({
                 _name: "DisputeGameFactory",
@@ -785,12 +797,13 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "DisputeGameFactoryImpl");
         _dio.set(_dio.disputeGameFactoryImpl.selector, address(impl));
     }
 
     function deployAnchorStateRegistryImpl(DeployImplementationsOutput _dio) public virtual {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IAnchorStateRegistry impl = IAnchorStateRegistry(
             DeployUtils.createDeterministic({
                 _name: "AnchorStateRegistry",
@@ -798,6 +811,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "AnchorStateRegistryImpl");
         _dio.set(_dio.anchorStateRegistryImpl.selector, address(impl));
     }
@@ -890,7 +904,7 @@ contract DeployImplementationsInterop is DeployImplementations {
             mipsImpl: address(_dio.mipsSingleton())
         });
 
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManagerInterop",
@@ -911,6 +925,7 @@ contract DeployImplementationsInterop is DeployImplementations {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
 
         vm.label(address(opcm_), "OPContractsManager");
         _dio.set(_dio.opcm.selector, address(opcm_));
@@ -925,7 +940,7 @@ contract DeployImplementationsInterop is DeployImplementations {
     {
         uint256 proofMaturityDelaySeconds = _dii.proofMaturityDelaySeconds();
         uint256 disputeGameFinalityDelaySeconds = _dii.disputeGameFinalityDelaySeconds();
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         IOptimismPortalInterop impl = IOptimismPortalInterop(
             DeployUtils.createDeterministic({
                 _name: "OptimismPortalInterop",
@@ -937,13 +952,14 @@ contract DeployImplementationsInterop is DeployImplementations {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
 
         vm.label(address(impl), "OptimismPortalImpl");
         _dio.set(_dio.optimismPortalImpl.selector, address(impl));
     }
 
     function deploySystemConfigImpl(DeployImplementationsOutput _dio) public override {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         ISystemConfigInterop impl = ISystemConfigInterop(
             DeployUtils.createDeterministic({
                 _name: "SystemConfigInterop",
@@ -951,6 +967,7 @@ contract DeployImplementationsInterop is DeployImplementations {
                 _salt: _salt
             })
         );
+        vm.stopBroadcast();
         vm.label(address(impl), "SystemConfigImpl");
         _dio.set(_dio.systemConfigImpl.selector, address(impl));
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
@@ -80,7 +80,6 @@ contract DeployMIPS is Script {
         IMIPS singleton;
         uint256 mipsVersion = _mi.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(_mi.preimageOracle());
-        vm.startBroadcast(msg.sender);
         singleton = IMIPS(
             DeployUtils.createDeterministic({
                 _name: mipsVersion == 1 ? "MIPS" : "MIPS64",
@@ -88,7 +87,6 @@ contract DeployMIPS is Script {
                 _salt: DeployUtils.DEFAULT_SALT
             })
         );
-        vm.stopBroadcast();
 
         vm.label(address(singleton), "MIPSSingleton");
         _mo.set(_mo.mipsSingleton.selector, address(singleton));

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
@@ -80,7 +80,7 @@ contract DeployMIPS is Script {
         IMIPS singleton;
         uint256 mipsVersion = _mi.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(_mi.preimageOracle());
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         singleton = IMIPS(
             DeployUtils.createDeterministic({
                 _name: mipsVersion == 1 ? "MIPS" : "MIPS64",
@@ -88,6 +88,7 @@ contract DeployMIPS is Script {
                 _salt: DeployUtils.DEFAULT_SALT
             })
         );
+        vm.stopBroadcast();
 
         vm.label(address(singleton), "MIPSSingleton");
         _mo.set(_mo.mipsSingleton.selector, address(singleton));

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -271,7 +271,7 @@ contract DeployOPCM is Script {
         public
         returns (IOPContractsManager opcm_)
     {
-        vm.broadcast(msg.sender);
+        vm.startBroadcast(msg.sender);
         opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManager",
@@ -292,6 +292,7 @@ contract DeployOPCM is Script {
                 _salt: DeployUtils.DEFAULT_SALT
             })
         );
+        vm.stopBroadcast();
         vm.label(address(opcm_), "OPContractsManager");
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -271,7 +271,6 @@ contract DeployOPCM is Script {
         public
         returns (IOPContractsManager opcm_)
     {
-        vm.startBroadcast(msg.sender);
         opcm_ = IOPContractsManager(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManager",
@@ -292,7 +291,6 @@ contract DeployOPCM is Script {
                 _salt: DeployUtils.DEFAULT_SALT
             })
         );
-        vm.stopBroadcast();
         vm.label(address(opcm_), "OPContractsManager");
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -342,7 +342,6 @@ contract DeploySuperchain is Script {
 
     function deploySuperchainImplementationContracts(DeploySuperchainInput, DeploySuperchainOutput _dso) public {
         // Deploy implementation contracts.
-        vm.startBroadcast(msg.sender);
         ISuperchainConfig superchainConfigImpl = ISuperchainConfig(
             DeployUtils.createDeterministic({
                 _name: "SuperchainConfig",
@@ -357,7 +356,6 @@ contract DeploySuperchain is Script {
                 _salt: _salt
             })
         );
-        vm.stopBroadcast();
 
         vm.label(address(superchainConfigImpl), "SuperchainConfigImpl");
         vm.label(address(protocolVersionsImpl), "ProtocolVersionsImpl");

--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -219,6 +219,7 @@ library DeployUtils {
         if (preComputedAddress.code.length > 0) {
             addr_ = payable(preComputedAddress);
         } else {
+            vm.broadcast(msg.sender);
             addr_ = DeployUtils.create2asm(initCode, _salt);
         }
     }


### PR DESCRIPTION
This backports https://github.com/ethereum-optimism/optimism/pull/14241 onto develop. While deploying the interop contracts we discovered a bug where nonces would incorrectly increase following calls to `createDeterministic`. This is because `vm.broadcast` will broadcast the _next_ call, but `createDeterministic` sometimes doesn't emit a call at all. This means that (in the case of the Sueprchain deployment) the calls to the input contract's `set` method would be called instead. This in turn caused nonces to increase incorrectly.

To fix this issue, this PR updates the Solidity implementation to call `vm.broadcast()` from within `createDeterministic`. This avoids the issue altogether. To prevent further incorrect usages of `vm.broadcast` I also opened https://github.com/ethereum-optimism/optimism/pull/14242 which adds a Semgrep rule to check for this case.
