### PR TITLE
chore: Show target directory when an error occurs in op-deployer artifact download

### DIFF
--- a/op-deployer/pkg/deployer/artifacts/download.go
+++ b/op-deployer/pkg/deployer/artifacts/download.go
@@ -112,7 +112,7 @@ func (d *HTTPDownloader) Download(ctx context.Context, url string, progress Down
 	defer res.Body.Close()
 
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return "", fmt.Errorf("failed to ensure cache directory: %w", err)
+		return "", fmt.Errorf("failed to ensure cache directory '%s': %w", targetDir, err)
 	}
 	tmpFile, err := os.CreateTemp(targetDir, "op-deployer-artifacts-*")
 	if err != nil {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

To help debug issues with `op-deployer` cached downloads, target directory has been added to the error message