### PR TITLE
op-e2e: Refactor GeneratedTransaction to avoid tests needing to calculate identifiers and payloads.

### DIFF
--- a/op-e2e/actions/helpers/l2_engine.go
+++ b/op-e2e/actions/helpers/l2_engine.go
@@ -191,7 +191,7 @@ func (e *L2Engine) ActL2RPCFail(t Testing, err error) {
 	}
 }
 
-// ActL2IncludeTx includes the next transaction from the given address in the block that is being built,
+// ActL2IncludeTxIgnoreForcedEmpty includes the next transaction from the given address in the block that is being built,
 // skipping the usual check for e.EngineApi.ForcedEmpty()
 func (e *L2Engine) ActL2IncludeTxIgnoreForcedEmpty(from common.Address) Action {
 	return func(t Testing) {
@@ -200,7 +200,7 @@ func (e *L2Engine) ActL2IncludeTxIgnoreForcedEmpty(from common.Address) Action {
 		}
 
 		tx := firstValidTx(t, from, e.EngineApi.PendingIndices, e.Eth.TxPool().ContentFrom, e.EthClient().NonceAt)
-		err := e.EngineApi.IncludeTx(tx, from)
+		_, err := e.EngineApi.IncludeTx(tx, from)
 		if errors.Is(err, engineapi.ErrNotBuildingBlock) {
 			t.InvalidAction(err.Error())
 		} else if errors.Is(err, engineapi.ErrUsesTooMuchGas) {
@@ -221,7 +221,7 @@ func (e *L2Engine) ActL2IncludeTx(from common.Address) Action {
 		}
 
 		tx := firstValidTx(t, from, e.EngineApi.PendingIndices, e.Eth.TxPool().ContentFrom, e.EthClient().NonceAt)
-		err := e.EngineApi.IncludeTx(tx, from)
+		_, err := e.EngineApi.IncludeTx(tx, from)
 		if errors.Is(err, engineapi.ErrNotBuildingBlock) {
 			t.InvalidAction(err.Error())
 		} else if errors.Is(err, engineapi.ErrUsesTooMuchGas) {

--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -150,8 +150,7 @@ func (d *InteropDSL) AddL2Block(chain *Chain, optionalArgs ...func(*AddL2BlockOp
 		priorSyncStatus := chain.Sequencer.SyncStatus()
 		chain.Sequencer.ActL2StartBlock(d.t)
 		for _, creator := range opts.TransactionCreators {
-			tx := creator(chain)
-			tx.Include(chain.SequencerEngine.EngineApi)
+			creator(chain).Include()
 		}
 		chain.Sequencer.ActL2EndBlock(d.t)
 		chain.Sequencer.SyncSupervisor(d.t)

--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -5,8 +5,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -116,7 +114,8 @@ func (d *InteropDSL) CreateUser() *DSLUser {
 	}
 }
 
-type TransactionCreator func(chain *Chain) (*types.Transaction, common.Address)
+type TransactionCreator func(chain *Chain) *GeneratedTransaction
+
 type AddL2BlockOpts struct {
 	BlockIsNotCrossUnsafe bool
 	TransactionCreators   []TransactionCreator
@@ -151,9 +150,8 @@ func (d *InteropDSL) AddL2Block(chain *Chain, optionalArgs ...func(*AddL2BlockOp
 		priorSyncStatus := chain.Sequencer.SyncStatus()
 		chain.Sequencer.ActL2StartBlock(d.t)
 		for _, creator := range opts.TransactionCreators {
-			tx, from := creator(chain)
-			err := chain.SequencerEngine.EngineApi.IncludeTx(tx, from)
-			require.NoError(d.t, err)
+			tx := creator(chain)
+			tx.Include(chain.SequencerEngine.EngineApi)
 		}
 		chain.Sequencer.ActL2EndBlock(d.t)
 		chain.Sequencer.SyncSupervisor(d.t)

--- a/op-e2e/actions/interop/dsl/transactions.go
+++ b/op-e2e/actions/interop/dsl/transactions.go
@@ -7,45 +7,59 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
+type TxIncluder interface {
+	IncludeTx(transaction *types.Transaction, from common.Address) (*types.Receipt, error)
+}
 type GeneratedTransaction struct {
 	t     helpers.Testing
 	chain *Chain
 	tx    *types.Transaction
+	from  common.Address
+
+	// rcpt is only available after inclusion
+	rcpt *types.Receipt
 }
 
-func NewGeneratedTransaction(t helpers.Testing, chain *Chain, tx *types.Transaction) *GeneratedTransaction {
+func NewGeneratedTransaction(t helpers.Testing, chain *Chain, tx *types.Transaction, from common.Address) *GeneratedTransaction {
 	return &GeneratedTransaction{
 		t:     t,
 		chain: chain,
 		tx:    tx,
+		from:  from,
 	}
 }
 
-func (m *GeneratedTransaction) Identifier() inbox.Identifier {
-	rcpt, err := m.chain.SequencerEngine.EthClient().TransactionReceipt(m.t.Ctx(), m.tx.Hash())
+func (m *GeneratedTransaction) Include(includer TxIncluder) {
+	rcpt, err := includer.IncludeTx(m.tx, m.from)
 	require.NoError(m.t, err)
-	block, err := m.chain.SequencerEngine.EthClient().BlockByHash(m.t.Ctx(), rcpt.BlockHash)
-	require.NoError(m.t, err)
-	require.NotZero(m.t, len(rcpt.Logs), "Transaction did not include any logs to reference")
+	m.rcpt = rcpt
+}
 
+func (m *GeneratedTransaction) Identifier() inbox.Identifier {
+	require.NotZero(m.t, len(m.rcpt.Logs), "Transaction did not include any logs to reference")
+
+	return Identifier(m.chain, m.tx, m.rcpt)
+}
+
+func Identifier(chain *Chain, tx *types.Transaction, rcpt *types.Receipt) inbox.Identifier {
+	blockTime := chain.RollupCfg.TimestampForBlock(rcpt.BlockNumber.Uint64())
 	return inbox.Identifier{
-		Origin:      *m.tx.To(),
+		Origin:      *tx.To(),
 		BlockNumber: rcpt.BlockNumber,
 		LogIndex:    new(big.Int).SetUint64(uint64(rcpt.Logs[0].Index)),
-		Timestamp:   new(big.Int).SetUint64(block.Time()),
-		ChainId:     m.chain.RollupCfg.L2ChainID,
+		Timestamp:   new(big.Int).SetUint64(blockTime),
+		ChainId:     chain.RollupCfg.L2ChainID,
 	}
 }
 
 func (m *GeneratedTransaction) MessagePayload() []byte {
-	rcpt, err := m.chain.SequencerEngine.EthClient().TransactionReceipt(m.t.Ctx(), m.tx.Hash())
-	require.NoError(m.t, err)
-	require.NotZero(m.t, len(rcpt.Logs), "Transaction did not include any logs to reference")
-	return stypes.LogToMessagePayload(rcpt.Logs[0])
+	require.NotZero(m.t, len(m.rcpt.Logs), "Transaction did not include any logs to reference")
+	return stypes.LogToMessagePayload(m.rcpt.Logs[0])
 }
 
 func (m *GeneratedTransaction) CheckIncluded() {

--- a/op-e2e/actions/interop/dsl/transactions.go
+++ b/op-e2e/actions/interop/dsl/transactions.go
@@ -34,8 +34,8 @@ func NewGeneratedTransaction(t helpers.Testing, chain *Chain, tx *types.Transact
 	}
 }
 
-func (m *GeneratedTransaction) Include(includer TxIncluder) {
-	rcpt, err := includer.IncludeTx(m.tx, m.from)
+func (m *GeneratedTransaction) Include() {
+	rcpt, err := m.chain.SequencerEngine.EngineApi.IncludeTx(m.tx, m.from)
 	require.NoError(m.t, err)
 	m.rcpt = rcpt
 }

--- a/op-e2e/actions/interop/emitter_contract_test.go
+++ b/op-e2e/actions/interop/emitter_contract_test.go
@@ -189,7 +189,8 @@ func includeTxOnChainBasic(t helpers.Testing, chain *dsl.Chain, tx *types.Transa
 	chain.Sequencer.ActL2StartBlock(t)
 	// is used for building an empty block with tx==nil
 	if tx != nil {
-		require.NoError(t, chain.SequencerEngine.EngineApi.IncludeTx(tx, sender))
+		_, err := chain.SequencerEngine.EngineApi.IncludeTx(tx, sender)
+		require.NoError(t, err)
 	}
 	chain.Sequencer.ActL2EndBlock(t)
 }

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -279,7 +279,8 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	require.NoError(t, err)
 
 	actors.ChainB.Sequencer.ActL2StartBlock(t)
-	require.NoError(t, actors.ChainB.SequencerEngine.EngineApi.IncludeTx(tx, aliceB.address))
+	_, err = actors.ChainB.SequencerEngine.EngineApi.IncludeTx(tx, aliceB.address)
+	require.NoError(t, err)
 	actors.ChainB.Sequencer.ActL2EndBlock(t)
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	originalBlock := actors.ChainB.Sequencer.SyncStatus().UnsafeL2

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -392,8 +392,8 @@ func TestInteropFaultProofs_Cycle(gt *testing.T) {
 	// execute them within the same block
 	actExecA := system.InboxContract.Execute(alice, emitTxB) // Exec msg on chain A referencing chain B
 	actExecB := system.InboxContract.Execute(alice, emitTxA) // Exec msg on chain B referencing chain A
-	actExecA(actors.ChainB).Include(actors.ChainB.SequencerEngine.EngineApi)
-	actExecB(actors.ChainA).Include(actors.ChainA.SequencerEngine.EngineApi)
+	actExecA(actors.ChainA).Include(actors.ChainA.SequencerEngine.EngineApi)
+	actExecB(actors.ChainB).Include(actors.ChainB.SequencerEngine.EngineApi)
 
 	actors.ChainA.Sequencer.ActL2EndBlock(t)
 	actors.ChainB.Sequencer.ActL2EndBlock(t)

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -364,7 +364,7 @@ func TestInteropFaultProofs(gt *testing.T) {
 func TestInteropFaultProofs_Cycle(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	// TODO(#14425): Handle cyclic valid messages
-	//t.Skip("Cyclic valid messages does not work")
+	t.Skip("Cyclic valid messages does not work")
 
 	system := dsl.NewInteropDSL(t)
 	actors := system.Actors

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -364,7 +364,7 @@ func TestInteropFaultProofs(gt *testing.T) {
 func TestInteropFaultProofs_Cycle(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	// TODO(#14425): Handle cyclic valid messages
-	t.Skip("Cyclic valid messages does not work")
+	//t.Skip("Cyclic valid messages does not work")
 
 	system := dsl.NewInteropDSL(t)
 	actors := system.Actors
@@ -385,15 +385,15 @@ func TestInteropFaultProofs_Cycle(gt *testing.T) {
 
 	// create init messages
 	emitTxA := actEmitA(actors.ChainA)
-	emitTxA.Include(actors.ChainA.SequencerEngine.EngineApi)
+	emitTxA.Include()
 	emitTxB := actEmitB(actors.ChainB)
-	emitTxB.Include(actors.ChainB.SequencerEngine.EngineApi)
+	emitTxB.Include()
 
 	// execute them within the same block
 	actExecA := system.InboxContract.Execute(alice, emitTxB) // Exec msg on chain A referencing chain B
 	actExecB := system.InboxContract.Execute(alice, emitTxA) // Exec msg on chain B referencing chain A
-	actExecA(actors.ChainA).Include(actors.ChainA.SequencerEngine.EngineApi)
-	actExecB(actors.ChainB).Include(actors.ChainB.SequencerEngine.EngineApi)
+	actExecA(actors.ChainA).Include()
+	actExecB(actors.ChainB).Include()
 
 	actors.ChainA.Sequencer.ActL2EndBlock(t)
 	actors.ChainB.Sequencer.ActL2EndBlock(t)

--- a/op-e2e/actions/upgrades/dencun_fork_test.go
+++ b/op-e2e/actions/upgrades/dencun_fork_test.go
@@ -234,6 +234,6 @@ func TestDencunBlobTxInclusion(gt *testing.T) {
 	tx := aliceSimpleBlobTx(t, dp)
 
 	sequencer.ActL2StartBlock(t)
-	err := engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
+	_, err := engine.EngineApi.IncludeTx(tx, dp.Addresses.Alice)
 	require.ErrorContains(t, err, "invalid L2 block (tx 1): failed to apply transaction to L2 block (tx 1): transaction type not supported")
 }

--- a/op-program/client/l2/engine_backend.go
+++ b/op-program/client/l2/engine_backend.go
@@ -209,7 +209,7 @@ func (o *OracleBackedL2Chain) InsertBlockWithoutSetHead(block *types.Block, make
 		return nil, err
 	}
 	for i, tx := range block.Transactions() {
-		err = processor.AddTx(tx)
+		_, err = processor.AddTx(tx)
 		if err != nil {
 			return nil, fmt.Errorf("invalid transaction (%d): %w", i, err)
 		}

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -136,16 +136,16 @@ func (b *BlockProcessor) CheckTxWithinGasLimit(tx *types.Transaction) error {
 	return nil
 }
 
-func (b *BlockProcessor) AddTx(tx *types.Transaction) error {
+func (b *BlockProcessor) AddTx(tx *types.Transaction) (*types.Receipt, error) {
 	txIndex := len(b.transactions)
 	b.state.SetTxContext(tx.Hash(), txIndex)
 	receipt, err := core.ApplyTransaction(b.evm, b.gasPool, b.state, b.header, tx, &b.header.GasUsed)
 	if err != nil {
-		return fmt.Errorf("failed to apply transaction to L2 block (tx %d): %w", txIndex, err)
+		return nil, fmt.Errorf("failed to apply transaction to L2 block (tx %d): %w", txIndex, err)
 	}
 	b.receipts = append(b.receipts, receipt)
 	b.transactions = append(b.transactions, tx)
-	return nil
+	return receipt, nil
 }
 
 func (b *BlockProcessor) Assemble() (*types.Block, types.Receipts, error) {


### PR DESCRIPTION
**Description**

Refactors the interop DSL so that transaction creators return a `GeneratedTransaction` and it can capture its receipt when it is included in a block. This allows it to calculate the identifier and payload even before the block it is included in is actually sealed. 
