### PR TITLE
vm-runner: Add metrics to track vm panics

### DIFF
--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -34,7 +34,7 @@ var (
 	ErrMissingL2Genesis    = errors.New("missing network or l2 genesis path")
 	ErrNetworkUnknown      = errors.New("unknown network")
 
-	ErrVMPanic = errors.New("vm exited with non-zero exit code")
+	ErrVMPanic = errors.New("vm exited with exit code 2 (panic)")
 )
 
 type Metricer = metrics.TypedVmMetricer

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -6,18 +6,19 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 )
 
@@ -32,6 +33,8 @@ var (
 	ErrMissingRollupConfig = errors.New("missing network or rollup config path")
 	ErrMissingL2Genesis    = errors.New("missing network or l2 genesis path")
 	ErrNetworkUnknown      = errors.New("unknown network")
+
+	ErrVMNonZeroExitCode = errors.New("vm exited with non-zero exit code")
 )
 
 type Metricer = metrics.TypedVmMetricer
@@ -178,6 +181,11 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 	e.logger.Info("Generating trace", "proof", end, "cmd", e.cfg.VmBin, "args", strings.Join(args, ", "))
 	execStart := time.Now()
 	err = e.cmdExecutor(ctx, e.logger.New("proof", end), e.cfg.VmBin, args...)
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		e.logger.Error("VM command exited with non-zero exit code", "exit_code", exitErr.ExitCode())
+		err = ErrVMNonZeroExitCode
+	}
 	execTime := time.Since(execStart)
 	memoryUsed := "unknown"
 	e.metrics.RecordExecutionTime(execTime)

--- a/op-challenger/game/fault/trace/vm/executor_test.go
+++ b/op-challenger/game/fault/trace/vm/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"math/big"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -21,7 +22,6 @@ import (
 )
 
 func TestGenerateProof(t *testing.T) {
-	input := "starting.json"
 	tempDir := t.TempDir()
 	dir := filepath.Join(tempDir, "gameDir")
 	cfg := Config{
@@ -35,7 +35,6 @@ func TestGenerateProof(t *testing.T) {
 		SnapshotFreq: 500,
 		InfoFreq:     900,
 	}
-	prestate := "pre.json"
 
 	inputs := utils.LocalGameInputs{
 		L1Head:        common.Hash{0x11},
@@ -56,42 +55,10 @@ func TestGenerateProof(t *testing.T) {
 		IdleStepCountThread0:         1314,
 	}
 
-	captureExec := func(t *testing.T, cfg Config, proofAt uint64, m Metricer) (string, string, map[string]string) {
-		executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, &noArgServerExecutor{}, prestate, inputs)
-		executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64, binary bool) (string, error) {
-			return input, nil
-		}
-		var binary string
-		var subcommand string
-		args := make(map[string]string)
-		executor.cmdExecutor = func(ctx context.Context, l log.Logger, b string, a ...string) error {
-			binary = b
-			subcommand = a[0]
-			for i := 1; i < len(a); {
-				if a[i] == "--" {
-					// Skip over the divider between vm and server program
-					i += 1
-					continue
-				}
-				args[a[i]] = a[i+1]
-				i += 2
-			}
-
-			// Write debuginfo file
-			debugPath := args["--debug-info"]
-			err := jsonutil.WriteJSON(info, ioutil.ToStdOutOrFileOrNoop(debugPath, 0o755))
-			require.NoError(t, err)
-			return nil
-		}
-		err := executor.GenerateProof(context.Background(), dir, proofAt)
-		require.NoError(t, err)
-		return binary, subcommand, args
-	}
-
 	t.Run("NoStopAtWhenProofIsMaxUInt", func(t *testing.T) {
 		m := newMetrics()
 		cfg.DebugInfo = true
-		_, _, args := captureExec(t, cfg, math.MaxUint64, m)
+		_, _, args := captureExec(t, dir, cfg, inputs, info, math.MaxUint64, m)
 		// stop-at would need to be one more than the proof step which would overflow back to 0
 		// so expect that it will be omitted. We'll ultimately want asterisc to execute until the program exits.
 		require.NotContains(t, args, "--stop-at")
@@ -101,7 +68,7 @@ func TestGenerateProof(t *testing.T) {
 	t.Run("BinarySnapshots", func(t *testing.T) {
 		m := newMetrics()
 		cfg.BinarySnapshots = true
-		_, _, args := captureExec(t, cfg, 100, m)
+		_, _, args := captureExec(t, dir, cfg, inputs, info, 100, m)
 		require.Equal(t, filepath.Join(dir, SnapsDir, "%d.bin.gz"), args["--snapshot-fmt"])
 		validateMetrics(t, m, info, cfg)
 	})
@@ -109,10 +76,87 @@ func TestGenerateProof(t *testing.T) {
 	t.Run("JsonSnapshots", func(t *testing.T) {
 		m := newMetrics()
 		cfg.BinarySnapshots = false
-		_, _, args := captureExec(t, cfg, 100, m)
+		_, _, args := captureExec(t, dir, cfg, inputs, info, 100, m)
 		require.Equal(t, filepath.Join(dir, SnapsDir, "%d.json.gz"), args["--snapshot-fmt"])
 		validateMetrics(t, m, info, cfg)
 	})
+
+	t.Run("FailingExecCmd", func(t *testing.T) {
+		m := newMetrics()
+		cfg.DebugInfo = true
+		cfg.BinarySnapshots = false
+		err, _ := failingExec(t, dir, cfg, inputs, info, 100, m)
+		require.Equal(t, ErrVMNonZeroExitCode, err)
+		requireEmptyMetrics(t, m)
+	})
+}
+
+func captureExec(t *testing.T, dir string, cfg Config, inputs utils.LocalGameInputs, info *mipsevm.DebugInfo, proofAt uint64, m Metricer) (string, string, map[string]string) {
+	input := "starting.json"
+	prestate := "pre.json"
+	executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, &noArgServerExecutor{}, prestate, inputs)
+	executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64, binary bool) (string, error) {
+		return input, nil
+	}
+	var binary string
+	var subcommand string
+	var args map[string]string
+	executor.cmdExecutor = func(ctx context.Context, l log.Logger, b string, a ...string) error {
+		binary = b
+		subcommand = a[0]
+		args = copyArgs(a)
+
+		// Write debuginfo file
+		debugPath := args["--debug-info"]
+		err := jsonutil.WriteJSON(info, ioutil.ToStdOutOrFileOrNoop(debugPath, 0o755))
+		require.NoError(t, err)
+		return nil
+	}
+	err := executor.GenerateProof(context.Background(), dir, proofAt)
+	require.NoError(t, err)
+	return binary, subcommand, args
+}
+
+func failingExec(t *testing.T, dir string, cfg Config, inputs utils.LocalGameInputs, info *mipsevm.DebugInfo, proofAt uint64, m Metricer) (error, map[string]string) {
+	input := "starting.json"
+	prestate := "pre.json"
+	executor := NewExecutor(testlog.Logger(t, log.LevelInfo), m, cfg, &noArgServerExecutor{}, prestate, inputs)
+	executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64, binary bool) (string, error) {
+		return input, nil
+	}
+
+	var args map[string]string
+	executor.cmdExecutor = func(ctx context.Context, l log.Logger, b string, a ...string) error {
+		args = copyArgs(a)
+
+		// Write debuginfo file
+		debugPath := args["--debug-info"]
+		err := jsonutil.WriteJSON(info, ioutil.ToStdOutOrFileOrNoop(debugPath, 0o755))
+		require.NoError(t, err)
+
+		// Get a non-zero exit error
+		cmd := exec.Command("sh", "-c", "exit 2") // On Windows, use `cmd /C exit 2`
+		cmdError := cmd.Run()
+
+		return cmdError
+	}
+	err := executor.GenerateProof(context.Background(), dir, proofAt)
+
+	return err, args
+}
+
+func copyArgs(a []string) map[string]string {
+	args := make(map[string]string)
+	for i := 1; i < len(a); {
+		if a[i] == "--" {
+			// Skip over the divider between vm and server program
+			i += 1
+			continue
+		}
+		args[a[i]] = a[i+1]
+		i += 2
+	}
+	return args
 }
 
 func validateMetrics(t require.TestingT, m *capturingVmMetrics, expected *mipsevm.DebugInfo, cfg Config) {
@@ -130,15 +174,19 @@ func validateMetrics(t require.TestingT, m *capturingVmMetrics, expected *mipsev
 		require.Equal(t, expected.IdleStepCountThread0, m.idleStepsThread0)
 	} else {
 		// If debugInfo is disabled, json file should not be written and metrics should be zeroed out
-		require.Equal(t, hexutil.Uint64(0), m.memoryUsed)
-		require.Equal(t, uint64(0), m.steps)
-		require.Equal(t, uint64(0), m.rmwSuccessCount)
-		require.Equal(t, uint64(0), m.rmwFailCount)
-		require.Equal(t, uint64(0), m.maxStepsBetweenLLAndSC)
-		require.Equal(t, uint64(0), m.reservationInvalidations)
-		require.Equal(t, uint64(0), m.forcedPreemptions)
-		require.Equal(t, uint64(0), m.idleStepsThread0)
+		requireEmptyMetrics(t, m)
 	}
+}
+
+func requireEmptyMetrics(t require.TestingT, m *capturingVmMetrics) {
+	require.Equal(t, hexutil.Uint64(0), m.memoryUsed)
+	require.Equal(t, uint64(0), m.steps)
+	require.Equal(t, uint64(0), m.rmwSuccessCount)
+	require.Equal(t, uint64(0), m.rmwFailCount)
+	require.Equal(t, uint64(0), m.maxStepsBetweenLLAndSC)
+	require.Equal(t, uint64(0), m.reservationInvalidations)
+	require.Equal(t, uint64(0), m.forcedPreemptions)
+	require.Equal(t, uint64(0), m.idleStepsThread0)
 }
 
 func newMetrics() *capturingVmMetrics {

--- a/op-challenger/runner/metrics.go
+++ b/op-challenger/runner/metrics.go
@@ -24,6 +24,7 @@ type Metrics struct {
 	vmLastMemoryUsed    *prometheus.GaugeVec
 	successTotal        *prometheus.CounterVec
 	failuresTotal       *prometheus.CounterVec
+	panicsTotal         *prometheus.CounterVec
 	invalidTotal        *prometheus.CounterVec
 }
 
@@ -69,6 +70,11 @@ func NewMetrics(runConfigs []RunConfig) *Metrics {
 			Name:      "failures_total",
 			Help:      "Number of failures to execute a VM",
 		}, []string{"type"}),
+		panicsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "panics_total",
+			Help:      "Number of times the VM panicked",
+		}, []string{"type"}),
 		invalidTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: Namespace,
 			Name:      "invalid_total",
@@ -79,6 +85,7 @@ func NewMetrics(runConfigs []RunConfig) *Metrics {
 	for _, runConfig := range runConfigs {
 		metrics.successTotal.WithLabelValues(runConfig.Name).Add(0)
 		metrics.failuresTotal.WithLabelValues(runConfig.Name).Add(0)
+		metrics.panicsTotal.WithLabelValues(runConfig.Name).Add(0)
 		metrics.invalidTotal.WithLabelValues(runConfig.Name).Add(0)
 		metrics.RecordUp()
 	}
@@ -111,6 +118,10 @@ func (m *Metrics) RecordSuccess(vmType string) {
 
 func (m *Metrics) RecordFailure(vmType string) {
 	m.failuresTotal.WithLabelValues(vmType).Inc()
+}
+
+func (m *Metrics) RecordPanic(vmType string) {
+	m.panicsTotal.WithLabelValues(vmType).Inc()
 }
 
 func (m *Metrics) RecordInvalid(vmType string) {

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	trace "github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -122,6 +123,9 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, runConfig RunConfig, clie
 		if errors.Is(err, ErrUnexpectedStatusCode) {
 			log.Error("Incorrect status code", "type", runConfig.Name, "err", err)
 			m.RecordInvalid(traceType)
+		} else if errors.Is(err, trace.ErrVMNonZeroExitCode) {
+			log.Error("VM returned non-zero exit code")
+			// TODO: record new metric
 		} else if err != nil {
 			log.Error("Failed to run", "type", runConfig.Name, "err", err)
 			m.RecordFailure(traceType)

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -40,6 +40,7 @@ type Metricer interface {
 	metrics.VmMetricer
 
 	RecordFailure(vmType string)
+	RecordPanic(vmType string)
 	RecordInvalid(vmType string)
 	RecordSuccess(vmType string)
 }
@@ -123,9 +124,9 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, runConfig RunConfig, clie
 		if errors.Is(err, ErrUnexpectedStatusCode) {
 			log.Error("Incorrect status code", "type", runConfig.Name, "err", err)
 			m.RecordInvalid(traceType)
-		} else if errors.Is(err, trace.ErrVMNonZeroExitCode) {
-			log.Error("VM returned non-zero exit code")
-			// TODO: record new metric
+		} else if errors.Is(err, trace.ErrVMPanic) {
+			log.Error("VM panicked", "type", runConfig.Name)
+			m.RecordPanic(traceType)
 		} else if err != nil {
 			log.Error("Failed to run", "type", runConfig.Name, "err", err)
 			m.RecordFailure(traceType)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add metrics to track vm panics in the vm runner. 

**Tests**

Update `executor_test.go` to check handling for vm execution errors. Also did some manual testing.

**Metadata**

Part of: https://github.com/ethereum-optimism/optimism/issues/14458
