### PR TITLE
op-e2e: show init log if `SHOW_INIT_LOG` is true

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -180,7 +180,11 @@ func init() {
 
 	// Start at warning level since alloc generation is heavy on the logs,
 	// which reduces CI performance.
-	oplog.SetGlobalLogHandler(errHandler)
+	if os.Getenv("SHOW_INIT_LOG") == "true" {
+		oplog.SetGlobalLogHandler(handler)
+	} else {
+		oplog.SetGlobalLogHandler(errHandler)
+	}
 
 	for _, allocType := range allocTypes {
 		if allocType == AllocTypeL2OO {


### PR DESCRIPTION
Currently logs are discarded during `initAllocType` calls.

This PR makes the behavior conditional, when `SHOW_INIT_LOG` is `true`, all logs are visible.

It's useful for investigating what actually happens during op-e2e init process.