### PR TITLE
op-e2e: cleanup unused MessageExpiryTime from interop recipe

### DIFF
--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -13,10 +13,9 @@ import (
 )
 
 type InteropDevRecipe struct {
-	L1ChainID         uint64
-	L2ChainIDs        []uint64
-	GenesisTimestamp  uint64
-	MessageExpiryTime uint64
+	L1ChainID        uint64
+	L2ChainIDs       []uint64
+	GenesisTimestamp uint64
 }
 
 func (r *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, error) {
@@ -91,7 +90,7 @@ func (r *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, error) 
 		L2s:        make(map[string]*L2Config),
 	}
 	for _, l2ChainID := range r.L2ChainIDs {
-		l2Cfg, err := InteropL2DevConfig(r.L1ChainID, l2ChainID, addrs, r.MessageExpiryTime)
+		l2Cfg, err := InteropL2DevConfig(r.L1ChainID, l2ChainID, addrs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate L2 config for chain %d: %w", l2ChainID, err)
 		}
@@ -127,7 +126,7 @@ func prefundL2Accounts(l1Cfg *L1Config, l2Cfg *L2Config, addrs devkeys.Addresses
 	return nil
 }
 
-func InteropL2DevConfig(l1ChainID, l2ChainID uint64, addrs devkeys.Addresses, messageExpiryTime uint64) (*L2Config, error) {
+func InteropL2DevConfig(l1ChainID, l2ChainID uint64, addrs devkeys.Addresses) (*L2Config, error) {
 	// Padded chain ID, hex encoded, prefixed with 0xff like inboxes, then 0x02 to signify devnet.
 	batchInboxAddress := common.HexToAddress(fmt.Sprintf("0xff02%016x", l2ChainID))
 	chainOps := devkeys.ChainOperatorKeys(new(big.Int).SetUint64(l2ChainID))

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -108,10 +108,9 @@ func SetupInterop(t helpers.Testing) *InteropSetup {
 	logger := testlog.Logger(t, log.LevelDebug)
 
 	recipe := interopgen.InteropDevRecipe{
-		L1ChainID:         900100,
-		L2ChainIDs:        []uint64{900200, 900201},
-		GenesisTimestamp:  uint64(time.Now().Unix() + 3),
-		MessageExpiryTime: messageExpiryTime,
+		L1ChainID:        900100,
+		L2ChainIDs:       []uint64{900200, 900201},
+		GenesisTimestamp: uint64(time.Now().Unix() + 3),
 	}
 	hdWallet, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(t, err)


### PR DESCRIPTION
Message expiry time is now configured in the depset. So it's no longer needed in the dev recipe.