### PR TITLE
op-challenger: Update op-program executor to handle interop properly

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -620,6 +620,196 @@ func TestAlphabetRequiredArgs(t *testing.T) {
 	})
 }
 
+func TestCannonCustomConfigArgs(t *testing.T) {
+	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned} {
+		traceType := traceType
+
+		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network"))
+			verifyArgsInvalid(
+				t,
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
+			verifyArgsInvalid(
+				t,
+				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
+				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			args := requiredArgs(traceType)
+			delete(args, "--network")
+			delete(args, "--game-factory-address")
+			args["--network"] = network
+			args["--cannon-rollup-config"] = "rollup.json"
+			args["--cannon-l2-genesis"] = "gensis.json"
+			args["--cannon-l2-custom"] = "true"
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
+				toArgList(args))
+		})
+
+		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
+				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+				"--cannon-rollup-config=rollup.json",
+				"--cannon-l2-genesis=genesis.json",
+				"--cannon-l2-custom"))
+			require.True(t, cfg.Cannon.L2Custom)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-rollup-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-l2-genesis"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
+			})
+		})
+	}
+}
+
+func TestSuperCannonCustomConfigArgs(t *testing.T) {
+	for _, traceType := range []types.TraceType{types.TraceTypeSuperCannon, types.TraceTypeSuperPermissioned} {
+		traceType := traceType
+
+		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesisAndDepset-%v", traceType), func(t *testing.T) {
+			expectedErrorMessage := "flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required"
+			// Missing all
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network"))
+			// Missing l2-genesis
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-depset-config=depset.json"))
+			// Missing rollup-config
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json", "--cannon-depset-config=depset.json"))
+			// Missing depset-config
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=gensis.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
+				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			args := requiredArgs(traceType)
+			delete(args, "--network")
+			delete(args, "--game-factory-address")
+			args["--network"] = network
+			args["--cannon-rollup-config"] = "rollup.json"
+			args["--cannon-l2-genesis"] = "gensis.json"
+			args["--cannon-l2-custom"] = "true"
+			verifyArgsInvalid(
+				t,
+				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
+				toArgList(args))
+		})
+
+		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredWhenRollupGenesisAndDepsetIsSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
+				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
+			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+				"--cannon-rollup-config=rollup.json",
+				"--cannon-l2-genesis=genesis.json",
+				"--cannon-depset-config=depset.json",
+				"--cannon-l2-custom"))
+			require.True(t, cfg.Cannon.L2Custom)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-rollup-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-l2-genesis"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonDepsetConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-depset-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
+				require.Equal(t, "depset.json", cfg.Cannon.DepsetConfigPath)
+			})
+		})
+	}
+}
+
 func TestCannonRequiredArgs(t *testing.T) {
 	for _, traceType := range []types.TraceType{types.TraceTypeCannon, types.TraceTypePermissioned, types.TraceTypeSuperCannon, types.TraceTypeSuperPermissioned} {
 		traceType := traceType
@@ -756,84 +946,21 @@ func TestCannonRequiredArgs(t *testing.T) {
 					addRequiredArgs(traceType, "--cannon-info-freq=abc"))
 			})
 		})
+	}
+}
 
-		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(
-				t,
-				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network"))
-			verifyArgsInvalid(
-				t,
-				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json"))
-			verifyArgsInvalid(
-				t,
-				"flag network or rollup-config/cannon-rollup-config and l2-genesis/cannon-l2-genesis is required",
-				addRequiredArgsExcept(traceType, "--network", "--cannon-l2-genesis=gensis.json"))
-		})
-
-		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
-			verifyArgsInvalid(
-				t,
-				"flag network can not be used with cannon-rollup-config, l2-genesis or cannon-l2-custom",
-				addRequiredArgs(traceType, "--cannon-rollup-config=rollup.json"))
-		})
-
-		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
-			args := requiredArgs(traceType)
-			delete(args, "--network")
-			delete(args, "--game-factory-address")
-			args["--network"] = network
-			args["--cannon-rollup-config"] = "rollup.json"
-			args["--cannon-l2-genesis"] = "gensis.json"
-			args["--cannon-l2-custom"] = "true"
-			verifyArgsInvalid(
-				t,
-				"flag network can not be used with cannon-rollup-config, cannon-l2-genesis or cannon-l2-custom",
-				toArgList(args))
-		})
-
-		t.Run(fmt.Sprintf("TestNetwork-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(traceType, "--network",
-					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+func TestDepsetConfig(t *testing.T) {
+	for _, traceType := range types.TraceTypes {
+		if traceType == types.TraceTypeSuperCannon || traceType == types.TraceTypeSuperPermissioned {
+			t.Run("Required-"+traceType.String(), func(t *testing.T) {
+				verifyArgsInvalid(t, "flag network or depset-config/cannon-depset-config is required", addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--network", testNetwork))
-				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
+		} else {
+			t.Run("NotRequired-"+traceType.String(), func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
+				require.Equal(t, "", cfg.Cannon.DepsetConfigPath)
 			})
-		})
-
-		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", traceType), func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network",
-				"--cannon-rollup-config=rollup.json",
-				"--cannon-l2-genesis=genesis.json",
-				"--cannon-l2-custom"))
-			require.True(t, cfg.Cannon.L2Custom)
-		})
-
-		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-rollup-config"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(types.TraceTypeAlphabet, "--cannon-l2-genesis"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
-			})
-		})
+		}
 	}
 }
 

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -953,7 +953,9 @@ func TestDepsetConfig(t *testing.T) {
 	for _, traceType := range types.TraceTypes {
 		if traceType == types.TraceTypeSuperCannon || traceType == types.TraceTypeSuperPermissioned {
 			t.Run("Required-"+traceType.String(), func(t *testing.T) {
-				verifyArgsInvalid(t, "flag network or depset-config/cannon-depset-config is required", addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
+				verifyArgsInvalid(t,
+					"flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required",
+					addRequiredArgsExcept(traceType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 			})
 		} else {
 			t.Run("NotRequired-"+traceType.String(), func(t *testing.T) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -27,6 +27,7 @@ var (
 	ErrMissingGameFactoryAddress     = errors.New("missing game factory address")
 	ErrMissingCannonSnapshotFreq     = errors.New("missing cannon snapshot freq")
 	ErrMissingCannonInfoFreq         = errors.New("missing cannon info freq")
+	ErrMissingDepsetConfig           = errors.New("missing network or depset config path")
 
 	ErrMissingRollupRpc     = errors.New("missing rollup rpc url")
 	ErrMissingSupervisorRpc = errors.New("missing supervisor rpc url")
@@ -188,6 +189,10 @@ func (c Config) Check() error {
 	if c.TraceTypeEnabled(types.TraceTypeSuperCannon) || c.TraceTypeEnabled(types.TraceTypeSuperPermissioned) {
 		if c.SupervisorRPC == "" {
 			return ErrMissingSupervisorRpc
+		}
+
+		if len(c.Cannon.Networks) == 0 && c.Cannon.DepsetConfigPath == "" {
+			return ErrMissingDepsetConfig
 		}
 		if err := c.validateBaseCannonOptions(); err != nil {
 			return err

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -58,6 +58,7 @@ type Config struct {
 	L2Custom          bool
 	RollupConfigPaths []string
 	L2GenesisPaths    []string
+	DepsetConfigPath  string
 }
 
 func (c *Config) Check() error {

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -26,10 +27,20 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 		"--l2", strings.Join(cfg.L2s, ","),
 		"--datadir", dataDir,
 		"--l1.head", inputs.L1Head.Hex(),
-		"--l2.head", inputs.L2Head.Hex(),
-		"--l2.outputroot", inputs.L2OutputRoot.Hex(),
 		"--l2.claim", inputs.L2Claim.Hex(),
 		"--l2.blocknumber", inputs.L2BlockNumber.Text(10),
+	}
+	if inputs.L2Head != (common.Hash{}) {
+		args = append(args, "--l2.head", inputs.L2Head.Hex())
+	}
+	if inputs.L2OutputRoot != (common.Hash{}) {
+		args = append(args, "--l2.outputroot", inputs.L2OutputRoot.Hex())
+	}
+	if len(inputs.AgreedPreState) > 0 {
+		args = append(args, "--l2.agreed-prestate", common.Bytes2Hex(inputs.AgreedPreState))
+	}
+	if cfg.DepsetConfigPath != "" {
+		args = append(args, "--depset.config", cfg.DepsetConfigPath)
 	}
 	if len(cfg.Networks) != 0 {
 		args = append(args, "--network", strings.Join(cfg.Networks, ","))

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -31,7 +31,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		return pairs
 	}
 
-	oracleCommand := func(t *testing.T, lvl slog.Level, configModifier func(c *Config)) map[string]string {
+	oracleCommand := func(t *testing.T, lvl slog.Level, configModifier func(c *Config, inputs *utils.LocalGameInputs)) map[string]string {
 		cfg := Config{
 			L1:       "http://localhost:8888",
 			L1Beacon: "http://localhost:9000",
@@ -45,7 +45,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 			L2Claim:       common.Hash{0x44},
 			L2BlockNumber: big.NewInt(3333),
 		}
-		configModifier(&cfg)
+		configModifier(&cfg, &inputs)
 		executor := NewOpProgramServerExecutor(testlog.Logger(t, lvl))
 
 		args, err := executor.OracleCommand(cfg, dir, inputs)
@@ -58,71 +58,69 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		require.Equal(t, strings.Join(cfg.L2s, ","), pairs["--l2"])
 		require.Equal(t, dir, pairs["--datadir"])
 		require.Equal(t, inputs.L1Head.Hex(), pairs["--l1.head"])
-		require.Equal(t, inputs.L2Head.Hex(), pairs["--l2.head"])
-		require.Equal(t, inputs.L2OutputRoot.Hex(), pairs["--l2.outputroot"])
 		require.Equal(t, inputs.L2Claim.Hex(), pairs["--l2.claim"])
 		require.Equal(t, inputs.L2BlockNumber.String(), pairs["--l2.blocknumber"])
 		return pairs
 	}
 
 	t.Run("NoExtras", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {})
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {})
 		require.NotContains(t, pairs, "--network")
 		require.NotContains(t, pairs, "--rollup.config")
 		require.NotContains(t, pairs, "--l2.genesis")
 	})
 
 	t.Run("WithNetwork", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.Networks = []string{"op-test"}
 		})
 		require.Equal(t, "op-test", pairs["--network"])
 	})
 
 	t.Run("WithMultipleNetworks", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.Networks = []string{"op-test", "op-other"}
 		})
 		require.Equal(t, "op-test,op-other", pairs["--network"])
 	})
 
 	t.Run("WithL2Custom", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.L2Custom = true
 		})
 		require.Equal(t, "true", pairs["--l2.custom"])
 	})
 
 	t.Run("WithRollupConfigPath", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.RollupConfigPaths = []string{"rollup.config.json"}
 		})
 		require.Equal(t, "rollup.config.json", pairs["--rollup.config"])
 	})
 
 	t.Run("WithMultipleRollupConfigPaths", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.RollupConfigPaths = []string{"rollup.config.json", "rollup2.json"}
 		})
 		require.Equal(t, "rollup.config.json,rollup2.json", pairs["--rollup.config"])
 	})
 
 	t.Run("WithL2GenesisPath", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.L2GenesisPaths = []string{"genesis.json"}
 		})
 		require.Equal(t, "genesis.json", pairs["--l2.genesis"])
 	})
 
 	t.Run("WithMultipleL2GenesisPaths", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.L2GenesisPaths = []string{"genesis.json", "genesis2.json"}
 		})
 		require.Equal(t, "genesis.json,genesis2.json", pairs["--l2.genesis"])
 	})
 
 	t.Run("WithAllExtras", func(t *testing.T) {
-		pairs := oracleCommand(t, log.LvlInfo, func(c *Config) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
 			c.Networks = []string{"op-test"}
 			c.RollupConfigPaths = []string{"rollup.config.json"}
 			c.L2GenesisPaths = []string{"genesis.json"}
@@ -130,6 +128,73 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		require.Equal(t, "op-test", pairs["--network"])
 		require.Equal(t, "rollup.config.json", pairs["--rollup.config"])
 		require.Equal(t, "genesis.json", pairs["--l2.genesis"])
+	})
+
+	t.Run("WithoutL2Head", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.L2Head = common.Hash{}
+		})
+		require.NotContains(t, pairs, "--l2.head")
+	})
+
+	t.Run("WithL2Head", func(t *testing.T) {
+		val := common.Hash{0xab}
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.L2Head = val
+		})
+		require.Equal(t, val.Hex(), pairs["--l2.head"])
+	})
+
+	t.Run("WithoutL2OutputRoot", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.L2OutputRoot = common.Hash{}
+		})
+		require.NotContains(t, pairs, "--l2.outputroot")
+	})
+
+	t.Run("WithL2OutputRoot", func(t *testing.T) {
+		val := common.Hash{0xab}
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.L2OutputRoot = val
+		})
+		require.Equal(t, val.Hex(), pairs["--l2.outputroot"])
+	})
+
+	t.Run("NilAgreedPrestate", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.AgreedPreState = nil
+		})
+		require.NotContains(t, pairs, "--l2.agreed-prestate")
+	})
+
+	t.Run("EmptyAgreedPrestate", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.AgreedPreState = []byte{}
+		})
+		require.NotContains(t, pairs, "--l2.agreed-prestate")
+	})
+
+	t.Run("WithAgreedPrestate", func(t *testing.T) {
+		val := []byte{1, 6, 53, 42}
+		pairs := oracleCommand(t, log.LvlInfo, func(_ *Config, inputs *utils.LocalGameInputs) {
+			inputs.AgreedPreState = val
+		})
+		require.Equal(t, common.Bytes2Hex(val), pairs["--l2.agreed-prestate"])
+	})
+
+	t.Run("WithouDepsetConfig", func(t *testing.T) {
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
+			c.DepsetConfigPath = ""
+		})
+		require.NotContains(t, pairs, "--depset.config")
+	})
+
+	t.Run("WithL2OutputRoot", func(t *testing.T) {
+		val := "depset.json"
+		pairs := oracleCommand(t, log.LvlInfo, func(c *Config, _ *utils.LocalGameInputs) {
+			c.DepsetConfigPath = val
+		})
+		require.Equal(t, val, pairs["--depset.config"])
 	})
 
 	logTests := []struct {
@@ -146,7 +211,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 	for _, logTest := range logTests {
 		logTest := logTest
 		t.Run(fmt.Sprintf("LogLevel-%v", logTest.arg), func(t *testing.T) {
-			pairs := oracleCommand(t, logTest.level, func(c *Config) {})
+			pairs := oracleCommand(t, logTest.level, func(c *Config, _ *utils.LocalGameInputs) {})
 			require.Equal(t, pairs["--log.level"], logTest.arg)
 		})
 	}


### PR DESCRIPTION
**Description**

Updates the op-program executor for op-challenger to pass through interop options correctly.  The L2 head and L2 output root options do not apply to interop, but L2 agreed prestate and --depset.config need to be passed through.

The executor deliberately doesn't try to check the validity of the input options, it just translates them through to op-program CLI options.  op-program already has validation to ensure required options are set etc so we don't want to duplicate those and risk them being out of sync.

**Tests**

Updated unit tests.


**Metadata**

Builds on https://github.com/ethereum-optimism/optimism/pull/14666

Another piece of https://github.com/ethereum-optimism/optimism/issues/13904