### PR TITLE
op-e2e: Write jwt.secret to a temp dir instead of into the source code tree

### DIFF
--- a/op-e2e/.gitignore
+++ b/op-e2e/.gitignore
@@ -1,2 +1,1 @@
 external_*/shim
-interop/jwt.secret

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -167,7 +167,7 @@ func (s *interopE2ESystem) newNodeForL2(
 			//SupervisorAddr:   s.supervisor.RPC(),
 			RPCAddr:          "127.0.0.1",
 			RPCPort:          0,
-			RPCJwtSecretPath: "jwt.secret",
+			RPCJwtSecretPath: s.t.TempDir() + "/jwt.secret",
 		},
 		P2P:                         nil, // disabled P2P setup for now
 		L1EpochPollInterval:         time.Second * 2,


### PR DESCRIPTION
**Description**

Small tidy up to interop e2e tests so it doesn't create spurious jwt.secret files in whatever directory it runs from.