### PR TITLE
chore: update links in directory structure after PRs #12968 & #12828

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,11 @@ The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vuln
 ├── <a href="./op-program">op-program</a>: Fault proof program
 ├── <a href="./op-proposer">op-proposer</a>: L2-Output Submitter, submits proposals to L1
 ├── <a href="./op-service">op-service</a>: Common codebase utilities
-├── <a href="./op-ufm">op-ufm</a>: Simulations for monitoring end-to-end transaction latency
 ├── <a href="./op-wheel">op-wheel</a>: Database utilities
 ├── <a href="./ops">ops</a>: Various operational packages
 ├── <a href="./packages">packages</a>
 │   ├── <a href="./packages/contracts-bedrock">contracts-bedrock</a>: OP Stack smart contracts
-├── <a href="./semgrep">semgrep</a>: Semgrep rules and tests
+├── <a href="./.semgrep">semgrep</a>: Semgrep rules and tests
 </pre>
 
 ## Development and Release Process


### PR DESCRIPTION
### Description

- After PR #12828 the `semgrep` folder was hidden invaldating the link to it on README.md. 
- `op-ufm` was moved to [ethereum-optimism/infra](https://github.com/ethereum-optimism/infra) as outlined in PR #12968