### PR TITLE
op-supervisor: Fix AddLink error type and clean up reset logic

### DIFF
--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -238,7 +238,7 @@ func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidate
 		return fmt.Errorf("cannot add block (%s derived from %s), last block (%s derived from %s) is too far behind: (%w)",
 			derived, derivedFrom,
 			lastDerived, lastSource,
-			types.ErrOutOfOrder)
+			types.ErrFuture)
 	} else {
 		return fmt.Errorf("derived block %s is older than current derived block %s: %w",
 			derived, lastDerived, types.ErrOutOfOrder)
@@ -262,7 +262,7 @@ func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidate
 		return fmt.Errorf("cannot add block (%s derived from %s), last block (%s derived from %s) is too far behind: (%w)",
 			derived, derivedFrom,
 			lastDerived, lastSource,
-			types.ErrOutOfOrder)
+			types.ErrFuture)
 	} else {
 		if lastDerived.Hash == derived.Hash {
 			// we might see L1 blocks repeat,

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -169,7 +169,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t,
 					db.AddDerived(toRef(fSource, dSource.Hash),
-						toRef(eDerived, dDerived.Hash)), types.ErrOutOfOrder)
+						toRef(eDerived, dDerived.Hash)), types.ErrFuture)
 			},
 			assertFn: noChange,
 		},
@@ -232,7 +232,7 @@ func TestBadUpdates(t *testing.T) {
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, db.AddDerived(
 					toRef(dSource, cSource.Hash),
-					toRef(fDerived, dDerived.Hash)), types.ErrOutOfOrder)
+					toRef(fDerived, dDerived.Hash)), types.ErrFuture)
 			},
 			assertFn: noChange,
 		},


### PR DESCRIPTION
- Makes `AddLink` return `ErrFuture` when the update provided is *ahead* of the Supervisor by more than one block, instead of returning `OutOfOrder`
- Makes `OutOfOrder` update errors Warn Log only, no more reset on these cases (the node is behind)
  - However, a new heuristic is checked -- if the node is far behind, we `sendReset` to bring it to tip more quickly. 
- Cleans up `resetSignal` to be more clearly about translating errors to special reset cases
- Uses `sendReset` as the default reset call to keep things DRY

**Testing**
E2E Test `TestReset` began failing when the reset handling was changed to only Warn for OutOfOrder errors, and started passing again once I updated the AddLink behavior.