### PR TITLE
op-program: Load DependencySet from boot config

### DIFF
--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -649,7 +651,7 @@ func runFppTest(gt *testing.T, test *transitionTest, actors *dsl.InteropActors) 
 		logger,
 		actors.L1Miner,
 		checkResult,
-		WithInteropEnabled(actors, test.agreedClaim, crypto.Keccak256Hash(test.disputedClaim), proposalTimestamp),
+		WithInteropEnabled(t, actors, test.agreedClaim, crypto.Keccak256Hash(test.disputedClaim), proposalTimestamp),
 		fpHelpers.WithL1Head(l1Head),
 	)
 }
@@ -697,13 +699,32 @@ func runChallengerTest(gt *testing.T, test *transitionTest, actors *dsl.InteropA
 	}
 }
 
-func WithInteropEnabled(actors *dsl.InteropActors, agreedPrestate []byte, disputedClaim common.Hash, claimTimestamp uint64) fpHelpers.FixtureInputParam {
+func WithInteropEnabled(t helpers.StatefulTesting, actors *dsl.InteropActors, agreedPrestate []byte, disputedClaim common.Hash, claimTimestamp uint64) fpHelpers.FixtureInputParam {
 	return func(f *fpHelpers.FixtureInputs) {
 		f.InteropEnabled = true
 		f.AgreedPrestate = agreedPrestate
 		f.L2OutputRoot = crypto.Keccak256Hash(agreedPrestate)
 		f.L2Claim = disputedClaim
 		f.L2BlockNumber = claimTimestamp
+
+		chainIndexA, err := actors.ChainA.ChainID.ToUInt32()
+		require.NoError(t, err)
+		chainIndexB, err := actors.ChainB.ChainID.ToUInt32()
+		require.NoError(t, err)
+		deps := map[eth.ChainID]*depset.StaticConfigDependency{
+			actors.ChainA.ChainID: {
+				ChainIndex:     supervisortypes.ChainIndex(chainIndexA),
+				ActivationTime: 0,
+				HistoryMinTime: 0,
+			},
+			actors.ChainB.ChainID: {
+				ChainIndex:     supervisortypes.ChainIndex(chainIndexB),
+				ActivationTime: 0,
+				HistoryMinTime: 0,
+			},
+		}
+		f.DependencySet, err = depset.NewStaticConfigDependencySet(deps)
+		require.NoError(t, err)
 
 		for _, chain := range []*dsl.Chain{actors.ChainA, actors.ChainB} {
 			f.L2Sources = append(f.L2Sources, &fpHelpers.FaultProofProgramL2Source{

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -707,22 +707,19 @@ func WithInteropEnabled(t helpers.StatefulTesting, actors *dsl.InteropActors, ag
 		f.L2Claim = disputedClaim
 		f.L2BlockNumber = claimTimestamp
 
-		chainIndexA, err := actors.ChainA.ChainID.ToUInt32()
-		require.NoError(t, err)
-		chainIndexB, err := actors.ChainB.ChainID.ToUInt32()
-		require.NoError(t, err)
 		deps := map[eth.ChainID]*depset.StaticConfigDependency{
 			actors.ChainA.ChainID: {
-				ChainIndex:     supervisortypes.ChainIndex(chainIndexA),
+				ChainIndex:     supervisortypes.ChainIndex(0),
 				ActivationTime: 0,
 				HistoryMinTime: 0,
 			},
 			actors.ChainB.ChainID: {
-				ChainIndex:     supervisortypes.ChainIndex(chainIndexB),
+				ChainIndex:     supervisortypes.ChainIndex(1),
 				ActivationTime: 0,
 				HistoryMinTime: 0,
 			},
 		}
+		var err error
 		f.DependencySet, err = depset.NewStaticConfigDependencySet(deps)
 		require.NoError(t, err)
 

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -222,5 +222,6 @@ func NewOpProgramCfg(
 		dfault.AgreedPrestate = fi.AgreedPrestate
 	}
 	dfault.InteropEnabled = fi.InteropEnabled
+	dfault.DependencySet = fi.DependencySet
 	return dfault
 }

--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -20,14 +21,15 @@ type FaultProofProgramL2Source struct {
 }
 
 type FixtureInputs struct {
-	L2BlockNumber  uint64      `toml:"l2-block-number"`
-	L2Claim        common.Hash `toml:"l2-claim"`
-	L2Head         common.Hash `toml:"l2-head"`
-	L2OutputRoot   common.Hash `toml:"l2-output-root"`
-	L2ChainID      eth.ChainID `toml:"l2-chain-id"`
-	L1Head         common.Hash `toml:"l1-head"`
-	AgreedPrestate []byte      `toml:"agreed-prestate"`
-	InteropEnabled bool        `toml:"use-interop"`
+	L2BlockNumber  uint64                            `toml:"l2-block-number"`
+	L2Claim        common.Hash                       `toml:"l2-claim"`
+	L2Head         common.Hash                       `toml:"l2-head"`
+	L2OutputRoot   common.Hash                       `toml:"l2-output-root"`
+	L2ChainID      eth.ChainID                       `toml:"l2-chain-id"`
+	L1Head         common.Hash                       `toml:"l1-head"`
+	AgreedPrestate []byte                            `toml:"agreed-prestate"`
+	DependencySet  *depset.StaticConfigDependencySet `toml:"dependency-set"`
+	InteropEnabled bool                              `toml:"use-interop"`
 
 	L2Sources []*FaultProofProgramL2Source
 }

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -30,7 +30,7 @@ type BootInfoInterop struct {
 type ConfigSource interface {
 	RollupConfig(chainID eth.ChainID) (*rollup.Config, error)
 	ChainConfig(chainID eth.ChainID) (*params.ChainConfig, error)
-	DependencySet(chainID eth.ChainID) (*depset.StaticConfigDependencySet, error)
+	DependencySet(chainID eth.ChainID) (depset.DependencySet, error)
 }
 type OracleConfigSource struct {
 	oracle oracleClient
@@ -80,7 +80,7 @@ func (c *OracleConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 	return cfg, nil
 }
 
-func (c *OracleConfigSource) DependencySet(chainID eth.ChainID) (*depset.StaticConfigDependencySet, error) {
+func (c *OracleConfigSource) DependencySet(chainID eth.ChainID) (depset.DependencySet, error) {
 	if c.depset != nil {
 		return c.depset, nil
 	}

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -29,6 +30,7 @@ type BootInfoInterop struct {
 type ConfigSource interface {
 	RollupConfig(chainID eth.ChainID) (*rollup.Config, error)
 	ChainConfig(chainID eth.ChainID) (*params.ChainConfig, error)
+	DependencySet(chainID eth.ChainID) (*depset.StaticConfigDependencySet, error)
 }
 type OracleConfigSource struct {
 	oracle oracleClient
@@ -37,6 +39,7 @@ type OracleConfigSource struct {
 
 	l2ChainConfigs map[eth.ChainID]*params.ChainConfig
 	rollupConfigs  map[eth.ChainID]*rollup.Config
+	depset         *depset.StaticConfigDependencySet
 }
 
 func (c *OracleConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, error) {
@@ -77,6 +80,15 @@ func (c *OracleConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 	return cfg, nil
 }
 
+func (c *OracleConfigSource) DependencySet(chainID eth.ChainID) (*depset.StaticConfigDependencySet, error) {
+	if c.depset != nil {
+		return c.depset, nil
+	}
+	// TODO(#13887): The embedded depset must be loaded first before falling back to using custom configs
+	c.loadCustomConfigs()
+	return c.depset, nil
+}
+
 func (c *OracleConfigSource) loadCustomConfigs() {
 	var rollupConfigs []*rollup.Config
 	err := json.Unmarshal(c.oracle.Get(RollupConfigLocalIndex), &rollupConfigs)
@@ -95,6 +107,13 @@ func (c *OracleConfigSource) loadCustomConfigs() {
 	for _, config := range chainConfigs {
 		c.l2ChainConfigs[eth.ChainIDFromBig(config.ChainID)] = config
 	}
+
+	var depset depset.StaticConfigDependencySet
+	err = json.Unmarshal(c.oracle.Get(DependencySetLocalIndex), &depset)
+	if err != nil {
+		panic("failed to bootstrap dependency set")
+	}
+	c.depset = &depset
 	c.customConfigsLoaded = true
 }
 

--- a/op-program/client/boot/common.go
+++ b/op-program/client/boot/common.go
@@ -12,6 +12,7 @@ const (
 	// These local keys are only used for custom chains
 	L2ChainConfigLocalIndex
 	RollupConfigLocalIndex
+	DependencySetLocalIndex
 )
 
 type oracleClient interface {

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -31,7 +31,6 @@ func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtyp
 			if err != nil {
 				return nil, 0, err
 			}
-			// TODO: e2e test for both executing and non-executing messages in the logs
 			if execMsg != nil {
 				execMsgs = append(execMsgs, execMsg)
 			}
@@ -207,7 +206,7 @@ func newConsolidateCheckDeps(
 	chains []eth.ChainIDAndOutput,
 	oracle l2.Oracle,
 ) (*consolidateCheckDeps, error) {
-	// TODO: handle case where dep set changes in a given timestamp
+	// TODO(#14415): handle case where dep set changes in a given timestamp
 	canonBlocks := make(map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle)
 	for i, chain := range chains {
 		progress := transitionState.PendingProgress[i]

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -62,7 +62,12 @@ func RunConsolidation(
 	superRoot *eth.SuperV1,
 	tasks taskExecutor,
 ) (eth.Bytes32, error) {
-	deps, err := newConsolidateCheckDeps(bootInfo, transitionState, superRoot.Chains, l2PreimageOracle)
+	// The depset is the same for all chains. So it suffices to use any chain ID
+	depset, err := bootInfo.Configs.DependencySet(superRoot.Chains[0].ChainID)
+	if err != nil {
+		return eth.Bytes32{}, fmt.Errorf("failed to get dependency set: %w", err)
+	}
+	deps, err := newConsolidateCheckDeps(depset, bootInfo, transitionState, superRoot.Chains, l2PreimageOracle)
 	if err != nil {
 		return eth.Bytes32{}, fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
@@ -195,18 +200,14 @@ type consolidateCheckDeps struct {
 	canonBlocks map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle
 }
 
-func newConsolidateCheckDeps(bootInfo *boot.BootInfoInterop, transitionState *types.TransitionState, chains []eth.ChainIDAndOutput, oracle l2.Oracle) (*consolidateCheckDeps, error) {
+func newConsolidateCheckDeps(
+	depset depset.DependencySet,
+	bootInfo *boot.BootInfoInterop,
+	transitionState *types.TransitionState,
+	chains []eth.ChainIDAndOutput,
+	oracle l2.Oracle,
+) (*consolidateCheckDeps, error) {
 	// TODO: handle case where dep set changes in a given timestamp
-	// TODO: Also replace dep set stubs with the actual dependency set in the RollupConfig.
-	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for i, chain := range chains {
-		deps[chain.ChainID] = &depset.StaticConfigDependency{
-			ChainIndex:     supervisortypes.ChainIndex(i),
-			ActivationTime: 0,
-			HistoryMinTime: 0,
-		}
-	}
-
 	canonBlocks := make(map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle)
 	for i, chain := range chains {
 		progress := transitionState.PendingProgress[i]
@@ -223,11 +224,6 @@ func newConsolidateCheckDeps(bootInfo *boot.BootInfoInterop, transitionState *ty
 		}
 		fallback := l2.NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
 		canonBlocks[chain.ChainID] = l2.NewFastCanonicalBlockHeaderOracle(head.Header(), blockByHash, l2ChainConfig, oracle, rawdb.NewMemoryDatabase(), fallback)
-	}
-
-	depset, err := depset.NewStaticConfigDependencySet(deps)
-	if err != nil {
-		return nil, fmt.Errorf("unexpected error: failed to create dependency set: %w", err)
 	}
 
 	return &consolidateCheckDeps{

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -48,9 +49,14 @@ func setupTwoChains() (*staticConfigSource, *eth.SuperV1, *stubTasks) {
 			{ChainID: eth.ChainIDFromBig(rollupCfg2.L2ChainID), Output: eth.OutputRoot(&eth.OutputV0{BlockHash: common.Hash{0x22}})},
 		},
 	}
+	depset, _ := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+		eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainIndex: supervisortypes.ChainIndex(rollupCfg1.L2ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainIndex: supervisortypes.ChainIndex(rollupCfg2.L2ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+	})
 	configSource := &staticConfigSource{
 		rollupCfgs:   []*rollup.Config{rollupCfg1, &rollupCfg2},
 		chainConfigs: []*params.ChainConfig{chainCfg1, &chainCfg2},
+		depset:       depset,
 	}
 	tasksStub := &stubTasks{
 		l2SafeHead: eth.L2BlockRef{Number: 918429823450218}, // Past the claimed block
@@ -568,6 +574,7 @@ func (t *stubTasks) ExpectBuildDepositOnlyBlock(
 type staticConfigSource struct {
 	rollupCfgs   []*rollup.Config
 	chainConfigs []*params.ChainConfig
+	depset       *depset.StaticConfigDependencySet
 }
 
 func (s *staticConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, error) {
@@ -586,4 +593,8 @@ func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 		}
 	}
 	return nil, fmt.Errorf("no chain config found for chain %d", chainID)
+}
+
+func (s *staticConfigSource) DependencySet(chainID eth.ChainID) (*depset.StaticConfigDependencySet, error) {
+	return s.depset, nil
 }

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -595,6 +595,6 @@ func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 	return nil, fmt.Errorf("no chain config found for chain %d", chainID)
 }
 
-func (s *staticConfigSource) DependencySet(chainID eth.ChainID) (*depset.StaticConfigDependencySet, error) {
+func (s *staticConfigSource) DependencySet(chainID eth.ChainID) (depset.DependencySet, error) {
 	return s.depset, nil
 }

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -50,8 +50,8 @@ func setupTwoChains() (*staticConfigSource, *eth.SuperV1, *stubTasks) {
 		},
 	}
 	depset, _ := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainIndex: supervisortypes.ChainIndex(rollupCfg1.L2ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainIndex: supervisortypes.ChainIndex(rollupCfg2.L2ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainIndex: chainA, ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainIndex: chainB, ActivationTime: 0, HistoryMinTime: 0},
 	})
 	configSource := &staticConfigSource{
 		rollupCfgs:   []*rollup.Config{rollupCfg1, &rollupCfg2},

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -257,7 +257,7 @@ func TestL2Head(t *testing.T) {
 		delete(req, "--l2.head")
 		delete(req, "--l2.outputroot")
 		args := append(toArgList(req), "--l2.agreed-prestate", "0x1234")
-		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		// TODO(#14416): Remove the --depset.config flag once there's a depset defined for sepolia.
 		// For now we stub a depset path to ensure the run succeeds
 		depsetFile := writeDepset(t)
 		args = append(args, "--depset.config", depsetFile)
@@ -279,7 +279,7 @@ func TestL2OutputRoot(t *testing.T) {
 
 	t.Run("NotRequiredWhenAgreedPrestateProvided", func(t *testing.T) {
 		optionalArgs := []string{"--l2.agreed-prestate", "0x1234"}
-		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		// TODO(#14416): Remove the --depset.config flag once there's a depset defined for sepolia.
 		depsetFile := writeDepset(t)
 		optionalArgs = append(optionalArgs, "--depset.config", depsetFile)
 		configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, optionalArgs...))
@@ -298,7 +298,7 @@ func TestL2OutputRoot(t *testing.T) {
 func TestL2AgreedPrestate(t *testing.T) {
 	t.Run("NotRequiredWhenL2OutputRootProvided", func(t *testing.T) {
 		optionalArgs := []string{"--l2.agreed-prestate", "0x1234"}
-		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		// TODO(#14416): Remove the --depset.config flag once there's a depset defined for sepolia.
 		depsetFile := writeDepset(t)
 		optionalArgs = append(optionalArgs, "--depset.config", depsetFile)
 		configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, optionalArgs...))
@@ -309,7 +309,7 @@ func TestL2AgreedPrestate(t *testing.T) {
 		prestateBytes := common.FromHex(prestate)
 		expectedOutputRoot := crypto.Keccak256Hash(prestateBytes)
 		optionalArgs := []string{"--l2.agreed-prestate", prestate}
-		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		// TODO(#14416): Remove the --depset.config flag once there's a depset defined for sepolia.
 		depsetFile := writeDepset(t)
 		optionalArgs = append(optionalArgs, "--depset.config", depsetFile)
 		cfg := configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, optionalArgs...))

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -256,6 +257,11 @@ func TestL2Head(t *testing.T) {
 		delete(req, "--l2.head")
 		delete(req, "--l2.outputroot")
 		args := append(toArgList(req), "--l2.agreed-prestate", "0x1234")
+		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		// For now we stub a depset path to ensure the run succeeds
+		depsetFile := writeDepset(t)
+		args = append(args, "--depset.config", depsetFile)
+
 		cfg := configForArgs(t, args)
 		require.Equal(t, common.Hash{}, cfg.L2Head)
 		require.True(t, cfg.InteropEnabled)
@@ -272,7 +278,11 @@ func TestL2OutputRoot(t *testing.T) {
 	})
 
 	t.Run("NotRequiredWhenAgreedPrestateProvided", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, "--l2.agreed-prestate", "0x1234"))
+		optionalArgs := []string{"--l2.agreed-prestate", "0x1234"}
+		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		depsetFile := writeDepset(t)
+		optionalArgs = append(optionalArgs, "--depset.config", depsetFile)
+		configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, optionalArgs...))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
@@ -287,14 +297,22 @@ func TestL2OutputRoot(t *testing.T) {
 
 func TestL2AgreedPrestate(t *testing.T) {
 	t.Run("NotRequiredWhenL2OutputRootProvided", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, "--l2.agreed-prestate", "0x1234"))
+		optionalArgs := []string{"--l2.agreed-prestate", "0x1234"}
+		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		depsetFile := writeDepset(t)
+		optionalArgs = append(optionalArgs, "--depset.config", depsetFile)
+		configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, optionalArgs...))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
 		prestate := "0x1234"
 		prestateBytes := common.FromHex(prestate)
 		expectedOutputRoot := crypto.Keccak256Hash(prestateBytes)
-		cfg := configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, "--l2.agreed-prestate", prestate))
+		optionalArgs := []string{"--l2.agreed-prestate", prestate}
+		// TODO: Remove the --depset.config flag once there's a depset defined for sepolia.
+		depsetFile := writeDepset(t)
+		optionalArgs = append(optionalArgs, "--depset.config", depsetFile)
+		cfg := configForArgs(t, addRequiredArgsExceptMultiple([]string{"--l2.outputroot", "--l2.head"}, optionalArgs...))
 		require.Equal(t, expectedOutputRoot, cfg.L2OutputRoot)
 		require.Equal(t, prestateBytes, cfg.AgreedPrestate)
 	})
@@ -546,6 +564,16 @@ func writeGenesis(t *testing.T, genesis *core.Genesis) string {
 	genesisFile := dir + "/genesis.json"
 	require.NoError(t, os.WriteFile(genesisFile, j, 0666))
 	return genesisFile
+}
+
+func writeDepset(t *testing.T) string {
+	var depset depset.StaticConfigDependencySet
+	dir := t.TempDir()
+	j, err := json.Marshal(&depset)
+	require.NoError(t, err)
+	depsetFile := dir + "/depset.json"
+	require.NoError(t, os.WriteFile(depsetFile, j, 0666))
+	return depsetFile
 }
 
 func writeValidRollupConfig(t *testing.T) string {

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -98,7 +98,7 @@ type Config struct {
 	// AgreedPrestate is the preimage of the agreed prestate claim. Required for interop.
 	AgreedPrestate []byte
 	// DependencySet is the dependency set for the interop host. Required for interop.
-	DependencySet *depset.StaticConfigDependencySet
+	DependencySet depset.DependencySet
 }
 
 func (c *Config) Check() error {
@@ -332,7 +332,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		return nil, fmt.Errorf("invalid %w: %v", ErrInvalidDataFormat, dbFormat)
 	}
 
-	var dependencySet *depset.StaticConfigDependencySet
+	var dependencySet depset.DependencySet
 	if interopEnabled {
 		depsetConfigPath := ctx.Path(flags.DepsetConfig.Name)
 		if depsetConfigPath == "" {

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-service/superutil"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
@@ -96,6 +97,8 @@ type Config struct {
 	InteropEnabled bool
 	// AgreedPrestate is the preimage of the agreed prestate claim. Required for interop.
 	AgreedPrestate []byte
+	// DependencySet is the dependency set for the interop host. Required for interop.
+	DependencySet *depset.StaticConfigDependencySet
 }
 
 func (c *Config) Check() error {
@@ -328,6 +331,20 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	if !slices.Contains(types.SupportedDataFormats, dbFormat) {
 		return nil, fmt.Errorf("invalid %w: %v", ErrInvalidDataFormat, dbFormat)
 	}
+
+	var dependencySet *depset.StaticConfigDependencySet
+	if interopEnabled {
+		depsetConfigPath := ctx.Path(flags.DepsetConfig.Name)
+		if depsetConfigPath == "" {
+			// TODO(#13887): Load static config dependency from embed if no path is provided
+			return nil, fmt.Errorf("empty depset config path")
+		}
+		dependencySet, err = loadDepsetConfig(depsetConfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid depset config: %w", err)
+		}
+	}
+
 	return &Config{
 		L2ChainID:          l2ChainID,
 		Rollups:            rollupCfgs,
@@ -339,6 +356,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 		L2Head:             l2Head,
 		L2OutputRoot:       l2OutputRoot,
 		AgreedPrestate:     agreedPrestate,
+		DependencySet:      dependencySet,
 		L2Claim:            l2Claim,
 		L2ClaimBlockNumber: l2ClaimBlockNum,
 		L1Head:             l1Head,
@@ -374,4 +392,17 @@ func loadRollupConfig(rollupConfigPath string) (*rollup.Config, error) {
 
 	var rollupConfig rollup.Config
 	return &rollupConfig, rollupConfig.ParseRollupConfig(file)
+}
+
+func loadDepsetConfig(path string) (*depset.StaticConfigDependencySet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read depset config: %w", err)
+	}
+	var depsetConfig depset.StaticConfigDependencySet
+	err = json.Unmarshal(data, &depsetConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse depset config: %w", err)
+	}
+	return &depsetConfig, nil
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -121,6 +121,12 @@ var (
 			return &out
 		}(),
 	}
+	DepsetConfig = &cli.PathFlag{
+		Name:      "depset.config",
+		Usage:     "Path to the static config dependency set JSON file. Used for interop-enabled games.",
+		EnvVars:   prefixEnvVars("DEPSET_CONFIG"),
+		TakesFile: true,
+	}
 	Exec = &cli.StringFlag{
 		Name:    "exec",
 		Usage:   "Run the specified client program as a separate process detached from the host. Default is to run the client program in the host process.",
@@ -158,6 +164,7 @@ var programFlags = []cli.Flag{
 	L1BeaconAddr,
 	L1TrustRPC,
 	L1RPCProviderKind,
+	DepsetConfig,
 	Exec,
 	Server,
 }

--- a/op-program/host/kvstore/local.go
+++ b/op-program/host/kvstore/local.go
@@ -3,6 +3,7 @@ package kvstore
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -26,6 +27,7 @@ var (
 	l2ChainIDKey          = boot.L2ChainIDLocalIndex.PreimageKey()
 	l2ChainConfigKey      = boot.L2ChainConfigLocalIndex.PreimageKey()
 	rollupKey             = boot.RollupConfigLocalIndex.PreimageKey()
+	dependencySetKey      = boot.DependencySetLocalIndex.PreimageKey()
 )
 
 func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
@@ -56,6 +58,11 @@ func (s *LocalPreimageSource) Get(key common.Hash) ([]byte, error) {
 			return json.Marshal(s.config.Rollups)
 		}
 		return json.Marshal(s.config.Rollups[0])
+	case dependencySetKey:
+		if !s.config.InteropEnabled {
+			return nil, errors.New("host is not configured to serve dependencySet local keys")
+		}
+		return json.Marshal(s.config.DependencySet)
 	default:
 		return nil, ErrNotFound
 	}


### PR DESCRIPTION
Previously, the op-program client constructed a hardcoded set of dependencies for interop. This patch removes that limitation by having the client load the dependency set from `BootInfoInterop`. As with the rollup and L2 chain configuration, the dependency set can be loaded either from an oracle using a local key or from a Go embed, depending on the environment. In dev environments, a new local key with the value `8` is used to load the dependency set, which is represented by a JSON-encoded [StaticConfigDependencySet](https://github.com/ethereum-optimism/optimism/blob/28f2f360e62a0400d8fcc381c0ac08057c8cfaf2/op-supervisor/supervisor/backend/depset/static.go#L30) string.