### PR TITLE
op-test-sequencer: structure sub-responsibilities

### DIFF
--- a/op-test-sequencer/README.md
+++ b/op-test-sequencer/README.md
@@ -30,3 +30,40 @@ This service is in active development.
 
 See [design doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/test-sequencing.md)
 for design considerations.
+
+### RPC
+
+On the configured RPC address/port multiple HTTP routes are served, each serving RPCs.
+Every RPC is authenticated with a JWT-secret.
+For every route, both HTTP and Websocket RPC connections are supported.
+
+#### Main RPC
+
+The main RPC is served on the root path `/` of the configured RPC host/port.
+
+##### `admin`
+
+Work in progress.
+
+##### `build`
+
+Types:
+- `BuilderID`: string, identifies a builder by its configured name
+- `BuildJobID`: string, identifies a build job
+- `BuildOpts`: `{parent: hash, l1Origin: hash,optional}` (work in progress, will be extended)
+- `Block`: block, a JSON object, as defined by the builder
+
+Methods:
+- `build_open(id: BuilderID, opts: BuildOpts) -> BuildJobID`
+- `build_cancel(jobID: BuildJobID)`
+- `build_seal(jobID: BuildJobID) -> Block`
+
+#### Sequencer RPC routes
+
+`/sequencers/{sequencerID}` serves an RPC (Both HTTP and Websocket)
+
+##### `sequencer`
+
+Actively changing. Methods to run through each part of the sequencing flow.
+See [`sequencer/frontend/sequencer.go`](./sequencer/frontend/sequencer.go).
+

--- a/op-test-sequencer/config/config.go
+++ b/op-test-sequencer/config/config.go
@@ -7,6 +7,12 @@ import (
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/config"
+)
+
+const (
+	DefaultConfigYaml = "config.yaml"
 )
 
 type Config struct {
@@ -18,6 +24,8 @@ type Config struct {
 	RPC           oprpc.CLIConfig
 
 	JWTSecretPath string
+
+	Ensemble work.Loader
 
 	MockRun bool
 }
@@ -37,5 +45,7 @@ func DefaultCLIConfig() *Config {
 		MetricsConfig: opmetrics.DefaultCLIConfig(),
 		PprofConfig:   oppprof.DefaultCLIConfig(),
 		RPC:           oprpc.DefaultCLIConfig(),
+		Ensemble:      &config.YamlLoader{Path: DefaultConfigYaml},
+		MockRun:       false,
 	}
 }

--- a/op-test-sequencer/flags/flags.go
+++ b/op-test-sequencer/flags/flags.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/config"
+	wconfig "github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/config"
 )
 
 const EnvVarPrefix = "OP_TEST_SEQUENCER"
@@ -20,7 +21,13 @@ func prefixEnvVars(name string) []string {
 }
 
 var (
-	RPCJWTSecret = &cli.StringFlag{
+	BuildersConfigFlag = &cli.StringFlag{
+		Name:    "builders.config",
+		Usage:   "Config file to builder(s) to load",
+		EnvVars: prefixEnvVars("BUILDERS_CONFIG"),
+		Value:   config.DefaultConfigYaml,
+	}
+	RPCJWTSecretFlag = &cli.StringFlag{
 		Name:      "rpc.jwt-secret",
 		Usage:     "Path to JWT secret key for sequencer admin RPC.",
 		EnvVars:   prefixEnvVars("RPC_JWT_SECRET"),
@@ -37,7 +44,8 @@ var (
 var requiredFlags = []cli.Flag{}
 
 var optionalFlags = []cli.Flag{
-	RPCJWTSecret,
+	BuildersConfigFlag,
+	RPCJWTSecretFlag,
 	MockRunFlag,
 }
 
@@ -70,7 +78,8 @@ func ConfigFromCLI(ctx *cli.Context, version string) *config.Config {
 		MetricsConfig: opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:   oppprof.ReadCLIConfig(ctx),
 		RPC:           oprpc.ReadCLIConfig(ctx),
+		JWTSecretPath: ctx.Path(RPCJWTSecretFlag.Name),
+		Ensemble:      &wconfig.YamlLoader{Path: ctx.String(BuildersConfigFlag.Name)},
 		MockRun:       ctx.Bool(MockRunFlag.Name),
-		JWTSecretPath: ctx.Path(RPCJWTSecret.Name),
 	}
 }

--- a/op-test-sequencer/sequencer/backend/backend.go
+++ b/op-test-sequencer/sequencer/backend/backend.go
@@ -2,46 +2,121 @@ package backend
 
 import (
 	"context"
-	"errors"
-	"sync/atomic"
+	"fmt"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/frontend"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
-var (
-	errAlreadyStarted = errors.New("already started")
-	errAlreadyStopped = errors.New("already stopped")
-)
-
-type Backend struct {
-	started atomic.Bool
-	logger  log.Logger
-	m       metrics.Metricer
+type APIRouter interface {
+	AddRPC(route string) error
+	AddAPIToRPC(route string, api rpc.API) error
 }
 
-func NewBackend(log log.Logger, m metrics.Metricer) *Backend {
-	return &Backend{
-		logger: log,
-		m:      m,
+type Backend struct {
+	started  bool
+	active   bool
+	activeMu sync.RWMutex
+
+	logger log.Logger
+	m      metrics.Metricer
+
+	ensemble *work.Ensemble
+	jobs     work.Jobs
+
+	router APIRouter
+}
+
+var _ frontend.BuildBackend = (*Backend)(nil)
+var _ frontend.AdminBackend = (*Backend)(nil)
+
+func NewBackend(log log.Logger, m metrics.Metricer, ensemble *work.Ensemble, jobs work.Jobs, router APIRouter) *Backend {
+	b := &Backend{
+		logger:   log,
+		m:        m,
+		ensemble: ensemble,
+		jobs:     jobs,
+		router:   router,
 	}
+	return b
+}
+
+// setupSequencerFrontend attaches the sequencer with the given ID as a new route, serving a sequencer RPC.
+// errors if the route was invalid (when it already exists, or the ID is not a valid HTTP route).
+func (ba *Backend) setupSequencerFrontend(id seqtypes.SequencerID) error {
+	route := "/sequencers/" + id.String()
+	if err := ba.router.AddRPC(route); err != nil {
+		return fmt.Errorf("invalid sequencer RPC route: %w", err)
+	}
+	f := &frontend.SequencerFrontend{Sequencer: ba.ensemble.Sequencer(id)}
+	if err := ba.router.AddAPIToRPC(route, rpc.API{
+		Namespace: "sequencer",
+		Service:   f,
+	}); err != nil {
+		return fmt.Errorf("invalid sequencer RPC frontend: %w", err)
+	}
+	ba.logger.Info("Added sequencer RPC route", "route", route)
+	return nil
+}
+
+func (ba *Backend) CreateJob(ctx context.Context, id seqtypes.BuilderID, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
+	ba.activeMu.RLock()
+	defer ba.activeMu.RUnlock()
+	if !ba.active {
+		return nil, seqtypes.ErrBackendInactive
+	}
+	bu := ba.ensemble.Builder(id)
+	if bu == nil {
+		return nil, seqtypes.ErrUnknownBuilder
+	}
+	job, err := bu.NewJob(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+// GetJob returns nil if the job isn't known.
+func (ba *Backend) GetJob(id seqtypes.BuildJobID) work.BuildJob {
+	return ba.jobs.GetJob(id)
 }
 
 func (ba *Backend) Start(ctx context.Context) error {
-	if !ba.started.CompareAndSwap(false, true) {
-		return errAlreadyStarted
+	ba.activeMu.Lock()
+	defer ba.activeMu.Unlock()
+	if ba.started { // can only start once, no restarts after stopping
+		return seqtypes.ErrBackendAlreadyStarted
 	}
+	ba.active = true
+	ba.started = true
 	ba.logger.Info("Starting sequencer backend")
+	// Each sequencer gets its own API route, for a distinct RPC to interact with just that sequencer.
+	for _, id := range ba.ensemble.Sequencers() {
+		if err := ba.setupSequencerFrontend(id); err != nil {
+			return fmt.Errorf("failed to setup sequencer %q RPC: %w", id, err)
+		}
+	}
 	return nil
 }
 
 func (ba *Backend) Stop(ctx context.Context) error {
-	if !ba.started.CompareAndSwap(true, false) {
-		return errAlreadyStopped
+	ba.activeMu.Lock()
+	defer ba.activeMu.Unlock()
+	if !ba.active {
+		return seqtypes.ErrBackendInactive
 	}
-	ba.logger.Info("Stopping sequencer backend")
-	return nil
+	ba.active = false
+	ba.logger.Info("Stopping backend")
+	result := ba.ensemble.Close()
+	// builders should have closed the build jobs gracefully where needed. We can clear the jobs now.
+	ba.jobs.Clear()
+	return result
 }
 
 func (ba *Backend) Hello(ctx context.Context, name string) (string, error) {

--- a/op-test-sequencer/sequencer/backend/backend_test.go
+++ b/op-test-sequencer/sequencer/backend/backend_test.go
@@ -2,26 +2,107 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/sequencers/fullseq"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
+type noopRouter struct {
+	log log.Logger
+}
+
+func (n *noopRouter) AddRPC(route string) error {
+	n.log.Debug("Adding RPC route", "route", route)
+	return nil
+}
+
+func (n noopRouter) AddAPIToRPC(route string, api rpc.API) error {
+	n.log.Debug("Adding API on route",
+		"route", route,
+		"namespace", api.Namespace,
+		"handler", fmt.Sprintf("%T", api.Service))
+	return nil
+}
+
+var _ APIRouter = (*noopRouter)(nil)
+
 func TestBackend(t *testing.T) {
-	logger := testlog.Logger(t, log.LevelWarn)
-	b := NewBackend(logger, metrics.NoopMetrics{})
+	logger := testlog.Logger(t, log.LevelDebug)
+	m := &metrics.NoopMetrics{}
+	builderID := seqtypes.BuilderID("test-builder")
+	signerID := seqtypes.SignerID("test-signer")
+	committerID := seqtypes.CommitterID("test-committer")
+	publisherID := seqtypes.PublisherID("test-publisher")
+	sequencerID := seqtypes.SequencerID("test-sequencer")
+	ensemble := &work.Ensemble{}
+	jobs := work.NewJobRegistry()
+	require.NoError(t, ensemble.AddBuilder(noopbuilder.NewBuilder(builderID, jobs)))
+	require.NoError(t, ensemble.AddSigner(noopsigner.NewSigner(signerID, logger)))
+	require.NoError(t, ensemble.AddCommitter(noopcommitter.NewCommitter(committerID, logger)))
+	require.NoError(t, ensemble.AddPublisher(nooppublisher.NewPublisher(publisherID, logger)))
+	seqCfg := &fullseq.Config{
+		ChainID:             eth.ChainIDFromUInt64(123),
+		Builder:             builderID,
+		Signer:              signerID,
+		Committer:           committerID,
+		Publisher:           publisherID,
+		SequencerConfDepth:  0,
+		SequencerEnabled:    false,
+		SequencerStopped:    false,
+		SequencerMaxSafeLag: 0,
+	}
+	sequencer, err := seqCfg.Start(context.Background(), sequencerID, &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: m,
+			Jobs:    jobs,
+		},
+		Services: ensemble,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ensemble.AddSequencer(sequencer))
+
+	router := &noopRouter{log: logger}
+	b := NewBackend(logger, m, ensemble, jobs, router)
 	require.NoError(t, b.Start(context.Background()))
-	require.ErrorIs(t, b.Start(context.Background()), errAlreadyStarted)
+	require.ErrorIs(t, b.Start(context.Background()), seqtypes.ErrBackendAlreadyStarted)
 
 	result, err := b.Hello(context.Background(), "alice")
 	require.NoError(t, err)
 	require.Contains(t, result, "alice")
 
+	_, err = b.CreateJob(context.Background(), "not there", nil)
+	require.ErrorIs(t, err, seqtypes.ErrUnknownBuilder)
+
+	job, err := b.CreateJob(context.Background(), builderID, nil)
+	require.NoError(t, err)
+
+	_, err = job.Seal(context.Background())
+	require.ErrorIs(t, err, noopbuilder.ErrNoBuild)
+
+	require.Equal(t, job, b.GetJob(job.ID()))
+
 	require.NoError(t, b.Stop(context.Background()))
-	require.ErrorIs(t, b.Stop(context.Background()), errAlreadyStopped)
+	require.ErrorIs(t, b.Stop(context.Background()), seqtypes.ErrBackendInactive)
+	require.ErrorIs(t, b.Start(context.Background()), seqtypes.ErrBackendAlreadyStarted, "no restarts")
+
+	_, err = b.CreateJob(context.Background(), builderID, nil)
+	require.ErrorIs(t, err, seqtypes.ErrBackendInactive)
+
+	require.Zero(t, b.jobs.Len())
 }

--- a/op-test-sequencer/sequencer/backend/mock.go
+++ b/op-test-sequencer/sequencer/backend/mock.go
@@ -1,11 +1,32 @@
 package backend
 
-import "context"
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/frontend"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
 
 type MockBackend struct{}
 
+var _ frontend.BuildBackend = (*MockBackend)(nil)
+var _ frontend.AdminBackend = (*MockBackend)(nil)
+
 func NewMockBackend() *MockBackend {
 	return &MockBackend{}
+}
+
+func (ba *MockBackend) CreateJob(ctx context.Context, id seqtypes.BuilderID, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
+	return nil, noopbuilder.ErrNoBuild
+}
+
+func (ba *MockBackend) GetJob(id seqtypes.BuildJobID) work.BuildJob {
+	return nil
+}
+
+func (ba *MockBackend) UnregisterJob(id seqtypes.BuildJobID) {
 }
 
 func (ba *MockBackend) Start(ctx context.Context) error {

--- a/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/builder.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/builder.go
@@ -1,0 +1,48 @@
+package noopbuilder
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+var ErrNoBuild = errors.New("no building supported")
+
+type Builder struct {
+	id       seqtypes.BuilderID
+	registry work.Jobs
+}
+
+var _ work.Builder = (*Builder)(nil)
+
+func NewBuilder(id seqtypes.BuilderID, registry work.Jobs) *Builder {
+	return &Builder{id: id, registry: registry}
+}
+
+func (n *Builder) NewJob(ctx context.Context, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
+	id := seqtypes.RandomJobID()
+	job := &Job{
+		id: id,
+		unregister: func() {
+			n.registry.UnregisterJob(id)
+		},
+	}
+	if err := n.registry.RegisterJob(job); err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+func (n *Builder) Close() error {
+	return nil
+}
+
+func (n *Builder) String() string {
+	return "noop-builder-" + n.id.String()
+}
+
+func (n *Builder) ID() seqtypes.BuilderID {
+	return n.id
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/builder_test.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/builder_test.go
@@ -1,0 +1,32 @@
+package noopbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestNoopBuilder(t *testing.T) {
+	id := seqtypes.BuilderID("foobar")
+	x := NewBuilder(id, work.NewJobRegistry())
+
+	job, err := x.NewJob(context.Background(), nil)
+	require.NoError(t, err)
+	require.Contains(t, job.String(), "noop-job-")
+	require.NotEmpty(t, job.ID())
+	require.NotNil(t, x.registry.GetJob(job.ID()))
+
+	_, err = job.Seal(context.Background())
+	require.ErrorIs(t, err, ErrNoBuild)
+
+	require.NoError(t, job.Cancel(context.Background()))
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "noop-builder-foobar", x.String())
+	job.Close()
+	require.Nil(t, x.registry.GetJob(job.ID()))
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/config.go
@@ -1,0 +1,18 @@
+package noopbuilder
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.ServiceOpts) (work.Builder, error) {
+	return &Builder{
+		id:       id,
+		registry: opts.Jobs,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/config_test.go
@@ -1,0 +1,32 @@
+package noopbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := &Config{}
+	id := seqtypes.BuilderID("test")
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+			Jobs:    work.NewJobRegistry(),
+		},
+		Services: &work.Ensemble{},
+	}
+	builder, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, builder.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/job.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/noopbuilder/job.go
@@ -1,0 +1,35 @@
+package noopbuilder
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Job struct {
+	id         seqtypes.BuildJobID
+	unregister func()
+}
+
+var _ work.BuildJob = (*Job)(nil)
+
+func (job *Job) ID() seqtypes.BuildJobID {
+	return job.id
+}
+
+func (job *Job) Cancel(ctx context.Context) error {
+	return nil
+}
+
+func (job *Job) Seal(ctx context.Context) (work.Block, error) {
+	return nil, ErrNoBuild
+}
+
+func (job *Job) String() string {
+	return "noop-job-" + job.id.String()
+}
+
+func (job *Job) Close() {
+	job.unregister()
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/committer.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/committer.go
@@ -1,0 +1,38 @@
+package noopcommitter
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Committer struct {
+	id  seqtypes.CommitterID
+	log log.Logger
+}
+
+var _ work.Committer = (*Committer)(nil)
+
+func NewCommitter(id seqtypes.CommitterID, log log.Logger) *Committer {
+	return &Committer{id: id, log: log}
+}
+
+func (n *Committer) Close() error {
+	return nil
+}
+
+func (n *Committer) String() string {
+	return "noop-committer-" + n.id.String()
+}
+
+func (n *Committer) ID() seqtypes.CommitterID {
+	return n.id
+}
+
+func (n *Committer) Commit(ctx context.Context, block work.SignedBlock) error {
+	n.log.Info("No-op commit", "block", block)
+	return nil
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/committer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/committer_test.go
@@ -1,0 +1,26 @@
+package noopcommitter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestNoopCommitter(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.CommitterID("foo")
+	x := NewCommitter(id, logger)
+
+	err := x.Commit(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "noop-committer-foo", x.String())
+	require.Equal(t, id, x.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/config.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/config.go
@@ -1,0 +1,18 @@
+package noopcommitter
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.CommitterID, opts *work.ServiceOpts) (work.Committer, error) {
+	return &Committer{
+		id:  id,
+		log: opts.Log,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/noopcommitter/config_test.go
@@ -1,0 +1,32 @@
+package noopcommitter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := &Config{}
+	id := seqtypes.CommitterID("test")
+	ensemble := &work.Ensemble{}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: ensemble,
+	}
+	committer, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, committer.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/config/builder.go
+++ b/op-test-sequencer/sequencer/backend/work/config/builder.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type BuilderEntry struct {
+	Noop *noopbuilder.Config `yaml:"noop,omitempty"`
+}
+
+func (b *BuilderEntry) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.ServiceOpts) (work.Builder, error) {
+	switch {
+	case b.Noop != nil:
+		return b.Noop.Start(ctx, id, opts)
+	default:
+		return nil, seqtypes.ErrUnknownKind
+	}
+}

--- a/op-test-sequencer/sequencer/backend/work/config/committer.go
+++ b/op-test-sequencer/sequencer/backend/work/config/committer.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type CommitterEntry struct {
+	Noop *noopcommitter.Config `yaml:"noop,omitempty"`
+}
+
+func (b *CommitterEntry) Start(ctx context.Context, id seqtypes.CommitterID, opts *work.ServiceOpts) (work.Committer, error) {
+	switch {
+	case b.Noop != nil:
+		return b.Noop.Start(ctx, id, opts)
+	default:
+		return nil, seqtypes.ErrUnknownKind
+	}
+}

--- a/op-test-sequencer/sequencer/backend/work/config/publisher.go
+++ b/op-test-sequencer/sequencer/backend/work/config/publisher.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type PublisherEntry struct {
+	Noop *nooppublisher.Config `yaml:"noop,omitempty"`
+}
+
+func (b *PublisherEntry) Start(ctx context.Context, id seqtypes.PublisherID, opts *work.ServiceOpts) (work.Publisher, error) {
+	switch {
+	case b.Noop != nil:
+		return b.Noop.Start(ctx, id, opts)
+	default:
+		return nil, seqtypes.ErrUnknownKind
+	}
+}

--- a/op-test-sequencer/sequencer/backend/work/config/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/config/sequencer.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/sequencers/fullseq"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/sequencers/noopseq"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type SequencerEntry struct {
+	Full *fullseq.Config `yaml:"full,omitempty"`
+	Noop *noopseq.Config `yaml:"noop,omitempty"`
+}
+
+func (b *SequencerEntry) Start(ctx context.Context, id seqtypes.SequencerID, opts *work.ServiceOpts) (work.Sequencer, error) {
+	switch {
+	case b.Full != nil:
+		return b.Full.Start(ctx, id, opts)
+	case b.Noop != nil:
+		return b.Noop.Start(ctx, id, opts)
+	default:
+		return nil, seqtypes.ErrUnknownKind
+	}
+}

--- a/op-test-sequencer/sequencer/backend/work/config/signer.go
+++ b/op-test-sequencer/sequencer/backend/work/config/signer.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type SignerEntry struct {
+	Noop *noopsigner.Config `yaml:"noop,omitempty"`
+}
+
+func (b *SignerEntry) Start(ctx context.Context, id seqtypes.SignerID, opts *work.ServiceOpts) (work.Signer, error) {
+	switch {
+	case b.Noop != nil:
+		return b.Noop.Start(ctx, id, opts)
+	default:
+		return nil, seqtypes.ErrUnknownKind
+	}
+}

--- a/op-test-sequencer/sequencer/backend/work/config/static.go
+++ b/op-test-sequencer/sequencer/backend/work/config/static.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Ensemble struct {
+	// Endpoints is a no-op list of endpoints
+	// to prevent repetitive endpoints in a yaml.
+	// This list can all be declared at the top, and items can be referenced with yaml refs.
+	Endpoints []string `yaml:"endpoints"`
+
+	Builders   map[seqtypes.BuilderID]*BuilderEntry     `yaml:"builders"`
+	Signers    map[seqtypes.SignerID]*SignerEntry       `yaml:"signers"`
+	Committers map[seqtypes.CommitterID]*CommitterEntry `yaml:"committers"`
+	Publishers map[seqtypes.PublisherID]*PublisherEntry `yaml:"publishers"`
+	Sequencers map[seqtypes.SequencerID]*SequencerEntry `yaml:"sequencers"`
+}
+
+var _ work.Loader = (*Ensemble)(nil)
+
+// Load is a short-cut to skip the config-loading phase, and use an existing config instead.
+// This can be used by tests to plug in a config directly,
+// without having to store it on disk somewhere.
+func (c *Ensemble) Load(ctx context.Context) (work.Starter, error) {
+	return c, nil
+}
+
+var _ work.Starter = (*Ensemble)(nil)
+
+// Start sets up the configured group of builders.
+func (c *Ensemble) Start(ctx context.Context, opts *work.StartOpts) (ensemble *work.Ensemble, errResult error) {
+	ensemble = new(work.Ensemble)
+	defer func() {
+		if errResult == nil {
+			return
+		}
+		// If there is any error, close the builders we may have opened already
+		errResult = errors.Join(errResult, ensemble.Close())
+	}()
+	serviceOpts := &work.ServiceOpts{
+		StartOpts: opts,
+		Services:  ensemble,
+	}
+	if err := startAndAdd(ctx, c.Builders, serviceOpts, ensemble.AddBuilder); err != nil {
+		return nil, fmt.Errorf("failed to start builders: %w", err)
+	}
+	if err := startAndAdd(ctx, c.Signers, serviceOpts, ensemble.AddSigner); err != nil {
+		return nil, fmt.Errorf("failed to start signers: %w", err)
+	}
+	if err := startAndAdd(ctx, c.Committers, serviceOpts, ensemble.AddCommitter); err != nil {
+		return nil, fmt.Errorf("failed to start committers: %w", err)
+	}
+	if err := startAndAdd(ctx, c.Publishers, serviceOpts, ensemble.AddPublisher); err != nil {
+		return nil, fmt.Errorf("failed to start publishers: %w", err)
+	}
+	if err := startAndAdd(ctx, c.Sequencers, serviceOpts, ensemble.AddSequencer); err != nil {
+		return nil, fmt.Errorf("failed to start sequencers: %w", err)
+	}
+	return ensemble, nil
+}
+
+type valueIface[K comparable, R any] interface {
+	Start(ctx context.Context, id K, opts *work.ServiceOpts) (result R, err error)
+}
+
+type keyIface interface {
+	comparable
+	String() string
+}
+
+// startAndAdd is a util function to start entities from a configuration map, and add them to the ensemble.
+func startAndAdd[K keyIface, R any, E valueIface[K, R]](
+	ctx context.Context,
+	entries map[K]E,
+	opts *work.ServiceOpts,
+	addFn func(v R) error) error {
+	for id, conf := range entries {
+		v, err := conf.Start(ctx, id, opts)
+		if err != nil {
+			return fmt.Errorf("failed to start %q: %w", id, err)
+		}
+		if err := addFn(v); err != nil {
+			return fmt.Errorf("failed to add %q: %w", id, err)
+		}
+	}
+	return nil
+}

--- a/op-test-sequencer/sequencer/backend/work/config/static_test.go
+++ b/op-test-sequencer/sequencer/backend/work/config/static_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/sequencers/noopseq"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestEnsemble_Start(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		v := new(Ensemble)
+		out, err := v.Start(context.Background(), nil)
+		require.NoError(t, err)
+		require.Empty(t, out.Builders())
+		require.Empty(t, out.Signers())
+		require.Empty(t, out.Committers())
+		require.Empty(t, out.Publishers())
+		require.Empty(t, out.Sequencers())
+	})
+	t.Run("noops", func(t *testing.T) {
+		v := &Ensemble{
+			Endpoints: nil,
+			Builders: map[seqtypes.BuilderID]*BuilderEntry{
+				"noop-builder": {
+					Noop: &noopbuilder.Config{},
+				},
+			},
+			Signers: map[seqtypes.SignerID]*SignerEntry{
+				"noop-signer": {
+					Noop: &noopsigner.Config{},
+				},
+			},
+			Committers: map[seqtypes.CommitterID]*CommitterEntry{
+				"noop-committer": {
+					Noop: &noopcommitter.Config{},
+				},
+			},
+			Publishers: map[seqtypes.PublisherID]*PublisherEntry{
+				"noop-publisher": {
+					Noop: &nooppublisher.Config{},
+				},
+			},
+			Sequencers: map[seqtypes.SequencerID]*SequencerEntry{
+				"noop-sequencer": {
+					Noop: &noopseq.Config{},
+				},
+			},
+		}
+		logger := testlog.Logger(t, log.LevelError)
+		out, err := v.Start(context.Background(), &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Builders(), 1)
+		require.Len(t, out.Signers(), 1)
+		require.Len(t, out.Committers(), 1)
+		require.Len(t, out.Publishers(), 1)
+		require.Len(t, out.Sequencers(), 1)
+	})
+}

--- a/op-test-sequencer/sequencer/backend/work/config/testdata/config.yaml
+++ b/op-test-sequencer/sequencer/backend/work/config/testdata/config.yaml
@@ -1,0 +1,42 @@
+endpoints: []
+
+builders:
+  builder-a:
+    noop:
+  builder-b:
+    noop:
+
+signers:
+  local-key-a:
+    local-key:
+      path: "./my-key.txt"
+  signer-b:
+    noop:
+
+committers:
+  commit-a:
+    noop:
+  commit-b:
+    noop:
+
+publishers:
+  pub-a:
+    noop:
+  pub-b:
+    noop:
+
+sequencers:
+  sequencer-a:
+    full:
+      builder: builder-a
+      signer: local-key-a
+      committer: commit-a
+      publisher: pub-a
+  sequencer-b:
+    full:
+      builder: builder-b
+      signer: signer-b
+      committer: commit-b
+      publisher: pub-b
+  sequencer-c:
+    noop:

--- a/op-test-sequencer/sequencer/backend/work/config/yaml.go
+++ b/op-test-sequencer/sequencer/backend/work/config/yaml.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+)
+
+// YamlLoader is a Loader that loads a builders configuration from a YAML file path.
+type YamlLoader struct {
+	Path string
+}
+
+var _ work.Loader = (*YamlLoader)(nil)
+
+func (l *YamlLoader) Load(ctx context.Context) (work.Starter, error) {
+	data, err := os.ReadFile(l.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+	var out Ensemble
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true) // ensure all the fields are known. Config correctness is critical.
+	if err := dec.Decode(&out); err != nil {
+		return nil, fmt.Errorf("failed to parse config YAML: %w", err)
+	}
+	return &out, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/config/yaml_test.go
+++ b/op-test-sequencer/sequencer/backend/work/config/yaml_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestYamlLoader_Load(t *testing.T) {
+	x := &YamlLoader{Path: filepath.Join(".", "testdata", "config.yaml")}
+	result, err := x.Load(context.Background())
+	require.NoError(t, err)
+	static := result.(*Ensemble)
+	require.NotEmpty(t, static.Builders)
+	require.NotEmpty(t, static.Signers)
+	require.NotEmpty(t, static.Committers)
+	require.NotEmpty(t, static.Publishers)
+	require.NotEmpty(t, static.Sequencers)
+}
+
+func TestYamlLoader_NotFound(t *testing.T) {
+	x := &YamlLoader{Path: filepath.Join(t.TempDir(), "missing.yaml")}
+	_, err := x.Load(context.Background())
+	require.ErrorContains(t, err, "failed to read config")
+}
+
+func TestYamlLoader_Invalid(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "invalid.yaml")
+	// Strictly speaking a valid yaml map, but missing all the data.
+	// The config decoder is strict
+	require.NoError(t, os.WriteFile(p, []byte("foobar: invalid"), 0755))
+
+	x := &YamlLoader{Path: p}
+	_, err := x.Load(context.Background())
+	require.ErrorContains(t, err, "field foobar not found")
+}

--- a/op-test-sequencer/sequencer/backend/work/ensemble.go
+++ b/op-test-sequencer/sequencer/backend/work/ensemble.go
@@ -1,0 +1,182 @@
+package work
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/locks"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+var ErrAlreadyExists = errors.New("entry with same ID already exists")
+
+// Ensemble is a group of active services to sequence blocks with.
+// Services can only be added to an ensemble,
+// the ensemble is meant to run for the full lifetime of the Go service.
+type Ensemble struct {
+	// builders build unsigned block alternatives
+	builders locks.RWMap[seqtypes.BuilderID, Builder]
+
+	// signers sign blocks
+	signers locks.RWMap[seqtypes.SignerID, Signer]
+
+	// committers commit to blocks for persistence
+	committers locks.RWMap[seqtypes.CommitterID, Committer]
+
+	// publishers publish blocks
+	publishers locks.RWMap[seqtypes.PublisherID, Publisher]
+
+	// sequencers perform all block responsibilities
+	sequencers locks.RWMap[seqtypes.SequencerID, Sequencer]
+}
+
+var _ Loader = (*Ensemble)(nil)
+
+// Load is a short-cut to skip the config phase, and use an existing group of builders.
+func (bs *Ensemble) Load(ctx context.Context) (Starter, error) {
+	return bs, nil
+}
+
+var _ Starter = (*Ensemble)(nil)
+
+// Start is a short-cut to skip the start phase, and use an existing group of builders.
+func (bs *Ensemble) Start(ctx context.Context, opts *StartOpts) (*Ensemble, error) {
+	return bs, nil
+}
+
+func (bs *Ensemble) Close() error {
+	// We close all services in reverse order: user-facing first most, then underlying services.
+	var result error
+	bs.sequencers.Range(func(id seqtypes.SequencerID, v Sequencer) bool {
+		if err := v.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close sequencer %q: %w", id, err))
+		}
+		return true
+	})
+	bs.publishers.Range(func(id seqtypes.PublisherID, v Publisher) bool {
+		if err := v.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close publisher %q: %w", id, err))
+		}
+		return true
+	})
+	bs.committers.Range(func(id seqtypes.CommitterID, v Committer) bool {
+		if err := v.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close committer %q: %w", id, err))
+		}
+		return true
+	})
+	bs.signers.Range(func(id seqtypes.SignerID, v Signer) bool {
+		if err := v.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close signer %q: %w", id, err))
+		}
+		return true
+	})
+	bs.builders.Range(func(id seqtypes.BuilderID, v Builder) bool {
+		if err := v.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close builder %q: %w", id, err))
+		}
+		return true
+	})
+	return result
+}
+
+type Collection interface {
+	Builder(id seqtypes.BuilderID) Builder
+	Signer(id seqtypes.SignerID) Signer
+	Committer(id seqtypes.CommitterID) Committer
+	Publisher(id seqtypes.PublisherID) Publisher
+	Sequencer(id seqtypes.SequencerID) Sequencer
+}
+
+var _ Collection = (*Ensemble)(nil)
+
+// Builder gets a builder. Nil is returned if the ID is unknown.
+func (bs *Ensemble) Builder(id seqtypes.BuilderID) Builder {
+	s, _ := bs.builders.Get(id)
+	return s
+}
+
+// Signer gets a signer. Nil is returned if the ID is unknown.
+func (bs *Ensemble) Signer(id seqtypes.SignerID) Signer {
+	s, _ := bs.signers.Get(id)
+	return s
+}
+
+// Committer gets a committer. Nil is returned if the ID is unknown.
+func (bs *Ensemble) Committer(id seqtypes.CommitterID) Committer {
+	s, _ := bs.committers.Get(id)
+	return s
+}
+
+// Publisher gets a publisher. Nil is returned if the ID is unknown.
+func (bs *Ensemble) Publisher(id seqtypes.PublisherID) Publisher {
+	s, _ := bs.publishers.Get(id)
+	return s
+}
+
+// Sequencer gets a sequencer. Nil is returned if the ID is unknown.
+func (bs *Ensemble) Sequencer(id seqtypes.SequencerID) Sequencer {
+	s, _ := bs.sequencers.Get(id)
+	return s
+}
+
+// AddBuilder adds a builder. Errors if the builder already exists.
+func (bs *Ensemble) AddBuilder(v Builder) error {
+	if !bs.builders.SetIfMissing(v.ID(), v) {
+		return ErrAlreadyExists
+	}
+	return nil
+}
+
+// AddSigner adds a signer. Errors if the signer already exists.
+func (bs *Ensemble) AddSigner(v Signer) error {
+	if !bs.signers.SetIfMissing(v.ID(), v) {
+		return ErrAlreadyExists
+	}
+	return nil
+}
+
+// AddCommitter adds a committer. Errors if the committer already exists.
+func (bs *Ensemble) AddCommitter(v Committer) error {
+	if !bs.committers.SetIfMissing(v.ID(), v) {
+		return ErrAlreadyExists
+	}
+	return nil
+}
+
+// AddPublisher adds a publisher. Errors if the publisher already exists.
+func (bs *Ensemble) AddPublisher(v Publisher) error {
+	if !bs.publishers.SetIfMissing(v.ID(), v) {
+		return ErrAlreadyExists
+	}
+	return nil
+}
+
+// AddSequencer adds a sequencer. Errors if the sequencer already exists.
+func (bs *Ensemble) AddSequencer(v Sequencer) error {
+	if !bs.sequencers.SetIfMissing(v.ID(), v) {
+		return ErrAlreadyExists
+	}
+	return nil
+}
+
+func (bs *Ensemble) Builders() []seqtypes.BuilderID {
+	return bs.builders.Keys()
+}
+
+func (bs *Ensemble) Signers() []seqtypes.SignerID {
+	return bs.signers.Keys()
+}
+
+func (bs *Ensemble) Committers() []seqtypes.CommitterID {
+	return bs.committers.Keys()
+}
+
+func (bs *Ensemble) Publishers() []seqtypes.PublisherID {
+	return bs.publishers.Keys()
+}
+
+func (bs *Ensemble) Sequencers() []seqtypes.SequencerID {
+	return bs.sequencers.Keys()
+}

--- a/op-test-sequencer/sequencer/backend/work/ensemble_test.go
+++ b/op-test-sequencer/sequencer/backend/work/ensemble_test.go
@@ -1,0 +1,77 @@
+package work_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/sequencers/noopseq"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestEnsemble(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	builderID := seqtypes.BuilderID("test-builder")
+	signerID := seqtypes.SignerID("test-signer")
+	committerID := seqtypes.CommitterID("test-committer")
+	publisherID := seqtypes.PublisherID("test-publisher")
+	sequencerID := seqtypes.SequencerID("test-sequencer")
+	ensemble := &work.Ensemble{}
+	jobs := work.NewJobRegistry()
+	require.NoError(t, ensemble.AddBuilder(noopbuilder.NewBuilder(builderID, jobs)))
+	require.ErrorIs(t, ensemble.AddBuilder(noopbuilder.NewBuilder(builderID, jobs)), work.ErrAlreadyExists)
+	require.NoError(t, ensemble.AddSigner(noopsigner.NewSigner(signerID, logger)))
+	require.ErrorIs(t, ensemble.AddSigner(noopsigner.NewSigner(signerID, logger)), work.ErrAlreadyExists)
+	require.NoError(t, ensemble.AddCommitter(noopcommitter.NewCommitter(committerID, logger)))
+	require.ErrorIs(t, ensemble.AddCommitter(noopcommitter.NewCommitter(committerID, logger)), work.ErrAlreadyExists)
+	require.NoError(t, ensemble.AddPublisher(nooppublisher.NewPublisher(publisherID, logger)))
+	require.ErrorIs(t, ensemble.AddPublisher(nooppublisher.NewPublisher(publisherID, logger)), work.ErrAlreadyExists)
+	require.NoError(t, ensemble.AddSequencer(noopseq.NewSequencer(sequencerID, logger)))
+	require.ErrorIs(t, ensemble.AddSequencer(noopseq.NewSequencer(sequencerID, logger)), work.ErrAlreadyExists)
+
+	require.NotNil(t, ensemble.Builder(builderID))
+	require.NotNil(t, ensemble.Signer(signerID))
+	require.NotNil(t, ensemble.Committer(committerID))
+	require.NotNil(t, ensemble.Publisher(publisherID))
+	require.NotNil(t, ensemble.Sequencer(sequencerID))
+
+	builderID2 := seqtypes.BuilderID("test-builder2")
+	signerID2 := seqtypes.SignerID("test-signer2")
+	committerID2 := seqtypes.CommitterID("test-committer2")
+	publisherID2 := seqtypes.PublisherID("test-publisher2")
+	sequencerID2 := seqtypes.SequencerID("test-sequencer2")
+	require.NoError(t, ensemble.AddBuilder(noopbuilder.NewBuilder(builderID2, jobs)))
+	require.NoError(t, ensemble.AddSigner(noopsigner.NewSigner(signerID2, logger)))
+	require.NoError(t, ensemble.AddCommitter(noopcommitter.NewCommitter(committerID2, logger)))
+	require.NoError(t, ensemble.AddPublisher(nooppublisher.NewPublisher(publisherID2, logger)))
+	require.NoError(t, ensemble.AddSequencer(noopseq.NewSequencer(sequencerID2, logger)))
+
+	require.Len(t, ensemble.Builders(), 2)
+	require.Len(t, ensemble.Signers(), 2)
+	require.Len(t, ensemble.Committers(), 2)
+	require.Len(t, ensemble.Publishers(), 2)
+	require.Len(t, ensemble.Sequencers(), 2)
+
+	starter, err := ensemble.Load(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, starter, ensemble, "can load in-place, to skip pre-config phase")
+
+	self, err := ensemble.Start(context.Background(), &work.StartOpts{
+		Log:     logger,
+		Metrics: metrics.NoopMetrics{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, self, ensemble, "can start in-place, to skip config phase")
+
+	require.NoError(t, ensemble.Close())
+}

--- a/op-test-sequencer/sequencer/backend/work/iface.go
+++ b/op-test-sequencer/sequencer/backend/work/iface.go
@@ -1,0 +1,177 @@
+package work
+
+import (
+	"context"
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+// Builder provides access to block-building work.
+// Different implementations are available, e.g. for local or remote block-building.
+type Builder interface {
+	NewJob(ctx context.Context, opts *seqtypes.BuildOpts) (BuildJob, error)
+	String() string
+	ID() seqtypes.BuilderID
+	io.Closer
+}
+
+type Block interface {
+	ID() eth.BlockID
+	String() string
+}
+
+type SignedBlock interface {
+	Block
+	VerifySignature() error
+}
+
+// BuildJob provides access to the building work of a single protocol block.
+// This may include extra access, such as inclusion of individual txs or block-building steps.
+type BuildJob interface {
+	ID() seqtypes.BuildJobID
+	Cancel(ctx context.Context) error
+	Seal(ctx context.Context) (Block, error)
+	String() string
+	Close() // cleans up and unregisters the job
+}
+
+// Jobs tracks block-building jobs by ID, so the jobs can be inspected and updated.
+type Jobs interface {
+	// RegisterJob registers the given block-building job.
+	// It may return an error if there already exists a job with the same ID.
+	RegisterJob(job BuildJob) error
+	// GetJob returns nil if the job isn't known.
+	GetJob(id seqtypes.BuildJobID) BuildJob
+	// UnregisterJob removes the block-building job from the tracker.
+	UnregisterJob(id seqtypes.BuildJobID)
+	// Clear unregisters all jobs
+	Clear()
+	// Len returns the number of registered jobs
+	Len() int
+}
+
+// Signer signs a block to be published
+type Signer interface {
+	String() string
+	ID() seqtypes.SignerID
+	io.Closer
+	Sign(ctx context.Context, block Block) (SignedBlock, error)
+}
+
+// Committer commits to a (signed) block to become canonical.
+// This work is critical: if a block cannot be committed,
+// the block is not safe to continue to work with, as it can be replaced by another block.
+// E.g.:
+// - commit a block to be persisted in the local node.
+// - commit a block to an op-conductor service.
+type Committer interface {
+	String() string
+	ID() seqtypes.CommitterID
+	io.Closer
+	Commit(ctx context.Context, block SignedBlock) error
+}
+
+// Publisher publishes a (signed) block to external actors.
+// Publishing may fail.
+// E.g. publish the block to node(s) for propagation via P2P.
+type Publisher interface {
+	String() string
+	ID() seqtypes.PublisherID
+	io.Closer
+	Publish(ctx context.Context, block SignedBlock) error
+}
+
+// Sequencer utilizes Builder, Committer, Signer, Publisher to
+// perform all the responsibilities to extend the chain.
+// A Sequencer may internally pipeline work,
+// but does not expose parallel work like a builder does.
+type Sequencer interface {
+	String() string
+	ID() seqtypes.SequencerID
+
+	// Close the sequencer. After closing successfully the sequencer is no longer usable.
+	Close() error
+
+	// Open starts a next sequencing slot
+	Open(ctx context.Context) error
+
+	// BuildJob identifies the current block-building work.
+	// This work may be interacted with through the block-building API.
+	// This may returns nil if there is no active job.
+	BuildJob() BuildJob
+
+	// Seal seals the current ongoing block-building job.
+	// Returns an error if there was no block-building job open.
+	Seal(ctx context.Context) error
+
+	// Prebuilt inserts a pre-built block, skipping block-building.
+	Prebuilt(ctx context.Context, block Block) error
+
+	// Sign the previously built block.
+	// Returns seqtypes.ErrAlreadySigned if already signed.
+	// Returns an error if the block could not be signed.
+	Sign(ctx context.Context) error
+
+	// Commit the previously signed block, this ensures we can persist it before relying on it as canonical block.
+	// Returns seqtypes.ErrAlreadyCommitted if already committed.
+	// Returns an error if the block failed to commit.
+	Commit(ctx context.Context) error
+
+	// Publish the previously committed block.
+	// Publishing is not respected by next steps.
+	// For harder guarantees, use Commit to ensure the payload is successfully shared before the next phase.
+	// Re-publishing is allowed.
+	// Returns an error if none was previously successfully committed.
+	// Returns an error if publishing fails.
+	Publish(ctx context.Context) error
+
+	// Next continues to the next sequencing slot.
+	// If the current slot is unfinished, then it will finish the current slot.
+	// If the current slot is fresh, it will be built.
+	// An error is returned if any step fails. It is safe to re-attempt with Next if so.
+	Next(ctx context.Context) error
+
+	// Start starts automatic sequencing, on top of the given chain head.
+	// An error is returned if the head of the chain does not match the provided head,
+	// as safety measure to prevent reorgs during sequencer rotations.
+	// An seqtypes.ErrSequencerAlreadyActive error is returned if the sequencer has already been started.
+	Start(ctx context.Context, head common.Hash) error
+
+	// Stop stops automatic sequencing, and returns the block-hash of the last sequenced block.
+	// An seqtypes.ErrSequencerInactive error is returned if the sequencer has already been stopped.
+	Stop(ctx context.Context) (last common.Hash, err error)
+
+	// Active returns true if the automatic sequencing (see Start and Stop) is actively running.
+	Active() bool
+
+	// TODO: later, to fit old sequencer functionality fully
+	//OverrideLeader(ctx context.Context) error
+	//ConductorEnabled(ctx context.Context) bool
+}
+
+// Loader loads a configuration, ready to start builders with.
+type Loader interface {
+	Load(ctx context.Context) (Starter, error)
+}
+
+type ServiceOpts struct {
+	*StartOpts
+	Services Collection
+}
+
+type StartOpts struct {
+	Log     log.Logger
+	Metrics metrics.Metricer
+	Jobs    Jobs
+}
+
+// Starter starts an ensemble from some form of setup.
+type Starter interface {
+	Start(ctx context.Context, opts *StartOpts) (*Ensemble, error)
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/config.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/config.go
@@ -1,0 +1,18 @@
+package nooppublisher
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.PublisherID, opts *work.ServiceOpts) (work.Publisher, error) {
+	return &Publisher{
+		id:  id,
+		log: opts.Log,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/config_test.go
@@ -1,0 +1,32 @@
+package nooppublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := &Config{}
+	id := seqtypes.PublisherID("test")
+	ensemble := &work.Ensemble{}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: ensemble,
+	}
+	publisher, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, publisher.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/publisher.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/publisher.go
@@ -1,0 +1,38 @@
+package nooppublisher
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Publisher struct {
+	id  seqtypes.PublisherID
+	log log.Logger
+}
+
+var _ work.Publisher = (*Publisher)(nil)
+
+func NewPublisher(id seqtypes.PublisherID, log log.Logger) *Publisher {
+	return &Publisher{id: id, log: log}
+}
+
+func (n *Publisher) Close() error {
+	return nil
+}
+
+func (n *Publisher) String() string {
+	return "noop-publisher-" + n.id.String()
+}
+
+func (n *Publisher) ID() seqtypes.PublisherID {
+	return n.id
+}
+
+func (n *Publisher) Publish(ctx context.Context, block work.SignedBlock) error {
+	n.log.Info("No-op publish", "block", block)
+	return nil
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/publisher_test.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher/publisher_test.go
@@ -1,0 +1,26 @@
+package nooppublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestNoopPublisher(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.PublisherID("foo")
+	x := NewPublisher(id, logger)
+
+	err := x.Publish(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "noop-publisher-foo", x.String())
+	require.Equal(t, id, x.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/registry.go
+++ b/op-test-sequencer/sequencer/backend/work/registry.go
@@ -1,0 +1,41 @@
+package work
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/locks"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type JobRegistry struct {
+	jobs locks.RWMap[seqtypes.BuildJobID, BuildJob]
+}
+
+var _ Jobs = (*JobRegistry)(nil)
+
+func NewJobRegistry() *JobRegistry {
+	return &JobRegistry{}
+}
+
+func (ba *JobRegistry) RegisterJob(job BuildJob) error {
+	if !ba.jobs.SetIfMissing(job.ID(), job) {
+		return seqtypes.ErrConflictingJob
+	}
+	return nil
+}
+
+// GetJob returns nil if the job isn't known.
+func (ba *JobRegistry) GetJob(id seqtypes.BuildJobID) BuildJob {
+	job, _ := ba.jobs.Get(id)
+	return job
+}
+
+func (ba *JobRegistry) UnregisterJob(id seqtypes.BuildJobID) {
+	ba.jobs.Delete(id)
+}
+
+func (ba *JobRegistry) Clear() {
+	ba.jobs.Clear()
+}
+
+func (ba *JobRegistry) Len() int {
+	return ba.jobs.Len()
+}

--- a/op-test-sequencer/sequencer/backend/work/registry_test.go
+++ b/op-test-sequencer/sequencer/backend/work/registry_test.go
@@ -1,0 +1,46 @@
+package work
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type mockJob struct {
+	id seqtypes.BuildJobID
+	BuildJob
+}
+
+func (m *mockJob) ID() seqtypes.BuildJobID {
+	return m.id
+}
+
+var _ BuildJob = (*mockJob)(nil)
+
+func TestRegistry(t *testing.T) {
+	reg := NewJobRegistry()
+	require.Equal(t, 0, reg.Len())
+	reg.Clear()
+
+	jobA := &mockJob{id: "A"}
+	require.NoError(t, reg.RegisterJob(jobA))
+	jobA2 := &mockJob{id: "A"}
+	require.ErrorIs(t, reg.RegisterJob(jobA2), seqtypes.ErrConflictingJob)
+	require.Equal(t, 1, reg.Len())
+
+	reg.UnregisterJob(jobA.ID())
+	require.Equal(t, 0, reg.Len())
+
+	job1 := &mockJob{id: "1"}
+	job2 := &mockJob{id: "2"}
+	job3 := &mockJob{id: "3"}
+	require.NoError(t, reg.RegisterJob(job1))
+	require.NoError(t, reg.RegisterJob(job2))
+	require.NoError(t, reg.RegisterJob(job3))
+	require.Equal(t, job2, reg.GetJob("2"))
+
+	reg.Clear()
+	require.Equal(t, 0, reg.Len())
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/config.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/config.go
@@ -1,0 +1,67 @@
+package fullseq
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+	ChainID eth.ChainID `yaml:"chainID"`
+
+	Builder   seqtypes.BuilderID   `yaml:"builder"`
+	Signer    seqtypes.SignerID    `yaml:"signer,omitempty"`
+	Committer seqtypes.CommitterID `yaml:"committer,omitempty"`
+	Publisher seqtypes.PublisherID `yaml:"publisher,omitempty"`
+
+	// SequencerConfDepth is the distance to keep from the L1 head as origin when sequencing new L2 blocks.
+	// If this distance is too large, the sequencer may:
+	// - not adopt a L1 origin within the allowed time (rollup.Config.MaxSequencerDrift)
+	// - not adopt a L1 origin that can be included on L1 within the allowed range (rollup.Config.SeqWindowSize)
+	// and thus fail to produce a block with anything more than deposits.
+	SequencerConfDepth uint64 `json:"sequencer_conf_depth"`
+
+	// SequencerEnabled is true when the sequencer is operational.
+	SequencerEnabled bool `json:"sequencer_enabled"`
+
+	// SequencerStopped is false when the sequencer should not be auto-sequencing at startup.
+	SequencerStopped bool `json:"sequencer_stopped"`
+
+	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
+	// Disabled if 0.
+	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.SequencerID, opts *work.ServiceOpts) (work.Sequencer, error) {
+
+	builder := opts.Services.Builder(c.Builder)
+	signer := opts.Services.Signer(c.Signer)
+	committer := opts.Services.Committer(c.Committer)
+	publisher := opts.Services.Publisher(c.Publisher)
+
+	// TODO(#14129) load persisted sequencer state (add config var for peristence path + use op-node persistence code)
+
+	seq := &Sequencer{
+		id: id,
+
+		chainID: c.ChainID,
+
+		log: opts.Log.New("chain", c.ChainID),
+		m:   opts.Metrics,
+
+		builder:   builder,
+		signer:    signer,
+		committer: committer,
+		publisher: publisher,
+	}
+
+	// TODO(#14129) check persisted state, to determine if we should really start or stop
+	//if c.SequencerEnabled && !c.SequencerStopped {
+	//	if err := seq.forceStart(); err != nil {
+	//		return nil, fmt.Errorf("failed to start sequencer at startup phase: %w", err)
+	//	}
+	//}
+	return seq, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/config_test.go
@@ -1,0 +1,57 @@
+package fullseq
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	builderID := seqtypes.BuilderID("test-builder")
+	signerID := seqtypes.SignerID("test-signer")
+	committerID := seqtypes.CommitterID("test-committer")
+	publisherID := seqtypes.PublisherID("test-publisher")
+	sequencerID := seqtypes.SequencerID("test-sequencer")
+	ensemble := &work.Ensemble{}
+	jobs := work.NewJobRegistry()
+	require.NoError(t, ensemble.AddBuilder(noopbuilder.NewBuilder(builderID, jobs)))
+	require.NoError(t, ensemble.AddSigner(noopsigner.NewSigner(signerID, logger)))
+	require.NoError(t, ensemble.AddCommitter(noopcommitter.NewCommitter(committerID, logger)))
+	require.NoError(t, ensemble.AddPublisher(nooppublisher.NewPublisher(publisherID, logger)))
+	cfg := &Config{
+		ChainID:             eth.ChainIDFromUInt64(1),
+		Builder:             builderID,
+		Signer:              signerID,
+		Committer:           committerID,
+		Publisher:           publisherID,
+		SequencerConfDepth:  2,
+		SequencerEnabled:    true,
+		SequencerStopped:    true,
+		SequencerMaxSafeLag: 10,
+	}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+			Jobs:    jobs,
+		},
+		Services: ensemble,
+	}
+	seq, err := cfg.Start(context.Background(), sequencerID, opts)
+	require.NoError(t, err)
+	require.NoError(t, ensemble.AddSequencer(seq))
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
@@ -1,0 +1,259 @@
+package fullseq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Sequencer struct {
+	id seqtypes.SequencerID
+
+	chainID eth.ChainID
+
+	log log.Logger
+	m   metrics.Metricer
+
+	stateMu sync.RWMutex
+
+	currentJob work.BuildJob
+	unsigned   work.Block
+	signed     work.SignedBlock
+	committed  bool
+	published  bool
+
+	// active is true when it's currently running through block-building automatically
+	active bool
+
+	builder   work.Builder
+	signer    work.Signer
+	committer work.Committer
+	publisher work.Publisher
+}
+
+var _ work.Sequencer = (*Sequencer)(nil)
+
+func (s *Sequencer) String() string {
+	return "sequencer-" + s.id.String()
+}
+
+func (s *Sequencer) ID() seqtypes.SequencerID {
+	return s.id
+}
+
+func (s *Sequencer) Close() error {
+	return nil
+}
+
+func (s *Sequencer) Open(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.unsigned != nil {
+		return seqtypes.ErrAlreadySealed
+	}
+	if s.currentJob != nil {
+		return seqtypes.ErrConflictingJob
+	}
+
+	opts := &seqtypes.BuildOpts{
+		Parent:   common.Hash{}, // TODO
+		L1Origin: nil,
+	}
+
+	job, err := s.builder.NewJob(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to start new build job: %w", err)
+	}
+	s.currentJob = job
+	return nil
+}
+
+func (s *Sequencer) BuildJob() work.BuildJob {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	return s.currentJob
+}
+
+func (s *Sequencer) Seal(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.unsigned != nil {
+		return seqtypes.ErrAlreadySealed
+	}
+	if s.currentJob == nil {
+		return seqtypes.ErrUnknownJob
+	}
+	block, err := s.currentJob.Seal(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to seal block: %w", err)
+	}
+	s.currentJob.Close()
+	s.unsigned = block
+	return nil
+}
+
+func (s *Sequencer) Prebuilt(ctx context.Context, block work.Block) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.currentJob != nil {
+		return seqtypes.ErrConflictingJob
+	}
+	if s.unsigned != nil {
+		return seqtypes.ErrAlreadySealed
+	}
+	s.unsigned = block
+	return nil
+}
+
+func (s *Sequencer) Sign(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.signed != nil {
+		return seqtypes.ErrAlreadySigned
+	}
+	if s.unsigned == nil {
+		return seqtypes.ErrNotSealed
+	}
+	result, err := s.signer.Sign(ctx, s.unsigned)
+	if err != nil {
+		return err
+	}
+	s.signed = result
+	return nil
+}
+
+func (s *Sequencer) Commit(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.committed {
+		return seqtypes.ErrAlreadyCommitted
+	}
+	if s.signed == nil {
+		return seqtypes.ErrUnsigned
+	}
+	if err := s.committer.Commit(ctx, s.signed); err != nil {
+		return err
+	}
+	s.committed = true
+	return nil
+}
+
+func (s *Sequencer) Publish(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	// re-publishing is allowed
+	return s.publish(ctx)
+}
+
+var errAlreadyPublished = errors.New("block alreadyb published")
+
+func (s *Sequencer) publishMaybe(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.published {
+		// Re-publishing is allowed, but not in the Next() routine
+		// which skips already-completed actions.
+		return errAlreadyPublished
+	}
+	return s.publish(ctx)
+}
+
+func (s *Sequencer) publish(ctx context.Context) error {
+	if !s.committed {
+		return seqtypes.ErrUncommitted
+	}
+	if err := s.publisher.Publish(ctx, s.signed); err != nil {
+		return err
+	}
+	s.published = true
+	return nil
+}
+
+func (s *Sequencer) Next(ctx context.Context) error {
+	if err := s.Open(ctx); err != nil && !(errors.Is(err, seqtypes.ErrAlreadySealed) ||
+		errors.Is(err, seqtypes.ErrConflictingJob)) { // forced-in blocks don't count as job
+		return fmt.Errorf("block-open failed: %w", err)
+	}
+	if err := s.Seal(ctx); err != nil && !errors.Is(err, seqtypes.ErrAlreadySealed) {
+		return fmt.Errorf("block-seal failed: %w", err)
+	}
+	if err := s.Sign(ctx); err != nil && !errors.Is(err, seqtypes.ErrAlreadySigned) {
+		return fmt.Errorf("block-sign failed: %w", err)
+	}
+	if err := s.Commit(ctx); err != nil && !errors.Is(err, seqtypes.ErrAlreadyCommitted) {
+		return fmt.Errorf("block-commit failed: %w", err)
+	}
+	if err := s.publishMaybe(ctx); err != nil && !errors.Is(err, errAlreadyPublished) {
+		return fmt.Errorf("block-publish failed: %w", err)
+	}
+	s.lockingReset()
+	return nil
+}
+
+func (s *Sequencer) lockingReset() {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	s.reset()
+}
+
+func (s *Sequencer) reset() {
+	if s.currentJob != nil {
+		s.currentJob.Close()
+	}
+	s.currentJob = nil
+	s.unsigned = nil
+	s.signed = nil
+	s.committed = false
+	s.published = false
+}
+
+func (s *Sequencer) Start(ctx context.Context, head common.Hash) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	if s.active {
+		return seqtypes.ErrSequencerAlreadyActive
+	}
+	return s.forceStart()
+}
+
+func (s *Sequencer) forceStart() error {
+	// TODO(#14129) start schedule
+	s.reset()
+
+	return seqtypes.ErrNotImplemented
+}
+
+func (s *Sequencer) Stop(ctx context.Context) (hash common.Hash, err error) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	if !s.active {
+		return common.Hash{}, seqtypes.ErrSequencerInactive
+	}
+
+	s.active = false
+	return common.Hash{}, seqtypes.ErrNotImplemented
+	/*
+		// TODO(#14129) stop schedule
+		var last common.Hash
+		s.reset()
+		return last, nil
+	*/
+}
+
+func (s *Sequencer) Active() bool {
+	s.stateMu.RLock()
+	active := s.active
+	s.stateMu.RUnlock()
+	return active
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
@@ -65,7 +65,7 @@ func (s *Sequencer) Open(ctx context.Context) error {
 	}
 
 	opts := &seqtypes.BuildOpts{
-		Parent:   common.Hash{}, // TODO
+		Parent:   common.Hash{}, // TODO(#14124): update sequencer to chain blocks together
 		L1Origin: nil,
 	}
 

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer_test.go
@@ -1,0 +1,419 @@
+package fullseq
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type mockBlock struct{}
+
+func (m *mockBlock) ID() eth.BlockID {
+	return eth.BlockID{Number: 123, Hash: common.Hash{0xff}}
+}
+
+func (m *mockBlock) String() string {
+	return "mock block"
+}
+
+var _ work.Block = (*mockBlock)(nil)
+
+type mockSignedBlock struct {
+	bl work.Block
+}
+
+func (m *mockSignedBlock) ID() eth.BlockID {
+	return m.bl.ID()
+}
+
+func (m *mockSignedBlock) String() string {
+	return "mock signed block"
+}
+
+func (m *mockSignedBlock) VerifySignature() error {
+	return nil
+}
+
+var _ work.SignedBlock = (*mockSignedBlock)(nil)
+
+type mockBuildJob struct {
+	id  seqtypes.BuildJobID
+	bl  work.Block
+	err error
+}
+
+func (m *mockBuildJob) ID() seqtypes.BuildJobID {
+	return m.id
+}
+
+func (m *mockBuildJob) Cancel(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockBuildJob) Seal(ctx context.Context) (work.Block, error) {
+	return m.bl, m.err
+}
+
+func (m *mockBuildJob) String() string {
+	return "mock build job"
+}
+
+func (m *mockBuildJob) Close() {}
+
+var _ work.BuildJob = (*mockBuildJob)(nil)
+
+type mockBuilder struct {
+	id     seqtypes.BuilderID
+	closed bool
+	job    func() (work.BuildJob, error)
+}
+
+func (m *mockBuilder) NewJob(ctx context.Context, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
+	return m.job()
+}
+
+func (m *mockBuilder) String() string {
+	return "mock-builder-" + m.id.String()
+}
+
+func (m *mockBuilder) ID() seqtypes.BuilderID {
+	return m.id
+}
+
+func (m *mockBuilder) Close() error {
+	m.closed = true
+	return nil
+}
+
+var _ work.Builder = (*mockBuilder)(nil)
+
+type mockSigner struct {
+	id     seqtypes.SignerID
+	closed bool
+	err    error
+}
+
+func (m *mockSigner) String() string {
+	return "mock-signer-" + m.id.String()
+}
+
+func (m *mockSigner) ID() seqtypes.SignerID {
+	return m.id
+}
+
+func (m *mockSigner) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockSigner) Sign(ctx context.Context, block work.Block) (work.SignedBlock, error) {
+	return &mockSignedBlock{bl: block}, m.err
+}
+
+var _ work.Signer = (*mockSigner)(nil)
+
+type mockCommitter struct {
+	id     seqtypes.CommitterID
+	closed bool
+	err    error
+}
+
+func (m *mockCommitter) String() string {
+	return "mock-committer-" + m.id.String()
+}
+
+func (m *mockCommitter) ID() seqtypes.CommitterID {
+	return m.id
+}
+
+func (m *mockCommitter) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockCommitter) Commit(ctx context.Context, block work.SignedBlock) error {
+	return m.err
+}
+
+var _ work.Committer = (*mockCommitter)(nil)
+
+type mockPublisher struct {
+	id     seqtypes.PublisherID
+	closed bool
+	err    error
+}
+
+func (m *mockPublisher) String() string {
+	return "mock-publisher-" + m.id.String()
+}
+
+func (m *mockPublisher) ID() seqtypes.PublisherID {
+	return m.id
+}
+
+func (m *mockPublisher) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockPublisher) Publish(ctx context.Context, block work.SignedBlock) error {
+	return m.err
+}
+
+var _ work.Publisher = (*mockPublisher)(nil)
+
+func TestSequencer(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	seqID := seqtypes.SequencerID("seq")
+	builder := &mockBuilder{id: seqtypes.BuilderID("builder")}
+	signer := &mockSigner{id: seqtypes.SignerID("signer")}
+	committer := &mockCommitter{id: seqtypes.CommitterID("committer")}
+	publisher := &mockPublisher{id: seqtypes.PublisherID("publisher")}
+	seq := &Sequencer{
+		id:        seqID,
+		chainID:   eth.ChainIDFromUInt64(1),
+		log:       logger,
+		m:         &metrics.NoopMetrics{},
+		builder:   builder,
+		signer:    signer,
+		committer: committer,
+		publisher: publisher,
+	}
+	require.Contains(t, seq.String(), "sequencer")
+	ctx := context.Background()
+
+	resetBuildJob := func() {
+		job := &mockBuildJob{
+			id:  seqtypes.RandomJobID(),
+			bl:  &mockBlock{},
+			err: nil,
+		}
+		builder.job = func() (work.BuildJob, error) {
+			return job, nil
+		}
+	}
+	t.Run("no action without the pre-requisite action", func(t *testing.T) {
+		seq.reset()
+		require.ErrorIs(t, seq.Seal(ctx), seqtypes.ErrUnknownJob)
+		require.ErrorIs(t, seq.Sign(ctx), seqtypes.ErrNotSealed)
+		require.ErrorIs(t, seq.Commit(ctx), seqtypes.ErrUnsigned)
+		require.ErrorIs(t, seq.Publish(ctx), seqtypes.ErrUncommitted)
+	})
+
+	t.Run("do a full routine", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.Nil(t, seq.BuildJob(), "no job yet")
+		require.NoError(t, seq.Open(ctx))
+		require.ErrorIs(t, seq.Open(ctx), seqtypes.ErrConflictingJob)
+		require.NotNil(t, seq.BuildJob(), "job is opened")
+		require.NoError(t, seq.Seal(ctx))
+		require.ErrorIs(t, seq.Seal(ctx), seqtypes.ErrAlreadySealed)
+		require.NoError(t, seq.Sign(ctx))
+		require.ErrorIs(t, seq.Sign(ctx), seqtypes.ErrAlreadySigned)
+		require.NoError(t, seq.Commit(ctx))
+		require.ErrorIs(t, seq.Commit(ctx), seqtypes.ErrAlreadyCommitted)
+		require.NoError(t, seq.Publish(ctx))
+		require.NoError(t, seq.Publish(ctx), "re-publishing blocks is allowed")
+	})
+
+	t.Run("continue from scratch", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("continue from open block", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("continue from sealed block", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("continue from signed block", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.NoError(t, seq.Sign(ctx))
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("continue from committed block", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.NoError(t, seq.Sign(ctx))
+		require.NoError(t, seq.Commit(ctx))
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("continue from published block", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.NoError(t, seq.Sign(ctx))
+		require.NoError(t, seq.Commit(ctx))
+		require.NoError(t, seq.Publish(ctx))
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("continue from prebuilt block", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		bl := &mockBlock{}
+		require.NoError(t, seq.Prebuilt(ctx, bl))
+		require.NoError(t, seq.Sign(ctx))
+		require.Equal(t, bl, seq.signed.(*mockSignedBlock).bl)
+		require.NoError(t, seq.Commit(ctx))
+		require.NoError(t, seq.Next(ctx))
+	})
+
+	t.Run("no prebuilt after job open", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		bl := &mockBlock{}
+		require.NoError(t, seq.Open(ctx))
+		require.ErrorIs(t, seq.Prebuilt(ctx, bl), seqtypes.ErrConflictingJob)
+	})
+
+	t.Run("no prebuilt after job", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		bl := &mockBlock{}
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.ErrorIs(t, seq.Prebuilt(ctx, bl), seqtypes.ErrConflictingJob)
+	})
+
+	t.Run("no duplicate prebuilt", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		bl := &mockBlock{}
+		require.NoError(t, seq.Prebuilt(ctx, bl))
+		require.ErrorIs(t, seq.Prebuilt(ctx, bl), seqtypes.ErrAlreadySealed)
+	})
+
+	t.Run("fail to open", func(t *testing.T) {
+		seq.reset()
+		testErr := errors.New("test open err")
+		builder.job = func() (work.BuildJob, error) {
+			return nil, testErr
+		}
+		require.ErrorIs(t, seq.Open(ctx), testErr)
+		require.ErrorIs(t, seq.Next(ctx), testErr)
+	})
+
+	t.Run("fail to seal", func(t *testing.T) {
+		seq.reset()
+		testErr := errors.New("test seal err")
+		job := &mockBuildJob{
+			id:  seqtypes.RandomJobID(),
+			bl:  nil,
+			err: testErr,
+		}
+		builder.job = func() (work.BuildJob, error) {
+			return job, nil
+		}
+		require.NoError(t, seq.Open(ctx))
+		require.ErrorIs(t, seq.Seal(ctx), testErr)
+		require.ErrorIs(t, seq.Next(ctx), testErr)
+	})
+
+	t.Run("fail to sign", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		testErr := errors.New("test sign err")
+		signer.err = testErr
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.ErrorIs(t, seq.Sign(ctx), testErr)
+		require.ErrorIs(t, seq.Next(ctx), testErr)
+		signer.err = nil
+	})
+
+	t.Run("fail to commit", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		testErr := errors.New("test commit err")
+		committer.err = testErr
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.NoError(t, seq.Sign(ctx))
+		require.ErrorIs(t, seq.Commit(ctx), testErr)
+		require.ErrorIs(t, seq.Next(ctx), testErr)
+		committer.err = nil
+	})
+
+	t.Run("fail to publish", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		testErr := errors.New("test publish err")
+		publisher.err = testErr
+		require.NoError(t, seq.Open(ctx))
+		require.NoError(t, seq.Seal(ctx))
+		require.NoError(t, seq.Sign(ctx))
+		require.NoError(t, seq.Commit(ctx))
+		require.ErrorIs(t, seq.Publish(ctx), testErr)
+		require.ErrorIs(t, seq.Next(ctx), testErr)
+		publisher.err = nil
+	})
+
+	t.Run("sequencer start/stop", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		require.False(t, seq.Active())
+		// Start/stop not supported yet
+		require.ErrorIs(t, seq.Start(ctx, common.Hash{}), seqtypes.ErrNotImplemented)
+		seq.active = true
+		_, err := seq.Stop(ctx)
+		require.ErrorIs(t, err, seqtypes.ErrNotImplemented)
+		// inactive again
+		require.False(t, seq.Active())
+	})
+
+	t.Run("no duplicate start", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		seq.active = true
+		require.ErrorIs(t, seq.Start(ctx, common.Hash{}), seqtypes.ErrSequencerAlreadyActive)
+		seq.active = false
+	})
+
+	t.Run("no duplicate stop", func(t *testing.T) {
+		seq.reset()
+		resetBuildJob()
+		seq.active = false
+		_, err := seq.Stop(ctx)
+		require.ErrorIs(t, err, seqtypes.ErrSequencerInactive)
+	})
+
+	require.NoError(t, seq.Close())
+	// other services are independent, not closed as part of the sequencer,
+	// but closed as part of the total ensemble.
+	require.False(t, builder.closed)
+	require.False(t, signer.closed)
+	require.False(t, committer.closed)
+	require.False(t, publisher.closed)
+
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/config.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/config.go
@@ -1,0 +1,18 @@
+package noopseq
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.SequencerID, opts *work.ServiceOpts) (work.Sequencer, error) {
+	return &Sequencer{
+		id:  id,
+		log: opts.Log,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/config_test.go
@@ -1,0 +1,32 @@
+package noopseq
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := &Config{}
+	id := seqtypes.SequencerID("test")
+	ensemble := &work.Ensemble{}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: ensemble,
+	}
+	sequencer, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, sequencer.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/sequencer.go
@@ -1,0 +1,78 @@
+package noopseq
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Sequencer struct {
+	id  seqtypes.SequencerID
+	log log.Logger
+}
+
+var _ work.Sequencer = (*Sequencer)(nil)
+
+func NewSequencer(id seqtypes.SequencerID, log log.Logger) *Sequencer {
+	return &Sequencer{id: id, log: log}
+}
+
+func (n *Sequencer) Close() error {
+	return nil
+}
+
+func (n *Sequencer) String() string {
+	return "noop-sequencer-" + n.id.String()
+}
+
+func (n *Sequencer) ID() seqtypes.SequencerID {
+	return n.id
+}
+
+func (n *Sequencer) Open(ctx context.Context) error {
+	return nil
+}
+
+func (n *Sequencer) BuildJob() work.BuildJob {
+	return nil
+}
+
+func (n *Sequencer) Seal(ctx context.Context) error {
+	return nil
+}
+
+func (n *Sequencer) Prebuilt(ctx context.Context, block work.Block) error {
+	return nil
+}
+
+func (n *Sequencer) Sign(ctx context.Context) error {
+	return nil
+}
+
+func (n *Sequencer) Commit(ctx context.Context) error {
+	return nil
+}
+
+func (n *Sequencer) Publish(ctx context.Context) error {
+	return nil
+}
+
+func (n *Sequencer) Next(ctx context.Context) error {
+	return nil
+}
+
+func (n *Sequencer) Start(ctx context.Context, head common.Hash) error {
+	return seqtypes.ErrSequencerInactive
+}
+
+func (n *Sequencer) Stop(ctx context.Context) (last common.Hash, err error) {
+	return common.Hash{}, seqtypes.ErrSequencerInactive
+}
+
+func (n *Sequencer) Active() bool {
+	return false
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/sequencer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/sequencer_test.go
@@ -1,0 +1,40 @@
+package noopseq
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestNoopSequencer(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.SequencerID("foo")
+	x := NewSequencer(id, logger)
+
+	ctx := context.Background()
+	require.NoError(t, x.Open(ctx))
+	job := x.BuildJob()
+	require.Nil(t, job)
+	require.NoError(t, x.Seal(ctx))
+	require.NoError(t, x.Prebuilt(ctx, nil))
+	require.NoError(t, x.Sign(ctx))
+	require.NoError(t, x.Commit(ctx))
+	require.NoError(t, x.Publish(ctx))
+	require.NoError(t, x.Next(ctx))
+	err := x.Start(ctx, common.Hash{})
+	require.ErrorIs(t, err, seqtypes.ErrSequencerInactive)
+	_, err = x.Stop(ctx)
+	require.ErrorIs(t, err, seqtypes.ErrSequencerInactive)
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "noop-sequencer-foo", x.String())
+	require.Equal(t, id, x.ID())
+	require.False(t, x.Active())
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/noopsigner/config.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/noopsigner/config.go
@@ -1,0 +1,18 @@
+package noopsigner
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.SignerID, opts *work.ServiceOpts) (work.Signer, error) {
+	return &Signer{
+		id:  id,
+		log: opts.Log,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/noopsigner/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/noopsigner/config_test.go
@@ -1,0 +1,32 @@
+package noopsigner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := &Config{}
+	id := seqtypes.SignerID("test")
+	ensemble := &work.Ensemble{}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: ensemble,
+	}
+	signer, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, signer.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/noopsigner/publisher.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/noopsigner/publisher.go
@@ -1,0 +1,38 @@
+package noopsigner
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Signer struct {
+	id  seqtypes.SignerID
+	log log.Logger
+}
+
+var _ work.Signer = (*Signer)(nil)
+
+func NewSigner(id seqtypes.SignerID, log log.Logger) *Signer {
+	return &Signer{id: id, log: log}
+}
+
+func (n *Signer) Close() error {
+	return nil
+}
+
+func (n *Signer) String() string {
+	return "noop-signer-" + n.id.String()
+}
+
+func (n *Signer) ID() seqtypes.SignerID {
+	return n.id
+}
+
+func (n *Signer) Sign(ctx context.Context, block work.Block) (work.SignedBlock, error) {
+	n.log.Info("No-op sign", "block", block)
+	return nil, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/noopsigner/publisher_test.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/noopsigner/publisher_test.go
@@ -1,0 +1,26 @@
+package noopsigner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestNoopSigner(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.SignerID("foo")
+	x := NewSigner(id, logger)
+
+	_, err := x.Sign(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "noop-signer-foo", x.String())
+	require.Equal(t, id, x.ID())
+}

--- a/op-test-sequencer/sequencer/frontend/admin.go
+++ b/op-test-sequencer/sequencer/frontend/admin.go
@@ -2,12 +2,12 @@ package frontend
 
 import "context"
 
-type Backend interface {
+type AdminBackend interface {
 	Hello(ctx context.Context, name string) (string, error)
 }
 
 type AdminFrontend struct {
-	Backend Backend
+	Backend AdminBackend
 }
 
 func (af *AdminFrontend) Hello(ctx context.Context, name string) (string, error) {

--- a/op-test-sequencer/sequencer/frontend/admin_test.go
+++ b/op-test-sequencer/sequencer/frontend/admin_test.go
@@ -1,0 +1,24 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockAdminBackend struct{}
+
+func (m *mockAdminBackend) Hello(ctx context.Context, name string) (string, error) {
+	return "hello " + name, nil
+}
+
+var _ AdminBackend = (*mockAdminBackend)(nil)
+
+func TestAdmin(t *testing.T) {
+	b := &mockAdminBackend{}
+	front := &AdminFrontend{Backend: b}
+	out, err := front.Hello(context.Background(), "world")
+	require.NoError(t, err)
+	require.Equal(t, "hello world", out)
+}

--- a/op-test-sequencer/sequencer/frontend/builder.go
+++ b/op-test-sequencer/sequencer/frontend/builder.go
@@ -1,0 +1,55 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type BuildBackend interface {
+	CreateJob(ctx context.Context, id seqtypes.BuilderID, opts *seqtypes.BuildOpts) (work.BuildJob, error)
+	GetJob(id seqtypes.BuildJobID) work.BuildJob
+}
+
+type BuildFrontend struct {
+	Backend BuildBackend
+}
+
+func (bf *BuildFrontend) Open(ctx context.Context, builderID seqtypes.BuilderID, opts *seqtypes.BuildOpts) (seqtypes.BuildJobID, error) {
+	job, err := bf.Backend.CreateJob(ctx, builderID, opts)
+	if err != nil {
+		return "", err
+	}
+	return job.ID(), nil
+}
+
+func (bf *BuildFrontend) Cancel(ctx context.Context, jobID seqtypes.BuildJobID) error {
+	job := bf.Backend.GetJob(jobID)
+	if job == nil {
+		return seqtypes.ErrUnknownJob
+	}
+	return toJsonError(job.Cancel(ctx))
+}
+
+func (bf *BuildFrontend) Seal(ctx context.Context, jobID seqtypes.BuildJobID) (work.Block, error) {
+	job := bf.Backend.GetJob(jobID)
+	if job == nil {
+		return eth.BlockRef{}, seqtypes.ErrUnknownJob
+	}
+	result, err := job.Seal(ctx)
+	if err != nil {
+		return nil, toJsonError(err)
+	}
+	return result, nil
+}
+
+func (bf *BuildFrontend) CloseJob(id seqtypes.BuildJobID) error {
+	job := bf.Backend.GetJob(id)
+	if job == nil {
+		return seqtypes.ErrUnknownJob
+	}
+	job.Close()
+	return nil
+}

--- a/op-test-sequencer/sequencer/frontend/builder_test.go
+++ b/op-test-sequencer/sequencer/frontend/builder_test.go
@@ -1,0 +1,182 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type mockBlock struct {
+	From    seqtypes.BuildJobID `json:"from"`
+	BlockID eth.BlockID
+}
+
+func (m *mockBlock) ID() eth.BlockID {
+	return m.BlockID
+}
+
+func (m *mockBlock) String() string {
+	return m.From.String() + "-" + m.BlockID.String()
+}
+
+var _ work.Block = (*mockBlock)(nil)
+
+type mockBuildJob struct {
+	id         seqtypes.BuildJobID
+	canceled   bool
+	sealed     bool
+	result     work.Block
+	err        error
+	unregister func()
+}
+
+func (m *mockBuildJob) ID() seqtypes.BuildJobID {
+	return m.id
+}
+
+func (m *mockBuildJob) Cancel(ctx context.Context) error {
+	m.canceled = true
+	return m.err
+}
+
+func (m *mockBuildJob) Seal(ctx context.Context) (work.Block, error) {
+	m.sealed = true
+	return m.result, m.err
+}
+
+func (m *mockBuildJob) String() string {
+	return "mock-build-job-" + m.id.String()
+}
+
+func (m *mockBuildJob) Close() {
+	m.unregister()
+}
+
+var _ work.BuildJob = (*mockBuildJob)(nil)
+
+type mockBuildBackend struct {
+	jobs map[seqtypes.BuildJobID]*mockBuildJob
+}
+
+const (
+	testBuilderA = seqtypes.BuilderID("builder-a")
+	testBuilderB = seqtypes.BuilderID("builder-b")
+)
+
+func (m *mockBuildBackend) CreateJob(ctx context.Context, id seqtypes.BuilderID, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
+	if id == testBuilderB {
+		return nil, seqtypes.ErrUnknownBuilder
+	}
+	jobID := seqtypes.RandomJobID()
+	job := &mockBuildJob{
+		id:       jobID,
+		canceled: false,
+		sealed:   false,
+		result: &mockBlock{
+			From:    jobID,
+			BlockID: eth.BlockID{Number: 123, Hash: crypto.Keccak256Hash([]byte(jobID))},
+		},
+		unregister: func() {
+			m.UnregisterJob(jobID)
+		},
+	}
+	m.jobs[jobID] = job
+	return job, nil
+}
+
+func (m *mockBuildBackend) GetJob(id seqtypes.BuildJobID) work.BuildJob {
+	job, ok := m.jobs[id]
+	if !ok {
+		return nil
+	}
+	return job
+}
+
+func (m *mockBuildBackend) UnregisterJob(id seqtypes.BuildJobID) {
+	delete(m.jobs, id)
+}
+
+var _ BuildBackend = (*mockBuildBackend)(nil)
+
+func TestBuildFrontend(t *testing.T) {
+	backend := &mockBuildBackend{
+		jobs: make(map[seqtypes.BuildJobID]*mockBuildJob),
+	}
+	front := &BuildFrontend{Backend: backend}
+	ctx := context.Background()
+
+	t.Run("unknown builder", func(t *testing.T) {
+		_, err := front.Open(ctx, testBuilderB, nil)
+		require.ErrorIs(t, err, seqtypes.ErrUnknownBuilder)
+	})
+
+	t.Run("non-existent jobs", func(t *testing.T) {
+		err := front.Cancel(ctx, seqtypes.RandomJobID())
+		require.ErrorIs(t, err, seqtypes.ErrUnknownJob)
+
+		_, err = front.Seal(ctx, seqtypes.RandomJobID())
+		require.ErrorIs(t, err, seqtypes.ErrUnknownJob)
+		err = front.CloseJob(seqtypes.RandomJobID())
+		require.ErrorIs(t, err, seqtypes.ErrUnknownJob)
+	})
+
+	t.Run("seal", func(t *testing.T) {
+		jobID, err := front.Open(ctx, testBuilderA, nil)
+		require.NoError(t, err)
+
+		require.False(t, backend.jobs[jobID].sealed)
+
+		block, err := front.Seal(ctx, jobID)
+		require.NoError(t, err)
+		require.Equal(t, uint64(123), block.ID().Number)
+		require.Equal(t, crypto.Keccak256Hash([]byte(jobID)), block.ID().Hash)
+
+		require.Contains(t, backend.jobs, jobID)
+		require.True(t, backend.jobs[jobID].sealed)
+		require.NoError(t, front.CloseJob(jobID))
+		require.NotContains(t, backend.jobs, jobID)
+	})
+
+	t.Run("seal error", func(t *testing.T) {
+		jobID, err := front.Open(ctx, testBuilderA, nil)
+		require.NoError(t, err)
+		require.False(t, backend.jobs[jobID].sealed)
+		backend.jobs[jobID].err = seqtypes.ErrAlreadySealed
+		_, err = front.Seal(ctx, jobID)
+		require.ErrorIs(t, err, seqtypes.ErrAlreadySealed)
+		require.Contains(t, backend.jobs, jobID)
+		require.NoError(t, front.CloseJob(jobID))
+		require.NotContains(t, backend.jobs, jobID)
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		jobID, err := front.Open(ctx, testBuilderA, nil)
+		require.NoError(t, err)
+		require.False(t, backend.jobs[jobID].canceled)
+		err = front.Cancel(ctx, jobID)
+		require.NoError(t, err)
+		require.Contains(t, backend.jobs, jobID)
+		require.True(t, backend.jobs[jobID].canceled)
+		require.NoError(t, front.CloseJob(jobID))
+		require.NotContains(t, backend.jobs, jobID)
+	})
+
+	t.Run("cancel error", func(t *testing.T) {
+		jobID, err := front.Open(ctx, testBuilderA, nil)
+		require.NoError(t, err)
+		require.False(t, backend.jobs[jobID].canceled)
+		backend.jobs[jobID].err = seqtypes.ErrAlreadySealed
+		err = front.Cancel(ctx, jobID)
+		require.ErrorIs(t, err, seqtypes.ErrAlreadySealed)
+		require.Contains(t, backend.jobs, jobID)
+		require.NoError(t, front.CloseJob(jobID))
+		require.NotContains(t, backend.jobs, jobID)
+	})
+}

--- a/op-test-sequencer/sequencer/frontend/sequencer.go
+++ b/op-test-sequencer/sequencer/frontend/sequencer.go
@@ -1,0 +1,82 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type SequencerFrontend struct {
+	Sequencer work.Sequencer
+}
+
+func (bf *SequencerFrontend) Open(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Open(ctx))
+}
+
+func (bf *SequencerFrontend) BuildJob() (seqtypes.BuildJobID, error) {
+	job := bf.Sequencer.BuildJob()
+	if job == nil {
+		return "", toJsonError(seqtypes.ErrUnknownJob)
+	}
+	return job.ID(), nil
+}
+
+func (bf *SequencerFrontend) Seal(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Seal(ctx))
+}
+
+func (bf *SequencerFrontend) PrebuiltEnvelope(ctx context.Context, block *eth.ExecutionPayloadEnvelope) error {
+	return toJsonError(bf.Sequencer.Prebuilt(ctx, block))
+}
+
+func (bf *SequencerFrontend) Sign(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Sign(ctx))
+}
+
+func (bf *SequencerFrontend) Commit(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Commit(ctx))
+}
+
+func (bf *SequencerFrontend) Publish(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Publish(ctx))
+}
+
+func (bf *SequencerFrontend) Next(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Next(ctx))
+}
+
+func (bf *SequencerFrontend) Start(ctx context.Context, head common.Hash) error {
+	return toJsonError(bf.Sequencer.Start(ctx, head))
+}
+
+func (bf *SequencerFrontend) Stop(ctx context.Context) (last common.Hash, err error) {
+	last, err = bf.Sequencer.Stop(ctx)
+	if err != nil {
+		return common.Hash{}, toJsonError(err)
+	}
+	return
+}
+
+type IncludeTxSupport interface {
+	IncludeTx(ctx context.Context, tx hexutil.Bytes) error
+}
+
+func (bf *SequencerFrontend) IncludeTx(ctx context.Context, tx hexutil.Bytes) error {
+	job := bf.Sequencer.BuildJob()
+	if job == nil {
+		return seqtypes.ErrUnknownJob
+	}
+	// Not all build-jobs may support manual forced tx inclusion
+	x, ok := job.(IncludeTxSupport)
+	if !ok {
+		return &rpc.JsonError{Code: -39000, Message: "not supported"}
+	}
+	return toJsonError(x.IncludeTx(ctx, tx))
+}

--- a/op-test-sequencer/sequencer/frontend/sequencer_test.go
+++ b/op-test-sequencer/sequencer/frontend/sequencer_test.go
@@ -1,0 +1,165 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type advancedBuildJob struct {
+	mockBuildJob
+	txs []hexutil.Bytes
+}
+
+var _ work.BuildJob = (*advancedBuildJob)(nil)
+var _ IncludeTxSupport = (*advancedBuildJob)(nil)
+
+func (a *advancedBuildJob) IncludeTx(ctx context.Context, tx hexutil.Bytes) error {
+	a.txs = append(a.txs, tx)
+	return nil
+}
+
+type mockSequencer struct {
+	id     seqtypes.SequencerID
+	job    work.BuildJob
+	err    error
+	action string
+}
+
+func (m *mockSequencer) String() string {
+	return "test"
+}
+
+func (m *mockSequencer) ID() seqtypes.SequencerID {
+	return m.id
+}
+
+func (m *mockSequencer) Close() error {
+	return m.err
+}
+
+func (m *mockSequencer) Open(ctx context.Context) error {
+	m.action = "open"
+	return m.err
+}
+
+func (m *mockSequencer) BuildJob() work.BuildJob {
+	return m.job
+}
+
+func (m *mockSequencer) Seal(ctx context.Context) error {
+	m.action = "seal"
+	return m.err
+}
+
+func (m *mockSequencer) Prebuilt(ctx context.Context, block work.Block) error {
+	m.action = "prebuilt"
+	return m.err
+}
+
+func (m *mockSequencer) Sign(ctx context.Context) error {
+	m.action = "sign"
+	return m.err
+}
+
+func (m *mockSequencer) Commit(ctx context.Context) error {
+	m.action = "commit"
+	return m.err
+}
+
+func (m *mockSequencer) Publish(ctx context.Context) error {
+	m.action = "publish"
+	return m.err
+}
+
+func (m *mockSequencer) Next(ctx context.Context) error {
+	m.action = "next"
+	return m.err
+}
+
+func (m *mockSequencer) Start(ctx context.Context, head common.Hash) error {
+	m.action = "start"
+	return m.err
+}
+
+func (m *mockSequencer) Stop(ctx context.Context) (last common.Hash, err error) {
+	m.action = "stop"
+	return common.Hash{0: 42}, m.err
+}
+
+func (m *mockSequencer) Active() bool {
+	m.action = "active"
+	return false
+}
+
+var _ work.Sequencer = (*mockSequencer)(nil)
+
+func TestSequencer(t *testing.T) {
+	seqId := seqtypes.SequencerID("foobar")
+	seq := &mockSequencer{id: seqId}
+	front := &SequencerFrontend{Sequencer: seq}
+
+	ctx := context.Background()
+
+	t.Run("unknown job", func(t *testing.T) {
+		_, err := front.BuildJob()
+		seq.err = seqtypes.ErrUnknownJob
+		require.ErrorIs(t, err, seqtypes.ErrUnknownJob)
+		seq.err = nil
+	})
+	t.Run("include tx", func(t *testing.T) {
+		dest := &advancedBuildJob{
+			mockBuildJob: mockBuildJob{id: seqtypes.RandomJobID()},
+			txs:          nil,
+		}
+		seq.job = dest
+		jobId, err := front.BuildJob()
+		require.NoError(t, err)
+		require.Equal(t, seq.job.ID(), jobId)
+		require.NoError(t, front.IncludeTx(ctx, []byte("test")))
+		require.NotEmpty(t, dest.txs)
+		seq.job = nil
+		require.ErrorIs(t, front.IncludeTx(ctx, []byte("abc")), seqtypes.ErrUnknownJob)
+		seq.job = &mockBuildJob{}
+		require.ErrorContains(t, front.IncludeTx(ctx, []byte("123")), "not supported")
+		seq.job = nil
+	})
+	t.Run("step by step", func(t *testing.T) {
+		seq.action = ""
+		require.NoError(t, front.Open(ctx))
+		require.Equal(t, "open", seq.action)
+		require.NoError(t, front.Seal(ctx))
+		require.Equal(t, "seal", seq.action)
+		require.NoError(t, front.Sign(ctx))
+		require.Equal(t, "sign", seq.action)
+		require.NoError(t, front.Commit(ctx))
+		require.Equal(t, "commit", seq.action)
+		require.NoError(t, front.Publish(ctx))
+		require.Equal(t, "publish", seq.action)
+		require.NoError(t, front.Next(ctx))
+		require.Equal(t, "next", seq.action)
+		require.NoError(t, front.PrebuiltEnvelope(ctx, nil))
+		require.Equal(t, "prebuilt", seq.action)
+		seq.action = ""
+	})
+	t.Run("start stop", func(t *testing.T) {
+		seq.err = seqtypes.ErrSequencerAlreadyActive
+		require.ErrorIs(t, front.Start(ctx, common.Hash{0: 123}), seqtypes.ErrSequencerAlreadyActive)
+		seq.err = nil
+		require.NoError(t, front.Start(ctx, common.Hash{0: 123}))
+		out, err := front.Stop(ctx)
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{0: 42}, out)
+		seq.err = seqtypes.ErrSequencerInactive
+		_, err = front.Stop(ctx)
+		require.ErrorIs(t, err, seqtypes.ErrSequencerInactive)
+		seq.err = nil
+	})
+}

--- a/op-test-sequencer/sequencer/frontend/util.go
+++ b/op-test-sequencer/sequencer/frontend/util.go
@@ -1,0 +1,25 @@
+package frontend
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+// toJsonError turns the error into a JSON error with error-code,
+// to preserve the code when the error is wrapped
+func toJsonError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var x *rpc.JsonError
+	if errors.As(err, &x) {
+		return x
+	}
+	return &rpc.JsonError{
+		Code:    seqtypes.ErrUnknownKind.Code,
+		Message: err.Error(),
+	}
+}

--- a/op-test-sequencer/sequencer/seqtypes/types.go
+++ b/op-test-sequencer/sequencer/seqtypes/types.go
@@ -1,0 +1,154 @@
+package seqtypes
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const maxIDLength = 100
+
+var ErrInvalidID = errors.New("invalid ID")
+
+type genericID string
+
+func (id genericID) String() string {
+	return string(id)
+}
+
+func (id genericID) MarshalText() ([]byte, error) {
+	if len(id) > maxIDLength {
+		return nil, ErrInvalidID
+	}
+	return []byte(id), nil
+}
+
+func (id *genericID) UnmarshalText(data []byte) error {
+	if len(data) > maxIDLength {
+		return ErrInvalidID
+	}
+	*id = genericID(data)
+	return nil
+}
+
+// BuildJobID identifies a block-building job.
+// Multiple alternative blocks may be built in parallel.
+type BuildJobID genericID
+
+func (id BuildJobID) String() string {
+	return genericID(id).String()
+}
+
+func (id BuildJobID) MarshalText() ([]byte, error) {
+	return genericID(id).MarshalText()
+}
+
+func (id *BuildJobID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).UnmarshalText(data)
+}
+
+type BuilderID genericID
+
+func (id BuilderID) String() string {
+	return genericID(id).String()
+}
+
+func (id BuilderID) MarshalText() ([]byte, error) {
+	return genericID(id).MarshalText()
+}
+
+func (id *BuilderID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).UnmarshalText(data)
+}
+
+type SignerID genericID
+
+func (id SignerID) String() string {
+	return genericID(id).String()
+}
+
+func (id SignerID) MarshalText() ([]byte, error) {
+	return genericID(id).MarshalText()
+}
+
+func (id *SignerID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).UnmarshalText(data)
+}
+
+type CommitterID genericID
+
+func (id CommitterID) String() string {
+	return genericID(id).String()
+}
+
+func (id CommitterID) MarshalText() ([]byte, error) {
+	return genericID(id).MarshalText()
+}
+
+func (id *CommitterID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).UnmarshalText(data)
+}
+
+type PublisherID genericID
+
+func (id PublisherID) String() string {
+	return genericID(id).String()
+}
+
+func (id PublisherID) MarshalText() ([]byte, error) {
+	return genericID(id).MarshalText()
+}
+
+func (id *PublisherID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).UnmarshalText(data)
+}
+
+type SequencerID genericID
+
+func (id SequencerID) String() string {
+	return genericID(id).String()
+}
+
+func (id SequencerID) MarshalText() ([]byte, error) {
+	return genericID(id).MarshalText()
+}
+
+func (id *SequencerID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).UnmarshalText(data)
+}
+
+var (
+	ErrGeneric                = &rpc.JsonError{Code: -38500, Message: "sequencer error"}
+	ErrUnknownKind            = &rpc.JsonError{Code: -38501, Message: "unknown kind"}
+	ErrUnknownBuilder         = &rpc.JsonError{Code: -38502, Message: "unknown builder"}
+	ErrNotImplemented         = &rpc.JsonError{Code: -38503, Message: "not implemented"}
+	ErrUnknownJob             = &rpc.JsonError{Code: -38510, Message: "unknown job"}
+	ErrConflictingJob         = &rpc.JsonError{Code: -38511, Message: "conflicting job"}
+	ErrNotSealed              = &rpc.JsonError{Code: -38520, Message: "block not yet sealed"}
+	ErrAlreadySealed          = &rpc.JsonError{Code: -38521, Message: "block already sealed"}
+	ErrUnsigned               = &rpc.JsonError{Code: -38530, Message: "block not yet signed"}
+	ErrAlreadySigned          = &rpc.JsonError{Code: -38531, Message: "block already signed"}
+	ErrUncommitted            = &rpc.JsonError{Code: -38540, Message: "block not yet committed"}
+	ErrAlreadyCommitted       = &rpc.JsonError{Code: -38541, Message: "block already committed"}
+	ErrSequencerInactive      = &rpc.JsonError{Code: -38550, Message: "sequencer inactive"}
+	ErrSequencerAlreadyActive = &rpc.JsonError{Code: -38551, Message: "sequencer already active"}
+	ErrBackendInactive        = &rpc.JsonError{Code: -38560, Message: "backend inactive"}
+	ErrBackendAlreadyStarted  = &rpc.JsonError{Code: -38561, Message: "backend already started"}
+)
+
+func RandomJobID() BuildJobID {
+	return BuildJobID("job-" + uuid.New().String())
+}
+
+type BuildOpts struct {
+	// Parent block to build on top of
+	Parent common.Hash `json:"parent"`
+
+	// L1Origin overrides the L1 origin of the block.
+	// Optional, by default the L1 origin of the parent block
+	// is progressed when first allowed (respecting time invariants).
+	L1Origin *common.Hash `json:"l1Origin,omitempty"`
+}

--- a/op-test-sequencer/sequencer/seqtypes/types_test.go
+++ b/op-test-sequencer/sequencer/seqtypes/types_test.go
@@ -1,0 +1,66 @@
+package seqtypes
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDs(t *testing.T) {
+	testID[*genericID](t, func() *genericID {
+		return new(genericID)
+	})
+	testID[*BuilderID](t, func() *BuilderID {
+		return new(BuilderID)
+	})
+	testID[*SignerID](t, func() *SignerID {
+		return new(SignerID)
+	})
+	testID[*CommitterID](t, func() *CommitterID {
+		return new(CommitterID)
+	})
+	testID[*PublisherID](t, func() *PublisherID {
+		return new(PublisherID)
+	})
+	testID[*SequencerID](t, func() *SequencerID {
+		return new(SequencerID)
+	})
+	testID[*BuildJobID](t, func() *BuildJobID {
+		return new(BuildJobID)
+	})
+}
+
+type id interface {
+	String() string
+	MarshalText() ([]byte, error)
+	UnmarshalText(data []byte) error
+}
+
+func testID[K id](t *testing.T, alloc func() K) {
+	var x K
+	name := fmt.Sprintf("%T", x)
+	t.Run(name, func(t *testing.T) {
+		v := alloc()
+		require.Equal(t, "", v.String())
+		out, err := v.MarshalText()
+		require.NoError(t, err)
+		require.Len(t, out, 0)
+		v = alloc()
+		require.NoError(t, v.UnmarshalText([]byte("123abc")))
+		require.Equal(t, "123abc", v.String())
+		out, err = v.MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, "123abc", string(out))
+
+		require.NoError(t, v.UnmarshalText(bytes.Repeat([]byte{'1'}, maxIDLength)))
+		require.ErrorIs(t, v.UnmarshalText(bytes.Repeat([]byte{'1'}, maxIDLength+1)), ErrInvalidID)
+	})
+}
+
+func TestRandomJobID(t *testing.T) {
+	a := RandomJobID()
+	b := RandomJobID()
+	require.NotEqual(t, a, b)
+}

--- a/op-test-sequencer/sequencer/service_test.go
+++ b/op-test-sequencer/sequencer/service_test.go
@@ -51,12 +51,13 @@ func TestService(t *testing.T) {
 		JWTSecretPath: filepath.Join(t.TempDir(), "test_jwt_secret.txt"),
 	}
 	logger := testlog.Logger(t, log.LevelError)
+
 	s, err := FromConfig(context.Background(), cfg, logger)
 	require.NoError(t, err)
 	require.NoError(t, s.Start(context.Background()), "start service")
 	// run some RPC tests against the service with the mock backend
 	{
-		endpoint := "http://" + s.rpcServer.Endpoint()
+		endpoint := s.httpServer.HTTPEndpoint()
 		t.Logf("dialing %s", endpoint)
 		opts := []client.RPCOption{
 			client.WithFixedDialBackoff(time.Second * 5),


### PR DESCRIPTION
**Description**

This PR builds on top of #14270 
This adds the config and typing structure, to manage all the sequencer sub-responsibilities:
- builder: create the block (e.g. with op-node, a test-specific builder, or something external)
- signer: sign the block (e.g. using local key, or using remote op-signer)
- committer: persist the block as canonical (e.g. to local node, and/or with op-conductor)
- publisher: distribute the block
- sequencer: to run through the above steps easily, like a composed configuration, that can loop.

The collection of the above is tentatively named an "ensemble".
Multiple sequencers can be configured, e.g. one per chain, or different test sequencers, to enable some test-specific behaviors without restarting the whole kurtosis stack.

This PR aims to add the minimum implementations, for testing: noop version of all of the above, and a sequencer implementation that combines it all.

Work in progress, to cover main line of sequencing (TBD: likely will split this into a stacked PR):
- local builder (op-node needs endpoint to open/seal a block using engine API, while keeping forkchoice compatible)
- local signer
- local committer (op-node needs to execute the newPayload call, and the forkchoice update)
- local publisher (op-node needs to publish to gossip)

For testing specifically, we now have the option to:
- configure customized builders, that can then insert txs etc. as desired

Also see README update: 
- the main RPC can expose any things, like a build API to interact with the build jobs
- each configured sequencer has its own RPC (!), making it much easier to interact with the sequencer, without parameterizing the sequencer-ID everywhere. We can make this serve `eth_sendRawTransaction` too, so test-tools can submit their txs to a queue, and the test-sequencer can just hand that list of txs as a pre-built block template to the op-node for processing.


**Tests**

Unit-tested all the new types, backends, config reading, etc.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
