### PR TITLE
op-batcher: use local-safe to reduce lag during interop sync

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -756,11 +756,11 @@ func (l *BatchSubmitter) safeL1Origin(ctx context.Context) (eth.BlockID, error) 
 	}
 
 	// If the safe L2 block origin is 0, we are at the genesis block and should use the L1 origin from the rollup config.
-	if status.SafeL2.L1Origin.Number == 0 {
+	if status.LocalSafeL2.L1Origin.Number == 0 {
 		return l.RollupConfig.Genesis.L1, nil
 	}
 
-	return status.SafeL2.L1Origin, nil
+	return status.LocalSafeL2.L1Origin, nil
 }
 
 // cancelBlockingTx creates an empty transaction of appropriate type to cancel out the incompatible

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -88,7 +88,7 @@ func TestBatchSubmitter_SafeL1Origin(t *testing.T) {
 				ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{}, errors.New("failed to fetch sync status"))
 			} else {
 				ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{
-					SafeL2: eth.L2BlockRef{
+					LocalSafeL2: eth.L2BlockRef{
 						L1Origin: eth.BlockID{
 							Number: tt.currentSafeOrigin,
 						},

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -95,10 +95,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// although the sequencer has derived up the same
 			// L1 block height, it derived fewer safe L2 blocks.
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 6},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 6},
+				CurrentL1:   eth.BlockRef{Number: 1},
+				LocalSafeL2: eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block102, block103}, // note absence of block101
@@ -113,10 +113,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen if another batcher instance got some blocks
 			// included in the safe chain:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 6},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 6},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -131,10 +131,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen if there is an L1 reorg, the safe chain is at an acceptable
 			// height but it does not descend from the blocks in state:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}}, // note hash mismatch
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}}, // note hash mismatch
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -149,10 +149,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This could happen if the batcher unexpectedly violates the
 			// Holocene derivation rules:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 3},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 3},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -166,10 +166,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "failed to make expected progress (unsafe=safe)",
 			// Edge case where unsafe = safe
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 3},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:      eth.BlockRef{Number: 3},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block102, block103},
@@ -185,10 +185,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// and we didn't submit or have any txs confirmed since
 			// the last sync.
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 4},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 4},
+				CurrentL1:   eth.BlockRef{Number: 1},
+				LocalSafeL2: eth.L2BlockRef{Number: 100},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -200,10 +200,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "no blocks",
 			// This happens when the batcher is starting up for the first time
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -216,10 +216,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "happy path",
 			// This happens when the safe chain is being progressed as expected:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -232,10 +232,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "happy path + multiple channels",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103, block104},
@@ -249,10 +249,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "no progress + unsafe=safe",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 100},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 100},
+				UnsafeL2:    eth.L2BlockRef{Number: 100},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -262,10 +262,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "no progress + unsafe=safe + blocks in state",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 101, Hash: block101.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101},


### PR DESCRIPTION
**Description**

Before interop, local-safe == cross-safe (`safe` label in RPC sync status).
After interop, we want to use local-safe, to not wait with batch-submitting for cross-safety, as that can create deadlock situations (batchers waiting for each other to submit).

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
