### PR TITLE
kt-devnet: add missing network params for supervisor

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -37,6 +37,7 @@ optimism_package:
         }
       extra_params:
       - {{ $flags.log_level }}
+      network: "kurtosis"
   chains:
     - participants:
       - el_type: op-geth

--- a/kurtosis-devnet/templates/devnet.yaml
+++ b/kurtosis-devnet/templates/devnet.yaml
@@ -15,6 +15,7 @@ optimism_package:
       image: {{ dig "overrides" "images" "op_supervisor" (localDockerImage "op-supervisor") $context }}
       extra_params:
       - {{ dig "overrides" "flags" "log_level" "!!str" $context }}
+      network: "kurtosis"
 {{ end }}
   chains:
   {{ range $l2_id, $l2 := $l2s }}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds missing params. Although they are filled in when not provided, worth to provide explicitly.

**Tests**

Monorepo interop-devnet succeeds.

**Metadata**

Merge this after https://github.com/ethpandaops/optimism-package/pull/187 is merged.
