### PR TITLE
op-batcher: prevent `SpanChannelOut` RLP bytes overflowing `MaxRLPBytesPerChannel`

### DIFF
--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -502,16 +502,16 @@ func TestSpanChannelOut_MaxRLPBytesPerChannel(t *testing.T) {
 
 func testSpanChannelOut_MaxRLPBytesPerChannel(t *testing.T, algo CompressionAlgo) {
 
-	largeBatchSize := int(rollup.NewChainSpec(&rollupCfg).MaxRLPBytesPerChannel(0))
+	maxRLPBytesPerChannel := int(rollup.NewChainSpec(&rollupCfg).MaxRLPBytesPerChannel(0))
 	cout, singularBatches := SpanChannelAndBatches(t, 100, 1, algo)
 
-	cout.rlp[0] = bytes.NewBuffer(make([]byte, largeBatchSize))
-	cout.rlp[1] = bytes.NewBuffer(make([]byte, largeBatchSize))
-	cout.sealedRLPBytes = largeBatchSize
+	cout.rlp[0] = bytes.NewBuffer(make([]byte, maxRLPBytesPerChannel))
+	cout.rlp[1] = bytes.NewBuffer(make([]byte, maxRLPBytesPerChannel))
+	cout.sealedRLPBytes = maxRLPBytesPerChannel
 
 	err := cout.addSingularBatch(singularBatches[0], 1)
-	require.ErrorIs(t, err, ErrTooManyRLPBytes)
+	require.ErrorIs(t, err, ErrTooManyRLPBytes, "error should be ErrTooManyRLPBytes")
 
-	require.Equal(t, cout.activeRLP().Len(), largeBatchSize, "active RLP should be equal to the max RLP limit")
-	require.Greater(t, cout.inactiveRLP().Len(), largeBatchSize)
+	require.Equal(t, cout.activeRLP().Len(), maxRLPBytesPerChannel, "active RLP should be equal to the max RLP limit")
+	require.Greater(t, cout.inactiveRLP().Len(), maxRLPBytesPerChannel, "inactive RLP should be greater than max RLP limit")
 }

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -492,15 +492,15 @@ func testSpanChannelOut_MaxBlocksPerSpanBatch(t *testing.T, tt maxBlocksTest) {
 	}
 }
 
-func TestSpanChannelOut_ExceedMaxRLPBytesPerChannel(t *testing.T) {
+func TestSpanChannelOut_MaxRLPBytesPerChannel(t *testing.T) {
 	for _, algo := range CompressionAlgos {
-		t.Run("testSpanChannelOut_ExceedMaxRLPBytesPerChannel_"+algo.String(), func(t *testing.T) {
-			testSpanChannelOut_ExceedMaxRLPBytesPerChannel(t, algo)
+		t.Run("testSpanChannelOut_MaxRLPBytesPerChannel_"+algo.String(), func(t *testing.T) {
+			testSpanChannelOut_MaxRLPBytesPerChannel(t, algo)
 		})
 	}
 }
 
-func testSpanChannelOut_ExceedMaxRLPBytesPerChannel(t *testing.T, algo CompressionAlgo) {
+func testSpanChannelOut_MaxRLPBytesPerChannel(t *testing.T, algo CompressionAlgo) {
 
 	largeBatchSize := int(rollup.NewChainSpec(&rollupCfg).MaxRLPBytesPerChannel(0))
 	cout, singularBatches := SpanChannelAndBatches(t, 100, 1, algo)
@@ -509,11 +509,9 @@ func testSpanChannelOut_ExceedMaxRLPBytesPerChannel(t *testing.T, algo Compressi
 	cout.rlp[1] = bytes.NewBuffer(make([]byte, largeBatchSize))
 	cout.sealedRLPBytes = largeBatchSize
 
-	for _, batch := range singularBatches {
-		err := cout.addSingularBatch(batch, 1)
-		require.ErrorIs(t, err, ErrTooManyRLPBytes)
-	}
+	err := cout.addSingularBatch(singularBatches[0], 1)
+	require.ErrorIs(t, err, ErrTooManyRLPBytes)
 
-	require.Equal(t, cout.activeRLP().Len(), largeBatchSize)
+	require.Equal(t, cout.activeRLP().Len(), largeBatchSize, "active RLP should be equal to the max RLP limit")
 	require.Greater(t, cout.inactiveRLP().Len(), largeBatchSize)
 }

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -493,9 +493,17 @@ func testSpanChannelOut_MaxBlocksPerSpanBatch(t *testing.T, tt maxBlocksTest) {
 }
 
 func TestSpanChannelOut_ExceedMaxRLPBytesPerChannel(t *testing.T) {
+	for _, algo := range CompressionAlgos {
+		t.Run("testSpanChannelOut_ExceedMaxRLPBytesPerChannel_"+algo.String(), func(t *testing.T) {
+			testSpanChannelOut_ExceedMaxRLPBytesPerChannel(t, algo)
+		})
+	}
+}
+
+func testSpanChannelOut_ExceedMaxRLPBytesPerChannel(t *testing.T, algo CompressionAlgo) {
 
 	largeBatchSize := int(rollup.NewChainSpec(&rollupCfg).MaxRLPBytesPerChannel(0))
-	cout, singularBatches := SpanChannelAndBatches(t, 100, 1, Zlib)
+	cout, singularBatches := SpanChannelAndBatches(t, 100, 1, algo)
 
 	cout.rlp[0] = bytes.NewBuffer(make([]byte, largeBatchSize))
 	cout.rlp[1] = bytes.NewBuffer(make([]byte, largeBatchSize))

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -178,6 +178,7 @@ func (co *SpanChannelOut) addSingularBatch(batch *SingularBatch, seqNum uint64) 
 	// the Fjord activation.
 	maxRLPBytesPerChannel := co.chainSpec.MaxRLPBytesPerChannel(batch.Timestamp)
 	if active.Len() > int(maxRLPBytesPerChannel) {
+		co.swapRLP()
 		return fmt.Errorf("could not take %d bytes as replacement of channel of %d bytes, max is %d. err: %w",
 			active.Len(), co.inactiveRLP().Len(), maxRLPBytesPerChannel, ErrTooManyRLPBytes)
 	}

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -178,7 +178,13 @@ func (co *SpanChannelOut) addSingularBatch(batch *SingularBatch, seqNum uint64) 
 	// the Fjord activation.
 	maxRLPBytesPerChannel := co.chainSpec.MaxRLPBytesPerChannel(batch.Timestamp)
 	if active.Len() > int(maxRLPBytesPerChannel) {
+
+		// if active size exceeds MaxRLPBytesPerChannel we revert the last batch
+		// by switching the RLP buffer and doing a fresh compression
 		co.swapRLP()
+		if err = co.compress(); err != nil {
+			return err
+		}
 		return fmt.Errorf("could not take %d bytes as replacement of channel of %d bytes, max is %d. err: %w",
 			active.Len(), co.inactiveRLP().Len(), maxRLPBytesPerChannel, ErrTooManyRLPBytes)
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Noticed that when the channel RLP bytes exceed MaxRLPBytesPerChannel, the batcher does not remove the excess batch. This causes the OP-Node to encounter an error.

`msg="failed to read batch from channel reader, skipping to next channel now" err="rlp: value size exceeds available input length"`

**Tests**

I added the test `testSpanChannelOut_ExceedMaxRLPBytesPerChannel` to ensure that the batcher removes the excess batch when the channel RLP bytes exceed MaxRLPBytesPerChannel.

**Additional context**

Batcher Log 
`lvl=info msg="Channel closed" input_bytes=10043790 output_bytes=74565 
full_reason="channel full: could not take 10043790 bytes as replacement of channel of 9925704 bytes, max is 10000000. err: batch would cause RLP bytes to go over limit" compr_ratio=0.007423990346273668`

Op-Node Derivation Log
`msg="failed to read batch from channel reader, skipping to next channel now" err="rlp: value size exceeds available input length"`

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
