### PR TITLE
Doctoc recipe for contracts

### DIFF
--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -18,6 +18,7 @@ High-level information about these contracts can be found within this README and
   - [Style Guide](#style-guide)
   - [Contract Interfaces](#contract-interfaces)
   - [Solidity Versioning](#solidity-versioning)
+  - [Frozen Code](#frozen-code)
 - [Deployment](#deployment)
   - [Deploying Production Networks](#deploying-production-networks)
 - [Generating L2 Genesis Allocs](#generating-l2-genesis-allocs)

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -351,3 +351,13 @@ lint-fix-no-fail:
 
 # Fixes linting errors and checks that the code is correctly formatted.
 lint: lint-fix lint-check
+
+
+########################################################
+#                         DOCS                         #
+########################################################
+
+# Update TOCs
+update-tocs:
+  doctoc README.md
+  doctoc meta/POLICY.md

--- a/packages/contracts-bedrock/meta/POLICY.md
+++ b/packages/contracts-bedrock/meta/POLICY.md
@@ -5,6 +5,7 @@
 - [Policy](#policy)
   - [Contributing](#contributing)
   - [Versioning Policy](#versioning-policy)
+  - [Code Freeze Policy](#code-freeze-policy)
   - [Upgrade Policy](#upgrade-policy)
   - [Style Guide](#style-guide)
   - [Revert Data](#revert-data)


### PR DESCRIPTION
**Description**

Added a `doctoc` recipe for the two docs in `packages/contracts-bedrock` that use it, and updated the outdated docs.

**Tests**
```
alcueca@localhost contracts-bedrock % just update-tocs     
doctoc README.md

DocToccing single file "README.md" for github.com.

==================

"README.md" will be updated

Everything is OK.
doctoc meta/POLICY.md

DocToccing single file "meta/POLICY.md" for github.com.

==================

"meta/POLICY.md" will be updated

Everything is OK.
```