### PR TITLE
op-deployer: add alias for intent-type flag

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -94,6 +94,9 @@ var (
 			state.IntentTypeStandardOverrides),
 		EnvVars: PrefixEnvVar("INTENT_TYPE"),
 		Value:   string(state.IntentTypeStandard),
+		Aliases: []string{
+			"intent-config-type",
+		},
 	}
 )
 

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -253,7 +253,7 @@ func NewIntent(configType IntentType, l1ChainId uint64, l2ChainIds []common.Hash
 		return NewIntentStandardOverrides(l1ChainId, l2ChainIds)
 
 	default:
-		return Intent{}, fmt.Errorf("intent config type not supported")
+		return Intent{}, fmt.Errorf("intent type not supported: %s (valid types: %s, %s, %s)", configType, IntentTypeStandard, IntentTypeCustom, IntentTypeStandardOverrides)
 	}
 }
 


### PR DESCRIPTION
Fix breaking change caused by flag renaming