### PR TITLE
interop: op-supervisor event metrics

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -637,6 +637,7 @@ func (m *Metrics) ReportProtocolVersions(local, engine, recommended, required pa
 
 type noopMetricer struct {
 	metrics.NoopRPCMetrics
+	event.NoopMetrics
 }
 
 var NoopMetrics Metricer = new(noopMetricer)
@@ -663,15 +664,6 @@ func (n *noopMetricer) RecordPublishingError() {
 }
 
 func (n *noopMetricer) RecordDerivationError() {
-}
-
-func (n *noopMetricer) RecordEmittedEvent(eventName string, emitter string) {
-}
-
-func (n *noopMetricer) RecordProcessedEvent(eventName string, deriver string, duration time.Duration) {
-}
-
-func (n *noopMetricer) RecordEventsRateLimited() {
 }
 
 func (n *noopMetricer) RecordReceivedUnsafePayload(payload *eth.ExecutionPayloadEnvelope) {

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -11,7 +11,7 @@ import (
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
-
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	ophttp "github.com/ethereum-optimism/optimism/op-service/httputil"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 
@@ -97,17 +97,7 @@ type Metrics struct {
 	PublishingErrors *metrics.Event
 	SequencerActive  prometheus.Gauge
 
-	EmittedEvents   *prometheus.CounterVec
-	ProcessedEvents *prometheus.CounterVec
-
-	// We don't use a histogram for observing time durations,
-	// as each vec entry (event-type, deriver type) is synchronous with other occurrences of the same entry key,
-	// so we can get a reasonably good understanding of execution by looking at the rate.
-	// Bucketing to detect outliers would be nice, but also increases the overhead by a lot,
-	// where we already track many event-type/deriver combinations.
-	EventsProcessTime *prometheus.CounterVec
-
-	EventsRateLimited *metrics.Event
+	*event.EventMetricsTracker
 
 	DerivedBatches metrics.EventVec
 
@@ -216,32 +206,7 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "sequencer_active",
 			Help:      "1 if sequencer active, 0 otherwise",
 		}),
-
-		EmittedEvents: factory.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: ns,
-				Subsystem: "events",
-				Name:      "emitted",
-				Help:      "number of emitted events",
-			}, []string{"event_type", "emitter"}),
-
-		ProcessedEvents: factory.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: ns,
-				Subsystem: "events",
-				Name:      "processed",
-				Help:      "number of processed events",
-			}, []string{"event_type", "deriver"}),
-
-		EventsProcessTime: factory.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: ns,
-				Subsystem: "events",
-				Name:      "process_time",
-				Help:      "total duration in seconds of processed events",
-			}, []string{"event_type", "deriver"}),
-
-		EventsRateLimited: metrics.NewEvent(factory, ns, "events", "rate_limited", "events rate limiter hits"),
+		EventMetricsTracker: event.NewMetricsTracker(ns, factory),
 
 		DerivedBatches: metrics.NewEventVec(factory, ns, "", "derived_batches", "derived batches", []string{"type"}),
 
@@ -493,21 +458,6 @@ func (m *Metrics) RecordSequencingError() {
 
 func (m *Metrics) RecordPublishingError() {
 	m.PublishingErrors.Record()
-}
-
-func (m *Metrics) RecordEmittedEvent(eventName string, emitter string) {
-	m.EmittedEvents.WithLabelValues(eventName, emitter).Inc()
-}
-
-func (m *Metrics) RecordProcessedEvent(eventName string, deriver string, duration time.Duration) {
-	m.ProcessedEvents.WithLabelValues(eventName, deriver).Inc()
-	// We take the absolute value; if the clock was not monotonically increased between start and top,
-	// there still was a duration gap. And the Counter metrics-type would panic if the duration is negative.
-	m.EventsProcessTime.WithLabelValues(eventName, deriver).Add(float64(duration.Abs()) / float64(time.Second))
-}
-
-func (m *Metrics) RecordEventsRateLimited() {
-	m.EventsRateLimited.Record()
 }
 
 func (m *Metrics) RecordDerivationError() {

--- a/op-node/rollup/event/metrics.go
+++ b/op-node/rollup/event/metrics.go
@@ -1,6 +1,12 @@
 package event
 
-import "time"
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
 
 type Metrics interface {
 	RecordEmittedEvent(eventName string, emitter string)
@@ -18,3 +24,62 @@ func (n NoopMetrics) RecordProcessedEvent(eventName string, deriver string, dura
 func (n NoopMetrics) RecordEventsRateLimited() {}
 
 var _ Metrics = NoopMetrics{}
+
+type EventMetricsTracker struct {
+	EmittedEvents   *prometheus.CounterVec
+	ProcessedEvents *prometheus.CounterVec
+
+	// We don't use a histogram for observing time durations,
+	// as each vec entry (event-type, deriver type) is synchronous with other occurrences of the same entry key,
+	// so we can get a reasonably good understanding of execution by looking at the rate.
+	// Bucketing to detect outliers would be nice, but also increases the overhead by a lot,
+	// where we already track many event-type/deriver combinations.
+	EventsProcessTime *prometheus.CounterVec
+
+	EventsRateLimited *metrics.Event
+}
+
+func NewMetricsTracker(ns string, factory metrics.Factory) *EventMetricsTracker {
+	return &EventMetricsTracker{
+		EmittedEvents: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: ns,
+				Subsystem: "events",
+				Name:      "emitted",
+				Help:      "number of emitted events",
+			}, []string{"event_type", "emitter"}),
+
+		ProcessedEvents: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: ns,
+				Subsystem: "events",
+				Name:      "processed",
+				Help:      "number of processed events",
+			}, []string{"event_type", "deriver"}),
+
+		EventsProcessTime: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: ns,
+				Subsystem: "events",
+				Name:      "process_time",
+				Help:      "total duration in seconds of processed events",
+			}, []string{"event_type", "deriver"}),
+
+		EventsRateLimited: metrics.NewEvent(factory, ns, "events", "rate_limited", "events rate limiter hits"),
+	}
+}
+
+func (m *EventMetricsTracker) RecordEmittedEvent(eventName string, emitter string) {
+	m.EmittedEvents.WithLabelValues(eventName, emitter).Inc()
+}
+
+func (m *EventMetricsTracker) RecordProcessedEvent(eventName string, deriver string, duration time.Duration) {
+	m.ProcessedEvents.WithLabelValues(eventName, deriver).Inc()
+	// We take the absolute value; if the clock was not monotonically increased between start and top,
+	// there still was a duration gap. And the Counter metrics-type would panic if the duration is negative.
+	m.EventsProcessTime.WithLabelValues(eventName, deriver).Add(float64(duration.Abs()) / float64(time.Second))
+}
+
+func (m *EventMetricsTracker) RecordEventsRateLimited() {
+	m.EventsRateLimited.Record()
+}

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -1,10 +1,10 @@
 package metrics
 
 import (
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/prometheus/client_golang/prometheus"
-
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const Namespace = "op_supervisor"
@@ -24,12 +24,16 @@ type Metricer interface {
 	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
 
 	Document() []opmetrics.DocumentedMetric
+
+	event.Metrics
 }
 
 type Metrics struct {
 	ns       string
 	registry *prometheus.Registry
 	factory  opmetrics.Factory
+
+	*event.EventMetricsTracker
 
 	opmetrics.RPCMetrics
 	RefMetrics opmetrics.RefMetricsWithChainID
@@ -46,6 +50,7 @@ type Metrics struct {
 }
 
 var _ Metricer = (*Metrics)(nil)
+var _ event.Metrics = (*Metrics)(nil)
 
 // implements the Registry getter, for metrics HTTP server to hook into
 var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
@@ -64,8 +69,9 @@ func NewMetrics(procName string) *Metrics {
 		registry: registry,
 		factory:  factory,
 
-		RPCMetrics: opmetrics.MakeRPCMetrics(ns, factory),
-		RefMetrics: opmetrics.MakeRefMetricsWithChainID(ns, factory),
+		EventMetricsTracker: event.NewMetricsTracker(ns, factory),
+		RPCMetrics:          opmetrics.MakeRPCMetrics(ns, factory),
+		RefMetrics:          opmetrics.MakeRefMetricsWithChainID(ns, factory),
 
 		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -1,12 +1,14 @@
 package metrics
 
 import (
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 )
 
 type noopMetrics struct {
 	opmetrics.NoopRPCMetrics
+	event.NoopMetrics
 }
 
 var NoopMetrics Metricer = new(noopMetrics)

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -108,6 +108,7 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 	}
 
 	eventSys := event.NewSystem(logger, eventExec)
+	eventSys.AddTracer(event.NewMetricsTracer(m))
 
 	sysCtx, sysCancel := context.WithCancel(ctx)
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -216,6 +216,7 @@ func TestBackendCallsMetrics(t *testing.T) {
 
 type MockMetrics struct {
 	mock.Mock
+	event.NoopMetrics
 }
 
 var _ Metrics = (*MockMetrics)(nil)

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
@@ -15,6 +16,8 @@ type Metrics interface {
 
 	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
+
+	event.Metrics
 }
 
 // chainMetrics is an adapter between the metrics API expected by clients that assume there's only a single chain


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Shares metrics code with op-node to expose event metrics in op-supervisor
