### PR TITLE
cannon: Extend cannon-stf-verify to include 64-bit vm

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -24,11 +24,22 @@ ARG GIT_DATE
 ARG TARGETOS TARGETARCH
 
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.4 AS cannon-v2
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0-alpha.1 AS cannon-multithreaded64-3
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-verify
 COPY --from=cannon-v2 /usr/local/bin/cannon /usr/local/bin/cannon-v2
+COPY --from=cannon-multithreaded64-3 /usr/local/bin/cannon /usr/local/bin/cannon-multithreaded64-3
+
+# Check cannon-v2
 # verify the latest singlethreaded VM behavior against cannon-v2
 RUN cd cannon && make diff-singlethreaded-2-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v2
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && \
   make diff-singlethreaded-2-cannon -e OTHER_CANNON=/usr/local/bin/cannon-v2 \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE
+
+# Check cannon-multithreaded64-3
+# verify the latest multithreaded VM behavior against multithreaded64-3
+RUN cd cannon && make diff-multithreaded64-3-cannon -e OTHER_CANNON=/usr/local/bin/cannon-multithreaded64-3
+RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && \
+ make diff-multithreaded64-3-cannon -e OTHER_CANNON=/usr/local/bin/cannon-multithreaded64-3 \
+ GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE

--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -23,7 +23,7 @@ ARG GIT_DATE
 
 ARG TARGETOS TARGETARCH
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0 AS cannon-v2
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.4 AS cannon-v2
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0 AS cannon-multithreaded64-3
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-verify

--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -23,8 +23,8 @@ ARG GIT_DATE
 
 ARG TARGETOS TARGETARCH
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0-alpha.4 AS cannon-v2
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0-alpha.1 AS cannon-multithreaded64-3
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.1.0 AS cannon-v2
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0 AS cannon-multithreaded64-3
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-verify
 COPY --from=cannon-v2 /usr/local/bin/cannon /usr/local/bin/cannon-v2

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -71,7 +71,7 @@ diff-%-cannon: cannon elf
 	# Load an elf file to create a prestate, and check that both cannon versions generate the same prestate
 	@VM=$*; \
 	echo "Running diff for VM type $${VM}"; \
-	if [ "$${VM#multithreaded64}" != "$${VM}" ]; then \
+	if echo "$$VM" | grep -q '^multithreaded64'; then \
 		echo "Loading 64-bit program"; \
 		ELF_SUFFIX="64.elf"; \
 	else \

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -68,15 +68,27 @@ test64: elf contract
 	go test -tags=cannon64 -run '(TestEVM.*64|TestHelloEVM|TestClaimEVM)' ./mipsevm/tests
 
 diff-%-cannon: cannon elf
-	$$OTHER_CANNON load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate-other.bin.gz --meta ""
-	./bin/cannon   load-elf --type $* --path ./testdata/example/bin/hello.elf --out ./bin/prestate.bin.gz --meta ""
-	@cmp ./bin/prestate-other.bin.gz ./bin/prestate.bin.gz
+	# Load an elf file to create a prestate, and check that both cannon versions generate the same prestate
+	@VM=$*; \
+	echo "Running diff for VM type $${VM}"; \
+	if [ "$${VM#multithreaded64}" != "$${VM}" ]; then \
+		echo "Loading 64-bit program"; \
+		ELF_SUFFIX="64.elf"; \
+	else \
+		echo "Loading 32-bit program"; \
+		ELF_SUFFIX="elf"; \
+	fi; \
+	$$OTHER_CANNON load-elf --type $$VM --path ./testdata/example/bin/hello.$${ELF_SUFFIX} --out ./bin/prestate-other.bin.gz --meta ""; \
+	./bin/cannon   load-elf --type $$VM --path ./testdata/example/bin/hello.$${ELF_SUFFIX} --out ./bin/prestate.bin.gz --meta "";
+	@cmp ./bin/prestate-other.bin.gz ./bin/prestate.bin.gz;
 	@if [ $$? -eq 0 ]; then \
 		echo "Generated identical prestates"; \
 	else \
 		echo "Generated different prestates"; \
 		exit 1; \
 	fi
+
+  # Run cannon and check that both cannon versions produce identical states
 	$$OTHER_CANNON run --proof-at '=0' --stop-at '=100000000' --input=./bin/prestate.bin.gz  --output ./bin/out-other.bin.gz --meta ""
 	./bin/cannon   run --proof-at '=0' --stop-at '=100000000' --input=./bin/prestate.bin.gz  --output ./bin/out.bin.gz --meta ""
 	@cmp ./bin/out-other.bin.gz ./bin/out.bin.gz


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Extend `cannon-stf-verify` task to compare the latest 64-bit VM to the 64-bit vm tagged at `cannon:v1.4.0-alpha.1`. 

**Tests**

Ran task manually to verify. 

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/12255
