### PR TITLE
docs: fix build instructions for op-node and op-proposer

### DIFF
--- a/op-node/README.md
+++ b/op-node/README.md
@@ -71,7 +71,8 @@ make op-node
 
 ```bash
 # from op-node dir:
-make op-node
+just op-node
+
 ./bin/op-node --help
 ```
 

--- a/op-proposer/README.md
+++ b/op-proposer/README.md
@@ -46,7 +46,8 @@ On test networks, `--allow-non-finalized` may be used to make proposals sooner, 
 ### Build from source
 
 ```bash
-make op-proposer
+# from op-proposer dir:
+just op-proposer
 
 ./bin/op-proposer --help
 ```


### PR DESCRIPTION
**Description**

[This PR](https://github.com/ethereum-optimism/optimism/pull/13042) broke the README.md related to [`op-node`](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/README.md) and [`op-proposer`](https://github.com/ethereum-optimism/optimism/blob/develop/op-proposer/README.md) as it now uses `just` instead of `make`. This PR fixes this.

I consider this more than a "typo" PR as it is currently complicated to find out how to build `op-node` from source as the [docs are outdated](https://docs.optimism.io/operators/node-operators/tutorials/node-from-source) [[issue](https://github.com/ethereum-optimism/docs/issues/1360)] and then the READMEs are also outdated.

This is a little step forward.

**Additional context**

- The Markdown files seems to not be formatted properly but I didn't include that in that PR to not add too many changes.

### References

- https://github.com/ethereum-optimism/optimism/pull/13042
- https://github.com/ethereum-optimism/docs/issues/1360