### PR TITLE
fix(op-deployer): default cache dir

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -52,15 +52,12 @@ func NewDeploymentTarget(s string) (DeploymentTarget, error) {
 	}
 }
 
-var DefaultCacheDir string
-
-func init() {
-	var err error
+func GetDefaultCacheDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		panic(fmt.Sprintf("failed to get home directory: %s", err))
+		return ".op-deployer/cache" // Fallback to local directory
 	}
-	DefaultCacheDir = path.Join(homeDir, ".op-deployer/cache")
+	return path.Join(homeDir, ".op-deployer/cache")
 }
 
 var (
@@ -82,7 +79,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   DefaultCacheDir,
+		Value:   GetDefaultCacheDir(),
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 
@@ -55,7 +56,9 @@ func NewDeploymentTarget(s string) (DeploymentTarget, error) {
 func GetDefaultCacheDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return ".op-deployer/cache" // Fallback to local directory
+		fallbackDir := ".op-deployer/cache"
+		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, fallbackDir)
+		return fallbackDir
 	}
 	return path.Join(homeDir, ".op-deployer/cache")
 }

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -87,7 +87,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse l1 contracts release locator: %w", err)
 	}
-	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.DefaultCacheDir)
+	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.GetDefaultCacheDir())
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}


### PR DESCRIPTION
Fixes a bug where the CacheDirFlag default value was not getting set in time in the `init()` function. Therefore, the default value used was `""` instead of `$HOME/.op-deployer/cache`