### PR TITLE
Add twrap in contracts just

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -357,6 +357,18 @@ pre-pr *ARGS:
     cp -r "$TEMP_BUILD_DIR/cache" ./
   fi
 
+twrap:
+    #!/usr/bin/env sh
+    if [ -z "$WRAP_DISABLED" ]; then
+        tput rmam
+        export WRAP_DISABLED=1
+        echo "Line wrapping disabled"
+    else
+        tput smam
+        unset WRAP_DISABLED
+        echo "Line wrapping enabled"
+    fi
+
 # Fixes linting errors.
 lint-fix:
   forge fmt

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -362,11 +362,11 @@ twrap:
     if [ -z "$WRAP_DISABLED" ]; then
         tput rmam
         export WRAP_DISABLED=1
-        echo "Line wrapping disabled"
+        echo "Terminal line wrapping disabled"
     else
         tput smam
         unset WRAP_DISABLED
-        echo "Line wrapping enabled"
+        echo "Terminal line wrapping enabled"
     fi
 
 # Fixes linting errors.


### PR DESCRIPTION
During testing, we often receive excessively long test inputs. This PR introduces a new command, `just twrap`, which toggles terminal wrapping on and off.

By switching between `tput rmam` (disable wrapping) and `tput smam` (enable wrapping), this command helps reduce visual noise, making test outputs easier to navigate and analyze. This is particularly useful for simplifying long logs and improving the overall debugging experience.