### PR TITLE
Add legal footer to op-deployer docs

### DIFF
--- a/op-deployer/book/book.toml
+++ b/op-deployer/book/book.toml
@@ -9,4 +9,5 @@ title = "OP Deployer Book"
 site-url = "/op-deployer/"
 git-repository-url = "https://github.com/ethereum-optimism/optimism/tree/develop/op-deployer/book"
 edit-url-template = "https://github.com/ethereum-optimism/optimism/tree/develop/op-deployer/book/{path}"
-additional-css = ["custom.css"]
+additional-css = ["custom.css", "theme/css/footer.css"]
+additional-js = ["theme/js/footer.js"]

--- a/op-deployer/book/theme/css/Footer.css
+++ b/op-deployer/book/theme/css/Footer.css
@@ -1,0 +1,71 @@
+.mdbook-footer {
+  width: 100%;
+  padding: 4rem 2.5rem;  /* Increased padding */
+  background-color: var(--bg);
+  border-top: 1px solid var(--sidebar-bg);
+  margin-top: 5rem;  /* Increased margin */
+}
+
+.mdbook-footer .footer-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;  /* Increased gap */
+  align-items: center;
+}
+
+.mdbook-footer .policy-links {
+  display: flex;
+  gap: 4rem;  /* Increased gap between links */
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.mdbook-footer .policy-links a {
+  color: var(--fg);
+  text-decoration: none;
+  transition: opacity 0.2s;
+  font-size: 1.35rem;  /* Increased font size */
+  opacity: 0.85;
+  font-weight: 400;
+  line-height: 1.6;  /* Increased line height */
+}
+
+.mdbook-footer .policy-links a:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.mdbook-footer .copyright {
+  color: var(--fg);
+  font-size: 1.35rem;  /* Increased font size */
+  opacity: 0.85;
+  text-align: center;
+  font-weight: 400;
+  line-height: 1.6;  /* Increased line height */
+}
+
+.mdbook-footer .copyright a {
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.mdbook-footer .copyright a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .mdbook-footer .policy-links {
+      gap: 2.5rem;  /* Increased gap for mobile */
+  }
+
+  .mdbook-footer {
+      padding: 3rem 2rem;  /* Increased padding for mobile */
+  }
+
+  .mdbook-footer .policy-links a,
+  .mdbook-footer .copyright {
+      font-size: 1.25rem;  /* Increased font size for mobile */
+  }
+}

--- a/op-deployer/book/theme/js/Footer.js
+++ b/op-deployer/book/theme/js/Footer.js
@@ -1,0 +1,41 @@
+// Create footer element
+function createFooter() {
+  const footer = document.createElement('footer');
+  footer.className = 'mdbook-footer';
+
+  const container = document.createElement('div');
+  container.className = 'footer-container';
+
+  // Add legal links
+  const policyLinks = document.createElement('div');
+  policyLinks.className = 'policy-links';
+
+  const links = [
+      { href: 'https://optimism.io/community-agreement', text: 'Community Agreement' },
+      { href: 'https://optimism.io/terms', text: 'Terms of Service' },
+      { href: 'https://optimism.io/data-privacy-policy', text: 'Privacy Policy' }
+  ];
+
+  links.forEach(link => {
+      const a = document.createElement('a');
+      a.href = link.href;
+      a.textContent = link.text;
+      policyLinks.appendChild(a);
+  });
+
+  // Add copyright notice
+  const copyright = document.createElement('div');
+  copyright.className = 'copyright';
+  copyright.innerHTML = `© ${new Date().getFullYear()} <a href="https://optimism.io">Optimism Foundation. All rights reserved.</a>`;
+
+  // Assemble footer
+  container.appendChild(policyLinks);
+  container.appendChild(copyright);
+  footer.appendChild(container);
+
+  // Add footer to page
+  document.body.appendChild(footer);
+}
+
+// Run after DOM is loaded
+document.addEventListener('DOMContentLoaded', createFooter);


### PR DESCRIPTION
# Add legal footer to op-deployer docs

## Description
This PR adds a standardized legal footer to the op-deployer documentation site, addressing the legal team's requirement to include essential privacy policy information and legal disclaimers across all OP documentation sites. This implementation serves as part of a broader initiative to standardize legal compliance across multiple documentation sites including specs, devnets, supersim, and op-deployer.

## Changes
- Added footer.js to implement the footer component
- Added footer.css for styling
- Updated book.toml to include the new footer assets
- Implemented responsive design for various screen sizes
- Added required legal elements:
  - Copyright notice
  - Community Agreement link
  - Terms of Service link
  - Privacy Policy link



## Screenshots
<img width="1501" alt="legal footer to op-deployer docs" src="https://github.com/user-attachments/assets/98a8f14c-55db-440a-866d-3f236aa7d294" />


## Related Issues
Closes - https://github.com/ethereum-optimism/devrel/issues/506
