### PR TITLE
ci: make frozen files check depend on contracts-bedrock-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1433,7 +1433,7 @@ workflows:
             - contracts-bedrock-build
       - contracts-bedrock-frozen-code:
           requires:
-            - contracts-bedrock-checks
+            - contracts-bedrock-build
       - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local


### PR DESCRIPTION
This parallelizes the job with contracts-bedrock-build so that results are returned more quickly.

