### PR TITLE
fix(kt-devnet): make docker images idempotent

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -36,7 +36,13 @@ _prestate-build PATH='.':
     docker buildx build --output {{PATH}} --progress plain -f ../op-program/Dockerfile.repro ../
 
 _docker_build TAG TARGET CONTEXT DOCKERFILE *ARGS:
-    docker buildx build --load -t {{TAG}} \
+    #!/usr/bin/env bash
+    # --load is needed to ensure the image ends up in the local registry
+    # --provenance=false is needed to make the build idempotent
+    docker buildx build \
+        --load \
+        --provenance=false \
+        -t {{TAG}} \
         -f {{CONTEXT}}/{{DOCKERFILE}} \
         {{ if TARGET != '' {  "--target " + TARGET } else { "" } }} \
         --build-arg GIT_COMMIT={git_commit} \


### PR DESCRIPTION
**Description**

Provenance attestations contain, among other things, a timestamp for the
build, which immediately makes the build non-reproducible.
This in turn creates unnecessary churn for the devnet, as each image
appears different even when it has the exact same content.

Conversely, skipping provenance is not really an issue in a devnet
environment.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
part of #14390