### PR TITLE
feat(devnet-sdk): Add kurtosis data fetcher for externally deployed enclaves

### DIFF
--- a/devnet-sdk/shell/env/devnet.go
+++ b/devnet-sdk/shell/env/devnet.go
@@ -20,9 +20,10 @@ type DataFetcher func(*url.URL) (string, []byte, error)
 
 // schemeToFetcher maps URL schemes to their respective data fetcher functions
 var schemeToFetcher = map[string]DataFetcher{
-	"":     fetchFileData,
-	"file": fetchFileData,
-	"kt":   fetchKurtosisData,
+	"":         fetchFileData,
+	"file":     fetchFileData,
+	"kt":       fetchKurtosisData,
+	"ktnative": fetchKurtosisNativeData,
 }
 
 // fetchDevnetData retrieves data from a URL based on its scheme

--- a/devnet-sdk/shell/env/kt_native_fetch.go
+++ b/devnet-sdk/shell/env/kt_native_fetch.go
@@ -25,11 +25,11 @@ func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
 
 // fetchKurtosisNativeData reads data directly from kurtosis API using default dependency implementations
 func fetchKurtosisNativeData(u *url.URL) (string, []byte, error) {
-	return fetchKurtosisNativeDataInternal(u, &defaultOSImpl{}, &defaultSpecImpl{}, &defaultKurtosisImpl{})
+	return fetchKurtosisNativeDataInternal(u, &defaultOSOpenImpl{}, &defaultSpecImpl{}, &defaultKurtosisImpl{})
 }
 
 // fetchKurtosisNativeDataInternal reads data directly from kurtosis API using provided dependency implementations
-func fetchKurtosisNativeDataInternal(u *url.URL, osImpl osInterface, specImpl specInterface, kurtosisImpl kurtosisInterface) (string, []byte, error) {
+func fetchKurtosisNativeDataInternal(u *url.URL, osImpl osOpenInterface, specImpl specInterface, kurtosisImpl kurtosisInterface) (string, []byte, error) {
 	// First let's parse the kurtosis URL
 	enclave, argsFileName := parseKurtosisNativeURL(u)
 
@@ -70,10 +70,10 @@ func fetchKurtosisNativeDataInternal(u *url.URL, osImpl osInterface, specImpl sp
 	return enclave, envBytes, nil
 }
 
-// osInterface describes a struct that can open filesystem files for reading
+// osOpenInterface describes a struct that can open filesystem files for reading
 //
-// osInterface is used when loading kurtosis args files from local filesystem
-type osInterface interface {
+// osOpenInterface is used when loading kurtosis args files from local filesystem
+type osOpenInterface interface {
 	Open(name string) (fileInterface, error)
 }
 
@@ -83,10 +83,10 @@ type fileInterface interface {
 	Close() error
 }
 
-// defaultOSImpl implements osInterface
-type defaultOSImpl struct{}
+// defaultOSOpenImpl implements osOpenInterface
+type defaultOSOpenImpl struct{}
 
-func (d *defaultOSImpl) Open(name string) (fileInterface, error) {
+func (d *defaultOSOpenImpl) Open(name string) (fileInterface, error) {
 	return os.Open(name)
 }
 

--- a/devnet-sdk/shell/env/kt_native_fetch.go
+++ b/devnet-sdk/shell/env/kt_native_fetch.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
 )
 
-// parseKurtosisURL parses a Kurtosis URL of the form kt://enclave/artifact/file
+// parseKurtosisNativeURL parses a Kurtosis URL of the form kt://enclave/artifact/file
 // If artifact is omitted, it defaults to "devnet"
 // If file is omitted, it defaults to "env.json"
 func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
@@ -23,11 +23,12 @@ func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
 	return
 }
 
-// fetchKurtosisData reads data directly from kurtosis API
+// fetchKurtosisNativeData reads data directly from kurtosis API using default dependency implementations
 func fetchKurtosisNativeData(u *url.URL) (string, []byte, error) {
 	return fetchKurtosisNativeDataInternal(u, &defaultOSImpl{}, &defaultSpecImpl{}, &defaultKurtosisImpl{})
 }
 
+// fetchKurtosisNativeDataInternal reads data directly from kurtosis API using provided dependency implementations
 func fetchKurtosisNativeDataInternal(u *url.URL, osImpl osInterface, specImpl specInterface, kurtosisImpl kurtosisInterface) (string, []byte, error) {
 	// First let's parse the kurtosis URL
 	enclave, argsFileName := parseKurtosisNativeURL(u)

--- a/devnet-sdk/shell/env/kt_native_fetch.go
+++ b/devnet-sdk/shell/env/kt_native_fetch.go
@@ -1,0 +1,23 @@
+package env
+
+import (
+	"net/url"
+	"strings"
+)
+
+// parseKurtosisURL parses a Kurtosis URL of the form kt://enclave/artifact/file
+// If artifact is omitted, it defaults to "devnet"
+// If file is omitted, it defaults to "env.json"
+func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
+	enclave = u.Host
+	argsFileName = strings.TrimPrefix(u.Path, "/")
+
+	return
+}
+
+// fetchKurtosisData reads data from a Kurtosis artifact
+func fetchKurtosisNativeData(u *url.URL) (string, []byte, error) {
+	// enclave, argsFileName := parseKurtosisNativeURL(u)
+
+	return "", nil, nil
+}

--- a/devnet-sdk/shell/env/kt_native_fetch.go
+++ b/devnet-sdk/shell/env/kt_native_fetch.go
@@ -13,17 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
 )
 
-var (
-	// Default implementation of any required OS functionality
-	osImpl osInterface = &defaultOSImpl{}
-
-	// Default implementation of any required spec functionality
-	specImpl specInterface = &defaultSpecImpl{}
-
-	// Default implementation of any required kurtosis functionality
-	kurtosisImpl kurtosisInterface = &defaultKurtosisImpl{}
-)
-
 // parseKurtosisURL parses a Kurtosis URL of the form kt://enclave/artifact/file
 // If artifact is omitted, it defaults to "devnet"
 // If file is omitted, it defaults to "env.json"
@@ -34,8 +23,12 @@ func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
 	return
 }
 
-// fetchKurtosisData reads data from a Kurtosis artifact
+// fetchKurtosisData reads data directly from kurtosis API
 func fetchKurtosisNativeData(u *url.URL) (string, []byte, error) {
+	return fetchKurtosisNativeDataInternal(u, &defaultOSImpl{}, &defaultSpecImpl{}, &defaultKurtosisImpl{})
+}
+
+func fetchKurtosisNativeDataInternal(u *url.URL, osImpl osInterface, specImpl specInterface, kurtosisImpl kurtosisInterface) (string, []byte, error) {
 	// First let's parse the kurtosis URL
 	enclave, argsFileName := parseKurtosisNativeURL(u)
 

--- a/devnet-sdk/shell/env/kt_native_fetch.go
+++ b/devnet-sdk/shell/env/kt_native_fetch.go
@@ -17,7 +17,7 @@ import (
 // If file is omitted, it defaults to "env.json"
 func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
 	enclave = u.Host
-	argsFileName = strings.TrimPrefix(u.Path, "/")
+	argsFileName = "/" + strings.Trim(u.Path, "/")
 
 	return
 }

--- a/devnet-sdk/shell/env/kt_native_fetch.go
+++ b/devnet-sdk/shell/env/kt_native_fetch.go
@@ -1,8 +1,15 @@
 package env
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/url"
+	"os"
 	"strings"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
 )
 
 // parseKurtosisURL parses a Kurtosis URL of the form kt://enclave/artifact/file
@@ -17,7 +24,42 @@ func parseKurtosisNativeURL(u *url.URL) (enclave, argsFileName string) {
 
 // fetchKurtosisData reads data from a Kurtosis artifact
 func fetchKurtosisNativeData(u *url.URL) (string, []byte, error) {
-	// enclave, argsFileName := parseKurtosisNativeURL(u)
+	// First let's parse the kurtosis URL
+	enclave, argsFileName := parseKurtosisNativeURL(u)
 
-	return "", nil, nil
+	// Open the arguments file
+	argsFile, err := os.Open(argsFileName)
+	if err != nil {
+		return "", nil, fmt.Errorf("error reading arguments file: %w", err)
+	}
+
+	// Make sure to close the file once we're done reading
+	defer argsFile.Close()
+
+	// Once we have the arguments file, we can extract the enclave spec
+	enclaveSpec, err := spec.NewSpec().ExtractData(argsFile)
+	if err != nil {
+		return enclave, nil, fmt.Errorf("error extracting enclave spec: %w", err)
+	}
+
+	// We'll use the deployer to extract the system spec
+	deployer, err := kurtosis.NewKurtosisDeployer(kurtosis.WithKurtosisEnclave(enclave))
+	if err != nil {
+		return enclave, nil, fmt.Errorf("error creating deployer: %w", err)
+	}
+
+	// We'll read the environment info from kurtosis directly
+	ctx := context.Background()
+	env, err := deployer.GetEnvironmentInfo(ctx, enclaveSpec)
+	if err != nil {
+		return enclave, nil, fmt.Errorf("error getting environment info: %w", err)
+	}
+
+	// And the last step is to encode this environment as JSON
+	envBytes, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return enclave, nil, fmt.Errorf("error converting environment info to JSON: %w", err)
+	}
+
+	return enclave, envBytes, nil
 }

--- a/devnet-sdk/shell/env/kt_native_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_native_fetch_test.go
@@ -19,15 +19,9 @@ func TestParseKurtosisNativeURL(t *testing.T) {
 	}{
 		{
 			name:        "absolute file path",
-			urlStr:      "ktnative://myenclave//absolute/path/args.yaml",
+			urlStr:      "ktnative://myenclave/path/args.yaml",
 			wantEnclave: "myenclave",
-			wantFile:    "/absolute/path/args.yaml",
-		},
-		{
-			name:        "relative file path",
-			urlStr:      "ktnative://myenclave/relative/path/args.yaml",
-			wantEnclave: "myenclave",
-			wantFile:    "relative/path/args.yaml",
+			wantFile:    "/path/args.yaml",
 		},
 		{
 			name:           "invalid url",

--- a/devnet-sdk/shell/env/kt_native_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_native_fetch_test.go
@@ -1,0 +1,53 @@
+package env
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseKurtosisNativeURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		urlStr         string
+		wantEnclave    string
+		wantArtifact   string
+		wantFile       string
+		wantParseError bool
+	}{
+		{
+			name:        "absolute file path",
+			urlStr:      "ktnative://myenclave//absolute/path/args.yaml",
+			wantEnclave: "myenclave",
+			wantFile:    "/absolute/path/args.yaml",
+		},
+		{
+			name:        "relative file path",
+			urlStr:      "ktnative://myenclave/relative/path/args.yaml",
+			wantEnclave: "myenclave",
+			wantFile:    "relative/path/args.yaml",
+		},
+		{
+			name:           "invalid url",
+			urlStr:         "://invalid",
+			wantParseError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.urlStr)
+			if tt.wantParseError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			enclave, argsFile := parseKurtosisNativeURL(u)
+			assert.Equal(t, tt.wantEnclave, enclave)
+			assert.Equal(t, tt.wantFile, argsFile)
+		})
+	}
+}

--- a/devnet-sdk/shell/env/kt_native_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_native_fetch_test.go
@@ -182,7 +182,7 @@ func TestFetchKurtosisNativeDataSuccess(t *testing.T) {
 }
 
 var (
-	_ osInterface = (*mockOSImpl)(nil)
+	_ osOpenInterface = (*mockOSImpl)(nil)
 
 	_ specInterface = (*mockSpecImpl)(nil)
 

--- a/devnet-sdk/shell/env/kt_native_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_native_fetch_test.go
@@ -64,11 +64,11 @@ func TestFetchKurtosisNativeDataFailures(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("non-existent args file", func(t *testing.T) {
-		osImpl = &mockOSImpl{
+		osImpl := &mockOSImpl{
 			err: fmt.Errorf("oh no"),
 		}
 
-		_, _, err = fetchKurtosisNativeData(url)
+		_, _, err = fetchKurtosisNativeDataInternal(url, osImpl, &defaultSpecImpl{}, &defaultKurtosisImpl{})
 		require.ErrorContains(t, err, "error reading arguments file: oh no")
 	})
 
@@ -76,11 +76,11 @@ func TestFetchKurtosisNativeDataFailures(t *testing.T) {
 		file, err := kurtosisTestData.Open("testdata/kurtosis/args--malformed.txt")
 		require.NoError(t, err)
 
-		osImpl = &mockOSImpl{
+		osImpl := &mockOSImpl{
 			value: file,
 		}
 
-		_, _, err = fetchKurtosisNativeData(url)
+		_, _, err = fetchKurtosisNativeDataInternal(url, osImpl, &defaultSpecImpl{}, &defaultKurtosisImpl{})
 		require.ErrorContains(t, err, "error extracting enclave spec: failed to decode YAML: yaml: unmarshal errors:")
 	})
 
@@ -88,15 +88,15 @@ func TestFetchKurtosisNativeDataFailures(t *testing.T) {
 		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
 		require.NoError(t, err)
 
-		osImpl = &mockOSImpl{
+		osImpl := &mockOSImpl{
 			value: file,
 		}
 
-		specImpl = &mockSpecImpl{
+		specImpl := &mockSpecImpl{
 			err: fmt.Errorf("oh no"),
 		}
 
-		_, _, err = fetchKurtosisNativeData(url)
+		_, _, err = fetchKurtosisNativeDataInternal(url, osImpl, specImpl, &defaultKurtosisImpl{})
 		require.ErrorContains(t, err, "error extracting enclave spec: oh no")
 	})
 
@@ -104,15 +104,15 @@ func TestFetchKurtosisNativeDataFailures(t *testing.T) {
 		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
 		require.NoError(t, err)
 
-		osImpl = &mockOSImpl{
+		osImpl := &mockOSImpl{
 			value: file,
 		}
 
-		kurtosisImpl = &mockKurtosisImpl{
+		kurtosisImpl := &mockKurtosisImpl{
 			err: fmt.Errorf("oh no"),
 		}
 
-		_, _, err = fetchKurtosisNativeData(url)
+		_, _, err = fetchKurtosisNativeDataInternal(url, osImpl, &defaultSpecImpl{}, kurtosisImpl)
 		require.ErrorContains(t, err, "error creating deployer: oh no")
 	})
 
@@ -120,7 +120,7 @@ func TestFetchKurtosisNativeDataFailures(t *testing.T) {
 		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
 		require.NoError(t, err)
 
-		osImpl = &mockOSImpl{
+		osImpl := &mockOSImpl{
 			value: file,
 		}
 
@@ -128,11 +128,11 @@ func TestFetchKurtosisNativeDataFailures(t *testing.T) {
 			err: fmt.Errorf("oh no"),
 		}
 
-		kurtosisImpl = &mockKurtosisImpl{
+		kurtosisImpl := &mockKurtosisImpl{
 			value: kurtosisDeployer,
 		}
 
-		_, _, err = fetchKurtosisNativeData(url)
+		_, _, err = fetchKurtosisNativeDataInternal(url, osImpl, &defaultSpecImpl{}, kurtosisImpl)
 		require.ErrorContains(t, err, "error getting environment info: oh no")
 	})
 }
@@ -158,11 +158,11 @@ func TestFetchKurtosisNativeDataSuccess(t *testing.T) {
 		jsonEnv, err := json.MarshalIndent(env, "", "  ")
 		require.NoError(t, err)
 
-		osImpl = &mockOSImpl{
+		osImpl := &mockOSImpl{
 			value: file,
 		}
 
-		specImpl = &mockSpecImpl{
+		specImpl := &mockSpecImpl{
 			value: envSpec,
 		}
 
@@ -170,11 +170,11 @@ func TestFetchKurtosisNativeDataSuccess(t *testing.T) {
 			value: env,
 		}
 
-		kurtosisImpl = &mockKurtosisImpl{
+		kurtosisImpl := &mockKurtosisImpl{
 			value: kurtosisDeployer,
 		}
 
-		enclave, jsonDescriptor, err := fetchKurtosisNativeData(url)
+		enclave, jsonDescriptor, err := fetchKurtosisNativeDataInternal(url, osImpl, specImpl, kurtosisImpl)
 		require.NoError(t, err)
 		require.Equal(t, "enclave", enclave)
 		require.Equal(t, jsonDescriptor, jsonEnv)

--- a/devnet-sdk/shell/env/kt_native_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_native_fetch_test.go
@@ -1,11 +1,24 @@
 package env
 
 import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/url"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	//go:embed testdata/kurtosis
+	kurtosisTestData embed.FS
 )
 
 func TestParseKurtosisNativeURL(t *testing.T) {
@@ -44,4 +57,172 @@ func TestParseKurtosisNativeURL(t *testing.T) {
 			assert.Equal(t, tt.wantFile, argsFile)
 		})
 	}
+}
+
+func TestFetchKurtosisNativeDataFailures(t *testing.T) {
+	url, err := url.Parse("ktnative://enclave/file/path")
+	require.NoError(t, err)
+
+	t.Run("non-existent args file", func(t *testing.T) {
+		osImpl = &mockOSImpl{
+			err: fmt.Errorf("oh no"),
+		}
+
+		_, _, err = fetchKurtosisNativeData(url)
+		require.ErrorContains(t, err, "error reading arguments file: oh no")
+	})
+
+	t.Run("malformed args file", func(t *testing.T) {
+		file, err := kurtosisTestData.Open("testdata/kurtosis/args--malformed.txt")
+		require.NoError(t, err)
+
+		osImpl = &mockOSImpl{
+			value: file,
+		}
+
+		_, _, err = fetchKurtosisNativeData(url)
+		require.ErrorContains(t, err, "error extracting enclave spec: failed to decode YAML: yaml: unmarshal errors:")
+	})
+
+	t.Run("spec extraction failure", func(t *testing.T) {
+		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
+		require.NoError(t, err)
+
+		osImpl = &mockOSImpl{
+			value: file,
+		}
+
+		specImpl = &mockSpecImpl{
+			err: fmt.Errorf("oh no"),
+		}
+
+		_, _, err = fetchKurtosisNativeData(url)
+		require.ErrorContains(t, err, "error extracting enclave spec: oh no")
+	})
+
+	t.Run("kurtosis deployer failure", func(t *testing.T) {
+		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
+		require.NoError(t, err)
+
+		osImpl = &mockOSImpl{
+			value: file,
+		}
+
+		kurtosisImpl = &mockKurtosisImpl{
+			err: fmt.Errorf("oh no"),
+		}
+
+		_, _, err = fetchKurtosisNativeData(url)
+		require.ErrorContains(t, err, "error creating deployer: oh no")
+	})
+
+	t.Run("kurtosis info extraction failure", func(t *testing.T) {
+		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
+		require.NoError(t, err)
+
+		osImpl = &mockOSImpl{
+			value: file,
+		}
+
+		kurtosisDeployer := &mockKurtosisDeployerImpl{
+			err: fmt.Errorf("oh no"),
+		}
+
+		kurtosisImpl = &mockKurtosisImpl{
+			value: kurtosisDeployer,
+		}
+
+		_, _, err = fetchKurtosisNativeData(url)
+		require.ErrorContains(t, err, "error getting environment info: oh no")
+	})
+}
+
+func TestFetchKurtosisNativeDataSuccess(t *testing.T) {
+	url, err := url.Parse("ktnative://enclave/file/path")
+	require.NoError(t, err)
+
+	t.Run("fetching success", func(t *testing.T) {
+		file, err := kurtosisTestData.Open("testdata/kurtosis/args--simple.yaml")
+		require.NoError(t, err)
+
+		// We'll prepare a mock spec to be returned
+		envSpec := &spec.EnclaveSpec{}
+		env := &kurtosis.KurtosisEnvironment{
+			DevnetEnvironment: descriptors.DevnetEnvironment{
+				L2:       make([]*descriptors.Chain, 0, 1),
+				Features: envSpec.Features,
+			},
+		}
+
+		// And serialize it so that we can compare values
+		jsonEnv, err := json.MarshalIndent(env, "", "  ")
+		require.NoError(t, err)
+
+		osImpl = &mockOSImpl{
+			value: file,
+		}
+
+		specImpl = &mockSpecImpl{
+			value: envSpec,
+		}
+
+		kurtosisDeployer := &mockKurtosisDeployerImpl{
+			value: env,
+		}
+
+		kurtosisImpl = &mockKurtosisImpl{
+			value: kurtosisDeployer,
+		}
+
+		enclave, jsonDescriptor, err := fetchKurtosisNativeData(url)
+		require.NoError(t, err)
+		require.Equal(t, "enclave", enclave)
+		require.Equal(t, jsonDescriptor, jsonEnv)
+	})
+}
+
+var (
+	_ osInterface = (*mockOSImpl)(nil)
+
+	_ specInterface = (*mockSpecImpl)(nil)
+
+	_ kurtosisInterface = (*mockKurtosisImpl)(nil)
+
+	_ kurtosisDeployerInterface = (*mockKurtosisDeployerImpl)(nil)
+)
+
+type mockOSImpl struct {
+	value fileInterface
+	err   error
+}
+
+func (o *mockOSImpl) Open(name string) (fileInterface, error) {
+	return o.value, o.err
+}
+
+type mockSpecImpl struct {
+	value *spec.EnclaveSpec
+	err   error
+}
+
+func (o *mockSpecImpl) ExtractData(r io.Reader) (*spec.EnclaveSpec, error) {
+	return o.value, o.err
+}
+
+type mockKurtosisImpl struct {
+	value kurtosisDeployerInterface
+	err   error
+}
+
+func (o *mockKurtosisImpl) NewKurtosisDeployer(opts ...kurtosis.KurtosisDeployerOptions) (kurtosisDeployerInterface, error) {
+	return o.value, o.err
+}
+
+type mockKurtosisDeployerImpl struct {
+	value *kurtosis.KurtosisEnvironment
+	err   error
+}
+
+func (o *mockKurtosisDeployerImpl) GetEnvironmentInfo(context.Context, *spec.EnclaveSpec) (*kurtosis.KurtosisEnvironment, error) {
+	return o.value, o.err
 }

--- a/devnet-sdk/shell/env/testdata/kurtosis/args--malformed.txt
+++ b/devnet-sdk/shell/env/testdata/kurtosis/args--malformed.txt
@@ -1,0 +1,1 @@
+what is this

--- a/devnet-sdk/shell/env/testdata/kurtosis/args--simple.yaml
+++ b/devnet-sdk/shell/env/testdata/kurtosis/args--simple.yaml
@@ -1,0 +1,5 @@
+optimism_package:
+  chains:
+    - whatakey:
+      - el_type: op-geth
+        cl_type: op-node


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Adds a `ktnative` URL schema for devnet data fetching directly from an externally deployed enclave

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
