### PR TITLE
op-challenger: Spike to demonstrate a possibly better way to handle different contract versions

### DIFF
--- a/op-challenger/game/fault/contracts/capturing.go
+++ b/op-challenger/game/fault/contracts/capturing.go
@@ -1,0 +1,32 @@
+package contracts
+
+import "github.com/ethereum-optimism/optimism/op-service/sources/batching"
+
+func newCapturingCall(call batching.Call, callback func(result *batching.CallResult) error) batching.Call {
+	return &resultCapturingCall{
+		call:     call,
+		callback: callback,
+	}
+}
+
+type resultCapturingCall struct {
+	call     batching.Call
+	callback func(result *batching.CallResult) error
+}
+
+func (c *resultCapturingCall) ToBatchElemCreator() (batching.BatchElementCreator, error) {
+	return c.call.ToBatchElemCreator()
+}
+
+func (c *resultCapturingCall) HandleResult(result interface{}) (*batching.CallResult, error) {
+	callResult, err := c.call.HandleResult(result)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.callback(callResult); err != nil {
+		return nil, err
+	}
+	return callResult, nil
+}
+
+var _ batching.Call = (*resultCapturingCall)(nil)

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -86,8 +86,13 @@ type faultDisputeGameOps struct {
 	GetMaxClockDuration        func(contract *batching.BoundContract) GetterContractOp[uint64]
 	GetL2BlockNumberChallenged func(contract *batching.BoundContract) GetterContractOp[bool]
 	GetL2BlockNumberChallenger func(contract *batching.BoundContract) GetterContractOp[common.Address]
+	GetBondDistributionMode    func(contract *batching.BoundContract) GetterContractOp[types.BondDistributionMode]
+	IsResolved                 func(contract *batching.BoundContract, claims ...types.Claim) GetterContractOp[[]bool]
 
-	ChallengeL2BlockNumberTx func(contract *batching.BoundContract, challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error)
+	ChallengeL2BlockNumberTx func(contract *batching.BoundContract, challenge *types.InvalidL2BlockNumberChallenge) (*batching.ContractCall, error)
+	ResolveClaimTx           func(contract *batching.BoundContract, claimIdx uint64) (*batching.ContractCall, error)
+	AttackTx                 func(contract *batching.BoundContract, parent types.Claim, pivot common.Hash) (*batching.ContractCall, error)
+	DefendTx                 func(contract *batching.BoundContract, parent types.Claim, pivot common.Hash) (*batching.ContractCall, error)
 }
 
 func latestFaultDisputeGameOps() *faultDisputeGameOps {
@@ -131,17 +136,41 @@ func latestFaultDisputeGameOps() *faultDisputeGameOps {
 				return result.GetAddress(0), nil
 			})
 		},
-		ChallengeL2BlockNumberTx: func(contract *batching.BoundContract, challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
+		GetBondDistributionMode: func(contract *batching.BoundContract) GetterContractOp[types.BondDistributionMode] {
+			return NewSimpleGetterOp(contract, methodBondDistributionMode, func(result *batching.CallResult) (types.BondDistributionMode, error) {
+				return types.BondDistributionMode(result.GetUint8(0)), nil
+			})
+		},
+		IsResolved: func(contract *batching.BoundContract, claims ...types.Claim) GetterContractOp[[]bool] {
+			args := make([]interface{}, len(claims))
+			for i, claim := range claims {
+				args[i] = big.NewInt(int64(claim.ContractIndex))
+			}
+			return NewMultiGetterOp(contract, methodResolvedSubgames, func(result *batching.CallResult, _ int) (bool, error) {
+				return result.GetBool(0), nil
+			}, args...)
+		},
+
+		ChallengeL2BlockNumberTx: func(contract *batching.BoundContract, challenge *types.InvalidL2BlockNumberChallenge) (*batching.ContractCall, error) {
 			headerRlp, err := rlp.EncodeToBytes(challenge.Header)
 			if err != nil {
-				return txmgr.TxCandidate{}, fmt.Errorf("failed to serialize header: %w", err)
+				return nil, fmt.Errorf("failed to serialize header: %w", err)
 			}
 			return contract.Call(methodChallengeRootL2Block, outputRootProof{
 				Version:                  challenge.Output.Version,
 				StateRoot:                challenge.Output.StateRoot,
 				MessagePasserStorageRoot: challenge.Output.WithdrawalStorageRoot,
 				LatestBlockhash:          challenge.Output.BlockRef.Hash,
-			}, headerRlp).ToTxCandidate()
+			}, headerRlp), nil
+		},
+		ResolveClaimTx: func(contract *batching.BoundContract, claimIdx uint64) (*batching.ContractCall, error) {
+			return contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx), maxChildChecks), nil
+		},
+		AttackTx: func(contract *batching.BoundContract, parent types.Claim, pivot common.Hash) (*batching.ContractCall, error) {
+			return contract.Call(methodAttack, parent.Value, big.NewInt(int64(parent.ContractIndex)), pivot), nil
+		},
+		DefendTx: func(contract *batching.BoundContract, parent types.Claim, pivot common.Hash) (*batching.ContractCall, error) {
+			return contract.Call(methodDefend, parent.Value, big.NewInt(int64(parent.ContractIndex)), pivot), nil
 		},
 	}
 }
@@ -166,82 +195,61 @@ func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.
 	var builder VersionedBuilder[FaultDisputeGameContract]
 	builder.AddVersion(0, 8, func() (FaultDisputeGameContract, error) {
 		legacyAbi := mustParseAbi(faultDisputeGameAbi020)
-		// Replace GetClaim with a version that also restores the original bond amount even for resolved claims.
-		// We could make these overrides reusable as well, since 0.8.0 typically has all the overrides from 0.18.0
-		// plus its unique changes. So we could start by applying the ops changes from 0.18.0 then only need to
-		// apply 0.8.0 specific changes here.
-		ops.GetClaim = func(contract *batching.BoundContract, idx uint64) GetterContractOp[types.Claim] {
-			getClaimOp := NewGetClaimOp(contract, idx)
-			fixBondOp := &FixBondOp{getClaimOp}
-			op := ChainOps(getClaimOp.Result, getClaimOp, fixBondOp)
-			return op
-		}
-		ops.GetMaxClockDuration = func(contract *batching.BoundContract) GetterContractOp[uint64] {
-			return NewSimpleGetterOp(contract, methodGameDuration, func(result *batching.CallResult) (uint64, error) {
-				return result.GetUint64(0) / 2, nil
-			})
-		}
-		ops.GetL2BlockNumberChallenged = func(contract *batching.BoundContract) GetterContractOp[bool] {
-			return NewStaticOp(false)
-		}
-		ops.GetL2BlockNumberChallenger = func(contract *batching.BoundContract) GetterContractOp[common.Address] {
-			return NewStaticOp(common.Address{})
-		}
+		v080Compatibility(ops)
 		// Note: If we made everything that needs to be overridden a ContractOp, we wouldn't need
 		// FaultDisputeGameContract080, we'd just use FaultDisputeGameContractLatest all the time.
 		// And we could potentially then remove the FaultDisputeGame interface as well, since the ops could be
 		// replaced with ones that return static results for mocking.
-		return &FaultDisputeGameContract080{
-			FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
-				metrics:     metrics,
-				multiCaller: caller,
-				contract:    batching.NewBoundContract(legacyAbi, addr),
-				ops:         ops,
-			},
+		return &FaultDisputeGameContractLatest{
+			metrics:     metrics,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(legacyAbi, addr),
+			ops:         ops,
 		}, nil
 	})
 	builder.AddVersion(0, 18, func() (FaultDisputeGameContract, error) {
 		legacyAbi := mustParseAbi(faultDisputeGameAbi0180)
-		return &FaultDisputeGameContract0180{
-			FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
-				metrics:     metrics,
-				multiCaller: caller,
-				contract:    batching.NewBoundContract(legacyAbi, addr),
-				ops:         ops,
-			},
+		distributionModeUnsupported(ops)
+		moveWithoutParentClaim(ops)
+		l2BlockNumberChallengeUnsupported(ops)
+		return &FaultDisputeGameContractLatest{
+			metrics:     metrics,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(legacyAbi, addr),
+			ops:         ops,
 		}, nil
 	})
 	builder.AddVersion(1, 0, func() (FaultDisputeGameContract, error) {
 		legacyAbi := mustParseAbi(faultDisputeGameAbi0180)
-		return &FaultDisputeGameContract0180{
-			FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
-				metrics:     metrics,
-				multiCaller: caller,
-				contract:    batching.NewBoundContract(legacyAbi, addr),
-				ops:         ops,
-			},
+		distributionModeUnsupported(ops)
+		moveWithoutParentClaim(ops)
+		l2BlockNumberChallengeUnsupported(ops)
+		return &FaultDisputeGameContractLatest{
+			metrics:     metrics,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(legacyAbi, addr),
+			ops:         ops,
 		}, nil
 	})
 	builder.AddVersion(1, 1, func() (FaultDisputeGameContract, error) {
 		legacyAbi := mustParseAbi(faultDisputeGameAbi111)
-		return &FaultDisputeGameContract111{
-			FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
-				metrics:     metrics,
-				multiCaller: caller,
-				contract:    batching.NewBoundContract(legacyAbi, addr),
-				ops:         ops,
-			},
+		distributionModeUnsupported(ops)
+		moveWithoutParentClaim(ops)
+		return &FaultDisputeGameContractLatest{
+			metrics:     metrics,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(legacyAbi, addr),
+			ops:         ops,
 		}, nil
 	})
 	v131Factory := func() (FaultDisputeGameContract, error) {
 		legacyAbi := mustParseAbi(faultDisputeGameAbi131)
-		return &FaultDisputeGameContract131{
-			FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
-				metrics:     metrics,
-				multiCaller: caller,
-				contract:    batching.NewBoundContract(legacyAbi, addr),
-				ops:         ops,
-			},
+		distributionModeUnsupported(ops)
+		return &FaultDisputeGameContractLatest{
+			metrics:     metrics,
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(legacyAbi, addr),
+			ops:         ops,
 		}, nil
 	}
 	// The ABI is equivalent between 1.2.x and 1.3.x - there were just changes to the constructor validation.
@@ -263,6 +271,28 @@ func mustParseAbi(json []byte) *abi.ABI {
 		panic(err)
 	}
 	return &loaded
+}
+
+func decodeClaim(result *batching.CallResult, contractIndex uint64) types.Claim {
+	parentIndex := result.GetUint32(0)
+	counteredBy := result.GetAddress(1)
+	claimant := result.GetAddress(2)
+	bond := result.GetBigInt(3)
+	claim := result.GetHash(4)
+	position := result.GetBigInt(5)
+	clock := result.GetBigInt(6)
+	return types.Claim{
+		ClaimData: types.ClaimData{
+			Value:    claim,
+			Position: types.NewPositionFromGIndex(position),
+			Bond:     bond,
+		},
+		CounteredBy:         counteredBy,
+		Claimant:            claimant,
+		Clock:               decodeClock(clock),
+		ContractIndex:       int(contractIndex),
+		ParentContractIndex: int(parentIndex),
+	}
 }
 
 // GetBalanceAndDelay returns the total amount of ETH controlled by this contract.
@@ -490,11 +520,11 @@ func (f *FaultDisputeGameContractLatest) GetOracle(ctx context.Context) (Preimag
 
 func (f *FaultDisputeGameContractLatest) GetMaxClockDuration(ctx context.Context) (time.Duration, error) {
 	defer f.metrics.StartContractRequest("GetMaxClockDuration")()
-	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodMaxClockDuration))
+	duration, err := ExecuteGetterOp(ctx, rpcblock.Latest, f.multiCaller, f.ops.GetMaxClockDuration(f.contract))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch max clock duration: %w", err)
 	}
-	return time.Duration(result.GetUint64(0)) * time.Second, nil
+	return time.Duration(duration) * time.Second, nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetMaxGameDepth(ctx context.Context) (types.Depth, error) {
@@ -554,41 +584,25 @@ func (f *FaultDisputeGameContractLatest) GetClaim(ctx context.Context, idx uint6
 
 func (f *FaultDisputeGameContractLatest) GetAllClaims(ctx context.Context, block rpcblock.Block) ([]types.Claim, error) {
 	defer f.metrics.StartContractRequest("GetAllClaims")()
-	results, err := batching.ReadArray(ctx, f.multiCaller, block, f.contract.Call(methodClaimCount), func(i *big.Int) *batching.ContractCall {
-		return f.contract.Call(methodClaim, i)
-	})
+	claims, err := ExecuteGetterOp(ctx, block, f.multiCaller,
+		NewGetArrayOp[types.Claim](f.contract, methodClaimCount, methodClaim, func(result *batching.CallResult, idx uint64) (types.Claim, error) {
+			return f.decodeClaim(result, int(idx)), nil
+		}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load claims: %w", err)
-	}
-
-	var claims []types.Claim
-	for idx, result := range results {
-		claims = append(claims, f.decodeClaim(result, idx))
 	}
 	return claims, nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (types.BondDistributionMode, error) {
-	result, err := f.multiCaller.SingleCall(ctx, block, f.contract.Call(methodBondDistributionMode))
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch bond mode: %w", err)
-	}
-	return types.BondDistributionMode(result.GetUint8(0)), nil
+	return ExecuteGetterOp(ctx, block, f.multiCaller, f.ops.GetBondDistributionMode(f.contract))
 }
 
 func (f *FaultDisputeGameContractLatest) IsResolved(ctx context.Context, block rpcblock.Block, claims ...types.Claim) ([]bool, error) {
 	defer f.metrics.StartContractRequest("IsResolved")()
-	calls := make([]batching.Call, 0, len(claims))
-	for _, claim := range claims {
-		calls = append(calls, f.contract.Call(methodResolvedSubgames, big.NewInt(int64(claim.ContractIndex))))
-	}
-	results, err := f.multiCaller.Call(ctx, block, calls...)
+	resolved, err := ExecuteGetterOp(ctx, block, f.multiCaller, f.ops.IsResolved(f.contract, claims...))
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve resolved subgames: %w", err)
-	}
-	resolved := make([]bool, 0, len(claims))
-	for _, result := range results {
-		resolved = append(resolved, result.GetBool(0))
 	}
 	return resolved, nil
 }
@@ -612,16 +626,26 @@ func (f *FaultDisputeGameContractLatest) IsL2BlockNumberChallenged(ctx context.C
 }
 
 func (f *FaultDisputeGameContractLatest) ChallengeL2BlockNumberTx(challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-	return f.ops.ChallengeL2BlockNumberTx(f.contract, challenge)
+	call, err := f.ops.ChallengeL2BlockNumberTx(f.contract, challenge)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
+	return call.ToTxCandidate()
 }
 
 func (f *FaultDisputeGameContractLatest) AttackTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodAttack, parent.Value, big.NewInt(int64(parent.ContractIndex)), pivot)
+	call, err := f.ops.AttackTx(f.contract, parent, pivot)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
 	return f.txWithBond(ctx, parent.Position.Attack(), call)
 }
 
 func (f *FaultDisputeGameContractLatest) DefendTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodDefend, parent.Value, big.NewInt(int64(parent.ContractIndex)), pivot)
+	call, err := f.ops.DefendTx(f.contract, parent, pivot)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
 	return f.txWithBond(ctx, parent.Position.Defend(), call)
 }
 
@@ -644,8 +668,11 @@ func (f *FaultDisputeGameContractLatest) StepTx(claimIdx uint64, isAttack bool, 
 
 func (f *FaultDisputeGameContractLatest) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
 	defer f.metrics.StartContractRequest("CallResolveClaim")()
-	call := f.resolveClaimCall(claimIdx)
-	_, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, call)
+	call, err := f.ops.ResolveClaimTx(f.contract, claimIdx)
+	if err != nil {
+		return err
+	}
+	_, err = f.multiCaller.SingleCall(ctx, rpcblock.Latest, call)
 	if err != nil {
 		return fmt.Errorf("failed to call resolve claim: %w", err)
 	}
@@ -653,12 +680,11 @@ func (f *FaultDisputeGameContractLatest) CallResolveClaim(ctx context.Context, c
 }
 
 func (f *FaultDisputeGameContractLatest) ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error) {
-	call := f.resolveClaimCall(claimIdx)
+	call, err := f.ops.ResolveClaimTx(f.contract, claimIdx)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
 	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContractLatest) resolveClaimCall(claimIdx uint64) *batching.ContractCall {
-	return f.contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx), maxChildChecks)
 }
 
 func (f *FaultDisputeGameContractLatest) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -65,6 +65,8 @@ type FaultDisputeGameContractLatest struct {
 	metrics     metrics.ContractMetricer
 	multiCaller *batching.MultiCaller
 	contract    *batching.BoundContract
+
+	ops *faultDisputeGameOps
 }
 
 // outputRootProof is designed to match the solidity OutputRootProof struct.
@@ -73,6 +75,84 @@ type outputRootProof struct {
 	StateRoot                [32]byte
 	MessagePasserStorageRoot [32]byte
 	LatestBlockhash          [32]byte
+}
+
+/*
+f.contract.Call(methodL1Head),
+f.contract.Call(methodL2BlockNumber),
+f.contract.Call(methodRootClaim),
+f.contract.Call(methodStatus),
+f.contract.Call(methodMaxClockDuration),
+f.contract.Call(methodL2BlockNumberChallenged),
+f.contract.Call(methodL2BlockNumberChallenger),
+*/
+type faultDisputeGameOps struct {
+	GetClaim                   func(contract *batching.BoundContract, idx uint64) GetterContractOp[types.Claim]
+	GetL1Head                  func(contract *batching.BoundContract) GetterContractOp[common.Hash]
+	GetL2SequenceNumber        func(contract *batching.BoundContract) GetterContractOp[uint64]
+	GetRootClaim               func(contract *batching.BoundContract) GetterContractOp[common.Hash]
+	GetStatus                  func(contract *batching.BoundContract) GetterContractOp[gameTypes.GameStatus]
+	GetMaxClockDuration        func(contract *batching.BoundContract) GetterContractOp[uint64]
+	GetL2BlockNumberChallenged func(contract *batching.BoundContract) GetterContractOp[bool]
+	GetL2BlockNumberChallenger func(contract *batching.BoundContract) GetterContractOp[common.Address]
+
+	ChallengeL2BlockNumberTx func(contract *batching.BoundContract, challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error)
+}
+
+func latestFaultDisputeGameOps() *faultDisputeGameOps {
+	return &faultDisputeGameOps{
+		GetClaim: func(contract *batching.BoundContract, idx uint64) GetterContractOp[types.Claim] {
+			return NewGetClaimOp(contract, idx)
+		},
+		GetL1Head: func(contract *batching.BoundContract) GetterContractOp[common.Hash] {
+			return NewSimpleGetterOp(contract, methodL1Head, func(result *batching.CallResult) (common.Hash, error) {
+				return result.GetHash(0), nil
+			})
+		},
+		GetL2SequenceNumber: func(contract *batching.BoundContract) GetterContractOp[uint64] {
+			return NewSimpleGetterOp(contract, methodL2BlockNumber, func(result *batching.CallResult) (uint64, error) {
+				return result.GetBigInt(0).Uint64(), nil
+			})
+		},
+		GetRootClaim: func(contract *batching.BoundContract) GetterContractOp[common.Hash] {
+			return NewSimpleGetterOp(contract, methodRootClaim, func(result *batching.CallResult) (common.Hash, error) {
+				return result.GetHash(0), nil
+			})
+		},
+		GetStatus: func(contract *batching.BoundContract) GetterContractOp[gameTypes.GameStatus] {
+			return NewSimpleGetterOp(contract, methodStatus, func(result *batching.CallResult) (gameTypes.GameStatus, error) {
+				statusCode := result.GetUint8(0)
+				return gameTypes.GameStatusFromUint8(statusCode)
+			})
+		},
+		GetMaxClockDuration: func(contract *batching.BoundContract) GetterContractOp[uint64] {
+			return NewSimpleGetterOp(contract, methodMaxClockDuration, func(result *batching.CallResult) (uint64, error) {
+				return result.GetUint64(0), nil
+			})
+		},
+		GetL2BlockNumberChallenged: func(contract *batching.BoundContract) GetterContractOp[bool] {
+			return NewSimpleGetterOp(contract, methodL2BlockNumberChallenged, func(result *batching.CallResult) (bool, error) {
+				return result.GetBool(0), nil
+			})
+		},
+		GetL2BlockNumberChallenger: func(contract *batching.BoundContract) GetterContractOp[common.Address] {
+			return NewSimpleGetterOp(contract, methodL2BlockNumberChallenger, func(result *batching.CallResult) (common.Address, error) {
+				return result.GetAddress(0), nil
+			})
+		},
+		ChallengeL2BlockNumberTx: func(contract *batching.BoundContract, challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
+			headerRlp, err := rlp.EncodeToBytes(challenge.Header)
+			if err != nil {
+				return txmgr.TxCandidate{}, fmt.Errorf("failed to serialize header: %w", err)
+			}
+			return contract.Call(methodChallengeRootL2Block, outputRootProof{
+				Version:                  challenge.Output.Version,
+				StateRoot:                challenge.Output.StateRoot,
+				MessagePasserStorageRoot: challenge.Output.WithdrawalStorageRoot,
+				LatestBlockhash:          challenge.Output.BlockRef.Hash,
+			}, headerRlp).ToTxCandidate()
+		},
+	}
 }
 
 func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
@@ -90,15 +170,42 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 
 func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
 	contractAbi := snapshots.LoadFaultDisputeGameABI()
+	ops := latestFaultDisputeGameOps()
 
 	var builder VersionedBuilder[FaultDisputeGameContract]
 	builder.AddVersion(0, 8, func() (FaultDisputeGameContract, error) {
 		legacyAbi := mustParseAbi(faultDisputeGameAbi020)
+		// Replace GetClaim with a version that also restores the original bond amount even for resolved claims.
+		// We could make these overrides reusable as well, since 0.8.0 typically has all the overrides from 0.18.0
+		// plus its unique changes. So we could start by applying the ops changes from 0.18.0 then only need to
+		// apply 0.8.0 specific changes here.
+		ops.GetClaim = func(contract *batching.BoundContract, idx uint64) GetterContractOp[types.Claim] {
+			getClaimOp := NewGetClaimOp(contract, idx)
+			fixBondOp := &FixBondOp{getClaimOp}
+			op := ChainOps(getClaimOp.Result, getClaimOp, fixBondOp)
+			return op
+		}
+		ops.GetMaxClockDuration = func(contract *batching.BoundContract) GetterContractOp[uint64] {
+			return NewSimpleGetterOp(contract, methodGameDuration, func(result *batching.CallResult) (uint64, error) {
+				return result.GetUint64(0) / 2, nil
+			})
+		}
+		ops.GetL2BlockNumberChallenged = func(contract *batching.BoundContract) GetterContractOp[bool] {
+			return NewStaticOp(false)
+		}
+		ops.GetL2BlockNumberChallenger = func(contract *batching.BoundContract) GetterContractOp[common.Address] {
+			return NewStaticOp(common.Address{})
+		}
+		// Note: If we made everything that needs to be overridden a ContractOp, we wouldn't need
+		// FaultDisputeGameContract080, we'd just use FaultDisputeGameContractLatest all the time.
+		// And we could potentially then remove the FaultDisputeGame interface as well, since the ops could be
+		// replaced with ones that return static results for mocking.
 		return &FaultDisputeGameContract080{
 			FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
 				metrics:     metrics,
 				multiCaller: caller,
 				contract:    batching.NewBoundContract(legacyAbi, addr),
+				ops:         ops,
 			},
 		}, nil
 	})
@@ -109,6 +216,7 @@ func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.
 				metrics:     metrics,
 				multiCaller: caller,
 				contract:    batching.NewBoundContract(legacyAbi, addr),
+				ops:         ops,
 			},
 		}, nil
 	})
@@ -119,6 +227,7 @@ func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.
 				metrics:     metrics,
 				multiCaller: caller,
 				contract:    batching.NewBoundContract(legacyAbi, addr),
+				ops:         ops,
 			},
 		}, nil
 	})
@@ -129,6 +238,7 @@ func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.
 				metrics:     metrics,
 				multiCaller: caller,
 				contract:    batching.NewBoundContract(legacyAbi, addr),
+				ops:         ops,
 			},
 		}, nil
 	})
@@ -139,6 +249,7 @@ func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.
 				metrics:     metrics,
 				multiCaller: caller,
 				contract:    batching.NewBoundContract(legacyAbi, addr),
+				ops:         ops,
 			},
 		}, nil
 	}
@@ -150,6 +261,7 @@ func NewPreInteropFaultDisputeGameContract(ctx context.Context, metrics metrics.
 			metrics:     metrics,
 			multiCaller: caller,
 			contract:    batching.NewBoundContract(contractAbi, addr),
+			ops:         ops,
 		}, nil
 	})
 }
@@ -211,39 +323,26 @@ type GameMetadata struct {
 // GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, max clock duration, and is l2 block number challenged.
 func (f *FaultDisputeGameContractLatest) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
 	defer f.metrics.StartContractRequest("GetGameMetadata")()
-	results, err := f.multiCaller.Call(ctx, block,
-		f.contract.Call(methodL1Head),
-		f.contract.Call(methodL2BlockNumber),
-		f.contract.Call(methodRootClaim),
-		f.contract.Call(methodStatus),
-		f.contract.Call(methodMaxClockDuration),
-		f.contract.Call(methodL2BlockNumberChallenged),
-		f.contract.Call(methodL2BlockNumberChallenger),
-	)
+	l1Head := f.ops.GetL1Head(f.contract)
+	l2BlockNumber := f.ops.GetL2SequenceNumber(f.contract)
+	rootClaim := f.ops.GetRootClaim(f.contract)
+	status := f.ops.GetStatus(f.contract)
+	maxClockDuration := f.ops.GetMaxClockDuration(f.contract)
+	l2BlockNumberChallenged := f.ops.GetL2BlockNumberChallenged(f.contract)
+	l2BlockNumberChallenger := f.ops.GetL2BlockNumberChallenger(f.contract)
+
+	err := ExecuteOps(ctx, block, f.multiCaller, l1Head, l2BlockNumber, rootClaim, status, maxClockDuration, l2BlockNumberChallenged, l2BlockNumberChallenger)
 	if err != nil {
 		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
 	}
-	if len(results) != 7 {
-		return GameMetadata{}, fmt.Errorf("expected 7 results but got %v", len(results))
-	}
-	l1Head := results[0].GetHash(0)
-	l2BlockNumber := results[1].GetBigInt(0).Uint64()
-	rootClaim := results[2].GetHash(0)
-	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
-	}
-	duration := results[4].GetUint64(0)
-	blockChallenged := results[5].GetBool(0)
-	blockChallenger := results[6].GetAddress(0)
 	return GameMetadata{
-		L1Head:                  l1Head,
-		L2BlockNum:              l2BlockNumber,
-		RootClaim:               rootClaim,
-		Status:                  status,
-		MaxClockDuration:        duration,
-		L2BlockNumberChallenged: blockChallenged,
-		L2BlockNumberChallenger: blockChallenger,
+		L1Head:                  l1Head.Result(),
+		L2BlockNum:              l2BlockNumber.Result(),
+		RootClaim:               rootClaim.Result(),
+		Status:                  status.Result(),
+		MaxClockDuration:        maxClockDuration.Result(),
+		L2BlockNumberChallenged: l2BlockNumberChallenged.Result(),
+		L2BlockNumberChallenger: l2BlockNumberChallenger.Result(),
 	}, nil
 }
 
@@ -454,11 +553,12 @@ func (f *FaultDisputeGameContractLatest) GetClaimCount(ctx context.Context) (uin
 
 func (f *FaultDisputeGameContractLatest) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
 	defer f.metrics.StartContractRequest("GetClaim")()
-	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodClaim, new(big.Int).SetUint64(idx)))
+	op := f.ops.GetClaim(f.contract, idx)
+	err := ExecuteOps(ctx, rpcblock.Latest, f.multiCaller, op)
 	if err != nil {
 		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
 	}
-	return f.decodeClaim(result, int(idx)), nil
+	return op.Result(), nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetAllClaims(ctx context.Context, block rpcblock.Block) ([]types.Claim, error) {
@@ -513,24 +613,15 @@ func (f *FaultDisputeGameContractLatest) Vm(ctx context.Context) (*VMContract, e
 
 func (f *FaultDisputeGameContractLatest) IsL2BlockNumberChallenged(ctx context.Context, block rpcblock.Block) (bool, error) {
 	defer f.metrics.StartContractRequest("IsL2BlockNumberChallenged")()
-	result, err := f.multiCaller.SingleCall(ctx, block, f.contract.Call(methodL2BlockNumberChallenged))
-	if err != nil {
+	op := f.ops.GetL2BlockNumberChallenged(f.contract)
+	if err := ExecuteOps(ctx, block, f.multiCaller, op); err != nil {
 		return false, fmt.Errorf("failed to fetch block number challenged: %w", err)
 	}
-	return result.GetBool(0), nil
+	return op.Result(), nil
 }
 
 func (f *FaultDisputeGameContractLatest) ChallengeL2BlockNumberTx(challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-	headerRlp, err := rlp.EncodeToBytes(challenge.Header)
-	if err != nil {
-		return txmgr.TxCandidate{}, fmt.Errorf("failed to serialize header: %w", err)
-	}
-	return f.contract.Call(methodChallengeRootL2Block, outputRootProof{
-		Version:                  challenge.Output.Version,
-		StateRoot:                challenge.Output.StateRoot,
-		MessagePasserStorageRoot: challenge.Output.WithdrawalStorageRoot,
-		LatestBlockhash:          challenge.Output.BlockRef.Hash,
-	}, headerRlp).ToTxCandidate()
+	return f.ops.ChallengeL2BlockNumberTx(f.contract, challenge)
 }
 
 func (f *FaultDisputeGameContractLatest) AttackTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -77,15 +77,6 @@ type outputRootProof struct {
 	LatestBlockhash          [32]byte
 }
 
-/*
-f.contract.Call(methodL1Head),
-f.contract.Call(methodL2BlockNumber),
-f.contract.Call(methodRootClaim),
-f.contract.Call(methodStatus),
-f.contract.Call(methodMaxClockDuration),
-f.contract.Call(methodL2BlockNumberChallenged),
-f.contract.Call(methodL2BlockNumberChallenger),
-*/
 type faultDisputeGameOps struct {
 	GetClaim                   func(contract *batching.BoundContract, idx uint64) GetterContractOp[types.Claim]
 	GetL1Head                  func(contract *batching.BoundContract) GetterContractOp[common.Hash]

--- a/op-challenger/game/fault/contracts/faultdisputegame0180.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame0180.go
@@ -1,77 +1,24 @@
 package contracts
 
 import (
-	"context"
 	_ "embed"
-	"fmt"
-	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
-	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 //go:embed abis/FaultDisputeGame-0.18.1.json
 var faultDisputeGameAbi0180 []byte
 
-type FaultDisputeGameContract0180 struct {
-	FaultDisputeGameContractLatest
-}
-
-// GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, and max clock duration.
-func (f *FaultDisputeGameContract0180) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
-	defer f.metrics.StartContractRequest("GetGameMetadata")()
-	results, err := f.multiCaller.Call(ctx, block,
-		f.contract.Call(methodL1Head),
-		f.contract.Call(methodL2BlockNumber),
-		f.contract.Call(methodRootClaim),
-		f.contract.Call(methodStatus),
-		f.contract.Call(methodMaxClockDuration),
-	)
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
+func l2BlockNumberChallengeUnsupported(ops *faultDisputeGameOps) {
+	ops.GetL2BlockNumberChallenged = func(contract *batching.BoundContract) GetterContractOp[bool] {
+		return NewStaticOp(false)
 	}
-	if len(results) != 5 {
-		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
+	ops.GetL2BlockNumberChallenger = func(contract *batching.BoundContract) GetterContractOp[common.Address] {
+		return NewStaticOp(common.Address{})
 	}
-	l1Head := results[0].GetHash(0)
-	l2BlockNumber := results[1].GetBigInt(0).Uint64()
-	rootClaim := results[2].GetHash(0)
-	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
+	ops.ChallengeL2BlockNumberTx = func(_ *batching.BoundContract, _ *types.InvalidL2BlockNumberChallenge) (*batching.ContractCall, error) {
+		return nil, ErrChallengeL2BlockNotSupported
 	}
-	duration := results[4].GetUint64(0)
-	return GameMetadata{
-		L1Head:                  l1Head,
-		L2BlockNum:              l2BlockNumber,
-		RootClaim:               rootClaim,
-		Status:                  status,
-		MaxClockDuration:        duration,
-		L2BlockNumberChallenged: false,
-	}, nil
-}
-
-func (f *FaultDisputeGameContract0180) IsL2BlockNumberChallenged(_ context.Context, _ rpcblock.Block) (bool, error) {
-	return false, nil
-}
-
-func (f *FaultDisputeGameContract0180) ChallengeL2BlockNumberTx(_ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-	return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
-}
-
-func (f *FaultDisputeGameContract0180) AttackTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodAttack, big.NewInt(int64(parent.ContractIndex)), pivot)
-	return f.txWithBond(ctx, parent.Position.Attack(), call)
-}
-
-func (f *FaultDisputeGameContract0180) DefendTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodDefend, big.NewInt(int64(parent.ContractIndex)), pivot)
-	return f.txWithBond(ctx, parent.Position.Defend(), call)
-}
-
-func (f *FaultDisputeGameContract0180) GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (types.BondDistributionMode, error) {
-	return types.LegacyDistributionMode, nil
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame080.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame080.go
@@ -1,17 +1,11 @@
 package contracts
 
 import (
-	"context"
 	_ "embed"
-	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
-	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 //go:embed abis/FaultDisputeGame-0.8.0.json
@@ -23,134 +17,33 @@ var (
 	methodGameDuration = "gameDuration"
 )
 
-type FaultDisputeGameContract080 struct {
-	FaultDisputeGameContractLatest
-}
-
-//// GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, and max clock duration.
-//func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
-//	defer f.metrics.StartContractRequest("GetGameMetadata")()
-//	results, err := f.multiCaller.Call(ctx, block,
-//		f.contract.Call(methodL1Head),
-//		f.contract.Call(methodL2BlockNumber),
-//		f.contract.Call(methodRootClaim),
-//		f.contract.Call(methodStatus),
-//		f.contract.Call(methodGameDuration))
-//	if err != nil {
-//		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
-//	}
-//	if len(results) != 5 {
-//		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
-//	}
-//	l1Head := results[0].GetHash(0)
-//	l2BlockNumber := results[1].GetBigInt(0).Uint64()
-//	rootClaim := results[2].GetHash(0)
-//	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
-//	if err != nil {
-//		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
-//	}
-//	duration := results[4].GetUint64(0)
-//	return GameMetadata{
-//		L1Head:                  l1Head,
-//		L2BlockNum:              l2BlockNumber,
-//		RootClaim:               rootClaim,
-//		Status:                  status,
-//		MaxClockDuration:        duration / 2,
-//		L2BlockNumberChallenged: false,
-//	}, nil
-//}
-
-func (f *FaultDisputeGameContract080) GetMaxClockDuration(ctx context.Context) (time.Duration, error) {
-	defer f.metrics.StartContractRequest("GetMaxClockDuration")()
-	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodGameDuration))
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
+func v080Compatibility(ops *faultDisputeGameOps) {
+	moveWithoutParentClaim(ops)
+	distributionModeUnsupported(ops)
+	l2BlockNumberChallengeUnsupported(ops)
+	// Replace GetClaim with a version that also restores the original bond amount even for resolved claims.
+	ops.GetClaim = func(contract *batching.BoundContract, idx uint64) GetterContractOp[types.Claim] {
+		getClaimOp := NewGetClaimOp(contract, idx)
+		fixBondOp := &FixBondOp{getClaimOp}
+		op := ChainOps(getClaimOp.Result, getClaimOp, fixBondOp)
+		return op
 	}
-	return time.Duration(result.GetUint64(0)) * time.Second / 2, nil
-}
-
-//func (f *FaultDisputeGameContract080) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
-//	defer f.metrics.StartContractRequest("GetClaim")()
-//	getClaimOp := NewGetClaimOp(f.contract, idx)
-//	err := ExecuteOps(ctx, rpcblock.Latest, f.multiCaller, ChainOps(getClaimOp, &FixBondOp{getClaimOp}))
-//	if err != nil {
-//		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
-//	}
-//	return getClaimOp.Claim, nil
-//}
-
-func (f *FaultDisputeGameContract080) GetAllClaims(ctx context.Context, block rpcblock.Block) ([]types.Claim, error) {
-	claims, err := f.FaultDisputeGameContractLatest.GetAllClaims(ctx, block)
-	if err != nil {
-		return nil, err
-	}
-	resolvedClaims := make([]*types.Claim, 0, len(claims))
-	positions := make([]*big.Int, 0, len(claims))
-	for i, claim := range claims {
-		if claim.Bond.Cmp(resolvedBondAmount) == 0 {
-			resolvedClaims = append(resolvedClaims, &claims[i])
-			positions = append(positions, claim.Position.ToGIndex())
+	ops.IsResolved = func(contract *batching.BoundContract, claims ...types.Claim) GetterContractOp[[]bool] {
+		args := make([]interface{}, len(claims))
+		for i, claim := range claims {
+			args[i] = big.NewInt(int64(claim.ContractIndex))
 		}
+		return NewMultiGetterOp(contract, methodClaim, func(result *batching.CallResult, idx int) (bool, error) {
+			claim := decodeClaim(result, uint64(idx))
+			return claim.Bond.Cmp(resolvedBondAmount) == 0, nil
+		}, args...)
 	}
-	bonds, err := f.GetRequiredBonds(ctx, block, positions...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get required bonds for resolved claims: %w", err)
+	ops.GetMaxClockDuration = func(contract *batching.BoundContract) GetterContractOp[uint64] {
+		return NewSimpleGetterOp(contract, methodGameDuration, func(result *batching.CallResult) (uint64, error) {
+			return result.GetUint64(0) / 2, nil
+		})
 	}
-	for i, bond := range bonds {
-		resolvedClaims[i].Bond = bond
+	ops.ResolveClaimTx = func(contract *batching.BoundContract, claimIdx uint64) (*batching.ContractCall, error) {
+		return contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx)), nil
 	}
-	return claims, nil
-}
-
-func (f *FaultDisputeGameContract080) IsResolved(ctx context.Context, block rpcblock.Block, claims ...types.Claim) ([]bool, error) {
-	rawClaims, err := f.FaultDisputeGameContractLatest.GetAllClaims(ctx, block)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get raw claim data: %w", err)
-	}
-	results := make([]bool, len(claims))
-	for i, claim := range claims {
-		results[i] = rawClaims[claim.ContractIndex].Bond.Cmp(resolvedBondAmount) == 0
-	}
-	return results, nil
-}
-
-func (f *FaultDisputeGameContract080) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
-	defer f.metrics.StartContractRequest("CallResolveClaim")()
-	call := f.resolveClaimCall(claimIdx)
-	_, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, call)
-	if err != nil {
-		return fmt.Errorf("failed to call resolve claim: %w", err)
-	}
-	return nil
-}
-
-func (f *FaultDisputeGameContract080) ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error) {
-	call := f.resolveClaimCall(claimIdx)
-	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContract080) resolveClaimCall(claimIdx uint64) *batching.ContractCall {
-	return f.contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx))
-}
-
-//func (f *FaultDisputeGameContract080) IsL2BlockNumberChallenged(_ context.Context, _ rpcblock.Block) (bool, error) {
-//	return false, nil
-//}
-
-func (f *FaultDisputeGameContract080) ChallengeL2BlockNumberTx(_ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-	return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
-}
-
-func (f *FaultDisputeGameContract080) AttackTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodAttack, big.NewInt(int64(parent.ContractIndex)), pivot)
-	return f.txWithBond(ctx, parent.Position.Attack(), call)
-}
-
-func (f *FaultDisputeGameContract080) DefendTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodDefend, big.NewInt(int64(parent.ContractIndex)), pivot)
-	return f.txWithBond(ctx, parent.Position.Defend(), call)
-}
-
-func (f *FaultDisputeGameContract080) GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (types.BondDistributionMode, error) {
-	return types.LegacyDistributionMode, nil
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame080.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame080.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -28,38 +27,38 @@ type FaultDisputeGameContract080 struct {
 	FaultDisputeGameContractLatest
 }
 
-// GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, and max clock duration.
-func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
-	defer f.metrics.StartContractRequest("GetGameMetadata")()
-	results, err := f.multiCaller.Call(ctx, block,
-		f.contract.Call(methodL1Head),
-		f.contract.Call(methodL2BlockNumber),
-		f.contract.Call(methodRootClaim),
-		f.contract.Call(methodStatus),
-		f.contract.Call(methodGameDuration))
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
-	}
-	if len(results) != 5 {
-		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
-	}
-	l1Head := results[0].GetHash(0)
-	l2BlockNumber := results[1].GetBigInt(0).Uint64()
-	rootClaim := results[2].GetHash(0)
-	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
-	}
-	duration := results[4].GetUint64(0)
-	return GameMetadata{
-		L1Head:                  l1Head,
-		L2BlockNum:              l2BlockNumber,
-		RootClaim:               rootClaim,
-		Status:                  status,
-		MaxClockDuration:        duration / 2,
-		L2BlockNumberChallenged: false,
-	}, nil
-}
+//// GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, and max clock duration.
+//func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
+//	defer f.metrics.StartContractRequest("GetGameMetadata")()
+//	results, err := f.multiCaller.Call(ctx, block,
+//		f.contract.Call(methodL1Head),
+//		f.contract.Call(methodL2BlockNumber),
+//		f.contract.Call(methodRootClaim),
+//		f.contract.Call(methodStatus),
+//		f.contract.Call(methodGameDuration))
+//	if err != nil {
+//		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
+//	}
+//	if len(results) != 5 {
+//		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
+//	}
+//	l1Head := results[0].GetHash(0)
+//	l2BlockNumber := results[1].GetBigInt(0).Uint64()
+//	rootClaim := results[2].GetHash(0)
+//	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
+//	if err != nil {
+//		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
+//	}
+//	duration := results[4].GetUint64(0)
+//	return GameMetadata{
+//		L1Head:                  l1Head,
+//		L2BlockNum:              l2BlockNumber,
+//		RootClaim:               rootClaim,
+//		Status:                  status,
+//		MaxClockDuration:        duration / 2,
+//		L2BlockNumberChallenged: false,
+//	}, nil
+//}
 
 func (f *FaultDisputeGameContract080) GetMaxClockDuration(ctx context.Context) (time.Duration, error) {
 	defer f.metrics.StartContractRequest("GetMaxClockDuration")()
@@ -70,21 +69,15 @@ func (f *FaultDisputeGameContract080) GetMaxClockDuration(ctx context.Context) (
 	return time.Duration(result.GetUint64(0)) * time.Second / 2, nil
 }
 
-func (f *FaultDisputeGameContract080) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
-	claim, err := f.FaultDisputeGameContractLatest.GetClaim(ctx, idx)
-	if err != nil {
-		return types.Claim{}, err
-	}
-	// Replace the resolved sentinel with what the bond would have been
-	if claim.Bond.Cmp(resolvedBondAmount) == 0 {
-		bond, err := f.GetRequiredBond(ctx, claim.Position)
-		if err != nil {
-			return types.Claim{}, err
-		}
-		claim.Bond = bond
-	}
-	return claim, nil
-}
+//func (f *FaultDisputeGameContract080) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
+//	defer f.metrics.StartContractRequest("GetClaim")()
+//	getClaimOp := NewGetClaimOp(f.contract, idx)
+//	err := ExecuteOps(ctx, rpcblock.Latest, f.multiCaller, ChainOps(getClaimOp, &FixBondOp{getClaimOp}))
+//	if err != nil {
+//		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
+//	}
+//	return getClaimOp.Claim, nil
+//}
 
 func (f *FaultDisputeGameContract080) GetAllClaims(ctx context.Context, block rpcblock.Block) ([]types.Claim, error) {
 	claims, err := f.FaultDisputeGameContractLatest.GetAllClaims(ctx, block)
@@ -140,9 +133,9 @@ func (f *FaultDisputeGameContract080) resolveClaimCall(claimIdx uint64) *batchin
 	return f.contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx))
 }
 
-func (f *FaultDisputeGameContract080) IsL2BlockNumberChallenged(_ context.Context, _ rpcblock.Block) (bool, error) {
-	return false, nil
-}
+//func (f *FaultDisputeGameContract080) IsL2BlockNumberChallenged(_ context.Context, _ rpcblock.Block) (bool, error) {
+//	return false, nil
+//}
 
 func (f *FaultDisputeGameContract080) ChallengeL2BlockNumberTx(_ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
 	return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported

--- a/op-challenger/game/fault/contracts/faultdisputegame111.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame111.go
@@ -1,33 +1,22 @@
 package contracts
 
 import (
-	"context"
 	_ "embed"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
-	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 //go:embed abis/FaultDisputeGame-1.1.1.json
 var faultDisputeGameAbi111 []byte
 
-type FaultDisputeGameContract111 struct {
-	FaultDisputeGameContractLatest
-}
-
-func (f *FaultDisputeGameContract111) AttackTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodAttack, big.NewInt(int64(parent.ContractIndex)), pivot)
-	return f.txWithBond(ctx, parent.Position.Attack(), call)
-}
-
-func (f *FaultDisputeGameContract111) DefendTx(ctx context.Context, parent types.Claim, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodDefend, big.NewInt(int64(parent.ContractIndex)), pivot)
-	return f.txWithBond(ctx, parent.Position.Defend(), call)
-}
-
-func (f *FaultDisputeGameContract111) GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (types.BondDistributionMode, error) {
-	return types.LegacyDistributionMode, nil
+func moveWithoutParentClaim(ops *faultDisputeGameOps) {
+	ops.AttackTx = func(contract *batching.BoundContract, parent types.Claim, pivot common.Hash) (*batching.ContractCall, error) {
+		return contract.Call(methodAttack, big.NewInt(int64(parent.ContractIndex)), pivot), nil
+	}
+	ops.DefendTx = func(contract *batching.BoundContract, parent types.Claim, pivot common.Hash) (*batching.ContractCall, error) {
+		return contract.Call(methodDefend, big.NewInt(int64(parent.ContractIndex)), pivot), nil
+	}
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame131.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame131.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 )
 
@@ -17,4 +18,10 @@ type FaultDisputeGameContract131 struct {
 
 func (f *FaultDisputeGameContract131) GetBondDistributionMode(ctx context.Context, block rpcblock.Block) (types.BondDistributionMode, error) {
 	return types.LegacyDistributionMode, nil
+}
+
+func distributionModeUnsupported(ops *faultDisputeGameOps) {
+	ops.GetBondDistributionMode = func(_ *batching.BoundContract) GetterContractOp[types.BondDistributionMode] {
+		return NewStaticOp(types.LegacyDistributionMode)
+	}
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -337,6 +337,43 @@ func TestGetClaim(t *testing.T) {
 	}
 }
 
+func TestGetResolvedClaim(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, game := setupFaultDisputeGameTest(t, version)
+			idx := big.NewInt(2)
+			parentIndex := uint32(1)
+			counteredBy := common.Address{0x01}
+			claimant := common.Address{0x02}
+			position := big.NewInt(2)
+			bond := big.NewInt(5)
+			contractBond := bond
+			if version.Is(vers080) {
+				contractBond = resolvedBondAmount
+				stubRpc.SetResponse(fdgAddr, methodRequiredBond, rpcblock.Latest, []interface{}{position}, []interface{}{bond})
+			}
+			value := common.Hash{0xab}
+			clock := big.NewInt(1234)
+			stubRpc.SetResponse(fdgAddr, methodClaim, rpcblock.Latest, []interface{}{idx}, []interface{}{parentIndex, counteredBy, claimant, contractBond, value, position, clock})
+			status, err := game.GetClaim(context.Background(), idx.Uint64())
+			require.NoError(t, err)
+			require.Equal(t, faultTypes.Claim{
+				ClaimData: faultTypes.ClaimData{
+					Value:    value,
+					Position: faultTypes.NewPositionFromGIndex(position),
+					Bond:     bond,
+				},
+				CounteredBy:         counteredBy,
+				Claimant:            claimant,
+				Clock:               decodeClock(big.NewInt(1234)),
+				ContractIndex:       int(idx.Uint64()),
+				ParentContractIndex: 1,
+			}, status)
+		})
+	}
+}
+
 func TestGetAllClaims(t *testing.T) {
 	for _, version := range versions {
 		version := version

--- a/op-challenger/game/fault/contracts/ops.go
+++ b/op-challenger/game/fault/contracts/ops.go
@@ -39,6 +39,15 @@ func ExecuteOps(ctx context.Context, block rpcblock.Block, caller *batching.Mult
 	}
 }
 
+func ExecuteGetterOp[Result any](ctx context.Context, block rpcblock.Block, caller *batching.MultiCaller, op GetterContractOp[Result]) (Result, error) {
+	err := ExecuteOps(ctx, block, caller, op)
+	if err != nil {
+		var noResult Result
+		return noResult, err
+	}
+	return op.Result(), nil
+}
+
 type GetClaimOp struct {
 	contract *batching.BoundContract
 	idx      uint64
@@ -59,7 +68,7 @@ func (o *GetClaimOp) NextCalls() ([]batching.Call, error) {
 	}
 	return []batching.Call{
 		newCapturingCall(o.contract.Call(methodClaim, big.NewInt(int64(o.idx))), func(result *batching.CallResult) error {
-			o.Claim = o.decodeClaim(result, o.idx)
+			o.Claim = decodeClaim(result, o.idx)
 			return nil
 		}),
 	}, nil
@@ -67,28 +76,6 @@ func (o *GetClaimOp) NextCalls() ([]batching.Call, error) {
 
 func (o *GetClaimOp) Result() types.Claim {
 	return o.Claim
-}
-
-func (o *GetClaimOp) decodeClaim(result *batching.CallResult, contractIndex uint64) types.Claim {
-	parentIndex := result.GetUint32(0)
-	counteredBy := result.GetAddress(1)
-	claimant := result.GetAddress(2)
-	bond := result.GetBigInt(3)
-	claim := result.GetHash(4)
-	position := result.GetBigInt(5)
-	clock := result.GetBigInt(6)
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    claim,
-			Position: types.NewPositionFromGIndex(position),
-			Bond:     bond,
-		},
-		CounteredBy:         counteredBy,
-		Claimant:            claimant,
-		Clock:               decodeClock(clock),
-		ContractIndex:       int(contractIndex),
-		ParentContractIndex: int(parentIndex),
-	}
 }
 
 var _ ContractOp = (*GetClaimOp)(nil)
@@ -112,6 +99,59 @@ func (o *FixBondOp) NextCalls() ([]batching.Call, error) {
 	}
 	// No further calls required
 	return nil, nil
+}
+
+type ContractArrayGetterOp[Item any] struct {
+	contract     *batching.BoundContract
+	lengthMethod string
+	getMethod    string
+	convert      func(result *batching.CallResult, idx uint64) (Item, error)
+
+	loadedLength bool
+	length       uint64
+	result       []Item
+}
+
+func NewGetArrayOp[Item any](contract *batching.BoundContract, lengthMethod string, getMethod string, convert func(result *batching.CallResult, idx uint64) (Item, error)) *ContractArrayGetterOp[Item] {
+	return &ContractArrayGetterOp[Item]{
+		contract:     contract,
+		lengthMethod: lengthMethod,
+		getMethod:    getMethod,
+		convert:      convert,
+	}
+}
+
+func (o *ContractArrayGetterOp[Item]) NextCalls() ([]batching.Call, error) {
+	if !o.loadedLength {
+		call := newCapturingCall(o.contract.Call(o.lengthMethod), func(result *batching.CallResult) error {
+			o.length = result.GetBigInt(0).Uint64()
+			o.loadedLength = true
+			return nil
+		})
+		return []batching.Call{call}, nil
+	}
+	if uint64(len(o.result)) == o.length {
+		// Already loaded all items
+		return nil, nil
+	}
+	o.result = make([]Item, o.length)
+	calls := make([]batching.Call, len(o.result))
+	for i := uint64(0); i < o.length; i++ {
+		i := i
+		calls[i] = newCapturingCall(o.contract.Call(o.getMethod, new(big.Int).SetUint64(i)), func(result *batching.CallResult) error {
+			item, err := o.convert(result, i)
+			if err != nil {
+				return err
+			}
+			o.result[i] = item
+			return nil
+		})
+	}
+	return calls, nil
+}
+
+func (o *ContractArrayGetterOp[Item]) Result() []Item {
+	return o.result
 }
 
 type SimpleContractGetterOp[Result any] struct {
@@ -199,4 +239,46 @@ func (o *chainedOps[Result]) NextCalls() ([]batching.Call, error) {
 
 func (o *chainedOps[Result]) Result() Result {
 	return o.resultSource()
+}
+
+type MultiGetterOp[Item any] struct {
+	contract *batching.BoundContract
+	method   string
+	args     []interface{}
+	convert  func(result *batching.CallResult, idx int) (Item, error)
+
+	result []Item
+}
+
+func NewMultiGetterOp[Item any](contract *batching.BoundContract, method string, convert func(result *batching.CallResult, idx int) (Item, error), args ...interface{}) GetterContractOp[[]Item] {
+	return &MultiGetterOp[Item]{
+		contract: contract,
+		method:   method,
+		args:     args,
+		convert:  convert,
+	}
+}
+
+func (o *MultiGetterOp[Item]) NextCalls() ([]batching.Call, error) {
+	if len(o.result) == len(o.args) {
+		return nil, nil
+	}
+	o.result = make([]Item, len(o.args))
+	calls := make([]batching.Call, len(o.args))
+	for i, arg := range o.args {
+		i := i
+		calls[i] = newCapturingCall(o.contract.Call(o.method, arg), func(result *batching.CallResult) error {
+			val, err := o.convert(result, i)
+			if err != nil {
+				return err
+			}
+			o.result[i] = val
+			return nil
+		})
+	}
+	return calls, nil
+}
+
+func (o *MultiGetterOp[Item]) Result() []Item {
+	return o.result
 }

--- a/op-challenger/game/fault/contracts/ops.go
+++ b/op-challenger/game/fault/contracts/ops.go
@@ -1,0 +1,202 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+)
+
+type ContractOp interface {
+	NextCalls() ([]batching.Call, error)
+}
+
+type GetterContractOp[Result any] interface {
+	ContractOp
+	Result() Result
+}
+
+func ExecuteOps(ctx context.Context, block rpcblock.Block, caller *batching.MultiCaller, ops ...ContractOp) error {
+	for {
+		calls := make([]batching.Call, 0, len(ops))
+		for _, op := range ops {
+			opCalls, err := op.NextCalls()
+			if err != nil {
+				return err
+			}
+			calls = append(calls, opCalls...)
+		}
+		if len(calls) == 0 {
+			return nil
+		}
+		_, err := caller.Call(ctx, block, calls...)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+type GetClaimOp struct {
+	contract *batching.BoundContract
+	idx      uint64
+
+	Claim types.Claim
+}
+
+func NewGetClaimOp(contract *batching.BoundContract, idx uint64) *GetClaimOp {
+	return &GetClaimOp{
+		contract: contract,
+		idx:      idx,
+	}
+}
+
+func (o *GetClaimOp) NextCalls() ([]batching.Call, error) {
+	if o.Claim != (types.Claim{}) {
+		return nil, nil
+	}
+	return []batching.Call{
+		newCapturingCall(o.contract.Call(methodClaim, big.NewInt(int64(o.idx))), func(result *batching.CallResult) error {
+			o.Claim = o.decodeClaim(result, o.idx)
+			return nil
+		}),
+	}, nil
+}
+
+func (o *GetClaimOp) Result() types.Claim {
+	return o.Claim
+}
+
+func (o *GetClaimOp) decodeClaim(result *batching.CallResult, contractIndex uint64) types.Claim {
+	parentIndex := result.GetUint32(0)
+	counteredBy := result.GetAddress(1)
+	claimant := result.GetAddress(2)
+	bond := result.GetBigInt(3)
+	claim := result.GetHash(4)
+	position := result.GetBigInt(5)
+	clock := result.GetBigInt(6)
+	return types.Claim{
+		ClaimData: types.ClaimData{
+			Value:    claim,
+			Position: types.NewPositionFromGIndex(position),
+			Bond:     bond,
+		},
+		CounteredBy:         counteredBy,
+		Claimant:            claimant,
+		Clock:               decodeClock(clock),
+		ContractIndex:       int(contractIndex),
+		ParentContractIndex: int(parentIndex),
+	}
+}
+
+var _ ContractOp = (*GetClaimOp)(nil)
+
+type FixBondOp struct {
+	source *GetClaimOp
+}
+
+func (o *FixBondOp) NextCalls() ([]batching.Call, error) {
+	fmt.Println(o.source)
+	fmt.Println(o.source.Claim)
+	fmt.Println(o.source.Claim.Bond)
+	// Set the required bond if required.
+	if o.source.Claim.Bond.Cmp(resolvedBondAmount) == 0 {
+		return []batching.Call{
+			newCapturingCall(o.source.contract.Call(methodRequiredBond, o.source.Claim.Position.ToGIndex()), func(result *batching.CallResult) error {
+				o.source.Claim.Bond = result.GetBigInt(0)
+				return nil
+			}),
+		}, nil
+	}
+	// No further calls required
+	return nil, nil
+}
+
+type SimpleContractGetterOp[Result any] struct {
+	contract *batching.BoundContract
+	method   string
+	convert  func(result *batching.CallResult) (Result, error)
+
+	called bool
+	result Result
+}
+
+func NewSimpleGetterOp[Result any](contract *batching.BoundContract, method string, convert func(result *batching.CallResult) (Result, error)) *SimpleContractGetterOp[Result] {
+	return &SimpleContractGetterOp[Result]{
+		contract: contract,
+		method:   method,
+		convert:  convert,
+	}
+}
+
+func (o *SimpleContractGetterOp[Result]) NextCalls() ([]batching.Call, error) {
+	if o.called {
+		return nil, nil
+	}
+	call := newCapturingCall(o.contract.Call(o.method), func(result *batching.CallResult) error {
+		o.called = true
+		converted, err := o.convert(result)
+		if err != nil {
+			return err
+		}
+		o.result = converted
+		return nil
+	})
+	return []batching.Call{call}, nil
+}
+
+func (o *SimpleContractGetterOp[Result]) Result() Result {
+	return o.result
+}
+
+type StaticGetterOp[Result any] struct {
+	result Result
+}
+
+func NewStaticOp[Result any](result Result) GetterContractOp[Result] {
+	return &StaticGetterOp[Result]{
+		result: result,
+	}
+}
+
+func (o *StaticGetterOp[Result]) NextCalls() ([]batching.Call, error) {
+	return nil, nil
+}
+
+func (o *StaticGetterOp[Result]) Result() Result {
+	return o.result
+}
+
+type chainedOps[Result any] struct {
+	remaining    []ContractOp
+	resultSource func() Result
+}
+
+func ChainOps[Result any](resultSource func() Result, ops ...ContractOp) GetterContractOp[Result] {
+	return &chainedOps[Result]{
+		remaining:    ops,
+		resultSource: resultSource,
+	}
+}
+
+func (o *chainedOps[Result]) NextCalls() ([]batching.Call, error) {
+	for len(o.remaining) > 0 {
+		calls, err := o.remaining[0].NextCalls()
+		if err != nil {
+			return nil, err
+		}
+		if len(calls) > 0 {
+			return calls, nil
+		}
+		// No remaining calls required by this op, move on to the next
+		o.remaining = o.remaining[1:]
+	}
+	// All calls from all ops complete.
+	return nil, nil
+}
+
+func (o *chainedOps[Result]) Result() Result {
+	return o.resultSource()
+}

--- a/op-challenger/game/fault/contracts/superfaultdisputegame.go
+++ b/op-challenger/game/fault/contracts/superfaultdisputegame.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
-	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -25,8 +24,8 @@ func NewSuperFaultDisputeGameContract(_ context.Context, metrics metrics.Contrac
 	ops.GetL2BlockNumberChallenger = func(contract *batching.BoundContract) GetterContractOp[common.Address] {
 		return NewStaticOp(common.Address{})
 	}
-	ops.ChallengeL2BlockNumberTx = func(_ *batching.BoundContract, _ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-		return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
+	ops.ChallengeL2BlockNumberTx = func(_ *batching.BoundContract, _ *types.InvalidL2BlockNumberChallenge) (*batching.ContractCall, error) {
+		return nil, ErrChallengeL2BlockNotSupported
 	}
 
 	ops.GetL2SequenceNumber = func(contract *batching.BoundContract) GetterContractOp[uint64] {

--- a/op-challenger/game/fault/contracts/superfaultdisputegame.go
+++ b/op-challenger/game/fault/contracts/superfaultdisputegame.go
@@ -15,7 +15,7 @@ var (
 	methodL2SequenceNumber = "l2SequenceNumber"
 )
 
-func NewSuperFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
+func NewSuperFaultDisputeGameContract(_ context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
 	contractAbi := snapshots.LoadFaultDisputeGameABI()
 	contract := batching.NewBoundContract(contractAbi, addr)
 	ops := latestFaultDisputeGameOps()
@@ -25,13 +25,14 @@ func NewSuperFaultDisputeGameContract(ctx context.Context, metrics metrics.Contr
 	ops.GetL2BlockNumberChallenger = func(contract *batching.BoundContract) GetterContractOp[common.Address] {
 		return NewStaticOp(common.Address{})
 	}
+	ops.ChallengeL2BlockNumberTx = func(_ *batching.BoundContract, _ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
+		return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
+	}
+
 	ops.GetL2SequenceNumber = func(contract *batching.BoundContract) GetterContractOp[uint64] {
 		return NewSimpleGetterOp(contract, methodL2SequenceNumber, func(result *batching.CallResult) (uint64, error) {
 			return result.GetBigInt(0).Uint64(), nil
 		})
-	}
-	ops.ChallengeL2BlockNumberTx = func(_ *batching.BoundContract, _ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-		return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
 	}
 	return &FaultDisputeGameContractLatest{
 		metrics:     metrics,

--- a/op-challenger/game/fault/contracts/superfaultdisputegame.go
+++ b/op-challenger/game/fault/contracts/superfaultdisputegame.go
@@ -2,70 +2,41 @@ package contracts
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type SuperFaultDisputeGameContractLatest struct {
-	FaultDisputeGameContractLatest
-}
+var (
+	methodL2SequenceNumber = "l2SequenceNumber"
+)
 
 func NewSuperFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
 	contractAbi := snapshots.LoadFaultDisputeGameABI()
-	return &SuperFaultDisputeGameContractLatest{
-		FaultDisputeGameContractLatest: FaultDisputeGameContractLatest{
-			metrics:     metrics,
-			multiCaller: caller,
-			contract:    batching.NewBoundContract(contractAbi, addr),
-		},
+	contract := batching.NewBoundContract(contractAbi, addr)
+	ops := latestFaultDisputeGameOps()
+	ops.GetL2BlockNumberChallenged = func(contract *batching.BoundContract) GetterContractOp[bool] {
+		return NewStaticOp(false)
+	}
+	ops.GetL2BlockNumberChallenger = func(contract *batching.BoundContract) GetterContractOp[common.Address] {
+		return NewStaticOp(common.Address{})
+	}
+	ops.GetL2SequenceNumber = func(contract *batching.BoundContract) GetterContractOp[uint64] {
+		return NewSimpleGetterOp(contract, methodL2SequenceNumber, func(result *batching.CallResult) (uint64, error) {
+			return result.GetBigInt(0).Uint64(), nil
+		})
+	}
+	ops.ChallengeL2BlockNumberTx = func(_ *batching.BoundContract, _ *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
+		return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
+	}
+	return &FaultDisputeGameContractLatest{
+		metrics:     metrics,
+		multiCaller: caller,
+		contract:    contract,
+		ops:         ops,
 	}, nil
-}
-
-// GetGameMetadata returns the game's L1 head, L2 block number, root claim, status, max clock duration, and is l2 block number challenged.
-func (f *SuperFaultDisputeGameContractLatest) GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error) {
-	defer f.metrics.StartContractRequest("GetGameMetadata")()
-	results, err := f.multiCaller.Call(ctx, block,
-		f.contract.Call(methodL1Head),
-		f.contract.Call(methodL2BlockNumber),
-		f.contract.Call(methodRootClaim),
-		f.contract.Call(methodStatus),
-		f.contract.Call(methodMaxClockDuration),
-	)
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to retrieve game metadata: %w", err)
-	}
-	if len(results) != 5 {
-		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
-	}
-	l1Head := results[0].GetHash(0)
-	l2BlockNumber := results[1].GetBigInt(0).Uint64()
-	rootClaim := results[2].GetHash(0)
-	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
-	if err != nil {
-		return GameMetadata{}, fmt.Errorf("failed to convert game status: %w", err)
-	}
-	duration := results[4].GetUint64(0)
-	return GameMetadata{
-		L1Head:           l1Head,
-		L2BlockNum:       l2BlockNumber,
-		RootClaim:        rootClaim,
-		Status:           status,
-		MaxClockDuration: duration,
-	}, nil
-}
-
-func (f *SuperFaultDisputeGameContractLatest) IsL2BlockNumberChallenged(ctx context.Context, block rpcblock.Block) (bool, error) {
-	return false, nil
-}
-
-func (f *SuperFaultDisputeGameContractLatest) ChallengeL2BlockNumberTx(challenge *types.InvalidL2BlockNumberChallenge) (txmgr.TxCandidate, error) {
-	return txmgr.TxCandidate{}, ErrChallengeL2BlockNotSupported
 }


### PR DESCRIPTION
**Description**

Currently different contract versions are handled by having `FaultDisputeGame` be an interface, the latest implementation in `FaultDisputeGameLatest` and then older version each have their own struct that extends `FaultDisputeGameLatest` and overrides the methods that need to be different.

This has a few drawbacks:
* New overridden implementations wind up needing to be copied to every previous version we support
* Methods like `GetGameMetadata` make multiple calls which can mean changes that should be simple like renaming `l2BlockNumber()` which should just mean using a different method name, require duplicating a lot more code than necessary (the entire `GetGameMetadata` method).
* You have to flick through multiple different files to work out what is different between versions

This spike tries an alternative approach where each basic operation is a `ContractOp` and gets created from `faultDisputeGameOps` which is basically just a set of factory functions (as variables).  When complete, we would only have `FaultDisputeGameLatest` and can likely even remove the `FaultDisputeGame` interface. Older versions would simply replace the factory functions for the operations they need to change with new versions.

The operation interface is designed to support multiple "rounds" of calls, for example version 0.8.0 needs to make two sequential calls to load a contract claim. First it loads the claim data, then if the claim is resolved, it has to make an additional call to get the original bond amount. This is supported because an operation is executed by asking it for `NextCalls` until it reports no more calls to make, so it can have multiple calls, optional calls etc.