### PR TITLE
op-program: Update test to ensure interop bootstrapping does not load L2 chain ID

### DIFF
--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -137,6 +137,8 @@ func (o *mockInteropBootstrapOracle) Get(key preimage.Key) []byte {
 		}
 		b, _ := json.Marshal(o.rollupCfgs)
 		return b
+	case L2ChainIDLocalIndex.PreimageKey():
+		panic("unexpected oracle request for l2 chain ID preimage key")
 	default:
 		return o.mockBoostrapOracle.Get(key)
 	}


### PR DESCRIPTION
**Description**

The L2 chain ID local key is not available in interop so ensure the bootstrap process never loads it.


**Metadata**

fixes #14160