### PR TITLE
fix: Update broken link to OPContractsManager.sol

### DIFF
--- a/packages/contracts-bedrock/book/src/policies/versioning.md
+++ b/packages/contracts-bedrock/book/src/policies/versioning.md
@@ -77,7 +77,7 @@ Versioning for monorepo releases works as follows:
 
 ## Optimism Contracts Manager (OPCM) Versioning
 
-The [OPCM](https://github.com/ethereum-optimism/optimism/blob/main/packages/contracts-bedrock/src/L1/OPContractsManager.sol) is the contract that manages the deployment of all contracts on L1.
+The [OPCM](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OPContractsManager.sol) is the contract that manages the deployment of all contracts on L1.
 
 The `OPCM` is the source of truth for the contracts that belong in a release, available as on-chain addresses by querying [the `getImplementations` function](https://github.com/ethereum-optimism/optimism/blob/4c8764f0453e141555846d8c9dd2af9edbc1d014/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L1061).
 


### PR DESCRIPTION
**Description**

Broken Link : 
![Pasted Graphic 22](https://github.com/user-attachments/assets/77932879-fe14-487a-8129-1e0c6b532e65)


This PR fixes a broken link in the documentation/repository. The original link was pointing to the main branch https://github.com/ethereum-optimism/optimism/blob/main/packages/contracts-bedrock/src/L1/OPContractsManager.sol, which does not exist in this repository.

Since the default branch is develop, the correct link should be:
https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OPContractsManager.sol

I have updated the link accordingly, and it now works as expected.

Fix :
![image](https://github.com/user-attachments/assets/78afc1ee-49e1-45b7-824f-b2a276664c97)

