### PR TITLE
`TestLoadSubWord_32bits`: remove `shouldSignExtend`

### DIFF
--- a/cannon/mipsevm/exec/mips_instructions32_test.go
+++ b/cannon/mipsevm/exec/mips_instructions32_test.go
@@ -13,13 +13,12 @@ import (
 // TestLoadSubWord_32bits validates LoadSubWord with 32-bit offsets (up to 3 bytes)
 func TestLoadSubWord_32bits(t *testing.T) {
 	cases := []struct {
-		name             string
-		byteLength       Word
-		addr             uint32
-		memVal           uint32
-		signExtend       bool
-		shouldSignExtend bool
-		expectedValue    uint32
+		name          string
+		byteLength    Word
+		addr          uint32
+		memVal        uint32
+		signExtend    bool
+		expectedValue uint32
 	}{
 		{name: "32-bit", byteLength: 4, addr: 0xFF00_0000, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
 		{name: "32-bit, extra bits", byteLength: 4, addr: 0xFF00_0001, memVal: 0x1234_5678, expectedValue: 0x1234_5678},
@@ -29,15 +28,15 @@ func TestLoadSubWord_32bits(t *testing.T) {
 		{name: "16-bit, offset=0, extra bit set", byteLength: 2, addr: 0x01, memVal: 0x1234_5678, expectedValue: 0x1234},
 		{name: "16-bit, offset=2", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678},
 		{name: "16-bit, offset=2, extra bit set", byteLength: 2, addr: 0x03, memVal: 0x1234_5678, expectedValue: 0x5678},
-		{name: "16-bit, sign extend positive val", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678, signExtend: true, shouldSignExtend: false},
-		{name: "16-bit, sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xFFFF_F678, signExtend: true, shouldSignExtend: true},
+		{name: "16-bit, sign extend positive val", byteLength: 2, addr: 0x02, memVal: 0x1234_5678, expectedValue: 0x5678, signExtend: true},
+		{name: "16-bit, sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xFFFF_F678, signExtend: true},
 		{name: "16-bit, do not sign extend negative val", byteLength: 2, addr: 0x02, memVal: 0x1234_F678, expectedValue: 0xF678, signExtend: false},
 		{name: "8-bit, offset=0", byteLength: 1, addr: 0x1230, memVal: 0x1234_5678, expectedValue: 0x12},
 		{name: "8-bit, offset=1", byteLength: 1, addr: 0x1231, memVal: 0x1234_5678, expectedValue: 0x34},
 		{name: "8-bit, offset=2", byteLength: 1, addr: 0x1232, memVal: 0x1234_5678, expectedValue: 0x56},
 		{name: "8-bit, offset=3", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78},
-		{name: "8-bit, sign extend positive", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78, signExtend: true, shouldSignExtend: false},
-		{name: "8-bit, sign extend negative", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0xFFFF_FF88, signExtend: true, shouldSignExtend: true},
+		{name: "8-bit, sign extend positive", byteLength: 1, addr: 0x1233, memVal: 0x1234_5678, expectedValue: 0x78, signExtend: true},
+		{name: "8-bit, sign extend negative", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0xFFFF_FF88, signExtend: true},
 		{name: "8-bit, do not sign extend neg value", byteLength: 1, addr: 0x1233, memVal: 0x1234_5688, expectedValue: 0x88, signExtend: false},
 	}
 
@@ -55,10 +54,6 @@ func TestLoadSubWord_32bits(t *testing.T) {
 
 			// If sign extending, make sure retVal is consistent across architectures
 			expected := Word(c.expectedValue)
-			if c.shouldSignExtend {
-				signedBits := ^Word(0xFFFF_FFFF)
-				expected = expected | signedBits
-			}
 			require.Equal(t, expected, retVal)
 		})
 	}


### PR DESCRIPTION
This block doesn't do anything useful and is confusing:

                       if c.shouldSignExtend {
                               signedBits := ^Word(0xFFFF_FFFF)
                               expected = expected | signedBits
                       }

`signedBits` is all 0, and `expected | signedBits` is always the same as `expected`.