### PR TITLE
op-node: Remove OverrideMessageExpiryTimeInterop from rollup.Config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -83,9 +83,6 @@ type DevDeployConfig struct {
 	// FundDevAccounts configures whether to fund the dev accounts.
 	// This should only be used during devnet deployments.
 	FundDevAccounts bool `json:"fundDevAccounts"`
-	// OverrideMessageExpiryTime configures the message expiry time of interop messages.
-	// This should only be used during devnet deployments.
-	OverrideMessageExpiryTime uint64 `json:"overrideMessageExpiryTime"`
 }
 
 type L2GenesisBlockDeployConfig struct {

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -74,7 +74,6 @@
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 0,
   "faultGameWithdrawalDelay": 604800,
-  "overrideMessageExpiryTime": 0,
   "preimageOracleMinProposalSize": 1800000,
   "preimageOracleChallengePeriod": 86400,
   "systemConfigStartBlock": 0,

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -329,9 +329,6 @@ func CompleteL2(l2Host *script.Host, cfg *L2Config, l1Block *types.Block, deploy
 	if err != nil {
 		return nil, fmt.Errorf("failed to build L2 rollup config: %w", err)
 	}
-	if cfg.OverrideMessageExpiryTime != 0 {
-		rollupCfg.OverrideMessageExpiryTimeInterop = cfg.OverrideMessageExpiryTime
-	}
 	return &L2Output{
 		Genesis:   l2Genesis,
 		RollupCfg: rollupCfg,

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -187,8 +187,7 @@ func InteropL2DevConfig(l1ChainID, l2ChainID uint64, addrs devkeys.Addresses, me
 		SystemConfigOwner: systemConfigOwner,
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			DevDeployConfig: genesis.DevDeployConfig{
-				FundDevAccounts:           true,
-				OverrideMessageExpiryTime: messageExpiryTime,
+				FundDevAccounts: true,
 			},
 			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
 				L2GenesisBlockGasLimit:      60_000_000,

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -550,7 +550,7 @@ func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 	system.SubmitBatchData()
 
 	// Advance the chain until the init msg expires
-	msgExpiryTime := actors.ChainA.RollupCfg.GetMessageExpiryTimeInterop()
+	msgExpiryTime := system.DepSet().MessageExpiryWindow()
 	end := emitTx.Identifier().Timestamp.Uint64() + msgExpiryTime
 	system.AddL2Block(actors.ChainA, dsl.WithL2BlocksUntilTimestamp(end))
 	system.AddL2Block(actors.ChainB, dsl.WithL2BlocksUntilTimestamp(end))

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
-	opparams "github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -150,11 +149,6 @@ type Config struct {
 	// parameters to the protocol values, like the execution layer does.
 	// If missing, it is loaded by the op-node from the embedded superchain config at startup.
 	ChainOpConfig *params.OptimismConfig `json:"chain_op_config,omitempty"`
-
-	// OverrideMessageExpiryTimeInterop is only used for testing purposes.
-	// It is used to override the protocol-defined interop message time expiry.
-	// DO NOT this read value directly. Use GetMessageExpiryTimeInterop instead.
-	OverrideMessageExpiryTimeInterop uint64 `json:"override_message_expiry_time_interop,omitempty"`
 }
 
 // ValidateL1Config checks L1 config variables for errors.
@@ -614,16 +608,6 @@ func (c *Config) GetOPAltDAConfig() (altda.Config, error) {
 		ResolveWindow:              c.AltDAConfig.DAResolveWindow,
 		CommitmentType:             t,
 	}, nil
-}
-
-// GetMessageExpiryTimeInterop returns the expiry time of interop messages in seconds.
-// If a message expiry override is set in the rollup config, it returns the override value.
-// Otherwise, it returns the protocol-defined interop message time expiry.
-func (c *Config) GetMessageExpiryTimeInterop() uint64 {
-	if c.OverrideMessageExpiryTimeInterop != 0 {
-		return c.OverrideMessageExpiryTimeInterop
-	}
-	return opparams.MessageExpiryTimeSecondsInterop
 }
 
 func (c *Config) AltDAEnabled() bool {

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -823,11 +822,4 @@ func TestConfigImplementsBlockType(t *testing.T) {
 			assert.Equal(t, config.HasOptimismWithdrawalsRoot(test.blockTime), test.hasOptimismWithdrawalsRoot)
 		})
 	}
-}
-
-func TestConfig_GetMessageExpiryTimeInterop(t *testing.T) {
-	config := randConfig()
-	assert.Equal(t, config.GetMessageExpiryTimeInterop(), uint64(params.MessageExpiryTimeSecondsInterop))
-	config.OverrideMessageExpiryTimeInterop = 100
-	assert.Equal(t, config.GetMessageExpiryTimeInterop(), uint64(100))
 }


### PR DESCRIPTION
The `OverrideMessageExpiryTimeInterop` rollup config parameter was moved to the dependency set configuration. 