### PR TITLE
opcm: Prep upgrade 14 for MTCannon

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -746,7 +746,7 @@ contract DeployImplementations is Script {
         uint256 mipsVersion = _dii.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(address(_dio.preimageOracleSingleton()));
 
-        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips64 on production networks.
+        // We want to ensure that the OPCM for upgrade 14 is deployed with Mips64 on production networks.
         if (mipsVersion != 2) {
             if (block.chainid == Chains.Mainnet || block.chainid == Chains.Sepolia) {
                 revert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -746,10 +746,10 @@ contract DeployImplementations is Script {
         uint256 mipsVersion = _dii.mipsVersion();
         IPreimageOracle preimageOracle = IPreimageOracle(address(_dio.preimageOracleSingleton()));
 
-        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips32 on production networks.
-        if (mipsVersion != 1) {
+        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips64 on production networks.
+        if (mipsVersion != 2) {
             if (block.chainid == Chains.Mainnet || block.chainid == Chains.Sepolia) {
-                revert("DeployImplementations: Only Mips32 should be deployed on Mainnet or Sepolia");
+                revert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
             }
         }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -3,5 +3,170 @@ import {OPContractsManager} from "./OPContractsManager.sol";
 ///  @title OPContractsManager14
 ///  @notice Represents the new OPContractsManager for Upgrade 14
 contract OPContractsManager14 is OPContractsManager {
-    
+
+    /// @notice Upgrades a set of chains to the latest implementation contracts
+    /// @param _opChainConfigs Array of OpChain structs, one per chain to upgrade
+    /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
+    function upgrade(OpChainConfig[] memory _opChainConfigs) external virtual {
+        if (address(this) == address(thisOPCM)) revert OnlyDelegatecall();
+
+        // If this is delegatecalled by the upgrade controller, set isRC to false first, else, continue execution.
+        if (address(this) == upgradeController) {
+            // Set isRC to false.
+            // This function asserts that the caller is the upgrade controller.
+            thisOPCM.setRC(false);
+        }
+
+        Implementations memory impls = getImplementations();
+        Blueprints memory bps = getBlueprints();
+
+        // If the SuperchainConfig is not already upgraded, upgrade it.
+        if (superchainProxyAdmin.getProxyImplementation(address(superchainConfig)) != impls.superchainConfigImpl) {
+            // Attempt to upgrade. If the ProxyAdmin is not the SuperchainConfig's admin, this will revert.
+            upgradeTo(superchainProxyAdmin, address(superchainConfig), impls.superchainConfigImpl);
+        }
+
+        // If the ProtocolVersions contract is not already upgraded, upgrade it.
+        if (superchainProxyAdmin.getProxyImplementation(address(protocolVersions)) != impls.protocolVersionsImpl) {
+            upgradeTo(superchainProxyAdmin, address(protocolVersions), impls.protocolVersionsImpl);
+        }
+
+        for (uint256 i = 0; i < _opChainConfigs.length; i++) {
+            assertValidOpChainConfig(_opChainConfigs[i]);
+
+            // After Upgrade 13, we will be able to use systemConfigProxy.getAddresses() here.
+            ISystemConfig.Addresses memory opChainAddrs = ISystemConfig.Addresses({
+                l1CrossDomainMessenger: _opChainConfigs[i].systemConfigProxy.l1CrossDomainMessenger(),
+                l1ERC721Bridge: _opChainConfigs[i].systemConfigProxy.l1ERC721Bridge(),
+                l1StandardBridge: _opChainConfigs[i].systemConfigProxy.l1StandardBridge(),
+                disputeGameFactory: address(getDisputeGameFactory(_opChainConfigs[i].systemConfigProxy)),
+                optimismPortal: _opChainConfigs[i].systemConfigProxy.optimismPortal(),
+                optimismMintableERC20Factory: _opChainConfigs[i].systemConfigProxy.optimismMintableERC20Factory()
+            });
+
+            // Check that all contracts have the correct superchainConfig
+            if (
+                getSuperchainConfig(opChainAddrs.optimismPortal) != superchainConfig
+                || getSuperchainConfig(opChainAddrs.l1CrossDomainMessenger) != superchainConfig
+                || getSuperchainConfig(opChainAddrs.l1ERC721Bridge) != superchainConfig
+                || getSuperchainConfig(opChainAddrs.l1StandardBridge) != superchainConfig
+            ) {
+                revert SuperchainConfigMismatch(_opChainConfigs[i].systemConfigProxy);
+            }
+
+            // -------- Upgrade Contracts Stored in SystemConfig --------
+            upgradeTo(
+                _opChainConfigs[i].proxyAdmin, address(_opChainConfigs[i].systemConfigProxy), impls.systemConfigImpl
+            );
+            upgradeTo(
+                _opChainConfigs[i].proxyAdmin, opChainAddrs.l1CrossDomainMessenger, impls.l1CrossDomainMessengerImpl
+            );
+            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.l1ERC721Bridge, impls.l1ERC721BridgeImpl);
+            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.l1StandardBridge, impls.l1StandardBridgeImpl);
+            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.disputeGameFactory, impls.disputeGameFactoryImpl);
+            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.optimismPortal, impls.optimismPortalImpl);
+            upgradeTo(
+                _opChainConfigs[i].proxyAdmin,
+                opChainAddrs.optimismMintableERC20Factory,
+                impls.optimismMintableERC20FactoryImpl
+            );
+
+            // -------- Discover and Upgrade Proofs Contracts --------
+            // Note that, the code below uses several independently scoped blocks to avoid stack too deep errors.
+
+            // All chains have the Permissioned Dispute Game. We get it first so that we can use it to
+            // retrieve its WETH and the Anchor State Registry when we need them.
+            IPermissionedDisputeGame permissionedDisputeGame = IPermissionedDisputeGame(
+                address(
+                    getGameImplementation(
+                        IDisputeGameFactory(opChainAddrs.disputeGameFactory), GameTypes.PERMISSIONED_CANNON
+                    )
+                )
+            );
+            // We're also going to need the l2ChainId below, so we cache it in the outer scope.
+            uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
+
+            // Replace the Anchor State Registry Proxy with a new Proxy and Implementation
+            // For this upgrade, we are replacing the previous Anchor State Registry, thus we:
+            // 1. deploy a new Anchor State Registry proxy
+            // 2. get the starting anchor root corresponding to the currently respected game type.
+            // 3. initialize the proxy with that anchor root
+            IAnchorStateRegistry newAnchorStateRegistryProxy;
+            {
+                // Deploy a new proxy, because we're replacing the old one.
+                // Include the system config address in the salt to ensure that the new proxy is unique,
+                // even if another chains with the same L2 chain ID has been deployed by this contract.
+                newAnchorStateRegistryProxy = IAnchorStateRegistry(
+                    deployProxy({
+                        _l2ChainId: l2ChainId,
+                        _proxyAdmin: _opChainConfigs[i].proxyAdmin,
+                        _saltMixer: reusableSaltMixer(_opChainConfigs[i]),
+                        _contractName: "AnchorStateRegistry"
+                    })
+                );
+
+                // Get the starting anchor root by:
+                // 1. getting the anchor state registry from the Permissioned Dispute Game.
+                // 2. getting the respected game type from the OptimismPortal.
+                // 3. getting the anchor root for the respected game type from the Anchor State Registry.
+                {
+                    GameType gameType = IOptimismPortal2(payable(opChainAddrs.optimismPortal)).respectedGameType();
+                    (Hash root, uint256 l2BlockNumber) =
+                                            getAnchorStateRegistry(IFaultDisputeGame(address(permissionedDisputeGame))).anchors(gameType);
+                    OutputRoot memory startingAnchorRoot = OutputRoot({ root: root, l2BlockNumber: l2BlockNumber });
+
+                    upgradeToAndCall(
+                        _opChainConfigs[i].proxyAdmin,
+                        address(newAnchorStateRegistryProxy),
+                        impls.anchorStateRegistryImpl,
+                        abi.encodeCall(
+                            IAnchorStateRegistry.initialize,
+                            (
+                                superchainConfig,
+                                IDisputeGameFactory(opChainAddrs.disputeGameFactory),
+                                IOptimismPortal2(payable(opChainAddrs.optimismPortal)),
+                                startingAnchorRoot
+                            )
+                        )
+                    );
+                }
+
+                // Deploy and set a new permissioned game to update its prestate
+
+                deployAndSetNewGameImpl({
+                    _l2ChainId: l2ChainId,
+                    _disputeGame: IDisputeGame(address(permissionedDisputeGame)),
+                    _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
+                    _gameType: GameTypes.PERMISSIONED_CANNON,
+                    _opChainConfig: _opChainConfigs[i],
+                    _implementations: impls,
+                    _blueprints: bps,
+                    _opChainAddrs: opChainAddrs
+                });
+            }
+
+            // Now retrieve the permissionless game. If it exists, upgrade its weth and replace its implementation.
+            IFaultDisputeGame permissionlessDisputeGame = IFaultDisputeGame(
+                address(getGameImplementation(IDisputeGameFactory(opChainAddrs.disputeGameFactory), GameTypes.CANNON))
+            );
+
+            if (address(permissionlessDisputeGame) != address(0)) {
+                // Deploy and set a new permissionless game to update its prestate
+                deployAndSetNewGameImpl({
+                    _l2ChainId: l2ChainId,
+                    _disputeGame: IDisputeGame(address(permissionlessDisputeGame)),
+                    _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
+                    _gameType: GameTypes.CANNON,
+                    _opChainConfig: _opChainConfigs[i],
+                    _implementations: impls,
+                    _blueprints: bps,
+                    _opChainAddrs: opChainAddrs
+                });
+            }
+
+            // Emit the upgraded event with the address of the caller. Since this will be a delegatecall,
+            // the caller will be the value of the ADDRESS opcode.
+            emit Upgraded(l2ChainId, _opChainConfigs[i].systemConfigProxy, address(this));
+        }
+    }
 }

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -4,6 +4,10 @@ import {OPContractsManager} from "./OPContractsManager.sol";
 ///  @notice Represents the new OPContractsManager for Upgrade 14
 contract OPContractsManager14 is OPContractsManager {
 
+    function version() public pure override returns (string memory) {
+        return string.concat(super.version(), "+upgrade14.1");
+    }
+
     /// @notice Upgrades a set of chains to the latest implementation contracts
     /// @param _opChainConfigs Array of OpChain structs, one per chain to upgrade
     /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -1,4 +1,7 @@
-import {OPContractsManager} from "./OPContractsManager.sol";
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { OPContractsManager } from "./OPContractsManager.sol";
 
 ///  @title OPContractsManager14
 ///  @notice Represents the new OPContractsManager for Upgrade 14

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -1,0 +1,7 @@
+import {OPContractsManager} from "./OPContractsManager.sol";
+
+///  @title OPContractsManager14
+///  @notice Represents the new OPContractsManager for Upgrade 14
+contract OPContractsManager14 is OPContractsManager {
+    
+}

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -19,7 +19,6 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 ///  @title OPContractsManager14
 ///  @notice Represents the new OPContractsManager for Upgrade 14
 contract OPContractsManager14 is OPContractsManager {
-
     function version() public pure override returns (string memory) {
         return string.concat(super.version(), "+upgrade14.1");
     }
@@ -61,62 +60,23 @@ contract OPContractsManager14 is OPContractsManager {
         Implementations memory impls = getImplementations();
         Blueprints memory bps = getBlueprints();
 
-        // If the SuperchainConfig is not already upgraded, upgrade it.
-        if (superchainProxyAdmin.getProxyImplementation(address(superchainConfig)) != impls.superchainConfigImpl) {
-            // Attempt to upgrade. If the ProxyAdmin is not the SuperchainConfig's admin, this will revert.
-            upgradeTo(superchainProxyAdmin, address(superchainConfig), impls.superchainConfigImpl);
-        }
-
-        // If the ProtocolVersions contract is not already upgraded, upgrade it.
-        if (superchainProxyAdmin.getProxyImplementation(address(protocolVersions)) != impls.protocolVersionsImpl) {
-            upgradeTo(superchainProxyAdmin, address(protocolVersions), impls.protocolVersionsImpl);
-        }
-
         for (uint256 i = 0; i < _opChainConfigs.length; i++) {
             assertValidOpChainConfig(_opChainConfigs[i]);
-
-            // After Upgrade 13, we will be able to use systemConfigProxy.getAddresses() here.
-            ISystemConfig.Addresses memory opChainAddrs = ISystemConfig.Addresses({
-                l1CrossDomainMessenger: _opChainConfigs[i].systemConfigProxy.l1CrossDomainMessenger(),
-                l1ERC721Bridge: _opChainConfigs[i].systemConfigProxy.l1ERC721Bridge(),
-                l1StandardBridge: _opChainConfigs[i].systemConfigProxy.l1StandardBridge(),
-                disputeGameFactory: address(getDisputeGameFactory(_opChainConfigs[i].systemConfigProxy)),
-                optimismPortal: _opChainConfigs[i].systemConfigProxy.optimismPortal(),
-                optimismMintableERC20Factory: _opChainConfigs[i].systemConfigProxy.optimismMintableERC20Factory()
-            });
+            ISystemConfig.Addresses memory opChainAddrs = _opChainConfigs[i].systemConfigProxy.getAddresses();
 
             // Check that all contracts have the correct superchainConfig
             if (
                 getSuperchainConfig(opChainAddrs.optimismPortal) != superchainConfig
-                || getSuperchainConfig(opChainAddrs.l1CrossDomainMessenger) != superchainConfig
-                || getSuperchainConfig(opChainAddrs.l1ERC721Bridge) != superchainConfig
-                || getSuperchainConfig(opChainAddrs.l1StandardBridge) != superchainConfig
+                    || getSuperchainConfig(opChainAddrs.l1CrossDomainMessenger) != superchainConfig
+                    || getSuperchainConfig(opChainAddrs.l1ERC721Bridge) != superchainConfig
+                    || getSuperchainConfig(opChainAddrs.l1StandardBridge) != superchainConfig
             ) {
                 revert SuperchainConfigMismatch(_opChainConfigs[i].systemConfigProxy);
             }
 
-            // -------- Upgrade Contracts Stored in SystemConfig --------
-            upgradeTo(
-                _opChainConfigs[i].proxyAdmin, address(_opChainConfigs[i].systemConfigProxy), impls.systemConfigImpl
-            );
-            upgradeTo(
-                _opChainConfigs[i].proxyAdmin, opChainAddrs.l1CrossDomainMessenger, impls.l1CrossDomainMessengerImpl
-            );
-            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.l1ERC721Bridge, impls.l1ERC721BridgeImpl);
-            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.l1StandardBridge, impls.l1StandardBridgeImpl);
-            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.disputeGameFactory, impls.disputeGameFactoryImpl);
-            upgradeTo(_opChainConfigs[i].proxyAdmin, opChainAddrs.optimismPortal, impls.optimismPortalImpl);
-            upgradeTo(
-                _opChainConfigs[i].proxyAdmin,
-                opChainAddrs.optimismMintableERC20Factory,
-                impls.optimismMintableERC20FactoryImpl
-            );
-
             // -------- Discover and Upgrade Proofs Contracts --------
-            // Note that, the code below uses several independently scoped blocks to avoid stack too deep errors.
 
-            // All chains have the Permissioned Dispute Game. We get it first so that we can use it to
-            // retrieve its WETH and the Anchor State Registry when we need them.
+            // All chains have the Permissioned Dispute Game.
             IPermissionedDisputeGame permissionedDisputeGame = IPermissionedDisputeGame(
                 address(
                     getGameImplementation(
@@ -127,66 +87,7 @@ contract OPContractsManager14 is OPContractsManager {
             // We're also going to need the l2ChainId below, so we cache it in the outer scope.
             uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
 
-            // Replace the Anchor State Registry Proxy with a new Proxy and Implementation
-            // For this upgrade, we are replacing the previous Anchor State Registry, thus we:
-            // 1. deploy a new Anchor State Registry proxy
-            // 2. get the starting anchor root corresponding to the currently respected game type.
-            // 3. initialize the proxy with that anchor root
-            IAnchorStateRegistry newAnchorStateRegistryProxy;
-            {
-                // Deploy a new proxy, because we're replacing the old one.
-                // Include the system config address in the salt to ensure that the new proxy is unique,
-                // even if another chains with the same L2 chain ID has been deployed by this contract.
-                newAnchorStateRegistryProxy = IAnchorStateRegistry(
-                    deployProxy({
-                        _l2ChainId: l2ChainId,
-                        _proxyAdmin: _opChainConfigs[i].proxyAdmin,
-                        _saltMixer: reusableSaltMixer(_opChainConfigs[i]),
-                        _contractName: "AnchorStateRegistry"
-                    })
-                );
-
-                // Get the starting anchor root by:
-                // 1. getting the anchor state registry from the Permissioned Dispute Game.
-                // 2. getting the respected game type from the OptimismPortal.
-                // 3. getting the anchor root for the respected game type from the Anchor State Registry.
-                {
-                    GameType gameType = IOptimismPortal2(payable(opChainAddrs.optimismPortal)).respectedGameType();
-                    (Hash root, uint256 l2BlockNumber) =
-                                            getAnchorStateRegistry(IFaultDisputeGame(address(permissionedDisputeGame))).anchors(gameType);
-                    OutputRoot memory startingAnchorRoot = OutputRoot({ root: root, l2BlockNumber: l2BlockNumber });
-
-                    upgradeToAndCall(
-                        _opChainConfigs[i].proxyAdmin,
-                        address(newAnchorStateRegistryProxy),
-                        impls.anchorStateRegistryImpl,
-                        abi.encodeCall(
-                            IAnchorStateRegistry.initialize,
-                            (
-                                superchainConfig,
-                                IDisputeGameFactory(opChainAddrs.disputeGameFactory),
-                                IOptimismPortal2(payable(opChainAddrs.optimismPortal)),
-                                startingAnchorRoot
-                            )
-                        )
-                    );
-                }
-
-                // Deploy and set a new permissioned game to update its prestate
-
-                deployAndSetNewGameImpl({
-                    _l2ChainId: l2ChainId,
-                    _disputeGame: IDisputeGame(address(permissionedDisputeGame)),
-                    _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
-                    _gameType: GameTypes.PERMISSIONED_CANNON,
-                    _opChainConfig: _opChainConfigs[i],
-                    _implementations: impls,
-                    _blueprints: bps,
-                    _opChainAddrs: opChainAddrs
-                });
-            }
-
-            // Now retrieve the permissionless game. If it exists, upgrade its weth and replace its implementation.
+            // Now retrieve the permissionless game. If it exists, replace its implementation.
             IFaultDisputeGame permissionlessDisputeGame = IFaultDisputeGame(
                 address(getGameImplementation(IDisputeGameFactory(opChainAddrs.disputeGameFactory), GameTypes.CANNON))
             );
@@ -196,7 +97,6 @@ contract OPContractsManager14 is OPContractsManager {
                 deployAndSetNewGameImpl({
                     _l2ChainId: l2ChainId,
                     _disputeGame: IDisputeGame(address(permissionlessDisputeGame)),
-                    _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
                     _gameType: GameTypes.CANNON,
                     _opChainConfig: _opChainConfigs[i],
                     _implementations: impls,
@@ -214,7 +114,6 @@ contract OPContractsManager14 is OPContractsManager {
     /// @notice Deploys and sets a new dispute game implementation
     /// @param _l2ChainId The L2 chain ID
     /// @param _disputeGame The current dispute game implementation
-    /// @param _newAnchorStateRegistryProxy The new anchor state registry proxy
     /// @param _gameType The type of game to deploy
     /// @param _opChainConfig The OP chain configuration
     /// @param _blueprints The blueprint addresses
@@ -223,29 +122,21 @@ contract OPContractsManager14 is OPContractsManager {
     function deployAndSetNewGameImpl(
         uint256 _l2ChainId,
         IDisputeGame _disputeGame,
-        IAnchorStateRegistry _newAnchorStateRegistryProxy,
         GameType _gameType,
         OpChainConfig memory _opChainConfig,
         Blueprints memory _blueprints,
         Implementations memory _implementations,
         ISystemConfig.Addresses memory _opChainAddrs
     )
-    internal
+        internal
     {
-        // independently scoped block to avoid stack too deep
-        {
-            // Get and upgrade the WETH proxy
-            IDelayedWETH delayedWethProxy = getWETH(IFaultDisputeGame(address(_disputeGame)));
-            upgradeTo(_opChainConfig.proxyAdmin, address(delayedWethProxy), _implementations.delayedWETHImpl);
-        }
-
         // Get the constructor params for the game
         IFaultDisputeGame.GameConstructorParams memory params =
-                        getGameConstructorParams(IFaultDisputeGame(address(_disputeGame)));
+            getGameConstructorParams(IFaultDisputeGame(address(_disputeGame)));
 
-        // Modify the params with the new anchorStateRegistry and vm values.
-        params.anchorStateRegistry = IAnchorStateRegistry(address(_newAnchorStateRegistryProxy));
+        // Set the new vm value.
         params.vm = IBigStepper(_implementations.mipsImpl);
+        // Set the new absolute prestate
         if (Claim.unwrap(_opChainConfig.absolutePrestate) == bytes32(0)) {
             revert PrestateNotSet();
         }
@@ -275,5 +166,4 @@ contract OPContractsManager14 is OPContractsManager {
         }
         setDGFImplementation(IDisputeGameFactory(_opChainAddrs.disputeGameFactory), _gameType, IDisputeGame(newGame));
     }
-
 }

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -2,6 +2,19 @@
 pragma solidity 0.8.15;
 
 import { OPContractsManager } from "./OPContractsManager.sol";
+// Libraries
+import { Blueprint } from "src/libraries/Blueprint.sol";
+import { Claim, GameType, GameTypes } from "src/dispute/lib/Types.sol";
+// Interfaces
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 ///  @title OPContractsManager14
 ///  @notice Represents the new OPContractsManager for Upgrade 14
@@ -11,10 +24,31 @@ contract OPContractsManager14 is OPContractsManager {
         return string.concat(super.version(), "+upgrade14.1");
     }
 
+    // TODO: Review required arguments
+    constructor(
+        ISuperchainConfig _superchainConfig,
+        IProtocolVersions _protocolVersions,
+        IProxyAdmin _superchainProxyAdmin,
+        string memory _l1ContractsRelease,
+        Blueprints memory _blueprints,
+        Implementations memory _implementations,
+        address _upgradeController
+    )
+    OPContractsManager(
+    _superchainConfig,
+    _protocolVersions,
+    _superchainProxyAdmin,
+    _l1ContractsRelease,
+    _blueprints,
+    _implementations,
+    _upgradeController
+    )
+    { }
+
     /// @notice Upgrades a set of chains to the latest implementation contracts
     /// @param _opChainConfigs Array of OpChain structs, one per chain to upgrade
     /// @dev This function is intended to be called via DELEGATECALL from the Upgrade Controller Safe
-    function upgrade(OpChainConfig[] memory _opChainConfigs) external virtual {
+    function upgrade(OpChainConfig[] memory _opChainConfigs) external override {
         if (address(this) == address(thisOPCM)) revert OnlyDelegatecall();
 
         // If this is delegatecalled by the upgrade controller, set isRC to false first, else, continue execution.

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -64,16 +64,6 @@ contract OPContractsManager14 is OPContractsManager {
             assertValidOpChainConfig(_opChainConfigs[i]);
             ISystemConfig.Addresses memory opChainAddrs = _opChainConfigs[i].systemConfigProxy.getAddresses();
 
-            // Check that all contracts have the correct superchainConfig
-            if (
-                getSuperchainConfig(opChainAddrs.optimismPortal) != superchainConfig
-                    || getSuperchainConfig(opChainAddrs.l1CrossDomainMessenger) != superchainConfig
-                    || getSuperchainConfig(opChainAddrs.l1ERC721Bridge) != superchainConfig
-                    || getSuperchainConfig(opChainAddrs.l1StandardBridge) != superchainConfig
-            ) {
-                revert SuperchainConfigMismatch(_opChainConfigs[i].systemConfigProxy);
-            }
-
             // -------- Discover and Upgrade Proofs Contracts --------
 
             // All chains have the Permissioned Dispute Game.

--- a/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager14.sol
@@ -23,10 +23,8 @@ contract OPContractsManager14 is OPContractsManager {
         return string.concat(super.version(), "+upgrade14.1");
     }
 
-    // TODO: Review required arguments
     constructor(
         ISuperchainConfig _superchainConfig,
-        IProtocolVersions _protocolVersions,
         IProxyAdmin _superchainProxyAdmin,
         string memory _l1ContractsRelease,
         Blueprints memory _blueprints,
@@ -35,7 +33,7 @@ contract OPContractsManager14 is OPContractsManager {
     )
     OPContractsManager(
     _superchainConfig,
-    _protocolVersions,
+    0x0, // No longer required for upgrade 14
     _superchainProxyAdmin,
     _l1ContractsRelease,
     _blueprints,

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -432,14 +432,14 @@ contract DeployImplementations_Test is Test {
 
     function test_run_deployMipsV1OnMainnetOrSepolia_reverts() public {
         setDefaults();
-        dii.set(dii.mipsVersion.selector, 2);
+        dii.set(dii.mipsVersion.selector, 1);
 
         vm.chainId(Chains.Mainnet);
-        vm.expectRevert("DeployImplementations: Only Mips32 should be deployed on Mainnet or Sepolia");
+        vm.expectRevert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
         deployImplementations.run(dii, dio);
 
         vm.chainId(Chains.Sepolia);
-        vm.expectRevert("DeployImplementations: Only Mips32 should be deployed on Mainnet or Sepolia");
+        vm.expectRevert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
         deployImplementations.run(dii, dio);
     }
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Builds on https://github.com/ethereum-optimism/optimism/pull/14564

Add a new OPCM contract for upgrade 14.  Cut out upgrade logic so that `upgrade()` is just deploying new game implementations with the new MIPS64.sol vm contract. 

**Tests**

TODO

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/14459
