### PR TITLE
chore(devnet-sdk): move kurtosis artifact fs to devnet-sdk

### DIFF
--- a/devnet-sdk/kt/fs/fs.go
+++ b/devnet-sdk/kt/fs/fs.go
@@ -1,4 +1,4 @@
-package artifact
+package fs
 
 import (
 	"archive/tar"

--- a/devnet-sdk/kt/fs/fs_test.go
+++ b/devnet-sdk/kt/fs/fs_test.go
@@ -1,4 +1,4 @@
-package artifact
+package fs
 
 import (
 	"archive/tar"

--- a/devnet-sdk/shell/env/kt_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_fetch_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/artifact"
+	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +14,7 @@ import (
 // testFS implements EnclaveFS for testing
 type testFS struct{}
 
-func (m *testFS) GetArtifact(_ context.Context, name string) (*artifact.Artifact, error) {
+func (m *testFS) GetArtifact(_ context.Context, name string) (*ktfs.Artifact, error) {
 	if name == "error" {
 		return nil, fmt.Errorf("mock error")
 	}

--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/deployer.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/deployer.go
@@ -9,8 +9,8 @@ import (
 	"math/big"
 	"strings"
 
+	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/artifact"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -252,7 +252,7 @@ func parseStateFile(r io.Reader) (*DeployerState, error) {
 
 // ExtractData downloads and parses the op-deployer state
 func (d *Deployer) ExtractData(ctx context.Context) (*DeployerData, error) {
-	fs, err := artifact.NewEnclaveFS(ctx, d.enclave)
+	fs, err := ktfs.NewEnclaveFS(ctx, d.enclave)
 	if err != nil {
 		return nil, err
 	}
@@ -265,8 +265,8 @@ func (d *Deployer) ExtractData(ctx context.Context) (*DeployerData, error) {
 	stateBuffer := bytes.NewBuffer(nil)
 	walletsBuffer := bytes.NewBuffer(nil)
 	if err := a.ExtractFiles(
-		artifact.NewArtifactFileWriter(d.stateName, stateBuffer),
-		artifact.NewArtifactFileWriter(d.walletsName, walletsBuffer),
+		ktfs.NewArtifactFileWriter(d.stateName, stateBuffer),
+		ktfs.NewArtifactFileWriter(d.walletsName, walletsBuffer),
 	); err != nil {
 		return nil, err
 	}

--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/artifact"
+	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -34,7 +34,7 @@ func getMnemonics(r io.Reader) (string, error) {
 	return config[0].Mnemonic, nil
 }
 
-func (d *Deployer) getKnownWallets(ctx context.Context, fs *artifact.EnclaveFS) ([]*Wallet, error) {
+func (d *Deployer) getKnownWallets(ctx context.Context, fs *ktfs.EnclaveFS) ([]*Wallet, error) {
 	a, err := fs.GetArtifact(ctx, d.genesisArtifactName)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (d *Deployer) getKnownWallets(ctx context.Context, fs *artifact.EnclaveFS) 
 
 	mnemonicsBuffer := bytes.NewBuffer(nil)
 	if err := a.ExtractFiles(
-		artifact.NewArtifactFileWriter(d.mnemonicsName, mnemonicsBuffer),
+		ktfs.NewArtifactFileWriter(d.mnemonicsName, mnemonicsBuffer),
 	); err != nil {
 		return nil, err
 	}

--- a/kurtosis-devnet/pkg/kurtosis/sources/jwt/jwt.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/jwt/jwt.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/artifact"
+	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 )
 
 const (
@@ -33,7 +33,7 @@ func NewExtractor(enclave string) *extractor {
 
 // ExtractData extracts JWT secrets from their respective artifacts
 func (e *extractor) ExtractData(ctx context.Context) (*Data, error) {
-	fs, err := artifact.NewEnclaveFS(ctx, e.enclave)
+	fs, err := ktfs.NewEnclaveFS(ctx, e.enclave)
 	if err != nil {
 		return nil, err
 	}
@@ -56,14 +56,14 @@ func (e *extractor) ExtractData(ctx context.Context) (*Data, error) {
 	}, nil
 }
 
-func extractJWTFromArtifact(ctx context.Context, fs *artifact.EnclaveFS, artifactName string) (string, error) {
+func extractJWTFromArtifact(ctx context.Context, fs *ktfs.EnclaveFS, artifactName string) (string, error) {
 	a, err := fs.GetArtifact(ctx, artifactName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get artifact: %w", err)
 	}
 
 	buffer := &bytes.Buffer{}
-	if err := a.ExtractFiles(artifact.NewArtifactFileWriter(jwtSecretFileName, buffer)); err != nil {
+	if err := a.ExtractFiles(ktfs.NewArtifactFileWriter(jwtSecretFileName, buffer)); err != nil {
 		return "", fmt.Errorf("failed to extract JWT: %w", err)
 	}
 


### PR DESCRIPTION
**Description**

This change makes devnet-sdk a leaf package as far as the rest of the
monorepo is concerned.

The artifact package was never really specific to kurtosis-devnet
anyway, as it contains a generic filesystem abstraction to access
kurtosis enclave artifacts. So we might as well add it to the rest of
kurtosis helper functions in devnet-sdk.

Going forward we'll likely want to split it into a separate module, so
that other repositories can import it without needing to import the
whole monorepo.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
