### PR TITLE
contracts/deploy: rm not used string format

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -232,7 +232,7 @@ library ChainAssertions {
 
     /// @notice Asserts that the PreimageOracle is setup correctly
     function checkPreimageOracle(IPreimageOracle _oracle, DeployConfig _cfg) internal view {
-        console.log("Running chain assertions on the PreimageOracle %s at %s", address(_oracle));
+        console.log("Running chain assertions on the PreimageOracle at %s", address(_oracle));
         require(address(_oracle) != address(0), "CHECK-PIO-10");
 
         require(_oracle.minProposalSize() == _cfg.preimageOracleMinProposalSize(), "CHECK-PIO-30");
@@ -241,7 +241,7 @@ library ChainAssertions {
 
     /// @notice Asserts that the MIPs contract is setup correctly
     function checkMIPS(IMIPS _mips, IPreimageOracle _oracle) internal view {
-        console.log("Running chain assertions on the MIPS %s at %s", address(_mips));
+        console.log("Running chain assertions on the MIPS at %s", address(_mips));
         require(address(_mips) != address(0), "CHECK-MIPS-10");
 
         require(_mips.oracle() == _oracle, "CHECK-MIPS-20");


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

From the deploy logs, we found some no-formated text as below: 

```
  Running chain assertions on the PreimageOracle 0x2392C9fC5691297b391Ce0932d70D87FAFb255eD at %s
  Running chain assertions on the MIPS 0x9a6cab1acB664b148219Fd2F2B21160eFF5521f6 at %s
```


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
