### PR TITLE
Remove reference to TODO #11693

### DIFF
--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -36,8 +36,6 @@ type CrossSafeDeps interface {
 
 func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) error {
 	logger.Debug("Cross-safe update call")
-	// TODO(#11693): establish L1 reorg-lock of scopeDerivedFrom
-	// defer unlock once we are done checking the chain
 	candidate, err := scopedCrossSafeUpdate(logger, chainID, d)
 	if err == nil {
 		// if we made progress, and no errors, then there is no need to bump the L1 scope yet.

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -50,9 +50,6 @@ func CrossUnsafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps
 
 	hazards, err := CrossUnsafeHazards(d, logger, chainID, candidate)
 	if err != nil {
-		// TODO(#11693): reorgs can be detected by checking if the error is ErrConflict,
-		// missing data is identified by ErrFuture,
-		// and other errors (e.g. DB issues) are identifier by remaining error kinds.
 		return fmt.Errorf("failed to check for cross-chain hazards: %w", err)
 	}
 


### PR DESCRIPTION
[Issue 11693](https://github.com/ethereum-optimism/optimism/issues/11693) was an old high level task describing the basic requirement for reorg support in the Supervisor.

During pre-reorg development of the supervisor, TODOs were created in areas which we knew wouldn't behave correctly without reorg support. However, as reorg support was added, these TODOs were left behind.

To address each removal individually:

- "establish L1 reorg-lock of scopeDerivedFrom...": This is suggesting that the database should be locked during a CrossSafeUpdate so that we don't try to process data when the database is being reorg'd. This isn't really a problem because the Supervisor now uses an event-driven system, so reorg events will be handled serially with other update events.
- "reorgs can be detected by checking if the error is ErrConflict...": this is indeed happening at higher scopes, but isn't really needed to be considered at all during unsafe updates, as invalidation and other reorg cases are handled elsewhere.

For the last two, I *do* see an opportunity for improvement, but it's not reorg specific:
- "make cross-unsafe reorg safe": The function `IsCrossUnsafe` would appear to tell you if a given block is Cross Unsafe or not. But what it *really* does is compare your given `block.Number` to the current `crossUnsafe.Number`.
- "make parent-lookup reorg safe": similarly, providing a block to this function makes it appear like the block to be returned is the parent of the given one. However what *really* happens is only the `block.Number` is consulted, and you get whatever is stored at `block.Number-1`

To call these last two "reorg support" would be misleading, so I'll say that these functions need to **Validate Consistency**. I have created [this issue](https://github.com/ethereum-optimism/optimism/issues/14765) to track it.