### PR TITLE
events: Increase Maximum Queue Size 10x

### DIFF
--- a/op-node/rollup/event/executor_global.go
+++ b/op-node/rollup/event/executor_global.go
@@ -11,7 +11,7 @@ import (
 
 // Don't queue up an endless number of events.
 // At some point it's better to drop events and warn something is exploding the number of events.
-const sanityEventLimit = 1000
+const sanityEventLimit = 10_000
 
 type GlobalSyncExec struct {
 	eventsLock sync.Mutex


### PR DESCRIPTION
# What
Increases the `sanityEventLimit` 10x, from 1,000 to 10,000.

# Why
Recently, the log message `Failed to enqueue event` has been cropping up on `op-supervisor`, and recently it happened on `op-node` too.

When this happened on `op-node`, the event system broke down a bit and the node needed to be reset before it could proceed. A large volume of unsafe payloads arrived on the node, and managed to choke out all other events. Once the standard event flow crashed, the node was left processing over 300 unsafe payload events per second.

![image](https://github.com/user-attachments/assets/1b99d3bc-1908-499e-b9b0-04d27eee5ef7)

# On Queuing Theory
At a macro level, queues either:
- Drain faster than they fill
- Fill faster than they drain

Any system which fills faster than it drains will *eventually* overflow and crash, so successful stream processing systems *tend toward* zero. In reality, events will sometimes arrive more quickly than the system can handle. This is where *spikes* come from.

changing the `sanityEventLimit` is specifically a response to the height of the spike being too tall. While we can't tell how tall the spike *was* because it was capped at 1k events, we can tell that in normal operation there are only ~16 events per second, up to ~128 per second during certain sync events.

It **is** possible that the way the particular events transpired, we were actually encountering a fork-bomb type of procession, where events create even *more* events before they can be processed. However, this event coincides with what appeared to be legitimately a high volume of unsafe payloads delivered over gossip.