### PR TITLE
deploy: Update deploy script to require MIPS64 for production networks

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -746,7 +746,7 @@ contract DeployImplementations is Script {
         uint256 mipsVersion = _dii.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(address(_dio.preimageOracleSingleton()));
 
-        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips64 on production networks.
+        // We want to ensure that the OPCM for upgrade 14 is deployed with Mips64 on production networks.
         if (mipsVersion != 2) {
             if (block.chainid == Chains.Mainnet || block.chainid == Chains.Sepolia) {
                 revert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -746,10 +746,10 @@ contract DeployImplementations is Script {
         uint256 mipsVersion = _dii.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(address(_dio.preimageOracleSingleton()));
 
-        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips32 on production networks.
-        if (mipsVersion != 1) {
+        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips64 on production networks.
+        if (mipsVersion != 2) {
             if (block.chainid == Chains.Mainnet || block.chainid == Chains.Sepolia) {
-                revert("DeployImplementations: Only Mips32 should be deployed on Mainnet or Sepolia");
+                revert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
             }
         }
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -432,14 +432,14 @@ contract DeployImplementations_Test is Test {
 
     function test_run_deployMipsV1OnMainnetOrSepolia_reverts() public {
         setDefaults();
-        dii.set(dii.mipsVersion.selector, 2);
+        dii.set(dii.mipsVersion.selector, 1);
 
         vm.chainId(Chains.Mainnet);
-        vm.expectRevert("DeployImplementations: Only Mips32 should be deployed on Mainnet or Sepolia");
+        vm.expectRevert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
         deployImplementations.run(dii, dio);
 
         vm.chainId(Chains.Sepolia);
-        vm.expectRevert("DeployImplementations: Only Mips32 should be deployed on Mainnet or Sepolia");
+        vm.expectRevert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
         deployImplementations.run(dii, dio);
     }
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

To prepare for Upgrade 14, update `DeployImplementations` script to require `MIPS64` for production networks.

**Tests**

Updated unit test.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/14459
