### PR TITLE
contracts/deploy: prestate-proof-interop wrong make task

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -677,7 +677,7 @@ contract Deploy is Deployer {
         string memory filePath = string.concat(vm.projectRoot(), "/../../op-program/bin/prestate-proof-interop.json");
         if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo \"present\""))).length == 0) {
             revert(
-                "Deploy: cannon prestate dump not found, generate it with `make cannon-prestate` in the monorepo root"
+                "Deploy: cannon prestate dump not found, generate it with `make cannon-prestate-interop` in the monorepo root"
             );
         }
         interopDevnetAbsolutePrestate_ =


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

The file `op-program/bin/prestate-proof-interop.json` was generated from `make cannon-prestate-interop`, not from `make cannon-prestate`, ref 
https://github.com/ethereum-optimism/optimism/blob/3048f24e91c2debf54666dbcba2714a74dec301a/Makefile#L157-L161

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
