### PR TITLE
op-node: Fix p2p to use default bootnodes if none provided

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -206,11 +206,10 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_UDP"),
 			Category: P2PCategory,
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:     BootnodesName,
 			Usage:    "Comma-separated base64-format ENR list. Bootnodes to start discovering other node records from.",
 			Required: false,
-			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "BOOTNODES"),
 			Category: P2PCategory,
 		},

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 )
@@ -178,8 +179,9 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 		return fmt.Errorf("failed to open discovery db: %w", err)
 	}
 
-	records := strings.Split(ctx.String(flags.BootnodesName), ",")
+	records := ctx.StringSlice(flags.BootnodesName)
 	if len(records) == 0 {
+		log.Info("Using default bootnodes, none provided.")
 		records = p2p.DefaultBootnodes
 	}
 


### PR DESCRIPTION
**Description**

Fixes a bug that prevented default bootnodes to be used if none are provided.

**Tests**

Confirmed in a local manual test that logs print "Using default bootnodes, none provided."

**Additional context**

This fixes a bug in the current v1.11.0 release that multiple users have reported.


