### PR TITLE
devnet-sdk: Take out RPC functionality as Node interface from Chain Interface

### DIFF
--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -28,7 +28,10 @@ type Chain interface {
 	Wallets(ctx context.Context) ([]Wallet, error)
 	ContractsRegistry() interfaces.ContractsRegistry
 	SupportsEIP(ctx context.Context, eip uint64) bool
+	Node() Node
+}
 
+type Node interface {
 	GasPrice(ctx context.Context) (*big.Int, error)
 	GasLimit(ctx context.Context, tx TransactionData) (uint64, error)
 	PendingNonceAt(ctx context.Context, address common.Address) (uint64, error)

--- a/devnet-sdk/system/node.go
+++ b/devnet-sdk/system/node.go
@@ -1,0 +1,61 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	// This will make sure that we implement the Node interface
+	_ Node = (*node)(nil)
+)
+
+type node struct {
+	rpcUrl string
+
+	clients *clientManager
+}
+
+func newNode(rpcUrl string, clients *clientManager) *node {
+	return &node{rpcUrl: rpcUrl, clients: clients}
+}
+
+func (n *node) GasPrice(ctx context.Context) (*big.Int, error) {
+	client, err := n.clients.Client(n.rpcUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
+	return client.SuggestGasPrice(ctx)
+}
+
+func (n *node) GasLimit(ctx context.Context, tx TransactionData) (uint64, error) {
+	client, err := n.clients.Client(n.rpcUrl)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get client: %w", err)
+	}
+
+	msg := ethereum.CallMsg{
+		From:  tx.From(),
+		To:    tx.To(),
+		Value: tx.Value(),
+		Data:  tx.Data(),
+	}
+	estimated, err := client.EstimateGas(ctx, msg)
+	if err != nil {
+		return 0, fmt.Errorf("failed to estimate gas: %w", err)
+	}
+
+	return estimated, nil
+}
+
+func (n *node) PendingNonceAt(ctx context.Context, address common.Address) (uint64, error) {
+	client, err := n.clients.Client(n.rpcUrl)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get client: %w", err)
+	}
+	return client.PendingNonceAt(ctx, address)
+}

--- a/devnet-sdk/system/txbuilder.go
+++ b/devnet-sdk/system/txbuilder.go
@@ -180,7 +180,7 @@ func (b *TxBuilder) chooseTxType(hasAccessList bool, hasBlobs bool) uint8 {
 
 // getNonce gets the next nonce for the given address
 func (b *TxBuilder) getNonce(from common.Address) (uint64, error) {
-	nonce, err := b.chain.PendingNonceAt(b.ctx, from)
+	nonce, err := b.chain.Node().PendingNonceAt(b.ctx, from)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get nonce: %w", err)
 	}
@@ -189,7 +189,7 @@ func (b *TxBuilder) getNonce(from common.Address) (uint64, error) {
 
 // getGasPrice gets the suggested gas price from the network
 func (b *TxBuilder) getGasPrice() (*big.Int, error) {
-	gasPrice, err := b.chain.GasPrice(b.ctx)
+	gasPrice, err := b.chain.Node().GasPrice(b.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gas price: %w", err)
 	}
@@ -202,7 +202,7 @@ func (b *TxBuilder) calculateGasLimit(opts *TxOpts) (uint64, error) {
 		return opts.gasLimit, nil
 	}
 
-	estimated, err := b.chain.GasLimit(b.ctx, opts)
+	estimated, err := b.chain.Node().GasLimit(b.ctx, opts)
 	if err != nil {
 		return 0, fmt.Errorf("failed to estimate gas: %w", err)
 	}

--- a/devnet-sdk/system/wallet_test.go
+++ b/devnet-sdk/system/wallet_test.go
@@ -135,6 +135,7 @@ func TestWallet_Address(t *testing.T) {
 func TestWallet_SendETH(t *testing.T) {
 	ctx := context.Background()
 	mockChain := newMockChain()
+	mockNode := newMockNode()
 	internalChain := &internalMockChain{mockChain}
 
 	// Use a valid 256-bit private key (32 bytes)
@@ -162,11 +163,14 @@ func TestWallet_SendETH(t *testing.T) {
 	mockChain.On("SupportsEIP", ctx, uint64(4844)).Return(false)
 
 	// Mock gas price and limit
-	mockChain.On("GasPrice", ctx).Return(big.NewInt(1000000000), nil)
-	mockChain.On("GasLimit", ctx, mock.Anything).Return(uint64(21000), nil)
+	mockChain.On("Node").Return(mockNode).Once()
+	mockNode.On("GasPrice", ctx).Return(big.NewInt(1000000000), nil)
+	mockChain.On("Node").Return(mockNode).Once()
+	mockNode.On("GasLimit", ctx, mock.Anything).Return(uint64(21000), nil)
 
 	// Mock nonce retrieval
-	mockChain.On("PendingNonceAt", ctx, fromAddr).Return(uint64(0), nil)
+	mockChain.On("Node").Return(mockNode).Once()
+	mockNode.On("PendingNonceAt", ctx, fromAddr).Return(uint64(0), nil)
 
 	// Mock client access
 	client, err := ethclient.Dial("http://this.domain.definitely.does.not.exist:8545")

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -78,6 +78,7 @@ func (m *mockTBRecorder) Skipped() bool { return m.skipped }
 // mockChain implements a minimal system.Chain for testing
 type mockChain struct{}
 
+func (m *mockChain) Node() system.Node                               { return nil }
 func (m *mockChain) RPCURL() string                                  { return "http://localhost:8545" }
 func (m *mockChain) Client() (*ethclient.Client, error)              { return ethclient.Dial(m.RPCURL()) }
 func (m *mockChain) ID() types.ChainID                               { return types.ChainID(big.NewInt(1)) }

--- a/devnet-sdk/testing/testlib/validators/validators_test.go
+++ b/devnet-sdk/testing/testlib/validators/validators_test.go
@@ -94,6 +94,7 @@ type mockChain struct {
 	wallets []system.Wallet
 }
 
+func (m *mockChain) Node() system.Node                               { return nil }
 func (m *mockChain) RPCURL() string                                  { return "http://localhost:8545" }
 func (m *mockChain) Client() (*ethclient.Client, error)              { return ethclient.Dial(m.RPCURL()) }
 func (m *mockChain) ID() types.ChainID                               { return types.ChainID(big.NewInt(1)) }

--- a/kurtosis-devnet/tests/interop/mocks_test.go
+++ b/kurtosis-devnet/tests/interop/mocks_test.go
@@ -134,6 +134,7 @@ func newMockFailingChain(id types.ChainID, wallets []system.Wallet) *mockFailing
 	}
 }
 
+func (m *mockFailingChain) Node() system.Node                  { return nil }
 func (m *mockFailingChain) RPCURL() string                     { return "mock://failing" }
 func (m *mockFailingChain) Client() (*ethclient.Client, error) { return ethclient.Dial(m.RPCURL()) }
 func (m *mockFailingChain) ID() types.ChainID                  { return m.id }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

An attempt to decouple the idea of a "chain" and a "node". Decoupled RPC methods to `Node` interface which follows [interface purity](https://github.com/ethereum-optimism/optimism/blob/develop/devnet-sdk/book/src/system.md#interface-purity).

Initialization of Node follows the behavior of initializing a Chain. They both do not trigger dialing to the RPC initially, rather, does it when it is actually used.

**Tests**

All existing unit tests passes. There were no unit tests for RPC methods wrappers, so did not add the new tests.
All locally ran interop devnet-sdk tests passes.

**Additional context**

Initial trial for https://github.com/ethereum-optimism/optimism/issues/14616
