### PR TITLE
ctb: Remove EIP-2935 preinstalls from v2.0.0 release

### DIFF
--- a/packages/contracts-bedrock/scripts/SetPreinstalls.s.sol
+++ b/packages/contracts-bedrock/scripts/SetPreinstalls.s.sol
@@ -30,7 +30,6 @@ contract SetPreinstalls is Script {
         _setPreinstallCode(Preinstalls.SenderCreator_v070); // ERC 4337 v0.7.0
         _setPreinstallCode(Preinstalls.EntryPoint_v070); // ERC 4337 v0.7.0
         _setPreinstallCode(Preinstalls.BeaconBlockRoots);
-        _setPreinstallCode(Preinstalls.HistoryStorage); // EIP-2935
         _setPreinstallCode(Preinstalls.CreateX);
         // 4788 sender nonce must be incremented, since it's part of later upgrade-transactions.
         // For the upgrade-tx to not create a contract that conflicts with an already-existing copy,

--- a/packages/contracts-bedrock/src/libraries/Preinstalls.sol
+++ b/packages/contracts-bedrock/src/libraries/Preinstalls.sol
@@ -118,9 +118,6 @@ library Preinstalls {
     bytes internal constant BeaconBlockRootsCode =
         hex"3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500";
 
-    bytes internal constant HistoryStorageCode =
-        hex"3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500";
-
     function getDeployedCode(address _addr, uint256 _chainID) internal pure returns (bytes memory out_) {
         if (_addr == MultiCall3) return MultiCall3Code;
         if (_addr == Create2Deployer) return Create2DeployerCode;
@@ -137,7 +134,6 @@ library Preinstalls {
 
         if (_addr == Permit2) return getPermit2Code(_chainID);
         if (_addr == BeaconBlockRoots) return BeaconBlockRootsCode;
-        if (_addr == HistoryStorage) return HistoryStorageCode;
         if (_addr == CreateX) return CreateXCode;
 
         revert("Preinstalls: unknown preinstall");
@@ -159,7 +155,6 @@ library Preinstalls {
         if (_addr == SenderCreator_v070) return "SenderCreator_v070";
         if (_addr == EntryPoint_v070) return "EntryPoint_v070";
         if (_addr == BeaconBlockRoots) return "BeaconBlockRoots";
-        if (_addr == HistoryStorage) return "HistoryStorage";
         if (_addr == CreateX) return "CreateX";
         revert("Preinstalls: unnamed preinstall");
     }

--- a/packages/contracts-bedrock/test/L2/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/L2/Preinstalls.t.sol
@@ -115,11 +115,6 @@ contract PreinstallsTest is CommonTest {
         assertEq(vm.getNonce(Preinstalls.BeaconBlockRootsSender), 1, "4788 sender must have nonce=1");
     }
 
-    function test_preinstall_historyStorage_succeeds() external view {
-        assertPreinstall(Preinstalls.HistoryStorage, Preinstalls.HistoryStorageCode);
-        assertEq(vm.getNonce(Preinstalls.HistoryStorageSender), 1, "2935 sender must have nonce=1");
-    }
-
     function test_preinstall_createX_succeeds() external view {
         assertPreinstall(Preinstalls.CreateX, Preinstalls.CreateXCode);
     }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -313,7 +313,6 @@ contract Setup {
         labelPreinstall(Preinstalls.SenderCreator_v070);
         labelPreinstall(Preinstalls.EntryPoint_v070);
         labelPreinstall(Preinstalls.BeaconBlockRoots);
-        labelPreinstall(Preinstalls.HistoryStorage);
         labelPreinstall(Preinstalls.CreateX);
 
         console.log("Setup: completed L2 genesis");


### PR DESCRIPTION
This preinstall was using an incorrect address as per the latest spec. Additionally, this preinstall is slated to go out with v3.0.0 rather than v2.0.0. Therefore this PR removes the preinstall altogether.
