### PR TITLE
node: Ignore No-Op Unsafe Reset Requests

### DIFF
--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -572,7 +572,10 @@ type ResetEngineControl interface {
 
 // ForceEngineReset is not to be used. The op-program needs it for now, until event processing is adopted there.
 func ForceEngineReset(ec ResetEngineControl, x rollup.ForceResetEvent) {
-	ec.SetUnsafeHead(x.Unsafe)
+	// if the unsafe head is not provided, do not override the existing unsafe head
+	if x.Unsafe != (eth.L2BlockRef{}) {
+		ec.SetUnsafeHead(x.Unsafe)
+	}
 	ec.SetLocalSafeHead(x.Safe)
 	ec.SetPendingSafeL2Head(x.Safe)
 	ec.SetFinalizedHead(x.Finalized)

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -287,7 +287,10 @@ func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.Blo
 		return result, nil
 	}
 
-	unsafeRef, err := verify(unsafe, "unsafe")
+	// unsafeRef is always unused, as it is either
+	// - invalid (does not match, and therefore cannot be used for reset)
+	// - valid, in which case we will use the full unsafe chain for reset
+	_, err := verify(unsafe, "unsafe")
 	if err != nil {
 		return err
 	}
@@ -301,7 +304,7 @@ func (m *ManagedMode) Reset(ctx context.Context, unsafe, safe, finalized eth.Blo
 	}
 
 	m.emitter.Emit(rollup.ForceResetEvent{
-		Unsafe:    unsafeRef,
+		Unsafe:    eth.L2BlockRef{},
 		Safe:      safeRef,
 		Finalized: finalizedRef,
 	})


### PR DESCRIPTION
When a reset signal is given, we shouldn't reset the unsafe in any case:
- if the unsafe head is unknown, this reset target is inappropriate and should fail
- if the unsafe head is known, the unsafe chain can be preserved, and we should only reset the safe/finalized heads (which will cascade to affect the unsafe head, if it is needed)