### PR TITLE
contracts: reenable semver-diff-check in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,8 +923,8 @@ jobs:
           command: semgrep
       - run-contracts-check:
           command: semver-lock-no-build
-      #- run-contracts-check:
-          #command: semver-diff-check-no-build
+      - run-contracts-check:
+          command: semver-diff-check-no-build
       - run-contracts-check:
           command: validate-deploy-configs
       - run-contracts-check:


### PR DESCRIPTION
Follow-up to temporary workaround in https://github.com/ethereum-optimism/optimism/pull/14722