### PR TITLE
fix(devnet-sdk): allow in-place redeployment

### DIFF
--- a/devnet-sdk/kt/fs/fs_test.go
+++ b/devnet-sdk/kt/fs/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/stretchr/testify/require"
 )
@@ -52,6 +53,12 @@ func (m *mockEnclaveContext) UploadFiles(pathToUpload string, artifactName strin
 
 	return "test-uuid", services.FileArtifactName(artifactName), err
 }
+
+func (m *mockEnclaveContext) GetAllFilesArtifactNamesAndUuids(ctx context.Context) ([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, error) {
+	return nil, nil
+}
+
+var _ EnclaveContextIface = (*mockEnclaveContext)(nil)
 
 func createTarGzArtifact(t *testing.T, files map[string]string) []byte {
 	var buf bytes.Buffer

--- a/devnet-sdk/testing/systest/provider.go
+++ b/devnet-sdk/testing/systest/provider.go
@@ -13,6 +13,3 @@ type defaultProvider struct{}
 func (p *defaultProvider) NewSystemFromURL(url string) (system.System, error) {
 	return system.NewSystemFromURL(url)
 }
-
-// currentPackage is the current package implementation
-var currentPackage systemProvider = &defaultProvider{}

--- a/kurtosis-devnet/pkg/deploy/deploy_test.go
+++ b/kurtosis-devnet/pkg/deploy/deploy_test.go
@@ -9,8 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +41,30 @@ func (m *mockDeployerForTest) Deploy(ctx context.Context, input io.Reader) (*spe
 
 func (m *mockDeployerForTest) GetEnvironmentInfo(ctx context.Context, spec *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error) {
 	return &kurtosis.KurtosisEnvironment{}, nil
+}
+
+// mockEnclaveContext implements EnclaveContextIface for testing
+type mockEnclaveContext struct {
+	artifacts []string
+}
+
+func (m *mockEnclaveContext) GetAllFilesArtifactNamesAndUuids(ctx context.Context) ([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, error) {
+	result := make([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, len(m.artifacts))
+	for i, name := range m.artifacts {
+		result[i] = &kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid{
+			FileName: name,
+			FileUuid: "test-uuid",
+		}
+	}
+	return result, nil
+}
+
+func (m *mockEnclaveContext) DownloadFilesArtifact(ctx context.Context, name string) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockEnclaveContext) UploadFiles(pathToUpload string, artifactName string) (services.FilesArtifactUUID, services.FileArtifactName, error) {
+	return "", "", nil
 }
 
 func TestDeploy(t *testing.T) {
@@ -68,12 +95,24 @@ func TestDeploy(t *testing.T) {
 		return &mockDeployerForTest{baseDir: tmpDir}, nil
 	}
 
+	// Create a mock EnclaveFS function
+	mockEnclaveFSFunc := func(ctx context.Context, enclave string) (*ktfs.EnclaveFS, error) {
+		mockCtx := &mockEnclaveContext{
+			artifacts: []string{
+				"devnet-descriptor-1",
+				"devnet-descriptor-2",
+			},
+		}
+		return ktfs.NewEnclaveFSWithContext(mockCtx), nil
+	}
+
 	d := NewDeployer(
 		WithBaseDir(tmpDir),
 		WithKurtosisDeployer(mockDeployerFunc),
 		WithDryRun(true),
 		WithTemplateFile(templatePath),
 		WithDataFile(dataPath),
+		WithNewEnclaveFSFunc(mockEnclaveFSFunc),
 	)
 
 	env, err := d.Deploy(ctx, deployConfig)
@@ -91,4 +130,72 @@ func TestDeploy(t *testing.T) {
 	err = json.Unmarshal(content, &envData)
 	require.NoError(t, err)
 	assert.Equal(t, "value", envData["test"])
+}
+
+func TestGetNextDevnetDescriptor(t *testing.T) {
+	tests := []struct {
+		name        string
+		artifacts   []string
+		wantName    string
+		wantErrText string
+	}{
+		{
+			name: "increments highest numbered descriptor",
+			artifacts: []string{
+				"devnet-descriptor-1",
+				"devnet-descriptor-5",
+				"devnet-descriptor-10",
+				"other",
+			},
+			wantName: "devnet-descriptor-11",
+		},
+		{
+			name: "handles non-numeric suffixes",
+			artifacts: []string{
+				"devnet-descriptor-1",
+				"devnet-descriptor-5",
+				"devnet-descriptor-abc",
+				"devnet-descriptor-10",
+				"other",
+				"devnet-descriptor-def",
+			},
+			wantName: "devnet-descriptor-11",
+		},
+		{
+			name:      "no descriptors",
+			artifacts: []string{},
+			wantName:  "devnet-descriptor-0",
+		},
+		{
+			name: "no valid descriptors",
+			artifacts: []string{
+				"other",
+				"devnet-abc",
+			},
+			wantName: "devnet-descriptor-0",
+		},
+		{
+			name: "handles negative numbers",
+			artifacts: []string{
+				"devnet-descriptor--1",
+				"devnet-descriptor-5",
+			},
+			wantName: "devnet-descriptor-6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtx := &mockEnclaveContext{artifacts: tt.artifacts}
+			fs := ktfs.NewEnclaveFSWithContext(mockCtx)
+			got, err := getNextDevnetDescriptor(context.Background(), fs)
+			if tt.wantErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, got)
+		})
+	}
 }


### PR DESCRIPTION
**Description**

Currently, the last step of the deployment (storing the devnet
descriptor into the enclave) fails the 2nd time around.
As kurtosis API doesn't allow us to overwrite an artifact, we sidestep
the issue by storing successive generations of the descriptor.

Also adjust the environment fetcher to detect and load the last
generation.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
Part of #14390