### PR TITLE
fix: fix `make help` and sort the targets printed by `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OP_STACK_GO_BUILDER?=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go
 PYTHON?=python3
 
 help: ## Prints this help message
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build: build-go build-contracts ## Builds Go components and contracts-bedrock
 .PHONY: build


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

1. Fix the output of `make help`
2. Sort the targets printed by `make help` so developers can conveniently search for their wanted commands.

**Tests**

After:
![image](https://github.com/user-attachments/assets/88552cf8-32c4-47db-8c12-68f998b2dd74)

Before:
![image](https://github.com/user-attachments/assets/d3b928b0-591c-46b5-9f7b-4b2f1829410a)


