### PR TITLE
devnet-sdk: Plugin op-service ethclient

### DIFF
--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -52,14 +54,15 @@ type Node interface {
 	GasPrice(ctx context.Context) (*big.Int, error)
 	GasLimit(ctx context.Context, tx TransactionData) (uint64, error)
 	PendingNonceAt(ctx context.Context, address common.Address) (uint64, error)
-	BlockByNumber(ctx context.Context, number *big.Int) (*coreTypes.Block, error)
+	BlockByNumber(ctx context.Context, number *big.Int) (eth.BlockInfo, error)
 }
 
 // LowLevelChain is a Chain that gives direct access to the low level RPC client.
 type LowLevelChain interface {
 	Chain
 	RPCURL() string
-	Client() (*ethclient.Client, error)
+	Client() (*sources.EthClient, error)
+	GethClient() (*ethclient.Client, error)
 }
 
 // Wallet represents a chain wallet.

--- a/devnet-sdk/system/node.go
+++ b/devnet-sdk/system/node.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	coreTypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
@@ -61,10 +61,19 @@ func (n *node) PendingNonceAt(ctx context.Context, address common.Address) (uint
 	return client.PendingNonceAt(ctx, address)
 }
 
-func (n *node) BlockByNumber(ctx context.Context, number *big.Int) (*coreTypes.Block, error) {
+func (n *node) BlockByNumber(ctx context.Context, number *big.Int) (eth.BlockInfo, error) {
 	client, err := n.clients.Client(n.rpcUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
-	return client.BlockByNumber(ctx, number)
+	var block eth.BlockInfo
+	if number != nil {
+		block, err = client.InfoByNumber(ctx, number.Uint64())
+	} else {
+		block, err = client.InfoByLabel(ctx, eth.Unsafe)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return block, nil
 }

--- a/devnet-sdk/system/txbuilder_test.go
+++ b/devnet-sdk/system/txbuilder_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -104,9 +105,9 @@ func (m *mockChain) RPCURL() string {
 	return args.String(0)
 }
 
-func (m *mockChain) Client() (*ethclient.Client, error) {
+func (m *mockChain) Client() (*sources.EthClient, error) {
 	args := m.Called()
-	return args.Get(0).(*ethclient.Client), nil
+	return args.Get(0).(*sources.EthClient), nil
 }
 
 func (m *mockChain) Wallets(ctx context.Context) ([]Wallet, error) {
@@ -145,9 +146,9 @@ func (m *mockNode) PendingNonceAt(ctx context.Context, addr common.Address) (uin
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *mockNode) BlockByNumber(ctx context.Context, number *big.Int) (*ethtypes.Block, error) {
+func (m *mockNode) BlockByNumber(ctx context.Context, number *big.Int) (eth.BlockInfo, error) {
 	args := m.Called(ctx, number)
-	return args.Get(0).(*ethtypes.Block), args.Error(1)
+	return args.Get(0).(eth.BlockInfo), args.Error(1)
 }
 
 func TestNewTxBuilder(t *testing.T) {

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
@@ -82,7 +83,8 @@ type mockChain struct{}
 
 func (m *mockChain) Node() system.Node                               { return nil }
 func (m *mockChain) RPCURL() string                                  { return "http://localhost:8545" }
-func (m *mockChain) Client() (*ethclient.Client, error)              { return ethclient.Dial(m.RPCURL()) }
+func (m *mockChain) Client() (*sources.EthClient, error)             { return nil, nil }
+func (m *mockChain) GethClient() (*ethclient.Client, error)          { return nil, nil }
 func (m *mockChain) ID() types.ChainID                               { return types.ChainID(big.NewInt(1)) }
 func (m *mockChain) ContractsRegistry() interfaces.ContractsRegistry { return nil }
 func (m *mockChain) Wallets(ctx context.Context) ([]system.Wallet, error) {

--- a/op-acceptance-tests/tests/ecotone/fees_test.go
+++ b/op-acceptance-tests/tests/ecotone/fees_test.go
@@ -99,7 +99,7 @@ func feesTestScenario(
 
 		// Get the L2 client
 		l2Chain := llsys.L2s()[chainIdx]
-		l2Client, err := l2Chain.Client()
+		l2Client, err := l2Chain.GethClient()
 		require.NoError(t, err)
 
 		// TODO: Wait for first block after genesis

--- a/op-acceptance-tests/tests/fjord/check_scripts_test.go
+++ b/op-acceptance-tests/tests/fjord/check_scripts_test.go
@@ -50,7 +50,7 @@ func checkFjordScriptScenario(lowLevelSystemGetter validators.LowLevelSystemGett
 		chainConfig := chainConfigGetter(t.Context())
 
 		l2 := sys.L2s()[chainIndex]
-		l2LowLevelClient, err := llsys.L2s()[chainIndex].Client()
+		l2LowLevelClient, err := llsys.L2s()[chainIndex].GethClient()
 		require.NoError(t, err)
 
 		// Get the wallet's private key and address
@@ -67,7 +67,7 @@ func checkFjordScriptScenario(lowLevelSystemGetter validators.LowLevelSystemGett
 
 		block, err := l2.Node().BlockByNumber(t.Context(), nil)
 		require.NoError(t, err)
-		time := block.Header().Time
+		time := block.Time()
 
 		isFjordActivated, err := validators.IsForkActivated(chainConfig, rollup.Fjord, time)
 		require.NoError(t, err)

--- a/op-acceptance-tests/tests/fjord/fees_test.go
+++ b/op-acceptance-tests/tests/fjord/fees_test.go
@@ -98,7 +98,7 @@ func feesTestScenario(
 
 		// Get the L2 client
 		l2Chain := llsys.L2s()[chainIdx]
-		l2Client, err := l2Chain.Client()
+		l2Client, err := l2Chain.GethClient()
 		require.NoError(t, err)
 
 		// TODO: Wait for first block after genesis

--- a/op-acceptance-tests/tests/isthmus/erc20_bridge_test.go
+++ b/op-acceptance-tests/tests/isthmus/erc20_bridge_test.go
@@ -62,11 +62,11 @@ func erc20BridgeTestScenario(lowLevelSystemGetter validators.LowLevelSystemGette
 		logger.Info("Started ERC20 bridge test")
 
 		// Connect to L1 and L2
-		l1Client, err := l1Chain.Client()
+		l1Client, err := l1Chain.GethClient()
 		require.NoError(t, err)
 		t.Cleanup(func() { l1Client.Close() })
 
-		l2Client, err := l2Chain.Client()
+		l2Client, err := l2Chain.GethClient()
 		require.NoError(t, err)
 		t.Cleanup(func() { l2Client.Close() })
 

--- a/op-acceptance-tests/tests/isthmus/fees_test.go
+++ b/op-acceptance-tests/tests/isthmus/fees_test.go
@@ -96,7 +96,7 @@ func feesTestScenario(
 
 		// Get the L2 client
 		l2Chain := llsys.L2s()[chainIdx]
-		l2Client, err := l2Chain.Client()
+		l2Client, err := l2Chain.GethClient()
 		require.NoError(t, err)
 
 		// TODO: Wait for first block after genesis

--- a/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
+++ b/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
@@ -49,7 +49,7 @@ func withdrawalRootTestScenario(chainIdx uint64, walletGetter validators.WalletG
 
 		llsys := llsysGetter(ctx)
 		chain := llsys.L2s()[chainIdx]
-		gethCl, err := chain.Client()
+		gethCl, err := chain.GethClient()
 		require.NoError(t, err)
 
 		logger := testlog.Logger(t, log.LevelInfo)

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -537,3 +537,15 @@ func (s *EthClient) PendingNonceAt(ctx context.Context, account common.Address) 
 	err := s.client.CallContext(ctx, &result, "eth_getTransactionCount", account, "pending")
 	return uint64(result), err
 }
+
+// BalanceAt returns the wei balance of the given account.
+func (s *EthClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	var result hexutil.Big
+	var err error
+	if blockNumber != nil {
+		err = s.client.CallContext(ctx, &result, "eth_getBalance", account, blockNumber)
+	} else {
+		err = s.client.CallContext(ctx, &result, "eth_getBalance", account, "latest")
+	}
+	return (*big.Int)(&result), err
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

An attempt to plug in op-service's `source.EthClient` to the devnet-sdk. We let both `ethclient.Client` and `source.EthClient` stay in the devnet sdk's Chain interface, and gradually remove usage of `ethclient.Client`. Currently interacting with the contract requires raw `ethclient.Client` usage so leave as is.

If you want to add more methods, add it to `sources.EthClient`.

However, there is a place that we need to use the low level `ethclient.Client`. Expose it as well

**Tests**

All existing devnet sdk interop/isthmus tests are passing

**Additional context**

sources.EthClient is good. It wraps around client.RPC interface, which we have more control over for instrumentation, dial strategy, lazy-dial, etc.

More op-service's ethclient methods will be added. Example in this PR and https://github.com/ethereum-optimism/optimism/pull/14747.
