### PR TITLE
devnet-sdk: Use L2Chain subinterface for more accurate domain modeling

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -31,16 +31,21 @@ type Node struct {
 // AddressMap is a map of address names to their corresponding addresses
 type AddressMap map[string]types.Address
 
-// Chain represents a chain (L1 or L2) in a devnet.
 type Chain struct {
 	Name      string              `json:"name"`
 	ID        string              `json:"id,omitempty"`
 	Services  ServiceMap          `json:"services,omitempty"`
 	Nodes     []Node              `json:"nodes"`
-	Addresses AddressMap          `json:"addresses,omitempty"`
 	Wallets   WalletMap           `json:"wallets,omitempty"`
 	JWT       string              `json:"jwt,omitempty"`
 	Config    *params.ChainConfig `json:"config,omitempty"`
+	Addresses AddressMap          `json:"addresses,omitempty"`
+}
+
+type L2Chain struct {
+	Chain
+	L1Addresses AddressMap `json:"l1_addresses,omitempty"`
+	L1Wallets   WalletMap  `json:"l1_wallets,omitempty"`
 }
 
 // Wallet represents a wallet with an address and optional private key.
@@ -54,9 +59,9 @@ type WalletMap map[string]Wallet
 
 // DevnetEnvironment exposes the relevant information to interact with a devnet.
 type DevnetEnvironment struct {
-	Name string   `json:"name"`
-	L1   *Chain   `json:"l1"`
-	L2   []*Chain `json:"l2"`
+	Name string     `json:"name"`
+	L1   *Chain     `json:"l1"`
+	L2   []*L2Chain `json:"l2"`
 
 	Features []string `json:"features,omitempty"`
 }

--- a/devnet-sdk/shell/env/devnet.go
+++ b/devnet-sdk/shell/env/devnet.go
@@ -67,7 +67,7 @@ func (d *DevnetEnv) GetChain(chainName string) (*ChainConfig, error) {
 	} else {
 		for _, l2Chain := range d.Config.L2 {
 			if l2Chain.Name == chainName {
-				chain = l2Chain
+				chain = &l2Chain.Chain
 				break
 			}
 		}

--- a/devnet-sdk/shell/env/env_test.go
+++ b/devnet-sdk/shell/env/env_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
-	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,25 +108,42 @@ func TestGetChain(t *testing.T) {
 					},
 				},
 				JWT: "0x1234",
+				Addresses: descriptors.AddressMap{
+					"deployer": common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				},
 			},
-			L2: []*descriptors.Chain{
+			L2: []*descriptors.L2Chain{
 				{
-					Name: "op",
-					Nodes: []descriptors.Node{
-						{
-							Services: descriptors.ServiceMap{
-								"el": {
-									Endpoints: descriptors.EndpointMap{
-										"rpc": {
-											Host: "localhost",
-											Port: 9545,
+					Chain: descriptors.Chain{
+						Name: "op",
+						Nodes: []descriptors.Node{
+							{
+								Services: descriptors.ServiceMap{
+									"el": {
+										Endpoints: descriptors.EndpointMap{
+											"rpc": {
+												Host: "localhost",
+												Port: 9545,
+											},
 										},
 									},
 								},
 							},
 						},
+						JWT: "0x5678",
+						Addresses: descriptors.AddressMap{
+							"deployer": common.HexToAddress("0x2345678901234567890123456789012345678901"),
+						},
 					},
-					JWT: "0x5678",
+					L1Addresses: descriptors.AddressMap{
+						"deployer": common.HexToAddress("0x2345678901234567890123456789012345678901"),
+					},
+					L1Wallets: descriptors.WalletMap{
+						"deployer": descriptors.Wallet{
+							Address:    common.HexToAddress("0x2345678901234567890123456789012345678901"),
+							PrivateKey: "0x2345678901234567890123456789012345678901",
+						},
+					},
 				},
 			},
 		},
@@ -176,7 +192,7 @@ func TestChainConfig(t *testing.T) {
 				},
 			},
 			JWT: "0x1234",
-			Addresses: map[string]types.Address{
+			Addresses: descriptors.AddressMap{
 				"deployer": common.HexToAddress("0x1234567890123456789012345678901234567890"),
 			},
 		},

--- a/devnet-sdk/shell/env/kt_native_fetch_test.go
+++ b/devnet-sdk/shell/env/kt_native_fetch_test.go
@@ -149,7 +149,7 @@ func TestFetchKurtosisNativeDataSuccess(t *testing.T) {
 		envSpec := &spec.EnclaveSpec{}
 		env := &kurtosis.KurtosisEnvironment{
 			DevnetEnvironment: descriptors.DevnetEnvironment{
-				L2:       make([]*descriptors.Chain, 0, 1),
+				L2:       make([]*descriptors.L2Chain, 0, 1),
 				Features: envSpec.Features,
 			},
 		}

--- a/devnet-sdk/system/txbuilder_test.go
+++ b/devnet-sdk/system/txbuilder_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
-	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -121,17 +120,17 @@ func (m *mockChain) Client() (*sources.EthClient, error) {
 	return args.Get(0).(*sources.EthClient), nil
 }
 
-func (m *mockChain) Wallets(ctx context.Context) ([]Wallet, error) {
-	return nil, nil
+func (m *mockChain) Wallets() WalletMap {
+	return nil
 }
 
 func (m *mockChain) Config() (*params.ChainConfig, error) {
 	return nil, fmt.Errorf("not implemented for mock chain")
 }
 
-func (m *mockChain) Addresses() descriptors.AddressMap {
+func (m *mockChain) Addresses() AddressMap {
 	args := m.Called()
-	return args.Get(0).(descriptors.AddressMap)
+	return args.Get(0).(AddressMap)
 }
 
 type mockNode struct {

--- a/devnet-sdk/system/wallet.go
+++ b/devnet-sdk/system/wallet.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -38,7 +39,19 @@ type wallet struct {
 	chain      internalChain
 }
 
-func newWallet(pk string, addr types.Address, chain *chain) (*wallet, error) {
+func newWalletMapFromDescriptorWalletMap(descriptorWalletMap descriptors.WalletMap, chain internalChain) (WalletMap, error) {
+	result := WalletMap{}
+	for k, v := range descriptorWalletMap {
+		wallet, err := newWallet(v.PrivateKey, v.Address, chain)
+		if err != nil {
+			return nil, err
+		}
+		result[k] = wallet
+	}
+	return result, nil
+}
+
+func newWallet(pk string, addr types.Address, chain internalChain) (*wallet, error) {
 	privateKey, err := privateKeyFromString(pk)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert private from string: %w", err)

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
@@ -23,7 +22,8 @@ import (
 )
 
 var (
-	_ system.Chain = (*mockChain)(nil)
+	_ system.Chain   = (*mockChain)(nil)
+	_ system.L2Chain = (*mockL2Chain)(nil)
 )
 
 // mockTB implements a minimal testing.TB for testing
@@ -90,8 +90,8 @@ func (m *mockChain) Client() (*sources.EthClient, error)             { return ni
 func (m *mockChain) GethClient() (*ethclient.Client, error)          { return nil, nil }
 func (m *mockChain) ID() types.ChainID                               { return types.ChainID(big.NewInt(1)) }
 func (m *mockChain) ContractsRegistry() interfaces.ContractsRegistry { return nil }
-func (m *mockChain) Wallets(ctx context.Context) ([]system.Wallet, error) {
-	return nil, nil
+func (m *mockChain) Wallets() system.WalletMap {
+	return nil
 }
 func (m *mockChain) GasPrice(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(1), nil
@@ -108,22 +108,34 @@ func (m *mockChain) SupportsEIP(ctx context.Context, eip uint64) bool {
 func (m *mockChain) Config() (*params.ChainConfig, error) {
 	return nil, fmt.Errorf("not implemented on mockChain")
 }
-func (m *mockChain) Addresses() descriptors.AddressMap {
-	return descriptors.AddressMap{}
+func (m *mockChain) Addresses() system.AddressMap {
+	return system.AddressMap{}
+}
+
+// mockL2Chain implements a minimal system.L2Chain for testing
+type mockL2Chain struct {
+	mockChain
+}
+
+func (m *mockL2Chain) L1Addresses() system.AddressMap {
+	return system.AddressMap{}
+}
+func (m *mockL2Chain) L1Wallets() system.WalletMap {
+	return system.WalletMap{}
 }
 
 // mockSystem implements a minimal system.System for testing
 type mockSystem struct{}
 
-func (m *mockSystem) Identifier() string  { return "mock" }
-func (m *mockSystem) L1() system.Chain    { return &mockChain{} }
-func (m *mockSystem) L2s() []system.Chain { return []system.Chain{&mockChain{}} }
-func (m *mockSystem) Close() error        { return nil }
+func (m *mockSystem) Identifier() string    { return "mock" }
+func (m *mockSystem) L1() system.Chain      { return &mockChain{} }
+func (m *mockSystem) L2s() []system.L2Chain { return []system.L2Chain{&mockL2Chain{}} }
+func (m *mockSystem) Close() error          { return nil }
 
 // mockInteropSet implements a minimal system.InteropSet for testing
 type mockInteropSet struct{}
 
-func (m *mockInteropSet) L2s() []system.Chain { return []system.Chain{&mockChain{}} }
+func (m *mockInteropSet) L2s() []system.L2Chain { return []system.L2Chain{&mockL2Chain{}} }
 
 // mockSupervisor implements the system.Supervisor interface for testing
 type mockSupervisor struct{}

--- a/devnet-sdk/testing/testlib/validators/lowlevel.go
+++ b/devnet-sdk/testing/testlib/validators/lowlevel.go
@@ -13,7 +13,7 @@ type LowLevelSystemGetter = func(context.Context) system.LowLevelSystem
 type lowLevelSystemWrapper struct {
 	identifier string
 	l1         system.LowLevelChain
-	l2         []system.LowLevelChain
+	l2         []system.LowLevelL2Chain
 }
 
 var _ system.LowLevelSystem = (*lowLevelSystemWrapper)(nil)
@@ -26,7 +26,7 @@ func (l *lowLevelSystemWrapper) L1() system.LowLevelChain {
 	return l.l1
 }
 
-func (l *lowLevelSystemWrapper) L2s() []system.LowLevelChain {
+func (l *lowLevelSystemWrapper) L2s() []system.LowLevelL2Chain {
 	return l.l2
 }
 
@@ -42,7 +42,7 @@ func lowLevelSystemValidator(sysMarker interface{}) systest.PreconditionValidato
 		}
 
 		for idx, l2 := range sys.L2s() {
-			if l2, ok := l2.(system.LowLevelChain); ok {
+			if l2, ok := l2.(system.LowLevelL2Chain); ok {
 				lowLevelSys.l2 = append(lowLevelSys.l2, l2)
 			} else {
 				return nil, fmt.Errorf("L2 chain %d is not a low level chain", idx)

--- a/devnet-sdk/testing/testlib/validators/wallet.go
+++ b/devnet-sdk/testing/testlib/validators/wallet.go
@@ -15,10 +15,7 @@ type WalletGetter = func(context.Context) system.Wallet
 func walletFundsValidator(chain system.Chain, minFunds types.Balance, userMarker interface{}) systest.PreconditionValidator {
 	constraint := constraints.WithBalance(minFunds)
 	return func(t systest.T, sys system.System) (context.Context, error) {
-		wallets, err := chain.Wallets(t.Context())
-		if err != nil {
-			return nil, err
-		}
+		wallets := chain.Wallets()
 
 		for _, wallet := range wallets {
 			if constraint.CheckWallet(wallet) {

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -236,13 +236,12 @@ func TestGetEnvironmentInfo(t *testing.T) {
 		"rpc": {Port: 52645},
 	}
 
-	testWallets := deployer.WalletList{
-		{
-			Name:       "test-wallet",
-			Address:    common.HexToAddress("0x123"),
-			PrivateKey: "0xabc",
-		},
+	testWallet := &deployer.Wallet{
+		Name:       "test-wallet",
+		Address:    common.HexToAddress("0x123"),
+		PrivateKey: "0xabc",
 	}
+	testWallets := deployer.WalletList{testWallet}
 
 	testJWTs := &jwt.Data{
 		L1JWT: "test-l1-jwt",
@@ -272,11 +271,20 @@ func TestGetEnvironmentInfo(t *testing.T) {
 			name:    "successful environment info with JWT",
 			spec:    testSpec,
 			inspect: &inspect.InspectData{UserServices: testServices},
-			deploy:  &deployer.DeployerData{L1ValidatorWallets: testWallets},
-			jwt:     testJWTs,
+			deploy: &deployer.DeployerData{
+				L1ValidatorWallets: testWallets,
+				State: &deployer.DeployerState{
+					Addresses: deployer.DeploymentAddresses{
+						"0x123": common.HexToAddress("0x123"),
+					},
+				},
+				L1ChainID: "1234",
+			},
+			jwt: testJWTs,
 			want: &KurtosisEnvironment{
 				DevnetEnvironment: descriptors.DevnetEnvironment{
 					L1: &descriptors.Chain{
+						ID:       "1234",
 						Name:     "Ethereum",
 						Services: make(descriptors.ServiceMap),
 						Nodes: []descriptors.Node{
@@ -285,13 +293,24 @@ func TestGetEnvironmentInfo(t *testing.T) {
 							},
 						},
 						JWT: testJWTs.L1JWT,
+						Addresses: descriptors.AddressMap{
+							"0x123": common.HexToAddress("0x123"),
+						},
+						Wallets: descriptors.WalletMap{
+							testWallet.Name: {
+								Address:    testWallet.Address,
+								PrivateKey: testWallet.PrivateKey,
+							},
+						},
 					},
-					L2: []*descriptors.Chain{
+					L2: []*descriptors.L2Chain{
 						{
-							Name:     "op-kurtosis",
-							ID:       "1234",
-							Services: make(descriptors.ServiceMap),
-							JWT:      testJWTs.L2JWT,
+							Chain: descriptors.Chain{
+								Name:     "op-kurtosis",
+								ID:       "1234",
+								Services: make(descriptors.ServiceMap),
+								JWT:      testJWTs.L2JWT,
+							},
 						},
 					},
 				},

--- a/kurtosis-devnet/pkg/kurtosis/sources/deployer/deployer_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/deployer/deployer_test.go
@@ -67,7 +67,8 @@ func TestParseStateFile(t *testing.T) {
 		require.True(t, ok, "Chain %s not found in result", tt.chainID)
 
 		for key, expected := range tt.expected {
-			actual := chain.Addresses[key]
+			actual := chain.L1Addresses[key]
+			// TODO: add L2 addresses
 			require.Equal(t, expected, actual, "Chain %s, %s: expected %s, got %s", tt.chainID, key, expected, actual)
 		}
 	}

--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -90,11 +90,17 @@ func TestSmokeTestFailure(t *testing.T) {
 		addr: mockAddr,
 		bal:  sdktypes.NewBalance(big.NewInt(1000000)),
 	}
-	mockChain := newMockFailingChain(
+	mockL1Chain := newMockFailingL1Chain(
 		sdktypes.ChainID(big.NewInt(1234)),
-		[]system.Wallet{mockWallet},
+		system.WalletMap{
+			"user1": mockWallet,
+		},
 	)
-	mockSys := &mockFailingSystem{chain: mockChain}
+	mockL2Chain := newMockFailingL2Chain(
+		sdktypes.ChainID(big.NewInt(1234)),
+		system.WalletMap{"user1": mockWallet},
+	)
+	mockSys := &mockFailingSystem{l1Chain: mockL1Chain, l2Chain: mockL2Chain}
 
 	// Run the smoke test logic and capture failures
 	getter := func(ctx context.Context) system.Wallet {


### PR DESCRIPTION
Fixes https://github.com/ethereum-optimism/optimism/issues/14791

The main change is that the interface goes from this:

```
type Chain interface {
	ID() types.ChainID
	ContractsRegistry() interfaces.ContractsRegistry
	SupportsEIP(ctx context.Context, eip uint64) bool
	Node() Node
	Config() (*params.ChainConfig, error)
	Wallets() WalletMap
	Addresses() AddressMap
}
```

To this, where L2Chain is now used to represent L2s:
```
type Chain interface {
	ID() types.ChainID
	ContractsRegistry() interfaces.ContractsRegistry
	SupportsEIP(ctx context.Context, eip uint64) bool
	Node() Node
	Config() (*params.ChainConfig, error)
	Wallets() WalletMap
	Addresses() AddressMap
}

type L2Chain interface {
	Chain
	L1Addresses() AddressMap
	L1Wallets() WalletMap
}
```

It splits up the organization of L2 wallets/addresses from L1 wallets/addresses within the L2 chain interface. This also lays the groundwork for us to add other L2-specific system interface functionality.