### PR TITLE
op-service: fix error handling in LoadOPStackChainConfigFromChainID

### DIFF
--- a/op-service/superutil/chain_config.go
+++ b/op-service/superutil/chain_config.go
@@ -16,9 +16,5 @@ func LoadOPStackChainConfigFromChainID(chainID uint64) (*params.ChainConfig, err
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve chain %d config: %w", chainID, err)
 	}
-	executionConfig, err := params.LoadOPStackChainConfig(chainCfg)
-	if err == nil {
-		return executionConfig, err
-	}
-	return executionConfig, nil
+	return params.LoadOPStackChainConfig(chainCfg)
 }


### PR DESCRIPTION
The error should be returned if it is NOT nil. Otherwise, nil will returned in both cases.