### PR TITLE
op-supervisor,op-service: fix server-client API consistency

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"context"
 	"math/big"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -120,6 +121,9 @@ func TestInterop_SupervisorFinality(t *testing.T) {
 		supervisor := s2.SupervisorClient()
 		require.Eventually(t, func() bool {
 			final, err := supervisor.FinalizedL1(context.Background())
+			if err != nil && strings.Contains(err.Error(), "not initialized") {
+				return false
+			}
 			require.NoError(t, err)
 			return final.Number > 0
 			// this test takes about 30 seconds, with a longer Eventually timeout for CI
@@ -370,6 +374,9 @@ func TestMultiNode(t *testing.T) {
 		supervisor := s2.SupervisorClient()
 		require.Eventually(t, func() bool {
 			final, err := supervisor.FinalizedL1(context.Background())
+			if err != nil && strings.Contains(err.Error(), "not initialized") {
+				return false
+			}
 			require.NoError(t, err)
 			return final.Number > 0
 			// this test takes about 30 seconds, with a longer Eventually timeout for CI

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -13,9 +13,33 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+type SupervisorAdminAPI interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error
+}
+
+type SupervisorQueryAPI interface {
+	CheckMessage(ctx context.Context, identifier types.Identifier, payloadHash common.Hash, executingDescriptor types.ExecutingDescriptor) (types.SafetyLevel, error)
+	CheckMessages(ctx context.Context, messages []types.Message, minSafety types.SafetyLevel) error
+	CheckMessagesV2(ctx context.Context, messages []types.Message, minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error
+	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
+	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
+	CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error)
+	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
+	FinalizedL1(ctx context.Context) (eth.BlockRef, error)
+	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
+	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
+	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
+}
+
 type SupervisorClient struct {
 	client client.RPC
 }
+
+// This type-check keeps the Server API and Client API in sync.
+var _ SupervisorQueryAPI = (*SupervisorClient)(nil)
+var _ SupervisorAdminAPI = (*SupervisorClient)(nil)
 
 func NewSupervisorClient(client client.RPC) *SupervisorClient {
 	return &SupervisorClient{
@@ -25,10 +49,7 @@ func NewSupervisorClient(client client.RPC) *SupervisorClient {
 
 func (cl *SupervisorClient) Stop(ctx context.Context) error {
 	var result error
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"admin_stop")
+	err := cl.client.CallContext(ctx, &result, "admin_stop")
 	if err != nil {
 		return fmt.Errorf("failed to stop Supervisor: %w", err)
 	}
@@ -37,10 +58,7 @@ func (cl *SupervisorClient) Stop(ctx context.Context) error {
 
 func (cl *SupervisorClient) Start(ctx context.Context) error {
 	var result error
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"admin_start")
+	err := cl.client.CallContext(ctx, &result, "admin_start")
 	if err != nil {
 		return fmt.Errorf("failed to start Supervisor: %w", err)
 	}
@@ -49,26 +67,18 @@ func (cl *SupervisorClient) Start(ctx context.Context) error {
 
 func (cl *SupervisorClient) AddL2RPC(ctx context.Context, rpc string, auth eth.Bytes32) error {
 	var result error
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"admin_addL2RPC",
-		rpc, auth)
+	err := cl.client.CallContext(ctx, &result, "admin_addL2RPC", rpc, auth)
 	if err != nil {
 		return fmt.Errorf("failed to Add L2 to Supervisor (rpc: %s): %w", rpc, err)
 	}
 	return result
 }
 
-func (cl *SupervisorClient) CheckMessage(ctx context.Context, identifier types.Identifier, logHash common.Hash, executingDescriptor types.ExecutingDescriptor) (types.SafetyLevel, error) {
+func (cl *SupervisorClient) CheckMessage(ctx context.Context, identifier types.Identifier, logHash common.Hash,
+	executingDescriptor types.ExecutingDescriptor) (types.SafetyLevel, error) {
+
 	var result types.SafetyLevel
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_checkMessage",
-		identifier,
-		logHash,
-		executingDescriptor)
+	err := cl.client.CallContext(ctx, &result, "supervisor_checkMessage", identifier, logHash, executingDescriptor)
 	if err != nil {
 		return types.Invalid, fmt.Errorf("failed to check message (chain %s), (block %v), (index %v), (logHash %s), (executingTimestamp %v): %w",
 			identifier.ChainID,
@@ -81,112 +91,63 @@ func (cl *SupervisorClient) CheckMessage(ctx context.Context, identifier types.I
 	return result, nil
 }
 
-func (cl *SupervisorClient) UnsafeView(ctx context.Context, chainID eth.ChainID, unsafe types.ReferenceView) (types.ReferenceView, error) {
-	var result types.ReferenceView
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_unsafeView",
-		chainID,
-		unsafe)
-	if err != nil {
-		return types.ReferenceView{}, fmt.Errorf("failed to share unsafe block view %s (chain %s): %w", unsafe, chainID, err)
-	}
-	return result, nil
+func (cl *SupervisorClient) CheckMessages(ctx context.Context, messages []types.Message, minSafety types.SafetyLevel) error {
+	return cl.client.CallContext(ctx, nil, "supervisor_checkMessages", messages, minSafety)
 }
 
-func (cl *SupervisorClient) SafeView(ctx context.Context, chainID eth.ChainID, safe types.ReferenceView) (types.ReferenceView, error) {
-	var result types.ReferenceView
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_safeView",
-		chainID,
-		safe)
-	if err != nil {
-		return types.ReferenceView{}, fmt.Errorf("failed to share safe block view %s (chain %s): %w", safe, chainID, err)
-	}
-	return result, nil
+func (cl *SupervisorClient) CheckMessagesV2(ctx context.Context, messages []types.Message, minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	return cl.client.CallContext(ctx, nil, "supervisor_checkMessagesV2", messages, minSafety, executingDescriptor)
+}
+
+func (cl *SupervisorClient) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+	var result eth.BlockRef
+	err = cl.client.CallContext(ctx, &result, "supervisor_crossDerivedToSource", chainID, derived)
+	return result, err
 }
 
 func (cl *SupervisorClient) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	var result eth.BlockID
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_localUnsafe",
-		chainID)
+	err := cl.client.CallContext(ctx, &result, "supervisor_localUnsafe", chainID)
 	return result, err
 }
 
 func (cl *SupervisorClient) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
 	var result types.DerivedIDPair
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_crossSafe",
-		chainID)
+	err := cl.client.CallContext(ctx, &result, "supervisor_crossSafe", chainID)
 	return result, err
 }
 
 func (cl *SupervisorClient) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
 	var result eth.BlockID
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_finalized",
-		chainID)
+	err := cl.client.CallContext(ctx, &result, "supervisor_finalized", chainID)
 	return result, err
 }
 
 func (cl *SupervisorClient) FinalizedL1(ctx context.Context) (eth.BlockRef, error) {
 	var result eth.BlockRef
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_finalizedL1")
+	err := cl.client.CallContext(ctx, &result, "supervisor_finalizedL1")
 	return result, err
 }
 
 func (cl *SupervisorClient) CrossDerivedFrom(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (eth.BlockRef, error) {
 	var result eth.BlockRef
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_crossDerivedFrom",
-		chainID,
-		derived)
+	err := cl.client.CallContext(ctx, &result, "supervisor_crossDerivedFrom", chainID, derived)
 	return result, err
 }
 
 func (cl *SupervisorClient) UpdateLocalUnsafe(ctx context.Context, chainID eth.ChainID, head eth.BlockRef) error {
-	return cl.client.CallContext(
-		ctx,
-		nil,
-		"supervisor_updateLocalUnsafe",
-		chainID,
-		head)
+	return cl.client.CallContext(ctx, nil, "supervisor_updateLocalUnsafe", chainID, head)
 }
 
 func (cl *SupervisorClient) UpdateLocalSafe(ctx context.Context, chainID eth.ChainID, derivedFrom eth.L1BlockRef, lastDerived eth.BlockRef) error {
-	return cl.client.CallContext(
-		ctx,
-		nil,
-		"supervisor_updateLocalSafe",
-		chainID,
-		derivedFrom,
-		lastDerived)
+	return cl.client.CallContext(ctx, nil, "supervisor_updateLocalSafe", chainID, derivedFrom, lastDerived)
 }
 
 // SuperRootAtTimestamp returns the super root at the specified timestamp.
 // Returns ethereum.NotFound if one of the chain's has not yet reached the block required for the requested super root.
 func (cl *SupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
 	var result eth.SuperRootResponse
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_superRootAtTimestamp",
-		timestamp)
+	err := cl.client.CallContext(ctx, &result, "supervisor_superRootAtTimestamp", timestamp)
 	if isNotFound(err) {
 		// Downstream users expect to get a properly typed error message for not found.
 		return result, fmt.Errorf("%w: %v", ethereum.NotFound, err.Error())
@@ -196,20 +157,13 @@ func (cl *SupervisorClient) SuperRootAtTimestamp(ctx context.Context, timestamp 
 
 func (cl *SupervisorClient) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
 	var result map[eth.ChainID]eth.BlockID
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_allSafeDerivedAt",
-		derivedFrom)
+	err := cl.client.CallContext(ctx, &result, "supervisor_allSafeDerivedAt", derivedFrom)
 	return result, err
 }
 
 func (cl *SupervisorClient) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
 	var result eth.SupervisorSyncStatus
-	err := cl.client.CallContext(
-		ctx,
-		&result,
-		"supervisor_syncStatus")
+	err := cl.client.CallContext(ctx, &result, "supervisor_syncStatus")
 	return result, err
 }
 

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -47,15 +47,15 @@ func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.By
 	return nil
 }
 
-func (m *MockBackend) CheckMessage(identifier types.Identifier, payloadHash common.Hash, executingDescriptor types.ExecutingDescriptor) (types.SafetyLevel, error) {
+func (m *MockBackend) CheckMessage(ctx context.Context, identifier types.Identifier, payloadHash common.Hash, executingDescriptor types.ExecutingDescriptor) (types.SafetyLevel, error) {
 	return types.CrossUnsafe, nil
 }
 
-func (m *MockBackend) CheckMessages(messages []types.Message, minSafety types.SafetyLevel) error {
+func (m *MockBackend) CheckMessages(ctx context.Context, messages []types.Message, minSafety types.SafetyLevel) error {
 	return nil
 }
 
-func (m *MockBackend) CheckMessagesV2(messages []types.Message, minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+func (m *MockBackend) CheckMessagesV2(ctx context.Context, messages []types.Message, minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
 	return nil
 }
 
@@ -71,8 +71,8 @@ func (m *MockBackend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.B
 	return eth.BlockID{}, nil
 }
 
-func (m *MockBackend) FinalizedL1() eth.BlockRef {
-	return eth.BlockRef{}
+func (m *MockBackend) FinalizedL1(ctx context.Context) (eth.BlockRef, error) {
+	return eth.BlockRef{}, nil
 }
 
 func (m *MockBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
@@ -83,7 +83,7 @@ func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexuti
 	return eth.SuperRootResponse{}, nil
 }
 
-func (m *MockBackend) SyncStatus() (eth.SupervisorSyncStatus, error) {
+func (m *MockBackend) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
 	return eth.SupervisorSyncStatus{}, nil
 }
 


### PR DESCRIPTION
**Description**

Clean up the supervisor RPC client bindings.

**Tests**

There interface type checks that assert the client bindings, the frontend, and the backend all match. This should keep them in sync.

**Additional context**

Also see specs PR: https://github.com/ethereum-optimism/specs/pull/533

**Metadata**

Fix #14229 
