### PR TITLE
feat: Ignore frozen files check by using a PR label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,8 +670,6 @@ jobs:
       - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
-      - check-changed:
-          patterns: contracts-bedrock
       - run:
           name: Check if target branch is develop
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,7 +684,7 @@ jobs:
             # If the target branch is not develop, do not run this check
             if [ "$TARGET_BRANCH" != "develop" ]; then
               echo "Target branch is not develop, skipping frozen files check"
-              exit 0
+              circleci-agent step halt
             fi
       - run:
           name: Check if PR has exempt label
@@ -698,7 +698,7 @@ jobs:
             # If the PR has the "S-exempt-frozen-files" label, do not run this check
             if echo $LABELS | jq -e 'any(.[]; .name == "S-exempt-frozen-files")' > /dev/null; then
               echo "Skipping frozen files check, PR has exempt label"
-              exit 0
+              circleci-agent step halt
             fi
       - run:
           name: Check frozen files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,7 +690,7 @@ jobs:
           name: Check frozen files
           command: just check-frozen-code
           working_directory: packages/contracts-bedrock
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'S-exempt-frozen-files') }}
+          if: ${{ !contains(github.event.pull_request.labels.*.name, 'S-exempt-frozen-files') }}
 
   contracts-bedrock-tests:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
             LABELS=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .labels)
 
             # If the PR has the "S-exempt-frozen-files" label, do not run this check
-            if (( "$LABELS" | grep '"name": "S-exempt-frozen-files"' | wc -l > 0 )); then
+            if echo $LABELS | jq -e 'any(.labels[]; .name == "S-exempt-frozen-files")'; then
               echo "PR is exempt from frozen files check"
               exit 0
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ jobs:
 
             # If the PR has the "S-exempt-frozen-files" label, do not run this check
             if echo $LABELS | jq -e 'any(.[]; .name == "S-exempt-frozen-files")' > /dev/null; then
-              echo "PR is exempt from frozen files check"
+              echo "Skipping frozen files check, PR has exempt label"
               exit 0
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,6 +690,7 @@ jobs:
           name: Check frozen files
           command: just check-frozen-code
           working_directory: packages/contracts-bedrock
+        if: "!contains(github.event.pull_request.labels.*.name, 'S-exempt-frozen-files')"
 
   contracts-bedrock-tests:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,10 +687,23 @@ jobs:
               exit 0
             fi
       - run:
+          name: Check if PR has exempt label
+          command: |
+            # Get PR number from CIRCLE_PULL_REQUEST
+            PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | rev | cut -d/ -f1 | rev)
+
+            # Use GitHub API to get labels
+            LABELS=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .labels)
+
+            # If the PR has the "S-exempt-frozen-files" label, do not run this check
+            if (( "$LABELS" | grep '"name": "S-exempt-frozen-files"' | wc -l > 0 )); then
+              echo "PR is exempt from frozen files check"
+              exit 0
+            fi
+      - run:
           name: Check frozen files
           command: just check-frozen-code
           working_directory: packages/contracts-bedrock
-          if: ${{ !contains(github.event.pull_request.labels.*.name, 'S-exempt-frozen-files') }}
 
   contracts-bedrock-tests:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,7 +690,7 @@ jobs:
           name: Check frozen files
           command: just check-frozen-code
           working_directory: packages/contracts-bedrock
-        if: "!contains(github.event.pull_request.labels.*.name, 'S-exempt-frozen-files')"
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'S-exempt-frozen-files') }}
 
   contracts-bedrock-tests:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
             LABELS=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .labels)
 
             # If the PR has the "S-exempt-frozen-files" label, do not run this check
-            if echo $LABELS | jq -e 'any(.[]; .name == "S-exempt-frozen-files")'; then
+            if echo $LABELS | jq -e 'any(.[]; .name == "S-exempt-frozen-files")' > /dev/null; then
               echo "PR is exempt from frozen files check"
               exit 0
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,6 +670,8 @@ jobs:
       - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
+      - check-changed:
+          patterns: contracts-bedrock
       - run:
           name: Check if target branch is develop
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
             LABELS=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .labels)
 
             # If the PR has the "S-exempt-frozen-files" label, do not run this check
-            if echo $LABELS | jq -e 'any(.labels[]; .name == "S-exempt-frozen-files")'; then
+            if echo $LABELS | jq -e 'any(.[]; .name == "S-exempt-frozen-files")'; then
               echo "PR is exempt from frozen files check"
               exit 0
             fi

--- a/packages/contracts-bedrock/meta/CODE_FREEZES.md
+++ b/packages/contracts-bedrock/meta/CODE_FREEZES.md
@@ -1,0 +1,22 @@
+# Smart Contract Code Freeze Process
+
+The Smart Contract Freeze Process is used to protect specific files from accidental changes during sensitive periods.
+
+## Code Freeze
+
+Code freezes are implemented by comparison of the bytecode and source code hashes of the local file against the upstream files.
+
+To enable a code freeze, follow these steps:
+
+1. Create a PR.
+2. The `semver-lock.json` file should already be up to date, but run anyway `just semver-lock` to be sure.
+3. Comment out the path and filename of the file/s you want to freeze in check-frozen-files.sh.
+
+To disable a code freeze, comment out the path and filename of the file/s you want to unfreeze in check-frozen-files.sh.
+1. Create a PR.
+2. Uncomment the path and filename of all files in check-frozen-files.sh.
+
+## Exceptions
+
+To bypass the freeze you can apply the "S-exempt-frozen-files" label on affected PRs. This should be done upon agreement with the code owner. Expected uses of this exception are to fix issues found on audits or to add comments to frozen files.
+

--- a/packages/contracts-bedrock/meta/POLICY.md
+++ b/packages/contracts-bedrock/meta/POLICY.md
@@ -23,6 +23,10 @@ For any policies on contributing, please see [CONTRIBUTING](./CONTRIBUTING.md)
 
 For our versioning policy, please see our policy on [VERSIONING](./VERSIONING.md)
 
+## Code Freeze Policy
+
+For our code freeze policy, please see our doc on [CODE FREEZES](./CODE_FREEZES.md)
+
 ## Upgrade Policy
 
 For the solidity upgrade policy, please see our doc on [SOLIDITY UPGRADES](./SOLIDITY_UPGRADES.md)


### PR DESCRIPTION
**Description**

As a mechanism to exempt files from the frozen files policy, for example for audit fixes, a PR can be assigned the `S-exempt-frozen-files` label. For now this works on an honesty basis.

**Tests**

Given that this is a CI change, I tested it by disabling the `check-changed` step, so that it would get triggered each time. The circleCI builds show the process untl the behaviour and output were right.

