### PR TITLE
ci: only tag finalized Docker images as 'latest'

### DIFF
--- a/ops/scripts/ci-docker-tag-op-stack-release.sh
+++ b/ops/scripts/ci-docker-tag-op-stack-release.sh
@@ -35,8 +35,8 @@ fi
 echo "Tagging $SOURCE_IMAGE_TAG with '$IMAGE_TAG'"
 gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG"
 
-# Do not tag with latest if the release is a release candidate.
-if [[ "$IMAGE_TAG" == *"rc"* ]]; then
+# Only tag finalized releases with 'latest'
+if ! [[ "$IMAGE_TAG" =~ v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Not tagging with 'latest' because the release is a release candidate."
   exit 0
 fi


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We're tagging dev releases of monorepo components with `latest` because our script excludes by pattern-matching `rc` instead of negatively matching finalized releases. This fixes it.

Note that this is similar to https://github.com/ethereum-optimism/op-geth/pull/515 but doesn't require the tag to start with `v` so the `^` in the regexp is missing because the monorepo has component-prefixed tags.