### PR TITLE
fix(kt-devnet): pin correct kt dependency

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -5,4 +5,4 @@ replace:
   github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@0b7814012ba6b0a60ea3cf23f9e54a4cc763aa43
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
-  github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae17
+  github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Was missing a single ascii for the commit hash.

**Tests**

Checked that `just isthmus-devnet` spins up locally.

**Additional context**

Based on https://github.com/ethereum-optimism/optimism/pull/14770

