### PR TITLE
op-node: emit local-safe status whenever forkchoice status is requested

### DIFF
--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -145,6 +145,15 @@ func (ev CrossSafeUpdateEvent) String() string {
 	return "cross-safe-update"
 }
 
+// LocalSafeStatusEvent signals what block is local-safe.
+type LocalSafeStatusEvent struct {
+	LocalSafeL2 eth.L2BlockRef
+}
+
+func (ev LocalSafeStatusEvent) String() string {
+	return "local-safe-status"
+}
+
 // LocalSafeUpdateEvent signals that a block is now considered to be local-safe.
 type LocalSafeUpdateEvent struct {
 	Ref    eth.L2BlockRef
@@ -427,6 +436,9 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			UnsafeL2Head:    d.ec.UnsafeL2Head(),
 			SafeL2Head:      d.ec.SafeL2Head(),
 			FinalizedL2Head: d.ec.Finalized(),
+		})
+		d.emitter.Emit(LocalSafeStatusEvent{
+			LocalSafeL2: d.ec.LocalSafeL2Head(),
 		})
 	case rollup.ForceResetEvent:
 		ForceEngineReset(d.ec, x)

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -67,6 +67,8 @@ func (st *StatusTracker) OnEvent(ev event.Event) bool {
 		st.data.UnsafeL2 = x.UnsafeL2Head
 		st.data.SafeL2 = x.SafeL2Head
 		st.data.FinalizedL2 = x.FinalizedL2Head
+	case engine.LocalSafeStatusEvent:
+		st.data.LocalSafeL2 = x.LocalSafeL2
 	case engine.PendingSafeUpdateEvent:
 		st.data.UnsafeL2 = x.Unsafe
 		st.data.PendingSafeL2 = x.PendingSafe


### PR DESCRIPTION
**Description**

The local-safe value in the status appears to be zeroed sometimes, when it shouldn't be.
This PR is a possible fix, as a backlog item for interop.

For now, we are rolling back https://github.com/ethereum-optimism/optimism/pull/14265 

Next, we are introducing optionality in op-batcher to use the local-safe or cross-safe, so interop batch-submitting can work as needed again.
And once that has landed, we should test this possible fix with the local-safe op-batcher mode.

For now, interop devnet should use `v1.11.2` of the op-batcher, which uses the local-safe by default (this is going to be rolled back until the above is resolved).

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
