### PR TITLE
Add testnets to upgrade tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1504,6 +1504,11 @@ workflows:
           fork_op_chain: unichain
           fork_base_chain: mainnet
           fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade op-sepolia
+          fork_op_chain: op
+          fork_base_chain: sepolia
+          fork_base_rpc: https://ci-sepolia-l1-archive.optimism.io
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build


### PR DESCRIPTION
Add support for unichain, op, ink and base on sepolia on the test-upgrade in CI.