### PR TITLE
feat(devnet-sdk): add helper to build execution environment

### DIFF
--- a/devnet-sdk/shell/cmd/enter/main.go
+++ b/devnet-sdk/shell/cmd/enter/main.go
@@ -23,20 +23,19 @@ func run(ctx *cli.Context) error {
 		return err
 	}
 
-	chainEnv, err := chain.GetEnv()
+	chainEnv, err := chain.GetEnv(
+		env.WithCastIntegration(true),
+	)
 	if err != nil {
 		return err
 	}
 
-	if motd := chainEnv.Motd; motd != "" {
+	if motd := chainEnv.GetMotd(); motd != "" {
 		fmt.Println(motd)
 	}
 
 	// Get current environment and append chain-specific vars
-	env := os.Environ()
-	for key, value := range chainEnv.EnvVars {
-		env = append(env, fmt.Sprintf("%s=%s", key, value))
-	}
+	env := chainEnv.ApplyToEnv(os.Environ())
 
 	// Get current shell
 	shell := os.Getenv("SHELL")

--- a/devnet-sdk/shell/cmd/motd/main.go
+++ b/devnet-sdk/shell/cmd/motd/main.go
@@ -27,7 +27,7 @@ func run(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Println(chainEnv.Motd)
+	fmt.Println(chainEnv.GetMotd())
 	return nil
 }
 

--- a/devnet-sdk/shell/env/chain.go
+++ b/devnet-sdk/shell/env/chain.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	EnvFileVar   = "DEVNET_ENV_FILE"
-	ChainNameVar = "DEVNET_CHAIN_NAME"
+	EnvFileVar             = "DEVNET_ENV_FILE"
+	ChainNameVar           = "DEVNET_CHAIN_NAME"
+	ExpectPreconditionsMet = "DEVNET_EXPECT_PRECONDITIONS_MET"
 )
 
 type ChainConfig struct {
@@ -21,8 +22,8 @@ type ChainConfig struct {
 }
 
 type ChainEnv struct {
-	Motd    string
-	EnvVars map[string]string
+	motd    string
+	envVars map[string]string
 }
 
 func (c *ChainConfig) getRpcUrl() (string, error) {
@@ -72,20 +73,54 @@ func (c *ChainConfig) motd() string {
 	return buf.String()
 }
 
-func (c *ChainConfig) GetEnv() (*ChainEnv, error) {
-	mapping := map[string]func() (string, error){
-		"ETH_RPC_URL":        c.getRpcUrl,
-		"ETH_RPC_JWT_SECRET": c.getJwtSecret,
+type ChainConfigOption func(*ChainConfig, *chainConfigOpts) error
+
+type chainConfigOpts struct {
+	extraEnvVars map[string]string
+}
+
+func WithCastIntegration(cast bool) ChainConfigOption {
+	return func(c *ChainConfig, o *chainConfigOpts) error {
+		mapping := map[string]func() (string, error){
+			"ETH_RPC_URL":        c.getRpcUrl,
+			"ETH_RPC_JWT_SECRET": c.getJwtSecret,
+		}
+
+		for key, fn := range mapping {
+			value := ""
+			var err error
+			if cast {
+				if value, err = fn(); err != nil {
+					return err
+				}
+			}
+			o.extraEnvVars[key] = value
+		}
+		return nil
+	}
+}
+
+func WithExpectedPreconditions(pre bool) ChainConfigOption {
+	return func(c *ChainConfig, o *chainConfigOpts) error {
+		if pre {
+			o.extraEnvVars[ExpectPreconditionsMet] = "true"
+		} else {
+			o.extraEnvVars[ExpectPreconditionsMet] = ""
+		}
+		return nil
+	}
+}
+
+func (c *ChainConfig) GetEnv(opts ...ChainConfigOption) (*ChainEnv, error) {
+	motd := c.motd()
+	o := &chainConfigOpts{
+		extraEnvVars: make(map[string]string),
 	}
 
-	motd := c.motd()
-	envVars := make(map[string]string)
-	for key, fn := range mapping {
-		value, err := fn()
-		if err != nil {
+	for _, opt := range opts {
+		if err := opt(c, o); err != nil {
 			return nil, err
 		}
-		envVars[key] = value
 	}
 
 	// To allow commands within the shell to know which devnet and chain they are in
@@ -93,11 +128,22 @@ func (c *ChainConfig) GetEnv() (*ChainEnv, error) {
 	if err != nil {
 		absPath = c.devnetFile // Fallback to original path if abs fails
 	}
-	envVars[EnvFileVar] = absPath
-	envVars[ChainNameVar] = c.name
+	o.extraEnvVars[EnvFileVar] = absPath
+	o.extraEnvVars[ChainNameVar] = c.name
 
 	return &ChainEnv{
-		Motd:    motd,
-		EnvVars: envVars,
+		motd:    motd,
+		envVars: o.extraEnvVars,
 	}, nil
+}
+
+func (e *ChainEnv) ApplyToEnv(env []string) []string {
+	for key, value := range e.envVars {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+	return env
+}
+
+func (e *ChainEnv) GetMotd() string {
+	return e.motd
 }

--- a/devnet-sdk/shell/env/env_test.go
+++ b/devnet-sdk/shell/env/env_test.go
@@ -186,15 +186,17 @@ func TestChainConfig(t *testing.T) {
 
 	// Test getting environment variables
 	t.Run("get environment variables", func(t *testing.T) {
-		env, err := chain.GetEnv()
+		env, err := chain.GetEnv(
+			WithCastIntegration(true),
+		)
 		require.NoError(t, err)
 
-		assert.Equal(t, "http://localhost:8545", env.EnvVars["ETH_RPC_URL"])
-		assert.Equal(t, "1234", env.EnvVars["ETH_RPC_JWT_SECRET"])
-		assert.Equal(t, "test.json", filepath.Base(env.EnvVars[EnvFileVar]))
-		assert.Equal(t, "test", env.EnvVars[ChainNameVar])
-		assert.Contains(t, env.Motd, "deployer")
-		assert.Contains(t, env.Motd, "0x1234567890123456789012345678901234567890")
+		assert.Equal(t, "http://localhost:8545", env.envVars["ETH_RPC_URL"])
+		assert.Equal(t, "1234", env.envVars["ETH_RPC_JWT_SECRET"])
+		assert.Equal(t, "test.json", filepath.Base(env.envVars[EnvFileVar]))
+		assert.Equal(t, "test", env.envVars[ChainNameVar])
+		assert.Contains(t, env.motd, "deployer")
+		assert.Contains(t, env.motd, "0x1234567890123456789012345678901234567890")
 	})
 
 	// Test chain with no nodes
@@ -205,7 +207,9 @@ func TestChainConfig(t *testing.T) {
 				Nodes: []descriptors.Node{},
 			},
 		}
-		_, err := noNodesChain.GetEnv()
+		_, err := noNodesChain.GetEnv(
+			WithCastIntegration(true),
+		)
 		assert.Error(t, err)
 	})
 
@@ -221,7 +225,9 @@ func TestChainConfig(t *testing.T) {
 				},
 			},
 		}
-		_, err := missingServiceChain.GetEnv()
+		_, err := missingServiceChain.GetEnv(
+			WithCastIntegration(true),
+		)
 		assert.Error(t, err)
 	})
 
@@ -241,7 +247,9 @@ func TestChainConfig(t *testing.T) {
 				},
 			},
 		}
-		_, err := missingEndpointChain.GetEnv()
+		_, err := missingEndpointChain.GetEnv(
+			WithCastIntegration(true),
+		)
 		assert.Error(t, err)
 	})
 }

--- a/devnet-sdk/testing/systest/systest.go
+++ b/devnet-sdk/testing/systest/systest.go
@@ -10,10 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 )
 
-const (
-	EnvVarExpectPreconditionsMet = "DEVNET_EXPECT_PRECONDITIONS_MET"
-)
-
 // envGetter abstracts environment variable access
 type envGetter interface {
 	Getenv(key string) string
@@ -109,7 +105,7 @@ func (h *basicSystemTestHelper) InteropSystemTest(t BasicT, f InteropSystemTestF
 
 // newBasicSystemTestHelper creates a new basicSystemTestHelper using environment variables
 func newBasicSystemTestHelper(envGetter envGetter) *basicSystemTestHelper {
-	val := envGetter.Getenv(EnvVarExpectPreconditionsMet)
+	val := envGetter.Getenv(env.ExpectPreconditionsMet)
 	expectPreconditionsMet, err := strconv.ParseBool(val)
 	if err != nil {
 		expectPreconditionsMet = false // empty string or invalid value returns false

--- a/devnet-sdk/testing/systest/systest_test.go
+++ b/devnet-sdk/testing/systest/systest_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/stretchr/testify/require"
 )
@@ -105,7 +106,7 @@ func TestSystemTestHelper(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				env := mockEnvGetter{
 					values: map[string]string{
-						EnvVarExpectPreconditionsMet: tc.envValue,
+						env.ExpectPreconditionsMet: tc.envValue,
 					},
 				}
 				helper := newBasicSystemTestHelper(env)


### PR DESCRIPTION
**Description**

This change facilitates the creation of a shell environment populated
with the right variables without having to know exactly what those
variables are.
That environment in turn can be loaded in SystemTest helpers for example.

Typical use-case: op-nat shouldn't need to know all the gory details
of how to setup an environment for the tests.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

see devnet-sdk/shell/cmd/enter/main.go for an example of how to use the capability.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
