### PR TITLE
fix: Revert Incorrect Change in Default Game Type

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -965,7 +965,7 @@ contract Deploy is Deployer {
             ),
             saltMixer: saltMixer,
             gasLimit: uint64(cfg.l2GenesisBlockGasLimit()),
-            disputeGameType: GameType.wrap(4),
+            disputeGameType: GameTypes.PERMISSIONED_CANNON,
             disputeAbsolutePrestate: Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate())),
             disputeMaxGameDepth: cfg.faultGameMaxDepth(),
             disputeSplitDepth: cfg.faultGameSplitDepth(),


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

During a previous PR when adding Permissioned Interop games I accidentally change the default dispute game type to SuperPermissioned FDG instead of regular Permissioned FGD

**Tests**

No tests needed, its a deployment correction

**Additional context**

Pointed out by @smartcontracts on discord

**Metadata**

