### PR TITLE
op-node: add sequencer "Recover Mode" feature

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -37,6 +37,10 @@ func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bl
 	return m.actual.FindL1Origin(ctx, l2Head)
 }
 
+func (m *MockL1OriginSelector) SetRecoverMode(bool) {
+	// noop
+}
+
 // L2Sequencer is an actor that functions like a rollup node,
 // without the full P2P/API/Node stack, but just the derivation state, and simplified driver with sequencing ability.
 type L2Sequencer struct {

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -30,11 +30,11 @@ type MockL1OriginSelector struct {
 	originOverride eth.L1BlockRef // override which origin gets picked
 }
 
-func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
 	if m.originOverride != (eth.L1BlockRef{}) {
 		return m.originOverride, nil
 	}
-	return m.actual.FindL1Origin(ctx, l2Head)
+	return m.actual.FindL1Origin(ctx, l2Head, recoverMode)
 }
 
 // L2Sequencer is an actor that functions like a rollup node,
@@ -176,7 +176,7 @@ func (s *L2Sequencer) ActBuildToL1HeadUnsafe(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 	for {
 		s.ActL2PipelineFull(t)
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head(), false)
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.syncStatus.L1Head().Number {
 			break
@@ -189,7 +189,7 @@ func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExclUnsafe(t Testing) {
 	for {
 		// Note: the derivation pipeline does not run, we are just sequencing a block on top of the existing L2 chain.
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head(), false)
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.syncStatus.L1Head().Number {
 			break

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -30,11 +30,11 @@ type MockL1OriginSelector struct {
 	originOverride eth.L1BlockRef // override which origin gets picked
 }
 
-func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
+func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
 	if m.originOverride != (eth.L1BlockRef{}) {
 		return m.originOverride, nil
 	}
-	return m.actual.FindL1Origin(ctx, l2Head, recoverMode)
+	return m.actual.FindL1Origin(ctx, l2Head)
 }
 
 // L2Sequencer is an actor that functions like a rollup node,
@@ -56,7 +56,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	ver := NewL2Verifier(t, log, l1, blobSrc, altDASrc, eng, cfg, &sync.Config{}, safedb.Disabled)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, eng)
 	seqConfDepthL1 := confdepth.NewConfDepth(seqConfDepth, ver.syncStatus.L1Head, l1)
-	originSelector := sequencing.NewL1OriginSelector(t.Ctx(), log, cfg, seqConfDepthL1)
+	originSelector := sequencing.NewL1OriginSelector(t.Ctx(), log, cfg, seqConfDepthL1, false)
 	l1OriginSelector := &MockL1OriginSelector{
 		actual: originSelector,
 	}
@@ -176,7 +176,7 @@ func (s *L2Sequencer) ActBuildToL1HeadUnsafe(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 	for {
 		s.ActL2PipelineFull(t)
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head(), false)
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.syncStatus.L1Head().Number {
 			break
@@ -189,7 +189,7 @@ func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExclUnsafe(t Testing) {
 	for {
 		// Note: the derivation pipeline does not run, we are just sequencing a block on top of the existing L2 chain.
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head(), false)
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.syncStatus.L1Head().Number {
 			break

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -60,7 +60,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	ver := NewL2Verifier(t, log, l1, blobSrc, altDASrc, eng, cfg, &sync.Config{}, safedb.Disabled)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, eng)
 	seqConfDepthL1 := confdepth.NewConfDepth(seqConfDepth, ver.syncStatus.L1Head, l1)
-	originSelector := sequencing.NewL1OriginSelector(t.Ctx(), log, cfg, seqConfDepthL1, false)
+	originSelector := sequencing.NewL1OriginSelector(t.Ctx(), log, cfg, seqConfDepthL1)
 	l1OriginSelector := &MockL1OriginSelector{
 		actual: originSelector,
 	}

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -283,6 +283,10 @@ func (s *l2VerifierBackend) ConductorEnabled(ctx context.Context) (bool, error) 
 	return false, nil
 }
 
+func (s *l2VerifierBackend) SetRecoverMode(ctx context.Context, mode bool) error {
+	return nil
+}
+
 func (s *L2Verifier) DerivationMetricsTracer() *testutils.TestDerivationMetrics {
 	return s.derivationMetrics
 }

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -284,7 +284,7 @@ func (s *l2VerifierBackend) ConductorEnabled(ctx context.Context) (bool, error) 
 }
 
 func (s *l2VerifierBackend) SetRecoverMode(ctx context.Context, mode bool) error {
-	return nil
+	return errors.New("recover mode unsupported")
 }
 
 func (s *L2Verifier) DerivationMetricsTracer() *testutils.TestDerivationMetrics {

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -236,6 +236,15 @@ If the sync-state is far behind, the op-node may need archived blob data to sync
 A faster alternative may be to bootstrap through the execution-layer sync mode,
 where the execution-engine may perform an optimized long-range sync, such as snap-sync.
 
+### Sequencer Window Expiry
+
+If the sequencer window expires (for example, due to extended batcher downtime), some manual intervention is required to help the chain recover.
+By restarting the sequencer with `SEQUENCER_RECOVER=true`, or by calling the `optimism_setRecoverMode` admin API method, the sequencer's behavior is changed.
+While recover mode is enabled, the tx pool is disabled and the l1 origin is progressed steadily: this means blocks are sequenced which are identical to those produced
+by verifiers under autoderivation. To enable the quickest recovery, the batcher should be configured for singular (not span) batches.
+After some time, the l1 origin of the l2 safe head will once again catch up close to the l1 head. Then, the recover mode should be disabled and the chain is
+back in a normal state.
+
 ## Testing
 
 <!-- describe testing methods and approach to test coverage -->

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -7,9 +7,11 @@ Pull requests:
 [monorepo](https://github.com/ethereum-optimism/optimism/pulls?q=is%3Aopen+is%3Apr+label%3AA-op-node)
 
 User docs:
+
 - [How to run a node](https://docs.optimism.io/builders/node-operators/rollup-node)
 
 Specs:
+
 - [rollup-node spec]
 
 The op-node implements the [rollup-node spec].
@@ -130,6 +132,7 @@ and design-choices should aim to improve the trade-off.
 ### Vision
 
 The op-node is changing in two ways:
+
 - [Reliability](#reliability): improve the reliability with improved processing, testing and syncing.
 - [Interoperability](#interoperability): cross-chain messaging support.
 
@@ -162,15 +165,16 @@ See [Interop specs] and [Interop design-docs] for more information about interop
 
 <!-- As a **actor** I want **achievement** so that I **benefit** -->
 
-As *a user* I want *reliability* so that I *don't miss blocks or fall out of sync*.
-As *a RaaS dev* I want *easy configuration and monitoring* so that I *can run more chains*.
-As *a customizoor* I want *clear extensible APIs* so that I *can avoid forking and be a contributor*.
-As *a protocol dev* I want *integration with tests* so that I *assert protocol conformance*
-As *a proof dev* I want *reusable state-transition code* so that I *don't reimplement the same thing*.
+As _a user_ I want _reliability_ so that I _don't miss blocks or fall out of sync_.
+As _a RaaS dev_ I want _easy configuration and monitoring_ so that I _can run more chains_.
+As _a customizoor_ I want _clear extensible APIs_ so that I _can avoid forking and be a contributor_.
+As _a protocol dev_ I want _integration with tests_ so that I _assert protocol conformance_
+As _a proof dev_ I want _reusable state-transition code_ so that I _don't reimplement the same thing_.
 
 ## Design principles
 
 <!-- design choices / trade-offs -->
+
 - Encapsulate the state-transition:
   - Use interfaces to abstract file-IO / concurrency / etc. away from state-transition logic.
   - Ensure code-sharing with action-tests and op-program.
@@ -180,7 +184,7 @@ As *a proof dev* I want *reusable state-transition code* so that I *don't reimpl
 - Keep the tech-stack compatible with ethereum L1:
   - L1 offers well-adopted and battle tested libraries and standards, e.g. LibP2P, DiscV5, JSON-RPC.
   - L1 supports a tech-stack in different languages, ensuring client-diversity, important to L2 as well.
-  - Downstream devs of OP-Stack should be able to pull in *one* instance of a library, that serves both OP-Stack and L1.
+  - Downstream devs of OP-Stack should be able to pull in _one_ instance of a library, that serves both OP-Stack and L1.
 
 ## Failure modes
 
@@ -239,7 +243,8 @@ where the execution-engine may perform an optimized long-range sync, such as sna
 ### Sequencer Window Expiry
 
 If the sequencer window expires (for example, due to extended batcher downtime), some manual intervention is required to help the chain recover.
-By restarting the sequencer with `SEQUENCER_RECOVER=true`, or by calling the `optimism_setRecoverMode` admin API method, the sequencer's behavior is changed.
+By restarting the sequencer with `SEQUENCER_RECOVER=true`,
+or by calling the `optimism_setRecoverMode` admin API method with the boolean parameter set to `true`, the sequencer's behavior is changed.
 While recover mode is enabled, the tx pool is disabled and the l1 origin is progressed steadily: this means blocks are sequenced which are identical to those produced
 by verifiers under autoderivation. To enable the quickest recovery, the batcher should be configured for singular (not span) batches.
 After some time, the l1 origin of the l2 safe head will once again catch up close to the l1 head. Then, the recover mode should be disabled and the chain is
@@ -259,4 +264,3 @@ back in a normal state.
 - Long-running devnet: roll-out for experimental features, to ensure sufficient stability for testnet users.
 - Long-running testnet: battle-testing in public environment.
 - Shadow-forks: design phase, testing experiments against shadow copies of real networks.
-

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -249,6 +249,13 @@ var (
 		Value:    4,
 		Category: SequencerCategory,
 	}
+	SequencerRecoverMode = &cli.BoolFlag{
+		Name:     "sequencer.recover",
+		Usage:    "Forces the sequencer to strictly prepare the next L1 origin and create empty L2 blocks",
+		EnvVars:  prefixEnvVars("SEQUENCER_RECOVER"),
+		Value:    false,
+		Category: SequencerCategory,
+	}
 	L1EpochPollIntervalFlag = &cli.DurationFlag{
 		Name:     "l1.epoch-poll-interval",
 		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
@@ -458,6 +465,7 @@ var optionalFlags = []cli.Flag{
 	SequencerStoppedFlag,
 	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
+	SequencerRecoverMode,
 	L1EpochPollIntervalFlag,
 	RuntimeConfigReloadIntervalFlag,
 	RPCEnableAdmin,

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -35,6 +35,7 @@ type driverClient interface {
 	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
 	OverrideLeader(ctx context.Context) error
 	ConductorEnabled(ctx context.Context) (bool, error)
+	SetRecoverMode(ctx context.Context, mode bool) error
 }
 
 type SafeDBReader interface {
@@ -104,6 +105,10 @@ func (n *adminAPI) ConductorEnabled(ctx context.Context) (bool, error) {
 	recordDur := n.M.RecordRPCServerRequest("admin_conductorEnabled")
 	defer recordDur()
 	return n.dr.ConductorEnabled(ctx)
+}
+
+func (n *adminAPI) SetRecoverMode(ctx context.Context, mode bool) error {
+	return n.dr.SetRecoverMode(ctx, mode)
 }
 
 type nodeAPI struct {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -291,6 +291,11 @@ func (c *mockDriverClient) ConductorEnabled(ctx context.Context) (bool, error) {
 	return c.Mock.MethodCalled("ConductorEnabled").Get(0).(bool), nil
 }
 
+func (c *mockDriverClient) SetRecoverMode(ctx context.Context, mode bool) error {
+	c.Mock.MethodCalled("SetRecoverMode")
+	return nil
+}
+
 type mockSafeDBReader struct {
 	mock.Mock
 }

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,8 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// RecoverMode forces the sequencer to select the next L1 Origin exactly, and create an empty block,
+	// to be compatible with verifiers forcefully generating the same block.
+	RecoverMode bool `json:"recover_mode"`
 }

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -22,6 +22,6 @@ type Config struct {
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
 
 	// RecoverMode forces the sequencer to select the next L1 Origin exactly, and create an empty block,
-	// to be compatible with verifiers forcefully generating the same block.
+	// to be compatible with verifiers forcefully generating the same block while catching up the sequencing window timeout.
 	RecoverMode bool `json:"recover_mode"`
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -238,7 +238,7 @@ func NewDriver(
 		asyncGossiper := async.NewAsyncGossiper(driverCtx, network, log, metrics)
 		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 		sequencerConfDepth := confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
-		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
+		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth, driverCfg.RecoverMode)
 		sys.Register("origin-selector", findL1Origin, opts)
 		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -238,7 +238,7 @@ func NewDriver(
 		asyncGossiper := async.NewAsyncGossiper(driverCtx, network, log, metrics)
 		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 		sequencerConfDepth := confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
-		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth, driverCfg.RecoverMode)
+		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
 		sys.Register("origin-selector", findL1Origin, opts)
 		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -81,7 +81,10 @@ func (s *Driver) Start() error {
 	log.Info("Starting driver", "sequencerEnabled", s.driverConfig.SequencerEnabled,
 		"sequencerStopped", s.driverConfig.SequencerStopped, "recoverMode", s.driverConfig.RecoverMode)
 	if s.driverConfig.SequencerEnabled {
-		s.sequencer.SetRecoverMode(s.driverConfig.RecoverMode)
+		if s.driverConfig.RecoverMode {
+			log.Warn("sequencer is in recover mode")
+			s.sequencer.SetRecoverMode(true)
+		}
 		if err := s.sequencer.SetMaxSafeLag(s.driverCtx, s.driverConfig.SequencerMaxSafeLag); err != nil {
 			return fmt.Errorf("failed to set sequencer max safe lag: %w", err)
 		}

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -79,8 +79,9 @@ type Driver struct {
 // The loop will have been started iff err is not nil.
 func (s *Driver) Start() error {
 	log.Info("Starting driver", "sequencerEnabled", s.driverConfig.SequencerEnabled,
-		"sequencerStopped", s.driverConfig.SequencerStopped)
+		"sequencerStopped", s.driverConfig.SequencerStopped, "recoverMode", s.driverConfig.RecoverMode)
 	if s.driverConfig.SequencerEnabled {
+		s.sequencer.SetRecoverMode(s.driverConfig.RecoverMode)
 		if err := s.sequencer.SetMaxSafeLag(s.driverCtx, s.driverConfig.SequencerMaxSafeLag); err != nil {
 			return fmt.Errorf("failed to set sequencer max safe lag: %w", err)
 		}
@@ -497,6 +498,11 @@ func (s *Driver) OverrideLeader(ctx context.Context) error {
 
 func (s *Driver) ConductorEnabled(ctx context.Context) (bool, error) {
 	return s.sequencer.ConductorEnabled(ctx), nil
+}
+
+func (s *Driver) SetRecoverMode(ctx context.Context, mode bool) error {
+	s.sequencer.SetRecoverMode(mode)
+	return nil
 }
 
 // SyncStatus blocks the driver event loop and captures the syncing status.

--- a/op-node/rollup/sequencing/disabled.go
+++ b/op-node/rollup/sequencing/disabled.go
@@ -52,4 +52,6 @@ func (ds DisabledSequencer) ConductorEnabled(ctx context.Context) bool {
 	return false
 }
 
+func (ds DisabledSequencer) SetRecoverMode(mode bool) {}
+
 func (ds DisabledSequencer) Close() {}

--- a/op-node/rollup/sequencing/iface.go
+++ b/op-node/rollup/sequencing/iface.go
@@ -20,5 +20,6 @@ type SequencerIface interface {
 	SetMaxSafeLag(ctx context.Context, v uint64) error
 	OverrideLeader(ctx context.Context) error
 	ConductorEnabled(ctx context.Context) bool
+	SetRecoverMode(mode bool)
 	Close()
 }

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -28,7 +29,7 @@ type L1OriginSelector struct {
 	cfg  *rollup.Config
 	spec *rollup.ChainSpec
 
-	recoverMode bool
+	recoverMode *atomic.Bool
 
 	l1 L1Blocks
 
@@ -40,14 +41,20 @@ type L1OriginSelector struct {
 }
 
 func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config, l1 L1Blocks, recoverMode bool) *L1OriginSelector {
+	r := atomic.Bool{}
+	r.Store(recoverMode)
 	return &L1OriginSelector{
 		ctx:         ctx,
 		log:         log.With("recover_mode", recoverMode),
 		cfg:         cfg,
 		spec:        rollup.NewChainSpec(cfg),
 		l1:          l1,
-		recoverMode: recoverMode,
+		recoverMode: &r,
 	}
+}
+
+func (los *L1OriginSelector) SetRecoverMode(enabled bool) {
+	los.recoverMode.Store(enabled)
 }
 
 func (los *L1OriginSelector) OnEvent(ev event.Event) bool {
@@ -117,7 +124,7 @@ func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head et
 	los.mu.Lock()
 	defer los.mu.Unlock()
 
-	if los.recoverMode {
+	if los.recoverMode.Load() {
 		currentOrigin, err := los.l1.L1BlockRefByHash(ctx, l2Head.L1Origin.Hash)
 		if err != nil {
 			return eth.L1BlockRef{}, eth.L1BlockRef{},

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -40,16 +40,13 @@ type L1OriginSelector struct {
 	mu sync.Mutex
 }
 
-func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config, l1 L1Blocks, recoverMode bool) *L1OriginSelector {
-	r := atomic.Bool{}
-	r.Store(recoverMode)
+func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config, l1 L1Blocks) *L1OriginSelector {
 	return &L1OriginSelector{
-		ctx:         ctx,
-		log:         log,
-		cfg:         cfg,
-		spec:        rollup.NewChainSpec(cfg),
-		l1:          l1,
-		recoverMode: &r,
+		ctx:  ctx,
+		log:  log,
+		cfg:  cfg,
+		spec: rollup.NewChainSpec(cfg),
+		l1:   l1,
 	}
 }
 

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -28,6 +28,8 @@ type L1OriginSelector struct {
 	cfg  *rollup.Config
 	spec *rollup.ChainSpec
 
+	recoverMode bool
+
 	l1 L1Blocks
 
 	// Internal cache of L1 origins for faster access.
@@ -37,13 +39,14 @@ type L1OriginSelector struct {
 	mu sync.Mutex
 }
 
-func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config, l1 L1Blocks) *L1OriginSelector {
+func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config, l1 L1Blocks, recoverMode bool) *L1OriginSelector {
 	return &L1OriginSelector{
-		ctx:  ctx,
-		log:  log,
-		cfg:  cfg,
-		spec: rollup.NewChainSpec(cfg),
-		l1:   l1,
+		ctx:         ctx,
+		log:         log,
+		cfg:         cfg,
+		spec:        rollup.NewChainSpec(cfg),
+		l1:          l1,
+		recoverMode: recoverMode,
 	}
 }
 
@@ -62,8 +65,8 @@ func (los *L1OriginSelector) OnEvent(ev event.Event) bool {
 // FindL1Origin determines what the next L1 Origin should be.
 // The L1 Origin is either the L2 Head's Origin, or the following L1 block
 // if the next L2 block's time is greater than or equal to the L2 Head's Origin.
-func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
-	currentOrigin, nextOrigin, err := los.CurrentAndNextOrigin(ctx, l2Head, recoverMode)
+func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+	currentOrigin, nextOrigin, err := los.CurrentAndNextOrigin(ctx, l2Head)
 	if err != nil {
 		return eth.L1BlockRef{}, err
 	}
@@ -110,11 +113,11 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 	return nextOrigin, nil
 }
 
-func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, eth.L1BlockRef, error) {
+func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, eth.L1BlockRef, error) {
 	los.mu.Lock()
 	defer los.mu.Unlock()
 
-	if recoverMode {
+	if los.recoverMode {
 		currentOrigin, err := los.l1.L1BlockRefByHash(ctx, l2Head.L1Origin.Hash)
 		if err != nil {
 			return eth.L1BlockRef{}, eth.L1BlockRef{},
@@ -170,7 +173,7 @@ func (los *L1OriginSelector) onForkchoiceUpdate(unsafeL2Head eth.L2BlockRef) {
 	ctx, cancel := context.WithTimeout(los.ctx, 500*time.Millisecond)
 	defer cancel()
 
-	currentOrigin, nextOrigin, err := los.CurrentAndNextOrigin(ctx, unsafeL2Head, false)
+	currentOrigin, nextOrigin, err := los.CurrentAndNextOrigin(ctx, unsafeL2Head)
 	if err != nil {
 		los.log.Error("Failed to get current and next L1 origin on forkchoice update", "err", err)
 		return

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -45,7 +45,7 @@ func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config
 	r.Store(recoverMode)
 	return &L1OriginSelector{
 		ctx:         ctx,
-		log:         log.With("recover_mode", recoverMode),
+		log:         log,
 		cfg:         cfg,
 		spec:        rollup.NewChainSpec(cfg),
 		l1:          l1,
@@ -137,6 +137,7 @@ func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head et
 				derive.NewTemporaryError(fmt.Errorf("failed to fetch next L1 origin: %w", err))
 		}
 		los.nextOrigin = nextOrigin
+		los.log.Info("origin selector in recover mode", "current_origin", los.currentOrigin, "next_origin", los.nextOrigin, "l2_head", l2Head)
 		return los.currentOrigin, los.nextOrigin, nil
 	}
 

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -29,7 +29,7 @@ type L1OriginSelector struct {
 	cfg  *rollup.Config
 	spec *rollup.ChainSpec
 
-	recoverMode *atomic.Bool
+	recoverMode atomic.Bool
 
 	l1 L1Blocks
 

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -42,7 +42,7 @@ type L1OriginSelector struct {
 func NewL1OriginSelector(ctx context.Context, log log.Logger, cfg *rollup.Config, l1 L1Blocks, recoverMode bool) *L1OriginSelector {
 	return &L1OriginSelector{
 		ctx:         ctx,
-		log:         log,
+		log:         log.With("recover_mode", recoverMode),
 		cfg:         cfg,
 		spec:        rollup.NewChainSpec(cfg),
 		l1:          l1,

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -202,8 +202,8 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	// It may not be ready yet. Expect an error, even if we could stick to c.
 	l1.ExpectL1BlockRefByNumber(d.Number, eth.BlockRef{}, ethereum.NotFound)
 
-	// at origin d, and can stick to c (thanks to timestamp), if it wasn't for recover mode.
-	s.recoverMode = true
+	// at origin d, and could stick to c (thanks to timestamp), if it wasn't for recover mode.
+	s.recoverMode.Store(true)
 	l2Head = eth.L2BlockRef{
 		L1Origin: c.ID(),
 		Time:     d.Time + 4,
@@ -216,7 +216,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
 	l1.ExpectL1BlockRefByNumber(d.Number, d, nil)
 	next, err = s.FindL1Origin(ctx, l2Head)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, d, next)
 }
 

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -50,18 +50,18 @@ func TestOriginSelectorFetchCurrentError(t *testing.T) {
 
 	l1.ExpectL1BlockRefByHash(a.Hash, eth.L1BlockRef{}, errors.New("test error"))
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 
-	_, err := s.FindL1Origin(ctx, l2Head, false)
+	_, err := s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "test error")
 
 	// The same outcome occurs when the cached origin is different from that of the L2 head.
 	l1.ExpectL1BlockRefByHash(a.Hash, eth.L1BlockRef{}, errors.New("test error"))
 
-	s = NewL1OriginSelector(ctx, log, cfg, l1)
+	s = NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = b
 
-	_, err = s.FindL1Origin(ctx, l2Head, false)
+	_, err = s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "test error")
 }
 
@@ -93,10 +93,10 @@ func TestOriginSelectorFetchNextError(t *testing.T) {
 		Time:     24,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 
@@ -111,7 +111,7 @@ func TestOriginSelectorFetchNextError(t *testing.T) {
 	require.True(t, handled)
 
 	// The next origin should still be `a` because the fetch failed.
-	next, err = s.FindL1Origin(ctx, l2Head, false)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
@@ -162,7 +162,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 		Time:     24,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
@@ -171,7 +171,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	handled := s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
 	require.True(t, handled)
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, b, next)
 
@@ -181,7 +181,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	}
 
 	// The origin is still `b` because the next origin has not been fetched yet.
-	next, err = s.FindL1Origin(ctx, l2Head, false)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, b, next)
 
@@ -193,7 +193,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	require.True(t, handled)
 
 	// The next origin should be `c` now.
-	next, err = s.FindL1Origin(ctx, l2Head, false)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, c, next)
 
@@ -203,18 +203,19 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	l1.ExpectL1BlockRefByNumber(d.Number, eth.BlockRef{}, ethereum.NotFound)
 
 	// at origin d, and can stick to c (thanks to timestamp), if it wasn't for recover mode.
+	s.recoverMode = true
 	l2Head = eth.L2BlockRef{
 		L1Origin: c.ID(),
 		Time:     d.Time + 4,
 	}
-	_, err = s.FindL1Origin(ctx, l2Head, true)
+	_, err = s.FindL1Origin(ctx, l2Head)
 	require.ErrorIs(t, err, derive.ErrTemporary)
 	require.ErrorIs(t, err, ethereum.NotFound)
 
 	// Now actually get to L1 origin d.
 	l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
 	l1.ExpectL1BlockRefByNumber(d.Number, d, nil)
-	next, err = s.FindL1Origin(ctx, l2Head, true)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, d, next)
 }
@@ -248,11 +249,11 @@ func TestOriginSelectorHandlesReset(t *testing.T) {
 		Time:     24,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, b, next)
 
@@ -264,7 +265,7 @@ func TestOriginSelectorHandlesReset(t *testing.T) {
 	// because the internal cache was reset.
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 
-	next, err = s.FindL1Origin(ctx, l2Head, false)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
@@ -305,15 +306,15 @@ func TestOriginSelectorFetchesNextOrigin(t *testing.T) {
 	// This is called as part of the background prefetch job
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 
 	// Selection is stable until the next origin is fetched
-	next, err = s.FindL1Origin(ctx, l2Head, false)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 
@@ -322,7 +323,7 @@ func TestOriginSelectorFetchesNextOrigin(t *testing.T) {
 	require.True(t, handled)
 
 	// The next origin should be `b` now.
-	next, err = s.FindL1Origin(ctx, l2Head, false)
+	next, err = s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, b, next)
 }
@@ -362,11 +363,11 @@ func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 		Time:     22,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
@@ -410,9 +411,9 @@ func TestOriginSelectorRespectsSeqDrift(t *testing.T) {
 
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.NoError(t, err)
 	require.Equal(t, b, next)
 }
@@ -452,10 +453,10 @@ func TestOriginSelectorRespectsConfDepth(t *testing.T) {
 	}
 
 	confDepthL1 := confdepth.NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
-	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1)
+	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1, false)
 	s.currentOrigin = a
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
@@ -499,9 +500,9 @@ func TestOriginSelectorStrictConfDepth(t *testing.T) {
 
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	confDepthL1 := confdepth.NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
-	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1)
+	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1, false)
 
-	_, err := s.FindL1Origin(ctx, l2Head, false)
+	_, err := s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "sequencer time drift")
 }
 
@@ -535,10 +536,10 @@ func TestOriginSelector_FjordSeqDrift(t *testing.T) {
 		Time:     27, // next L2 block time would be past pre-Fjord seq drift
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.NoError(t, err, "with Fjord activated, have increased max seq drift")
 	require.Equal(t, a, next)
 }
@@ -576,11 +577,11 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTime(t *testing.T) {
 		Time:     27,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
@@ -622,10 +623,10 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTimeNoCache(t *testing.T) {
 
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 	s.currentOrigin = a
 
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
@@ -685,17 +686,17 @@ func TestOriginSelectorHandlesLateL1Blocks(t *testing.T) {
 
 	l1Head := b
 	confDepthL1 := confdepth.NewConfDepth(2, func() eth.L1BlockRef { return l1Head }, l1)
-	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1)
+	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1, false)
 
-	_, err := s.FindL1Origin(ctx, l2Head, false)
+	_, err := s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "sequencer time drift")
 
 	l1Head = c
-	_, err = s.FindL1Origin(ctx, l2Head, false)
+	_, err = s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "sequencer time drift")
 
 	l1Head = d
-	next, err := s.FindL1Origin(ctx, l2Head, false)
+	next, err := s.FindL1Origin(ctx, l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next, "must stay on a because the L1 time may not be higher than the L2 time")
 }
@@ -714,7 +715,7 @@ func TestOriginSelectorMiscEvent(t *testing.T) {
 	l1 := &testutils.MockL1Source{}
 	defer l1.AssertExpectations(t)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1)
+	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
 
 	// This event is not handled
 	handled := s.OnEvent(rollup.L1TemporaryErrorEvent{})

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -50,7 +50,7 @@ func TestOriginSelectorFetchCurrentError(t *testing.T) {
 
 	l1.ExpectL1BlockRefByHash(a.Hash, eth.L1BlockRef{}, errors.New("test error"))
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 
 	_, err := s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "test error")
@@ -58,7 +58,7 @@ func TestOriginSelectorFetchCurrentError(t *testing.T) {
 	// The same outcome occurs when the cached origin is different from that of the L2 head.
 	l1.ExpectL1BlockRefByHash(a.Hash, eth.L1BlockRef{}, errors.New("test error"))
 
-	s = NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s = NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = b
 
 	_, err = s.FindL1Origin(ctx, l2Head)
@@ -93,7 +93,7 @@ func TestOriginSelectorFetchNextError(t *testing.T) {
 		Time:     24,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 
 	next, err := s.FindL1Origin(ctx, l2Head)
@@ -164,7 +164,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 			Time:     24,
 		}
 
-		s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+		s := NewL1OriginSelector(ctx, log, cfg, l1)
 
 		requireL1OriginAt := func(l2Head eth.L2BlockRef, want eth.L1BlockRef) {
 			got, err := s.FindL1Origin(ctx, l2Head)
@@ -261,7 +261,7 @@ func TestOriginSelectorHandlesReset(t *testing.T) {
 		Time:     24,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
@@ -318,7 +318,7 @@ func TestOriginSelectorFetchesNextOrigin(t *testing.T) {
 	// This is called as part of the background prefetch job
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 
 	next, err := s.FindL1Origin(ctx, l2Head)
@@ -375,7 +375,7 @@ func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 		Time:     22,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
@@ -423,7 +423,7 @@ func TestOriginSelectorRespectsSeqDrift(t *testing.T) {
 
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 
 	next, err := s.FindL1Origin(ctx, l2Head)
 	require.NoError(t, err)
@@ -465,7 +465,7 @@ func TestOriginSelectorRespectsConfDepth(t *testing.T) {
 	}
 
 	confDepthL1 := confdepth.NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
-	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1)
 	s.currentOrigin = a
 
 	next, err := s.FindL1Origin(ctx, l2Head)
@@ -512,7 +512,7 @@ func TestOriginSelectorStrictConfDepth(t *testing.T) {
 
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	confDepthL1 := confdepth.NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
-	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1)
 
 	_, err := s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "sequencer time drift")
@@ -548,7 +548,7 @@ func TestOriginSelector_FjordSeqDrift(t *testing.T) {
 		Time:     27, // next L2 block time would be past pre-Fjord seq drift
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 
 	next, err := s.FindL1Origin(ctx, l2Head)
@@ -589,7 +589,7 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTime(t *testing.T) {
 		Time:     27,
 	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 	s.nextOrigin = b
 
@@ -635,7 +635,7 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTimeNoCache(t *testing.T) {
 
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 	s.currentOrigin = a
 
 	next, err := s.FindL1Origin(ctx, l2Head)
@@ -698,7 +698,7 @@ func TestOriginSelectorHandlesLateL1Blocks(t *testing.T) {
 
 	l1Head := b
 	confDepthL1 := confdepth.NewConfDepth(2, func() eth.L1BlockRef { return l1Head }, l1)
-	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, confDepthL1)
 
 	_, err := s.FindL1Origin(ctx, l2Head)
 	require.ErrorContains(t, err, "sequencer time drift")
@@ -727,7 +727,7 @@ func TestOriginSelectorMiscEvent(t *testing.T) {
 	l1 := &testutils.MockL1Source{}
 	defer l1.AssertExpectations(t)
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+	s := NewL1OriginSelector(ctx, log, cfg, l1)
 
 	// This event is not handled
 	handled := s.OnEvent(rollup.L1TemporaryErrorEvent{})

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -124,100 +124,112 @@ func TestOriginSelectorFetchNextError(t *testing.T) {
 // is no conf depth to stop the origin selection so block `b` should
 // be the next L1 origin, and then block `c` is the subsequent L1 origin.
 func TestOriginSelectorAdvances(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	log := testlog.Logger(t, log.LevelCrit)
-	cfg := &rollup.Config{
-		MaxSequencerDrift: 500,
-		BlockTime:         2,
+	testOriginSelectorAdvances := func(t *testing.T, recoverMode bool) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		log := testlog.Logger(t, log.LevelCrit)
+		cfg := &rollup.Config{
+			MaxSequencerDrift: 500,
+			BlockTime:         2,
+		}
+		l1 := &testutils.MockL1Source{}
+		defer l1.AssertExpectations(t)
+		a := eth.L1BlockRef{
+			Hash:   common.Hash{'a'},
+			Number: 10,
+			Time:   20,
+		}
+		b := eth.L1BlockRef{
+			Hash:       common.Hash{'b'},
+			Number:     11,
+			Time:       22,
+			ParentHash: a.Hash,
+		}
+		c := eth.L1BlockRef{
+			Hash:       common.Hash{'c'},
+			Number:     12,
+			Time:       24,
+			ParentHash: b.Hash,
+		}
+		d := eth.L1BlockRef{
+			Hash:       common.Hash{'d'},
+			Number:     13,
+			Time:       36,
+			ParentHash: c.Hash,
+		}
+		l2Head := eth.L2BlockRef{
+			L1Origin: a.ID(),
+			Time:     24,
+		}
+
+		s := NewL1OriginSelector(ctx, log, cfg, l1, false)
+
+		requireL1OriginAt := func(l2Head eth.L2BlockRef, want eth.L1BlockRef) {
+			got, err := s.FindL1Origin(ctx, l2Head)
+			require.Nil(t, err)
+			require.Equal(t, want, got)
+		}
+
+		s.currentOrigin = a
+		s.nextOrigin = b
+
+		// Trigger the background fetch via a forkchoice update.
+		// This should be a no-op because the next origin is already cached.
+		handled := s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+		require.True(t, handled)
+
+		requireL1OriginAt(l2Head, b)
+
+		l2Head = eth.L2BlockRef{
+			L1Origin: b.ID(),
+			Time:     26,
+		}
+
+		// The origin is still `b` because the next origin has not been fetched yet.
+		requireL1OriginAt(l2Head, b)
+
+		l1.ExpectL1BlockRefByNumber(c.Number, c, nil)
+
+		// Trigger the background fetch via a forkchoice update.
+		// This will actually fetch the next origin because the internal cache is empty.
+		handled = s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+		require.True(t, handled)
+
+		// The next origin should be `c` now.
+		requireL1OriginAt(l2Head, c)
+
+		// Now force the retrieval of the next L1 origin
+		s.recoverMode.Store(recoverMode)
+
+		l2Head = eth.L2BlockRef{
+			L1Origin: c.ID(),
+			Time:     d.Time + 4,
+		}
+
+		if recoverMode {
+			// In recovery mode (only) we make two RPC calls.
+			// First, cover the case where the nextOrigin
+			// is not ready yet by simulating a NotFound error.
+			l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
+			l1.ExpectL1BlockRefByNumber(d.Number, eth.BlockRef{}, ethereum.NotFound)
+			_, err := s.FindL1Origin(ctx, l2Head)
+			require.ErrorIs(t, err, derive.ErrTemporary)
+			require.ErrorIs(t, err, ethereum.NotFound)
+
+			// Now, simulate the block being ready, and ensure
+			// that the origin advances to the next block.
+			l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
+			l1.ExpectL1BlockRefByNumber(d.Number, d, nil)
+			requireL1OriginAt(l2Head, d)
+		} else {
+			requireL1OriginAt(l2Head, c)
+		}
 	}
-	l1 := &testutils.MockL1Source{}
-	defer l1.AssertExpectations(t)
-	a := eth.L1BlockRef{
-		Hash:   common.Hash{'a'},
-		Number: 10,
-		Time:   20,
-	}
-	b := eth.L1BlockRef{
-		Hash:       common.Hash{'b'},
-		Number:     11,
-		Time:       22,
-		ParentHash: a.Hash,
-	}
-	c := eth.L1BlockRef{
-		Hash:       common.Hash{'c'},
-		Number:     12,
-		Time:       24,
-		ParentHash: b.Hash,
-	}
-	d := eth.L1BlockRef{
-		Hash:       common.Hash{'d'},
-		Number:     13,
-		Time:       36,
-		ParentHash: c.Hash,
-	}
-	l2Head := eth.L2BlockRef{
-		L1Origin: a.ID(),
-		Time:     24,
-	}
 
-	s := NewL1OriginSelector(ctx, log, cfg, l1, false)
-	s.currentOrigin = a
-	s.nextOrigin = b
-
-	// Trigger the background fetch via a forkchoice update.
-	// This should be a no-op because the next origin is already cached.
-	handled := s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
-	require.True(t, handled)
-
-	next, err := s.FindL1Origin(ctx, l2Head)
-	require.Nil(t, err)
-	require.Equal(t, b, next)
-
-	l2Head = eth.L2BlockRef{
-		L1Origin: b.ID(),
-		Time:     26,
-	}
-
-	// The origin is still `b` because the next origin has not been fetched yet.
-	next, err = s.FindL1Origin(ctx, l2Head)
-	require.Nil(t, err)
-	require.Equal(t, b, next)
-
-	l1.ExpectL1BlockRefByNumber(c.Number, c, nil)
-
-	// Trigger the background fetch via a forkchoice update.
-	// This will actually fetch the next origin because the internal cache is empty.
-	handled = s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
-	require.True(t, handled)
-
-	// The next origin should be `c` now.
-	next, err = s.FindL1Origin(ctx, l2Head)
-	require.Nil(t, err)
-	require.Equal(t, c, next)
-
-	// Now force the retrieval of the next L1 origin
-	l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
-	// It may not be ready yet. Expect an error, even if we could stick to c.
-	l1.ExpectL1BlockRefByNumber(d.Number, eth.BlockRef{}, ethereum.NotFound)
-
-	// at origin d, and could stick to c (thanks to timestamp), if it wasn't for recover mode.
-	s.recoverMode.Store(true)
-	l2Head = eth.L2BlockRef{
-		L1Origin: c.ID(),
-		Time:     d.Time + 4,
-	}
-	_, err = s.FindL1Origin(ctx, l2Head)
-	require.ErrorIs(t, err, derive.ErrTemporary)
-	require.ErrorIs(t, err, ethereum.NotFound)
-
-	// Now actually get to L1 origin d.
-	l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
-	l1.ExpectL1BlockRefByNumber(d.Number, d, nil)
-	next, err = s.FindL1Origin(ctx, l2Head)
-	require.NoError(t, err)
-	require.Equal(t, d, next)
+	t.Run("normal", func(t *testing.T) { testOriginSelectorAdvances(t, false) })
+	t.Run("recover_mode", func(t *testing.T) { testOriginSelectorAdvances(t, true) })
 }
 
 // TestOriginSelectorHandlesReset ensures that the origin selector

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -29,7 +29,7 @@ var (
 )
 
 type L1OriginSelectorIface interface {
-	FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error)
+	FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error)
 }
 
 type Metrics interface {
@@ -493,7 +493,7 @@ func (d *Sequencer) startBuildingBlock() {
 	recoverMode := d.recoverMode.Load()
 
 	// Figure out which L1 origin block we're going to be building on top of.
-	l1Origin, err := d.l1OriginSelector.FindL1Origin(ctx, l2Head, recoverMode)
+	l1Origin, err := d.l1OriginSelector.FindL1Origin(ctx, l2Head)
 	if err != nil {
 		d.nextAction = d.timeNow().Add(time.Second)
 		d.nextActionOK = d.active.Load()

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -568,7 +568,7 @@ func (d *Sequencer) startBuildingBlock() {
 
 	if recoverMode {
 		attrs.NoTxPool = true
-		d.log.Warn("Sequencing temporarily without user transactions, in catch-up mode")
+		d.log.Warn("Sequencing temporarily without user transactions, in recover mode")
 	}
 
 	d.log.Debug("prepared attributes for new block",

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -30,6 +30,7 @@ var (
 
 type L1OriginSelectorIface interface {
 	FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error)
+	SetRecoverMode(bool)
 }
 
 type Metrics interface {
@@ -753,6 +754,7 @@ func (d *Sequencer) ConductorEnabled(ctx context.Context) bool {
 }
 
 func (d *Sequencer) SetRecoverMode(mode bool) {
+	d.l1OriginSelector.SetRecoverMode(mode)
 	d.recoverMode.Store(mode)
 }
 

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -29,7 +29,7 @@ var (
 )
 
 type L1OriginSelectorIface interface {
-	FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error)
+	FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error)
 }
 
 type Metrics interface {
@@ -84,6 +84,8 @@ type Sequencer struct {
 	spec      *rollup.ChainSpec
 
 	maxSafeLag atomic.Uint64
+
+	recoverMode atomic.Bool
 
 	// active identifies whether the sequencer is running.
 	// This is an atomic value, so it can be read without locking the whole sequencer.
@@ -488,8 +490,10 @@ func (d *Sequencer) startBuildingBlock() {
 		return
 	}
 
+	recoverMode := d.recoverMode.Load()
+
 	// Figure out which L1 origin block we're going to be building on top of.
-	l1Origin, err := d.l1OriginSelector.FindL1Origin(ctx, l2Head)
+	l1Origin, err := d.l1OriginSelector.FindL1Origin(ctx, l2Head, recoverMode)
 	if err != nil {
 		d.nextAction = d.timeNow().Add(time.Second)
 		d.nextActionOK = d.active.Load()
@@ -560,6 +564,11 @@ func (d *Sequencer) startBuildingBlock() {
 	if d.rollupCfg.IsInteropActivationBlock(uint64(attrs.Timestamp)) {
 		attrs.NoTxPool = true
 		d.log.Info("Sequencing Interop upgrade block")
+	}
+
+	if recoverMode {
+		attrs.NoTxPool = true
+		d.log.Warn("Sequencing temporarily without user transactions, in catch-up mode")
 	}
 
 	d.log.Debug("prepared attributes for new block",
@@ -741,6 +750,10 @@ func (d *Sequencer) OverrideLeader(ctx context.Context) error {
 
 func (d *Sequencer) ConductorEnabled(ctx context.Context) bool {
 	return d.conductor.Enabled(ctx)
+}
+
+func (d *Sequencer) SetRecoverMode(mode bool) {
+	d.recoverMode.Store(mode)
 }
 
 func (d *Sequencer) Close() {

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -80,6 +80,10 @@ func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bl
 	return f.l1OriginFn(l2Head)
 }
 
+func (f *FakeL1OriginSelector) SetRecoverMode(bool) {
+	// noop
+}
+
 var _ L1OriginSelectorIface = (*FakeL1OriginSelector)(nil)
 
 type BasicSequencerStateListener struct {

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -75,7 +75,7 @@ type FakeL1OriginSelector struct {
 	l1OriginFn func(l2Head eth.L2BlockRef) (eth.L1BlockRef, error)
 }
 
-func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
 	f.request = l2Head
 	return f.l1OriginFn(l2Head)
 }

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -75,7 +75,7 @@ type FakeL1OriginSelector struct {
 	l1OriginFn func(l2Head eth.L2BlockRef) (eth.L1BlockRef, error)
 }
 
-func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef, recoverMode bool) (eth.L1BlockRef, error) {
+func (f *FakeL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
 	f.request = l2Head
 	return f.l1OriginFn(l2Head)
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -196,6 +196,7 @@ func NewDriverConfig(ctx *cli.Context) *driver.Config {
 		SequencerEnabled:    ctx.Bool(flags.SequencerEnabledFlag.Name),
 		SequencerStopped:    ctx.Bool(flags.SequencerStoppedFlag.Name),
 		SequencerMaxSafeLag: ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		RecoverMode:         ctx.Bool(flags.SequencerRecoverMode.Name),
 	}
 }
 


### PR DESCRIPTION
See https://github.com/ethereum-optimism/optimism/pull/13550 where we already deployed this as a hotfix successfully.  This PR seeks to mainline the feature. 

**Description**

E.g. on a testnet, if not batch-submitting for prolonged time, the sequencer may need to build new L2 blocks on top of actively new generated L2 blocks.

For blocks to be compatible, the L1 origin needs to be selected such that it progresses to the next L1 origin as soon as valid. And blocks need to be empty as well.


**Tests**

Updated L1 origin selector unit-tests to cover the forced next-L1-origin preparation.