### PR TITLE
Replace doctoc for md-doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
   <br />
 </div>
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
+
+<!--TOC-->
 
 - [What is Optimism?](#what-is-optimism)
 - [Documentation](#documentation)
@@ -24,7 +24,7 @@
   - [Development branch](#development-branch)
 - [License](#license)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!--TOC-->
 
 ## What is Optimism?
 

--- a/justfile
+++ b/justfile
@@ -13,3 +13,7 @@ semgrep-test:
 # Runs shellcheck.
 shellcheck:
   find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path './packages/contracts-bedrock/lib/*' -not -path './packages/contracts-bedrock/kout*/*' -exec sh -c 'echo "Checking $1"; shellcheck "$1"' _ {} \;
+
+# Generates a table of contents for the README.md file.
+toc:
+  md_toc -p github README.md

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ just = "1.37.0"
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"
 "pipx:semgrep" = "1.90.0"
-"pipx:frnmst/md-toc" = "875c4368f1cec75115e8d1b76e91fc9a9a45c6b0"
+"pipx:md_toc" = "9.0.0"
 
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,7 @@ just = "1.37.0"
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"
 "pipx:semgrep" = "1.90.0"
+"pipx:frnmst/md-toc" = "9.0.0"
 
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ just = "1.37.0"
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"
 "pipx:semgrep" = "1.90.0"
-"pipx:frnmst/md-toc" = "9.0.0"
+"pipx:frnmst/md-toc" = "875c4368f1cec75115e8d1b76e91fc9a9a45c6b0"
 
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -355,7 +355,6 @@ lint: lint-fix lint-check
 #                         DOCS                         #
 ########################################################
 
-# Update TOCs
-update-tocs:
-  doctoc README.md
-  doctoc meta/POLICY.md
+# Generates a table of contents for the POLICY.md file.
+toc:
+  md_toc -p github meta/POLICY.md

--- a/packages/contracts-bedrock/meta/POLICY.md
+++ b/packages/contracts-bedrock/meta/POLICY.md
@@ -1,6 +1,6 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+**Table of Contents**
+
+<!--TOC-->
 
 - [Policy](#policy)
   - [Contributing](#contributing)
@@ -10,7 +10,7 @@
   - [Style Guide](#style-guide)
   - [Revert Data](#revert-data)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!--TOC-->
 
 # Policy
 


### PR DESCRIPTION
**Description**

`doctoc` is currently used to generate TOCs, but it is a JS tool and would make the repo depend in yet another runtime. I've replaced it for [md-toc](https://github.com/frnmst/md-toc) which reuses our python runtime, is well maintained and does the same thing.

**Alternatives Considered**

The alternative would be to add `node` to our `mise` configuration, which would make builds slower and more fragile, or to warn users to install `node` and `doctoc` manually if they need to edit the TOCs. Or even manage the TOCs manually. This seems like a better option.

**Tests**

Local testing.

**Notes**

Please consider [a donation for the developer](https://github.com/frnmst/md-toc?tab=readme-ov-file#support-this-project) - Crypto accepted, but not ETH or EVM coins. Booo.
