### PR TITLE
op-conductor: Add HeartbeatTimeout & LeaderLeaseTimeout flags

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -50,6 +50,13 @@ type Config struct {
 	// RaftTrailingLogs is the number of logs to keep after a snapshot.
 	RaftTrailingLogs uint64
 
+	// RaftHeartbeatTimeout is the interval timeout between leader and followers.
+	RaftHeartbeatTimeout time.Duration
+
+	// RaftLeaderLeaseTimeout is the timeout for leader lease.
+	// If the leader reaches this timeout without contacts to followers, it resigns.
+	RaftLeaderLeaseTimeout time.Duration
+
 	// NodeRPC is the HTTP provider URL for op-node.
 	NodeRPC string
 
@@ -129,15 +136,17 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		// The consensus server will advertise the address it binds to if this is empty/unspecified.
 		ConsensusAdvertisedAddr: ctx.String(flags.AdvertisedFullAddr.Name),
 
-		RaftBootstrap:         ctx.Bool(flags.RaftBootstrap.Name),
-		RaftServerID:          ctx.String(flags.RaftServerID.Name),
-		RaftStorageDir:        ctx.String(flags.RaftStorageDir.Name),
-		RaftSnapshotInterval:  ctx.Duration(flags.RaftSnapshotInterval.Name),
-		RaftSnapshotThreshold: ctx.Uint64(flags.RaftSnapshotThreshold.Name),
-		RaftTrailingLogs:      ctx.Uint64(flags.RaftTrailingLogs.Name),
-		NodeRPC:               ctx.String(flags.NodeRPC.Name),
-		ExecutionRPC:          ctx.String(flags.ExecutionRPC.Name),
-		Paused:                ctx.Bool(flags.Paused.Name),
+		RaftBootstrap:          ctx.Bool(flags.RaftBootstrap.Name),
+		RaftServerID:           ctx.String(flags.RaftServerID.Name),
+		RaftStorageDir:         ctx.String(flags.RaftStorageDir.Name),
+		RaftSnapshotInterval:   ctx.Duration(flags.RaftSnapshotInterval.Name),
+		RaftSnapshotThreshold:  ctx.Uint64(flags.RaftSnapshotThreshold.Name),
+		RaftTrailingLogs:       ctx.Uint64(flags.RaftTrailingLogs.Name),
+		RaftHeartbeatTimeout:   ctx.Duration(flags.RaftHeartbeatTimeout.Name),
+		RaftLeaderLeaseTimeout: ctx.Duration(flags.RaftLeaderLeaseTimeout.Name),
+		NodeRPC:                ctx.String(flags.NodeRPC.Name),
+		ExecutionRPC:           ctx.String(flags.ExecutionRPC.Name),
+		Paused:                 ctx.Bool(flags.Paused.Name),
 		HealthCheck: HealthCheckConfig{
 			Interval:       ctx.Uint64(flags.HealthCheckInterval.Name),
 			UnsafeInterval: ctx.Uint64(flags.HealthCheckUnsafeInterval.Name),

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -172,15 +172,17 @@ func (c *OpConductor) initConsensus(ctx context.Context) error {
 	raftConsensusConfig := &consensus.RaftConsensusConfig{
 		ServerID: c.cfg.RaftServerID,
 		// AdvertisedAddr may be empty: the server will then default to what it binds to.
-		AdvertisedAddr:    raft.ServerAddress(c.cfg.ConsensusAdvertisedAddr),
-		ListenAddr:        c.cfg.ConsensusAddr,
-		ListenPort:        c.cfg.ConsensusPort,
-		StorageDir:        c.cfg.RaftStorageDir,
-		Bootstrap:         c.cfg.RaftBootstrap,
-		RollupCfg:         &c.cfg.RollupCfg,
-		SnapshotInterval:  c.cfg.RaftSnapshotInterval,
-		SnapshotThreshold: c.cfg.RaftSnapshotThreshold,
-		TrailingLogs:      c.cfg.RaftTrailingLogs,
+		AdvertisedAddr:     raft.ServerAddress(c.cfg.ConsensusAdvertisedAddr),
+		ListenAddr:         c.cfg.ConsensusAddr,
+		ListenPort:         c.cfg.ConsensusPort,
+		StorageDir:         c.cfg.RaftStorageDir,
+		Bootstrap:          c.cfg.RaftBootstrap,
+		RollupCfg:          &c.cfg.RollupCfg,
+		SnapshotInterval:   c.cfg.RaftSnapshotInterval,
+		SnapshotThreshold:  c.cfg.RaftSnapshotThreshold,
+		TrailingLogs:       c.cfg.RaftTrailingLogs,
+		HeartbeatTimeout:   c.cfg.RaftHeartbeatTimeout,
+		LeaderLeaseTimeout: c.cfg.RaftLeaderLeaseTimeout,
 	}
 	cons, err := consensus.NewRaftConsensus(c.log, raftConsensusConfig)
 	if err != nil {

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -53,12 +53,14 @@ type RaftConsensusConfig struct {
 	// E.g. use 0.0.0.0 to bind to an external-facing network.
 	ListenAddr string
 
-	StorageDir        string
-	Bootstrap         bool
-	RollupCfg         *rollup.Config
-	SnapshotInterval  time.Duration
-	SnapshotThreshold uint64
-	TrailingLogs      uint64
+	StorageDir         string
+	Bootstrap          bool
+	RollupCfg          *rollup.Config
+	SnapshotInterval   time.Duration
+	SnapshotThreshold  uint64
+	TrailingLogs       uint64
+	HeartbeatTimeout   time.Duration
+	LeaderLeaseTimeout time.Duration
 }
 
 // checkTCPPortOpen attempts to connect to the specified address and returns an error if the connection fails.
@@ -77,6 +79,8 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 	rc.SnapshotInterval = cfg.SnapshotInterval
 	rc.TrailingLogs = cfg.TrailingLogs
 	rc.SnapshotThreshold = cfg.SnapshotThreshold
+	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
+	rc.LeaderLeaseTimeout = cfg.LeaderLeaseTimeout
 	rc.LocalID = raft.ServerID(cfg.ServerID)
 
 	baseDir := filepath.Join(cfg.StorageDir, cfg.ServerID)

--- a/op-conductor/consensus/raft_test.go
+++ b/op-conductor/consensus/raft_test.go
@@ -27,16 +27,18 @@ func TestCommitAndRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	raftConsensusConfig := &RaftConsensusConfig{
-		ServerID:          "SequencerA",
-		ListenPort:        0,
-		ListenAddr:        "127.0.0.1", // local test, don't bind to external interface
-		AdvertisedAddr:    "",          // use local address that the server binds to
-		StorageDir:        storageDir,
-		Bootstrap:         true,
-		RollupCfg:         rollupCfg,
-		SnapshotInterval:  120 * time.Second,
-		SnapshotThreshold: 10240,
-		TrailingLogs:      8192,
+		ServerID:           "SequencerA",
+		ListenPort:         0,
+		ListenAddr:         "127.0.0.1", // local test, don't bind to external interface
+		AdvertisedAddr:     "",          // use local address that the server binds to
+		StorageDir:         storageDir,
+		Bootstrap:          true,
+		RollupCfg:          rollupCfg,
+		SnapshotInterval:   120 * time.Second,
+		SnapshotThreshold:  10240,
+		TrailingLogs:       8192,
+		HeartbeatTimeout:   1000 * time.Millisecond,
+		LeaderLeaseTimeout: 500 * time.Millisecond,
 	}
 
 	cons, err := NewRaftConsensus(log, raftConsensusConfig)

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -69,6 +69,18 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_TRAILING_LOGS"),
 		Value:   10240,
 	}
+	RaftHeartbeatTimeout = &cli.DurationFlag{
+		Name:    "raft.heartbeat-timeout",
+		Usage:   "Heartbeat interval timeout",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_HEARTBEAT_TIMEOUT"),
+		Value:   1000 * time.Millisecond,
+	}
+	RaftLeaderLeaseTimeout = &cli.DurationFlag{
+		Name:    "raft.lease-timeout",
+		Usage:   "Leader lease timeout",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_LEASE_TIMEOUT"),
+		Value:   500 * time.Millisecond,
+	}
 	NodeRPC = &cli.StringFlag{
 		Name:    "node.rpc",
 		Usage:   "HTTP provider URL for op-node",

--- a/op-e2e/system/conductor/sequencer_failover_setup.go
+++ b/op-e2e/system/conductor/sequencer_failover_setup.go
@@ -211,15 +211,17 @@ func setupConductor(
 		ConsensusPort:           0,  // let the system select a port, avoid conflicts
 		ConsensusAdvertisedAddr: "", // use the local address we bind to
 
-		RaftServerID:          serverID,
-		RaftStorageDir:        dir,
-		RaftBootstrap:         bootstrap,
-		RaftSnapshotInterval:  120 * time.Second,
-		RaftSnapshotThreshold: 8192,
-		RaftTrailingLogs:      10240,
-		NodeRPC:               nodeRPC,
-		ExecutionRPC:          engineRPC,
-		Paused:                true,
+		RaftServerID:           serverID,
+		RaftStorageDir:         dir,
+		RaftBootstrap:          bootstrap,
+		RaftSnapshotInterval:   120 * time.Second,
+		RaftSnapshotThreshold:  8192,
+		RaftTrailingLogs:       10240,
+		RaftHeartbeatTimeout:   1000 * time.Millisecond,
+		RaftLeaderLeaseTimeout: 500 * time.Millisecond,
+		NodeRPC:                nodeRPC,
+		ExecutionRPC:           engineRPC,
+		Paused:                 true,
 		HealthCheck: con.HealthCheckConfig{
 			Interval:     1, // per test setup, l2 block time is 1s.
 			MinPeerCount: 2, // per test setup, each sequencer has 2 peers


### PR DESCRIPTION
**Description**

Add `HeartbeatTimeout` & `LeaderLeaseTimeout` flags to configure op-conductor Raft consensus.
Default values are Raft library's default values
- https://github.com/hashicorp/raft/blob/v1.7.2/config.go#L319
- https://github.com/hashicorp/raft/blob/v1.7.2/config.go#L327