### PR TITLE
op-supervisor: Fix Candidate Cross Safe

### DIFF
--- a/op-e2e/actions/interop/emitter_contract_test.go
+++ b/op-e2e/actions/interop/emitter_contract_test.go
@@ -52,7 +52,7 @@ func TestEmitterContract(gt *testing.T) {
 		resetTest(t)
 
 		// Execute message on destination chain and verify that the heads progress
-		execTx := newExecuteMessageTx(t, actors, actors.ChainB, aliceB, emitTx)
+		execTx := newExecuteMessageTx(t, actors.ChainB, aliceB, actors.ChainA, emitTx)
 		includeTxOnChain(t, actors, actors.ChainB, execTx, aliceB.address)
 		// assert the tx is included
 		rec, err := actors.ChainB.SequencerEngine.EthClient().TransactionReceipt(t.Ctx(), execTx.Hash())
@@ -68,7 +68,7 @@ func TestEmitterContract(gt *testing.T) {
 		// Create a message with a conflicting payload
 		fakeMessage := []byte("this message was never emitted")
 		auth := newL2TxOpts(t, aliceB.secret, actors.ChainB)
-		id := idForTx(t, actors, emitTx)
+		id := idForTx(t, emitTx, actors.ChainA)
 		contract, err := inbox.NewInbox(predeploys.CrossL2InboxAddr, actors.ChainB.SequencerEngine.EthClient())
 		require.NoError(t, err)
 		tx, err := contract.ValidateMessage(auth, id, crypto.Keccak256Hash(fakeMessage))
@@ -113,10 +113,10 @@ func newEmitMessageTx(t helpers.Testing, chain *dsl.Chain, user *userWithKeys, e
 	return tx
 }
 
-func newExecuteMessageTx(t helpers.Testing, actors *dsl.InteropActors, destChain *dsl.Chain, executor *userWithKeys, srcTx *types.Transaction) *types.Transaction {
+func newExecuteMessageTx(t helpers.Testing, destChain *dsl.Chain, executor *userWithKeys, srcChain *dsl.Chain, srcTx *types.Transaction) *types.Transaction {
 	// Create the id and payload
-	id := idForTx(t, actors, srcTx)
-	receipt, err := actors.ChainA.SequencerEngine.EthClient().TransactionReceipt(t.Ctx(), srcTx.Hash())
+	id := idForTx(t, srcTx, srcChain)
+	receipt, err := srcChain.SequencerEngine.EthClient().TransactionReceipt(t.Ctx(), srcTx.Hash())
 	require.NoError(t, err)
 	payload := stypes.LogToMessagePayload(receipt.Logs[0])
 
@@ -130,10 +130,10 @@ func newExecuteMessageTx(t helpers.Testing, actors *dsl.InteropActors, destChain
 	return tx
 }
 
-func idForTx(t helpers.Testing, actors *dsl.InteropActors, tx *types.Transaction) inbox.Identifier {
-	receipt, err := actors.ChainA.SequencerEngine.EthClient().TransactionReceipt(t.Ctx(), tx.Hash())
+func idForTx(t helpers.Testing, tx *types.Transaction, srcChain *dsl.Chain) inbox.Identifier {
+	receipt, err := srcChain.SequencerEngine.EthClient().TransactionReceipt(t.Ctx(), tx.Hash())
 	require.NoError(t, err)
-	block, err := actors.ChainA.SequencerEngine.EthClient().BlockByNumber(t.Ctx(), receipt.BlockNumber)
+	block, err := srcChain.SequencerEngine.EthClient().BlockByNumber(t.Ctx(), receipt.BlockNumber)
 	require.NoError(t, err)
 
 	return inbox.Identifier{
@@ -141,7 +141,7 @@ func idForTx(t helpers.Testing, actors *dsl.InteropActors, tx *types.Transaction
 		BlockNumber: receipt.BlockNumber,
 		LogIndex:    common.Big0,
 		Timestamp:   big.NewInt(int64(block.Time())),
-		ChainId:     actors.ChainA.RollupCfg.L2ChainID,
+		ChainId:     srcChain.RollupCfg.L2ChainID,
 	}
 }
 
@@ -185,14 +185,14 @@ func initializeEmitterContractTest(t helpers.Testing, aliceA *userWithKeys, acto
 	return emitTx
 }
 
-func includeTxOnChain(t helpers.Testing, actors *dsl.InteropActors, chain *dsl.Chain, tx *types.Transaction, sender common.Address) {
-	// Create L2 block on the given chain
+func includeTxOnChainBasic(t helpers.Testing, chain *dsl.Chain, tx *types.Transaction, sender common.Address) {
 	chain.Sequencer.ActL2StartBlock(t)
-	if tx != nil {
-		err := chain.SequencerEngine.EngineApi.IncludeTx(tx, sender)
-		require.NoError(t, err)
-	}
+	require.NoError(t, chain.SequencerEngine.EngineApi.IncludeTx(tx, sender))
 	chain.Sequencer.ActL2EndBlock(t)
+}
+
+func includeTxOnChain(t helpers.Testing, actors *dsl.InteropActors, chain *dsl.Chain, tx *types.Transaction, sender common.Address) {
+	includeTxOnChainBasic(t, chain, tx, sender)
 
 	// Sync the chain and the supervisor
 	chain.Sequencer.SyncSupervisor(t)

--- a/op-e2e/actions/interop/emitter_contract_test.go
+++ b/op-e2e/actions/interop/emitter_contract_test.go
@@ -187,7 +187,10 @@ func initializeEmitterContractTest(t helpers.Testing, aliceA *userWithKeys, acto
 
 func includeTxOnChainBasic(t helpers.Testing, chain *dsl.Chain, tx *types.Transaction, sender common.Address) {
 	chain.Sequencer.ActL2StartBlock(t)
-	require.NoError(t, chain.SequencerEngine.EngineApi.IncludeTx(tx, sender))
+	// is used for building an empty block with tx==nil
+	if tx != nil {
+		require.NoError(t, chain.SequencerEngine.EngineApi.IncludeTx(tx, sender))
+	}
 	chain.Sequencer.ActL2EndBlock(t)
 }
 

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -5,13 +5,14 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
@@ -367,4 +368,95 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	status = actors.ChainB.Sequencer.SyncStatus()
 	require.Equal(t, uint64(2), status.SafeL2.Number)
+}
+
+func TestInteropCrossSafeDependencyDelay(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+
+	// get both sequencers set up
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
+	// sync the supervisor, handle initial events emitted by the nodes
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+
+	// We create a batch with some empty blocks before and after the cross-chain message,
+	// so multiple L2 blocks are all derived from the same L1 block.
+	actors.ChainA.Sequencer.ActL2EmptyBlock(t)
+	actors.ChainA.Sequencer.ActL2EmptyBlock(t)
+	actors.ChainA.Sequencer.ActL2EmptyBlock(t)
+
+	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
+
+	aliceA := setupUser(t, is, actors.ChainA, 0)
+	aliceB := setupUser(t, is, actors.ChainB, 0)
+
+	// create a log event in chain B
+	auth := newL2TxOpts(t, aliceB.secret, actors.ChainB)
+	emitContractAddr, deployTx, _, err := emit.DeployEmit(auth, actors.ChainB.SequencerEngine.EthClient())
+	require.NoError(t, err)
+	includeTxOnChainBasic(t, actors.ChainB, deployTx, aliceB.address)
+	emitTx := newEmitMessageTx(t, actors.ChainB, aliceB, emitContractAddr, []byte("hello from B"))
+	includeTxOnChainBasic(t, actors.ChainB, emitTx, aliceB.address)
+
+	// consume the log event in chain A
+	execTx := newExecuteMessageTx(t, actors.ChainA, aliceA, actors.ChainB, emitTx)
+	includeTxOnChainBasic(t, actors.ChainA, execTx, aliceA.address)
+	execTxIncludedIn := actors.ChainA.Sequencer.SyncStatus().UnsafeL2
+
+	actors.ChainA.Sequencer.ActL2EmptyBlock(t)
+	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
+
+	chainAHead := actors.ChainA.Sequencer.SyncStatus().UnsafeL2
+	chainBHead := actors.ChainB.Sequencer.SyncStatus().UnsafeL2
+
+	// Now submit the data for chain A, and submit the data of chain B late,
+	// so the scope has to be bumped even though we know of the event in the unsafe chain already.
+
+	actors.ChainA.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+
+	actors.L1Miner.ActEmptyBlock(t)
+	actors.L1Miner.ActEmptyBlock(t)
+
+	actors.ChainB.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+	chainBSubmittedIn, err := actors.L1Miner.EthClient().BlockByNumber(t.Ctx(), nil)
+	require.NoError(t, err)
+
+	actors.Supervisor.SignalLatestL1(t)
+	actors.Supervisor.ProcessFull(t)
+
+	actors.ChainA.Sequencer.ActL1HeadSignal(t)
+	actors.ChainB.Sequencer.ActL1HeadSignal(t)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
+	// it takes a few round trips to sync the L1 blocks
+	for i := 0; i < 5; i++ {
+		actors.ChainA.Sequencer.SyncSupervisor(t)
+		actors.ChainB.Sequencer.SyncSupervisor(t)
+		actors.Supervisor.ProcessFull(t)
+		actors.ChainA.Sequencer.ActL2PipelineFull(t)
+		actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	}
+
+	// Assert the blocks are now cross-safe
+	require.Equal(t, chainAHead, actors.ChainA.Sequencer.SyncStatus().SafeL2)
+	require.Equal(t, chainBHead, actors.ChainB.Sequencer.SyncStatus().SafeL2)
+
+	// Assert that the executing message in chain A only
+	// became cross-safe when the dependency of chain B became cross safe later.
+	source, err := actors.Supervisor.CrossDerivedFrom(t.Ctx(), actors.ChainA.ChainID, execTxIncludedIn.ID())
+	require.NoError(t, err)
+	require.Equal(t, chainBSubmittedIn.NumberU64(), source.Number)
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -167,6 +167,10 @@ func (su *SupervisorBackend) OnEvent(ev event.Event) bool {
 		su.emitter.Emit(superevents.UpdateCrossUnsafeRequestEvent{
 			ChainID: x.ChainID,
 		})
+	case superevents.CrossUnsafeUpdateEvent:
+		su.emitter.Emit(superevents.UpdateCrossUnsafeRequestEvent{
+			ChainID: x.ChainID,
+		})
 	case superevents.LocalSafeUpdateEvent:
 		su.emitter.Emit(superevents.UpdateCrossSafeRequestEvent{
 			ChainID: x.ChainID,

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -171,6 +171,10 @@ func (su *SupervisorBackend) OnEvent(ev event.Event) bool {
 		su.emitter.Emit(superevents.UpdateCrossSafeRequestEvent{
 			ChainID: x.ChainID,
 		})
+	case superevents.CrossSafeUpdateEvent:
+		su.emitter.Emit(superevents.UpdateCrossSafeRequestEvent{
+			ChainID: x.ChainID,
+		})
 	default:
 		return false
 	}

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -212,6 +212,7 @@ func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidate
 		// Repeat of same information. No entries to be written.
 		// But we can silently ignore and not return an error, as that brings the caller
 		// in a consistent state, after which it can insert the actual new derived-from information.
+		db.log.Debug("Database link already written", "derived", derived, "lastDerived", lastDerived)
 		return nil
 	}
 

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -291,18 +291,6 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 	if !ok {
 		return types.DerivedBlockRefPair{}, types.ErrUnknownChain
 	}
-
-	// Example:
-	// A B C D      <- L1
-	// 1     2      <- L2
-	// return:
-	// (A, 0) -> initial scope, no L2 block yet. Genesis found to be cross-safe
-	// (A, 1) -> 1 is determined cross-safe, won't be a candidate anymore after. 2 is the new candidate
-	// (B, 2) -> 2 is out of scope, go to B
-	// (C, 2) -> 2 is out of scope, go to C
-	// (D, 2) -> 2 is in scope, stay on D, promote candidate to cross-safe
-	// (D, 3) -> look at 3 next, see if we have to bump L1 yet, try with same L1 scope first
-
 	crossSafe, err := xDB.Last()
 	if err != nil {
 		if errors.Is(err, types.ErrFuture) {
@@ -328,14 +316,7 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 		return types.DerivedBlockRefPair{}, err
 	}
 
-	// Find the local-safe block that comes right after the last seen cross-safe block.
-	// Just L2 block by block traversal, conditional on being local-safe.
-	// This will be the candidate L2 block to promote.
-
-	// While the local-safe block isn't cross-safe given limited L1 scope, we'll keep bumping the L1 scope,
-	// And update cross-safe accordingly.
-	// This method will keep returning the latest known scope that has been verified to be cross-safe.
-	candidatePair, err := lDB.NextDerived(crossSafe.Derived.ID())
+	candidate, err := lDB.NextDerived(crossSafe.Derived.ID())
 	if err != nil {
 		if errors.Is(err, types.ErrAwaitReplacementBlock) {
 			// If we cannot promote due to need for replacement, then abort
@@ -343,46 +324,24 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 		}
 		return types.DerivedBlockRefPair{}, err
 	}
+	candidateRef := candidate.Derived.MustWithParent(crossSafe.Derived.ID())
 
-	candidateRef := candidatePair.Derived.MustWithParent(crossSafe.Derived.ID())
-
-	parentSource, err := lDB.PreviousSource(candidatePair.Source.ID())
-	// if we are working with the first item in the database, PreviousSource will return ErrPreviousToFirst
-	// in which case we can attach a zero parent to the cross-derived-from block, as the parent block is unknown
+	parentSource, err := lDB.PreviousSource(crossSafe.Source.ID())
 	if errors.Is(err, types.ErrPreviousToFirst) {
 		parentSource = types.BlockSeal{}
 	} else if err != nil {
-		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to find parent-block of derived-from %s: %w", candidatePair.Source, err)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to find parent-block of derived-from %s: %w", crossSafe.Source, err)
 	}
-	candidateFromRef := candidatePair.Source.MustWithParent(parentSource.ID())
+	crossSafeSourceRef := crossSafe.Source.MustWithParent(parentSource.ID())
 
-	// Allow increment of DA by 1, if we know the floor (due to local safety) is 1 ahead of the current cross-safe L1 scope.
-	if candidatePair.Source.Number > crossSafe.Source.Number+1 {
-		// If we are not ready to process the candidate block,
-		// then we need to stick to the current scope, so the caller can bump up from there.
-		var crossSourceRef eth.BlockRef
-		parent, err := lDB.PreviousSource(crossSafe.Source.ID())
-		// if we are working with the first item in the database, PreviousSource will return ErrPreviousToFirst
-		// in which case we can attach a zero parent to the cross-derived-from block, as the parent block is unknown
-		if errors.Is(err, types.ErrPreviousToFirst) {
-			crossSourceRef = crossSafe.Source.ForceWithParent(eth.BlockID{})
-		} else if err != nil {
-			return types.DerivedBlockRefPair{},
-				fmt.Errorf("failed to find parent-block of cross-derived-from %s: %w", crossSafe.Source, err)
-		} else {
-			crossSourceRef = crossSafe.Source.MustWithParent(parent.ID())
-		}
+	if candidate.Source.Number <= crossSafe.Source.Number {
+		db.logger.Debug("Cross-safe source matches or exceeds candidate source", "crossSafe", crossSafe, "candidate", candidate)
 		return types.DerivedBlockRefPair{
-				Source:  crossSourceRef,
-				Derived: eth.BlockRef{},
-			},
-			fmt.Errorf("candidate is from %s, while current scope is %s: %w",
-				candidateFromRef, crossSafe.Source, types.ErrOutOfScope)
+			Source:  crossSafeSourceRef,
+			Derived: candidateRef,
+		}, nil
 	}
-	return types.DerivedBlockRefPair{
-		Source:  candidateFromRef,
-		Derived: candidateRef,
-	}, nil
+	return types.DerivedBlockRefPair{}, types.ErrOutOfScope
 }
 
 func (db *ChainsDB) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -334,14 +334,15 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 	}
 	crossSafeSourceRef := crossSafe.Source.MustWithParent(parentSource.ID())
 
+	result = types.DerivedBlockRefPair{
+		Source:  crossSafeSourceRef,
+		Derived: candidateRef,
+	}
 	if candidate.Source.Number <= crossSafe.Source.Number {
 		db.logger.Debug("Cross-safe source matches or exceeds candidate source", "crossSafe", crossSafe, "candidate", candidate)
-		return types.DerivedBlockRefPair{
-			Source:  crossSafeSourceRef,
-			Derived: candidateRef,
-		}, nil
+		return result, nil
 	}
-	return types.DerivedBlockRefPair{}, types.ErrOutOfScope
+	return result, types.ErrOutOfScope
 }
 
 func (db *ChainsDB) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {


### PR DESCRIPTION
A collection of fixes to bugs encountered on alpha network 1:
- Cross Safe Scope Bumping was sticking: The Cross Safe Candidate (the next block we'd like to promote to cross-safe) had run out of scope (ie, not enough data to validate yet), and the scope-bumping mechanism was being ignored, leading to the same block being used as the candidate repeatedly. This was fixed by simplifying the candidate rules: the L1 increments on every scope bump, which eventually extends far enough to include the L2 block needed to make forward progress.
- Once Repaired, the Cross Safe and Cross Unsafe started increasing, but only at real-time speed, not catching up. This is because we don't eagerly try making more updates. That is fixed by emitting new request events whenever the Cross update happens.