### PR TITLE
fix(devnet-sdk): detect if op-geth types are used

### DIFF
--- a/devnet-sdk/system/chain.go
+++ b/devnet-sdk/system/chain.go
@@ -14,15 +14,28 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/common"
+	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// this is to differentiate between op-geth and go-ethereum
+type opBlock interface {
+	WithdrawalsRoot() *common.Hash
+}
+
 var (
 	// This will make sure that we implement the Chain interface
 	_ Chain = (*chain)(nil)
+
+	// Make sure we're using op-geth in place of go-ethereum.
+	// If you're wondering why this fails at compile time,
+	// it's most likely because you're not using a "replace"
+	// directive in your go.mod file.
+	_ opBlock = (*coreTypes.Block)(nil)
 )
 
 // clientManager handles ethclient connections


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
This change detects at build time if we're using the right version of
go-ethereum (op-geth).

Hopefully this will avoid having downstream repositories wonder why
some operations mysteriously fail when they forget to add the right
"replace" directive in their go.mod.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
