### PR TITLE
op-node: Define message expiry time constant

### DIFF
--- a/op-node/params/constants.go
+++ b/op-node/params/constants.go
@@ -1,6 +1,8 @@
 package params
 
 const (
-	// Post-Granite constant: Number of L1 blocks between when a channel can be opened and when it must be closed by.
+	// ChannelTimeoutGranite is a post-Granite constant: Number of L1 blocks between when a channel can be opened and when it must be closed by.
 	ChannelTimeoutGranite uint64 = 50
+	// MessageExpiryTimeSecondsInterop is a post-Interop constant for the minimum age of a message before it can be considered executable
+	MessageExpiryTimeSecondsInterop = 15552000
 )

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	opparams "github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -149,6 +150,11 @@ type Config struct {
 	// parameters to the protocol values, like the execution layer does.
 	// If missing, it is loaded by the op-node from the embedded superchain config at startup.
 	ChainOpConfig *params.OptimismConfig `json:"chain_op_config,omitempty"`
+
+	// OverrideMessageExpiryTimeInterop is only used for testing purposes.
+	// It is used to override the protocol-defined interop message time expiry.
+	// DO NOT this read value directly. Use GetMessageExpiryTimeInterop instead.
+	OverrideMessageExpiryTimeInterop uint64 `json:"override_message_expiry_time_interop,omitempty"`
 }
 
 // ValidateL1Config checks L1 config variables for errors.
@@ -608,6 +614,16 @@ func (c *Config) GetOPAltDAConfig() (altda.Config, error) {
 		ResolveWindow:              c.AltDAConfig.DAResolveWindow,
 		CommitmentType:             t,
 	}, nil
+}
+
+// GetMessageExpiryTimeInterop returns the expiry time of interop messages in seconds.
+// If a message expiry override is set in the rollup config, it returns the override value.
+// Otherwise, it returns the protocol-defined interop message time expiry.
+func (c *Config) GetMessageExpiryTimeInterop() uint64 {
+	if c.OverrideMessageExpiryTimeInterop != 0 {
+		return c.OverrideMessageExpiryTimeInterop
+	}
+	return opparams.MessageExpiryTimeSecondsInterop
 }
 
 func (c *Config) AltDAEnabled() bool {

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -822,4 +823,11 @@ func TestConfigImplementsBlockType(t *testing.T) {
 			assert.Equal(t, config.HasOptimismWithdrawalsRoot(test.blockTime), test.hasOptimismWithdrawalsRoot)
 		})
 	}
+}
+
+func TestConfig_GetMessageExpiryTimeInterop(t *testing.T) {
+	config := randConfig()
+	assert.Equal(t, config.GetMessageExpiryTimeInterop(), uint64(params.MessageExpiryTimeSecondsInterop))
+	config.OverrideMessageExpiryTimeInterop = 100
+	assert.Equal(t, config.GetMessageExpiryTimeInterop(), uint64(100))
 }


### PR DESCRIPTION
Also adds a way to override the message expiry time via the rollup config. This is done as a convenience for easier interop testing.