### PR TITLE
op-supervisor: backend: Fully rename DerivedFrom -> Source

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -514,8 +514,8 @@ func (su *SupervisorBackend) CrossUnsafe(ctx context.Context, chainID eth.ChainI
 	return v.ID(), nil
 }
 
-func (su *SupervisorBackend) SafeDerivedAt(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (eth.BlockID, error) {
-	v, err := su.chainDBs.SafeDerivedAt(chainID, derivedFrom)
+func (su *SupervisorBackend) SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (eth.BlockID, error) {
+	v, err := su.chainDBs.SafeDerivedAt(chainID, source)
 	if err != nil {
 		return eth.BlockID{}, err
 	}
@@ -523,11 +523,11 @@ func (su *SupervisorBackend) SafeDerivedAt(ctx context.Context, chainID eth.Chai
 }
 
 // AllSafeDerivedAt returns the last derived block for each chain, from the given L1 block
-func (su *SupervisorBackend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
+func (su *SupervisorBackend) AllSafeDerivedAt(ctx context.Context, source eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
 	chains := su.depSet.Chains()
 	ret := map[eth.ChainID]eth.BlockID{}
 	for _, chainID := range chains {
-		derived, err := su.SafeDerivedAt(ctx, chainID, derivedFrom)
+		derived, err := su.SafeDerivedAt(ctx, chainID, source)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get last derived block for chain %v: %w", chainID, err)
 		}
@@ -596,12 +596,12 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		if err != nil {
 			return eth.SuperRootResponse{}, err
 		}
-		derivedFrom, err := su.chainDBs.CrossDerivedToSource(chainID, ref.ID())
+		source, err := su.chainDBs.CrossDerivedToSource(chainID, ref.ID())
 		if err != nil {
 			return eth.SuperRootResponse{}, err
 		}
-		if crossSafeSource.Number == 0 || crossSafeSource.Number < derivedFrom.Number {
-			crossSafeSource = derivedFrom.ID()
+		if crossSafeSource.Number == 0 || crossSafeSource.Number < source.Number {
+			crossSafeSource = source.ID()
 		}
 	}
 	superRoot := eth.SuperRoot(&eth.SuperV1{

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -12,7 +12,7 @@ import (
 type SafeFrontierCheckDeps interface {
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
 
-	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -44,7 +44,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		l1Source := eth.BlockID{Number: 2}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
 		// when there is one hazard, and CrossSource returns a BlockSeal within scope
-		// (ie the hazard's block number is less than or equal to the derivedFrom block number),
+		// (ie the hazard's block number is less than or equal to the source block number),
 		// no error is returned
 		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		l1Source := eth.BlockID{Number: 2}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
 		// when there is one hazard, and CrossSource returns a BlockSeal out of scope
-		// (ie the hazard's block number is greater than the derivedFrom block number),
+		// (ie the hazard's block number is greater than the source block number),
 		// an error is returned as a ErrOutOfScope
 		err := HazardSafeFrontierChecks(sfcd, l1Source, hazards)
 		require.ErrorIs(t, err, types.ErrOutOfScope)
@@ -144,7 +144,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 type mockSafeFrontierCheckDeps struct {
 	deps                 mockDependencySet
 	candidateCrossSafeFn func() (candidate types.DerivedBlockRefPair, err error)
-	crossSourceFn        func() (derivedFrom types.BlockSeal, err error)
+	crossSourceFn        func() (source types.BlockSeal, err error)
 }
 
 func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error) {
@@ -154,7 +154,7 @@ func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candi
 	return types.DerivedBlockRefPair{}, nil
 }
 
-func (m *mockSafeFrontierCheckDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockSafeFrontierCheckDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error) {
 	if m.crossSourceFn != nil {
 		return m.crossSourceFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -12,7 +12,7 @@ import (
 type SafeStartDeps interface {
 	Contains(chain eth.ChainID, query types.ContainsQuery) (includedIn types.BlockSeal, err error)
 
-	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
 
 	DependencySet() depset.DependencySet
 }

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -229,7 +229,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		ssd.checkFn = func() (includedIn types.BlockSeal, err error) {
 			return sampleBlockSeal, nil
 		}
-		ssd.derivedToSrcFn = func() (derivedFrom types.BlockSeal, err error) {
+		ssd.derivedToSrcFn = func() (source types.BlockSeal, err error) {
 			return types.BlockSeal{}, errors.New("some error")
 		}
 		ssd.deps = mockDependencySet{}
@@ -252,7 +252,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleBlockSeal, nil
 		}
 		sampleSource := types.BlockSeal{Number: 4, Hash: common.BytesToHash([]byte{0x03})}
-		ssd.derivedToSrcFn = func() (derivedFrom types.BlockSeal, err error) {
+		ssd.derivedToSrcFn = func() (source types.BlockSeal, err error) {
 			return sampleSource, nil
 		}
 		ssd.deps = mockDependencySet{}
@@ -275,7 +275,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleBlockSeal, nil
 		}
 		sampleSource := types.BlockSeal{Number: 1, Hash: common.BytesToHash([]byte{0x03})}
-		ssd.derivedToSrcFn = func() (derivedFrom types.BlockSeal, err error) {
+		ssd.derivedToSrcFn = func() (source types.BlockSeal, err error) {
 			return sampleSource, nil
 		}
 		ssd.deps = mockDependencySet{}
@@ -298,7 +298,7 @@ func TestCrossSafeHazards(t *testing.T) {
 			return sampleBlockSeal, nil
 		}
 		sampleSource := types.BlockSeal{Number: 1, Hash: common.BytesToHash([]byte{0x03})}
-		ssd.derivedToSrcFn = func() (derivedFrom types.BlockSeal, err error) {
+		ssd.derivedToSrcFn = func() (source types.BlockSeal, err error) {
 			return sampleSource, nil
 		}
 		ssd.deps = mockDependencySet{}
@@ -319,7 +319,7 @@ func TestCrossSafeHazards(t *testing.T) {
 type mockSafeStartDeps struct {
 	deps           mockDependencySet
 	checkFn        func() (includedIn types.BlockSeal, err error)
-	derivedToSrcFn func() (derivedFrom types.BlockSeal, err error)
+	derivedToSrcFn func() (source types.BlockSeal, err error)
 }
 
 func (m *mockSafeStartDeps) Contains(chain eth.ChainID, q types.ContainsQuery) (includedIn types.BlockSeal, err error) {
@@ -329,7 +329,7 @@ func (m *mockSafeStartDeps) Contains(chain eth.ChainID, q types.ContainsQuery) (
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockSafeStartDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockSafeStartDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error) {
 	if m.derivedToSrcFn != nil {
 		return m.derivedToSrcFn()
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -19,7 +19,7 @@ type CrossSafeDeps interface {
 	SafeStartDeps
 
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
-	NextSource(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
+	NextSource(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error)
 	PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
 
 	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -125,7 +125,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
 		}
 		newScope := eth.BlockRef{Number: 3}
-		csd.nextSourceFn = func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+		csd.nextSourceFn = func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error) {
 			return newScope, nil
 		}
 		currentCrossSafe := types.BlockSeal{Number: 5}
@@ -172,7 +172,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, types.ErrOutOfScope
 		}
-		csd.nextSourceFn = func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+		csd.nextSourceFn = func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error) {
 			return eth.BlockRef{}, errors.New("some error")
 		}
 		csd.deps = mockDependencySet{}
@@ -455,7 +455,7 @@ type mockCrossSafeDeps struct {
 	candidateCrossSafeFn  func() (candidate types.DerivedBlockRefPair, err error)
 	openBlockFn           func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 	updateCrossSafeFn     func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
-	nextSourceFn          func(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error)
+	nextSourceFn          func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error)
 	previousDerivedFn     func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
 	checkFn               func(chainID eth.ChainID, blockNum uint64, logIdx uint32, logHash common.Hash) (types.BlockSeal, error)
 	invalidateLocalSafeFn func(chainID eth.ChainID, candidate types.DerivedBlockRefPair) error
@@ -481,7 +481,7 @@ func (m *mockCrossSafeDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockCrossSafeDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error) {
+func (m *mockCrossSafeDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error) {
 	return types.BlockSeal{}, nil
 }
 
@@ -492,9 +492,9 @@ func (m *mockCrossSafeDeps) Contains(chainID eth.ChainID, q types.ContainsQuery)
 	return types.BlockSeal{}, nil
 }
 
-func (m *mockCrossSafeDeps) NextSource(chain eth.ChainID, derivedFrom eth.BlockID) (after eth.BlockRef, err error) {
+func (m *mockCrossSafeDeps) NextSource(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error) {
 	if m.nextSourceFn != nil {
-		return m.nextSourceFn(chain, derivedFrom)
+		return m.nextSourceFn(chain, source)
 	}
 	return eth.BlockRef{}, nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -95,7 +95,7 @@ func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal,
 }
 
 // Latest returns the last known values:
-// derivedFrom: the L1 block that the L2 block is safe for (not necessarily the first, multiple L2 blocks may be derived from the same L1 block).
+// source: the L1 block that the L2 block is safe for (not necessarily the first, multiple L2 blocks may be derived from the same L1 block).
 // derived: the L2 block that was derived (not necessarily the first, the L1 block may have been empty and repeated the last safe L2 block).
 // If the last entry is invalidated, this returns a types.ErrAwaitReplacementBlock error.
 func (db *DB) Last() (pair types.DerivedBlockSealPair, err error) {
@@ -314,11 +314,11 @@ func (db *DB) sourceNumToLastDerived(sourceNum uint64) (entrydb.EntryIdx, LinkEn
 	})
 }
 
-func (db *DB) lookup(derivedFrom, derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
+func (db *DB) lookup(source, derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	return db.find(false, func(link LinkEntry) int {
 		res := cmp.Compare(link.derived.Number, derived)
 		if res == 0 {
-			return cmp.Compare(link.source.Number, derivedFrom)
+			return cmp.Compare(link.source.Number, source)
 		}
 		return res
 	})

--- a/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
@@ -94,16 +94,16 @@ func invariantDerivedTimestamp(prev, current LinkEntry) error {
 func invariantNumberIncrement(prev, current LinkEntry) error {
 	// derived stays the same if the new L1 block is empty.
 	derivedSame := current.derived.Number == prev.derived.Number
-	// derivedFrom stays the same if this L2 block is derived from the same L1 block as the last L2 block
-	derivedFromSame := current.source.Number == prev.source.Number
+	// source stays the same if this L2 block is derived from the same L1 block as the last L2 block
+	sourceSame := current.source.Number == prev.source.Number
 	// At least one of the two must increment, otherwise we are just repeating data in the DB.
-	if derivedSame && derivedFromSame {
-		return errors.New("expected at least either derivedFrom or derived to increment, but both have same number")
+	if derivedSame && sourceSame {
+		return errors.New("expected at least either source or derived to increment, but both have same number")
 	}
 	derivedIncrement := current.derived.Number == prev.derived.Number+1
-	derivedFromIncrement := current.source.Number == prev.source.Number+1
-	if derivedIncrement == derivedFromIncrement { // one of the two must be true, the other false, to pass.
-		return errors.New("expected derivedFrom or (excl.) derived to increment")
+	sourceIncrement := current.source.Number == prev.source.Number+1
+	if derivedIncrement == sourceIncrement { // one of the two must be true, the other false, to pass.
+		return errors.New("expected source or (excl.) derived to increment")
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -167,7 +167,7 @@ func TestSingleEntryDB(t *testing.T) {
 			_, err = db.SourceToLastDerived(eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedSource.Number})
 			require.ErrorIs(t, err, types.ErrConflict)
 
-			// Next with a non-existent block (derived and derivedFrom)
+			// Next with a non-existent block (derived and source)
 			_, err = db.Next(types.DerivedIDPair{
 				Source:  eth.BlockID{Hash: common.Hash{0xaa}, Number: expectedSource.Number},
 				Derived: expectedDerived.ID()})
@@ -178,9 +178,9 @@ func TestSingleEntryDB(t *testing.T) {
 			require.ErrorIs(t, err, types.ErrConflict)
 
 			// First Source
-			derivedFrom, err := db.DerivedToFirstSource(expectedDerived.ID())
+			source, err := db.DerivedToFirstSource(expectedDerived.ID())
 			require.NoError(t, err)
-			require.Equal(t, expectedSource, derivedFrom)
+			require.Equal(t, expectedSource, source)
 
 			// Source with a non-existent Derived
 			_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: expectedDerived.Number})
@@ -264,9 +264,9 @@ func TestThreeBlocksDB(t *testing.T) {
 		_, err = db.SourceToLastDerived(eth.BlockID{Hash: common.Hash{0xaa}, Number: l1Block2.Number})
 		require.ErrorIs(t, err, types.ErrConflict)
 
-		derivedFrom, err := db.DerivedToFirstSource(l2Block2.ID())
+		source, err := db.DerivedToFirstSource(l2Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
+		require.Equal(t, l1Block2, source)
 
 		_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: l2Block2.Number})
 		require.ErrorIs(t, err, types.ErrConflict)
@@ -275,17 +275,17 @@ func TestThreeBlocksDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, derived)
 
-		derivedFrom, err = db.DerivedToFirstSource(l2Block1.ID())
+		source, err = db.DerivedToFirstSource(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
+		require.Equal(t, l1Block1, source)
 
 		derived, err = db.SourceToLastDerived(l1Block0.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		derivedFrom, err = db.DerivedToFirstSource(l2Block0.ID())
+		source, err = db.DerivedToFirstSource(l2Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, derivedFrom)
+		require.Equal(t, l1Block0, source)
 
 		derived, err = db.PreviousDerived(l2Block0.ID())
 		require.NoError(t, err)
@@ -312,25 +312,25 @@ func TestThreeBlocksDB(t *testing.T) {
 		_, err = db.NextDerived(l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		derivedFrom, err = db.PreviousSource(l1Block0.ID())
+		source, err = db.PreviousSource(l1Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, types.BlockSeal{}, derivedFrom)
+		require.Equal(t, types.BlockSeal{}, source)
 
-		derivedFrom, err = db.PreviousSource(l1Block1.ID())
+		source, err = db.PreviousSource(l1Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, derivedFrom)
+		require.Equal(t, l1Block0, source)
 
-		derivedFrom, err = db.PreviousSource(l1Block2.ID())
+		source, err = db.PreviousSource(l1Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
+		require.Equal(t, l1Block1, source)
 
-		derivedFrom, err = db.NextSource(l1Block0.ID())
+		source, err = db.NextSource(l1Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
+		require.Equal(t, l1Block1, source)
 
-		derivedFrom, err = db.NextSource(l1Block1.ID())
+		source, err = db.NextSource(l1Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
+		require.Equal(t, l1Block2, source)
 
 		_, err = db.NextSource(l1Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
@@ -409,15 +409,15 @@ func TestFastL2Batcher(t *testing.T) {
 		require.Equal(t, l2Block5, derived)
 
 		// test what tip was derived from
-		derivedFrom, err := db.DerivedToFirstSource(l2Block5.ID())
+		source, err := db.DerivedToFirstSource(l2Block5.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
+		require.Equal(t, l1Block2, source)
 
 		// Multiple L2 blocks all derived from same older L1 block
 		for _, b := range []types.BlockSeal{l2Block1, l2Block2, l2Block3, l2Block4} {
-			derivedFrom, err = db.DerivedToFirstSource(b.ID())
+			source, err = db.DerivedToFirstSource(b.ID())
 			require.NoError(t, err)
-			require.Equal(t, l1Block1, derivedFrom)
+			require.Equal(t, l1Block1, source)
 		}
 
 		// test that the Last L2 counts, not the intermediate
@@ -464,19 +464,19 @@ func TestFastL2Batcher(t *testing.T) {
 		_, err = db.NextDerived(l2Block5.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		derivedFrom, err = db.PreviousSource(l1Block2.ID())
+		source, err = db.PreviousSource(l1Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		derivedFrom, err = db.PreviousSource(l1Block1.ID())
+		require.Equal(t, l1Block1, source)
+		source, err = db.PreviousSource(l1Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, derivedFrom)
+		require.Equal(t, l1Block0, source)
 
-		derivedFrom, err = db.NextSource(l1Block0.ID())
+		source, err = db.NextSource(l1Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		derivedFrom, err = db.NextSource(l1Block1.ID())
+		require.Equal(t, l1Block1, source)
+		source, err = db.NextSource(l1Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
+		require.Equal(t, l1Block2, source)
 		_, err = db.NextSource(l1Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
@@ -537,9 +537,9 @@ func TestSlowL2Batcher(t *testing.T) {
 		}
 
 		// test that the first L1 counts, not the ones that repeat the L2 info
-		derivedFrom, err := db.DerivedToFirstSource(l2Block1.ID())
+		source, err := db.DerivedToFirstSource(l2Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
+		require.Equal(t, l1Block1, source)
 
 		derived, err = db.PreviousDerived(l2Block2.ID())
 		require.NoError(t, err)
@@ -559,34 +559,34 @@ func TestSlowL2Batcher(t *testing.T) {
 		_, err = db.NextDerived(l2Block2.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
-		derivedFrom, err = db.PreviousSource(l1Block5.ID())
+		source, err = db.PreviousSource(l1Block5.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block4, derivedFrom)
-		derivedFrom, err = db.PreviousSource(l1Block4.ID())
+		require.Equal(t, l1Block4, source)
+		source, err = db.PreviousSource(l1Block4.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block3, derivedFrom)
-		derivedFrom, err = db.PreviousSource(l1Block3.ID())
+		require.Equal(t, l1Block3, source)
+		source, err = db.PreviousSource(l1Block3.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
-		derivedFrom, err = db.PreviousSource(l1Block2.ID())
+		require.Equal(t, l1Block2, source)
+		source, err = db.PreviousSource(l1Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		derivedFrom, err = db.PreviousSource(l1Block1.ID())
+		require.Equal(t, l1Block1, source)
+		source, err = db.PreviousSource(l1Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block0, derivedFrom)
+		require.Equal(t, l1Block0, source)
 
-		derivedFrom, err = db.NextSource(l1Block0.ID())
+		source, err = db.NextSource(l1Block0.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block1, derivedFrom)
-		derivedFrom, err = db.NextSource(l1Block1.ID())
+		require.Equal(t, l1Block1, source)
+		source, err = db.NextSource(l1Block1.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block2, derivedFrom)
-		derivedFrom, err = db.NextSource(l1Block2.ID())
+		require.Equal(t, l1Block2, source)
+		source, err = db.NextSource(l1Block2.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block3, derivedFrom)
-		derivedFrom, err = db.NextSource(l1Block4.ID())
+		require.Equal(t, l1Block3, source)
+		source, err = db.NextSource(l1Block4.ID())
 		require.NoError(t, err)
-		require.Equal(t, l1Block5, derivedFrom)
+		require.Equal(t, l1Block5, source)
 		_, err = db.NextSource(l1Block5.ID())
 		require.ErrorIs(t, err, types.ErrFuture)
 
@@ -638,13 +638,13 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 			case 1: // bump L2
 				pair.Derived = mockL2(pair.Derived.Number + 1)
 			}
-			derivedFromRef := toRef(pair.Source, mockL1(pair.Source.Number-1).Hash)
+			sourceRef := toRef(pair.Source, mockL1(pair.Source.Number-1).Hash)
 			derivedRef := toRef(pair.Derived, mockL2(pair.Derived.Number-1).Hash)
-			lastDerived[derivedFromRef.ID()] = pair.Derived
+			lastDerived[sourceRef.ID()] = pair.Derived
 			if _, ok := firstSource[derivedRef.ID()]; !ok {
 				firstSource[derivedRef.ID()] = pair.Source
 			}
-			require.NoError(t, db.AddDerived(derivedFromRef, derivedRef))
+			require.NoError(t, db.AddDerived(sourceRef, derivedRef))
 		}
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 		// Now assert we can find what they are all derived from, and match the expectations.
@@ -663,10 +663,10 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 
 		for i := offsetL2; i <= pair.Derived.Number; i++ {
 			l2ID := mockL2(i).ID()
-			derivedFrom, err := db.DerivedToFirstSource(l2ID)
+			source, err := db.DerivedToFirstSource(l2ID)
 			require.NoError(t, err)
 			require.Contains(t, firstSource, l2ID)
-			require.Equal(t, firstSource[l2ID], derivedFrom)
+			require.Equal(t, firstSource[l2ID], source)
 		}
 
 		// if not started at genesis, try to read older data, assert it's unavailable.

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -48,18 +48,18 @@ func (EntryBinary) EntrySize() int {
 	return EntrySize
 }
 
-// LinkEntry is a DerivedFromV0 or a InvalidatedFromV0 kind
+// LinkEntry is a SourceV0 or a InvalidatedFromV0 kind
 type LinkEntry struct {
 	source  types.BlockSeal
 	derived types.BlockSeal
 	// when it exists as local-safe, but cannot be cross-safe.
-	// If false: this link is a DerivedFromV0
+	// If false: this link is a SourceV0
 	// If true: this link is a InvalidatedFromV0
 	invalidated bool
 }
 
 func (d LinkEntry) String() string {
-	return fmt.Sprintf("LinkEntry(derivedFrom: %s, derived: %s, invalidated: %v)", d.source, d.derived, d.invalidated)
+	return fmt.Sprintf("LinkEntry(source: %s, derived: %s, invalidated: %v)", d.source, d.derived, d.invalidated)
 }
 
 func (d *LinkEntry) decode(e Entry) error {

--- a/op-supervisor/supervisor/backend/db/fromda/update_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update_test.go
@@ -42,7 +42,7 @@ func TestBadUpdates(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "add on old derivedFrom before DB start",
+			name: "add on old source before DB start",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, db.AddDerived(
 					toRef(bSource, aSource.Hash), // b is before c
@@ -71,7 +71,7 @@ func TestBadUpdates(t *testing.T) {
 			assertFn: noChange,
 		},
 		{
-			name: "repeat latest derived, old derivedFrom",
+			name: "repeat latest derived, old source",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.NoError(t, db.AddDerived(
 					toRef(eSource, dSource.Hash),   // new L1 block
@@ -90,7 +90,7 @@ func TestBadUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "repeat latest derived, conflicting old derivedFrom",
+			name: "repeat latest derived, conflicting old source",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.NoError(t, db.AddDerived(
 					toRef(eSource, dSource.Hash),   // new L1 block
@@ -109,7 +109,7 @@ func TestBadUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "new derived, old derivedFrom",
+			name: "new derived, old source",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.NoError(t, db.AddDerived(
 					toRef(eSource, dSource.Hash),   // new L1 block
@@ -128,7 +128,7 @@ func TestBadUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "add on conflicting derivedFrom, same height. And new derived value",
+			name: "add on conflicting source, same height. And new derived value",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, db.AddDerived(
 					toRef(types.BlockSeal{
@@ -155,7 +155,7 @@ func TestBadUpdates(t *testing.T) {
 			},
 		},
 		{
-			name: "Conflicting derivedFrom parent root, new L1 height, same L2",
+			name: "Conflicting source parent root, new L1 height, same L2",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t,
 					db.AddDerived(
@@ -165,7 +165,7 @@ func TestBadUpdates(t *testing.T) {
 			assertFn: noChange,
 		},
 		{
-			name: "add on too new derivedFrom (even if parent-hash looks correct)",
+			name: "add on too new source (even if parent-hash looks correct)",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t,
 					db.AddDerived(toRef(fSource, dSource.Hash),
@@ -174,7 +174,7 @@ func TestBadUpdates(t *testing.T) {
 			assertFn: noChange,
 		},
 		{
-			name: "add on old derivedFrom (even if parent-hash looks correct)",
+			name: "add on old source (even if parent-hash looks correct)",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, db.AddDerived(
 					toRef(cSource, bSource.Hash),
@@ -183,7 +183,7 @@ func TestBadUpdates(t *testing.T) {
 			assertFn: noChange,
 		},
 		{
-			name: "add on even older derivedFrom",
+			name: "add on even older source",
 			setupFn: func(t *testing.T, db *DB, m *stubMetrics) {
 				require.ErrorIs(t, db.AddDerived(
 					toRef(bSource, aSource.Hash),

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -39,7 +39,7 @@ func (m *MockBackend) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (m *MockBackend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error) {
+func (m *MockBackend) AllSafeDerivedAt(ctx context.Context, source eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error) {
 	return nil, nil
 }
 
@@ -71,7 +71,7 @@ func (m *MockBackend) FinalizedL1() eth.BlockRef {
 	return eth.BlockRef{}
 }
 
-func (m *MockBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+func (m *MockBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
 	return eth.BlockRef{}, nil
 }
 

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -21,9 +21,9 @@ type l1Node interface {
 type rewinderDB interface {
 	DependencySet() depset.DependencySet
 
-	CrossSourceToLastDerived(chainID eth.ChainID, derivedFrom eth.BlockID) (derived types.BlockSeal, err error)
+	CrossSourceToLastDerived(chainID eth.ChainID, source eth.BlockID) (derived types.BlockSeal, err error)
 	PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource types.BlockSeal, err error)
-	CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
+	CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error)
 
 	LocalSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
 	CrossSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
@@ -35,7 +35,7 @@ type rewinderDB interface {
 	FindSealedBlock(eth.ChainID, uint64) (types.BlockSeal, error)
 	Finalized(eth.ChainID) (types.BlockSeal, error)
 
-	LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID) (derivedFrom types.BlockSeal, err error)
+	LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
 }
 
 // Rewinder is responsible for handling the rewinding of databases to the latest common ancestor between
@@ -201,7 +201,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 		}
 
 		// Get the previous L1 block from our DB
-		prevDerivedFrom, err := r.db.PreviousSource(chainID, currentL1)
+		prevSource, err := r.db.PreviousSource(chainID, currentL1)
 		if err != nil {
 			// If we hit the first block, use it as common ancestor
 			if errors.Is(err, types.ErrPreviousToFirst) {
@@ -222,7 +222,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 		}
 
 		// Move to the parent
-		currentL1 = prevDerivedFrom.ID()
+		currentL1 = prevSource.ID()
 	}
 
 	// Rewind LocalSafe to not include data derived from the old L1 chain

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -21,7 +21,7 @@ type mockSyncControl struct {
 	anchorPointFn       func(ctx context.Context) (types.DerivedBlockRefPair, error)
 	provideL1Fn         func(ctx context.Context, ref eth.BlockRef) error
 	resetFn             func(ctx context.Context, unsafe, safe, finalized eth.BlockID) error
-	updateCrossSafeFn   func(ctx context.Context, derived, derivedFrom eth.BlockID) error
+	updateCrossSafeFn   func(ctx context.Context, derived, source eth.BlockID) error
 	updateCrossUnsafeFn func(ctx context.Context, derived eth.BlockID) error
 	updateFinalizedFn   func(ctx context.Context, id eth.BlockID) error
 	pullEventFn         func(ctx context.Context) (*types.ManagedEvent, error)
@@ -65,9 +65,9 @@ func (m *mockSyncControl) SubscribeEvents(ctx context.Context, ch chan *types.Ma
 	return m.subscribeEvents.Subscribe(ch), nil
 }
 
-func (m *mockSyncControl) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error {
+func (m *mockSyncControl) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, source eth.BlockID) error {
 	if m.updateCrossSafeFn != nil {
-		return m.updateCrossSafeFn(ctx, derived, derivedFrom)
+		return m.updateCrossSafeFn(ctx, derived, source)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func (m *mockSyncControl) String() string {
 var _ SyncControl = (*mockSyncControl)(nil)
 
 type mockBackend struct {
-	safeDerivedAtFn func(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (eth.BlockID, error)
+	safeDerivedAtFn func(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (eth.BlockID, error)
 }
 
 func (m *mockBackend) LocalSafe(ctx context.Context, chainID eth.ChainID) (pair types.DerivedIDPair, err error) {
@@ -108,9 +108,9 @@ func (m *mockBackend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
-func (m *mockBackend) SafeDerivedAt(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (derived eth.BlockID, err error) {
+func (m *mockBackend) SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (derived eth.BlockID, err error) {
 	if m.safeDerivedAtFn != nil {
-		return m.safeDerivedAtFn(ctx, chainID, derivedFrom)
+		return m.safeDerivedAtFn(ctx, chainID, source)
 	}
 	return eth.BlockID{}, nil
 }

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -38,7 +38,7 @@ type SyncControl interface {
 	PullEvent(ctx context.Context) (*types.ManagedEvent, error)
 
 	UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) error
-	UpdateCrossSafe(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error
+	UpdateCrossSafe(ctx context.Context, derived eth.BlockID, source eth.BlockID) error
 	UpdateFinalized(ctx context.Context, id eth.BlockID) error
 
 	InvalidateBlock(ctx context.Context, seal types.BlockSeal) error

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -26,7 +26,7 @@ type backend interface {
 	LocalSafe(ctx context.Context, chainID eth.ChainID) (pair types.DerivedIDPair, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	CrossSafe(ctx context.Context, chainID eth.ChainID) (pair types.DerivedIDPair, err error)
-	SafeDerivedAt(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (derived eth.BlockID, err error)
+	SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (derived eth.BlockID, err error)
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
 }
@@ -250,7 +250,7 @@ func (m *ManagedNode) onCrossUnsafeUpdate(seal types.BlockSeal) {
 }
 
 func (m *ManagedNode) onCrossSafeUpdate(pair types.DerivedBlockSealPair) {
-	m.log.Debug("updating cross safe", "derived", pair.Derived, "derivedFrom", pair.Source)
+	m.log.Debug("updating cross safe", "derived", pair.Derived, "source", pair.Source)
 	ctx, cancel := context.WithTimeout(m.ctx, nodeTimeout)
 	defer cancel()
 	pairIDs := pair.IDs()
@@ -283,7 +283,7 @@ func (m *ManagedNode) onUnsafeBlock(unsafeRef eth.BlockRef) {
 
 func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	m.log.Info("Node derived new block", "derived", pair.Derived,
-		"derivedParent", pair.Derived.ParentID(), "derivedFrom", pair.Source)
+		"derivedParent", pair.Derived.ParentID(), "source", pair.Source)
 	m.emitter.Emit(superevents.LocalDerivedEvent{
 		ChainID: m.chainID,
 		Derived: pair,

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -45,7 +45,7 @@ func TestEventResponse(t *testing.T) {
 		return nil
 	}
 	// the node will call UpdateCrossSafe when a cross-safe event is received from the database
-	syncCtrl.updateCrossSafeFn = func(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error {
+	syncCtrl.updateCrossSafeFn = func(ctx context.Context, derived eth.BlockID, source eth.BlockID) error {
 		crossSafe++
 		return nil
 	}
@@ -166,8 +166,8 @@ func TestResetConflict(t *testing.T) {
 				},
 			}
 			backend := &mockBackend{
-				safeDerivedAtFn: func(ctx context.Context, chainID eth.ChainID, derivedFrom eth.BlockID) (eth.BlockID, error) {
-					return eth.BlockID{Number: derivedFrom.Number}, nil
+				safeDerivedAtFn: func(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (eth.BlockID, error) {
+					return eth.BlockID{Number: source.Number}, nil
 				},
 			}
 

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -114,8 +114,8 @@ func (rs *RPCSyncNode) UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) er
 	return rs.cl.CallContext(ctx, nil, "interop_updateCrossUnsafe", id)
 }
 
-func (rs *RPCSyncNode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, derivedFrom eth.BlockID) error {
-	return rs.cl.CallContext(ctx, nil, "interop_updateCrossSafe", derived, derivedFrom)
+func (rs *RPCSyncNode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID, source eth.BlockID) error {
+	return rs.cl.CallContext(ctx, nil, "interop_updateCrossSafe", derived, source)
 }
 
 func (rs *RPCSyncNode) UpdateFinalized(ctx context.Context, id eth.BlockID) error {


### PR DESCRIPTION
I did a second pass on the token `derivedFrom` across all files in the supervisor backend. In all but 2 cases I renamed `derivedFrom` to `source`:
- one is a TODO comment that points at a github issue
- one is the `CrossSafeDerivedFrom` of `eth.SuperRootResponse` which is outside the scope of the supervisor and is not the current target for cleanup.