### PR TITLE
op-challenger: Add Super DG contract caller

### DIFF
--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -1,0 +1,44 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	methodGameType = "gameType"
+
+	gameTypeABI = mustParseAbi([]byte(`[{
+		"inputs": [],
+		"name": "gameType",
+		"outputs": [{"type": "uint32"}],
+		"stateMutability": "view",
+		"type": "function"
+	}]`))
+)
+
+func DetectGameType(ctx context.Context, addr common.Address, caller *batching.MultiCaller) (faultTypes.GameType, error) {
+	result, err := caller.SingleCall(ctx, rpcblock.Latest, batching.NewContractCall(gameTypeABI, addr, methodGameType))
+	if err != nil {
+		return faultTypes.UnknownGameType, fmt.Errorf("failed to detect game type: %w", err)
+	}
+	gameType := faultTypes.GameType(result.GetUint32(0))
+	switch gameType {
+	case faultTypes.CannonGameType,
+		faultTypes.PermissionedGameType,
+		faultTypes.AsteriscGameType,
+		faultTypes.AlphabetGameType,
+		faultTypes.FastGameType,
+		faultTypes.AsteriscKonaGameType,
+		faultTypes.SuperCannonGameType,
+		faultTypes.SuperPermissionedGameType:
+		return gameType, nil
+	default:
+		return faultTypes.UnknownGameType, fmt.Errorf("unsupported game type: %d", gameType)
+	}
+}

--- a/op-challenger/game/fault/contracts/superfaultdisputegame.go
+++ b/op-challenger/game/fault/contracts/superfaultdisputegame.go
@@ -1,0 +1,71 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type SuperFaultDisputeGameContractLatest struct {
+	FaultDisputeGameContractLatest
+}
+
+func NewSuperFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
+	contractAbi := snapshots.LoadFaultDisputeGameABI()
+	return &SuperFaultDisputeGameContractLatest{
+		FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
+			metrics:     metrics,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(contractAbi, addr),
+		},
+	}, nil
+}
+
+// GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, max clock duration, and is l2 block number challenged.
+func (f *SuperFaultDisputeGameContractLatest) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
+	defer f.metrics.StartContractRequest("GetGameMetadata")()
+	results, err := f.multiCaller.Call(ctx, block,
+		f.contract.Call(methodL1Head),
+		f.contract.Call(methodL2BlockNumber),
+		f.contract.Call(methodRootClaim),
+		f.contract.Call(methodStatus),
+		f.contract.Call(methodMaxClockDuration),
+	)
+	if err != nil {
+		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
+	}
+	if len(results) != 5 {
+		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
+	}
+	l1Head := results[0].GetHash(0)
+	l2BlockNumber := results[1].GetBigInt(0).Uint64()
+	rootClaim := results[2].GetHash(0)
+	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
+	if err != nil {
+		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
+	}
+	duration := results[4].GetUint64(0)
+	return GameMetadata{
+		L1Head:           l1Head,
+		L2BlockNum:       l2BlockNumber,
+		RootClaim:        rootClaim,
+		Status:           status,
+		MaxClockDuration: duration,
+	}, nil
+}
+
+func (f *SuperFaultDisputeGameContractLatest) IsL2BlockNumberChallenged(ctx context.Context, block rpcblock.Block) (bool, error) {
+	return false, nil
+}
+
+func (f *SuperFaultDisputeGameContractLatest) ChallengeL2BlockNumberTx(challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
+	return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
+}

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -2,6 +2,7 @@ package fault
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
@@ -39,33 +40,38 @@ func TestRegisterOracle_MissingGameImpl(t *testing.T) {
 }
 
 func TestRegisterOracle_AddsOracle(t *testing.T) {
-	gameFactoryAddr := common.Address{0xaa}
-	gameImplAddr := common.Address{0xbb}
-	vmAddr := common.Address{0xcc}
-	oracleAddr := common.Address{0xdd}
-	rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
-	rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
-	rpc.AddContract(vmAddr, snapshots.LoadMIPSABI())
-	rpc.AddContract(oracleAddr, snapshots.LoadPreimageOracleABI())
-	m := metrics.NoopMetrics
-	caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
-	gameFactory := contracts.NewDisputeGameFactoryContract(m, gameFactoryAddr, caller)
+	for _, gameType := range []faultTypes.GameType{faultTypes.CannonGameType, faultTypes.SuperCannonGameType} {
+		t.Run(fmt.Sprintf("%v", gameType), func(t *testing.T) {
+			gameFactoryAddr := common.Address{0xaa}
+			gameImplAddr := common.Address{0xbb}
+			vmAddr := common.Address{0xcc}
+			oracleAddr := common.Address{0xdd}
+			rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
+			rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
+			rpc.AddContract(vmAddr, snapshots.LoadMIPSABI())
+			rpc.AddContract(oracleAddr, snapshots.LoadPreimageOracleABI())
+			m := metrics.NoopMetrics
+			caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
+			gameFactory := contracts.NewDisputeGameFactoryContract(m, gameFactoryAddr, caller)
 
-	logger := testlog.Logger(t, log.LvlInfo)
-	oracles := registry.NewOracleRegistry()
-	gameType := faultTypes.CannonGameType
+			logger := testlog.Logger(t, log.LvlInfo)
+			oracles := registry.NewOracleRegistry()
 
-	// Use the latest v1 of these contracts. Doesn't have to be an exact match for the version.
-	rpc.SetResponse(gameImplAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
-	rpc.SetResponse(oracleAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
+			// Use the latest v1 of these contracts. Doesn't have to be an exact match for the version.
+			rpc.SetResponse(gameImplAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
+			rpc.SetResponse(oracleAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
 
-	rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{gameImplAddr})
-	rpc.SetResponse(gameImplAddr, "vm", rpcblock.Latest, []interface{}{}, []interface{}{vmAddr})
-	rpc.SetResponse(vmAddr, "oracle", rpcblock.Latest, []interface{}{}, []interface{}{oracleAddr})
+			rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{gameImplAddr})
+			rpc.SetResponse(gameImplAddr, "vm", rpcblock.Latest, []interface{}{}, []interface{}{vmAddr})
+			rpc.SetResponse(vmAddr, "oracle", rpcblock.Latest, []interface{}{}, []interface{}{oracleAddr})
 
-	err := registerOracle(context.Background(), logger, m, oracles, gameFactory, caller, gameType)
-	require.NoError(t, err)
-	registered := oracles.Oracles()
-	require.Len(t, registered, 1)
-	require.Equal(t, oracleAddr, registered[0].Addr())
+			rpc.SetResponse(gameImplAddr, "gameType", rpcblock.Latest, []interface{}{}, []interface{}{uint32(gameType)})
+
+			err := registerOracle(context.Background(), logger, m, oracles, gameFactory, caller, gameType)
+			require.NoError(t, err)
+			registered := oracles.Oracles()
+			require.Len(t, registered, 1)
+			require.Equal(t, oracleAddr, registered[0].Addr())
+		})
+	}
 }

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -56,7 +56,9 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 		faultTypes.AsteriscGameType,
 		faultTypes.AlphabetGameType,
 		faultTypes.FastGameType,
-		faultTypes.AsteriscKonaGameType:
+		faultTypes.AsteriscKonaGameType,
+		faultTypes.SuperCannonGameType,
+		faultTypes.SuperPermissionedGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create fault dispute game contract: %w", err)

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -52,16 +52,24 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 			game: types.GameMetadata{GameType: uint32(faultTypes.AsteriscKonaGameType), Proxy: fdgAddr},
 		},
 		{
+			name: "validSuperCannonGameType",
+			game: types.GameMetadata{GameType: uint32(faultTypes.SuperCannonGameType), Proxy: fdgAddr},
+		},
+		{
+			name: "validSuperPermissionedGameType",
+			game: types.GameMetadata{GameType: uint32(faultTypes.SuperPermissionedGameType), Proxy: fdgAddr},
+		},
+		{
 			name:        "InvalidGameType",
-			game:        types.GameMetadata{GameType: 4, Proxy: fdgAddr},
-			expectedErr: fmt.Errorf("unsupported game type: 4"),
+			game:        types.GameMetadata{GameType: 6, Proxy: fdgAddr},
+			expectedErr: fmt.Errorf("unsupported game type: 6"),
 		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			caller, metrics := setupMetadataLoaderTest(t)
+			caller, metrics := setupMetadataLoaderTest(t, test.game.GameType)
 			creator := NewGameCallerCreator(metrics, caller)
 			_, err := creator.CreateContract(context.Background(), test.game)
 			require.Equal(t, test.expectedErr, err)
@@ -79,11 +87,12 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 	}
 }
 
-func setupMetadataLoaderTest(t *testing.T) (*batching.MultiCaller, *mockCacheMetrics) {
+func setupMetadataLoaderTest(t *testing.T, gameType uint32) (*batching.MultiCaller, *mockCacheMetrics) {
 	fdgAbi := snapshots.LoadFaultDisputeGameABI()
 	stubRpc := batchingTest.NewAbiBasedRpc(t, fdgAddr, fdgAbi)
 	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
 	stubRpc.SetResponse(fdgAddr, "version", rpcblock.Latest, nil, []interface{}{"0.18.0"})
+	stubRpc.SetResponse(fdgAddr, "gameType", rpcblock.Latest, nil, []interface{}{gameType})
 	return caller, &mockCacheMetrics{}
 }
 


### PR DESCRIPTION
Add a `SuperFaultDisputeGame` contract caller implementation so that op-challenger can interact with the new game type.

The game type is used to determine which dispute game contract caller to use. The game type is auto-detected so that other callers of `contracts.NewFaultDisputeGameContract`, including dispute-mon and the vm-runner, can also interact with the `SuperFaultDisputeGame`.

fixes https://github.com/ethereum-optimism/optimism/issues/14508