### PR TITLE
op-service: check if TLS is enabled and move middleware

### DIFF
--- a/op-service/httputil/server.go
+++ b/op-service/httputil/server.go
@@ -74,7 +74,7 @@ func (s *HTTPServer) Start() error {
 		},
 	}
 
-	if s.config.tls != nil {
+	if s.config.tls != nil && s.config.tls.CLIConfig.Enabled {
 		srv.TLSConfig = s.config.tls.Config
 	}
 


### PR DESCRIPTION
Both need config presence and Enabled flag, otherwise the TLS is going to be on in cases where you add the option but say it needs to be `Enabled: false` inside of that option.

And the middleware needed to move so the health endpoint is always available, before auth.