### PR TITLE
op-signer, op-node: fix block signer utils

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 )
 
 const (
@@ -569,7 +570,7 @@ func (p *publisher) PublishL2Payload(ctx context.Context, envelope *eth.Executio
 
 	data := buf.Bytes()
 	payloadData := data[65:]
-	sig, err := signer.Sign(ctx, SigningDomainBlocksV1, p.cfg.L2ChainID, payloadData)
+	sig, err := signer.Sign(ctx, SigningDomainBlocksV1, eth.ChainIDFromBig(p.cfg.L2ChainID), opsigner.PayloadHash(payloadData))
 	if err != nil {
 		return fmt.Errorf("failed to sign execution payload with signer: %w", err)
 	}

--- a/op-node/p2p/signer_test.go
+++ b/op-node/p2p/signer_test.go
@@ -15,12 +15,14 @@ func TestSigningHash_DifferentDomain(t *testing.T) {
 	}
 
 	payloadBytes := []byte("arbitraryData")
-	hash, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, payloadBytes, nil).ToSigningHash()
+	msg, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, payloadBytes, nil).Message()
 	require.NoError(t, err, "creating first signing hash")
 
-	hash2, err := opsigner.NewBlockPayloadArgs([32]byte{3}, cfg.L2ChainID, payloadBytes, nil).ToSigningHash()
+	msg2, err := opsigner.NewBlockPayloadArgs([32]byte{3}, cfg.L2ChainID, payloadBytes, nil).Message()
 	require.NoError(t, err, "creating second signing hash")
 
+	hash := msg.ToSigningHash()
+	hash2 := msg2.ToSigningHash()
 	require.NotEqual(t, hash, hash2, "signing hash should be different when domain is different")
 }
 
@@ -33,27 +35,31 @@ func TestSigningHash_DifferentChainID(t *testing.T) {
 	}
 
 	payloadBytes := []byte("arbitraryData")
-	hash, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg1.L2ChainID, payloadBytes, nil).ToSigningHash()
+	msg, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg1.L2ChainID, payloadBytes, nil).Message()
 	require.NoError(t, err, "creating first signing hash")
 
-	hash2, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg2.L2ChainID, payloadBytes, nil).ToSigningHash()
+	msg2, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg2.L2ChainID, payloadBytes, nil).Message()
 	require.NoError(t, err, "creating second signing hash")
 
+	hash := msg.ToSigningHash()
+	hash2 := msg2.ToSigningHash()
 	require.NotEqual(t, hash, hash2, "signing hash should be different when chain ID is different")
 }
 
-func TestSigningHash_DifferentMessage(t *testing.T) {
+func TestSigningHash_DifferentPayload(t *testing.T) {
 	cfg := &rollup.Config{
 		L2ChainID: big.NewInt(100),
 	}
 
-	hash, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, []byte("msg1"), nil).ToSigningHash()
+	msg, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, []byte("payload1"), nil).Message()
 	require.NoError(t, err, "creating first signing hash")
 
-	hash2, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, []byte("msg2"), nil).ToSigningHash()
+	msg2, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, []byte("payload2"), nil).Message()
 	require.NoError(t, err, "creating second signing hash")
 
-	require.NotEqual(t, hash, hash2, "signing hash should be different when message is different")
+	hash := msg.ToSigningHash()
+	hash2 := msg2.ToSigningHash()
+	require.NotEqual(t, hash, hash2, "signing hash should be different when payload is different")
 }
 
 func TestSigningHash_LimitChainID(t *testing.T) {
@@ -63,6 +69,6 @@ func TestSigningHash_LimitChainID(t *testing.T) {
 	cfg := &rollup.Config{
 		L2ChainID: chainID,
 	}
-	_, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, []byte("arbitraryData"), nil).ToSigningHash()
+	_, err := opsigner.NewBlockPayloadArgs(SigningDomainBlocksV1, cfg.L2ChainID, []byte("arbitraryData"), nil).Message()
 	require.ErrorContains(t, err, "chain_id is too large")
 }

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -211,6 +211,14 @@ type ExecutionPayloadEnvelope struct {
 	RequestsHash          *common.Hash      `json:"requestsHash,omitempty"`
 }
 
+func (env *ExecutionPayloadEnvelope) ID() BlockID {
+	return env.ExecutionPayload.ID()
+}
+
+func (env *ExecutionPayloadEnvelope) String() string {
+	return fmt.Sprintf("envelope(%s)", env.ID())
+}
+
 type ExecutionPayload struct {
 	ParentHash    common.Hash     `json:"parentHash"`
 	FeeRecipient  common.Address  `json:"feeRecipient"`
@@ -240,6 +248,10 @@ type ExecutionPayload struct {
 
 func (payload *ExecutionPayload) ID() BlockID {
 	return BlockID{Hash: payload.BlockHash, Number: uint64(payload.BlockNumber)}
+}
+
+func (payload *ExecutionPayload) String() string {
+	return fmt.Sprintf("payload(%s)", payload.ID())
 }
 
 func (payload *ExecutionPayload) ParentID() BlockID {

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -71,6 +71,32 @@ func (ie InputError) Is(target error) bool {
 	return ok // we implement Unwrap, so we do not have to check the inner type now
 }
 
+// Bytes65 is a 65-byte long byte string, and encoded with 0x-prefix in hex.
+// This can be used to represent encoded secp256k ethereum signatures.
+type Bytes65 [65]byte
+
+func (b *Bytes65) UnmarshalJSON(text []byte) error {
+	return hexutil.UnmarshalFixedJSON(reflect.TypeOf(b), text, b[:])
+}
+
+func (b *Bytes65) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("Bytes65", text, b[:])
+}
+
+func (b Bytes65) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(b[:]).MarshalText()
+}
+
+func (b Bytes65) String() string {
+	return hexutil.Encode(b[:])
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (b Bytes65) TerminalString() string {
+	return fmt.Sprintf("0x%x..%x", b[:3], b[65-3:])
+}
+
 type Bytes32 [32]byte
 
 func (b *Bytes32) UnmarshalJSON(text []byte) error {
@@ -92,7 +118,7 @@ func (b Bytes32) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (b Bytes32) TerminalString() string {
-	return fmt.Sprintf("%x..%x", b[:3], b[29:])
+	return fmt.Sprintf("0x%x..%x", b[:3], b[29:])
 }
 
 type Bytes8 [8]byte
@@ -116,7 +142,7 @@ func (b Bytes8) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (b Bytes8) TerminalString() string {
-	return fmt.Sprintf("%x", b[:])
+	return fmt.Sprintf("0x%x", b[:])
 }
 
 type Bytes96 [96]byte
@@ -140,7 +166,7 @@ func (b Bytes96) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (b Bytes96) TerminalString() string {
-	return fmt.Sprintf("%x..%x", b[:3], b[93:])
+	return fmt.Sprintf("0x%x..%x", b[:3], b[93:])
 }
 
 type Bytes256 [256]byte
@@ -164,7 +190,7 @@ func (b Bytes256) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console
 // output during logging.
 func (b Bytes256) TerminalString() string {
-	return fmt.Sprintf("%x..%x", b[:3], b[253:])
+	return fmt.Sprintf("0x%x..%x", b[:3], b[253:])
 }
 
 type Uint64Quantity = hexutil.Uint64

--- a/op-service/signer/blockpayload_args.go
+++ b/op-service/signer/blockpayload_args.go
@@ -10,10 +10,9 @@ import (
 
 // BlockPayloadArgs represents the arguments to sign a new block payload from the sequencer.
 type BlockPayloadArgs struct {
-	Domain        [32]byte `json:"domain"`
-	ChainID       *big.Int `json:"chainId"`
-	PayloadHash   []byte   `json:"payloadHash"`
-	PayloadBytes  []byte
+	Domain        [32]byte        `json:"domain"`
+	ChainID       *big.Int        `json:"chainId"`
+	PayloadHash   []byte          `json:"payloadHash"`
 	SenderAddress *common.Address `json:"senderAddress"`
 }
 
@@ -24,7 +23,6 @@ func NewBlockPayloadArgs(domain [32]byte, chainId *big.Int, payloadBytes []byte,
 		Domain:        domain,
 		ChainID:       chainId,
 		PayloadHash:   payloadHash,
-		PayloadBytes:  payloadBytes,
 		SenderAddress: senderAddress,
 	}
 	return args

--- a/op-service/signer/blockpayload_args.go
+++ b/op-service/signer/blockpayload_args.go
@@ -6,55 +6,115 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // BlockPayloadArgs represents the arguments to sign a new block payload from the sequencer.
+// This is maintained until the V1 signing API in the op-signer server is no longer served.
 type BlockPayloadArgs struct {
 	Domain        [32]byte        `json:"domain"`
 	ChainID       *big.Int        `json:"chainId"`
 	PayloadHash   []byte          `json:"payloadHash"`
 	SenderAddress *common.Address `json:"senderAddress"`
+
+	// note: older versions of this included a `PayloadBytes` value,
+	// not JSON-named, but JSON-encoded anyway.
+	// Since this was unused, it is no longer included.
 }
 
 // NewBlockPayloadArgs creates a BlockPayloadArgs struct
 func NewBlockPayloadArgs(domain [32]byte, chainId *big.Int, payloadBytes []byte, senderAddress *common.Address) *BlockPayloadArgs {
-	payloadHash := crypto.Keccak256(payloadBytes)
+	payloadHash := PayloadHash(payloadBytes)
 	args := &BlockPayloadArgs{
 		Domain:        domain,
 		ChainID:       chainId,
-		PayloadHash:   payloadHash,
+		PayloadHash:   payloadHash[:],
 		SenderAddress: senderAddress,
 	}
 	return args
 }
 
+// Check checks that the attributes are set and conform to type assumptions.
 func (args *BlockPayloadArgs) Check() error {
 	if args.ChainID == nil {
 		return errors.New("chainId not specified")
 	}
+	if args.ChainID.BitLen() > 256 {
+		return errors.New("chain_id is too large")
+	}
 	if len(args.PayloadHash) == 0 {
 		return errors.New("payloadHash not specified")
+	}
+	if len(args.PayloadHash) != 32 {
+		return errors.New("payloadHash has unexpected length")
 	}
 	return nil
 }
 
+func (args *BlockPayloadArgs) Message() (*BlockSigningMessage, error) {
+	if err := args.Check(); err != nil {
+		return nil, err
+	}
+	return &BlockSigningMessage{
+		Domain:      args.Domain,
+		ChainID:     eth.ChainIDFromBig(args.ChainID),
+		PayloadHash: common.BytesToHash(args.PayloadHash),
+	}, nil
+}
+
+// BlockPayloadArgsV2 represents the arguments to sign a new block payload from the sequencer.
+// This replaces BlockPayloadArgs, to fix JSON encoding.
+type BlockPayloadArgsV2 struct {
+	Domain      eth.Bytes32 `json:"domain"`
+	ChainID     eth.ChainID `json:"chainId"`
+	PayloadHash common.Hash `json:"payloadHash"`
+
+	// SenderAddress is optional, it helps determine which account to sign with,
+	// if multiple accounts are available.
+	SenderAddress *common.Address `json:"senderAddress"`
+}
+
+// PayloadHash computes the hash of the payload, an attribute of the signing message.
+// The payload-hash is NOT the signing-hash.
+func PayloadHash(payload []byte) common.Hash {
+	return crypto.Keccak256Hash(payload)
+}
+
+func (args *BlockPayloadArgsV2) Message() (*BlockSigningMessage, error) {
+	// A zero Domain is valid, and thus not checked.
+	if args.ChainID == (eth.ChainID{}) {
+		return nil, errors.New("chainId not specified")
+	}
+	if args.PayloadHash == (common.Hash{}) {
+		return nil, errors.New("payloadHash not specified")
+	}
+	return &BlockSigningMessage{
+		Domain:      args.Domain,
+		ChainID:     args.ChainID,
+		PayloadHash: args.PayloadHash,
+	}, nil
+}
+
+// BlockSigningMessage is the message representing a block. For signing-message construction.
+// NOT FOR API USAGE. See BlockPayloadArgsV2 instead.
+type BlockSigningMessage struct {
+	Domain      eth.Bytes32
+	ChainID     eth.ChainID
+	PayloadHash common.Hash
+}
+
 // ToSigningHash creates a signingHash from the block payload args.
 // Uses the hashing scheme from https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/rollup-node-p2p.md#block-signatures
-func (args *BlockPayloadArgs) ToSigningHash() (common.Hash, error) {
-	if err := args.Check(); err != nil {
-		return common.Hash{}, err
-	}
+func (msg *BlockSigningMessage) ToSigningHash() common.Hash {
 	var msgInput [32 + 32 + 32]byte
 	// domain: first 32 bytes
-	copy(msgInput[:32], args.Domain[:])
+	copy(msgInput[:32], msg.Domain[:])
 	// chain_id: second 32 bytes
-	if args.ChainID.BitLen() > 256 {
-		return common.Hash{}, errors.New("chain_id is too large")
-	}
-	args.ChainID.FillBytes(msgInput[32:64])
-
+	chainID := msg.ChainID.Bytes32()
+	copy(msgInput[32:64], chainID[:])
 	// payload_hash: third 32 bytes, hash of encoded payload
-	copy(msgInput[64:], args.PayloadHash[:])
+	copy(msgInput[64:], msg.PayloadHash[:])
 
-	return crypto.Keccak256Hash(msgInput[:]), nil
+	return crypto.Keccak256Hash(msgInput[:])
 }

--- a/op-service/signer/blockpayload_args_test.go
+++ b/op-service/signer/blockpayload_args_test.go
@@ -1,0 +1,33 @@
+package signer
+
+import (
+	"encoding/json"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+func TestBlockPayloadArgs(t *testing.T) {
+	cfg := &rollup.Config{
+		L2ChainID: big.NewInt(100),
+	}
+	payloadBytes := []byte("arbitraryData")
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+	exampleDomain := [32]byte{0: 123, 1: 42}
+	args := NewBlockPayloadArgs(exampleDomain, cfg.L2ChainID, payloadBytes, &addr)
+	out, err := json.MarshalIndent(args, "  ", "  ")
+	require.NoError(t, err)
+	content := string(out)
+	// previously erroneously included in every request. Not used on server-side. Should be dropped now.
+	require.NotContains(t, content, "PayloadBytes")
+	// mistyped as list of ints in v0
+	require.Contains(t, content, `"domain": [`)
+	require.Contains(t, content, ` 123,`)
+	require.Contains(t, content, ` 42,`)
+	require.Contains(t, content, `"chainId": 100`)
+	// mistyped as standard Go bytes, hence base64
+	require.Contains(t, content, `"payloadHash": "7qa7ZZHSC1LytldPsgv3J5zQPVgWE9jqHojIK4QAFEs="`)
+	require.Contains(t, content, `"senderAddress": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"`)
+}

--- a/op-service/signer/blockpayload_args_test.go
+++ b/op-service/signer/blockpayload_args_test.go
@@ -2,21 +2,21 @@ package signer
 
 import (
 	"encoding/json"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestBlockPayloadArgs(t *testing.T) {
-	cfg := &rollup.Config{
-		L2ChainID: big.NewInt(100),
-	}
+	l2ChainID := big.NewInt(100)
 	payloadBytes := []byte("arbitraryData")
 	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 	exampleDomain := [32]byte{0: 123, 1: 42}
-	args := NewBlockPayloadArgs(exampleDomain, cfg.L2ChainID, payloadBytes, &addr)
+	args := NewBlockPayloadArgs(exampleDomain, l2ChainID, payloadBytes, &addr)
 	out, err := json.MarshalIndent(args, "  ", "  ")
 	require.NoError(t, err)
 	content := string(out)
@@ -30,4 +30,23 @@ func TestBlockPayloadArgs(t *testing.T) {
 	// mistyped as standard Go bytes, hence base64
 	require.Contains(t, content, `"payloadHash": "7qa7ZZHSC1LytldPsgv3J5zQPVgWE9jqHojIK4QAFEs="`)
 	require.Contains(t, content, `"senderAddress": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"`)
+
+	// Assert signing hash, to detect breaking changes to hashing
+	msg, err := args.Message()
+	require.NoError(t, err)
+	h := msg.ToSigningHash()
+	require.Equal(t, common.HexToHash("0xc724de7aefa316a12cbbd5edc39d512830598cce5d6ac81d1b518ef69450ad77"), h)
+
+	argsV2 := BlockPayloadArgsV2{
+		Domain:        eth.Bytes32(exampleDomain),
+		ChainID:       eth.ChainIDFromUInt64(100),
+		PayloadHash:   PayloadHash(payloadBytes),
+		SenderAddress: &addr,
+	}
+	msg2, err := argsV2.Message()
+	require.NoError(t, err)
+	require.Equal(t, msg, msg2)
+	h2 := msg2.ToSigningHash()
+	require.NoError(t, err)
+	require.Equal(t, h, h2, "signing hash still the same in V2 API")
 }


### PR DESCRIPTION
**Description**

Fixes:
- improve RPC typing in backwards compatible way
  - The full block payload was being sent with every request, even though only the payload-hash was being used. Likely caused by a Go language mistake/footgun with the missing json tag.
- improve typing and API to be more reusable outside of p2p package
- cleanup unused op-signer RPC client struct attribute, log the server version instead

New:
- V2 block-args type, with more Go-native and less error-prone typing. No weird JSON encoding to signer server anymore with V2. This helps others implement their own signer server also.
- Client binding for the V2 endpoint

Also see infra-repo PR for the server-side improvements.
https://github.com/ethereum-optimism/infra/pull/203

**Tests**

- Update block signer tests
- Add tests for type encoding
- Add test to ensure the signing-hash is still computed the same

Note: we are not using `eth.ChainID` type everywhere yet, so some tests still need to convert from big-int to chain-id, but that will change once we improve the rollup-config typing.

TODO: I'd like to e2e test this, but couldn't yet get the op-signer server running. Integration into kurtosis of more of the infra would be nice.

**Additional context**

Besides more efficiency and better typing, this also helps with re-use the block-signer code. This is important for the test-sequencer work.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
