### PR TITLE
minimal devnet-sdk test on op-e2e stack

### DIFF
--- a/devnet-sdk/system/chain.go
+++ b/devnet-sdk/system/chain.go
@@ -72,6 +72,9 @@ func (c *chain) Client() (*ethclient.Client, error) {
 }
 
 func newChain(chainID string, rpcUrl string, users map[string]Wallet) *chain {
+	if users == nil {
+		users = make(map[string]Wallet)
+	}
 	return &chain{
 		id:      chainID,
 		rpcUrl:  rpcUrl,

--- a/devnet-sdk/system/e2e.go
+++ b/devnet-sdk/system/e2e.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+)
+
+type e2eSystem struct {
+	sys *e2esys.System
+}
+
+var _ System = (*e2eSystem)(nil)
+
+func (s *e2eSystem) Identifier() string {
+	return "e2e"
+}
+
+func (s *e2eSystem) L1() Chain {
+	rpc := s.sys.NodeEndpoint("l1").RPC()
+	// TODO(yann): populate wallets
+	return newChain("l1", rpc, nil)
+}
+
+func (s *e2eSystem) L2s() []Chain {
+	l2Endpoint := s.sys.NodeEndpoint("sequencer").RPC()
+
+	return []Chain{
+		newChain("l2", l2Endpoint, nil),
+	}
+}
+
+func NewE2ESystem(t *testing.T) (System, error) {
+	t.Helper()
+	cfg := e2esys.DefaultSystemConfig(t)
+	sys, err := cfg.Start(t)
+	if err != nil {
+		return nil, err
+	}
+	return &e2eSystem{sys: sys}, nil
+}

--- a/devnet-sdk/testing/systest/provider.go
+++ b/devnet-sdk/testing/systest/provider.go
@@ -1,15 +1,31 @@
 package systest
 
-import "github.com/ethereum-optimism/optimism/devnet-sdk/system"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+)
 
 // systemProvider defines the interface for package-level functionality
 type systemProvider interface {
 	NewSystemFromURL(string) (system.System, error)
+	NewE2ESystem(BasicT) (system.System, error)
 }
 
 // defaultProvider is the default implementation of the package
 type defaultProvider struct{}
 
+var _ systemProvider = (*defaultProvider)(nil)
+
 func (p *defaultProvider) NewSystemFromURL(url string) (system.System, error) {
 	return system.NewSystemFromURL(url)
+}
+
+func (p *defaultProvider) NewE2ESystem(t BasicT) (system.System, error) {
+	tt, ok := t.(*testing.T)
+	if !ok {
+		return nil, fmt.Errorf("e2e system test requires a *testing.T")
+	}
+	return system.NewE2ESystem(tt)
 }

--- a/devnet-sdk/testing/systest/systest.go
+++ b/devnet-sdk/testing/systest/systest.go
@@ -86,6 +86,7 @@ type basicSystemTestHelper struct {
 
 // acquireFromEnvURL attempts to create a system from the URL specified in the environment variable.
 func (h *basicSystemTestHelper) acquireFromEnvURL(t BasicT) (system.System, error) {
+	t.Log("attempting to acquire system from env URL")
 	url := h.envGetter.Getenv(env.EnvURLVar)
 	if url == "" {
 		return nil, nil // Skip this acquirer
@@ -94,6 +95,17 @@ func (h *basicSystemTestHelper) acquireFromEnvURL(t BasicT) (system.System, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to create system from URL %q: %w", url, err)
 	}
+	t.Logf("system acquired from %s", url)
+	return sys, nil
+}
+
+func (h *basicSystemTestHelper) acquireFromE2E(t BasicT) (system.System, error) {
+	t.Log("attempting to acquire system from e2e")
+	sys, err := h.provider.NewE2ESystem(t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create system from e2e: %w", err)
+	}
+	t.Log("system acquired from e2e backend")
 	return sys, nil
 }
 
@@ -161,6 +173,7 @@ func newBasicSystemTestHelper(envGetter envGetter) *basicSystemTestHelper {
 	// Set up acquirers after helper is constructed so we can use the method
 	helper.acquirers = []SystemAcquirer{
 		helper.acquireFromEnvURL,
+		helper.acquireFromE2E,
 	}
 
 	return helper

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -140,6 +140,10 @@ func (p *testPackage) NewSystemFromURL(string) (system.System, error) {
 	return p.creator()
 }
 
+func (p *testPackage) NewE2ESystem(t BasicT) (system.System, error) {
+	return p.creator()
+}
+
 // TestNewT tests the creation and basic functionality of the test wrapper
 func TestNewT(t *testing.T) {
 	t.Run("wraps *testing.T correctly", func(t *testing.T) {

--- a/kurtosis-devnet/tests/e2e/e2e_test.go
+++ b/kurtosis-devnet/tests/e2e/e2e_test.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
+	"github.com/stretchr/testify/require"
+)
+
+func e2eTestScenario(sysGetter validators.LowLevelSystemGetter) systest.SystemTestFunc {
+	return func(t systest.T, sys system.System) {
+		ctx := t.Context()
+		t.Log("e2e test scenario")
+		lsys := sysGetter(ctx)
+
+		l1 := lsys.L1()
+		cl1, err := l1.Client()
+		require.NoError(t, err)
+
+		chainID, err := cl1.ChainID(ctx)
+		require.NoError(t, err)
+		t.Logf("chain ID: %d", chainID)
+
+		l2s := lsys.L2s()
+		l2 := l2s[0]
+		cl2, err := l2.Client()
+		require.NoError(t, err)
+
+		chainID, err = cl2.ChainID(ctx)
+		require.NoError(t, err)
+		t.Logf("chain ID: %d", chainID)
+	}
+}
+
+func TestE2ESystem(t *testing.T) {
+	lowLevelSys, validator := validators.AcquireLowLevelSystem()
+	systest.SystemTest(t,
+		e2eTestScenario(lowLevelSys),
+		validator,
+	)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
the stupidest possible test that:
- runs an op-e2e in-memory stack
- slaps a minimal devnet-sdk System interface on it
- runs a test against it

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
