### PR TITLE
op-e2e: Add action test for cascading reorgs in interop fault proofs

### DIFF
--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -54,6 +54,8 @@ type InteropDSL struct {
 	Outputs *Outputs
 	setup   *InteropSetup
 
+	InboxContract *InboxContract
+
 	// allChains contains all chains in the interop set.
 	// Currently this is always two chains, but as the setup code becomes more flexible it could be more
 	// and likely this array would be replaced by something in InteropActors
@@ -90,6 +92,8 @@ func NewInteropDSL(t helpers.Testing) *InteropDSL {
 			superRootSource: superRootSource,
 		},
 		setup: setup,
+
+		InboxContract: NewInboxContract(t),
 
 		allChains: allChains,
 	}

--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -118,13 +118,19 @@ func (d *InteropDSL) CreateUser() *DSLUser {
 
 type TransactionCreator func(chain *Chain) (*types.Transaction, common.Address)
 type AddL2BlockOpts struct {
-	BlockIsNotCrossSafe bool
-	TransactionCreators []TransactionCreator
+	BlockIsNotCrossUnsafe bool
+	TransactionCreators   []TransactionCreator
 }
 
 func WithL2BlockTransactions(mkTxs ...TransactionCreator) func(*AddL2BlockOpts) {
 	return func(o *AddL2BlockOpts) {
 		o.TransactionCreators = mkTxs
+	}
+}
+
+func WithL1BlockCrossUnsafe() func(*AddL2BlockOpts) {
+	return func(o *AddL2BlockOpts) {
+		o.BlockIsNotCrossUnsafe = true
 	}
 }
 
@@ -149,7 +155,7 @@ func (d *InteropDSL) AddL2Block(chain *Chain, optionalArgs ...func(*AddL2BlockOp
 	status := chain.Sequencer.SyncStatus()
 	expectedBlockNum := priorSyncStatus.UnsafeL2.Number + 1
 	require.Equal(d.t, expectedBlockNum, status.UnsafeL2.Number, "Unsafe head did not advance")
-	if opts.BlockIsNotCrossSafe {
+	if opts.BlockIsNotCrossUnsafe {
 		require.Equal(d.t, priorSyncStatus.CrossUnsafeL2.Number, status.CrossUnsafeL2.Number, "CrossUnsafe head advanced unexpectedly")
 	} else {
 		require.Equal(d.t, expectedBlockNum, status.CrossUnsafeL2.Number, "CrossUnsafe head did not advance")

--- a/op-e2e/actions/interop/dsl/emitter.go
+++ b/op-e2e/actions/interop/dsl/emitter.go
@@ -1,34 +1,36 @@
 package dsl
 
 import (
+	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/emit"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
 type EmitterContract struct {
-	t        helpers.Testing
-	bindings *emit.Emit
-	address  common.Address
+	t              helpers.Testing
+	addressByChain map[eth.ChainID]common.Address
 
 	EmittedMessages []*GeneratedTransaction
 }
 
 func NewEmitterContract(t helpers.Testing) *EmitterContract {
 	return &EmitterContract{
-		t: t,
+		t:              t,
+		addressByChain: make(map[eth.ChainID]common.Address),
 	}
 }
 
 func (c *EmitterContract) Deploy(user *DSLUser) TransactionCreator {
 	return func(chain *Chain) (*types.Transaction, common.Address) {
 		opts, from := user.TransactOpts(chain)
-		emitContract, tx, emitBindings, err := emit.DeployEmit(opts, chain.SequencerEngine.EthClient())
+		emitContract, tx, _, err := emit.DeployEmit(opts, chain.SequencerEngine.EthClient())
 		require.NoError(c.t, err)
-		c.bindings = emitBindings
-		c.address = emitContract
+		c.addressByChain[chain.ChainID] = emitContract
 		return tx, from
 	}
 }
@@ -36,7 +38,13 @@ func (c *EmitterContract) Deploy(user *DSLUser) TransactionCreator {
 func (c *EmitterContract) EmitMessage(user *DSLUser, message string) TransactionCreator {
 	return func(chain *Chain) (*types.Transaction, common.Address) {
 		opts, from := user.TransactOpts(chain)
-		tx, err := c.bindings.EmitData(opts, []byte(message))
+		address, ok := c.addressByChain[chain.ChainID]
+		if !ok {
+			c.t.Fatal(fmt.Errorf("not deployed on chain %d", chain.ChainID))
+		}
+		bindings, err := emit.NewEmitTransactor(address, chain.SequencerEngine.EthClient())
+		require.NoError(c.t, err)
+		tx, err := bindings.EmitData(opts, []byte(message))
 		require.NoError(c.t, err)
 		c.EmittedMessages = append(c.EmittedMessages, NewGeneratedTransaction(c.t, chain, tx))
 		return tx, from

--- a/op-e2e/actions/interop/dsl/emitter.go
+++ b/op-e2e/actions/interop/dsl/emitter.go
@@ -1,8 +1,6 @@
 package dsl
 
 import (
-	"fmt"
-
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -39,9 +37,7 @@ func (c *EmitterContract) EmitMessage(user *DSLUser, message string) Transaction
 	return func(chain *Chain) (*types.Transaction, common.Address) {
 		opts, from := user.TransactOpts(chain)
 		address, ok := c.addressByChain[chain.ChainID]
-		if !ok {
-			c.t.Fatal(fmt.Errorf("not deployed on chain %d", chain.ChainID))
-		}
+		require.Truef(c.t, ok, "not deployed on chain %d", chain.ChainID)
 		bindings, err := emit.NewEmitTransactor(address, chain.SequencerEngine.EthClient())
 		require.NoError(c.t, err)
 		tx, err := bindings.EmitData(opts, []byte(message))

--- a/op-e2e/actions/interop/dsl/transactions.go
+++ b/op-e2e/actions/interop/dsl/transactions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
+	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,13 @@ func (m *GeneratedTransaction) Identifier() inbox.Identifier {
 		Timestamp:   new(big.Int).SetUint64(block.Time()),
 		ChainId:     m.chain.RollupCfg.L2ChainID,
 	}
+}
+
+func (m *GeneratedTransaction) MessagePayload() []byte {
+	rcpt, err := m.chain.SequencerEngine.EthClient().TransactionReceipt(m.t.Ctx(), m.tx.Hash())
+	require.NoError(m.t, err)
+	require.NotZero(m.t, len(rcpt.Logs), "Transaction did not include any logs to reference")
+	return stypes.LogToMessagePayload(rcpt.Logs[0])
 }
 
 func (m *GeneratedTransaction) CheckIncluded() {

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -361,6 +361,8 @@ func TestInteropFaultProofs(gt *testing.T) {
 
 func TestInteropFaultProofs_CascadeInvalidBlock(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
+	// TODO(#14307): Support cascading invalidation in op-supervisor
+	t.Skip("Cascading invalidation not yet working")
 
 	system := dsl.NewInteropDSL(t)
 
@@ -430,8 +432,9 @@ func TestInteropFaultProofs_CascadeInvalidBlock(gt *testing.T) {
 			disputedClaim:      optimisticEnd.Marshal(),
 			disputedTraceIndex: 1023,
 			expectValid:        false,
-			skipProgram:        true,
-			skipChallenger:     true,
+			// TODO(#14306): Support cascading re-orgs in op-program
+			skipProgram:    true,
+			skipChallenger: true,
 		},
 		{
 			name:               "Consolidate-ReplaceInvalidBlocks",
@@ -439,8 +442,9 @@ func TestInteropFaultProofs_CascadeInvalidBlock(gt *testing.T) {
 			disputedClaim:      crossSafeEnd.Marshal(),
 			disputedTraceIndex: 1023,
 			expectValid:        true,
-			skipProgram:        true,
-			skipChallenger:     true,
+			// TODO(#14306): Support cascading re-orgs in op-program
+			skipProgram:    true,
+			skipChallenger: true,
 		},
 	}
 	runFppAndChallengerTests(gt, system, tests)


### PR DESCRIPTION
**Description**

Adds an action test to check that the FPP handles cascading invalidations where a block is initially valid, but becomes invalid because the block it depends on is invalidated.

Also adds a test for consolidation with all valid messages (instead of just empty blocks) to ensure the cross-chain messages are generated by the tests correctly and test the consolidation happy path a bit better.
