### PR TITLE
docs: fix build instructions

### DIFF
--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -7,7 +7,7 @@ The `op-dispute-mon` is an off-chain service to monitor dispute games.
 Clone this repo. Then run:
 
 ```shell
-make op-dispute-mon
+just op-dispute-mon
 ```
 
 This will build the `op-dispute-mon` binary which can be run with

--- a/op-program/README.md
+++ b/op-program/README.md
@@ -12,7 +12,7 @@ on-chain VM as part of the dispute resolution process.
 To build op-program, from within the `op-program` directory run:
 
 ```shell
-make op-program
+just op-program
 ```
 
 This resulting executable will be in `./bin/op-program`


### PR DESCRIPTION
This change migrates `op-dispute-mon` and  `op-program` builds to `just`