### PR TITLE
op-supervisor: cleanup stale todo comment

### DIFF
--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -60,8 +60,6 @@ func TestEventResponse(t *testing.T) {
 		return nil
 	}
 
-	// TODO(#13595): rework node-reset, and include testing for it here
-
 	node.Start()
 
 	// send events and continue to do so until at least one of each type has been received


### PR DESCRIPTION

**Description**

Remove stale comment that refers to https://github.com/ethereum-optimism/optimism/issues/13595

The comment mentions a test rework, which I believe was done with the introduction of `TestPrepareReset`, introduced in https://github.com/ethereum-optimism/optimism/pull/14444

**Metadata**


Fix https://github.com/ethereum-optimism/optimism/issues/13595