### PR TITLE
chore: Update go version

### DIFF
--- a/cannon/testdata/example/alloc/go.mod
+++ b/cannon/testdata/example/alloc/go.mod
@@ -1,8 +1,6 @@
 module alloc
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.23.6
 
 require github.com/ethereum-optimism/optimism v0.0.0
 

--- a/cannon/testdata/example/claim/go.mod
+++ b/cannon/testdata/example/claim/go.mod
@@ -1,8 +1,6 @@
 module claim
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.23.6
 
 require github.com/ethereum-optimism/optimism v0.0.0
 

--- a/cannon/testdata/example/claim/go.sum
+++ b/cannon/testdata/example/claim/go.sum
@@ -4,8 +4,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
-golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/ethereum-optimism/optimism
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.23.6
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Core dependencies
-go = "1.22.7"
+go = "1.23.6"
 rust = "1.83.0"
 python = "3.12.0"
 uv = "0.5.5"
@@ -15,7 +15,7 @@ just = "1.37.0"
 "cargo:svm-rs" = "0.5.8"
 
 # Go dependencies
-"go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.10.25"
+"go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.0"
 "go:gotest.tools/gotestsum" = "1.12.0"
 "go:github.com/vektra/mockery/v2" = "2.46.0"
 "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.61.0"

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -17,7 +17,7 @@ ARG UBUNTU_TARGET_BASE_IMAGE=ubuntu:22.04
 ARG KONA_VERSION=none
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.22.7-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.6-alpine3.20 AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq bash
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Go 1.23 introduces, amongst others, [`iter` package ](https://tip.golang.org/doc/go1.23#iterators) that's very handy when dealing with streams and lists of large sizes which would otherwise consume lots of memory when passed around as whole.

This functionality has been available in 1.22 under an experiment (which makes especially IDE-based life super difficult, since the only way to enable it is to `export GOEXPERIMENT=rangefunc`).

Iterators are very useful when it comes to modeling e.g. account derivation based on mnemonics, something that the new `devnet-sdk` functionality could use. 

~~Edit: looks like `abigen` is [not yet compatible](https://github.com/ethereum/go-ethereum/issues/30100) with go 1.23, what a shame~~

Edit: Updating `abigen` to `1.15.0` seems to have solved the issue