### PR TITLE
Install doctoc with mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "20.10.0"
+node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "22.14.0"
+node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "20.0.0"
+node = "22.14.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 
 # NPM dependencies
-"npm:doctoc" = "2.2.0"
+# "npm:doctoc" = "2.2.0"
 
 # Other dependencies
 codecov-uploader = "0.8.0"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-# node = "20.0.0"
+node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
+node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"
@@ -31,6 +32,9 @@ just = "1.37.0"
 forge = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
+
+# NPM dependencies
+"npm:doctoc" = "2.2.0"
 
 # Other dependencies
 codecov-uploader = "0.8.0"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "20.0.0"
+node = "20.18.3"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "20.0.0"
+# node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"
@@ -34,7 +34,7 @@ cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 
 # NPM dependencies
-"npm:doctoc@node:20.0.0" = "2.2.0"
+"npm:doctoc" = "2.2.0"
 
 # Other dependencies
 codecov-uploader = "0.8.0"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "20.18.3"
+node = "20.10.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 
 # NPM dependencies
-"npm:doctoc" = "2.2.1"
+"npm:doctoc@node:20.0.0" = "2.2.0"
 
 # Other dependencies
 codecov-uploader = "0.8.0"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-node = "20.0.0"
+# node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
-# node = "20.0.0"
+node = "20.0.0"
 
 # Cargo dependencies
 "cargo:svm-rs" = "0.5.8"
@@ -34,7 +34,7 @@ cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
 
 # NPM dependencies
-# "npm:doctoc" = "2.2.0"
+"npm:doctoc" = "2.2.1"
 
 # Other dependencies
 codecov-uploader = "0.8.0"


### PR DESCRIPTION
**Description**

`doctoc` is used for the TOCs in README.md and POLICY.md, but it is not installed by `mise install`. This PR fixes that.

**Tests**

Local tests using `mise install`, `doctoc --version` and `mise uninstall npm:doctoc`.
