### PR TITLE
op-challenger: Add config option to set dependency set config

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -620,6 +620,196 @@ func TestAlphabetRequiredArgs(t *testing.T) {
 	})
 }
 
+func TestCannonCustomConfigArgs(t *testing.T) {
+	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned} {
+		traceType := traceType
+
+		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network"))
+			verifyArgsInvalid(
+				t,
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
+			verifyArgsInvalid(
+				t,
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
+				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			args := requiredArgs(traceType)
+			delete(args, "--network")
+			delete(args, "--game-factory-address")
+			args["--network"] = network
+			args["--cannon-rollup-config"] = "rollup.json"
+			args["--cannon-l2-genesis"] = "gensis.json"
+			args["--cannon-l2-custom"] = "true"
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
+				toArgList(args))
+		})
+
+		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
+				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+				"--cannon-rollup-config=rollup.json",
+				"--cannon-l2-genesis=genesis.json",
+				"--cannon-l2-custom"))
+			require.True(t, cfg.Cannon.L2Custom)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-rollup-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-l2-genesis"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
+			})
+		})
+	}
+}
+
+func TestSuperCannonCustomConfigArgs(t *testing.T) {
+	for _, traceType := range []types.TraceType{types.TraceTypeSuperCannon, types.TraceTypeSuperPermissioned} {
+		traceType := traceType
+
+		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesisAndDepset-%v", traceType), func(t *testing.T) {
+			expectedErrorMessage := "flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required"
+			// Missing all
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network"))
+			// Missing l2-genesis
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-depset-config=depset.json"))
+			// Missing rollup-config
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json", "--cannon-depset-config=depset.json"))
+			// Missing depset-config
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=gensis.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
+				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			args := requiredArgs(traceType)
+			delete(args, "--network")
+			delete(args, "--game-factory-address")
+			args["--network"] = network
+			args["--cannon-rollup-config"] = "rollup.json"
+			args["--cannon-l2-genesis"] = "gensis.json"
+			args["--cannon-l2-custom"] = "true"
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
+				toArgList(args))
+		})
+
+		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredWhenRollupGenesisAndDepsetIsSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
+				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+				"--cannon-rollup-config=rollup.json",
+				"--cannon-l2-genesis=genesis.json",
+				"--cannon-depset-config=depset.json",
+				"--cannon-l2-custom"))
+			require.True(t, cfg.Cannon.L2Custom)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-rollup-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-l2-genesis"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonDepsetConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-depset-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+				require.Equal(t, "depset.json", cfg.Cannon.DepsetConfigPath)
+			})
+		})
+	}
+}
+
 func TestCannonRequiredArgs(t *testing.T) {
 	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeSuperCannon, types.TraceTypeSuperPermissioned} {
 		traceType := traceType
@@ -756,84 +946,21 @@ func TestCannonRequiredArgs(t *testing.T) {
 					addRequiredArgs(traceType, "--cannon-info-freq=abc"))
 			})
 		})
+	}
+}
 
-		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(
-				t,
-				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network"))
-			verifyArgsInvalid(
-				t,
-				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
-			verifyArgsInvalid(
-				t,
-				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
-		})
-
-		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(
-				t,
-				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
-				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
-		})
-
-		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
-			args := requiredArgs(traceType)
-			delete(args, "--network")
-			delete(args, "--game-factory-address")
-			args["--network"] = network
-			args["--cannon-rollup-config"] = "rollup.json"
-			args["--cannon-l2-genesis"] = "gensis.json"
-			args["--cannon-l2-custom"] = "true"
-			verifyArgsInvalid(
-				t,
-				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
-				toArgList(args))
-		})
-
-		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
-					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+func TestDepsetConfig(t *testing.T) {
+	for _, traceType := range types.TraceTypes {
+		if traceType == types.TraceTypeSuperCannon || traceType == types.TraceTypeSuperPermissioned {
+			t.Run("Required-"+traceType.String(), func(t *testing.T) {
+				verifyArgsInvalid(t, "flag network or depset-config/cannon-depset-config is required", addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
-				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
+		} else {
+			t.Run("NotRequired-"+traceType.String(), func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
+				require.Equal(t, "", cfg.Cannon.DepsetConfigPath)
 			})
-		})
-
-		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
-				"--cannon-rollup-config=rollup.json",
-				"--cannon-l2-genesis=genesis.json",
-				"--cannon-l2-custom"))
-			require.True(t, cfg.Cannon.L2Custom)
-		})
-
-		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-rollup-config"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-l2-genesis"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
-			})
-		})
+		}
 	}
 }
 

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -953,7 +953,9 @@ func TestDepsetConfig(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		if traceType == types.TraceTypeSuperCannon || traceType == types.TraceTypeSuperPermissioned {
 			t.Run("Required-"+traceType.String(), func(t *testing.T) {
-				verifyArgsInvalid(t, "flag network or depset-config/cannon-depset-config is required", addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
+				verifyArgsInvalid(t,
+					"flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required",
+					addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 			})
 		} else {
 			t.Run("NotRequired-"+traceType.String(), func(t *testing.T) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -27,6 +27,7 @@ var (
 	ErrMissingGameFactoryAddress     = errors.New("missing game factory address")
 	ErrMissingCannonSnapshotFreq     = errors.New("missing cannon snapshot freq")
 	ErrMissingCannonInfoFreq         = errors.New("missing cannon info freq")
+	ErrMissingDepsetConfig           = errors.New("missing network or depset config path")
 
 	ErrMissingRollupRpc     = errors.New("missing rollup rpc url")
 	ErrMissingSupervisorRpc = errors.New("missing supervisor rpc url")
@@ -188,6 +189,10 @@ func (c Config) Check() error {
 	if c.TraceTypeEnabled(types.TraceTypeSuperCannon) || c.TraceTypeEnabled(types.TraceTypeSuperPermissioned) {
 		if c.SupervisorRPC == "" {
 			return ErrMissingSupervisorRpc
+		}
+
+		if len(c.Cannon.Networks) == 0 && c.Cannon.DepsetConfigPath == "" {
+			return ErrMissingDepsetConfig
 		}
 		if err := c.validateBaseCannonOptions(); err != nil {
 			return err

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -58,6 +58,7 @@ type Config struct {
 	L2Custom          bool
 	RollupConfigPaths []string
 	L2GenesisPaths    []string
+	DepsetConfigPath  string
 }
 
 func (c *Config) Check() error {


### PR DESCRIPTION
**Description**

Adds a new `--depset.config` vm config option to set the dependency set config file for interop. Currently this is unused but will ultimately need to be passed through to op-program and kona. Will do that in a follow up PR as there's some other fixes required for op-program execution as well.

**Tests**
 
Updated unit tests.  

Working towards https://github.com/ethereum-optimism/optimism/issues/13904