### PR TITLE
fix: bump patch version for mise orb.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ orbs:
   slack: circleci/slack@4.10.1
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.7
+  utils: ethereum-optimism/circleci-utils@1.0.8
 
 commands:
   gcp-oidc-authenticate:


### PR DESCRIPTION
releated: https://github.com/ethereum-optimism/circleci-utils/pull/9 

Closes: https://github.com/ethereum-optimism/superchain-registry/issues/892 