### PR TITLE
remove devnetL1 files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,8 +342,6 @@ jobs:
             - "packages/contracts-bedrock/cache"
             - "packages/contracts-bedrock/artifacts"
             - "packages/contracts-bedrock/forge-artifacts"
-            - "packages/contracts-bedrock/deploy-config/devnetL1.json"
-            - "packages/contracts-bedrock/deployments/devnetL1"
       - notify-failures-on-develop
 
   check-kontrol-build:

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ cache
 
 !op-deployer/pkg/deployer/artifacts
 
-packages/contracts-bedrock/deployments/devnetL1
+
 packages/contracts-bedrock/deployments/anvil
 
 # vim

--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -36,8 +36,7 @@ deployments/kontrol-fp.json
 deployments/kontrol-fp.jsonReversed
 deployments/1-deploy.json
 
-# Devnet config which changes with each 'make devnet-up'
-deploy-config/devnetL1.json
+
 
 # Getting Started guide deploy config
 deploy-config/getting-started.json


### PR DESCRIPTION
These files are gone with the old devnet.

(`devnetL1-template.json` is removed [here](https://github.com/ethereum-optimism/optimism/pull/14146))