### PR TITLE
op-deployer: doc: Fix outdir flag

### DIFF
--- a/op-deployer/book/src/user-guide/init.md
+++ b/op-deployer/book/src/user-guide/init.md
@@ -9,7 +9,7 @@ The `init` command is used like this:
 op-deployer init \
   --l1-chain-id <chain ID of your L1> \
   --l2-chain-ids <comman separated list of chain IDs for your L2s> \
-  --output-dir <directory to write the intent and state files> \
+  --outdir <directory to write the intent and state files> \
   --intent-config-type <standard/custom/strict/standard-overrides/strict-overrides>
 ```
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The correct flag name is `outdir` or `workdir`. Source: https://github.com/ethereum-optimism/optimism/blob/e0811070016ebd07ee62652535efd4c897055cbe/op-deployer/pkg/deployer/flags.go#L19-L20