### PR TITLE
op-e2e: Add message expiry action test

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -83,6 +83,9 @@ type DevDeployConfig struct {
 	// FundDevAccounts configures whether to fund the dev accounts.
 	// This should only be used during devnet deployments.
 	FundDevAccounts bool `json:"fundDevAccounts"`
+	// OverrideMessageExpiryTime configures the message expiry time of interop messages.
+	// This should only be used during devnet deployments.
+	OverrideMessageExpiryTime uint64 `json:"overrideMessageExpiryTime"`
 }
 
 type L2GenesisBlockDeployConfig struct {

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -74,6 +74,7 @@
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 0,
   "faultGameWithdrawalDelay": 604800,
+  "overrideMessageExpiryTime": 0,
   "preimageOracleMinProposalSize": 1800000,
   "preimageOracleChallengePeriod": 86400,
   "systemConfigStartBlock": 0,

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -329,6 +329,9 @@ func CompleteL2(l2Host *script.Host, cfg *L2Config, l1Block *types.Block, deploy
 	if err != nil {
 		return nil, fmt.Errorf("failed to build L2 rollup config: %w", err)
 	}
+	if cfg.OverrideMessageExpiryTime != 0 {
+		rollupCfg.OverrideMessageExpiryTimeInterop = cfg.OverrideMessageExpiryTime
+	}
 	return &L2Output{
 		Genesis:   l2Genesis,
 		RollupCfg: rollupCfg,

--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -120,6 +120,7 @@ type TransactionCreator func(chain *Chain) (*types.Transaction, common.Address)
 type AddL2BlockOpts struct {
 	BlockIsNotCrossUnsafe bool
 	TransactionCreators   []TransactionCreator
+	UntilTimestamp        uint64
 }
 
 func WithL2BlockTransactions(mkTxs ...TransactionCreator) func(*AddL2BlockOpts) {
@@ -134,31 +135,42 @@ func WithL1BlockCrossUnsafe() func(*AddL2BlockOpts) {
 	}
 }
 
+func WithL2BlocksUntilTimestamp(timestamp uint64) func(*AddL2BlockOpts) {
+	return func(o *AddL2BlockOpts) {
+		o.UntilTimestamp = timestamp
+	}
+}
+
 // AddL2Block adds a new unsafe block to the specified chain and fully processes it in the supervisor
 func (d *InteropDSL) AddL2Block(chain *Chain, optionalArgs ...func(*AddL2BlockOpts)) {
 	opts := AddL2BlockOpts{}
 	for _, arg := range optionalArgs {
 		arg(&opts)
 	}
-	priorSyncStatus := chain.Sequencer.SyncStatus()
-	chain.Sequencer.ActL2StartBlock(d.t)
-	for _, creator := range opts.TransactionCreators {
-		tx, from := creator(chain)
-		err := chain.SequencerEngine.EngineApi.IncludeTx(tx, from)
-		require.NoError(d.t, err)
-	}
-	chain.Sequencer.ActL2EndBlock(d.t)
-	chain.Sequencer.SyncSupervisor(d.t)
-	d.Actors.Supervisor.ProcessFull(d.t)
-	chain.Sequencer.ActL2PipelineFull(d.t)
+	for opts.UntilTimestamp == 0 || chain.Sequencer.L2Unsafe().Time <= opts.UntilTimestamp {
+		priorSyncStatus := chain.Sequencer.SyncStatus()
+		chain.Sequencer.ActL2StartBlock(d.t)
+		for _, creator := range opts.TransactionCreators {
+			tx, from := creator(chain)
+			err := chain.SequencerEngine.EngineApi.IncludeTx(tx, from)
+			require.NoError(d.t, err)
+		}
+		chain.Sequencer.ActL2EndBlock(d.t)
+		chain.Sequencer.SyncSupervisor(d.t)
+		d.Actors.Supervisor.ProcessFull(d.t)
+		chain.Sequencer.ActL2PipelineFull(d.t)
 
-	status := chain.Sequencer.SyncStatus()
-	expectedBlockNum := priorSyncStatus.UnsafeL2.Number + 1
-	require.Equal(d.t, expectedBlockNum, status.UnsafeL2.Number, "Unsafe head did not advance")
-	if opts.BlockIsNotCrossUnsafe {
-		require.Equal(d.t, priorSyncStatus.CrossUnsafeL2.Number, status.CrossUnsafeL2.Number, "CrossUnsafe head advanced unexpectedly")
-	} else {
-		require.Equal(d.t, expectedBlockNum, status.CrossUnsafeL2.Number, "CrossUnsafe head did not advance")
+		status := chain.Sequencer.SyncStatus()
+		expectedBlockNum := priorSyncStatus.UnsafeL2.Number + 1
+		require.Equal(d.t, expectedBlockNum, status.UnsafeL2.Number, "Unsafe head did not advance")
+		if opts.BlockIsNotCrossUnsafe {
+			require.Equal(d.t, priorSyncStatus.CrossUnsafeL2.Number, status.CrossUnsafeL2.Number, "CrossUnsafe head advanced unexpectedly")
+		} else {
+			require.Equal(d.t, expectedBlockNum, status.CrossUnsafeL2.Number, "CrossUnsafe head did not advance")
+		}
+		if opts.UntilTimestamp == 0 {
+			break
+		}
 	}
 }
 

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -73,9 +73,10 @@ func SetupInterop(t helpers.Testing) *InteropSetup {
 	logger := testlog.Logger(t, log.LevelDebug)
 
 	recipe := interopgen.InteropDevRecipe{
-		L1ChainID:        900100,
-		L2ChainIDs:       []uint64{900200, 900201},
-		GenesisTimestamp: uint64(time.Now().Unix() + 3),
+		L1ChainID:         900100,
+		L2ChainIDs:        []uint64{900200, 900201},
+		GenesisTimestamp:  uint64(time.Now().Unix() + 3),
+		MessageExpiryTime: 300, // 5 minutes
 	}
 	hdWallet, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(t, err)

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -68,6 +68,10 @@ type InteropActors struct {
 	ChainB     *Chain
 }
 
+// messageExpiryTime is the time in seconds that a message will be valid for on the L2 chain.
+// At a 2 second block time, this should be small enough to cover all events buffered in the supervisor event queue.
+const messageExpiryTime = 120 // 2 minutes
+
 // SetupInterop creates an InteropSetup to instantiate actors on, with 2 L2 chains.
 func SetupInterop(t helpers.Testing) *InteropSetup {
 	logger := testlog.Logger(t, log.LevelDebug)
@@ -76,7 +80,7 @@ func SetupInterop(t helpers.Testing) *InteropSetup {
 		L1ChainID:         900100,
 		L2ChainIDs:        []uint64{900200, 900201},
 		GenesisTimestamp:  uint64(time.Now().Unix() + 3),
-		MessageExpiryTime: 300, // 5 minutes
+		MessageExpiryTime: messageExpiryTime,
 	}
 	hdWallet, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(t, err)

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -455,7 +455,7 @@ func TestInteropFaultProofs_CascadeInvalidBlock(gt *testing.T) {
 func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	// TODO(#14234): Check message expiry in op-supervisor
-	//t.Skip("Message expiry not yet implemented")
+	t.Skip("Message expiry not yet implemented")
 
 	system := dsl.NewInteropDSL(t)
 

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -475,7 +475,7 @@ func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 	system.AddL2Block(actors.ChainB)
 	system.SubmitBatchData()
 
-	// Wait until message expires an expired message
+	// Advance the chain until the init msg expires
 	msgExpiryTime := actors.ChainA.RollupCfg.GetMessageExpiryTimeInterop()
 	end := emitTx.Identifier().Timestamp.Uint64() + msgExpiryTime
 	for {

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -452,6 +452,87 @@ func TestInteropFaultProofs_CascadeInvalidBlock(gt *testing.T) {
 	runFppAndChallengerTests(gt, system, tests)
 }
 
+func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	// TODO(#14234): Check message expiry in op-supervisor
+	t.Skip("Message expiry not yet implemented")
+
+	system := dsl.NewInteropDSL(t)
+
+	actors := system.Actors
+	alice := system.CreateUser()
+	emitterContract := dsl.NewEmitterContract(t)
+	system.AddL2Block(actors.ChainA, dsl.WithL2BlockTransactions(
+		emitterContract.Deploy(alice),
+	))
+	system.AddL2Block(actors.ChainA, dsl.WithL2BlockTransactions(
+		emitterContract.EmitMessage(alice, "test message"),
+	))
+	emitTx := emitterContract.LastEmittedMessage()
+
+	// Bring ChainB to the same height and timestamp
+	system.AddL2Block(actors.ChainB)
+	system.AddL2Block(actors.ChainB)
+	system.SubmitBatchData()
+
+	// Wait until message expires an expired message
+	msgExpiryTime := actors.ChainA.RollupCfg.GetMessageExpiryTimeInterop()
+	end := emitTx.Identifier().Timestamp.Uint64() + msgExpiryTime
+	for {
+		if system.Actors.ChainB.Sequencer.L2Unsafe().Time >= end {
+			break
+		}
+		system.AddL2Block(actors.ChainA)
+		system.AddL2Block(actors.ChainB)
+	}
+	system.SubmitBatchData()
+
+	system.AddL2Block(actors.ChainB, func(opts *dsl.AddL2BlockOpts) {
+		opts.TransactionCreators = []dsl.TransactionCreator{system.InboxContract.Execute(alice, emitTx.Identifier(), emitTx.MessagePayload())}
+		opts.BlockIsNotCrossUnsafe = true
+	})
+	system.AddL2Block(actors.ChainA)
+
+	system.SubmitBatchData(func(opts *dsl.SubmitBatchDataOpts) {
+		opts.SkipCrossSafeUpdate = true
+	})
+	execTx := system.InboxContract.LastTransaction()
+	execTx.CheckIncluded()
+
+	endTimestamp := actors.ChainB.Sequencer.L2Unsafe().Time
+	startTimestamp := endTimestamp - 1
+	optimisticEnd := system.Outputs.SuperRoot(endTimestamp)
+
+	preConsolidation := system.Outputs.TransitionState(startTimestamp, 1023,
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainA, endTimestamp),
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainB, endTimestamp),
+	).Marshal()
+
+	// Induce block replacement
+	system.ProcessCrossSafe()
+	// assert that the invalid message txs were reorged out
+	execTx.CheckNotIncluded()
+	crossSafeEnd := system.Outputs.SuperRoot(endTimestamp)
+
+	tests := []*transitionTest{
+		{
+			name:               "Consolidate-ExpectInvalidPendingBlock",
+			agreedClaim:        preConsolidation,
+			disputedClaim:      optimisticEnd.Marshal(),
+			disputedTraceIndex: 1023,
+			expectValid:        false,
+		},
+		{
+			name:               "Consolidate-ReplaceInvalidBlocks",
+			agreedClaim:        preConsolidation,
+			disputedClaim:      crossSafeEnd.Marshal(),
+			disputedTraceIndex: 1023,
+			expectValid:        true,
+		},
+	}
+	runFppAndChallengerTests(gt, system, tests)
+}
+
 func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 


### PR DESCRIPTION
- Setup configurable message expiry for interop devnet configuration
- Add an interop action test that covers the reorg of blocks containing expired messages 