### PR TITLE
chore: use op-geth provided predeploy address

### DIFF
--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -337,7 +337,7 @@ func TestIsthmusNetworkUpgradeTransactions(gt *testing.T) {
 	require.NotEmpty(t, txn.Data(), "upgrade tx must provide input data")
 
 	// EIP-2935 contract is deployed
-	expectedBlockHashAddress := crypto.CreateAddress(derive.BlockHashDeployerAddress, 0)
+	expectedBlockHashAddress := crypto.CreateAddress(predeploys.EIP2935ContractDeployer, 0)
 	require.Equal(t, predeploys.EIP2935ContractAddr, expectedBlockHashAddress)
 	code := verifyCodeHashMatches(t, ethCl, predeploys.EIP2935ContractAddr, predeploys.EIP2935ContractCodeHash)
 	require.Equal(t, predeploys.EIP2935ContractCode, code)

--- a/op-node/rollup/derive/isthmus_upgrade_transactions.go
+++ b/op-node/rollup/derive/isthmus_upgrade_transactions.go
@@ -3,13 +3,13 @@ package derive
 import (
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
-	BlockHashDeployerAddress    = common.HexToAddress("0xE9f0662359Bb2c8111840eFFD73B9AFA77CbDE10")
 	blockHashDeployerSource     = UpgradeDepositSource{Intent: "Isthmus: EIP-2935 Contract Deployment"}
 	blockHashDeploymentBytecode = common.FromHex("0x60538060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500")
 )
@@ -19,7 +19,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 
 	deployHistoricalBlockHashesContract, err := types.NewTx(&types.DepositTx{
 		SourceHash:          blockHashDeployerSource.SourceHash(),
-		From:                BlockHashDeployerAddress,
+		From:                predeploys.EIP2935ContractDeployer,
 		To:                  nil,
 		Mint:                big.NewInt(0),
 		Value:               big.NewInt(0),

--- a/op-service/predeploys/eip2935.go
+++ b/op-service/predeploys/eip2935.go
@@ -1,12 +1,15 @@
 package predeploys
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
 
 // EIP-2935 defines a deterministic deployment transaction that deploys the recent block hashes contract.
 // See https://eips.ethereum.org/EIPS/eip-2935
 var (
-	EIP2935ContractAddr     = common.HexToAddress("0x0F792be4B0c0cb4DAE440Ef133E90C0eCD48CCCC")
-	EIP2935ContractCode     = common.FromHex("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500")
+	EIP2935ContractAddr     = params.HistoryStorageAddress
+	EIP2935ContractCode     = params.HistoryStorageCode
 	EIP2935ContractCodeHash = common.HexToHash("0x6e49e66782037c0555897870e29fa5e552daf4719552131a0abce779daec0a5d")
 	EIP2935ContractDeployer = common.HexToAddress("0xE9f0662359Bb2c8111840eFFD73B9AFA77CbDE10")
 )

--- a/packages/contracts-bedrock/test/L2/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2Genesis.t.sol
@@ -179,6 +179,7 @@ contract L2GenesisTest is Test {
         expected += 256; // precompiles
         expected += 13; // preinstalls
         expected += 1; // 4788 deployer account
+        expected += 1; // 2935 deployer account
         // 16 prefunded dev accounts are excluded
         assertEq(expected, getJSONKeyCount(_path), "key count check");
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updates EIP-2935 address to use built-in Geth address. This will mean the test will fail once we update to the latest geth which changes the predeploy address. We'll have to update the deployer once we update geth.