### PR TITLE
devnet-sdk: Use geth logger instead of slog

### DIFF
--- a/devnet-sdk/book/src/testing.md
+++ b/devnet-sdk/book/src/testing.md
@@ -57,7 +57,6 @@ Here's a complete example showing these principles in action:
 
 ```go
 import (
-    "log/slog"
     "math/big"
     
     "github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
@@ -65,6 +64,8 @@ import (
     "github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
     "github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
     "github.com/ethereum-optimism/optimism/devnet-sdk/types"
+    "github.com/ethereum-optimism/optimism/op-service/testlog"
+    "github.com/ethereum/go-ethereum/log"
     "github.com/stretchr/testify/require"
 )
 
@@ -72,7 +73,9 @@ import (
 func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) systest.SystemTestFunc {
     return func(t systest.T, sys system.System) {
         ctx := t.Context()
-        logger := slog.With("test", "WrapETH", "devnet", sys.Identifier())
+
+        logger := testlog.Logger(t, log.LevelInfo)
+        logger := logger.With("test", "WrapETH", "devnet", sys.Identifier())
 
         // Get the L2 chain we want to test with
         chain := sys.L2(chainIdx)

--- a/devnet-sdk/constraints/constraints.go
+++ b/devnet-sdk/constraints/constraints.go
@@ -1,7 +1,7 @@
 package constraints
 
 import (
-	"log/slog"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
@@ -20,7 +20,7 @@ func (f WalletConstraintFunc) CheckWallet(wallet system.Wallet) bool {
 func WithBalance(amount types.Balance) WalletConstraint {
 	return WalletConstraintFunc(func(wallet system.Wallet) bool {
 		balance := wallet.Balance()
-		slog.Debug("checking balance", "wallet", wallet.Address(), "balance", balance, "needed", amount)
+		log.Debug("checking balance", "wallet", wallet.Address(), "balance", balance, "needed", amount)
 		return balance.GreaterThan(amount)
 	})
 }

--- a/devnet-sdk/system/txbuilder.go
+++ b/devnet-sdk/system/txbuilder.go
@@ -3,8 +3,9 @@ package system
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -78,7 +79,7 @@ func NewTxBuilder(ctx context.Context, chain Chain, opts ...TxBuilderOption) *Tx
 		}
 	}
 
-	slog.InfoContext(ctx, "Instantiated TxBuilder",
+	log.Info("Instantiated TxBuilder",
 		"supportedTxTypes", builder.supportedTxTypes,
 		"forcedTxType", builder.forcedTxType,
 		"gasLimitMargin", builder.gasLimitMarginPercent,

--- a/devnet-sdk/types/balance.go
+++ b/devnet-sdk/types/balance.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"log/slog"
 	"math/big"
 )
 
@@ -66,10 +65,10 @@ func (b Balance) Equal(other Balance) bool {
 	return b.Int.Cmp(other.Int) == 0
 }
 
-// LogValue implements slog.LogValuer to format Balance in the most readable unit
-func (b Balance) LogValue() slog.Value {
+// String implements fmt.Stringer to format Balance in the most readable unit
+func (b Balance) String() string {
 	if b.Int == nil {
-		return slog.StringValue("0 ETH")
+		return "0 ETH"
 	}
 
 	val := new(big.Float).SetInt(b.Int)
@@ -78,16 +77,16 @@ func (b Balance) LogValue() slog.Value {
 	// 1 ETH = 1e18 Wei
 	if eth.Cmp(new(big.Float).SetFloat64(0.001)) >= 0 {
 		str := eth.Text('f', 0)
-		return slog.StringValue(fmt.Sprintf("%s ETH", str))
+		return fmt.Sprintf("%s ETH", str)
 	}
 
 	// 1 Gwei = 1e9 Wei
 	gwei := new(big.Float).Quo(val, new(big.Float).SetInt64(1e9))
 	if gwei.Cmp(new(big.Float).SetFloat64(0.001)) >= 0 {
 		str := gwei.Text('g', 3)
-		return slog.StringValue(fmt.Sprintf("%s Gwei", str))
+		return fmt.Sprintf("%s Gwei", str)
 	}
 
 	// Wei
-	return slog.StringValue(fmt.Sprintf("%s Wei", b.Text(10)))
+	return fmt.Sprintf("%s Wei", b.Text(10))
 }

--- a/devnet-sdk/types/balance_test.go
+++ b/devnet-sdk/types/balance_test.go
@@ -261,8 +261,7 @@ func TestBalanceLogValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logValue := tt.balance.LogValue()
-			assert.Equal(t, tt.expected, logValue.String())
+			assert.Equal(t, tt.expected, tt.balance.String())
 		})
 	}
 }

--- a/kurtosis-devnet/tests/interop/boilerplate_test.go
+++ b/kurtosis-devnet/tests/interop/boilerplate_test.go
@@ -1,10 +1,12 @@
 package interop
 
 import (
-	"log/slog"
 	"os"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func init() {
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	oplog.SetGlobalLogHandler(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelDebug, true))
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes slog usage at `devnet-sdk/*` and `kurtosis-devnet/*`. Better compatibility and formatting. By using the `testlog` package, it handles filename padding when log is printed inside tests.

**Tests**

Locally ran interop devnet-sdk tests.
```
cd kurtosis-devnet
just interop-devnet
DEVNET_ENV_URL=kt://interop-devnet/devnet go test -v ./tests/...
```

Tests all passing, with enriched logs. Example log:
```
=== RUN   TestSystemWrapETH
DEBUG[03-05|20:53:17.459] checking balance                         wallet=0xafF0CA253b97e54440965855cec0A8a2E2399896 balance="0 Wei" needed="1 ETH"
DEBUG[03-05|20:53:17.461] checking balance                         wallet=0x589A698b7b7dA0Bec545177D3963A2741105C7C9 balance="0 Wei" needed="1 ETH"
DEBUG[03-05|20:53:17.462] checking balance                         wallet=0xb0994E702b603df7191cd68E6544f99126135e34 balance="0 Wei" needed="1 ETH"
DEBUG[03-05|20:53:17.463] checking balance                         wallet=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 balance="10000 ETH" needed="1 ETH"
    interop_smoke_test.go:28:   INFO [03-05|20:53:17.463] starting test                            test=TestMinimal devnet=interop-devnet chain=2,151,908
    interop_smoke_test.go:36:   INFO [03-05|20:53:17.464] using SuperchainWETH                     test=TestMinimal devnet=interop-devnet chain=2,151,908 contract=0x4200000000000000000000000000000000000024
    interop_smoke_test.go:41:   INFO [03-05|20:53:17.467] initial balance retrieved                test=TestMinimal devnet=interop-devnet chain=2,151,908 user=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 balance="0 Wei"
    interop_smoke_test.go:43:   INFO [03-05|20:53:17.467] sending ETH to contract                  test=TestMinimal devnet=interop-devnet chain=2,151,908 user=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 amount="0 ETH"
INFO [03-05|20:53:17.468] Instantiated TxBuilder                   supportedTxTypes="[0 2 1 3]" forcedTxType=<nil> gasLimitMargin=20 feeCapMultiplier=2
    interop_smoke_test.go:48:   INFO [03-05|20:54:54.475] final balance retrieved                  test=TestMinimal devnet=interop-devnet chain=2,151,908 user=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 balance="0 ETH"
--- PASS: TestSystemWrapETH (97.03s)
=== RUN   TestInteropSystemNoop
    interop_smoke_test.go:67:   INFO [03-05|20:54:54.479] noop
--- PASS: TestInteropSystemNoop (0.00s)
=== RUN   TestSmokeTestFailure
--- PASS: TestSmokeTestFailure (0.00s)
=== RUN   TestLowLevelSystem
    interop_smoke_test.go:103:  INFO [03-05|20:54:54.481] low level system acquired                test=TestLowLevelSystem devnet=interop-devnet
--- PASS: TestLowLevelSystem (0.00s)
PASS
ok      github.com/ethereum-optimism/optimism/kurtosis-devnet/tests/interop     97.713s
```

Previous logs before this PR:
```
=== RUN   TestSystemWrapETH
time=2025-03-05T21:03:34.298+09:00 level=DEBUG msg="checking balance" wallet=0x589a698b7b7da0bec545177d3963a2741105c7c9 balance="0 Wei" needed="1 ETH"
time=2025-03-05T21:03:34.299+09:00 level=DEBUG msg="checking balance" wallet=0xd3f2c5afb2d76f5579f326b0cd7da5f5a4126c35 balance="0 Wei" needed="1 ETH"
time=2025-03-05T21:03:34.300+09:00 level=DEBUG msg="checking balance" wallet=0xf08f610d1956caaab34f18e9e0a122e389496529 balance="0 Wei" needed="1 ETH"
time=2025-03-05T21:03:34.301+09:00 level=DEBUG msg="checking balance" wallet=0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 balance="10000 ETH" needed="1 ETH"
time=2025-03-05T21:03:34.301+09:00 level=INFO msg="starting test" test=TestMinimal devnet=interop-devnet chain=2151908
time=2025-03-05T21:03:34.301+09:00 level=INFO msg="using SuperchainWETH" test=TestMinimal devnet=interop-devnet chain=2151908 contract=0x4200000000000000000000000000000000000024
time=2025-03-05T21:03:34.303+09:00 level=INFO msg="initial balance retrieved" test=TestMinimal devnet=interop-devnet chain=2151908 user=0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 balance="0 Wei"
time=2025-03-05T21:03:34.303+09:00 level=INFO msg="sending ETH to contract" test=TestMinimal devnet=interop-devnet chain=2151908 user=0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 amount="0 ETH"
time=2025-03-05T21:03:34.304+09:00 level=INFO msg="Instantiated TxBuilder" supportedTxTypes="\x00\x02\x01\x03" forcedTxType=<nil> gasLimitMargin=20 feeCapMultiplier=2
time=2025-03-05T21:05:14.312+09:00 level=INFO msg="final balance retrieved" test=TestMinimal devnet=interop-devnet chain=2151908 user=0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 balance="0 ETH"
--- PASS: TestSystemWrapETH (100.02s)
=== RUN   TestInteropSystemNoop
time=2025-03-05T21:05:14.320+09:00 level=INFO msg=noop
--- PASS: TestInteropSystemNoop (0.01s)
=== RUN   TestSmokeTestFailure
time=2025-03-05T21:05:14.320+09:00 level=INFO msg="starting test" test=TestMinimal devnet=mock-failing-system chain=1234
time=2025-03-05T21:05:14.320+09:00 level=INFO msg="using SuperchainWETH" test=TestMinimal devnet=mock-failing-system chain=1234 contract=0x4200000000000000000000000000000000000024
time=2025-03-05T21:05:14.320+09:00 level=INFO msg="initial balance retrieved" test=TestMinimal devnet=mock-failing-system chain=1234 user=0x1234567890123456789012345678901234567890 balance="0 Wei"
time=2025-03-05T21:05:14.320+09:00 level=INFO msg="sending ETH to contract" test=TestMinimal devnet=mock-failing-system chain=1234 user=0x1234567890123456789012345678901234567890 amount="0 ETH"
--- PASS: TestSmokeTestFailure (0.00s)
=== RUN   TestLowLevelSystem
time=2025-03-05T21:05:14.327+09:00 level=INFO msg="low level system acquired" test=TestLowLevelSystem devnet=interop-devnet
--- PASS: TestLowLevelSystem (0.01s)
PASS
ok      github.com/ethereum-optimism/optimism/kurtosis-devnet/tests/interop     100.721s

```

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/14618
