### PR TITLE
op-deployer: add command to verify contracts on etherscan

### DIFF
--- a/op-chain-ops/foundry/artifact.go
+++ b/op-chain-ops/foundry/artifact.go
@@ -18,20 +18,12 @@ import (
 // JSON marshaling logic is implemented to maintain the ability
 // to roundtrip serialize an artifact
 type Artifact struct {
-	ABI               abi.ABI
-	abi               json.RawMessage
-	StorageLayout     solc.StorageLayout
-	DeployedBytecode  DeployedBytecode
-	Bytecode          Bytecode
-	Metadata          Metadata
-	ContractName      string            `json:"contractName"`
-	Version           string            `json:"version"`
-	Source            string            `json:"source"`
-	Language          string            `json:"language"`
-	CompilerVersion   string            `json:"compiler"`
-	License           string            `json:"license"`
-	MethodIdentifiers map[string]string `json:"methodIdentifiers"`
-	GasEstimates      json.RawMessage   `json:"gasEstimates"`
+	ABI              abi.ABI
+	abi              json.RawMessage
+	StorageLayout    solc.StorageLayout
+	DeployedBytecode DeployedBytecode
+	Bytecode         Bytecode
+	Metadata         Metadata
 }
 
 func (a *Artifact) UnmarshalJSON(data []byte) error {
@@ -49,7 +41,6 @@ func (a *Artifact) UnmarshalJSON(data []byte) error {
 	a.DeployedBytecode = artifact.DeployedBytecode
 	a.Bytecode = artifact.Bytecode
 	a.Metadata = artifact.Metadata
-	a.Source = artifact.Source
 	return nil
 }
 
@@ -60,7 +51,6 @@ func (a Artifact) MarshalJSON() ([]byte, error) {
 		DeployedBytecode: a.DeployedBytecode,
 		Bytecode:         a.Bytecode,
 		Metadata:         a.Metadata,
-		Source:           a.Source,
 	}
 	return json.Marshal(artifact)
 }

--- a/op-chain-ops/foundry/artifact.go
+++ b/op-chain-ops/foundry/artifact.go
@@ -18,12 +18,20 @@ import (
 // JSON marshaling logic is implemented to maintain the ability
 // to roundtrip serialize an artifact
 type Artifact struct {
-	ABI              abi.ABI
-	abi              json.RawMessage
-	StorageLayout    solc.StorageLayout
-	DeployedBytecode DeployedBytecode
-	Bytecode         Bytecode
-	Metadata         Metadata
+	ABI               abi.ABI
+	abi               json.RawMessage
+	StorageLayout     solc.StorageLayout
+	DeployedBytecode  DeployedBytecode
+	Bytecode          Bytecode
+	Metadata          Metadata
+	ContractName      string            `json:"contractName"`
+	Version           string            `json:"version"`
+	Source            string            `json:"source"`
+	Language          string            `json:"language"`
+	CompilerVersion   string            `json:"compiler"`
+	License           string            `json:"license"`
+	MethodIdentifiers map[string]string `json:"methodIdentifiers"`
+	GasEstimates      json.RawMessage   `json:"gasEstimates"`
 }
 
 func (a *Artifact) UnmarshalJSON(data []byte) error {
@@ -41,6 +49,7 @@ func (a *Artifact) UnmarshalJSON(data []byte) error {
 	a.DeployedBytecode = artifact.DeployedBytecode
 	a.Bytecode = artifact.Bytecode
 	a.Metadata = artifact.Metadata
+	a.Source = artifact.Source
 	return nil
 }
 
@@ -51,6 +60,7 @@ func (a Artifact) MarshalJSON() ([]byte, error) {
 		DeployedBytecode: a.DeployedBytecode,
 		Bytecode:         a.Bytecode,
 		Metadata:         a.Metadata,
+		Source:           a.Source,
 	}
 	return json.Marshal(artifact)
 }
@@ -59,6 +69,7 @@ func (a Artifact) MarshalJSON() ([]byte, error) {
 // foundry artifacts.
 type artifactMarshaling struct {
 	ABI              json.RawMessage    `json:"abi"`
+	Source           string             `json:"source"`
 	StorageLayout    solc.StorageLayout `json:"storageLayout"`
 	DeployedBytecode DeployedBytecode   `json:"deployedBytecode"`
 	Bytecode         Bytecode           `json:"bytecode"`
@@ -102,6 +113,7 @@ type Metadata struct {
 type ContractSource struct {
 	Keccak256 common.Hash `json:"keccak256"`
 	URLs      []string    `json:"urls"`
+	Content   string      `json:"content"`
 	License   string      `json:"license"`
 }
 

--- a/op-chain-ops/foundry/artifact.go
+++ b/op-chain-ops/foundry/artifact.go
@@ -156,8 +156,9 @@ func ReadArtifact(path string) (*Artifact, error) {
 	return &artifact, nil
 }
 
-// SearchRemappings applies the configured remappings to a given source path.
-// It assumes that each remapping is of the form "alias/=actualPath".
+// SearchRemappings applies the configured remappings to a given source path,
+// or returns the source path unchanged if no remapping is found. It assumes that
+// each remapping is of the form "alias/=actualPath".
 func (a Artifact) SearchRemappings(sourcePath string) string {
 	for _, mapping := range a.Metadata.Settings.Remappings {
 		parts := strings.Split(mapping, "/=")

--- a/op-deployer/cmd/op-deployer/main.go
+++ b/op-deployer/cmd/op-deployer/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/clean"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/bootstrap"
@@ -65,6 +66,12 @@ func main() {
 			Name:        "clean",
 			Usage:       "cleans up various things",
 			Subcommands: clean.Commands,
+		},
+		{
+			Name:   "verify",
+			Usage:  "verifies deployed contracts on Etherscan",
+			Flags:  cliapp.ProtectFlags(deployer.VerifyFlags),
+			Action: verify.VerifyCLI,
 		},
 	}
 	app.Writer = os.Stdout

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -161,6 +161,7 @@ func ApplyPipeline(
 		return fmt.Errorf("failed to download L1 artifacts: %w", err)
 	}
 
+	fmt.Println("Downloading L2 artifacts")
 	var l2ArtifactsFS foundry.StatDirFs
 	if intent.L1ContractsLocator.Equal(intent.L2ContractsLocator) {
 		l2ArtifactsFS = l1ArtifactsFS

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -161,7 +161,6 @@ func ApplyPipeline(
 		return fmt.Errorf("failed to download L1 artifacts: %w", err)
 	}
 
-	fmt.Println("Downloading L2 artifacts")
 	var l2ArtifactsFS foundry.StatDirFs
 	if intent.L1ContractsLocator.Equal(intent.L2ContractsLocator) {
 		l2ArtifactsFS = l1ArtifactsFS

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -13,15 +13,17 @@ import (
 )
 
 const (
-	EnvVarPrefix       = "DEPLOYER"
-	L1RPCURLFlagName   = "l1-rpc-url"
-	CacheDirFlagName   = "cache-dir"
-	L1ChainIDFlagName  = "l1-chain-id"
-	L2ChainIDsFlagName = "l2-chain-ids"
-	WorkdirFlagName    = "workdir"
-	OutdirFlagName     = "outdir"
-	PrivateKeyFlagName = "private-key"
-	IntentTypeFlagName = "intent-type"
+	EnvVarPrefix            = "DEPLOYER"
+	L1RPCURLFlagName        = "l1-rpc-url"
+	CacheDirFlagName        = "cache-dir"
+	L1ChainIDFlagName       = "l1-chain-id"
+	L2ChainIDsFlagName      = "l2-chain-ids"
+	WorkdirFlagName         = "workdir"
+	OutdirFlagName          = "outdir"
+	PrivateKeyFlagName      = "private-key"
+	IntentTypeFlagName      = "intent-type"
+	EtherscanAPIKeyFlagName = "etherscan-api-key"
+	ContractBundleFlagName  = "contract-bundle"
 )
 
 type DeploymentTarget string
@@ -117,6 +119,17 @@ var (
 			"intent-config-type",
 		},
 	}
+	EtherscanAPIKeyFlag = &cli.StringFlag{
+		Name:     EtherscanAPIKeyFlagName,
+		Usage:    "Etherscan API key for contract verification.",
+		EnvVars:  PrefixEnvVar("ETHERSCAN_API_KEY"),
+		Required: true,
+	}
+	ContractBundleFlag = &cli.StringFlag{
+		Name:    ContractBundleFlagName,
+		Usage:   "Which contract bundle/grouping to use (superchain, opchain, or implementations)",
+		EnvVars: PrefixEnvVar("CONTRACT_BUNDLE"),
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{CacheDirFlag}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -139,6 +152,13 @@ var UpgradeFlags = []cli.Flag{
 	L1RPCURLFlag,
 	PrivateKeyFlag,
 	DeploymentTargetFlag,
+}
+
+var VerifyFlags = []cli.Flag{
+	L1RPCURLFlag,
+	WorkdirFlag,
+	EtherscanAPIKeyFlag,
+	ContractBundleFlag,
 }
 
 func PrefixEnvVar(name string) []string {

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -24,6 +24,8 @@ const (
 	IntentTypeFlagName      = "intent-type"
 	EtherscanAPIKeyFlagName = "etherscan-api-key"
 	ContractBundleFlagName  = "contract-bundle"
+	ContractNameFlagName    = "contract-name"
+	L2ChainIDFlagName       = "l2-chain-id"
 )
 
 type DeploymentTarget string
@@ -87,6 +89,11 @@ var (
 		Usage:   "Comma-separated list of L2 chain IDs to deploy.",
 		EnvVars: PrefixEnvVar("L2_CHAIN_IDS"),
 	}
+	L2ChainIDFlag = &cli.StringFlag{
+		Name:    L2ChainIDFlagName,
+		Usage:   "Single L2 chain ID",
+		EnvVars: PrefixEnvVar("L2_CHAIN_ID"),
+	}
 	WorkdirFlag = &cli.StringFlag{
 		Name:    WorkdirFlagName,
 		Usage:   "Directory storing intent and stage. Defaults to the current directory.",
@@ -127,19 +134,13 @@ var (
 	}
 	ContractBundleFlag = &cli.StringFlag{
 		Name:    ContractBundleFlagName,
-		Usage:   "contract bundle/grouping to verify (superchain, opchain, or implementations)",
+		Usage:   "contract bundle/grouping (superchain|implementations|opchain)",
 		EnvVars: PrefixEnvVar("CONTRACT_BUNDLE"),
 	}
 	ContractNameFlag = &cli.StringFlag{
 		Name:    ContractNameFlagName,
-		Usage:   "contract name (mathcing a field within state.json) to verify",
+		Usage:   "contract name (matching a field within state.json)",
 		EnvVars: PrefixEnvVar("CONTRACT_NAME"),
-	}
-	L2ChainIndexFlag = &cli.IntFlag{
-		Name:    "l2-chain-index",
-		Usage:   "index of the L2 chain within the state.AppliedIntent.Chains array",
-		EnvVars: PrefixEnvVar("L2_CHAIN_INDEX"),
-		Value:   0,
 	}
 )
 
@@ -171,7 +172,7 @@ var VerifyFlags = []cli.Flag{
 	EtherscanAPIKeyFlag,
 	ContractBundleFlag,
 	ContractNameFlag,
-	L2ChainIndexFlag,
+	L2ChainIDFlag,
 }
 
 func PrefixEnvVar(name string) []string {

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -52,14 +52,15 @@ func NewDeploymentTarget(s string) (DeploymentTarget, error) {
 	}
 }
 
-var homeDir string
+var DefaultCacheDir string
 
 func init() {
 	var err error
-	homeDir, err = os.UserHomeDir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(fmt.Sprintf("failed to get home directory: %s", err))
 	}
+	DefaultCacheDir = path.Join(homeDir, ".op-deployer/cache")
 }
 
 var (
@@ -76,7 +77,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   path.Join(homeDir, ".op-deployer/cache"),
+		Value:   DefaultCacheDir,
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -135,6 +135,12 @@ var (
 		Usage:   "contract name (mathcing a field within state.json) to verify",
 		EnvVars: PrefixEnvVar("CONTRACT_NAME"),
 	}
+	L2ChainIndexFlag = &cli.IntFlag{
+		Name:    "l2-chain-index",
+		Usage:   "index of the L2 chain within the state.AppliedIntent.Chains array",
+		EnvVars: PrefixEnvVar("L2_CHAIN_INDEX"),
+		Value:   0,
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{CacheDirFlag}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -165,6 +171,7 @@ var VerifyFlags = []cli.Flag{
 	EtherscanAPIKeyFlag,
 	ContractBundleFlag,
 	ContractNameFlag,
+	L2ChainIndexFlag,
 }
 
 func PrefixEnvVar(name string) []string {

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -121,14 +121,19 @@ var (
 	}
 	EtherscanAPIKeyFlag = &cli.StringFlag{
 		Name:     EtherscanAPIKeyFlagName,
-		Usage:    "Etherscan API key for contract verification.",
+		Usage:    "etherscan API key for contract verification.",
 		EnvVars:  PrefixEnvVar("ETHERSCAN_API_KEY"),
 		Required: true,
 	}
 	ContractBundleFlag = &cli.StringFlag{
 		Name:    ContractBundleFlagName,
-		Usage:   "Which contract bundle/grouping to use (superchain, opchain, or implementations)",
+		Usage:   "contract bundle/grouping to verify (superchain, opchain, or implementations)",
 		EnvVars: PrefixEnvVar("CONTRACT_BUNDLE"),
+	}
+	ContractNameFlag = &cli.StringFlag{
+		Name:    ContractNameFlagName,
+		Usage:   "contract name (mathcing a field within state.json) to verify",
+		EnvVars: PrefixEnvVar("CONTRACT_NAME"),
 	}
 )
 
@@ -159,6 +164,7 @@ var VerifyFlags = []cli.Flag{
 	WorkdirFlag,
 	EtherscanAPIKeyFlag,
 	ContractBundleFlag,
+	ContractNameFlag,
 }
 
 func PrefixEnvVar(name string) []string {

--- a/op-deployer/pkg/deployer/inspect/l1.go
+++ b/op-deployer/pkg/deployer/inspect/l1.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 
@@ -18,6 +19,33 @@ type L1Contracts struct {
 	SuperchainDeployment      SuperchainDeployment      `json:"superchainDeployment"`
 	OpChainDeployment         OpChainDeployment         `json:"opChainDeployment"`
 	ImplementationsDeployment ImplementationsDeployment `json:"implementationsDeployment"`
+}
+
+const (
+	SuperchainBundle      = "superchain"
+	ImplementationsBundle = "implementations"
+	OpChainBundle         = "opchain"
+)
+
+func (l L1Contracts) GetContractAddress(name string, bundleName string) (common.Address, error) {
+	var bundle interface{}
+	switch bundleName {
+	case SuperchainBundle:
+		bundle = l.SuperchainDeployment
+	case ImplementationsBundle:
+		bundle = l.ImplementationsDeployment
+	case OpChainBundle:
+		bundle = l.OpChainDeployment
+	default:
+		return common.Address{}, fmt.Errorf("invalid contract bundle type: %s", bundleName)
+	}
+
+	field := reflect.ValueOf(bundle).FieldByName(name)
+	if !field.IsValid() {
+		return common.Address{}, fmt.Errorf("contract %s not found in %s bundle", name, bundleName)
+	}
+
+	return field.Interface().(common.Address), nil
 }
 
 func (l L1Contracts) AsL1Deployments() *genesis.L1Deployments {

--- a/op-deployer/pkg/deployer/inspect/l1.go
+++ b/op-deployer/pkg/deployer/inspect/l1.go
@@ -27,6 +27,12 @@ const (
 	OpChainBundle         = "opchain"
 )
 
+var ContractBundles = []string{
+	SuperchainBundle,
+	ImplementationsBundle,
+	OpChainBundle,
+}
+
 func (l L1Contracts) GetContractAddress(name string, bundleName string) (common.Address, error) {
 	var bundle interface{}
 	switch bundleName {

--- a/op-deployer/pkg/deployer/verify/artifacts.go
+++ b/op-deployer/pkg/deployer/verify/artifacts.go
@@ -67,7 +67,7 @@ func (v *Verifier) getContractArtifact(name string) (*contractArtifact, error) {
 	for sourcePath, sourceInfo := range art.Metadata.Sources {
 		remappedKey := art.SearchRemappings(sourcePath)
 		sources[remappedKey] = map[string]string{"content": sourceInfo.Content}
-		v.log.Info("added source contract", "originalPath", sourcePath, "remappedKey", remappedKey)
+		v.log.Debug("added source contract", "originalPath", sourcePath, "remappedKey", remappedKey)
 	}
 
 	var optimizer struct {
@@ -119,8 +119,11 @@ func (v *Verifier) getContractArtifact(name string) (*contractArtifact, error) {
 	}
 	v.log.Info("contractName", "name", contractName)
 
-	constructorArgs := GetConstructorArgs(name, v.st)
-	v.log.Info("constructorArgs", "args", constructorArgs)
+	constructorArgs, err := v.getEncodedConstructorArgs(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get constructor args: %w", err)
+	}
+	v.log.Debug("constructorArgs", "args", constructorArgs)
 
 	return &contractArtifact{
 		ContractName:     contractName,

--- a/op-deployer/pkg/deployer/verify/artifacts.go
+++ b/op-deployer/pkg/deployer/verify/artifacts.go
@@ -1,0 +1,134 @@
+package verify
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+)
+
+type contractArtifact struct {
+	ContractName     string
+	CompilerVersion  string
+	OptimizationUsed bool
+	OptimizationRuns int
+	EVMVersion       string
+	StandardInput    string
+	ConstructorArgs  string
+}
+
+// Map state.json struct's contract field names to forge artifact names
+var contractNameExceptions = map[string]string{
+	"OptimismPortalImpl":          "OptimismPortal2",
+	"L1StandardBridgeProxy":       "L1ChugSplashProxy",
+	"L1CrossDomainMessengerProxy": "ResolvedDelegateProxy",
+	"Opcm":                        "OPContractsManager",
+}
+
+func getArtifactName(name string) string {
+	lookupName := strings.TrimSuffix(name, "Address")
+
+	if artifactName, exists := contractNameExceptions[lookupName]; exists {
+		return artifactName
+	}
+
+	lookupName = strings.TrimSuffix(lookupName, "Proxy")
+	lookupName = strings.TrimSuffix(lookupName, "Impl")
+	lookupName = strings.TrimSuffix(lookupName, "Singleton")
+
+	// If it was a proxy and not a special case, return "Proxy"
+	if strings.HasSuffix(name, "ProxyAddress") {
+		return "Proxy"
+	}
+
+	return lookupName
+}
+
+func (v *Verifier) getContractArtifact(name string) (*contractArtifact, error) {
+	artifactName := getArtifactName(name)
+	artifactPath := path.Join(artifactName+".sol", artifactName+".json")
+
+	v.log.Info("Opening artifact", "path", artifactPath, "name", name)
+	f, err := v.artifactsFS.Open(artifactPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open artifact: %w", err)
+	}
+	defer f.Close()
+
+	var art foundry.Artifact
+	if err := json.NewDecoder(f).Decode(&art); err != nil {
+		return nil, fmt.Errorf("failed to decode artifact: %w", err)
+	}
+
+	// Add all sources (main contract and dependencies)
+	sources := make(map[string]map[string]string)
+	for sourcePath, sourceInfo := range art.Metadata.Sources {
+		remappedKey := art.SearchRemappings(sourcePath)
+		sources[remappedKey] = map[string]string{"content": sourceInfo.Content}
+		v.log.Info("added source contract", "originalPath", sourcePath, "remappedKey", remappedKey)
+	}
+
+	var optimizer struct {
+		Enabled bool `json:"enabled"`
+		Runs    int  `json:"runs"`
+	}
+	if err := json.Unmarshal(art.Metadata.Settings.Optimizer, &optimizer); err != nil {
+		return nil, fmt.Errorf("failed to parse optimizer settings: %w", err)
+	}
+
+	standardInput := map[string]interface{}{
+		"language": "Solidity",
+		"sources":  sources,
+		"settings": map[string]interface{}{
+			"optimizer": map[string]interface{}{
+				"enabled": optimizer.Enabled,
+				"runs":    optimizer.Runs,
+			},
+			"evmVersion": art.Metadata.Settings.EVMVersion,
+			"metadata": map[string]interface{}{
+				"useLiteralContent": true,
+				"bytecodeHash":      "none",
+			},
+			"outputSelection": map[string]interface{}{
+				"*": map[string]interface{}{
+					"*": []string{
+						"abi",
+						"evm.bytecode.object",
+						"evm.bytecode.sourceMap",
+						"evm.deployedBytecode.object",
+						"evm.deployedBytecode.sourceMap",
+						"metadata",
+					},
+				},
+			},
+		},
+	}
+
+	standardInputJSON, err := json.Marshal(standardInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate standard input: %w", err)
+	}
+
+	// Get the contract name from the compilation target
+	var contractName string
+	for contractFile, name := range art.Metadata.Settings.CompilationTarget {
+		contractName = contractFile + ":" + name
+		break
+	}
+	v.log.Info("contractName", "name", contractName)
+
+	constructorArgs := GetConstructorArgs(name, v.st)
+	v.log.Info("constructorArgs", "args", constructorArgs)
+
+	return &contractArtifact{
+		ContractName:     contractName,
+		CompilerVersion:  art.Metadata.Compiler.Version,
+		OptimizationUsed: optimizer.Enabled,
+		OptimizationRuns: optimizer.Runs,
+		EVMVersion:       art.Metadata.Settings.EVMVersion,
+		StandardInput:    string(standardInputJSON),
+		ConstructorArgs:  constructorArgs,
+	}, nil
+}

--- a/op-deployer/pkg/deployer/verify/constructors.go
+++ b/op-deployer/pkg/deployer/verify/constructors.go
@@ -1,0 +1,22 @@
+package verify
+
+import (
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// GetConstructorArgs returns the ABI‑encoded constructor arguments for the specified contract, so
+// that they can be passed to etherscan for contract verification.
+func GetConstructorArgs(contractName string, state *state.State) string {
+	// Normalize the contract name (for example, to lower-case)
+	switch contractName {
+	case "ProxyAdminAddress":
+		addr := state.AppliedIntent.SuperchainRoles.ProxyAdminOwner
+		padded := common.LeftPadBytes(addr.Bytes(), 32)
+		return hexutil.Encode(padded)[2:]
+
+	default:
+		return ""
+	}
+}

--- a/op-deployer/pkg/deployer/verify/constructors.go
+++ b/op-deployer/pkg/deployer/verify/constructors.go
@@ -1,22 +1,233 @@
 package verify
 
 import (
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"math/big"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/lmittmann/w3"
+	"github.com/lmittmann/w3/module/eth"
 )
 
-// GetConstructorArgs returns the ABI‑encoded constructor arguments for the specified contract, so
-// that they can be passed to etherscan for contract verification.
-func GetConstructorArgs(contractName string, state *state.State) string {
-	// Normalize the contract name (for example, to lower-case)
-	switch contractName {
-	case "ProxyAdminAddress":
-		addr := state.AppliedIntent.SuperchainRoles.ProxyAdminOwner
-		padded := common.LeftPadBytes(addr.Bytes(), 32)
-		return hexutil.Encode(padded)[2:]
+type constructorArgEncoder func(*Verifier) (string, error)
 
-	default:
-		return ""
+var constructorArgEncoders = map[string]constructorArgEncoder{
+	"ProxyAdminAddress":              encodeProxyAdminArgs,
+	"OpcmAddress":                    encodeOpcmArgs,
+	"DelayedWETHImplAddress":         encodeDelayedWETHArgs,
+	"OptimismPortalImplAddress":      encodeOptimismPortalArgs,
+	"PreimageOracleSingletonAddress": encodePreimageOracleArgs,
+	"MipsSingletonAddress":           encodeMipsArgs,
+}
+
+func (v *Verifier) getEncodedConstructorArgs(contractName string) (string, error) {
+	encoder, exists := constructorArgEncoders[contractName]
+	if !exists {
+		return "", nil
 	}
+	return encoder(v)
+}
+
+func encodeProxyAdminArgs(v *Verifier) (string, error) {
+	addr := v.st.AppliedIntent.SuperchainRoles.ProxyAdminOwner
+	padded := common.LeftPadBytes(addr.Bytes(), 32)
+	return hexutil.Encode(padded)[2:], nil
+}
+
+func encodeDelayedWETHArgs(v *Verifier) (string, error) {
+	var withdrawalDelay big.Int
+	withdrawalDelayFn := w3.MustNewFunc("delay()", "uint256")
+	if err := v.w3Client.Call(
+		eth.CallFunc(v.st.ImplementationsDeployment.DelayedWETHImplAddress, withdrawalDelayFn).Returns(&withdrawalDelay),
+	); err != nil {
+		return "", err
+	}
+	paddedDelay := common.LeftPadBytes(withdrawalDelay.Bytes(), 32)
+	return strings.TrimPrefix(hexutil.Encode(paddedDelay), "0x"), nil
+}
+
+func encodeOptimismPortalArgs(v *Verifier) (string, error) {
+	var maturityDelay big.Int
+	proofMaturityDelayFn := w3.MustNewFunc("proofMaturityDelaySeconds()", "uint256")
+	if err := v.w3Client.Call(
+		eth.CallFunc(v.st.ImplementationsDeployment.OptimismPortalImplAddress, proofMaturityDelayFn).Returns(&maturityDelay),
+	); err != nil {
+		return "", err
+	}
+
+	var finalityDelay big.Int
+	disputeGameFinalityDelayFn := w3.MustNewFunc("disputeGameFinalityDelaySeconds()", "uint256")
+	if err := v.w3Client.Call(
+		eth.CallFunc(v.st.ImplementationsDeployment.OptimismPortalImplAddress, disputeGameFinalityDelayFn).Returns(&finalityDelay),
+	); err != nil {
+		return "", err
+	}
+
+	paddedMaturity := common.LeftPadBytes(maturityDelay.Bytes(), 32)
+	paddedFinality := common.LeftPadBytes(finalityDelay.Bytes(), 32)
+	concatenated := append(paddedMaturity, paddedFinality...)
+	return strings.TrimPrefix(hexutil.Encode(concatenated), "0x"), nil
+}
+
+func encodePreimageOracleArgs(v *Verifier) (string, error) {
+	var minProposalSize big.Int
+	minProposalSizeFn := w3.MustNewFunc("minProposalSize()", "uint256")
+	if err := v.w3Client.Call(
+		eth.CallFunc(v.st.ImplementationsDeployment.PreimageOracleSingletonAddress, minProposalSizeFn).Returns(&minProposalSize),
+	); err != nil {
+		return "", err
+	}
+
+	var challengePeriod big.Int
+	challengePeriodFn := w3.MustNewFunc("challengePeriod()", "uint256")
+	if err := v.w3Client.Call(
+		eth.CallFunc(v.st.ImplementationsDeployment.PreimageOracleSingletonAddress, challengePeriodFn).Returns(&challengePeriod),
+	); err != nil {
+		return "", err
+	}
+
+	paddedMinProposalSize := common.LeftPadBytes(minProposalSize.Bytes(), 32)
+	paddedChallengePeriod := common.LeftPadBytes(challengePeriod.Bytes(), 32)
+	concatenated := append(paddedMinProposalSize, paddedChallengePeriod...)
+	return strings.TrimPrefix(hexutil.Encode(concatenated), "0x"), nil
+}
+
+func encodeMipsArgs(v *Verifier) (string, error) {
+	addr := v.st.ImplementationsDeployment.PreimageOracleSingletonAddress
+	padded := common.LeftPadBytes(addr.Bytes(), 32)
+	return hexutil.Encode(padded)[2:], nil
+}
+
+func encodeOpcmArgs(v *Verifier) (string, error) {
+	type Blueprints struct {
+		AddressManager             common.Address `abi:"field0"`
+		Proxy                      common.Address `abi:"field1"`
+		ProxyAdmin                 common.Address `abi:"field2"`
+		L1ChugSplashProxy          common.Address `abi:"field3"`
+		ResolvedDelegateProxy      common.Address `abi:"field4"`
+		PermissionedDisputeGame1   common.Address `abi:"field5"`
+		PermissionedDisputeGame2   common.Address `abi:"field6"`
+		PermissionlessDisputeGame1 common.Address `abi:"field7"`
+		PermissionlessDisputeGame2 common.Address `abi:"field8"`
+	}
+
+	type Implementations struct {
+		SuperchainConfigImpl             common.Address `abi:"field0"`
+		ProtocolVersionsImpl             common.Address `abi:"field1"`
+		L1ERC721BridgeImpl               common.Address `abi:"field2"`
+		OptimismPortalImpl               common.Address `abi:"field3"`
+		SystemConfigImpl                 common.Address `abi:"field4"`
+		OptimismMintableERC20FactoryImpl common.Address `abi:"field5"`
+		L1CrossDomainMessengerImpl       common.Address `abi:"field6"`
+		L1StandardBridgeImpl             common.Address `abi:"field7"`
+		DisputeGameFactoryImpl           common.Address `abi:"field8"`
+		AnchorStateRegistryImpl          common.Address `abi:"field9"`
+		DelayedWETHImpl                  common.Address `abi:"field10"`
+		MipsImpl                         common.Address `abi:"field11"`
+	}
+
+	var blueprints Blueprints
+	blueprintsFn := w3.MustNewFunc("blueprints()", "(address addressManager,address proxy,address proxyAdmin,address l1ChugSplashProxy,address resolvedDelegateProxy,address permissionedDisputeGame1,address permissionedDisputeGame2,address permissionlessDisputeGame1,address permissionlessDisputeGame2)")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, blueprintsFn).Returns(&blueprints)); err != nil {
+		return "", err
+	}
+
+	var impls Implementations
+	implementationsFn := w3.MustNewFunc("implementations()", "(address superchainConfigImpl,address protocolVersionsImpl,address l1ERC721BridgeImpl,address optimismPortalImpl,address systemConfigImpl,address optimismMintableERC20FactoryImpl,address l1CrossDomainMessengerImpl,address l1StandardBridgeImpl,address disputeGameFactoryImpl,address anchorStateRegistryImpl,address delayedWETHImpl,address mipsImpl)")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, implementationsFn).Returns(&impls)); err != nil {
+		return "", err
+	}
+
+	var release string
+	releaseFn := w3.MustNewFunc("l1ContractsRelease()", "string")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, releaseFn).Returns(&release)); err != nil {
+		return "", err
+	}
+
+	var isRc bool
+	isRcFn := w3.MustNewFunc("isRC()", "bool")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, isRcFn).Returns(&isRc)); err != nil {
+		return "", err
+	}
+	if isRc {
+		// Opcm code appends the "-rc" suffix, so we need to remove it to recreate the constructor arg
+		release = strings.TrimSuffix(release, "-rc")
+	}
+
+	var upgradeController common.Address
+	upgradeControllerFn := w3.MustNewFunc("upgradeController()", "address")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, upgradeControllerFn).Returns(&upgradeController)); err != nil {
+		return "", err
+	}
+
+	var superchainConfig common.Address
+	superchainConfigFn := w3.MustNewFunc("superchainConfig()", "address")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, superchainConfigFn).Returns(&superchainConfig)); err != nil {
+		return "", err
+	}
+
+	var protocolVersions common.Address
+	protocolVersionsFn := w3.MustNewFunc("protocolVersions()", "address")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, protocolVersionsFn).Returns(&protocolVersions)); err != nil {
+		return "", err
+	}
+
+	var superchainProxyAdmin common.Address
+	superchainProxyAdminFn := w3.MustNewFunc("superchainProxyAdmin()", "address")
+	if err := v.w3Client.Call(eth.CallFunc(v.st.ImplementationsDeployment.OpcmAddress, superchainProxyAdminFn).Returns(&superchainProxyAdmin)); err != nil {
+		return "", err
+	}
+
+	result := []byte{}
+	result = append(result, common.LeftPadBytes(superchainConfig.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(protocolVersions.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(superchainProxyAdmin.Bytes(), 32)...)
+
+	// Calculate dynamic offset for _l1ContractsRelease.
+	// 3 addresses
+	// 1 dynamic offset for _l1ContractsRelease,
+	// 9 addresses for blueprints
+	// 12 addresses for implementations
+	// 1 address for _upgradeController.
+	// --------------------------------
+	// Total: 26 slots
+	// Offset = 26 * 32 = 832 bytes.
+	offset := big.NewInt(26 * 32) // 832
+	result = append(result, common.LeftPadBytes(offset.Bytes(), 32)...)
+
+	// blueprints
+	result = append(result, common.LeftPadBytes(blueprints.AddressManager.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.Proxy.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.ProxyAdmin.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.L1ChugSplashProxy.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.ResolvedDelegateProxy.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.PermissionedDisputeGame1.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.PermissionedDisputeGame2.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.PermissionlessDisputeGame1.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(blueprints.PermissionlessDisputeGame2.Bytes(), 32)...)
+
+	// implementations
+	result = append(result, common.LeftPadBytes(impls.SuperchainConfigImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.ProtocolVersionsImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.L1ERC721BridgeImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.OptimismPortalImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.SystemConfigImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.OptimismMintableERC20FactoryImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.L1CrossDomainMessengerImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.L1StandardBridgeImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.DisputeGameFactoryImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.AnchorStateRegistryImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.DelayedWETHImpl.Bytes(), 32)...)
+	result = append(result, common.LeftPadBytes(impls.MipsImpl.Bytes(), 32)...)
+
+	// upgrade controller
+	result = append(result, common.LeftPadBytes(upgradeController.Bytes(), 32)...)
+
+	// l1ContractsRelease (dynamic args appended to the end)
+	releaseBytes := []byte(release)
+	result = append(result, common.LeftPadBytes(big.NewInt(int64(len(releaseBytes))).Bytes(), 32)...)
+	result = append(result, common.RightPadBytes(releaseBytes, (len(releaseBytes)+31)/32*32)...)
+
+	return strings.TrimPrefix(hexutil.Encode(result), "0x"), nil
 }

--- a/op-deployer/pkg/deployer/verify/constructors.go
+++ b/op-deployer/pkg/deployer/verify/constructors.go
@@ -241,7 +241,11 @@ func encodeSuperchainConfigProxyArgs(v *Verifier) (string, error) {
 }
 
 func encodePermissionedDisputeGameArgs(v *Verifier) (string, error) {
-	addr := v.st.Chains[v.l2ChainIndex].PermissionedDisputeGameAddress
+	chainState, err := v.st.Chain(v.l2ChainID)
+	if err != nil {
+		return "", err
+	}
+	addr := chainState.PermissionedDisputeGameAddress
 	result := []byte{}
 
 	var gameType uint32
@@ -313,10 +317,14 @@ func encodePermissionedDisputeGameArgs(v *Verifier) (string, error) {
 	}
 	result = append(result, common.LeftPadBytes(l2ChainId.Bytes(), 32)...)
 
-	proposer := v.st.AppliedIntent.Chains[v.l2ChainIndex].Roles.Proposer
+	chainIntent, err := v.st.AppliedIntent.Chain(v.l2ChainID)
+	if err != nil {
+		return "", err
+	}
+	proposer := chainIntent.Roles.Proposer
 	result = append(result, common.LeftPadBytes(proposer.Bytes(), 32)...)
 
-	challenger := v.st.AppliedIntent.Chains[v.l2ChainIndex].Roles.Challenger
+	challenger := chainIntent.Roles.Challenger
 	result = append(result, common.LeftPadBytes(challenger.Bytes(), 32)...)
 
 	return strings.TrimPrefix(hexutil.Encode(result), "0x"), nil

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -1,0 +1,158 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type EtherscanResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Result  string `json:"result"`
+}
+
+func getAPIEndpoint(chainID uint64) string {
+	switch chainID {
+	case 1:
+		return "https://api.etherscan.io/api" // mainnet
+	case 11155111:
+		return "https://api-sepolia.etherscan.io/api" // sepolia
+	default:
+		return ""
+	}
+}
+
+func (v *Verifier) verifyContract(address common.Address, contractName string) error {
+	v.log.Info("Preparing contract verification", "name", contractName, "address", address.Hex())
+
+	verified, err := v.isVerified(address)
+	if err != nil {
+		return fmt.Errorf("failed to check verification status: %w", err)
+	}
+	if verified {
+		v.log.Info("Contract is already verified", "name", contractName, "address", address.Hex())
+		return nil
+	}
+	v.log.Info("Formatting etherscan verification request", "name", contractName, "address", address.Hex())
+
+	source, err := v.getContractArtifact(contractName)
+	if err != nil {
+		return fmt.Errorf("failed to get contract source: %w", err)
+	}
+
+	optimized := "0"
+	if source.OptimizationUsed {
+		optimized = "1"
+	}
+
+	data := url.Values{
+		"apikey":           {v.apiKey},
+		"module":           {"contract"},
+		"action":           {"verifysourcecode"},
+		"contractaddress":  {address.Hex()},
+		"sourceCode":       {source.SourceCode},
+		"codeformat":       {"solidity-single-file"},
+		"contractname":     {contractName},
+		"compilerversion":  {fmt.Sprintf("v%s", source.CompilerVersion)},
+		"optimizationUsed": {optimized},
+		"runs":             {fmt.Sprintf("%d", source.OptimizationRuns)},
+		"evmversion":       {source.EVMVersion},
+	}
+
+	resp, err := http.PostForm(v.etherscanUrl, data)
+	if err != nil {
+		return fmt.Errorf("failed to submit verification request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result EtherscanResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if result.Status != "1" {
+		return fmt.Errorf("verification request failed: status=%s message=%s result=%s",
+			result.Status, result.Message, result.Result)
+	}
+	v.log.Info("Verification request submitted successfully", "name", contractName, "address", address.Hex())
+
+	return v.checkVerificationStatus(result.Result)
+}
+
+// sendRateLimitedRequest is a helper function which waits for a rate limit token
+// before sending a request
+func (v *Verifier) sendRateLimitedRequest(req *http.Request) (*http.Response, error) {
+	if err := v.rateLimiter.Wait(context.Background()); err != nil {
+		return nil, fmt.Errorf("rate limiter error: %w", err)
+	}
+
+	return http.DefaultClient.Do(req)
+}
+
+func (v *Verifier) isVerified(address common.Address) (bool, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?module=contract&action=getabi&address=%s&apikey=%s",
+		v.etherscanUrl, address.Hex(), v.apiKey), nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := v.sendRateLimitedRequest(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	var result EtherscanResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return false, err
+	}
+
+	v.log.Debug("Contract verification status", "status", result.Status, "message", result.Message)
+	return result.Status == "1", nil
+}
+
+func (v *Verifier) checkVerificationStatus(reqId string) error {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?apikey=%s&module=contract&action=checkverifystatus&guid=%s",
+		v.etherscanUrl, v.apiKey, reqId), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create checkverifystatus request: %w", err)
+	}
+
+	for i := 0; i < 10; i++ { // Try 10 times with increasing delays
+		v.log.Info("Checking verification status", "guid", reqId)
+		time.Sleep(time.Duration(i+2) * time.Second)
+
+		resp, err := v.sendRateLimitedRequest(req)
+		if err != nil {
+			return fmt.Errorf("failed to send checkverifystatus request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var result struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+			Result  string `json:"result"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return fmt.Errorf("failed to decode checkverifystatus response: %w", err)
+		}
+
+		if result.Status == "1" {
+			return nil
+		}
+		if result.Result == "Already Verified" {
+			v.log.Info("Contract is already verified")
+			return nil
+		}
+		if result.Result != "Pending in queue" {
+			return fmt.Errorf("verification failed: %s, %s", result.Result, result.Message)
+		}
+	}
+	return fmt.Errorf("verification timed out")
+}

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -53,17 +53,18 @@ func (v *Verifier) verifyContract(address common.Address, contractName string) e
 	}
 
 	data := url.Values{
-		"apikey":           {v.apiKey},
-		"module":           {"contract"},
-		"action":           {"verifysourcecode"},
-		"contractaddress":  {address.Hex()},
-		"codeformat":       {"solidity-standard-json-input"},
-		"sourceCode":       {source.StandardInput},
-		"contractname":     {source.ContractName},
-		"compilerversion":  {fmt.Sprintf("v%s", source.CompilerVersion)},
-		"optimizationUsed": {optimized},
-		"runs":             {fmt.Sprintf("%d", source.OptimizationRuns)},
-		"evmversion":       {source.EVMVersion},
+		"apikey":                {v.apiKey},
+		"module":                {"contract"},
+		"action":                {"verifysourcecode"},
+		"contractaddress":       {address.Hex()},
+		"codeformat":            {"solidity-standard-json-input"},
+		"sourceCode":            {source.StandardInput},
+		"contractname":          {source.ContractName},
+		"compilerversion":       {fmt.Sprintf("v%s", source.CompilerVersion)},
+		"optimizationUsed":      {optimized},
+		"runs":                  {fmt.Sprintf("%d", source.OptimizationRuns)},
+		"evmversion":            {source.EVMVersion},
+		"constructorArguements": {source.ConstructorArgs},
 	}
 
 	req, err := http.NewRequest("POST", v.etherscanUrl, strings.NewReader(data.Encode()))

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -36,6 +36,7 @@ func (v *Verifier) verifyContract(address common.Address, contractName string) e
 	}
 	if verified {
 		v.log.Info("Contract is already verified", "name", contractName, "address", address.Hex())
+		v.numSkipped++
 		return nil
 	}
 
@@ -85,8 +86,13 @@ func (v *Verifier) verifyContract(address common.Address, contractName string) e
 		return fmt.Errorf("verification request failed: status=%s message=%s result=%s",
 			result.Status, result.Message, result.Result)
 	}
-	v.log.Info("Verification request submitted successfully", "name", contractName, "address", address.Hex())
-	return v.checkVerificationStatus(result.Result)
+	v.log.Info("Verification request submitted", "name", contractName, "address", address.Hex())
+	err = v.checkVerificationStatus(result.Result)
+	if err == nil {
+		v.log.Info("Verification complete", "name", contractName, "address", address.Hex())
+		v.numVerified++
+	}
+	return err
 }
 
 // sendRateLimitedRequest is a helper function which waits for a rate limit token

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -30,8 +30,6 @@ func getAPIEndpoint(chainID uint64) string {
 }
 
 func (v *Verifier) verifyContract(address common.Address, contractName string) error {
-	v.log.Info("Preparing contract verification", "name", contractName, "address", address.Hex())
-
 	verified, err := v.isVerified(address)
 	if err != nil {
 		return fmt.Errorf("failed to check verification status: %w", err)
@@ -40,8 +38,8 @@ func (v *Verifier) verifyContract(address common.Address, contractName string) e
 		v.log.Info("Contract is already verified", "name", contractName, "address", address.Hex())
 		return nil
 	}
-	v.log.Info("Formatting etherscan verification request", "name", contractName, "address", address.Hex())
 
+	v.log.Info("Formatting etherscan verification request", "name", contractName, "address", address.Hex())
 	source, err := v.getContractArtifact(contractName)
 	if err != nil {
 		return fmt.Errorf("failed to get contract source: %w", err)

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -37,7 +37,7 @@ func NewVerifier(apiKey string, l1ChainID uint64, st *state.State, artifactsFS f
 		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}
 
-	v := &Verifier{
+	return &Verifier{
 		apiKey:       apiKey,
 		l1ChainID:    l1ChainID,
 		st:           st,
@@ -45,9 +45,7 @@ func NewVerifier(apiKey string, l1ChainID uint64, st *state.State, artifactsFS f
 		log:          l,
 		etherscanUrl: etherscanUrl,
 		rateLimiter:  rate.NewLimiter(rate.Limit(3), 2),
-	}
-
-	return v, nil
+	}, nil
 }
 
 func VerifyCLI(cliCtx *cli.Context) error {
@@ -135,12 +133,12 @@ func (v *Verifier) verifyContractBundle(bundleName string, l2ChainIndex int) err
 	// Select the appropriate bundle based on the input bundleName.
 	var bundle interface{}
 	switch bundleName {
-	case "superchain":
+	case inspect.SuperchainBundle:
 		bundle = l1Contracts.SuperchainDeployment
-	case "opchain":
-		bundle = l1Contracts.OpChainDeployment
-	case "implementations":
+	case inspect.ImplementationsBundle:
 		bundle = l1Contracts.ImplementationsDeployment
+	case inspect.OpChainBundle:
+		bundle = l1Contracts.OpChainDeployment
 	default:
 		return fmt.Errorf("invalid contract bundle: %s", bundleName)
 	}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -48,8 +48,7 @@ func NewVerifier(apiKey string, l1ChainID uint64, st *state.State, artifactsFS f
 		artifactsFS:  artifactsFS,
 		log:          l,
 		etherscanUrl: etherscanUrl,
-		//rateLimiter:  rate.NewLimiter(rate.Limit(3), 2),
-		rateLimiter: rate.NewLimiter(rate.Limit(5), 5),
+		rateLimiter:  rate.NewLimiter(rate.Limit(3), 2),
 	}
 
 	return v, nil

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -1,0 +1,253 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"reflect"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/time/rate"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+type Verifier struct {
+	apiKey       string
+	l1ChainID    uint64
+	st           *state.State
+	artifactsFS  foundry.StatDirFs
+	log          log.Logger
+	etherscanUrl string
+	rateLimiter  *rate.Limiter
+}
+
+func NewVerifier(apiKey string, l1ChainID uint64, st *state.State, artifactsFS foundry.StatDirFs, l log.Logger) (*Verifier, error) {
+	etherscanUrl := getAPIEndpoint(l1ChainID)
+	if etherscanUrl == "" {
+		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
+	}
+
+	v := &Verifier{
+		apiKey:       apiKey,
+		l1ChainID:    l1ChainID,
+		st:           st,
+		artifactsFS:  artifactsFS,
+		log:          l,
+		etherscanUrl: etherscanUrl,
+		//rateLimiter:  rate.NewLimiter(rate.Limit(3), 2),
+		rateLimiter: rate.NewLimiter(rate.Limit(5), 5),
+	}
+
+	return v, nil
+}
+
+func VerifyCLI(cliCtx *cli.Context) error {
+	logCfg := oplog.ReadCLIConfig(cliCtx)
+	l := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
+	oplog.SetGlobalLogHandler(l.Handler())
+
+	l1RPCUrl := cliCtx.String(deployer.L1RPCURLFlagName)
+	workdir := cliCtx.String(deployer.WorkdirFlagName)
+	etherscanAPIKey := cliCtx.String(deployer.EtherscanAPIKeyFlagName)
+
+	ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
+
+	client, err := ethclient.Dial(l1RPCUrl)
+	if err != nil {
+		return fmt.Errorf("failed to connect to L1: %w", err)
+	}
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+
+	st, err := pipeline.ReadState(workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read state: %w", err)
+	}
+
+	progressor := func(curr, total int64) {
+		l.Info("artifacts download progress", "current", curr, "total", total)
+	}
+
+	// Get artifacts filesystem (either local or downloaded)
+	artifactsFS, err := artifacts.Download(ctx, st.AppliedIntent.L1ContractsLocator, progressor)
+	if err != nil {
+		return fmt.Errorf("failed to get artifacts: %w", err)
+	}
+	l.Info("Downloaded artifacts", "artifacts", artifactsFS)
+
+	v, err := NewVerifier(etherscanAPIKey, chainID.Uint64(), st, artifactsFS, l)
+	if err != nil {
+		return fmt.Errorf("failed to create verifier: %w", err)
+	}
+
+	if cliCtx.Args().Len() > 0 {
+		// If a contract name is provided, verify just that contract
+		bundleName := cliCtx.String(deployer.ContractBundleFlagName)
+		contractName := cliCtx.Args().First()
+		if err := v.VerifySingleContract(ctx, contractName, bundleName); err != nil {
+			return err
+		}
+	} else {
+		if err := v.VerifyAll(ctx, client, workdir); err != nil {
+			return err
+		}
+	}
+
+	v.log.Info("--- SUCCESS --- all requested contracts verified")
+	return nil
+}
+
+func (v *Verifier) VerifySingleContract(ctx context.Context, contractName string, bundleName string) error {
+	l1Contracts, err := inspect.L1(v.st, v.st.AppliedIntent.Chains[0].ID)
+	if err != nil {
+		return fmt.Errorf("failed to extract L1 contracts from state: %w", err)
+	}
+
+	v.log.Info("Looking up contract address", "name", contractName, "bundle", bundleName)
+	addr, err := l1Contracts.GetContractAddress(contractName, bundleName)
+	if err != nil {
+		return fmt.Errorf("failed to find address for contract %s: %w", contractName, err)
+	}
+
+	return v.verifyContract(addr, contractName)
+}
+
+func (v *Verifier) VerifyAll(ctx context.Context, client *ethclient.Client, workdir string) error {
+	l1Contracts, err := inspect.L1(v.st, v.st.AppliedIntent.Chains[0].ID)
+	if err != nil {
+		return fmt.Errorf("failed to extract L1 contracts from state: %w", err)
+	}
+
+	if err := v.verifyContractBundle(l1Contracts.SuperchainDeployment); err != nil {
+		return err
+	}
+	if err := v.verifyContractBundle(l1Contracts.OpChainDeployment); err != nil {
+		return err
+	}
+	if err := v.verifyContractBundle(l1Contracts.ImplementationsDeployment); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *Verifier) verifyContractBundle(s interface{}) error {
+	val := reflect.ValueOf(s)
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+		if field.Type() == reflect.TypeOf(common.Address{}) {
+			addr := field.Interface().(common.Address)
+			if addr != (common.Address{}) { // Skip zero addresses
+				name := typ.Field(i).Name
+				if err := v.verifyContract(addr, name); err != nil {
+					return fmt.Errorf("failed to verify %s: %w", name, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type ContractArtifact struct {
+	SourceCode       string
+	ContractName     string
+	CompilerVersion  string
+	OptimizationUsed bool
+	OptimizationRuns int
+	EVMVersion       string
+}
+
+func (v *Verifier) getContractArtifact(name string) (*ContractArtifact, error) {
+	// Remove suffix if present
+	lookupName := strings.TrimSuffix(name, "ProxyAddress")
+	lookupName = strings.TrimSuffix(lookupName, "Address")
+
+	artifactPath := path.Join(lookupName+".sol", lookupName+".json")
+
+	v.log.Info("Opening artifact", "path", artifactPath, "lookupName", lookupName)
+	f, err := v.artifactsFS.Open(artifactPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open artifact: %w", err)
+	}
+	defer f.Close()
+
+	var art foundry.Artifact
+	if err := json.NewDecoder(f).Decode(&art); err != nil {
+		return nil, fmt.Errorf("failed to decode artifact: %w", err)
+	}
+
+	var optimizer struct {
+		Enabled bool `json:"enabled"`
+		Runs    int  `json:"runs"`
+	}
+	if err := json.Unmarshal(art.Metadata.Settings.Optimizer, &optimizer); err != nil {
+		return nil, fmt.Errorf("failed to parse optimizer settings: %w", err)
+	}
+
+	// Get compiler version from the main artifact and clean it
+	compilerVersion := art.Metadata.Compiler.Version
+	compilerVersion = strings.Split(compilerVersion, "+")[0] // Remove the "+commit..." part
+	v.log.Info("Using compiler version", "version", compilerVersion)
+
+	// Combine all sources into one flat file
+	var combinedSource strings.Builder
+	for sourcePath := range art.Metadata.Sources {
+		// Extract just the filename from the path
+		baseName := strings.TrimSuffix(path.Base(sourcePath), ".sol")
+		contractDir := baseName + ".sol"
+
+		baseName = strings.TrimPrefix(baseName, "draft-")
+
+		// Try to find the JSON file with matching compiler version
+		sourceArtifactPath := path.Join(contractDir, fmt.Sprintf("%s.%s.json",
+			baseName,
+			compilerVersion))
+
+		f, err := v.artifactsFS.Open(sourceArtifactPath)
+		if err != nil {
+			// Fallback to non-versioned file if version-specific one doesn't exist
+			sourceArtifactPath = path.Join(contractDir, baseName+".json")
+			f, err = v.artifactsFS.Open(sourceArtifactPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read source file %s: %w", baseName, err)
+			}
+		}
+		content, err := io.ReadAll(f)
+		f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read source content %s: %w", sourceArtifactPath, err)
+		}
+		combinedSource.Write(content)
+		combinedSource.WriteString("\n\n")
+
+		v.log.Info("added source", "contract", baseName)
+	}
+
+	return &ContractArtifact{
+		SourceCode:       combinedSource.String(),
+		ContractName:     lookupName,
+		CompilerVersion:  art.Metadata.Compiler.Version,
+		OptimizationUsed: optimizer.Enabled,
+		OptimizationRuns: optimizer.Runs,
+		EVMVersion:       art.Metadata.Settings.EVMVersion,
+	}, nil
+}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -103,7 +103,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 		return fmt.Errorf("rpc l1 chain ID does not match state l1 chain ID: %d != %d", l1ChainId, st.AppliedIntent.L1ChainID)
 	}
 
-	artifactsFS, err := artifacts.Download(ctx, st.AppliedIntent.L1ContractsLocator, nil)
+	artifactsFS, err := artifacts.Download(ctx, st.AppliedIntent.L1ContractsLocator, nil, deployer.DefaultCacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -25,6 +25,7 @@ import (
 type Verifier struct {
 	apiKey       string
 	l1ChainID    uint64
+	l2ChainIndex int
 	st           *state.State
 	artifactsFS  foundry.StatDirFs
 	log          log.Logger
@@ -35,7 +36,7 @@ type Verifier struct {
 	numSkipped   int
 }
 
-func NewVerifier(apiKey string, l1ChainID uint64, st *state.State, artifactsFS foundry.StatDirFs, l log.Logger, w3Client *w3.Client) (*Verifier, error) {
+func NewVerifier(apiKey string, l1ChainID uint64, l2ChainIndex int, st *state.State, artifactsFS foundry.StatDirFs, l log.Logger, w3Client *w3.Client) (*Verifier, error) {
 	etherscanUrl := getAPIEndpoint(l1ChainID)
 	if etherscanUrl == "" {
 		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
@@ -44,6 +45,7 @@ func NewVerifier(apiKey string, l1ChainID uint64, st *state.State, artifactsFS f
 	return &Verifier{
 		apiKey:       apiKey,
 		l1ChainID:    l1ChainID,
+		l2ChainIndex: l2ChainIndex,
 		st:           st,
 		artifactsFS:  artifactsFS,
 		log:          l,
@@ -91,7 +93,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	}
 	l.Info("Downloaded artifacts", "path", artifactsFS)
 
-	v, err := NewVerifier(etherscanAPIKey, l1ChainId, st, artifactsFS, l, w3Client)
+	v, err := NewVerifier(etherscanAPIKey, l1ChainId, l2ChainIndex, st, artifactsFS, l, w3Client)
 	if err != nil {
 		return fmt.Errorf("failed to create verifier: %w", err)
 	}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 )
@@ -25,7 +26,7 @@ import (
 type Verifier struct {
 	apiKey       string
 	l1ChainID    uint64
-	l2ChainIndex int
+	l2ChainID    common.Hash
 	st           *state.State
 	artifactsFS  foundry.StatDirFs
 	log          log.Logger
@@ -36,16 +37,20 @@ type Verifier struct {
 	numSkipped   int
 }
 
-func NewVerifier(apiKey string, l1ChainID uint64, l2ChainIndex int, st *state.State, artifactsFS foundry.StatDirFs, l log.Logger, w3Client *w3.Client) (*Verifier, error) {
+func NewVerifier(apiKey string, l1ChainID uint64, l2ChainID common.Hash, st *state.State, artifactsFS foundry.StatDirFs, l log.Logger, w3Client *w3.Client) (*Verifier, error) {
 	etherscanUrl := getAPIEndpoint(l1ChainID)
 	if etherscanUrl == "" {
 		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}
 
+	if l2ChainID == (common.Hash{}) {
+		l2ChainID = st.AppliedIntent.Chains[0].ID
+	}
+
 	return &Verifier{
 		apiKey:       apiKey,
 		l1ChainID:    l1ChainID,
-		l2ChainIndex: l2ChainIndex,
+		l2ChainID:    l2ChainID,
 		st:           st,
 		artifactsFS:  artifactsFS,
 		log:          l,
@@ -63,7 +68,18 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	l1RPCUrl := cliCtx.String(deployer.L1RPCURLFlagName)
 	workdir := cliCtx.String(deployer.WorkdirFlagName)
 	etherscanAPIKey := cliCtx.String(deployer.EtherscanAPIKeyFlagName)
-	l2ChainIndex := cliCtx.Int(deployer.L2ChainIndexFlagName)
+	bundleName := cliCtx.String(deployer.ContractBundleFlagName)
+	contractName := cliCtx.String(deployer.ContractNameFlagName)
+	l2ChainIDRaw := cliCtx.String(deployer.L2ChainIDFlagName)
+
+	var l2ChainID common.Hash
+	var err error
+	if l2ChainIDRaw != "" {
+		l2ChainID, err = op_service.Parse256BitChainID(l2ChainIDRaw)
+		if err != nil {
+			return fmt.Errorf("invalid L2 chain ID '%s': %w", l2ChainIDRaw, err)
+		}
+	}
 
 	ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
 
@@ -93,29 +109,25 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	}
 	l.Info("Downloaded artifacts", "path", artifactsFS)
 
-	v, err := NewVerifier(etherscanAPIKey, l1ChainId, l2ChainIndex, st, artifactsFS, l, w3Client)
+	v, err := NewVerifier(etherscanAPIKey, l1ChainId, l2ChainID, st, artifactsFS, l, w3Client)
 	if err != nil {
 		return fmt.Errorf("failed to create verifier: %w", err)
 	}
-
-	// Retrieve the CLI flags for the contract bundle and contract name.
-	bundleName := cliCtx.String(deployer.ContractBundleFlagName)
-	contractName := cliCtx.String(deployer.ContractNameFlagName)
 
 	defer func() {
 		v.log.Info("final results", "numVerified", v.numVerified, "numSkipped", v.numSkipped)
 	}()
 
 	if bundleName == "" && contractName == "" {
-		if err := v.verifyAll(ctx, l2ChainIndex); err != nil {
+		if err := v.verifyAll(ctx); err != nil {
 			return err
 		}
 	} else if bundleName != "" && contractName == "" {
-		if err := v.verifyContractBundle(bundleName, l2ChainIndex); err != nil {
+		if err := v.verifyContractBundle(bundleName); err != nil {
 			return err
 		}
 	} else if bundleName != "" && contractName != "" {
-		if err := v.verifySingleContract(ctx, contractName, bundleName, l2ChainIndex); err != nil {
+		if err := v.verifySingleContract(ctx, contractName, bundleName); err != nil {
 			return err
 		}
 	} else {
@@ -126,18 +138,18 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	return nil
 }
 
-func (v *Verifier) verifyAll(ctx context.Context, l2ChainIndex int) error {
+func (v *Verifier) verifyAll(ctx context.Context) error {
 	for _, bundleName := range inspect.ContractBundles {
-		if err := v.verifyContractBundle(bundleName, l2ChainIndex); err != nil {
+		if err := v.verifyContractBundle(bundleName); err != nil {
 			return fmt.Errorf("failed to verify bundle %s: %w", bundleName, err)
 		}
 	}
 	return nil
 }
 
-func (v *Verifier) verifyContractBundle(bundleName string, l2ChainIndex int) error {
+func (v *Verifier) verifyContractBundle(bundleName string) error {
 	// Retrieve the L1 contracts from state.
-	l1Contracts, err := inspect.L1(v.st, v.st.AppliedIntent.Chains[l2ChainIndex].ID)
+	l1Contracts, err := inspect.L1(v.st, v.l2ChainID)
 	if err != nil {
 		return fmt.Errorf("failed to extract L1 contracts from state: %w", err)
 	}
@@ -173,8 +185,8 @@ func (v *Verifier) verifyContractBundle(bundleName string, l2ChainIndex int) err
 	return nil
 }
 
-func (v *Verifier) verifySingleContract(ctx context.Context, contractName string, bundleName string, l2ChainIndex int) error {
-	l1Contracts, err := inspect.L1(v.st, v.st.AppliedIntent.Chains[l2ChainIndex].ID)
+func (v *Verifier) verifySingleContract(ctx context.Context, contractName string, bundleName string) error {
+	l1Contracts, err := inspect.L1(v.st, v.l2ChainID)
 	if err != nil {
 		return fmt.Errorf("failed to extract L1 contracts from state: %w", err)
 	}

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -12,6 +12,7 @@ snapshots = 'notarealpath' # workaround for foundry#9477
 
 optimizer = true
 optimizer_runs = 999999
+use_literal_content = true
 
 # IMPORTANT:
 # When adding any new compiler profiles or compilation restrictions, you must


### PR DESCRIPTION
## Overview
Closes https://github.com/ethereum-optimism/optimism/issues/13544

Provides a user-friendly command to verify L1 contracts on etherscan. The following information is used for verification:
* contract addresses: pulled from the state.json file
* contract artifact info (source code, compile settings): pulled from artifacts specified by `l1ContractLocator` field in the state.json.
* constructor args: encode by pulling data from deployed contracts and state.json file

## Usage
1. Verify all contracts:
```
go run ./cmd/op-deployer verify \
  --l1-rpc-url "xxx" \
  --etherscan-api-key xxx
```
2. Verify one of the contract bundles (i.e. `superchain`, `implementations`, `opchain`)
```
go run ./cmd/op-deployer verify \
  --l1-rpc-url "xxx" \
  --etherscan-api-key xxx
  --contract-bundle superchain
```
3. Verify a single contract
```
go run ./cmd/op-deployer verify \
  --l1-rpc-url "xxx" \
  --etherscan-api-key xxx
  --contract-bundle superchain
  --contract-name ProxyAdminAddress
```

## Testing
Manually tested by running the following sequence:

1. Modified the implementation source code for `ProxyAdmin`, `SuperchainConfig`, and `ProtocolVersions` by just adding an extra function to each one called `fakeFunction` so that the bytecode was unique and the contract was not automatically verified by etherscan.
2. `just build` - compile the contracts
3. Ran the following command to deploy the superchain contract bundle to sepolia
```
go run ./cmd/op-deployer bootstrap superchain \
  --l1-rpc-url="xxx" \
  --private-key="xxx" \
  --artifacts-locator="file:///Users/<username>/repos/op-labs/optimism/packages/contracts-bedrock/forge-artifacts" \
  --required-protocol-version="0x33a0e51eCD7188d2F13769D7B4feE4390e970C7D000000000000000000000000" \
  --recommended-protocol-version="0x33a0e51eCD7188d2F13769D7B4feE4390e970C7D000000000000000000000000" \
  --superchain-proxy-admin-owner="0x83D4eB702690413a0A1E5819ECc48b62160dFb42" \
  --protocol-versions-owner="0x83D4eB702690413a0A1E5819ECc48b62160dFb42" \
  --guardian="0x83D4eB702690413a0A1E5819ECc48b62160dFb42" \
  --paused=true
```
4. Ran the following command to verify that contract bundle on sepolia:
```
go run ./cmd/op-deployer verify \
  --l1-rpc-url "xxx" \
  --etherscan-api-key xxx \
  --contract-bundle superchain
```
Contract addresses used for this test:
```
  "superchainDeployment": {
    "proxyAdminAddress": "0x9513783d80312af0e50f37849039738571d6b413",
    "superchainConfigProxyAddress": "0x96b69609c739e66a2be0803cd0e14037d0ea3bb7",
    "superchainConfigImplAddress": "0x77fa21851150a174d00addc5b2cd2f9321904474",
    "protocolVersionsProxyAddress": "0xed4278224700e847a24414fdea46dad6339b0252",
    "protocolVersionsImplAddress": "0x01206c8e4654faf1387c8eb334fa56723b1f791c"
  }
```