### PR TITLE
op-batcher: correctly track block metrics in `handleChannelInvalidated()`

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -171,7 +171,7 @@ func (s *channelManager) handleChannelInvalidated(c *channel) {
 	}
 
 	for i := invalidatedChannelIdx; i < len(s.channelQueue); i++ {
-		s.log.Info("dropped channel",
+		s.log.Warn("Dropped channel",
 			"id", s.channelQueue[i].ID(),
 			"none_submitted", s.channelQueue[i].NoneSubmitted(),
 			"fully_submitted", s.channelQueue[i].isFullySubmitted(),

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -417,10 +417,9 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 	// Place an old channel in the queue.
 	// This channel should not be affected by
 	// a requeue or a later channel timing out.
-	oldChannel := newChannel(l, nil, m.defaultCfg, defaultTestRollupConfig, 0, nil)
+	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
+	oldChannel := m.currentChannel
 	oldChannel.Close()
-	m.channelQueue = []*channel{oldChannel}
-	metrics.RecordChannelQueueLength(1) // we need to do this manually b/c we are not using the usual codepath to set state
 	require.Len(t, m.channelQueue, 1)
 	require.Equal(t, metrics.ChannelQueueLength, 1)
 

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -397,7 +397,7 @@ func TestChannelManager_TxData(t *testing.T) {
 // and then calls handleChannelInvalidated. It asserts on the final state of
 // the channel manager.
 func TestChannelManager_handleChannelInvalidated(t *testing.T) {
-	l := testlog.Logger(t, log.LevelCrit)
+	l := testlog.Logger(t, log.LevelDebug)
 	cfg := channelManagerTestConfig(100, derive.SingularBatchType)
 	metrics := new(metrics.TestMetrics)
 	m := NewChannelManager(l, metrics, cfg, defaultTestRollupConfig)
@@ -433,7 +433,6 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 	require.Len(t, m.channelQueue, 2)
 	require.Equal(t, metrics.ChannelQueueLength, 2)
-
 	require.NoError(t, m.processBlocks())
 
 	// Assert that at least one block was processed into the channel
@@ -445,18 +444,29 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 
 	l1OriginBefore := m.l1OriginLastSubmittedChannel
 
-	m.handleChannelInvalidated(m.currentChannel)
+	// Add another newer channel, this will be wiped when we invalidate
+	channelToInvalidate := m.currentChannel
+	m.currentChannel.Close()
+	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
+	require.Len(t, m.channelQueue, 3)
+	require.Equal(t, metrics.ChannelQueueLength, 3)
+	require.NoError(t, m.processBlocks())
+	require.Equal(t, 2, m.blockCursor)
+
+	m.handleChannelInvalidated(channelToInvalidate)
 
 	// Ensure we got back to the state above
 	require.Equal(t, m.blocks, stateSnapshot)
 	require.Contains(t, m.channelQueue, oldChannel)
+	require.NotContains(t, m.channelQueue, channelToInvalidate)
+	require.NotContains(t, m.channelQueue, newChannel)
 	require.Len(t, m.channelQueue, 1)
 	require.Equal(t, metrics.ChannelQueueLength, 1)
 
 	// Check metric came back up to previous value
 	require.Equal(t, pendingBytesBefore, metrics.PendingBlocksBytesCurrent)
 
-	// Ensure the l1OridingLastSubmittedChannel was
+	// Ensure the l1OriginLastSubmittedChannel was
 	// not changed. This ensures the next channel
 	// has its duration timeout deadline computed
 	// properly.


### PR DESCRIPTION
Closes #14518