### PR TITLE
feat(op-wheel): add update-finality flag to control safe and finalized blocks updates

### DIFF
--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -117,6 +117,11 @@ var (
 		Usage:   "allow gaps in block building, like missed slots on the beacon chain.",
 		EnvVars: prefixEnvVars("ALLOW_GAPS"),
 	}
+	UpdateFinality = &cli.BoolFlag{
+		Name:    "update-finality",
+		Usage:   "update safe and finalized blocks during auto mode.",
+		EnvVars: prefixEnvVars("UPDATE_FINALITY"),
+	}
 )
 
 func withEngineFlags(flags ...cli.Flag) []cli.Flag {
@@ -127,11 +132,12 @@ func withEngineFlags(flags ...cli.Flag) []cli.Flag {
 
 func ParseBuildingArgs(ctx *cli.Context) *engine.BlockBuildingSettings {
 	return &engine.BlockBuildingSettings{
-		BlockTime:    ctx.Uint64(BlockTimeFlag.Name),
-		AllowGaps:    ctx.Bool(AllowGaps.Name),
-		Random:       hashFlagValue(RandaoFlag.Name, ctx),
-		FeeRecipient: addrFlagValue(FeeRecipientFlag.Name, ctx),
-		BuildTime:    ctx.Duration(BuildingTime.Name),
+		BlockTime:      ctx.Uint64(BlockTimeFlag.Name),
+		AllowGaps:      ctx.Bool(AllowGaps.Name),
+		Random:         hashFlagValue(RandaoFlag.Name, ctx),
+		FeeRecipient:   addrFlagValue(FeeRecipientFlag.Name, ctx),
+		BuildTime:      ctx.Duration(BuildingTime.Name),
+		UpdateFinality: ctx.Bool(UpdateFinality.Name),
 	}
 }
 
@@ -256,6 +262,8 @@ func rollupFromGethConfig(cfg *params.ChainConfig) *rollup.Config {
 		CanyonTime:   cfg.CanyonTime,
 		EcotoneTime:  cfg.EcotoneTime,
 		GraniteTime:  cfg.GraniteTime,
+		HoloceneTime: cfg.HoloceneTime,
+		IsthmusTime:  cfg.IsthmusTime,
 		InteropTime:  cfg.InteropTime,
 	}
 }
@@ -471,11 +479,10 @@ var (
 		Name:  "block",
 		Usage: "build the next block using the Engine API",
 		Flags: withEngineFlags(
-			FeeRecipientFlag, RandaoFlag, BlockTimeFlag, BuildingTime, AllowGaps,
+			FeeRecipientFlag, RandaoFlag, BlockTimeFlag, BuildingTime, AllowGaps, UpdateFinality,
 		),
 		// TODO: maybe support transaction and tx pool engine flags, since we use op-geth?
 		// TODO: reorg flag
-		// TODO: finalize/safe flag
 
 		Action: EngineAction(func(ctx *cli.Context, client *sources.EngineAPIClient, _ log.Logger) error {
 			settings := ParseBuildingArgs(ctx)
@@ -496,11 +503,10 @@ var (
 		Usage:       "Run a proof-of-nothing chain with fixed block time.",
 		Description: "The block time can be changed. The execution engine must be synced to a post-Merge state first.",
 		Flags: append(withEngineFlags(
-			FeeRecipientFlag, RandaoFlag, BlockTimeFlag, BuildingTime, AllowGaps),
+			FeeRecipientFlag, RandaoFlag, BlockTimeFlag, BuildingTime, AllowGaps, UpdateFinality),
 			opmetrics.CLIFlags(envVarPrefix)...),
 		Action: EngineAction(func(ctx *cli.Context, client *sources.EngineAPIClient, l log.Logger) error {
 			settings := ParseBuildingArgs(ctx)
-			// TODO: finalize/safe flag
 
 			metricsCfg := opmetrics.ReadCLIConfig(ctx)
 


### PR DESCRIPTION
### Description
This PR adds a new flag --update-finality to the op-wheel engine commands that controls whether safe and finalized blocks should be updated during auto mode. The flag is added to both engine block and engine auto commands, allowing users to control the finality behavior of the chain. When enabled, the flag causes the engine to update safe and finalized blocks during "beacon epoch transitions" (every 32 blocks).
This implementation resolves the TODO comments about adding a finalize/safe flag in the codebase.
### Tests
The changes are primarily focused on adding a new configuration option to existing functionality. The existing functionality is already well-tested, and this change simply makes the finality update behavior configurable rather than always enabled.
The implementation follows the same pattern as other flags in the codebase, such as --allow-gaps.
### Additional context
This change improves the flexibility of the op-wheel tool by allowing users to control whether finality updates should occur during auto mode. This can be useful in testing scenarios where users want to simulate different finality behaviors.
### Metadata
Fixes the TODO comments in op-wheel/commands.go related to adding a finalize/safe flag.