### PR TITLE
op-node: drop stale todo in finality code

### DIFF
--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -224,7 +224,6 @@ func (fi *Finalizer) tryFinalize() {
 		// Sanity check the finality signal of L1.
 		// Even though the signal is trusted and we do the below check also,
 		// the signal itself has to be canonical to proceed.
-		// TODO(#10724): This check could be removed if the finality signal is fully trusted, and if tests were more flexible for this case.
 		signalRef, err := fi.l1Fetcher.L1BlockRefByNumber(ctx, fi.finalizedL1.Number)
 		if err != nil {
 			fi.emitter.Emit(rollup.L1TemporaryErrorEvent{Err: fmt.Errorf("failed to check if on finalizing L1 chain, could not fetch block %d: %w", fi.finalizedL1.Number, err)})


### PR DESCRIPTION
**Description**

See https://github.com/ethereum-optimism/optimism/issues/10724#issuecomment-2697426885

**Metadata**

Fix #10724

