### PR TITLE
Add consistency checks in ChainsDB Queries

### DIFF
--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -309,8 +309,8 @@ func (d *consolidateCheckDeps) IsLocalUnsafe(chainID eth.ChainID, block eth.Bloc
 	return nil
 }
 
-func (d *consolidateCheckDeps) ParentBlock(chainID eth.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error) {
-	block, err := d.CanonBlockByNumber(d.oracle, parentOf.Number-1, chainID)
+func (d *consolidateCheckDeps) FindBlockID(chainID eth.ChainID, num uint64) (blockID eth.BlockID, err error) {
+	block, err := d.CanonBlockByNumber(d.oracle, num, chainID)
 	if err != nil {
 		return eth.BlockID{}, err
 	}

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
@@ -10,7 +10,7 @@ import (
 )
 
 type UnsafeFrontierCheckDeps interface {
-	ParentBlock(chainID eth.ChainID, parentOf eth.BlockID) (parent eth.BlockID, err error)
+	FindBlockID(chainID eth.ChainID, blockNum uint64) (eth.BlockID, error)
 
 	IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error
 	IsLocalUnsafe(chainID eth.ChainID, block eth.BlockID) error
@@ -46,7 +46,7 @@ func HazardUnsafeFrontierChecks(d UnsafeFrontierCheckDeps, hazards *HazardSet) e
 				// If it doesn't have a parent block, then there is no prior block required to be cross-safe
 				if hazardBlock.Number > 0 {
 					// Check that parent of hazardBlockID is cross-safe within view
-					parent, err := d.ParentBlock(hazardChainID, hazardBlock.ID())
+					parent, err := d.FindBlockID(hazardChainID, hazardBlock.Number-1)
 					if err != nil {
 						return fmt.Errorf("failed to retrieve parent-block of hazard block %s (chain %s): %w", hazardBlock, hazardChainID, err)
 					}

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
@@ -68,7 +68,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3}}
 		ufcd.isCrossUnsafe = types.ErrFuture
-		ufcd.parentBlockFn = func() (parent eth.BlockID, err error) {
+		ufcd.findBlockIDFn = func() (parent eth.BlockID, err error) {
 			return eth.BlockID{}, errors.New("some error")
 		}
 		// when there is one hazard, and IsCrossUnsafe returns an ErrFuture,
@@ -81,7 +81,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
 		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3}}
 		ufcd.isCrossUnsafe = types.ErrFuture
-		ufcd.parentBlockFn = func() (parent eth.BlockID, err error) {
+		ufcd.findBlockIDFn = func() (parent eth.BlockID, err error) {
 			// when getting the parent block, prep isCrossSafe to be err
 			ufcd.isCrossUnsafe = errors.New("not cross unsafe!")
 			return eth.BlockID{}, nil
@@ -105,7 +105,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 
 type mockUnsafeFrontierCheckDeps struct {
 	deps          mockDependencySet
-	parentBlockFn func() (parent eth.BlockID, err error)
+	findBlockIDFn func() (parent eth.BlockID, err error)
 	isCrossUnsafe error
 	isLocalUnsafe error
 }
@@ -114,9 +114,9 @@ func (m *mockUnsafeFrontierCheckDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockUnsafeFrontierCheckDeps) ParentBlock(chainID eth.ChainID, block eth.BlockID) (parent eth.BlockID, err error) {
-	if m.parentBlockFn != nil {
-		return m.parentBlockFn()
+func (m *mockUnsafeFrontierCheckDeps) FindBlockID(chainID eth.ChainID, num uint64) (parent eth.BlockID, err error) {
+	if m.findBlockIDFn != nil {
+		return m.findBlockIDFn()
 	}
 	return eth.BlockID{}, nil
 }

--- a/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
@@ -240,6 +240,6 @@ func (m *mockCrossUnsafeDeps) IsLocalUnsafe(chainID eth.ChainID, blockNum eth.Bl
 	return nil
 }
 
-func (m *mockCrossUnsafeDeps) ParentBlock(chainID eth.ChainID, blockNum eth.BlockID) (eth.BlockID, error) {
+func (m *mockCrossUnsafeDeps) FindBlockID(chainID eth.ChainID, num uint64) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
 }


### PR DESCRIPTION
Two issues were identified in an old TODO, and are now resolved:

### IsCrossUnsafe

`IsCrossUnsafe` wasn't actually checking if a given block was valid at all! It was just checking that the provided `block.Number` was behind the current `crossUnsafe.Number`.

This is fixed by way of checking the log database before returning.

### ParentBlock

`ParentBlock` wasn't actually returning the given block's parent at all! It was just taking the given `block.Number` and looking up the block at `Number - 1`.

Because this function was **only** used in hazard checks, and already had guard-rails in place to prevent getting the parent of Block 0, I replaced this function with `FindBlockID`, which wraps `FindSealedBlock`. Now the caller asks for the given block number directly.

This also meant I needed to change the `op-program` logic, which I have done in the same way.