### PR TITLE
feat(devnet-sdk): isolate low-level interfaces

### DIFF
--- a/devnet-sdk/system/chain_test.go
+++ b/devnet-sdk/system/chain_test.go
@@ -72,7 +72,9 @@ func TestChainFromDescriptor(t *testing.T) {
 	chain, err := chainFromDescriptor(descriptor)
 	assert.Nil(t, err)
 	assert.NotNil(t, chain)
-	assert.Equal(t, "http://localhost:8545", chain.RPCURL())
+	lowLevelChain, ok := chain.(LowLevelChain)
+	assert.True(t, ok)
+	assert.Equal(t, "http://localhost:8545", lowLevelChain.RPCURL())
 
 	// Compare the underlying big.Int values
 	chainID := chain.ID()

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -6,25 +6,25 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-// System represents a complete Optimism system with L1 and L2 chains
-type System interface {
+type genSystem[T Chain] interface {
 	Identifier() string
-	L1() Chain
-	// TODO: fix the chain ID type
-	L2(uint64) Chain
+	L1() T
+	L2s() []T
 }
+
+// System represents a complete Optimism system with L1 and L2 chains
+type System = genSystem[Chain]
+
+type LowLevelSystem = genSystem[LowLevelChain]
 
 // Chain represents an Ethereum chain (L1 or L2)
 type Chain interface {
-	RPCURL() string
 	ID() types.ChainID
-	Client() (*ethclient.Client, error)
 	Wallets(ctx context.Context) ([]Wallet, error)
 	ContractsRegistry() interfaces.ContractsRegistry
 	SupportsEIP(ctx context.Context, eip uint64) bool
@@ -34,22 +34,34 @@ type Chain interface {
 	PendingNonceAt(ctx context.Context, address common.Address) (uint64, error)
 }
 
+// LowLevelChain is a Chain that gives direct access to the low level RPC client.
+type LowLevelChain interface {
+	Chain
+	RPCURL() string
+	Client() (*ethclient.Client, error)
+}
+
+// Wallet represents a chain wallet.
+// In particular it can process transactions.
+type Wallet interface {
+	PrivateKey() types.Key
+	Address() types.Address
+	SendETH(to types.Address, amount types.Balance) types.WriteInvocation[any]
+	Balance() types.Balance
+	Nonce() uint64
+
+	TransactionProcessor
+}
+
+// TransactionProcessor is a helper interface for signing and sending transactions.
 type TransactionProcessor interface {
 	Sign(tx Transaction) (Transaction, error)
 	Send(ctx context.Context, tx Transaction) error
 }
 
-// InteropSystem extends System with interoperability features
-type InteropSystem interface {
-	System
-	InteropSet() InteropSet
-}
+// Transaction interfaces:
 
-// InteropSet provides access to L2 chains in an interop environment
-type InteropSet interface {
-	L2(uint64) Chain
-}
-
+// TransactionData is the input for a transaction creation.
 type TransactionData interface {
 	From() common.Address
 	To() *common.Address
@@ -57,6 +69,7 @@ type TransactionData interface {
 	Data() []byte
 }
 
+// Transaction is the instantiated transaction object.
 type Transaction interface {
 	Type() uint8
 	Hash() common.Hash
@@ -66,20 +79,20 @@ type Transaction interface {
 // RawTransaction is an optional interface that can be implemented by a Transaction
 // to provide access to the raw transaction data.
 // It is currently necessary to perform processing operations (signing, sending)
-// on the transaction.
+// on the transaction. We would need to do better here.
 type RawTransaction interface {
 	Raw() *coreTypes.Transaction
 }
 
-type Wallet interface {
-	PrivateKey() types.Key
-	Address() types.Address
-	SendETH(to types.Address, amount types.Balance) types.WriteInvocation[any]
-	Balance() types.Balance
-	Nonce() uint64
+// Specialized interop interfaces:
 
-	Sign(tx Transaction) (Transaction, error)
-	Send(ctx context.Context, tx Transaction) error
+// InteropSystem extends System with interoperability features
+type InteropSystem interface {
+	System
+	InteropSet() InteropSet
+}
 
-	Transactor() *bind.TransactOpts
+// InteropSet provides access to L2 chains in an interop environment
+type InteropSet interface {
+	L2s() []Chain
 }

--- a/devnet-sdk/system/system.go
+++ b/devnet-sdk/system/system.go
@@ -34,8 +34,8 @@ func (s *system) L1() Chain {
 	return s.l1
 }
 
-func (s *system) L2(chainID uint64) Chain {
-	return s.l2s[chainID]
+func (s *system) L2s() []Chain {
+	return s.l2s
 }
 
 func (s *system) Identifier() string {

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -101,15 +101,15 @@ func (m *mockChain) SupportsEIP(ctx context.Context, eip uint64) bool {
 // mockSystem implements a minimal system.System for testing
 type mockSystem struct{}
 
-func (m *mockSystem) Identifier() string     { return "mock" }
-func (m *mockSystem) L1() system.Chain       { return &mockChain{} }
-func (m *mockSystem) L2(uint64) system.Chain { return &mockChain{} }
-func (m *mockSystem) Close() error           { return nil }
+func (m *mockSystem) Identifier() string  { return "mock" }
+func (m *mockSystem) L1() system.Chain    { return &mockChain{} }
+func (m *mockSystem) L2s() []system.Chain { return []system.Chain{&mockChain{}} }
+func (m *mockSystem) Close() error        { return nil }
 
 // mockInteropSet implements a minimal system.InteropSet for testing
 type mockInteropSet struct{}
 
-func (m *mockInteropSet) L2(uint64) system.Chain { return &mockChain{} }
+func (m *mockInteropSet) L2s() []system.Chain { return []system.Chain{&mockChain{}} }
 
 // mockInteropSystem implements a minimal system.InteropSystem for testing
 type mockInteropSystem struct {

--- a/devnet-sdk/testing/testlib/validators/lowlevel.go
+++ b/devnet-sdk/testing/testlib/validators/lowlevel.go
@@ -1,0 +1,62 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+)
+
+type LowLevelSystemGetter = func(context.Context) system.LowLevelSystem
+
+type lowLevelSystemWrapper struct {
+	identifier string
+	l1         system.LowLevelChain
+	l2         []system.LowLevelChain
+}
+
+var _ system.LowLevelSystem = (*lowLevelSystemWrapper)(nil)
+
+func (l *lowLevelSystemWrapper) Identifier() string {
+	return l.identifier
+}
+
+func (l *lowLevelSystemWrapper) L1() system.LowLevelChain {
+	return l.l1
+}
+
+func (l *lowLevelSystemWrapper) L2s() []system.LowLevelChain {
+	return l.l2
+}
+
+func lowLevelSystemValidator(sysMarker interface{}) systest.PreconditionValidator {
+	return func(t systest.T, sys system.System) (context.Context, error) {
+		lowLevelSys := &lowLevelSystemWrapper{}
+
+		// If any chain is not a low level chain, return an error
+		if l1, ok := sys.L1().(system.LowLevelChain); ok {
+			lowLevelSys.l1 = l1
+		} else {
+			return nil, fmt.Errorf("L1 chain is not a low level chain")
+		}
+
+		for idx, l2 := range sys.L2s() {
+			if l2, ok := l2.(system.LowLevelChain); ok {
+				lowLevelSys.l2 = append(lowLevelSys.l2, l2)
+			} else {
+				return nil, fmt.Errorf("L2 chain %d is not a low level chain", idx)
+			}
+		}
+
+		return context.WithValue(t.Context(), sysMarker, lowLevelSys), nil
+	}
+}
+
+func AcquireLowLevelSystem() (LowLevelSystemGetter, systest.PreconditionValidator) {
+	sysMarker := &struct{}{}
+	validator := lowLevelSystemValidator(sysMarker)
+	return func(ctx context.Context) system.LowLevelSystem {
+		return ctx.Value(sysMarker).(system.LowLevelSystem)
+	}, validator
+}

--- a/devnet-sdk/testing/testlib/validators/wallet.go
+++ b/devnet-sdk/testing/testlib/validators/wallet.go
@@ -15,7 +15,7 @@ type WalletGetter = func(context.Context) system.Wallet
 func walletFundsValidator(chainIdx uint64, minFunds types.Balance, userMarker interface{}) systest.PreconditionValidator {
 	constraint := constraints.WithBalance(minFunds)
 	return func(t systest.T, sys system.System) (context.Context, error) {
-		chain := sys.L2(chainIdx)
+		chain := sys.L2s()[chainIdx]
 		wallets, err := chain.Wallets(t.Context())
 		if err != nil {
 			return nil, err

--- a/kurtosis-devnet/tests/interop/interop_smoke_test.go
+++ b/kurtosis-devnet/tests/interop/interop_smoke_test.go
@@ -18,7 +18,7 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		ctx := t.Context()
 		logger := slog.With("test", "TestMinimal", "devnet", sys.Identifier())
 
-		chain := sys.L2(chainIdx)
+		chain := sys.L2s()[chainIdx]
 		logger = logger.With("chain", chain.ID())
 		logger.InfoContext(ctx, "starting test")
 
@@ -93,3 +93,19 @@ func TestInteropSystemNoop(t *testing.T) {
 // 	require.True(t, rt.Failed(), "test should have failed")
 // 	require.Contains(t, rt.Logs(), "transaction failure", "unexpected failure message")
 // }
+
+func lowLevelSystemScenario(sysGetter validators.LowLevelSystemGetter) systest.SystemTestFunc {
+	return func(t systest.T, sys system.System) {
+		logger := slog.With("test", "TestLowLevelSystem", "devnet", sys.Identifier())
+		_ = sysGetter(t.Context())
+		logger.InfoContext(t.Context(), "low level system acquired")
+	}
+}
+
+func TestLowLevelSystem(t *testing.T) {
+	lowLevelSys, validator := validators.AcquireLowLevelSystem()
+	systest.SystemTest(t,
+		lowLevelSystemScenario(lowLevelSys),
+		validator,
+	)
+}


### PR DESCRIPTION
**Description**

This refactors the system interfaces a bit, to expose lower-level
details only at the express demand of the test.

The rationale being that for each test we want to eventually not have
them manipulate the implementation details of the underlying system.
But at the same time, we need an escape hatch for when the
higher-level interfaces are not sufficient.

But adding an explicit validator to gain access to these interfaces,
we can eventually statically detect which tests are well-behaved, and
which are not (yet)


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
