### PR TITLE
kurtosis-devnet: self-contained enclaves

### DIFF
--- a/devnet-sdk/shell/cmd/enter/main.go
+++ b/devnet-sdk/shell/cmd/enter/main.go
@@ -10,10 +10,10 @@ import (
 )
 
 func run(ctx *cli.Context) error {
-	devnetFile := ctx.String("devnet")
+	devnetURL := ctx.String("devnet")
 	chainName := ctx.String("chain")
 
-	devnetEnv, err := env.LoadDevnetEnv(devnetFile)
+	devnetEnv, err := env.LoadDevnetFromURL(devnetURL)
 	if err != nil {
 		return err
 	}
@@ -64,8 +64,8 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "devnet",
-				Usage:    "Path to devnet JSON file",
-				EnvVars:  []string{env.EnvFileVar},
+				Usage:    "URL to devnet JSON file",
+				EnvVars:  []string{env.EnvURLVar},
 				Required: true,
 			},
 			&cli.StringFlag{

--- a/devnet-sdk/shell/cmd/motd/main.go
+++ b/devnet-sdk/shell/cmd/motd/main.go
@@ -9,10 +9,10 @@ import (
 )
 
 func run(ctx *cli.Context) error {
-	devnetFile := ctx.String("devnet")
+	devnetURL := ctx.String("devnet")
 	chainName := ctx.String("chain")
 
-	devnetEnv, err := env.LoadDevnetEnv(devnetFile)
+	devnetEnv, err := env.LoadDevnetFromURL(devnetURL)
 	if err != nil {
 		return err
 	}
@@ -38,8 +38,8 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "devnet",
-				Usage:    "Path to devnet JSON file",
-				EnvVars:  []string{env.EnvFileVar},
+				Usage:    "URL to devnet JSON file",
+				EnvVars:  []string{env.EnvURLVar},
 				Required: true,
 			},
 			&cli.StringFlag{

--- a/devnet-sdk/shell/env/devnet.go
+++ b/devnet-sdk/shell/env/devnet.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
@@ -23,6 +22,7 @@ type DataFetcher func(*url.URL) (string, []byte, error)
 var schemeToFetcher = map[string]DataFetcher{
 	"":     fetchFileData,
 	"file": fetchFileData,
+	"kt":   fetchKurtosisData,
 }
 
 // fetchDevnetData retrieves data from a URL based on its scheme
@@ -39,23 +39,6 @@ func fetchDevnetData(devnetURL string) (string, []byte, error) {
 	}
 
 	return fetcher(parsedURL)
-}
-
-// fetchFileData reads data from a local file
-func fetchFileData(u *url.URL) (string, []byte, error) {
-	body, err := os.ReadFile(u.Path)
-	if err != nil {
-		return "", nil, fmt.Errorf("error reading file: %w", err)
-	}
-
-	basename := u.Path
-	if lastSlash := strings.LastIndex(basename, "/"); lastSlash >= 0 {
-		basename = basename[lastSlash+1:]
-	}
-	if lastDot := strings.LastIndex(basename, "."); lastDot >= 0 {
-		basename = basename[:lastDot]
-	}
-	return basename, body, nil
 }
 
 func LoadDevnetFromURL(devnetURL string) (*DevnetEnv, error) {

--- a/devnet-sdk/shell/env/devnet.go
+++ b/devnet-sdk/shell/env/devnet.go
@@ -3,20 +3,65 @@ package env
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 )
 
 type DevnetEnv struct {
-	config descriptors.DevnetEnvironment
-	fname  string
+	Config descriptors.DevnetEnvironment
+	Name   string
+	URL    string
 }
 
-func LoadDevnetEnv(devnetFile string) (*DevnetEnv, error) {
-	data, err := os.ReadFile(devnetFile)
+// DataFetcher is a function type for fetching data from a URL
+type DataFetcher func(*url.URL) (string, []byte, error)
+
+// schemeToFetcher maps URL schemes to their respective data fetcher functions
+var schemeToFetcher = map[string]DataFetcher{
+	"":     fetchFileData,
+	"file": fetchFileData,
+}
+
+// fetchDevnetData retrieves data from a URL based on its scheme
+func fetchDevnetData(devnetURL string) (string, []byte, error) {
+	parsedURL, err := url.Parse(devnetURL)
 	if err != nil {
-		return nil, fmt.Errorf("error reading devnet file: %w", err)
+		return "", nil, fmt.Errorf("error parsing URL: %w", err)
+	}
+
+	scheme := strings.ToLower(parsedURL.Scheme)
+	fetcher, ok := schemeToFetcher[scheme]
+	if !ok {
+		return "", nil, fmt.Errorf("unsupported URL scheme: %s", scheme)
+	}
+
+	return fetcher(parsedURL)
+}
+
+// fetchFileData reads data from a local file
+func fetchFileData(u *url.URL) (string, []byte, error) {
+	body, err := os.ReadFile(u.Path)
+	if err != nil {
+		return "", nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	basename := u.Path
+	if lastSlash := strings.LastIndex(basename, "/"); lastSlash >= 0 {
+		basename = basename[lastSlash+1:]
+	}
+	if lastDot := strings.LastIndex(basename, "."); lastDot >= 0 {
+		basename = basename[:lastDot]
+	}
+	return basename, body, nil
+}
+
+func LoadDevnetFromURL(devnetURL string) (*DevnetEnv, error) {
+	name, data, err := fetchDevnetData(devnetURL)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching devnet data: %w", err)
 	}
 
 	var config descriptors.DevnetEnvironment
@@ -25,17 +70,18 @@ func LoadDevnetEnv(devnetFile string) (*DevnetEnv, error) {
 	}
 
 	return &DevnetEnv{
-		config: config,
-		fname:  devnetFile,
+		Config: config,
+		Name:   name,
+		URL:    devnetURL,
 	}, nil
 }
 
 func (d *DevnetEnv) GetChain(chainName string) (*ChainConfig, error) {
 	var chain *descriptors.Chain
-	if d.config.L1.Name == chainName {
-		chain = d.config.L1
+	if d.Config.L1.Name == chainName {
+		chain = d.Config.L1
 	} else {
-		for _, l2Chain := range d.config.L2 {
+		for _, l2Chain := range d.Config.L2 {
 			if l2Chain.Name == chainName {
 				chain = l2Chain
 				break
@@ -48,8 +94,8 @@ func (d *DevnetEnv) GetChain(chainName string) (*ChainConfig, error) {
 	}
 
 	return &ChainConfig{
-		chain:      chain,
-		devnetFile: d.fname,
-		name:       chainName,
+		chain:     chain,
+		devnetURL: d.URL,
+		name:      chainName,
 	}, nil
 }

--- a/devnet-sdk/shell/env/env_test.go
+++ b/devnet-sdk/shell/env/env_test.go
@@ -66,15 +66,15 @@ func TestLoadDevnetEnv(t *testing.T) {
 
 	// Test successful load
 	t.Run("successful load", func(t *testing.T) {
-		env, err := LoadDevnetEnv(tmpfile.Name())
+		env, err := LoadDevnetFromURL(tmpfile.Name())
 		require.NoError(t, err)
-		assert.Equal(t, "l1", env.config.L1.Name)
-		assert.Equal(t, "op", env.config.L2[0].Name)
+		assert.Equal(t, "l1", env.Config.L1.Name)
+		assert.Equal(t, "op", env.Config.L2[0].Name)
 	})
 
 	// Test loading non-existent file
 	t.Run("non-existent file", func(t *testing.T) {
-		_, err := LoadDevnetEnv("non-existent.json")
+		_, err := LoadDevnetFromURL("non-existent.json")
 		assert.Error(t, err)
 	})
 
@@ -84,14 +84,14 @@ func TestLoadDevnetEnv(t *testing.T) {
 		err := os.WriteFile(invalidFile, []byte("{invalid json}"), 0644)
 		require.NoError(t, err)
 
-		_, err = LoadDevnetEnv(invalidFile)
+		_, err = LoadDevnetFromURL(invalidFile)
 		assert.Error(t, err)
 	})
 }
 
 func TestGetChain(t *testing.T) {
 	devnet := &DevnetEnv{
-		config: descriptors.DevnetEnvironment{
+		Config: descriptors.DevnetEnvironment{
 			L1: &descriptors.Chain{
 				Name: "l1",
 				Nodes: []descriptors.Node{
@@ -131,7 +131,7 @@ func TestGetChain(t *testing.T) {
 				},
 			},
 		},
-		fname: "test.json",
+		URL: "test.json",
 	}
 
 	// Test getting L1 chain
@@ -180,8 +180,8 @@ func TestChainConfig(t *testing.T) {
 				"deployer": common.HexToAddress("0x1234567890123456789012345678901234567890"),
 			},
 		},
-		devnetFile: "test.json",
-		name:       "test",
+		devnetURL: "test.json",
+		name:      "test",
 	}
 
 	// Test getting environment variables
@@ -193,7 +193,7 @@ func TestChainConfig(t *testing.T) {
 
 		assert.Equal(t, "http://localhost:8545", env.envVars["ETH_RPC_URL"])
 		assert.Equal(t, "1234", env.envVars["ETH_RPC_JWT_SECRET"])
-		assert.Equal(t, "test.json", filepath.Base(env.envVars[EnvFileVar]))
+		assert.Equal(t, "test.json", filepath.Base(env.envVars[EnvURLVar]))
 		assert.Equal(t, "test", env.envVars[ChainNameVar])
 		assert.Contains(t, env.motd, "deployer")
 		assert.Contains(t, env.motd, "0x1234567890123456789012345678901234567890")

--- a/devnet-sdk/shell/env/file_fetch.go
+++ b/devnet-sdk/shell/env/file_fetch.go
@@ -1,0 +1,25 @@
+package env
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// fetchFileData reads data from a local file
+func fetchFileData(u *url.URL) (string, []byte, error) {
+	body, err := os.ReadFile(u.Path)
+	if err != nil {
+		return "", nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	basename := u.Path
+	if lastSlash := strings.LastIndex(basename, "/"); lastSlash >= 0 {
+		basename = basename[lastSlash+1:]
+	}
+	if lastDot := strings.LastIndex(basename, "."); lastDot >= 0 {
+		basename = basename[:lastDot]
+	}
+	return basename, body, nil
+}

--- a/devnet-sdk/shell/env/file_fetch_test.go
+++ b/devnet-sdk/shell/env/file_fetch_test.go
@@ -1,0 +1,55 @@
+package env
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchFileData(t *testing.T) {
+	// Create a temporary test file
+	content := []byte("test content")
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.json")
+	err := os.WriteFile(tmpFile, content, 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		path        string
+		wantName    string
+		wantContent []byte
+		wantError   bool
+	}{
+		{
+			name:        "existing file",
+			path:        tmpFile,
+			wantName:    "test",
+			wantContent: content,
+		},
+		{
+			name:      "non-existent file",
+			path:      filepath.Join(tmpDir, "nonexistent.json"),
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &url.URL{Path: tt.path}
+			name, content, err := fetchFileData(u)
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantContent, content)
+		})
+	}
+}

--- a/devnet-sdk/shell/env/kt_fetch.go
+++ b/devnet-sdk/shell/env/kt_fetch.go
@@ -1,0 +1,90 @@
+package env
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/deploy"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/artifact"
+)
+
+// EnclaveFS is an interface that both our mock and the real implementation satisfy
+type EnclaveFS interface {
+	GetArtifact(ctx context.Context, name string) (*artifact.Artifact, error)
+	Close() error
+}
+
+// enclaveFSWrapper wraps the artifact.EnclaveFS to implement our EnclaveFS interface
+type enclaveFSWrapper struct {
+	fs *artifact.EnclaveFS
+}
+
+func (w *enclaveFSWrapper) GetArtifact(ctx context.Context, name string) (*artifact.Artifact, error) {
+	return w.fs.GetArtifact(ctx, name)
+}
+
+func (w *enclaveFSWrapper) Close() error {
+	// The underlying EnclaveFS doesn't have a Close method, but we need it for our interface
+	return nil
+}
+
+// NewEnclaveFSFunc is the type for functions that create new enclave filesystems
+type NewEnclaveFSFunc func(ctx context.Context, enclave string) (EnclaveFS, error)
+
+// NewEnclaveFS is a variable that holds the function to create a new enclave filesystem
+// It can be replaced in tests
+var NewEnclaveFS NewEnclaveFSFunc = func(ctx context.Context, enclave string) (EnclaveFS, error) {
+	fs, err := artifact.NewEnclaveFS(ctx, enclave)
+	if err != nil {
+		return nil, err
+	}
+	return &enclaveFSWrapper{fs: fs}, nil
+}
+
+// parseKurtosisURL parses a Kurtosis URL of the form kt://enclave/artifact/file
+// If artifact is omitted, it defaults to "devnet"
+// If file is omitted, it defaults to "env.json"
+func parseKurtosisURL(u *url.URL) (enclave, artifactName, fileName string) {
+	enclave = u.Host
+	artifactName = deploy.DevnetEnvArtifactName
+	fileName = deploy.DevnetEnvArtifactPath
+
+	// Trim both prefix and suffix slashes before splitting
+	trimmedPath := strings.Trim(u.Path, "/")
+	parts := strings.Split(trimmedPath, "/")
+	if len(parts) > 0 && parts[0] != "" {
+		artifactName = parts[0]
+	}
+	if len(parts) > 1 && parts[1] != "" {
+		fileName = parts[1]
+	}
+
+	return
+}
+
+// fetchKurtosisData reads data from a Kurtosis artifact
+func fetchKurtosisData(u *url.URL) (string, []byte, error) {
+	enclave, artifactName, fileName := parseKurtosisURL(u)
+
+	fs, err := NewEnclaveFS(context.Background(), enclave)
+	if err != nil {
+		return "", nil, fmt.Errorf("error creating enclave fs: %w", err)
+	}
+
+	art, err := fs.GetArtifact(context.Background(), artifactName)
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting artifact: %w", err)
+	}
+
+	var buf bytes.Buffer
+	writer := artifact.NewArtifactFileWriter(fileName, &buf)
+
+	if err := art.ExtractFiles(writer); err != nil {
+		return "", nil, fmt.Errorf("error extracting file from artifact: %w", err)
+	}
+
+	return enclave, buf.Bytes(), nil
+}

--- a/devnet-sdk/shell/env/kt_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_fetch_test.go
@@ -1,0 +1,130 @@
+package env
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/artifact"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testFS implements EnclaveFS for testing
+type testFS struct{}
+
+func (m *testFS) GetArtifact(_ context.Context, name string) (*artifact.Artifact, error) {
+	if name == "error" {
+		return nil, fmt.Errorf("mock error")
+	}
+	// We don't need to return a real artifact since we're only testing error cases
+	return nil, nil
+}
+
+func (m *testFS) Close() error {
+	return nil
+}
+
+func TestParseKurtosisURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		urlStr         string
+		wantEnclave    string
+		wantArtifact   string
+		wantFile       string
+		wantParseError bool
+	}{
+		{
+			name:         "basic url",
+			urlStr:       "kt://myenclave",
+			wantEnclave:  "myenclave",
+			wantArtifact: "devnet",
+			wantFile:     "env.json",
+		},
+		{
+			name:         "with artifact",
+			urlStr:       "kt://myenclave/custom-artifact",
+			wantEnclave:  "myenclave",
+			wantArtifact: "custom-artifact",
+			wantFile:     "env.json",
+		},
+		{
+			name:         "with artifact and file",
+			urlStr:       "kt://myenclave/custom-artifact/config.json",
+			wantEnclave:  "myenclave",
+			wantArtifact: "custom-artifact",
+			wantFile:     "config.json",
+		},
+		{
+			name:         "with trailing slash",
+			urlStr:       "kt://enclave/artifact/",
+			wantEnclave:  "enclave",
+			wantArtifact: "artifact",
+			wantFile:     "env.json",
+		},
+		{
+			name:           "invalid url",
+			urlStr:         "://invalid",
+			wantParseError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.urlStr)
+			if tt.wantParseError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			enclave, artifact, file := parseKurtosisURL(u)
+			assert.Equal(t, tt.wantEnclave, enclave)
+			assert.Equal(t, tt.wantArtifact, artifact)
+			assert.Equal(t, tt.wantFile, file)
+		})
+	}
+}
+
+func TestFetchKurtosisDataErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupMock func()
+		urlStr    string
+	}{
+		{
+			name: "error creating fs",
+			setupMock: func() {
+				NewEnclaveFS = func(_ context.Context, _ string) (EnclaveFS, error) {
+					return nil, fmt.Errorf("mock error")
+				}
+			},
+			urlStr: "kt://myenclave",
+		},
+		{
+			name: "error getting artifact",
+			setupMock: func() {
+				NewEnclaveFS = func(_ context.Context, _ string) (EnclaveFS, error) {
+					return &testFS{}, nil
+				}
+			},
+			urlStr: "kt://myenclave/error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origNewEnclaveFS := NewEnclaveFS
+			defer func() { NewEnclaveFS = origNewEnclaveFS }()
+
+			tt.setupMock()
+
+			u, err := url.Parse(tt.urlStr)
+			require.NoError(t, err)
+
+			_, _, err = fetchKurtosisData(u)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/devnet-sdk/system/system_test.go
+++ b/devnet-sdk/system/system_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
-	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -72,18 +71,9 @@ func TestNewSystemFromEnv(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(devnetFile, data, 0644))
 
-	// Test with valid environment
-	envVar := env.EnvFileVar
-	os.Setenv(envVar, devnetFile)
-	sys, err := NewSystemFromEnv(envVar)
+	sys, err := NewSystemFromURL(devnetFile)
 	assert.NoError(t, err)
 	assert.NotNil(t, sys)
-
-	// Test with unset environment variable
-	os.Unsetenv(envVar)
-	sys, err = NewSystemFromEnv(envVar)
-	assert.Error(t, err)
-	assert.Nil(t, sys)
 }
 
 func TestSystemFromDevnet(t *testing.T) {
@@ -169,59 +159,6 @@ func TestSystemFromDevnet(t *testing.T) {
 
 			_, isInterop := sys.(InteropSystem)
 			assert.Equal(t, tt.isInterop, isInterop)
-		})
-	}
-}
-
-func TestDevnetFromFile(t *testing.T) {
-	// Create a temporary devnet file
-	tempDir := t.TempDir()
-	validFile := filepath.Join(tempDir, "valid.json")
-	invalidFile := filepath.Join(tempDir, "invalid.json")
-
-	validDevnet := &descriptors.DevnetEnvironment{
-		L1: &descriptors.Chain{ID: "1"},
-		L2: []*descriptors.Chain{{ID: "2"}},
-	}
-
-	validData, err := json.Marshal(validDevnet)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(validFile, validData, 0644))
-
-	require.NoError(t, os.WriteFile(invalidFile, []byte("invalid json"), 0644))
-
-	tests := []struct {
-		name    string
-		file    string
-		wantErr bool
-	}{
-		{
-			name:    "valid file",
-			file:    validFile,
-			wantErr: false,
-		},
-		{
-			name:    "invalid file",
-			file:    invalidFile,
-			wantErr: true,
-		},
-		{
-			name:    "non-existent file",
-			file:    "nonexistent.json",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devnet, err := devnetFromFile(tt.file)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, devnet)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, devnet)
-			}
 		})
 	}
 }

--- a/devnet-sdk/testing/systest/provider.go
+++ b/devnet-sdk/testing/systest/provider.go
@@ -4,14 +4,14 @@ import "github.com/ethereum-optimism/optimism/devnet-sdk/system"
 
 // systemProvider defines the interface for package-level functionality
 type systemProvider interface {
-	NewSystemFromEnv(string) (system.System, error)
+	NewSystemFromURL(string) (system.System, error)
 }
 
 // defaultProvider is the default implementation of the package
 type defaultProvider struct{}
 
-func (p *defaultProvider) NewSystemFromEnv(envVar string) (system.System, error) {
-	return system.NewSystemFromEnv(envVar)
+func (p *defaultProvider) NewSystemFromURL(url string) (system.System, error) {
+	return system.NewSystemFromURL(url)
 }
 
 // currentPackage is the current package implementation

--- a/devnet-sdk/testing/systest/systest.go
+++ b/devnet-sdk/testing/systest/systest.go
@@ -42,6 +42,47 @@ func (e *PreconditionError) Unwrap() error {
 	return e.err
 }
 
+// SystemAcquirer attempts to create a System instance.
+// Returns (nil, nil) to indicate this acquirer should be skipped (e.g., when prerequisites are not met).
+// Any other result indicates this acquirer was selected and its result (success or failure) should be used.
+type SystemAcquirer func(t BasicT) (system.System, error)
+
+// systemAcquirers is the list of ways to acquire a system, tried in order
+var systemAcquirers = []SystemAcquirer{
+	acquireFromEnvURL,
+	// Add more acquirers here as needed
+}
+
+// tryAcquirers attempts to acquire a system using the provided acquirers in order.
+// Each acquirer is tried in sequence until one returns a non-(nil,nil) result.
+// If an acquirer returns (nil, nil), it is skipped and the next one is tried.
+// Any other result from an acquirer (success or failure) is returned immediately.
+func tryAcquirers(t BasicT, acquirers []SystemAcquirer) (system.System, error) {
+	for _, acquirer := range acquirers {
+		sys, err := acquirer(t)
+		if sys == nil && err == nil {
+			// Acquirer signaled it should be skipped
+			continue
+		}
+		// Any other result means this acquirer was selected, return its result
+		return sys, err
+	}
+	return nil, fmt.Errorf("no acquirer was able to create a system")
+}
+
+// acquireFromEnvURL attempts to create a system from the URL specified in the environment variable.
+func acquireFromEnvURL(t BasicT) (system.System, error) {
+	url := os.Getenv(env.EnvURLVar)
+	if url == "" {
+		return nil, nil // Skip this acquirer
+	}
+	sys, err := currentPackage.NewSystemFromURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create system from URL %q: %w", url, err)
+	}
+	return sys, nil
+}
+
 type PreconditionValidator func(t T, sys system.System) (context.Context, error)
 type SystemTestFunc func(t T, sys system.System)
 type InteropSystemTestFunc func(t T, sys system.InteropSystem)
@@ -76,9 +117,9 @@ func (h *basicSystemTestHelper) SystemTest(t BasicT, f SystemTestFunc, validator
 
 	wt = wt.WithContext(ctx)
 
-	sys, err := currentPackage.NewSystemFromEnv(env.EnvFileVar)
+	sys, err := tryAcquirers(t, systemAcquirers)
 	if err != nil {
-		t.Fatalf("failed to parse system from environment: %v", err)
+		t.Fatalf("failed to acquire system: %v", err)
 	}
 
 	for _, validator := range validators {

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -18,19 +18,27 @@ import (
 // mockTB implements a minimal testing.TB for testing
 type mockTB struct {
 	testing.TB
-	name string
+	name      string
+	failed    bool
+	lastError string
 }
 
-func (m *mockTB) Helper()                  {}
-func (m *mockTB) Name() string             { return m.name }
-func (m *mockTB) Cleanup(func())           {}
-func (m *mockTB) Error(args ...any)        {}
-func (m *mockTB) Errorf(string, ...any)    {}
-func (m *mockTB) Fail()                    {}
-func (m *mockTB) FailNow()                 {}
-func (m *mockTB) Failed() bool             { return false }
-func (m *mockTB) Fatal(args ...any)        {}
-func (m *mockTB) Fatalf(string, ...any)    {}
+func (m *mockTB) Helper()               {}
+func (m *mockTB) Name() string          { return m.name }
+func (m *mockTB) Cleanup(func())        {}
+func (m *mockTB) Error(args ...any)     {}
+func (m *mockTB) Errorf(string, ...any) {}
+func (m *mockTB) Fail()                 {}
+func (m *mockTB) FailNow()              {}
+func (m *mockTB) Failed() bool          { return false }
+func (m *mockTB) Fatal(args ...any) {
+	m.failed = true
+	m.lastError = fmt.Sprint(args...)
+}
+func (m *mockTB) Fatalf(format string, args ...any) {
+	m.failed = true
+	m.lastError = fmt.Sprintf(format, args...)
+}
 func (m *mockTB) Log(args ...any)          {}
 func (m *mockTB) Logf(string, ...any)      {}
 func (m *mockTB) Skip(args ...any)         {}
@@ -110,26 +118,24 @@ type testPackage struct {
 	creator testSystemCreator
 }
 
-func (p *testPackage) NewSystemFromEnv(string) (system.System, error) {
+func (p *testPackage) NewSystemFromURL(string) (system.System, error) {
 	return p.creator()
 }
 
 // withTestSystem runs a test with a custom system creator
 func withTestSystem(t *testing.T, creator testSystemCreator, f func(t *testing.T)) {
-	// Save original env var
-	origEnvFile := os.Getenv(env.EnvFileVar)
-	defer os.Setenv(env.EnvFileVar, origEnvFile)
-
-	// Set empty env var for testing
-	os.Setenv(env.EnvFileVar, "")
-
-	// Create a test-specific package
-	pkg := &testPackage{creator: creator}
-	origPkg := currentPackage
-	currentPackage = pkg
+	// Save original acquirers and restore after test
+	origAcquirers := systemAcquirers
 	defer func() {
-		currentPackage = origPkg
+		systemAcquirers = origAcquirers
 	}()
+
+	// Replace acquirers with just our test creator
+	systemAcquirers = []SystemAcquirer{
+		func(t BasicT) (system.System, error) {
+			return creator()
+		},
+	}
 
 	f(t)
 }
@@ -200,5 +206,159 @@ func TestTWrapper(t *testing.T) {
 
 		require.True(t, level1Called)
 		require.True(t, level2Called)
+	})
+}
+
+// mockAcquirer creates a SystemAcquirer that returns the given system and error
+func mockAcquirer(sys system.System, err error) SystemAcquirer {
+	return func(t BasicT) (system.System, error) {
+		return sys, err
+	}
+}
+
+// TestTryAcquirers tests the tryAcquirers helper function directly
+func TestTryAcquirers(t *testing.T) {
+	t.Run("empty acquirers list", func(t *testing.T) {
+		sys, err := tryAcquirers(t, nil)
+		require.EqualError(t, err, "no acquirer was able to create a system")
+		require.Nil(t, sys)
+	})
+
+	t.Run("skips nil,nil results", func(t *testing.T) {
+		sys1 := newMockSystem()
+		acquirers := []SystemAcquirer{
+			mockAcquirer(nil, nil),  // skipped
+			mockAcquirer(nil, nil),  // skipped
+			mockAcquirer(sys1, nil), // selected and succeeds
+		}
+		sys, err := tryAcquirers(t, acquirers)
+		require.NoError(t, err)
+		require.Equal(t, sys1, sys)
+	})
+
+	t.Run("returns first non-skip result (success)", func(t *testing.T) {
+		sys1, sys2 := newMockSystem(), newMockSystem()
+		acquirers := []SystemAcquirer{
+			mockAcquirer(nil, nil),  // skipped
+			mockAcquirer(sys1, nil), // selected and succeeds
+			mockAcquirer(sys2, nil), // not reached
+		}
+		sys, err := tryAcquirers(t, acquirers)
+		require.NoError(t, err)
+		require.Equal(t, sys1, sys)
+	})
+
+	t.Run("returns first non-skip result (failure)", func(t *testing.T) {
+		expectedErr := fmt.Errorf("selected acquirer failed")
+		sys1 := newMockSystem()
+		acquirers := []SystemAcquirer{
+			mockAcquirer(nil, nil),         // skipped
+			mockAcquirer(nil, expectedErr), // selected and fails
+			mockAcquirer(sys1, nil),        // not reached
+		}
+		sys, err := tryAcquirers(t, acquirers)
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, sys)
+	})
+
+	t.Run("all acquirers skip", func(t *testing.T) {
+		acquirers := []SystemAcquirer{
+			mockAcquirer(nil, nil),
+			mockAcquirer(nil, nil),
+		}
+		sys, err := tryAcquirers(t, acquirers)
+		require.EqualError(t, err, "no acquirer was able to create a system")
+		require.Nil(t, sys)
+	})
+}
+
+// Update TestSystemAcquisition to match new behavior
+func TestSystemAcquisition(t *testing.T) {
+	// Save original acquirers and restore after test
+	origAcquirers := systemAcquirers
+	defer func() {
+		systemAcquirers = origAcquirers
+	}()
+
+	t.Run("uses first non-skip acquirer (success)", func(t *testing.T) {
+		sys1, sys2 := newMockSystem(), newMockSystem()
+		acquirers := []SystemAcquirer{
+			mockAcquirer(nil, nil),  // skipped
+			mockAcquirer(sys1, nil), // selected and succeeds
+			mockAcquirer(sys2, nil), // not reached
+		}
+		systemAcquirers = acquirers
+
+		var acquiredSys system.System
+		SystemTest(t, func(t T, sys system.System) {
+			acquiredSys = sys
+		})
+		require.Equal(t, sys1, acquiredSys)
+	})
+
+	t.Run("fails when selected acquirer fails", func(t *testing.T) {
+		expectedErr := fmt.Errorf("selected acquirer failed")
+		systemAcquirers = []SystemAcquirer{
+			mockAcquirer(nil, nil),         // skipped
+			mockAcquirer(nil, expectedErr), // selected and fails
+		}
+
+		mock := &mockTB{name: "mock"}
+		SystemTest(mock, func(t T, sys system.System) {
+			require.Fail(t, "should not reach here")
+		})
+		require.True(t, mock.failed)
+		require.Contains(t, mock.lastError, expectedErr.Error())
+	})
+
+	t.Run("fails when all acquirers skip", func(t *testing.T) {
+		systemAcquirers = []SystemAcquirer{
+			mockAcquirer(nil, nil),
+			mockAcquirer(nil, nil),
+		}
+
+		mock := &mockTB{name: "mock"}
+		SystemTest(mock, func(t T, sys system.System) {
+			require.Fail(t, "should not reach here")
+		})
+		require.True(t, mock.failed)
+		require.Contains(t, mock.lastError, "no acquirer was able to create a system")
+	})
+
+	t.Run("acquireFromEnvURL behavior", func(t *testing.T) {
+		// Save original env var and package
+		origEnvFile := os.Getenv(env.EnvURLVar)
+		origPkg := currentPackage
+		defer func() {
+			os.Setenv(env.EnvURLVar, origEnvFile)
+			currentPackage = origPkg
+		}()
+
+		t.Run("skips when env var not set", func(t *testing.T) {
+			os.Unsetenv(env.EnvURLVar)
+			sys, err := acquireFromEnvURL(t)
+			require.NoError(t, err)
+			require.Nil(t, sys)
+		})
+
+		t.Run("fails with error for invalid URL", func(t *testing.T) {
+			os.Setenv(env.EnvURLVar, "invalid://url")
+			sys, err := acquireFromEnvURL(t)
+			require.Error(t, err)
+			require.Nil(t, sys)
+		})
+
+		t.Run("succeeds with valid URL", func(t *testing.T) {
+			// Set up test package that returns a mock system
+			currentPackage = &testPackage{
+				creator: func() (system.System, error) {
+					return newMockSystem(), nil
+				},
+			}
+			os.Setenv(env.EnvURLVar, "file:///valid/url")
+			sys, err := acquireFromEnvURL(t)
+			require.NoError(t, err)
+			require.NotNil(t, sys)
+		})
 	})
 }

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -89,4 +89,4 @@ pectra-devnet: (devnet "pectra.yaml")
 
 # subshells
 enter-devnet DEVNET CHAIN='Ethereum':
-    exec go run ../devnet-sdk/shell/cmd/enter/main.go --devnet tests/{{DEVNET}}.json --chain {{CHAIN}}
+    exec go run ../devnet-sdk/shell/cmd/enter/main.go --devnet kt://{{DEVNET}} --chain {{CHAIN}}

--- a/kurtosis-devnet/pkg/kurtosis/sources/artifact/fs_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/artifact/fs_test.go
@@ -5,17 +5,52 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/stretchr/testify/require"
 )
 
 type mockEnclaveContext struct {
 	artifacts map[string][]byte
+	uploaded  map[string]map[string][]byte // artifactName -> path -> content
 }
 
 func (m *mockEnclaveContext) DownloadFilesArtifact(_ context.Context, name string) ([]byte, error) {
 	return m.artifacts[name], nil
+}
+
+func (m *mockEnclaveContext) UploadFiles(pathToUpload string, artifactName string) (services.FilesArtifactUUID, services.FileArtifactName, error) {
+	if m.uploaded == nil {
+		m.uploaded = make(map[string]map[string][]byte)
+	}
+	m.uploaded[artifactName] = make(map[string][]byte)
+
+	err := filepath.Walk(pathToUpload, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(pathToUpload, path)
+		if err != nil {
+			return err
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		m.uploaded[artifactName][relPath] = content
+		return nil
+	})
+
+	return "test-uuid", services.FileArtifactName(artifactName), err
 }
 
 func createTarGzArtifact(t *testing.T, files map[string]string) []byte {
@@ -113,6 +148,67 @@ func TestArtifactExtraction(t *testing.T) {
 			// Verify contents
 			for reqPath, wantContent := range tt.requests {
 				require.Equal(t, wantContent, buffers[reqPath].String(), "content mismatch for %s", reqPath)
+			}
+		})
+	}
+}
+
+func TestPutArtifact(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   map[string]string
+		wantErr bool
+	}{
+		{
+			name: "single file",
+			files: map[string]string{
+				"file1.txt": "content1",
+			},
+		},
+		{
+			name: "multiple files",
+			files: map[string]string{
+				"file1.txt":     "content1",
+				"dir/file2.txt": "content2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtx := &mockEnclaveContext{
+				artifacts: make(map[string][]byte),
+			}
+
+			fs := NewEnclaveFSWithContext(mockCtx)
+
+			// Create readers for all files
+			var readers []*ArtifactFileReader
+			for path, content := range tt.files {
+				readers = append(readers, NewArtifactFileReader(
+					path,
+					bytes.NewReader([]byte(content)),
+				))
+			}
+
+			// Put the artifact
+			err := fs.PutArtifact(context.Background(), "test-artifact", readers...)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify uploaded contents
+			require.NotNil(t, mockCtx.uploaded)
+			uploaded := mockCtx.uploaded["test-artifact"]
+			require.NotNil(t, uploaded)
+			require.Equal(t, len(tt.files), len(uploaded))
+
+			for path, wantContent := range tt.files {
+				content, exists := uploaded[path]
+				require.True(t, exists, "missing file: %s", path)
+				require.Equal(t, wantContent, string(content), "content mismatch for %s", path)
 			}
 		})
 	}


### PR DESCRIPTION
**Description**

This makes the kurtosis-based devnets more self-contained, by storing
the devnet final descriptor into the enclave itself.

This avoids potential discrepancies between local filesystem and available enclave
(e.g. dangling descriptor after enclave cleanup)

We therefore need to introduce a URL-based scheme to load environments
from the enclave.
Note that the previous file-based approach still works the same, as
scheme-less URLs map to the filesystem anyway.

We also expand slightly the SystemTest helper to allow for multiple
ways of acquiring a System implementation, even though currently the
only available acquisition mechanism is this URL-based scheme.

Down the road we'll add dynamic provisioning and other options.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

- Fixes ethereum-optimism/platforms-team#568