### PR TITLE
op-supervisor: Anchor Point Initialization Fixes

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -285,6 +285,11 @@ func (su *SupervisorBackend) AttachSyncNode(ctx context.Context, src syncnode.Sy
 	if !su.depSet.HasChain(chainID) {
 		return nil, fmt.Errorf("chain %s is not part of the interop dependency set: %w", chainID, types.ErrUnknownChain)
 	}
+	// before attaching the sync source to the backend at all,
+	// query the anchor point to initialize the database
+	if err := su.QueryAnchorpoint(chainID, src); err != nil {
+		return nil, fmt.Errorf("failed to query anchor point: %w", err)
+	}
 	err = su.AttachProcessorSource(chainID, src)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach sync source to processor: %w", err)
@@ -294,6 +299,18 @@ func (su *SupervisorBackend) AttachSyncNode(ctx context.Context, src syncnode.Sy
 		return nil, fmt.Errorf("failed to attach sync source to node: %w", err)
 	}
 	return su.syncNodesController.AttachNodeController(chainID, src, noSubscribe)
+}
+
+func (su *SupervisorBackend) QueryAnchorpoint(chainID eth.ChainID, src syncnode.SyncNode) error {
+	anchor, err := src.AnchorPoint(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to get anchor point: %w", err)
+	}
+	su.emitter.Emit(superevents.AnchorEvent{
+		ChainID: chainID,
+		Anchor:  anchor,
+	})
+	return nil
 }
 
 func (su *SupervisorBackend) AttachProcessorSource(chainID eth.ChainID, src processors.Source) error {

--- a/op-supervisor/supervisor/backend/db/anchor.go
+++ b/op-supervisor/supervisor/backend/db/anchor.go
@@ -2,58 +2,90 @@ package db
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+func (db *ChainsDB) isInitialized(id eth.ChainID) bool {
+	_, ok := db.initialized.Get(id)
+	return ok
+}
+
+func (db *ChainsDB) initFromAnchor(id eth.ChainID, anchor types.DerivedBlockRefPair) {
+	// Check if the chain database is already initialized
+	if db.isInitialized(id) {
+		db.logger.Debug("chain database already initialized")
+		return
+	}
+	db.logger.Debug("initializing chain database from anchor point")
+
+	// Initialize the local and cross safe databases
+	if err := db.maybeInitSafeDB(id, anchor); err != nil {
+		db.logger.Warn("failed to initialize local and cross safe databases", "err", err)
+		return
+	}
+
+	// Initialize the events database
+	if err := db.maybeInitEventsDB(id, anchor); err != nil {
+		db.logger.Warn("failed to initialize events database", "err", err)
+		return
+	}
+
+	// Mark the chain database as initialized
+	db.initialized.Set(id, struct{}{})
+}
+
 // maybeInitSafeDB initializes the chain database if it is not already initialized
 // it checks if the Local Safe database is empty, and loads both the Local and Cross Safe databases
 // with the anchor point if they are empty.
-func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRefPair) {
+func (db *ChainsDB) maybeInitSafeDB(id eth.ChainID, anchor types.DerivedBlockRefPair) error {
 	logger := db.logger.New("chain", id, "derived", anchor.Derived, "source", anchor.Source)
 	localDB, ok := db.localDBs.Get(id)
 	if !ok {
-		logger.Error("failed to get local database", "chain", id)
+		return types.ErrUnknownChain
 	}
 	first, err := localDB.First()
 	if errors.Is(err, types.ErrFuture) {
 		logger.Info("local database is empty, initializing")
-		if err := db.UpdateCrossSafe(id, anchor.Source, anchor.Derived); err != nil {
-			logger.Warn("failed to initialize cross safe", "err", err)
+		if err := db.initializedUpdateCrossSafe(id, anchor.Source, anchor.Derived); err != nil {
+			return err
 		}
-		db.UpdateLocalSafe(id, anchor.Source, anchor.Derived)
+		db.initializedUpdateLocalSafe(id, anchor.Source, anchor.Derived)
 	} else if err != nil {
-		logger.Warn("failed to check if chain database is initialized", "err", err)
+		return fmt.Errorf("failed to check if chain database is initialized: %w", err)
 	} else {
 		logger.Debug("chain database already initialized")
 		if first.Derived.Hash != anchor.Derived.Hash ||
 			first.Source.Hash != anchor.Source.Hash {
-			logger.Warn("local database does not match anchor point",
-				"anchor", anchor,
-				"database", first)
+			return fmt.Errorf("local database (%s) does not match anchor point (%s): %w",
+				first,
+				anchor,
+				types.ErrConflict)
 		}
 	}
+	return nil
 }
 
-func (db *ChainsDB) maybeInitEventsDB(id eth.ChainID, anchor types.DerivedBlockRefPair) {
+func (db *ChainsDB) maybeInitEventsDB(id eth.ChainID, anchor types.DerivedBlockRefPair) error {
 	logger := db.logger.New("chain", id, "derived", anchor.Derived, "source", anchor.Source)
 	seal, _, _, err := db.OpenBlock(id, 0)
 	if errors.Is(err, types.ErrFuture) {
 		logger.Debug("initializing events database")
-		err := db.SealBlock(id, anchor.Derived)
+		err := db.initializedSealBlock(id, anchor.Derived)
 		if err != nil {
-			logger.Warn("failed to seal initial block", "err", err)
+			return err
 		}
 		logger.Info("Initialized events database")
 	} else if err != nil {
-		logger.Warn("Failed to check if logDB is initialized", "err", err)
+		return fmt.Errorf("failed to check if logDB is initialized: %w", err)
 	} else {
 		logger.Debug("Events database already initialized")
-		if seal.Hash != anchor.Derived.Hash {
-			logger.Warn("events database does not match anchor point",
-				"anchor", anchor,
-				"database", seal)
-		}
+		return fmt.Errorf("events database (%s) does not match anchor point (%s): %w",
+			seal,
+			anchor,
+			types.ErrConflict)
 	}
+	return nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -186,6 +186,7 @@ func (db *DB) addLink(derivedFrom eth.BlockRef, derived eth.BlockRef, invalidate
 		if err := db.store.Append(e); err != nil {
 			return err
 		}
+		db.log.Debug("First entry in DB", "entry", link)
 		db.m.RecordDBDerivedEntryCount(db.store.Size())
 		return nil
 	}

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -85,7 +85,7 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 func (db *ChainsDB) UpdateLocalSafe(chain eth.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
 	logger := db.logger.New("chain", chain, "derivedFrom", derivedFrom, "lastDerived", lastDerived)
 	if !db.isInitialized(chain) {
-		logger.Error("cannot UpdateLocalSafe on uninitialized database: %s", chain)
+		logger.Error("cannot UpdateLocalSafe on uninitialized database", "chain", chain)
 		return
 	}
 	db.initializedUpdateLocalSafe(chain, derivedFrom, lastDerived)
@@ -96,10 +96,6 @@ func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, derivedFrom et
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		logger.Error("Cannot update local-safe DB, unknown chain")
-		return
-	}
-	if !db.isInitialized(chain) {
-		logger.Error("cannot UpdateLocalSafe on uninitialized database: %s", chain)
 		return
 	}
 	logger.Debug("Updating local safe DB")

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -24,7 +24,16 @@ func (db *ChainsDB) AddLog(
 	return logDB.AddLog(logHash, parentBlock, logIdx, execMsg)
 }
 
+// SealBlock seals the block in the logDB.
+// it wraps an inner function, blocking the call if the database is not initialized.
 func (db *ChainsDB) SealBlock(chain eth.ChainID, block eth.BlockRef) error {
+	if !db.isInitialized(chain) {
+		return fmt.Errorf("cannot SealBlock on uninitialized database: %w", types.ErrUninitialized)
+	}
+	return db.initializedSealBlock(chain, block)
+}
+
+func (db *ChainsDB) initializedSealBlock(chain eth.ChainID, block eth.BlockRef) error {
 	logDB, ok := db.logDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot SealBlock: %w: %v", types.ErrUnknownChain, chain)
@@ -71,11 +80,26 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 	return nil
 }
 
+// UpdateLocalSafe updates the local-safe database with the given derivedFrom and lastDerived blocks.
+// It wraps an inner function, blocking the call if the database is not initialized.
 func (db *ChainsDB) UpdateLocalSafe(chain eth.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
+	logger := db.logger.New("chain", chain, "derivedFrom", derivedFrom, "lastDerived", lastDerived)
+	if !db.isInitialized(chain) {
+		logger.Error("cannot UpdateLocalSafe on uninitialized database: %s", chain)
+		return
+	}
+	db.initializedUpdateLocalSafe(chain, derivedFrom, lastDerived)
+}
+
+func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, derivedFrom eth.BlockRef, lastDerived eth.BlockRef) {
 	logger := db.logger.New("chain", chain, "derivedFrom", derivedFrom, "lastDerived", lastDerived)
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		logger.Error("Cannot update local-safe DB, unknown chain")
+		return
+	}
+	if !db.isInitialized(chain) {
+		logger.Error("cannot UpdateLocalSafe on uninitialized database: %s", chain)
 		return
 	}
 	logger.Debug("Updating local safe DB")
@@ -107,6 +131,9 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.Block
 	if !ok {
 		return fmt.Errorf("cannot UpdateCrossUnsafe: %w: %s", types.ErrUnknownChain, chain)
 	}
+	if !db.isInitialized(chain) {
+		return fmt.Errorf("cannot UpdateCrossSafe on uninitialized database: %w", types.ErrUninitialized)
+	}
 	v.Set(crossUnsafe)
 	db.logger.Info("Updated cross-unsafe", "chain", chain, "crossUnsafe", crossUnsafe)
 	db.emitter.Emit(superevents.CrossUnsafeUpdateEvent{
@@ -122,6 +149,13 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.Block
 }
 
 func (db *ChainsDB) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+	if !db.isInitialized(chain) {
+		return fmt.Errorf("cannot UpdateCrossSafe on uninitialized database: %w", types.ErrUninitialized)
+	}
+	return db.initializedUpdateCrossSafe(chain, l1View, lastCrossDerived)
+}
+
+func (db *ChainsDB) initializedUpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 	crossDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot UpdateCrossSafe: %w: %s", types.ErrUnknownChain, chain)

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -57,6 +57,7 @@ func TestRewindL1(t *testing.T) {
 		Time:       901,
 		ParentHash: l1Block1A.Hash,
 	}
+	s.chainsDB.ForceInitialized(chainID) // force init for test
 
 	// Setup the L1 node with initial chain
 	chain.l1Node.blocks[l1Block0.Number] = l1Block0
@@ -138,6 +139,7 @@ func TestRewindL2(t *testing.T) {
 	chain.l1Node.blocks[l1Genesis.Number] = l1Genesis
 	chain.l1Node.blocks[l1Block1.Number] = l1Block1
 	chain.l1Node.blocks[l1Block2.Number] = l1Block2
+	s.chainsDB.ForceInitialized(chainID) // force init for test
 
 	// Seal genesis and block1
 	s.sealBlocks(chainID, genesis, block1)
@@ -217,6 +219,7 @@ func TestNoRewindNeeded(t *testing.T) {
 	}
 	chain.l1Node.blocks[l1Block1.Number] = l1Block1
 	chain.l1Node.blocks[l1Block2.Number] = l1Block2
+	s.chainsDB.ForceInitialized(chainID) // force init for test
 
 	// Seal genesis and block1
 	s.sealBlocks(chainID, genesis, block1)
@@ -284,6 +287,7 @@ func TestRewindLongChain(t *testing.T) {
 
 	chainID := eth.ChainID{1}
 	chain := s.chains[chainID]
+	s.chainsDB.ForceInitialized(chainID) // force init for test
 
 	// Create a chain with blocks 0-100
 	var blocks []eth.L2BlockRef
@@ -380,6 +384,8 @@ func TestRewindMultiChain(t *testing.T) {
 	chain2ID := eth.ChainID{2}
 	s := setupTestChains(t, chain1ID, chain2ID)
 	defer s.Close()
+	s.chainsDB.ForceInitialized(chain1ID) // force init for test
+	s.chainsDB.ForceInitialized(chain2ID) // force init for test
 
 	// Create common blocks for both chains
 	genesis, block1, block2A, block2B := createTestBlocks()
@@ -454,6 +460,7 @@ func TestRewindL2WalkBack(t *testing.T) {
 	defer s.Close()
 	chainID := eth.ChainID{1}
 	chain := s.chains[chainID]
+	s.chainsDB.ForceInitialized(chainID)
 	// Create a chain of blocks: genesis -> block1 -> block2 -> block3 -> block4A
 	genesis := eth.L2BlockRef{
 		Hash:           common.HexToHash("0x1110"),
@@ -588,6 +595,7 @@ func TestRewindL1PastCrossSafe(t *testing.T) {
 
 	chainID := eth.ChainID{1}
 	chain := s.chains[chainID]
+	s.chainsDB.ForceInitialized(chainID) // force init for test
 
 	// Create blocks: genesis -> block1 -> block2 -> block3A/3B
 	genesis := eth.L2BlockRef{

--- a/op-supervisor/supervisor/backend/syncnode/controller.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller.go
@@ -1,7 +1,6 @@
 package syncnode
 
 import (
-	"context"
 	"fmt"
 	"sync/atomic"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -82,18 +80,10 @@ func (snc *SyncNodesController) AttachNodeController(chainID eth.ChainID, ctrl S
 
 	logger.Info("Attaching node", "chain", chainID, "passive", noSubscribe)
 
+	// create the managed node, register and return
 	node := NewManagedNode(logger, chainID, ctrl, snc.backend, noSubscribe)
 	snc.eventSys.Register(name, node, event.DefaultRegisterOpts())
-
 	controllersForChain.Set(node, struct{}{})
-	anchor, err := ctrl.AnchorPoint(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get anchor point: %w", err)
-	}
-	snc.emitter.Emit(superevents.AnchorEvent{
-		ChainID: chainID,
-		Anchor:  anchor,
-	})
 	node.Start()
 	return node, nil
 }

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -165,45 +164,6 @@ func (m *eventMonitor) OnEvent(ev event.Event) bool {
 		return false
 	}
 	return true
-}
-
-// TestInitFromAnchorPoint tests that the SyncNodesController uses the Anchor Point to initialize databases
-func TestInitFromAnchorPoint(t *testing.T) {
-	logger := testlog.Logger(t, log.LvlInfo)
-	depSet := sampleDepSet(t)
-	ex := event.NewGlobalSynchronous(context.Background())
-	eventSys := event.NewSystem(logger, ex)
-
-	mon := &eventMonitor{}
-	eventSys.Register("monitor", mon, event.DefaultRegisterOpts())
-
-	controller := NewSyncNodesController(logger, depSet, eventSys, &mockBackend{})
-	eventSys.Register("controller", controller, event.DefaultRegisterOpts())
-
-	require.Zero(t, controller.controllers.Len(), "controllers should be empty to start")
-
-	// Attach a controller for chain 900
-	// make the controller return an anchor point
-	ctrl := mockSyncControl{}
-	ctrl.anchorPointFn = func(ctx context.Context) (types.DerivedBlockRefPair, error) {
-		return types.DerivedBlockRefPair{
-			Derived: eth.BlockRef{Number: 1},
-			Source:  eth.BlockRef{Number: 0},
-		}, nil
-	}
-
-	// after the first attach, both databases are called for update
-	_, err := controller.AttachNodeController(eth.ChainIDFromUInt64(900), &ctrl, false)
-	require.NoError(t, err)
-	require.NoError(t, ex.Drain())
-	require.Equal(t, 1, mon.anchorCalled, "an anchor point should be received")
-
-	// on second attach we send the anchor again; it's up to the DB to use it or not.
-	ctrl2 := mockSyncControl{}
-	_, err = controller.AttachNodeController(eth.ChainIDFromUInt64(901), &ctrl2, false)
-	require.NoError(t, err)
-	require.NoError(t, ex.Drain())
-	require.Equal(t, 2, mon.anchorCalled, "anchor point again")
 }
 
 // TestAttachNodeController tests the AttachNodeController function of the SyncNodesController.

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -33,4 +33,6 @@ var (
 	ErrUnknownChain = errors.New("unknown chain")
 	// ErrNoRPCSource happens when a sub-service needs an RPC data source, but is not configured with one.
 	ErrNoRPCSource = errors.New("no RPC client configured")
+	// ErrUninitialized happens when a chain database is not initialized yet
+	ErrUninitialized = errors.New("uninitialized chain database")
 )


### PR DESCRIPTION
- `AnchorEvent`are now emitted *before* the source is hooked up to any processors, meaning that the first event to come from a node will always be the `AnchorEvent`. The logic to query and emit the event is moved up to the `SupervisorBackend`
- Updates which the initialization routine uses now check for an `initialized` flag per chain before running. The anchor point functions call the inner functions, skipping the check.
- Initializing of both Safe and Unsafe events are checked when the db is already initialized, but the provided anchor point doesn't match.
- Log when the first item is recorded to a database