### PR TITLE
op-supervisor: make fromda DB more strict

### DIFF
--- a/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
@@ -1,6 +1,7 @@
 package fromda
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -97,15 +98,15 @@ func invariantNumberIncrement(prev, current LinkEntry) error {
 	derivedFromSame := current.source.Number == prev.source.Number
 	// At least one of the two must increment, otherwise we are just repeating data in the DB.
 	if derivedSame && derivedFromSame {
-		return fmt.Errorf("expected at least either derivedFrom or derived to increment, but both have same number")
+		return errors.New("expected at least either derivedFrom or derived to increment, but both have same number")
 	}
 	derivedIncrement := current.derived.Number == prev.derived.Number+1
 	derivedFromIncrement := current.source.Number == prev.source.Number+1
-	if !(derivedSame || derivedIncrement) {
-		return fmt.Errorf("expected derived to either stay the same or increment, got prev %s current %s", prev.derived, current.derived)
+	if derivedIncrement && derivedFromIncrement {
+		return errors.New("expected derivedFrom or derived to increment, but not both")
 	}
-	if !(derivedFromSame || derivedFromIncrement) {
-		return fmt.Errorf("expected derivedFrom to either stay the same or increment, got prev %s current %s", prev.source, current.source)
+	if !derivedIncrement && !derivedFromIncrement {
+		return errors.New("expected derivedFrom or derived to increment, but not neither")
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
@@ -102,11 +102,8 @@ func invariantNumberIncrement(prev, current LinkEntry) error {
 	}
 	derivedIncrement := current.derived.Number == prev.derived.Number+1
 	derivedFromIncrement := current.source.Number == prev.source.Number+1
-	if derivedIncrement && derivedFromIncrement {
-		return errors.New("expected derivedFrom or derived to increment, but not both")
-	}
-	if !derivedIncrement && !derivedFromIncrement {
-		return errors.New("expected derivedFrom or derived to increment, but not neither")
+	if derivedIncrement == derivedFromIncrement { // one of the two must be true, the other false, to pass.
+		return errors.New("expected derivedFrom or (excl.) derived to increment")
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -200,9 +200,14 @@ func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidate
 	lastSource := last.source
 	lastDerived := last.derived
 
+	if (lastSource.Number+1 == derivedFrom.Number) && (lastDerived.Number+1 == derived.Number) {
+		return fmt.Errorf("cannot add source:%s derived:%s on top of last entry source:%s derived:%s, must increment source or derived, not both: %w",
+			derivedFrom, derived, last.source, last.derived, types.ErrOutOfOrder)
+	}
+
 	if lastDerived.ID() == derived.ID() && lastSource.ID() == derivedFrom.ID() {
 		// it shouldn't be possible, but the ID component of a block ref doesn't include the timestamp
-		// so if the timestampt doesn't match, still return no error to the caller, but at least log a warning
+		// so if the timestamp doesn't match, still return no error to the caller, but at least log a warning
 		if lastDerived.Timestamp != derived.Time {
 			db.log.Warn("Derived block already exists with different timestamp", "derived", derived, "lastDerived", lastDerived)
 		}
@@ -222,7 +227,7 @@ func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidate
 		// I.e. we encountered an empty L1 block, and the same L2 block continues to be the last block that was derived from it.
 		if invalidated != (common.Hash{}) {
 			if lastDerived.Hash != invalidated {
-				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s", derived.Hash, invalidated, lastDerived.Number, lastDerived.Hash)
+				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s: %w", derived.Hash, invalidated, lastDerived.Number, lastDerived.Hash, types.ErrConflict)
 			}
 		} else {
 			if lastDerived.Hash != derived.Hash {

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -73,11 +73,13 @@ func TestRewindL1(t *testing.T) {
 	// Make genesis block derived from l1Block0 and make it safe
 	s.makeBlockSafe(chainID, genesis, l1Block0, true)
 
+	s.makeBlockSafe(chainID, genesis, l1Block1A, true) // Bump scope
 	// Make block1 local-safe and cross-safe using l1Block1A
 	s.makeBlockSafe(chainID, block1, l1Block1A, true)
 
 	// Add block2A and make it local-safe and cross-safe using l1Block2A
 	s.sealBlocks(chainID, block2A)
+	s.makeBlockSafe(chainID, block1, l1Block2A, true) // Bump scope
 	s.makeBlockSafe(chainID, block2A, l1Block2A, true)
 
 	// Verify block2A is the latest sealed block and is cross-safe
@@ -145,6 +147,7 @@ func TestRewindL2(t *testing.T) {
 	// Make genesis safe and derived from L1 genesis
 	s.makeBlockSafe(chainID, genesis, l1Genesis, true)
 
+	s.makeBlockSafe(chainID, genesis, l1Block1, true) // Bump scope
 	// Make block1 local-safe and cross-safe
 	s.makeBlockSafe(chainID, block1, l1Block1, true)
 
@@ -237,9 +240,11 @@ func TestNoRewindNeeded(t *testing.T) {
 		},
 	})
 
+	s.makeBlockSafe(chainID, genesis, l1Block1, true) // Bump scope
 	// Make block1 local-safe and cross-safe
 	s.makeBlockSafe(chainID, block1, l1Block1, true)
 
+	s.makeBlockSafe(chainID, block1, l1Block2, true) // Bump scope
 	// Add block2A and make it local-safe and cross-safe
 	s.sealBlocks(chainID, block2A)
 	s.makeBlockSafe(chainID, block2A, l1Block2, true)
@@ -338,6 +343,9 @@ func TestRewindLongChain(t *testing.T) {
 	// Make blocks up to 95 safe
 	for i := uint64(1); i <= 95; i++ {
 		l1Index := i / 10
+		if (i-1)/10 != l1Index { // bump scope
+			s.makeBlockSafe(chainID, blocks[i-1], l1Blocks[l1Index], true)
+		}
 		s.makeBlockSafe(chainID, blocks[i], l1Blocks[l1Index], true)
 	}
 
@@ -409,6 +417,8 @@ func TestRewindMultiChain(t *testing.T) {
 
 		// Make genesis safe and derived from L1 genesis
 		s.makeBlockSafe(chainID, genesis, l1Genesis, true)
+
+		s.makeBlockSafe(chainID, genesis, l1Block1, true) // Bump scope
 
 		// Make block1 local-safe and cross-safe
 		s.makeBlockSafe(chainID, block1, l1Block1, true)
@@ -554,9 +564,12 @@ func TestRewindL2WalkBack(t *testing.T) {
 		FinalizedL1: l1Genesis,
 	})
 
+	s.makeBlockSafe(chainID, genesis, l1Block1, true) // bump scope
 	// Make blocks up to block3 safe
 	s.makeBlockSafe(chainID, block1, l1Block1, true)
+	s.makeBlockSafe(chainID, block1, l1Block2, true) // bump scope
 	s.makeBlockSafe(chainID, block2, l1Block2, true)
+	s.makeBlockSafe(chainID, block2, l1Block3, true) // bump scope
 	s.makeBlockSafe(chainID, block3, l1Block3, true)
 
 	// Create rewinder with all dependencies
@@ -680,12 +693,15 @@ func TestRewindL1PastCrossSafe(t *testing.T) {
 		FinalizedL1: l1Genesis,
 	})
 
+	s.makeBlockSafe(chainID, genesis, l1Block1, true) // bump scope
 	// Make block1 local-safe and cross-safe
 	s.makeBlockSafe(chainID, block1, l1Block1, true)
 
+	s.makeBlockSafe(chainID, block1, l1Block2, true) // bump scope
 	// Make block2 local-safe and cross-safe
 	s.makeBlockSafe(chainID, block2, l1Block2, true)
 
+	s.makeBlockSafe(chainID, block2, l1Block3A, false) // bump scope
 	// Make block3A only local-safe (not cross-safe)
 	s.makeBlockSafe(chainID, block3A, l1Block3A, false)
 


### PR DESCRIPTION
**Description**

This makes the fromda DB more strict by enforcing the `source` and `derived` parts to never bump at the same time.

This also detects a data corruption edge case, where the lookup hit some in-the-middle entry in the database that is missing.

And add more fromDA tests to improve coverage.

This requires the scope-bumping fix we made in the PR from @axelKingsley in the chainsDB code, before we can start enforcing the behavior in the DB.
See PR https://github.com/ethereum-optimism/optimism/pull/14345

**Tests**

See new DB tests.

**Additional context**

We debugged some of this on the devnet, and realized it could have been more strict and the lookup function could have been better commented. This fixes that.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
