### PR TITLE
Revert "chore: update kurtosis to 1.4.4 (#14255)"

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -35,7 +35,6 @@ anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 # Other dependencies
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
-kurtosis = "1.4.4"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't
@@ -52,7 +51,6 @@ anvil = "ubi:foundry-rs/foundry[exe=anvil]"
 just = "ubi:casey/just"
 codecov-uploader = "ubi:codecov/uploader"
 goreleaser-pro = "ubi:goreleaser/goreleaser-pro[exe=goreleaser]"
-kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"
 
 [settings]
 experimental = true


### PR DESCRIPTION
**Description**

This reverts commit ae26df3366e1267666c73a495d8c5346d3d29994.

runtimeverification/optimism-ci doesn't seem to like installing kurtosis :'(

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
