### PR TITLE
ci: Enable strict TODO checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -956,7 +956,7 @@ jobs:
           command: sudo apt-get install -y ripgrep
       - run:
           name: Check TODO issues
-          command: ./ops/scripts/todo-checker.sh --verbose <<#parameters.check_closed>> --check-closed <</parameters.check_closed>>
+          command: ./ops/scripts/todo-checker.sh --verbose --strict <<#parameters.check_closed>> --check-closed <</parameters.check_closed>>
       - notify-failures-on-develop
 
   fuzz-golang:

--- a/packages/contracts-bedrock/test/safe/DeputyGuardianModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/DeputyGuardianModule.t.sol
@@ -241,7 +241,7 @@ contract DeputyGuardianModule_setRespectedGameType_Test is DeputyGuardianModule_
     /// guardian.
     function testFuzz_setRespectedGameType_succeeds(GameType _gameType) external {
         // Game type(uint32).max is reserved for setting the respectedGameTypeUpdatedAt timestamp.
-        // TODO(kelvin): Remove this once we've removed the hack.
+        // TODO(#14638): Remove this once we've removed the hack.
         uint32 boundedGameType = uint32(bound(_gameType.raw(), 0, type(uint32).max - 1));
         _gameType = GameType.wrap(boundedGameType);
 


### PR DESCRIPTION
**Description**

Enable strict TODO checks so that all TODO comments must reference a GitHub issue.
Fix the few TODOs that didn't correctly reference issues.

No requests to github are made when not checking closed issues. Ensures this runs fast and reliably in CI pre-merge.
Closed issues are then checked with a scheduled job.