### PR TITLE
show more error info when `EngineAPIError` is returned

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -342,7 +342,7 @@ func (e *EngineController) TryUpdateEngine(ctx context.Context) error {
 		if errors.As(err, &rpcErr) {
 			switch eth.ErrorCode(rpcErr.ErrorCode()) {
 			case eth.InvalidForkchoiceState:
-				return derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr))
+				return derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", err))
 			default:
 				return derive.NewTemporaryError(fmt.Errorf("unexpected error code in forkchoice-updated response: %w", err))
 			}
@@ -423,7 +423,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		if errors.As(err, &rpcErr) {
 			switch eth.ErrorCode(rpcErr.ErrorCode()) {
 			case eth.InvalidForkchoiceState:
-				return derive.NewResetError(fmt.Errorf("pre-unsafe-block forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr))
+				return derive.NewResetError(fmt.Errorf("pre-unsafe-block forkchoice update was inconsistent with engine, need reset to resolve: %w", err))
 			default:
 				return derive.NewTemporaryError(fmt.Errorf("unexpected error code in forkchoice-updated response: %w", err))
 			}
@@ -513,7 +513,7 @@ func (e *EngineController) TryBackupUnsafeReorg(ctx context.Context) (bool, erro
 			switch eth.ErrorCode(rpcErr.ErrorCode()) {
 			case eth.InvalidForkchoiceState:
 				e.SetBackupUnsafeL2Head(eth.L2BlockRef{}, false)
-				return true, derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr))
+				return true, derive.NewResetError(fmt.Errorf("forkchoice update was inconsistent with engine, need reset to resolve: %w", err))
 			default:
 				// Retry when forkChoiceUpdate returns non-input error.
 				// Do not reset backupUnsafeHead because it will be used again.

--- a/op-node/rollup/engine/engine_update.go
+++ b/op-node/rollup/engine/engine_update.go
@@ -89,9 +89,9 @@ func startPayload(ctx context.Context, eng ExecEngine, fc eth.ForkchoiceState, a
 		if errors.As(err, &rpcErr) {
 			switch code := eth.ErrorCode(rpcErr.ErrorCode()); code {
 			case eth.InvalidForkchoiceState:
-				return eth.PayloadID{}, BlockInsertPrestateErr, fmt.Errorf("pre-block-creation forkchoice update was inconsistent with engine, need reset to resolve: %w", rpcErr)
+				return eth.PayloadID{}, BlockInsertPrestateErr, fmt.Errorf("pre-block-creation forkchoice update was inconsistent with engine, need reset to resolve: %w", err)
 			case eth.InvalidPayloadAttributes:
-				return eth.PayloadID{}, BlockInsertPayloadErr, fmt.Errorf("payload attributes are not valid, cannot build block: %w", rpcErr)
+				return eth.PayloadID{}, BlockInsertPayloadErr, fmt.Errorf("payload attributes are not valid, cannot build block: %w", err)
 			default:
 				if code.IsEngineError() {
 					return eth.PayloadID{}, BlockInsertPrestateErr, fmt.Errorf("unexpected engine error code in forkchoice-updated response: %w", err)


### PR DESCRIPTION
[`EngineAPIError.err`](https://github.com/ethereum-optimism/op-geth/blob/3a8a214395e44457aa6c096917ea3aa4de593d8e/beacon/engine/errors.go#L29) often contains information most useful for debug, but will be omitted if only `rpcErr` is printed.


This PR makes it output more error detail.