### PR TITLE
feat(op-program-svc): introduce new service to compute prestates

### DIFF
--- a/kurtosis-devnet/op-program-svc/Dockerfile
+++ b/kurtosis-devnet/op-program-svc/Dockerfile
@@ -9,7 +9,30 @@ RUN go mod init op-program-svc
 RUN go build -o op-program-svc .
 
 
-FROM op-program-base:${BASE_VERSION}
+FROM op-program-base:${BASE_VERSION} AS svc
+
+ARG GIT_COMMIT
+ARG GIT_DATE
+
+ARG CANNON_VERSION=v0.0.0
+ARG OP_PROGRAM_VERSION=v0.0.0
+
+ARG TARGETOS TARGETARCH
+
+WORKDIR /app
+
+# build cannon ahead of time
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
+        -d /app/op-program \
+        -f /app/op-program/repro.justfile \
+        GOOS="$TARGETOS" \
+        GOARCH="$TARGETARCH" \
+        GIT_COMMIT="$GIT_COMMIT" \
+        GIT_DATE="$GIT_DATE" \
+        CANNON_VERSION="$CANNON_VERSION" \
+        OP_PROGRAM_VERSION="$OP_PROGRAM_VERSION" \
+        cannon
+
 COPY --from=builder /app/op-program-svc .
 EXPOSE 8080
 CMD ["./op-program-svc"]

--- a/kurtosis-devnet/op-program-svc/Dockerfile
+++ b/kurtosis-devnet/op-program-svc/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_VERSION=latest
+
+FROM golang:1.22.7-alpine3.20 AS builder
+
+COPY ./*.go /app/
+WORKDIR /app
+
+RUN go mod init op-program-svc
+RUN go build -o op-program-svc .
+
+
+FROM op-program-base:${BASE_VERSION}
+COPY --from=builder /app/op-program-svc .
+EXPOSE 8080
+CMD ["./op-program-svc"]

--- a/kurtosis-devnet/op-program-svc/README.md
+++ b/kurtosis-devnet/op-program-svc/README.md
@@ -1,0 +1,10 @@
+# Trigger new build:
+
+```
+$ curl -X POST -H "Content-Type: multipart/form-data" \
+    -F "files[]=@rollup-2151908.json" \
+    -F "files[]=@rollup-2151909.json" \
+    -F "files[]=@genesis-2151908.json" \
+    -F "files[]=@genesis-2151909.json" \
+    http://localhost:8080
+```

--- a/kurtosis-devnet/op-program-svc/README.md
+++ b/kurtosis-devnet/op-program-svc/README.md
@@ -6,5 +6,6 @@ $ curl -X POST -H "Content-Type: multipart/form-data" \
     -F "files[]=@rollup-2151909.json" \
     -F "files[]=@genesis-2151908.json" \
     -F "files[]=@genesis-2151909.json" \
+    -F "files[]=@depsets.json" \
     http://localhost:8080
 ```

--- a/kurtosis-devnet/op-program-svc/build.go
+++ b/kurtosis-devnet/op-program-svc/build.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"bufio"
+)
+
+type Builder struct {
+	appRoot    string
+	configsDir string
+	buildDir   string
+	buildCmd   string
+}
+
+func NewBuilder(appRoot, configsDir, buildDir, buildCmd string) *Builder {
+	return &Builder{
+		appRoot:    appRoot,
+		configsDir: configsDir,
+		buildDir:   buildDir,
+		buildCmd:   buildCmd,
+	}
+}
+
+func (b *Builder) SaveUploadedFiles(files []*multipart.FileHeader) error {
+	// Create configs directory if it doesn't exist
+	fullConfigsDir := filepath.Join(b.appRoot, b.buildDir, b.configsDir)
+	if err := os.MkdirAll(fullConfigsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// Save the files
+	for _, fileHeader := range files {
+		file, err := fileHeader.Open()
+		if err != nil {
+			return fmt.Errorf("failed to open file: %w", err)
+		}
+		defer file.Close()
+
+		destPath := filepath.Join(fullConfigsDir, b.normalizeFilename(fileHeader.Filename))
+		dst, err := os.Create(destPath)
+		if err != nil {
+			return fmt.Errorf("failed to create destination file: %w", err)
+		}
+		defer dst.Close()
+
+		if _, err := io.Copy(dst, file); err != nil {
+			return fmt.Errorf("failed to save file: %w", err)
+		}
+		log.Printf("Saved file: %s", destPath)
+	}
+
+	return nil
+}
+
+func (b *Builder) ExecuteBuild() ([]byte, error) {
+	log.Printf("Starting build...")
+	cmdParts := strings.Fields(b.buildCmd)
+	cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+	cmd.Dir = filepath.Join(b.appRoot, b.buildDir)
+
+	// Create pipes for stdout and stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	// Buffer to store complete output for error reporting
+	var output bytes.Buffer
+	output.WriteString("Build output:\n")
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start build: %w", err)
+	}
+
+	// Create a WaitGroup to wait for both stdout and stderr to be processed
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Stream stdout
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			log.Printf("[build] %s", line)
+			output.WriteString(line + "\n")
+		}
+	}()
+
+	// Stream stderr
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			log.Printf("[build][stderr] %s", line)
+			output.WriteString(line + "\n")
+		}
+	}()
+
+	// Wait for both streams to complete
+	wg.Wait()
+
+	// Wait for the command to complete
+	if err := cmd.Wait(); err != nil {
+		return output.Bytes(), fmt.Errorf("build failed: %w", err)
+	}
+
+	log.Printf("Build completed successfully")
+	return output.Bytes(), nil
+}
+
+func (b *Builder) normalizeFilename(filename string) string {
+	// Get just the filename without directories
+	filename = filepath.Base(filename)
+
+	// Check if filename matches PREFIX-NUMBER.json pattern
+	if parts := strings.Split(filename, "-"); len(parts) == 2 {
+		if numStr := strings.TrimSuffix(parts[1], ".json"); numStr != parts[1] {
+			// Check if the number part is actually numeric
+			if _, err := strconv.Atoi(numStr); err == nil {
+				// It matches the pattern and has a valid number, reorder to NUMBER-PREFIX.json
+				return numStr + "-" + parts[0] + ".json"
+			}
+		}
+	}
+
+	return filename
+}

--- a/kurtosis-devnet/op-program-svc/build_test.go
+++ b/kurtosis-devnet/op-program-svc/build_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSaveUploadedFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []struct {
+			filename string
+			content  []byte
+		}
+		shouldFail bool
+	}{
+		{
+			name: "successful save",
+			files: []struct {
+				filename string
+				content  []byte
+			}{
+				{
+					filename: "test1.json",
+					content:  []byte("test1 content"),
+				},
+				{
+					filename: "test2.json",
+					content:  []byte("test2 content"),
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			name: "filesystem error",
+			files: []struct {
+				filename string
+				content  []byte
+			}{
+				{
+					filename: "test1.json",
+					content:  []byte("test1 content"),
+				},
+			},
+			shouldFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := NewMockFS()
+			mockFS.ShouldFail = tt.shouldFail
+
+			// Create mock uploaded files
+			files := make([]UploadedFile, len(tt.files))
+			for i, f := range tt.files {
+				files[i] = NewMockUploadedFile(f.filename, f.content)
+			}
+
+			b := &Builder{
+				appRoot:    "app",
+				configsDir: "configs",
+				buildDir:   "build",
+				fs:         mockFS,
+			}
+
+			err := b.SaveUploadedFiles(files)
+
+			if tt.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if !tt.shouldFail {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				// Verify correct directory was created
+				if len(mockFS.MkdirCalls) != 1 {
+					t.Errorf("expected 1 mkdir call, got %d", len(mockFS.MkdirCalls))
+				}
+
+				// Verify files were created
+				expectedCreateCalls := len(tt.files)
+				if len(mockFS.CreateCalls) != expectedCreateCalls {
+					t.Errorf("expected %d create calls, got %d", expectedCreateCalls, len(mockFS.CreateCalls))
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteBuild(t *testing.T) {
+	tests := []struct {
+		name       string
+		stdout     string
+		stderr     string
+		shouldFail bool
+	}{
+		{
+			name:       "successful build",
+			stdout:     "build successful\n",
+			stderr:     "",
+			shouldFail: false,
+		},
+		{
+			name:       "build failure",
+			stdout:     "",
+			stderr:     "build failed\n",
+			shouldFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &MockCommandRunner{
+				ShouldFail: tt.shouldFail,
+				Stdout:     tt.stdout,
+				Stderr:     tt.stderr,
+			}
+
+			mockFactory := &MockCommandFactory{
+				Runner: mockRunner,
+			}
+
+			mockFS := NewMockFS()
+
+			b := &Builder{
+				appRoot:    "app",
+				buildDir:   "build",
+				buildCmd:   "make build",
+				cmdFactory: mockFactory,
+				fs:         mockFS,
+			}
+
+			output, err := b.ExecuteBuild()
+
+			if tt.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if !tt.shouldFail {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				if !mockRunner.StartCalled {
+					t.Error("Start was not called")
+				}
+
+				if !mockRunner.WaitCalled {
+					t.Error("Wait was not called")
+				}
+
+				if !strings.Contains(string(output), tt.stdout) {
+					t.Errorf("expected output to contain %q, got %q", tt.stdout, string(output))
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard format",
+			input:    "prefix-123.json",
+			expected: "123-prefix.json",
+		},
+		{
+			name:     "no number",
+			input:    "test.json",
+			expected: "test.json",
+		},
+		{
+			name:     "invalid number",
+			input:    "prefix-abc.json",
+			expected: "prefix-abc.json",
+		},
+		{
+			name:     "no json extension",
+			input:    "prefix-123.txt",
+			expected: "prefix-123.txt",
+		},
+	}
+
+	b := &Builder{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := b.normalizeFilename(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/kurtosis-devnet/op-program-svc/defaults.go
+++ b/kurtosis-devnet/op-program-svc/defaults.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// osFile wraps os.File to implement File
+type osFile struct {
+	*os.File
+}
+
+func (f *osFile) Readdir(count int) ([]fs.FileInfo, error) {
+	return f.File.Readdir(count)
+}
+
+// DefaultFileSystem implements testutils.FS using actual OS calls
+type DefaultFileSystem struct{}
+
+func (fs *DefaultFileSystem) Open(name string) (File, error) {
+	file, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &osFile{File: file}, nil
+}
+
+func (fs *DefaultFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(name)
+}
+
+func (fs *DefaultFileSystem) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}
+
+func (fs *DefaultFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (fs *DefaultFileSystem) Create(name string) (io.WriteCloser, error) {
+	return os.Create(name)
+}
+
+func (fs *DefaultFileSystem) Join(elem ...string) string {
+	return filepath.Join(elem...)
+}
+
+// commandWrapper wraps exec.Cmd to implement CommandRunner
+type commandWrapper struct {
+	*exec.Cmd
+}
+
+func (c *commandWrapper) SetDir(dir string) {
+	c.Cmd.Dir = dir
+}
+
+// DefaultCommandFactory implements testutils.CommandFactory using actual OS exec
+type DefaultCommandFactory struct{}
+
+func (f *DefaultCommandFactory) CreateCommand(name string, args ...string) CommandRunner {
+	cmd := exec.Command(name, args...)
+	return &commandWrapper{Cmd: cmd}
+}

--- a/kurtosis-devnet/op-program-svc/fs.go
+++ b/kurtosis-devnet/op-program-svc/fs.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// proofFileSystem implements http.FileSystem, mapping hash-based virtual paths to actual files
+type proofFileSystem struct {
+	root       string
+	proofFiles map[string]string // hash -> variable part mapping
+	proofMutex sync.RWMutex
+}
+
+// proofFile implements http.File, representing a virtual file in our proof filesystem
+type proofFile struct {
+	*os.File
+}
+
+func (f *proofFile) Readdir(count int) ([]fs.FileInfo, error) {
+	// For actual files, we don't support directory listing
+	return nil, fmt.Errorf("not a directory")
+}
+
+// proofDir implements http.File for the root directory
+type proofDir struct {
+	*proofFileSystem
+	pos int
+}
+
+func (d *proofDir) Close() error {
+	return nil
+}
+
+func (d *proofDir) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("cannot read a directory")
+}
+
+func (d *proofDir) Seek(offset int64, whence int) (int64, error) {
+	return 0, fmt.Errorf("cannot seek a directory")
+}
+
+func (d *proofDir) Readdir(count int) ([]fs.FileInfo, error) {
+	d.proofMutex.RLock()
+	defer d.proofMutex.RUnlock()
+
+	// If we've already read all entries
+	if d.pos >= len(d.proofFiles)*2 {
+		if count <= 0 {
+			return nil, nil
+		}
+		return nil, io.EOF
+	}
+
+	// Convert hashes to virtual file entries
+	var entries []fs.FileInfo
+	hashes := make([]string, 0, len(d.proofFiles))
+	for hash := range d.proofFiles {
+		hashes = append(hashes, hash)
+	}
+
+	start := d.pos
+	end := start + count
+	if count <= 0 || end > len(d.proofFiles)*2 {
+		end = len(d.proofFiles) * 2
+	}
+
+	for i := start; i < end; i++ {
+		hash := hashes[i/2]
+		isJSON := i%2 == 0
+
+		var name string
+		if isJSON {
+			name = hash + ".json"
+		} else {
+			name = hash + ".bin.gz"
+		}
+
+		// Create a virtual file info
+		entries = append(entries, virtualFileInfo{
+			name:    name,
+			size:    0, // Size will be determined when actually opening the file
+			mode:    0644,
+			modTime: time.Now(),
+			isDir:   false,
+		})
+	}
+
+	d.pos = end
+	return entries, nil
+}
+
+func (d *proofDir) Stat() (fs.FileInfo, error) {
+	return virtualFileInfo{
+		name:    ".",
+		size:    0,
+		mode:    0755,
+		modTime: time.Now(),
+		isDir:   true,
+	}, nil
+}
+
+// virtualFileInfo implements fs.FileInfo for our virtual files
+type virtualFileInfo struct {
+	name    string
+	size    int64
+	mode    fs.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (v virtualFileInfo) Name() string       { return v.name }
+func (v virtualFileInfo) Size() int64        { return v.size }
+func (v virtualFileInfo) Mode() fs.FileMode  { return v.mode }
+func (v virtualFileInfo) ModTime() time.Time { return v.modTime }
+func (v virtualFileInfo) IsDir() bool        { return v.isDir }
+func (v virtualFileInfo) Sys() interface{}   { return nil }
+
+func newProofFileSystem(root string) *proofFileSystem {
+	return &proofFileSystem{
+		root:       root,
+		proofFiles: make(map[string]string),
+	}
+}
+
+func (fs *proofFileSystem) Open(name string) (http.File, error) {
+	if name == "/" || name == "" {
+		return &proofDir{proofFileSystem: fs}, nil
+	}
+
+	// Clean the path and remove leading slash
+	name = strings.TrimPrefix(filepath.Clean(name), "/")
+
+	fs.proofMutex.RLock()
+	defer fs.proofMutex.RUnlock()
+
+	var targetFile string
+	if strings.HasSuffix(name, ".json") {
+		hash := strings.TrimSuffix(name, ".json")
+		if variablePart, ok := fs.proofFiles[hash]; ok {
+			targetFile = fmt.Sprintf("prestate-proof%s.json", variablePart)
+		}
+	} else if strings.HasSuffix(name, ".bin.gz") {
+		hash := strings.TrimSuffix(name, ".bin.gz")
+		if variablePart, ok := fs.proofFiles[hash]; ok {
+			targetFile = fmt.Sprintf("prestate%s.bin.gz", variablePart)
+		}
+	}
+
+	if targetFile == "" {
+		return nil, fs.Error("file not found")
+	}
+
+	file, err := os.Open(filepath.Join(fs.root, targetFile))
+	if err != nil {
+		return nil, err
+	}
+
+	return &proofFile{File: file}, nil
+}
+
+func (fs *proofFileSystem) scanProofFiles() error {
+	fs.proofMutex.Lock()
+	defer fs.proofMutex.Unlock()
+
+	// Clear existing mappings
+	fs.proofFiles = make(map[string]string)
+
+	// Read directory entries
+	entries, err := os.ReadDir(fs.root)
+	if err != nil {
+		return fmt.Errorf("failed to read proofs directory: %v", err)
+	}
+
+	// Regexp for matching prestate-proof files and extracting the variable part
+	proofRegexp := regexp.MustCompile(`^prestate-proof(.*)\.json$`)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		matches := proofRegexp.FindStringSubmatch(entry.Name())
+		if matches == nil {
+			continue
+		}
+
+		// matches[1] contains the variable part (including the leading hyphen if present)
+		variablePart := matches[1]
+
+		// Read and parse the JSON file
+		data, err := os.ReadFile(filepath.Join(fs.root, entry.Name()))
+		if err != nil {
+			log.Printf("Warning: failed to read proof file %s: %v", entry.Name(), err)
+			continue
+		}
+
+		var proofData struct {
+			Pre string `json:"pre"`
+		}
+		if err := json.Unmarshal(data, &proofData); err != nil {
+			log.Printf("Warning: failed to parse proof file %s: %v", entry.Name(), err)
+			continue
+		}
+
+		// Store the mapping from hash to variable part of filename
+		fs.proofFiles[proofData.Pre] = variablePart
+		log.Printf("Mapped hash %s to proof file pattern%s", proofData.Pre, variablePart)
+	}
+
+	return nil
+}
+
+func (fs *proofFileSystem) Error(msg string) error {
+	return &os.PathError{Op: "open", Path: "virtual path", Err: errors.New(msg)}
+}

--- a/kurtosis-devnet/op-program-svc/fs_test.go
+++ b/kurtosis-devnet/op-program-svc/fs_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func TestProofFileSystem(t *testing.T) {
+	// Create mock filesystem
+	mockfs := NewMockFS()
+
+	// Add test files
+	proofData := map[string]interface{}{
+		"pre": "hash123",
+	}
+	proofJSON, _ := json.Marshal(proofData)
+
+	mockfs.Files["/proofs/prestate-proof-test.json"] = NewMockFile(
+		"prestate-proof-test.json",
+		proofJSON,
+	)
+	mockfs.Files["/proofs/prestate-test.bin.gz"] = NewMockFile(
+		"prestate-test.bin.gz",
+		[]byte("mock binary data"),
+	)
+
+	// Create proof filesystem and set mock fs
+	pfs := newProofFileSystem("/proofs")
+	pfs.SetFS(mockfs)
+
+	// Test scanning proof files
+	t.Run("ScanProofFiles", func(t *testing.T) {
+		err := pfs.scanProofFiles()
+		if err != nil {
+			t.Errorf("scanProofFiles failed: %v", err)
+		}
+
+		// Verify mapping was created
+		if mapping, ok := pfs.proofFiles["hash123"]; !ok || mapping != "-test" {
+			t.Errorf("Expected mapping for hash123 to be -test, got %v", mapping)
+		}
+	})
+
+	t.Run("OpenJSONFile", func(t *testing.T) {
+		file, err := pfs.Open("/hash123.json")
+		if err != nil {
+			t.Errorf("Failed to open JSON file: %v", err)
+		}
+		defer file.Close()
+
+		// Read contents
+		contents, err := io.ReadAll(file)
+		if err != nil {
+			t.Errorf("Failed to read file contents: %v", err)
+		}
+
+		if !bytes.Equal(contents, proofJSON) {
+			t.Errorf("File contents don't match expected")
+		}
+	})
+
+	t.Run("OpenBinaryFile", func(t *testing.T) {
+		file, err := pfs.Open("/hash123.bin.gz")
+		if err != nil {
+			t.Errorf("Failed to open binary file: %v", err)
+		}
+		defer file.Close()
+
+		contents, err := io.ReadAll(file)
+		if err != nil {
+			t.Errorf("Failed to read file contents: %v", err)
+		}
+
+		if !bytes.Equal(contents, []byte("mock binary data")) {
+			t.Errorf("File contents don't match expected")
+		}
+	})
+
+	t.Run("OpenNonExistentFile", func(t *testing.T) {
+		_, err := pfs.Open("/nonexistent.json")
+		if err == nil {
+			t.Error("Expected error opening non-existent file")
+		}
+	})
+
+	t.Run("ListDirectory", func(t *testing.T) {
+		dir, err := pfs.Open("/")
+		if err != nil {
+			t.Errorf("Failed to open root directory: %v", err)
+		}
+		defer dir.Close()
+
+		files, err := dir.Readdir(-1)
+		if err != nil {
+			t.Errorf("Failed to read directory: %v", err)
+		}
+
+		if len(files) != 2 { // We expect both .json and .bin.gz files
+			t.Errorf("Expected 2 files, got %d", len(files))
+		}
+	})
+}

--- a/kurtosis-devnet/op-program-svc/interfaces.go
+++ b/kurtosis-devnet/op-program-svc/interfaces.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"os"
+)
+
+// File interface abstracts file operations
+type File interface {
+	fs.File
+	io.Seeker
+	Readdir(count int) ([]fs.FileInfo, error)
+}
+
+// FS defines the interface for all filesystem operations
+type FS interface {
+	// Core FS operations
+	Open(name string) (File, error)
+	ReadDir(name string) ([]fs.DirEntry, error)
+	ReadFile(name string) ([]byte, error)
+	Join(elem ...string) string
+
+	// Additional FileSystem operations
+	MkdirAll(path string, perm os.FileMode) error
+	Create(name string) (io.WriteCloser, error)
+}
+
+// UploadedFile represents a file that has been uploaded
+type UploadedFile interface {
+	Open() (io.ReadCloser, error)
+	GetFilename() string
+}
+
+// CommandRunner abstracts command execution for testing
+type CommandRunner interface {
+	Start() error
+	Wait() error
+	StdoutPipe() (io.ReadCloser, error)
+	StderrPipe() (io.ReadCloser, error)
+	SetDir(dir string)
+}
+
+// CommandFactory creates commands
+type CommandFactory interface {
+	CreateCommand(name string, args ...string) CommandRunner
+}

--- a/kurtosis-devnet/op-program-svc/justfile
+++ b/kurtosis-devnet/op-program-svc/justfile
@@ -1,0 +1,5 @@
+op-program-base:
+    docker buildx build -f ../../op-program/Dockerfile.repro --target=src -t op-program-base:latest ../..
+
+op-program-svc: op-program-base
+    docker buildx build -f Dockerfile -t op-program-svc:latest .

--- a/kurtosis-devnet/op-program-svc/main.go
+++ b/kurtosis-devnet/op-program-svc/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+)
+
+var (
+	flagAppRoot    = flag.String("app-root", "/app", "Root directory for the application")
+	flagConfigsDir = flag.String("configs-dir", "chainconfig/configs", "Directory for config files (relative to build-dir)")
+	flagBuildDir   = flag.String("build-dir", "op-program", "Directory where the build command will be executed (relative to app-root)")
+	flagBuildCmd   = flag.String("build-cmd", "just build", "Build command to execute")
+	flagPort       = flag.Int("port", 8080, "Port to listen on")
+)
+
+func main() {
+	flag.Parse()
+
+	srv := createServer()
+
+	// Set up routes
+	http.HandleFunc("/", srv.handleUpload)
+	http.Handle("/proofs/", http.StripPrefix("/proofs/", http.FileServer(srv.proofFS)))
+
+	log.Printf("Starting server on :%d with:", srv.port)
+	log.Printf("  app-root: %s", srv.appRoot)
+	log.Printf("  configs-dir: %s", filepath.Join(srv.appRoot, srv.buildDir, srv.configsDir))
+	log.Printf("  build-dir: %s", filepath.Join(srv.appRoot, srv.buildDir))
+	log.Printf("  build-cmd: %s", srv.buildCmd)
+	log.Printf("  proofs-dir: %s", filepath.Join(srv.appRoot, srv.buildDir, "bin"))
+
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", srv.port), nil); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}

--- a/kurtosis-devnet/op-program-svc/main.go
+++ b/kurtosis-devnet/op-program-svc/main.go
@@ -12,7 +12,7 @@ var (
 	flagAppRoot    = flag.String("app-root", "/app", "Root directory for the application")
 	flagConfigsDir = flag.String("configs-dir", "chainconfig/configs", "Directory for config files (relative to build-dir)")
 	flagBuildDir   = flag.String("build-dir", "op-program", "Directory where the build command will be executed (relative to app-root)")
-	flagBuildCmd   = flag.String("build-cmd", "just build", "Build command to execute")
+	flagBuildCmd   = flag.String("build-cmd", "just -f repro.justfile build-all", "Build command to execute")
 	flagPort       = flag.Int("port", 8080, "Port to listen on")
 )
 

--- a/kurtosis-devnet/op-program-svc/mocks.go
+++ b/kurtosis-devnet/op-program-svc/mocks.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MockFile implements both File and fs.FileInfo interfaces for testing
+type MockFile struct {
+	name     string
+	contents []byte
+	pos      int64
+	isDir    bool
+}
+
+func NewMockFile(name string, contents []byte) *MockFile {
+	return &MockFile{
+		name:     name,
+		contents: contents,
+	}
+}
+
+func (m *MockFile) Close() error { return nil }
+func (m *MockFile) Read(p []byte) (n int, err error) {
+	if m.pos >= int64(len(m.contents)) {
+		return 0, io.EOF
+	}
+	n = copy(p, m.contents[m.pos:])
+	m.pos += int64(n)
+	return n, nil
+}
+
+func (m *MockFile) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = m.pos + offset
+	case io.SeekEnd:
+		abs = int64(len(m.contents)) + offset
+	default:
+		return 0, fmt.Errorf("invalid whence")
+	}
+	if abs < 0 {
+		return 0, fmt.Errorf("negative position")
+	}
+	m.pos = abs
+	return abs, nil
+}
+
+func (m *MockFile) Stat() (fs.FileInfo, error) { return m, nil }
+func (m *MockFile) Name() string               { return m.name }
+func (m *MockFile) Size() int64                { return int64(len(m.contents)) }
+func (m *MockFile) Mode() fs.FileMode          { return 0644 }
+func (m *MockFile) ModTime() time.Time         { return time.Now() }
+func (m *MockFile) IsDir() bool                { return m.isDir }
+func (m *MockFile) Sys() interface{}           { return nil }
+func (m *MockFile) Readdir(count int) ([]fs.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// MockFS implements both FS and FileSystem interfaces for testing
+type MockFS struct {
+	Files       map[string]*MockFile
+	MkdirCalls  []string
+	CreateCalls []string
+	JoinCalls   [][]string
+	ShouldFail  bool
+}
+
+func NewMockFS() *MockFS {
+	return &MockFS{
+		Files:       make(map[string]*MockFile),
+		MkdirCalls:  make([]string, 0),
+		CreateCalls: make([]string, 0),
+		JoinCalls:   make([][]string, 0),
+	}
+}
+
+// FS interface methods
+func (m *MockFS) Open(name string) (File, error) {
+	if m.ShouldFail {
+		return nil, fmt.Errorf("mock open error")
+	}
+	if file, ok := m.Files[name]; ok {
+		file.pos = 0 // Reset position for new reads
+		return file, nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (m *MockFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if m.ShouldFail {
+		return nil, fmt.Errorf("mock readdir error")
+	}
+	var entries []fs.DirEntry
+	for path, file := range m.Files {
+		if filepath.Dir(path) == name {
+			entries = append(entries, fs.FileInfoToDirEntry(file))
+		}
+	}
+	return entries, nil
+}
+
+func (m *MockFS) ReadFile(name string) ([]byte, error) {
+	if m.ShouldFail {
+		return nil, fmt.Errorf("mock readfile error")
+	}
+	if file, ok := m.Files[name]; ok {
+		return file.contents, nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+// FileSystem interface methods
+func (m *MockFS) MkdirAll(path string, perm os.FileMode) error {
+	if m.ShouldFail {
+		return fmt.Errorf("mock mkdir error")
+	}
+	m.MkdirCalls = append(m.MkdirCalls, path)
+	return nil
+}
+
+func (m *MockFS) Create(name string) (io.WriteCloser, error) {
+	if m.ShouldFail {
+		return nil, fmt.Errorf("mock create error")
+	}
+	m.CreateCalls = append(m.CreateCalls, name)
+	return &MockWriteCloser{}, nil
+}
+
+func (m *MockFS) Join(elem ...string) string {
+	m.JoinCalls = append(m.JoinCalls, elem)
+	return filepath.Join(elem...)
+}
+
+// MockWriteCloser implements io.WriteCloser for testing
+type MockWriteCloser struct {
+	bytes.Buffer
+}
+
+func (m *MockWriteCloser) Close() error {
+	return nil
+}
+
+// MockUploadedFile implements UploadedFile for testing
+type MockUploadedFile struct {
+	filename string
+	content  []byte
+}
+
+func NewMockUploadedFile(filename string, content []byte) *MockUploadedFile {
+	return &MockUploadedFile{
+		filename: filename,
+		content:  content,
+	}
+}
+
+func (m *MockUploadedFile) Open() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(m.content)), nil
+}
+
+func (m *MockUploadedFile) GetFilename() string {
+	return m.filename
+}
+
+// MockCommandRunner implements CommandRunner for testing
+type MockCommandRunner struct {
+	StartCalled bool
+	WaitCalled  bool
+	ShouldFail  bool
+	Stdout      string
+	Stderr      string
+	Dir         string
+}
+
+func (m *MockCommandRunner) Start() error {
+	if m.ShouldFail {
+		return fmt.Errorf("mock start error")
+	}
+	m.StartCalled = true
+	return nil
+}
+
+func (m *MockCommandRunner) Wait() error {
+	if m.ShouldFail {
+		return fmt.Errorf("mock wait error")
+	}
+	m.WaitCalled = true
+	return nil
+}
+
+func (m *MockCommandRunner) StdoutPipe() (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(m.Stdout)), nil
+}
+
+func (m *MockCommandRunner) StderrPipe() (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(m.Stderr)), nil
+}
+
+func (m *MockCommandRunner) SetDir(dir string) {
+	m.Dir = dir
+}
+
+// MockCommandFactory implements CommandFactory for testing
+type MockCommandFactory struct {
+	Runner *MockCommandRunner
+}
+
+func (f *MockCommandFactory) CreateCommand(name string, args ...string) CommandRunner {
+	return f.Runner
+}
+
+// MockProofFS is a mock implementation of ProofFS
+type MockProofFS struct {
+	scanProofFilesFn func() error
+	fs               *MockFS
+}
+
+func NewMockProofFS() *MockProofFS {
+	return &MockProofFS{
+		fs: NewMockFS(),
+	}
+}
+
+func (m *MockProofFS) scanProofFiles() error {
+	if m.scanProofFilesFn != nil {
+		return m.scanProofFilesFn()
+	}
+	return nil
+}
+
+func (m *MockProofFS) Open(name string) (http.File, error) {
+	file, err := m.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	// MockFile implements http.File (including Seek)
+	return file.(http.File), nil
+}
+
+// AddFile adds a file to the mock filesystem
+func (m *MockProofFS) AddFile(name string, contents []byte) {
+	m.fs.Files[name] = NewMockFile(name, contents)
+}
+
+// MockBuilder is a mock implementation of BuildSystem
+type MockBuilder struct {
+	saveUploadedFilesFn func(files []UploadedFile) error
+	executeBuildFn      func() ([]byte, error)
+}
+
+func (m *MockBuilder) SaveUploadedFiles(files []UploadedFile) error {
+	if m.saveUploadedFilesFn != nil {
+		return m.saveUploadedFilesFn(files)
+	}
+	return nil
+}
+
+func (m *MockBuilder) ExecuteBuild() ([]byte, error) {
+	if m.executeBuildFn != nil {
+		return m.executeBuildFn()
+	}
+	return []byte("mock build output"), nil
+}

--- a/kurtosis-devnet/op-program-svc/server.go
+++ b/kurtosis-devnet/op-program-svc/server.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"sync"
+)
+
+type server struct {
+	appRoot       string
+	configsDir    string
+	buildDir      string
+	buildCmd      string
+	port          int
+	lastBuildHash string
+	buildMutex    sync.Mutex
+	proofFS       *proofFileSystem
+	builder       *Builder
+}
+
+func createServer() *server {
+	srv := &server{
+		appRoot:    *flagAppRoot,
+		configsDir: *flagConfigsDir,
+		buildDir:   *flagBuildDir,
+		buildCmd:   *flagBuildCmd,
+		port:       *flagPort,
+	}
+
+	// Initialize the proof filesystem
+	proofsDir := filepath.Join(srv.appRoot, srv.buildDir, "bin")
+	srv.proofFS = newProofFileSystem(proofsDir)
+
+	// Initialize the builder
+	srv.builder = NewBuilder(srv.appRoot, srv.configsDir, srv.buildDir, srv.buildCmd)
+
+	return srv
+}
+
+func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	log.Printf("Received upload request from %s", r.RemoteAddr)
+
+	files, currentHash, err := s.processMultipartForm(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.buildMutex.Lock()
+	defer s.buildMutex.Unlock()
+
+	// Check if we need to rebuild
+	if currentHash == s.lastBuildHash {
+		log.Printf("Hash matches last build, skipping")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "Files unchanged, skipping build")
+		return
+	}
+
+	log.Printf("Hash differs from last build (%s), proceeding with build", s.lastBuildHash)
+
+	// Save the files using the builder
+	if err := s.builder.SaveUploadedFiles(files); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Execute the build
+	out, err := s.builder.ExecuteBuild()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("%v\nOutput: %s", err, out), http.StatusInternalServerError)
+		return
+	}
+
+	// After successful build, scan for new proof files
+	if err := s.proofFS.scanProofFiles(); err != nil {
+		log.Printf("Warning: failed to scan proof files: %v", err)
+	}
+
+	// Update the last successful build hash
+	s.lastBuildHash = currentHash
+
+	// Redirect to the proofs endpoint
+	http.Redirect(w, r, "/proofs", http.StatusSeeOther)
+}
+
+func (s *server) processMultipartForm(r *http.Request) ([]*multipart.FileHeader, string, error) {
+	// Parse the multipart form
+	if err := r.ParseMultipartForm(1 << 30); err != nil { // 1GB max memory
+		return nil, "", fmt.Errorf("failed to parse form: %w", err)
+	}
+
+	// Get uploaded files
+	files := r.MultipartForm.File["files[]"]
+	if len(files) == 0 {
+		return nil, "", fmt.Errorf("no files uploaded")
+	}
+
+	log.Printf("Processing %d files:", len(files))
+	for _, fileHeader := range files {
+		log.Printf("  - %s (size: %d bytes)", fileHeader.Filename, fileHeader.Size)
+	}
+
+	// Calculate hash of all files
+	hash, err := s.calculateFilesHash(files)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to calculate files hash: %w", err)
+	}
+
+	return files, hash, nil
+}
+
+func (s *server) calculateFilesHash(files []*multipart.FileHeader) (string, error) {
+	hasher := sha256.New()
+	for _, fileHeader := range files {
+		file, err := fileHeader.Open()
+		if err != nil {
+			return "", fmt.Errorf("failed to open file: %w", err)
+		}
+		if _, err := io.Copy(hasher, file); err != nil {
+			file.Close()
+			return "", fmt.Errorf("failed to hash file: %w", err)
+		}
+		file.Close()
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/kurtosis-devnet/op-program-svc/server_test.go
+++ b/kurtosis-devnet/op-program-svc/server_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func createTestServer(t *testing.T) (*server, *MockProofFS, *MockBuilder) {
+	t.Helper()
+	mockProofFS := NewMockProofFS()
+	mockBuilder := &MockBuilder{}
+
+	srv := &server{
+		appRoot:    "test-root",
+		configsDir: "test-configs",
+		buildDir:   "test-build",
+		buildCmd:   "test-cmd",
+		port:       8080,
+		proofFS:    mockProofFS,
+		builder:    mockBuilder,
+	}
+
+	return srv, mockProofFS, mockBuilder
+}
+
+func createMultipartRequest(t *testing.T, files map[string][]byte) (*http.Request, error) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	for filename, content := range files {
+		part, err := writer.CreateFormFile("files[]", filename)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(part, bytes.NewReader(content)); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	req := httptest.NewRequest("POST", "/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
+}
+
+func TestHandleUpload_MethodNotAllowed(t *testing.T) {
+	srv, _, _ := createTestServer(t)
+
+	req := httptest.NewRequest("GET", "/upload", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleUpload(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status code %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+}
+
+func TestHandleUpload_NoFiles(t *testing.T) {
+	srv, _, _ := createTestServer(t)
+
+	req := httptest.NewRequest("POST", "/upload", nil)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+	w := httptest.NewRecorder()
+
+	srv.handleUpload(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestHandleUpload_Success(t *testing.T) {
+	srv, mockProofFS, mockBuilder := createTestServer(t)
+
+	// Setup test data
+	files := map[string][]byte{
+		"test.txt": []byte("test content"),
+	}
+
+	// Setup mocks
+	mockBuilder.saveUploadedFilesFn = func(files []UploadedFile) error {
+		return nil
+	}
+	mockBuilder.executeBuildFn = func() ([]byte, error) {
+		return []byte("build successful"), nil
+	}
+	mockProofFS.scanProofFilesFn = func() error {
+		return nil
+	}
+
+	// Create request
+	req, err := createMultipartRequest(t, files)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleUpload(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("Expected status code %d, got %d", http.StatusSeeOther, w.Code)
+	}
+
+	if location := w.Header().Get("Location"); location != "/proofs" {
+		t.Errorf("Expected redirect to /proofs, got %s", location)
+	}
+}
+
+func TestHandleUpload_SaveError(t *testing.T) {
+	srv, _, mockBuilder := createTestServer(t)
+
+	// Setup test data
+	files := map[string][]byte{
+		"test.txt": []byte("test content"),
+	}
+
+	// Setup mock to return error
+	mockBuilder.saveUploadedFilesFn = func(files []UploadedFile) error {
+		return fmt.Errorf("failed to save files")
+	}
+
+	// Create request
+	req, err := createMultipartRequest(t, files)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleUpload(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+func TestHandleUpload_BuildError(t *testing.T) {
+	srv, _, mockBuilder := createTestServer(t)
+
+	// Setup test data
+	files := map[string][]byte{
+		"test.txt": []byte("test content"),
+	}
+
+	// Setup mocks
+	mockBuilder.saveUploadedFilesFn = func(files []UploadedFile) error {
+		return nil
+	}
+	mockBuilder.executeBuildFn = func() ([]byte, error) {
+		return []byte("build failed"), fmt.Errorf("build error")
+	}
+
+	// Create request
+	req, err := createMultipartRequest(t, files)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleUpload(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), "build error") {
+		t.Errorf("Expected error message to contain 'build error', got %s", w.Body.String())
+	}
+}
+
+func TestHandleUpload_ScanError(t *testing.T) {
+	srv, mockProofFS, mockBuilder := createTestServer(t)
+
+	// Setup test data
+	files := map[string][]byte{
+		"test.txt": []byte("test content"),
+	}
+
+	// Setup mocks
+	mockBuilder.saveUploadedFilesFn = func(files []UploadedFile) error {
+		return nil
+	}
+	mockBuilder.executeBuildFn = func() ([]byte, error) {
+		return []byte("build successful"), nil
+	}
+	mockProofFS.scanProofFilesFn = func() error {
+		return fmt.Errorf("scan error")
+	}
+
+	// Create request
+	req, err := createMultipartRequest(t, files)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleUpload(w, req)
+
+	// Even with scan error, we should still redirect
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("Expected status code %d, got %d", http.StatusSeeOther, w.Code)
+	}
+}
+
+func TestHandleUpload_UnchangedFiles(t *testing.T) {
+	srv, _, _ := createTestServer(t)
+
+	// Setup test data
+	files := map[string][]byte{
+		"test.txt": []byte("test content"),
+	}
+
+	// First request
+	req1, err := createMultipartRequest(t, files)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w1 := httptest.NewRecorder()
+	srv.handleUpload(w1, req1)
+
+	if w1.Code != http.StatusSeeOther {
+		t.Errorf("Expected status code %d, got %d", http.StatusSeeOther, w1.Code)
+	}
+
+	// Second request with same files
+	req2, err := createMultipartRequest(t, files)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	w2 := httptest.NewRecorder()
+	srv.handleUpload(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, w2.Code)
+	}
+
+	if !strings.Contains(w2.Body.String(), "Files unchanged") {
+		t.Errorf("Expected response to contain 'Files unchanged', got %s", w2.Body.String())
+	}
+}

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -1,6 +1,6 @@
-FROM golang:1.22.7-alpine3.20 AS builder
+FROM golang:1.22.7-alpine3.20 AS src
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash just
 
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
@@ -13,7 +13,10 @@ RUN echo "go build cache: $(go env GOCACHE)"
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go mod download
 
 COPY . /app
+COPY ./op-program/repro.justfile /app/op-program/justfile
 
+# we need a separate stage for src so we can build a service provides prestates for unnanounced chains
+FROM src AS builder
 # We avoid copying the full .git dir into the build for just some metadata.
 # Instead, specify:
 # --build-arg GIT_COMMIT=$(git rev-parse HEAD)
@@ -26,35 +29,19 @@ ARG OP_PROGRAM_VERSION=v0.0.0
 
 ARG TARGETOS TARGETARCH
 
-# Build the cannon and op-program-client.elf binaries.
-RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
-  GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
-RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-client-mips  \
-  GOOS=linux GOARCH=mips GOMIPS=softfloat GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
-
-# Run the op-program-client.elf binary directly through cannon's load-elf subcommand.
-RUN /app/cannon/bin/cannon load-elf --type singlethreaded-2 --path /app/op-program/bin/op-program-client.elf --out /app/op-program/bin/prestate.bin.gz --meta "/app/op-program/bin/meta.json"
-RUN /app/cannon/bin/cannon load-elf --type multithreaded64-3 --path /app/op-program/bin/op-program-client64.elf --out /app/op-program/bin/prestate-mt64.bin.gz --meta "/app/op-program/bin/meta-mt64.json"
-RUN /app/cannon/bin/cannon load-elf --type multithreaded64-3 --path /app/op-program/bin/op-program-client-interop.elf --out /app/op-program/bin/prestate-interop.bin.gz --meta "/app/op-program/bin/meta-interop.json"
-
-# Generate the prestate proof containing the absolute pre-state hash.
-RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d.json' --output ""
-RUN mv /app/op-program/bin/0.json /app/op-program/bin/prestate-proof.json
-
-RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-mt64.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-mt64.json' --output ""
-RUN mv /app/op-program/bin/0-mt64.json /app/op-program/bin/prestate-proof-mt64.json
-
-RUN /app/cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input /app/op-program/bin/prestate-interop.bin.gz --meta "" --proof-fmt '/app/op-program/bin/%d-interop.json' --output ""
-RUN mv /app/op-program/bin/0-interop.json /app/op-program/bin/prestate-proof-interop.json
+WORKDIR /app
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
+        GOOS="$TARGETOS" \
+        GOARCH="$TARGETARCH" \
+        GIT_COMMIT="$GIT_COMMIT" \
+        GIT_DATE="$GIT_DATE" \
+        CANNON_VERSION="$CANNON_VERSION" \
+        OP_PROGRAM_VERSION="$OP_PROGRAM_VERSION" \
+        op-program/build
 
 # Exports files to the specified output location.
 # Writing files to host requires buildkit to be enabled.
 # e.g. `BUILDKIT=1 docker build ...`
-FROM scratch AS export-stage-proofs
-COPY --from=builder /app/op-program/bin/prestate-proof.json .
-COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .
-COPY --from=builder /app/op-program/bin/prestate-proof-interop.json .
-
 FROM scratch AS export-stage
 COPY --from=builder /app/op-program/bin/op-program-client.elf .
 COPY --from=builder /app/op-program/bin/op-program-client64.elf .

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -13,7 +13,6 @@ RUN echo "go build cache: $(go env GOCACHE)"
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go mod download
 
 COPY . /app
-COPY ./op-program/repro.justfile /app/op-program/justfile
 
 # we need a separate stage for src so we can build a service provides prestates for unnanounced chains
 FROM src AS builder
@@ -31,13 +30,15 @@ ARG TARGETOS TARGETARCH
 
 WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
+        -d /app/op-program \
+        -f /app/op-program/repro.justfile \
         GOOS="$TARGETOS" \
         GOARCH="$TARGETARCH" \
         GIT_COMMIT="$GIT_COMMIT" \
         GIT_DATE="$GIT_DATE" \
         CANNON_VERSION="$CANNON_VERSION" \
         OP_PROGRAM_VERSION="$OP_PROGRAM_VERSION" \
-        op-program/build
+        build-all
 
 # Exports files to the specified output location.
 # Writing files to host requires buildkit to be enabled.

--- a/op-program/repro.justfile
+++ b/op-program/repro.justfile
@@ -10,6 +10,8 @@ GOARCH := ""
 # Build the cannon binary
 cannon:
     #!/bin/bash
+    # in devnet scenario, the cannon binary is already built.
+    [ -x /app/cannon/bin/cannon ] && exit 0
     cd ../cannon
     make cannon \
         GOOS={{GOOS}} \
@@ -51,8 +53,8 @@ prestate TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: (client TYPE CLIENT_SUFFIX PRESTATE
         --output ""
     mv /app/op-program/bin/0{{PRESTATE_SUFFIX}}.json /app/op-program/bin/prestate-proof{{PRESTATE_SUFFIX}}.json
 
-_default: (prestate "singlethreaded-2" "" "")
-_mt64: (prestate "multithreaded64-3" "64" "-mt64")
-_interop: (prestate "multithreaded64-3" "-interop" "-interop")
+build-default: (prestate "singlethreaded-2" "" "")
+build-mt64: (prestate "multithreaded64-3" "64" "-mt64")
+build-interop: (prestate "multithreaded64-3" "-interop" "-interop")
 
-build: _default _mt64 _interop
+build-all: build-default build-mt64 build-interop

--- a/op-program/repro.justfile
+++ b/op-program/repro.justfile
@@ -1,0 +1,58 @@
+GIT_COMMIT := ""
+GIT_DATE := ""
+
+CANNON_VERSION := "v0.0.0"
+OP_PROGRAM_VERSION := "v0.0.0"
+
+GOOS := ""
+GOARCH := ""
+
+# Build the cannon binary
+cannon:
+    #!/bin/bash
+    cd ../cannon
+    make cannon \
+        GOOS={{GOOS}} \
+        GOARCH={{GOARCH}} \
+        GITCOMMIT={{GIT_COMMIT}} \
+        GITDATE={{GIT_DATE}} \
+        VERSION={{CANNON_VERSION}}
+
+# Build the op-program-client elf binaries
+op-program-client-mips:
+    #!/bin/bash
+    cd ../op-program
+    make op-program-client-mips \
+        GOOS=linux \
+        GOARCH=mips \
+        GOMIPS=softfloat \
+        GITCOMMIT={{GIT_COMMIT}} \
+        GITDATE={{GIT_DATE}} \
+        VERSION={{OP_PROGRAM_VERSION}}
+
+# Run the op-program-client elf binary directly through cannon's load-elf subcommand.
+client TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: cannon op-program-client-mips
+    #!/bin/bash
+    /app/cannon/bin/cannon load-elf \
+        --type {{TYPE}} \
+        --path /app/op-program/bin/op-program-client{{CLIENT_SUFFIX}}.elf \
+        --out /app/op-program/bin/prestate{{PRESTATE_SUFFIX}}.bin.gz \
+        --meta "/app/op-program/bin/meta{{PRESTATE_SUFFIX}}.json"
+
+# Generate the prestate proof containing the absolute pre-state hash.
+prestate TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: (client TYPE CLIENT_SUFFIX PRESTATE_SUFFIX)
+    #!/bin/bash
+    /app/cannon/bin/cannon run \
+        --proof-at '=0' \
+        --stop-at '=1' \
+        --input /app/op-program/bin/prestate{{PRESTATE_SUFFIX}}.bin.gz \
+        --meta "" \
+        --proof-fmt '/app/op-program/bin/%d{{PRESTATE_SUFFIX}}.json' \
+        --output ""
+    mv /app/op-program/bin/0{{PRESTATE_SUFFIX}}.json /app/op-program/bin/prestate-proof{{PRESTATE_SUFFIX}}.json
+
+_default: (prestate "singlethreaded-2" "" "")
+_mt64: (prestate "multithreaded64-3" "64" "-mt64")
+_interop: (prestate "multithreaded64-3" "-interop" "-interop")
+
+build: _default _mt64 _interop


### PR DESCRIPTION
**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This change addresses the fact that we currently deploy devnets the wrong way, in the sense that the prestates are built ahead of time, when really they need to be built with knowledge of the chains those devnets host.

It does this by:
- splitting the current build logic from Dockerfile.repro into a separate build script
- which enables us to better control at which stage of the build process we stop, between the "offline" portion, and the "online" one that requires chain awareness
- adding a new service (very primitive) to receive the inputs needed, build the right prestates in response, and serve them to whatever needs them (op-challenger at least, maybe others?)

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

overall context: https://github.com/ethereum-optimism/platforms-team/issues/642

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Fixes https://github.com/ethereum-optimism/platforms-team/issues/643