### PR TITLE
op-service: fix isthmus block-attributes handling

### DIFF
--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -313,11 +313,10 @@ func TestBlockValidator(t *testing.T) {
 	}{
 		{"V3RejectNonZeroExcessGas", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &one, &zero, nil)},
 		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one, nil)},
-		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one, nil)},
 		{"V3Valid", v3Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero, nil)},
 		{"V4Valid", v4Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, &withdrawalsRoot, &zero, &zero, &types.EmptyRequestsHash)},
 		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero, &types.EmptyRequestsHash)},
-		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, &common.Hash{}, &zero, &zero, nil)},
+		{"V4RejectNoRequestsHash", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, &common.Hash{}, &zero, &zero, nil)},
 	}
 
 	for _, tt := range envelopeTests {

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -252,10 +252,11 @@ func createExecutionPayload(w types.Withdrawals, withdrawalsRoot *common.Hash, e
 	}
 }
 
-func createEnvelope(h *common.Hash, w types.Withdrawals, withdrawalsRoot *common.Hash, excessGas, gasUsed *uint64) *eth.ExecutionPayloadEnvelope {
+func createEnvelope(h *common.Hash, w types.Withdrawals, withdrawalsRoot *common.Hash, excessGas, gasUsed *uint64, requestsHash *common.Hash) *eth.ExecutionPayloadEnvelope {
 	return &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload:      createExecutionPayload(w, withdrawalsRoot, excessGas, gasUsed),
 		ParentBeaconBlockRoot: h,
+		RequestsHash:          requestsHash,
 	}
 }
 
@@ -310,12 +311,13 @@ func TestBlockValidator(t *testing.T) {
 		result    pubsub.ValidationResult
 		payload   *eth.ExecutionPayloadEnvelope
 	}{
-		{"V3RejectNonZeroExcessGas", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &one, &zero)},
-		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one)},
-		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one)},
-		{"V3Valid", v3Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero)},
-		{"V4Valid", v4Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, &withdrawalsRoot, &zero, &zero)},
-		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero)},
+		{"V3RejectNonZeroExcessGas", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &one, &zero, nil)},
+		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one, nil)},
+		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one, nil)},
+		{"V3Valid", v3Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero, nil)},
+		{"V4Valid", v4Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, &withdrawalsRoot, &zero, &zero, &types.EmptyRequestsHash)},
+		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero, &types.EmptyRequestsHash)},
+		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, &common.Hash{}, &zero, &zero, nil)},
 	}
 
 	for _, tt := range envelopeTests {

--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -85,6 +85,11 @@ func (v BlockVersion) HasWithdrawalsRoot() bool {
 	return v == BlockV4
 }
 
+// ImpliesRequestsRoot returns whether an empty requests-root should be assumed to be there, but not encoded.
+func (v BlockVersion) ImpliesRequestsRoot() bool {
+	return v == BlockV4
+}
+
 func executionPayloadFixedPart(version BlockVersion) uint32 {
 	if version == BlockV4 {
 		return blockV4FixedPart
@@ -488,6 +493,11 @@ func (envelope *ExecutionPayloadEnvelope) UnmarshalSSZ(version BlockVersion, sco
 	err = payload.UnmarshalSSZ(version, scope-32, r)
 	if err != nil {
 		return err
+	}
+
+	if version.ImpliesRequestsRoot() {
+		h := types.EmptyRequestsHash
+		envelope.RequestsHash = &h
 	}
 
 	envelope.ExecutionPayload = &payload


### PR DESCRIPTION
**Description**

This fix withdrawals-root verification, missing check-block-hash attributes, and add missing implied requests-hash

This does not fix the engine-API usage yet, which should pass in the requests-hash or handle the implied requests-hash, or some mitigation to reproduce the block correctly.

**Tests**

Updated the isthmus test to check the created block and the prior genesis attributes.

**Additional context**

Op-node didn't work with trustRPC=false, due the genesis block having an incorrect hash verification check. This should fix that, as well as fix block-gossip checks.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
