### PR TITLE
fix(op-deployer): goreleaser linker flags for rendering the right version

### DIFF
--- a/op-deployer/.goreleaser.yaml
+++ b/op-deployer/.goreleaser.yaml
@@ -32,8 +32,8 @@ builds:
     ldflags:
       - -X main.GitCommit={{ .FullCommit }}
       - -X main.GitDate={{ .CommitDate }}
-      - -X github.com/ethereum-optimism/optimism/op-chain-ops/deployer/version.Version={{ .Version }}
-      - -X github.com/ethereum-optimism/optimism/op-chain-ops/deployer/version.Meta="unstable"
+      - -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Version={{ .Version }}
+      - -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Meta=
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Corrects the linker flags' references to the right variables in op-deployer

**Tests**

```
go build -ldflags "-X main.GitCommit=test -X main.GitDate=2024-01-01 -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Version=v0.0.7 -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Meta=" -o bin/op-deployer cmd/op-deployer/main.go
```

Output
```
~/OPLabs/optimism/op-deployer yash/fix-op-deployer-version-subcmd*                                                                             16:24:05
❯ ./bin/op-deployer -v
op-deployer version v0.0.7-test-2024-01-01
```

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

Fixes #13111 
