### PR TITLE
feat: remove DisputeGameFactory input from SystemConfig

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -17,7 +17,6 @@ interface ISystemConfig {
         address l1CrossDomainMessenger;
         address l1ERC721Bridge;
         address l1StandardBridge;
-        address disputeGameFactory;
         address optimismPortal;
         address optimismMintableERC20Factory;
     }

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -28,6 +28,7 @@ interface ISystemConfig {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     function BATCH_INBOX_SLOT() external view returns (bytes32);
+    function DISPUTE_GAME_FACTORY_SLOT() external view returns (bytes32);
     function L1_CROSS_DOMAIN_MESSENGER_SLOT() external view returns (bytes32);
     function L1_ERC_721_BRIDGE_SLOT() external view returns (bytes32);
     function L1_STANDARD_BRIDGE_SLOT() external view returns (bytes32);

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -28,7 +28,6 @@ interface ISystemConfig {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     function BATCH_INBOX_SLOT() external view returns (bytes32);
-    function DISPUTE_GAME_FACTORY_SLOT() external view returns (bytes32);
     function L1_CROSS_DOMAIN_MESSENGER_SLOT() external view returns (bytes32);
     function L1_ERC_721_BRIDGE_SLOT() external view returns (bytes32);
     function L1_STANDARD_BRIDGE_SLOT() external view returns (bytes32);

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -91,7 +91,6 @@ library ChainAssertions {
             require(config.l1CrossDomainMessenger() == _contracts.L1CrossDomainMessenger, "CHECK-SCFG-160");
             require(config.l1ERC721Bridge() == _contracts.L1ERC721Bridge, "CHECK-SCFG-170");
             require(config.l1StandardBridge() == _contracts.L1StandardBridge, "CHECK-SCFG-180");
-            require(config.disputeGameFactory() == _contracts.DisputeGameFactory, "CHECK-SCFG-190");
             require(config.optimismPortal() == _contracts.OptimismPortal, "CHECK-SCFG-200");
             require(config.optimismMintableERC20Factory() == _contracts.OptimismMintableERC20Factory, "CHECK-SCFG-210");
         } else {
@@ -116,7 +115,6 @@ library ChainAssertions {
             require(config.l1CrossDomainMessenger() == address(0), "CHECK-SCFG-380");
             require(config.l1ERC721Bridge() == address(0), "CHECK-SCFG-390");
             require(config.l1StandardBridge() == address(0), "CHECK-SCFG-400");
-            require(config.disputeGameFactory() == address(0), "CHECK-SCFG-410");
             require(config.optimismPortal() == address(0), "CHECK-SCFG-420");
             require(config.optimismMintableERC20Factory() == address(0), "CHECK-SCFG-430");
         }

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -516,7 +516,6 @@ contract Deploy is Deployer {
                         l1CrossDomainMessenger: artifacts.mustGetAddress("L1CrossDomainMessengerProxy"),
                         l1ERC721Bridge: artifacts.mustGetAddress("L1ERC721BridgeProxy"),
                         l1StandardBridge: artifacts.mustGetAddress("L1StandardBridgeProxy"),
-                        disputeGameFactory: artifacts.mustGetAddress("DisputeGameFactoryProxy"),
                         optimismPortal: artifacts.mustGetAddress("OptimismPortalProxy"),
                         optimismMintableERC20Factory: artifacts.mustGetAddress("OptimismMintableERC20FactoryProxy")
                     }),

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -421,9 +421,8 @@ contract DeployImplementationsOutput is BaseDeployIO {
         require(systemConfig.l1CrossDomainMessenger() == address(0), "SYSCON-170");
         require(systemConfig.l1ERC721Bridge() == address(0), "SYSCON-180");
         require(systemConfig.l1StandardBridge() == address(0), "SYSCON-190");
-        require(systemConfig.disputeGameFactory() == address(0), "SYSCON-200");
-        require(systemConfig.optimismPortal() == address(0), "SYSCON-210");
-        require(systemConfig.optimismMintableERC20Factory() == address(0), "SYSCON-220");
+        require(systemConfig.optimismPortal() == address(0), "SYSCON-200");
+        require(systemConfig.optimismMintableERC20Factory() == address(0), "SYSCON-210");
     }
 
     function assertValidL1CrossDomainMessengerImpl(DeployImplementationsInput) internal view {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -562,11 +562,10 @@ contract DeployOPChain is Script {
         require(systemConfig.l1CrossDomainMessenger() == address(_doo.l1CrossDomainMessengerProxy()), "SYSCON-160");
         require(systemConfig.l1ERC721Bridge() == address(_doo.l1ERC721BridgeProxy()), "SYSCON-170");
         require(systemConfig.l1StandardBridge() == address(_doo.l1StandardBridgeProxy()), "SYSCON-180");
-        require(systemConfig.disputeGameFactory() == address(_doo.disputeGameFactoryProxy()), "SYSCON-190");
-        require(systemConfig.optimismPortal() == address(_doo.optimismPortalProxy()), "SYSCON-200");
+        require(systemConfig.optimismPortal() == address(_doo.optimismPortalProxy()), "SYSCON-190");
         require(
             systemConfig.optimismMintableERC20Factory() == address(_doo.optimismMintableERC20FactoryProxy()),
-            "SYSCON-210"
+            "SYSCON-200"
         );
     }
 

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -19,6 +19,19 @@
   },
   {
     "inputs": [],
+    "name": "DISPUTE_GAME_FACTORY_SLOT",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "L1_CROSS_DOMAIN_MESSENGER_SLOT",
     "outputs": [
       {

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -19,19 +19,6 @@
   },
   {
     "inputs": [],
-    "name": "DISPUTE_GAME_FACTORY_SLOT",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "L1_CROSS_DOMAIN_MESSENGER_SLOT",
     "outputs": [
       {

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -261,11 +261,6 @@
           },
           {
             "internalType": "address",
-            "name": "disputeGameFactory",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
             "name": "optimismPortal",
             "type": "address"
           },
@@ -385,11 +380,6 @@
           {
             "internalType": "address",
             "name": "l1StandardBridge",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "disputeGameFactory",
             "type": "address"
           },
           {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xfd56e63e76b1f203cceeb9bbb14396ae803cbbbf7e80ca0ee11fb586321812af"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x3b6ea6b31667e4826f5aea639c8618bc67f5e18fe3b41bc85b0fae3aa50d8b69",
-    "sourceCodeHash": "0xe3356db87dd2a40100184bccbc4f5bd9d3a93d072a6fc2b496e122f02d59358f"
+    "initCodeHash": "0x1edc0fd719aaa39eef32e3b29bacec77b512a3494904643bab2a21a855507bbc",
+    "sourceCodeHash": "0xfa541a4f124ef5568f80ddefbcb257a9204b94ebef921c854598b8b510ea14d1"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xc403d4c555d8e69a2699e01d192ae7327136701fa02da10a6d75a584b3c364c9",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
     "initCodeHash": "0xaa8ca04a37dfcc419f5fc53f0411e5a7bd772b88d4df5da7558aaceea26547d1",
-    "sourceCodeHash": "0xde61cc4bd79086ed8176f658866f4faba1147614c025a9e642ae517245827aad"
+    "sourceCodeHash": "0x11f9627893eabb8f81c538a79d55abffb0c37bef6e8d1121b085fac4008726c9"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xbc7db7b1016025228d99a40db1760290b333bb90563dff5514fd253fd91019ba",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xfd56e63e76b1f203cceeb9bbb14396ae803cbbbf7e80ca0ee11fb586321812af"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x1b6e38845f19654ed8e1fb0a46ac6719c5b3e95bb2a9556a632d0d6dd3a31da8",
-    "sourceCodeHash": "0xed1fc17ef252575e511bad4054fba2508457e901dfe4a05362b4ebbefda6f875"
+    "initCodeHash": "0x3b6ea6b31667e4826f5aea639c8618bc67f5e18fe3b41bc85b0fae3aa50d8b69",
+    "sourceCodeHash": "0xe3356db87dd2a40100184bccbc4f5bd9d3a93d072a6fc2b496e122f02d59358f"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xc403d4c555d8e69a2699e01d192ae7327136701fa02da10a6d75a584b3c364c9",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x44797707aea8c63dec049a02d69ea056662a06e5cf320028ab8b388634bf1c67"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x04ecca6917f73f77cf808097e48bf2fb025393907982438ae6fd9810f0f271b7",
-    "sourceCodeHash": "0x75ed03f4fbf1039e0f4df0c36de6944f341aa980d1e6d9087f8baceb3b19c851"
+    "initCodeHash": "0xaa8ca04a37dfcc419f5fc53f0411e5a7bd772b88d4df5da7558aaceea26547d1",
+    "sourceCodeHash": "0x0e0446068f14c7b6bb793d80a6386b32db3f86c4401de6eba3db75cf32f21f1c"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xbc7db7b1016025228d99a40db1760290b333bb90563dff5514fd253fd91019ba",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xfd56e63e76b1f203cceeb9bbb14396ae803cbbbf7e80ca0ee11fb586321812af"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x471ac69544fdee81d0734b87151297ad4cf91ca1d43a2c95e9e644c0424eed65",
-    "sourceCodeHash": "0x8c3ccb8f3718c00c3f9bf7c866a22d87ea18a87a6e9454c31d1c97638107434c"
+    "initCodeHash": "0xe89869750daf14d073d439a7f16356797e1b3401114c50598c1f21b0a486e446",
+    "sourceCodeHash": "0xc48765e11e620140403f94364ff86e67293b361b416739a57ff9458754cb9e35"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xc403d4c555d8e69a2699e01d192ae7327136701fa02da10a6d75a584b3c364c9",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
     "initCodeHash": "0xaa8ca04a37dfcc419f5fc53f0411e5a7bd772b88d4df5da7558aaceea26547d1",
-    "sourceCodeHash": "0x0e0446068f14c7b6bb793d80a6386b32db3f86c4401de6eba3db75cf32f21f1c"
+    "sourceCodeHash": "0xde61cc4bd79086ed8176f658866f4faba1147614c025a9e642ae517245827aad"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xbc7db7b1016025228d99a40db1760290b333bb90563dff5514fd253fd91019ba",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xfd56e63e76b1f203cceeb9bbb14396ae803cbbbf7e80ca0ee11fb586321812af"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xe89869750daf14d073d439a7f16356797e1b3401114c50598c1f21b0a486e446",
-    "sourceCodeHash": "0xc48765e11e620140403f94364ff86e67293b361b416739a57ff9458754cb9e35"
+    "initCodeHash": "0x1b6e38845f19654ed8e1fb0a46ac6719c5b3e95bb2a9556a632d0d6dd3a31da8",
+    "sourceCodeHash": "0xed1fc17ef252575e511bad4054fba2508457e901dfe4a05362b4ebbefda6f875"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xc403d4c555d8e69a2699e01d192ae7327136701fa02da10a6d75a584b3c364c9",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { console2 as console } from "forge-std/console2.sol";
-
 // Libraries
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
@@ -543,8 +541,6 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
 
             // Grab the L2 chain ID from the PermissionedDisputeGame.
             uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
-
-            console.log(opChainAddrs.optimismPortal);
 
             // Grab the current respectedGameType from the OptimismPortal contract before the upgrade.
             GameType respectedGameType = IOptimismPortal(payable(opChainAddrs.optimismPortal)).respectedGameType();

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -530,7 +530,6 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
 
         for (uint256 i = 0; i < _opChainConfigs.length; i++) {
             assertValidOpChainConfig(_opChainConfigs[i]);
-            ISystemConfig.Addresses memory opChainAddrs = _opChainConfigs[i].systemConfigProxy.getAddresses();
 
             // Use the SystemConfig to grab the DisputeGameFactory address.
             IDisputeGameFactory dgf = IDisputeGameFactory(_opChainConfigs[i].systemConfigProxy.disputeGameFactory());
@@ -542,13 +541,6 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
             // Grab the L2 chain ID from the PermissionedDisputeGame.
             uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
 
-            // Grab the current respectedGameType from the OptimismPortal contract before the upgrade.
-            GameType respectedGameType = IOptimismPortal(payable(opChainAddrs.optimismPortal)).respectedGameType();
-
-            // Grab the current SuperchainConfig from the OptimismPortal contract before the upgrade.
-            ISuperchainConfig superchainConfig =
-                IOptimismPortal(payable(opChainAddrs.optimismPortal)).superchainConfig();
-
             // Start by upgrading the SystemConfig contract to have the l2ChainId.
             upgradeToAndCall(
                 _opChainConfigs[i].proxyAdmin,
@@ -556,6 +548,17 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
                 impls.systemConfigImpl,
                 abi.encodeCall(ISystemConfig.upgrade, (l2ChainId))
             );
+
+            // Grab chain addresses here. We need to do this after the SystemConfig upgrade or the
+            // addresses will be incorrect.
+            ISystemConfig.Addresses memory opChainAddrs = _opChainConfigs[i].systemConfigProxy.getAddresses();
+
+            // Grab the current respectedGameType from the OptimismPortal contract before the upgrade.
+            GameType respectedGameType = IOptimismPortal(payable(opChainAddrs.optimismPortal)).respectedGameType();
+
+            // Grab the current SuperchainConfig from the OptimismPortal contract before the upgrade.
+            ISuperchainConfig superchainConfig =
+                IOptimismPortal(payable(opChainAddrs.optimismPortal)).superchainConfig();
 
             // Separate context to avoid stack too deep.
             IAnchorStateRegistry newAnchorStateRegistryProxy;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -532,14 +532,12 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
             assertValidOpChainConfig(_opChainConfigs[i]);
             ISystemConfig.Addresses memory opChainAddrs = _opChainConfigs[i].systemConfigProxy.getAddresses();
 
+            // Use the SystemConfig to grab the DisputeGameFactory address.
+            IDisputeGameFactory dgf = IDisputeGameFactory(_opChainConfigs[i].systemConfigProxy.disputeGameFactory());
+
             // All chains have the PermissionedDisputeGame, grab that.
-            IPermissionedDisputeGame permissionedDisputeGame = IPermissionedDisputeGame(
-                address(
-                    getGameImplementation(
-                        IDisputeGameFactory(opChainAddrs.disputeGameFactory), GameTypes.PERMISSIONED_CANNON
-                    )
-                )
-            );
+            IPermissionedDisputeGame permissionedDisputeGame =
+                IPermissionedDisputeGame(address(getGameImplementation(dgf, GameTypes.PERMISSIONED_CANNON)));
 
             // Grab the L2 chain ID from the PermissionedDisputeGame.
             uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
@@ -591,7 +589,7 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
                             IAnchorStateRegistry.initialize,
                             (
                                 superchainConfig,
-                                IDisputeGameFactory(opChainAddrs.disputeGameFactory),
+                                dgf,
                                 OutputRoot({ root: root, l2BlockNumber: l2BlockNumber }),
                                 respectedGameType
                             )
@@ -641,19 +639,15 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
                     _disputeGame: IDisputeGame(address(permissionedDisputeGame)),
                     _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
                     _gameType: GameTypes.PERMISSIONED_CANNON,
-                    _opChainConfig: _opChainConfigs[i],
-                    _opChainAddrs: opChainAddrs
+                    _opChainConfig: _opChainConfigs[i]
                 });
             }
 
             // Separate context to avoid stack too deep.
             {
                 // Now retrieve the permissionless game.
-                IFaultDisputeGame permissionlessDisputeGame = IFaultDisputeGame(
-                    address(
-                        getGameImplementation(IDisputeGameFactory(opChainAddrs.disputeGameFactory), GameTypes.CANNON)
-                    )
-                );
+                IFaultDisputeGame permissionlessDisputeGame =
+                    IFaultDisputeGame(address(getGameImplementation(dgf, GameTypes.CANNON)));
 
                 // If it exists, replace its implementation.
                 if (address(permissionlessDisputeGame) != address(0)) {
@@ -663,8 +657,7 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
                         _disputeGame: IDisputeGame(address(permissionlessDisputeGame)),
                         _newAnchorStateRegistryProxy: newAnchorStateRegistryProxy,
                         _gameType: GameTypes.CANNON,
-                        _opChainConfig: _opChainConfigs[i],
-                        _opChainAddrs: opChainAddrs
+                        _opChainConfig: _opChainConfigs[i]
                     });
                 }
             }
@@ -700,14 +693,12 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
     /// @param _newAnchorStateRegistryProxy The new anchor state registry proxy
     /// @param _gameType The type of game to deploy
     /// @param _opChainConfig The OP chain configuration
-    /// @param _opChainAddrs The OP chain addresses
     function deployAndSetNewGameImpl(
         uint256 _l2ChainId,
         IDisputeGame _disputeGame,
         IAnchorStateRegistry _newAnchorStateRegistryProxy,
         GameType _gameType,
-        OPContractsManager.OpChainConfig memory _opChainConfig,
-        ISystemConfig.Addresses memory _opChainAddrs
+        OPContractsManager.OpChainConfig memory _opChainConfig
     )
         internal
     {
@@ -755,7 +746,12 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
                 )
             );
         }
-        setDGFImplementation(IDisputeGameFactory(_opChainAddrs.disputeGameFactory), _gameType, IDisputeGame(newGame));
+
+        // Grab the DisputeGameFactory from the SystemConfig.
+        IDisputeGameFactory dgf = IDisputeGameFactory(_opChainConfig.systemConfigProxy.disputeGameFactory());
+
+        // Set the new implementation.
+        setDGFImplementation(dgf, _gameType, IDisputeGame(newGame));
     }
 }
 
@@ -988,7 +984,6 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
             l1CrossDomainMessenger: address(_output.l1CrossDomainMessengerProxy),
             l1ERC721Bridge: address(_output.l1ERC721BridgeProxy),
             l1StandardBridge: address(_output.l1StandardBridgeProxy),
-            disputeGameFactory: address(_output.disputeGameFactoryProxy),
             optimismPortal: address(_output.optimismPortalProxy),
             optimismMintableERC20Factory: address(_output.optimismMintableERC20FactoryProxy)
         });
@@ -996,7 +991,6 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
         assertValidContractAddress(opChainAddrs_.l1CrossDomainMessenger);
         assertValidContractAddress(opChainAddrs_.l1ERC721Bridge);
         assertValidContractAddress(opChainAddrs_.l1StandardBridge);
-        assertValidContractAddress(opChainAddrs_.disputeGameFactory);
         assertValidContractAddress(opChainAddrs_.optimismPortal);
         assertValidContractAddress(opChainAddrs_.optimismMintableERC20Factory);
     }
@@ -1294,9 +1288,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.11.1
+    /// @custom:semver 1.12.0
     function version() public pure virtual returns (string memory) {
-        return "1.11.1";
+        return "1.12.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+import { console2 as console } from "forge-std/console2.sol";
+
 // Libraries
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
@@ -541,6 +543,8 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
 
             // Grab the L2 chain ID from the PermissionedDisputeGame.
             uint256 l2ChainId = getL2ChainId(IFaultDisputeGame(address(permissionedDisputeGame)));
+
+            console.log(opChainAddrs.optimismPortal);
 
             // Grab the current respectedGameType from the OptimismPortal contract before the upgrade.
             GameType respectedGameType = IOptimismPortal(payable(opChainAddrs.optimismPortal)).respectedGameType();

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -11,6 +11,8 @@ import { Storage } from "src/libraries/Storage.sol";
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 
 /// @custom:proxied true
 /// @title SystemConfig
@@ -40,7 +42,6 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         address l1CrossDomainMessenger;
         address l1ERC721Bridge;
         address l1StandardBridge;
-        address disputeGameFactory;
         address optimismPortal;
         address optimismMintableERC20Factory;
     }
@@ -140,9 +141,9 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 2.6.0
+    /// @custom:semver 2.7.0
     function version() public pure virtual returns (string memory) {
-        return "2.6.0";
+        return "2.7.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -194,7 +195,6 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         Storage.setAddress(L1_CROSS_DOMAIN_MESSENGER_SLOT, _addresses.l1CrossDomainMessenger);
         Storage.setAddress(L1_ERC_721_BRIDGE_SLOT, _addresses.l1ERC721Bridge);
         Storage.setAddress(L1_STANDARD_BRIDGE_SLOT, _addresses.l1StandardBridge);
-        Storage.setAddress(DISPUTE_GAME_FACTORY_SLOT, _addresses.disputeGameFactory);
         Storage.setAddress(OPTIMISM_PORTAL_SLOT, _addresses.optimismPortal);
         Storage.setAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT, _addresses.optimismMintableERC20Factory);
 
@@ -254,7 +254,9 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
 
     /// @notice Getter for the DisputeGameFactory address.
     function disputeGameFactory() public view returns (address addr_) {
-        addr_ = Storage.getAddress(DISPUTE_GAME_FACTORY_SLOT);
+        IOptimismPortal2 portal = IOptimismPortal2(payable(Storage.getAddress(OPTIMISM_PORTAL_SLOT)));
+        IAnchorStateRegistry asr = IAnchorStateRegistry(portal.anchorStateRegistry());
+        addr_ = address(asr.disputeGameFactory());
     }
 
     /// @notice Getter for the OptimismPortal address.
@@ -273,7 +275,6 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
             l1CrossDomainMessenger: l1CrossDomainMessenger(),
             l1ERC721Bridge: l1ERC721Bridge(),
             l1StandardBridge: l1StandardBridge(),
-            disputeGameFactory: disputeGameFactory(),
             optimismPortal: optimismPortal(),
             optimismMintableERC20Factory: optimismMintableERC20Factory()
         });

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -81,10 +81,6 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Storage slot for block at which the op-node can start searching for logs from.
     bytes32 public constant START_BLOCK_SLOT = bytes32(uint256(keccak256("systemconfig.startBlock")) - 1);
 
-    /// @notice Storage slot for the DisputeGameFactory address.
-    bytes32 public constant DISPUTE_GAME_FACTORY_SLOT =
-        bytes32(uint256(keccak256("systemconfig.disputegamefactory")) - 1);
-
     /// @notice The maximum gas limit that can be set for L2 blocks. This limit is used to enforce that the blocks
     ///         on L2 are not too large to process and prove. Over time, this value can be increased as various
     ///         optimizations and improvements are made to the system at large.
@@ -211,7 +207,8 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         l2ChainId = _l2ChainId;
 
         // Clear out the old dispute game factory address, it's derived now.
-        Storage.setAddress(DISPUTE_GAME_FACTORY_SLOT, address(0));
+        bytes32 disputeGameFactorySlot = bytes32(uint256(keccak256("systemconfig.disputegamefactory")) - 1);
+        Storage.setAddress(disputeGameFactorySlot, address(0));
     }
 
     /// @notice Returns the minimum L2 gas limit that can be safely set for the system to

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -12,7 +12,6 @@ import { Storage } from "src/libraries/Storage.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 
 /// @custom:proxied true
 /// @title SystemConfig
@@ -81,10 +80,6 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
 
     /// @notice Storage slot for block at which the op-node can start searching for logs from.
     bytes32 public constant START_BLOCK_SLOT = bytes32(uint256(keccak256("systemconfig.startBlock")) - 1);
-
-    /// @notice Storage slot for the DisputeGameFactory address.
-    bytes32 public constant DISPUTE_GAME_FACTORY_SLOT =
-        bytes32(uint256(keccak256("systemconfig.disputegamefactory")) - 1);
 
     /// @notice The maximum gas limit that can be set for L2 blocks. This limit is used to enforce that the blocks
     ///         on L2 are not too large to process and prove. Over time, this value can be increased as various
@@ -255,8 +250,7 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Getter for the DisputeGameFactory address.
     function disputeGameFactory() public view returns (address addr_) {
         IOptimismPortal2 portal = IOptimismPortal2(payable(Storage.getAddress(OPTIMISM_PORTAL_SLOT)));
-        IAnchorStateRegistry asr = IAnchorStateRegistry(portal.anchorStateRegistry());
-        addr_ = address(asr.disputeGameFactory());
+        addr_ = address(portal.disputeGameFactory());
     }
 
     /// @notice Getter for the OptimismPortal address.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -81,6 +81,10 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Storage slot for block at which the op-node can start searching for logs from.
     bytes32 public constant START_BLOCK_SLOT = bytes32(uint256(keccak256("systemconfig.startBlock")) - 1);
 
+    /// @notice Storage slot for the DisputeGameFactory address.
+    bytes32 public constant DISPUTE_GAME_FACTORY_SLOT =
+        bytes32(uint256(keccak256("systemconfig.disputegamefactory")) - 1);
+
     /// @notice The maximum gas limit that can be set for L2 blocks. This limit is used to enforce that the blocks
     ///         on L2 are not too large to process and prove. Over time, this value can be increased as various
     ///         optimizations and improvements are made to the system at large.
@@ -136,9 +140,9 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 2.7.0
+    /// @custom:semver 3.0.0
     function version() public pure virtual returns (string memory) {
-        return "2.7.0";
+        return "3.0.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -203,7 +207,11 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Upgrades the SystemConfig by setting the L2 chain ID variable.
     /// @param _l2ChainId The L2 chain ID that this SystemConfig configures.
     function upgrade(uint256 _l2ChainId) external reinitializer(initVersion()) {
+        // Set the L2 chain ID.
         l2ChainId = _l2ChainId;
+
+        // Clear out the old dispute game factory address, it's derived now.
+        Storage.setAddress(DISPUTE_GAME_FACTORY_SLOT, address(0));
     }
 
     /// @notice Returns the minimum L2 gas limit that can be safely set for the system to

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -554,7 +554,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Make sure that the SystemConfig is upgraded to the right version. It must also have the
         // right l2ChainId and must be properly initialized.
-        assertEq(ISemver(address(systemConfig)).version(), "2.7.0");
+        assertEq(ISemver(address(systemConfig)).version(), "3.0.0");
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(systemConfig.l2ChainId(), l2ChainId);
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -554,7 +554,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Make sure that the SystemConfig is upgraded to the right version. It must also have the
         // right l2ChainId and must be properly initialized.
-        assertEq(ISemver(address(systemConfig)).version(), "2.6.0");
+        assertEq(ISemver(address(systemConfig)).version(), "2.7.0");
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(systemConfig.l2ChainId(), l2ChainId);
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -111,8 +111,6 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         assertEq(addrs.l1ERC721Bridge, address(l1ERC721Bridge));
         assertEq(address(systemConfig.l1StandardBridge()), address(l1StandardBridge));
         assertEq(addrs.l1StandardBridge, address(l1StandardBridge));
-        assertEq(address(systemConfig.disputeGameFactory()), address(disputeGameFactory));
-        assertEq(addrs.disputeGameFactory, address(disputeGameFactory));
         assertEq(address(systemConfig.optimismPortal()), address(optimismPortal2));
         assertEq(addrs.optimismPortal, address(optimismPortal2));
         assertEq(address(systemConfig.optimismMintableERC20Factory()), address(optimismMintableERC20Factory));
@@ -146,7 +144,6 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 l1CrossDomainMessenger: address(0),
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
-                disputeGameFactory: address(0),
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0)
             }),
@@ -176,7 +173,6 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 l1CrossDomainMessenger: address(0),
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
-                disputeGameFactory: address(0),
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0)
             }),
@@ -207,7 +203,6 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 l1CrossDomainMessenger: address(0),
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
-                disputeGameFactory: address(0),
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0)
             }),
@@ -322,7 +317,6 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
                 l1CrossDomainMessenger: address(0),
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
-                disputeGameFactory: address(0),
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0)
             }),

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -497,6 +497,13 @@ contract SystemConfig_upgrade_Test is SystemConfig_Init {
         // Set the initialized slot to 0.
         vm.store(address(systemConfig), bytes32(slot.slot), bytes32(0));
 
+        // Verify the initial dispute game factory slot is non-zero.
+        // We set a value here since it seems this defaults to zero.
+        bytes32 disputeGameFactorySlot = bytes32(uint256(keccak256("systemconfig.disputegamefactory")) - 1);
+        vm.store(address(systemConfig), disputeGameFactorySlot, bytes32(uint256(1)));
+        assertNotEq(systemConfig.disputeGameFactory(), address(0));
+        assertNotEq(vm.load(address(systemConfig), disputeGameFactorySlot), bytes32(0));
+
         // Trigger upgrade().
         systemConfig.upgrade(1234);
 
@@ -508,7 +515,7 @@ contract SystemConfig_upgrade_Test is SystemConfig_Init {
         assertEq(systemConfig.l2ChainId(), 1234);
 
         // Verify that the dispute game factory address was cleared.
-        assertEq(vm.load(address(systemConfig), bytes32(systemConfig.DISPUTE_GAME_FACTORY_SLOT())), bytes32(0));
+        assertEq(vm.load(address(systemConfig), disputeGameFactorySlot), bytes32(0));
     }
 
     /// @notice Tests that the upgrade() function reverts if called a second time.

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -506,6 +506,9 @@ contract SystemConfig_upgrade_Test is SystemConfig_Init {
 
         // Verify that the l2ChainId was updated.
         assertEq(systemConfig.l2ChainId(), 1234);
+
+        // Verify that the dispute game factory address was cleared.
+        assertEq(vm.load(address(systemConfig), bytes32(systemConfig.DISPUTE_GAME_FACTORY_SLOT())), bytes32(0));
     }
 
     /// @notice Tests that the upgrade() function reverts if called a second time.

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -74,7 +74,6 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         assertEq(address(impl.l1CrossDomainMessenger()), address(0));
         assertEq(address(impl.l1ERC721Bridge()), address(0));
         assertEq(address(impl.l1StandardBridge()), address(0));
-        assertEq(address(impl.disputeGameFactory()), address(0));
         assertEq(address(impl.optimismPortal()), address(0));
         assertEq(address(impl.optimismMintableERC20Factory()), address(0));
     }

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -42,7 +42,6 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         l1CrossDomainMessenger: address(0),
                         l1ERC721Bridge: address(0),
                         l1StandardBridge: address(0),
-                        disputeGameFactory: address(0),
                         optimismPortal: address(0),
                         optimismMintableERC20Factory: address(0)
                     }),

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -360,7 +360,6 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "SystemConfig", _sel: _getSel("OPTIMISM_PORTAL_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("BATCH_INBOX_SLOT()") });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("DISPUTE_GAME_FACTORY_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("disputeGameFactory()") });
         _addSpec({
             _name: "SystemConfig",

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -360,6 +360,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "SystemConfig", _sel: _getSel("OPTIMISM_PORTAL_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("BATCH_INBOX_SLOT()") });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("DISPUTE_GAME_FACTORY_SLOT()") })
         _addSpec({ _name: "SystemConfig", _sel: _getSel("disputeGameFactory()") });
         _addSpec({
             _name: "SystemConfig",

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -360,7 +360,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "SystemConfig", _sel: _getSel("OPTIMISM_PORTAL_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("BATCH_INBOX_SLOT()") });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("DISPUTE_GAME_FACTORY_SLOT()") })
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("DISPUTE_GAME_FACTORY_SLOT()") });
         _addSpec({ _name: "SystemConfig", _sel: _getSel("disputeGameFactory()") });
         _addSpec({
             _name: "SystemConfig",

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -166,7 +166,6 @@ contract Initializer_Test is CommonTest {
                             l1CrossDomainMessenger: address(0),
                             l1ERC721Bridge: address(0),
                             l1StandardBridge: address(0),
-                            disputeGameFactory: address(0),
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0)
                         }),
@@ -202,7 +201,6 @@ contract Initializer_Test is CommonTest {
                             l1CrossDomainMessenger: address(0),
                             l1ERC721Bridge: address(0),
                             l1StandardBridge: address(0),
-                            disputeGameFactory: address(0),
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0)
                         }),


### PR DESCRIPTION
Updates the SystemConfig to kill the DisputeGameFactory input. By getting this address from the OptimismPortal we can remove the need for unnecessary inputs that would have to be changed if the DisputeGameFactory changes.