### PR TITLE
Ingest L1 Chain ID into devnet-sdk

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -173,6 +173,7 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, spec *spec.En
 	finder := NewServiceFinder(inspectResult.UserServices)
 	if nodes, services := finder.FindL1Services(); len(nodes) > 0 {
 		chain := &descriptors.Chain{
+			ID:       deployerState.L1ChainID,
 			Name:     "Ethereum",
 			Services: services,
 			Nodes:    nodes,

--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/deployer.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/deployer.go
@@ -68,6 +68,7 @@ type WalletList []*Wallet
 type DeployerData struct {
 	L1ValidatorWallets WalletList     `json:"wallets"`
 	State              *DeployerState `json:"state"`
+	L1ChainID          string         `json:"l1_chain_id"`
 }
 
 type Deployer struct {
@@ -342,7 +343,13 @@ func (d *Deployer) ExtractData(ctx context.Context) (*DeployerData, error) {
 		return nil, err
 	}
 
+	l1ChainID, err := d.getL1ChainID(deployerArtifact)
+	if err != nil {
+		return nil, err
+	}
+
 	return &DeployerData{
+		L1ChainID:          l1ChainID,
 		State:              state,
 		L1ValidatorWallets: l1ValidatorWallets,
 	}, nil

--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
@@ -2,12 +2,14 @@ package deployer
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 
 	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"gopkg.in/yaml.v3"
 )
@@ -36,7 +38,7 @@ func getMnemonics(r io.Reader) (string, error) {
 func (d *Deployer) getL1ValidatorWallets(deployerArtifact *ktfs.Artifact) ([]*Wallet, error) {
 	mnemonicsBuffer := bytes.NewBuffer(nil)
 	if err := deployerArtifact.ExtractFiles(
-		ktfs.NewArtifactFileWriter(d.l1ValidatorMnemonicName, mnemonicsBuffer),
+		ktfs.NewArtifactFileWriter(d.mnemonicsName, mnemonicsBuffer),
 	); err != nil {
 		return nil, err
 	}
@@ -66,4 +68,21 @@ func (d *Deployer) getL1ValidatorWallets(deployerArtifact *ktfs.Artifact) ([]*Wa
 	}
 
 	return knownWallets, nil
+}
+
+func (d *Deployer) getL1ChainID(genesisArtifact *ktfs.Artifact) (string, error) {
+	genesisBuffer := bytes.NewBuffer(nil)
+	if err := genesisArtifact.ExtractFiles(
+		ktfs.NewArtifactFileWriter(d.l1GenesisName, genesisBuffer),
+	); err != nil {
+		return "", err
+	}
+
+	// Parse the genesis file JSON into a core.Genesis struct
+	var genesis core.Genesis
+	if err := json.NewDecoder(genesisBuffer).Decode(&genesis); err != nil {
+		return "", fmt.Errorf("failed to parse genesis file %s in artifact %s: %w", d.l1GenesisName, d.genesisArtifactName, err)
+	}
+
+	return genesis.Config.ChainID.String(), nil
 }

--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/wallets.go
@@ -36,7 +36,7 @@ func getMnemonics(r io.Reader) (string, error) {
 func (d *Deployer) getL1ValidatorWallets(deployerArtifact *ktfs.Artifact) ([]*Wallet, error) {
 	mnemonicsBuffer := bytes.NewBuffer(nil)
 	if err := deployerArtifact.ExtractFiles(
-		ktfs.NewArtifactFileWriter(d.mnemonicsName, mnemonicsBuffer),
+		ktfs.NewArtifactFileWriter(d.l1ValidatorMnemonicName, mnemonicsBuffer),
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Stacks on top of:
* https://github.com/ethereum-optimism/optimism/pull/14668
* https://github.com/ethereum-optimism/optimism/pull/14703

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Adds support for ingesting the L1 chain ID for the devnet-sdk framework.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Tested by NAT tests in later stacked PRs.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
