### PR TITLE
op-e2e: move DefaultMnemonicConfig to separate package

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/exp/maps"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -256,11 +257,7 @@ func initAllocType(root string, allocType AllocType) {
 	l2Alloc := make(map[genesis.L2AllocsMode]*foundry.ForgeAllocs)
 	var wg sync.WaitGroup
 
-	// Corresponds with the Deployer address in cfg.secrets
-	pk, err := crypto.HexToECDSA("7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6")
-	if err != nil {
-		panic(fmt.Errorf("failed to parse private key: %w", err))
-	}
+	pk := secrets.DefaultSecrets.Deployer
 	deployerAddr := crypto.PubkeyToAddress(pk.PublicKey)
 	lgr.Info("deployer address", "address", deployerAddr.Hex())
 
@@ -361,6 +358,8 @@ func initAllocType(root string, allocType AllocType) {
 }
 
 func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address, allocType AllocType) *state.Intent {
+	secrets := secrets.DefaultSecrets
+	addresses := secrets.Addresses()
 	defaultPrestate := common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98")
 	genesisOutputRoot := common.HexToHash("0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
 	return &state.Intent{
@@ -380,7 +379,7 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 			"channelTimeout":                           120,
 			"l2OutputOracleSubmissionInterval":         10,
 			"l2OutputOracleStartingTimestamp":          0,
-			"l2OutputOracleProposer":                   "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+			"l2OutputOracleProposer":                   addresses.Proposer,
 			"l2OutputOracleChallenger":                 "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
 			"l2GenesisBlockGasLimit":                   "0x1c9c380",
 			"l1BlockTime":                              6,
@@ -428,8 +427,8 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 					L2ProxyAdminOwner: deployer,
 					SystemConfigOwner: deployer,
 					UnsafeBlockSigner: common.HexToAddress("0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"),
-					Batcher:           common.HexToAddress("0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"),
-					Proposer:          common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+					Batcher:           addresses.Batcher,
+					Proposer:          addresses.Proposer,
 					Challenger:        common.HexToAddress("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"),
 				},
 				AdditionalDisputeGames: []state.AdditionalDisputeGame{

--- a/op-e2e/config/secrets/secrets.go
+++ b/op-e2e/config/secrets/secrets.go
@@ -1,4 +1,4 @@
-package e2eutils
+package secrets
 
 import (
 	"crypto/ecdsa"
@@ -29,6 +29,17 @@ var DefaultMnemonicConfig = &MnemonicConfig{
 	Bob:          "m/44'/60'/0'/0/7",
 	Mallory:      "m/44'/60'/0'/0/8",
 	SysCfgOwner:  "m/44'/60'/0'/0/9",
+}
+
+// DefaultSecrets is the precomputed secrets for the default mnemonic.
+var DefaultSecrets *Secrets
+
+func init() {
+	var err error
+	DefaultSecrets, err = DefaultMnemonicConfig.Secrets()
+	if err != nil {
+		panic(fmt.Sprintf("invalid DefaultMnemonicConfig: %v", err))
+	}
 }
 
 // MnemonicConfig configures the private keys for the hive testnet.

--- a/op-e2e/config/secrets/secrets_test.go
+++ b/op-e2e/config/secrets/secrets_test.go
@@ -1,0 +1,14 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecrets(t *testing.T) {
+	addresses := DefaultSecrets.Addresses()
+	require.Equal(t, addresses.Proposer, common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"))
+	require.Equal(t, addresses.Batcher, common.HexToAddress("0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"))
+}

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -36,9 +37,9 @@ func WriteDefaultJWT(t TestingBase) string {
 // DeployParams bundles the deployment parameters to generate further testing inputs with.
 type DeployParams struct {
 	DeployConfig   *genesis.DeployConfig
-	MnemonicConfig *MnemonicConfig
-	Secrets        *Secrets
-	Addresses      *Addresses
+	MnemonicConfig *secrets.MnemonicConfig
+	Secrets        *secrets.Secrets
+	Addresses      *secrets.Addresses
 	AllocType      config.AllocType
 }
 
@@ -53,9 +54,8 @@ type TestParams struct {
 }
 
 func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
-	mnemonicCfg := DefaultMnemonicConfig
-	secrets, err := mnemonicCfg.Secrets()
-	require.NoError(t, err)
+	mnemonicCfg := secrets.DefaultMnemonicConfig
+	secrets := secrets.DefaultSecrets
 	addresses := secrets.Addresses()
 
 	deployConfig := config.DeployConfig(tp.AllocType)

--- a/op-e2e/system/bridge/validity_test.go
+++ b/op-e2e/system/bridge/validity_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	legacybindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
@@ -355,7 +355,7 @@ func testMixedWithdrawalValidity(t *testing.T, allocType config.AllocType) {
 			// Create a test account state for our transactor.
 			transactor := &TestAccountState{
 				Account: &TestAccount{
-					HDPath: e2eutils.DefaultMnemonicConfig.Alice,
+					HDPath: secrets.DefaultMnemonicConfig.Alice,
 					Key:    cfg.Secrets.Alice,
 					L1Opts: nil,
 					L2Opts: nil,

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -48,6 +48,7 @@ import (
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
+	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/batcher"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
@@ -106,8 +107,7 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 		opt(sco)
 	}
 
-	secrets, err := e2eutils.DefaultMnemonicConfig.Secrets()
-	require.NoError(t, err)
+	secrets := secrets.DefaultSecrets
 	deployConfig := config.DeployConfig(sco.AllocType)
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	e2eutils.ApplyDeployConfigForks(deployConfig)
@@ -262,7 +262,7 @@ type DepositContractConfig struct {
 }
 
 type SystemConfig struct {
-	Secrets                *e2eutils.Secrets
+	Secrets                *secrets.Secrets
 	L1InfoPredeployAddress common.Address
 
 	DeployConfig  *genesis.DeployConfig


### PR DESCRIPTION
This PR moves `DefaultMnemonicConfig` to separate package so that it can be referenced from both `op-e2e/config` and `op-e2e/e2eutils` without cyclic dependencies.

Then this PR also replaces some hardcode values.

The `TestSecrets` ensures that it's the same as the hardcoded version.