### PR TITLE
op-conductor: Remove block time check for unsafe head progress

### DIFF
--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -93,8 +93,8 @@ func (s *HealthMonitorTestSuite) TestUnhealthyLowPeerCount() {
 	monitor := s.SetupMonitor(now, 60, 60, rc, pc)
 
 	healthUpdateCh := monitor.Subscribe()
-	healthy := <-healthUpdateCh
-	s.NotNil(healthy)
+	healthFailure := <-healthUpdateCh
+	s.NotNil(healthFailure)
 
 	s.NoError(monitor.Stop())
 }
@@ -105,21 +105,24 @@ func (s *HealthMonitorTestSuite) TestUnhealthyUnsafeHeadNotProgressing() {
 
 	rc := &testutils.MockRollupClient{}
 	ss1 := mockSyncStatus(now, 5, now-8, 1)
-	for i := 0; i < 5; i++ {
+	unsafeBlocksInterval := uint64(10)
+	// every clock tick until the unsafe block interval is hit, expect no errors:
+	for i := uint64(0); i < unsafeBlocksInterval-1; i++ {
 		rc.ExpectSyncStatus(ss1, nil)
 	}
+	rc.ExpectSyncStatus(ss1, ErrSequencerNotHealthy)
 
-	monitor := s.SetupMonitor(now, 60, 60, rc, nil)
+	monitor := s.SetupMonitor(now, unsafeBlocksInterval, 60, rc, nil)
 	healthUpdateCh := monitor.Subscribe()
 
-	for i := 0; i < 5; i++ {
-		healthy := <-healthUpdateCh
-		if i < 4 {
-			s.Nil(healthy)
+	for i := uint64(0); i < unsafeBlocksInterval; i++ {
+		healthFailure := <-healthUpdateCh
+		if i < unsafeBlocksInterval-1 {
+			s.Nil(healthFailure)
 			s.Equal(now, monitor.lastSeenUnsafeTime)
 			s.Equal(uint64(5), monitor.lastSeenUnsafeNum)
 		} else {
-			s.NotNil(healthy)
+			s.NotNil(healthFailure)
 		}
 	}
 
@@ -142,11 +145,11 @@ func (s *HealthMonitorTestSuite) TestUnhealthySafeHeadNotProgressing() {
 	healthUpdateCh := monitor.Subscribe()
 
 	for i := 0; i < 5; i++ {
-		healthy := <-healthUpdateCh
+		healthFailure := <-healthUpdateCh
 		if i < 4 {
-			s.Nil(healthy)
+			s.Nil(healthFailure)
 		} else {
-			s.NotNil(healthy)
+			s.NotNil(healthFailure)
 		}
 	}
 
@@ -181,24 +184,24 @@ func (s *HealthMonitorTestSuite) TestHealthyWithUnsafeLag() {
 	s.Zero(monitor.lastSeenUnsafeTime)
 
 	// confirm state after first check
-	healthy := <-healthUpdateCh
-	s.Nil(healthy)
+	healthFailure := <-healthUpdateCh
+	s.Nil(healthFailure)
 	lastSeenUnsafeTime := monitor.lastSeenUnsafeTime
 	s.NotZero(monitor.lastSeenUnsafeTime)
 	s.Equal(uint64(1), monitor.lastSeenUnsafeNum)
 
-	healthy = <-healthUpdateCh
-	s.Nil(healthy)
+	healthFailure = <-healthUpdateCh
+	s.Nil(healthFailure)
 	s.Equal(lastSeenUnsafeTime, monitor.lastSeenUnsafeTime)
 	s.Equal(uint64(1), monitor.lastSeenUnsafeNum)
 
-	healthy = <-healthUpdateCh
-	s.Nil(healthy)
+	healthFailure = <-healthUpdateCh
+	s.Nil(healthFailure)
 	s.Equal(lastSeenUnsafeTime+2, monitor.lastSeenUnsafeTime)
 	s.Equal(uint64(2), monitor.lastSeenUnsafeNum)
 
-	healthy = <-healthUpdateCh
-	s.Nil(healthy)
+	healthFailure = <-healthUpdateCh
+	s.Nil(healthFailure)
 	s.Equal(lastSeenUnsafeTime+2, monitor.lastSeenUnsafeTime)
 	s.Equal(uint64(2), monitor.lastSeenUnsafeNum)
 

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -106,18 +106,17 @@ func (s *HealthMonitorTestSuite) TestUnhealthyUnsafeHeadNotProgressing() {
 	rc := &testutils.MockRollupClient{}
 	ss1 := mockSyncStatus(now, 5, now-8, 1)
 	unsafeBlocksInterval := 10
-	// every clock tick until the unsafe block interval is hit, expect no errors:
-	for i := 0; i < unsafeBlocksInterval-1; i++ {
+	for i := 0; i < unsafeBlocksInterval+2; i++ {
 		rc.ExpectSyncStatus(ss1, nil)
 	}
-	rc.ExpectSyncStatus(ss1, ErrSequencerNotHealthy)
 
 	monitor := s.SetupMonitor(now, uint64(unsafeBlocksInterval), 60, rc, nil)
 	healthUpdateCh := monitor.Subscribe()
 
-	for i := 0; i < unsafeBlocksInterval; i++ {
+	// once the unsafe interval is surpassed, we should expect "unsafe head is falling behind the unsafe interval"
+	for i := 0; i < unsafeBlocksInterval+2; i++ {
 		healthFailure := <-healthUpdateCh
-		if i < unsafeBlocksInterval-1 {
+		if i <= unsafeBlocksInterval {
 			s.Nil(healthFailure)
 			s.Equal(now, monitor.lastSeenUnsafeTime)
 			s.Equal(uint64(5), monitor.lastSeenUnsafeNum)

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -105,17 +105,17 @@ func (s *HealthMonitorTestSuite) TestUnhealthyUnsafeHeadNotProgressing() {
 
 	rc := &testutils.MockRollupClient{}
 	ss1 := mockSyncStatus(now, 5, now-8, 1)
-	unsafeBlocksInterval := uint64(10)
+	unsafeBlocksInterval := 10
 	// every clock tick until the unsafe block interval is hit, expect no errors:
-	for i := uint64(0); i < unsafeBlocksInterval-1; i++ {
+	for i := 0; i < unsafeBlocksInterval-1; i++ {
 		rc.ExpectSyncStatus(ss1, nil)
 	}
 	rc.ExpectSyncStatus(ss1, ErrSequencerNotHealthy)
 
-	monitor := s.SetupMonitor(now, unsafeBlocksInterval, 60, rc, nil)
+	monitor := s.SetupMonitor(now, uint64(unsafeBlocksInterval), 60, rc, nil)
 	healthUpdateCh := monitor.Subscribe()
 
-	for i := uint64(0); i < unsafeBlocksInterval; i++ {
+	for i := 0; i < unsafeBlocksInterval; i++ {
 		healthFailure := <-healthUpdateCh
 		if i < unsafeBlocksInterval-1 {
 			s.Nil(healthFailure)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
Addresses the issue reported in https://github.com/ethereum-optimism/optimism/issues/14585 where op-conductor's UNSAFE_INTERVAL is effectively ignored in health checks whenever it is larger than the block time. 

The agreed on solution is to remove the health check that enforces sequencers create blocks in a span no longer than the block time, so the UNSAFE_INTERVAL check gets used

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Updating `TestUnhealthyUnsafeHeadNotProgressing` to expect the monitor to return no error for each second that passes without an unsafe head update -- until **after** `unsafeBlocksInterval` time passes.

Also renaming the variable name `healthy` to `healthFailure` in that test suite to help with clarity

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
Fixes #14585 