### PR TITLE
op-program/client: add check for nil withdrawalsroot

### DIFF
--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -80,6 +80,7 @@ func TestIsthmusActivationAtGenesis(gt *testing.T) {
 	require.NoError(t, err)
 	genesisPayload, err := l2Cl.PayloadByNumber(t.Ctx(), 0)
 	require.NoError(t, err)
+	require.NotNil(t, genesisPayload.ExecutionPayload.WithdrawalsRoot)
 	require.Equal(t, genesisPayload.ExecutionPayload.WithdrawalsRoot, genesisBlock.WithdrawalsRoot())
 	require.Equal(t, types.EmptyRequestsHash, *genesisPayload.RequestsHash)
 	got, ok := genesisPayload.CheckBlockHash()

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -390,6 +390,10 @@ func (ea *L2EngineAPI) NewPayloadV4(ctx context.Context, params *eth.ExecutionPa
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.UnsupportedFork.With(errors.New("newPayloadV4 called pre-isthmus"))
 	}
 
+	if params.WithdrawalsRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+	}
+
 	requests := convertRequests(executionRequests)
 	return ea.newPayload(ctx, params, versionedHashes, beaconRoot, requests)
 }


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/optimism/issues/14808

See https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv4 and https://github.com/ethereum-optimism/op-geth/pull/544

TODO 
- [x] unit test
- [x] root cause the underlying issue