### PR TITLE
fix: add mirrored restrictions to lite profile

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -13,6 +13,11 @@ snapshots = 'notarealpath' # workaround for foundry#9477
 optimizer = true
 optimizer_runs = 999999
 
+# IMPORTANT:
+# When adding any new compiler profiles or compilation restrictions, you must
+# also update the restrictions in the "LITE" profile to match. This guarantees
+# that builds will fully overwrite one another without needing to clean the
+# entire build directory.
 additional_compiler_profiles = [
   { name = "dispute", optimizer_runs = 5000 },
 ]
@@ -121,8 +126,17 @@ timeout = 300
 
 [profile.lite]
 optimizer = false
-compilation_restrictions = []
 
+# IMPORTANT:
+# See the info in the "DEFAULT" profile to understand this section.
+additional_compiler_profiles = [
+  { name = "dispute", optimizer_runs = 0 },
+]
+compilation_restrictions = [
+  { paths = "src/dispute/FaultDisputeGame.sol", optimizer_runs = 0 },
+  { paths = "src/dispute/PermissionedDisputeGame.sol", optimizer_runs = 0 },
+  { paths = "src/L1/OPContractsManager.sol", optimizer_runs = 0 },
+]
 
 ################################################################
 #                         PROFILE: KONTROL                     #


### PR DESCRIPTION
Adds mirrored compiler restrictions to the lite profile so that all generated artifacts get overwritten when switching between build and build-dev.