### PR TITLE
op-proposer: Support multiple supervisor endpoints

### DIFF
--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -221,7 +221,7 @@ func (s *interopE2ESystem) newProposerForL2(
 	logger := s.logger.New("role", "proposer"+id)
 	proposerCLIConfig := &l2os.CLIConfig{
 		L1EthRpc:          s.l1.UserRPC().RPC(),
-		SupervisorRpc:     s.Supervisor().RPC(),
+		SupervisorRpcs:    []string{s.Supervisor().RPC()},
 		DGFAddress:        s.worldDeployment.L2s[id].DisputeGameFactoryProxy.Hex(),
 		ProposalInterval:  6 * time.Second,
 		DisputeGameType:   1, // Permissioned game type is the only one currently deployed

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -32,10 +32,10 @@ var (
 		Usage:   "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
-	SupervisorRpcFlag = &cli.StringSliceFlag{
-		Name:    "supervisor-rpc",
-		Usage:   "HTTP provider URL for the supervisor node. Multiple URLs can be provided to automatically fail over.",
-		EnvVars: prefixEnvVars("SUPERVISOR_RPC"),
+	SupervisorRpcsFlag = &cli.StringSliceFlag{
+		Name:    "supervisor-rpcs",
+		Usage:   "HTTP provider URLs for the supervisor nodes. Multiple URLs can be provided to automatically fail over.",
+		EnvVars: prefixEnvVars("SUPERVISOR_RPCS"),
 	}
 
 	// Optional flags
@@ -94,7 +94,7 @@ var requiredFlags = []cli.Flag{
 
 var optionalFlags = []cli.Flag{
 	RollupRpcFlag,
-	SupervisorRpcFlag,
+	SupervisorRpcsFlag,
 	L2OOAddressFlag,
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -32,9 +32,9 @@ var (
 		Usage:   "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
-	SupervisorRpcFlag = &cli.StringFlag{
+	SupervisorRpcFlag = &cli.StringSliceFlag{
 		Name:    "supervisor-rpc",
-		Usage:   "HTTP provider URL for the supervisor node. A comma-separated list enables fallback mode.",
+		Usage:   "HTTP provider URL for the supervisor node. Multiple URLs can be provided to automatically fail over.",
 		EnvVars: prefixEnvVars("SUPERVISOR_RPC"),
 	}
 

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -34,7 +34,7 @@ var (
 	}
 	SupervisorRpcFlag = &cli.StringFlag{
 		Name:    "supervisor-rpc",
-		Usage:   "HTTP provider URL for the supervisor node",
+		Usage:   "HTTP provider URL for the supervisor node. A comma-separated list enables fallback mode.",
 		EnvVars: prefixEnvVars("SUPERVISOR_RPC"),
 	}
 

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -133,7 +133,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     ctx.String(flags.L1EthRpcFlag.Name),
 		RollupRpc:                    ctx.String(flags.RollupRpcFlag.Name),
-		SupervisorRpcs:               ctx.StringSlice(flags.SupervisorRpcFlag.Name),
+		SupervisorRpcs:               ctx.StringSlice(flags.SupervisorRpcsFlag.Name),
 		L2OOAddress:                  ctx.String(flags.L2OOAddressFlag.Name),
 		PollInterval:                 ctx.Duration(flags.PollIntervalFlag.Name),
 		TxMgrConfig:                  txmgr.ReadCLIConfig(ctx),

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -43,8 +43,8 @@ type CLIConfig struct {
 	// RollupRpc is the HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.
 	RollupRpc string
 
-	// SupervisorRpc is the HTTP provider URL for the supervisor node.
-	SupervisorRpc string
+	// SupervisorRpcs is the list of HTTP provider URLs for supervisor nodes.
+	SupervisorRpcs []string
 
 	// L2OOAddress is the L2OutputOracle contract address.
 	L2OOAddress string
@@ -109,7 +109,7 @@ func (c *CLIConfig) Check() error {
 	if c.ProposalInterval != 0 && c.DGFAddress == "" {
 		return errors.New("the `ProposalInterval` was provided but the `DisputeGameFactory` address was not set")
 	}
-	if c.RollupRpc != "" && c.SupervisorRpc != "" {
+	if c.RollupRpc != "" && len(c.SupervisorRpcs) != 0 {
 		return ErrConflictingSource
 	}
 	// Require rollup RPC for L2OO
@@ -121,7 +121,7 @@ func (c *CLIConfig) Check() error {
 		return ErrMissingRollupRpc
 	}
 	// Require supervisor RPC for post interop game types
-	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && c.SupervisorRpc == "" {
+	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SupervisorRpcs) == 0 {
 		return ErrMissingSupervisorRpc
 	}
 
@@ -133,7 +133,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     ctx.String(flags.L1EthRpcFlag.Name),
 		RollupRpc:                    ctx.String(flags.RollupRpcFlag.Name),
-		SupervisorRpc:                ctx.String(flags.SupervisorRpcFlag.Name),
+		SupervisorRpcs:               ctx.StringSlice(flags.SupervisorRpcFlag.Name),
 		L2OOAddress:                  ctx.String(flags.L2OOAddressFlag.Name),
 		PollInterval:                 ctx.Duration(flags.PollIntervalFlag.Name),
 		TxMgrConfig:                  txmgr.ReadCLIConfig(ctx),

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -24,7 +24,7 @@ func TestRollupRpc(t *testing.T) {
 		cfg.L2OOAddress = common.Address{0xaa}.Hex()
 		cfg.ProposalInterval = 0
 		cfg.RollupRpc = ""
-		cfg.SupervisorRpc = "http://localhost:8882/supervisor"
+		cfg.SupervisorRpcs = []string{"http://localhost:8882/supervisor"}
 		require.ErrorIs(t, cfg.Check(), ErrMissingRollupRpc)
 	})
 
@@ -34,7 +34,7 @@ func TestRollupRpc(t *testing.T) {
 			cfg.DGFAddress = common.Address{0xaa}.Hex()
 			cfg.ProposalInterval = 20
 			cfg.RollupRpc = ""
-			cfg.SupervisorRpc = "http://localhost:8882/supervisor"
+			cfg.SupervisorRpcs = []string{"http://localhost:8882/supervisor"}
 			cfg.DisputeGameType = gameType
 			require.ErrorIs(t, cfg.Check(), ErrMissingRollupRpc)
 		})
@@ -45,7 +45,7 @@ func TestRollupRpc(t *testing.T) {
 		cfg.DGFAddress = common.Address{0xaa}.Hex()
 		cfg.ProposalInterval = 20
 		cfg.RollupRpc = ""
-		cfg.SupervisorRpc = "http://localhost:8882/supervisor"
+		cfg.SupervisorRpcs = []string{"http://localhost:8882/supervisor"}
 		cfg.DisputeGameType = 492743
 		require.NoError(t, cfg.Check())
 	})
@@ -58,7 +58,7 @@ func TestSupervisorRpc(t *testing.T) {
 		cfg.L2OOAddress = common.Address{0xaa}.Hex()
 		cfg.ProposalInterval = 0
 		cfg.RollupRpc = "http://localhost/rollup"
-		cfg.SupervisorRpc = ""
+		cfg.SupervisorRpcs = nil
 		require.NoError(t, cfg.Check())
 	})
 
@@ -68,7 +68,7 @@ func TestSupervisorRpc(t *testing.T) {
 			cfg.DGFAddress = common.Address{0xaa}.Hex()
 			cfg.ProposalInterval = 20
 			cfg.RollupRpc = "http://localhost:8882/rollup"
-			cfg.SupervisorRpc = ""
+			cfg.SupervisorRpcs = nil
 			cfg.DisputeGameType = gameType
 			require.ErrorIs(t, cfg.Check(), ErrMissingSupervisorRpc)
 		})
@@ -78,7 +78,7 @@ func TestSupervisorRpc(t *testing.T) {
 			cfg.DGFAddress = common.Address{0xaa}.Hex()
 			cfg.ProposalInterval = 20
 			cfg.RollupRpc = "http://localhost:8882/rollup"
-			cfg.SupervisorRpc = ""
+			cfg.SupervisorRpcs = nil
 			cfg.DisputeGameType = 492743
 			require.NoError(t, cfg.Check())
 		})
@@ -89,7 +89,7 @@ func TestDisallowRollupAndSupervisorRPC(t *testing.T) {
 	cfg := validConfig()
 	cfg.ProposalInterval = 20
 	cfg.RollupRpc = "http://localhost:8882/rollup"
-	cfg.SupervisorRpc = "http://localhost:8882/supervisor"
+	cfg.SupervisorRpcs = []string{"http://localhost:8882/supervisor"}
 	cfg.DisputeGameType = 492743
 	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
 }
@@ -98,7 +98,7 @@ func validConfig() *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     "http://localhost:8888/l1",
 		RollupRpc:                    "http://localhost:8888/l2",
-		SupervisorRpc:                "",
+		SupervisorRpcs:               nil,
 		L2OOAddress:                  "",
 		PollInterval:                 100,
 		AllowNonFinalized:            false,

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -145,16 +145,10 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 		}
 		ps.ProposalSource = source.NewRollupProposalSource(rollupProvider)
 	}
-	if cfg.SupervisorRpc != "" {
-		var supervisorUrls []string
-		if strings.Contains(cfg.SupervisorRpc, ",") {
-			supervisorUrls = strings.Split(cfg.SupervisorRpc, ",")
-		} else {
-			supervisorUrls = []string{cfg.SupervisorRpc}
-		}
+	if len(cfg.SupervisorRpcs) != 0 {
 		var clients []source.SupervisorClient
-		for _, url := range supervisorUrls {
-			supervisorRpc, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, ps.Log, cfg.SupervisorRpc)
+		for _, url := range cfg.SupervisorRpcs {
+			supervisorRpc, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, ps.Log, url)
 			if err != nil {
 				return fmt.Errorf("failed to dial supervisor RPC client (%v): %w", url, err)
 			}

--- a/op-proposer/proposer/source/source_supervisor.go
+++ b/op-proposer/proposer/source/source_supervisor.go
@@ -2,51 +2,108 @@ package source
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
 )
 
-type SupervisorProposalSource struct {
-	client *sources.SupervisorClient
+type SupervisorClient interface {
+	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
+	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
+	Close()
 }
 
-func NewSupervisorProposalSource(client *sources.SupervisorClient) *SupervisorProposalSource {
-	return &SupervisorProposalSource{
-		client: client,
+type SupervisorProposalSource struct {
+	log     log.Logger
+	clients []SupervisorClient
+}
+
+func NewSupervisorProposalSource(logger log.Logger, clients ...SupervisorClient) *SupervisorProposalSource {
+	if len(clients) == 0 {
+		panic("no supervisor clients provided")
 	}
+	return &SupervisorProposalSource{
+		log:     logger,
+		clients: clients,
+	}
+}
+
+type statusResult struct {
+	idx    int
+	status eth.SupervisorSyncStatus
+	err    error
 }
 
 func (s *SupervisorProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
-	status, err := s.client.SyncStatus(ctx)
-	if err != nil {
-		return SyncStatus{}, err
+	var wg sync.WaitGroup
+	results := make(chan statusResult, len(s.clients))
+	wg.Add(len(s.clients))
+	for i, client := range s.clients {
+		i := i
+		client := client
+		go func() {
+			defer wg.Done()
+			status, err := client.SyncStatus(ctx)
+			results <- statusResult{
+				idx:    i,
+				status: status,
+				err:    err,
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+	var errs []error
+	var earliestResponse eth.SupervisorSyncStatus
+	for result := range results {
+		if result.err != nil {
+			s.log.Warn("Failed to retrieve sync status from supervisor", "idx", result.idx, "err", result.err)
+			errs = append(errs, result.err)
+			continue
+		}
+		if earliestResponse.MinSyncedL1 == (eth.L1BlockRef{}) || result.status.MinSyncedL1.Number < earliestResponse.MinSyncedL1.Number {
+			earliestResponse = result.status
+		}
+	}
+	if earliestResponse.MinSyncedL1 == (eth.L1BlockRef{}) {
+		return SyncStatus{}, fmt.Errorf("no available sync status sources: %w", errors.Join(errs...))
 	}
 	return SyncStatus{
-		CurrentL1:   status.MinSyncedL1,
-		SafeL2:      status.SafeTimestamp,
-		FinalizedL2: status.FinalizedTimestamp,
+		CurrentL1:   earliestResponse.MinSyncedL1,
+		SafeL2:      earliestResponse.SafeTimestamp,
+		FinalizedL2: earliestResponse.FinalizedTimestamp,
 	}, nil
 }
 
 func (s *SupervisorProposalSource) ProposalAtSequenceNum(ctx context.Context, timestamp uint64) (Proposal, error) {
-	output, err := s.client.SuperRootAtTimestamp(ctx, hexutil.Uint64(timestamp))
-	if err != nil {
-		return Proposal{}, err
-	}
-	return Proposal{
-		Version:     eth.Bytes32{output.Version},
-		Root:        common.Hash(output.SuperRoot),
-		SequenceNum: output.Timestamp,
-		CurrentL1:   output.CrossSafeDerivedFrom,
+	var errs []error
+	for i, client := range s.clients {
+		output, err := client.SuperRootAtTimestamp(ctx, hexutil.Uint64(timestamp))
+		if err != nil {
+			errs = append(errs, err)
+			s.log.Warn("Failed to retrieve proposal from supervisor", "idx", i, "err", err)
+			continue
+		}
+		return Proposal{
+			Version:     eth.Bytes32{output.Version},
+			Root:        common.Hash(output.SuperRoot),
+			SequenceNum: output.Timestamp,
+			CurrentL1:   output.CrossSafeDerivedFrom,
 
-		// Unsupported by super root proposals
-		Legacy: LegacyProposalData{},
-	}, nil
+			// Unsupported by super root proposals
+			Legacy: LegacyProposalData{},
+		}, nil
+	}
+	return Proposal{}, fmt.Errorf("no available proposal sources: %w", errors.Join(errs...))
 }
 
 func (s *SupervisorProposalSource) Close() {
-	s.client.Close()
+	for _, client := range s.clients {
+		client.Close()
+	}
 }

--- a/op-proposer/proposer/source/source_supervisor_test.go
+++ b/op-proposer/proposer/source/source_supervisor_test.go
@@ -1,0 +1,271 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupervisorSource_SyncStatus(t *testing.T) {
+	t.Run("Single-Success", func(t *testing.T) {
+		response := eth.SupervisorSyncStatus{
+			MinSyncedL1: eth.L1BlockRef{
+				Hash:       common.Hash{0xbc},
+				Number:     48292,
+				ParentHash: common.Hash{0xdd},
+				Time:       98599217,
+			},
+			SafeTimestamp:      1234,
+			FinalizedTimestamp: 45523,
+		}
+		client := &mockSupervisorClient{
+			status: response,
+		}
+		source := NewSupervisorProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		actual, err := source.SyncStatus(context.Background())
+		require.NoError(t, err)
+		expected := SyncStatus{
+			CurrentL1:   response.MinSyncedL1,
+			SafeL2:      response.SafeTimestamp,
+			FinalizedL2: response.FinalizedTimestamp,
+		}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("Single-Error", func(t *testing.T) {
+		expected := errors.New("test error")
+		client := &mockSupervisorClient{
+			statusErr: expected,
+		}
+		source := NewSupervisorProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		_, err := source.SyncStatus(context.Background())
+		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("Multi-ReturnLowestMinSyncedL1", func(t *testing.T) {
+		response1 := eth.SupervisorSyncStatus{
+			MinSyncedL1: eth.L1BlockRef{
+				Hash:       common.Hash{0xdd},
+				Number:     9999999999,
+				ParentHash: common.Hash{0xee},
+				Time:       4,
+			},
+			SafeTimestamp:      2,
+			FinalizedTimestamp: 4,
+		}
+		response2 := eth.SupervisorSyncStatus{
+			MinSyncedL1: eth.L1BlockRef{
+				Hash:       common.Hash{0xbc},
+				Number:     48292,
+				ParentHash: common.Hash{0xdd},
+				Time:       98599217,
+			},
+			SafeTimestamp:      1234,
+			FinalizedTimestamp: 45523,
+		}
+		client1 := &mockSupervisorClient{
+			status: response1,
+		}
+		client2 := &mockSupervisorClient{
+			status: response2,
+		}
+		source := NewSupervisorProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
+		actual, err := source.SyncStatus(context.Background())
+		require.NoError(t, err)
+		// Should use the response with the lowest MinSyncedL1 block number
+		expected := SyncStatus{
+			CurrentL1:   response2.MinSyncedL1,
+			SafeL2:      response2.SafeTimestamp,
+			FinalizedL2: response2.FinalizedTimestamp,
+		}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("Multi-SkipFailingClients", func(t *testing.T) {
+		response := eth.SupervisorSyncStatus{
+			MinSyncedL1: eth.L1BlockRef{
+				Hash:       common.Hash{0xdd},
+				Number:     9999999999,
+				ParentHash: common.Hash{0xee},
+				Time:       4,
+			},
+			SafeTimestamp:      2,
+			FinalizedTimestamp: 4,
+		}
+		client1 := &mockSupervisorClient{
+			statusErr: errors.New("test error"),
+		}
+		client2 := &mockSupervisorClient{
+			status: response,
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSupervisorProposalSource(logger, client1, client2)
+		actual, err := source.SyncStatus(context.Background())
+		require.NoError(t, err)
+		// Should use the one successful response
+		expected := SyncStatus{
+			CurrentL1:   response.MinSyncedL1,
+			SafeL2:      response.SafeTimestamp,
+			FinalizedL2: response.FinalizedTimestamp,
+		}
+		require.Equal(t, expected, actual)
+		require.NotNil(t, logs.FindLog(
+			testlog.NewLevelFilter(slog.LevelWarn),
+			testlog.NewAttributesFilter("err", client1.statusErr.Error())))
+	})
+
+	t.Run("Multi-AllFailingClients", func(t *testing.T) {
+		client1 := &mockSupervisorClient{
+			statusErr: errors.New("test error1"),
+		}
+		client2 := &mockSupervisorClient{
+			statusErr: errors.New("test error2"),
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSupervisorProposalSource(logger, client1, client2)
+		_, err := source.SyncStatus(context.Background())
+		// Should return both errors
+		require.ErrorIs(t, err, client1.statusErr)
+		require.ErrorIs(t, err, client2.statusErr)
+		require.NotNil(t, logs.FindLog(
+			testlog.NewLevelFilter(slog.LevelWarn),
+			testlog.NewAttributesFilter("err", client1.statusErr.Error())))
+		require.NotNil(t, logs.FindLog(
+			testlog.NewLevelFilter(slog.LevelWarn),
+			testlog.NewAttributesFilter("err", client2.statusErr.Error())))
+	})
+}
+
+func TestSupervisorSource_ProposalAtSequenceNum(t *testing.T) {
+	response := eth.SuperRootResponse{
+		CrossSafeDerivedFrom: eth.BlockID{
+			Hash:   common.Hash{0x11},
+			Number: 589111,
+		},
+		Timestamp: 59298244,
+		SuperRoot: eth.Bytes32{0xaa, 0xbb},
+		Version:   3,
+		Chains:    nil,
+	}
+	expected := Proposal{
+		Version:     eth.Bytes32{3},
+		Root:        common.Hash(response.SuperRoot),
+		SequenceNum: response.Timestamp,
+		CurrentL1:   response.CrossSafeDerivedFrom,
+		Legacy:      LegacyProposalData{},
+	}
+	sequenceNum := uint64(599)
+	t.Run("Single-Success", func(t *testing.T) {
+		client := &mockSupervisorClient{
+			roots: map[uint64]eth.SuperRootResponse{
+				sequenceNum: response,
+			},
+		}
+		source := NewSupervisorProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), sequenceNum)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("Single-Error", func(t *testing.T) {
+		expected := errors.New("test error")
+		client := &mockSupervisorClient{
+			rootErr: expected,
+		}
+		source := NewSupervisorProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		_, err := source.ProposalAtSequenceNum(context.Background(), 294)
+		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("Multi-FirstSourceSuccess", func(t *testing.T) {
+		client1 := &mockSupervisorClient{
+			roots: map[uint64]eth.SuperRootResponse{
+				sequenceNum: response,
+			},
+		}
+		client2 := &mockSupervisorClient{}
+		source := NewSupervisorProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), sequenceNum)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+		require.Equal(t, 1, client1.rootRequestCount)
+		require.Equal(t, 0, client2.rootRequestCount)
+	})
+
+	t.Run("Multi-FailOverToSecondSource", func(t *testing.T) {
+		client1 := &mockSupervisorClient{
+			rootErr: errors.New("test error"),
+		}
+		client2 := &mockSupervisorClient{
+			roots: map[uint64]eth.SuperRootResponse{
+				sequenceNum: response,
+			},
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSupervisorProposalSource(logger, client1, client2)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), sequenceNum)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+		require.Equal(t, 1, client1.rootRequestCount)
+		require.Equal(t, 1, client2.rootRequestCount)
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client1.rootErr.Error())))
+	})
+
+	t.Run("Multi-AllFail", func(t *testing.T) {
+		client1 := &mockSupervisorClient{
+			rootErr: errors.New("test error1"),
+		}
+		client2 := &mockSupervisorClient{
+			rootErr: errors.New("test error2"),
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSupervisorProposalSource(logger, client1, client2)
+		_, err := source.ProposalAtSequenceNum(context.Background(), sequenceNum)
+		// Should provide all errors
+		require.ErrorIs(t, err, client1.rootErr)
+		require.ErrorIs(t, err, client2.rootErr)
+		require.Equal(t, 1, client1.rootRequestCount)
+		require.Equal(t, 1, client2.rootRequestCount)
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client1.rootErr.Error())))
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client2.rootErr.Error())))
+	})
+}
+
+type mockSupervisorClient struct {
+	status    eth.SupervisorSyncStatus
+	statusErr error
+
+	roots            map[uint64]eth.SuperRootResponse
+	rootErr          error
+	rootRequestCount int
+}
+
+func (m *mockSupervisorClient) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
+	if m.statusErr != nil {
+		return eth.SupervisorSyncStatus{}, m.statusErr
+	}
+	return m.status, nil
+}
+
+func (m *mockSupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
+	m.rootRequestCount++
+	if m.rootErr != nil {
+		return eth.SuperRootResponse{}, m.rootErr
+	}
+	root, ok := m.roots[uint64(timestamp)]
+	if !ok {
+		return eth.SuperRootResponse{}, ethereum.NotFound
+	}
+	return root, nil
+}
+
+func (m *mockSupervisorClient) Close() {}


### PR DESCRIPTION
**Description**

Adds support for multiple supervisor endpoints to op-proposer.  The selection algorithm is quite basic:
For SyncStatus, the supervisor with the lowest `MinSyncedL1` is used, ignoring any that are offline. This ensures that the wait for sync option waits for all source nodes to be in sync.  The sync status response is also used to select the block proposals are taken from, so this ensures that even if a different source node is used to retrieve the proposal, it will still be a finalized block even if the node is slightly behind.

For retrieving proposals, the nodes are simply tried in turn.

The main downside of this approach is that if one of the source nodes is lagging well behind, it will cause proposals to be more stale, but it is safer if nodes are going offline temporarily. With other approaches the sync status may come from one node and the proposal from another, causing it to return data that is later reorged even if the sync status (from a different node) indicated the data was finalized. Making SyncStatus return the lowest value avoids this risk as all nodes have reached the required safety level for the data requested for the proposal.

Builds on https://github.com/ethereum-optimism/optimism/pull/14400

**Tests**

Added unit tests.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/13909