### PR TITLE
fix: update latest prestate

### DIFF
--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -261,7 +261,7 @@ func InteropL2DevConfig(l1ChainID, l2ChainID uint64, addrs devkeys.Addresses, me
 		SaltMixer:               "",
 		GasLimit:                60_000_000,
 		DisputeGameType:         1, // PERMISSIONED_CANNON Game Type
-		DisputeAbsolutePrestate: common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+		DisputeAbsolutePrestate: common.HexToHash("0x0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd"),
 		DisputeMaxGameDepth:     73,
 		DisputeSplitDepth:       30,
 		DisputeClockExtension:   10800,  // 3 hours (input in seconds)

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,7 +42,7 @@ const (
 	ContractsV170Beta1L2Tag = "op-contracts/v1.7.0-beta.1+l2-contracts"
 )
 
-var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
+var DisputeAbsolutePrestate = common.HexToHash("0x0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd")
 
 //go:embed standard-versions-mainnet.toml
 var VersionsMainnetData string

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -463,7 +463,7 @@ contract DeployOPChain is Script {
         // `EXPECTED_PRESTATE_HASH` is defined in `config.yml`.
         require(
             Claim.unwrap(game.absolutePrestate())
-                == bytes32(hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+                == bytes32(hex"0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd"),
             "DPG-20"
         );
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -662,7 +662,7 @@ contract OPContractsManager_AddGameType_Test is Test {
                 gasLimit: 30_000_000,
                 disputeGameType: GameType.wrap(1),
                 disputeAbsolutePrestate: Claim.wrap(
-                    bytes32(hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
+                    bytes32(hex"0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd")
                 ),
                 disputeMaxGameDepth: 73,
                 disputeSplitDepth: 30,

--- a/packages/contracts-bedrock/test/L1/OPPrestateUpdater.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPPrestateUpdater.t.sol
@@ -169,7 +169,7 @@ contract OPPrestateUpdater_Test is Test {
                 gasLimit: 30_000_000,
                 disputeGameType: GameType.wrap(1),
                 disputeAbsolutePrestate: Claim.wrap(
-                    bytes32(hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
+                    bytes32(hex"0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd")
                 ),
                 disputeMaxGameDepth: 73,
                 disputeSplitDepth: 30,

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -334,7 +334,7 @@ contract DeployOPChain_TestBase is Test {
     uint64 gasLimit = 60_000_000;
     // Configurable dispute game parameters.
     uint32 disputeGameType = GameType.unwrap(GameTypes.PERMISSIONED_CANNON);
-    bytes32 disputeAbsolutePrestate = hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c";
+    bytes32 disputeAbsolutePrestate = hex"0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd";
     uint256 disputeMaxGameDepth = 73;
     uint256 disputeSplitDepth = 30;
     uint64 disputeClockExtension = Duration.unwrap(Duration.wrap(3 hours));
@@ -473,7 +473,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         assertEq(doo.permissionedDisputeGame().l2BlockNumber(), 0, "3000");
         assertEq(
             Claim.unwrap(doo.permissionedDisputeGame().absolutePrestate()),
-            0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c,
+            0x0x035ac388b5cb22acf52a2063cfde108d09b1888655d21f02f595f9c3ea6cbdcd,
             "3100"
         );
         assertEq(Duration.unwrap(doo.permissionedDisputeGame().clockExtension()), 10800, "3200");


### PR DESCRIPTION
latest op-deployer checks prestate hash matches this hardcoded version `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` throwing validation error on deployment with error `DPG-20`

this align the prestate hash to the latest compatible as mentioned in 

https://docs.optimism.io/notices/pectra-changes#for-fault-proof-enabled-chains

