### PR TITLE
op-dispute-mon: Support interop

### DIFF
--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -59,15 +59,32 @@ func TestL1EthRpc(t *testing.T) {
 	})
 }
 
+func TestMustSpecifyEitherRollupRpcOrSupervisorRpc(t *testing.T) {
+	verifyArgsInvalid(t, "flag rollup-rpc or supervisor-rpc is required", addRequiredArgsExcept("--rollup-rpc"))
+}
+
 func TestRollupRpc(t *testing.T) {
-	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept("--rollup-rpc"))
+	t.Run("NotRequiredIfSupervisorRpcSupplied", func(t *testing.T) {
+		configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supervisor-rpc", "http://localhost/supervisor"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {
 		url := "http://example.com:9999"
 		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--rollup-rpc", url))
 		require.Equal(t, url, cfg.RollupRpc)
+	})
+}
+
+func TestSupervisorRpc(t *testing.T) {
+	t.Run("NotRequiredIfRollupRpcSupplied", func(t *testing.T) {
+		// rollup-rpc is in the default args.
+		configForArgs(t, addRequiredArgsExcept("--supervisor-rpc"))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		url := "http://example.com:9999"
+		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supervisor-rpc", url))
+		require.Equal(t, url, cfg.SupervisorRpc)
 	})
 }
 

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -12,6 +12,7 @@ var (
 	validL1EthRpc           = "http://localhost:8545"
 	validGameFactoryAddress = common.Address{0x23}
 	validRollupRpc          = "http://localhost:8555"
+	validSupervisorRpc      = "http://localhost:8999"
 )
 
 func validConfig() Config {
@@ -34,10 +35,25 @@ func TestGameFactoryAddressRequired(t *testing.T) {
 	require.ErrorIs(t, config.Check(), ErrMissingGameFactoryAddress)
 }
 
-func TestRollupRpcRequired(t *testing.T) {
+func TestRollupRpcOrSupervisorRpcRequired(t *testing.T) {
 	config := validConfig()
 	config.RollupRpc = ""
-	require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
+	config.SupervisorRpc = ""
+	require.ErrorIs(t, config.Check(), ErrMissingRollupAndSupervisorRpc)
+}
+
+func TestRollupRpcNotRequiredWhenSupervisorRpcSet(t *testing.T) {
+	config := validConfig()
+	config.RollupRpc = ""
+	config.SupervisorRpc = validSupervisorRpc
+	require.NoError(t, config.Check())
+}
+
+func TestSupervisorRpcNotRequiredWhenRollupRpcSet(t *testing.T) {
+	config := validConfig()
+	config.RollupRpc = validRollupRpc
+	config.SupervisorRpc = ""
+	require.NoError(t, config.Check())
 }
 
 func TestMaxConcurrencyRequired(t *testing.T) {

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -32,12 +32,17 @@ var (
 		Usage:   "HTTP provider URL for L1.",
 		EnvVars: prefixEnvVars("L1_ETH_RPC"),
 	}
+	// Optional Flags
 	RollupRpcFlag = &cli.StringFlag{
 		Name:    "rollup-rpc",
 		Usage:   "HTTP provider URL for the rollup node",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
-	// Optional Flags
+	SupervisorRpcFlag = &cli.StringFlag{
+		Name:    "supervisor-rpc",
+		Usage:   "HTTP provider URL for the supervisor node",
+		EnvVars: prefixEnvVars("SUPERVISOR_RPC"),
+	}
 	GameFactoryAddressFlag = &cli.StringFlag{
 		Name:    "game-factory-address",
 		Usage:   "Address of the fault game factory contract.",
@@ -78,11 +83,12 @@ var (
 // requiredFlags are checked by [CheckRequired]
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
-	RollupRpcFlag,
 }
 
 // optionalFlags is a list of unchecked cli flags
 var optionalFlags = []cli.Flag{
+	RollupRpcFlag,
+	SupervisorRpcFlag,
 	GameFactoryAddressFlag,
 	NetworkFlag,
 	HonestActorsFlag,
@@ -108,6 +114,9 @@ func CheckRequired(ctx *cli.Context) error {
 		if !ctx.IsSet(f.Names()[0]) {
 			return fmt.Errorf("flag %s is required", f.Names()[0])
 		}
+	}
+	if !ctx.IsSet(RollupRpcFlag.Name) && !ctx.IsSet(SupervisorRpcFlag.Name) {
+		return fmt.Errorf("flag %s or %s is required", RollupRpcFlag.Name, SupervisorRpcFlag.Name)
 	}
 	return nil
 }
@@ -156,6 +165,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 		L1EthRpc:           ctx.String(L1EthRpcFlag.Name),
 		GameFactoryAddress: gameFactoryAddress,
 		RollupRpc:          ctx.String(RollupRpcFlag.Name),
+		SupervisorRpc:      ctx.String(SupervisorRpcFlag.Name),
 
 		HonestActors:    actors,
 		MonitorInterval: ctx.Duration(MonitorIntervalFlag.Name),

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -2,16 +2,22 @@ package extract
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
-	"time"
 
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+)
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
+var (
+	ErrRollupRpcRequired = errors.New("rollup rpc required")
+	outputRootGameTypes  = []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
 )
 
 type OutputRollupClient interface {
@@ -23,22 +29,30 @@ type OutputMetrics interface {
 	RecordOutputFetchTime(float64)
 }
 
-type AgreementEnricher struct {
+type OutputAgreementEnricher struct {
 	log     log.Logger
 	metrics OutputMetrics
 	client  OutputRollupClient
+	clock   clock.Clock
 }
 
-func NewAgreementEnricher(logger log.Logger, metrics OutputMetrics, client OutputRollupClient) *AgreementEnricher {
-	return &AgreementEnricher{
+func NewOutputAgreementEnricher(logger log.Logger, metrics OutputMetrics, client OutputRollupClient, cl clock.Clock) *OutputAgreementEnricher {
+	return &OutputAgreementEnricher{
 		log:     logger,
 		metrics: metrics,
 		client:  client,
+		clock:   cl,
 	}
 }
 
 // Enrich validates the specified root claim against the output at the given block number.
-func (o *AgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+	if !slices.Contains(outputRootGameTypes, game.GameType) {
+		return nil
+	}
+	if o.client == nil {
+		return fmt.Errorf("%w but required for game type %v", ErrRollupRpcRequired, game.GameType)
+	}
 	output, err := o.client.OutputAtBlock(ctx, game.L2BlockNumber)
 	if err != nil {
 		// string match as the error comes from the remote server so we can't use Errors.Is sadly.
@@ -49,7 +63,7 @@ func (o *AgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, ca
 		}
 		return fmt.Errorf("failed to get output at block: %w", err)
 	}
-	o.metrics.RecordOutputFetchTime(float64(time.Now().Unix()))
+	o.metrics.RecordOutputFetchTime(float64(o.clock.Now().Unix()))
 	game.ExpectedRootClaim = common.Hash(output.OutputRoot)
 	rootMatches := game.RootClaim == game.ExpectedRootClaim
 	if !rootMatches {

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
@@ -17,7 +16,6 @@ import (
 
 var (
 	ErrRollupRpcRequired = errors.New("rollup rpc required")
-	outputRootGameTypes  = []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
 )
 
 type OutputRollupClient interface {
@@ -47,7 +45,7 @@ func NewOutputAgreementEnricher(logger log.Logger, metrics OutputMetrics, client
 
 // Enrich validates the specified root claim against the output at the given block number.
 func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	if !slices.Contains(outputRootGameTypes, game.GameType) {
+	if !game.UsesOutputRoots() {
 		return nil
 	}
 	if o.client == nil {

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -1,0 +1,67 @@
+package extract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	ErrSupervisorRpcRequired = errors.New("supervisor rpc required")
+)
+
+type SuperRootProvider interface {
+	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
+}
+
+type SuperAgreementEnricher struct {
+	log     log.Logger
+	metrics OutputMetrics
+	client  SuperRootProvider
+	clock   clock.Clock
+}
+
+func NewSuperAgreementEnricher(logger log.Logger, metrics OutputMetrics, client SuperRootProvider, cl clock.Clock) *SuperAgreementEnricher {
+	return &SuperAgreementEnricher{
+		log:     logger,
+		metrics: metrics,
+		client:  client,
+		clock:   cl,
+	}
+}
+
+func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
+	// TODO: Would be better to have a bool flag that another enricher sets to indicate if the game uses super roots
+	if slices.Contains(outputRootGameTypes, game.GameType) {
+		return nil
+	}
+	if e.client == nil {
+		return fmt.Errorf("%w but required for game type %v", ErrSupervisorRpcRequired, game.GameType)
+	}
+	response, err := e.client.SuperRootAtTimestamp(ctx, hexutil.Uint64(game.L2BlockNumber))
+	if errors.Is(err, ethereum.NotFound) {
+		// Super root doesn't exist, so we must disagree with it.
+		game.AgreeWithClaim = false
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to retrieve super root at timestamp %v: %w", game.L2BlockNumber, err)
+	}
+	e.metrics.RecordOutputFetchTime(float64(e.clock.Now().Unix()))
+	game.ExpectedRootClaim = common.Hash(response.SuperRoot)
+	if game.RootClaim != game.ExpectedRootClaim {
+		game.AgreeWithClaim = false
+		return nil
+	}
+	game.AgreeWithClaim = response.CrossSafeDerivedFrom.Number <= game.L1HeadNum
+	return nil
+}

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -41,8 +40,7 @@ func NewSuperAgreementEnricher(logger log.Logger, metrics OutputMetrics, client 
 }
 
 func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	// TODO: Would be better to have a bool flag that another enricher sets to indicate if the game uses super roots
-	if slices.Contains(outputRootGameTypes, game.GameType) {
+	if game.UsesOutputRoots() {
 		return nil
 	}
 	if e.client == nil {

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -1,0 +1,236 @@
+package extract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetector_CheckSuperRootAgreement(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ErrorWhenNoSupervisorClient", func(t *testing.T) {
+		validator, _, _ := setupSuperValidatorTest(t)
+		validator.client = nil
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.ErrorIs(t, err, ErrSupervisorRpcRequired)
+	})
+
+	t.Run("SkipOutputRootGameTypes", func(t *testing.T) {
+		gameTypes := []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
+		for _, gameType := range gameTypes {
+			gameType := gameType
+			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
+				validator, _, metrics := setupSuperValidatorTest(t)
+				validator.client = nil // Should not error even though there's no rollup client
+				game := &types.EnrichedGameData{
+					GameMetadata: challengerTypes.GameMetadata{
+						GameType: gameType,
+					},
+					L1HeadNum:     200,
+					L2BlockNumber: 0,
+					RootClaim:     mockRootClaim,
+				}
+				err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+				require.NoError(t, err)
+				require.Zero(t, metrics.fetchTime)
+			})
+		}
+	})
+
+	t.Run("FetchAllNonOutputRootGameTypes", func(t *testing.T) {
+		gameTypes := []uint32{4, 5, 7, 8, 10, 49812} // Treat unknown game types as using super roots
+		for _, gameType := range gameTypes {
+			gameType := gameType
+			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
+				validator, _, metrics := setupSuperValidatorTest(t)
+				game := &types.EnrichedGameData{
+					GameMetadata: challengerTypes.GameMetadata{
+						GameType: gameType,
+					},
+					L1HeadNum:     200,
+					L2BlockNumber: 0,
+					RootClaim:     mockRootClaim,
+				}
+				err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+				require.NoError(t, err)
+				require.NotZero(t, metrics.fetchTime, "should have fetched output root")
+			})
+		}
+	})
+
+	t.Run("OutputFetchFails", func(t *testing.T) {
+		validator, rollup, metrics := setupSuperValidatorTest(t)
+		rollup.outputErr = errors.New("boom")
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.ErrorIs(t, err, rollup.outputErr)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.Zero(t, metrics.fetchTime)
+	})
+
+	t.Run("OutputMismatch_Safe", func(t *testing.T) {
+		validator, _, metrics := setupSuperValidatorTest(t)
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     common.Hash{},
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("OutputMatches_Safe_DerivedFromGameHead", func(t *testing.T) {
+		validator, client, metrics := setupSuperValidatorTest(t)
+		client.derivedFromL1BlockNum = 200
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.True(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("OutputMatches_Safe_DerivedFromBeforeGameHead", func(t *testing.T) {
+		validator, client, metrics := setupSuperValidatorTest(t)
+		client.derivedFromL1BlockNum = 199
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.True(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("OutputMismatch_NotSafe", func(t *testing.T) {
+		validator, client, metrics := setupSuperValidatorTest(t)
+		client.derivedFromL1BlockNum = 101
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     common.Hash{},
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("OutputMatches_NotSafe", func(t *testing.T) {
+		validator, client, metrics := setupSuperValidatorTest(t)
+		client.derivedFromL1BlockNum = 201
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 100,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("OutputNotFound", func(t *testing.T) {
+		validator, client, metrics := setupSuperValidatorTest(t)
+		// The supervisor client automatically translates RPC errors back to ethereum.NotFound for us
+		client.outputErr = ethereum.NotFound
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     100,
+			L2BlockNumber: 42984924,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.Zero(t, metrics.fetchTime)
+	})
+}
+
+func setupSuperValidatorTest(t *testing.T) (*SuperAgreementEnricher, *stubSupervisorClient, *stubOutputMetrics) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	client := &stubSupervisorClient{derivedFromL1BlockNum: 0}
+	metrics := &stubOutputMetrics{}
+	validator := NewSuperAgreementEnricher(logger, metrics, client, clock.NewDeterministicClock(time.Unix(9824924, 499)))
+	return validator, client, metrics
+}
+
+type stubSupervisorClient struct {
+	requestedTimestamp    uint64
+	outputErr             error
+	derivedFromL1BlockNum uint64
+}
+
+func (s *stubSupervisorClient) SuperRootAtTimestamp(_ context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
+	s.requestedTimestamp = uint64(timestamp)
+	if s.outputErr != nil {
+		return eth.SuperRootResponse{}, s.outputErr
+	}
+	return eth.SuperRootResponse{
+		CrossSafeDerivedFrom: eth.BlockID{Number: s.derivedFromL1BlockNum},
+		Timestamp:            uint64(timestamp),
+		SuperRoot:            eth.Bytes32(mockRootClaim),
+		Version:              eth.SuperRootVersionV1,
+	}, nil
+}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -157,6 +157,9 @@ func (s *Service) initBonds() {
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {
+	if cfg.RollupRpc == "" {
+		return nil
+	}
 	outputRollupClient, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.RollupRpc)
 	if err != nil {
 		return fmt.Errorf("failed to dial rollup client: %w", err)

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -38,14 +38,15 @@ type Service struct {
 
 	cl clock.Clock
 
-	extractor    *extract.Extractor
-	forecast     *Forecast
-	bonds        *bonds.Bonds
-	game         *extract.GameCallerCreator
-	resolutions  *ResolutionMonitor
-	claims       *ClaimMonitor
-	withdrawals  *WithdrawalMonitor
-	rollupClient *sources.RollupClient
+	extractor        *extract.Extractor
+	forecast         *Forecast
+	bonds            *bonds.Bonds
+	game             *extract.GameCallerCreator
+	resolutions      *ResolutionMonitor
+	claims           *ClaimMonitor
+	withdrawals      *WithdrawalMonitor
+	rollupClient     *sources.RollupClient
+	supervisorClient *sources.SupervisorClient
 
 	l1RPC    rpcclient.RPC
 	l1Client *sources.L1Client
@@ -88,6 +89,9 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	}
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init rollup client: %w", err)
+	}
+	if err := s.initSupervisorClient(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init supervisor client: %w", err)
 	}
 
 	s.initClaimMonitor(cfg)
@@ -139,7 +143,8 @@ func (s *Service) initExtractor(cfg *config.Config) {
 		extract.NewBondEnricher(),
 		extract.NewBalanceEnricher(),
 		extract.NewL1HeadBlockNumEnricher(s.l1Client),
-		extract.NewAgreementEnricher(s.logger, s.metrics, s.rollupClient),
+		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.supervisorClient, clock.SystemClock),
+		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.rollupClient, clock.SystemClock),
 	)
 }
 
@@ -157,6 +162,18 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 		return fmt.Errorf("failed to dial rollup client: %w", err)
 	}
 	s.rollupClient = outputRollupClient
+	return nil
+}
+
+func (s *Service) initSupervisorClient(ctx context.Context, cfg *config.Config) error {
+	if cfg.SupervisorRpc == "" {
+		return nil
+	}
+	rpcClient, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.SupervisorRpc)
+	if err != nil {
+		return fmt.Errorf("failed to dial supervisor client: %w", err)
+	}
+	s.supervisorClient = sources.NewSupervisorClient(rpcclient.NewBaseRPCClient(rpcClient))
 	return nil
 }
 

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
@@ -9,6 +10,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+// outputRootGameTypes lists the set of legacy game types that use output roots
+// It is assumed that all other game types use super roots
+var outputRootGameTypes = []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
 
 // EnrichedClaim extends the faultTypes.Claim with additional context.
 type EnrichedClaim struct {
@@ -54,6 +59,11 @@ type EnrichedGameData struct {
 	// This ETH balance will be used to pay out any bonds required by the games
 	// that use the same DelayedWETH contract.
 	ETHCollateral *big.Int
+}
+
+// UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.
+func (g EnrichedGameData) UsesOutputRoots() bool {
+	return slices.Contains(outputRootGameTypes, g.GameType)
 }
 
 // BidirectionalTree is a tree of claims represented as a flat list of claims.

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrichedGameData_UsesOutputRoots(t *testing.T) {
+	for _, gameType := range outputRootGameTypes {
+		gameType := gameType
+		t.Run(fmt.Sprintf("GameType-%v", gameType), func(t *testing.T) {
+			data := EnrichedGameData{
+				GameMetadata: types.GameMetadata{GameType: gameType},
+			}
+			require.True(t, data.UsesOutputRoots())
+		})
+	}
+
+	nonOutputRootTypes := []uint32{4, 5, 9, 42982, 20013130}
+	for _, gameType := range nonOutputRootTypes {
+		gameType := gameType
+		t.Run(fmt.Sprintf("GameType-%v", gameType), func(t *testing.T) {
+			data := EnrichedGameData{
+				GameMetadata: types.GameMetadata{GameType: gameType},
+			}
+			require.False(t, data.UsesOutputRoots())
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Adds support for interop dispute game types to op-dispute-mon.

* The rollup-rpc and supervisor-rpc CLI flag and config options are now optional with at least one required.
  * Supplying both is allowed as it is possible to have a DisputeGameFactory that has both interop and pre-interop game types configured. Unusual but possible...
* A fixed list of the current game types that use output roots is included. All other game types are assumed to use super roots.
  * If this assumption ever winds up being wrong (eg there's a new output root based game type) then all valid proposals would be reported as incorrect so as long as there is at least one valid proposal the configuration problem would be picked up.  In the worst case, if all proposals also used the wrong root type, they would still have to be from the canonical chain so funds couldn't be stolen.
* If the required RPC (rollup for output root, supervisor for super root) isn't configured, reporting for that game will return an error and be reported as a failed game (metrics already report the number of failed games so alerting can pick up the issue)


**Tests**

Added.


**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/13941