### PR TITLE
op-program: Consolidate cascading block replacements

### DIFF
--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -146,19 +146,20 @@ const (
 )
 
 func TestDeriveBlockForConsolidateStep(t *testing.T) {
-	createExecMessage := func(initIncludedIn uint64, config *staticConfigSource) interoptypes.Message {
+	createExecMessage := func(initIncludedIn uint64, config *staticConfigSource, initChainIndex supervisortypes.ChainIndex) interoptypes.Message {
 		exec := interoptypes.Message{
 			Identifier: interoptypes.Identifier{
 				Origin:      initiatingMessageOrigin,
 				BlockNumber: initIncludedIn,
 				LogIndex:    0,
-				Timestamp:   initIncludedIn * config.rollupCfgs[chainA].BlockTime,
-				ChainID:     uint256.Int(eth.ChainIDFromBig(config.rollupCfgs[chainA].L2ChainID)),
+				Timestamp:   initIncludedIn * config.rollupCfgs[initChainIndex].BlockTime,
+				ChainID:     uint256.Int(eth.ChainIDFromBig(config.rollupCfgs[initChainIndex].L2ChainID)),
 			},
 			PayloadHash: initPayloadHash,
 		}
 		return exec
 	}
+
 	createInitLog := func() *gethTypes.Log {
 		return &gethTypes.Log{
 			Address: initiatingMessageOrigin,
@@ -179,7 +180,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 			testCase: consolidationTestCase{
 				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
 					init := createInitLog()
-					exec := createExecMessage(includeBlockNumbers[chainA], config)
+					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, exec)}}
 				},
 			},
@@ -189,17 +190,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 			testCase: consolidationTestCase{
 				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
 					init := createInitLog()
-					initPayloadHash := crypto.Keccak256Hash(initiatingMessageTopic[:])
-					execMsg := interoptypes.Message{
-						Identifier: interoptypes.Identifier{
-							Origin:      init.Address,
-							BlockNumber: includeBlockNumbers[chainB],
-							LogIndex:    0,
-							Timestamp:   includeBlockNumbers[chainB] * config.rollupCfgs[chainB].BlockTime,
-							ChainID:     uint256.Int(eth.ChainIDFromBig(config.rollupCfgs[chainB].L2ChainID)),
-						},
-						PayloadHash: initPayloadHash,
-					}
+					execMsg := createExecMessage(includeBlockNumbers[chainB], config, chainB)
 					exec := convertExecutingMessageToLog(t, execMsg)
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {exec}, chainB: {init}}
 				},
@@ -217,7 +208,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 						Address: initiatingMessageOrigin2,
 						Topics:  []common.Hash{initiatingMessageTopic},
 					}
-					exec := createExecMessage(includeBlockNumbers[chainA], config)
+					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.Origin = init2.Address
 					exec.Identifier.LogIndex = 1
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
@@ -228,11 +219,29 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 			},
 		},
 		{
+			name: "HappyPathWithValidMessages-IntraBlockCycle",
+			testCase: consolidationTestCase{
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+					initA := createInitLog()
+					initB := createInitLog()
+
+					execMsgA := createExecMessage(includeBlockNumbers[chainB], config, chainB)
+					execA := convertExecutingMessageToLog(t, execMsgA)
+					execMsgB := createExecMessage(includeBlockNumbers[chainA], config, chainA)
+					execB := convertExecutingMessageToLog(t, execMsgB)
+					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+						chainA: {initA, execA},
+						chainB: {initB, execB},
+					}
+				},
+			},
+		},
+		{
 			name: "ReplaceChainB-UnknownChainID",
 			testCase: consolidationTestCase{
 				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
 					init := createInitLog()
-					exec := createExecMessage(includeBlockNumbers[chainA], config)
+					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.ChainID = uint256.Int(eth.ChainIDFromUInt64(0xdeadbeef))
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, exec)}}
 				},
@@ -253,7 +262,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 						Address: initiatingMessageOrigin2,
 						Topics:  []common.Hash{initiatingMessageTopic},
 					}
-					exec := createExecMessage(includeBlockNumbers[chainA], config)
+					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.Origin = init2.Address
 					exec.Identifier.LogIndex = 0
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
@@ -271,7 +280,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 			testCase: consolidationTestCase{
 				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
 					init := createInitLog()
-					execMsg := createExecMessage(includeBlockNumbers[chainA], config)
+					execMsg := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					execMsg.PayloadHash = crypto.Keccak256Hash([]byte("invalid hash"))
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, execMsg)}}
 				},
@@ -285,7 +294,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 			testCase: consolidationTestCase{
 				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
 					init := createInitLog()
-					execMsg := createExecMessage(includeBlockNumbers[chainA], config)
+					execMsg := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					execMsg.Identifier.Timestamp = execMsg.Identifier.Timestamp - 1
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, execMsg)}}
 				},
@@ -298,10 +307,33 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 			name: "ReplaceBothChains",
 			testCase: consolidationTestCase{
 				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
-					invalidExecMsg := createExecMessage(includeBlockNumbers[chainA], config)
+					invalidExecMsg := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					invalidExecMsg.PayloadHash = crypto.Keccak256Hash([]byte("invalid hash"))
 					log := convertExecutingMessageToLog(t, invalidExecMsg)
 					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {log}, chainB: {log}}
+				},
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
+					return []supervisortypes.ChainIndex{chainA, chainB}
+				},
+			},
+		},
+		{
+			name: "ReplaceBothChains-CascadingReorg",
+			testCase: consolidationTestCase{
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+					initA := createInitLog()
+					initB := createInitLog()
+
+					execMsgA := createExecMessage(includeBlockNumbers[chainB], config, chainB)
+					execA := convertExecutingMessageToLog(t, execMsgA)
+					execMsgB := createExecMessage(includeBlockNumbers[chainA], config, chainA)
+					execMsgB.PayloadHash = crypto.Keccak256Hash([]byte("invalid hash"))
+					execB := convertExecutingMessageToLog(t, execMsgB)
+
+					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+						chainA: {initA, execA},
+						chainB: {initB, execB},
+					}
 				},
 				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
 					return []supervisortypes.ChainIndex{chainA, chainB}
@@ -312,6 +344,10 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "ReplaceBothChains-CascadingReorg" || tt.name == "HappyPathWithValidMessages-IntraBlockCycle" {
+				// TODO(#14425): Note that the cascading reorg test setup also contains cyclic dependencies.
+				t.Skip("Intra-block cycles is not yet supported")
+			}
 			runConsolidationTestCase(t, tt.testCase)
 		})
 	}
@@ -391,10 +427,16 @@ func runConsolidationTestCase(t *testing.T, testCase consolidationTestCase) {
 			replacedBlockOutputRoot := common.Hash(eth.OutputRoot(replacedBlockOutput))
 			l2PreimageOracle.Outputs[replacedBlockOutputRoot] = replacedBlockOutput
 
-			depositsOnlyBlock, _ := createBlock(rng, configSource.rollupCfgs[chainIndexToReplace], 2, nil)
-			depositsOnlyOutputRoot := eth.OutputRoot(createOutput(depositsOnlyBlock.Hash()))
+			depositsOnlyBlock, depositsOnlyBlockReceipts := createBlock(rng, configSource.rollupCfgs[chainIndexToReplace], 2, nil)
+			depositsOnlyOutput := createOutput(depositsOnlyBlock.Hash())
+			depositsOnlyOutputRoot := eth.OutputRoot(depositsOnlyOutput)
 			tasksStub.ExpectBuildDepositOnlyBlock(common.Hash{}, agreedSuperRoot.Chains[chainIndexToReplace].Output, depositsOnlyBlock.Hash(), depositsOnlyOutputRoot)
 			finalRoots[chainIndexToReplace] = depositsOnlyOutputRoot
+			// stub the preimages in the replacement block
+			l2PreimageOracle.Blocks[depositsOnlyBlock.Hash()] = depositsOnlyBlock
+			l2PreimageOracle.BlockData[depositsOnlyBlock.Hash()] = depositsOnlyBlock
+			l2PreimageOracle.Outputs[common.Hash(depositsOnlyOutputRoot)] = depositsOnlyOutput
+			l2PreimageOracle.Receipts[depositsOnlyBlock.Hash()] = depositsOnlyBlockReceipts
 		}
 	}
 	expectedClaim := common.Hash(eth.SuperRoot(&eth.SuperV1{


### PR DESCRIPTION
Handle the case during the interop program consolidation where a block replacement cascades into further block replacements. That is when a block/chain's dependency is found to be invalid and replaced.

fixes #14306 