### PR TITLE
op-e2e: update genesis.L2AllocsGranite to genesis.L2AllocsHolocene

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -329,7 +329,7 @@ func initAllocType(root string, allocType AllocType) {
 			mtx.Unlock()
 
 			// This needs to be updated whenever the latest hardfork is changed.
-			if mode == genesis.L2AllocsGranite {
+			if mode == genesis.L2AllocsHolocene {
 				dc, err := inspect.DeployConfig(st, intent.Chains[0].ID)
 				if err != nil {
 					panic(fmt.Errorf("failed to inspect deploy config: %w", err))


### PR DESCRIPTION
in `config/init.go`.

This feels right to me, but it causes `TestPendingGasLimit` in `op-e2e/system/verifier/legacy_pending_test.go` to fail.