### PR TITLE
op-supervisor: Return the replaced block's output root as pending output

### DIFF
--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -536,8 +536,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      step2Expected,
 			disputedTraceIndex: 1,
 			expectValid:        true,
-			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
-			skipChallenger: true,
 		},
 		{
 			name:               "FirstPaddingStep",
@@ -545,8 +543,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      paddingStep(3),
 			disputedTraceIndex: 2,
 			expectValid:        true,
-			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
-			skipChallenger: true,
 		},
 		{
 			name:               "SecondPaddingStep",
@@ -554,8 +550,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      paddingStep(4),
 			disputedTraceIndex: 3,
 			expectValid:        true,
-			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
-			skipChallenger: true,
 		},
 		{
 			name:               "LastPaddingStep",
@@ -563,8 +557,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      paddingStep(1023),
 			disputedTraceIndex: 1022,
 			expectValid:        true,
-			// skipChallenger because the challenger's reorg view won't match the pre-reorg disputed claim
-			skipChallenger: true,
 		},
 		{
 			name:               "Consolidate-ExpectInvalidPendingBlock",
@@ -572,7 +564,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      end.Marshal(),
 			disputedTraceIndex: 1023,
 			expectValid:        false,
-			skipChallenger:     true,
 		},
 		{
 			name:               "Consolidate-ReplaceInvalidBlock",
@@ -580,7 +571,6 @@ func TestInteropFaultProofsInvalidBlock(gt *testing.T) {
 			disputedClaim:      crossSafeSuperRootEnd.Marshal(),
 			disputedTraceIndex: 1023,
 			expectValid:        true,
-			skipChallenger:     true,
 		},
 		{
 			name:               "AlreadyAtClaimedTimestamp",

--- a/op-node/rollup/interop/managed/attributes_test.go
+++ b/op-node/rollup/interop/managed/attributes_test.go
@@ -142,6 +142,7 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		require.NoError(t, err, "must encode")
 		_, err = DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.Error(t, err, "expected deposit")
+		require.ErrorIs(t, err, ErrNotReplacementBlock)
 	})
 	t.Run("bad tx sender", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
@@ -159,6 +160,7 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		require.NoError(t, err, "must encode")
 		_, err = DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.Error(t, err, "expected system tx sender")
+		require.ErrorIs(t, err, ErrNotReplacementBlock)
 	})
 	t.Run("bad preimage", func(t *testing.T) {
 		tx := InvalidatedBlockSourceDepositTx([]byte("invalid output root preimage"))
@@ -166,5 +168,6 @@ func TestInvalidatedBlockTx(t *testing.T) {
 		require.NoError(t, err, "must encode")
 		_, err = DecodeInvalidatedBlockTxFromReplacement([]eth.Data{encoded})
 		require.Error(t, err, "failed to unmarshal")
+		require.NotErrorIs(t, err, ErrNotReplacementBlock)
 	})
 }


### PR DESCRIPTION
**Description**

Report the replaced block's output root correctly instead of always returning the canonical block. Allows the challenger to create the correct trace when blocks are replaced.

**Tests**

Enabled the challenger action tests (except for cascading reorgs which supervisor still doesn't support).
