### PR TITLE
Make docs clear about contributing to individual packages, in particular smart contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,8 @@ Additionally, if you are writing a new feature, please ensure you add appropriat
 
 Follow the [Development Quick Start](#development-quick-start) to set up your local development environment.
 
+Read any README files in the packages you are contributing to. Some packages have additional instructions that are not covered in this guide.
+
 We recommend using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format on commit messages.
 
 Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -67,7 +67,13 @@ See the [Optimism Developer Docs](https://docs.optimism.io/chain/addresses) for 
 ### Contributing Guide
 
 Contributions to the OP Stack are always welcome.
-Please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) for more information about how to contribute to the OP Stack smart contracts.
+Please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) for general information about how to contribute to the OP Stack monorepo.
+
+When contributing to the `contracts-bedrock` package there are some additional steps you should follow. These have been conveniently packaged into a just command which you should run before pushing your changes.
+
+```bash
+just pre-pr
+```
 
 ### Style Guide
 


### PR DESCRIPTION
**Description**

When contributing to different packages inside the monorepo, there are often additional instructions in their READMEs that are not covered in the general CONTRIBUTING guide. Added a line to point that out.

Related to this, when contributing to the `packages/contracts-bedrock` directory there exist such additional instructions. Added that to the docs.

