### PR TITLE
refactor(contracts-bedrock): move `regexp.MustCompile` with constant out of func

### DIFF
--- a/packages/contracts-bedrock/scripts/autogen/generate-snapshots/main.go
+++ b/packages/contracts-bedrock/scripts/autogen/generate-snapshots/main.go
@@ -16,6 +16,10 @@ const (
 	abiDir           = "snapshots/abi"
 )
 
+var (
+	versionPattern = regexp.MustCompile(`(.*?)\.([0-9]+\.[0-9]+\.[0-9]+)?`)
+)
+
 type SnapshotResult struct {
 	ContractName  string
 	Abi           interface{}
@@ -121,9 +125,8 @@ func processFile(file string) (*SnapshotResult, []error) {
 // ContractName.0.9.8.json -> ContractName.sol
 // ContractName.json -> ContractName.sol
 func parseArtifactName(artifactVersionFile string) (string, error) {
-	re := regexp.MustCompile(`(.*?)\.([0-9]+\.[0-9]+\.[0-9]+)?`)
 	baseName := filepath.Base(artifactVersionFile)
-	match := re.FindStringSubmatch(baseName)
+	match := versionPattern.FindStringSubmatch(baseName)
 	if len(match) < 2 {
 		return "", fmt.Errorf("invalid artifact file name: %q", artifactVersionFile)
 	}

--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -54,6 +54,10 @@ type Artifact struct {
 	ABI json.RawMessage `json:"abi"`
 }
 
+var (
+	internalTypePattern = regexp.MustCompile(`(contract|struct|enum)\s+([^I]\w+|I[a-z]\w*)`)
+)
+
 func main() {
 	if _, err := common.ProcessFilesGlob(
 		[]string{"forge-artifacts/**/*.json"},
@@ -237,11 +241,10 @@ func normalizeInternalType(internalType string) string {
 	}
 
 	// Replace patterns like "contract Something" with "contract ISomething"
-	internalType = regexp.MustCompile(`(contract|struct|enum)\s+([^I]\w+|I[a-z]\w*)`).
-		ReplaceAllStringFunc(internalType, func(s string) string {
-			parts := strings.SplitN(s, " ", 2)
-			return parts[0] + " " + addIPrefix(parts[1])
-		})
+	internalType = internalTypePattern.ReplaceAllStringFunc(internalType, func(s string) string {
+		parts := strings.SplitN(s, " ", 2)
+		return parts[0] + " " + addIPrefix(parts[1])
+	})
 
 	return internalType
 }

--- a/packages/contracts-bedrock/scripts/checks/spacers/main.go
+++ b/packages/contracts-bedrock/scripts/checks/spacers/main.go
@@ -11,6 +11,12 @@ import (
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/scripts/checks/common"
 )
 
+var (
+	uintPattern  = regexp.MustCompile(`uint(\d+)`)
+	bytesPattern = regexp.MustCompile(`bytes(\d+)`)
+	arrayPattern = regexp.MustCompile(`^t_array\((\w+)\)(\d+)`)
+)
+
 func parseVariableLength(variableType string, types map[string]solc.StorageLayoutType) (int, error) {
 	if t, exists := types[variableType]; exists {
 		return int(t.NumberOfBytes), nil
@@ -19,8 +25,7 @@ func parseVariableLength(variableType string, types map[string]solc.StorageLayou
 	if strings.HasPrefix(variableType, "t_mapping") {
 		return 32, nil
 	} else if strings.HasPrefix(variableType, "t_uint") {
-		re := regexp.MustCompile(`uint(\d+)`)
-		matches := re.FindStringSubmatch(variableType)
+		matches := uintPattern.FindStringSubmatch(variableType)
 		if len(matches) > 1 {
 			bitSize, _ := strconv.Atoi(matches[1])
 			return bitSize / 8, nil
@@ -28,8 +33,7 @@ func parseVariableLength(variableType string, types map[string]solc.StorageLayou
 	} else if strings.HasPrefix(variableType, "t_bytes_") {
 		return 32, nil
 	} else if strings.HasPrefix(variableType, "t_bytes") {
-		re := regexp.MustCompile(`bytes(\d+)`)
-		matches := re.FindStringSubmatch(variableType)
+		matches := bytesPattern.FindStringSubmatch(variableType)
 		if len(matches) > 1 {
 			return strconv.Atoi(matches[1])
 		}
@@ -38,8 +42,7 @@ func parseVariableLength(variableType string, types map[string]solc.StorageLayou
 	} else if strings.HasPrefix(variableType, "t_bool") {
 		return 1, nil
 	} else if strings.HasPrefix(variableType, "t_array") {
-		re := regexp.MustCompile(`^t_array\((\w+)\)(\d+)`)
-		matches := re.FindStringSubmatch(variableType)
+		matches := arrayPattern.FindStringSubmatch(variableType)
 		if len(matches) > 2 {
 			innerType := matches[1]
 			size, _ := strconv.Atoi(matches[2])


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Compiling regex patterns is computationally expensive, define inside a function, it will recompile the regex every time the function is called.

This PR moves them outside to ensure they are compiled only once.