### PR TITLE
Move to foundry v1 and benchmark

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -29,9 +29,9 @@ just = "1.37.0"
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
 # The git ref here should be on the `stable` branch.
-forge = "stable"
-cast = "stable"
-anvil = "stable"
+forge = "v1.0.0"
+cast = "v1.0.0"
+anvil = "v1.0.0"
 
 # Other dependencies
 codecov-uploader = "0.8.0"

--- a/mise.toml
+++ b/mise.toml
@@ -29,9 +29,9 @@ just = "1.37.0"
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
 # The git ref here should be on the `stable` branch.
-forge = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
-cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
-anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
+forge = "stable"
+cast = "stable"
+anvil = "stable"
 
 # Other dependencies
 codecov-uploader = "0.8.0"

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -7,7 +7,15 @@ import { Test } from "forge-std/Test.sol";
 // Target contract
 import { Bytes } from "src/libraries/Bytes.sol";
 
+contract Bytes_Harness {
+    function exposed_slice(bytes memory _input, uint256 _start, uint256 _length) public pure returns (bytes memory) {
+        return Bytes.slice(_input, _start, _length);
+    }
+}
+
 contract Bytes_slice_Test is Test {
+    Bytes_Harness harness;
+
     /// @notice Tests that the `slice` function works as expected when starting from index 0.
     function test_slice_fromZeroIdx_works() public pure {
         bytes memory input = hex"11223344556677889900";
@@ -124,6 +132,12 @@ contract Bytes_slice_Test is Test {
 }
 
 contract Bytes_slice_TestFail is Test {
+    Bytes_Harness harness;
+
+    function setUp() public {
+        harness = new Bytes_Harness();
+    }
+
     /// @notice Tests that, when given an input bytes array of length `n`, the `slice` function will
     ///         always revert if `_start + _length > n`.
     function testFuzz_slice_outOfBounds_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
@@ -142,7 +156,7 @@ contract Bytes_slice_TestFail is Test {
         }
 
         vm.expectRevert("slice_outOfBounds");
-        Bytes.slice(_input, _start, _length);
+        harness.exposed_slice(_input, _start, _length);
     }
 
     /// @notice Tests that, when given a length `n` that is greater than `type(uint256).max - 31`,
@@ -152,7 +166,7 @@ contract Bytes_slice_TestFail is Test {
         _length = uint256(bound(_length, type(uint256).max - 30, type(uint256).max));
 
         vm.expectRevert("slice_overflow");
-        Bytes.slice(_input, _start, _length);
+        harness.exposed_slice(_input, _start, _length);
     }
 
     /// @notice Tests that, when given a start index `n` that is greater than
@@ -169,7 +183,7 @@ contract Bytes_slice_TestFail is Test {
         vm.assume(_start > type(uint256).max - _length);
 
         vm.expectRevert("slice_overflow");
-        Bytes.slice(_input, _start, _length);
+        harness.exposed_slice(_input, _start, _length);
     }
 }
 

--- a/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
+++ b/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
@@ -7,9 +7,21 @@ import { Constants } from "src/libraries/Constants.sol";
 import { Test } from "forge-std/Test.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 
+contract GasPayingToken_Harness {
+    function exposed_sanitize(string memory _str) public pure returns (bytes32) {
+        return GasPayingToken.sanitize(_str);
+    }
+}
+
 /// @title GasPayingToken_Roundtrip_Test
 /// @notice Tests the roundtrip of setting and getting the gas paying token.
 contract GasPayingToken_Roundtrip_Test is Test {
+    GasPayingToken_Harness harness;
+
+    function setUp() public {
+        harness = new GasPayingToken_Harness();
+    }
+
     /// @dev Test that the gas paying token correctly sets values in storage.
     function testFuzz_set_succeeds(address _token, uint8 _decimals, bytes32 _name, bytes32 _symbol) external {
         GasPayingToken.set(_token, _decimals, _name, _symbol);
@@ -104,7 +116,7 @@ contract GasPayingToken_Roundtrip_Test is Test {
 
         vm.expectRevert("GasPayingToken: string cannot be greater than 32 bytes");
 
-        GasPayingToken.sanitize(_str);
+        harness.exposed_sanitize(_str);
     }
 
     /// @dev Test that `sanitize` works as expected when the input string is empty.

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 import "src/libraries/rlp/RLPErrors.sol";
 
-/// @notice Here we allow internal reverts as readRawBytes uses memory allocations and can only be tested internally.
+/// @notice Here we allow internal reverts as readRawBytes uses memory allocations and can only be tested internally
 contract RLPReader_readBytes_Test is Test {
     function test_readBytes_bytestring00_succeeds() external pure {
         assertEq(RLPReader.readBytes(hex"00"), hex"00");

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -6,249 +6,257 @@ import { Test } from "forge-std/Test.sol";
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 import "src/libraries/rlp/RLPErrors.sol";
 
-library RLPReader_Harness {
-    function readBytes(bytes memory _in) public pure returns (bytes memory) {
-        return RLPReader.readBytes(_in);
-    }
-
-    function readList(bytes memory _in) public pure returns (RLPReader.RLPItem[] memory) {
-        return RLPReader.readList(_in);
-    }
-
-    function readList(RLPReader.RLPItem memory _in) public pure returns (RLPReader.RLPItem[] memory) {
-        return RLPReader.readList(_in);
-    }
-
-    function readRawBytes(RLPReader.RLPItem memory _in) public pure returns (bytes memory) {
-        return RLPReader.readRawBytes(_in);
-    }
-}
-
+/// @notice Here we allow internal reverts as readRawBytes uses memory allocations and can only be tested internally.
 contract RLPReader_readBytes_Test is Test {
     function test_readBytes_bytestring00_succeeds() external pure {
-        assertEq(RLPReader_Harness.readBytes(hex"00"), hex"00");
+        assertEq(RLPReader.readBytes(hex"00"), hex"00");
     }
 
     function test_readBytes_bytestring01_succeeds() external pure {
-        assertEq(RLPReader_Harness.readBytes(hex"01"), hex"01");
+        assertEq(RLPReader.readBytes(hex"01"), hex"01");
     }
 
     function test_readBytes_bytestring7f_succeeds() external pure {
-        assertEq(RLPReader_Harness.readBytes(hex"7f"), hex"7f");
+        assertEq(RLPReader.readBytes(hex"7f"), hex"7f");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readBytes_revertListItem_reverts() external {
         vm.expectRevert(UnexpectedList.selector);
-        RLPReader_Harness.readBytes(hex"c7c0c1c0c3c0c1c0");
+        RLPReader.readBytes(hex"c7c0c1c0c3c0c1c0");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readBytes_invalidStringLength_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readBytes(hex"b9");
+        RLPReader.readBytes(hex"b9");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readBytes_invalidListLength_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readBytes(hex"ff");
+        RLPReader.readBytes(hex"ff");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readBytes_invalidRemainder_reverts() external {
         vm.expectRevert(InvalidDataRemainder.selector);
-        RLPReader_Harness.readBytes(hex"800a");
+        RLPReader.readBytes(hex"800a");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readBytes_invalidPrefix_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readBytes(hex"810a");
+        RLPReader.readBytes(hex"810a");
     }
 }
 
 contract RLPReader_readList_Test is Test {
     function test_readList_empty_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c0");
+        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c0");
         assertEq(list.length, 0);
     }
 
     function test_readList_multiList_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c6827a77c10401");
+        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c6827a77c10401");
         assertEq(list.length, 3);
 
-        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"827a77");
-        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"c104");
-        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"01");
+        assertEq(RLPReader.readRawBytes(list[0]), hex"827a77");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"c104");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"01");
     }
 
     function test_readList_shortListMax1_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
+        RLPReader.RLPItem[] memory list = RLPReader.readList(
             hex"f784617364668471776572847a78637684617364668471776572847a78637684617364668471776572847a78637684617364668471776572"
         );
 
         assertEq(list.length, 11);
-        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"8461736466");
-        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"8471776572");
-        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"847a786376");
-        assertEq(RLPReader_Harness.readRawBytes(list[3]), hex"8461736466");
-        assertEq(RLPReader_Harness.readRawBytes(list[4]), hex"8471776572");
-        assertEq(RLPReader_Harness.readRawBytes(list[5]), hex"847a786376");
-        assertEq(RLPReader_Harness.readRawBytes(list[6]), hex"8461736466");
-        assertEq(RLPReader_Harness.readRawBytes(list[7]), hex"8471776572");
-        assertEq(RLPReader_Harness.readRawBytes(list[8]), hex"847a786376");
-        assertEq(RLPReader_Harness.readRawBytes(list[9]), hex"8461736466");
-        assertEq(RLPReader_Harness.readRawBytes(list[10]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[0]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"847a786376");
+        assertEq(RLPReader.readRawBytes(list[3]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[4]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[5]), hex"847a786376");
+        assertEq(RLPReader.readRawBytes(list[6]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[7]), hex"8471776572");
+        assertEq(RLPReader.readRawBytes(list[8]), hex"847a786376");
+        assertEq(RLPReader.readRawBytes(list[9]), hex"8461736466");
+        assertEq(RLPReader.readRawBytes(list[10]), hex"8471776572");
     }
 
     function test_readList_longList1_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
+        RLPReader.RLPItem[] memory list = RLPReader.readList(
             hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
 
         assertEq(list.length, 4);
-        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader_Harness.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
     }
 
     function test_readList_longList2_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
+        RLPReader.RLPItem[] memory list = RLPReader.readList(
             hex"f90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
         assertEq(list.length, 32);
 
         for (uint256 i = 0; i < 32; i++) {
-            assertEq(RLPReader_Harness.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
+            assertEq(RLPReader.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_listLongerThan32Elements_reverts() external {
         vm.expectRevert(stdError.indexOOBError);
-        RLPReader_Harness.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
+        RLPReader.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
     }
 
     function test_readList_listOfLists_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c4c2c0c0c0");
+        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c4c2c0c0c0");
         assertEq(list.length, 2);
-        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"c2c0c0");
-        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"c0");
+        assertEq(RLPReader.readRawBytes(list[0]), hex"c2c0c0");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"c0");
     }
 
     function test_readList_listOfLists2_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c7c0c1c0c3c0c1c0");
+        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c7c0c1c0c3c0c1c0");
         assertEq(list.length, 3);
 
-        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"c0");
-        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"c1c0");
-        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"c3c0c1c0");
+        assertEq(RLPReader.readRawBytes(list[0]), hex"c0");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"c1c0");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"c3c0c1c0");
     }
 
     function test_readList_dictTest1_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
+        RLPReader.RLPItem[] memory list = RLPReader.readList(
             hex"ecca846b6579318476616c31ca846b6579328476616c32ca846b6579338476616c33ca846b6579348476616c34"
         );
         assertEq(list.length, 4);
 
-        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"ca846b6579318476616c31");
-        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"ca846b6579328476616c32");
-        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"ca846b6579338476616c33");
-        assertEq(RLPReader_Harness.readRawBytes(list[3]), hex"ca846b6579348476616c34");
+        assertEq(RLPReader.readRawBytes(list[0]), hex"ca846b6579318476616c31");
+        assertEq(RLPReader.readRawBytes(list[1]), hex"ca846b6579328476616c32");
+        assertEq(RLPReader.readRawBytes(list[2]), hex"ca846b6579338476616c33");
+        assertEq(RLPReader.readRawBytes(list[3]), hex"ca846b6579348476616c34");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_invalidShortList_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"efdebd");
+        RLPReader.readList(hex"efdebd");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_longStringLength_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"efb83600");
+        RLPReader.readList(hex"efb83600");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_notLongEnough_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_int32Overflow_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"bf0f000000000000021111");
+        RLPReader.readList(hex"bf0f000000000000021111");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_int32Overflow2_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"ff0f000000000000021111");
+        RLPReader.readList(hex"ff0f000000000000021111");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_incorrectLengthInArray_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
+        RLPReader.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_leadingZerosInLongLengthArray1_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(
+        RLPReader.readList(
             hex"b90040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_leadingZerosInLongLengthArray2_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(hex"b800");
+        RLPReader.readList(hex"b800");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_leadingZerosInLongLengthList1_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(
+        RLPReader.readList(
             hex"fb00000040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_nonOptimalLongLengthArray1_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(hex"b81000112233445566778899aabbccddeeff");
+        RLPReader.readList(hex"b81000112233445566778899aabbccddeeff");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_nonOptimalLongLengthArray2_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(hex"b801ff");
+        RLPReader.readList(hex"b801ff");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_invalidValue_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"91");
+        RLPReader.readList(hex"91");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_invalidRemainder_reverts() external {
         vm.expectRevert(InvalidDataRemainder.selector);
-        RLPReader_Harness.readList(hex"c000");
+        RLPReader.readList(hex"c000");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_notEnoughContentForString1_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"ba010000aabbccddeeff");
+        RLPReader.readList(hex"ba010000aabbccddeeff");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_notEnoughContentForString2_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"b840ffeeddccbbaa99887766554433221100");
+        RLPReader.readList(hex"b840ffeeddccbbaa99887766554433221100");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_notEnoughContentForList1_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"f90180");
+        RLPReader.readList(hex"f90180");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_notEnoughContentForList2_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader_Harness.readList(hex"ffffffffffffffffff0001020304050607");
+        RLPReader.readList(hex"ffffffffffffffffff0001020304050607");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_longStringLessThan56Bytes_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(hex"b80100");
+        RLPReader.readList(hex"b80100");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_readList_longListLessThan56Bytes_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader_Harness.readList(hex"f80100");
+        RLPReader.readList(hex"f80100");
     }
 }

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -19,7 +19,7 @@ library RLPReader_Harness {
         return RLPReader.readList(_in);
     }
 
-    function readRawBytes(RLPReader.RLPItem memory _in) public pure returns (bytes memory out_) {
+    function readRawBytes(RLPReader.RLPItem memory _in) public pure returns (bytes memory) {
         return RLPReader.readRawBytes(_in);
     }
 }

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -6,231 +6,249 @@ import { Test } from "forge-std/Test.sol";
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 import "src/libraries/rlp/RLPErrors.sol";
 
+library RLPReader_Harness {
+    function readBytes(bytes memory _in) public pure returns (bytes memory) {
+        return RLPReader.readBytes(_in);
+    }
+
+    function readList(bytes memory _in) public pure returns (RLPReader.RLPItem[] memory) {
+        return RLPReader.readList(_in);
+    }
+
+    function readList(RLPReader.RLPItem memory _in) public pure returns (RLPReader.RLPItem[] memory) {
+        return RLPReader.readList(_in);
+    }
+
+    function readRawBytes(RLPReader.RLPItem memory _in) public pure returns (bytes memory out_) {
+        return RLPReader.readRawBytes(_in);
+    }
+}
+
 contract RLPReader_readBytes_Test is Test {
     function test_readBytes_bytestring00_succeeds() external pure {
-        assertEq(RLPReader.readBytes(hex"00"), hex"00");
+        assertEq(RLPReader_Harness.readBytes(hex"00"), hex"00");
     }
 
     function test_readBytes_bytestring01_succeeds() external pure {
-        assertEq(RLPReader.readBytes(hex"01"), hex"01");
+        assertEq(RLPReader_Harness.readBytes(hex"01"), hex"01");
     }
 
     function test_readBytes_bytestring7f_succeeds() external pure {
-        assertEq(RLPReader.readBytes(hex"7f"), hex"7f");
+        assertEq(RLPReader_Harness.readBytes(hex"7f"), hex"7f");
     }
 
     function test_readBytes_revertListItem_reverts() external {
         vm.expectRevert(UnexpectedList.selector);
-        RLPReader.readBytes(hex"c7c0c1c0c3c0c1c0");
+        RLPReader_Harness.readBytes(hex"c7c0c1c0c3c0c1c0");
     }
 
     function test_readBytes_invalidStringLength_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readBytes(hex"b9");
+        RLPReader_Harness.readBytes(hex"b9");
     }
 
     function test_readBytes_invalidListLength_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readBytes(hex"ff");
+        RLPReader_Harness.readBytes(hex"ff");
     }
 
     function test_readBytes_invalidRemainder_reverts() external {
         vm.expectRevert(InvalidDataRemainder.selector);
-        RLPReader.readBytes(hex"800a");
+        RLPReader_Harness.readBytes(hex"800a");
     }
 
     function test_readBytes_invalidPrefix_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readBytes(hex"810a");
+        RLPReader_Harness.readBytes(hex"810a");
     }
 }
 
 contract RLPReader_readList_Test is Test {
     function test_readList_empty_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c0");
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c0");
         assertEq(list.length, 0);
     }
 
     function test_readList_multiList_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c6827a77c10401");
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c6827a77c10401");
         assertEq(list.length, 3);
 
-        assertEq(RLPReader.readRawBytes(list[0]), hex"827a77");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"c104");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"01");
+        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"827a77");
+        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"c104");
+        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"01");
     }
 
     function test_readList_shortListMax1_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
             hex"f784617364668471776572847a78637684617364668471776572847a78637684617364668471776572847a78637684617364668471776572"
         );
 
         assertEq(list.length, 11);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"8471776572");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"847a786376");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[4]), hex"8471776572");
-        assertEq(RLPReader.readRawBytes(list[5]), hex"847a786376");
-        assertEq(RLPReader.readRawBytes(list[6]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[7]), hex"8471776572");
-        assertEq(RLPReader.readRawBytes(list[8]), hex"847a786376");
-        assertEq(RLPReader.readRawBytes(list[9]), hex"8461736466");
-        assertEq(RLPReader.readRawBytes(list[10]), hex"8471776572");
+        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"8461736466");
+        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"8471776572");
+        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[3]), hex"8461736466");
+        assertEq(RLPReader_Harness.readRawBytes(list[4]), hex"8471776572");
+        assertEq(RLPReader_Harness.readRawBytes(list[5]), hex"847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[6]), hex"8461736466");
+        assertEq(RLPReader_Harness.readRawBytes(list[7]), hex"8471776572");
+        assertEq(RLPReader_Harness.readRawBytes(list[8]), hex"847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[9]), hex"8461736466");
+        assertEq(RLPReader_Harness.readRawBytes(list[10]), hex"8471776572");
     }
 
     function test_readList_longList1_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
             hex"f840cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
 
         assertEq(list.length, 4);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
+        assertEq(RLPReader_Harness.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
     }
 
     function test_readList_longList2_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
             hex"f90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
         assertEq(list.length, 32);
 
         for (uint256 i = 0; i < 32; i++) {
-            assertEq(RLPReader.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
+            assertEq(RLPReader_Harness.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
         }
     }
 
     function test_readList_listLongerThan32Elements_reverts() external {
         vm.expectRevert(stdError.indexOOBError);
-        RLPReader.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
+        RLPReader_Harness.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
     }
 
     function test_readList_listOfLists_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c4c2c0c0c0");
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c4c2c0c0c0");
         assertEq(list.length, 2);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"c2c0c0");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"c0");
+        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"c2c0c0");
+        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"c0");
     }
 
     function test_readList_listOfLists2_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c7c0c1c0c3c0c1c0");
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(hex"c7c0c1c0c3c0c1c0");
         assertEq(list.length, 3);
 
-        assertEq(RLPReader.readRawBytes(list[0]), hex"c0");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"c1c0");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"c3c0c1c0");
+        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"c0");
+        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"c1c0");
+        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"c3c0c1c0");
     }
 
     function test_readList_dictTest1_succeeds() external pure {
-        RLPReader.RLPItem[] memory list = RLPReader.readList(
+        RLPReader.RLPItem[] memory list = RLPReader_Harness.readList(
             hex"ecca846b6579318476616c31ca846b6579328476616c32ca846b6579338476616c33ca846b6579348476616c34"
         );
         assertEq(list.length, 4);
 
-        assertEq(RLPReader.readRawBytes(list[0]), hex"ca846b6579318476616c31");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"ca846b6579328476616c32");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"ca846b6579338476616c33");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"ca846b6579348476616c34");
+        assertEq(RLPReader_Harness.readRawBytes(list[0]), hex"ca846b6579318476616c31");
+        assertEq(RLPReader_Harness.readRawBytes(list[1]), hex"ca846b6579328476616c32");
+        assertEq(RLPReader_Harness.readRawBytes(list[2]), hex"ca846b6579338476616c33");
+        assertEq(RLPReader_Harness.readRawBytes(list[3]), hex"ca846b6579348476616c34");
     }
 
     function test_readList_invalidShortList_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"efdebd");
+        RLPReader_Harness.readList(hex"efdebd");
     }
 
     function test_readList_longStringLength_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"efb83600");
+        RLPReader_Harness.readList(hex"efb83600");
     }
 
     function test_readList_notLongEnough_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        RLPReader_Harness.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
     function test_readList_int32Overflow_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"bf0f000000000000021111");
+        RLPReader_Harness.readList(hex"bf0f000000000000021111");
     }
 
     function test_readList_int32Overflow2_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"ff0f000000000000021111");
+        RLPReader_Harness.readList(hex"ff0f000000000000021111");
     }
 
     function test_readList_incorrectLengthInArray_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
+        RLPReader_Harness.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
     }
 
     function test_readList_leadingZerosInLongLengthArray1_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(
+        RLPReader_Harness.readList(
             hex"b90040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
 
     function test_readList_leadingZerosInLongLengthArray2_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(hex"b800");
+        RLPReader_Harness.readList(hex"b800");
     }
 
     function test_readList_leadingZerosInLongLengthList1_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(
+        RLPReader_Harness.readList(
             hex"fb00000040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
 
     function test_readList_nonOptimalLongLengthArray1_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(hex"b81000112233445566778899aabbccddeeff");
+        RLPReader_Harness.readList(hex"b81000112233445566778899aabbccddeeff");
     }
 
     function test_readList_nonOptimalLongLengthArray2_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(hex"b801ff");
+        RLPReader_Harness.readList(hex"b801ff");
     }
 
     function test_readList_invalidValue_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"91");
+        RLPReader_Harness.readList(hex"91");
     }
 
     function test_readList_invalidRemainder_reverts() external {
         vm.expectRevert(InvalidDataRemainder.selector);
-        RLPReader.readList(hex"c000");
+        RLPReader_Harness.readList(hex"c000");
     }
 
     function test_readList_notEnoughContentForString1_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"ba010000aabbccddeeff");
+        RLPReader_Harness.readList(hex"ba010000aabbccddeeff");
     }
 
     function test_readList_notEnoughContentForString2_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"b840ffeeddccbbaa99887766554433221100");
+        RLPReader_Harness.readList(hex"b840ffeeddccbbaa99887766554433221100");
     }
 
     function test_readList_notEnoughContentForList1_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"f90180");
+        RLPReader_Harness.readList(hex"f90180");
     }
 
     function test_readList_notEnoughContentForList2_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
-        RLPReader.readList(hex"ffffffffffffffffff0001020304050607");
+        RLPReader_Harness.readList(hex"ffffffffffffffffff0001020304050607");
     }
 
     function test_readList_longStringLessThan56Bytes_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(hex"b80100");
+        RLPReader_Harness.readList(hex"b80100");
     }
 
     function test_readList_longListLessThan56Bytes_reverts() external {
         vm.expectRevert(InvalidHeader.selector);
-        RLPReader.readList(hex"f80100");
+        RLPReader_Harness.readList(hex"f80100");
     }
 }


### PR DESCRIPTION
Prepare the changes to move to foundry's version 1. @mds1 asked for a benchmark of building and testing, here you have the results on a M3 Max.

### After migration:

- just build-dev: 38.94s
- just build:  185.64s

(this includes the build as I am running just clean between benchmarks)

- just test-dev:  1043.79s (- compilation: 1004.85s)
- just test  917.71s (- compilation: 732.07s)

### Before migration:

- just build-dev:  39.15s
- just build: 188.48s 

(this includes the build as I am running just clean between benchmarks)

- just test-dev : 1011.86s (- compilation: 972.71s)
- just test: 935.23s (- compilation:  746.75s)