### PR TITLE
ctb: Add StandardValidator

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -145,7 +145,7 @@ rules:
       - pattern-not: revert $ERR(...);
       - focus-metavariable: $MSG
       - pattern-not-regex: \"(\w+:\s[^"]+)\"
-      - pattern-not-regex: string\.concat\(\"(\w+:\s[^"]+)\"\,[^"]+\)
+      - pattern-not-regex: string\.concat\(\"(\w+:\s[^"]*)\"\,[^"]+\)
       - pattern-not-regex: \"([a-zA-Z0-9\s]+-[a-zA-Z0-9\s]+)\"
       - pattern-not-regex: \"([a-zA-Z0-9\s]+-[a-zA-Z0-9\s]+-[a-zA-Z0-9\s]+)\"
     paths:

--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -145,7 +145,7 @@ rules:
       - pattern-not: revert $ERR(...);
       - focus-metavariable: $MSG
       - pattern-not-regex: \"(\w+:\s[^"]+)\"
-      - pattern-not-regex: string\.concat\(\"(\w+:\s[^"]*)\"\,[^"]+\)
+      - pattern-not-regex: string\.concat\(\"(\w+:\s[^"]*)\"\,.+\)
       - pattern-not-regex: \"([a-zA-Z0-9\s]+-[a-zA-Z0-9\s]+)\"
       - pattern-not-regex: \"([a-zA-Z0-9\s]+-[a-zA-Z0-9\s]+-[a-zA-Z0-9\s]+)\"
     paths:

--- a/.semgrep/tests/sol-rules.t.sol
+++ b/.semgrep/tests/sol-rules.t.sol
@@ -564,6 +564,9 @@ contract SemgrepTest__sol_style_malformed_revert {
             )
         );
 
+        // ok: sol-style-malformed-revert
+        revert(string.concat("StandardValidatorV180: ", _errors));
+
         // ruleid: sol-style-malformed-revert
         revert("MyContract: ");
 

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Libraries
+import { GameType, Claim, GameTypes, Hash } from "src/dispute/lib/Types.sol";
+import { Duration } from "src/dispute/lib/LibUDT.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+contract StandardValidatorV180 {
+    Implementations internal impls;
+    ISuperchainConfig internal superchainConfig;
+    address internal l1PAOMultisig;
+    address internal mips;
+    address internal guardian;
+    address internal challenger;
+
+    // Semver strings for our contracts. Pulled from the Superchain Registry.
+    string internal constant systemConfigVersion = "2.3.0";
+    string internal constant permissionedDisputeGameVersion = "1.3.1";
+    string internal constant mipsVersion = "1.2.1";
+    string internal constant optimismPortalVersion = "3.10.0";
+    string internal constant anchorStateRegistryVersion = "2.0.0";
+    string internal constant delayedWETHVersion = "1.1.0";
+    string internal constant disputeGameFactoryVersion = "1.0.0";
+    string internal constant l1CrossDomainMessengerVersion = "2.3.0";
+    string internal constant l1ERC721BridgeVersion = "2.1.0";
+    string internal constant l1StandardBridgeVersion = "2.1.0";
+    string internal constant optimismMintableERC20FactoryVersion = "1.9.0";
+    string internal constant preimageOracleVersion = "1.1.2";
+
+    struct Implementations {
+        address l1ERC721BridgeImpl;
+        address optimismPortalImpl;
+        address systemConfigImpl;
+        address optimismMintableERC20FactoryImpl;
+        address l1CrossDomainMessengerImpl;
+        address l1StandardBridgeImpl;
+        address disputeGameFactoryImpl;
+        address anchorStateRegistryImpl;
+        address delayedWETHImpl;
+        address mipsImpl;
+    }
+
+    struct Input {
+        IProxyAdmin proxyAdmin;
+        ISystemConfig sysCfg;
+        bytes32 absolutePrestate;
+        uint256 l2ChainID;
+    }
+
+    constructor(
+        Implementations memory _implementations,
+        ISuperchainConfig _superchainConfig,
+        address _l1PAOMultisig,
+        address _mips,
+        address _guardian,
+        address _challenger
+    ) {
+        impls = _implementations;
+        superchainConfig = _superchainConfig;
+        l1PAOMultisig = _l1PAOMultisig;
+        mips = _mips;
+        guardian = _guardian;
+        challenger = _challenger;
+    }
+
+    function validate(
+        StandardValidatorV180.Input memory _input,
+        bool _allowFailure
+    )
+        public
+        view
+        returns (string memory)
+    {
+        string memory _errors = "";
+
+        _errors = assertValidSuperchainConfig(_errors);
+        _errors = assertValidProxyAdmin(_errors, _input.proxyAdmin);
+        address _l1PAO = _input.proxyAdmin.owner();
+
+        ISystemConfig _sysCfg = _input.sysCfg;
+        _errors = assertValidSystemConfig(_errors, _sysCfg, _input.proxyAdmin);
+        _errors = assertValidL1CrossDomainMessenger(_errors, _sysCfg, _input.proxyAdmin);
+        _errors = assertValidL1StandardBridge(_errors, _sysCfg, _input.proxyAdmin);
+        _errors = assertValidOptimismMintableERC20Factory(_errors, _sysCfg, _input.proxyAdmin);
+        _errors = assertValidL1ERC721Bridge(_errors, _sysCfg, _input.proxyAdmin);
+        _errors = assertValidOptimismPortal(_errors, _sysCfg, _input.proxyAdmin);
+        _errors = assertValidDisputeGameFactory(_errors, _sysCfg, _l1PAO, _input.proxyAdmin);
+        _errors = assertValidPermissionedDisputeGame(
+            _errors, _sysCfg, _input.absolutePrestate, _input.l2ChainID, _input.proxyAdmin
+        );
+        _errors = assertValidPermissionlessDisputeGame(
+            _errors, _sysCfg, _input.absolutePrestate, _input.l2ChainID, _input.proxyAdmin
+        );
+
+        if (bytes(_errors).length > 0 && !_allowFailure) {
+            revert(string.concat("StandardValidatorV180: ", _errors));
+        }
+
+        return _errors;
+    }
+
+    function implementations() public view returns (Implementations memory) {
+        return impls;
+    }
+
+    function assertValidSuperchainConfig(string memory _errors) internal view returns (string memory) {
+        _errors = internalRequire(superchainConfig.guardian() == guardian, "SPRCFG-10", _errors);
+        _errors = internalRequire(!superchainConfig.paused(), "SPRCFG-20", _errors);
+        return _errors;
+    }
+
+    function assertValidProxyAdmin(string memory _errors, IProxyAdmin _admin) internal view returns (string memory) {
+        _errors = internalRequire(_admin.owner() == l1PAOMultisig, "PROXYA-10", _errors);
+        return _errors;
+    }
+
+    function assertValidSystemConfig(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        ISemver _semver = ISemver(address(_sysCfg));
+        _errors = internalRequire(stringEq(_semver.version(), systemConfigVersion), "SYSCON-10", _errors);
+        _errors = internalRequire(_sysCfg.gasLimit() == uint64(60_000_000), "SYSCON-20", _errors);
+        _errors = internalRequire(_sysCfg.scalar() >> 248 == 1, "SYSCON-30", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_sysCfg)) == impls.systemConfigImpl, "SYSCON-40", _errors
+        );
+
+        IResourceMetering.ResourceConfig memory outputConfig = _sysCfg.resourceConfig();
+        _errors = internalRequire(outputConfig.maxResourceLimit == 20_000_000, "SYSCON-50", _errors);
+        _errors = internalRequire(outputConfig.elasticityMultiplier == 10, "SYSCON-60", _errors);
+        _errors = internalRequire(outputConfig.baseFeeMaxChangeDenominator == 8, "SYSCON-70", _errors);
+        _errors = internalRequire(outputConfig.systemTxMaxGas == 1_000_000, "SYSCON-80", _errors);
+        _errors = internalRequire(outputConfig.minimumBaseFee == 1 gwei, "SYSCON-90", _errors);
+        _errors = internalRequire(outputConfig.maximumBaseFee == type(uint128).max, "SYSCON-100", _errors);
+        return _errors;
+    }
+
+    function assertValidL1CrossDomainMessenger(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IL1CrossDomainMessenger _messenger = IL1CrossDomainMessenger(_sysCfg.l1CrossDomainMessenger());
+        _errors = internalRequire(stringEq(_messenger.version(), l1CrossDomainMessengerVersion), "L1xDM-10", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_messenger)) == address(impls.l1CrossDomainMessengerImpl),
+            "L1xDM-20",
+            _errors
+        );
+
+        IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
+
+        _errors = internalRequire(
+            address(_messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L1xDM-30", _errors
+        );
+        _errors = internalRequire(
+            address(_messenger.otherMessenger()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L1xDM-40", _errors
+        );
+        _errors = internalRequire(address(_messenger.PORTAL()) == address(_portal), "L1xDM-50", _errors);
+        _errors = internalRequire(address(_messenger.portal()) == address(_portal), "L1xDM-60", _errors);
+        _errors =
+            internalRequire(address(_messenger.superchainConfig()) == address(superchainConfig), "L1xDM-70", _errors);
+        return _errors;
+    }
+
+    function assertValidL1StandardBridge(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IL1StandardBridge _bridge = IL1StandardBridge(payable(_sysCfg.l1StandardBridge()));
+        _errors = internalRequire(stringEq(_bridge.version(), l1StandardBridgeVersion), "L1SB-10", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_bridge)) == address(impls.l1StandardBridgeImpl), "L1SB-20", _errors
+        );
+
+        IL1CrossDomainMessenger _messenger = IL1CrossDomainMessenger(_sysCfg.l1CrossDomainMessenger());
+
+        _errors = internalRequire(address(_bridge.MESSENGER()) == address(_messenger), "L1SB-30", _errors);
+        _errors = internalRequire(address(_bridge.messenger()) == address(_messenger), "L1SB-40", _errors);
+        _errors = internalRequire(address(_bridge.OTHER_BRIDGE()) == Predeploys.L2_STANDARD_BRIDGE, "L1SB-50", _errors);
+        _errors = internalRequire(address(_bridge.otherBridge()) == Predeploys.L2_STANDARD_BRIDGE, "L1SB-60", _errors);
+        _errors = internalRequire(address(_bridge.superchainConfig()) == address(superchainConfig), "L1SB-70", _errors);
+        return _errors;
+    }
+
+    function assertValidOptimismMintableERC20Factory(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IOptimismMintableERC20Factory _factory = IOptimismMintableERC20Factory(_sysCfg.optimismMintableERC20Factory());
+        _errors =
+            internalRequire(stringEq(_factory.version(), optimismMintableERC20FactoryVersion), "MERC20F-10", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_factory)) == address(impls.optimismMintableERC20FactoryImpl),
+            "MERC20F-20",
+            _errors
+        );
+
+        IL1StandardBridge _bridge = IL1StandardBridge(payable(_sysCfg.l1StandardBridge()));
+        _errors = internalRequire(_factory.BRIDGE() == address(_bridge), "MERC20F-30", _errors);
+        _errors = internalRequire(_factory.bridge() == address(_bridge), "MERC20F-40", _errors);
+        return _errors;
+    }
+
+    function assertValidL1ERC721Bridge(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IL1ERC721Bridge _bridge = IL1ERC721Bridge(_sysCfg.l1ERC721Bridge());
+        _errors = internalRequire(stringEq(_bridge.version(), l1ERC721BridgeVersion), "L721B-10", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_bridge)) == address(impls.l1ERC721BridgeImpl), "L721B-20", _errors
+        );
+
+        IL1CrossDomainMessenger _l1XDM = IL1CrossDomainMessenger(_sysCfg.l1CrossDomainMessenger());
+        _errors = internalRequire(address(_bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE, "L721B-30", _errors);
+        _errors = internalRequire(address(_bridge.otherBridge()) == Predeploys.L2_ERC721_BRIDGE, "L721B-40", _errors);
+        _errors = internalRequire(address(_bridge.MESSENGER()) == address(_l1XDM), "L721B-50", _errors);
+        _errors = internalRequire(address(_bridge.messenger()) == address(_l1XDM), "L721B-60", _errors);
+        _errors = internalRequire(address(_bridge.superchainConfig()) == address(superchainConfig), "L721B-70", _errors);
+        return _errors;
+    }
+
+    function assertValidOptimismPortal(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
+        _errors = internalRequire(stringEq(_portal.version(), optimismPortalVersion), "PORTAL-10", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_portal)) == address(impls.optimismPortalImpl), "PORTAL-20", _errors
+        );
+
+        IDisputeGameFactory _dgf = IDisputeGameFactory(_sysCfg.disputeGameFactory());
+        _errors = internalRequire(address(_portal.disputeGameFactory()) == address(_dgf), "PORTAL-30", _errors);
+        _errors = internalRequire(address(_portal.systemConfig()) == address(_sysCfg), "PORTAL-40", _errors);
+        _errors =
+            internalRequire(address(_portal.superchainConfig()) == address(superchainConfig), "PORTAL-50", _errors);
+        _errors = internalRequire(_portal.guardian() == guardian, "PORTAL-60", _errors);
+        _errors = internalRequire(_portal.paused() == superchainConfig.paused(), "PORTAL-70", _errors);
+        _errors = internalRequire(_portal.l2Sender() == Constants.DEFAULT_L2_SENDER, "PORTAL-80", _errors);
+        return _errors;
+    }
+
+    function assertValidDisputeGameFactory(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        address _l1PAO,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IDisputeGameFactory _factory = IDisputeGameFactory(_sysCfg.disputeGameFactory());
+        _errors = internalRequire(stringEq(_factory.version(), disputeGameFactoryVersion), "DF-10", _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_factory)) == address(impls.disputeGameFactoryImpl), "DF-20", _errors
+        );
+        _errors = internalRequire(_factory.owner() == address(_l1PAO), "DF-30", _errors);
+        return _errors;
+    }
+
+    function assertValidPermissionedDisputeGame(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        bytes32 _absolutePrestate,
+        uint256 _l2ChainID,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IDisputeGameFactory _factory = IDisputeGameFactory(_sysCfg.disputeGameFactory());
+        IPermissionedDisputeGame _game =
+            IPermissionedDisputeGame(address(_factory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
+
+        if (address(_game) == address(0)) {
+            _errors = internalRequire(false, "PDDG-10", _errors);
+            // Return early to avoid reverting, since this means that there is no valid game impl
+            // for this game type.
+            return _errors;
+        }
+
+        _errors = assertValidDisputeGame(
+            _errors, _game, _factory, _absolutePrestate, _l2ChainID, _admin, GameTypes.PERMISSIONED_CANNON, "PDDG"
+        );
+        _errors = internalRequire(_game.challenger() == challenger, "PDDG-120", _errors);
+
+        return _errors;
+    }
+
+    function assertValidPermissionlessDisputeGame(
+        string memory _errors,
+        ISystemConfig _sysCfg,
+        bytes32 _absolutePrestate,
+        uint256 _l2ChainID,
+        IProxyAdmin _admin
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        IDisputeGameFactory _factory = IDisputeGameFactory(_sysCfg.disputeGameFactory());
+        IPermissionedDisputeGame _game = IPermissionedDisputeGame(address(_factory.gameImpls(GameTypes.CANNON)));
+
+        if (address(_game) == address(0)) {
+            _errors = internalRequire(false, "PLDG-10", _errors);
+            // Return early to avoid reverting, since this means that there is no valid game impl
+            // for this game type.
+            return _errors;
+        }
+
+        _errors = assertValidDisputeGame(
+            _errors, _game, _factory, _absolutePrestate, _l2ChainID, _admin, GameTypes.CANNON, "PLDG"
+        );
+
+        return _errors;
+    }
+
+    function assertValidDisputeGame(
+        string memory _errors,
+        IPermissionedDisputeGame _game,
+        IDisputeGameFactory _factory,
+        bytes32 _absolutePrestate,
+        uint256 _l2ChainID,
+        IProxyAdmin _admin,
+        GameType _gameType,
+        string memory _errorPrefix
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        bool validGameVM = address(_game.vm()) == address(mips);
+
+        _errors = internalRequire(
+            stringEq(_game.version(), permissionedDisputeGameVersion), string.concat(_errorPrefix, "-20"), _errors
+        );
+        IAnchorStateRegistry _asr = _game.anchorStateRegistry();
+        _errors = internalRequire(
+            GameType.unwrap(_game.gameType()) == GameType.unwrap(_gameType), string.concat(_errorPrefix, "-30"), _errors
+        );
+        _errors = internalRequire(
+            Claim.unwrap(_game.absolutePrestate()) == _absolutePrestate, string.concat(_errorPrefix, "-40"), _errors
+        );
+        _errors = internalRequire(validGameVM, string.concat(_errorPrefix, "-50"), _errors);
+        _errors = internalRequire(_game.l2ChainId() == _l2ChainID, string.concat(_errorPrefix, "-60"), _errors);
+        _errors = internalRequire(_game.l2BlockNumber() == 0, string.concat(_errorPrefix, "-70"), _errors);
+        _errors = internalRequire(
+            Duration.unwrap(_game.clockExtension()) == 10800, string.concat(_errorPrefix, "-80"), _errors
+        );
+        _errors = internalRequire(_game.splitDepth() == 30, string.concat(_errorPrefix, "-90"), _errors);
+        _errors = internalRequire(_game.maxGameDepth() == 73, string.concat(_errorPrefix, "-100"), _errors);
+        _errors = internalRequire(
+            Duration.unwrap(_game.maxClockDuration()) == 302400, string.concat(_errorPrefix, "-110"), _errors
+        );
+
+        _errors = assertValidDelayedWETH(_errors, _game.weth(), _admin, _errorPrefix);
+        _errors = assertValidAnchorStateRegistry(_errors, _factory, _asr, _admin, _gameType, _errorPrefix);
+
+        // Only assert valid preimage oracle if the game VM is valid, since otherwise
+        // the contract is likely to revert.
+        if (validGameVM) {
+            _errors = assertValidPreimageOracle(_errors, _game.vm().oracle(), _errorPrefix);
+        }
+
+        return _errors;
+    }
+
+    function assertValidDelayedWETH(
+        string memory _errors,
+        IDelayedWETH _weth,
+        IProxyAdmin _admin,
+        string memory _errorPrefix
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        _errorPrefix = string.concat(_errorPrefix, "-DWETH");
+        _errors =
+            internalRequire(stringEq(_weth.version(), delayedWETHVersion), string.concat(_errorPrefix, "-10"), _errors);
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_weth)) == address(impls.delayedWETHImpl),
+            string.concat(_errorPrefix, "-20"),
+            _errors
+        );
+        _errors = internalRequire(_weth.owner() == challenger, string.concat(_errorPrefix, "-30"), _errors);
+        _errors = internalRequire(_weth.delay() == 1 weeks, string.concat(_errorPrefix, "-40"), _errors);
+        return _errors;
+    }
+
+    function assertValidAnchorStateRegistry(
+        string memory _errors,
+        IDisputeGameFactory _dgf,
+        IAnchorStateRegistry _asr,
+        IProxyAdmin _admin,
+        GameType _gameType,
+        string memory _errorPrefix
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        _errorPrefix = string.concat(_errorPrefix, "-ANCHORP");
+        _errors = internalRequire(
+            stringEq(_asr.version(), anchorStateRegistryVersion), string.concat(_errorPrefix, "-10"), _errors
+        );
+        _errors = internalRequire(
+            _admin.getProxyImplementation(address(_asr)) == address(impls.anchorStateRegistryImpl),
+            string.concat(_errorPrefix, "-20"),
+            _errors
+        );
+        _errors = internalRequire(
+            address(_asr.disputeGameFactory()) == address(_dgf), string.concat(_errorPrefix, "-30"), _errors
+        );
+
+        (Hash actualRoot,) = _asr.anchors(_gameType);
+        bytes32 expectedRoot = 0xdead000000000000000000000000000000000000000000000000000000000000;
+        _errors = internalRequire(Hash.unwrap(actualRoot) == expectedRoot, string.concat(_errorPrefix, "-40"), _errors);
+        _errors = internalRequire(
+            address(_asr.superchainConfig()) == address(superchainConfig), string.concat(_errorPrefix, "-50"), _errors
+        );
+        return _errors;
+    }
+
+    function assertValidPreimageOracle(
+        string memory _errors,
+        IPreimageOracle _oracle,
+        string memory _errorPrefix
+    )
+        internal
+        view
+        returns (string memory)
+    {
+        _errorPrefix = string.concat(_errorPrefix, "-PIMGO");
+        // The preimage oracle's address is correct if the MIPS address is correct.
+        _errors = internalRequire(
+            stringEq(_oracle.version(), preimageOracleVersion), string.concat(_errorPrefix, "-10"), _errors
+        );
+        _errors = internalRequire(_oracle.challengePeriod() == 86400, string.concat(_errorPrefix, "-20"), _errors);
+        _errors = internalRequire(_oracle.minProposalSize() == 126000, string.concat(_errorPrefix, "-30"), _errors);
+        return _errors;
+    }
+
+    function internalRequire(
+        bool _condition,
+        string memory _message,
+        string memory _errors
+    )
+        internal
+        pure
+        returns (string memory)
+    {
+        if (_condition) {
+            return _errors;
+        }
+        if (bytes(_errors).length == 0) {
+            _errors = _message;
+        } else {
+            _errors = string.concat(_errors, ",", _message);
+        }
+        return _errors;
+    }
+
+    function stringEq(string memory _a, string memory _b) internal pure returns (bool) {
+        return keccak256(bytes(_a)) == keccak256(bytes(_b));
+    }
+}

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -29,7 +29,6 @@ contract StandardValidatorV180 {
     ISuperchainConfig internal superchainConfig;
     address internal l1PAOMultisig;
     address internal mips;
-    address internal guardian;
     address internal challenger;
 
     // Semver strings for our contracts. Pulled from the Superchain Registry.
@@ -71,14 +70,12 @@ contract StandardValidatorV180 {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _guardian,
         address _challenger
     ) {
         impls = _implementations;
         superchainConfig = _superchainConfig;
         l1PAOMultisig = _l1PAOMultisig;
         mips = _mips;
-        guardian = _guardian;
         challenger = _challenger;
     }
 
@@ -123,8 +120,7 @@ contract StandardValidatorV180 {
     }
 
     function assertValidSuperchainConfig(string memory _errors) internal view returns (string memory) {
-        _errors = internalRequire(superchainConfig.guardian() == guardian, "SPRCFG-10", _errors);
-        _errors = internalRequire(!superchainConfig.paused(), "SPRCFG-20", _errors);
+        _errors = internalRequire(!superchainConfig.paused(), "SPRCFG-10", _errors);
         return _errors;
     }
 
@@ -285,7 +281,7 @@ contract StandardValidatorV180 {
         _errors = internalRequire(address(_portal.systemConfig()) == address(_sysCfg), "PORTAL-40", _errors);
         _errors =
             internalRequire(address(_portal.superchainConfig()) == address(superchainConfig), "PORTAL-50", _errors);
-        _errors = internalRequire(_portal.guardian() == guardian, "PORTAL-60", _errors);
+        _errors = internalRequire(_portal.guardian() == superchainConfig.guardian(), "PORTAL-60", _errors);
         _errors = internalRequire(_portal.paused() == superchainConfig.paused(), "PORTAL-70", _errors);
         _errors = internalRequire(_portal.l2Sender() == Constants.DEFAULT_L2_SENDER, "PORTAL-80", _errors);
         return _errors;

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -124,7 +124,7 @@ contract StandardValidatorV180_Test is Test {
     }
 
     function test_validate_opMainnet_succeeds() public {
-        string memory rpcUrl = vm.envString("MAINNET_RPC_URL");
+        string memory rpcUrl = vm.envOr(string("MAINNET_RPC_URL"), string(""));
         if (bytes(rpcUrl).length == 0) {
             return;
         }
@@ -199,7 +199,7 @@ contract StandardValidatorV180_Test is Test {
         );
 
         // Expect revert with PDDG-10 error message
-        vm.expectRevert("StandardValidator: PDDG-10");
+        vm.expectRevert("StandardValidatorV180: PDDG-10");
         validator.validate(input, false);
     }
 

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -1,0 +1,1102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing
+import { Test } from "forge-std/Test.sol";
+
+// Target contract
+import { StandardValidatorV180 } from "src/L1/StandardValidator.sol";
+
+// Libraries
+import { GameType, GameTypes, Hash } from "src/dispute/lib/Types.sol";
+import { Duration } from "src/dispute/lib/LibUDT.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IERC721Bridge } from "interfaces/universal/IERC721Bridge.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IMIPS } from "interfaces/cannon/IMIPS.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IStandardBridge } from "interfaces/universal/IStandardBridge.sol";
+
+contract StandardValidatorV180_Test is Test {
+    StandardValidatorV180 validator;
+    ISuperchainConfig superchainConfig;
+    address l1PAOMultisig;
+    address mips;
+    address guardian;
+    address challenger;
+
+    // Mock contracts for validation
+    IProxyAdmin proxyAdmin;
+    ISystemConfig systemConfig;
+    bytes32 absolutePrestate;
+    uint256 l2ChainID;
+
+    // Mock addresses for dependencies
+    address disputeGameFactory;
+    address permissionedDisputeGame;
+    address permissionlessDisputeGame;
+    address permissionedASR;
+    address permissionlessASR;
+    address optimismPortal;
+    address l1CrossDomainMessenger;
+    address l1StandardBridge;
+    address l1ERC721Bridge;
+    address optimismMintableERC20Factory;
+    address permissionedDelayedWETH;
+    address permissionlessDelayedWETH;
+    address preimageOracle;
+
+    function setUp() public {
+        // Setup test addresses
+        l1PAOMultisig = makeAddr("l1PAOMultisig");
+        mips = makeAddr("mips");
+        guardian = makeAddr("guardian");
+        challenger = makeAddr("challenger");
+        superchainConfig = ISuperchainConfig(makeAddr("superchainConfig"));
+
+        // Mock superchainConfig calls needed in setup
+        vm.mockCall(address(superchainConfig), abi.encodeCall(ISuperchainConfig.guardian, ()), abi.encode(guardian));
+        vm.mockCall(address(superchainConfig), abi.encodeCall(ISuperchainConfig.paused, ()), abi.encode(false));
+
+        // Deploy validator with all required constructor args
+        validator = new StandardValidatorV180(
+            StandardValidatorV180.Implementations({
+                systemConfigImpl: makeAddr("systemConfigImpl"),
+                optimismPortalImpl: makeAddr("optimismPortalImpl"),
+                l1CrossDomainMessengerImpl: makeAddr("l1CrossDomainMessengerImpl"),
+                l1StandardBridgeImpl: makeAddr("l1StandardBridgeImpl"),
+                l1ERC721BridgeImpl: makeAddr("l1ERC721BridgeImpl"),
+                optimismMintableERC20FactoryImpl: makeAddr("optimismMintableERC20FactoryImpl"),
+                disputeGameFactoryImpl: makeAddr("disputeGameFactoryImpl"),
+                mipsImpl: makeAddr("mipsImpl"),
+                anchorStateRegistryImpl: makeAddr("anchorStateRegistryImpl"),
+                delayedWETHImpl: makeAddr("delayedWETHImpl")
+            }),
+            superchainConfig,
+            l1PAOMultisig,
+            mips,
+            guardian,
+            challenger
+        );
+
+        // Setup mock contracts for validation
+        proxyAdmin = IProxyAdmin(makeAddr("proxyAdmin"));
+        systemConfig = ISystemConfig(makeAddr("systemConfig"));
+        absolutePrestate = bytes32(uint256(0xdead));
+        l2ChainID = 10;
+
+        // Setup mock dependency addresses
+        disputeGameFactory = makeAddr("disputeGameFactory");
+        permissionedDisputeGame = makeAddr("permissionedDisputeGame");
+        permissionlessDisputeGame = makeAddr("permissionlessDisputeGame");
+        permissionedASR = makeAddr("anchorStateRegistry");
+        permissionlessASR = makeAddr("permissionlessAnchorStateRegistry");
+        optimismPortal = makeAddr("optimismPortal");
+        l1CrossDomainMessenger = makeAddr("l1CrossDomainMessenger");
+        l1StandardBridge = makeAddr("l1StandardBridge");
+        l1ERC721Bridge = makeAddr("l1ERC721Bridge");
+        optimismMintableERC20Factory = makeAddr("optimismMintableERC20Factory");
+        permissionedDelayedWETH = makeAddr("delayedWETH");
+        permissionlessDelayedWETH = makeAddr("permissionlessDelayedWETH");
+        preimageOracle = makeAddr("preimageOracle");
+
+        // Mock proxyAdmin owner
+        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(l1PAOMultisig));
+
+        preimageOracle = makeAddr("preimageOracle");
+    }
+
+    function test_validate_opMainnet_succeeds() public {
+        string memory rpcUrl = vm.envString("MAINNET_RPC_URL");
+        if (bytes(rpcUrl).length == 0) {
+            return;
+        }
+
+        vm.createSelectFork(rpcUrl);
+
+        StandardValidatorV180 mainnetValidator = new StandardValidatorV180(
+            StandardValidatorV180.Implementations({
+                systemConfigImpl: address(0xAB9d6cB7A427c0765163A7f45BB91cAfe5f2D375),
+                optimismPortalImpl: address(0xe2F826324b2faf99E513D16D266c3F80aE87832B),
+                l1CrossDomainMessengerImpl: address(0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65),
+                l1StandardBridgeImpl: address(0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF),
+                l1ERC721BridgeImpl: address(0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d),
+                optimismMintableERC20FactoryImpl: address(0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846),
+                disputeGameFactoryImpl: address(0xc641A33cab81C559F2bd4b21EA34C290E2440C2B),
+                mipsImpl: address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C),
+                anchorStateRegistryImpl: address(0x1B5CC028A4276597C607907F24E1AC05d3852cFC),
+                delayedWETHImpl: address(0x71e966Ae981d1ce531a7b6d23DC0f27B38409087)
+            }),
+            ISuperchainConfig(address(0x95703e0982140D16f8ebA6d158FccEde42f04a4C)),
+            address(0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A), // l1PAOMultisig
+            address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C), // mips
+            address(0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2), // guardian
+            address(0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A) // challenger
+        );
+
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: IProxyAdmin(address(0x543bA4AADBAb8f9025686Bd03993043599c6fB04)),
+            sysCfg: ISystemConfig(address(0x229047fed2591dbec1eF1118d64F7aF3dB9EB290)),
+            absolutePrestate: bytes32(0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568),
+            l2ChainID: 10
+        });
+
+        // OP Mainnet has a different expected root than the default one, so we expect to see ANCHORP-40.
+        string memory errors = mainnetValidator.validate(input, true);
+        assertEq(errors, "PDDG-ANCHORP-40,PLDG-ANCHORP-40");
+    }
+
+    /// @notice Tests that validation succeeds with valid inputs and mocked dependencies
+    function test_validate_allowFailureTrue_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Mock all necessary calls for validation
+        _mockValidationCalls();
+
+        // Validate with allowFailure = true
+        string memory errors = validator.validate(input, true);
+        assertEq(errors, "");
+    }
+
+    /// @notice Tests that validation reverts with error message when allowFailure is false
+    function test_validate_allowFailureFalse_reverts() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        _mockValidationCalls();
+
+        // Mock null implementation for permissioned dispute game
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.PERMISSIONED_CANNON)),
+            abi.encode(address(0))
+        );
+
+        // Expect revert with PDDG-10 error message
+        vm.expectRevert("StandardValidator: PDDG-10");
+        validator.validate(input, false);
+    }
+
+    /// @notice Tests that validation fails with invalid proxy admin owner
+    function test_validate_proxyAdmin_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        _mockValidationCalls();
+
+        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(address(0xbad)));
+
+        // Mocking the proxy admin like this will also break ownership checks
+        // for the DGF, DelayedWETH, and other contracts.
+        assertErrorCode(input, "PROXYA-10,DF-30");
+    }
+
+    /// @notice Tests validation of SystemConfig
+    function test_validate_systemConfig_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "SYSCON-10");
+
+        // Test invalid gas limit
+        _mockValidationCalls();
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.gasLimit, ()), abi.encode(uint64(1_000_000)));
+        assertErrorCode(input, "SYSCON-20");
+
+        // Test invalid scalar
+        _mockValidationCalls();
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.scalar, ()), abi.encode(uint256(2) << 248));
+        assertErrorCode(input, "SYSCON-30");
+
+        // Test invalid proxy implementation
+        _mockValidationCalls();
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(systemConfig))),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "SYSCON-40");
+
+        // Test invalid resource config - maxResourceLimit
+        _mockValidationCalls();
+        IResourceMetering.ResourceConfig memory badConfig = IResourceMetering.ResourceConfig({
+            maxResourceLimit: 1_000_000,
+            elasticityMultiplier: 10,
+            baseFeeMaxChangeDenominator: 8,
+            systemTxMaxGas: 1_000_000,
+            minimumBaseFee: 1 gwei,
+            maximumBaseFee: type(uint128).max
+        });
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(badConfig));
+        assertErrorCode(input, "SYSCON-50");
+
+        // Test invalid resource config - elasticityMultiplier
+        _mockValidationCalls();
+        badConfig.maxResourceLimit = 20_000_000;
+        badConfig.elasticityMultiplier = 5;
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(badConfig));
+        assertErrorCode(input, "SYSCON-60");
+
+        // Test invalid resource config - baseFeeMaxChangeDenominator
+        _mockValidationCalls();
+        badConfig.elasticityMultiplier = 10;
+        badConfig.baseFeeMaxChangeDenominator = 4;
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(badConfig));
+        assertErrorCode(input, "SYSCON-70");
+
+        // Test invalid resource config - systemTxMaxGas
+        _mockValidationCalls();
+        badConfig.baseFeeMaxChangeDenominator = 8;
+        badConfig.systemTxMaxGas = 500_000;
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(badConfig));
+        assertErrorCode(input, "SYSCON-80");
+
+        // Test invalid resource config - minimumBaseFee
+        _mockValidationCalls();
+        badConfig.systemTxMaxGas = 1_000_000;
+        badConfig.minimumBaseFee = 2 gwei;
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(badConfig));
+        assertErrorCode(input, "SYSCON-90");
+
+        // Test invalid resource config - maximumBaseFee
+        _mockValidationCalls();
+        badConfig.minimumBaseFee = 1 gwei;
+        badConfig.maximumBaseFee = 1_000_000;
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(badConfig));
+        assertErrorCode(input, "SYSCON-100");
+    }
+
+    /// @notice Tests validation of L1CrossDomainMessenger
+    function test_validate_l1CrossDomainMessenger_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(l1CrossDomainMessenger), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "L1xDM-10");
+
+        // Test invalid OTHER_MESSENGER
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(ICrossDomainMessenger.OTHER_MESSENGER, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1xDM-30");
+
+        // Test invalid otherMessenger
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(ICrossDomainMessenger.otherMessenger, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1xDM-40");
+
+        // Test invalid PORTAL
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(IL1CrossDomainMessenger.PORTAL, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1xDM-50");
+
+        // Test invalid portal
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(IL1CrossDomainMessenger.portal, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1xDM-60");
+
+        // Test invalid superchainConfig
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(IL1CrossDomainMessenger.superchainConfig, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1xDM-70");
+    }
+
+    /// @notice Tests validation of OptimismMintableERC20Factory
+    function test_validate_optimismMintableERC20Factory_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(optimismMintableERC20Factory), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "MERC20F-10");
+
+        // Test invalid BRIDGE
+        _mockValidationCalls();
+        vm.mockCall(
+            address(optimismMintableERC20Factory),
+            abi.encodeCall(IOptimismMintableERC20Factory.BRIDGE, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "MERC20F-30");
+
+        // Test invalid bridge
+        _mockValidationCalls();
+        vm.mockCall(
+            address(optimismMintableERC20Factory),
+            abi.encodeCall(IOptimismMintableERC20Factory.bridge, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "MERC20F-40");
+    }
+
+    /// @notice Tests validation of L1ERC721Bridge
+    function test_validate_l1ERC721Bridge_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(l1ERC721Bridge), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "L721B-10");
+
+        // Test invalid OTHER_BRIDGE
+        _mockValidationCalls();
+        vm.mockCall(address(l1ERC721Bridge), abi.encodeCall(IERC721Bridge.OTHER_BRIDGE, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, "L721B-30");
+
+        // Test invalid otherBridge
+        _mockValidationCalls();
+        vm.mockCall(address(l1ERC721Bridge), abi.encodeCall(IERC721Bridge.otherBridge, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, "L721B-40");
+
+        // Test invalid MESSENGER
+        _mockValidationCalls();
+        vm.mockCall(address(l1ERC721Bridge), abi.encodeCall(IERC721Bridge.MESSENGER, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, "L721B-50");
+
+        // Test invalid messenger
+        _mockValidationCalls();
+        vm.mockCall(address(l1ERC721Bridge), abi.encodeCall(IERC721Bridge.messenger, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, "L721B-60");
+
+        // Test invalid superchainConfig
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1ERC721Bridge), abi.encodeCall(IL1ERC721Bridge.superchainConfig, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L721B-70");
+    }
+
+    /// @notice Tests validation of OptimismPortal
+    function test_validate_optimismPortal_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(optimismPortal), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "PORTAL-10");
+
+        // Test invalid disputeGameFactory
+        _mockValidationCalls();
+        vm.mockCall(
+            address(optimismPortal), abi.encodeCall(IOptimismPortal2.disputeGameFactory, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "PORTAL-30");
+
+        // Test invalid systemConfig
+        _mockValidationCalls();
+        vm.mockCall(
+            address(optimismPortal), abi.encodeCall(IOptimismPortal2.systemConfig, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "PORTAL-40");
+
+        // Test invalid superchainConfig
+        _mockValidationCalls();
+        vm.mockCall(
+            address(optimismPortal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "PORTAL-50");
+
+        // Test invalid guardian
+        _mockValidationCalls();
+        vm.mockCall(address(optimismPortal), abi.encodeCall(IOptimismPortal2.guardian, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, "PORTAL-60");
+
+        // Test invalid paused
+        _mockValidationCalls();
+        vm.mockCall(address(optimismPortal), abi.encodeCall(IOptimismPortal2.paused, ()), abi.encode(true));
+        assertErrorCode(input, "PORTAL-70");
+
+        // Test invalid l2Sender
+        _mockValidationCalls();
+        vm.mockCall(address(optimismPortal), abi.encodeCall(IOptimismPortal2.l2Sender, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, "PORTAL-80");
+    }
+
+    /// @notice Tests validation of DisputeGameFactory
+    function test_validate_disputeGameFactory_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(disputeGameFactory), abi.encodeCall(ISemver.version, ()), abi.encode("0.9.0"));
+        assertErrorCode(input, "DF-10");
+
+        // Test invalid implementation
+        _mockValidationCalls();
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(disputeGameFactory))),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "DF-20");
+
+        // Test invalid owner
+        _mockValidationCalls();
+        vm.mockCall(
+            address(disputeGameFactory), abi.encodeCall(IDisputeGameFactory.owner, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "DF-30");
+    }
+
+    /// @notice Tests validation of PermissionedDisputeGame. The ASR, PreimageOracle, and DelayedWETH are
+    /// validated for each PDG and so are included here.
+    function test_validate_permissionedDisputeGame_succeeds() public {
+        _testDisputeGame(
+            permissionedDisputeGame, permissionedASR, permissionedDelayedWETH, GameTypes.PERMISSIONED_CANNON
+        );
+    }
+
+    function test_validate_permissionlessDisputeGame_succeeds() public {
+        _testDisputeGame(permissionlessDisputeGame, permissionlessASR, permissionlessDelayedWETH, GameTypes.CANNON);
+    }
+
+    /// @notice Tests validation of L1StandardBridge
+    function test_validate_l1StandardBridge_succeeds() public {
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(l1StandardBridge), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "L1SB-10");
+
+        // Test invalid MESSENGER
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1StandardBridge), abi.encodeCall(IStandardBridge.MESSENGER, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1SB-30");
+
+        // Test invalid messenger
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1StandardBridge), abi.encodeCall(IStandardBridge.messenger, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1SB-40");
+
+        // Test invalid OTHER_BRIDGE
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1StandardBridge), abi.encodeCall(IStandardBridge.OTHER_BRIDGE, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1SB-50");
+
+        // Test invalid otherBridge
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1StandardBridge), abi.encodeCall(IStandardBridge.otherBridge, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1SB-60");
+
+        // Test invalid superchainConfig
+        _mockValidationCalls();
+        vm.mockCall(
+            address(l1StandardBridge),
+            abi.encodeCall(IL1StandardBridge.superchainConfig, ()),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, "L1SB-70");
+    }
+
+    /// @notice Helper function to assert error codes in validation
+    function assertErrorCode(StandardValidatorV180.Input memory _input, string memory _errCode) internal view {
+        string memory errCodes = validator.validate(_input, true);
+        assertEq(errCodes, _errCode);
+    }
+
+    /// @notice Helper function to mock all necessary calls for successful validation
+    function _mockValidationCalls() internal {
+        // Mock SystemConfig dependencies
+        vm.mockCall(
+            address(systemConfig), abi.encodeCall(ISystemConfig.disputeGameFactory, ()), abi.encode(disputeGameFactory)
+        );
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISemver.version, ()), abi.encode("2.3.0"));
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.gasLimit, ()), abi.encode(uint64(60_000_000)));
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.scalar, ()), abi.encode(uint256(1) << 248));
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.l1CrossDomainMessenger, ()),
+            abi.encode(l1CrossDomainMessenger)
+        );
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.optimismPortal, ()), abi.encode(optimismPortal));
+        vm.mockCall(
+            address(systemConfig), abi.encodeCall(ISystemConfig.l1StandardBridge, ()), abi.encode(l1StandardBridge)
+        );
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.l1ERC721Bridge, ()), abi.encode(l1ERC721Bridge));
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.optimismMintableERC20Factory, ()),
+            abi.encode(optimismMintableERC20Factory)
+        );
+
+        // Mock proxy implementations
+        StandardValidatorV180.Implementations memory impls = validator.implementations();
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(systemConfig))),
+            abi.encode(impls.systemConfigImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(optimismPortal))),
+            abi.encode(impls.optimismPortalImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(l1CrossDomainMessenger))),
+            abi.encode(impls.l1CrossDomainMessengerImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(l1StandardBridge))),
+            abi.encode(impls.l1StandardBridgeImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(l1ERC721Bridge))),
+            abi.encode(impls.l1ERC721BridgeImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(optimismMintableERC20Factory))),
+            abi.encode(impls.optimismMintableERC20FactoryImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(disputeGameFactory))),
+            abi.encode(impls.disputeGameFactoryImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(mips))),
+            abi.encode(impls.mipsImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(permissionedASR))),
+            abi.encode(impls.anchorStateRegistryImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(permissionedDelayedWETH))),
+            abi.encode(impls.delayedWETHImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(permissionlessDelayedWETH))),
+            abi.encode(impls.delayedWETHImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(permissionedASR))),
+            abi.encode(impls.anchorStateRegistryImpl)
+        );
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(permissionlessASR))),
+            abi.encode(impls.anchorStateRegistryImpl)
+        );
+
+        // Mock AnchorStateRegistry
+        _mockAnchorStateRegistry(
+            permissionedASR, disputeGameFactory, address(superchainConfig), GameTypes.PERMISSIONED_CANNON
+        );
+        _mockAnchorStateRegistry(permissionlessASR, disputeGameFactory, address(superchainConfig), GameTypes.CANNON);
+
+        // Mock resource config
+        IResourceMetering.ResourceConfig memory config = IResourceMetering.ResourceConfig({
+            maxResourceLimit: 20_000_000,
+            elasticityMultiplier: 10,
+            baseFeeMaxChangeDenominator: 8,
+            systemTxMaxGas: 1_000_000,
+            minimumBaseFee: 1e9,
+            maximumBaseFee: type(uint128).max
+        });
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.resourceConfig, ()), abi.encode(config));
+
+        // Mock DisputeGameFactory
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.PERMISSIONED_CANNON)),
+            abi.encode(permissionedDisputeGame)
+        );
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.CANNON)),
+            abi.encode(permissionlessDisputeGame)
+        );
+        vm.mockCall(address(disputeGameFactory), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        vm.mockCall(
+            address(disputeGameFactory), abi.encodeCall(IDisputeGameFactory.owner, ()), abi.encode(l1PAOMultisig)
+        );
+
+        _mockDisputeGame(
+            permissionlessDisputeGame, permissionlessASR, permissionlessDelayedWETH, absolutePrestate, GameTypes.CANNON
+        );
+        _mockDisputeGame(
+            permissionedDisputeGame,
+            permissionedASR,
+            permissionedDelayedWETH,
+            absolutePrestate,
+            GameTypes.PERMISSIONED_CANNON
+        );
+        vm.mockCall(
+            address(permissionedDisputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.challenger, ()),
+            abi.encode(challenger)
+        );
+
+        // Mock MIPS
+        vm.mockCall(address(mips), abi.encodeCall(IMIPS.oracle, ()), abi.encode(preimageOracle));
+
+        // Mock PreimageOracle
+        vm.mockCall(address(preimageOracle), abi.encodeCall(ISemver.version, ()), abi.encode("1.1.2"));
+        vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.challengePeriod, ()), abi.encode(86400));
+        vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.minProposalSize, ()), abi.encode(126000));
+
+        // Mock L1CrossDomainMessenger
+        vm.mockCall(address(l1CrossDomainMessenger), abi.encodeCall(ISemver.version, ()), abi.encode("2.3.0"));
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(ICrossDomainMessenger.OTHER_MESSENGER, ()),
+            abi.encode(ICrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER))
+        );
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(ICrossDomainMessenger.otherMessenger, ()),
+            abi.encode(ICrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER))
+        );
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(IL1CrossDomainMessenger.PORTAL, ()),
+            abi.encode(optimismPortal)
+        );
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(IL1CrossDomainMessenger.portal, ()),
+            abi.encode(optimismPortal)
+        );
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(IL1CrossDomainMessenger.superchainConfig, ()),
+            abi.encode(superchainConfig)
+        );
+
+        // Mock OptimismPortal
+        vm.mockCall(address(optimismPortal), abi.encodeCall(ISemver.version, ()), abi.encode("3.10.0"));
+        vm.mockCall(
+            address(optimismPortal),
+            abi.encodeCall(IOptimismPortal2.disputeGameFactory, ()),
+            abi.encode(disputeGameFactory)
+        );
+        vm.mockCall(
+            address(optimismPortal), abi.encodeCall(IOptimismPortal2.systemConfig, ()), abi.encode(systemConfig)
+        );
+        vm.mockCall(
+            address(optimismPortal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
+        );
+        vm.mockCall(
+            address(optimismPortal),
+            abi.encodeCall(IOptimismPortal2.guardian, ()),
+            abi.encode(superchainConfig.guardian())
+        );
+        vm.mockCall(
+            address(optimismPortal), abi.encodeCall(IOptimismPortal2.paused, ()), abi.encode(superchainConfig.paused())
+        );
+        vm.mockCall(
+            address(optimismPortal),
+            abi.encodeCall(IOptimismPortal2.l2Sender, ()),
+            abi.encode(address(0x000000000000000000000000000000000000dEaD))
+        );
+
+        // Mock SuperchainConfig
+        vm.mockCall(
+            address(superchainConfig), abi.encodeCall(ISuperchainConfig.guardian, ()), abi.encode(makeAddr("guardian"))
+        );
+        vm.mockCall(address(superchainConfig), abi.encodeCall(ISuperchainConfig.paused, ()), abi.encode(false));
+
+        // Mock L1StandardBridge
+        vm.mockCall(address(l1StandardBridge), abi.encodeCall(ISemver.version, ()), abi.encode("2.1.0"));
+        vm.mockCall(
+            address(l1StandardBridge), abi.encodeCall(IStandardBridge.MESSENGER, ()), abi.encode(l1CrossDomainMessenger)
+        );
+        vm.mockCall(
+            address(l1StandardBridge), abi.encodeCall(IStandardBridge.messenger, ()), abi.encode(l1CrossDomainMessenger)
+        );
+        vm.mockCall(
+            address(l1StandardBridge),
+            abi.encodeCall(IStandardBridge.OTHER_BRIDGE, ()),
+            abi.encode(Predeploys.L2_STANDARD_BRIDGE)
+        );
+        vm.mockCall(
+            address(l1StandardBridge),
+            abi.encodeCall(IStandardBridge.otherBridge, ()),
+            abi.encode(Predeploys.L2_STANDARD_BRIDGE)
+        );
+        vm.mockCall(
+            address(l1StandardBridge),
+            abi.encodeCall(IL1StandardBridge.superchainConfig, ()),
+            abi.encode(superchainConfig)
+        );
+
+        // Mock L1ERC721Bridge
+        vm.mockCall(address(l1ERC721Bridge), abi.encodeCall(ISemver.version, ()), abi.encode("2.1.0"));
+        vm.mockCall(
+            address(l1ERC721Bridge),
+            abi.encodeCall(IERC721Bridge.OTHER_BRIDGE, ()),
+            abi.encode(Predeploys.L2_ERC721_BRIDGE)
+        );
+        vm.mockCall(
+            address(l1ERC721Bridge),
+            abi.encodeCall(IERC721Bridge.otherBridge, ()),
+            abi.encode(Predeploys.L2_ERC721_BRIDGE)
+        );
+        vm.mockCall(
+            address(l1ERC721Bridge), abi.encodeCall(IERC721Bridge.MESSENGER, ()), abi.encode(l1CrossDomainMessenger)
+        );
+        vm.mockCall(
+            address(l1ERC721Bridge), abi.encodeCall(IERC721Bridge.messenger, ()), abi.encode(l1CrossDomainMessenger)
+        );
+        vm.mockCall(
+            address(l1ERC721Bridge), abi.encodeCall(IL1ERC721Bridge.superchainConfig, ()), abi.encode(superchainConfig)
+        );
+
+        // Mock OptimismMintableERC20Factory
+        vm.mockCall(address(optimismMintableERC20Factory), abi.encodeCall(ISemver.version, ()), abi.encode("1.9.0"));
+        vm.mockCall(
+            address(optimismMintableERC20Factory),
+            abi.encodeCall(IOptimismMintableERC20Factory.BRIDGE, ()),
+            abi.encode(l1StandardBridge)
+        );
+        vm.mockCall(
+            address(optimismMintableERC20Factory),
+            abi.encodeCall(IOptimismMintableERC20Factory.bridge, ()),
+            abi.encode(l1StandardBridge)
+        );
+
+        _mockDelayedWETH(permissionedDelayedWETH);
+        _mockDelayedWETH(permissionlessDelayedWETH);
+    }
+
+    function _mockAnchorStateRegistry(
+        address _asr,
+        address _disputeGameFactory,
+        address _superchainConfig,
+        GameType _gameType
+    )
+        internal
+    {
+        vm.mockCall(address(_asr), abi.encodeCall(ISemver.version, ()), abi.encode("2.0.0"));
+        vm.mockCall(
+            address(_asr), abi.encodeCall(IAnchorStateRegistry.disputeGameFactory, ()), abi.encode(_disputeGameFactory)
+        );
+        vm.mockCall(
+            address(_asr),
+            abi.encodeCall(IAnchorStateRegistry.anchors, (_gameType)),
+            abi.encode(Hash.wrap(0xdead000000000000000000000000000000000000000000000000000000000000), 0)
+        );
+        vm.mockCall(
+            address(_asr), abi.encodeCall(IAnchorStateRegistry.superchainConfig, ()), abi.encode(_superchainConfig)
+        );
+    }
+
+    function _mockDisputeGame(
+        address _disputeGame,
+        address _asr,
+        address _weth,
+        bytes32 _absolutePrestate,
+        GameType _gameType
+    )
+        internal
+    {
+        vm.mockCall(address(_disputeGame), abi.encodeCall(ISemver.version, ()), abi.encode("1.3.1"));
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IDisputeGame.gameType, ()), abi.encode(_gameType));
+        vm.mockCall(
+            address(_disputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.absolutePrestate, ()),
+            abi.encode(_absolutePrestate)
+        );
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.vm, ()), abi.encode(mips));
+        vm.mockCall(
+            address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.anchorStateRegistry, ()), abi.encode(_asr)
+        );
+        vm.mockCall(
+            address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.l2ChainId, ()), abi.encode(l2ChainID)
+        );
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.l2BlockNumber, ()), abi.encode(0));
+        vm.mockCall(
+            address(_disputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.clockExtension, ()),
+            abi.encode(Duration.wrap(10800))
+        );
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.splitDepth, ()), abi.encode(30));
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.maxGameDepth, ()), abi.encode(73));
+        vm.mockCall(
+            address(_disputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.maxClockDuration, ()),
+            abi.encode(Duration.wrap(302400))
+        );
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.weth, ()), abi.encode(_weth));
+    }
+
+    function _mockDelayedWETH(address _weth) public {
+        vm.mockCall(address(_weth), abi.encodeCall(ISemver.version, ()), abi.encode("1.1.0"));
+        vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.owner, ()), abi.encode(challenger));
+        vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(1 weeks));
+    }
+
+    function _testDisputeGame(address _disputeGame, address _asr, address _weth, GameType _gameType) public {
+        string memory errorPrefix;
+        if (_gameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()) {
+            errorPrefix = string.concat(errorPrefix, "PDDG");
+        } else {
+            errorPrefix = string.concat(errorPrefix, "PLDG");
+        }
+
+        StandardValidatorV180.Input memory input = StandardValidatorV180.Input({
+            proxyAdmin: proxyAdmin,
+            sysCfg: systemConfig,
+            absolutePrestate: absolutePrestate,
+            l2ChainID: l2ChainID
+        });
+
+        // Test null implementation
+        _mockValidationCalls();
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (_gameType)),
+            abi.encode(address(0))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-10"));
+
+        // Test invalid version
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, string.concat(errorPrefix, "-20"));
+
+        // Test invalid game type
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IDisputeGame.gameType, ()), abi.encode(GameType.wrap(123)));
+        assertErrorCode(input, string.concat(errorPrefix, "-30"));
+
+        // Test invalid absolute prestate
+        _mockValidationCalls();
+        vm.mockCall(
+            address(_disputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.absolutePrestate, ()),
+            abi.encode(bytes32(uint256(0xbad)))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-40"));
+
+        // Test invalid vm
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.vm, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, string.concat(errorPrefix, "-50"));
+
+        // Test invalid l2ChainId
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.l2ChainId, ()), abi.encode(123));
+        assertErrorCode(input, string.concat(errorPrefix, "-60"));
+
+        // Test invalid l2BlockNumber
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.l2BlockNumber, ()), abi.encode(1));
+        assertErrorCode(input, string.concat(errorPrefix, "-70"));
+
+        // Test invalid clockExtension
+        _mockValidationCalls();
+        vm.mockCall(
+            address(_disputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.clockExtension, ()),
+            abi.encode(Duration.wrap(1000))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-80"));
+
+        // Test invalid splitDepth
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.splitDepth, ()), abi.encode(20));
+        assertErrorCode(input, string.concat(errorPrefix, "-90"));
+
+        // Test invalid maxGameDepth
+        _mockValidationCalls();
+        vm.mockCall(address(_disputeGame), abi.encodeCall(IPermissionedDisputeGame.maxGameDepth, ()), abi.encode(50));
+        assertErrorCode(input, string.concat(errorPrefix, "-100"));
+
+        // Test invalid maxClockDuration
+        _mockValidationCalls();
+        vm.mockCall(
+            address(_disputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.maxClockDuration, ()),
+            abi.encode(Duration.wrap(1000))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-110"));
+
+        if (_gameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()) {
+            _mockValidationCalls();
+            vm.mockCall(
+                address(_disputeGame),
+                abi.encodeCall(IPermissionedDisputeGame.challenger, ()),
+                abi.encode(address(0xbad))
+            );
+            assertErrorCode(input, string.concat(errorPrefix, "-120"));
+        }
+
+        // Test invalid anchor state registry version
+        _mockValidationCalls();
+        vm.mockCall(address(_asr), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, string.concat(errorPrefix, "-ANCHORP-10"));
+
+        // Test invalid anchor state registry implementation
+        _mockValidationCalls();
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_asr))),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-ANCHORP-20"));
+
+        // Test invalid anchor state registry factory
+        _mockValidationCalls();
+        vm.mockCall(
+            address(_asr), abi.encodeCall(IAnchorStateRegistry.disputeGameFactory, ()), abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-ANCHORP-30"));
+
+        // Test invalid anchor state registry root
+        _mockValidationCalls();
+        vm.mockCall(
+            address(_asr),
+            abi.encodeCall(IAnchorStateRegistry.anchors, (_gameType)),
+            abi.encode(Hash.wrap(bytes32(uint256(0xbad))), 0)
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-ANCHORP-40"));
+
+        // Test invalid DelayedWETH version
+        _mockValidationCalls();
+        vm.mockCall(address(_weth), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, string.concat(errorPrefix, "-DWETH-10"));
+
+        // Test invalid DelayedWETH implementation for permissioned game
+        _mockValidationCalls();
+        vm.mockCall(
+            address(proxyAdmin),
+            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_weth))),
+            abi.encode(address(0xbad))
+        );
+        assertErrorCode(input, string.concat(errorPrefix, "-DWETH-20"));
+
+        // Test invalid DelayedWETH owner
+        _mockValidationCalls();
+        vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.owner, ()), abi.encode(address(0xbad)));
+        assertErrorCode(input, string.concat(errorPrefix, "-DWETH-30"));
+
+        // Test invalid DelayedWETH delay
+        _mockValidationCalls();
+        vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(2));
+        assertErrorCode(input, string.concat(errorPrefix, "-DWETH-40"));
+
+        // Since the preimage oracle is shared, the errors need to include both
+        // the permissioned and permissionless game type.
+
+        // Test invalid PreimageOracle version
+        _mockValidationCalls();
+        vm.mockCall(address(preimageOracle), abi.encodeCall(ISemver.version, ()), abi.encode("1.0.0"));
+        assertErrorCode(input, "PDDG-PIMGO-10,PLDG-PIMGO-10");
+
+        // Test invalid PreimageOracle challenge period
+        _mockValidationCalls();
+        vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.challengePeriod, ()), abi.encode(1000));
+        assertErrorCode(input, "PDDG-PIMGO-20,PLDG-PIMGO-20");
+
+        // Test invalid PreimageOracle min proposal size for permissioned game
+        _mockValidationCalls();
+        vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.minProposalSize, ()), abi.encode(1000));
+        assertErrorCode(input, "PDDG-PIMGO-30,PLDG-PIMGO-30");
+    }
+}

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -92,7 +92,6 @@ contract StandardValidatorV180_Test is Test {
             superchainConfig,
             l1PAOMultisig,
             mips,
-            guardian,
             challenger
         );
 
@@ -147,7 +146,6 @@ contract StandardValidatorV180_Test is Test {
             ISuperchainConfig(address(0x95703e0982140D16f8ebA6d158FccEde42f04a4C)),
             address(0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A), // l1PAOMultisig
             address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C), // mips
-            address(0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2), // guardian
             address(0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A) // challenger
         );
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -875,7 +875,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "LivenessModule", _sel: _getSel("version()") });
 
         _addSpec({ _name: "StandardValidator", _sel: _getSel("validate((address,address,bytes32,uint256),bool)") });
-        _addSpec({ _name: "StandardValidator", _sel: bytes4(0x30e9012c) });
+        _addSpec({ _name: "StandardValidator", _sel: _getSel("implementations()") });
     }
 
     /// @dev Computes the selector from a function signature.

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -873,6 +873,8 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "LivenessModule", _sel: _getSel("safe()") });
         _addSpec({ _name: "LivenessModule", _sel: _getSel("thresholdPercentage()") });
         _addSpec({ _name: "LivenessModule", _sel: _getSel("version()") });
+
+        _addSpec({ _name: "StandardValidator", _sel: _getSel("validate((address,address,bytes32,uint256),bool)") });
     }
 
     /// @dev Computes the selector from a function signature.

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -875,6 +875,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "LivenessModule", _sel: _getSel("version()") });
 
         _addSpec({ _name: "StandardValidator", _sel: _getSel("validate((address,address,bytes32,uint256),bool)") });
+        _addSpec({ _name: "StandardValidator", _sel: bytes4(0x30e9012c) });
     }
 
     /// @dev Computes the selector from a function signature.


### PR DESCRIPTION
Adds a validation contract for chains at version 1.8.0. The contract moves as many checks as possible from `DeployOPChain.s.sol` into a contract that can be deployed on chain.
