### PR TITLE
op-supervisor: Don't reset when node is far behind

### DIFF
--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -311,8 +311,8 @@ func (m *ManagedNode) resetFromError(errSignal error, l1Ref eth.BlockRef) {
 		// if the out of order signal shows the node is far enough behind,
 		// push a reset to attempt to get the node to tip more quickly.
 		if m.farBehind(l1Ref.ID()) {
-			m.log.Warn("Node is far behind, resetting", "l1Ref", l1Ref, "err", errSignal)
-			m.sendReset()
+			m.log.Warn("Node is far behind and should be reset", "l1Ref", l1Ref, "err", errSignal)
+			// m.sendReset()
 		} else {
 			// otherwise, ignore the out of order signal, the node is near enough to the tip.
 			m.log.Warn("Node is behind, ignoring", "l1Ref", l1Ref, "err", errSignal)


### PR DESCRIPTION
Previously, we heuristically decided that if a node were more than 20 blocks behind, we should ask it to reset up to a the height of the supervisor.

This did not work in 2 different ways:
- nodes which are very far behind can't accept arbitrary heads to reset to
- when batches are larger than 20 blocks, nodes cannot progress

This PR surpresses the reset, but leaves the warning log in place for observation.