### PR TITLE
op-node/rollup/sequencing: No user txs in Isthmus & Interop upgrade block

### DIFF
--- a/op-e2e/actions/helpers/l2_engine.go
+++ b/op-e2e/actions/helpers/l2_engine.go
@@ -200,7 +200,10 @@ func (e *L2Engine) ActL2IncludeTxIgnoreForcedEmpty(from common.Address) Action {
 		}
 
 		tx := firstValidTx(t, from, e.EngineApi.PendingIndices, e.Eth.TxPool().ContentFrom, e.EthClient().NonceAt)
+		prevState := e.EngineApi.ForcedEmpty()
+		e.EngineApi.SetForceEmpty(false) // ensure the engine API can include it
 		_, err := e.EngineApi.IncludeTx(tx, from)
+		e.EngineApi.SetForceEmpty(prevState)
 		if errors.Is(err, engineapi.ErrNotBuildingBlock) {
 			t.InvalidAction(err.Error())
 		} else if errors.Is(err, engineapi.ErrUsesTooMuchGas) {

--- a/op-e2e/actions/proofs/holocene_helpers_test.go
+++ b/op-e2e/actions/proofs/holocene_helpers_test.go
@@ -21,6 +21,8 @@ type holoceneExpectations struct {
 }
 
 func (h holoceneExpectations) RequireExpectedProgressAndLogs(t actionsHelpers.StatefulTesting, actualSafeHead eth.L2BlockRef, isHolocene bool, engine *actionsHelpers.L2Engine, logs *testlog.CapturingHandler) {
+	t.Helper()
+
 	var exp expectations
 	if isHolocene {
 		exp = h.holocene
@@ -28,16 +30,15 @@ func (h holoceneExpectations) RequireExpectedProgressAndLogs(t actionsHelpers.St
 		exp = h.preHolocene
 	}
 
-	require.Equal(t, exp.safeHead, actualSafeHead.Number)
-	expectedHash := engine.L2Chain().GetBlockByNumber(exp.safeHead).Hash()
-	require.Equal(t, expectedHash, actualSafeHead.Hash)
+	require.Equal(t, exp.safeHead, actualSafeHead.Number, "safe head: wrong number")
+	expectedHash := engine.L2Chain().GetHeaderByNumber(exp.safeHead).Hash()
+	require.Equal(t, expectedHash, actualSafeHead.Hash, "safe head: wrong hash")
 
 	for _, l := range exp.logs {
 		t.Helper()
 		recs := logs.FindLogs(testlog.NewMessageContainsFilter(l.filter), testlog.NewAttributesFilter("role", l.role))
-		require.Len(t, recs, l.num, "searching for %d instances of '%s' in logs from role %s", l.num, l.filter, l.role)
+		require.Len(t, recs, l.num, "searching for %d instances of %q in logs from role %s", l.num, l.filter, l.role)
 	}
-
 }
 
 func sequencerOnce(filter string) []logExpectations {

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -70,10 +70,12 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			name: "invalid-payload", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
 			useSpanBatch: false,
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 1, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-					logs: sequencerOnce("could not process payload attributes"),
+				preHolocene: expectations{
+					safeHead: 1, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+					logs:     sequencerOnce("could not process payload attributes"),
 				},
-				holocene: expectations{safeHead: 2, // We expect the safe head to move to 2 due to creation of a deposit-only block.
+				holocene: expectations{
+					safeHead: 2, // We expect the safe head to move to 2 due to creation of a deposit-only block.
 					logs: append(
 						sequencerOnce("Holocene active, requesting deposits-only attributes"),
 						sequencerOnce("could not process payload attributes")...,
@@ -85,12 +87,14 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			name: "invalid-payload-span", blocks: []uint{1, 2, 3}, blockModifiers: []actionsHelpers.BlockModifier{nil, invalidPayload, nil},
 			useSpanBatch: true,
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 0, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
-					logs: sequencerOnce("could not process payload attributes"),
+				preHolocene: expectations{
+					safeHead: 0, // Invalid signature in block 2 causes an invalid _payload_ in the engine queue. Entire span batch is invalidated.
+					logs:     sequencerOnce("could not process payload attributes"),
 				},
 
-				holocene: expectations{safeHead: 2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
-					logs: sequencerOnce("could not process payload attributes"),
+				holocene: expectations{
+					safeHead: 2, // We expect the safe head to move to 2 due to creation of an deposit-only block.
+					logs:     sequencerOnce("could not process payload attributes"),
 				},
 			},
 		},
@@ -109,11 +113,13 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			useSpanBatch:            true,
 			breachMaxSequencerDrift: true,
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 0, // Entire span batch invalidated.
-					logs: sequencerOnce("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid"),
+				preHolocene: expectations{
+					safeHead: 0, // Entire span batch invalidated.
+					logs:     sequencerOnce("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again"),
 				},
-				holocene: expectations{safeHead: 1800, // We expect partial validity until we hit sequencer drift.
-					logs: sequencerOnce("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid"),
+				holocene: expectations{
+					safeHead: 1800, // We expect partial validity until we hit sequencer drift.
+					logs:     sequencerOnce("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again"),
 				},
 			},
 		},
@@ -123,11 +129,13 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 			useSpanBatch:        true,
 			overAdvanceL1Origin: 3, // this will over-advance the L1 origin of block 3
 			holoceneExpectations: holoceneExpectations{
-				preHolocene: expectations{safeHead: 0, // Entire span batch invalidated.
-					logs: sequencerOnce("block timestamp is less than L1 origin timestamp"),
+				preHolocene: expectations{
+					safeHead: 0, // Entire span batch invalidated.
+					logs:     sequencerOnce("block timestamp is less than L1 origin timestamp"),
 				},
-				holocene: expectations{safeHead: 2, // We expect partial validity, safe head should move to block 2, dropping invalid block 3 and remaining channel.
-					logs: sequencerOnce("batch timestamp is less than L1 origin timestamp"),
+				holocene: expectations{
+					safeHead: 2, // We expect partial validity, safe head should move to block 2, dropping invalid block 3 and remaining channel.
+					logs:     sequencerOnce("batch timestamp is less than L1 origin timestamp"),
 				},
 			},
 		},

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -198,7 +198,7 @@ func testWithdrawlsRootIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlo
 			tx, err = l2withdrawer.Receive(l2opts)
 			require.NoError(t, err)
 
-			// include the transaction
+			// force-include the transaction, also in upgrade blocks
 			engine.ActL2IncludeTxIgnoreForcedEmpty(dp.Addresses.Alice)(t)
 		}
 		sequencer.ActL2EndBlock(t)

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -150,6 +150,7 @@ func TestWithdrawalsRootBeforeAtAndAfterIsthmus(t *testing.T) {
 		{"BeforeIsthmusWithoutWithdrawalTx", false, 0, 1},
 		{"BeforeIsthmusWithWithdrawalTx", true, 1, 1},
 		{"AtIsthmusWithoutWithdrawalTx", false, 0, 2},
+		{"AtIsthmusWithWithdrawalTx", true, 2, 2},
 		{"AfterIsthmusWithoutWithdrawalTx", false, 0, 3},
 		{"AfterIsthmusWithWithdrawalTx", true, 3, 3},
 	}
@@ -198,7 +199,7 @@ func testWithdrawlsRootIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlo
 			require.NoError(t, err)
 
 			// include the transaction
-			engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
+			engine.ActL2IncludeTxIgnoreForcedEmpty(dp.Addresses.Alice)(t)
 		}
 		sequencer.ActL2EndBlock(t)
 

--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -35,6 +35,8 @@ var (
 	isthmusOperatorFeeVaultCodeHash = common.HexToHash("0x57dc55c9c09ca456fa728f253fe7b895d3e6aae0706104935fe87c7721001971")
 )
 
+var zeroHex64 = hexutil.Uint64(0)
+
 func TestIsthmusActivationAtGenesis(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	env := helpers.SetupEnv(t, helpers.WithActiveGenesisFork(rollup.Isthmus))
@@ -91,7 +93,6 @@ func TestIsthmusActivationAtGenesis(gt *testing.T) {
 func TestWithdrawlsRootPreCanyonAndIsthmus(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-	genesisBlock := hexutil.Uint64(0)
 	canyonOffset := hexutil.Uint64(2)
 
 	log := testlog.Logger(t, log.LvlDebug)
@@ -99,14 +100,7 @@ func TestWithdrawlsRootPreCanyonAndIsthmus(gt *testing.T) {
 	dp.DeployConfig.L1CancunTimeOffset = &canyonOffset
 
 	// Activate pre-canyon forks at genesis, and schedule Canyon the block after
-	dp.DeployConfig.L2GenesisRegolithTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisCanyonTimeOffset = &canyonOffset
-	dp.DeployConfig.L2GenesisDeltaTimeOffset = nil
-	dp.DeployConfig.L2GenesisEcotoneTimeOffset = nil
-	dp.DeployConfig.L2GenesisFjordTimeOffset = nil
-	dp.DeployConfig.L2GenesisGraniteTimeOffset = nil
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = nil
-	dp.DeployConfig.L2GenesisIsthmusTimeOffset = nil
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Canyon, uint64(canyonOffset))
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
@@ -149,42 +143,31 @@ func TestWithdrawlsRootPreCanyonAndIsthmus(gt *testing.T) {
 func TestWithdrawalsRootBeforeAtAndAfterIsthmus(t *testing.T) {
 	tests := []struct {
 		name              string
-		f                 func(gt *testing.T, withdrawalTx bool, withdrawalTxBlock, totalBlocks int)
 		withdrawalTx      bool
 		withdrawalTxBlock int
 		totalBlocks       int
 	}{
-		{"BeforeIsthmusWithoutWithdrawalTx", testWithdrawlsRootAtIsthmus, false, 0, 1},
-		{"BeforeIsthmusWithWithdrawalTx", testWithdrawlsRootAtIsthmus, true, 1, 1},
-		{"AtIsthmusWithoutWithdrawalTx", testWithdrawlsRootAtIsthmus, false, 0, 2},
-		{"AtIsthmusWithWithdrawalTx", testWithdrawlsRootAtIsthmus, true, 2, 2},
-		{"AfterIsthmusWithoutWithdrawalTx", testWithdrawlsRootAtIsthmus, false, 0, 3},
-		{"AfterIsthmusWithWithdrawalTx", testWithdrawlsRootAtIsthmus, true, 3, 3},
+		{"BeforeIsthmusWithoutWithdrawalTx", false, 0, 1},
+		{"BeforeIsthmusWithWithdrawalTx", true, 1, 1},
+		{"AtIsthmusWithoutWithdrawalTx", false, 0, 2},
+		{"AfterIsthmusWithoutWithdrawalTx", false, 0, 3},
+		{"AfterIsthmusWithWithdrawalTx", true, 3, 3},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			test.f(t, test.withdrawalTx, test.withdrawalTxBlock, test.totalBlocks)
+			testWithdrawlsRootIsthmus(t, test.withdrawalTx, test.withdrawalTxBlock, test.totalBlocks)
 		})
 	}
 }
 
-func testWithdrawlsRootAtIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlock, totalBlocks int) {
+func testWithdrawlsRootIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlock, totalBlocks int) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-	genesisBlock := hexutil.Uint64(0)
-	isthmusOffset := hexutil.Uint64(2)
+	const isthmusOffset = 2
 
 	log := testlog.Logger(t, log.LvlDebug)
 
-	dp.DeployConfig.L2GenesisRegolithTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisCanyonTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisIsthmusTimeOffset = &isthmusOffset
-	dp.DeployConfig.L2GenesisDeltaTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisFjordTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisGraniteTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = &genesisBlock
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Isthmus, isthmusOffset)
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
@@ -204,15 +187,15 @@ func testWithdrawlsRootAtIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxB
 
 		if withdrawalTx && withdrawalTxBlock == i {
 			l2withdrawer, err := bindings.NewL2ToL1MessagePasser(predeploys.L2ToL1MessagePasserAddr, ethCl)
-			require.Nil(t, err, "binding withdrawer on L2")
+			require.NoError(t, err, "binding withdrawer on L2")
 
 			// Initiate Withdrawal
 			// Bind L2 Withdrawer Contract and invoke the Receive function
 			l2opts, err := bind.NewKeyedTransactorWithChainID(dp.Secrets.Alice, new(big.Int).SetUint64(dp.DeployConfig.L2ChainID))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			l2opts.Value = big.NewInt(500)
 			tx, err = l2withdrawer.Receive(l2opts)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			// include the transaction
 			engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
@@ -222,14 +205,14 @@ func testWithdrawlsRootAtIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxB
 		if withdrawalTx && withdrawalTxBlock == i {
 			// wait for withdrawal to be included in a block
 			receipt, err := geth.WaitForTransaction(tx.Hash(), ethCl, 10*time.Duration(dp.DeployConfig.L2BlockTime)*time.Second)
-			require.Nil(t, err, "withdrawal initiated on L2 sequencer")
+			require.NoError(t, err, "withdrawal initiated on L2 sequencer")
 			require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "transaction had incorrect status")
 		}
 	}
 	rpcCl := engine.RPCClient()
 
 	// we set withdrawals root only at or after isthmus
-	if totalBlocks >= 2 {
+	if totalBlocks >= isthmusOffset {
 		verifyIsthmusHeaderWithdrawalsRoot(gt, rpcCl, engine.L2Chain().CurrentBlock(), true)
 	}
 }
@@ -237,19 +220,12 @@ func testWithdrawlsRootAtIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxB
 func TestWithdrawlsRootPostIsthmus(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-	genesisBlock := hexutil.Uint64(0)
-	isthmusOffset := hexutil.Uint64(2)
+	const isthmusOffset = 2
 
 	log := testlog.Logger(t, log.LvlDebug)
 
-	dp.DeployConfig.L2GenesisRegolithTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisCanyonTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisIsthmusTimeOffset = &isthmusOffset
-	dp.DeployConfig.L2GenesisDeltaTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisFjordTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisGraniteTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = &genesisBlock
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Isthmus, isthmusOffset)
+	dp.DeployConfig.L1PragueTimeOffset = &zeroHex64
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
@@ -268,15 +244,15 @@ func TestWithdrawlsRootPostIsthmus(gt *testing.T) {
 	// Bind L2 Withdrawer Contract
 	ethCl := engine.EthClient()
 	l2withdrawer, err := bindings.NewL2ToL1MessagePasser(predeploys.L2ToL1MessagePasserAddr, ethCl)
-	require.Nil(t, err, "binding withdrawer on L2")
+	require.NoError(t, err, "binding withdrawer on L2")
 
 	// Initiate Withdrawal
 	l2opts, err := bind.NewKeyedTransactorWithChainID(dp.Secrets.Alice, new(big.Int).SetUint64(dp.DeployConfig.L2ChainID))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	l2opts.Value = big.NewInt(500)
 
 	tx, err := l2withdrawer.Receive(l2opts)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// build blocks until Isthmus activates
 	sequencer.ActL2StartBlock(t)
@@ -289,7 +265,7 @@ func TestWithdrawlsRootPostIsthmus(gt *testing.T) {
 
 	// wait for withdrawal to be included in a block
 	receipt, err := geth.WaitForTransaction(tx.Hash(), ethCl, 10*time.Duration(dp.DeployConfig.L2BlockTime)*time.Second)
-	require.Nil(t, err, "withdrawal initiated on L2 sequencer")
+	require.NoError(t, err, "withdrawal initiated on L2 sequencer")
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "transaction had incorrect status")
 
 	verifyIsthmusHeaderWithdrawalsRoot(gt, rpcCl, engine.L2Chain().CurrentBlock(), true)
@@ -309,7 +285,7 @@ func verifyIsthmusHeaderWithdrawalsRoot(gt *testing.T, rpcCl client.RPC, header 
 	getStorageRoot := func(rpcCl client.RPC, ctx context.Context, address common.Address, blockTag string) common.Hash {
 		var getProofResponse *eth.AccountResult
 		err := rpcCl.CallContext(ctx, &getProofResponse, "eth_getProof", address, []common.Hash{}, blockTag)
-		assert.Nil(gt, err)
+		assert.NoError(gt, err)
 		assert.NotNil(gt, getProofResponse)
 		return getProofResponse.StorageHash
 	}
@@ -335,17 +311,12 @@ func checkContractVersion(gt *testing.T, client *ethclient.Client, addr common.A
 func TestIsthmusNetworkUpgradeTransactions(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-	isthmusOffset := hexutil.Uint64(4)
+	const isthmusOffset = 2
 
-	log := testlog.Logger(t, log.LevelDebug)
+	log := testlog.Logger(t, log.LvlDebug)
 
-	zero := hexutil.Uint64(0)
-
-	// Activate all forks at genesis, and schedule Isthmus the block after
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = &zero
-	dp.DeployConfig.L2GenesisIsthmusTimeOffset = &isthmusOffset
-	dp.DeployConfig.L1PragueTimeOffset = &zero
-	// New forks have to be added here...
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Isthmus, isthmusOffset)
+	dp.DeployConfig.L1PragueTimeOffset = &zeroHex64
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -545,9 +545,21 @@ func (d *Sequencer) startBuildingBlock() {
 		d.log.Info("Sequencing Fjord upgrade block")
 	}
 
-	// For the Granite activation block we shouldn't include any sequencer transactions.
+	// For the Granite activation block we can include sequencer transactions.
 	if d.rollupCfg.IsGraniteActivationBlock(uint64(attrs.Timestamp)) {
 		d.log.Info("Sequencing Granite upgrade block")
+	}
+
+	// For the Isthmus activation block we shouldn't include any sequencer transactions.
+	if d.rollupCfg.IsIsthmusActivationBlock(uint64(attrs.Timestamp)) {
+		attrs.NoTxPool = true
+		d.log.Info("Sequencing Isthmus upgrade block")
+	}
+
+	// For the Interop activation block we must not include any sequencer transactions.
+	if d.rollupCfg.IsInteropActivationBlock(uint64(attrs.Timestamp)) {
+		attrs.NoTxPool = true
+		d.log.Info("Sequencing Interop upgrade block")
 	}
 
 	d.log.Debug("prepared attributes for new block",

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -123,6 +123,11 @@ func (ea *L2EngineAPI) ForcedEmpty() bool {
 	return ea.l2ForceEmpty
 }
 
+// SetForceEmpty changes the way the remainder of the block is being built
+func (ea *L2EngineAPI) SetForceEmpty(v bool) {
+	ea.l2ForceEmpty = v
+}
+
 func (ea *L2EngineAPI) PendingIndices(from common.Address) uint64 {
 	return ea.pendingIndices[from]
 }


### PR DESCRIPTION
**Description**

Adds the policy in the sequencer to not include user txs in the Isthmus and Interop upgrade blocks.

I also couldn't resist to brush up the existing Isthmus fork tests.

**Tests**

We don't test this policy currently, as it's not a consensus rule.

**Additional context**

This is taken from https://github.com/ethereum-optimism/optimism/pull/14797 which was decided not to include in Isthmus. But we still want the _policy_.


