### PR TITLE
feat(ctb): `OptimismPortalInterop` SuperRoot support

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -8,6 +8,7 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { ConfigType } from "interfaces/L2/IL1BlockInterop.sol";
+import { SuperRootProof } from "src/libraries/SuperRoot.sol";
 
 interface IOptimismPortalInterop {
     error AlreadyFinalized();
@@ -33,7 +34,6 @@ interface IOptimismPortalInterop {
     error UnexpectedString();
     error Unproven();
     error LegacyGame();
-    error OutputRootNotFound();
     error InvalidVersion();
     error UnexpectedLength();
 
@@ -87,8 +87,7 @@ interface IOptimismPortalInterop {
     function proveWithdrawalTransaction(
         Types.WithdrawalTransaction memory _tx,
         uint256 _disputeGameIndex,
-        uint256 _l2ChainId,
-        bytes memory _rawSuperRoot,
+        SuperRootProof memory _superRootProof,
         Types.OutputRootProof memory _outputRootProof,
         bytes[] memory _withdrawalProof
     ) external;

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -33,6 +33,9 @@ interface IOptimismPortalInterop {
     error UnexpectedString();
     error Unproven();
     error LegacyGame();
+    error OutputRootNotFound();
+    error InvalidVersion();
+    error UnexpectedLength();
 
     event DisputeGameBlacklisted(IDisputeGame indexed disputeGame);
     event Initialized(uint8 version);
@@ -84,8 +87,16 @@ interface IOptimismPortalInterop {
     function proveWithdrawalTransaction(
         Types.WithdrawalTransaction memory _tx,
         uint256 _disputeGameIndex,
+        uint256 _l2ChainId,
+        bytes memory _rawSuperRoot,
         Types.OutputRootProof memory _outputRootProof,
         bytes[] memory _withdrawalProof
+    ) external;
+    function proveWithdrawalTransaction(
+        Types.WithdrawalTransaction memory,
+        uint256,
+        Types.OutputRootProof memory,
+        bytes[] memory
     )
         external;
     function provenWithdrawals(

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
@@ -450,98 +450,6 @@
           }
         ],
         "internalType": "struct Types.WithdrawalTransaction",
-        "name": "_tx",
-        "type": "tuple"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_disputeGameIndex",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_l2ChainId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bytes",
-        "name": "_rawSuperRoot",
-        "type": "bytes"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes32",
-            "name": "version",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "stateRoot",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "messagePasserStorageRoot",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "latestBlockhash",
-            "type": "bytes32"
-          }
-        ],
-        "internalType": "struct Types.OutputRootProof",
-        "name": "_outputRootProof",
-        "type": "tuple"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "_withdrawalProof",
-        "type": "bytes[]"
-      }
-    ],
-    "name": "proveWithdrawalTransaction",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "nonce",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "sender",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "value",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "gasLimit",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct Types.WithdrawalTransaction",
         "name": "",
         "type": "tuple"
       },
@@ -586,6 +494,110 @@
     "name": "proveWithdrawalTransaction",
     "outputs": [],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_disputeGameIndex",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "rawSuperRoot",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2ChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "index",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SuperRootProof",
+        "name": "_superRootProof",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "version",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "stateRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "_outputRootProof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_withdrawalProof",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "proveWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -940,11 +952,6 @@
   {
     "inputs": [],
     "name": "OutOfGas",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "OutputRootNotFound",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
@@ -459,6 +459,16 @@
         "type": "uint256"
       },
       {
+        "internalType": "uint256",
+        "name": "_l2ChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_rawSuperRoot",
+        "type": "bytes"
+      },
+      {
         "components": [
           {
             "internalType": "bytes32",
@@ -494,6 +504,88 @@
     "name": "proveWithdrawalTransaction",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "version",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "stateRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "proveWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -827,6 +919,11 @@
   },
   {
     "inputs": [],
+    "name": "InvalidVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "LargeCalldata",
     "type": "error"
   },
@@ -847,6 +944,11 @@
   },
   {
     "inputs": [],
+    "name": "OutputRootNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "ProposalNotValidated",
     "type": "error"
   },
@@ -858,6 +960,11 @@
   {
     "inputs": [],
     "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnexpectedLength",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -28,12 +28,12 @@
     "sourceCodeHash": "0x8a4eb72a9c0d5c73542239b6dfe25c7dfc29d3b26a1c0a8a9f2f5b16c01c9fd6"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0x2cc5776c92d6cb154aa3d9897c476deaf49d98dc81493fabaea72987b9588853",
-    "sourceCodeHash": "0x09d877d68eb2439759e0a912a5d86d85b4742dfd205bdc1ac9dfbb32f8ccb7b0"
+    "initCodeHash": "0x969e3687d4497cc168af61e610ba0ae187e80f86aaa7b5d5bb598de19f279f08",
+    "sourceCodeHash": "0x613da036e2aff9b938213121d0ddc2cc3b36f16ee45d4e5abc10258f078daa33"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x1d97b348b70a43a4dd96f8285252593931f4e0b2ff4e6d549169e82c8ddea4f9",
-    "sourceCodeHash": "0x1610886629862a69b043f45fa8a187341f5a9ab05fd2c2d84f0add56e2be4439"
+    "initCodeHash": "0x29cbb4caf36eb03c31e03a87dc0895a4bdc6c282d77a55042b947036250f2ed1",
+    "sourceCodeHash": "0xddb5db34fae658d1d3f28089efd142fd3a7e2e41c120ef74b1f0b46ac4b694a3"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -33,7 +33,7 @@
   },
   "src/L1/OptimismPortalInterop.sol": {
     "initCodeHash": "0x29cbb4caf36eb03c31e03a87dc0895a4bdc6c282d77a55042b947036250f2ed1",
-    "sourceCodeHash": "0xddb5db34fae658d1d3f28089efd142fd3a7e2e41c120ef74b1f0b46ac4b694a3"
+    "sourceCodeHash": "0xc2c6279bf673b97c45bc3e8ecac5878d38dfeb60fe727faf6cfb19778ab8df8e"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0x613da036e2aff9b938213121d0ddc2cc3b36f16ee45d4e5abc10258f078daa33"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x29cbb4caf36eb03c31e03a87dc0895a4bdc6c282d77a55042b947036250f2ed1",
-    "sourceCodeHash": "0xc2c6279bf673b97c45bc3e8ecac5878d38dfeb60fe727faf6cfb19778ab8df8e"
+    "initCodeHash": "0x4d078f4dff11833ba508632a482e929acaa375bda692230c419f3c11489b2ac6",
+    "sourceCodeHash": "0xfb65728abc17ac46323bd8b8640e446b42c6f0cf16879030d925264b35aef81b"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -177,9 +177,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.12.0
+    /// @custom:semver 3.12.0-beta.1
     function version() public pure virtual returns (string memory) {
-        return "3.12.0";
+        return "3.12.0-beta.1";
     }
 
     /// @notice Constructs the OptimismPortal contract.
@@ -295,6 +295,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         bytes[] calldata _withdrawalProof
     )
         external
+        virtual
         whenNotPaused
     {
         // Prevent users from creating a deposit transaction where this address is the message

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -8,9 +8,23 @@ import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Unauthorized } from "src/libraries/PortalErrors.sol";
+import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { LibSuperRoot, SuperRoot } from "src/libraries/SuperRoot.sol";
+import { Types } from "src/libraries/Types.sol";
+import {
+    BadTarget,
+    InvalidGameType,
+    InvalidProof,
+    InvalidDisputeGame,
+    InvalidMerkleProof,
+    LegacyGame
+} from "src/libraries/PortalErrors.sol";
+import { GameType, Claim, GameStatus } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IL1BlockInterop, ConfigType } from "interfaces/L2/IL1BlockInterop.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 
 /// @custom:proxied true
 /// @title OptimismPortalInterop
@@ -27,7 +41,7 @@ contract OptimismPortalInterop is OptimismPortal2 {
 
     /// @custom:semver +interop
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop");
+        return string.concat(super.version(), "+interop.1");
     }
 
     /// @notice Sets static configuration options for the L2 system.
@@ -53,5 +67,127 @@ contract OptimismPortalInterop is OptimismPortal2 {
                 abi.encodeCall(IL1BlockInterop.setConfig, (_type, _value))
             )
         );
+    }
+
+    /// @notice Proves a withdrawal transaction.
+    /// @param _tx               Withdrawal transaction to finalize.
+    /// @param _disputeGameIndex Index of the dispute game to prove the withdrawal against.
+    /// @param _l2ChainId        Chain ID of the L2 chain that the withdrawal was made on.
+    /// @param _rawSuperRoot     Pre-image of the SuperRoot commitment proposed in the passed dispute game.
+    /// @param _outputRootProof  Proof of the output root's preimage.
+    /// @param _withdrawalProof  Inclusion proof of the withdrawal in L2ToL1MessagePasser contract.
+    function proveWithdrawalTransaction(
+        Types.WithdrawalTransaction memory _tx,
+        uint256 _disputeGameIndex,
+        uint256 _l2ChainId,
+        bytes calldata _rawSuperRoot,
+        Types.OutputRootProof memory _outputRootProof,
+        bytes[] calldata _withdrawalProof
+    )
+        external
+        whenNotPaused
+    {
+        // Prevent users from creating a deposit transaction where this address is the message
+        // sender on L2. Because this is checked here, we do not need to check again in
+        // `finalizeWithdrawalTransaction`.
+        if (_tx.target == address(this)) revert BadTarget();
+
+        // Fetch the dispute game proxy from the `DisputeGameFactory` contract.
+        (GameType gameType,, IDisputeGame gameProxy) = disputeGameFactory.gameAtIndex(_disputeGameIndex);
+        Claim superRootCommitment = gameProxy.rootClaim();
+
+        // The game type of the dispute game must be the respected game type.
+        if (gameType.raw() != respectedGameType.raw()) revert InvalidGameType();
+
+        // The game type of the DisputeGame must have been the respected game type at creation.
+        try gameProxy.wasRespectedGameTypeWhenCreated() returns (bool wasRespected_) {
+            if (!wasRespected_) revert InvalidGameType();
+        } catch {
+            revert LegacyGame();
+        }
+
+        // Game must have been created after the respected game type was updated. This check is a
+        // strict inequality because we want to prevent users from being able to prove or finalize
+        // withdrawals against games that were created in the same block that the retirement
+        // timestamp was set. If the retirement timestamp and game type are changed in the same
+        // block, such games could still be considered valid even if they used the old game type
+        // that we intended to invalidate.
+        require(
+            gameProxy.createdAt().raw() > respectedGameTypeUpdatedAt,
+            "OptimismPortal: dispute game created before respected game type was updated"
+        );
+
+        // We do not allow for proving withdrawals against dispute games that have resolved against the favor
+        // of the root claim.
+        if (gameProxy.status() == GameStatus.CHALLENGER_WINS) revert InvalidDisputeGame();
+
+        // Verify that the super root committed to in the dispute game is the raw super root that was passed.
+        if (superRootCommitment.raw() != keccak256(_rawSuperRoot)) revert InvalidProof();
+
+        // Decode the SuperRoot type from the raw bytes. This function also verifies that the encoding
+        // of the SuperRoot is correct, and will revert if it is malformatted.
+        SuperRoot memory superRoot = LibSuperRoot.decode(_rawSuperRoot);
+
+        // Find the output root within the super root that corresponds to the L2 chain ID passed.
+        bytes32 outputRoot = LibSuperRoot.findOutputRoot(superRoot, _l2ChainId);
+
+        // Verify that the output root can be generated with the elements in the proof.
+        if (outputRoot != Hashing.hashOutputRootProof(_outputRootProof)) revert InvalidProof();
+
+        // Load the ProvenWithdrawal into memory, using the withdrawal hash as a unique identifier.
+        bytes32 withdrawalHash = Hashing.hashWithdrawal(_tx);
+
+        // Compute the storage slot of the withdrawal hash in the L2ToL1MessagePasser contract.
+        // Refer to the Solidity documentation for more information on how storage layouts are
+        // computed for mappings.
+        bytes32 storageKey = keccak256(
+            abi.encode(
+                withdrawalHash,
+                uint256(0) // The withdrawals mapping is at the first slot in the layout.
+            )
+        );
+
+        // Verify that the hash of this withdrawal was stored in the L2toL1MessagePasser contract
+        // on L2. If this is true, under the assumption that the SecureMerkleTrie does not have
+        // bugs, then we know that this withdrawal was actually triggered on L2 and can therefore
+        // be relayed on L1.
+        if (
+            SecureMerkleTrie.verifyInclusionProof({
+                _key: abi.encode(storageKey),
+                _value: hex"01",
+                _proof: _withdrawalProof,
+                _root: _outputRootProof.messagePasserStorageRoot
+            }) == false
+        ) revert InvalidMerkleProof();
+
+        // Designate the withdrawalHash as proven by storing the `disputeGameProxy` & `timestamp` in the
+        // `provenWithdrawals` mapping. A `withdrawalHash` can only be proven once unless the dispute game it proved
+        // against resolves against the favor of the root claim.
+        provenWithdrawals[withdrawalHash][msg.sender] =
+            ProvenWithdrawal({ disputeGameProxy: gameProxy, timestamp: uint64(block.timestamp) });
+
+        // Emit a `WithdrawalProven` event.
+        emit WithdrawalProven(withdrawalHash, _tx.sender, _tx.target);
+        // Emit a `WithdrawalProvenExtension1` event.
+        emit WithdrawalProvenExtension1(withdrawalHash, msg.sender);
+
+        // Add the proof submitter to the list of proof submitters for this withdrawal hash.
+        proofSubmitters[withdrawalHash].push(msg.sender);
+    }
+
+    /// @notice Deprecated function signature of `proveWithdrawalTransaction`. This function is no longer supported,
+    ///         and will revert if called.
+    function proveWithdrawalTransaction(
+        Types.WithdrawalTransaction memory,
+        uint256,
+        Types.OutputRootProof calldata,
+        bytes[] calldata
+    )
+        external
+        view
+        override
+        whenNotPaused
+    {
+        revert("OptimismPortalInterop: this function is deprecated");
     }
 }

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -39,7 +39,7 @@ contract OptimismPortalInterop is OptimismPortal2 {
         OptimismPortal2(_proofMaturityDelaySeconds, _disputeGameFinalityDelaySeconds)
     { }
 
-    /// @custom:semver +interop
+    /// @custom:semver +interop.1
     function version() public pure override returns (string memory) {
         return string.concat(super.version(), "+interop.1");
     }

--- a/packages/contracts-bedrock/src/libraries/SuperRoot.sol
+++ b/packages/contracts-bedrock/src/libraries/SuperRoot.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+bytes1 constant SUPER_ROOT_VERSION = 0x01;
+
+/// @notice Error thrown when the version of the encoded SuperRoot is invalid.
+error InvalidVersion();
+
+/// @notice Error thrown when the length of the encoded SuperRoot is unexpected.
+error UnexpectedLength();
+
+/// @notice Error thrown when the output root with the given chain ID is not found.
+error OutputRootNotFound();
+
+/// @notice Error thrown when the output roots are not sorted in ascending order.
+error OutputRootsNotSorted();
+
+/// @notice The SuperRoot type represents the state of the Superchain at a given timestamp.
+struct SuperRoot {
+    /// @notice The timestamp of the SuperRoot.
+    uint64 timestamp;
+    /// @notice The output roots that the SuperRoot commits to. MUST be sorted in ascending order by L2 chain ID.
+    OutputRootWithChainId[] outputRoots;
+}
+
+/// @notice Represents an output root commitment and the L2 chain ID that it commits to.
+struct OutputRootWithChainId {
+    /// @notice The chain ID of the L2 chain that the output root commits to.
+    uint256 l2ChainId;
+    /// @notice The output root.
+    bytes32 outputRoot;
+}
+
+/// @title LibSuperRoot
+/// @notice SuperRoot is a library that supports the `SuperRoot` type.
+library LibSuperRoot {
+    /// @notice Decodes an encoded SuperRoot into a SuperRoot struct.
+    /// @param _raw The encoded SuperRoot.
+    /// @return superRoot_ The decoded SuperRoot.
+    /// @dev The encoded layout of the encoded super root is as follows:
+    /// ┌───────────────┬─────────────────────────────┬───────────────────────────────┐
+    /// │      0        │           [1, 9)            │         [9, 9 + n*64)         │
+    /// ├───────────────┼─────────────────────────────┼───────────────────────────────┤
+    /// │ Version Byte  │ Timestamp (big-endian, u64) │ Output Root & Chain ID tuples │
+    /// └───────────────┴─────────────────────────────┴───────────────────────────────┘
+    function decode(bytes calldata _raw) internal pure returns (SuperRoot memory superRoot_) {
+        // Ensure the length is at least 1 + 8 + 64 bytes. (version + timestamp + a single
+        // output root with chain ID).
+        if (_raw.length < 1 + 8 + 64) revert UnexpectedLength();
+
+        // Ensure the version is correct.
+        if (_raw[0] != SUPER_ROOT_VERSION) revert InvalidVersion();
+
+        // Extract the timestamp as a big-endian uint64.
+        uint64 rootTimestamp;
+        assembly {
+            rootTimestamp := shr(0xC0, calldataload(add(_raw.offset, 0x01)))
+        }
+
+        // Decode the output roots iteratively, starting at the 9th byte.
+        OutputRootWithChainId[] memory outputRoots;
+        assembly {
+            // Place the `outputRoots` array at the free memory pointer.
+            outputRoots := mload(0x40)
+
+            // Compute the offset of the output root tuples within the encoded super root.
+            let outputRootsCalldataOffset := add(_raw.offset, 0x09)
+
+            // Calculate the remaining length of the encoded super root.
+            let remaining := sub(add(_raw.offset, _raw.length), outputRootsCalldataOffset)
+
+            // Check if the calldata is well-formed. At this point, the remaining length must be
+            // a multiple of 64.
+            if mod(remaining, 0x40) {
+                // Signature of `UnexpectedLength()` error
+                mstore(0x00, 0x10345c7c)
+                revert(0x1c, 0x04)
+            }
+
+            // Store the data offsets on the stack. Arrays of dynamically sized objects in solidity
+            // are comprised of pointers, so we must allocate two blocks of memory - one for the array
+            // of pointers, and one for the data itself.
+            let ptrArrayMemoryOffset := add(outputRoots, 0x20)
+            let outputRootsMemoryOffset := add(ptrArrayMemoryOffset, shr(0x01, remaining))
+
+            // Iteratively decode the output roots, checking that they are sorted in ascending order.
+            let lastChainId := 0x00
+            for { let i := 0x00 } lt(i, remaining) { i := add(i, 0x40) } {
+                let chainIdLocalOffset := i
+                let outputRootLocalOffset := add(i, 0x20)
+
+                // Extract the chain ID and output root commitment from the calldata.
+                let chainId := calldataload(add(outputRootsCalldataOffset, chainIdLocalOffset))
+                let outputRoot := calldataload(add(outputRootsCalldataOffset, outputRootLocalOffset))
+
+                // Check that the chain IDs are sorted in ascending order.
+                if lt(chainId, lastChainId) {
+                    // Signature of `OutputRootsNotSorted()` error
+                    mstore(0x00, 0x0277c843)
+                    revert(0x1c, 0x04)
+                }
+                lastChainId := chainId
+
+                // Store the tuple data.
+                let dataPtr := add(outputRootsMemoryOffset, i)
+                mstore(dataPtr, chainId)
+                mstore(add(dataPtr, 0x20), outputRoot)
+
+                // Store the pointer to the tuple data in the array of pointers.
+                mstore(add(ptrArrayMemoryOffset, shr(0x01, i)), dataPtr)
+            }
+
+            // Store the length of the output root tuple array in memory.
+            mstore(outputRoots, shr(0x06, remaining))
+
+            // Compute the new free memory pointer, adding the length of the output roots array
+            // (32 + num tuples * 32) and the length of the tuple data (num tuples * 64).
+            let endPtr := add(outputRoots, add(add(0x20, shr(0x01, remaining)), remaining))
+            let fmp := and(not(0x1F), add(endPtr, 0x1F))
+
+            // Finally, update the free memory pointer to the nearest aligned word to account for
+            // our allocations.
+            mstore(0x40, fmp)
+        }
+
+        superRoot_ = SuperRoot({ timestamp: rootTimestamp, outputRoots: outputRoots });
+    }
+
+    /// @notice Finds the output root with the given chain ID in the SuperRoot.
+    /// @param _superRoot The SuperRoot to search.
+    /// @param _chainId The chain ID to search for.
+    /// @return outputRoot_ The output root committing to the given chain ID at the timestamp
+    ///                     of the super root.
+    function findOutputRoot(
+        SuperRoot memory _superRoot,
+        uint256 _chainId
+    )
+        internal
+        pure
+        returns (bytes32 outputRoot_)
+    {
+        // Perform a binary search to find the output root with the given chain ID.
+        uint256 low = 0;
+        uint256 high = _superRoot.outputRoots.length;
+        while (low < high) {
+            // (low + high) / 2 can overflow, so we use this alternative calculation.
+            uint256 mid = (low & high) + (low ^ high) / 2;
+
+            if (_superRoot.outputRoots[mid].l2ChainId > _chainId) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        // Ensure the output root with the given chain ID exists before returning it.
+        uint256 idx = low > 0 ? low - 1 : low;
+        OutputRootWithChainId memory outputRoot = _superRoot.outputRoots[idx];
+        if (outputRoot.l2ChainId == _chainId) {
+            outputRoot_ = outputRoot.outputRoot;
+        } else {
+            revert OutputRootNotFound();
+        }
+    }
+}

--- a/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
@@ -8,7 +8,7 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Types } from "src/libraries/Types.sol";
-import { OutputRootWithChainId, SUPER_ROOT_VERSION } from "src/libraries/SuperRoot.sol";
+import { OutputRootWithChainId, SuperRootProof, SUPER_ROOT_VERSION } from "src/libraries/SuperRoot.sol";
 import "src/dispute/lib/Types.sol";
 import "src/libraries/PortalErrors.sol";
 
@@ -125,8 +125,7 @@ contract OptimismPortalInterop_Test is CommonTest {
         _optimismPortalInterop().proveWithdrawalTransaction({
             _tx: defaultTx,
             _disputeGameIndex: disputeGameFactory.gameCount() - 1,
-            _l2ChainId: 10,
-            _rawSuperRoot: rawSuperRoot,
+            _superRootProof: SuperRootProof({ rawSuperRoot: rawSuperRoot, l2ChainId: 10, index: 0 }),
             _outputRootProof: _outputRootProof,
             _withdrawalProof: withdrawalProof
         });

--- a/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
@@ -7,6 +7,9 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Types } from "src/libraries/Types.sol";
+import { OutputRootWithChainId, SUPER_ROOT_VERSION } from "src/libraries/SuperRoot.sol";
+import "src/dispute/lib/Types.sol";
 import "src/libraries/PortalErrors.sol";
 
 // Interfaces
@@ -71,6 +74,62 @@ contract OptimismPortalInterop_Test is CommonTest {
     function testFuzz_setConfig_removeDependencyButNotSystemConfig_reverts(bytes calldata _value) public {
         vm.expectRevert(Unauthorized.selector);
         _optimismPortalInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, _value);
+    }
+
+    /// @dev Tests that `proveWithdrawalTransaction` succeeds.
+    function test_proveWithdrawalTransaction_validSuperWithdrawalProof_succeeds() external {
+        vm.warp(block.timestamp + 1);
+
+        // Craft test withdrawal transaction.
+        Types.WithdrawalTransaction memory defaultTx = Types.WithdrawalTransaction({
+            nonce: 0,
+            sender: alice,
+            target: bob,
+            value: 100,
+            gasLimit: 100_000,
+            data: hex"aa" // includes calldata for ERC20 withdrawal test
+         });
+        (
+            bytes32 stateRoot,
+            bytes32 storageRoot,
+            bytes32 outputRoot,
+            bytes32 withdrawalHash,
+            bytes[] memory withdrawalProof
+        ) = ffi.getProveWithdrawalTransactionInputs(defaultTx);
+
+        // Construct the output root proof
+        Types.OutputRootProof memory _outputRootProof = Types.OutputRootProof({
+            version: bytes32(uint256(0)),
+            stateRoot: stateRoot,
+            messagePasserStorageRoot: storageRoot,
+            latestBlockhash: bytes32(uint256(0))
+        });
+
+        // Construct the super root, comprising of only one chain.
+        OutputRootWithChainId memory outputRootWithChain =
+            OutputRootWithChainId({ l2ChainId: 10, outputRoot: outputRoot });
+        bytes memory rawSuperRoot = abi.encodePacked(
+            SUPER_ROOT_VERSION, uint64(block.timestamp), outputRootWithChain.l2ChainId, outputRootWithChain.outputRoot
+        );
+
+        // Set up the dummy game, proposing the super root.
+        GameType respectedGameType = _optimismPortalInterop().respectedGameType();
+        disputeGameFactory.create{ value: disputeGameFactory.initBonds(respectedGameType) }(
+            respectedGameType, Claim.wrap(keccak256(rawSuperRoot)), abi.encode(block.timestamp)
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawalProven(withdrawalHash, alice, bob);
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawalProvenExtension1(withdrawalHash, address(this));
+        _optimismPortalInterop().proveWithdrawalTransaction({
+            _tx: defaultTx,
+            _disputeGameIndex: disputeGameFactory.gameCount() - 1,
+            _l2ChainId: 10,
+            _rawSuperRoot: rawSuperRoot,
+            _outputRootProof: _outputRootProof,
+            _withdrawalProof: withdrawalProof
+        });
     }
 
     /// @dev Returns the OptimismPortalInterop instance.

--- a/packages/contracts-bedrock/test/libraries/SuperRoot.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SuperRoot.t.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing utilities
+import { CommonTest } from "test/setup/CommonTest.sol";
+
+// Target contract
+import {
+    LibSuperRoot,
+    SuperRoot,
+    UnexpectedLength,
+    InvalidVersion,
+    OutputRootNotFound,
+    OutputRootsNotSorted,
+    SUPER_ROOT_VERSION,
+    OutputRootWithChainId
+} from "src/libraries/SuperRoot.sol";
+
+/// @title LibSuperRoot_Test
+/// @notice Tests for the `LibSuperRoot` library.
+contract LibSuperRoot_Test is CommonTest {
+    /// @dev The minimum length of a super root.
+    uint256 constant MIN_SUPER_ROOT_LENGTH = 1 + 8 + 64;
+
+    /// @dev The test harness contract for `LibSuperRoot.decode`.
+    LibSuperRoot_CalldataDecodeHarness public harness;
+
+    function setUp() public override {
+        super.setUp();
+        harness = new LibSuperRoot_CalldataDecodeHarness();
+    }
+
+    /// @notice Tests that `LibSuperRoot.decode` can decode a static super root case.
+    function test_decode_static_succeeds() external view {
+        bytes memory exampleCase =
+            hex"01000000000000c0dedeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeadbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+
+        SuperRoot memory superRoot = harness.decode(exampleCase);
+        assertEq(superRoot.timestamp, 0xc0de);
+        assertEq(superRoot.outputRoots.length, 1);
+        assertEq(superRoot.outputRoots[0].l2ChainId, 0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead);
+        assertEq(
+            superRoot.outputRoots[0].outputRoot, 0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef
+        );
+    }
+
+    /// @notice Tests that `LibSuperRoot.decode` is memory safe.
+    function test_decode_memorySafety_succeeds() external {
+        bytes memory exampleCase =
+            hex"01000000000000c0dedeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeadbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+        harness.decodeCheckMemorySafety(exampleCase);
+    }
+
+    /// @notice Tests that `LibSuperRoot.decode` reverts when the data is less than 1 + 8 + 64 bytes.
+    function test_decode_insufficientData_reverts(uint256 _seed) external {
+        _seed = bound(_seed, 1, MIN_SUPER_ROOT_LENGTH - 1);
+        bytes memory data = new bytes(_seed);
+
+        // Set a valid super root version, to ensure that the test will not fail due to
+        // the version check.
+        data[0] = SUPER_ROOT_VERSION;
+
+        vm.expectRevert(UnexpectedLength.selector);
+        harness.decode(data);
+    }
+
+    /// @notice Tests that `LibSuperRoot.decode` reverts when the version byte is incorrect.
+    function test_decode_invalidVersion_reverts(bytes1 _seed) external {
+        // If the seed is the SUPER_ROOT_VERSION, increment it to avoid the success case.
+        if (_seed == SUPER_ROOT_VERSION) {
+            _seed = bytes1(uint8(_seed) + 1);
+        }
+
+        bytes memory data = new bytes(MIN_SUPER_ROOT_LENGTH);
+        data[0] = _seed;
+
+        vm.expectRevert(InvalidVersion.selector);
+        harness.decode(data);
+    }
+
+    /// @notice Tests that `LibSuperRoot.decode` reverts when the length of the output root tuple array
+    ///         is not a multiple of 64 bytes with at least one element.
+    function test_decode_badOutputRootsLength_reverts(bytes calldata _seed) external {
+        bytes memory baseData = new bytes(MIN_SUPER_ROOT_LENGTH);
+        baseData[0] = SUPER_ROOT_VERSION;
+
+        // If the seed a multiple of 64 bytes, append some extra data to avoid the success case.
+        bytes memory outputRoots = _seed;
+        if (_seed.length % 64 == 0) {
+            outputRoots = abi.encodePacked(_seed, hex"0badc0de");
+        }
+
+        vm.expectRevert(UnexpectedLength.selector);
+        harness.decode(abi.encodePacked(baseData, outputRoots));
+    }
+
+    /// @notice Tests that `LibSuperRoot.decode` reverts when the output roots are not sorted in
+    ///         ascending order by L2 chain ID.
+    function test_decode_unsortedOutputRoots_reverts() external {
+        bytes memory exampleCase =
+            hex"01000000000000c0dedeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeadbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef0000000000000000000000000000000000000000000000000000000000000000beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+
+        vm.expectRevert(OutputRootsNotSorted.selector);
+        harness.decode(exampleCase);
+    }
+
+    /// @notice Tests that `LibSuperRoot.findOutputRoot` can find an output root in a super root by chain ID.
+    function test_findOutputRoot_succeeds(bytes32[] calldata _outputRoots, uint256 _index) external pure {
+        vm.assume(_outputRoots.length > 0);
+
+        // Create a sorted array of output roots.
+        OutputRootWithChainId[] memory sortedOutputRoots = new OutputRootWithChainId[](_outputRoots.length);
+        for (uint256 i = 0; i < _outputRoots.length; i++) {
+            sortedOutputRoots[i] = OutputRootWithChainId({ l2ChainId: i, outputRoot: _outputRoots[i] });
+        }
+
+        _index = bound(_index, 0, sortedOutputRoots.length - 1);
+        bytes32 expectedOutputRoot = sortedOutputRoots[_index].outputRoot;
+        uint256 expectedChainId = sortedOutputRoots[_index].l2ChainId;
+
+        SuperRoot memory superRoot = SuperRoot({ timestamp: 0, outputRoots: sortedOutputRoots });
+
+        bytes32 outputRoot = LibSuperRoot.findOutputRoot(superRoot, expectedChainId);
+        assertEq(outputRoot, expectedOutputRoot);
+    }
+
+    /// @notice Tests that `LibSuperRoot.findOutputRoot` reverts when the chain ID being searched for is not
+    ///         present in the super root.
+    function test_findOutputRoot_notFound_reverts(bytes32[] calldata _outputRoots) external {
+        vm.assume(_outputRoots.length > 0);
+
+        // Create a sorted array of output roots.
+        OutputRootWithChainId[] memory sortedOutputRoots = new OutputRootWithChainId[](_outputRoots.length);
+        for (uint256 i = 0; i < _outputRoots.length; i++) {
+            sortedOutputRoots[i] = OutputRootWithChainId({ l2ChainId: i, outputRoot: _outputRoots[i] });
+        }
+
+        SuperRoot memory superRoot = SuperRoot({ timestamp: 0, outputRoots: sortedOutputRoots });
+
+        vm.expectRevert(OutputRootNotFound.selector);
+        LibSuperRoot.findOutputRoot(superRoot, sortedOutputRoots.length);
+    }
+}
+
+/// @title LibSuperRoot_CalldataDecodeHarness
+/// @notice Harness for testing the `LibSuperRoot.decode` function, which accepts calldata.
+contract LibSuperRoot_CalldataDecodeHarness is CommonTest {
+    function decode(bytes calldata _raw) external pure returns (SuperRoot memory) {
+        return LibSuperRoot.decode(_raw);
+    }
+
+    function decodeCheckMemorySafety(bytes calldata _raw) external {
+        uint64 ptr;
+        assembly {
+            ptr := mload(0x40)
+        }
+        uint64 outputRootsArrSize = 0x20 + 0x20;
+        uint64 outputRootsDataSize = 0x40;
+        uint64 superRootSize = 0x40;
+
+        vm.expectSafeMemory(ptr, ptr + 0x40 + outputRootsArrSize + outputRootsDataSize + superRootSize);
+        LibSuperRoot.decode(_raw);
+    }
+}

--- a/packages/contracts-bedrock/test/libraries/SuperRoot.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SuperRoot.t.sol
@@ -10,10 +10,8 @@ import {
     SuperRoot,
     UnexpectedLength,
     InvalidVersion,
-    OutputRootNotFound,
     OutputRootsNotSorted,
-    SUPER_ROOT_VERSION,
-    OutputRootWithChainId
+    SUPER_ROOT_VERSION
 } from "src/libraries/SuperRoot.sol";
 
 /// @title LibSuperRoot_Test
@@ -102,43 +100,6 @@ contract LibSuperRoot_Test is CommonTest {
 
         vm.expectRevert(OutputRootsNotSorted.selector);
         harness.decode(exampleCase);
-    }
-
-    /// @notice Tests that `LibSuperRoot.findOutputRoot` can find an output root in a super root by chain ID.
-    function test_findOutputRoot_succeeds(bytes32[] calldata _outputRoots, uint256 _index) external pure {
-        vm.assume(_outputRoots.length > 0);
-
-        // Create a sorted array of output roots.
-        OutputRootWithChainId[] memory sortedOutputRoots = new OutputRootWithChainId[](_outputRoots.length);
-        for (uint256 i = 0; i < _outputRoots.length; i++) {
-            sortedOutputRoots[i] = OutputRootWithChainId({ l2ChainId: i, outputRoot: _outputRoots[i] });
-        }
-
-        _index = bound(_index, 0, sortedOutputRoots.length - 1);
-        bytes32 expectedOutputRoot = sortedOutputRoots[_index].outputRoot;
-        uint256 expectedChainId = sortedOutputRoots[_index].l2ChainId;
-
-        SuperRoot memory superRoot = SuperRoot({ timestamp: 0, outputRoots: sortedOutputRoots });
-
-        bytes32 outputRoot = LibSuperRoot.findOutputRoot(superRoot, expectedChainId);
-        assertEq(outputRoot, expectedOutputRoot);
-    }
-
-    /// @notice Tests that `LibSuperRoot.findOutputRoot` reverts when the chain ID being searched for is not
-    ///         present in the super root.
-    function test_findOutputRoot_notFound_reverts(bytes32[] calldata _outputRoots) external {
-        vm.assume(_outputRoots.length > 0);
-
-        // Create a sorted array of output roots.
-        OutputRootWithChainId[] memory sortedOutputRoots = new OutputRootWithChainId[](_outputRoots.length);
-        for (uint256 i = 0; i < _outputRoots.length; i++) {
-            sortedOutputRoots[i] = OutputRootWithChainId({ l2ChainId: i, outputRoot: _outputRoots[i] });
-        }
-
-        SuperRoot memory superRoot = SuperRoot({ timestamp: 0, outputRoots: sortedOutputRoots });
-
-        vm.expectRevert(OutputRootNotFound.selector);
-        LibSuperRoot.findOutputRoot(superRoot, sortedOutputRoots.length);
     }
 }
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -234,6 +234,13 @@ contract Specification_Test is CommonTest {
             _sel: IOptimismPortal2.proveWithdrawalTransaction.selector,
             _pausable: true
         });
+        _addSpec({
+            _name: "OptimismPortalInterop",
+            _sel: _getSel(
+                "proveWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes),uint256,uint256,bytes,(bytes32,bytes32,bytes32,bytes32),bytes[])"
+            ),
+            _pausable: true
+        });
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("provenWithdrawals(bytes32,address)") });
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("systemConfig()") });

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -237,7 +237,7 @@ contract Specification_Test is CommonTest {
         _addSpec({
             _name: "OptimismPortalInterop",
             _sel: _getSel(
-                "proveWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes),uint256,uint256,bytes,(bytes32,bytes32,bytes32,bytes32),bytes[])"
+                "proveWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes),uint256,(bytes,uint256,uint256),(bytes32,bytes32,bytes32,bytes32),bytes[])"
             ),
             _pausable: true
         });


### PR DESCRIPTION
## Overview

> [!NOTE]
> Experimental, but works. Open to feedback, this needs a spec.

Adds support for proving a withdrawal transaction within a `SuperRoot` to the `OptimismPortalInterop`.

### Open Questions

- An breaking change to the `proveWithdrawalTransaction` function is needed to pass in the raw super root. As it stands, this implementation deprecates that function entirely, and forces it to revert. Any qualms w/ this?
- Will we have shared lockbox for the first release? If not, we will also need the portal to know its L2 chain ID, and restrict which L2 chain's output root can be used to prove against.

closes https://github.com/ethereum-optimism/optimism/issues/14075