### PR TITLE
refactor(kurtosis-devnet): use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/kurtosis-devnet/cmd/main_test.go
+++ b/kurtosis-devnet/cmd/main_test.go
@@ -87,13 +87,11 @@ func TestParseFlags(t *testing.T) {
 
 func TestMainFuncValidatesConfig(t *testing.T) {
 	// Create a temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "main-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create test template
 	templatePath := filepath.Join(tmpDir, "template.yaml")
-	err = os.WriteFile(templatePath, []byte("name: test"), 0644)
+	err := os.WriteFile(templatePath, []byte("name: test"), 0644)
 	require.NoError(t, err)
 
 	// Create environment output path

--- a/kurtosis-devnet/pkg/deploy/deploy_test.go
+++ b/kurtosis-devnet/pkg/deploy/deploy_test.go
@@ -72,13 +72,11 @@ func TestDeploy(t *testing.T) {
 	defer cancel()
 
 	// Create a temporary directory for the environment output
-	tmpDir, err := os.MkdirTemp("", "deploy-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create a simple template file
 	templatePath := filepath.Join(tmpDir, "template.yaml")
-	err = os.WriteFile(templatePath, []byte("test: {{ .Config }}"), 0644)
+	err := os.WriteFile(templatePath, []byte("test: {{ .Config }}"), 0644)
 	require.NoError(t, err)
 
 	// Create a simple data file

--- a/kurtosis-devnet/pkg/deploy/fileserver_test.go
+++ b/kurtosis-devnet/pkg/deploy/fileserver_test.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"context"
 	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,9 +15,7 @@ func TestDeployFileserver(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tmpDir, err := os.MkdirTemp("", "deploy-fileserver-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create a mock deployer function
 	mockDeployerFunc := func(opts ...kurtosis.KurtosisDeployerOptions) (deployer, error) {

--- a/kurtosis-devnet/pkg/deploy/prestate_test.go
+++ b/kurtosis-devnet/pkg/deploy/prestate_test.go
@@ -33,12 +33,10 @@ func TestLocalPrestate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "prestate-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			// Create a mock justfile for each test case
-			err = os.WriteFile(filepath.Join(tmpDir, "justfile"), []byte(`
+			err := os.WriteFile(filepath.Join(tmpDir, "justfile"), []byte(`
 _prestate-build target:
 	@echo "Mock prestate build"
 `), 0644)

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestRenderTemplate(t *testing.T) {
 	// Create a temporary directory for test files
-	tmpDir, err := os.MkdirTemp("", "template-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create a test template file
 	templateContent := `
@@ -23,7 +21,7 @@ image: {{localDockerImage "test-project"}}
 artifacts: {{localContractArtifacts "l1"}}`
 
 	templatePath := filepath.Join(tmpDir, "template.yaml")
-	err = os.WriteFile(templatePath, []byte(templateContent), 0644)
+	err := os.WriteFile(templatePath, []byte(templateContent), 0644)
 	require.NoError(t, err)
 
 	// Create a test data file


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.

More about TempDir https://pkg.go.dev/testing#B.TempDir

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
