### PR TITLE
fix(kurtosis-devnet): make logs more readable

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
@@ -2,7 +2,7 @@ package wrappers
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
@@ -156,21 +156,21 @@ func (w *starlarkRunFinishedEventWrapper) GetIsRunSuccessful() bool {
 
 func (w *starlarkErrorWrapper) GetInterpretationError() error {
 	if err := w.StarlarkError.GetInterpretationError(); err != nil {
-		return fmt.Errorf("%v", err)
+		return errors.New(err.GetErrorMessage())
 	}
 	return nil
 }
 
 func (w *starlarkErrorWrapper) GetValidationError() error {
 	if err := w.StarlarkError.GetValidationError(); err != nil {
-		return fmt.Errorf("%v", err)
+		return errors.New(err.GetErrorMessage())
 	}
 	return nil
 }
 
 func (w *starlarkErrorWrapper) GetExecutionError() error {
 	if err := w.StarlarkError.GetExecutionError(); err != nil {
-		return fmt.Errorf("%v", err)
+		return errors.New(err.GetErrorMessage())
 	}
 	return nil
 }


### PR DESCRIPTION

**Description**

By wrapping the observed errors one layer too deep we were introducing
escaped strings into the logs. Now multi-line and quoted strings appear as-is.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

- Fixes ethereum-optimism/platforms-team#580