### PR TITLE
fix: reduce context size for docker images

### DIFF
--- a/op-program/Dockerfile.repro.dockerignore
+++ b/op-program/Dockerfile.repro.dockerignore
@@ -8,6 +8,9 @@
 !op-node/
 !op-preimage/
 !op-program/
-op-program/bin/
 !op-service/
 !op-supervisor/
+
+**/bin
+**/testdata
+**/tests

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -23,3 +23,7 @@
 !/go.sum
 !/justfiles
 !/mise.toml
+
+**/bin
+**/testdata
+**/tests


### PR DESCRIPTION
**Description**

This change tries to trim further the set of artifacts that land in the
docker build context for images that contribute to kurtosis devnets.
We would like idempotent builds to be as fast as possible.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
part of #14390