### PR TITLE
interop: hash example

### DIFF
--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"encoding/binary"
 	"encoding/json"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"testing"
 
@@ -37,4 +39,43 @@ func FuzzRoundtripIdentifierJSONMarshal(f *testing.F) {
 		require.Equal(t, id.Timestamp, dec.Timestamp)
 		require.Equal(t, id.ChainID, dec.ChainID)
 	})
+}
+
+func TestHashing(t *testing.T) {
+	keccak256 := func(name string, parts ...[]byte) (h common.Hash) {
+		t.Logf("%s = H(", name)
+		for _, p := range parts {
+			t.Logf("  %x,", p)
+		}
+		t.Logf(")")
+		h = crypto.Keccak256Hash(parts...)
+		t.Logf("%s = %s", name, h)
+		return h
+	}
+	id := Identifier{
+		Origin:      common.Address{},
+		BlockNumber: 0xa1a2_a3a4_a5a6_a7a8,
+		LogIndex:    0xb1b2_b3b4,
+		Timestamp:   0xc1c2_c3c4_c5c6_c7c8,
+		ChainID:     eth.ChainIDFromUInt64(0xd1d2_d3d4_d5d6_d7d8),
+	}
+	payloadHash := keccak256("payloadHash", []byte("example payload")) // aka msgHash
+	logHash := keccak256("logHash", id.Origin[:], payloadHash[:])
+	x := PayloadHashToLogHash(payloadHash, id.Origin)
+	require.Equal(t, logHash, x, "check op-supervisor version of log-hashing matches intermediate value")
+
+	var idPacked []byte
+	idPacked = append(idPacked, make([]byte, 12)...)
+	idPacked = binary.BigEndian.AppendUint64(idPacked, id.BlockNumber)
+	idPacked = binary.BigEndian.AppendUint64(idPacked, id.Timestamp)
+	idPacked = binary.BigEndian.AppendUint32(idPacked, id.LogIndex)
+	t.Logf("idPacked: %x", idPacked)
+
+	idLogHash := keccak256("idLogHash", logHash[:], idPacked)
+	chainID := id.ChainID.Bytes32()
+	bareChecksum := keccak256("bareChecksum", idLogHash[:], chainID[:])
+
+	checksum := bareChecksum
+	checksum[0] = 0x03
+	t.Logf("Checksum: %s", checksum)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Example, to hash the access-list entry into a checksum, formatted as the spec in https://github.com/ethereum-optimism/specs/pull/612 

Output:
```
payloadHash = H(
  6578616d706c65207061796c6f6164,
)
payloadHash = 0x8017559a85b12c04b14a1a425d53486d1015f833714a09bd62f04152a7e2ae9b
logHash = H(
  0000000000000000000000000000000000000000,
  8017559a85b12c04b14a1a425d53486d1015f833714a09bd62f04152a7e2ae9b,
)
logHash = 0xfa35a6fe1dcc034ef6b7440a61011451828964643b58ebcb5f3658e2b630edeb
idPacked: 000000000000000000000000a1a2a3a4a5a6a7a8c1c2c3c4c5c6c7c8b1b2b3b4
idLogHash = H(
  fa35a6fe1dcc034ef6b7440a61011451828964643b58ebcb5f3658e2b630edeb,
  000000000000000000000000a1a2a3a4a5a6a7a8c1c2c3c4c5c6c7c8b1b2b3b4,
)
idLogHash = 0x0cb2888b92be9029ab1c5a2af1d99fc92fe28d0ab924bfae7e138e15f382c6c9
bareChecksum = H(
  0cb2888b92be9029ab1c5a2af1d99fc92fe28d0ab924bfae7e138e15f382c6c9,
  000000000000000000000000000000000000000000000000d1d2d3d4d5d6d7d8,
)
bareChecksum = 0xdf139ddd21106abad4bb82800fedfa3a103f53f242c2d5b7615b0baad8379531
Checksum: 0x03139ddd21106abad4bb82800fedfa3a103f53f242c2d5b7615b0baad8379531
```