### PR TITLE
chore(test-logger): fix test logger.Crit which wasn't getting flushed

### DIFF
--- a/op-service/testlog/testlog.go
+++ b/op-service/testlog/testlog.go
@@ -186,8 +186,10 @@ func (l *logger) Crit(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Crit(msg, ctx...)
+	// We can't use l.l.Crit because that will exit the program before we can flush the buffer.
+	l.l.Write(log.LevelCrit, msg, ctx...)
 	l.flush()
+	os.Exit(1)
 }
 
 func (l *logger) Log(level slog.Level, msg string, ctx ...any) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

test logger's function had a bug where it would flush after the call to geth's log.Crit, which exits the process; so the flush would never actually appear on stdout.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
