### PR TITLE
fix: Fix docker build in scheduled-docker-publish workflow

### DIFF
--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -21,6 +21,9 @@ FROM --platform=$BUILDPLATFORM golang:1.22.7-alpine3.20 AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq bash
 
+# Install mise (the apk version is outdated)
+RUN curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
 ARG TARGETARCH
 
 # Install yq
@@ -29,10 +32,7 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$TARG
 
 # Install versioned toolchain
 COPY ./mise.toml .
-RUN JUST_VERSION=$(yq '.tools.just' mise.toml) && \
-    ARCH_MAPPING=$(echo $TARGETARCH | sed 's/amd64/x86_64/;s/arm64/aarch64/') && \
-    curl -L https://github.com/casey/just/releases/download/$JUST_VERSION/just-$JUST_VERSION-$ARCH_MAPPING-unknown-linux-musl.tar.gz | \
-    tar xz -C /usr/local/bin just
+RUN mise trust && mise install -v -y just && cp $(mise which just) /usr/local/bin/just
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -32,7 +32,7 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$TARG
 
 # Install versioned toolchain
 COPY ./mise.toml .
-RUN mise trust && mise install -v -y just && cp $(mise which just) /usr/local/bin/just
+RUN mise trust && mise install -v -y just && cp $(mise which just) /usr/local/bin/just && just --version
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The docker build is currently parsing `mise.toml`, extracting the version of `just`, compiling the artifact URL, downloading the tarball & extracting the `just` binary. Instead, we can use `mise` directly to install `just` (and only `just`).

- First, we install `mise`. `apk add mise` unfortunately only provides an outdated version so we use the `curl`-based installation.
- Second, we install `just`

The failing jobs:

- https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/81848/workflows/1f7ffa9e-181e-4c02-b824-fa31ac4d4048
- https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/81724/workflows/6f2c0774-fff1-4384-b447-aa58e4a3fb94