### PR TITLE
op-service: show height when "failed to verify block hash" happens

### DIFF
--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -133,7 +133,7 @@ func (hdr *RPCHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo
 	}
 	if !trustCache {
 		if computed := hdr.computeBlockHash(); computed != hdr.Hash {
-			return nil, fmt.Errorf("failed to verify block hash: computed %s but RPC said %s", computed, hdr.Hash)
+			return nil, fmt.Errorf("failed to verify block hash: computed %s but RPC said %s, height:%s", computed, hdr.Hash, hdr.Number)
 		}
 	}
 	return eth.HeaderBlockInfoTrusted(hdr.Hash, hdr.CreateGethHeader()), nil
@@ -154,7 +154,7 @@ type RPCBlock struct {
 
 func (block *RPCBlock) Verify() error {
 	if computed := block.computeBlockHash(); computed != block.Hash {
-		return fmt.Errorf("failed to verify block hash: computed %s but RPC said %s", computed, block.Hash)
+		return fmt.Errorf("failed to verify block hash: computed %s but RPC said %s, height:%s", computed, block.Hash, block.Number)
 	}
 	for i, tx := range block.Transactions {
 		if tx == nil {


### PR DESCRIPTION
This PR adds the block height when "failed to verify block hash" happens, otherwise the log is like this:

<img width="978" alt="image" src="https://github.com/user-attachments/assets/7a2fbaa3-b0c8-406d-af87-5cf0fb3ce174" />

It's much easier to investigate if the block height is shown.