### PR TITLE
perf(kt-devnet): use deterministic tarballs of contract code to make fileserver runs idempotent

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -6,10 +6,31 @@ test:
 _kurtosis-run PACKAGE_NAME ARG_FILE ENCLAVE:
 	kurtosis run {{PACKAGE_NAME}} --args-file {{ARG_FILE}} --enclave {{ENCLAVE}} --show-enclave-inspect=false --image-download=missing
 
-# Internal recipes for kurtosis-devnet
+# Internal recipes for kurtosis-devnet.
+# This builds the forge contracts and bundles them into a tarball,
+# which is uploaded to the kurtosis enclave as a file artifact.
+# We need to ensure that the tarball is reproducible (always has the same content)
+# because kurtosis uses the md5 hash of the tarball to determine if it needs to be re-uploaded:
+# https://github.com/kurtosis-tech/kurtosis/blob/bf315c6993d5e70a47265f1f41f0f7273fdd904b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go#L206
+# BSD tar on macOS doesn't support the --mtime flag, so we need to use GNU tar if we're on macOS.
+# See https://unix.stackexchange.com/questions/438329/tar-produces-different-files-each-time
+# Couldn't find gnu tar on mise so we're recommending it to be installed via brew.
 _contracts-build BUNDLE='contracts-bundle.tar.gz':
+    #!/usr/bin/env bash
     just ../packages/contracts-bedrock/forge-build
-    tar -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
+    if tar --version | grep -q GNU; then
+      # Linux
+      GZIP=-n tar --mtime='1970-01-01 00:00:00' \
+        -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
+    else
+      # macOS
+      if ! command -v gtar &> /dev/null; then
+        echo "GNU tar not found. Please install with: brew install gnu-tar"
+        exit 1
+      fi
+      GZIP=-n gtar --mtime='1970-01-01 00:00:00' \
+        -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
+    fi
 
 _prestate-build PATH='.':
     docker buildx build --output {{PATH}} --progress plain -f ../op-program/Dockerfile.repro ../

--- a/kurtosis-devnet/pkg/deploy/fileserver.go
+++ b/kurtosis-devnet/pkg/deploy/fileserver.go
@@ -31,7 +31,11 @@ func (f *FileServer) Deploy(ctx context.Context, sourceDir string) error {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return fmt.Errorf("error creating base directory: %w", err)
 	}
-	tempDir, err := os.MkdirTemp(baseDir, "upload-content")
+	// Can't use MkdirTemp here because the directory name needs to always be the same
+	// in order for kurtosis file artifact upload to be idempotent.
+	// (i.e. the file upload and all its downstream dependencies can be SKIPPED on re-runs)
+	tempDir := filepath.Join(baseDir, "upload-content")
+	err := os.Mkdir(tempDir, 0755)
 	if err != nil {
 		return fmt.Errorf("error creating temporary directory: %w", err)
 	}


### PR DESCRIPTION
Kurtosis is built to make `kurtosis run` idempotent to allow for enclave edits (e.g. only change batcher flags and rerunning `kt run ...` should only redeploy batcher and its dependencies, if any).

Right now ethereum-package and optimism-package have idempotent runs (try running against same enclave twice, you will see `SKIPPED` on all the instructions the second time). The golang cli wrapper used in the optimism monorepo to allow building images and uploading contract artifacts however, break all of this idempotency, which makes making enclave edits a nightmare (takes 10 mins+ to redeploy everything).

This PR is a first step in helping make the op kurtosis wrapper cli idempotent. For details see the comments in the code, but the gist is that the tarballs being uploaded weren't deterministically constructed, which was breaking idempotency. With this change, the kurtosis package inside the op repo (that deploys the fileserver) is now idempotent:
![image](https://github.com/user-attachments/assets/8136b190-0aaa-494c-8ade-fb80e6b4dc30)

Unfortunately, I thought this would be enough to make the entire deployment idempotent, but the ethereum-package and optimism-package being deployed on top for some weird reason keep redeploying everything....... :(

At least this is one step in the right direction... maybe someone will have an idea for how to make eth-package and op-package idempotent as well.

CAVEAT: deterministic tarball creation relies on gnu tar, which isn't available out of the box on macos, and now needs to be downloaded via brew (not available on mise unfortunately). I added an error to the justfile which prints how to do this. Also have only tested on mac, not linux or windows.


> There are 2 hard problems in computer science: cache invalidation, naming things, and off-by-1 errors.
