### PR TITLE
chore: Use floats for fee multipliers, add base multiplier

### DIFF
--- a/devnet-sdk/system/periphery/go-ethereum/fees.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees.go
@@ -27,18 +27,29 @@ type EIP1559FeeEstimator struct {
 	// Access to the Ethereum client is needed to get the fee information from the chain
 	client EIP1159FeeEthClient
 
+	// The tip multiplier is used to increase the maxFeePerGas (GasFeeCap) by a factor
+	baseMultiplier float64
+
 	// The tip multiplier is used to increase the maxPriorityFeePerGas (GasTipCap) by a factor
-	tipMultiplier *big.Int
+	tipMultiplier float64
 }
 
 func NewEIP1559FeeEstimator(client EIP1159FeeEthClient) *EIP1559FeeEstimator {
 	return &EIP1559FeeEstimator{
-		client:        client,
-		tipMultiplier: big.NewInt(1),
+		client:         client,
+		baseMultiplier: 1.0,
+		tipMultiplier:  1.0,
 	}
 }
 
-func (f *EIP1559FeeEstimator) WithTipMultiplier(multiplier *big.Int) *EIP1559FeeEstimator {
+func (f *EIP1559FeeEstimator) WithBaseMultiplier(multiplier float64) *EIP1559FeeEstimator {
+	newF := *f
+	newF.baseMultiplier = multiplier
+
+	return &newF
+}
+
+func (f *EIP1559FeeEstimator) WithTipMultiplier(multiplier float64) *EIP1559FeeEstimator {
 	newF := *f
 	newF.tipMultiplier = multiplier
 
@@ -57,21 +68,23 @@ func (f *EIP1559FeeEstimator) EstimateFees(ctx context.Context, opts *bind.Trans
 		}
 
 		// GasTipCap represents the maxPriorityFeePerGas
-		newOpts.GasTipCap = big.NewInt(0).Mul(tipCap, f.tipMultiplier)
+		newOpts.GasTipCap = multiplyBigInt(tipCap, f.tipMultiplier)
 	}
 
 	// Add a gas fee cap if needed
 	if newOpts.GasFeeCap == nil {
 		block, err := f.client.BlockByNumber(ctx, nil)
-
 		if err != nil {
 			return nil, err
 		}
 
 		baseFee := block.BaseFee()
 		if baseFee != nil {
+			// The adjusted base fee takes the multiplier into account
+			adjustedBaseFee := multiplyBigInt(baseFee, f.baseMultiplier)
+
 			// The total fee (maxFeePerGas) is the sum of the base fee and the tip
-			newOpts.GasFeeCap = big.NewInt(0).Add(block.BaseFee(), newOpts.GasTipCap)
+			newOpts.GasFeeCap = big.NewInt(0).Add(adjustedBaseFee, newOpts.GasTipCap)
 		}
 	}
 
@@ -82,4 +95,18 @@ func (f *EIP1559FeeEstimator) EstimateFees(ctx context.Context, opts *bind.Trans
 type EIP1159FeeEthClient interface {
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+}
+
+// multiplyBigInt is a little helper for a messy big.Int x float64 multiplication
+//
+// It uses the AwayFromZero rounding mode to ensure that the result is always rounded up
+func multiplyBigInt(b *big.Int, m float64) *big.Int {
+	bFloat := big.NewFloat(0).SetInt(b)
+	mFloat := big.NewFloat(m)
+	ceiled, accuracy := big.NewFloat(0).Mul(bFloat, mFloat).Int(nil)
+	if accuracy == big.Below {
+		ceiled = ceiled.Add(ceiled, big.NewInt(1))
+	}
+
+	return ceiled
 }

--- a/devnet-sdk/system/periphery/go-ethereum/fees.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees.go
@@ -27,7 +27,7 @@ type EIP1559FeeEstimator struct {
 	// Access to the Ethereum client is needed to get the fee information from the chain
 	client EIP1159FeeEthClient
 
-	// The tip multiplier is used to increase the maxFeePerGas (GasFeeCap) by a factor
+	// The base multiplier is used to increase the maxFeePerGas (GasFeeCap) by a factor
 	baseMultiplier float64
 
 	// The tip multiplier is used to increase the maxPriorityFeePerGas (GasTipCap) by a factor

--- a/devnet-sdk/system/periphery/go-ethereum/fees.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees.go
@@ -27,6 +27,10 @@ type EIP1559FeeEstimator struct {
 	// Access to the Ethereum client is needed to get the fee information from the chain
 	client EIP1159FeeEthClient
 
+	options eip1559FeeEstimatorOptions
+}
+
+type eip1559FeeEstimatorOptions struct {
 	// The base multiplier is used to increase the maxFeePerGas (GasFeeCap) by a factor
 	baseMultiplier float64
 
@@ -34,26 +38,44 @@ type EIP1559FeeEstimator struct {
 	tipMultiplier float64
 }
 
-func NewEIP1559FeeEstimator(client EIP1159FeeEthClient) *EIP1559FeeEstimator {
-	return &EIP1559FeeEstimator{
-		client:         client,
+type EIP1559FeeEstimatorOption interface {
+	apply(*eip1559FeeEstimatorOptions)
+}
+
+type eip1559FeeEstimatorOptionBaseMultiplier float64
+
+func (o eip1559FeeEstimatorOptionBaseMultiplier) apply(opts *eip1559FeeEstimatorOptions) {
+	opts.baseMultiplier = float64(o)
+}
+
+func WithEIP1559BaseMultiplier(multiplier float64) EIP1559FeeEstimatorOption {
+	return eip1559FeeEstimatorOptionBaseMultiplier(multiplier)
+}
+
+type eip1559FeeEstimatorOptionTipMultiplier float64
+
+func (o eip1559FeeEstimatorOptionTipMultiplier) apply(opts *eip1559FeeEstimatorOptions) {
+	opts.tipMultiplier = float64(o)
+}
+
+func WithEIP1559TipMultiplier(multiplier float64) EIP1559FeeEstimatorOption {
+	return eip1559FeeEstimatorOptionTipMultiplier(multiplier)
+}
+
+func NewEIP1559FeeEstimator(client EIP1159FeeEthClient, opts ...EIP1559FeeEstimatorOption) *EIP1559FeeEstimator {
+	options := eip1559FeeEstimatorOptions{
 		baseMultiplier: 1.0,
 		tipMultiplier:  1.0,
 	}
-}
 
-func (f *EIP1559FeeEstimator) WithBaseMultiplier(multiplier float64) *EIP1559FeeEstimator {
-	newF := *f
-	newF.baseMultiplier = multiplier
+	for _, o := range opts {
+		o.apply(&options)
+	}
 
-	return &newF
-}
-
-func (f *EIP1559FeeEstimator) WithTipMultiplier(multiplier float64) *EIP1559FeeEstimator {
-	newF := *f
-	newF.tipMultiplier = multiplier
-
-	return &newF
+	return &EIP1559FeeEstimator{
+		client:  client,
+		options: options,
+	}
 }
 
 func (f *EIP1559FeeEstimator) EstimateFees(ctx context.Context, opts *bind.TransactOpts) (*bind.TransactOpts, error) {
@@ -68,7 +90,7 @@ func (f *EIP1559FeeEstimator) EstimateFees(ctx context.Context, opts *bind.Trans
 		}
 
 		// GasTipCap represents the maxPriorityFeePerGas
-		newOpts.GasTipCap = multiplyBigInt(tipCap, f.tipMultiplier)
+		newOpts.GasTipCap = multiplyBigInt(tipCap, f.options.tipMultiplier)
 	}
 
 	// Add a gas fee cap if needed
@@ -81,7 +103,7 @@ func (f *EIP1559FeeEstimator) EstimateFees(ctx context.Context, opts *bind.Trans
 		baseFee := block.BaseFee()
 		if baseFee != nil {
 			// The adjusted base fee takes the multiplier into account
-			adjustedBaseFee := multiplyBigInt(baseFee, f.baseMultiplier)
+			adjustedBaseFee := multiplyBigInt(baseFee, f.options.baseMultiplier)
 
 			// The total fee (maxFeePerGas) is the sum of the base fee and the tip
 			newOpts.GasFeeCap = big.NewInt(0).Add(adjustedBaseFee, newOpts.GasTipCap)

--- a/devnet-sdk/system/periphery/go-ethereum/fees.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees.go
@@ -99,7 +99,7 @@ type EIP1159FeeEthClient interface {
 
 // multiplyBigInt is a little helper for a messy big.Int x float64 multiplication
 //
-// It uses the AwayFromZero rounding mode to ensure that the result is always rounded up
+// It rounds the result away from zero since that's the lower risk behavior for fee estimation
 func multiplyBigInt(b *big.Int, m float64) *big.Int {
 	bFloat := big.NewFloat(0).SetInt(b)
 	mFloat := big.NewFloat(m)

--- a/devnet-sdk/system/periphery/go-ethereum/fees_test.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees_test.go
@@ -13,6 +13,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMultiplyBigInt(t *testing.T) {
+	type TestCase struct {
+		value      *big.Int
+		multiplier float64
+		expected   *big.Int
+	}
+
+	testCases := []TestCase{
+		{
+			value:      big.NewInt(10),
+			multiplier: 1.0,
+			expected:   big.NewInt(10),
+		},
+		{
+			value:      big.NewInt(7),
+			multiplier: 0.0,
+			expected:   big.NewInt(0),
+		},
+		{
+			value:      big.NewInt(10),
+			multiplier: 1.01,
+			expected:   big.NewInt(11),
+		},
+		{
+			value:      big.NewInt(10),
+			multiplier: 1.11,
+			expected:   big.NewInt(12),
+		},
+		{
+			value:      big.NewInt(5),
+			multiplier: 1.2,
+			expected:   big.NewInt(6),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("should return %d for %d multplied by %f", testCase.expected.Int64(), testCase.value.Int64(), testCase.multiplier), func(t *testing.T) {
+			result := multiplyBigInt(testCase.value, testCase.multiplier)
+			require.Equal(t, testCase.expected, result)
+		})
+	}
+}
+
 func TestEstimateEIP1559Fees(t *testing.T) {
 	t.Run("if GasFeeCap and GasTipCap are not nil", func(t *testing.T) {
 		opts := &bind.TransactOpts{

--- a/devnet-sdk/system/periphery/go-ethereum/fees_test.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees_test.go
@@ -73,7 +73,7 @@ func TestEstimateEIP1559Fees(t *testing.T) {
 		t.Run("with custom tip multiplier", func(t *testing.T) {
 			t.Run("should set the GasTipCap to the client's suggested tip cap multplied by the tip multiplier", func(t *testing.T) {
 				tipCapValue := big.NewInt(5)
-				tipMultiplier := big.NewInt(10)
+				tipMultiplier := 10.0
 				// The expected tip is a product of the tip cap and the tip multiplier
 				expectedTip := big.NewInt(50)
 
@@ -164,6 +164,38 @@ func TestEstimateEIP1559Fees(t *testing.T) {
 
 			// We make sure that we get a copy of the object to prevent mutating the original
 			assert.NotSame(t, defaultOpts, newOpts)
+		})
+
+		t.Run("with custom base multiplier", func(t *testing.T) {
+			t.Run("should set the GasFeeCap to the block base fee multplied by the base multiplier", func(t *testing.T) {
+				baseMultiplier := 1.2
+				baseFeeValue := big.NewInt(9)
+				blockValue := types.NewBlock(&types.Header{
+					BaseFee: baseFeeValue,
+					Time:    0,
+				}, nil, nil, nil, &mockBlockType{})
+
+				// We expect the total gas cap to be the base fee (9) multiplied by 1.2 (= 10.8, rounded up to 11) plus the tip cap (1)
+				expectedGas := big.NewInt(0).Add(big.NewInt(11), defaultOpts.GasTipCap)
+
+				// We create a fee estimator with a custom tip multiplier
+				feeEstimator := NewEIP1559FeeEstimator(&mockFeeEthClientImpl{
+					blockValue: blockValue,
+				}).WithBaseMultiplier(baseMultiplier)
+
+				newOpts, err := feeEstimator.EstimateFees(context.Background(), defaultOpts)
+				require.NoError(t, err)
+
+				// We create a new opts with the expected tip cap added
+				expectedOpts := *defaultOpts
+				expectedOpts.GasFeeCap = expectedGas
+
+				// We check that the tip has been added
+				require.Equal(t, &expectedOpts, newOpts)
+
+				// We make sure that we get a copy of the object to prevent mutating the original
+				assert.NotSame(t, defaultOpts, newOpts)
+			})
 		})
 	})
 }

--- a/devnet-sdk/system/periphery/go-ethereum/fees_test.go
+++ b/devnet-sdk/system/periphery/go-ethereum/fees_test.go
@@ -80,7 +80,7 @@ func TestEstimateEIP1559Fees(t *testing.T) {
 				// We create a fee estimator with a custom tip multiplier
 				feeEstimator := NewEIP1559FeeEstimator(&mockFeeEthClientImpl{
 					tipCapValue: tipCapValue,
-				}).WithTipMultiplier(tipMultiplier)
+				}, WithEIP1559TipMultiplier(tipMultiplier))
 
 				newOpts, err := feeEstimator.EstimateFees(context.Background(), defaultOpts)
 				require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestEstimateEIP1559Fees(t *testing.T) {
 				// We create a fee estimator with a custom tip multiplier
 				feeEstimator := NewEIP1559FeeEstimator(&mockFeeEthClientImpl{
 					blockValue: blockValue,
-				}).WithBaseMultiplier(baseMultiplier)
+				}, WithEIP1559BaseMultiplier(baseMultiplier))
 
 				newOpts, err := feeEstimator.EstimateFees(context.Background(), defaultOpts)
 				require.NoError(t, err)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The fee estimator for devnet-sdk had a bit of a usability issue with it - the base & tip multipliers were defined as `big.Int`s which meant the fees could only be increased by integer multiples. This is not great as there are plenty of numbers between `1` and `2` (some would even say an infinite amount of numbers but those people are not working with `float64` limitations).

This PR fixes the issue and adds base multiplier besides the tip multiplier. Some libraries set this to `1.2` by default (ethers, viem) but to avoid any surprises, a value of `1.0` will be used for both of these by default.

On top of the changes in the logic, the functional options pattern has been used (thanks @scharissis for this)