### PR TITLE
contract/deploy: avoid bash error exit

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -711,7 +711,7 @@ contract Deploy is Deployer {
     function _loadDevnetMtMipsAbsolutePrestate() internal returns (Claim mipsAbsolutePrestate_) {
         // Fetch the absolute prestate dump
         string memory filePath = string.concat(vm.projectRoot(), "/../../op-program/bin/prestate-proof-mt64.json");
-        if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo \"present\""))).length == 0) {
+        if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo present || echo"))).length == 0) {
             revert(
                 "Deploy: MT-Cannon prestate dump not found, generate it with `make cannon-prestate-mt64` in the monorepo root"
             );

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -675,7 +675,7 @@ contract Deploy is Deployer {
 
     function loadInteropDevnetAbsolutePrestate() internal returns (Claim interopDevnetAbsolutePrestate_) {
         string memory filePath = string.concat(vm.projectRoot(), "/../../op-program/bin/prestate-proof-interop.json");
-        if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo \"present\""))).length == 0) {
+        if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo present || echo"))).length == 0) {
             revert(
                 "Deploy: cannon prestate dump not found, generate it with `make cannon-prestate` in the monorepo root"
             );
@@ -693,7 +693,7 @@ contract Deploy is Deployer {
     function _loadDevnetStMipsAbsolutePrestate() internal returns (Claim mipsAbsolutePrestate_) {
         // Fetch the absolute prestate dump
         string memory filePath = string.concat(vm.projectRoot(), "/../../op-program/bin/prestate-proof.json");
-        if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo \"present\""))).length == 0) {
+        if (bytes(Process.bash(string.concat("[[ -f ", filePath, " ]] && echo present || echo"))).length == 0) {
             revert(
                 "Deploy: cannon prestate dump not found, generate it with `make cannon-prestate` in the monorepo root"
             );


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
This is a follow up PR of https://github.com/ethereum-optimism/optimism/pull/14594. 

When I'm running the deploy on Linux, met the below error: 

```
  FaultDisputeGame_255 deployed at 0x80c36401333dE87E48b5e8C6D387444Bf127D9E2
  DisputeGameFactoryProxy: set `FaultDisputeGame` implementation (Backend: Alphabet | GameType: 255)
  Setting SuperFaultDisputeGame implementation
Error: script failed: FfiFailed("Command: bash -c [[ -f /code/op-stack/optimism/packages/contracts-bedrock/../../op-program/bin/prestate-proof-interop.json ]] && echo \"present\" \nError: ")
```

I'm not sure this is Linux's default behavior or just my case, if the file not exists, then the command's exit code is not zero:

```bash
[[ -f xxx ]] && echo present
echo $? # return 1

[[ -f xxx ]] && echo present || echo 
echo $? # return 0
```

So I think we can append a `||` to catch the notmatched case, in a more robust way. 

Or another fix is use `vm.exists` instead, but it need to add the json files into foundry's `fs_permissions`


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
