### PR TITLE
op-e2e: add interop messaging dsl

### DIFF
--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -285,3 +285,16 @@ func (d *InteropDSL) AdvanceL1(optionalArgs ...func(*AdvanceL1Opts)) {
 		require.Equalf(d.t, newBlock, status.CurrentL1, "Chain %v did not process new L1 head", chain.ChainID)
 	}
 }
+
+// DeployEmitterContracts deploys an emitter contract on both chains
+func (d *InteropDSL) DeployEmitterContracts() *EmitterContract {
+	emitter := NewEmitterContract(d.t)
+	alice := d.CreateUser()
+	d.AddL2Block(d.Actors.ChainA, WithL2BlockTransactions(
+		emitter.Deploy(alice),
+	))
+	d.AddL2Block(d.Actors.ChainB, WithL2BlockTransactions(
+		emitter.Deploy(alice),
+	))
+	return emitter
+}

--- a/op-e2e/actions/interop/dsl/message.go
+++ b/op-e2e/actions/interop/dsl/message.go
@@ -1,0 +1,73 @@
+package dsl
+
+import (
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/interop/contracts/bindings/inbox"
+	"github.com/stretchr/testify/require"
+)
+
+type Message struct {
+	t       helpers.Testing
+	user    *DSLUser
+	chain   *Chain
+	message string
+	emitter *EmitterContract
+	inbox   *InboxContract
+
+	initTx *GeneratedTransaction
+	execTx *GeneratedTransaction
+}
+
+func NewMessage(dsl *InteropDSL, chain *Chain, emitter *EmitterContract, message string) *Message {
+	return &Message{
+		t:       dsl.t,
+		user:    dsl.CreateUser(),
+		chain:   chain,
+		emitter: emitter,
+		inbox:   dsl.InboxContract,
+		message: message,
+	}
+}
+
+func (m *Message) Emit() *Message {
+	emitAction := m.emitter.EmitMessage(m.user, m.message)
+	m.initTx = emitAction(m.chain)
+	m.initTx.IncludeOK()
+	return m
+}
+
+func (m *Message) ExecuteOn(target *Chain, execOpts ...func(*ExecuteOpts)) *Message {
+	require.NotNil(m.t, m.initTx, "message must be emitted before it can be executed")
+	execAction := m.inbox.Execute(m.user, m.initTx, execOpts...)
+	m.execTx = execAction(target)
+	m.execTx.IncludeOK()
+	return m
+}
+
+func (m *Message) CheckEmitted() {
+	require.NotNil(m.t, m.initTx, "message must be emitted before it can be checked")
+	m.initTx.CheckIncluded()
+}
+
+func (m *Message) CheckNotEmitted() {
+	require.NotNil(m.t, m.initTx, "message must be emitted before it can be checked")
+	m.initTx.CheckNotIncluded()
+}
+
+func (m *Message) CheckNotExecuted() {
+	require.NotNil(m.t, m.execTx, "message must be executed before it can be checked")
+	m.execTx.CheckNotIncluded()
+}
+
+func (m *Message) CheckExecuted() {
+	require.NotNil(m.t, m.execTx, "message must be executed before it can be checked")
+	m.execTx.CheckIncluded()
+}
+
+func (m *Message) ExecutePayload() []byte {
+	return m.execTx.MessagePayload()
+}
+
+func (m *Message) ExecuteIdentifier() inbox.Identifier {
+	return m.execTx.Identifier()
+}


### PR DESCRIPTION
Simplify messaging in intra-block tests using dsl helpers.

Also add a couple intra-block tests covering messaging within the same chain.

part of [#14479](https://github.com/ethereum-optimism/optimism/issues/14479)