### PR TITLE
op-program: Fix log index of executing messages in block

### DIFF
--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -363,8 +363,6 @@ func TestInteropFaultProofs(gt *testing.T) {
 
 func TestInteropFaultProofs_Cycle(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
-	// TODO(#14425): Handle cyclic valid messages
-	t.Skip("Cyclic valid messages does not work")
 
 	system := dsl.NewInteropDSL(t)
 	actors := system.Actors

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -21,22 +21,23 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtypes.Receipts) ([]*supervisortypes.ExecutingMessage, uint32, error) {
-	var execMsgs []*supervisortypes.ExecutingMessage
-	var logCount uint32
+// ReceiptsToExecutingMessages returns the executing messages in the receipts indexed by their position in the log.
+func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
+	execMsgs := make(map[uint32]*supervisortypes.ExecutingMessage)
+	var curr uint32
 	for _, rcpt := range receipts {
-		logCount += uint32(len(rcpt.Logs))
 		for _, l := range rcpt.Logs {
 			execMsg, err := processors.DecodeExecutingMessageLog(l, depset)
 			if err != nil {
 				return nil, 0, err
 			}
 			if execMsg != nil {
-				execMsgs = append(execMsgs, execMsg)
+				execMsgs[curr] = execMsg
 			}
+			curr++
 		}
 	}
-	return execMsgs, logCount, nil
+	return execMsgs, curr, nil
 }
 
 func fetchAgreedBlockHashes(oracle l2.Oracle, superRoot *eth.SuperV1) ([]common.Hash, error) {
@@ -168,7 +169,7 @@ func checkHazards(
 	deps ConsolidateCheckDeps,
 	candidate supervisortypes.BlockSeal,
 	chainID eth.ChainID,
-	execMsgs []*supervisortypes.ExecutingMessage,
+	execMsgs map[uint32]*supervisortypes.ExecutingMessage,
 ) error {
 	// TODO(#14234): remove this check once the supervisor is updated handle msg expiry
 	messageExpiryTimeSeconds := rollupCfg.GetMessageExpiryTimeInterop()
@@ -303,15 +304,11 @@ func (d *consolidateCheckDeps) OpenBlock(
 		Number: block.NumberU64(),
 	}
 	_, receipts := d.oracle.ReceiptsByBlockHash(block.Hash(), chainID)
-	execs, logCount, err := ReceiptsToExecutingMessages(d.depset, receipts)
+	execMsgs, logCount, err = ReceiptsToExecutingMessages(d.depset, receipts)
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, err
 	}
-	execMsgs = make(map[uint32]*supervisortypes.ExecutingMessage, len(execs))
-	for _, exec := range execs {
-		execMsgs[exec.LogIdx] = exec
-	}
-	return ref, uint32(logCount), execMsgs, nil
+	return ref, logCount, execMsgs, nil
 }
 
 func (d *consolidateCheckDeps) DependencySet() depset.DependencySet {


### PR DESCRIPTION
Fixes the indexing of executing messages during consolidation checks.
The index should have been based on the log that contains the executing message, rather than the initiating message.