### PR TITLE
fix(op-deployer): don't deploy dachallenge contract when using Generic Commitments

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/alt_da.go
+++ b/op-deployer/pkg/deployer/pipeline/alt_da.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum/go-ethereum/common"
@@ -48,7 +49,7 @@ func DeployAltDA(env *Env, intent *state.Intent, st *state.State, chainID common
 }
 
 func shouldDeployAltDA(chainIntent *state.ChainIntent, chainState *state.ChainState) bool {
-	if !chainIntent.DangerousAltDAConfig.UseAltDA {
+	if !(chainIntent.DangerousAltDAConfig.UseAltDA && chainIntent.DangerousAltDAConfig.DACommitmentType == altda.KeccakCommitmentString) {
 		return false
 	}
 


### PR DESCRIPTION
da challenge contract shouldn't be deployed when using GenericCommitments.
This causes a bug in kurtosis devnet where GenericCommitments can't be used with a non-zero da_challenge_contract. Forget where exactly right now...

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
