### PR TITLE
feat: implement EIP-7251, EIP-7002 end-to-end test

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -73,7 +73,13 @@ func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eut
 			override(dp.DeployConfig)
 		}
 	})
-	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
+
+	genesisAlloc := testCfg.Allocs
+	if genesisAlloc == nil {
+		genesisAlloc = helpers.DefaultAlloc
+	}
+
+	sd := e2eutils.Setup(t, dp, genesisAlloc)
 
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 

--- a/op-e2e/actions/proofs/helpers/matrix.go
+++ b/op-e2e/actions/proofs/helpers/matrix.go
@@ -3,6 +3,8 @@ package helpers
 import (
 	"fmt"
 	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 )
 
 type RunTest[cfg any] func(t *testing.T, testCfg *TestCfg[cfg])
@@ -12,6 +14,7 @@ type TestCfg[cfg any] struct {
 	CheckResult CheckResult
 	InputParams []FixtureInputParam
 	Custom      cfg
+	Allocs      *e2eutils.AllocParams
 }
 
 type TestCase[cfg any] struct {

--- a/op-e2e/actions/proofs/isthmus_requests_test.go
+++ b/op-e2e/actions/proofs/isthmus_requests_test.go
@@ -1,0 +1,127 @@
+package proofs_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsthmusExcludedPredeploys(gt *testing.T) {
+	// Ensures that if EIP-6110, EIP-7251, or EIP-7002 predeploys are deployed manually after the fork,
+	// Isthmus block processing still works correctly. Also ensures that if requests are sent to these
+	// contracts, they are not processed and do not show up in the block body or requests hash.
+
+	allocs := *actionsHelpers.DefaultAlloc
+	allocs.L2Alloc = make(map[common.Address]types.Account)
+
+	// Deploy EIP-7251 and EIP-7002 contracts
+	allocs.L2Alloc[params.WithdrawalQueueAddress] = types.Account{ // EIP-7002
+		Code:    params.WithdrawalQueueCode,
+		Nonce:   1,
+		Balance: new(big.Int),
+	}
+	allocs.L2Alloc[params.ConsolidationQueueAddress] = types.Account{ // EIP-7251
+		Code:    params.ConsolidationQueueCode,
+		Nonce:   1,
+		Balance: new(big.Int),
+	}
+
+	t := actionsHelpers.NewDefaultTesting(gt)
+	testCfg := &helpers.TestCfg[interface{}]{
+		Hardfork: helpers.Isthmus,
+		Allocs:   &allocs,
+	}
+
+	tp := helpers.NewTestParams()
+	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, helpers.NewBatcherCfg())
+
+	dp := e2eutils.MakeDeployParams(t, actionsHelpers.DefaultRollupTestParams())
+
+	engine := env.Engine
+	sequencer := env.Sequencer
+
+	ethCl := engine.EthClient()
+	signer := types.NewPragueSigner(new(big.Int).SetUint64(dp.DeployConfig.L2ChainID))
+
+	sequencer.ActL2StartBlock(t)
+
+	ret, err := ethCl.CallContract(context.Background(), ethereum.CallMsg{
+		To:   &params.WithdrawalQueueAddress,
+		Data: []byte{},
+	}, nil)
+
+	require.NoError(t, err)
+	fee := new(uint256.Int).SetBytes(ret)
+
+	// Send a transaction to the EIP-7251 contract
+	txdata := &types.DynamicFeeTx{
+		ChainID:   new(big.Int).SetUint64(dp.DeployConfig.L2ChainID),
+		Nonce:     0,
+		To:        &params.WithdrawalQueueAddress,
+		Gas:       500000,
+		Data:      make([]byte, 56),
+		Value:     fee.ToBig(),
+		GasFeeCap: new(big.Int).SetUint64(5000000000),
+		GasTipCap: new(big.Int).SetUint64(2),
+	}
+	tx := types.MustSignNewTx(dp.Secrets.Alice, signer, txdata)
+
+	err = ethCl.SendTransaction(t.Ctx(), tx)
+	require.NoError(gt, err, "failed to send withdrawal request tx")
+
+	_, err = engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	require.NoError(gt, err, "failed to include tx")
+
+	ret, err = ethCl.CallContract(context.Background(), ethereum.CallMsg{
+		To:   &params.ConsolidationQueueAddress,
+		Data: []byte{},
+	}, nil)
+
+	require.NoError(t, err)
+	fee = new(uint256.Int).SetBytes(ret)
+
+	// Send a transaction to the EIP-7251 contract
+	txdata = &types.DynamicFeeTx{
+		ChainID:   new(big.Int).SetUint64(dp.DeployConfig.L2ChainID),
+		Nonce:     1,
+		To:        &params.ConsolidationQueueAddress,
+		Gas:       500000,
+		Data:      make([]byte, 96),
+		Value:     fee.ToBig(),
+		GasFeeCap: new(big.Int).SetUint64(5000000000),
+		GasTipCap: new(big.Int).SetUint64(2),
+	}
+	tx = types.MustSignNewTx(dp.Secrets.Alice, signer, txdata)
+
+	err = ethCl.SendTransaction(t.Ctx(), tx)
+	require.NoError(gt, err, "failed to send consolidation queue request tx")
+
+	_, err = engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	require.NoError(gt, err, "failed to include tx")
+
+	sequencer.ActL2EndBlock(t)
+
+	// ensure requests hash is still empty
+	latestBlock, err := ethCl.BlockByNumber(t.Ctx(), nil)
+	require.NoError(t, err, "error fetching latest block")
+	require.Equal(t, types.EmptyRequestsHash, *latestBlock.RequestsHash())
+
+	// get receipt
+	receipt, err := ethCl.TransactionReceipt(context.Background(), tx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "transaction must pass")
+
+	env.RunFaultProofProgram(t, latestBlock.NumberU64()-1, func(t actionsHelpers.Testing, err error) {
+		require.NoError(t, err, "no error expected running FP program")
+	})
+}

--- a/op-e2e/actions/proofs/isthmus_requests_test.go
+++ b/op-e2e/actions/proofs/isthmus_requests_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestIsthmusExcludedPredeploys(gt *testing.T) {
-	// Ensures that if EIP-6110, EIP-7251, or EIP-7002 predeploys are deployed manually after the fork,
+	// Ensures that if EIP-7251, or EIP-7002 predeploys are deployed manually after the fork,
 	// Isthmus block processing still works correctly. Also ensures that if requests are sent to these
 	// contracts, they are not processed and do not show up in the block body or requests hash.
 

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -460,7 +460,8 @@ func TestIsthmusExcludedPredeploys(gt *testing.T) {
 	err = ethCl.SendTransaction(t.Ctx(), tx)
 	require.NoError(gt, err, "failed to send withdrawal request tx")
 
-	engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	_, err = engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	require.NoError(gt, err, "failed to include tx")
 
 	ret, err = ethCl.CallContract(context.Background(), ethereum.CallMsg{
 		To:   &params.ConsolidationQueueAddress,
@@ -486,7 +487,8 @@ func TestIsthmusExcludedPredeploys(gt *testing.T) {
 	err = ethCl.SendTransaction(t.Ctx(), tx)
 	require.NoError(gt, err, "failed to send consolidation queue request tx")
 
-	engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	_, err = engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	require.NoError(gt, err, "failed to include tx")
 
 	sequencer.ActL2EndBlock(t)
 

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -16,15 +16,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -396,109 +393,4 @@ func TestIsthmusNetworkUpgradeTransactions(gt *testing.T) {
 	latestBlock, err = ethCl.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err)
 	checkRecentBlockHash(latestBlock.NumberU64()-1, latestBlock.Header().ParentHash, "post-activation")
-}
-
-func TestIsthmusExcludedPredeploys(gt *testing.T) {
-	// Ensures that if EIP-6110, EIP-7251, or EIP-7002 predeploys are deployed manually after the fork,
-	// Isthmus block processing still works correctly. Also ensures that if requests are sent to these
-	// contracts, they are not processed and do not show up in the block body or requests hash.
-
-	t := helpers.NewDefaultTesting(gt)
-	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-
-	log := testlog.Logger(t, log.LevelDebug)
-
-	// Activate Isthmus at genesis
-	dp.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
-
-	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
-
-	alloc := *helpers.DefaultAlloc
-	alloc.L2Alloc = make(map[common.Address]types.Account)
-
-	// Deploy EIP-7251 and EIP-7002 contracts
-	alloc.L2Alloc[params.WithdrawalQueueAddress] = types.Account{ // EIP-7002
-		Code:    params.WithdrawalQueueCode,
-		Nonce:   1,
-		Balance: new(big.Int),
-	}
-	alloc.L2Alloc[params.ConsolidationQueueAddress] = types.Account{ // EIP-7251
-		Code:    params.ConsolidationQueueCode,
-		Nonce:   1,
-		Balance: new(big.Int),
-	}
-
-	sd := e2eutils.Setup(t, dp, &alloc)
-
-	_, _, _, sequencer, engine, _, _, _ := helpers.SetupReorgTestActors(t, dp, sd, log)
-	ethCl := engine.EthClient()
-	signer := types.NewPragueSigner(new(big.Int).SetUint64(dp.DeployConfig.L2ChainID))
-
-	sequencer.ActL2StartBlock(t)
-
-	ret, err := ethCl.CallContract(context.Background(), ethereum.CallMsg{
-		To:   &params.WithdrawalQueueAddress,
-		Data: []byte{},
-	}, nil)
-
-	require.NoError(t, err)
-	fee := new(uint256.Int).SetBytes(ret)
-
-	// Send a transaction to the EIP-7251 contract
-	txdata := &types.DynamicFeeTx{
-		ChainID:   new(big.Int).SetUint64(dp.DeployConfig.L2ChainID),
-		Nonce:     0,
-		To:        &params.WithdrawalQueueAddress,
-		Gas:       500000,
-		Data:      make([]byte, 56),
-		Value:     fee.ToBig(),
-		GasFeeCap: new(big.Int).SetUint64(5000000000),
-		GasTipCap: new(big.Int).SetUint64(2),
-	}
-	tx := types.MustSignNewTx(dp.Secrets.Alice, signer, txdata)
-
-	err = ethCl.SendTransaction(t.Ctx(), tx)
-	require.NoError(gt, err, "failed to send withdrawal request tx")
-
-	_, err = engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
-	require.NoError(gt, err, "failed to include tx")
-
-	ret, err = ethCl.CallContract(context.Background(), ethereum.CallMsg{
-		To:   &params.ConsolidationQueueAddress,
-		Data: []byte{},
-	}, nil)
-
-	require.NoError(t, err)
-	fee = new(uint256.Int).SetBytes(ret)
-
-	// Send a transaction to the EIP-7251 contract
-	txdata = &types.DynamicFeeTx{
-		ChainID:   new(big.Int).SetUint64(dp.DeployConfig.L2ChainID),
-		Nonce:     1,
-		To:        &params.ConsolidationQueueAddress,
-		Gas:       500000,
-		Data:      make([]byte, 96),
-		Value:     fee.ToBig(),
-		GasFeeCap: new(big.Int).SetUint64(5000000000),
-		GasTipCap: new(big.Int).SetUint64(2),
-	}
-	tx = types.MustSignNewTx(dp.Secrets.Alice, signer, txdata)
-
-	err = ethCl.SendTransaction(t.Ctx(), tx)
-	require.NoError(gt, err, "failed to send consolidation queue request tx")
-
-	_, err = engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
-	require.NoError(gt, err, "failed to include tx")
-
-	sequencer.ActL2EndBlock(t)
-
-	// ensure requests hash is still empty
-	latestBlock, err := ethCl.BlockByNumber(t.Ctx(), nil)
-	require.NoError(t, err, "error fetching latest block")
-	require.Equal(t, types.EmptyRequestsHash, *latestBlock.RequestsHash())
-
-	// get receipt
-	receipt, err := ethCl.TransactionReceipt(context.Background(), tx.Hash())
-	require.NoError(t, err)
-	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "transaction must pass")
 }

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -492,6 +492,11 @@ func TestIsthmusExcludedPredeploys(gt *testing.T) {
 
 	sequencer.ActL2EndBlock(t)
 
+	// ensure requests hash is still empty
+	latestBlock, err := ethCl.BlockByNumber(t.Ctx(), nil)
+	require.NoError(t, err, "error fetching latest block")
+	require.Equal(t, types.EmptyRequestsHash, *latestBlock.RequestsHash())
+
 	// get receipt
 	receipt, err := ethCl.TransactionReceipt(context.Background(), tx.Hash())
 	require.NoError(t, err)

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -152,7 +152,15 @@ func (b *BlockProcessor) Assemble() (*types.Block, types.Receipts, error) {
 	body := types.Body{
 		Transactions: b.transactions,
 	}
+	if b.dataProvider.Config().IsPrague(b.header.Number, b.header.Time) {
+		_requests := [][]byte{}
+		// EIP-6110 - no-op because we just ignore all deposit requests, so no need to parse logs
+		// EIP-7002
+		core.ProcessWithdrawalQueue(&_requests, b.evm)
+		// EIP-7251
+		core.ProcessConsolidationQueue(&_requests, b.evm)
 
+	}
 	block, err := b.dataProvider.Engine().FinalizeAndAssemble(b.dataProvider, b.header, b.state, &body, b.receipts)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a test to deploy withdrawal queue and consolidation queue and sends a valid transaction to each queue to ensure it can be mined post-Isthmus.

**Metadata**

Blocked by https://github.com/ethereum-optimism/op-geth/pull/498

Fixes #14155 