### PR TITLE
op-dispute-mon: Update credit monitoring to handle new withdrawal path

### DIFF
--- a/op-dispute-mon/mon/extract/bond_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_enricher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -18,6 +19,7 @@ var ErrIncorrectCreditCount = errors.New("incorrect credit count")
 
 type BondCaller interface {
 	GetCredits(context.Context, rpcblock.Block, ...common.Address) ([]*big.Int, error)
+	GetBondDistributionMode(context.Context, rpcblock.Block) (types.BondDistributionMode, error)
 }
 
 type BondEnricher struct{}
@@ -38,6 +40,10 @@ func (b *BondEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller 
 	game.Credits = make(map[common.Address]*big.Int)
 	for i, credit := range credits {
 		game.Credits[recipientAddrs[i]] = credit
+	}
+	game.BondDistributionMode, err = caller.GetBondDistributionMode(ctx, block)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/op-dispute-mon/mon/extract/bond_enricher_test.go
+++ b/op-dispute-mon/mon/extract/bond_enricher_test.go
@@ -87,7 +87,7 @@ func TestBondEnricher(t *testing.T) {
 			recipients[1]: big.NewInt(30),
 			recipients[2]: big.NewInt(40),
 		}
-		caller := &mockGameCaller{credits: expectedCredits}
+		caller := &mockGameCaller{credits: expectedCredits, bondDistributionMode: faultTypes.RefundDistributionMode}
 		err := enricher.Enrich(context.Background(), rpcblock.Latest, caller, game)
 		require.NoError(t, err)
 
@@ -96,5 +96,6 @@ func TestBondEnricher(t *testing.T) {
 			require.Contains(t, caller.requestedCredits, recipient)
 		}
 		require.Equal(t, expectedCredits, game.Credits)
+		require.Equal(t, faultTypes.RefundDistributionMode, game.BondDistributionMode)
 	})
 }

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -273,25 +273,26 @@ func (m *mockGameCallerCreator) CreateGameCaller(_ context.Context, _ gameTypes.
 }
 
 type mockGameCaller struct {
-	metadataCalls    int
-	metadataErr      error
-	claimsCalls      int
-	claimsErr        error
-	rootClaim        common.Hash
-	claims           []faultTypes.Claim
-	requestedCredits []common.Address
-	creditsErr       error
-	credits          map[common.Address]*big.Int
-	extraCredit      []*big.Int
-	balanceErr       error
-	balance          *big.Int
-	delayDuration    time.Duration
-	balanceAddr      common.Address
-	withdrawalsCalls int
-	withdrawalsErr   error
-	withdrawals      []*contracts.WithdrawalRequest
-	resolvedErr      error
-	resolved         map[int]bool
+	metadataCalls        int
+	metadataErr          error
+	claimsCalls          int
+	claimsErr            error
+	rootClaim            common.Hash
+	claims               []faultTypes.Claim
+	requestedCredits     []common.Address
+	creditsErr           error
+	credits              map[common.Address]*big.Int
+	extraCredit          []*big.Int
+	bondDistributionMode faultTypes.BondDistributionMode
+	balanceErr           error
+	balance              *big.Int
+	delayDuration        time.Duration
+	balanceAddr          common.Address
+	withdrawalsCalls     int
+	withdrawalsErr       error
+	withdrawals          []*contracts.WithdrawalRequest
+	resolvedErr          error
+	resolved             map[int]bool
 }
 
 func (m *mockGameCaller) GetWithdrawals(_ context.Context, _ rpcblock.Block, _ ...common.Address) ([]*contracts.WithdrawalRequest, error) {
@@ -348,6 +349,10 @@ func (m *mockGameCaller) GetCredits(_ context.Context, _ rpcblock.Block, recipie
 	}
 	response = append(response, m.extraCredit...)
 	return response, nil
+}
+
+func (m *mockGameCaller) GetBondDistributionMode(_ context.Context, _ rpcblock.Block) (faultTypes.BondDistributionMode, error) {
+	return m.bondDistributionMode, nil
 }
 
 func (m *mockGameCaller) GetBalanceAndDelay(_ context.Context, _ rpcblock.Block) (*big.Int, time.Duration, common.Address, error) {

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -38,6 +38,8 @@ type EnrichedGameData struct {
 	// Credits records the paid out bonds for the game, keyed by recipient.
 	Credits map[common.Address]*big.Int
 
+	BondDistributionMode faultTypes.BondDistributionMode
+
 	// WithdrawalRequests maps recipients with withdrawal requests in DelayedWETH for this game.
 	WithdrawalRequests map[common.Address]*contracts.WithdrawalRequest
 

--- a/op-dispute-mon/mon/withdrawals.go
+++ b/op-dispute-mon/mon/withdrawals.go
@@ -94,7 +94,8 @@ func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.EnrichedGameData
 				total := honestWithdrawableAmounts[recipient]
 				total = new(big.Int).Add(total, game.Credits[recipient])
 				honestWithdrawableAmounts[recipient] = total
-			} else if bigs.IsPositive(withdrawalAmount.Amount) && time.Unix(withdrawalAmount.Timestamp.Int64(), 0).Add(game.WETHDelay).Before(now) {
+			}
+			if bigs.IsPositive(withdrawalAmount.Amount) && time.Unix(withdrawalAmount.Timestamp.Int64(), 0).Add(game.WETHDelay).Before(now) {
 				// Credits are fully withdrawable
 				total := honestWithdrawableAmounts[recipient]
 				total = new(big.Int).Add(total, withdrawalAmount.Amount)

--- a/op-dispute-mon/mon/withdrawals.go
+++ b/op-dispute-mon/mon/withdrawals.go
@@ -4,7 +4,9 @@ import (
 	"math/big"
 	"time"
 
+	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -56,16 +58,44 @@ func (w *WithdrawalMonitor) validateGameWithdrawals(game *types.EnrichedGameData
 	matching := 0
 	divergent := 0
 	for recipient, withdrawalAmount := range game.WithdrawalRequests {
-		if withdrawalAmount.Amount != nil && withdrawalAmount.Amount.Cmp(game.Credits[recipient]) == 0 {
-			matching++
-		} else {
+		switch game.BondDistributionMode {
+		case challengerTypes.LegacyDistributionMode:
+			if bigs.Equal(withdrawalAmount.Amount, game.Credits[recipient]) {
+				matching++
+			} else {
+				divergent++
+				w.logger.Error("Withdrawal request amount does not match credit", "game", game.Proxy, "recipient", recipient, "credit", game.Credits[recipient], "withdrawal", game.WithdrawalRequests[recipient].Amount)
+			}
+		case challengerTypes.UndecidedDistributionMode:
+			// DelayedWETH should not have any withdrawal request yet because the bond distribution mode is undecided
+			if !bigs.IsZero(withdrawalAmount.Amount) {
+				divergent++
+				w.logger.Error("Withdrawal request created before bond distribution mode set", "game", game.Proxy, "recipient", recipient, "withdrawal", game.WithdrawalRequests[recipient].Amount)
+			}
+		case challengerTypes.NormalDistributionMode, challengerTypes.RefundDistributionMode:
+			// The withdrawal request is only created on the first claim to claimCredit, so it may not have been set.
+			// If it has been set, it should match the game credit amount.
+			if bigs.IsZero(withdrawalAmount.Amount) || bigs.Equal(withdrawalAmount.Amount, game.Credits[recipient]) {
+				matching++
+			} else {
+				divergent++
+				w.logger.Error("Withdrawal request amount does not match credit", "game", game.Proxy, "recipient", recipient, "credit", game.Credits[recipient], "withdrawal", game.WithdrawalRequests[recipient].Amount)
+			}
+		default:
+			// Treat unknown distribution mode as divergent - better to alert than to ignore.
 			divergent++
-			w.logger.Error("Withdrawal request amount does not match credit", "game", game.Proxy, "recipient", recipient, "credit", game.Credits[recipient], "withdrawal", game.WithdrawalRequests[recipient].Amount)
+			w.logger.Error("Unsupported distribution mode", "game", game.Proxy, "recipient", recipient, "mode", game.BondDistributionMode)
 		}
 
-		if withdrawalAmount.Amount.Cmp(big.NewInt(0)) > 0 && w.honestActors.Contains(recipient) {
-			if time.Unix(withdrawalAmount.Timestamp.Int64(), 0).Add(game.WETHDelay).Before(now) {
-				// Credits are withdrawable
+		if w.honestActors.Contains(recipient) {
+			if game.BondDistributionMode != challengerTypes.UndecidedDistributionMode && bigs.IsZero(withdrawalAmount.Amount) && !bigs.IsZero(game.Credits[recipient]) {
+				w.logger.Warn("Found uninitiated withdrawal", "recipient", recipient, "game", game.Proxy, "amount", game.Credits[recipient])
+				// Treat credits as withdrawable because the first step of withdrawing can be performed
+				total := honestWithdrawableAmounts[recipient]
+				total = new(big.Int).Add(total, game.Credits[recipient])
+				honestWithdrawableAmounts[recipient] = total
+			} else if bigs.IsPositive(withdrawalAmount.Amount) && time.Unix(withdrawalAmount.Timestamp.Int64(), 0).Add(game.WETHDelay).Before(now) {
+				// Credits are fully withdrawable
 				total := honestWithdrawableAmounts[recipient]
 				total = new(big.Int).Add(total, withdrawalAmount.Amount)
 				honestWithdrawableAmounts[recipient] = total

--- a/op-dispute-mon/mon/withdrawals_test.go
+++ b/op-dispute-mon/mon/withdrawals_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -27,7 +28,7 @@ var (
 	nowUnix = int64(10_000)
 )
 
-func makeGames() []*monTypes.EnrichedGameData {
+func makeGames(distributionMode faultTypes.BondDistributionMode, noWithdrawalRequest bool) []*monTypes.EnrichedGameData {
 	weth1Balance := big.NewInt(4200)
 	weth2Balance := big.NewInt(6000)
 
@@ -37,6 +38,7 @@ func makeGames() []*monTypes.EnrichedGameData {
 			honestActor1: big.NewInt(3),
 			honestActor2: big.NewInt(1),
 		},
+		BondDistributionMode: distributionMode,
 		WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
 			honestActor1: {Amount: big.NewInt(3), Timestamp: big.NewInt(nowUnix - 101)}, // Claimable
 			honestActor2: {Amount: big.NewInt(1), Timestamp: big.NewInt(nowUnix - 99)},  // Not claimable
@@ -46,7 +48,8 @@ func makeGames() []*monTypes.EnrichedGameData {
 		WETHDelay:     100 * time.Second,
 	}
 	game2 := &monTypes.EnrichedGameData{
-		GameMetadata: types.GameMetadata{Proxy: common.Address{0x22, 0x22, 0x22}},
+		GameMetadata:         types.GameMetadata{Proxy: common.Address{0x22, 0x22, 0x22}},
+		BondDistributionMode: distributionMode,
 		Credits: map[common.Address]*big.Int{
 			honestActor1: big.NewInt(46),
 			honestActor2: big.NewInt(1),
@@ -60,7 +63,8 @@ func makeGames() []*monTypes.EnrichedGameData {
 		WETHDelay:     500 * time.Second,
 	}
 	game3 := &monTypes.EnrichedGameData{
-		GameMetadata: types.GameMetadata{Proxy: common.Address{0x33, 0x33, 0x33}},
+		GameMetadata:         types.GameMetadata{Proxy: common.Address{0x33, 0x33, 0x33}},
+		BondDistributionMode: distributionMode,
 		Credits: map[common.Address]*big.Int{
 			honestActor3:    big.NewInt(2),
 			dishonestActor4: big.NewInt(4),
@@ -73,10 +77,123 @@ func makeGames() []*monTypes.EnrichedGameData {
 		ETHCollateral: weth2Balance,
 		WETHDelay:     0 * time.Second,
 	}
+	if noWithdrawalRequest {
+		// eth_call will return 0s, not nil, when no withdrawal request is present
+		game1.WithdrawalRequests[honestActor2] = &contracts.WithdrawalRequest{
+			Amount:    big.NewInt(0),
+			Timestamp: big.NewInt(0),
+		}
+	}
 	return []*monTypes.EnrichedGameData{game1, game2, game3}
 }
 
 func TestCheckWithdrawals(t *testing.T) {
+	tests := []struct {
+		name                string
+		distributionMode    faultTypes.BondDistributionMode
+		noWithdrawalRequest bool
+	}{
+		{
+			name:             "Legacy",
+			distributionMode: faultTypes.LegacyDistributionMode,
+		},
+		{
+			name:             "Normal",
+			distributionMode: faultTypes.NormalDistributionMode,
+		},
+		{
+			name:                "Normal-NoWithdrawalRequest",
+			distributionMode:    faultTypes.NormalDistributionMode,
+			noWithdrawalRequest: true,
+		},
+		{
+			name:             "Refund",
+			distributionMode: faultTypes.RefundDistributionMode,
+		},
+		{
+			name:                "Refund-NoWithdrawalRequest",
+			distributionMode:    faultTypes.RefundDistributionMode,
+			noWithdrawalRequest: true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Unix(nowUnix, 0)
+			cl := clock.NewDeterministicClock(now)
+			logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+			metrics := &stubWithdrawalsMetrics{
+				matching:  make(map[common.Address]int),
+				divergent: make(map[common.Address]int),
+			}
+			honestActors := monTypes.NewHonestActors([]common.Address{honestActor1, honestActor2, honestActor3})
+			withdrawals := NewWithdrawalMonitor(logger, cl, metrics, honestActors)
+			games := makeGames(test.distributionMode, test.noWithdrawalRequest)
+			withdrawals.CheckWithdrawals(games)
+
+			require.Equal(t, metrics.matchCalls, 2)
+			require.Equal(t, metrics.divergeCalls, 2)
+			require.Len(t, metrics.matching, 2)
+			require.Len(t, metrics.divergent, 2)
+			require.Contains(t, metrics.matching, weth1)
+			require.Contains(t, metrics.matching, weth2)
+			require.Contains(t, metrics.divergent, weth1)
+			require.Contains(t, metrics.divergent, weth2)
+			require.Equal(t, metrics.matching[weth1], 2)
+			require.Equal(t, metrics.matching[weth2], 3)
+			require.Equal(t, metrics.divergent[weth1], 0)
+			require.Equal(t, metrics.divergent[weth2], 1)
+
+			require.Len(t, metrics.honestWithdrawable, 3)
+			requireBigInt := func(name string, expected, actual *big.Int) {
+				require.Truef(t, expected.Cmp(actual) == 0, "Expected %v withdrawable to be %v but was %v", name, expected, actual)
+			}
+			requireBigInt("honest addr1", big.NewInt(6), metrics.honestWithdrawable[honestActor1])
+			if test.noWithdrawalRequest && test.distributionMode != faultTypes.UndecidedDistributionMode {
+				// Withdrawal should have been initiated but hasn't been so the bond is treated as unclaimed
+				requireBigInt("honest addr2", big.NewInt(1), metrics.honestWithdrawable[honestActor2])
+			} else {
+				requireBigInt("honest addr2", big.NewInt(0), metrics.honestWithdrawable[honestActor2])
+			}
+			requireBigInt("honest addr3", big.NewInt(2), metrics.honestWithdrawable[honestActor3])
+			require.Nil(t, metrics.honestWithdrawable[dishonestActor4], "should only report withdrawable credits for honest actors")
+
+			findUnclaimedCreditWarning := func(game common.Address, actor common.Address) *testlog.CapturedRecord {
+				return logs.FindLog(
+					testlog.NewLevelFilter(log.LevelWarn),
+					testlog.NewMessageFilter("Found unclaimed credit"),
+					testlog.NewAttributesFilter("game", game.Hex()),
+					testlog.NewAttributesFilter("recipient", actor.Hex()))
+			}
+			requireUnclaimedWarning := func(game common.Address, actor common.Address) {
+				require.NotNil(t, findUnclaimedCreditWarning(game, actor))
+			}
+			noUnclaimedWarning := func(game common.Address, actor common.Address) {
+				require.Nil(t, findUnclaimedCreditWarning(game, actor))
+			}
+			// Game 1, unclaimed for honestActor1 only
+			requireUnclaimedWarning(games[0].Proxy, honestActor1)
+			noUnclaimedWarning(games[0].Proxy, honestActor2)
+			noUnclaimedWarning(games[0].Proxy, honestActor3)
+			noUnclaimedWarning(games[0].Proxy, dishonestActor4)
+
+			// Game 2, unclaimed for honestActor1 only
+			requireUnclaimedWarning(games[1].Proxy, honestActor1)
+			noUnclaimedWarning(games[1].Proxy, honestActor2)
+			noUnclaimedWarning(games[1].Proxy, honestActor3)
+			noUnclaimedWarning(games[1].Proxy, dishonestActor4)
+
+			// Game 3, unclaimed for honestActor3 only
+			// dishonestActor4 has unclaimed credits but we don't track them
+			noUnclaimedWarning(games[2].Proxy, honestActor1)
+			noUnclaimedWarning(games[2].Proxy, honestActor2)
+			requireUnclaimedWarning(games[2].Proxy, honestActor3)
+			noUnclaimedWarning(games[2].Proxy, dishonestActor4)
+		})
+	}
+}
+
+func TestWithdrawalNotInitiated(t *testing.T) {
 	now := time.Unix(nowUnix, 0)
 	cl := clock.NewDeterministicClock(now)
 	logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
@@ -86,62 +203,30 @@ func TestCheckWithdrawals(t *testing.T) {
 	}
 	honestActors := monTypes.NewHonestActors([]common.Address{honestActor1, honestActor2, honestActor3})
 	withdrawals := NewWithdrawalMonitor(logger, cl, metrics, honestActors)
-	games := makeGames()
+	games := []*monTypes.EnrichedGameData{
+		{
+			GameMetadata: types.GameMetadata{Proxy: common.Address{0x11, 0x11, 0x11}},
+			Credits: map[common.Address]*big.Int{
+				honestActor1: big.NewInt(3),
+			},
+			BondDistributionMode: faultTypes.NormalDistributionMode,
+			WithdrawalRequests: map[common.Address]*contracts.WithdrawalRequest{
+				honestActor1: {Amount: big.NewInt(0), Timestamp: big.NewInt(0)},
+			},
+			WETHContract:  weth1,
+			ETHCollateral: big.NewInt(3),
+			WETHDelay:     100 * time.Second,
+		},
+	}
 	withdrawals.CheckWithdrawals(games)
 
-	require.Equal(t, metrics.matchCalls, 2)
-	require.Equal(t, metrics.divergeCalls, 2)
-	require.Len(t, metrics.matching, 2)
-	require.Len(t, metrics.divergent, 2)
-	require.Contains(t, metrics.matching, weth1)
-	require.Contains(t, metrics.matching, weth2)
-	require.Contains(t, metrics.divergent, weth1)
-	require.Contains(t, metrics.divergent, weth2)
-	require.Equal(t, metrics.matching[weth1], 2)
-	require.Equal(t, metrics.matching[weth2], 3)
-	require.Equal(t, metrics.divergent[weth1], 0)
-	require.Equal(t, metrics.divergent[weth2], 1)
+	require.NotNil(t, logs.FindLog(testlog.NewMessageFilter("Found uninitiated withdrawal"),
+		testlog.NewAttributesFilter("recipient", honestActor1.Hex()),
+		testlog.NewAttributesFilter("game", games[0].Proxy.Hex()),
+		testlog.NewAttributesFilter("amount", "3")))
 
-	require.Len(t, metrics.honestWithdrawable, 3)
-	requireBigInt := func(name string, expected, actual *big.Int) {
-		require.Truef(t, expected.Cmp(actual) == 0, "Expected %v withdrawable to be %v but was %v", name, expected, actual)
-	}
-	requireBigInt("honest addr1", big.NewInt(6), metrics.honestWithdrawable[honestActor1])
-	requireBigInt("honest addr2", big.NewInt(0), metrics.honestWithdrawable[honestActor2])
-	requireBigInt("honest addr3", big.NewInt(2), metrics.honestWithdrawable[honestActor3])
-	require.Nil(t, metrics.honestWithdrawable[dishonestActor4], "should only report withdrawable credits for honest actors")
-
-	findUnclaimedCreditWarning := func(game common.Address, actor common.Address) *testlog.CapturedRecord {
-		return logs.FindLog(
-			testlog.NewLevelFilter(log.LevelWarn),
-			testlog.NewMessageFilter("Found unclaimed credit"),
-			testlog.NewAttributesFilter("game", game.Hex()),
-			testlog.NewAttributesFilter("recipient", actor.Hex()))
-	}
-	requireUnclaimedWarning := func(game common.Address, actor common.Address) {
-		require.NotNil(t, findUnclaimedCreditWarning(game, actor))
-	}
-	noUnclaimedWarning := func(game common.Address, actor common.Address) {
-		require.Nil(t, findUnclaimedCreditWarning(game, actor))
-	}
-	// Game 1, unclaimed for honestActor1 only
-	requireUnclaimedWarning(games[0].Proxy, honestActor1)
-	noUnclaimedWarning(games[0].Proxy, honestActor2)
-	noUnclaimedWarning(games[0].Proxy, honestActor3)
-	noUnclaimedWarning(games[0].Proxy, dishonestActor4)
-
-	// Game 2, unclaimed for honestActor1 only
-	requireUnclaimedWarning(games[1].Proxy, honestActor1)
-	noUnclaimedWarning(games[1].Proxy, honestActor2)
-	noUnclaimedWarning(games[1].Proxy, honestActor3)
-	noUnclaimedWarning(games[1].Proxy, dishonestActor4)
-
-	// Game 3, unclaimed for honestActor3 only
-	// dishonestActor4 has unclaimed credits but we don't track them
-	noUnclaimedWarning(games[2].Proxy, honestActor1)
-	noUnclaimedWarning(games[2].Proxy, honestActor2)
-	requireUnclaimedWarning(games[2].Proxy, honestActor3)
-	noUnclaimedWarning(games[2].Proxy, dishonestActor4)
+	require.Truef(t, big.NewInt(3).Cmp(metrics.honestWithdrawable[honestActor1]) == 0,
+		"Expected %v withdrawable to be %v but was %v", honestActor1, 3, metrics.honestWithdrawable[honestActor1])
 }
 
 type stubWithdrawalsMetrics struct {

--- a/op-service/bigs/bigutil.go
+++ b/op-service/bigs/bigutil.go
@@ -1,0 +1,19 @@
+package bigs
+
+import "math/big"
+
+func Equal(a *big.Int, b *big.Int) bool {
+	return a.Cmp(b) == 0
+}
+
+func IsZero(val *big.Int) bool {
+	return val.Cmp(big.NewInt(0)) == 0
+}
+
+func IsPositive(val *big.Int) bool {
+	return val.Cmp(big.NewInt(0)) > 0
+}
+
+func IsNegative(val *big.Int) bool {
+	return val.Cmp(big.NewInt(0)) < 0
+}

--- a/op-service/bigs/bigutil_test.go
+++ b/op-service/bigs/bigutil_test.go
@@ -1,0 +1,43 @@
+package bigs
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEqual(t *testing.T) {
+	require.True(t, Equal(big.NewInt(0), big.NewInt(0)))
+	require.True(t, Equal(big.NewInt(1), big.NewInt(1)))
+	require.True(t, Equal(big.NewInt(1900), big.NewInt(1900)))
+	require.True(t, Equal(big.NewInt(-1), big.NewInt(-1)))
+	require.True(t, Equal(big.NewInt(-1900), big.NewInt(-1900)))
+
+	require.False(t, Equal(big.NewInt(0), big.NewInt(1)))
+	require.False(t, Equal(big.NewInt(1), big.NewInt(0)))
+	require.False(t, Equal(big.NewInt(1), big.NewInt(2)))
+	require.False(t, Equal(big.NewInt(-1900), big.NewInt(1900)))
+}
+
+func TestIsZero(t *testing.T) {
+	require.True(t, IsZero(big.NewInt(0)))
+	require.False(t, IsZero(big.NewInt(1)))
+	require.False(t, IsZero(big.NewInt(-1)))
+}
+
+func TestIsPositive(t *testing.T) {
+	require.True(t, IsPositive(big.NewInt(1)))
+	require.True(t, IsPositive(big.NewInt(2)))
+
+	require.False(t, IsPositive(big.NewInt(0)))
+	require.False(t, IsPositive(big.NewInt(-1)))
+}
+
+func TestIsNegative(t *testing.T) {
+	require.True(t, IsNegative(big.NewInt(-1)))
+	require.True(t, IsNegative(big.NewInt(-2)))
+
+	require.False(t, IsNegative(big.NewInt(0)))
+	require.False(t, IsNegative(big.NewInt(1)))
+}


### PR DESCRIPTION
**Description**

Updates op-dispute-mon to handle the new withdrawal path for bonds. The withdrawal request isn't created in `DelayedWETH` until the game is closed so if the game is in undecided bond distribution mode, all withdrawal requests should be 0 (previously this alerted because it differs from the game credits).  In normal or refund mode, it should either be 0 (haven't yet called claimCredit to start the withdrawal process) or matching the credit. Older versions of contracts report bond distribution mode as `LegacyDistributionMode` and the old rules still apply.

Also added some utility methods for comparing big ints because I'm sick of having to stop and think what the long `.Cmp` invocation actually means.

**Tests**

Updated unit tests.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/14448