### PR TITLE
op-program: Fast canonical block lookup

### DIFF
--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -114,6 +114,9 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 	if optimismChainConfig.IsHolocene(genesis.Timestamp) {
 		genesis.ExtraData = HoloceneExtraData
 	}
+	if optimismChainConfig.IsIsthmus(genesis.Timestamp) {
+		genesis.Alloc[params.HistoryStorageAddress] = types.Account{Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0}
+	}
 
 	return genesis, nil
 }

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -45,7 +45,9 @@ func BuildL2Genesis(config *DeployConfig, dump *foundry.ForgeAllocs, l1StartBloc
 	if err != nil {
 		return nil, err
 	}
-	genspec.Alloc = dump.Copy().Accounts
+	for addr, val := range dump.Copy().Accounts {
+		genspec.Alloc[addr] = val
+	}
 	// ensure the dev accounts are not funded unintentionally
 	if devAccounts, err := RetrieveDevAccounts(genspec.Alloc); err != nil {
 		return nil, fmt.Errorf("failed to check dev accounts: %w", err)

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -320,7 +320,9 @@ func CompleteL2(l2Host *script.Host, cfg *L2Config, l1Block *types.Block, deploy
 		allocs.Accounts[addr] = acc
 	}
 
-	l2Genesis.Alloc = allocs.Accounts
+	for addr, account := range allocs.Accounts {
+		l2Genesis.Alloc[addr] = account
+	}
 	l2GenesisBlock := l2Genesis.ToBlock()
 
 	rollupCfg, err := deployCfg.RollupConfig(l1Block.Header(), l2GenesisBlock.Hash(), l2GenesisBlock.NumberU64())

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -205,7 +205,7 @@ func newConsolidateCheckDeps(bootInfo *boot.BootInfoInterop, transitionState *ty
 
 func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes.ContainsQuery) (includedIn supervisortypes.BlockSeal, err error) {
 	// We can assume the oracle has the block the executing message is in
-	block, err := d.BlockByNumber(d.oracle, query.BlockNum, chain)
+	block, err := d.CanonBlockByNumber(d.oracle, query.BlockNum, chain)
 	if err != nil {
 		return supervisortypes.BlockSeal{}, err
 	}
@@ -227,7 +227,7 @@ func (d *consolidateCheckDeps) IsLocalUnsafe(chainID eth.ChainID, block eth.Bloc
 }
 
 func (d *consolidateCheckDeps) ParentBlock(chainID eth.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error) {
-	block, err := d.BlockByNumber(d.oracle, parentOf.Number-1, chainID)
+	block, err := d.CanonBlockByNumber(d.oracle, parentOf.Number-1, chainID)
 	if err != nil {
 		return eth.BlockID{}, err
 	}
@@ -241,7 +241,7 @@ func (d *consolidateCheckDeps) OpenBlock(
 	chainID eth.ChainID,
 	blockNum uint64,
 ) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*supervisortypes.ExecutingMessage, err error) {
-	block, err := d.BlockByNumber(d.oracle, blockNum, chainID)
+	block, err := d.CanonBlockByNumber(d.oracle, blockNum, chainID)
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, err
 	}
@@ -265,7 +265,7 @@ func (d *consolidateCheckDeps) DependencySet() depset.DependencySet {
 	return d.depset
 }
 
-func (d *consolidateCheckDeps) BlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
+func (d *consolidateCheckDeps) CanonBlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
 	head := d.canonBlocks[chainID].GetHeaderByNumber(blockNum)
 	if head == nil {
 		return nil, fmt.Errorf("head not found for chain %v", chainID)

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -59,7 +60,7 @@ func RunConsolidation(
 	superRoot *eth.SuperV1,
 	tasks taskExecutor,
 ) (eth.Bytes32, error) {
-	deps, err := newConsolidateCheckDeps(transitionState, superRoot.Chains, l2PreimageOracle)
+	deps, err := newConsolidateCheckDeps(bootInfo, transitionState, superRoot.Chains, l2PreimageOracle)
 	if err != nil {
 		return eth.Bytes32{}, fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
@@ -157,10 +158,10 @@ func checkHazards(
 type consolidateCheckDeps struct {
 	oracle      l2.Oracle
 	depset      depset.DependencySet
-	canonBlocks map[eth.ChainID]*l2.CanonicalBlockHeaderOracle
+	canonBlocks map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle
 }
 
-func newConsolidateCheckDeps(transitionState *types.TransitionState, chains []eth.ChainIDAndOutput, oracle l2.Oracle) (*consolidateCheckDeps, error) {
+func newConsolidateCheckDeps(bootInfo *boot.BootInfoInterop, transitionState *types.TransitionState, chains []eth.ChainIDAndOutput, oracle l2.Oracle) (*consolidateCheckDeps, error) {
 	// TODO: handle case where dep set changes in a given timestamp
 	// TODO: Also replace dep set stubs with the actual dependency set in the RollupConfig.
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
@@ -172,7 +173,7 @@ func newConsolidateCheckDeps(transitionState *types.TransitionState, chains []et
 		}
 	}
 
-	canonBlocks := make(map[eth.ChainID]*l2.CanonicalBlockHeaderOracle)
+	canonBlocks := make(map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle)
 	for i, chain := range chains {
 		progress := transitionState.PendingProgress[i]
 		// This is the optimistic head. It's OK if it's replaced by a deposits-only block.
@@ -182,7 +183,12 @@ func newConsolidateCheckDeps(transitionState *types.TransitionState, chains []et
 		blockByHash := func(hash common.Hash) *ethtypes.Block {
 			return oracle.BlockByHash(hash, chain.ChainID)
 		}
-		canonBlocks[chain.ChainID] = l2.NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
+		l2ChainConfig, err := bootInfo.Configs.ChainConfig(chain.ChainID)
+		if err != nil {
+			return nil, fmt.Errorf("no chain config available for chain ID %v: %w", chain.ChainID, err)
+		}
+		fallback := l2.NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
+		canonBlocks[chain.ChainID] = l2.NewFastCanonicalBlockHeaderOracle(head.Header(), blockByHash, l2ChainConfig, oracle, rawdb.NewMemoryDatabase(), fallback)
 	}
 
 	depset, err := depset.NewStaticConfigDependencySet(deps)

--- a/op-program/client/l2/canon.go
+++ b/op-program/client/l2/canon.go
@@ -77,6 +77,9 @@ func (o *CanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Has
 			break
 		}
 		o.hashByNum[h.Number.Uint64()] = newHash
+		if h.Number.Uint64() == 0 {
+			break
+		}
 		h = o.blockByHashFn(h.ParentHash).Header()
 	}
 	o.earliestIndexedBlock = h

--- a/op-program/client/l2/canon.go
+++ b/op-program/client/l2/canon.go
@@ -78,6 +78,7 @@ func (o *CanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Has
 		}
 		o.hashByNum[h.Number.Uint64()] = newHash
 		if h.Number.Uint64() == 0 {
+			// Reachable if there aren't any cached blocks at or before the common ancestor
 			break
 		}
 		h = o.blockByHashFn(h.ParentHash).Header()

--- a/op-program/client/l2/canon_test.go
+++ b/op-program/client/l2/canon_test.go
@@ -123,15 +123,26 @@ func TestCanonicalBlockNumberOracle_SetCanonical(t *testing.T) {
 		chainCfg, blocks, oracle := setupOracle(t, blockCount, headBlockNumber, true)
 		head := blocks[headBlockNumber].Header()
 
+		blockRequestCount := 0
 		blockByHash := func(hash common.Hash) *types.Block {
+			blockRequestCount++
 			return oracle.BlockByHash(hash, eth.ChainIDFromBig(chainCfg.ChainID))
 		}
 		canon := NewCanonicalBlockHeaderOracle(head, blockByHash)
-		// the cache is empty (save for the head) so this should reset the cache up to genesis
-		canon.SetCanonical(blocks[2].Header())
-		require.Nil(t, canon.GetHeaderByNumber(3))
-		require.Equal(t, blocks[2].Hash(), canon.CurrentHeader().Hash())
-		require.Equal(t, blocks[1].Hash(), canon.GetHeaderByNumber(1).Hash())
-		require.Equal(t, blocks[0].Hash(), canon.GetHeaderByNumber(0).Hash())
+		oracle.Blocks[blocks[2].Hash()] = blocks[2]
+		oracle.Blocks[blocks[1].Hash()] = blocks[1]
+		oracle.Blocks[blocks[0].Hash()] = blocks[0]
+
+		// create a fork at genesis
+		header1b := *blocks[1].Header()
+		header1b.Time = header1b.Time + 2
+		block1b := types.NewBlockWithHeader(&header1b)
+		require.NotEqual(t, blocks[1].Hash(), block1b.Hash())
+		oracle.Blocks[block1b.Hash()] = block1b
+
+		canon.SetCanonical(block1b.Header())
+		blockRequestCount = 0
+		require.Equal(t, block1b.Hash(), canon.CurrentHeader().Hash())
+		require.Equal(t, 0, blockRequestCount, "Should not have needed to fetch a block")
 	})
 }

--- a/op-program/client/l2/engine_backend.go
+++ b/op-program/client/l2/engine_backend.go
@@ -30,7 +30,7 @@ type OracleBackedL2Chain struct {
 	finalized  *types.Header
 	vmCfg      vm.Config
 
-	canon *CanonicalBlockHeaderOracle
+	canon *FastCanonicalBlockHeaderOracle
 
 	// Inserted blocks
 	blocks map[common.Hash]*types.Block
@@ -92,7 +92,8 @@ func NewOracleBackedL2ChainFromHead(
 	blockByHash := func(hash common.Hash) *types.Block {
 		return chain.GetBlockByHash(hash)
 	}
-	chain.canon = NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
+	fallback := NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
+	chain.canon = NewFastCanonicalBlockHeaderOracle(head.Header(), blockByHash, chainCfg, oracle, db, fallback)
 	return chain
 }
 

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -147,11 +147,7 @@ func (o *FastCanonicalBlockHeaderOracle) getHistoricalBlockHash(head *types.Head
 func (o *FastCanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Hash {
 	o.head = head
 	o.fallback.SetCanonical(head)
-	for _, number := range o.cache.Keys() {
-		if number >= head.Number.Uint64() {
-			o.cache.Remove(number)
-		}
-	}
+	o.cache.Purge()
 	return head.Hash()
 }
 

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -1,0 +1,169 @@
+package l2
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+// historicalCacheSize is the number of cached eip-2935 historical block lookups
+// This covers 4 weeks worth of blocks on a 2 second block time.
+// We keep the cache size small to reduce memory usage and to ensure cache scans are fast.
+const historicalCacheSize = 160
+
+type FastCanonicalBlockHeaderOracle struct {
+	head          *types.Header
+	blockByHashFn BlockByHashFn
+	config        *params.ChainConfig
+	fallback      *CanonicalBlockHeaderOracle
+	ctx           *chainContext
+	db            ethdb.KeyValueStore
+	cache         *simplelru.LRU[uint64, *types.Header]
+}
+
+func NewFastCanonicalBlockHeaderOracle(
+	head *types.Header,
+	blockByHashFn BlockByHashFn,
+	chainCfg *params.ChainConfig,
+	stateOracle StateOracle,
+	kvdb KeyValueStore,
+	fallback *CanonicalBlockHeaderOracle,
+) *FastCanonicalBlockHeaderOracle {
+	chainID := eth.ChainIDFromBig(chainCfg.ChainID)
+	ctx := &chainContext{engine: beacon.New(nil)}
+	db := NewOracleBackedDB(kvdb, stateOracle, chainID)
+	cache, _ := simplelru.NewLRU[uint64, *types.Header](historicalCacheSize, nil)
+	return &FastCanonicalBlockHeaderOracle{
+		head:          head,
+		blockByHashFn: blockByHashFn,
+		config:        chainCfg,
+		fallback:      fallback,
+		ctx:           ctx,
+		db:            db,
+		cache:         cache,
+	}
+}
+
+func (o *FastCanonicalBlockHeaderOracle) CurrentHeader() *types.Header {
+	return o.head
+}
+
+func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {
+	if o.head.Number.Uint64() < n {
+		return nil
+	}
+	if o.head.Number.Uint64() == n {
+		return o.head
+	}
+
+	// scan the cache for a header that contains the requested block in its historical block window
+	cover := uint64(math.MaxUint64)
+	for _, number := range o.cache.Keys() {
+		if number >= n && number < cover {
+			cover = number
+		}
+	}
+	h := o.head
+	if cover != math.MaxUint64 {
+		h, _ = o.cache.Get(cover)
+	}
+
+	for h.Number.Uint64() >= n {
+		headNumber := h.Number.Uint64()
+		if headNumber == n {
+			return h
+		}
+		if !o.config.IsIsthmus(h.Time) {
+			return o.fallback.GetHeaderByNumber(n)
+		}
+		var currEarliestHistory uint64
+		if params.HistoryServeWindow-1 < headNumber {
+			currEarliestHistory = headNumber - (params.HistoryServeWindow - 1)
+		}
+		if currEarliestHistory <= n {
+			block := o.getHistoricalBlockHash(h, n)
+			if block == nil {
+				return o.fallback.GetHeaderByNumber(n)
+			}
+			return block.Header()
+		}
+		block := o.getHistoricalBlockHash(h, uint64(currEarliestHistory))
+		if block == nil {
+			return o.fallback.GetHeaderByNumber(n)
+		}
+		h = block.Header()
+		o.cache.Add(h.Number.Uint64(), h)
+	}
+	return h
+}
+
+func (o *FastCanonicalBlockHeaderOracle) getHistoricalBlockHash(head *types.Header, n uint64) *types.Block {
+	statedb, err := state.New(head.Root, state.NewDatabase(triedb.NewDatabase(rawdb.NewDatabase(o.db), nil), nil))
+	if err != nil {
+		panic(fmt.Errorf("failed to get state at %v: %w", head.Hash(), err))
+	}
+	// for safety. But it shouldn't be required since we only read from state
+	statedb.MakeSinglethreaded()
+
+	context := core.NewEVMBlockContext(head, o.ctx, nil, o.config, statedb)
+	vmenv := vm.NewEVM(context, statedb, o.config, vm.Config{})
+	var caller vm.AccountRef // can be anything as long aa it's not the system contract
+	gas := uint64(1000000)
+	var input [32]byte
+	binary.BigEndian.PutUint64(input[24:], n)
+	ret, _, err := vmenv.StaticCall(caller, params.HistoryStorageAddress, input[:], gas)
+	if err != nil {
+		panic(fmt.Errorf("failed to get history block hash: %w", err))
+	}
+	if len(ret) != 32 {
+		panic(fmt.Errorf("invalid history storage result. got %d bytes, expected %d bytes", len(ret), common.HashLength))
+	}
+	hash := common.Hash(ret)
+	if hash == (common.Hash{}) {
+		// we're near eip-2935 activation so the history ringbuffer isn't filled up yet
+		return nil
+	}
+	header := o.blockByHashFn(hash)
+	if header == nil {
+		panic(fmt.Errorf("failed to get history block header for %v", n))
+	}
+	return header
+}
+
+func (o *FastCanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Hash {
+	o.head = head
+	o.fallback.SetCanonical(head)
+	for _, number := range o.cache.Keys() {
+		if number >= head.Number.Uint64() {
+			o.cache.Remove(number)
+		}
+	}
+	return head.Hash()
+}
+
+type chainContext struct {
+	engine consensus.Engine
+}
+
+func (c *chainContext) Engine() consensus.Engine {
+	return c.engine
+}
+
+func (c *chainContext) GetHeader(hash common.Hash, number uint64) *types.Header {
+	// The EVM should never call this method during eip-2935 historical block retrieval
+	panic("unexpected call to GetHeader")
+}

--- a/op-program/client/l2/fast_canon_test.go
+++ b/op-program/client/l2/fast_canon_test.go
@@ -1,0 +1,277 @@
+package l2
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-program/client/l2/test"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFastCanonBlockHeaderOracle_GetHeaderByNumber(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+	miner, backend := test.NewMiner(t, logger, 0)
+	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+	miner.Mine(t, nil)
+	miner.Mine(t, nil)
+	miner.Mine(t, nil)
+	head := backend.CurrentHeader()
+	require.Equal(t, uint64(3), head.Number.Uint64())
+
+	// Create invalid fallback to assert that it's never used.
+	fatalBlockByHash := func(hash common.Hash) *types.Block {
+		t.Fatalf("Unexpected fallback for block: %v", hash)
+		return nil
+	}
+	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
+	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
+
+	// Ensure we read directly from historical state on every lookup by failing if a block is loaded multiple times.
+	requestedBlocks := make(map[common.Hash]bool)
+	blockByHash := func(hash common.Hash) *types.Block {
+		if requestedBlocks[hash] {
+			t.Fatalf("Requested duplicate block: %v", hash)
+		}
+		requestedBlocks[hash] = true
+		return backend.GetBlockByHash(hash)
+	}
+	canon := NewFastCanonicalBlockHeaderOracle(head, blockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
+	require.Nil(t, canon.GetHeaderByNumber(4))
+
+	h := canon.GetHeaderByNumber(3)
+	require.Equal(t, backend.GetBlockByNumber(3).Hash(), h.Hash())
+	h = canon.GetHeaderByNumber(2)
+	require.Equal(t, backend.GetBlockByNumber(2).Hash(), h.Hash())
+	h = canon.GetHeaderByNumber(1)
+	require.Equal(t, backend.GetBlockByNumber(1).Hash(), h.Hash())
+	h = canon.GetHeaderByNumber(0)
+	require.Equal(t, backend.GetBlockByNumber(0).Hash(), h.Hash())
+}
+
+func TestFastCanonBlockHeaderOracle_LargeWindow(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+	miner, backend := test.NewMiner(t, logger, 0)
+	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+	numBlocks := 16384 // params.HistoryServeWindow * 2
+	for i := 0; i < numBlocks; i++ {
+		miner.Mine(t, nil)
+	}
+	head := backend.CurrentHeader()
+	headNum := head.Number.Uint64()
+	require.Equal(t, uint64(numBlocks), headNum)
+	// Note: we have three non-overlapping historical block windows
+	// head: [8193, 16383]
+	// 8193: [2, 8192]
+	// 2:    [0, 1]
+
+	// Create invalid fallback to assert that it's never used.
+	fatalBlockByHash := func(hash common.Hash) *types.Block {
+		t.Fatalf("Unexpected fallback for block: %v", hash)
+		return nil
+	}
+	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
+	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
+
+	requestedBlocks := make(map[common.Hash]int)
+	numRequests := 0
+	blockByHash := func(hash common.Hash) *types.Block {
+		requestedBlocks[hash] += 1
+		numRequests += 1
+		return backend.GetBlockByHash(hash)
+	}
+	canon := NewFastCanonicalBlockHeaderOracle(head, blockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
+	require.Nil(t, canon.GetHeaderByNumber(headNum+1))
+
+	h := canon.GetHeaderByNumber(headNum)
+	require.Equal(t, backend.GetBlockByNumber(headNum).Hash(), h.Hash())
+
+	for i := int(headNum - 1); i >= 0; i-- {
+		expect := backend.GetBlockByNumber(uint64(i)).Hash()
+		h = canon.GetHeaderByNumber(uint64(i))
+		require.Equal(t, expect, h.Hash())
+		// Since we're iterating backwards, we will fetch exactly one block from the oracle.
+		// Because, other than the historical window at head, all other canonical queries will short-circuit to a cached historical block.
+		require.Equalf(t, 1, requestedBlocks[expect], "Unexpected number of requests for block: %v (%d)", expect, i)
+	}
+
+	runCanonicalCacheTest(t, backend, 0, 3)
+	runCanonicalCacheTest(t, backend, 1, 3)
+	runCanonicalCacheTest(t, backend, 2, 2)
+	runCanonicalCacheTest(t, backend, 3, 2)
+	runCanonicalCacheTest(t, backend, 4, 2)
+	runCanonicalCacheTest(t, backend, 8191, 2)
+	runCanonicalCacheTest(t, backend, 8192, 2)
+	runCanonicalCacheTest(t, backend, 8193, 1)
+	runCanonicalCacheTest(t, backend, 16382, 1)
+	runCanonicalCacheTest(t, backend, 16383, 1)
+}
+
+func TestFastCannonBlockHeaderOracle_WithFallback(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+	isthmusTime := uint64(4)
+	isthmusBlockActivation := 2 // isthmusTime / blockTime
+	miner, backend := test.NewMiner(t, logger, isthmusTime)
+	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+	numBlocks := 5
+	for i := 0; i < numBlocks; i++ {
+		miner.Mine(t, nil)
+	}
+	head := backend.CurrentHeader()
+	headNum := head.Number.Uint64()
+	require.Equal(t, uint64(numBlocks), headNum)
+
+	fallbackOracleRequests := make(map[common.Hash]int)
+	fallbackBlockByHash := func(hash common.Hash) *types.Block {
+		fallbackOracleRequests[hash] += 1
+		return backend.GetBlockByHash(hash)
+	}
+	fallback := NewCanonicalBlockHeaderOracle(head, fallbackBlockByHash)
+	canon := NewFastCanonicalBlockHeaderOracle(head, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+
+	for i := 0; i <= int(isthmusBlockActivation); i++ {
+		i := uint64(i)
+		expected := backend.GetBlockByNumber(i).Hash()
+		require.Equalf(t, expected, canon.GetHeaderByNumber(i).Hash(), "Expected block %d to be canonical", i)
+		require.Equalf(t, 1, fallbackOracleRequests[expected], "Expected 1 fallback request for block %d", i)
+	}
+	fallbackOracleRequests = make(map[common.Hash]int)
+	for i := int(isthmusBlockActivation) + 1; i < numBlocks; i++ {
+		i := uint64(i)
+		expected := backend.GetBlockByNumber(i).Hash()
+		require.Equalf(t, expected, canon.GetHeaderByNumber(i).Hash(), "Expected block %d to be canonical", i)
+		require.Equalf(t, 0, fallbackOracleRequests[expected], "Expected 0 fallback requests for block %d", i)
+	}
+}
+
+func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reset on same chain", func(t *testing.T) {
+		t.Parallel()
+		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+		miner, backend := test.NewMiner(t, logger, 0)
+		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+		numBlocks := 5
+		for i := 0; i < numBlocks; i++ {
+			miner.Mine(t, nil)
+		}
+		head := backend.CurrentHeader()
+		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
+		canon := NewFastCanonicalBlockHeaderOracle(head, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+		canon.SetCanonical(head)
+		require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
+		require.Equal(t, head.Hash(), fallback.CurrentHeader().Hash())
+
+		parent := backend.GetBlockByNumber(head.Number.Uint64() - 1)
+		canon.SetCanonical(parent.Header())
+		require.Nil(t, canon.GetHeaderByNumber(head.Number.Uint64()))
+		require.Equal(t, parent.Hash(), canon.CurrentHeader().Hash())
+		require.Equal(t, parent.Hash(), fallback.CurrentHeader().Hash())
+	})
+
+	t.Run("fork", func(t *testing.T) {
+		t.Parallel()
+		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+		miner, backend := test.NewMiner(t, logger, 0)
+		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+		numBlocks := uint64(16384) // params.HistoryServeWindow * 2
+		for i := uint64(0); i < numBlocks; i++ {
+			miner.Mine(t, nil)
+		}
+		head := backend.CurrentHeader()
+		headNum := head.Number.Uint64()
+
+		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
+		requestedBlocks := make(map[common.Hash]int)
+		numRequests := 0
+		blockByHash := func(hash common.Hash) *types.Block {
+			requestedBlocks[hash] += 1
+			numRequests += 1
+			return backend.GetBlockByHash(hash)
+		}
+		canon := NewFastCanonicalBlockHeaderOracle(head, blockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+		for i := uint64(0); i <= headNum; i++ {
+			// prime the cache
+			canon.GetHeaderByNumber(i)
+		}
+
+		forkBlockNumber := uint64(7000)
+		miner.Fork(t, forkBlockNumber, nil)
+		for i := forkBlockNumber + 1; i < numBlocks; i++ {
+			miner.Mine(t, nil)
+		}
+		forkHead := backend.CurrentHeader()
+		require.NotEqual(t, head.Hash(), forkHead.Hash())
+		require.Equal(t, numBlocks, forkHead.Number.Uint64())
+
+		canon.SetCanonical(backend.GetBlockByNumber(forkBlockNumber + 1).Header())
+
+		runTest := func(blockNum uint64, expectedNumRequests int) {
+			requestedBlocks = make(map[common.Hash]int)
+			numRequests = 0
+			expect := backend.GetBlockByNumber(blockNum).Hash()
+			h := canon.GetHeaderByNumber(blockNum)
+			require.Equalf(t, expect, h.Hash(), "Unexpected block hash for block: %v (%d)", expect, blockNum)
+			require.Equalf(t, expectedNumRequests, numRequests, "Unexpected number of requests for block: %v (%d)", expect, blockNum)
+		}
+
+		// historical windows:
+		// head: [8193, 16383]
+		// 8193: [2, 8192]
+		// 2:    [0, 1]
+
+		// the cached historical headers prior to fork are still valid; so expect 1 oracle request for the target block
+		for i := uint64(0); i <= forkBlockNumber+1; i++ {
+			switch i {
+			case 2:
+				runTest(i, 0) // at a start window, it's cached
+			case forkBlockNumber + 1:
+				runTest(i, 0) // no oracle requests at head
+			default:
+				runTest(i, 1)
+			}
+		}
+	})
+}
+
+// runCanonicalCacheTest asserts the number of oracle requests made for a given block number.
+// It also asserts that the retrieved block hash at the specified height is canonical
+func runCanonicalCacheTest(t *testing.T, backend *core.BlockChain, blockNum uint64, expectedNumRequests int) {
+	head := backend.CurrentHeader()
+	requestedBlocks := make(map[common.Hash]int)
+	numRequests := 0
+	blockByHash := func(hash common.Hash) *types.Block {
+		requestedBlocks[hash] += 1
+		numRequests += 1
+		return backend.GetBlockByHash(hash)
+	}
+	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+	// Create invalid fallback to assert that it's never used.
+	fatalBlockByHash := func(hash common.Hash) *types.Block {
+		t.Fatalf("Unexpected fallback for block: %v", hash)
+		return nil
+	}
+	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
+	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
+	canon := NewFastCanonicalBlockHeaderOracle(head, blockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+
+	expect := backend.GetBlockByNumber(blockNum).Hash()
+	h := canon.GetHeaderByNumber(blockNum)
+	require.Equal(t, expect, h.Hash())
+	require.Equalf(t, expectedNumRequests, numRequests, "Unexpected number of requests for block: %v (%d)", expect, blockNum)
+}

--- a/op-program/client/l2/test/miner.go
+++ b/op-program/client/l2/test/miner.go
@@ -61,7 +61,8 @@ func NewMiner(t *testing.T, logger log.Logger, isthmusTime uint64) (*Miner, *cor
 		NoPruning:   true,
 	}
 	nodeCfg := &node.Config{
-		Name: "l2-geth",
+		Name:    "l2-geth",
+		DataDir: t.TempDir(),
 	}
 	n, err := node.New(nodeCfg)
 	require.NoError(t, err)

--- a/op-program/client/l2/test/miner.go
+++ b/op-program/client/l2/test/miner.go
@@ -1,0 +1,156 @@
+package test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	geth "github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+type Miner struct {
+	backend   *core.BlockChain
+	engineAPI *engineapi.L2EngineAPI
+}
+
+func NewMiner(t *testing.T, logger log.Logger, isthmusTime uint64) (*Miner, *core.BlockChain) {
+	config := *params.MergedTestChainConfig
+	var zero uint64
+	// activate recent OP-stack forks
+	config.RegolithTime = &zero
+	config.CanyonTime = &zero
+	config.EcotoneTime = &zero
+	config.FjordTime = &zero
+	config.GraniteTime = &zero
+	config.HoloceneTime = &zero
+	config.IsthmusTime = &isthmusTime
+	config.PragueTime = &isthmusTime
+	denomCanyon := uint64(250)
+	config.Optimism = &params.OptimismConfig{
+		EIP1559Denominator:       50,
+		EIP1559Elasticity:        10,
+		EIP1559DenominatorCanyon: &denomCanyon,
+	}
+	genesis := &core.Genesis{
+		Config:     &config,
+		Difficulty: common.Big0,
+		ParentHash: common.Hash{},
+		BaseFee:    big.NewInt(7),
+		Alloc: map[common.Address]types.Account{
+			params.HistoryStorageAddress: {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0}, // for Isthmus eip-2935
+		},
+		ExtraData: []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}, // for Holocene eip-1559 params
+	}
+	ethCfg := &ethconfig.Config{
+		NetworkId:   genesis.Config.ChainID.Uint64(),
+		Genesis:     genesis,
+		StateScheme: rawdb.HashScheme,
+		NoPruning:   true,
+	}
+	nodeCfg := &node.Config{
+		Name: "l2-geth",
+	}
+	n, err := node.New(nodeCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = n.Close()
+	})
+	backend, err := geth.New(n, ethCfg)
+	require.NoError(t, err)
+	chain := backend.BlockChain()
+
+	engineAPI := engineapi.NewL2EngineAPI(logger, chain, nil)
+	require.NotNil(t, engineAPI)
+	return &Miner{backend: chain, engineAPI: engineAPI}, chain
+}
+
+// Mine builds a block on top of the current head and adds it to the chain.
+func (m *Miner) Mine(t *testing.T, attrs *eth.PayloadAttributes) {
+	head := m.backend.CurrentHeader()
+	m.MineAt(t, head, attrs)
+}
+
+func (m *Miner) Fork(t *testing.T, blockNumber uint64, attrs *eth.PayloadAttributes) {
+	head := m.backend.GetHeaderByNumber(blockNumber)
+	if attrs == nil {
+		gasLimit := eth.Uint64Quantity(head.GasLimit)
+		eip1559Params := eth.Bytes8([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88})
+		attrs = &eth.PayloadAttributes{
+			Timestamp:             eth.Uint64Quantity(head.Time + 2),
+			PrevRandao:            eth.Bytes32{0x11},
+			SuggestedFeeRecipient: common.Address{0x33},
+			Withdrawals:           &types.Withdrawals{},
+			ParentBeaconBlockRoot: &common.Hash{0x22},
+			NoTxPool:              true,
+			GasLimit:              &gasLimit,
+			EIP1559Params:         &eip1559Params,
+		}
+	}
+	m.MineAt(t, head, attrs)
+}
+
+func (m *Miner) MineAt(t *testing.T, head *types.Header, attrs *eth.PayloadAttributes) {
+	hash := head.Hash()
+	genesis := m.backend.Genesis()
+	if attrs == nil {
+		eip1559Params := eth.Bytes8([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8})
+		gasLimit := eth.Uint64Quantity(4712388)
+		attrs = &eth.PayloadAttributes{
+			Timestamp:             eth.Uint64Quantity(head.Time + 2),
+			PrevRandao:            eth.Bytes32{0x11},
+			SuggestedFeeRecipient: common.Address{0x33},
+			Withdrawals:           &types.Withdrawals{},
+			ParentBeaconBlockRoot: &common.Hash{0x22},
+			NoTxPool:              true,
+			GasLimit:              &gasLimit,
+			EIP1559Params:         &eip1559Params,
+		}
+	}
+	result, err := m.engineAPI.ForkchoiceUpdatedV3(context.Background(), &eth.ForkchoiceState{
+		HeadBlockHash:      hash,
+		SafeBlockHash:      hash,
+		FinalizedBlockHash: genesis.Hash(),
+	}, attrs)
+	require.NoError(t, err)
+	require.EqualValues(t, engine.VALID, result.PayloadStatus.Status)
+	require.NotNil(t, result.PayloadID)
+
+	var envelope *eth.ExecutionPayloadEnvelope
+	if m.backend.Config().IsIsthmus(uint64(attrs.Timestamp)) {
+		envelope, err = m.engineAPI.GetPayloadV4(context.Background(), *result.PayloadID)
+	} else {
+		envelope, err = m.engineAPI.GetPayloadV3(context.Background(), *result.PayloadID)
+	}
+	require.NoError(t, err)
+	require.NotNil(t, envelope)
+
+	var newPayloadResult *eth.PayloadStatusV1
+	if m.backend.Config().IsIsthmus(uint64(attrs.Timestamp)) {
+		newPayloadResult, err = m.engineAPI.NewPayloadV4(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
+	} else {
+		newPayloadResult, err = m.engineAPI.NewPayloadV3(context.Background(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot)
+	}
+	require.NoError(t, err)
+	require.EqualValues(t, engine.VALID, newPayloadResult.Status)
+
+	result, err = m.engineAPI.ForkchoiceUpdatedV3(context.Background(), &eth.ForkchoiceState{
+		HeadBlockHash:      envelope.ExecutionPayload.BlockHash,
+		SafeBlockHash:      envelope.ExecutionPayload.BlockHash,
+		FinalizedBlockHash: envelope.ExecutionPayload.BlockHash,
+	}, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, engine.VALID, result.PayloadStatus.Status)
+}

--- a/op-program/client/l2/test/stub_oracle.go
+++ b/op-program/client/l2/test/stub_oracle.go
@@ -56,7 +56,7 @@ func NewStubOracleWithBlocks(t *testing.T, chain []*gethTypes.Block, outputs []e
 		t:           t,
 		Blocks:      blocks,
 		Outputs:     o,
-		stateOracle: &KvStateOracle{t: t, Source: db},
+		stateOracle: &KvStateOracle{T: t, Source: db},
 	}
 }
 
@@ -101,13 +101,13 @@ func (o StubBlockOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.
 
 // KvStateOracle loads data from a source ethdb.KeyValueStore
 type KvStateOracle struct {
-	t      *testing.T
+	T      *testing.T
 	Source ethdb.KeyValueStore
 }
 
 func NewKvStateOracle(t *testing.T, db ethdb.KeyValueStore) *KvStateOracle {
 	return &KvStateOracle{
-		t:      t,
+		T:      t,
 		Source: db,
 	}
 }
@@ -115,7 +115,7 @@ func NewKvStateOracle(t *testing.T, db ethdb.KeyValueStore) *KvStateOracle {
 func (o *KvStateOracle) NodeByHash(nodeHash common.Hash, chainID eth.ChainID) []byte {
 	val, err := o.Source.Get(nodeHash.Bytes())
 	if err != nil {
-		o.t.Fatalf("error retrieving node %v: %v", nodeHash, err)
+		o.T.Fatalf("error retrieving node %v: %v", nodeHash, err)
 	}
 	return val
 }


### PR DESCRIPTION
Use EIP-2935 to speedup blockbynumber lookups in the program.

fixes https://github.com/ethereum-optimism/optimism/issues/13961