### PR TITLE
ci: enable devnet-sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1566,6 +1566,7 @@ workflows:
             packages/contracts-bedrock/scripts/checks
             packages/contracts-bedrock/scripts/verify
             op-dripper
+            devnet-sdk
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

adds devnet-sdk dir for ci.