### PR TITLE
op-conductor: Add new Raft flags into optional flags list

### DIFF
--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -154,6 +154,8 @@ var optionalFlags = []cli.Flag{
 	RaftSnapshotInterval,
 	RaftSnapshotThreshold,
 	RaftTrailingLogs,
+	RaftHeartbeatTimeout,
+	RaftLeaderLeaseTimeout,
 }
 
 func init() {


### PR DESCRIPTION
**Description**

followup for https://github.com/ethereum-optimism/optimism/pull/14271

**Tests**

confirmed that new flags are applied in my local machine

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
