### PR TITLE
interop: include return data in relayed message event

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -59,7 +59,9 @@ interface IL2ToL2CrossDomainMessenger {
     /// @param source       Chain ID of the source chain.
     /// @param messageNonce Nonce associated with the messsage sent
     /// @param messageHash  Hash of the message that was relayed.
-    event RelayedMessage(uint256 indexed source, uint256 indexed messageNonce, bytes32 indexed messageHash);
+    event RelayedMessage(
+        uint256 indexed source, uint256 indexed messageNonce, bytes32 indexed messageHash, bytes returnData
+    );
 
     function version() external view returns (string memory);
 

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -201,6 +201,12 @@
         "internalType": "bytes32",
         "name": "messageHash",
         "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
       }
     ],
     "name": "RelayedMessage",

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -71,8 +71,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.14
-    string public constant version = "1.0.0-beta.14";
+    /// @custom:semver 1.0.0-beta.15
+    string public constant version = "1.0.0-beta.15";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -97,7 +97,9 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param source       Chain ID of the source chain.
     /// @param messageNonce Nonce associated with the messsage sent
     /// @param messageHash  Hash of the message that was relayed.
-    event RelayedMessage(uint256 indexed source, uint256 indexed messageNonce, bytes32 indexed messageHash);
+    event RelayedMessage(
+        uint256 indexed source, uint256 indexed messageNonce, bytes32 indexed messageHash, bytes returnData
+    );
 
     /// @notice Retrieves the sender of the current cross domain message. If not entered, reverts.
     /// @return sender_ Address of the sender of the current cross domain message.
@@ -210,7 +212,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
         }
 
         successfulMessages[messageHash] = true;
-        emit RelayedMessage(source, nonce, messageHash);
+        emit RelayedMessage(source, nonce, messageHash, returnData_);
 
         _storeMessageMetadata(0, address(0));
     }

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -281,7 +281,10 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Look for correct emitted event
         vm.expectEmit(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
         emit L2ToL2CrossDomainMessenger.RelayedMessage(
-            _source, _nonce, keccak256(abi.encode(block.chainid, _source, _nonce, _sender, _target, _message))
+            _source,
+            _nonce,
+            keccak256(abi.encode(block.chainid, _source, _nonce, _sender, _target, _message)),
+            abi.encode(true)
         );
 
         // relay the message
@@ -365,7 +368,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
 
         // Look for correct emitted event
         vm.expectEmit(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
-        emit L2ToL2CrossDomainMessenger.RelayedMessage(_source, _nonce, msgHash);
+        emit L2ToL2CrossDomainMessenger.RelayedMessage(_source, _nonce, msgHash, "");
 
         // Ensure the target contract is called with the correct parameters
         vm.expectCall({ callee: target, msgValue: _value, data: message });
@@ -716,7 +719,10 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Look for correct emitted event for first call.
         vm.expectEmit(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
         emit L2ToL2CrossDomainMessenger.RelayedMessage(
-            _source, _nonce, keccak256(abi.encode(block.chainid, _source, _nonce, _sender, _target, _message))
+            _source,
+            _nonce,
+            keccak256(abi.encode(block.chainid, _source, _nonce, _sender, _target, _message)),
+            abi.encode(true)
         );
 
         Identifier memory id =


### PR DESCRIPTION
Buy including the return data as an event field, the emitted `RelayedMessage` event can be used
to continue a callback back into the source chain with the field.

This allows any view function can be invoked cross-chain using L2ToL2CDM.
