### PR TITLE
kt-devnet: minimal interop test: execute message

### DIFF
--- a/devnet-sdk/constraints/constraints_test.go
+++ b/devnet-sdk/constraints/constraints_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -36,6 +37,10 @@ func (m mockWallet) SendETH(to types.Address, amount types.Balance) types.WriteI
 }
 
 func (m mockWallet) InitiateMessage(chainID types.ChainID, target common.Address, message []byte) types.WriteInvocation[any] {
+	panic("not implemented")
+}
+
+func (m mockWallet) ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
 	panic("not implemented")
 }
 

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
@@ -74,6 +75,7 @@ type Wallet interface {
 	Address() types.Address
 	SendETH(to types.Address, amount types.Balance) types.WriteInvocation[any]
 	InitiateMessage(chainID types.ChainID, target common.Address, message []byte) types.WriteInvocation[any]
+	ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any]
 	Balance() types.Balance
 	Nonce() uint64
 
@@ -101,6 +103,12 @@ type Transaction interface {
 	Type() uint8
 	Hash() common.Hash
 	TransactionData
+}
+
+type Receipt interface {
+	BlockNumber() *big.Int
+	Logs() []*coreTypes.Log
+	TxHash() common.Hash
 }
 
 // RawTransaction is an optional interface that can be implemented by a Transaction

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 )
 

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 )
 

--- a/devnet-sdk/system/tx.go
+++ b/devnet-sdk/system/tx.go
@@ -198,3 +198,22 @@ func (t *EthTx) Type() uint8 {
 func (t *EthTx) Raw() *types.Transaction {
 	return t.tx
 }
+
+// EthReceipt is the default implementation of Receipt that wraps types.Receipt
+type EthReceipt struct {
+	blockNumber *big.Int
+	logs        []*types.Log
+	txHash      common.Hash
+}
+
+func (t *EthReceipt) BlockNumber() *big.Int {
+	return t.blockNumber
+}
+
+func (t *EthReceipt) Logs() []*types.Log {
+	return t.logs
+}
+
+func (t *EthReceipt) TxHash() common.Hash {
+	return t.txHash
+}

--- a/devnet-sdk/system/txbuilder_test.go
+++ b/devnet-sdk/system/txbuilder_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
@@ -56,6 +57,11 @@ func (m *mockWallet) SendETH(to types.Address, amount types.Balance) types.Write
 
 func (m *mockWallet) InitiateMessage(chainID types.ChainID, target common.Address, message []byte) types.WriteInvocation[any] {
 	args := m.Called(chainID, target, message)
+	return args.Get(0).(types.WriteInvocation[any])
+}
+
+func (m *mockWallet) ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
+	args := m.Called(identifier, sentMessage)
 	return args.Get(0).(types.WriteInvocation[any])
 }
 

--- a/devnet-sdk/system/wallet.go
+++ b/devnet-sdk/system/wallet.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
@@ -114,6 +115,16 @@ func (w *wallet) InitiateMessage(chainID types.ChainID, target common.Address, m
 	}
 }
 
+func (w *wallet) ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
+	return &executeMessageImpl{
+		chain:       w.chain,
+		processor:   w,
+		from:        w.address,
+		identifier:  identifier,
+		sentMessage: sentMessage,
+	}
+}
+
 type initiateMessageImpl struct {
 	chain     internalChain
 	processor TransactionProcessor
@@ -153,6 +164,58 @@ func (i *initiateMessageImpl) Call(ctx context.Context) (any, error) {
 }
 
 func (i *initiateMessageImpl) Send(ctx context.Context) types.InvocationResult {
+	result, err := i.Call(ctx)
+	if err != nil {
+		return &sendResult{chain: i.chain, tx: nil, err: err}
+	}
+	tx, ok := result.(Transaction)
+	if !ok {
+		return &sendResult{chain: i.chain, tx: nil, err: fmt.Errorf("unexpected return type")}
+	}
+	err = i.processor.Send(ctx, tx)
+	return &sendResult{
+		chain: i.chain,
+		tx:    tx,
+		err:   err,
+	}
+}
+
+type executeMessageImpl struct {
+	chain     internalChain
+	processor TransactionProcessor
+	from      types.Address
+
+	identifier  bindings.Identifier
+	sentMessage []byte
+}
+
+func (i *executeMessageImpl) Call(ctx context.Context) (any, error) {
+	builder := NewTxBuilder(ctx, i.chain)
+	messenger, err := i.chain.ContractsRegistry().L2ToL2CrossDomainMessenger(constants.L2ToL2CrossDomainMessenger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init transaction: %w", err)
+	}
+	data, err := messenger.ABI().Pack("relayMessage", i.identifier, i.sentMessage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build calldata: %w", err)
+	}
+	tx, err := builder.BuildTx(
+		WithFrom(i.from),
+		WithTo(constants.L2ToL2CrossDomainMessenger),
+		WithValue(big.NewInt(0)),
+		WithData(data),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build transaction: %w", err)
+	}
+	tx, err = i.processor.Sign(tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign transaction: %w", err)
+	}
+	return tx, nil
+}
+
+func (i *executeMessageImpl) Send(ctx context.Context) types.InvocationResult {
 	result, err := i.Call(ctx)
 	if err != nil {
 		return &sendResult{chain: i.chain, tx: nil, err: err}
@@ -291,9 +354,10 @@ func (i *sendImpl) Send(ctx context.Context) types.InvocationResult {
 }
 
 type sendResult struct {
-	chain internalChain
-	tx    Transaction
-	err   error
+	chain   internalChain
+	tx      Transaction
+	receipt Receipt
+	err     error
 }
 
 func (r *sendResult) Error() error {
@@ -318,11 +382,15 @@ func (r *sendResult) Wait() error {
 		if err != nil {
 			return fmt.Errorf("failed waiting for transaction confirmation: %w", err)
 		}
-
+		r.receipt = &EthReceipt{blockNumber: receipt.BlockNumber, logs: receipt.Logs, txHash: receipt.TxHash}
 		if receipt.Status == 0 {
 			return fmt.Errorf("transaction failed")
 		}
 	}
 
 	return nil
+}
+
+func (r *sendResult) Info() any {
+	return r.receipt
 }

--- a/devnet-sdk/system/wallet.go
+++ b/devnet-sdk/system/wallet.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/devnet-sdk/system/wallet.go
+++ b/devnet-sdk/system/wallet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/devnet-sdk/testing/testlib/validators/validators_test.go
+++ b/devnet-sdk/testing/testlib/validators/validators_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
@@ -325,6 +326,10 @@ func (m mockWallet) SendETH(to types.Address, amount types.Balance) types.WriteI
 }
 
 func (m mockWallet) InitiateMessage(chainID types.ChainID, target common.Address, message []byte) types.WriteInvocation[any] {
+	panic("not implemented")
+}
+
+func (m mockWallet) ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
 	panic("not implemented")
 }
 

--- a/devnet-sdk/testing/testlib/validators/validators_test.go
+++ b/devnet-sdk/testing/testlib/validators/validators_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 

--- a/devnet-sdk/testing/testlib/validators/validators_test.go
+++ b/devnet-sdk/testing/testlib/validators/validators_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 

--- a/devnet-sdk/types/types.go
+++ b/devnet-sdk/types/types.go
@@ -24,6 +24,7 @@ type WriteInvocation[T any] interface {
 type InvocationResult interface {
 	Error() error
 	Wait() error
+	Info() any
 }
 
 type Key = *ecdsa.PrivateKey

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -87,7 +87,8 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		execTxHash := execReceipt.TxHash()
 		logger.Info("Execute message", "txHash", execTxHash.Hex())
 
-		blockB, err := chainB.Node().BlockByNumber(ctx, blockNumber)
+		blockNumberB := execReceipt.BlockNumber()
+		blockB, err := chainB.Node().BlockByNumber(ctx, blockNumberB)
 		require.NoError(t, err)
 		blockTimeB := big.NewInt(int64(blockB.Time()))
 		logger.Info("Execute message was included at", "timestamp", blockTimeB.String())

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -37,10 +37,10 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		// userB is funded at chainB and want to execute message to chainB
 		userB := destWalletGetter(ctx)
 
-		// Initiate message
 		sha256PrecompileAddr := common.BytesToAddress([]byte{0x2})
 		dummyMessage := []byte("l33t message")
 
+		// Initiate message
 		logger.Info("Initiate message", "address", sha256PrecompileAddr, "message", dummyMessage)
 		initResult := userA.InitiateMessage(chainB.ID(), sha256PrecompileAddr, dummyMessage).Send(ctx)
 		require.NoError(t, initResult.Wait())
@@ -52,6 +52,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		require.Equal(t, 1, len(logs), "expected single log")
 		log := logs[0]
 
+		// Build sentMessage for message execution
 		blockNumber := initReceipt.BlockNumber()
 		block, err := chainA.Node().BlockByNumber(ctx, blockNumber)
 		require.NoError(t, err)
@@ -62,6 +63,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		}
 		sentMessage = append(sentMessage, log.Data...)
 
+		// Build identifier for message execution
 		logIndex := big.NewInt(int64(log.Index))
 		identifier := bindings.Identifier{
 			Origin:      constants.L2ToL2CrossDomainMessenger,
@@ -71,6 +73,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 			ChainId:     chainA.ID(),
 		}
 
+		// Execute message
 		logger.Info("Execute message", "address", sha256PrecompileAddr, "message", dummyMessage)
 		execResult := userB.ExecuteMessage(identifier, sentMessage).Send(ctx)
 		require.NoError(t, execResult.Wait())
@@ -81,6 +84,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		execTxHash := execReceipt.TxHash()
 		logger.Info("Execute message", "txHash", execTxHash.Hex())
 
+		// Validation that message has passed and got executed successfully
 		gethClient, err := chainB.GethClient()
 		require.NoError(t, err)
 

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -1,6 +1,7 @@
 package interop
 
 import (
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -10,21 +11,24 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
 	sdktypes "github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
-func messagePassingScenario(sourceChainIdx, destChainIdx uint64, sourceWalletGetter, destWalletGetter validators.WalletGetter) systest.InteropSystemTestFunc {
+func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter, sourceChainIdx, destChainIdx uint64, sourceWalletGetter, destWalletGetter validators.WalletGetter) systest.InteropSystemTestFunc {
 	return func(t systest.T, sys system.InteropSystem) {
 		ctx := t.Context()
+		llsys := lowLevelSystemGetter(ctx)
 
 		logger := testlog.Logger(t, log.LevelInfo)
 		logger = logger.With("test", "TestInitiateMessage", "devnet", sys.Identifier())
 
 		chainA := sys.L2s()[sourceChainIdx]
-		chainB := sys.L2s()[destChainIdx]
+		chainB := llsys.L2s()[destChainIdx]
 
 		logger = logger.With("sourceChain", chainA.ID(), "destChain", chainB.ID())
 
@@ -34,10 +38,11 @@ func messagePassingScenario(sourceChainIdx, destChainIdx uint64, sourceWalletGet
 		userB := destWalletGetter(ctx)
 
 		// Initiate message
-		dummyAddress := common.Address{0x13, 0x37}
-		dummyMessage := []byte{0x13, 0x33, 0x33, 0x37}
-		logger.Info("Initiate message", "address", dummyAddress, "message", dummyMessage)
-		initResult := userA.InitiateMessage(chainB.ID(), dummyAddress, dummyMessage).Send(ctx)
+		sha256PrecompileAddr := common.BytesToAddress([]byte{0x2})
+		dummyMessage := []byte("l33t message")
+
+		logger.Info("Initiate message", "address", sha256PrecompileAddr, "message", dummyMessage)
+		initResult := userA.InitiateMessage(chainB.ID(), sha256PrecompileAddr, dummyMessage).Send(ctx)
 		require.NoError(t, initResult.Wait())
 
 		initReceipt, ok := initResult.Info().(system.Receipt)
@@ -56,7 +61,6 @@ func messagePassingScenario(sourceChainIdx, destChainIdx uint64, sourceWalletGet
 			sentMessage = append(sentMessage, topic.Bytes()...)
 		}
 		sentMessage = append(sentMessage, log.Data...)
-		logger.Info("Execute message", "sentMessage", sentMessage)
 
 		logIndex := big.NewInt(int64(log.Index))
 		identifier := bindings.Identifier{
@@ -66,27 +70,49 @@ func messagePassingScenario(sourceChainIdx, destChainIdx uint64, sourceWalletGet
 			Timestamp:   blockTime,
 			ChainId:     chainA.ID(),
 		}
-		logger.Info("Execute message", "identifier", identifier)
 
-		logger.Info("Execute message", "address", dummyAddress, "message", dummyMessage)
+		logger.Info("Execute message", "address", sha256PrecompileAddr, "message", dummyMessage)
 		execResult := userB.ExecuteMessage(identifier, sentMessage).Send(ctx)
 		require.NoError(t, execResult.Wait())
 
 		execReceipt, ok := execResult.Info().(system.Receipt)
 		require.True(t, ok)
 
-		logger.Info("Execute message", "txHash", execReceipt.TxHash().Hex())
+		execTxHash := execReceipt.TxHash()
+		logger.Info("Execute message", "txHash", execTxHash.Hex())
+
+		gethClient, err := chainB.GethClient()
+		require.NoError(t, err)
+
+		trace, err := wait.DebugTraceTx(ctx, gethClient, execTxHash)
+		require.NoError(t, err)
+
+		precompile := vm.PrecompiledContractsHomestead[sha256PrecompileAddr]
+		expected, err := precompile.Run(dummyMessage)
+		require.NoError(t, err)
+		logger.Info("sha256 computed offchain", "value", hex.EncodeToString(expected))
+
+		// length of sha256 image is 32
+		output := trace.CallTrace.Output
+		require.GreaterOrEqual(t, len(output), 32)
+		actual := []byte(output[len(output)-32:])
+		logger.Info("sha256 computed onchain", "value", hex.EncodeToString(actual))
+
+		require.Equal(t, expected, actual)
 	}
 }
 
-func TestInteropSystemInitiateMessage(t *testing.T) {
+func TestInteropSystemMessagePassing(t *testing.T) {
 	sourceChainIdx := uint64(0)
 	destChainIdx := uint64(1)
 	sourceWalletGetter, sourcefundsValidator := validators.AcquireL2WalletWithFunds(sourceChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
 	destWalletGetter, destfundsValiator := validators.AcquireL2WalletWithFunds(destChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
+	lowLevelSystemGetter, lowLevelSystemValidator := validators.AcquireLowLevelSystem()
+
 	systest.InteropSystemTest(t,
-		messagePassingScenario(sourceChainIdx, destChainIdx, sourceWalletGetter, destWalletGetter),
+		messagePassingScenario(lowLevelSystemGetter, sourceChainIdx, destChainIdx, sourceWalletGetter, destWalletGetter),
 		sourcefundsValidator,
 		destfundsValiator,
+		lowLevelSystemValidator,
 	)
 }

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -25,12 +25,12 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		llsys := lowLevelSystemGetter(ctx)
 
 		logger := testlog.Logger(t, log.LevelInfo)
-		logger = logger.With("test", "TestInitiateMessage", "devnet", sys.Identifier())
+		logger = logger.With("test", "TestMessagePassing", "devnet", sys.Identifier())
 
 		chainA := sys.L2s()[sourceChainIdx]
 		chainB := llsys.L2s()[destChainIdx]
 
-		logger = logger.With("sourceChain", chainA.ID(), "destChain", chainB.ID())
+		logger.Info("chain info", "sourceChain", chainA.ID(), "destChain", chainB.ID())
 
 		// userA is funded at chainA and want to initialize message at chain A
 		userA := sourceWalletGetter(ctx)

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -106,7 +106,9 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 	}
 }
 
-func TestInteropSystemMessagePassing(t *testing.T) {
+// TestMessagePassing checks the basic functionality of message passing two interoperable chains.
+// Scenario: Source chain initiates message to make destination chain execute sha256 precompile.
+func TestMessagePassing(t *testing.T) {
 	sourceChainIdx := uint64(0)
 	destChainIdx := uint64(1)
 	sourceWalletGetter, sourcefundsValidator := validators.AcquireL2WalletWithFunds(sourceChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
@@ -15,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func initiateMessageScenario(sourceChainIdx, destChainIdx uint64, walletGetter validators.WalletGetter) systest.InteropSystemTestFunc {
+func messagePassingScenario(sourceChainIdx, destChainIdx uint64, sourceWalletGetter, destWalletGetter validators.WalletGetter) systest.InteropSystemTestFunc {
 	return func(t systest.T, sys system.InteropSystem) {
 		ctx := t.Context()
 
@@ -27,24 +28,65 @@ func initiateMessageScenario(sourceChainIdx, destChainIdx uint64, walletGetter v
 
 		logger = logger.With("sourceChain", chainA.ID(), "destChain", chainB.ID())
 
-		// userA is funded at chainA and want to send message to chainB
-		userA := walletGetter(ctx)
+		// userA is funded at chainA and want to initialize message at chain A
+		userA := sourceWalletGetter(ctx)
+		// userB is funded at chainB and want to execute message to chainB
+		userB := destWalletGetter(ctx)
 
 		// Initiate message
 		dummyAddress := common.Address{0x13, 0x37}
 		dummyMessage := []byte{0x13, 0x33, 0x33, 0x37}
 		logger.Info("Initiate message", "address", dummyAddress, "message", dummyMessage)
-		require.NoError(t, userA.InitiateMessage(chainB.ID(), dummyAddress, dummyMessage).Send(ctx).Wait())
+		initResult := userA.InitiateMessage(chainB.ID(), dummyAddress, dummyMessage).Send(ctx)
+		require.NoError(t, initResult.Wait())
+
+		initReceipt, ok := initResult.Info().(system.Receipt)
+		require.True(t, ok)
+		logger.Info("Execute message", "txHash", initReceipt.TxHash().Hex())
+		logs := initReceipt.Logs()
+		require.Equal(t, 1, len(logs), "expected single log")
+		log := logs[0]
+
+		blockNumber := initReceipt.BlockNumber()
+		block, err := chainA.Node().BlockByNumber(ctx, blockNumber)
+		require.NoError(t, err)
+		blockTime := big.NewInt(int64(block.Time()))
+		sentMessage := []byte{}
+		for _, topic := range log.Topics {
+			sentMessage = append(sentMessage, topic.Bytes()...)
+		}
+		sentMessage = append(sentMessage, log.Data...)
+		logger.Info("Execute message", "sentMessage", sentMessage)
+
+		logIndex := big.NewInt(int64(log.Index))
+		identifier := bindings.Identifier{
+			Origin:      constants.L2ToL2CrossDomainMessenger,
+			BlockNumber: blockNumber,
+			LogIndex:    logIndex,
+			Timestamp:   blockTime,
+			ChainId:     chainA.ID(),
+		}
+		logger.Info("Execute message", "identifier", identifier)
+
+		logger.Info("Execute message", "address", dummyAddress, "message", dummyMessage)
+		execResult := userB.ExecuteMessage(identifier, sentMessage).Send(ctx)
+		require.NoError(t, execResult.Wait())
+
+		execReceipt, ok := execResult.Info().(system.Receipt)
+		require.True(t, ok)
+
+		logger.Info("Execute message", "txHash", execReceipt.TxHash().Hex())
 	}
 }
 
 func TestInteropSystemInitiateMessage(t *testing.T) {
 	sourceChainIdx := uint64(0)
 	destChainIdx := uint64(1)
-	walletGetter, fundsValidator := validators.AcquireL2WalletWithFunds(sourceChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
-
+	sourceWalletGetter, sourcefundsValidator := validators.AcquireL2WalletWithFunds(sourceChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
+	destWalletGetter, destfundsValiator := validators.AcquireL2WalletWithFunds(destChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
 	systest.InteropSystemTest(t,
-		initiateMessageScenario(sourceChainIdx, destChainIdx, walletGetter),
-		fundsValidator,
+		messagePassingScenario(sourceChainIdx, destChainIdx, sourceWalletGetter, destWalletGetter),
+		sourcefundsValidator,
+		destfundsValiator,
 	)
 }

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -49,6 +49,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 		require.True(t, ok)
 		logger.Info("Execute message", "txHash", initReceipt.TxHash().Hex())
 		logs := initReceipt.Logs()
+		// We are directly calling sendMessage, so we expect single log for SentMessage event
 		require.Equal(t, 1, len(logs), "expected single log")
 		log := logs[0]
 

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -47,7 +47,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 
 		initReceipt, ok := initResult.Info().(system.Receipt)
 		require.True(t, ok)
-		logger.Info("Execute message", "txHash", initReceipt.TxHash().Hex())
+		logger.Info("Initiate message", "txHash", initReceipt.TxHash().Hex())
 		logs := initReceipt.Logs()
 		// We are directly calling sendMessage, so we expect single log for SentMessage event
 		require.Equal(t, 1, len(logs), "expected single log")
@@ -55,9 +55,11 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 
 		// Build sentMessage for message execution
 		blockNumber := initReceipt.BlockNumber()
-		block, err := chainA.Node().BlockByNumber(ctx, blockNumber)
+		blockA, err := chainA.Node().BlockByNumber(ctx, blockNumber)
 		require.NoError(t, err)
-		blockTime := big.NewInt(int64(block.Time()))
+		blockTimeA := big.NewInt(int64(blockA.Time()))
+		logger.Info("Initiate message was included at", "timestamp", blockTimeA.String())
+
 		sentMessage := []byte{}
 		for _, topic := range log.Topics {
 			sentMessage = append(sentMessage, topic.Bytes()...)
@@ -70,7 +72,7 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 			Origin:      constants.L2ToL2CrossDomainMessenger,
 			BlockNumber: blockNumber,
 			LogIndex:    logIndex,
-			Timestamp:   blockTime,
+			Timestamp:   blockTimeA,
 			ChainId:     chainA.ID(),
 		}
 
@@ -84,6 +86,11 @@ func messagePassingScenario(lowLevelSystemGetter validators.LowLevelSystemGetter
 
 		execTxHash := execReceipt.TxHash()
 		logger.Info("Execute message", "txHash", execTxHash.Hex())
+
+		blockB, err := chainB.Node().BlockByNumber(ctx, blockNumber)
+		require.NoError(t, err)
+		blockTimeB := big.NewInt(int64(blockB.Time()))
+		logger.Info("Execute message was included at", "timestamp", blockTimeB.String())
 
 		// Validation that message has passed and got executed successfully
 		gethClient, err := chainB.GethClient()

--- a/op-acceptance-tests/tests/interop/mocks_test.go
+++ b/op-acceptance-tests/tests/interop/mocks_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/registry/empty"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
@@ -51,6 +52,10 @@ func (m *mockFailingTx) Wait() error {
 	return fmt.Errorf("transaction failure")
 }
 
+func (m *mockFailingTx) Info() any {
+	return nil
+}
+
 // mockFailingWallet implements types.Wallet that fails on SendETH
 type mockFailingWallet struct {
 	addr types.Address
@@ -82,6 +87,9 @@ func (m *mockFailingWallet) InitiateMessage(chainID types.ChainID, target common
 	return &mockFailingTx{}
 }
 
+func (m *mockFailingWallet) ExecuteMessage(identifer bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
+	return &mockFailingTx{}
+}
 func (m *mockFailingWallet) Nonce() uint64 {
 	return 0
 }

--- a/op-acceptance-tests/tests/interop/mocks_test.go
+++ b/op-acceptance-tests/tests/interop/mocks_test.go
@@ -90,6 +90,7 @@ func (m *mockFailingWallet) InitiateMessage(chainID types.ChainID, target common
 func (m *mockFailingWallet) ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
 	return &mockFailingTx{}
 }
+
 func (m *mockFailingWallet) Nonce() uint64 {
 	return 0
 }

--- a/op-acceptance-tests/tests/interop/mocks_test.go
+++ b/op-acceptance-tests/tests/interop/mocks_test.go
@@ -87,7 +87,7 @@ func (m *mockFailingWallet) InitiateMessage(chainID types.ChainID, target common
 	return &mockFailingTx{}
 }
 
-func (m *mockFailingWallet) ExecuteMessage(identifer bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
+func (m *mockFailingWallet) ExecuteMessage(identifier bindings.Identifier, sentMessage []byte) types.WriteInvocation[any] {
 	return &mockFailingTx{}
 }
 func (m *mockFailingWallet) Nonce() uint64 {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

~Building upon https://github.com/ethereum-optimism/optimism/pull/14782 (stacked PR)~ Merged

This PR achieves below statement on the devnet-sdk abstraction.

> Wallets can trigger [executing messages](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/messaging.md#executing-messages)

To invoke executing message, we need to transact `L2ToL2CrossDomainMessenger.RelayMessage` with parameters. We now do this in one-liner:

```
userB.ExecuteMessage(identifier, sentMessage).Send(ctx).Wait()
```

**Tests**

Fixed `interop_tx_test.go` for initiating and executing messages.

Test scenario.
1. Wallet A on Chain A initiates message for computing `sha256(dummyMessage)` at ChainB using precompile.
2. Wallet B on Chain B executes messages
3. Use `debug_traceTransaction` to parse transaction result output, and check that the sha256 image computed is correct, comparing with offchain computation.

Example test log:
```
=== RUN   TestMessagePassing
DEBUG[03-15|00:17:44.883] checking balance                         wallet=0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f balance="10000 ETH" needed="1 ETH"
DEBUG[03-15|00:17:44.887] checking balance                         wallet=0x9DCCe783B6464611f38631e6C851bf441907c710 balance="10000 ETH" needed="1 ETH"
    interop_tx_test.go:33:      INFO [03-15|00:17:44.887] chain info                               test=TestMessagePassing devnet=interop-devnet sourceChain=2,151,908 destChain=2,151,909
    interop_tx_test.go:44:      INFO [03-15|00:17:44.887] Initiate message                         test=TestMessagePassing devnet=interop-devnet address=0x0000000000000000000000000000000000000002 message="[108 51 51 116 32 109 101 115 115 97 103 101]"
INFO [03-15|00:17:44.890] Instantiated TxBuilder                   supportedTxTypes="[0 2 1 3]" forcedTxType=<nil> gasLimitMargin=20 feeCapMultiplier=2
    interop_tx_test.go:50:      INFO [03-15|00:17:47.000] Initiate message                         test=TestMessagePassing devnet=interop-devnet txHash=0x0011bb31c5887c40aeba97a5e229961592ce89d98a12adf016024be1dd96e340
    interop_tx_test.go:61:      INFO [03-15|00:17:47.001] Initiate message was included at         test=TestMessagePassing devnet=interop-devnet timestamp=1741965467
    interop_tx_test.go:80:      INFO [03-15|00:17:47.001] Execute message                          test=TestMessagePassing devnet=interop-devnet address=0x0000000000000000000000000000000000000002 message="[108 51 51 116 32 109 101 115 115 97 103 101]"
INFO [03-15|00:17:47.007] Instantiated TxBuilder                   supportedTxTypes="[0 2 1 3]" forcedTxType=<nil> gasLimitMargin=20 feeCapMultiplier=2
    interop_tx_test.go:88:      INFO [03-15|00:17:51.017] Execute message                          test=TestMessagePassing devnet=interop-devnet txHash=0xc8fb3bbf978e188be3f1604796bcc3cb06c89ede425703c219e698eb71b4a010
    interop_tx_test.go:94:      INFO [03-15|00:17:51.020] Execute message was included at          test=TestMessagePassing devnet=interop-devnet timestamp=1741965471
    interop_tx_test.go:106:     INFO [03-15|00:17:51.027] sha256 computed offchain                 test=TestMessagePassing devnet=interop-devnet value=994b47a5aa4360c7e4dca5975b41650c73614c6e91870da4a76572d2b09f5e16
    interop_tx_test.go:112:     INFO [03-15|00:17:51.028] sha256 computed onchain                  test=TestMessagePassing devnet=interop-devnet value=994b47a5aa4360c7e4dca5975b41650c73614c6e91870da4a76572d2b09f5e16
--- PASS: TestMessagePassing (6.16s)
PASS
ok      github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop 6.566s
```

**Metadata**

Closing https://github.com/ethereum-optimism/optimism/issues/14681, this PR is a second building block of the simplest interop test.
