### PR TITLE
scripts/getting-started: set faultGameGenesisOutputRoot to 0xdead

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -137,7 +137,7 @@ cat << EOL >> tmp_config.json
   "faultGameClockExtension": 0,
   "faultGameMaxClockDuration": 1200,
   "faultGameGenesisBlock": 0,
-  "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "faultGameGenesisOutputRoot": "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
   "faultGameSplitDepth": 14,
   "faultGameWithdrawalDelay": 600,
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

As we haved checked the `startingAnchorRoot` in https://github.com/ethereum-optimism/optimism/pull/14357, so the default zero value will raise the `InvalidStartingAnchorRoot` error, change this value to the same as hardhat's https://github.com/ethereum-optimism/optimism/blob/67f7480a0a17810671ccd974632b426ad760c639/packages/contracts-bedrock/deploy-config/hardhat.json#L51

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
