### PR TITLE
op-batcher: always `updateCursorAndMetrics` when returning from `processBlocks()`

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -346,6 +346,25 @@ func (s *channelManager) processBlocks() error {
 		latestL2ref eth.L2BlockRef
 	)
 
+	updateCursorAndMetrics := func() {
+		s.blockCursor += blocksAdded
+
+		s.metr.RecordL2BlocksAdded(latestL2ref,
+			blocksAdded,
+			s.pendingBlocks(),
+			s.currentChannel.InputBytes(),
+			s.currentChannel.ReadyBytes())
+		s.log.Debug("Added blocks to channel",
+			"blocks_added", blocksAdded,
+			"blocks_pending", s.pendingBlocks(),
+			"channel_full", s.currentChannel.IsFull(),
+			"input_bytes", s.currentChannel.InputBytes(),
+			"ready_bytes", s.currentChannel.ReadyBytes(),
+		)
+	}
+
+	defer updateCursorAndMetrics()
+
 	for i := s.blockCursor; ; i++ {
 		block, ok := s.blocks.PeekN(i)
 		if !ok {
@@ -369,21 +388,6 @@ func (s *channelManager) processBlocks() error {
 			break
 		}
 	}
-
-	s.blockCursor += blocksAdded
-
-	s.metr.RecordL2BlocksAdded(latestL2ref,
-		blocksAdded,
-		s.pendingBlocks(),
-		s.currentChannel.InputBytes(),
-		s.currentChannel.ReadyBytes())
-	s.log.Debug("Added blocks to channel",
-		"blocks_added", blocksAdded,
-		"blocks_pending", s.pendingBlocks(),
-		"channel_full", s.currentChannel.IsFull(),
-		"input_bytes", s.currentChannel.InputBytes(),
-		"ready_bytes", s.currentChannel.ReadyBytes(),
-	)
 	return nil
 }
 

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -346,7 +346,7 @@ func (s *channelManager) processBlocks() error {
 		latestL2ref eth.L2BlockRef
 	)
 
-	updateCursorAndMetrics := func() {
+	defer func() {
 		s.blockCursor += blocksAdded
 
 		s.metr.RecordL2BlocksAdded(latestL2ref,
@@ -361,9 +361,7 @@ func (s *channelManager) processBlocks() error {
 			"input_bytes", s.currentChannel.InputBytes(),
 			"ready_bytes", s.currentChannel.ReadyBytes(),
 		)
-	}
-
-	defer updateCursorAndMetrics()
+	}()
 
 	for i := s.blockCursor; ; i++ {
 		block, ok := s.blocks.PeekN(i)


### PR DESCRIPTION
I believe there is an edge case here where we add multiple blocks to a channel before hitting an error. 

Under those conditions, we would not update the channel manager's blockCursor which could lead to strange behaviour, including adding the same blocks to a channel multiple times (this would also cause the pending blocks bytes metric to be inaccurate and even go negative). 