### PR TITLE
kt-devnet: Store local images even for non-native docker driver

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -15,7 +15,7 @@ _prestate-build PATH='.':
     docker buildx build --output {{PATH}} --progress plain -f ../op-program/Dockerfile.repro ../
 
 _docker_build TAG TARGET CONTEXT DOCKERFILE *ARGS:
-    docker buildx build -t {{TAG}} \
+    docker buildx build --load -t {{TAG}} \
         -f {{CONTEXT}}/{{DOCKERFILE}} \
         {{ if TARGET != '' {  "--target " + TARGET } else { "" } }} \
         --build-arg GIT_COMMIT={git_commit} \


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Explicitly set `--load` store images locally, even if we do not use default docker builder, such as `docker-container` driver. 

After building the images and not using the default docker builder, further steps of kurtosis could not proceed because image not found.

Docker docs: https://docs.docker.com/reference/cli/docker/buildx/create/#docker-driver

