### PR TITLE
kt-devnet: switch to geth-teku for l1

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -167,6 +167,9 @@ optimism_package:
   global_tolerations: []
   persistent: false
 ethereum_package:
+  participants:
+    - el_type: geth
+      cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -66,6 +66,9 @@ optimism_package:
   global_tolerations: []
   persistent: false
 ethereum_package:
+  participants:
+    - el_type: geth
+      cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/kurtosis-devnet/templates/devnet.yaml
+++ b/kurtosis-devnet/templates/devnet.yaml
@@ -1,6 +1,6 @@
 {{- $context := or . (dict)}}
-{{- $default_l2s := dict 
-    "2151908" (dict "nodes" (list "op-geth")) 
+{{- $default_l2s := dict
+    "2151908" (dict "nodes" (list "op-geth"))
     "2151909" (dict "nodes" (list "op-geth"))
 }}
 {{- $l2s := dig "l2s" $default_l2s $context }}
@@ -33,6 +33,9 @@ optimism_package:
   global_tolerations: []
   persistent: false
 ethereum_package:
+  participants:
+    - el_type: geth
+      cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Local kt devnet did not work because it tries to spin up l1 consensus using lighthouse image `ethpandaops/lighthouse:stable`. We can bypass this simply by pinning l1 consensus using teku. Similar PR at [optimism-pacakge](https://github.com/ethpandaops/optimism-package): https://github.com/ethpandaops/optimism-package/pull/160. 

Switching devnet to use teku instead of lighthouse for the monorepo as well.

**Tests**

Validated below commands works, spinning with L1 teku.
```
just simple-devnet
just interop-devnet
just interop-devnet-test
```



