### PR TITLE
cannon: mipsevm: Support `mips64r2` for kona

### DIFF
--- a/cannon/mipsevm/README.md
+++ b/cannon/mipsevm/README.md
@@ -19,8 +19,22 @@ Supported 63 instructions:
 | `Conditional Branch` | `bne`         | Branch on not equal.                         |
 | `Logical`            | `clo`         | Count leading ones.                          |
 | `Logical`            | `clz`         | Count leading zeros.                         |
+| `Logical`            | `dclz`        | Count Leading Zeros in Doubleword.           |
+| `Bit Manipulation`   | `dext`        | Doubleword Extract Bit Field.                |
+| `Bit Manipulation`   | `dextm`       | Doubleword Extract Bit Field Middle.         |
+| `Bit Manipulation`   | `dextu`       | Doubleword Extract Bit Field Upper.          |
+| `Bit Manipulation`   | `dins`        | Doubleword Insert Bit Field.                 |
+| `Bit Manipulation`   | `dinsm`       | Doubleword Insert Bit Field Middle.          |
+| `Bit Manipulation`   | `dinsu`       | Doubleword Insert Bit Field Upper.           |
 | `Arithmetic`         | `div`         | Divide.                                      |
 | `Arithmetic`         | `divu`        | Divide unsigned.                             |
+| `Logical`            | `drotr`       | Doubleword Rotate Right.                     |
+| `Logical`            | `drotr32`     | Doubleword Rotate Right Plus 32.             |
+| `Logical`            | `drotrv`      | Doubleword Rotate Right Variable.            |
+| `Bit Manipulation`   | `dsbh`        | Doubleword Swap Bytes Within Halfwords.      |
+| `Bit Manipulation`   | `dshd`        | Doubleword Swap Halfwords Within Doublewords.|
+| `Bit Manipulation`   | `ext`         | Extract Bit Field.                           |
+| `Bit Manipulation`   | `ins`         | Insert Bit Field.                            |
 | `Unconditional Jump` | `j`           | Jump.                                        |
 | `Unconditional Jump` | `jal`         | Jump and link.                               |
 | `Unconditional Jump` | `jalr`        | Jump and link register.                      |
@@ -46,8 +60,12 @@ Supported 63 instructions:
 | `Logical`            | `nor`         | Bitwise NOR.                                 |
 | `Logical`            | `or`          | Bitwise OR.                                  |
 | `Logical`            | `ori`         | Bitwise OR immediate.                        |
+| `Logical`            | `rotr`        | Rotate Word Right.                           |
+| `Logical`            | `rotrv`       | Rotate Word Right Variable.                  |
 | `Data Transfer`      | `sb`          | Store byte.                                  |
 | `Data Transfer`      | `sc`          | Store conditional.                           |
+| `Arithmetic`         | `seb`         | Sign-Extend Byte.                            |
+| `Arithmetic`         | `seh`         | Sign-Extend Halfword.                        |
 | `Data Transfer`      | `sh`          | Store halfword.                              |
 | `Logical`            | `sll`         | Shift left logical.                          |
 | `Logical`            | `sllv`        | Shift left logical variable.                 |
@@ -66,6 +84,7 @@ Supported 63 instructions:
 | `Data Transfer`      | `swr`         | Store word right.                            |
 | `Serialization`      | `sync`        | Synchronize shared memory.                   |
 | `System Calls`       | `syscall`     | System call.                                 |
+| `Bit Manipulation`   | `wsbh`        | Word Swap Bytes Within Halfwords.            |
 | `Logical`            | `xor`         | Bitwise XOR.                                 |
 | `Logical`            | `xori`        | Bitwise XOR immediate.                       |
 

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -472,7 +472,6 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 				return UpdateSubWord(rs, mem, 4, Word(swrResult))
 			}
 
-		// MIPS64
 		case 0x1A: // ldl
 			assertMips64(insn)
 			sl := (rs & 0x7) << 3

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -391,7 +391,7 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 				return Word(i)
 			case 0x24: // dclz
 				assertMips64(insn)
-				return Word(bits.LeadingZeros64(uint64(rt)))
+				return Word(bits.LeadingZeros64(uint64(rs)))
 			}
 		case 0x0F: // lui
 			return SignExtend(rt<<16, 32)

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -72,13 +72,19 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 		rdReg = Word((insn >> 11) & 0x1F)
 	} else if opcode == 0x2f { // SPECIAL3
 		// SPECIAL3 is generally R-type with exceptions
-		assertMips64(insn)
-		if fun == 0x20 || fun == 0x24 { // seb, seh, dsbh, dshd
+		if fun == 0x20 {
+			// seb, seh, wsbh
 			// R-type (stores rd)
 			rdReg = Word((insn >> 11) & 0x1F)
-		} else if fun == 0x3 || fun == 0x1 || fun == 0x2 || fun == 0x7 || fun == 0x5 || fun == 0x6 {
-			// dext, dextm, dextu, dins, dinsm, dinsu
+		} else if fun == 0x24 {
+			// dsbh, dshd
+			// R-type (stores rd)
+			assertMips64(insn)
+			rdReg = Word((insn >> 11) & 0x1F)
+		} else if fun == 0x3 || fun == 0x1 || fun == 0x2 || fun == 0x7 || fun == 0x5 || fun == 0x6 || fun == 0x4 || fun == 0x0 {
+			// dext, dextm, dextu, dins, dinsm, dinsu, ins, ext
 			// Exception (stores rt)
+			assertMips64(insn)
 			rdReg = Word((insn >> 16) & 0x1F)
 		}
 	} else if opcode < 0x20 {

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -509,51 +509,51 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 					return SignExtend(rt&0xFF, 8)
 				case 0x18: // seh
 					return SignExtend(rt&0xFFFF, 16)
-				case 0x2: // wsbh
+				case 0x02: // wsbh
 					return SignExtend(((rt&0xFF00FF00)>>8)|((rt&0x00FF00FF)<<8), 32)
 				}
-			case 0x3: // dext
+			case 0x03: // dext
 				assertMips64(insn)
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1
 				mask := ((Word(1) << size) - 1) << lsb
 				return Word((rs & mask) >> lsb)
-			case 0x1: // dextm
+			case 0x01: // dextm
 				assertMips64(insn)
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1 + 32
 				mask := ((Word(1) << size) - 1) << lsb
 				return Word((rs & mask) >> lsb)
-			case 0x2: // dextu
+			case 0x02: // dextu
 				assertMips64(insn)
 				lsb := (insn>>6)&0x1F + 32
 				size := ((insn >> 11) & 0x1F) + 1
 				mask := ((Word(1) << size) - 1) << lsb
 				return Word((rs & mask) >> lsb)
-			case 0x7: // dins
+			case 0x07: // dins
 				assertMips64(insn)
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1 - lsb
 				mask := (Word(1) << size) - 1
 				return (rt & ^(mask << lsb)) | ((rs & mask) << lsb)
-			case 0x5: // dinsm
+			case 0x05: // dinsm
 				assertMips64(insn)
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1 + 32 - lsb
 				mask := (Word(1) << size) - 1
 				return (rt & ^(mask << lsb)) | ((rs & mask) << lsb)
-			case 0x6: // dinsu
+			case 0x06: // dinsu
 				assertMips64(insn)
 				lsb := (insn>>6)&0x1F + 32
 				size := ((insn >> 11) & 0x1F) + 1 + 32 - lsb
 				mask := (Word(1) << size) - 1
 				return (rt & ^(mask << lsb)) | ((rs & mask) << lsb)
-			case 0x4: // ins
+			case 0x04: // ins
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1 - lsb
 				mask := (Word(1) << size) - 1
 				return SignExtend(((rt & ^(mask << lsb)) | ((rs & mask) << lsb)), 32)
-			case 0x0: // ext
+			case 0x00: // ext
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1
 				mask := (Word(1) << size) - 1
@@ -561,9 +561,9 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 			case 0x24: // dbshfl
 				assertMips64(insn)
 				switch (insn >> 6) & 0x1f {
-				case 0x2: // dsbh
+				case 0x02: // dsbh
 					return Word(((uint64(rt) & 0xFF00FF00FF00FF00) >> 8) | ((uint64(rt) & 0x00FF00FF00FF00FF) << 8))
-				case 0x5: // dshd
+				case 0x05: // dshd
 					return Word(((uint64(rt) & 0xFFFF) << 48) | (((uint64(rt) >> 16) & 0xFFFF) << 32) | (((uint64(rt) >> 32) & 0xFFFF) << 16) | ((uint64(rt) >> 48) & 0xFFFF))
 				}
 			}
@@ -634,7 +634,7 @@ func HandleBranch(cpu *mipsevm.CpuScalars, registers *[32]Word, opcode uint32, i
 }
 
 // HandleHiLo handles instructions that modify HI and LO registers. It also additionally handles doubleword variable shift operations
-func HandleHiLo(cpu *mipsevm.CpuScalars, registers *[32]Word, insn uint32, fun uint32, rs Word, rt Word, storeReg Word) error {
+func HandleHiLo(cpu *mipsevm.CpuScalars, registers *[32]Word, insn, fun uint32, rs Word, rt Word, storeReg Word) error {
 	val := Word(0)
 	switch fun {
 	case 0x10: // mfhi

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -86,7 +86,9 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 		} else if fun == 0x3 || fun == 0x1 || fun == 0x2 || fun == 0x7 || fun == 0x5 || fun == 0x6 || fun == 0x4 || fun == 0x0 {
 			// dext, dextm, dextu, dins, dinsm, dinsu, ins, ext
 			// Exception (stores rt)
-			assertMips64(insn)
+			if !(fun == 0x4 || fun == 0x0) {
+				assertMips64(insn)
+			}
 			rt = registers[rtReg]
 			rdReg = Word((insn >> 16) & 0x1F)
 		}
@@ -560,7 +562,7 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 				lsb := (insn >> 6) & 0x1F
 				size := ((insn >> 11) & 0x1F) + 1
 				mask := (Word(1) << size) - 1
-				return SignExtend((rt & ^(mask<<lsb))>>lsb, 32)
+				return SignExtend((rs&(mask<<lsb))>>lsb, 32)
 			case 0x24: // dbshfl
 				assertMips64(insn)
 				switch (insn >> 6) & 0x1f {

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -70,16 +70,18 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 		// R-type (stores rd)
 		rt = registers[rtReg]
 		rdReg = Word((insn >> 11) & 0x1F)
-	} else if opcode == 0x2f { // SPECIAL3
+	} else if opcode == 0x1f { // SPECIAL3
 		// SPECIAL3 is generally R-type with exceptions
 		if fun == 0x20 {
 			// seb, seh, wsbh
 			// R-type (stores rd)
+			rt = registers[rtReg]
 			rdReg = Word((insn >> 11) & 0x1F)
 		} else if fun == 0x24 {
 			// dsbh, dshd
 			// R-type (stores rd)
 			assertMips64(insn)
+			rt = registers[rtReg]
 			rdReg = Word((insn >> 11) & 0x1F)
 		} else if fun == 0x3 || fun == 0x1 || fun == 0x2 || fun == 0x7 || fun == 0x5 || fun == 0x6 || fun == 0x4 || fun == 0x0 {
 			// dext, dextm, dextu, dins, dinsm, dinsu, ins, ext

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -70,6 +70,17 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 		// R-type (stores rd)
 		rt = registers[rtReg]
 		rdReg = Word((insn >> 11) & 0x1F)
+	} else if opcode == 0x2f { // SPECIAL3
+		// SPECIAL3 is generally R-type with exceptions
+		assertMips64(insn)
+		if fun == 0x20 || fun == 0x24 { // seb, seh, dsbh, dshd
+			// R-type (stores rd)
+			rdReg = Word((insn >> 11) & 0x1F)
+		} else if fun == 0x3 || fun == 0x1 || fun == 0x2 || fun == 0x7 || fun == 0x5 || fun == 0x6 {
+			// dext, dextm, dextu, dins, dinsm, dinsu
+			// Exception (stores rt)
+			rdReg = Word((insn >> 16) & 0x1F)
+		}
 	} else if opcode < 0x20 {
 		// rt is SignExtImm
 		// don't sign extend for andi, ori, xori

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -87,6 +87,7 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 			// dext, dextm, dextu, dins, dinsm, dinsu, ins, ext
 			// Exception (stores rt)
 			assertMips64(insn)
+			rt = registers[rtReg]
 			rdReg = Word((insn >> 16) & 0x1F)
 		}
 	} else if opcode < 0x20 {

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -898,6 +898,16 @@ func TestEVM_SingleStep_Swap64(t *testing.T) {
 		{name: "dshd with zero", rt: Word(0x0000FFFF0000FFFF), funct: 0b100100, special: 0b00101, expectedResult: Word(0xFFFF0000FFFF0000)},
 		// Swap halfwords within doubleword when all bytes are different
 		{name: "dshd half reversed", rt: Word(0x123456789ABCDEF0), funct: 0b100100, special: 0b00101, expectedResult: Word(0xDEF09ABC56781234)},
+
+		// wsbh
+		// Swap bytes within halfwords (lower 32 bits)
+		{name: "wsbh", rt: Word(0x11223344), funct: 0b100000, special: 0b00010, expectedResult: Word(0x0000000022114433)},
+		// Swap bytes within halfwords (sign extend)
+		{name: "wsbh sign extend", rt: Word(0xEEFF0011), funct: 0b100000, special: 0b00010, expectedResult: Word(0xFFFFFFFFFFEE1100)},
+		// Swap bytes within halfwords (all bits set)
+		{name: "wsbh all ones 64-bit", rt: Word(0xFFFFFFFF), funct: 0b100000, special: 0b00010, expectedResult: Word(0xFFFFFFFFFFFFFFFF)},
+		// Swap bytes within halfwords (all bits zero)
+		{name: "wsbh all zero 64-bit", rt: Word(0x00000000), funct: 0b100000, special: 0b00010, expectedResult: Word(0x0000000000000000)},
 	}
 
 	versions := GetMipsVersionTestCases(t)

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -755,7 +755,7 @@ func TestEVM_SingleStep_Ext64(t *testing.T) {
 				state := goVm.GetState()
 
 				var insn uint32
-				if tt.funct == 0b00_0011 { // dext
+				if tt.funct == 0b00_0011 || tt.funct == 0b00_0000 { // dext, ext
 					insn = 0b011111<<26 | rsReg<<21 | rtReg<<16 | tt.msbd<<11 | tt.lsb<<6 | tt.funct
 				} else if tt.funct == 0b00_0001 { // dextm
 					require.GreaterOrEqual(t, tt.msbd, uint32(32), "msbd should be >= 32 for dextm")
@@ -763,8 +763,6 @@ func TestEVM_SingleStep_Ext64(t *testing.T) {
 				} else if tt.funct == 0b00_0010 { // dextu
 					require.GreaterOrEqual(t, tt.lsb, uint32(32), "lsb should be >= 32 for dextu")
 					insn = 0b011111<<26 | rsReg<<21 | rtReg<<16 | tt.msbd<<11 | (tt.lsb-32)<<6 | tt.funct
-				} else if tt.funct == 0b00_0000 { // ext
-					insn = 0b011111<<26 | rsReg<<21 | rtReg<<16 | tt.msbd<<11 | tt.lsb<<6 | tt.funct
 				}
 
 				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -516,7 +516,6 @@ func TestEVM_SingleStep_Branch64(t *testing.T) {
 }
 
 func TestEVM_SingleStep_Clz64(t *testing.T) {
-	t.Parallel()
 	rsReg := uint32(7)
 	rdReg := uint32(8)
 	cases := []struct {
@@ -557,7 +556,7 @@ func TestEVM_SingleStep_Clz64(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -670,7 +669,7 @@ func TestEVM_SingleStep_Rot64(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -779,7 +778,7 @@ func TestEVM_SingleStep_Ext64(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -887,7 +886,7 @@ func TestEVM_SingleStep_Ins64(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -965,7 +964,7 @@ func TestEVM_SingleStep_Swap64(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -1033,7 +1032,7 @@ func TestEVM_SingleStep_SignExtend64(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1172,47 +1172,47 @@ func TestEVM_SingleStep_Rot(t *testing.T) {
 	}{
 		// rotr
 		// No rotation (should return the same number)
-		{name: "rotr no shift", rt: Word(0x12345678), sa: 0, funct: 0b000010, expectVal: Word(0x12345678)},
+		{name: "rotr no shift", rt: Word(0x12345678), sa: 0, funct: 0b000010, expectVal: signExtend64(Word(0x12345678))},
 		// Rotate by 1 bit
-		{name: "rotr by 1", rt: Word(0x12345678), sa: 1, funct: 0b000010, expectVal: Word(0x091A2B3C)},
+		{name: "rotr by 1", rt: Word(0x12345678), sa: 1, funct: 0b000010, expectVal: signExtend64(Word(0x091A2B3C))},
 		// Rotate by 4 bits (nibble rotation)
-		{name: "rotr by 4", rt: Word(0x12345678), sa: 4, funct: 0b000010, expectVal: Word(0x81234567)},
+		{name: "rotr by 4", rt: Word(0x12345678), sa: 4, funct: 0b000010, expectVal: signExtend64(Word(0x81234567))},
 		// Rotate by 8 bits (byte rotation)
-		{name: "rotr by 8", rt: Word(0x12345678), sa: 8, funct: 0b000010, expectVal: Word(0x78123456)},
+		{name: "rotr by 8", rt: Word(0x12345678), sa: 8, funct: 0b000010, expectVal: signExtend64(Word(0x78123456))},
 		// Rotate by 16 bits (half-word rotation)
-		{name: "rotr by 16", rt: Word(0x12345678), sa: 16, funct: 0b000010, expectVal: Word(0x56781234)},
+		{name: "rotr by 16", rt: Word(0x12345678), sa: 16, funct: 0b000010, expectVal: signExtend64(Word(0x56781234))},
 		// Rotate by 24 bits
-		{name: "rotr by 24", rt: Word(0x12345678), sa: 24, funct: 0b000010, expectVal: Word(0x34567812)},
+		{name: "rotr by 24", rt: Word(0x12345678), sa: 24, funct: 0b000010, expectVal: signExtend64(Word(0x34567812))},
 		// Rotate by 31 bits (almost a full cycle)
-		{name: "rotr by 31", rt: Word(0x12345678), sa: 31, funct: 0b000010, expectVal: Word(0x2468ACF0)},
+		{name: "rotr by 31", rt: Word(0x12345678), sa: 31, funct: 0b000010, expectVal: signExtend64(Word(0x2468ACF0))},
 		// Rotate with MSB set
-		{name: "rotr MSB set", rt: Word(0x80000000), sa: 4, funct: 0b000010, expectVal: Word(0x08000000)},
+		{name: "rotr MSB set", rt: Word(0x80000000), sa: 4, funct: 0b000010, expectVal: signExtend64(Word(0x08000000))},
 		// Rotate all ones (0xFFFFFFFF) should remain unchanged
-		{name: "rotr all ones", rt: Word(0xFFFFFFFF), sa: 8, funct: 0b000010, expectVal: Word(0xFFFFFFFF)},
+		{name: "rotr all ones", rt: Word(0xFFFFFFFF), sa: 8, funct: 0b000010, expectVal: signExtend64(Word(0xFFFFFFFF))},
 		// Rotate zero (should remain zero)
-		{name: "rotr zero", rt: Word(0x00000000), sa: 5, funct: 0b000010, expectVal: Word(0x00000000)},
+		{name: "rotr zero", rt: Word(0x00000000), sa: 5, funct: 0b000010, expectVal: signExtend64(Word(0x00000000))},
 
 		// rotrv
 		// No rotation (should return the same number)
-		{name: "rotrv no shift", rt: Word(0x12345678), rs: Word(0), funct: 0b000110, expectVal: Word(0x12345678)},
+		{name: "rotrv no shift", rt: Word(0x12345678), rs: Word(0), funct: 0b000110, expectVal: signExtend64(Word(0x12345678))},
 		// Rotate by 1 bit
-		{name: "rotrv by 1", rt: Word(0x12345678), rs: Word(1), funct: 0b000110, expectVal: Word(0x091A2B3C)},
+		{name: "rotrv by 1", rt: Word(0x12345678), rs: Word(1), funct: 0b000110, expectVal: signExtend64(Word(0x091A2B3C))},
 		// Rotate by 4 bits (nibble rotation)
-		{name: "rotrv by 4", rt: Word(0x12345678), rs: Word(4), funct: 0b000110, expectVal: Word(0x81234567)},
+		{name: "rotrv by 4", rt: Word(0x12345678), rs: Word(4), funct: 0b000110, expectVal: signExtend64(Word(0x81234567))},
 		// Rotate by 8 bits (byte rotation)
-		{name: "rotrv by 8", rt: Word(0x12345678), rs: Word(8), funct: 0b000110, expectVal: Word(0x78123456)},
+		{name: "rotrv by 8", rt: Word(0x12345678), rs: Word(8), funct: 0b000110, expectVal: signExtend64(Word(0x78123456))},
 		// Rotate by 16 bits (half-word rotation)
-		{name: "rotrv by 16", rt: Word(0x12345678), rs: Word(16), funct: 0b000110, expectVal: Word(0x56781234)},
+		{name: "rotrv by 16", rt: Word(0x12345678), rs: Word(16), funct: 0b000110, expectVal: signExtend64(Word(0x56781234))},
 		// Rotate by 24 bits
-		{name: "rotrv by 24", rt: Word(0x12345678), rs: Word(24), funct: 0b000110, expectVal: Word(0x34567812)},
+		{name: "rotrv by 24", rt: Word(0x12345678), rs: Word(24), funct: 0b000110, expectVal: signExtend64(Word(0x34567812))},
 		// Rotate by 31 bits (almost a full cycle)
-		{name: "rotrv by 31", rt: Word(0x12345678), rs: Word(31), funct: 0b000110, expectVal: Word(0x2468ACF0)},
+		{name: "rotrv by 31", rt: Word(0x12345678), rs: Word(31), funct: 0b000110, expectVal: signExtend64(Word(0x2468ACF0))},
 		// Rotate with MSB set
-		{name: "rotrv MSB set", rt: Word(0x80000000), rs: Word(4), funct: 0b000110, expectVal: Word(0x08000000)},
+		{name: "rotrv MSB set", rt: Word(0x80000000), rs: Word(4), funct: 0b000110, expectVal: signExtend64(Word(0x08000000))},
 		// Rotate all ones (0xFFFFFFFF) should remain unchanged
-		{name: "rotrv all ones", rt: Word(0xFFFFFFFF), rs: Word(8), funct: 0b000110, expectVal: Word(0xFFFFFFFF)},
+		{name: "rotrv all ones", rt: Word(0xFFFFFFFF), rs: Word(8), funct: 0b000110, expectVal: signExtend64(Word(0xFFFFFFFF))},
 		// Rotate zero (should remain zero)
-		{name: "rotrv zero", rt: Word(0x00000000), rs: Word(5), funct: 0b000110, expectVal: Word(0x00000000)},
+		{name: "rotrv zero", rt: Word(0x00000000), rs: Word(5), funct: 0b000110, expectVal: signExtend64(Word(0x00000000))},
 	}
 
 	for _, v := range versions {
@@ -1267,27 +1267,27 @@ func TestEVM_SingleStep_SignExtend(t *testing.T) {
 	}{
 		// seb
 		// Sign-extend byte (positive value)
-		{name: "seb positive", rt: Word(0x0000007F), funct: 0b100000, special: 0b10000, expectVal: Word(0x0000007F)},
+		{name: "seb positive", rt: Word(0x0000007F), funct: 0b100000, special: 0b10000, expectVal: signExtend64(Word(0x0000007F))},
 		// Sign-extend byte (negative value)
-		{name: "seb negative", rt: Word(0x00000080), funct: 0b100000, special: 0b10000, expectVal: Word(0xFFFFFF80)},
+		{name: "seb negative", rt: Word(0x00000080), funct: 0b100000, special: 0b10000, expectVal: signExtend64(Word(0xFFFFFF80))},
 		// Sign-extend byte (mid-range)
-		{name: "seb mid-range", rt: Word(0x00000055), funct: 0b100000, special: 0b10000, expectVal: Word(0x00000055)},
+		{name: "seb mid-range", rt: Word(0x00000055), funct: 0b100000, special: 0b10000, expectVal: signExtend64(Word(0x00000055))},
 		// Sign-extend byte (full 8-bit set)
-		{name: "seb full-byte", rt: Word(0x000000FF), funct: 0b100000, special: 0b10000, expectVal: Word(0xFFFFFFFF)},
+		{name: "seb full-byte", rt: Word(0x000000FF), funct: 0b100000, special: 0b10000, expectVal: signExtend64(Word(0xFFFFFFFF))},
 		// Sign-extend byte with upper bits set
-		{name: "seb upper bits", rt: Word(0x123456FF), funct: 0b100000, special: 0b10000, expectVal: Word(0xFFFFFFFF)},
+		{name: "seb upper bits", rt: Word(0x123456FF), funct: 0b100000, special: 0b10000, expectVal: signExtend64(Word(0xFFFFFFFF))},
 
 		// seh
 		// Sign-extend halfword (positive value)
-		{name: "seh positive", rt: Word(0x00007FFF), funct: 0b100000, special: 0b11000, expectVal: Word(0x00007FFF)},
+		{name: "seh positive", rt: Word(0x00007FFF), funct: 0b100000, special: 0b11000, expectVal: signExtend64(Word(0x00007FFF))},
 		// Sign-extend halfword (negative value)
-		{name: "seh negative", rt: Word(0x00008000), funct: 0b100000, special: 0b11000, expectVal: Word(0xFFFF8000)},
+		{name: "seh negative", rt: Word(0x00008000), funct: 0b100000, special: 0b11000, expectVal: signExtend64(Word(0xFFFF8000))},
 		// Sign-extend halfword (mid-range)
-		{name: "seh mid-range", rt: Word(0x00005555), funct: 0b100000, special: 0b11000, expectVal: Word(0x00005555)},
+		{name: "seh mid-range", rt: Word(0x00005555), funct: 0b100000, special: 0b11000, expectVal: signExtend64(Word(0x00005555))},
 		// Sign-extend halfword (full 16-bit set)
-		{name: "seh full-halfword", rt: Word(0x0000FFFF), funct: 0b100000, special: 0b11000, expectVal: Word(0xFFFFFFFF)},
+		{name: "seh full-halfword", rt: Word(0x0000FFFF), funct: 0b100000, special: 0b11000, expectVal: signExtend64(Word(0xFFFFFFFF))},
 		// Sign-extend halfword with upper bits set
-		{name: "seh upper bits", rt: Word(0x1234FFFF), funct: 0b100000, special: 0b11000, expectVal: Word(0xFFFFFFFF)},
+		{name: "seh upper bits", rt: Word(0x1234FFFF), funct: 0b100000, special: 0b11000, expectVal: signExtend64(Word(0xFFFFFFFF))},
 	}
 
 	for _, v := range versions {
@@ -1336,15 +1336,15 @@ func TestEVM_SingleStep_Swap(t *testing.T) {
 	}{
 		// wsbh
 		// Swap bytes within halfwords (standard case)
-		{name: "wsbh", rt: Word(0x11223344), funct: 0b100000, special: 0b00010, expectedResult: Word(0x22114433)},
+		{name: "wsbh", rt: Word(0x11223344), funct: 0b100000, special: 0b00010, expectedResult: signExtend64(Word(0x22114433))},
 		// Swap bytes within halfwords (alternating pattern)
-		{name: "wsbh pattern", rt: Word(0xAABBCCDD), funct: 0b100000, special: 0b00010, expectedResult: Word(0xBBAADDCC)},
+		{name: "wsbh pattern", rt: Word(0xAABBCCDD), funct: 0b100000, special: 0b00010, expectedResult: signExtend64(Word(0xBBAADDCC))},
 		// Swap bytes within halfwords (all bits set)
-		{name: "wsbh all ones", rt: Word(0xFFFFFFFF), funct: 0b100000, special: 0b00010, expectedResult: Word(0xFFFFFFFF)},
+		{name: "wsbh all ones", rt: Word(0xFFFFFFFF), funct: 0b100000, special: 0b00010, expectedResult: signExtend64(Word(0xFFFFFFFF))},
 		// Swap bytes within halfwords (all bits zero)
-		{name: "wsbh all zero", rt: Word(0x00000000), funct: 0b100000, special: 0b00010, expectedResult: Word(0x00000000)},
+		{name: "wsbh all zero", rt: Word(0x00000000), funct: 0b100000, special: 0b00010, expectedResult: signExtend64(Word(0x00000000))},
 		// Swap bytes within halfwords (mixed values)
-		{name: "wsbh mixed", rt: Word(0x12345678), funct: 0b100000, special: 0b00010, expectedResult: Word(0x34127856)},
+		{name: "wsbh mixed", rt: Word(0x12345678), funct: 0b100000, special: 0b00010, expectedResult: signExtend64(Word(0x34127856))},
 	}
 
 	versions := GetMipsVersionTestCases(t)
@@ -1395,17 +1395,17 @@ func TestEVM_SingleStep_Ext(t *testing.T) {
 	}{
 		// ext
 		// Extract lower 8 bits (byte 0)
-		{name: "ext byte 0", rs: Word(0x12345678), msbd: 8 - 1, lsb: 0, funct: 0b000000, expectedResult: Word(0x78)},
+		{name: "ext byte 0", rs: Word(0x12345678), msbd: 8 - 1, lsb: 0, funct: 0b000000, expectedResult: signExtend64(Word(0x78))},
 		// Extract bits 8-15 (byte 1)
-		{name: "ext byte 1", rs: Word(0x12345678), msbd: 8 - 1, lsb: 8, funct: 0b000000, expectedResult: Word(0x56)},
+		{name: "ext byte 1", rs: Word(0x12345678), msbd: 8 - 1, lsb: 8, funct: 0b000000, expectedResult: signExtend64(Word(0x56))},
 		// Extract bits 16-23 (byte 2)
-		{name: "ext byte 2", rs: Word(0x12345678), msbd: 8 - 1, lsb: 16, funct: 0b000000, expectedResult: Word(0x34)},
+		{name: "ext byte 2", rs: Word(0x12345678), msbd: 8 - 1, lsb: 16, funct: 0b000000, expectedResult: signExtend64(Word(0x34))},
 		// Extract bits 24-31 (byte 3)
-		{name: "ext byte 3", rs: Word(0x12345678), msbd: 8 - 1, lsb: 24, funct: 0b000000, expectedResult: Word(0x12)},
+		{name: "ext byte 3", rs: Word(0x12345678), msbd: 8 - 1, lsb: 24, funct: 0b000000, expectedResult: signExtend64(Word(0x12))},
 		// Extract 16-bit halfword from bits 8-23
-		{name: "ext halfword", rs: Word(0x12345678), msbd: 16 - 1, lsb: 8, funct: 0b000000, expectedResult: Word(0x3456)},
+		{name: "ext halfword", rs: Word(0x12345678), msbd: 16 - 1, lsb: 8, funct: 0b000000, expectedResult: signExtend64(Word(0x3456))},
 		// Extract full 32-bit word (should return the same value)
-		{name: "ext full word", rs: Word(0x12345678), msbd: 32 - 1, lsb: 0, funct: 0b000000, expectedResult: Word(0x12345678)},
+		{name: "ext full word", rs: Word(0x12345678), msbd: 32 - 1, lsb: 0, funct: 0b000000, expectedResult: signExtend64(Word(0x12345678))},
 	}
 
 	versions := GetMipsVersionTestCases(t)
@@ -1457,17 +1457,17 @@ func TestEVM_SingleStep_Ins(t *testing.T) {
 	}{
 		// ins
 		// Insert 8-bit value from rs into rt at bit 0
-		{name: "ins byte 0", rs: Word(0x000000AA), rt: Word(0xFFFF0000), msb: 0 + (8 - 1), lsb: 0, funct: 0b000100, expectedResult: Word(0xFFFF00AA)},
+		{name: "ins byte 0", rs: Word(0x000000AA), rt: Word(0xFFFF0000), msb: 0 + (8 - 1), lsb: 0, funct: 0b000100, expectedResult: signExtend64(Word(0xFFFF00AA))},
 		// Insert 8-bit value from rs into rt at bit 8
-		{name: "ins byte 1", rs: Word(0x000000AA), rt: Word(0xFFFF0000), msb: 8 + (8 - 1), lsb: 8, funct: 0b000100, expectedResult: Word(0xFFFFAA00)},
+		{name: "ins byte 1", rs: Word(0x000000AA), rt: Word(0xFFFF0000), msb: 8 + (8 - 1), lsb: 8, funct: 0b000100, expectedResult: signExtend64(Word(0xFFFFAA00))},
 		// Insert 16-bit value from rs into rt at bit 0
-		{name: "ins halfword 0", rs: Word(0x0000AAAA), rt: Word(0xFFFF0000), msb: 0 + (16 - 1), lsb: 0, funct: 0b000100, expectedResult: Word(0xFFFFAAAA)},
+		{name: "ins halfword 0", rs: Word(0x0000AAAA), rt: Word(0xFFFF0000), msb: 0 + (16 - 1), lsb: 0, funct: 0b000100, expectedResult: signExtend64(Word(0xFFFFAAAA))},
 		// Insert 16-bit value from rs into rt at bit 8
-		{name: "ins halfword 1", rs: Word(0x0000AAAA), rt: Word(0xFFFF0000), msb: 8 + (16 - 1), lsb: 8, funct: 0b000100, expectedResult: Word(0xFFAAAA00)},
+		{name: "ins halfword 1", rs: Word(0x0000AAAA), rt: Word(0xFFFF0000), msb: 8 + (16 - 1), lsb: 8, funct: 0b000100, expectedResult: signExtend64(Word(0xFFAAAA00))},
 		// Insert 24-bit value from rs into rt at bit 4
-		{name: "ins 24-bit", rs: Word(0x00AAAAAA), rt: Word(0xFFFF0000), msb: 4 + (24 - 1), lsb: 4, funct: 0b000100, expectedResult: Word(0xFAAAAAA0)},
+		{name: "ins 24-bit", rs: Word(0x00AAAAAA), rt: Word(0xFFFF0000), msb: 4 + (24 - 1), lsb: 4, funct: 0b000100, expectedResult: signExtend64(Word(0xFAAAAAA0))},
 		// Insert full 32-bit value from rs into rt
-		{name: "ins full word", rs: Word(0xAAAAAAAA), rt: Word(0xFFFF0000), msb: 0 + (32 - 1), lsb: 0, funct: 0b000100, expectedResult: Word(0xAAAAAAAA)},
+		{name: "ins full word", rs: Word(0xAAAAAAAA), rt: Word(0xFFFF0000), msb: 0 + (32 - 1), lsb: 0, funct: 0b000100, expectedResult: signExtend64(Word(0xAAAAAAAA))},
 	}
 
 	versions := GetMipsVersionTestCases(t)

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1246,6 +1246,7 @@ func TestEVM_SingleStep_Rot(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -1314,6 +1315,7 @@ func TestEVM_SingleStep_SignExtend(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -1371,7 +1373,7 @@ func TestEVM_SingleStep_Swap(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -1432,7 +1434,7 @@ func TestEVM_SingleStep_Ext(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}
@@ -1495,7 +1497,7 @@ func TestEVM_SingleStep_Ins(t *testing.T) {
 
 				// Check expectations
 				expected.Validate(t, state)
-
+				// TODO(pcw109550): Implement onchaim VM for mips64r2
 				// testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
 			})
 		}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This attempts cannon's offchain version(mipsevm) to support minimal instruction subset to run [kona](https://github.com/op-rs/kona) compiled down to mips64r2 introduced [here](https://github.com/op-rs/kona/pull/943). Relevant issue: https://github.com/ethereum-optimism/optimism/issues/13969. We can extract all instructions by diassembling kona mips64r2 binary. Onchain fixes are not introduced intentionally. If we decide to merge this PR, further contract impls needed.

After building kona binary using `just build-cannon --bin kona --profile release-client-lto` at root of kona repo, 
```
$ file target/mips64-unknown-none/release-client-lto/kona
target/mips64-unknown-none/release-client-lto/kona: ELF 64-bit MSB executable, MIPS, MIPS64 rel2 version 1 (SYSV), statically linked, BuildID[sha1]=792eedc498a7888b3e50bfd606fce50be217966a, for GNU/Linux 3.2.0, not stripped
```
Run 
```
$ llvm-objdump -d --mattr=mips64 target/mips64-unknown-none/release-client-lto/kona | awk '{print $6}' |  sort | uniq -c | sort -nr | awk '{
    printf "%s{\"c\": %s, \"i\": \"%s\"}", (NR==1?"[":" ,"), $1, $2
} END { print "]" }'
[{"c": 108339, "i": "sd"} ,{"c": 99874, "i": "daddiu"} ,{"c": 90576, "i": "ld"} ,{"c": 45429, "i": "daddu"} ,{"c": 35282, "i": "dsll"} ,{"c": 30513, "i": "move"} ,{"c": 27572, "i": "nop"} ,{"c": 22125, "i": "ori"} ,{"c": 19788, "i": "jal"} ,{"c": 18817, "i": "lui"} ,{"c": 14231, "i": "beqz"} ,{"c": 11924, "i": "addiu"} ,{"c": 11650, "i": "j"} ,{"c": 10596, "i": "sltu"} ,{"c": 7239, "i": "lbu"} ,{"c": 7018, "i": "bnez"} ,{"c": 6384, "i": "sb"} ,{"c": 6345, "i": "dext"} ,{"c": 5533, "i": "ldr"} ,{"c": 5533, "i": "ldl"} ,{"c": 5473, "i": "bne"} ,{"c": 5398, "i": ""} ,{"c": 5075, "i": "and"} ,{"c": 4931, "i": "dsubu"} ,{"c": 4649, "i": "or"} ,{"c": 4634, "i": "sdr"} ,{"c": 4634, "i": "sdl"} ,{"c": 4348, "i": "mflo"} ,{"c": 4286, "i": "xor"} ,{"c": 3968, "i": "jr"} ,{"c": 3851, "i": "mfhi"} ,{"c": 3787, "i": "andi"} ,{"c": 3708, "i": "sltiu"} ,{"c": 3527, "i": "lw"} ,{"c": 3140, "i": "sw"} ,{"c": 3056, "i": "jalr"} ,{"c": 2766, "i": "dmultu"} ,{"c": 2612, "i": "dsll32"} ,{"c": 2478, "i": "beq"} ,{"c": 2071, "i": "dsrl32"} ,{"c": 2047, "i": "dsrl"} ,{"c": 1967, "i": "movn"} ,{"c": 1604, "i": "addu"} ,{"c": 1524, "i": "sll"} ,{"c": 1197, "i": "mtlo"} ,{"c": 1197, "i": "mthi"} ,{"c": 1159, "i": "sync"} ,{"c": 1131, "i": "lwr"} ,{"c": 1131, "i": "lwl"} ,{"c": 1032, "i": "movz"} ,{"c": 975, "i": "sh"} ,{"c": 929, "i": "rotr"} ,{"c": 838, "i": "swr"} ,{"c": 838, "i": "swl"} ,{"c": 818, "i": "dshd"} ,{"c": 818, "i": "dsbh"} ,{"c": 769, "i": "dclz"} ,{"c": 721, "i": "dmult"} ,{"c": 699, "i": "lhu"} ,{"c": 618, "i": "xori"} ,{"c": 596, "i": "lb"} ,{"c": 576, "i": "scd"} ,{"c": 576, "i": "lld"} ,{"c": 573, "i": "subu"} ,{"c": 540, "i": "bltz"} ,{"c": 496, "i": "srl"} ,{"c": 447, "i": "dnegu"} ,{"c": 364, "i": "dsllv"} ,{"c": 243, "i": "dsra32"} ,{"c": 197, "i": "not"} ,{"c": 187, "i": "dsrlv"} ,{"c": 156, "i": "break"} ,{"c": 143, "i": "slti"} ,{"c": 140, "i": "bgez"} ,{"c": 109, "i": "slt"} ,{"c": 106, "i": "sllv"} ,{"c": 87, "i": "ins"} ,{"c": 78, "i": "lwu"} ,{"c": 52, "i": "srlv"} ,{"c": 41, "i": "seb"} ,{"c": 41, "i": "multu"} ,{"c": 37, "i": "ext"} ,{"c": 37, "i": "drotr32"} ,{"c": 34, "i": "wsbh"} ,{"c": 30, "i": "mul"} ,{"c": 28, "i": "negu"} ,{"c": 28, "i": "lh"} ,{"c": 26, "i": "drotr"} ,{"c": 25, "i": "seh"} ,{"c": 22, "i": "sc"} ,{"c": 22, "i": "ll"} ,{"c": 20, "i": "nor"} ,{"c": 19, "i": "sra"} ,{"c": 17, "i": "dsra"} ,{"c": 17, "i": "blez"} ,{"c": 16, "i": "ddivu"} ,{"c": 5, "i": "syscall"} ,{"c": 5, "i": "dins"} ,{"c": 5, "i": "clz"} ,{"c": 4, "i": "bal"} ,{"c": 3, "i": "bgtz"} ,{"c": 2, "i": "srav"} ,{"c": 2, "i": "mult"} ,{"c": 2, "i": "divu"} ,{"c": 1, "i": "b"}]
```
and get all instructions for kona. This PR implements instructions which were not implemented in mipsevm, for running kona mips64r2 binary.

Instruction manual here: https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MIPS_Architecture_MIPS64_InstructionSet_%20AFP_P_MD00087_06.05.pdf

**Tests**

Unit tests added per execution of new instructions off chain.

Validated that kona mips64r2 binary runs inside cannon by using preimage https://github.com/op-rs/kona/blob/main/bin/client/testdata/holocene-op-sepolia-22012816-witness.tar.zst, based on https://github.com/op-rs/kona/pull/1052 and [kona ci](https://github.com/op-rs/kona/blob/main/.github/workflows/client_host.yaml).
```
just run-client-cannon-offline 22012816 0x42ff78e504c207c3786cb30ecb74fe915984b48649165f95bbf6f9248584be69 0x9084f101b85cd1c7c624946feca169768896d88b3ecf4eea3a7760bfceb9cd73 0x6a34183664b9ad39de024a8d4077c78abf05198148b6dbfc6e39fbe4a70de299 0x02a50d0b5a3226758a6e9b2bdeb5deb5f0779ab55b2b34a52331d0eac48c9389 11155420
```

Differential testing not implemented because only implemented the offchain version. Also no fuzz tests yet.

**Metadata**

https://github.com/ethereum-optimism/optimism/issues/13969
