### PR TITLE
op-e2e: Use RPC client to query op-supervisor in action tests

### DIFF
--- a/op-e2e/actions/helpers/rpc_server.go
+++ b/op-e2e/actions/helpers/rpc_server.go
@@ -1,0 +1,86 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+type SimpleRPCServer struct {
+	handler  *rpc.Server
+	listener net.Listener
+	apis     []rpc.API
+	ipcDir   string
+}
+
+func NewSimpleRPCServer() *SimpleRPCServer {
+	return &SimpleRPCServer{
+		handler: rpc.NewServer(),
+	}
+}
+
+func (s *SimpleRPCServer) AddAPI(api rpc.API) {
+	s.apis = append(s.apis, api)
+}
+
+func (s *SimpleRPCServer) Start(t Testing) {
+	t.Cleanup(func() {
+		require.NoError(t, s.Stop())
+	})
+
+	// Register all APIs to the RPC server.
+	for _, api := range s.apis {
+		if err := s.handler.RegisterName(api.Namespace, api.Service); err != nil {
+			require.NoError(t, fmt.Errorf("failed to register API %s: %w", api.Namespace, err))
+		}
+		t.Logf("registered API namespace %v", api.Namespace)
+	}
+
+	// Note: We don't use t.TempDir() here because it includes the test name in the path which can make it longer
+	// than the 104 char limit for ipc socket paths.
+	ipcDir, err := os.MkdirTemp("", "ipc*")
+	require.NoError(t, err, "failed to create temp dir for IPC")
+	s.ipcDir = ipcDir
+	listener, err := ipcListen(t, s.ipcDir)
+	require.NoError(t, err, "failed to start ipc listener")
+	s.listener = listener
+	go func() {
+		err := s.handler.ServeListener(listener)
+		if !errors.Is(err, net.ErrClosed) {
+			require.NoError(t, err)
+		}
+	}()
+}
+
+func (s *SimpleRPCServer) Connect(t Testing) client.RPC {
+	ipc, err := rpc.DialIPC(t.Ctx(), s.listener.Addr().String())
+	require.NoError(t, err)
+	return client.NewBaseRPCClient(ipc)
+}
+
+func (s *SimpleRPCServer) Stop() error {
+	if s.listener != nil {
+		// Best effort to close, but make sure we go on to remove the file
+		_ = s.listener.Close()
+	}
+	if s.ipcDir != "" {
+		return os.RemoveAll(s.ipcDir)
+	}
+	return nil
+}
+
+// ipcListen will create a Unix socket on the given endpoint.
+func ipcListen(t Testing, dir string) (net.Listener, error) {
+	endpoint := filepath.Join(dir, "ipc")
+	l, err := net.Listen("unix", endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -131,7 +131,7 @@ func (is *InteropSetup) CreateActors() *InteropActors {
 type SupervisorActor struct {
 	exec    *event.GlobalSyncExec
 	backend *backend.SupervisorBackend
-	Client  *sources.SupervisorClient
+	sources.SupervisorClient
 }
 
 func (sa *SupervisorActor) ProcessFull(t helpers.Testing) {
@@ -186,9 +186,9 @@ func NewSupervisor(t helpers.Testing, logger log.Logger, depSet depset.Dependenc
 	rpcServer.Start(t)
 	supervisorClient := sources.NewSupervisorClient(rpcServer.Connect(t))
 	return &SupervisorActor{
-		exec:    evExec,
-		backend: b,
-		Client:  supervisorClient,
+		exec:             evExec,
+		backend:          b,
+		SupervisorClient: *supervisorClient,
 	}
 }
 

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -63,7 +63,7 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, uint64(0), status.LocalSafeL2.Number)
 		require.Equal(t, uint64(0), status.SafeL2.Number)
 		require.Equal(t, uint64(0), status.FinalizedL2.Number)
-		supervisorStatus, err := actors.Supervisor.Client.SyncStatus(t.Ctx())
+		supervisorStatus, err := actors.Supervisor.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 
@@ -91,7 +91,7 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, head, status.LocalSafeL2.ID())
 		require.Equal(t, uint64(0), status.SafeL2.Number)
 		require.Equal(t, uint64(0), status.FinalizedL2.Number)
-		supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
+		supervisorStatus, err = actors.Supervisor.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 		// Local-safe does not count as "safe" in RPC
@@ -113,7 +113,7 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, head, status.LocalSafeL2.ID())
 		require.Equal(t, head, status.SafeL2.ID())
 		require.Equal(t, uint64(0), status.FinalizedL2.Number)
-		supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
+		supervisorStatus, err = actors.Supervisor.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 		h := chain.SequencerEngine.L2Chain().CurrentSafeBlock().Hash()
@@ -128,7 +128,7 @@ func TestFullInterop(gt *testing.T) {
 		actors.Supervisor.SignalFinalizedL1(t)
 		actors.Supervisor.ProcessFull(t)
 		chain.Sequencer.ActL2PipelineFull(t)
-		finalizedL2BlockID, err := actors.Supervisor.Client.Finalized(t.Ctx(), chain.ChainID)
+		finalizedL2BlockID, err := actors.Supervisor.Finalized(t.Ctx(), chain.ChainID)
 		require.NoError(t, err)
 		require.Equal(t, head, finalizedL2BlockID)
 
@@ -141,19 +141,19 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, head, status.LocalSafeL2.ID())
 		require.Equal(t, head, status.SafeL2.ID())
 		require.Equal(t, head, status.FinalizedL2.ID())
-		supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
+		supervisorStatus, err = actors.Supervisor.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 	}
 	// first run Chain A, processing 1 L1 block
 	full(actors.ChainA, 1)
-	supervisorStatus, err := actors.Supervisor.Client.SyncStatus(t.Ctx())
+	supervisorStatus, err := actors.Supervisor.SyncStatus(t.Ctx())
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), supervisorStatus.MinSyncedL1.Number)
 
 	// then run Chain B, processing 2 L1 blocks (because L1 is further ahead now)
 	full(actors.ChainB, 2)
-	supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
+	supervisorStatus, err = actors.Supervisor.SyncStatus(t.Ctx())
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), supervisorStatus.MinSyncedL1.Number)
 }
@@ -221,9 +221,9 @@ func TestFinality(gt *testing.T) {
 
 		// Process the supervisor to update the finality, and pull L1, L2 finality
 		actors.Supervisor.ProcessFull(t)
-		l1Finalized, err := actors.Supervisor.Client.FinalizedL1(t.Ctx())
+		l1Finalized, err := actors.Supervisor.FinalizedL1(t.Ctx())
 		require.NoError(t, err)
-		l2Finalized, err := actors.Supervisor.Client.Finalized(t.Ctx(), actors.ChainA.ChainID)
+		l2Finalized, err := actors.Supervisor.Finalized(t.Ctx(), actors.ChainA.ChainID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(tip), l1Finalized.Number)
 		// the L2 finality is the latest L2 block, because L1 finality is beyond anything the L2 used to derive
@@ -318,7 +318,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.ChainB.Sequencer.SyncSupervisor(t)
 	actors.Supervisor.ProcessFull(t)
 	// check supervisor head, expect it to be rewound
-	localUnsafe, err := actors.Supervisor.Client.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
+	localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), localUnsafe.Number, "unsafe chain needs to be rewound")
 
@@ -329,7 +329,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.ChainB.Sequencer.SyncSupervisor(t)
 	actors.Supervisor.ProcessFull(t)
 	// Check that the replacement is recognized as cross-safe
-	crossSafe, err := actors.Supervisor.Client.CrossSafe(t.Ctx(), actors.ChainB.ChainID)
+	crossSafe, err := actors.Supervisor.CrossSafe(t.Ctx(), actors.ChainB.ChainID)
 	require.NoError(t, err)
 	require.NotEqual(t, originalBlock.ID(), crossSafe.Derived)
 	require.NotEqual(t, extraBlock.ID(), crossSafe.Derived)

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -1,23 +1,21 @@
 package interop
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 )
 
 func TestFullInterop(gt *testing.T) {
@@ -65,7 +63,7 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, uint64(0), status.LocalSafeL2.Number)
 		require.Equal(t, uint64(0), status.SafeL2.Number)
 		require.Equal(t, uint64(0), status.FinalizedL2.Number)
-		supervisorStatus, err := actors.Supervisor.SyncStatus()
+		supervisorStatus, err := actors.Supervisor.Client.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 
@@ -93,7 +91,7 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, head, status.LocalSafeL2.ID())
 		require.Equal(t, uint64(0), status.SafeL2.Number)
 		require.Equal(t, uint64(0), status.FinalizedL2.Number)
-		supervisorStatus, err = actors.Supervisor.SyncStatus()
+		supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 		// Local-safe does not count as "safe" in RPC
@@ -115,7 +113,7 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, head, status.LocalSafeL2.ID())
 		require.Equal(t, head, status.SafeL2.ID())
 		require.Equal(t, uint64(0), status.FinalizedL2.Number)
-		supervisorStatus, err = actors.Supervisor.SyncStatus()
+		supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 		h := chain.SequencerEngine.L2Chain().CurrentSafeBlock().Hash()
@@ -130,7 +128,7 @@ func TestFullInterop(gt *testing.T) {
 		actors.Supervisor.SignalFinalizedL1(t)
 		actors.Supervisor.ProcessFull(t)
 		chain.Sequencer.ActL2PipelineFull(t)
-		finalizedL2BlockID, err := actors.Supervisor.Finalized(t.Ctx(), chain.ChainID)
+		finalizedL2BlockID, err := actors.Supervisor.Client.Finalized(t.Ctx(), chain.ChainID)
 		require.NoError(t, err)
 		require.Equal(t, head, finalizedL2BlockID)
 
@@ -143,19 +141,19 @@ func TestFullInterop(gt *testing.T) {
 		require.Equal(t, head, status.LocalSafeL2.ID())
 		require.Equal(t, head, status.SafeL2.ID())
 		require.Equal(t, head, status.FinalizedL2.ID())
-		supervisorStatus, err = actors.Supervisor.SyncStatus()
+		supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 	}
 	// first run Chain A, processing 1 L1 block
 	full(actors.ChainA, 1)
-	supervisorStatus, err := actors.Supervisor.SyncStatus()
+	supervisorStatus, err := actors.Supervisor.Client.SyncStatus(t.Ctx())
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), supervisorStatus.MinSyncedL1.Number)
 
 	// then run Chain B, processing 2 L1 blocks (because L1 is further ahead now)
 	full(actors.ChainB, 2)
-	supervisorStatus, err = actors.Supervisor.SyncStatus()
+	supervisorStatus, err = actors.Supervisor.Client.SyncStatus(t.Ctx())
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), supervisorStatus.MinSyncedL1.Number)
 }
@@ -223,8 +221,9 @@ func TestFinality(gt *testing.T) {
 
 		// Process the supervisor to update the finality, and pull L1, L2 finality
 		actors.Supervisor.ProcessFull(t)
-		l1Finalized := actors.Supervisor.FinalizedL1()
-		l2Finalized, err := actors.Supervisor.Finalized(context.Background(), actors.ChainA.ChainID)
+		l1Finalized, err := actors.Supervisor.Client.FinalizedL1(t.Ctx())
+		require.NoError(t, err)
+		l2Finalized, err := actors.Supervisor.Client.Finalized(t.Ctx(), actors.ChainA.ChainID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(tip), l1Finalized.Number)
 		// the L2 finality is the latest L2 block, because L1 finality is beyond anything the L2 used to derive
@@ -319,7 +318,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.ChainB.Sequencer.SyncSupervisor(t)
 	actors.Supervisor.ProcessFull(t)
 	// check supervisor head, expect it to be rewound
-	localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
+	localUnsafe, err := actors.Supervisor.Client.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), localUnsafe.Number, "unsafe chain needs to be rewound")
 
@@ -330,7 +329,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.ChainB.Sequencer.SyncSupervisor(t)
 	actors.Supervisor.ProcessFull(t)
 	// Check that the replacement is recognized as cross-safe
-	crossSafe, err := actors.Supervisor.CrossSafe(t.Ctx(), actors.ChainB.ChainID)
+	crossSafe, err := actors.Supervisor.Client.CrossSafe(t.Ctx(), actors.ChainB.ChainID)
 	require.NoError(t, err)
 	require.NotEqual(t, originalBlock.ID(), crossSafe.Derived)
 	require.NotEqual(t, extraBlock.ID(), crossSafe.Derived)

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -678,7 +678,7 @@ func runChallengerTest(gt *testing.T, test *transitionTest, actors *dsl.InteropA
 		endTimestamp = actors.ChainA.Sequencer.L2Unsafe().Time
 	}
 	startTimestamp := actors.ChainA.Sequencer.L2Unsafe().Time - 1
-	prestateProvider := super.NewSuperRootPrestateProvider(actors.Supervisor.Client, startTimestamp)
+	prestateProvider := super.NewSuperRootPrestateProvider(actors.Supervisor, startTimestamp)
 	var l1Head eth.BlockID
 	if test.l1Head == (common.Hash{}) {
 		l1Head = eth.ToBlockID(eth.HeaderBlockInfo(actors.L1Miner.L1Chain().CurrentBlock()))
@@ -688,7 +688,7 @@ func runChallengerTest(gt *testing.T, test *transitionTest, actors *dsl.InteropA
 	gameDepth := challengerTypes.Depth(30)
 	rollupCfgs, err := super.NewRollupConfigsFromParsed(actors.ChainA.RollupCfg, actors.ChainB.RollupCfg)
 	require.NoError(t, err)
-	provider := super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, actors.Supervisor.Client, l1Head, gameDepth, startTimestamp, endTimestamp)
+	provider := super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, actors.Supervisor, l1Head, gameDepth, startTimestamp, endTimestamp)
 	var agreedPrestate []byte
 	if test.disputedTraceIndex > 0 {
 		agreedPrestate, err = provider.GetPreimageBytes(t.Ctx(), challengerTypes.NewPosition(gameDepth, big.NewInt(test.disputedTraceIndex-1)))

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -678,7 +678,7 @@ func runChallengerTest(gt *testing.T, test *transitionTest, actors *dsl.InteropA
 		endTimestamp = actors.ChainA.Sequencer.L2Unsafe().Time
 	}
 	startTimestamp := actors.ChainA.Sequencer.L2Unsafe().Time - 1
-	prestateProvider := super.NewSuperRootPrestateProvider(&actors.Supervisor.QueryFrontend, startTimestamp)
+	prestateProvider := super.NewSuperRootPrestateProvider(actors.Supervisor.Client, startTimestamp)
 	var l1Head eth.BlockID
 	if test.l1Head == (common.Hash{}) {
 		l1Head = eth.ToBlockID(eth.HeaderBlockInfo(actors.L1Miner.L1Chain().CurrentBlock()))
@@ -688,7 +688,7 @@ func runChallengerTest(gt *testing.T, test *transitionTest, actors *dsl.InteropA
 	gameDepth := challengerTypes.Depth(30)
 	rollupCfgs, err := super.NewRollupConfigsFromParsed(actors.ChainA.RollupCfg, actors.ChainB.RollupCfg)
 	require.NoError(t, err)
-	provider := super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, &actors.Supervisor.QueryFrontend, l1Head, gameDepth, startTimestamp, endTimestamp)
+	provider := super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, actors.Supervisor.Client, l1Head, gameDepth, startTimestamp, endTimestamp)
 	var agreedPrestate []byte
 	if test.disputedTraceIndex > 0 {
 		agreedPrestate, err = provider.GetPreimageBytes(t.Ctx(), challengerTypes.NewPosition(gameDepth, big.NewInt(test.disputedTraceIndex-1)))

--- a/op-e2e/actions/interop/reset_test.go
+++ b/op-e2e/actions/interop/reset_test.go
@@ -125,7 +125,7 @@ func TestReset(gt *testing.T) {
 			actors.Supervisor.SignalFinalizedL1(t)
 			actors.Supervisor.ProcessFull(t)
 			actors.ChainA.Sequencer.ActL2PipelineFull(t)
-			finalizedL2BlockID, err := actors.Supervisor.Client.Finalized(t.Ctx(), actors.ChainA.ChainID)
+			finalizedL2BlockID, err := actors.Supervisor.Finalized(t.Ctx(), actors.ChainA.ChainID)
 			require.NoError(t, err)
 			require.Equal(t, blocksAdded[0], finalizedL2BlockID)
 		}

--- a/op-e2e/actions/interop/reset_test.go
+++ b/op-e2e/actions/interop/reset_test.go
@@ -125,7 +125,7 @@ func TestReset(gt *testing.T) {
 			actors.Supervisor.SignalFinalizedL1(t)
 			actors.Supervisor.ProcessFull(t)
 			actors.ChainA.Sequencer.ActL2PipelineFull(t)
-			finalizedL2BlockID, err := actors.Supervisor.Finalized(t.Ctx(), actors.ChainA.ChainID)
+			finalizedL2BlockID, err := actors.Supervisor.Client.Finalized(t.Ctx(), actors.ChainA.ChainID)
 			require.NoError(t, err)
 			require.Equal(t, blocksAdded[0], finalizedL2BlockID)
 		}

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -105,6 +105,26 @@ func (cl *SupervisorClient) SafeView(ctx context.Context, chainID eth.ChainID, s
 	return result, nil
 }
 
+func (cl *SupervisorClient) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	var result eth.BlockID
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_localUnsafe",
+		chainID)
+	return result, err
+}
+
+func (cl *SupervisorClient) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
+	var result types.DerivedIDPair
+	err := cl.client.CallContext(
+		ctx,
+		&result,
+		"supervisor_crossSafe",
+		chainID)
+	return result, err
+}
+
 func (cl *SupervisorClient) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	var result eth.BlockID
 	err := cl.client.CallContext(


### PR DESCRIPTION
**Description**

Replaces direct access to the supervisor `QueryFrontend` and `AdminFrontend` in action tests with use of the `SupervisorClient` using an IPC server.  This ensures the queries and responses are actually serialised and deserialised in tests the same way they would be in production but we avoid the need to allocate ports as would be necessary with a http server.

The IPC server used for RPCs is tailored to tests, always creating a unique temp dir and automatically cleaning everything up via t.Cleanup. Eventually it would be nice to have support for IPC in the production code as well as rework `op-service/rpc/server` to support configuring different transport layers rather than hard coding HTTP but that's a much bigger change affecting nearly all services. Given the action tests don't use the supervisor service's init process now anyway it doesn't seem worth the effort.

The actual registration of the RPC handlers, including creating the QueryFrontend and AdminFrontend is extracted to a method that can be reused in the action tests so new RPC namespaces will automatically become available in action tests and we are testing the production code for registering them.


**Metadata**

Required for the cleanup blocking #14077 