### PR TITLE
op-batcher: improve `computeSyncActions()` logging

### DIFF
--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -43,18 +43,18 @@ func (s syncActions) TerminalString() string {
 		"SyncActions{blocksToPrune: %d, channelsToPrune: %d, clearState: %v, blocksToLoad: %v}", s.blocksToPrune, s.channelsToPrune, cs, btl)
 }
 
-func summarizeSyncStatusNumbers(ss eth.SyncStatus) string {
-	return fmt.Sprintf("SyncStatus{HeadL1: %d, CurrentL1: %d, LocalSafeL2: %d, UnsafeL2: %d}",
-		ss.HeadL1.Number, ss.CurrentL1.Number, ss.LocalSafeL2.Number, ss.UnsafeL2.Number)
-}
-
 // computeSyncActions determines the actions that should be taken based on the inputs provided. The inputs are the current
 // state of the batcher (blocks and channels), the new sync status, and the previous current L1 block. The actions are returned
 // in a struct specifying the number of blocks to prune, the number of channels to prune, whether to wait for node sync, the block
 // range to load into the local state, and whether to clear the state entirely. Returns an boolean indicating if the sequencer is out of sync.
 func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCurrentL1 eth.L1BlockRef, blocks queue.Queue[*types.Block], channels []T, l log.Logger) (syncActions, bool) {
 
-	m := l.With("newSyncStatus", summarizeSyncStatusNumbers(newSyncStatus))
+	m := l.With(
+		"syncStatus.headL1", newSyncStatus.HeadL1,
+		"syncStatus.currentL1", newSyncStatus.CurrentL1,
+		"syncStatus.localSafeL2", newSyncStatus.LocalSafeL2,
+		"syncStatus.unsafeL2", newSyncStatus.UnsafeL2,
+	)
 
 	// PART 1: Initial checks on the sync status
 	if newSyncStatus.HeadL1 == (eth.L1BlockRef{}) {

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -17,6 +17,11 @@ type channelStatuser interface {
 }
 
 type inclusiveBlockRange struct{ start, end uint64 }
+
+func (r *inclusiveBlockRange) TerminalString() string {
+	return fmt.Sprintf("[%d, %d]", r.start, r.end)
+}
+
 type syncActions struct {
 	clearState      *eth.BlockID
 	blocksToPrune   int
@@ -25,9 +30,22 @@ type syncActions struct {
 	// NOTE this range is inclusive on both ends, which is a change to previous behaviour.
 }
 
-func (s syncActions) String() string {
+func (s syncActions) TerminalString() string {
+	cs := "nil"
+	if s.clearState != nil {
+		cs = s.clearState.TerminalString()
+	}
+	btl := "nil"
+	if s.blocksToLoad != nil {
+		btl = s.blocksToLoad.TerminalString()
+	}
 	return fmt.Sprintf(
-		"SyncActions{blocksToPrune: %d, channelsToPrune: %d, clearState: %v, blocksToLoad: %v}", s.blocksToPrune, s.channelsToPrune, s.clearState, s.blocksToLoad)
+		"SyncActions{blocksToPrune: %d, channelsToPrune: %d, clearState: %v, blocksToLoad: %v}", s.blocksToPrune, s.channelsToPrune, cs, btl)
+}
+
+func summarizeSyncStatusNumbers(ss eth.SyncStatus) string {
+	return fmt.Sprintf("SyncStatus{HeadL1: %d, CurrentL1: %d, LocalSafeL2: %d, UnsafeL2: %d}",
+		ss.HeadL1.Number, ss.CurrentL1.Number, ss.LocalSafeL2.Number, ss.UnsafeL2.Number)
 }
 
 // computeSyncActions determines the actions that should be taken based on the inputs provided. The inputs are the current
@@ -36,15 +54,17 @@ func (s syncActions) String() string {
 // range to load into the local state, and whether to clear the state entirely. Returns an boolean indicating if the sequencer is out of sync.
 func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCurrentL1 eth.L1BlockRef, blocks queue.Queue[*types.Block], channels []T, l log.Logger) (syncActions, bool) {
 
+	m := l.With("newSyncStatus", summarizeSyncStatusNumbers(newSyncStatus))
+
 	// PART 1: Initial checks on the sync status
 	if newSyncStatus.HeadL1 == (eth.L1BlockRef{}) {
-		l.Warn("empty sync status")
+		m.Warn("empty sync status")
 		return syncActions{}, true
 	}
 
 	if newSyncStatus.CurrentL1.Number < prevCurrentL1.Number {
 		// This can happen when the sequencer restarts
-		l.Warn("sequencer currentL1 reversed")
+		m.Warn("sequencer currentL1 reversed", "prevCurrentL1", prevCurrentL1)
 		return syncActions{}, true
 	}
 
@@ -60,7 +80,7 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 		s := syncActions{
 			blocksToLoad: allUnsafeBlocks,
 		}
-		l.Info("no blocks in state", "syncActions", s)
+		m.Info("no blocks in state", "syncActions", s)
 		return s, false
 	}
 
@@ -77,10 +97,9 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 	nextSafeBlockNum := newSyncStatus.LocalSafeL2.Number + 1
 
 	if nextSafeBlockNum < oldestBlockInStateNum {
-		l.Warn("next safe block is below oldest block in state",
+		m.Warn("next safe block is below oldest block in state",
 			"syncActions", startAfresh,
-			"oldestBlockInState", oldestBlockInState,
-			"safeL2", newSyncStatus.LocalSafeL2)
+			"oldestBlockInStateNum", oldestBlockInStateNum)
 		return startAfresh, false
 	}
 
@@ -94,19 +113,17 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 		// This could happen if the batcher restarted.
 		// The sequencer may have derived the safe chain
 		// from channels sent by a previous batcher instance.
-		l.Warn("safe head above newest block in state, clearing channel manager state",
+		m.Warn("safe head above newest block in state, clearing channel manager state",
 			"syncActions", startAfresh,
-			"safeL2", newSyncStatus.LocalSafeL2,
 			"newestBlockInState", eth.ToBlockID(newestBlockInState),
 		)
 		return startAfresh, false
 	}
 
 	if numBlocksToDequeue > 0 && blocks[numBlocksToDequeue-1].Hash() != newSyncStatus.LocalSafeL2.Hash {
-		l.Warn("safe chain reorg, clearing channel manager state",
+		m.Warn("safe chain reorg, clearing channel manager state",
 			"syncActions", startAfresh,
-			"existingBlock", eth.ToBlockID(blocks[numBlocksToDequeue-1]),
-			"safeL2", newSyncStatus.LocalSafeL2)
+			"existingBlock", eth.ToBlockID(blocks[numBlocksToDequeue-1]))
 		return startAfresh, false
 	}
 
@@ -120,10 +137,9 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 			// for a fully submitted channel. This indicates
 			// that the derivation pipeline may have stalled
 			// e.g. because of Holocene strict ordering rules.
-			l.Warn("sequencer did not make expected progress",
+			m.Warn("sequencer did not make expected progress",
 				"syncActions", startAfresh,
-				"existingBlock", ch.LatestL2(),
-				"safeL2", newSyncStatus.LocalSafeL2)
+				"existingBlock", ch.LatestL2())
 			return startAfresh, false
 		}
 	}
@@ -144,9 +160,11 @@ func computeSyncActions[T channelStatuser](newSyncStatus eth.SyncStatus, prevCur
 		allUnsafeBlocksAboveState = &inclusiveBlockRange{newestBlockInStateNum + 1, newSyncStatus.UnsafeL2.Number}
 	}
 
-	return syncActions{
+	a := syncActions{
 		blocksToPrune:   int(numBlocksToDequeue),
 		channelsToPrune: numChannelsToPrune,
 		blocksToLoad:    allUnsafeBlocksAboveState,
-	}, false
+	}
+	m.Debug("computed sync actions", "syncActions", a)
+	return a, false
 }

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -55,7 +55,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		timedOut:       false,
 	}
 
-	happyCaseLogs := []string{} // in the happy case we expect no logs
+	happyCaseLogs := []string{"computed sync actions"}
 
 	type TestCase struct {
 		name string
@@ -196,6 +196,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{104, 109},
 			},
+			expectedLogs: happyCaseLogs,
 		},
 		{name: "no blocks",
 			// This happens when the batcher is starting up for the first time
@@ -229,6 +230,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				channelsToPrune: 1,
 				blocksToLoad:    &inclusiveBlockRange{104, 109},
 			},
+			expectedLogs: happyCaseLogs,
 		},
 		{name: "happy path + multiple channels",
 			newSyncStatus: eth.SyncStatus{
@@ -277,7 +279,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases[len(testCases)-1:] {
+	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
 			l, h := testlog.CaptureLogger(t, log.LevelDebug)


### PR DESCRIPTION
Test output covers the various cases:


```log
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestBatchSubmitter_computeSyncActions$ github.com/ethereum-optimism/optimism/op-batcher/batcher -v

=== RUN   TestBatchSubmitter_computeSyncActions
=== RUN   TestBatchSubmitter_computeSyncActions/empty_sync_status
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:61:         WARN [02-27|17:49:03.385] empty sync status                        newSyncStatus="SyncStatus{HeadL1: 0, CurrentL1: 0, LocalSafeL2: 0, UnsafeL2: 0}"
=== RUN   TestBatchSubmitter_computeSyncActions/current_l1_reversed
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:67:         WARN [02-27|17:49:03.385] sequencer currentL1 reversed             newSyncStatus="SyncStatus{HeadL1: 2, CurrentL1: 1, LocalSafeL2: 0, UnsafeL2: 0}" prevCurrentL1=000000..000000:2
=== RUN   TestBatchSubmitter_computeSyncActions/gap_between_safe_chain_and_state
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:100:        WARN [02-27|17:49:03.385] next safe block is below oldest block in state newSyncStatus="SyncStatus{HeadL1: 6, CurrentL1: 1, LocalSafeL2: 100, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: 000000..000000:1, blocksToLoad: [101, 109]}" oldestBlockInStateNum=102
=== RUN   TestBatchSubmitter_computeSyncActions/unexpectedly_good_progress
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:116:        WARN [02-27|17:49:03.385] safe head above newest block in state, clearing channel manager state newSyncStatus="SyncStatus{HeadL1: 6, CurrentL1: 2, LocalSafeL2: 104, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: 000000..000000:1, blocksToLoad: [105, 109]}" newestBlockInState=e9b71a..2b29ec:103
=== RUN   TestBatchSubmitter_computeSyncActions/safe_chain_reorg
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:124:        WARN [02-27|17:49:03.385] safe chain reorg, clearing channel manager state newSyncStatus="SyncStatus{HeadL1: 5, CurrentL1: 2, LocalSafeL2: 103, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: 000000..000000:1, blocksToLoad: [104, 109]}" existingBlock=e9b71a..2b29ec:103
=== RUN   TestBatchSubmitter_computeSyncActions/failed_to_make_expected_progress
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:140:        WARN [02-27|17:49:03.385] sequencer did not make expected progress newSyncStatus="SyncStatus{HeadL1: 3, CurrentL1: 2, LocalSafeL2: 101, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: 000000..000000:1, blocksToLoad: [102, 109]}" existingBlock=e9b71a..2b29ec:103
=== RUN   TestBatchSubmitter_computeSyncActions/failed_to_make_expected_progress_(unsafe=safe)
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:140:        WARN [02-27|17:49:03.385] sequencer did not make expected progress newSyncStatus="SyncStatus{HeadL1: 3, CurrentL1: 2, LocalSafeL2: 101, UnsafeL2: 101}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: 000000..000000:1, blocksToLoad: nil}" existingBlock=e9b71a..2b29ec:103
=== RUN   TestBatchSubmitter_computeSyncActions/no_progress
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:168:        DEBUG[02-27|17:49:03.385] computed sync actions                    newSyncStatus="SyncStatus{HeadL1: 4, CurrentL1: 1, LocalSafeL2: 100, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: nil, blocksToLoad: [104, 109]}"
=== RUN   TestBatchSubmitter_computeSyncActions/no_blocks
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:83:         INFO [02-27|17:49:03.385] no blocks in state                       newSyncStatus="SyncStatus{HeadL1: 5, CurrentL1: 2, LocalSafeL2: 103, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: nil, blocksToLoad: [104, 109]}"
=== RUN   TestBatchSubmitter_computeSyncActions/happy_path
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:168:        DEBUG[02-27|17:49:03.385] computed sync actions                    newSyncStatus="SyncStatus{HeadL1: 5, CurrentL1: 2, LocalSafeL2: 103, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 3, channelsToPrune: 1, clearState: nil, blocksToLoad: [104, 109]}"
=== RUN   TestBatchSubmitter_computeSyncActions/happy_path_+_multiple_channels
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:168:        DEBUG[02-27|17:49:03.385] computed sync actions                    newSyncStatus="SyncStatus{HeadL1: 5, CurrentL1: 2, LocalSafeL2: 103, UnsafeL2: 109}" syncActions="SyncActions{blocksToPrune: 3, channelsToPrune: 1, clearState: nil, blocksToLoad: [105, 109]}"
=== RUN   TestBatchSubmitter_computeSyncActions/no_progress_+_unsafe=safe
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:83:         INFO [02-27|17:49:03.385] no blocks in state                       newSyncStatus="SyncStatus{HeadL1: 5, CurrentL1: 2, LocalSafeL2: 100, UnsafeL2: 100}" syncActions="SyncActions{blocksToPrune: 0, channelsToPrune: 0, clearState: nil, blocksToLoad: nil}"
=== RUN   TestBatchSubmitter_computeSyncActions/no_progress_+_unsafe=safe_+_blocks_in_state
    /Users/georgeknee/code/ethereum-optimism/optimism/op-batcher/batcher/sync_actions.go:168:        DEBUG[02-27|17:49:03.385] computed sync actions                    newSyncStatus="SyncStatus{HeadL1: 5, CurrentL1: 2, LocalSafeL2: 101, UnsafeL2: 101}" syncActions="SyncActions{blocksToPrune: 1, channelsToPrune: 0, clearState: nil, blocksToLoad: nil}"
--- PASS: TestBatchSubmitter_computeSyncActions (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/empty_sync_status (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/current_l1_reversed (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/gap_between_safe_chain_and_state (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/unexpectedly_good_progress (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/safe_chain_reorg (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/failed_to_make_expected_progress (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/failed_to_make_expected_progress_(unsafe=safe) (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/no_progress (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/no_blocks (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/happy_path (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/happy_path_+_multiple_channels (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/no_progress_+_unsafe=safe (0.00s)
    --- PASS: TestBatchSubmitter_computeSyncActions/no_progress_+_unsafe=safe_+_blocks_in_state (0.00s)
PASS
ok      github.com/ethereum-optimism/optimism/op-batcher/batcher        0.417s
```