### PR TITLE
ci: Fix preimage-reproducibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1220,6 +1220,9 @@ jobs:
       - utils/checkout-with-mise
       - setup_remote_docker
       - run: make -C op-program verify-reproducibility
+      - store_artifacts:
+          path: ./op-program/temp/logs
+          when: always
       - notify-failures-on-develop:
           mentions: "@proofs-team"
 

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -34,6 +34,11 @@ do
     LOG_FILE="${LOGS_DIR}/build-${SHORT_VERSION}.txt"
     echo "Building Version: ${VERSION} Logs: ${LOG_FILE}"
     git checkout "${VERSION}" > "${LOG_FILE}" 2>&1
+    if [ -f mise.toml ]
+    then
+      echo "Install dependencies with mise" >> "${LOG_FILE}"
+      mise install -v -y >> "${LOG_FILE}" 2>&1
+    fi
     rm -rf "${BIN_DIR}"
     make reproducible-prestate >> "${LOG_FILE}" 2>&1
     HASH=$(cat "${BIN_DIR}/prestate-proof.json" | jq -r .pre)


### PR DESCRIPTION
**Description**

Fix preimage-reproducibility hanging by running `mise install` if `mise.toml` is present in the checked out version.  Oddly, executing `jq` hangs forever if you haven't run `mise install` in the directory first.

Also capture logs from building tagged prestates to aid in diagnosing future failures.
