### PR TITLE
kurtosis-devnet: allow specifying a custom package

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -71,7 +71,7 @@ op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target"
 KURTOSIS_PACKAGE := "github.com/ethpandaops/optimism-package"
 
 # Devnet template recipe
-devnet TEMPLATE_FILE DATA_FILE="" NAME="":
+devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE:
     #!/usr/bin/env bash
     export DEVNET_NAME={{NAME}}
     if [ -z "{{NAME}}" ]; then
@@ -82,7 +82,7 @@ devnet TEMPLATE_FILE DATA_FILE="" NAME="":
         fi
     fi
     export ENCL_NAME="$DEVNET_NAME"-devnet
-    go run cmd/main.go -kurtosis-package {{KURTOSIS_PACKAGE}} \
+    go run cmd/main.go -kurtosis-package {{PACKAGE}} \
         -environment "tests/$ENCL_NAME.json" \
         -template "{{TEMPLATE_FILE}}" \
         -data "{{DATA_FILE}}" \


### PR DESCRIPTION
This PR adds a `PACKAGE` parameter to the `devnet` recipe, if not specified, it's compatible with the old behavior as the default value is `KURTOSIS_PACKAGE`.