### PR TITLE
op-service: Expand EthClient for tx handling

### DIFF
--- a/op-e2e/actions/helpers/l2_proposer.go
+++ b/op-e2e/actions/helpers/l2_proposer.go
@@ -198,31 +198,11 @@ func (p *L2Proposer) sendTx(t Testing, data []byte) {
 // will be created so pending must be used.
 func estimateGasPending(ctx context.Context, ec *ethclient.Client, msg ethereum.CallMsg) (uint64, error) {
 	var hex hexutil.Uint64
-	err := ec.Client().CallContext(ctx, &hex, "eth_estimateGas", toCallArg(msg), "pending")
+	err := ec.Client().CallContext(ctx, &hex, "eth_estimateGas", sources.ToCallArg(msg), "pending")
 	if err != nil {
 		return 0, err
 	}
 	return uint64(hex), nil
-}
-
-func toCallArg(msg ethereum.CallMsg) interface{} {
-	arg := map[string]interface{}{
-		"from": msg.From,
-		"to":   msg.To,
-	}
-	if len(msg.Data) > 0 {
-		arg["data"] = hexutil.Bytes(msg.Data)
-	}
-	if msg.Value != nil {
-		arg["value"] = (*hexutil.Big)(msg.Value)
-	}
-	if msg.Gas != 0 {
-		arg["gas"] = hexutil.Uint64(msg.Gas)
-	}
-	if msg.GasPrice != nil {
-		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
-	}
-	return arg
 }
 
 func (p *L2Proposer) fetchNextOutput(t Testing) (source.Proposal, bool, error) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds tx building RPC call functionality for op-service's `sources.EthClient`.

**Additional context**

op-service's source utility is for rpc client bindings. This is the dependency that we want to introduce in devnet-sdk's `Node` implementation which currently wraps around `ethclient.Client`. Will substitute `ethclient.Client` usage to `sources.EthClient`.

`ethclient.Client` usage:
https://github.com/ethereum-optimism/optimism/blob/ef780b289d5f6d081d8f8107126ba9ad812d0113/devnet-sdk/system/chain.go#L24-L27

`Node` implementation:
https://github.com/ethereum-optimism/optimism/blob/ef780b289d5f6d081d8f8107126ba9ad812d0113/devnet-sdk/system/node.go#L18-L22

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/14617

