### PR TITLE
docs: migrate build instructions from make to just

### DIFF
--- a/op-wheel/README.md
+++ b/op-wheel/README.md
@@ -45,7 +45,7 @@ go run ./op-wheel/cmd engine --help
 
 ```bash
 # from op-wheel dir:
-make op-wheel
+just op-wheel
 ./bin/op-wheel --help
 ```
 


### PR DESCRIPTION
## Description
This PR updates the build instructions in several README.md files to use just instead of make. The project has been migrating from Makefile-based builds to just-based builds, and these documentation changes ensure that users are directed to use the preferred build method.
The following components have been updated:

op-wheel


## Tests
No tests were added as this is a documentation-only change.

## Additional context
The project has been migrating from Makefile to justfile for build instructions. The Makefiles now include DEPRECATED_TARGETS and import the justfiles/deprecated.mk file, which shows a deprecation warning when make is used and redirects to the just command.

Metadata
<!--
Include a link to any github issues that this may close in the following form:
Fixes #[Link to Issue]
-->