### PR TITLE
op-test-sequencer: introduce standard builder/signer/committer/publisher

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -225,6 +225,10 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 			Public:        true, // TODO: this field is deprecated. Do we even need this anymore?
 			Authenticated: false,
 		},
+		{
+			Namespace: "opstack",
+			Service:   node.NewOpstackAPI(ec, &testutils.FakePublishAPI{Log: log}),
+		},
 	}
 	require.NoError(t, gnode.RegisterApis(apis, nil, rollupNode.rpc), "failed to set up APIs")
 	return rollupNode

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -445,10 +445,10 @@ var (
 	}
 
 	ExperimentalOPStackAPI = &cli.BoolFlag{
-		Name:     "experimental.opstack-api",
-		Usage:    "Enables experimental opstack RPC namespace",
+		Name:     "experimental.sequencer-api",
+		Usage:    "Enables experimental test sequencer RPC functionality",
 		Required: false,
-		EnvVars:  prefixEnvVars("EXPERIMENTAL_OPSTACK_API"),
+		EnvVars:  prefixEnvVars("EXPERIMENTAL_SEQUENCER_API"),
 		Category: MiscCategory,
 	}
 )

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -443,6 +443,14 @@ var (
 		Category: RollupCategory,
 		Hidden:   true,
 	}
+
+	ExperimentalOPStackAPI = &cli.BoolFlag{
+		Name:     "experimental.opstack-api",
+		Usage:    "Enables experimental opstack RPC namespace",
+		Required: false,
+		EnvVars:  prefixEnvVars("EXPERIMENTAL_OPSTACK_API"),
+		Category: MiscCategory,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -498,6 +506,7 @@ var optionalFlags = []cli.Flag{
 	InteropRPCPort,
 	InteropJWTSecret,
 	IgnoreMissingPectraBlobSchedule,
+	ExperimentalOPStackAPI,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -79,6 +79,9 @@ type Config struct {
 
 	IgnoreMissingPectraBlobSchedule bool
 	FetchWithdrawalRootFromState    bool
+
+	// Experimental. Enables new opstack RPC namespace. Used by op-test-sequencer.
+	ExperimentalOPStackAPI bool
 }
 
 // ConductorRPCFunc retrieves the endpoint. The RPC may not immediately be available.

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -42,7 +42,7 @@ type SimpleAsyncGossiper struct {
 // To avoid import cycles, we define a new Network interface here
 // this interface is compatible with driver.Network
 type Network interface {
-	PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error
 }
 
 // To avoid import cycles, we define a new Metrics interface here
@@ -132,7 +132,7 @@ func (p *SimpleAsyncGossiper) Start() {
 // it is called by the Start loop when a new payload is set
 // the payload is only stored if the publish is successful
 func (p *SimpleAsyncGossiper) gossip(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) {
-	if err := p.net.PublishL2Payload(ctx, payload); err == nil {
+	if err := p.net.SignAndPublishL2Payload(ctx, payload); err == nil {
 		p.currentPayload = payload
 	} else {
 		p.log.Warn("failed to publish newly created block",

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -16,7 +16,7 @@ type mockNetwork struct {
 	reqs []*eth.ExecutionPayloadEnvelope
 }
 
-func (m *mockNetwork) PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+func (m *mockNetwork) SignAndPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
 	m.reqs = append(m.reqs, payload)
 	return nil
 }
@@ -115,7 +115,7 @@ func TestAsyncGossiperLoop(t *testing.T) {
 // failingNetwork is a mock network that always fails to publish
 type failingNetwork struct{}
 
-func (f *failingNetwork) PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+func (f *failingNetwork) SignAndPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
 	return errors.New("failed to publish")
 }
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -79,6 +79,7 @@ type DerivationPipeline interface {
 }
 
 type EngineController interface {
+	engine.RollupAPI
 	engine.LocalEngineControl
 	IsEngineSyncing() bool
 	InsertUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error
@@ -122,8 +123,8 @@ type SyncStatusTracker interface {
 }
 
 type Network interface {
-	// PublishL2Payload is called by the driver whenever there is a new payload to publish, synchronously with the driver main loop.
-	PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	// SignAndPublishL2Payload is called by the driver whenever there is a new payload to publish, synchronously with the driver main loop.
+	SignAndPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
 }
 
 type AltSync interface {
@@ -261,7 +262,6 @@ func NewDriver(
 		driverCancel:     driverCancel,
 		log:              log,
 		sequencer:        sequencer,
-		network:          network,
 		metrics:          metrics,
 		l1HeadSig:        make(chan eth.L1BlockRef, 10),
 		l1SafeSig:        make(chan eth.L1BlockRef, 10),

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -64,7 +64,6 @@ type Driver struct {
 	unsafeL2Payloads chan *eth.ExecutionPayloadEnvelope
 
 	sequencer sequencing.SequencerIface
-	network   Network // may be nil, network for is optional
 
 	metrics Metrics
 	log     log.Logger

--- a/op-node/rollup/engine/api.go
+++ b/op-node/rollup/engine/api.go
@@ -1,0 +1,124 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+)
+
+// RollupAPI is the API we serve as rollup-node to interact with the execution engine and forkchoice state.
+type RollupAPI interface {
+	apis.BuildAPI
+	apis.CommitAPI
+}
+
+var _ RollupAPI = (*EngineController)(nil)
+
+func (ec *EngineController) OpenBlock(ctx context.Context, parent eth.BlockID, attrs *eth.PayloadAttributes) (eth.PayloadInfo, error) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+
+	_, err := ec.engine.L2BlockRefByHash(ctx, parent.Hash)
+	if err != nil {
+		return eth.PayloadInfo{}, fmt.Errorf("failed to retrieve parent block %s from engine: %w", parent, err)
+	}
+
+	if err := ec.initializeUnknowns(ctx); err != nil {
+		return eth.PayloadInfo{}, fmt.Errorf("failed to initialize forkchoice pre-state: %w", err)
+	}
+
+	fc := eth.ForkchoiceState{
+		HeadBlockHash:      parent.Hash,
+		SafeBlockHash:      ec.safeHead.Hash,
+		FinalizedBlockHash: ec.finalizedHead.Hash,
+	}
+	id, errTyp, err := startPayload(ctx, ec.engine, fc, attrs)
+	if err != nil {
+		switch errTyp {
+		case BlockInsertTemporaryErr:
+			// RPC errors are not persistent block processing errors
+			return eth.PayloadInfo{}, fmt.Errorf("temporarily cannot insert new safe block: %w", err)
+		case BlockInsertPrestateErr:
+			return eth.PayloadInfo{}, fmt.Errorf("need reset to resolve pre-state problem: %w", err)
+		case BlockInsertPayloadErr:
+			return eth.PayloadInfo{}, fmt.Errorf("invalid payload attributes")
+		default:
+			return eth.PayloadInfo{}, fmt.Errorf("unknown error type %d: %w", errTyp, err)
+		}
+	}
+	return eth.PayloadInfo{
+		ID:        id,
+		Timestamp: uint64(attrs.Timestamp),
+	}, nil
+}
+
+func (ec *EngineController) CancelBlock(ctx context.Context, id eth.PayloadInfo) error {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	_, err := ec.engine.GetPayload(ctx, id)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
+			return &rpc.JsonError{ // unwrap error, to serve opstack RPC
+				Code:    int(eth.UnknownPayload),
+				Message: "unknown payload",
+			}
+		}
+		return fmt.Errorf("failed to cancel payload: %w", err)
+	}
+	return nil
+}
+
+func (ec *EngineController) SealBlock(ctx context.Context, id eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	envelope, err := ec.engine.GetPayload(ctx, id)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
+			return nil, &rpc.JsonError{ // unwrap error, to serve opstack RPC
+				Code:    int(eth.UnknownPayload),
+				Message: "unknown payload",
+			}
+		}
+		return nil, fmt.Errorf("failed to cancel payload: %w", err)
+	}
+	return envelope, nil
+}
+
+func (ec *EngineController) CommitBlock(ctx context.Context, signed *opsigner.SignedExecutionPayloadEnvelope) error {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+
+	envelope := signed.Envelope
+	ref, err := derive.PayloadToBlockRef(ec.rollupCfg, envelope.ExecutionPayload)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %w", err)
+	}
+
+	status, err := ec.engine.NewPayload(ctx, envelope.ExecutionPayload, envelope.ParentBeaconBlockRoot)
+	if err != nil {
+		return fmt.Errorf("failed to insert payload: %w", err)
+	}
+
+	switch status.Status {
+	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
+		return fmt.Errorf("execution invalid: %w", err)
+	case eth.ExecutionValid:
+		break
+	}
+
+	ec.SetUnsafeHead(ref)
+	ec.emitter.Emit(UnsafeUpdateEvent{Ref: ref})
+	if err := ec.TryUpdateEngine(ctx); err != nil {
+		return fmt.Errorf("failed to update engine forkchoice: %w", err)
+	}
+	return nil
+}

--- a/op-node/rollup/engine/api.go
+++ b/op-node/rollup/engine/api.go
@@ -44,13 +44,25 @@ func (ec *EngineController) OpenBlock(ctx context.Context, parent eth.BlockID, a
 		switch errTyp {
 		case BlockInsertTemporaryErr:
 			// RPC errors are not persistent block processing errors
-			return eth.PayloadInfo{}, fmt.Errorf("temporarily cannot insert new safe block: %w", err)
+			return eth.PayloadInfo{}, &rpc.JsonError{
+				Code:    apis.BuildErrCodeTemporary,
+				Message: fmt.Sprintf("temporarily cannot insert new safe block: %v", err),
+			}
 		case BlockInsertPrestateErr:
-			return eth.PayloadInfo{}, fmt.Errorf("need reset to resolve pre-state problem: %w", err)
+			return eth.PayloadInfo{}, &rpc.JsonError{
+				Code:    apis.BuildErrCodePrestate,
+				Message: fmt.Sprintf("need reset to resolve pre-state problem: %v", err),
+			}
 		case BlockInsertPayloadErr:
-			return eth.PayloadInfo{}, fmt.Errorf("invalid payload attributes")
+			return eth.PayloadInfo{}, &rpc.JsonError{
+				Code:    apis.BuildErrCodePrestate,
+				Message: fmt.Sprintf("invalid payload attributes: %v", err),
+			}
 		default:
-			return eth.PayloadInfo{}, fmt.Errorf("unknown error type %d: %w", errTyp, err)
+			return eth.PayloadInfo{}, &rpc.JsonError{
+				Code:    apis.BuildErrCodeOther,
+				Message: fmt.Sprintf("unknown error type %d: %v", errTyp, err),
+			}
 		}
 	}
 	return eth.PayloadInfo{
@@ -67,11 +79,14 @@ func (ec *EngineController) CancelBlock(ctx context.Context, id eth.PayloadInfo)
 		var rpcErr rpc.Error
 		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
 			return &rpc.JsonError{ // unwrap error, to serve opstack RPC
-				Code:    int(eth.UnknownPayload),
+				Code:    apis.BuildErrCodeUnknownPayload,
 				Message: "unknown payload",
 			}
 		}
-		return fmt.Errorf("failed to cancel payload: %w", err)
+		return &rpc.JsonError{
+			Code:    apis.BuildErrCodeOther,
+			Message: fmt.Sprintf("failed to cancel payload: %v", err),
+		}
 	}
 	return nil
 }
@@ -84,11 +99,14 @@ func (ec *EngineController) SealBlock(ctx context.Context, id eth.PayloadInfo) (
 		var rpcErr rpc.Error
 		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
 			return nil, &rpc.JsonError{ // unwrap error, to serve opstack RPC
-				Code:    int(eth.UnknownPayload),
+				Code:    apis.BuildErrCodeUnknownPayload,
 				Message: "unknown payload",
 			}
 		}
-		return nil, fmt.Errorf("failed to cancel payload: %w", err)
+		return nil, &rpc.JsonError{
+			Code:    apis.BuildErrCodeOther,
+			Message: fmt.Sprintf("failed to seal payload: %v", err),
+		}
 	}
 	return envelope, nil
 }
@@ -110,7 +128,10 @@ func (ec *EngineController) CommitBlock(ctx context.Context, signed *opsigner.Si
 
 	switch status.Status {
 	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
-		return fmt.Errorf("execution invalid: %w", err)
+		return &rpc.JsonError{
+			Code:    apis.BuildErrCodeInvalidInput,
+			Message: fmt.Sprintf("execution invalid: %v", err),
+		}
 	case eth.ExecutionValid:
 		break
 	}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	gosync "sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -41,6 +42,7 @@ type ExecEngine interface {
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
+	L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error)
 }
 
 type EngineController struct {
@@ -55,6 +57,9 @@ type EngineController struct {
 	clock      clock.Clock
 
 	emitter event.Emitter
+
+	// To lock the engine RPC usage, such that components like the API, which need direct access, can protect their access.
+	mu gosync.RWMutex
 
 	// Block Head State
 	unsafeHead eth.L2BlockRef

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -362,6 +362,8 @@ func (d *EngDeriver) AttachEmitter(em event.Emitter) {
 }
 
 func (d *EngDeriver) OnEvent(ev event.Event) bool {
+	d.ec.mu.Lock()
+	defer d.ec.mu.Unlock()
 	switch x := ev.(type) {
 	case TryBackupUnsafeReorgEvent:
 		// If we don't need to call FCU to restore unsafeHead using backupUnsafe, keep going b/c

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -118,6 +118,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 
 		IgnoreMissingPectraBlobSchedule: ctx.Bool(flags.IgnoreMissingPectraBlobSchedule.Name),
 		FetchWithdrawalRootFromState:    ctx.Bool(flags.FetchWithdrawalRootFromState.Name),
+
+		ExperimentalOPStackAPI: ctx.Bool(flags.ExperimentalOPStackAPI.Name),
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {

--- a/op-service/README.md
+++ b/op-service/README.md
@@ -12,6 +12,7 @@ Pull requests: [monorepo](https://github.com/ethereum-optimism/optimism/pulls?q=
 ├── cliapp          - Flag and lifecycle handling for a Urfave v2 CLI app.
 ├── client          - RPC and HTTP client utils
 ├── clock           - Clock interface, system clock, tickers, mock/test time utils
+├── closer          - Convenience methods / patterns for closing resources
 ├── crypto          - Cryptography utils, complements geth crypto package
 ├── ctxinterrupt    - Blocking/Interrupt handling
 ├── dial            - Dialing util functions for RPC clients

--- a/op-service/apis/opstack.go
+++ b/op-service/apis/opstack.go
@@ -7,6 +7,14 @@ import (
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 )
 
+const (
+	BuildErrCodeTemporary      = -40100
+	BuildErrCodePrestate       = -40101
+	BuildErrCodeInvalidInput   = -40110
+	BuildErrCodeUnknownPayload = -40120
+	BuildErrCodeOther          = -40199
+)
+
 type BuildAPI interface {
 	// OpenBlock starts a block-building job with the given attributes.
 	// The identifier of the job is returned, if successfully started.

--- a/op-service/apis/opstack.go
+++ b/op-service/apis/opstack.go
@@ -1,0 +1,33 @@
+package apis
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+)
+
+type BuildAPI interface {
+	// OpenBlock starts a block-building job with the given attributes.
+	// The identifier of the job is returned, if successfully started.
+	OpenBlock(ctx context.Context, parent eth.BlockID, attrs *eth.PayloadAttributes) (eth.PayloadInfo, error)
+	// CancelBlock cancels block-building.
+	CancelBlock(ctx context.Context, id eth.PayloadInfo) error
+	// SealBlock completes block-building. The block will not be canonical until committed to by CommitBlock
+	SealBlock(ctx context.Context, id eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
+}
+
+type CommitAPI interface {
+	// CommitBlock processes the block, and sets it as canonical block of the chain.
+	CommitBlock(ctx context.Context, envelope *opsigner.SignedExecutionPayloadEnvelope) error
+}
+
+type PublishAPI interface {
+	PublishBlock(ctx context.Context, signed *opsigner.SignedExecutionPayloadEnvelope) error
+}
+
+type OPStackAPI interface {
+	BuildAPI
+	CommitAPI
+	PublishAPI
+}

--- a/op-service/closer/closer.go
+++ b/op-service/closer/closer.go
@@ -1,0 +1,32 @@
+package closer
+
+// CloseFn types the given function to be used for closing of a resource.
+type CloseFn func()
+
+// Stack adds the given "stacked" function to run upon close.
+// It will be called before this (method-receiver) function that it is stacked on top of.
+func (fn *CloseFn) Stack(stacked func()) {
+	self := *fn
+	*fn = func() {
+		stacked()
+		self()
+	}
+}
+
+// Maybe prepares a conditional close:
+// it may be canceled by calling cancel, and the close call will then be a no-op.
+// This helps e.g. constructors to close their resources,
+// if there is some issue before constructor completion.
+// But then cancel if the constructor is successful.
+func (fn CloseFn) Maybe() (cancel func(), close func()) {
+	do := true
+	cancel = func() {
+		do = false
+	}
+	close = func() {
+		if do {
+			fn()
+		}
+	}
+	return
+}

--- a/op-service/closer/closer_test.go
+++ b/op-service/closer/closer_test.go
@@ -1,0 +1,39 @@
+package closer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloser(t *testing.T) {
+	setup := func() (CloseFn, *string) {
+		data := ""
+		fn := CloseFn(func() {
+			data += "world"
+		})
+		fn.Stack(func() {
+			data += "hello "
+		})
+		fn.Stack(func() {
+			data += "1234 "
+		})
+		return fn, &data
+	}
+
+	t.Run("closed", func(t *testing.T) {
+		fn, data := setup()
+		cancelClose, closeMaybe := fn.Maybe()
+		closeMaybe()
+		require.Equal(t, "1234 hello world", *data)
+		cancelClose() // cancel is no-op after already closed
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		fn, data := setup()
+		cancelClose, closeMaybe := fn.Maybe()
+		cancelClose()
+		closeMaybe()
+		require.Equal(t, "", *data)
+	})
+}

--- a/op-service/endpoint/rpc.go
+++ b/op-service/endpoint/rpc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// MustRPC forces the RPC URL string to be non-empty when decoding or encoding.
 type MustRPC struct {
 	Value RPC
 }
@@ -34,6 +35,8 @@ func (u MustRPC) MarshalText() ([]byte, error) {
 	return []byte(out), nil
 }
 
+// OptionalRPC is the opposite of MustRPC:
+// it allows the RPC URL to be empty during decoding/encoding.
 type OptionalRPC struct {
 	Value RPC
 }

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -223,13 +223,12 @@ type Uint256Quantity = hexutil.U256
 
 type Data = hexutil.Bytes
 
-type (
-	PayloadID   = engine.PayloadID
-	PayloadInfo struct {
-		ID        PayloadID
-		Timestamp uint64
-	}
-)
+type PayloadID = engine.PayloadID
+
+type PayloadInfo struct {
+	ID        PayloadID `json:"id"`
+	Timestamp uint64    `json:"timestamp"`
+}
 
 type ExecutionPayloadEnvelope struct {
 	ParentBeaconBlockRoot *common.Hash      `json:"parentBeaconBlockRoot,omitempty"`

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -42,6 +42,10 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 	if span > 1000 { // sanity cap. If a large sequencing window is configured, do not make the cache too large
 		span = 1000
 	}
+	return L2ClientSimpleConfig(config, trustRPC, span, fullSpan)
+}
+
+func L2ClientSimpleConfig(config *rollup.Config, trustRPC bool, span, fullSpan int) *L2ClientConfig {
 	return &L2ClientConfig{
 		EthClientConfig: EthClientConfig{
 			// receipts and transactions are cached per block
@@ -49,7 +53,7 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 			TransactionsCacheSize: span,
 			HeadersCacheSize:      span,
 			PayloadsCacheSize:     span,
-			MaxRequestsPerBatch:   20, // TODO: tune batch param
+			MaxRequestsPerBatch:   20,
 			MaxConcurrentRequests: 10,
 			BlockRefsCacheSize:    span,
 			TrustRPC:              trustRPC,

--- a/op-service/sources/opstack_client.go
+++ b/op-service/sources/opstack_client.go
@@ -1,0 +1,48 @@
+package sources
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+)
+
+type OPStackClient struct {
+	rpc client.RPC
+}
+
+var _ apis.OPStackAPI = (*OPStackClient)(nil)
+
+func NewOPStackClient(rpc client.RPC) *OPStackClient {
+	return &OPStackClient{rpc}
+}
+
+func (r *OPStackClient) OpenBlock(ctx context.Context, parent eth.BlockID, attrs *eth.PayloadAttributes) (eth.PayloadInfo, error) {
+	var result eth.PayloadInfo
+	err := r.rpc.CallContext(ctx, &result, "opstack_openBlockV1", parent, attrs)
+	return result, err
+}
+
+func (r *OPStackClient) CancelBlock(ctx context.Context, id eth.PayloadInfo) error {
+	return r.rpc.CallContext(ctx, nil, "opstack_cancelBlockV1", id)
+}
+
+func (r *OPStackClient) SealBlock(ctx context.Context, id eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	var result *eth.ExecutionPayloadEnvelope
+	err := r.rpc.CallContext(ctx, &result, "opstack_sealBlockV1", id)
+	return result, err
+}
+
+func (r *OPStackClient) CommitBlock(ctx context.Context, envelope *opsigner.SignedExecutionPayloadEnvelope) error {
+	return r.rpc.CallContext(ctx, nil, "opstack_commitBlockV1", envelope)
+}
+
+func (r *OPStackClient) PublishBlock(ctx context.Context, signed *opsigner.SignedExecutionPayloadEnvelope) error {
+	return r.rpc.CallContext(ctx, nil, "opstack_publishBlockV1", signed)
+}
+
+func (r *OPStackClient) Close() {
+	r.rpc.Close()
+}

--- a/op-service/testutils/fake_publish.go
+++ b/op-service/testutils/fake_publish.go
@@ -1,0 +1,22 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+)
+
+// FakePublishAPI is used to instantiate an opstack API backend without full block publishing
+type FakePublishAPI struct {
+	Log log.Logger
+}
+
+var _ apis.PublishAPI = (*FakePublishAPI)(nil)
+
+func (f *FakePublishAPI) PublishBlock(ctx context.Context, signed *opsigner.SignedExecutionPayloadEnvelope) error {
+	f.Log.Info("Publish block", "signed", signed)
+	return nil
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder.go
@@ -32,12 +32,35 @@ type Builder struct {
 	l2       L2BlockRefByHash
 	attrPrep derive.AttributesBuilder
 	cl       apis.BuildAPI
-	onClose  func()
+
+	onClose func() // always non-nil
 
 	registry work.Jobs
 }
 
 var _ work.Builder = (*Builder)(nil)
+
+func NewBuilder(id seqtypes.BuilderID,
+	log log.Logger,
+	m metrics.Metricer,
+	l1 L1BlockRefByHash,
+	l2 L2BlockRefByHash,
+	attrPrep derive.AttributesBuilder,
+	cl apis.BuildAPI,
+	registry work.Jobs) *Builder {
+
+	return &Builder{
+		id:       id,
+		log:      log,
+		m:        m,
+		l1:       l1,
+		l2:       l2,
+		attrPrep: attrPrep,
+		cl:       cl,
+		onClose:  func() {},
+		registry: registry,
+	}
+}
 
 func (b *Builder) NewJob(ctx context.Context, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
 	parentRef, err := b.l2.L2BlockRefByHash(ctx, opts.Parent)
@@ -68,7 +91,7 @@ func (b *Builder) NewJob(ctx context.Context, opts *seqtypes.BuildOpts) (work.Bu
 	if err := b.registry.RegisterJob(job); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	return job, nil
 }
 
 func (b *Builder) Close() error {

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder.go
@@ -1,0 +1,85 @@
+package standardbuilder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type L1BlockRefByHash interface {
+	L1BlockRefByHash(ctx context.Context, h common.Hash) (eth.L1BlockRef, error)
+}
+
+type L2BlockRefByHash interface {
+	L2BlockRefByHash(ctx context.Context, h common.Hash) (eth.L2BlockRef, error)
+}
+
+type Builder struct {
+	id  seqtypes.BuilderID
+	log log.Logger
+	m   metrics.Metricer
+
+	l1       L1BlockRefByHash
+	l2       L2BlockRefByHash
+	attrPrep derive.AttributesBuilder
+	cl       apis.BuildAPI
+	onClose  func()
+
+	registry work.Jobs
+}
+
+var _ work.Builder = (*Builder)(nil)
+
+func (b *Builder) NewJob(ctx context.Context, opts *seqtypes.BuildOpts) (work.BuildJob, error) {
+	parentRef, err := b.l2.L2BlockRefByHash(ctx, opts.Parent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve parent-block: %w", err)
+	}
+	l1OriginRef, err := b.l1.L1BlockRefByHash(ctx, *opts.L1Origin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve L1 origin: %w", err)
+	}
+	attrs, err := b.attrPrep.PreparePayloadAttributes(ctx, parentRef, l1OriginRef.ID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare payload attributes: %w", err)
+	}
+	id := seqtypes.RandomJobID()
+	info, err := b.cl.OpenBlock(ctx, parentRef.ID(), attrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open block: %w", err)
+	}
+	job := &Job{
+		id:          id,
+		eng:         b.cl,
+		payloadInfo: info,
+		unregister: func() {
+			b.registry.UnregisterJob(id)
+		},
+	}
+	if err := b.registry.RegisterJob(job); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (b *Builder) Close() error {
+	b.onClose()
+	return nil
+}
+
+func (b *Builder) String() string {
+	return "standard-builder-" + b.id.String()
+}
+
+func (b *Builder) ID() seqtypes.BuilderID {
+	return b.id
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder_test.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder_test.go
@@ -1,0 +1,118 @@
+package standardbuilder
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type testAPI struct {
+	parent eth.BlockID
+	attrs  *eth.PayloadAttributes
+	info   eth.PayloadInfo
+	v      *eth.ExecutionPayloadEnvelope
+}
+
+func (t *testAPI) OpenBlock(ctx context.Context, parent eth.BlockID, attrs *eth.PayloadAttributes) (eth.PayloadInfo, error) {
+	t.parent = parent
+	t.attrs = attrs
+	return t.info, nil
+}
+
+func (t *testAPI) CancelBlock(ctx context.Context, id eth.PayloadInfo) error {
+	t.info = eth.PayloadInfo{}
+	return nil
+}
+
+func (t *testAPI) SealBlock(ctx context.Context, id eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	if t.info != id {
+		return nil, &rpc.JsonError{Code: apis.BuildErrCodeUnknownPayload, Message: "unknown payload"}
+	}
+	return t.v, nil
+}
+
+var _ apis.BuildAPI = (*testAPI)(nil)
+
+type fakeAttributesBuilder struct {
+}
+
+func (f *fakeAttributesBuilder) PreparePayloadAttributes(ctx context.Context, l2Parent eth.L2BlockRef, epoch eth.BlockID) (attrs *eth.PayloadAttributes, err error) {
+	return &eth.PayloadAttributes{
+		Timestamp: eth.Uint64Quantity(l2Parent.Time) + 2,
+	}, nil
+}
+
+var _ derive.AttributesBuilder = (*fakeAttributesBuilder)(nil)
+
+func TestStandardBuilder(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.BuilderID("foo")
+	api := &testAPI{}
+	m := &metrics.NoopMetrics{}
+	l1 := &testutils.MockL1Source{}
+	l2 := &testutils.MockL2Client{}
+	fb := &fakeAttributesBuilder{}
+	reg := work.NewJobRegistry()
+
+	x := NewBuilder(id, logger, m, l1, l2, fb, api, reg)
+
+	ctx := context.Background()
+	rng := rand.New(rand.NewSource(123))
+
+	l2Parent := testutils.RandomL2BlockRef(rng)
+	l1Origin := testutils.RandomBlockRef(rng)
+	opts := &seqtypes.BuildOpts{
+		Parent:   l2Parent.Hash,
+		L1Origin: &l1Origin.Hash,
+	}
+	l1.ExpectL1BlockRefByHash(l1Origin.Hash, l1Origin, nil)
+	l2.ExpectL2BlockRefByHash(l2Parent.Hash, l2Parent, nil)
+	job, err := x.NewJob(ctx, opts)
+	require.NoError(t, err)
+	require.NotNil(t, reg.GetJob(job.ID()), "job should be there now")
+	require.Equal(t, l2Parent.Time+2, uint64(api.attrs.Timestamp), "must be building the right block")
+	l1.AssertExpectations(t)
+	l2.AssertExpectations(t)
+
+	// prepare block-sealing result
+	api.v = &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
+		BlockHash:   testutils.RandomHash(rng),
+		BlockNumber: eth.Uint64Quantity(l2Parent.Number + 1),
+		Timestamp:   api.attrs.Timestamp,
+	}}
+
+	result, err := job.Seal(ctx)
+	require.NoError(t, err)
+	require.Equal(t, api.v.ID(), result.ID())
+	require.NotNil(t, reg.GetJob(job.ID()), "job is not removed upon sealing but upon closing")
+
+	job.Close()
+	require.Nil(t, reg.GetJob(job.ID()), "job should be cleaned up")
+
+	l1.ExpectL1BlockRefByHash(l1Origin.Hash, l1Origin, nil)
+	l2.ExpectL2BlockRefByHash(l2Parent.Hash, l2Parent, nil)
+	job2, err := x.NewJob(ctx, opts)
+	require.NoError(t, err)
+	l1.AssertExpectations(t)
+	l2.AssertExpectations(t)
+	require.NotNil(t, reg.GetJob(job2.ID()), "job 2 should be there now")
+
+	require.NoError(t, job2.Cancel(ctx))
+	require.NotNil(t, reg.GetJob(job2.ID()), "job is not removed upon canceling but upon closing")
+	job2.Close()
+	require.Nil(t, reg.GetJob(job2.ID()), "job 2 should be cleaned up")
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
@@ -1,0 +1,109 @@
+package standardbuilder
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+	// L1 execution-layer RPC endpoint
+	L1EL endpoint.MustRPC `yaml:"l1EL,omitempty"`
+
+	// L2 execution-layer RPC endpoint
+	L2EL endpoint.MustRPC `yaml:"l2EL,omitempty"`
+	// L2 consensus-layer RPC endpoint
+	L2CL endpoint.MustRPC `yaml:"l2CL,omitempty"`
+}
+
+type CloseFn func()
+
+func (fn *CloseFn) Prepend(other func()) {
+	self := *fn
+	*fn = func() {
+		other()
+		self()
+	}
+}
+
+func (fn CloseFn) Maybe() (cancel func(), close func()) {
+	do := true
+	cancel = func() {
+		do = false
+	}
+	close = func() {
+		if do {
+			fn()
+		}
+	}
+	return
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.ServiceOpts) (work.Builder, error) {
+	onClose := CloseFn(func() {
+		opts.Log.Info("Closed")
+	})
+	cancelCloseEarly, closeEarly := onClose.Maybe()
+	defer closeEarly()
+
+	l2CLRPCClient, err := client.NewRPC(ctx, opts.Log, c.L2CL.Value.RPC(), client.WithLazyDial())
+	if err != nil {
+		return nil, err
+	}
+	onClose.Prepend(l2CLRPCClient.Close)
+	l2ELRPCClient, err := client.NewRPC(ctx, opts.Log, c.L2EL.Value.RPC(), client.WithLazyDial())
+	if err != nil {
+		return nil, err
+	}
+	onClose.Prepend(l2ELRPCClient.Close)
+	l1ELRPCClient, err := client.NewRPC(ctx, opts.Log, c.L1EL.Value.RPC(), client.WithLazyDial())
+	if err != nil {
+		return nil, err
+	}
+	onClose.Prepend(l1ELRPCClient.Close)
+
+	rolCl := sources.NewRollupClient(l2CLRPCClient)
+	cfg, err := retry.Do(ctx, 0, retry.Exponential(), func() (*rollup.Config, error) {
+		opts.Log.Info("Fetching rollup-config for block-building")
+		cfg, err := rolCl.RollupConfig(ctx)
+		if err != nil {
+			opts.Log.Warn("Failed to fetch rollup-config", "err", err)
+		}
+		return cfg, err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	l1Cl, err := sources.NewL1Client(l1ELRPCClient, opts.Log, nil,
+		sources.L1ClientSimpleConfig(false, sources.RPCKindAny, 10))
+	if err != nil {
+		return nil, err
+	}
+	l2Cl, err := sources.NewL2Client(l2ELRPCClient, opts.Log, nil,
+		sources.L2ClientSimpleConfig(cfg, false, 10, 10))
+	if err != nil {
+		return nil, err
+	}
+	fb := derive.NewFetchingAttributesBuilder(cfg, l1Cl, l2Cl)
+	cl := sources.NewOPStackClient(l2CLRPCClient)
+	cancelCloseEarly()
+	return &Builder{
+		id:       id,
+		log:      opts.Log,
+		m:        opts.Metrics,
+		registry: opts.Jobs,
+		l1:       l1Cl,
+		l2:       l2Cl,
+		attrPrep: fb,
+		cl:       cl,
+		onClose:  onClose,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/closer"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -15,39 +16,16 @@ import (
 
 type Config struct {
 	// L1 execution-layer RPC endpoint
-	L1EL endpoint.MustRPC `yaml:"l1EL,omitempty"`
+	L1EL endpoint.MustRPC `yaml:"l1EL"`
 
 	// L2 execution-layer RPC endpoint
-	L2EL endpoint.MustRPC `yaml:"l2EL,omitempty"`
+	L2EL endpoint.MustRPC `yaml:"l2EL"`
 	// L2 consensus-layer RPC endpoint
-	L2CL endpoint.MustRPC `yaml:"l2CL,omitempty"`
-}
-
-type CloseFn func()
-
-func (fn *CloseFn) Prepend(other func()) {
-	self := *fn
-	*fn = func() {
-		other()
-		self()
-	}
-}
-
-func (fn CloseFn) Maybe() (cancel func(), close func()) {
-	do := true
-	cancel = func() {
-		do = false
-	}
-	close = func() {
-		if do {
-			fn()
-		}
-	}
-	return
+	L2CL endpoint.MustRPC `yaml:"l2CL"`
 }
 
 func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.ServiceOpts) (work.Builder, error) {
-	onClose := CloseFn(func() {
+	onClose := closer.CloseFn(func() {
 		opts.Log.Info("Closed")
 	})
 	cancelCloseEarly, closeEarly := onClose.Maybe()
@@ -57,17 +35,17 @@ func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.Se
 	if err != nil {
 		return nil, err
 	}
-	onClose.Prepend(l2CLRPCClient.Close)
+	onClose.Stack(l2CLRPCClient.Close)
 	l2ELRPCClient, err := client.NewRPC(ctx, opts.Log, c.L2EL.Value.RPC(), client.WithLazyDial())
 	if err != nil {
 		return nil, err
 	}
-	onClose.Prepend(l2ELRPCClient.Close)
+	onClose.Stack(l2ELRPCClient.Close)
 	l1ELRPCClient, err := client.NewRPC(ctx, opts.Log, c.L1EL.Value.RPC(), client.WithLazyDial())
 	if err != nil {
 		return nil, err
 	}
-	onClose.Prepend(l1ELRPCClient.Close)
+	onClose.Stack(l1ELRPCClient.Close)
 
 	rolCl := sources.NewRollupClient(l2CLRPCClient)
 	cfg, err := retry.Do(ctx, 0, retry.Exponential(), func() (*rollup.Config, error) {

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/job.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/job.go
@@ -2,7 +2,10 @@ package standardbuilder
 
 import (
 	"context"
+	"errors"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -18,7 +21,7 @@ type Job struct {
 	mu          sync.Mutex
 	payloadInfo eth.PayloadInfo
 	result      *eth.ExecutionPayloadEnvelope
-	unregister  func()
+	unregister  func() // always non-nil
 }
 
 func (job *Job) ID() seqtypes.BuildJobID {
@@ -30,7 +33,11 @@ func (job *Job) Cancel(ctx context.Context) error {
 	defer job.mu.Unlock()
 	err := job.eng.CancelBlock(ctx, job.payloadInfo)
 	if err != nil {
-		// TODO not-found error is acceptable
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
+			// This error is acceptable, as there is nothing to cancel
+			return nil
+		}
 		return err
 	}
 	return nil
@@ -39,6 +46,9 @@ func (job *Job) Cancel(ctx context.Context) error {
 func (job *Job) Seal(ctx context.Context) (work.Block, error) {
 	job.mu.Lock()
 	defer job.mu.Unlock()
+	if job.result != nil {
+		return job.result, nil
+	}
 	envelope, err := job.eng.SealBlock(ctx, job.payloadInfo)
 	if err != nil {
 		return nil, err
@@ -52,6 +62,8 @@ func (job *Job) String() string {
 }
 
 func (job *Job) Close() {
+	job.mu.Lock()
+	defer job.mu.Unlock()
 	job.unregister()
 }
 

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/job.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/job.go
@@ -1,0 +1,58 @@
+package standardbuilder
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Job struct {
+	id seqtypes.BuildJobID
+
+	eng apis.BuildAPI
+
+	mu          sync.Mutex
+	payloadInfo eth.PayloadInfo
+	result      *eth.ExecutionPayloadEnvelope
+	unregister  func()
+}
+
+func (job *Job) ID() seqtypes.BuildJobID {
+	return job.id
+}
+
+func (job *Job) Cancel(ctx context.Context) error {
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	err := job.eng.CancelBlock(ctx, job.payloadInfo)
+	if err != nil {
+		// TODO not-found error is acceptable
+		return err
+	}
+	return nil
+}
+
+func (job *Job) Seal(ctx context.Context) (work.Block, error) {
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	envelope, err := job.eng.SealBlock(ctx, job.payloadInfo)
+	if err != nil {
+		return nil, err
+	}
+	job.result = envelope
+	return envelope, nil
+}
+
+func (job *Job) String() string {
+	return job.id.String()
+}
+
+func (job *Job) Close() {
+	job.unregister()
+}
+
+var _ work.BuildJob = (*Job)(nil)

--- a/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/committer.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/committer.go
@@ -1,0 +1,54 @@
+package standardcommitter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+// Committer commits blocks with the op-stack commit API.
+// This can be an op-node that processes and persists the block as canonical.
+type Committer struct {
+	api     apis.CommitAPI
+	onClose func()
+
+	id  seqtypes.CommitterID
+	log log.Logger
+}
+
+var _ work.Committer = (*Committer)(nil)
+
+func NewCommitter(id seqtypes.CommitterID, log log.Logger, api apis.CommitAPI) *Committer {
+	return &Committer{id: id, log: log, api: api, onClose: func() {}}
+}
+
+func (n *Committer) Close() error {
+	n.onClose()
+	return nil
+}
+
+func (n *Committer) String() string {
+	return "standard-committer-" + n.id.String()
+}
+
+func (n *Committer) ID() seqtypes.CommitterID {
+	return n.id
+}
+
+func (n *Committer) Commit(ctx context.Context, block work.SignedBlock) error {
+	bl, ok := block.(*opsigner.SignedExecutionPayloadEnvelope)
+	if !ok {
+		return fmt.Errorf("cannot commit block of type %T: %w", block, seqtypes.ErrUnknownKind)
+	}
+	err := n.api.CommitBlock(ctx, bl)
+	if err != nil {
+		n.log.Error("Failed to publish block", "block", block, "err", err)
+	}
+	return err
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/committer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/committer_test.go
@@ -1,0 +1,79 @@
+package standardcommitter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type testAPI struct {
+	v   *opsigner.SignedExecutionPayloadEnvelope
+	err error
+}
+
+func (t *testAPI) CommitBlock(ctx context.Context, envelope *opsigner.SignedExecutionPayloadEnvelope) error {
+	t.v = envelope
+	return t.err
+}
+
+type dummySignedBlock struct {
+}
+
+func (s *dummySignedBlock) ID() eth.BlockID {
+	return eth.BlockID{Number: 1000}
+}
+
+func (s *dummySignedBlock) String() string {
+	return "test signed block"
+}
+
+func (s *dummySignedBlock) VerifySignature(authContext opsigner.Authenticator) error {
+	return errors.New("not supported")
+}
+
+var _ work.SignedBlock = (*dummySignedBlock)(nil)
+
+var _ apis.CommitAPI = (*testAPI)(nil)
+
+func TestStandardCommitter(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.CommitterID("foo")
+	api := &testAPI{}
+	x := NewCommitter(id, logger, api)
+
+	require.ErrorIs(t, x.Commit(context.Background(), &dummySignedBlock{}), seqtypes.ErrUnknownKind)
+
+	signed := &opsigner.SignedExecutionPayloadEnvelope{
+		Envelope: &eth.ExecutionPayloadEnvelope{
+			ParentBeaconBlockRoot: nil,
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash: common.Hash{123},
+			},
+		},
+		Signature: eth.Bytes65{42},
+	}
+	err := x.Commit(context.Background(), signed)
+	require.NoError(t, err)
+	require.Equal(t, signed, api.v)
+
+	api.v = nil
+	api.err = errors.New("test err")
+	err = x.Commit(context.Background(), signed)
+	require.ErrorIs(t, err, api.err)
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "standard-committer-foo", x.String())
+	require.Equal(t, id, x.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/config.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/config.go
@@ -1,0 +1,30 @@
+package standardcommitter
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+	// RPC to commit block to using op-stack RPC
+	RPC endpoint.MustRPC `yaml:"rpc"`
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.CommitterID, opts *work.ServiceOpts) (work.Committer, error) {
+	rpcCl, err := client.NewRPC(ctx, opts.Log, c.RPC.Value.RPC(), client.WithLazyDial())
+	if err != nil {
+		return nil, err
+	}
+	cl := sources.NewOPStackClient(rpcCl)
+	return &Committer{
+		id:      id,
+		log:     opts.Log,
+		api:     cl,
+		onClose: rpcCl.Close,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/committers/standardcommitter/config_test.go
@@ -1,0 +1,76 @@
+package standardcommitter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type apiFrontend struct {
+	testAPI
+}
+
+func (t *apiFrontend) CommitBlockV1(ctx context.Context, envelope *opsigner.SignedExecutionPayloadEnvelope) error {
+	t.v = envelope
+	return t.err
+}
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	server := oprpc.NewServer("localhost", 0,
+		"v0.0.1", oprpc.WithLogger(logger))
+	api := &apiFrontend{}
+	server.AddAPI(rpc.API{
+		Namespace: "opstack",
+		Service:   api,
+	})
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+	cfg := &Config{
+		RPC: endpoint.MustRPC{
+			Value: endpoint.HttpURL("http://" + server.Endpoint()),
+		},
+	}
+	id := seqtypes.CommitterID("test")
+	ensemble := &work.Ensemble{}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: ensemble,
+	}
+	committer, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, committer.ID())
+
+	signed := &opsigner.SignedExecutionPayloadEnvelope{
+		Envelope: &eth.ExecutionPayloadEnvelope{
+			ParentBeaconBlockRoot: nil,
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash: common.Hash{123},
+			},
+		},
+		Signature: eth.Bytes65{42},
+	}
+	err = committer.Commit(context.Background(), signed)
+	require.NoError(t, err)
+	require.Equal(t, signed.Signature, api.v.Signature)
+	require.Equal(t, signed.Envelope.ExecutionPayload.BlockHash, api.v.Envelope.ExecutionPayload.BlockHash)
+}

--- a/op-test-sequencer/sequencer/backend/work/config/builder.go
+++ b/op-test-sequencer/sequencer/backend/work/config/builder.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/noopbuilder"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/standardbuilder"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
 type BuilderEntry struct {
-	Noop *noopbuilder.Config `yaml:"noop,omitempty"`
+	Standard *standardbuilder.Config `yaml:"standard,omitempty"`
+	Noop     *noopbuilder.Config     `yaml:"noop,omitempty"`
 }
 
 func (b *BuilderEntry) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.ServiceOpts) (work.Builder, error) {
 	switch {
+	case b.Standard != nil:
+		return b.Standard.Start(ctx, id, opts)
 	case b.Noop != nil:
 		return b.Noop.Start(ctx, id, opts)
 	default:

--- a/op-test-sequencer/sequencer/backend/work/config/committer.go
+++ b/op-test-sequencer/sequencer/backend/work/config/committer.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/standardcommitter"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
 type CommitterEntry struct {
-	Noop *noopcommitter.Config `yaml:"noop,omitempty"`
+	Standard *standardcommitter.Config `yaml:"standard,omitempty"`
+	Noop     *noopcommitter.Config     `yaml:"noop,omitempty"`
 }
 
 func (b *CommitterEntry) Start(ctx context.Context, id seqtypes.CommitterID, opts *work.ServiceOpts) (work.Committer, error) {
 	switch {
+	case b.Standard != nil:
+		return b.Standard.Start(ctx, id, opts)
 	case b.Noop != nil:
 		return b.Noop.Start(ctx, id, opts)
 	default:

--- a/op-test-sequencer/sequencer/backend/work/config/publisher.go
+++ b/op-test-sequencer/sequencer/backend/work/config/publisher.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
 type PublisherEntry struct {
-	Noop *nooppublisher.Config `yaml:"noop,omitempty"`
+	Standard *standardpublisher.Config `yaml:"standard,omitempty"`
+	Noop     *nooppublisher.Config     `yaml:"noop,omitempty"`
 }
 
 func (b *PublisherEntry) Start(ctx context.Context, id seqtypes.PublisherID, opts *work.ServiceOpts) (work.Publisher, error) {
 	switch {
+	case b.Standard != nil:
+		return b.Standard.Start(ctx, id, opts)
 	case b.Noop != nil:
 		return b.Noop.Start(ctx, id, opts)
 	default:

--- a/op-test-sequencer/sequencer/backend/work/config/signer.go
+++ b/op-test-sequencer/sequencer/backend/work/config/signer.go
@@ -4,16 +4,20 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/localkey"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
 type SignerEntry struct {
-	Noop *noopsigner.Config `yaml:"noop,omitempty"`
+	LocalKey *localkey.Config   `yaml:"local-key,omitempty"`
+	Noop     *noopsigner.Config `yaml:"noop,omitempty"`
 }
 
 func (b *SignerEntry) Start(ctx context.Context, id seqtypes.SignerID, opts *work.ServiceOpts) (work.Signer, error) {
 	switch {
+	case b.LocalKey != nil:
+		return b.LocalKey.Start(ctx, id, opts)
 	case b.Noop != nil:
 		return b.Noop.Start(ctx, id, opts)
 	default:

--- a/op-test-sequencer/sequencer/backend/work/iface.go
+++ b/op-test-sequencer/sequencer/backend/work/iface.go
@@ -63,6 +63,7 @@ type Signer interface {
 	ID() seqtypes.SignerID
 	io.Closer
 	Sign(ctx context.Context, block Block) (SignedBlock, error)
+	ChainID() eth.ChainID
 }
 
 // Committer commits to a (signed) block to become canonical.

--- a/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/config.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/config.go
@@ -1,0 +1,30 @@
+package standardpublisher
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+	// RPC to publish block to using op-stack RPC
+	RPC endpoint.MustRPC `yaml:"rpc"`
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.PublisherID, opts *work.ServiceOpts) (work.Publisher, error) {
+	rpcCl, err := client.NewRPC(ctx, opts.Log, c.RPC.Value.RPC(), client.WithLazyDial())
+	if err != nil {
+		return nil, err
+	}
+	cl := sources.NewOPStackClient(rpcCl)
+	return &Publisher{
+		id:      id,
+		log:     opts.Log,
+		api:     cl,
+		onClose: rpcCl.Close,
+	}, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/config_test.go
@@ -1,0 +1,76 @@
+package standardpublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type apiFrontend struct {
+	testAPI
+}
+
+func (t *apiFrontend) PublishBlockV1(ctx context.Context, envelope *opsigner.SignedExecutionPayloadEnvelope) error {
+	t.v = envelope
+	return t.err
+}
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	server := oprpc.NewServer("localhost", 0,
+		"v0.0.1", oprpc.WithLogger(logger))
+	api := &apiFrontend{}
+	server.AddAPI(rpc.API{
+		Namespace: "opstack",
+		Service:   api,
+	})
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+	cfg := &Config{
+		RPC: endpoint.MustRPC{
+			Value: endpoint.HttpURL("http://" + server.Endpoint()),
+		},
+	}
+	id := seqtypes.PublisherID("test")
+	ensemble := &work.Ensemble{}
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: ensemble,
+	}
+	publisher, err := cfg.Start(context.Background(), id, opts)
+	require.NoError(t, err)
+	require.Equal(t, id, publisher.ID())
+
+	signed := &opsigner.SignedExecutionPayloadEnvelope{
+		Envelope: &eth.ExecutionPayloadEnvelope{
+			ParentBeaconBlockRoot: nil,
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash: common.Hash{123},
+			},
+		},
+		Signature: eth.Bytes65{42},
+	}
+	err = publisher.Publish(context.Background(), signed)
+	require.NoError(t, err)
+	require.Equal(t, signed.Signature, api.v.Signature)
+	require.Equal(t, signed.Envelope.ExecutionPayload.BlockHash, api.v.Envelope.ExecutionPayload.BlockHash)
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/publisher.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/publisher.go
@@ -1,0 +1,52 @@
+package standardpublisher
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Publisher struct {
+	api     apis.PublishAPI
+	onClose func()
+
+	id  seqtypes.PublisherID
+	log log.Logger
+}
+
+var _ work.Publisher = (*Publisher)(nil)
+
+func NewPublisher(id seqtypes.PublisherID, log log.Logger, api apis.PublishAPI) *Publisher {
+	return &Publisher{id: id, log: log, api: api, onClose: func() {}}
+}
+
+func (n *Publisher) Close() error {
+	n.onClose()
+	return nil
+}
+
+func (n *Publisher) String() string {
+	return "standard-publisher-" + n.id.String()
+}
+
+func (n *Publisher) ID() seqtypes.PublisherID {
+	return n.id
+}
+
+func (n *Publisher) Publish(ctx context.Context, block work.SignedBlock) error {
+	bl, ok := block.(*opsigner.SignedExecutionPayloadEnvelope)
+	if !ok {
+		return fmt.Errorf("cannot publish block of type %T: %w", block, seqtypes.ErrUnknownKind)
+	}
+	err := n.api.PublishBlock(ctx, bl)
+	if err != nil {
+		n.log.Error("Failed to publish block", "block", block, "err", err)
+	}
+	return err
+}

--- a/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/publisher_test.go
+++ b/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher/publisher_test.go
@@ -1,0 +1,79 @@
+package standardpublisher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type testAPI struct {
+	v   *opsigner.SignedExecutionPayloadEnvelope
+	err error
+}
+
+func (t *testAPI) PublishBlock(ctx context.Context, envelope *opsigner.SignedExecutionPayloadEnvelope) error {
+	t.v = envelope
+	return t.err
+}
+
+type dummySignedBlock struct {
+}
+
+func (s *dummySignedBlock) ID() eth.BlockID {
+	return eth.BlockID{Number: 1000}
+}
+
+func (s *dummySignedBlock) String() string {
+	return "test signed block"
+}
+
+func (s *dummySignedBlock) VerifySignature(authContext opsigner.Authenticator) error {
+	return errors.New("not supported")
+}
+
+var _ work.SignedBlock = (*dummySignedBlock)(nil)
+
+var _ apis.PublishAPI = (*testAPI)(nil)
+
+func TestStandardPublisher(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	id := seqtypes.PublisherID("foo")
+	api := &testAPI{}
+	x := NewPublisher(id, logger, api)
+
+	require.ErrorIs(t, x.Publish(context.Background(), &dummySignedBlock{}), seqtypes.ErrUnknownKind)
+
+	signed := &opsigner.SignedExecutionPayloadEnvelope{
+		Envelope: &eth.ExecutionPayloadEnvelope{
+			ParentBeaconBlockRoot: nil,
+			ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash: common.Hash{123},
+			},
+		},
+		Signature: eth.Bytes65{42},
+	}
+	err := x.Publish(context.Background(), signed)
+	require.NoError(t, err)
+	require.Equal(t, signed, api.v)
+
+	api.v = nil
+	api.err = errors.New("test err")
+	err = x.Publish(context.Background(), signed)
+	require.ErrorIs(t, err, api.err)
+
+	require.NoError(t, x.Close())
+	require.Equal(t, "standard-publisher-foo", x.String())
+	require.Equal(t, id, x.ID())
+}

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer_test.go
@@ -121,6 +121,10 @@ func (m *mockSigner) Sign(ctx context.Context, block work.Block) (work.SignedBlo
 	return &mockSignedBlock{bl: block}, m.err
 }
 
+func (m *mockSigner) ChainID() eth.ChainID {
+	return eth.ChainIDFromUInt64(123)
+}
+
 var _ work.Signer = (*mockSigner)(nil)
 
 type mockCommitter struct {

--- a/op-test-sequencer/sequencer/backend/work/signers/localkey/config.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/localkey/config.go
@@ -1,0 +1,64 @@
+package localkey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Config struct {
+	ChainID eth.ChainID    `yaml:"chainID"`
+	KeyPath string         `yaml:"path,omitempty"`
+	RawKey  *hexutil.Bytes `yaml:"raw,omitempty"`
+}
+
+func readHexBytes(keyPath string) ([]byte, error) {
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file %q: %w", keyPath, err)
+	}
+	// Remove optional 0x prefix
+	key := strings.TrimPrefix(string(data), "0x")
+	// Geth always wants the 0x prefix
+	return hexutil.Decode("0x" + key)
+}
+
+func (c *Config) Start(ctx context.Context, id seqtypes.SignerID, opts *work.ServiceOpts) (work.Signer, error) {
+	var keyBytes []byte
+	if c.KeyPath != "" && c.RawKey != nil {
+		return nil, errors.New("cannot specify both keyPath and rawKey")
+	} else if c.KeyPath != "" {
+		x, err := readHexBytes(c.KeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("")
+		}
+		keyBytes = x
+	} else if c.RawKey != nil {
+		keyBytes = *c.RawKey
+	} else {
+		return nil, errors.New("no key specified")
+	}
+	priv, err := crypto.ToECDSA(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid key: %w", err)
+	}
+	signer := opsigner.NewLocalSigner(priv)
+
+	bu := &Signer{
+		id:      id,
+		log:     opts.Log,
+		chainID: c.ChainID,
+		signer:  signer,
+	}
+	return bu, nil
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/localkey/config_test.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/localkey/config_test.go
@@ -1,0 +1,95 @@
+package localkey
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// Create a key
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	// select a chain
+	chainID := eth.ChainIDFromUInt64(123)
+
+	id := seqtypes.SignerID("foobar")
+	opts := &work.ServiceOpts{
+		StartOpts: &work.StartOpts{
+			Log:     logger,
+			Metrics: &metrics.NoopMetrics{},
+		},
+		Services: &work.Ensemble{},
+	}
+
+	t.Run("from-file", func(t *testing.T) {
+
+		keyDir := t.TempDir()
+		keyPath := filepath.Join(keyDir, "key.txt")
+		require.NoError(t, crypto.SaveECDSA(keyPath, key))
+		loaded, err := crypto.LoadECDSA(keyPath)
+		require.NoError(t, err)
+		require.Equal(t, addr, crypto.PubkeyToAddress(loaded.PublicKey))
+
+		cfg := &Config{
+			ChainID: chainID,
+			KeyPath: keyPath,
+			RawKey:  nil,
+		}
+		signer, err := cfg.Start(context.Background(), id, opts)
+		require.NoError(t, err)
+		testSigner(t, signer, chainID, addr)
+	})
+
+	t.Run("from-raw", func(t *testing.T) {
+		rawKey := crypto.FromECDSA(key)
+		cfg := &Config{
+			ChainID: chainID,
+			KeyPath: "",
+			RawKey:  (*hexutil.Bytes)(&rawKey),
+		}
+		signer, err := cfg.Start(context.Background(), id, opts)
+		require.NoError(t, err)
+		testSigner(t, signer, chainID, addr)
+	})
+}
+
+func testSigner(t *testing.T, signer work.Signer, chainID eth.ChainID, addr common.Address) {
+	require.Equal(t, chainID, signer.ChainID(), "sanity-check chain ID")
+
+	parentBeaconBlockRoot := common.Hash{0x42}
+	block := &eth.ExecutionPayloadEnvelope{
+		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+		ExecutionPayload:      &eth.ExecutionPayload{BlockNumber: 1234},
+	}
+	// Sign a test payload
+	signedBlock, err := signer.Sign(context.Background(), block)
+	require.NoError(t, err)
+
+	authCtx := &opsigner.OPStackP2PBlockAuthV1{Allowed: addr, Chain: chainID}
+	require.NoError(t, signedBlock.VerifySignature(authCtx))
+
+	otherKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	otherAddr := crypto.PubkeyToAddress(otherKey.PublicKey)
+	authCtx2 := &opsigner.OPStackP2PBlockAuthV1{Allowed: otherAddr, Chain: chainID}
+	require.Error(t, signedBlock.VerifySignature(authCtx2), "sanity check that other address is not also valid")
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/localkey/signer.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/localkey/signer.go
@@ -51,7 +51,6 @@ func (s *Signer) Sign(ctx context.Context, v work.Block) (work.SignedBlock, erro
 	if _, err := envelope.MarshalSSZ(&buf); err != nil {
 		return nil, fmt.Errorf("failed to encode execution payload: %w", err)
 	}
-
 	payloadHash := opsigner.PayloadHash(buf.Bytes())
 	sig, err := s.signer.SignBlockV1(ctx, s.chainID, payloadHash)
 	if err != nil {

--- a/op-test-sequencer/sequencer/backend/work/signers/localkey/signer.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/localkey/signer.go
@@ -1,0 +1,68 @@
+package localkey
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+type Signer struct {
+	id  seqtypes.SignerID
+	log log.Logger
+
+	chainID eth.ChainID
+	signer  *opsigner.LocalSigner
+}
+
+var _ work.Signer = (*Signer)(nil)
+
+func NewSigner(id seqtypes.SignerID, log log.Logger, chainID eth.ChainID, priv *ecdsa.PrivateKey) *Signer {
+	s := opsigner.NewLocalSigner(priv)
+	return &Signer{id: id, log: log, chainID: chainID, signer: s}
+}
+
+func (s *Signer) String() string {
+	return "local-key-signer-" + s.id.String()
+}
+
+func (s *Signer) ID() seqtypes.SignerID {
+	return s.id
+}
+
+func (s *Signer) Close() error {
+	return nil
+}
+
+func (s *Signer) Sign(ctx context.Context, v work.Block) (work.SignedBlock, error) {
+	envelope, ok := v.(*eth.ExecutionPayloadEnvelope)
+	if !ok {
+		return nil, fmt.Errorf("cannot sign unknown block kind %T: %w", v, seqtypes.ErrUnknownKind)
+	}
+
+	var buf bytes.Buffer
+	if _, err := envelope.MarshalSSZ(&buf); err != nil {
+		return nil, fmt.Errorf("failed to encode execution payload: %w", err)
+	}
+
+	payloadHash := opsigner.PayloadHash(buf.Bytes())
+	sig, err := s.signer.SignBlockV1(ctx, s.chainID, payloadHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign with local key: %w", err)
+	}
+	return &opsigner.SignedExecutionPayloadEnvelope{
+		Envelope:  envelope,
+		Signature: sig,
+	}, nil
+}
+
+func (s *Signer) ChainID() eth.ChainID {
+	return s.chainID
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/localkey/signer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/localkey/signer_test.go
@@ -1,0 +1,26 @@
+package localkey
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+)
+
+func TestSigner(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	chainID := eth.ChainIDFromUInt64(123)
+	id := seqtypes.SignerID("foobar")
+
+	signer := NewSigner(id, logger, chainID, key)
+	testSigner(t, signer, chainID, addr)
+}

--- a/op-test-sequencer/sequencer/backend/work/signers/noopsigner/signer.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/noopsigner/signer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
@@ -35,4 +36,8 @@ func (n *Signer) ID() seqtypes.SignerID {
 func (n *Signer) Sign(ctx context.Context, block work.Block) (work.SignedBlock, error) {
 	n.log.Info("No-op sign", "block", block)
 	return nil, nil
+}
+
+func (n *Signer) ChainID() eth.ChainID {
+	return eth.ChainID{}
 }

--- a/op-test-sequencer/sequencer/backend/work/signers/noopsigner/signer_test.go
+++ b/op-test-sequencer/sequencer/backend/work/signers/noopsigner/signer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
@@ -23,4 +24,6 @@ func TestNoopSigner(t *testing.T) {
 	require.NoError(t, x.Close())
 	require.Equal(t, "noop-signer-foo", x.String())
 	require.Equal(t, id, x.ID())
+
+	require.Equal(t, eth.ChainID{}, x.ChainID())
 }


### PR DESCRIPTION
**Description**

This introduces:
- op-node API to serve (enabled with feature-flag `--experimental.opstack-api`):
  - `opstack_openBlockV1`
  - `opstack_cancelBlockV1`
  - `opstack_sealBlockV1`
  - `opstack_commitBlockV1`
  - `opstack_publishBlockV1`
- op-service changes:
  - payloadInfo (payload ID and timestamp) is now an API type
  - add RPC client bindings for above opstack methods
- op-test-sequencer components:
  - `standardbuilder`: uses open/cancel/seal RPC methods to create a block
  - `localkey`: uses local key to sign a block
  - `standardcommitter`: uses commit RPC method to commit the signed block
  - `standardpublisher`: uses publish RPC method to publish the signed block

This aims to make the test-sequencer core functionality work, to build L2 blocks on demand in a full system, while keeping things flexible for additional different ways of doing each of these sub-tasks.

**Tests**

Includes unit-tests for the new standard signer/committer/publisher.
Builder testing relies on integration with devnet-sdk, hence all of the above is behind a feature flag for now. 

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/14124