### PR TITLE
op-node/rollup/derive: Drop SetCodeTxs in pre-Isthmus batches

### DIFF
--- a/op-e2e/actions/altda/altda_test.go
+++ b/op-e2e/actions/altda/altda_test.go
@@ -143,7 +143,7 @@ func (a *L2AltDA) NewVerifier(t helpers.Testing) *helpers.L2Verifier {
 
 	daMgr := altda.NewAltDAWithStorage(a.log, a.altDACfg, a.storage, &altda.NoopMetrics{})
 
-	verifier := helpers.NewL2Verifier(t, a.log, l1F, a.miner.BlobStore(), daMgr, engCl, a.sd.RollupCfg, &sync.Config{}, safedb.Disabled)
+	verifier := helpers.NewL2Verifier(t, a.log, l1F, a.miner.BlobStore(), daMgr, engCl, a.sd.RollupCfg, &sync.Config{}, safedb.Disabled, nil)
 
 	return verifier
 }

--- a/op-e2e/actions/derivation/batch_queue_test.go
+++ b/op-e2e/actions/derivation/batch_queue_test.go
@@ -95,7 +95,7 @@ func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
 	l2Cl, err := sources.NewEngineClient(seqEngine.RPCClient(), logger, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))
 	require.NoError(gt, err)
 	verifier := helpers.NewL2Verifier(t, logger, miner.L1Client(t, sd.RollupCfg), miner.BlobStore(), altda.Disabled,
-		l2Cl, sequencer.RollupCfg, &sync.Config{}, safedb.Disabled)
+		l2Cl, sequencer.RollupCfg, &sync.Config{}, safedb.Disabled, nil)
 	verifier.ActL2PipelineFull(t) // Should not get stuck in a reset loop forever
 	require.EqualValues(gt, l2BlockNum, seqEngine.L2Chain().CurrentSafeBlock().Number.Uint64())
 	require.EqualValues(gt, l2BlockNum, seqEngine.L2Chain().CurrentFinalBlock().Number.Uint64())

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -53,7 +53,7 @@ type L2Sequencer struct {
 func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc derive.L1BlobsFetcher,
 	altDASrc driver.AltDAIface, eng L2API, cfg *rollup.Config, seqConfDepth uint64,
 ) *L2Sequencer {
-	ver := NewL2Verifier(t, log, l1, blobSrc, altDASrc, eng, cfg, &sync.Config{}, safedb.Disabled)
+	ver := NewL2Verifier(t, log, l1, blobSrc, altDASrc, eng, cfg, &sync.Config{}, safedb.Disabled, nil)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, eng)
 	seqConfDepthL1 := confdepth.NewConfDepth(seqConfDepth, ver.syncStatus.L1Head, l1)
 	originSelector := sequencing.NewL1OriginSelector(t.Ctx(), log, cfg, seqConfDepthL1)

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -108,6 +108,7 @@ type safeDB interface {
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	blobsSrc derive.L1BlobsFetcher, altDASrc driver.AltDAIface,
 	eng L2API, cfg *rollup.Config, syncCfg *sync.Config, safeHeadListener safeDB,
+	derivationPipelineCfg *rollup.Config,
 ) *L2Verifier {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -160,7 +161,12 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		attributes.NewAttributesHandler(log, cfg, ctx, eng), opts)
 
 	managedMode := interopSys != nil
-	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, altDASrc, eng, metrics, managedMode)
+
+	// set derivation pipeline cfg separately if needed
+	if derivationPipelineCfg == nil {
+		derivationPipelineCfg = cfg
+	}
+	pipeline := derive.NewDerivationPipeline(log, derivationPipelineCfg, l1, blobsSrc, altDASrc, eng, metrics, managedMode)
 	sys.Register("pipeline", derive.NewPipelineDeriver(ctx, pipeline), opts)
 
 	testActionEmitter := sys.Register("test-action", nil, opts)

--- a/op-e2e/actions/helpers/setups.go
+++ b/op-e2e/actions/helpers/setups.go
@@ -42,7 +42,7 @@ func SetupVerifier(t Testing, sd *e2eutils.SetupData, log log.Logger,
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 	engine := NewL2Engine(t, log.New("role", "verifier-engine"), sd.L2Cfg, jwtPath, EngineWithP2P())
 	engCl := engine.EngineClient(t, sd.RollupCfg)
-	verifier := NewL2Verifier(t, log.New("role", "verifier"), l1F, blobSrc, altda.Disabled, engCl, sd.RollupCfg, syncCfg, cfg.SafeHeadListener)
+	verifier := NewL2Verifier(t, log.New("role", "verifier"), l1F, blobSrc, altda.Disabled, engCl, sd.RollupCfg, syncCfg, cfg.SafeHeadListener, nil)
 	return engine, verifier
 }
 

--- a/op-e2e/actions/proofs/block_data_hint_test.go
+++ b/op-e2e/actions/proofs/block_data_hint_test.go
@@ -154,5 +154,6 @@ func createVerifier(t actionsHelpers.Testing, env *helpers.L2FaultProofEnv) (*ac
 		env.Sd.RollupCfg,
 		&sync.Config{},
 		safedb.Disabled,
+		nil,
 	), engine
 }

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -1,75 +1,37 @@
 package proofs_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm/program"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-)
-
-var (
-	aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
-	bb = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 )
 
 func runSetCodeTxTypeTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
-
-	// hardcoded because it's not available until after we need it
-	bobAddr := common.HexToAddress("0x14dC79964da2C08b23698B3D3cc7Ca32193d9955")
-
-	// Create 2 contracts, (1) writes 42 to slot 42, (2) calls (1)
-	store42Program := program.New().Sstore(0x42, 0x42)
-	callBobProgram := program.New().Call(nil, bobAddr, 1, 0, 0, 0, 0)
-
-	alloc := *actionsHelpers.DefaultAlloc
-	alloc.L2Alloc = make(map[common.Address]types.Account)
-	alloc.L2Alloc[aa] = types.Account{
-		Code: store42Program.Bytes(),
-	}
-	alloc.L2Alloc[bb] = types.Account{
-		Code: callBobProgram.Bytes(),
-	}
-
-	testCfg.Allocs = &alloc
-
-	tp := helpers.NewTestParams()
-	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, helpers.NewBatcherCfg())
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
 
 	cl := env.Engine.EthClient()
+	sequencer := env.Sequencer
+	miner := env.Miner
 
-	env.Sequencer.ActL2PipelineFull(t)
-	env.Miner.ActEmptyBlock(t)
-	env.Sequencer.ActL2StartBlock(t)
+	miner.ActEmptyBlock(t)
+	sequencer.ActL1HeadSignal(t)
+
+	sequencer.ActL2EmptyBlock(t)
+
+	batcher := env.Batcher
 
 	aliceSecret := env.Alice.L2.Secret()
-	bobSecret := env.Bob.L2.Secret()
 
 	chainID := env.Sequencer.RollupCfg.L2ChainID
-
-	// Sign authorization tuples.
-	// The way the auths are combined, it becomes
-	// 1. tx -> addr1 which is delegated to 0xaaaa
-	// 2. addr1:0xaaaa calls into addr2:0xbbbb
-	// 3. addr2:0xbbbb  writes to storage
-	auth1, err := types.SignSetCode(aliceSecret, types.SetCodeAuthorization{
-		ChainID: *uint256.MustFromBig(chainID),
-		Address: bb,
-		Nonce:   1,
-	})
-	require.NoError(gt, err, "failed to sign auth1")
-	auth2, err := types.SignSetCode(bobSecret, types.SetCodeAuthorization{
-		Address: aa,
-		Nonce:   0,
-	})
-	require.NoError(gt, err, "failed to sign auth2")
 
 	txdata := &types.SetCodeTx{
 		ChainID:   uint256.MustFromBig(chainID),
@@ -78,44 +40,25 @@ func runSetCodeTxTypeTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		Gas:       500000,
 		GasFeeCap: uint256.NewInt(5000000000),
 		GasTipCap: uint256.NewInt(2),
-		AuthList:  []types.SetCodeAuthorization{auth1, auth2},
+		AuthList:  []types.SetCodeAuthorization{},
 	}
 	signer := types.NewIsthmusSigner(chainID)
 	tx := types.MustSignNewTx(aliceSecret, signer, txdata)
 
-	err = cl.SendTransaction(t.Ctx(), tx)
-	require.NoError(gt, err, "failed to send set code tx")
+	batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+		// inject user tx into upgrade batch
+		return block.WithBody(types.Body{Transactions: append(block.Transactions(), tx)})
+	})
 
-	_, err = env.Engine.EngineApi.IncludeTx(tx, env.Alice.Address())
-	require.NoError(t, err, "failed to include set code tx")
+	batcher.ActL2ChannelClose(t)
+	batcher.ActL2BatchSubmit(t)
 
-	env.Sequencer.ActL2EndBlock(t)
+	env.Miner.ActL1StartBlock(12)(t)
+	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+	env.Miner.ActL1EndBlock(t)
 
-	// Verify delegation designations were deployed.
-	bobCode, err := cl.PendingCodeAt(t.Ctx(), env.Bob.Address())
-	require.NoError(gt, err, "failed to get bob code")
-	want := types.AddressToDelegation(auth2.Address)
-	if !bytes.Equal(bobCode, want) {
-		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(bobCode), common.Bytes2Hex(want))
-	}
-	aliceCode, err := cl.PendingCodeAt(t.Ctx(), env.Alice.Address())
-	require.NoError(gt, err, "failed to get alice code")
-	want = types.AddressToDelegation(auth1.Address)
-	if !bytes.Equal(aliceCode, want) {
-		t.Fatalf("addr2 code incorrect: got %s, want %s", common.Bytes2Hex(aliceCode), common.Bytes2Hex(want))
-	}
-
-	// Verify delegation executed the correct code.
-	fortyTwo := common.BytesToHash([]byte{0x42})
-	actual, err := cl.PendingStorageAt(t.Ctx(), env.Bob.Address(), fortyTwo)
-	require.NoError(gt, err, "failed to get addr1 storage")
-
-	if !bytes.Equal(actual, fortyTwo[:]) {
-		t.Fatalf("addr2 storage wrong: expected %d, got %d", fortyTwo, actual)
-	}
-
-	// batch submit to L1. batcher should submit span batches.
-	env.BatchAndMine(t)
+	env.Sequencer.ActL1HeadSignal(t)
+	env.Sequencer.ActL2PipelineFull(t)
 
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
@@ -126,13 +69,49 @@ func runSetCodeTxTypeTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.RunFaultProofProgram(t, latestBlock.NumberU64(), testCfg.CheckResult, testCfg.InputParams...)
 }
 
+type setCodeParams struct {
+	fork rollup.ForkName
+}
+
 func TestSetCodeTx(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	matrix.AddDefaultTestCases(
-		nil,
-		helpers.LatestForkOnly,
-		runSetCodeTxTypeTest,
-	)
+	cases := []struct {
+		name          string
+		expectSuccess bool
+		hardfork      helpers.Hardfork
+	}{
+		{
+			name:          "PreIsthmus",
+			expectSuccess: false,
+			hardfork:      *helpers.Holocene,
+		},
+		{
+			name:          "Isthmus",
+			expectSuccess: true,
+			hardfork:      *helpers.Isthmus,
+		},
+	}
+
+	for _, c := range cases {
+		matrix.AddTestCase(
+			"HonestClaim-"+c.name+"-Failure",
+			nil,
+			helpers.NewForkMatrix(&c.hardfork),
+			runSetCodeTxTypeTest,
+			helpers.ExpectError(claim.ErrClaimNotValid),
+		)
+
+		if c.expectSuccess {
+			matrix.AddTestCase(
+				"JunkClaim-"+c.name,
+				nil,
+				helpers.NewForkMatrix(&c.hardfork),
+				runSetCodeTxTypeTest,
+				helpers.ExpectError(claim.ErrClaimNotValid),
+				helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+			)
+		}
+	}
 }

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -10,7 +10,6 @@ import (
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 )
 
@@ -67,10 +66,6 @@ func runSetCodeTxTypeTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	require.NoError(t, err, "error fetching latest block")
 
 	env.RunFaultProofProgram(t, latestBlock.NumberU64(), testCfg.CheckResult, testCfg.InputParams...)
-}
-
-type setCodeParams struct {
-	fork rollup.ForkName
 }
 
 func TestSetCodeTx(gt *testing.T) {

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -821,7 +821,7 @@ func TestELSyncTransitionsToCLSyncAfterNodeRestart(gt *testing.T) {
 	PrepareELSyncedNode(t, miner, sequencer, seqEng, verifier, verEng, seqEngCl, batcher, dp)
 
 	// Create a new verifier which is essentially a new op-node with the sync mode of ELSync and default geth engine kind.
-	verifier = actionsHelpers.NewL2Verifier(t, captureLog, miner.L1Client(t, sd.RollupCfg), miner.BlobStore(), altda.Disabled, verifier.Eng, sd.RollupCfg, &sync.Config{SyncMode: sync.ELSync}, actionsHelpers.DefaultVerifierCfg().SafeHeadListener)
+	verifier = actionsHelpers.NewL2Verifier(t, captureLog, miner.L1Client(t, sd.RollupCfg), miner.BlobStore(), altda.Disabled, verifier.Eng, sd.RollupCfg, &sync.Config{SyncMode: sync.ELSync}, actionsHelpers.DefaultVerifierCfg().SafeHeadListener, nil)
 
 	// Build another 10 L1 blocks on the sequencer
 	for i := 0; i < 10; i++ {
@@ -863,7 +863,7 @@ func TestForcedELSyncCLAfterNodeRestart(gt *testing.T) {
 	PrepareELSyncedNode(t, miner, sequencer, seqEng, verifier, verEng, seqEngCl, batcher, dp)
 
 	// Create a new verifier which is essentially a new op-node with the sync mode of ELSync and erigon engine kind.
-	verifier2 := actionsHelpers.NewL2Verifier(t, captureLog, miner.L1Client(t, sd.RollupCfg), miner.BlobStore(), altda.Disabled, verifier.Eng, sd.RollupCfg, &sync.Config{SyncMode: sync.ELSync, SupportsPostFinalizationELSync: true}, actionsHelpers.DefaultVerifierCfg().SafeHeadListener)
+	verifier2 := actionsHelpers.NewL2Verifier(t, captureLog, miner.L1Client(t, sd.RollupCfg), miner.BlobStore(), altda.Disabled, verifier.Eng, sd.RollupCfg, &sync.Config{SyncMode: sync.ELSync, SupportsPostFinalizationELSync: true}, actionsHelpers.DefaultVerifierCfg().SafeHeadListener, nil)
 
 	// Build another 10 L1 blocks on the sequencer
 	for i := 0; i < 10; i++ {

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -1,24 +1,18 @@
 package upgrades
 
 import (
-	"bytes"
 	"context"
-	"log/slog"
 	"math/big"
 	"testing"
 	"time"
 
-	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
-	upgradesHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/upgrades/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -31,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -467,162 +460,4 @@ func TestIsthmusNetworkUpgradeTransactions(gt *testing.T) {
 	latestBlock, err = ethCl.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err)
 	checkRecentBlockHash(latestBlock.NumberU64()-1, latestBlock.Header().ParentHash, "post-activation")
-}
-
-func TestSetCodeTxTypePreIsthmus(gt *testing.T) {
-	// Ensure that batches that include SetCodeTxs are dropped if before Isthmus
-	// Sets up a network with Isthmus starting at block 1
-	// Send SetCodeTx at block 3
-	// Verifier pipeline uses Isthmus starting at block 5
-	// Ensure verifier drops the batch with a SetCodeTx too early
-
-	t := helpers.NewDefaultTesting(gt)
-	p := &e2eutils.TestParams{
-		MaxSequencerDrift:   20,
-		SequencerWindowSize: 24,
-		ChannelTimeout:      20,
-		L1BlockTime:         12,
-		AllocType:           config.AllocTypeStandard,
-	}
-	dp := e2eutils.MakeDeployParams(t, p)
-	dp.DeployConfig.ActivateForkAtOffset(rollup.Isthmus, 2)
-	minTs := hexutil.Uint64(0)
-	upgradesHelpers.ApplyDeltaTimeOffset(dp, &minTs)
-
-	var (
-		aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
-		bb = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
-	)
-
-	// Create 2 contracts, (1) writes 42 to slot 42, (2) calls (1)
-	store42Program := program.New().Sstore(0x42, 0x42)
-	callBobProgram := program.New().Call(nil, dp.Addresses.Bob, 1, 0, 0, 0, 0)
-
-	alloc := helpers.DefaultAlloc
-	alloc.L2Alloc = make(map[common.Address]types.Account)
-	alloc.L2Alloc[aa] = types.Account{
-		Code: store42Program.Bytes(),
-	}
-	alloc.L2Alloc[bb] = types.Account{
-		Code: callBobProgram.Bytes(),
-	}
-
-	sd := e2eutils.Setup(t, dp, alloc)
-	log, captureLogger := testlog.CaptureLogger(t, log.LevelDebug)
-	miner, seqEngine, sequencer := helpers.SetupSequencerTest(t, sd, log)
-
-	l1F := miner.L1Client(t, sd.RollupCfg)
-	blobSrc := miner.BlobStore()
-	syncCfg := &sync.Config{}
-	cfg := helpers.DefaultVerifierCfg()
-	jwtPath := e2eutils.WriteDefaultJWT(t)
-	verifierEngine := helpers.NewL2Engine(t, log.New("role", "verifier-engine"), sd.L2Cfg, jwtPath, helpers.EngineWithP2P())
-	engCl := verifierEngine.EngineClient(t, sd.RollupCfg)
-
-	newIsthmusTime := uint64(sd.RollupCfg.Genesis.L2Time + 10)
-	newRollupCfg := *sd.RollupCfg
-	newRollupCfg.IsthmusTime = &newIsthmusTime
-	verifier := helpers.NewL2Verifier(t, log.New("role", "verifier"), l1F, blobSrc, altda.Disabled, engCl, sd.RollupCfg, syncCfg, cfg.SafeHeadListener, &newRollupCfg)
-
-	rollupSeqCl := sequencer.RollupClient()
-	cl := seqEngine.EthClient()
-
-	batcher := helpers.NewL2Batcher(log, sd.RollupCfg, &helpers.BatcherCfg{
-		MinL1TxSize:          0,
-		MaxL1TxSize:          128_000,
-		BatcherKey:           dp.Secrets.Batcher,
-		DataAvailabilityType: batcherFlags.CalldataType,
-		ForceSubmitSpanBatch: true,
-	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
-
-	sequencer.ActL2PipelineFull(t)
-	verifier.ActL2PipelineFull(t)
-
-	miner.ActEmptyBlock(t)
-
-	sequencer.ActL2StartBlock(t) // 1
-	sequencer.ActL2EndBlock(t)
-
-	sequencer.ActL2StartBlock(t) // 2
-	sequencer.ActL2EndBlock(t)
-
-	sequencer.ActL2StartBlock(t) // 3 (bad)
-
-	auth1, err := types.SignSetCode(dp.Secrets.Alice, types.SetCodeAuthorization{
-		ChainID: *uint256.NewInt(dp.DeployConfig.L2ChainID),
-		Address: bb,
-		Nonce:   1,
-	})
-	require.NoError(gt, err, "failed to sign auth1")
-	auth2, err := types.SignSetCode(dp.Secrets.Bob, types.SetCodeAuthorization{
-		Address: aa,
-		Nonce:   0,
-	})
-	require.NoError(gt, err, "failed to sign auth2")
-
-	txdata := &types.SetCodeTx{
-		ChainID:   uint256.NewInt(dp.DeployConfig.L2ChainID),
-		Nonce:     0,
-		To:        dp.Addresses.Alice,
-		Gas:       500000,
-		GasFeeCap: uint256.NewInt(5000000000),
-		GasTipCap: uint256.NewInt(2),
-		AuthList:  []types.SetCodeAuthorization{auth1, auth2},
-	}
-	signer := types.NewPragueSigner(new(big.Int).SetUint64(dp.DeployConfig.L2ChainID))
-	tx := types.MustSignNewTx(dp.Secrets.Alice, signer, txdata)
-
-	err = cl.SendTransaction(t.Ctx(), tx)
-	require.NoError(gt, err, "failed to send set code tx")
-
-	require.NoError(t, seqEngine.EngineApi.IncludeTx(tx, dp.Addresses.Alice), "failed to include set code tx")
-
-	sequencer.ActL2EndBlock(t)
-
-	// Verify delegation designations were deployed.
-	bobCode, err := cl.PendingCodeAt(t.Ctx(), dp.Addresses.Bob)
-	require.NoError(gt, err, "failed to get bob code")
-	want := types.AddressToDelegation(auth2.Address)
-	if !bytes.Equal(bobCode, want) {
-		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(bobCode), common.Bytes2Hex(want))
-	}
-	aliceCode, err := cl.PendingCodeAt(t.Ctx(), dp.Addresses.Alice)
-	require.NoError(gt, err, "failed to get alice code")
-	want = types.AddressToDelegation(auth1.Address)
-	if !bytes.Equal(aliceCode, want) {
-		t.Fatalf("addr2 code incorrect: got %s, want %s", common.Bytes2Hex(aliceCode), common.Bytes2Hex(want))
-	}
-
-	// Verify delegation executed the correct code.
-	fortyTwo := common.BytesToHash([]byte{0x42})
-	actual, err := cl.PendingStorageAt(t.Ctx(), dp.Addresses.Bob, fortyTwo)
-	require.NoError(gt, err, "failed to get addr1 storage")
-
-	if !bytes.Equal(actual, fortyTwo[:]) {
-		t.Fatalf("addr2 storage wrong: expected %d, got %d", fortyTwo, actual)
-	}
-
-	// batch submit to L1. batcher should submit span batches.
-	batcher.ActSubmitAll(t)
-	miner.ActL1StartBlock(12)(t)
-	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
-	miner.ActL1EndBlock(t)
-
-	sequencer.ActL1HeadSignal(t)
-	sequencer.ActL2PipelineFull(t)
-
-	verifier.ActL1HeadSignal(t)
-	verifier.ActL2PipelineFull(t)
-
-	levelFilter := testlog.NewLevelFilter(slog.LevelWarn)
-	msgFilter := testlog.NewMessageFilter("sequencers may not embed any SetCode transactions before Isthmus")
-	msg := captureLogger.FindLog(levelFilter, msgFilter)
-	require.NotNil(t, msg)
-
-	// ensure sequencer has the latest block finalized
-	require.Equal(t, sequencer.L2Unsafe(), sequencer.L2Safe())
-
-	// ensure verifier dropped the last singular batch
-	require.Equal(t, uint64(2), verifier.SyncStatus().SafeL2.Number)
-	require.Equal(t, uint64(2), verifier.SyncStatus().UnsafeL2.Number)
 }

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -1,18 +1,24 @@
 package upgrades
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"math/big"
 	"testing"
 	"time"
 
+	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	upgradesHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/upgrades/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -25,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -460,4 +467,162 @@ func TestIsthmusNetworkUpgradeTransactions(gt *testing.T) {
 	latestBlock, err = ethCl.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err)
 	checkRecentBlockHash(latestBlock.NumberU64()-1, latestBlock.Header().ParentHash, "post-activation")
+}
+
+func TestSetCodeTxTypePreIsthmus(gt *testing.T) {
+	// Ensure that batches that include SetCodeTxs are dropped if before Isthmus
+	// Sets up a network with Isthmus starting at block 1
+	// Send SetCodeTx at block 3
+	// Verifier pipeline uses Isthmus starting at block 5
+	// Ensure verifier drops the batch with a SetCodeTx too early
+
+	t := helpers.NewDefaultTesting(gt)
+	p := &e2eutils.TestParams{
+		MaxSequencerDrift:   20,
+		SequencerWindowSize: 24,
+		ChannelTimeout:      20,
+		L1BlockTime:         12,
+		AllocType:           config.AllocTypeStandard,
+	}
+	dp := e2eutils.MakeDeployParams(t, p)
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Isthmus, 2)
+	minTs := hexutil.Uint64(0)
+	upgradesHelpers.ApplyDeltaTimeOffset(dp, &minTs)
+
+	var (
+		aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+		bb = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
+	)
+
+	// Create 2 contracts, (1) writes 42 to slot 42, (2) calls (1)
+	store42Program := program.New().Sstore(0x42, 0x42)
+	callBobProgram := program.New().Call(nil, dp.Addresses.Bob, 1, 0, 0, 0, 0)
+
+	alloc := helpers.DefaultAlloc
+	alloc.L2Alloc = make(map[common.Address]types.Account)
+	alloc.L2Alloc[aa] = types.Account{
+		Code: store42Program.Bytes(),
+	}
+	alloc.L2Alloc[bb] = types.Account{
+		Code: callBobProgram.Bytes(),
+	}
+
+	sd := e2eutils.Setup(t, dp, alloc)
+	log, captureLogger := testlog.CaptureLogger(t, log.LevelDebug)
+	miner, seqEngine, sequencer := helpers.SetupSequencerTest(t, sd, log)
+
+	l1F := miner.L1Client(t, sd.RollupCfg)
+	blobSrc := miner.BlobStore()
+	syncCfg := &sync.Config{}
+	cfg := helpers.DefaultVerifierCfg()
+	jwtPath := e2eutils.WriteDefaultJWT(t)
+	verifierEngine := helpers.NewL2Engine(t, log.New("role", "verifier-engine"), sd.L2Cfg, jwtPath, helpers.EngineWithP2P())
+	engCl := verifierEngine.EngineClient(t, sd.RollupCfg)
+
+	newIsthmusTime := uint64(sd.RollupCfg.Genesis.L2Time + 10)
+	newRollupCfg := *sd.RollupCfg
+	newRollupCfg.IsthmusTime = &newIsthmusTime
+	verifier := helpers.NewL2Verifier(t, log.New("role", "verifier"), l1F, blobSrc, altda.Disabled, engCl, sd.RollupCfg, syncCfg, cfg.SafeHeadListener, &newRollupCfg)
+
+	rollupSeqCl := sequencer.RollupClient()
+	cl := seqEngine.EthClient()
+
+	batcher := helpers.NewL2Batcher(log, sd.RollupCfg, &helpers.BatcherCfg{
+		MinL1TxSize:          0,
+		MaxL1TxSize:          128_000,
+		BatcherKey:           dp.Secrets.Batcher,
+		DataAvailabilityType: batcherFlags.CalldataType,
+		ForceSubmitSpanBatch: true,
+	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
+
+	sequencer.ActL2PipelineFull(t)
+	verifier.ActL2PipelineFull(t)
+
+	miner.ActEmptyBlock(t)
+
+	sequencer.ActL2StartBlock(t) // 1
+	sequencer.ActL2EndBlock(t)
+
+	sequencer.ActL2StartBlock(t) // 2
+	sequencer.ActL2EndBlock(t)
+
+	sequencer.ActL2StartBlock(t) // 3 (bad)
+
+	auth1, err := types.SignSetCode(dp.Secrets.Alice, types.SetCodeAuthorization{
+		ChainID: *uint256.NewInt(dp.DeployConfig.L2ChainID),
+		Address: bb,
+		Nonce:   1,
+	})
+	require.NoError(gt, err, "failed to sign auth1")
+	auth2, err := types.SignSetCode(dp.Secrets.Bob, types.SetCodeAuthorization{
+		Address: aa,
+		Nonce:   0,
+	})
+	require.NoError(gt, err, "failed to sign auth2")
+
+	txdata := &types.SetCodeTx{
+		ChainID:   uint256.NewInt(dp.DeployConfig.L2ChainID),
+		Nonce:     0,
+		To:        dp.Addresses.Alice,
+		Gas:       500000,
+		GasFeeCap: uint256.NewInt(5000000000),
+		GasTipCap: uint256.NewInt(2),
+		AuthList:  []types.SetCodeAuthorization{auth1, auth2},
+	}
+	signer := types.NewPragueSigner(new(big.Int).SetUint64(dp.DeployConfig.L2ChainID))
+	tx := types.MustSignNewTx(dp.Secrets.Alice, signer, txdata)
+
+	err = cl.SendTransaction(t.Ctx(), tx)
+	require.NoError(gt, err, "failed to send set code tx")
+
+	require.NoError(t, seqEngine.EngineApi.IncludeTx(tx, dp.Addresses.Alice), "failed to include set code tx")
+
+	sequencer.ActL2EndBlock(t)
+
+	// Verify delegation designations were deployed.
+	bobCode, err := cl.PendingCodeAt(t.Ctx(), dp.Addresses.Bob)
+	require.NoError(gt, err, "failed to get bob code")
+	want := types.AddressToDelegation(auth2.Address)
+	if !bytes.Equal(bobCode, want) {
+		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(bobCode), common.Bytes2Hex(want))
+	}
+	aliceCode, err := cl.PendingCodeAt(t.Ctx(), dp.Addresses.Alice)
+	require.NoError(gt, err, "failed to get alice code")
+	want = types.AddressToDelegation(auth1.Address)
+	if !bytes.Equal(aliceCode, want) {
+		t.Fatalf("addr2 code incorrect: got %s, want %s", common.Bytes2Hex(aliceCode), common.Bytes2Hex(want))
+	}
+
+	// Verify delegation executed the correct code.
+	fortyTwo := common.BytesToHash([]byte{0x42})
+	actual, err := cl.PendingStorageAt(t.Ctx(), dp.Addresses.Bob, fortyTwo)
+	require.NoError(gt, err, "failed to get addr1 storage")
+
+	if !bytes.Equal(actual, fortyTwo[:]) {
+		t.Fatalf("addr2 storage wrong: expected %d, got %d", fortyTwo, actual)
+	}
+
+	// batch submit to L1. batcher should submit span batches.
+	batcher.ActSubmitAll(t)
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
+	miner.ActL1EndBlock(t)
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+
+	levelFilter := testlog.NewLevelFilter(slog.LevelWarn)
+	msgFilter := testlog.NewMessageFilter("sequencers may not embed any SetCode transactions before Isthmus")
+	msg := captureLogger.FindLog(levelFilter, msgFilter)
+	require.NotNil(t, msg)
+
+	// ensure sequencer has the latest block finalized
+	require.Equal(t, sequencer.L2Unsafe(), sequencer.L2Safe())
+
+	// ensure verifier dropped the last singular batch
+	require.Equal(t, uint64(2), verifier.SyncStatus().SafeL2.Number)
+	require.Equal(t, uint64(2), verifier.SyncStatus().UnsafeL2.Number)
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -161,6 +161,8 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 		}
 	}
 
+	isIsthmus := cfg.IsIsthmus(batch.Timestamp)
+
 	// We can do this check earlier, but it's a more intensive one, so we do this last.
 	for i, txBytes := range batch.Transactions {
 		if len(txBytes) == 0 {
@@ -169,6 +171,10 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 		}
 		if txBytes[0] == types.DepositTxType {
 			log.Warn("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", i)
+			return BatchDrop
+		}
+		if !isIsthmus && txBytes[0] == types.SetCodeTxType {
+			log.Warn("sequencers may not embed any SetCode transactions before Isthmus", "tx_index", i)
 			return BatchDrop
 		}
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a test to ensure SetCode transactions before Isthmus result in the channel being dropped.

This is tested by configuring a network to hardfork to Isthmus prior to the derivation pipeline of the verifier. When the verifier tries to check the singular batch containing a SetCode tx, it drops the batch and prints an error which is checked by the test.
