### PR TITLE
interop: Multi-Managed-Mode

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -72,8 +72,8 @@ func TestInterop_IsolatedChains(t *testing.T) {
 		// send a tx from Alice to Bob
 		s2.SendL2Tx(
 			chainA,
-			"Alice",
 			"sequencer",
+			"Alice",
 			func(l2Opts *helpers.TxOpts) {
 				l2Opts.ToAddr = &bobAddr
 				l2Opts.Value = big.NewInt(1000000)

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -2,7 +2,6 @@ package interop
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"sync"
 	"testing"
@@ -369,7 +368,6 @@ func TestMultiNode(t *testing.T) {
 		seqClient := s2.L2RollupClient(chainA, "sequencer")
 		originalStatus, err := seqClient.SyncStatus(context.Background())
 		require.NoError(t, err)
-		fmt.Println("Current status of chain A:", originalStatus)
 
 		// and then add a new node to the system
 		s2.AddNode(chainA, "new-node")
@@ -382,11 +380,6 @@ func TestMultiNode(t *testing.T) {
 			require.NoError(t, err)
 			newNodeStatus, err := newNodeClient.SyncStatus(context.Background())
 			require.NoError(t, err)
-			// I'm leaving these printouts for my own sanity for now
-			// they won't be here when it's merge-ready
-			fmt.Println("Original status of chain A:", prettyStatus(originalStatus))
-			fmt.Println("Current status of new node:", prettyStatus(newNodeStatus))
-			fmt.Println("Current status of seq node:", prettyStatus(seqStatus))
 			// check that all heads for both nodes are greater than the original status
 			return seqStatus.UnsafeL2.Number > originalStatus.UnsafeL2.Number &&
 				seqStatus.CrossUnsafeL2.Number > originalStatus.CrossUnsafeL2.Number &&
@@ -396,26 +389,10 @@ func TestMultiNode(t *testing.T) {
 				newNodeStatus.CrossUnsafeL2.Number > originalStatus.CrossUnsafeL2.Number &&
 				newNodeStatus.SafeL2.Number > originalStatus.SafeL2.Number &&
 				newNodeStatus.SafeL1.Number > originalStatus.SafeL1.Number
-		}, time.Second*15, time.Second, "wait for all nodes to advance past the original status")
+		}, time.Second*60, time.Second, "wait for all nodes to advance past the original status")
 	}
 	config := SuperSystemConfig{
 		mempoolFiltering: false,
 	}
 	setupAndRun(t, config, test)
-}
-
-func prettyStatus(s *eth.SyncStatus) string {
-	ret := ""
-	ret += fmt.Sprintf("CurrentL1: %d\n", s.CurrentL1.Number)
-	ret += fmt.Sprintf("CurrentL1Finalized: %d\n", s.CurrentL1Finalized.Number)
-	ret += fmt.Sprintf("HeadL1: %d\n", s.HeadL1.Number)
-	ret += fmt.Sprintf("SafeL1: %d\n", s.SafeL1.Number)
-	ret += fmt.Sprintf("FinalizedL1: %d\n", s.FinalizedL1.Number)
-	ret += fmt.Sprintf("UnsafeL2: %d\n", s.UnsafeL2.Number)
-	ret += fmt.Sprintf("SafeL2: %d\n", s.SafeL2.Number)
-	ret += fmt.Sprintf("FinalizedL2: %d\n", s.FinalizedL2.Number)
-	ret += fmt.Sprintf("PendingSafeL2: %d\n", s.PendingSafeL2.Number)
-	ret += fmt.Sprintf("CrossUnsafeL2: %d\n", s.CrossUnsafeL2.Number)
-	ret += fmt.Sprintf("LocalSafeL2: %d\n", s.LocalSafeL2.Number)
-	return ret
 }

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -74,6 +74,7 @@ type SuperSystem interface {
 	L2RollupClient(network string, node string) *sources.RollupClient
 	SendL2Tx(network string, node string, username string, applyTxOpts helpers.TxOptsFn) *types.Receipt
 	EmitData(ctx context.Context, network string, node string, username string, data string) *types.Receipt
+	AddNode(network string, nodeName string)
 
 	// L2 level
 	ChainID(network string) *big.Int

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -19,14 +19,11 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	gn "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
-	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
@@ -36,17 +33,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/systemconfig"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/services"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
-	"github.com/ethereum-optimism/optimism/op-node/node"
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -73,41 +61,28 @@ import (
 // for example, interopE2ESystem is the default implementation, but a shim to
 // kurtosis or another testing framework could be implemented
 type SuperSystem interface {
-	// get the supervisor
-	Supervisor() *supervisor.SupervisorService
-	// get the supervisor client
-	SupervisorClient() *sources.SupervisorClient
-	// get the batcher for a network
-	Batcher(network string) *bss.BatcherService
-	// get the proposer for a network
-	Proposer(network string) *l2os.ProposerService
-	// get the opnode for a network
-	OpNode(network string) *opnode.Opnode
-	// get the geth instance for a network
-	L2Geth(network string) *geth.GethInstance
-	// get the L2 geth client for a network
-	L2GethClient(network string) *ethclient.Client
-	// get the secret for a network and role
-	L2OperatorKey(network string, role devkeys.ChainOperatorRole) ecdsa.PrivateKey
-	// get the list of network IDs as key-strings
+	// Superchain level
 	L2IDs() []string
-	// get the chain ID for a network
-	ChainID(network string) *big.Int
-	// register a username to an account on all L2s
+	Supervisor() *supervisor.SupervisorService
+	Batcher(network string) *bss.BatcherService
+	Proposer(network string) *l2os.ProposerService
 	AddUser(username string)
-	// get the user key for a user on an L2
-	UserKey(id, username string) ecdsa.PrivateKey
-	// send a transaction on an L2 on the given network, from the given user
-	SendL2Tx(network string, username string, applyTxOpts helpers.TxOptsFn) *types.Receipt
-	// get the address for a user on an L2
+	SupervisorClient() *sources.SupervisorClient
+
+	// L2 client specific
+	L2GethClient(network string, node string) *ethclient.Client
+	L2RollupClient(network string, node string) *sources.RollupClient
+	SendL2Tx(network string, node string, username string, applyTxOpts helpers.TxOptsFn) *types.Receipt
+	EmitData(ctx context.Context, network string, node string, username string, data string) *types.Receipt
+
+	// L2 level
+	ChainID(network string) *big.Int
+	UserKey(nework, username string) ecdsa.PrivateKey
+	L2OperatorKey(network string, role devkeys.ChainOperatorRole) ecdsa.PrivateKey
 	Address(network string, username string) common.Address
-	// Deploy the Emitter Contract, which emits Event Logs
+	Contract(network string, contractName string) interface{}
 	DeployEmitterContract(network string, username string) common.Address
-	// Use the Emitter Contract to emit an Event Log
-	EmitData(ctx context.Context, network string, username string, data string) *types.Receipt
-	// AddDependency adds a dependency (by chain ID) to the given chain
 	AddDependency(ctx context.Context, network string, dep *big.Int) *types.Receipt
-	// ValidateMessage calls the CrossL2Inbox ValidateMessage function
 	ValidateMessage(
 		ctx context.Context,
 		id string,
@@ -117,7 +92,6 @@ type SuperSystem interface {
 		expectedError error,
 	) (*types.Receipt, error)
 	// Access a contract on a network by name
-	Contract(network string, contractName string) interface{}
 }
 type SuperSystemConfig struct {
 	mempoolFiltering bool
@@ -143,24 +117,12 @@ type interopE2ESystem struct {
 	worldOutput     *interopgen.WorldOutput
 	beacon          *fakebeacon.FakeBeacon
 	l1              *geth.GethInstance
-	l2s             map[string]l2Set
-	l1GethClient    *ethclient.Client
-	l2GethClients   map[string]*ethclient.Client
-	supervisor      *supervisor.SupervisorService
-	superClient     *sources.SupervisorClient
-	config          *SuperSystemConfig
-}
-
-// l2Set is a set of resources for an L2 chain
-type l2Set struct {
-	chainID      *big.Int
-	opNode       *opnode.Opnode
-	l2Geth       *geth.GethInstance
-	proposer     *l2os.ProposerService
-	batcher      *bss.BatcherService
-	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey
-	userKeys     map[string]ecdsa.PrivateKey
-	contracts    map[string]interface{}
+	l2s             map[string]l2Net
+	// supervisor and L1 clients should be singletons, so they are cached
+	l1GethClient *ethclient.Client
+	superClient  *sources.SupervisorClient
+	supervisor   *supervisor.SupervisorService
+	config       *SuperSystemConfig
 }
 
 // prepareHDWallet creates a new HD wallet to derive keys from
@@ -261,203 +223,6 @@ func (s *interopE2ESystem) newOperatorKeysForL2(l2Out *interopgen.L2Output) map[
 	return operatorKeys
 }
 
-// newGethForL2 creates a new Geth instance for an L2 chain
-func (s *interopE2ESystem) newGethForL2(id string, l2Out *interopgen.L2Output) *geth.GethInstance {
-	jwtPath := writeDefaultJWT(s.t)
-	name := "l2-" + id
-	l2Geth, err := geth.InitL2(name, l2Out.Genesis, jwtPath,
-		func(ethCfg *ethconfig.Config, nodeCfg *gn.Config) error {
-			ethCfg.InteropMessageRPC = s.supervisor.RPC()
-			ethCfg.InteropMempoolFiltering = s.config.mempoolFiltering
-			return nil
-		})
-	require.NoError(s.t, err)
-	require.NoError(s.t, l2Geth.Node.Start())
-	s.t.Cleanup(func() {
-		s.t.Logf("Closing L2 geth of chain %s", id)
-		closeErr := l2Geth.Close()
-		s.t.Logf("Closed L2 geth of chain %s: %v", id, closeErr)
-	})
-	return l2Geth
-}
-
-// newNodeForL2 creates a new Opnode for an L2 chain
-func (s *interopE2ESystem) newNodeForL2(
-	id string,
-	l2Out *interopgen.L2Output,
-	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey,
-	l2Geth *geth.GethInstance,
-) *opnode.Opnode {
-	logger := s.logger.New("role", "op-node-"+id)
-	p2pKey := operatorKeys[devkeys.SequencerP2PRole]
-	nodeCfg := &node.Config{
-		L1: &node.PreparedL1Endpoint{
-			Client: client.NewBaseRPCClient(endpoint.DialRPC(
-				endpoint.PreferAnyRPC,
-				s.l1.UserRPC(),
-				mustDial(s.t, logger))),
-			TrustRPC:        false,
-			RPCProviderKind: sources.RPCKindDebugGeth,
-		},
-		L2: &node.L2EndpointConfig{
-			L2EngineAddr:      l2Geth.AuthRPC().RPC(),
-			L2EngineJWTSecret: testingJWTSecret,
-		},
-		Beacon: &node.L1BeaconEndpointConfig{
-			BeaconAddr: s.beacon.BeaconAddr(),
-		},
-		Driver: driver.Config{
-			SequencerEnabled: true,
-		},
-		Rollup: *l2Out.RollupCfg,
-		P2PSigner: &p2p.PreparedSigner{
-			Signer: p2p.NewLocalSigner(&p2pKey)},
-		RPC: node.RPCConfig{
-			ListenAddr:  "127.0.0.1",
-			ListenPort:  0,
-			EnableAdmin: true,
-		},
-		InteropConfig: &interop.Config{
-			//SupervisorAddr:   s.supervisor.RPC(),
-			RPCAddr:          "127.0.0.1",
-			RPCPort:          0,
-			RPCJwtSecretPath: "jwt.secret",
-		},
-		P2P:                         nil, // disabled P2P setup for now
-		L1EpochPollInterval:         time.Second * 2,
-		RuntimeConfigReloadInterval: 0,
-		Tracer:                      nil,
-		Sync: sync.Config{
-			SyncMode:                       sync.CLSync,
-			SkipSyncStartCheck:             false,
-			SupportsPostFinalizationELSync: false,
-		},
-		ConfigPersistence: node.DisabledConfigPersistence{},
-	}
-	opNode, err := opnode.NewOpnode(logger.New("service", "op-node"),
-		nodeCfg, func(err error) {
-			s.t.Error(err)
-		})
-	require.NoError(s.t, err)
-	s.t.Cleanup(func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // force-quit
-		s.t.Logf("Closing op-node of chain %s", id)
-		_ = opNode.Stop(ctx)
-		s.t.Logf("Closed op-node of chain %s", id)
-	})
-	return opNode
-}
-
-// newProposerForL2 creates a new Proposer for an L2 chain
-// it is currently unused, as the generated world does not have a DisputeGameFactoryProxy
-// TODO(#11888): name this function "newProposerForL2" and use it in the prepareL2s function when the DisputeGameFactoryProxy is available
-func (s *interopE2ESystem) _(
-	id string,
-	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey,
-	opNode *opnode.Opnode,
-) *l2os.ProposerService {
-	proposerSecret := operatorKeys[devkeys.ProposerRole]
-	logger := s.logger.New("role", "proposer"+id)
-	proposerCLIConfig := &l2os.CLIConfig{
-		L1EthRpc:          s.l1.UserRPC().RPC(),
-		RollupRpc:         opNode.UserRPC().RPC(),
-		DGFAddress:        s.worldDeployment.L2s[id].DisputeGameFactoryProxy.Hex(),
-		ProposalInterval:  6 * time.Second,
-		DisputeGameType:   254, // Fast game type
-		PollInterval:      500 * time.Millisecond,
-		TxMgrConfig:       setuputils.NewTxMgrConfig(s.l1.UserRPC(), &proposerSecret),
-		AllowNonFinalized: false,
-		LogConfig: oplog.CLIConfig{
-			Level:  log.LvlInfo,
-			Format: oplog.FormatText,
-		},
-	}
-	proposer, err := l2os.ProposerServiceFromCLIConfig(
-		context.Background(),
-		"0.0.1",
-		proposerCLIConfig,
-		logger.New("service", "proposer"))
-	require.NoError(s.t, err, "must start proposer")
-	require.NoError(s.t, proposer.Start(context.Background()))
-	s.t.Cleanup(func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // force-quit
-		_ = proposer.Stop(ctx)
-	})
-	return proposer
-}
-
-// newBatcherForL2 creates a new Batcher for an L2 chain
-func (s *interopE2ESystem) newBatcherForL2(
-	id string,
-	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey,
-	l2Geth *geth.GethInstance,
-	opNode *opnode.Opnode,
-) *bss.BatcherService {
-	batcherSecret := operatorKeys[devkeys.BatcherRole]
-	logger := s.logger.New("role", "batcher"+id)
-	batcherCLIConfig := &bss.CLIConfig{
-		L1EthRpc:                 s.l1.UserRPC().RPC(),
-		L2EthRpc:                 l2Geth.UserRPC().RPC(),
-		RollupRpc:                opNode.UserRPC().RPC(),
-		MaxPendingTransactions:   1,
-		MaxChannelDuration:       1,
-		MaxL1TxSize:              120_000,
-		TestUseMaxTxSizeForBlobs: false,
-		TargetNumFrames:          1,
-		ApproxComprRatio:         0.4,
-		SubSafetyMargin:          4,
-		PollInterval:             50 * time.Millisecond,
-		TxMgrConfig:              setuputils.NewTxMgrConfig(s.l1.UserRPC(), &batcherSecret),
-		LogConfig: oplog.CLIConfig{
-			Level:  log.LevelInfo,
-			Format: oplog.FormatText,
-		},
-		Stopped:               false,
-		BatchType:             derive.SpanBatchType,
-		MaxBlocksPerSpanBatch: 10,
-		DataAvailabilityType:  batcherFlags.CalldataType,
-		CompressionAlgo:       derive.Brotli,
-	}
-	batcher, err := bss.BatcherServiceFromCLIConfig(
-		context.Background(), "0.0.1", batcherCLIConfig,
-		logger.New("service", "batcher"))
-	require.NoError(s.t, err)
-	require.NoError(s.t, batcher.Start(context.Background()))
-	s.t.Cleanup(func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // force-quit
-		s.t.Logf("Closing batcher of chain %s", id)
-		_ = batcher.Stop(ctx)
-		s.t.Logf("Closed batcher of chain %s", id)
-	})
-	return batcher
-}
-
-// newL2 creates a new L2, starting with the L2Output from the world configuration
-// and iterating through the resources needed for the L2.
-// it returns a l2Set with the resources for the L2
-func (s *interopE2ESystem) newL2(id string, l2Out *interopgen.L2Output) l2Set {
-	operatorKeys := s.newOperatorKeysForL2(l2Out)
-	l2Geth := s.newGethForL2(id, l2Out)
-	opNode := s.newNodeForL2(id, l2Out, operatorKeys, l2Geth)
-	// TODO(#11886): proposer does not work with the generated world as there is no DisputeGameFactoryProxy
-	//proposer := s.newProposerForL2(id, operatorKeys, opNode)
-	batcher := s.newBatcherForL2(id, operatorKeys, l2Geth, opNode)
-
-	return l2Set{
-		chainID:      l2Out.Genesis.Config.ChainID,
-		opNode:       opNode,
-		l2Geth:       l2Geth,
-		proposer:     nil,
-		batcher:      batcher,
-		operatorKeys: operatorKeys,
-		userKeys:     make(map[string]ecdsa.PrivateKey),
-		contracts:    make(map[string]interface{}),
-	}
-}
-
 func (s *interopE2ESystem) ChainID(network string) *big.Int {
 	return s.l2s[network].chainID
 }
@@ -552,9 +317,11 @@ func (s *interopE2ESystem) prepare(t *testing.T, w worldResourcePaths) {
 	// add the L2 RPCs to the supervisor now that the L2s are created
 	ctx := context.Background()
 	for _, l2 := range s.l2s {
-		rpcEndpoint, secret := l2.opNode.InteropRPC()
-		err := s.SupervisorClient().AddL2RPC(ctx, rpcEndpoint, secret)
-		require.NoError(s.t, err, "failed to add L2 RPC to supervisor")
+		for _, node := range l2.nodes {
+			rpcEndpoint, secret := node.opNode.InteropRPC()
+			err := s.SupervisorClient().AddL2RPC(ctx, rpcEndpoint, secret)
+			require.NoError(s.t, err, "failed to add L2 RPC to supervisor")
+		}
 	}
 
 	// Try to close the op-supervisor first
@@ -600,8 +367,8 @@ func (s *interopE2ESystem) Address(id, username string) common.Address {
 }
 
 // prepareL2s creates the L2s for the system, returning a map of L2s
-func (s *interopE2ESystem) prepareL2s() map[string]l2Set {
-	l2s := make(map[string]l2Set)
+func (s *interopE2ESystem) prepareL2s() map[string]l2Net {
+	l2s := make(map[string]l2Net)
 	for id, l2Out := range s.worldOutput.L2s {
 		l2s[id] = s.newL2(id, l2Out)
 	}
@@ -614,7 +381,7 @@ func (s *interopE2ESystem) prepareContracts() {
 	l1GethClient := s.L1GethClient()
 	for id, l2Dep := range s.worldDeployment.L2s {
 		{
-			contract, err := inbox.NewInbox(predeploys.CrossL2InboxAddr, s.L2GethClient(id))
+			contract, err := inbox.NewInbox(predeploys.CrossL2InboxAddr, s.L2GethClient(id, "sequencer"))
 			require.NoError(s.t, err)
 			s.l2s[id].contracts["inbox"] = contract
 		}
@@ -646,55 +413,9 @@ func (s *interopE2ESystem) L1GethClient() *ethclient.Client {
 	return nodeClient
 }
 
-func (s *interopE2ESystem) L2GethClient(id string) *ethclient.Client {
-	// guard: check if the client already exists and return it in that case
-	nodeClient, ok := s.l2GethClients[id]
-	if ok {
-		return nodeClient
-	}
-	// create a new client for the L2 from the L2's geth instance
-	var ethClient services.EthInstance = s.L2Geth(id)
-	rpcEndpoint := ethClient.UserRPC()
-	rpcCl := endpoint.DialRPC(
-		endpoint.PreferAnyRPC,
-		rpcEndpoint,
-		func(v string) *rpc.Client {
-			logger := testlog.Logger(s.t, log.LevelInfo).New("node", id)
-			cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
-			require.NoError(s.t, err, "failed to dial eth node instance %s", id)
-			return cl
-		})
-	nodeClient = ethclient.NewClient(rpcCl)
-	// register the client so it can be reused
-	s.addL2GethClient(id, nodeClient)
-	return nodeClient
-}
-
-func (sys *interopE2ESystem) addL2GethClient(name string, client *ethclient.Client) {
-	if sys.l2GethClients == nil {
-		sys.l2GethClients = make(map[string]*ethclient.Client)
-	}
-	sys.l2GethClients[name] = client
-}
-
-// getter functions for L1 entities
-func (s *interopE2ESystem) Supervisor() *supervisor.SupervisorService {
-	return s.supervisor
-}
-
-// gettter functions for the individual L2s
-func (s *interopE2ESystem) Batcher(id string) *bss.BatcherService {
-	return s.l2s[id].batcher
-}
-func (s *interopE2ESystem) Proposer(id string) *l2os.ProposerService {
-	return s.l2s[id].proposer
-}
-func (s *interopE2ESystem) OpNode(id string) *opnode.Opnode {
-	return s.l2s[id].opNode
-}
-func (s *interopE2ESystem) L2Geth(id string) *geth.GethInstance {
-	return s.l2s[id].l2Geth
-}
+func (s *interopE2ESystem) Supervisor() *supervisor.SupervisorService { return s.supervisor }
+func (s *interopE2ESystem) Batcher(id string) *bss.BatcherService     { return s.l2s[id].batcher }
+func (s *interopE2ESystem) Proposer(id string) *l2os.ProposerService  { return s.l2s[id].proposer }
 func (s *interopE2ESystem) L2OperatorKey(id string, role devkeys.ChainOperatorRole) ecdsa.PrivateKey {
 	return s.l2s[id].operatorKeys[role]
 }
@@ -714,12 +435,13 @@ func (s *interopE2ESystem) L2IDs() []string {
 // and uses the L2's chain ID, username key, and geth client.
 func (s *interopE2ESystem) SendL2Tx(
 	id string,
+	node string,
 	sender string,
 	applyTxOpts helpers.TxOptsFn,
 ) *types.Receipt {
 	senderSecret := s.UserKey(id, sender)
 	require.NotNil(s.t, senderSecret, "no secret found for sender %s", sender)
-	nonce, err := s.L2GethClient(id).PendingNonceAt(context.Background(), crypto.PubkeyToAddress(senderSecret.PublicKey))
+	nonce, err := s.L2GethClient(id, node).PendingNonceAt(context.Background(), crypto.PubkeyToAddress(senderSecret.PublicKey))
 	require.NoError(s.t, err, "failed to get nonce")
 	newApply := func(opts *helpers.TxOpts) {
 		applyTxOpts(opts)
@@ -728,7 +450,7 @@ func (s *interopE2ESystem) SendL2Tx(
 	return helpers.SendL2TxWithID(
 		s.t,
 		s.l2s[id].chainID,
-		s.L2GethClient(id),
+		s.L2GethClient(id, node),
 		&senderSecret,
 		newApply)
 }
@@ -769,7 +491,7 @@ func (s *interopE2ESystem) ValidateMessage(
 		require.NoError(s.t, err)
 	}
 	s.logger.Info("Validating message", "tx", tx.Hash(), "to", tx.To(), "data", hexutil.Bytes(tx.Data()))
-	return bind.WaitMined(ctx, s.L2GethClient(id), tx)
+	return bind.WaitMined(ctx, s.L2GethClient(id, "sequencer"), tx) // use the sequencer client to wait for the tx
 }
 
 func (s *interopE2ESystem) AddDependency(ctx context.Context, id string, dep *big.Int) *types.Receipt {
@@ -800,6 +522,8 @@ func (s *interopE2ESystem) AddDependency(ctx context.Context, id string, dep *bi
 	return receipt
 }
 
+// DeployEmitterContract deploys the Emitter contract on the L2
+// it uses the sequencer node to deploy the contract
 func (s *interopE2ESystem) DeployEmitterContract(
 	id string,
 	sender string,
@@ -809,9 +533,9 @@ func (s *interopE2ESystem) DeployEmitterContract(
 	require.NoError(s.t, err)
 	auth.GasLimit = uint64(3000000)
 	auth.GasPrice = big.NewInt(20000000000)
-	address, _, _, err := emit.DeployEmit(auth, s.L2GethClient(id))
+	address, _, _, err := emit.DeployEmit(auth, s.L2GethClient(id, "sequencer"))
 	require.NoError(s.t, err)
-	contract, err := emit.NewEmit(address, s.L2GethClient(id))
+	contract, err := emit.NewEmit(address, s.L2GethClient(id, "sequencer"))
 	require.NoError(s.t, err)
 	s.l2s[id].contracts["emitter"] = contract
 	return address
@@ -820,6 +544,7 @@ func (s *interopE2ESystem) DeployEmitterContract(
 func (s *interopE2ESystem) EmitData(
 	ctx context.Context,
 	id string,
+	node string,
 	sender string,
 	data string,
 ) *types.Receipt {
@@ -834,7 +559,7 @@ func (s *interopE2ESystem) EmitData(
 	contract := s.Contract(id, "emitter").(*emit.Emit)
 	tx, err := contract.EmitTransactor.EmitData(auth, []byte(data))
 	require.NoError(s.t, err)
-	receipt, err := bind.WaitMined(ctx, s.L2GethClient(id), tx)
+	receipt, err := bind.WaitMined(ctx, s.L2GethClient(id, node), tx)
 	require.NoError(s.t, err)
 	return receipt
 }

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -1,0 +1,262 @@
+package interop
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"time"
+
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/services"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
+	"github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+type l2Node struct {
+	name         string
+	opNode       *opnode.Opnode
+	l2Geth       *geth.GethInstance
+	rollupClient *sources.RollupClient
+	gethClient   *ethclient.Client
+}
+
+type l2Net struct {
+	chainID      *big.Int
+	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey
+	contracts    map[string]interface{}
+	userKeys     map[string]ecdsa.PrivateKey
+
+	proposer *l2os.ProposerService
+	batcher  *bss.BatcherService
+	nodes    map[string]*l2Node
+}
+
+func (s *interopE2ESystem) L2GethClient(id string, name string) *ethclient.Client {
+	net := s.l2s[id]
+	node := net.nodes[name]
+	fmt.Println("id", id)
+	fmt.Println("net", net)
+	fmt.Println("name", name)
+	fmt.Println("node", node)
+	if node.gethClient != nil {
+		return node.gethClient
+	}
+	// create a new client for the L2 from the L2's geth instance
+	var ethClient services.EthInstance = node.l2Geth
+	rpcEndpoint := ethClient.UserRPC()
+	rpcCl := endpoint.DialRPC(
+		endpoint.PreferAnyRPC,
+		rpcEndpoint,
+		func(v string) *rpc.Client {
+			logger := testlog.Logger(s.t, log.LevelInfo).New("node", id)
+			cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
+			require.NoError(s.t, err, "failed to dial eth node instance %s", id)
+			return cl
+		})
+	node.gethClient = ethclient.NewClient(rpcCl)
+	return node.gethClient
+}
+
+func (s *interopE2ESystem) L2RollupClient(id string, name string) *sources.RollupClient {
+	net := s.l2s[id]
+	node := net.nodes[name]
+	if node.rollupClient != nil {
+		return node.rollupClient
+	}
+	rollupClA, err := dial.DialRollupClientWithTimeout(
+		context.Background(),
+		time.Second*15,
+		s.logger,
+		node.opNode.UserRPC().RPC())
+	require.NoError(s.t, err, "failed to dial rollup client")
+	node.rollupClient = rollupClA
+	return node.rollupClient
+}
+
+// newL2 creates a new L2, starting with the L2Output from the world configuration
+// and iterating through the resources needed for the L2.
+// it returns a l2Set with the resources for the L2
+func (s *interopE2ESystem) newL2(id string, l2Out *interopgen.L2Output) l2Net {
+	operatorKeys := s.newOperatorKeysForL2(l2Out)
+	l2Geth := s.newGethForL2(id, l2Out)
+	opNode := s.newNodeForL2(id, l2Out, operatorKeys, l2Geth, true, "sequencer")
+	// TODO(#11886): proposer does not work with the generated world as there is no DisputeGameFactoryProxy
+	//proposer := s.newProposerForL2(id, operatorKeys, opNode)
+	batcher := s.newBatcherForL2(id, operatorKeys, l2Geth, opNode)
+
+	return l2Net{
+		chainID:      l2Out.Genesis.Config.ChainID,
+		nodes:        map[string]*l2Node{"sequencer": {name: "sequencer", opNode: opNode, l2Geth: l2Geth}},
+		proposer:     nil,
+		batcher:      batcher,
+		operatorKeys: operatorKeys,
+		userKeys:     make(map[string]ecdsa.PrivateKey),
+		contracts:    make(map[string]interface{}),
+	}
+}
+
+func (s *interopE2ESystem) addNode(id string, name string, l2Out *interopgen.L2Output) {
+	l2 := s.l2s[id]
+	l2Geth := s.newGethForL2(id, l2Out)
+	opNode := s.newNodeForL2(id, l2Out, l2.operatorKeys, l2Geth, false, name)
+	l2.nodes[name] = &l2Node{name: name, opNode: opNode, l2Geth: l2Geth}
+}
+
+// newNodeForL2 creates a new Opnode for an L2 chain
+func (s *interopE2ESystem) newNodeForL2(
+	id string,
+	l2Out *interopgen.L2Output,
+	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey,
+	l2Geth *geth.GethInstance,
+	isSequencer bool,
+	name string,
+) *opnode.Opnode {
+	logger := s.logger.New("role", "op-node-"+id+"-"+name)
+	p2pKey := operatorKeys[devkeys.SequencerP2PRole]
+	nodeCfg := &node.Config{
+		L1: &node.PreparedL1Endpoint{
+			Client: client.NewBaseRPCClient(
+				endpoint.DialRPC(endpoint.PreferAnyRPC, s.l1.UserRPC(), mustDial(s.t, logger))),
+			TrustRPC:        false,
+			RPCProviderKind: sources.RPCKindDebugGeth,
+		},
+		L2: &node.L2EndpointConfig{
+			L2EngineAddr:      l2Geth.AuthRPC().RPC(),
+			L2EngineJWTSecret: testingJWTSecret,
+		},
+		Beacon: &node.L1BeaconEndpointConfig{
+			BeaconAddr: s.beacon.BeaconAddr(),
+		},
+		Driver: driver.Config{
+			SequencerEnabled: isSequencer,
+		},
+		Rollup: *l2Out.RollupCfg,
+		P2PSigner: &p2p.PreparedSigner{
+			Signer: p2p.NewLocalSigner(&p2pKey)},
+		RPC: node.RPCConfig{
+			ListenAddr:  "127.0.0.1",
+			ListenPort:  0,
+			EnableAdmin: true,
+		},
+		InteropConfig: &interop.Config{
+			//SupervisorAddr:   s.supervisor.RPC(),
+			RPCAddr:          "127.0.0.1",
+			RPCPort:          0,
+			RPCJwtSecretPath: "jwt.secret",
+		},
+		P2P:                         nil, // disabled P2P setup for now
+		L1EpochPollInterval:         time.Second * 2,
+		RuntimeConfigReloadInterval: 0,
+		Tracer:                      nil,
+		Sync: sync.Config{
+			SyncMode:                       sync.CLSync,
+			SkipSyncStartCheck:             false,
+			SupportsPostFinalizationELSync: false,
+		},
+		ConfigPersistence: node.DisabledConfigPersistence{},
+	}
+	opNode, err := opnode.NewOpnode(logger.New("service", "op-node"),
+		nodeCfg, func(err error) {
+			s.t.Error(err)
+		})
+	require.NoError(s.t, err)
+	s.t.Cleanup(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // force-quit
+		s.t.Logf("Closing op-node of chain %s", id)
+		_ = opNode.Stop(ctx)
+		s.t.Logf("Closed op-node of chain %s", id)
+	})
+	return opNode
+}
+
+// newGethForL2 creates a new Geth instance for an L2 chain
+func (s *interopE2ESystem) newGethForL2(id string, l2Out *interopgen.L2Output) *geth.GethInstance {
+	jwtPath := writeDefaultJWT(s.t)
+	name := "l2-" + id
+	l2Geth, err := geth.InitL2(name, l2Out.Genesis, jwtPath,
+		func(ethCfg *ethconfig.Config, nodeCfg *gn.Config) error {
+			ethCfg.InteropMessageRPC = s.supervisor.RPC()
+			ethCfg.InteropMempoolFiltering = s.config.mempoolFiltering
+			return nil
+		})
+	require.NoError(s.t, err)
+	require.NoError(s.t, l2Geth.Node.Start())
+	s.t.Cleanup(func() {
+		s.t.Logf("Closing L2 geth of chain %s", id)
+		closeErr := l2Geth.Close()
+		s.t.Logf("Closed L2 geth of chain %s: %v", id, closeErr)
+	})
+	return l2Geth
+}
+
+// newBatcherForL2 creates a new Batcher for an L2 chain
+func (s *interopE2ESystem) newBatcherForL2(
+	id string,
+	operatorKeys map[devkeys.ChainOperatorRole]ecdsa.PrivateKey,
+	l2Geth *geth.GethInstance,
+	opNode *opnode.Opnode,
+) *bss.BatcherService {
+	batcherSecret := operatorKeys[devkeys.BatcherRole]
+	logger := s.logger.New("role", "batcher"+id)
+	batcherCLIConfig := &bss.CLIConfig{
+		L1EthRpc:                 s.l1.UserRPC().RPC(),
+		L2EthRpc:                 l2Geth.UserRPC().RPC(),
+		RollupRpc:                opNode.UserRPC().RPC(),
+		MaxPendingTransactions:   1,
+		MaxChannelDuration:       1,
+		MaxL1TxSize:              120_000,
+		TestUseMaxTxSizeForBlobs: false,
+		TargetNumFrames:          1,
+		ApproxComprRatio:         0.4,
+		SubSafetyMargin:          4,
+		PollInterval:             50 * time.Millisecond,
+		TxMgrConfig:              setuputils.NewTxMgrConfig(s.l1.UserRPC(), &batcherSecret),
+		LogConfig: oplog.CLIConfig{
+			Level:  log.LevelInfo,
+			Format: oplog.FormatText,
+		},
+		Stopped:               false,
+		BatchType:             derive.SpanBatchType,
+		MaxBlocksPerSpanBatch: 10,
+		DataAvailabilityType:  batcherFlags.CalldataType,
+		CompressionAlgo:       derive.Brotli,
+	}
+	batcher, err := bss.BatcherServiceFromCLIConfig(
+		context.Background(), "0.0.1", batcherCLIConfig,
+		logger.New("service", "batcher"))
+	require.NoError(s.t, err)
+	require.NoError(s.t, batcher.Start(context.Background()))
+	s.t.Cleanup(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // force-quit
+		s.t.Logf("Closing batcher of chain %s", id)
+		_ = batcher.Stop(ctx)
+		s.t.Logf("Closed batcher of chain %s", id)
+	})
+	return batcher
+}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -504,6 +504,14 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			CrossSafe: d.ec.SafeL2Head(),
 			LocalSafe: d.ec.LocalSafeL2Head(),
 		})
+		if x.Ref.Number > d.ec.crossUnsafeHead.Number {
+			d.log.Debug("Cross Unsafe Head is stale, updating to match cross safe", "cross_unsafe", d.ec.crossUnsafeHead, "cross_safe", x.Ref)
+			d.ec.SetCrossUnsafeHead(x.Ref)
+			d.emitter.Emit(CrossUnsafeUpdateEvent{
+				CrossUnsafe: x.Ref,
+				LocalUnsafe: d.ec.UnsafeL2Head(),
+			})
+		}
 		// Try to apply the forkchoice changes
 		d.emitter.Emit(TryUpdateEngineEvent{})
 	case PromoteFinalizedEvent:

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -301,7 +301,7 @@ func (su *SupervisorBackend) AttachProcessorSource(chainID eth.ChainID, src proc
 	if !ok {
 		return fmt.Errorf("unknown chain %s, cannot attach RPC to processor", chainID)
 	}
-	proc.SetSource(src)
+	proc.AddSource(src)
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -266,5 +266,5 @@ func (m *MockProcessorSource) BlockRefByNumber(ctx context.Context, num uint64) 
 }
 
 func (m *MockProcessorSource) ExpectBlockRefByNumber(num uint64, ref eth.BlockRef, err error) {
-	m.Mock.On("BlockRefByNumber", num).Once().Return(ref, err)
+	m.Mock.On("BlockRefByNumber", num).Return(ref, err)
 }

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -45,8 +45,10 @@ func (fn BlockProcessorFn) ProcessBlock(ctx context.Context, block eth.BlockRef)
 type ChainProcessor struct {
 	log log.Logger
 
-	client     Source
-	clientLock sync.Mutex
+	clients      []Source
+	activeClient Source
+	clientIndex  int
+	clientLock   sync.Mutex
 
 	chain eth.ChainID
 
@@ -67,7 +69,6 @@ func NewChainProcessor(systemContext context.Context, log log.Logger, chain eth.
 	out := &ChainProcessor{
 		systemContext:     systemContext,
 		log:               log.New("chain", chain),
-		client:            nil,
 		chain:             chain,
 		processor:         processor,
 		rewinder:          rewinder,
@@ -80,10 +81,13 @@ func (s *ChainProcessor) AttachEmitter(em event.Emitter) {
 	s.emitter = em
 }
 
-func (s *ChainProcessor) SetSource(cl Source) {
+func (s *ChainProcessor) AddSource(cl Source) {
 	s.clientLock.Lock()
 	defer s.clientLock.Unlock()
-	s.client = cl
+	s.clients = append(s.clients, cl)
+	if s.activeClient == nil {
+		s.activeClient = s.clients[0]
+	}
 }
 
 func (s *ChainProcessor) nextNum() uint64 {
@@ -108,7 +112,7 @@ func (s *ChainProcessor) OnEvent(ev event.Event) bool {
 }
 
 func (s *ChainProcessor) onRequest(target uint64) {
-	_, err := s.rangeUpdate(target)
+	processed, err := s.rangeUpdate(target)
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
 			s.log.Debug("Event-indexer cannot find next block yet", "target", target, "err", err)
@@ -116,6 +120,16 @@ func (s *ChainProcessor) onRequest(target uint64) {
 			s.log.Warn("No RPC source configured, cannot process new blocks")
 		} else {
 			s.log.Error("Failed to process new block", "err", err)
+		}
+		// if the client failed to get *any* blocks, it probably isn't the source of this sync request
+		// so we should try the next client. Clients will be tried in round-robin order until one succeeds.
+		if processed == 0 {
+			s.log.Debug("Active client found no blocks, trying again with next client", "activeClient", s.activeClient)
+			s.nextActiveClient()
+			s.emitter.Emit(superevents.ChainProcessEvent{
+				ChainID: s.chain,
+				Target:  target,
+			})
 		}
 	} else if x := s.nextNum(); x <= target {
 		s.log.Debug("Continuing with next block", "target", target, "next", x)
@@ -128,10 +142,21 @@ func (s *ChainProcessor) onRequest(target uint64) {
 	}
 }
 
+// nextActiveClient advances the client index and sets the active client.
+func (s *ChainProcessor) nextActiveClient() {
+	s.clientLock.Lock()
+	defer s.clientLock.Unlock()
+	if len(s.clients) == 0 {
+		return
+	}
+	s.clientIndex = (s.clientIndex + 1) % len(s.clients)
+	s.activeClient = s.clients[s.clientIndex]
+}
+
 func (s *ChainProcessor) rangeUpdate(target uint64) (int, error) {
 	s.clientLock.Lock()
 	defer s.clientLock.Unlock()
-	if s.client == nil {
+	if len(s.clients) == 0 {
 		return 0, types.ErrNoRPCSource
 	}
 
@@ -175,7 +200,7 @@ func (s *ChainProcessor) rangeUpdate(target uint64) (int, error) {
 
 		// fetch the block ref
 		ctx, cancel := context.WithTimeout(s.systemContext, time.Second*10)
-		next, err := s.client.BlockRefByNumber(ctx, num)
+		next, err := s.activeClient.BlockRefByNumber(ctx, num)
 		cancel()
 		if err != nil {
 			result.err = err
@@ -190,7 +215,7 @@ func (s *ChainProcessor) rangeUpdate(target uint64) (int, error) {
 
 		// fetch receipts
 		ctx, cancel = context.WithTimeout(s.systemContext, time.Second*10)
-		receipts, err := s.client.FetchReceipts(ctx, next.Hash)
+		receipts, err := s.activeClient.FetchReceipts(ctx, next.Hash)
 		cancel()
 		if err != nil {
 			result.err = err

--- a/op-supervisor/supervisor/backend/processors/chain_processor_test.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor_test.go
@@ -1,0 +1,88 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailover(t *testing.T) {
+	log := testlog.Logger(t, slog.LevelDebug)
+	ctx := context.Background()
+	chainID := eth.ChainID{1}
+	source := &mockSource{}
+	processor := &mockProcessor{}
+	rewinder := &mockRewinder{}
+	chainProc := NewChainProcessor(ctx, log, chainID, processor, rewinder)
+	chainProc.AttachEmitter(&mockEmitter{})
+
+	chainProc.AddSource(source)
+	require.Equal(t, source, chainProc.activeClient)
+
+	badSource := &mockSource{}
+	badSource.blockRefFunc = func(ctx context.Context, number uint64) (eth.BlockRef, error) {
+		return eth.BlockRef{}, errors.New("bad source")
+	}
+	// after adding the second source, the activeClient hasn't changed
+	chainProc.AddSource(badSource)
+	require.Equal(t, source, chainProc.activeClient)
+
+	// when no error, the activeClient should be unchanged
+	chainProc.onRequest(2)
+	require.Equal(t, source, chainProc.activeClient)
+
+	// force the activeClient to be the bad source
+	chainProc.nextActiveClient()
+	require.Equal(t, badSource, chainProc.activeClient)
+
+	// when the bad source errors, the activeClient should be back to the first source
+	chainProc.onRequest(2)
+	require.Equal(t, source, chainProc.activeClient)
+}
+
+type mockEmitter struct{}
+
+func (m *mockEmitter) Emit(ev event.Event) {
+}
+
+type mockSource struct {
+	blockRefFunc func(ctx context.Context, number uint64) (eth.BlockRef, error)
+}
+
+func (m *mockSource) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {
+	if m.blockRefFunc != nil {
+		return m.blockRefFunc(ctx, number)
+	}
+	return eth.BlockRef{}, nil
+}
+func (m *mockSource) FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error) {
+	return gethtypes.Receipts{}, nil
+}
+
+type mockProcessor struct {
+}
+
+func (m *mockProcessor) ProcessLogs(ctx context.Context, block eth.BlockRef, receipts gethtypes.Receipts) error {
+	return nil
+}
+
+type mockRewinder struct {
+}
+
+func (m *mockRewinder) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
+	return nil
+}
+func (m *mockRewinder) LatestBlockNum(chain eth.ChainID) (num uint64, ok bool) {
+	return 0, true
+}
+func (m *mockRewinder) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
+	return nil
+}


### PR DESCRIPTION
# What
Tests that multiple managed nodes can sync from a supervisor, and adds fixes required to do so.

# How
- Full E2E test which
  - Runs the network for a while
  - Attaches a second node
  - Confirms both the original and new node sync beyond the point where the second node was attached
- Chain Processor now accepts multiple sources
  - Simple round-robin fallback mechanism with a limit to not cycle more than once
    - An E2E test expectation needed to drop the `Once()` to play nicely with this.
  - Unit test to show that round robin keeps the valid source in play
- Supersystem now supports multiple nodes per L2 network
  - Nodes are given "names" as a key
  - Default node is called "sequencer"
  - L2 specific content moved to its own file for cleanliness
- Managed Nodes use CrossSafe to update CrossUnsafe in some cases
  - When the Cross Safe signal comes in and the Cross Unsafe is *behind it*, we know it can be advanced