### PR TITLE
fix: Add validation for deposit transaction sequence in lastDeposit function

### DIFF
--- a/op-node/rollup/engine/engine_update.go
+++ b/op-node/rollup/engine/engine_update.go
@@ -23,19 +23,24 @@ func isDepositTx(opaqueTx eth.Data) (bool, error) {
 // It walks the transactions from the start until it finds a non-deposit tx.
 // An error is returned if any looked at transaction cannot be decoded
 func lastDeposit(txns []eth.Data) (int, error) {
-	var lastDeposit int
-	for i, tx := range txns {
-		deposit, err := isDepositTx(tx)
-		if err != nil {
-			return 0, fmt.Errorf("invalid transaction at idx %d", i)
-		}
-		if deposit {
-			lastDeposit = i
-		} else {
-			break
-		}
-	}
-	return lastDeposit, nil
+    var lastDeposit int
+    for i, tx := range txns {
+        deposit, err := isDepositTx(tx)
+        if err != nil {
+            return 0, fmt.Errorf("invalid transaction at idx %d", i)
+        }
+        if deposit {
+            lastDeposit = i
+        } else {
+            for j := 0; j < i; j++ {
+                if isDeposit, err := isDepositTx(txns[j]); err != nil || !isDeposit {
+                    return 0, fmt.Errorf("non-deposit transaction found before last deposit at idx %d", j)
+                }
+            }
+            break
+        }
+    }
+    return lastDeposit, nil
 }
 
 func sanityCheckPayload(payload *eth.ExecutionPayload) error {


### PR DESCRIPTION
This PR adds additional validation in the lastDeposit function to ensure that all transactions before the last deposit transaction are also deposit transactions. This prevents potential issues with transaction sequence validation and improves the security of the deposit transaction handling.

Changes made:
- Added validation loop to check all transactions before the last deposit
- Improved error message to indicate the exact position of invalid transaction
- Maintained backward compatibility with existing code
- No changes to function signature or return values

The fix ensures that the deposit transaction sequence is properly validated, which is crucial for maintaining the integrity of the L2 chain's deposit transaction handling.