### PR TITLE
fix: Fix type error in balance calculation

### DIFF
--- a/kurtosis-devnet/tests/interop/interop_smoke_test.go
+++ b/kurtosis-devnet/tests/interop/interop_smoke_test.go
@@ -28,7 +28,7 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		logger = logger.With("chain", chain.ID())
 		logger.Info("starting test")
 
-		funds := sdktypes.NewBalance(big.NewInt(0.5 * constants.ETH))
+		funds := sdktypes.NewBalance(new(big.Int).Div(big.NewInt(constants.ETH), big.NewInt(2)))
 		user := walletGetter(ctx)
 
 		scw0Addr := constants.SuperchainWETH


### PR DESCRIPTION
**Description:**  
Fixed an issue where a float64 value was passed to `big.NewInt()`. Instead of `0.5 * constants.ETH`, I now use division by 2 with `big.Int`. This resolves the compiler error, and the balance calculation works correctly.

**Tests:**  
Tested the updated calculation and verified that the balance is correctly computed without any type errors.