### PR TITLE
op-e2e: Fix fpp bls precompile tests

### DIFF
--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -49,7 +49,7 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 			ctx := context.Background()
 			genesisTime := hexutil.Uint64(0)
-			cfg := e2esys.EcotoneSystemConfig(t, &genesisTime, e2esys.WithAllocType(allocType))
+			cfg := e2esys.IsthmusSystemConfig(t, &genesisTime, e2esys.WithAllocType(allocType))
 			// We don't need a verifier - just the sequencer is enough
 			delete(cfg.Nodes, "verifier")
 
@@ -107,7 +107,7 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 				t.Skipf("%v is not accelerated so no preimgae to upload", test.Name)
 			}
 			ctx := context.Background()
-			sys, _ := StartFaultDisputeSystem(t, WithBlobBatches(), WithAllocType(allocType))
+			sys, _ := StartFaultDisputeSystem(t, WithLatestFork(), WithAllocType(allocType))
 
 			l2Seq := sys.NodeClient("sequencer")
 			aliceKey := sys.Cfg.Secrets.Alice

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -44,6 +44,22 @@ func WithBlobBatches() faultDisputeConfigOpts {
 	}
 }
 
+func WithLatestFork() faultDisputeConfigOpts {
+	return func(fdc *faultDisputeConfig) {
+		fdc.cfgModifiers = append(fdc.cfgModifiers, func(cfg *e2esys.SystemConfig) {
+			genesisActivation := hexutil.Uint64(0)
+			cfg.DeployConfig.L1CancunTimeOffset = &genesisActivation
+			cfg.DeployConfig.L1PragueTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisDeltaTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisFjordTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisGraniteTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisHoloceneTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisIsthmusTimeOffset = &genesisActivation
+		})
+	}
+}
+
 func WithEcotone() faultDisputeConfigOpts {
 	return func(fdc *faultDisputeConfig) {
 		fdc.cfgModifiers = append(fdc.cfgModifiers, func(cfg *e2esys.SystemConfig) {


### PR DESCRIPTION
The bls precompiles tested weren't activated on the test setup.