### PR TITLE
op-e2e: Configurable blocktime setup for interop

### DIFF
--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -62,8 +62,8 @@ type InteropDSL struct {
 	createdUsers uint64
 }
 
-func NewInteropDSL(t helpers.Testing) *InteropDSL {
-	setup := SetupInterop(t)
+func NewInteropDSL(t helpers.Testing, opts ...setupOption) *InteropDSL {
+	setup := SetupInterop(t, opts...)
 	actors := setup.CreateActors()
 	actors.PrepareChainState(t)
 

--- a/op-e2e/faultproofs/util_interop.go
+++ b/op-e2e/faultproofs/util_interop.go
@@ -21,7 +21,7 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 	}
 	recipe := interopgen.InteropDevRecipe{
 		L1ChainID:        900100,
-		L2ChainIDs:       []uint64{900200, 900201},
+		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
 		GenesisTimestamp: uint64(time.Now().Unix() + 3), // start chain 3 seconds from now
 	}
 	worldResources := interop.WorldResourcePaths{

--- a/op-e2e/interop/interop_recipe_test.go
+++ b/op-e2e/interop/interop_recipe_test.go
@@ -18,7 +18,7 @@ import (
 func TestInteropDevRecipe(t *testing.T) {
 	rec := interopgen.InteropDevRecipe{
 		L1ChainID:        900100,
-		L2ChainIDs:       []uint64{900200, 900201},
+		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
 		GenesisTimestamp: uint64(1234567),
 	}
 	hd, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -34,7 +34,7 @@ import (
 func setupAndRun(t *testing.T, config SuperSystemConfig, fn func(*testing.T, SuperSystem)) {
 	recipe := interopgen.InteropDevRecipe{
 		L1ChainID:        900100,
-		L2ChainIDs:       []uint64{900200, 900201},
+		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
 		GenesisTimestamp: uint64(time.Now().Unix() + 3), // start chain 3 seconds from now
 	}
 	worldResources := WorldResourcePaths{

--- a/op-node/cmd/interop/interop.go
+++ b/op-node/cmd/interop/interop.go
@@ -96,9 +96,14 @@ var InteropDevSetup = &cli.Command{
 		logCfg := oplog.ReadCLIConfig(cliCtx)
 		logger := oplog.NewLogger(cliCtx.App.Writer, logCfg)
 
+		l2ChainIDs := cliCtx.Uint64Slice(l2ChainIDsFlag.Name)
+		l2Recipes := make([]interopgen.InteropDevL2Recipe, len(l2ChainIDs))
+		for i, id := range l2ChainIDs {
+			l2Recipes[i] = interopgen.InteropDevL2Recipe{ChainID: id}
+		}
 		recipe := &interopgen.InteropDevRecipe{
 			L1ChainID:        cliCtx.Uint64(l1ChainIDFlag.Name),
-			L2ChainIDs:       cliCtx.Uint64Slice(l2ChainIDsFlag.Name),
+			L2s:              l2Recipes,
 			GenesisTimestamp: cliCtx.Uint64(timestampFlag.Name),
 		}
 		if recipe.GenesisTimestamp == 0 {


### PR DESCRIPTION
Add support for chains with varied block times in the interop e2e setup.