### PR TITLE
op-program: make `NewBlockProcessorFromHeader` call `mkEVM` after the blob gas fields are set

### DIFF
--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -95,7 +95,7 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 		vmenv := vm.NewEVM(context, statedb, provider.Config(), vm.Config{PrecompileOverrides: precompileOverrides})
 		return vmenv
 	}
-	vmenv := mkEVM()
+	var vmenv *vm.EVM
 	if h.ParentBeaconRoot != nil {
 		if provider.Config().IsCancun(header.Number, header.Time) {
 			// Blob tx not supported on optimism chains but fields must be set when Cancun is active.
@@ -103,7 +103,11 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 			header.BlobGasUsed = &zero
 			header.ExcessBlobGas = &zero
 		}
+		// core.NewEVMBlockContext need to be called after the blob gas fields are set
+		vmenv = mkEVM()
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv)
+	} else {
+		vmenv = mkEVM()
 	}
 	if provider.Config().IsPrague(header.Number, header.Time) {
 		core.ProcessParentBlockHash(header.ParentHash, vmenv)


### PR DESCRIPTION
This PR makes `NewBlockProcessorFromHeader` call `mkEVM` after the blob gas fields are set, so that `core.NewEVMBlockContext` can correctly set a `blobBaseFee` [here](https://github.com/ethereum-optimism/op-geth/blob/963ab50dff5f88c50cc76fb6070cdb0d5f53fa8e/core/evm.go#L65), otherwise it'll be `nil`.

Note that even OP hasn't enabled blob tx, these fields are require as long as `CanCun` is enabled, as can be seen [here](https://github.com/ethereum-optimism/op-geth/blob/963ab50dff5f88c50cc76fb6070cdb0d5f53fa8e/miner/worker.go#L304-L312).