### PR TITLE
The exempt frozen files label is meta, not status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,8 +636,8 @@ jobs:
             # Use GitHub API to get labels
             LABELS=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .labels)
 
-            # If the PR has the "S-exempt-frozen-files" label, do not run this check
-            if echo $LABELS | jq -e 'any(.[]; .name == "S-exempt-frozen-files")' > /dev/null; then
+            # If the PR has the "M-exempt-frozen-files" label, do not run this check
+            if echo $LABELS | jq -e 'any(.[]; .name == "M-exempt-frozen-files")' > /dev/null; then
               echo "Skipping frozen files check, PR has exempt label"
               circleci-agent step halt
             fi

--- a/packages/contracts-bedrock/meta/CODE_FREEZES.md
+++ b/packages/contracts-bedrock/meta/CODE_FREEZES.md
@@ -18,5 +18,5 @@ To disable a code freeze, comment out the path and filename of the file/s you wa
 
 ## Exceptions
 
-To bypass the freeze you can apply the "S-exempt-frozen-files" label on affected PRs. This should be done upon agreement with the code owner. Expected uses of this exception are to fix issues found on audits or to add comments to frozen files.
+To bypass the freeze you can apply the "M-exempt-frozen-files" label on affected PRs. This should be done upon agreement with the code owner. Expected uses of this exception are to fix issues found on audits or to add comments to frozen files.
 


### PR DESCRIPTION

**Description**

According to the [CONTRIBUTING](https://github.com/ethereum-optimism/optimism/blob/develop/CONTRIBUTING.md#labels) guidelines, being exempt from the frozen files check is a meta, information on the PR, not a status.

**Note:** The S-exempt-stale label is also meta, not status

