### PR TITLE
feat(ha): Add HA with flashblock support to op-batcher for DA size configuration distribution

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -117,6 +117,13 @@ type CLIConfig struct {
 	// Should only be used for testing purposes.
 	TestUseMaxTxSizeForBlobs bool
 
+	// SequencerEndpoints is a list of sequencer endpoints to distribute configuration updates to.
+	// This is used for HA mode with rollup boost enabled, where multiple sequencer nodes exist.
+	SequencerEndpoints []string
+
+	// BuilderEndpoint is the endpoint for the block builder to distribute configuration updates to.
+	BuilderEndpoint string
+
 	TxMgrConfig   txmgr.CLIConfig
 	LogConfig     oplog.CLIConfig
 	MetricsConfig opmetrics.CLIConfig
@@ -219,5 +226,9 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ThrottleBlockSize:            ctx.Uint64(flags.ThrottleBlockSizeFlag.Name),
 		ThrottleAlwaysBlockSize:      ctx.Uint64(flags.ThrottleAlwaysBlockSizeFlag.Name),
 		PreferLocalSafeL2:            ctx.Bool(flags.PreferLocalSafeL2Flag.Name),
+
+		// HA configuration with rollup boost enabled
+		SequencerEndpoints: ctx.StringSlice(flags.SequencerEndpointsFlag.Name),
+		BuilderEndpoint:    ctx.String(flags.BuilderEndpointFlag.Name),
 	}
 }

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -117,10 +117,8 @@ type CLIConfig struct {
 	// Should only be used for testing purposes.
 	TestUseMaxTxSizeForBlobs bool
 
-	// DAUpdateEndpoints is a list of endpoints to distribute DA configuration updates to.
-	// This can include sequencer nodes, builders, or any other node that needs to be updated.
-	// If not set, defaults to using the L2EthRpc client.
-	DAUpdateEndpoints []string
+	// ThrottlingEndpoints is a list of endpoints to throttle in addition to the active sequencer.
+	ThrottlingEndpoints []string
 
 	TxMgrConfig   txmgr.CLIConfig
 	LogConfig     oplog.CLIConfig
@@ -224,6 +222,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ThrottleBlockSize:            ctx.Uint64(flags.ThrottleBlockSizeFlag.Name),
 		ThrottleAlwaysBlockSize:      ctx.Uint64(flags.ThrottleAlwaysBlockSizeFlag.Name),
 		PreferLocalSafeL2:            ctx.Bool(flags.PreferLocalSafeL2Flag.Name),
-		DAUpdateEndpoints:            ctx.StringSlice(flags.DAUpdateEndpointsFlag.Name),
+		ThrottlingEndpoints:          ctx.StringSlice(flags.ThrottlingEndpointsFlag.Name),
 	}
 }

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -117,12 +117,10 @@ type CLIConfig struct {
 	// Should only be used for testing purposes.
 	TestUseMaxTxSizeForBlobs bool
 
-	// SequencerEndpoints is a list of sequencer endpoints to distribute configuration updates to.
-	// This is used for HA mode with rollup boost enabled, where multiple sequencer nodes exist.
-	SequencerEndpoints []string
-
-	// BuilderEndpoint is the endpoint for the block builder to distribute configuration updates to.
-	BuilderEndpoint string
+	// DAUpdateEndpoints is a list of endpoints to distribute DA configuration updates to.
+	// This can include sequencer nodes, builders, or any other node that needs to be updated.
+	// If not set, defaults to using the L2EthRpc client.
+	DAUpdateEndpoints []string
 
 	TxMgrConfig   txmgr.CLIConfig
 	LogConfig     oplog.CLIConfig
@@ -226,9 +224,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ThrottleBlockSize:            ctx.Uint64(flags.ThrottleBlockSizeFlag.Name),
 		ThrottleAlwaysBlockSize:      ctx.Uint64(flags.ThrottleAlwaysBlockSizeFlag.Name),
 		PreferLocalSafeL2:            ctx.Bool(flags.PreferLocalSafeL2Flag.Name),
-
-		// HA configuration with rollup boost enabled
-		SequencerEndpoints: ctx.StringSlice(flags.SequencerEndpointsFlag.Name),
-		BuilderEndpoint:    ctx.String(flags.BuilderEndpointFlag.Name),
+		DAUpdateEndpoints:            ctx.StringSlice(flags.DAUpdateEndpointsFlag.Name),
 	}
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -558,6 +558,11 @@ func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint st
 	return nil
 }
 
+// distributeThrottlingToEndpoints configures throttling parameters across all DA endpoints.
+//
+// The function returns true if throttling configuration was successfully distributed to all
+// endpoints. If any endpoint fails, it returns false and resets the retry timer to attempt
+// again after the retry interval.
 func (l *BatchSubmitter) distributeThrottlingToEndpoints(ctx context.Context, maxTxSize, maxBlockSize uint64, daClients map[string]*rpc.Client, retryTimer *time.Timer, retryInterval time.Duration) bool {
 	l.Log.Info("Distributing throttling configuration",
 		"tx_size", maxTxSize,

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -535,6 +535,31 @@ func (l *BatchSubmitter) receiptsLoop(wg *sync.WaitGroup, receiptsCh chan txmgr.
 	l.Log.Info("receiptsLoop returning")
 }
 
+// setMaxDASizeOnEndpoint attempts to call the SetMaxDASize method on the given RPC endpoint
+// and returns whether it was successful
+func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint string, client *rpc.Client, maxTxSize, maxBlockSize uint64) (bool, error) {
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer timeoutCancel()
+
+	var result bool
+	err := client.CallContext(timeoutCtx, &result, SetMaxDASizeMethod,
+		hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
+
+	if err != nil {
+		l.Log.Error("Failed to set max DA size on endpoint",
+			"endpoint", endpoint, "error", err)
+		return false, err
+	} else if !result {
+		l.Log.Error("Endpoint returned false for SetMaxDASize",
+			"endpoint", endpoint)
+		return false, fmt.Errorf("endpoint returned false")
+	}
+
+	l.Log.Info("Successfully set max DA size on endpoint",
+		"endpoint", endpoint)
+	return true, nil
+}
+
 // throttlingLoop monitors the backlog in bytes we need to make available, and appropriately enables or disables
 // throttling of incoming data prevent the backlog from growing too large. By looping & calling the miner API setter
 // continuously, we ensure the engine currently in use is always going to be reset to the proper throttling settings
@@ -547,35 +572,19 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 	retryTimer := time.NewTimer(retryInterval)
 	retryTimer.Stop()
 
-	// Initialize clients for sequencer endpoints and builder
-	// This is used for HA mode with rollup boost enabled, where we have multiple sequencer endpoints and a builder endpoint
-	// In the case of a single sequencer with rollup boost enabled, the sequencerClients will be a map with one entry
-	// In the case of a single sequencer without rollup boost enabled, we will use the old approach of dialing the sequencer endpoint directly
-	sequencerClients := make(map[string]*rpc.Client)
-	var builderClient *rpc.Client
+	// Initialize clients for DA update endpoints
+	daClients := make(map[string]*rpc.Client)
 
 	// Initialize clients if endpoints are configured
-	if len(l.Config.SequencerEndpoints) > 0 {
-		// Initialize sequencer clients
-		for _, endpoint := range l.Config.SequencerEndpoints {
+	if len(l.Config.DAUpdateEndpoints) > 0 {
+		for _, endpoint := range l.Config.DAUpdateEndpoints {
 			client, err := rpc.Dial(endpoint)
 			if err != nil {
-				l.Log.Warn("Failed to connect to sequencer endpoint", "endpoint", endpoint, "err", err)
+				l.Log.Warn("Failed to connect to DA endpoint", "endpoint", endpoint, "err", err)
 				continue
 			}
-			sequencerClients[endpoint] = client
-			l.Log.Info("Connected to sequencer for configuration distribution", "endpoint", endpoint)
-		}
-	}
-
-	// Initialize builder client
-	if l.Config.BuilderEndpoint != "" {
-		var err error
-		builderClient, err = rpc.Dial(l.Config.BuilderEndpoint)
-		if err != nil {
-			l.Log.Warn("Failed to connect to builder endpoint", "endpoint", l.Config.BuilderEndpoint, "err", err)
-		} else {
-			l.Log.Info("Connected to builder for configuration distribution", "endpoint", l.Config.BuilderEndpoint)
+			daClients[endpoint] = client
+			l.Log.Info("Connected to endpoint for configuration distribution", "endpoint", endpoint)
 		}
 	}
 
@@ -594,68 +603,28 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 			}
 		}
 
-		// If we have configured sequencer endpoints, distribute the configuration
-		if len(sequencerClients) > 0 {
+		// If we have configured DA update endpoints, distribute the configuration
+		if len(daClients) > 0 {
 			l.Log.Info("Distributing DA size configuration", "tx_size", maxTxSize, "block_size", maxBlockSize,
-				"sequencer_endpoints", len(sequencerClients), "has_builder", builderClient != nil)
+				"endpoints", len(daClients))
 
 			var wg sync.WaitGroup
-			errors := make(chan error, len(sequencerClients)+1) // +1 for builder
-			success := make(chan bool, len(sequencerClients)+1)
+			errors := make(chan error, len(daClients))
+			success := make(chan bool, len(daClients))
 
-			// Set DA size on all sequencer nodes
-			for endpoint, client := range sequencerClients {
+			// Set DA size on all endpoints
+			for endpoint, client := range daClients {
 				wg.Add(1)
 				go func(endpoint string, client *rpc.Client) {
 					defer wg.Done()
 
-					timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
-					defer timeoutCancel()
-
-					var result bool
-					err := client.CallContext(timeoutCtx, &result, SetMaxDASizeMethod,
-						hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
-
+					succeeded, err := l.setMaxDASizeOnEndpoint(ctx, endpoint, client, maxTxSize, maxBlockSize)
 					if err != nil {
-						l.Log.Error("Failed to set max DA size on sequencer",
-							"endpoint", endpoint, "error", err)
 						errors <- err
-					} else if !result {
-						l.Log.Error("Sequencer returned false for SetMaxDASize",
-							"endpoint", endpoint)
-						errors <- fmt.Errorf("sequencer returned false")
-					} else {
-						l.Log.Info("Successfully set max DA size on sequencer",
-							"endpoint", endpoint)
+					} else if succeeded {
 						success <- true
 					}
 				}(endpoint, client)
-			}
-
-			// Set DA size on builder if configured
-			if builderClient != nil {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-
-					timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
-					defer timeoutCancel()
-
-					var result bool
-					err := builderClient.CallContext(timeoutCtx, &result, SetMaxDASizeMethod,
-						hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
-
-					if err != nil {
-						l.Log.Error("Failed to set max DA size on builder", "error", err)
-						errors <- err
-					} else if !result {
-						l.Log.Error("Builder returned false for SetMaxDASize")
-						errors <- fmt.Errorf("builder returned false")
-					} else {
-						l.Log.Info("Successfully set max DA size on builder")
-						success <- true
-					}
-				}()
 			}
 
 			// Wait for all operations to complete
@@ -665,59 +634,53 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 
 			// Count successes vs. required endpoints
 			successCount := len(success)
-			requiredCount := len(sequencerClients)
-			if builderClient != nil {
-				requiredCount++
-			}
+			requiredCount := len(daClients)
 
 			if successCount < requiredCount {
-				l.Log.Error("Failed to distribute DA size configuration to all targets",
+				l.Log.Error("Failed to distribute DA size configuration to all endpoints",
 					"success", successCount, "required", requiredCount)
 				retryTimer.Reset(retryInterval)
 				return
 			}
 
-			l.Log.Info("Successfully distributed DA size configuration to all targets",
+			l.Log.Info("Successfully distributed DA size configuration to all endpoints",
 				"tx_size", maxTxSize, "block_size", maxBlockSize)
 		} else {
-			// Fall back to the original approach if no sequencer endpoints are configured
-			// meaning in this case we don't have HA mode with rollup boost enabled
+			// Fall back to the original approach if no endpoints are configured
 			cl, err := l.EndpointProvider.EthClient(ctx)
 			if err != nil {
 				l.Log.Error("Can't reach sequencer execution RPC", "err", err)
 				return
 			}
 
-			var (
-				success bool
-				rpcErr  rpc.Error
-			)
-			err = cl.Client().CallContext(
-				ctx, &success, SetMaxDASizeMethod, hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize),
-			)
+			succeeded, err := l.setMaxDASizeOnEndpoint(ctx, "default-l2-endpoint", cl.Client(), maxTxSize, maxBlockSize)
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// If the context was cancelled, our work is done and we expect an error here:
 				// So log it quietly and exit.
 				l.Log.Debug("DA throttling context cancelled")
 				return
 			}
-			if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()).IsGenericRPCError() {
-				l.Log.Error("SetMaxDASize rpc unavailable or broken, shutting down. Either enable it or disable throttling.", "err", err)
-				// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancel()
-				// Call StopBatchSubmitting in another goroutine to avoid deadlock.
-				go func() {
-					// Always returns nil. An error is only returned to expose this function as an RPC.
-					_ = l.StopBatchSubmitting(ctx)
-				}()
-				return
-			} else if err != nil {
+
+			if err != nil {
+				var rpcErr rpc.Error
+				if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()).IsGenericRPCError() {
+					l.Log.Error("SetMaxDASize rpc unavailable or broken, shutting down. Either enable it or disable throttling.", "err", err)
+					// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					// Call StopBatchSubmitting in another goroutine to avoid deadlock.
+					go func() {
+						// Always returns nil. An error is only returned to expose this function as an RPC.
+						_ = l.StopBatchSubmitting(ctx)
+					}()
+					return
+				}
 				l.Log.Error("SetMaxDASize rpc failed, retrying.", "err", err)
 				retryTimer.Reset(retryInterval)
 				return
 			}
-			if !success {
+
+			if !succeeded {
 				l.Log.Error("Result of SetMaxDASize was false, retrying.")
 				retryTimer.Reset(retryInterval)
 			}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/big"
 	_ "net/http/pprof"
+	"strings"
 	"sync"
 	"time"
 
@@ -91,7 +92,6 @@ type DriverSetup struct {
 	ChannelConfig     ChannelConfigProvider
 	AltDA             *altda.DAClient
 	ChannelOutFactory ChannelOutFactory
-	ActiveSeqChanged  chan struct{} // optional
 }
 
 // BatchSubmitter encapsulates a service responsible for submitting L2 tx
@@ -544,8 +544,28 @@ func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint st
 		hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
 
 	if err != nil {
-		l.Log.Error("Failed to set max DA size on endpoint",
-			"endpoint", endpoint, "error", err)
+		if errors.Is(ctx.Err(), context.Canceled) {
+			// If the context was cancelled, our work is done and we expect an error here
+			l.Log.Debug("DA throttling context cancelled for endpoint", "endpoint", endpoint)
+			return ctx.Err()
+		}
+
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()).IsGenericRPCError() {
+			l.Log.Error("SetMaxDASize RPC method unavailable on endpoint, shutting down. Either enable it or disable throttling.",
+				"endpoint", endpoint, "err", err)
+
+			// We keep the strict throttling requirement behavior - shut down if RPC not available
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			// Call StopBatchSubmitting in another goroutine to avoid deadlock.
+			go func() {
+				_ = l.StopBatchSubmitting(ctx)
+			}()
+		} else {
+			l.Log.Error("Failed to set max DA size on endpoint",
+				"endpoint", endpoint, "error", err)
+		}
 		return err
 	} else if !result {
 		l.Log.Error("Endpoint returned false for SetMaxDASize",
@@ -554,55 +574,10 @@ func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint st
 	}
 
 	l.Log.Info("Successfully set max DA size on endpoint",
-		"endpoint", endpoint)
+		"endpoint", endpoint,
+		"max_tx_size", maxTxSize,
+		"max_block_size", maxBlockSize)
 	return nil
-}
-
-// distributeThrottlingToEndpoints configures throttling parameters across all DA endpoints.
-//
-// The function returns true if throttling configuration was successfully distributed to all
-// endpoints. If any endpoint fails, it returns false and resets the retry timer to attempt
-// again after the retry interval.
-func (l *BatchSubmitter) distributeThrottlingToEndpoints(ctx context.Context, maxTxSize, maxBlockSize uint64, daClients map[string]*rpc.Client, retryTimer *time.Timer, retryInterval time.Duration) bool {
-	l.Log.Info("Distributing throttling configuration",
-		"tx_size", maxTxSize,
-		"block_size", maxBlockSize,
-		"endpoints", len(daClients))
-
-	var wg sync.WaitGroup
-	results := make(chan error, len(daClients))
-
-	// Set throttling on all endpoints
-	for endpoint, client := range daClients {
-		wg.Add(1)
-		go func(endpoint string, client *rpc.Client) {
-			defer wg.Done()
-			results <- l.setMaxDASizeOnEndpoint(ctx, endpoint, client, maxTxSize, maxBlockSize)
-		}(endpoint, client)
-	}
-
-	// Wait for all operations to complete
-	wg.Wait()
-	close(results)
-
-	// Count successes vs. required endpoints
-	successCount := 0
-	for err := range results {
-		if err == nil {
-			successCount++
-		}
-	}
-
-	if successCount < len(daClients) {
-		l.Log.Error("Failed to distribute throttling configuration to all endpoints",
-			"success", successCount, "required", len(daClients))
-		retryTimer.Reset(retryInterval)
-		return false
-	}
-
-	l.Log.Info("Successfully distributed throttling configuration to all endpoints",
-		"tx_size", maxTxSize, "block_size", maxBlockSize)
-	return true
 }
 
 // throttlingLoop monitors the backlog in bytes we need to make available, and appropriately enables or disables
@@ -617,30 +592,86 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 	retryTimer := time.NewTimer(retryInterval)
 	retryTimer.Stop()
 
-	// Initialize clients for throttling endpoints
+	// Initialize map to store all throttling client connections
 	throttlingClients := make(map[string]*rpc.Client)
 
-	// Initialize clients using throttling endpoints if configured
-	if len(l.Config.ThrottlingEndpoints) > 0 {
-		l.Log.Info("Using throttling endpoints configuration", "count", len(l.Config.ThrottlingEndpoints))
-		for _, endpoint := range l.Config.ThrottlingEndpoints {
+	// Function to connect to all configured endpoints or fallback to default
+	connectToEndpoints := func() bool {
+		endpoints := l.Config.ThrottlingEndpoints
+
+		// Clear existing connections to ensure we have a fresh set
+		for endpoint := range throttlingClients {
+			delete(throttlingClients, endpoint)
+		}
+
+		// If no throttling endpoints are configured, use the default L2 endpoint
+		if len(endpoints) == 0 {
+			ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
+			cl, err := l.EndpointProvider.EthClient(ctx)
+			cancel()
+
+			if err != nil {
+				l.Log.Warn("Failed to get default L2 endpoint", "err", err)
+				return false
+			}
+
+			// Add default endpoint to our map
+			defaultEndpoint := "default-l2-endpoint"
+			throttlingClients[defaultEndpoint] = cl.Client()
+			l.Log.Info("Using default L2 endpoint for throttling", "endpoint", defaultEndpoint)
+			return true
+		}
+
+		// Process configured throttling endpoints
+		allConnected := true
+		for _, endpoint := range endpoints {
 			client, err := rpc.Dial(endpoint)
 			if err != nil {
 				l.Log.Warn("Failed to connect to throttling endpoint", "endpoint", endpoint, "err", err)
+				allConnected = false
 				continue
 			}
 			throttlingClients[endpoint] = client
 			l.Log.Info("Connected to endpoint for throttling distribution", "endpoint", endpoint)
 		}
-	} else {
-		l.Log.Info("No throttling endpoints configured, will use default L2 endpoint")
+
+		// Only return true if we connected to all endpoints
+		if !allConnected {
+			// Clean up any connections we did make
+			for endpoint := range throttlingClients {
+				delete(throttlingClients, endpoint)
+			}
+			return false
+		}
+
+		return len(throttlingClients) > 0
+	}
+
+	// Initial connection to endpoints
+	endpointsConnected := connectToEndpoints()
+	if !endpointsConnected {
+		l.Log.Warn("Could not connect to all throttling endpoints, will retry periodically")
+		retryTimer.Reset(retryInterval)
 	}
 
 	updateParams := func(pendingBytes int64) {
 		retryTimer.Stop()
+
+		// If we have no endpoint connections, try to connect again
+		if len(throttlingClients) == 0 {
+			l.Log.Warn("No throttling endpoints available, attempting to reconnect")
+			endpointsConnected = connectToEndpoints()
+			if !endpointsConnected {
+				l.Log.Warn("Still could not connect to all throttling endpoints, will retry")
+				retryTimer.Reset(retryInterval)
+				return
+			}
+		}
+
 		ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
 		defer cancel()
 
+		// Determine throttling parameters based on pending bytes
 		maxTxSize := uint64(0)
 		maxBlockSize := l.Config.ThrottleAlwaysBlockSize
 		if pendingBytes > int64(l.Config.ThrottleThreshold) {
@@ -651,48 +682,45 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 			}
 		}
 
-		// If we have configured throttling endpoints, distribute the configuration
-		if len(throttlingClients) > 0 {
-			if !l.distributeThrottlingToEndpoints(ctx, maxTxSize, maxBlockSize, throttlingClients, retryTimer, retryInterval) {
-				return // Return after a failed attempt, as we've scheduled a retry
-			}
-		} else {
-			// Fall back to the original approach if no endpoints are configured
-			cl, err := l.EndpointProvider.EthClient(ctx)
-			if err != nil {
-				l.Log.Error("Can't reach sequencer execution RPC", "err", err)
-				return
-			}
+		// Apply throttling to all connected endpoints - all must succeed
+		success := true
+		failedEndpoints := make([]string, 0)
 
-			err = l.setMaxDASizeOnEndpoint(ctx, "default-l2-endpoint", cl.Client(), maxTxSize, maxBlockSize)
-			if errors.Is(ctx.Err(), context.Canceled) {
-				// If the context was cancelled, our work is done and we expect an error here:
-				// So log it quietly and exit.
-				l.Log.Debug("DA throttling context cancelled")
-				return
-			}
-
+		for endpoint, client := range throttlingClients {
+			err := l.setMaxDASizeOnEndpoint(ctx, endpoint, client, maxTxSize, maxBlockSize)
 			if err != nil {
-				var rpcErr rpc.Error
-				if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()).IsGenericRPCError() {
-					l.Log.Error("SetMaxDASize rpc unavailable or broken, shutting down. Either enable it or disable throttling.", "err", err)
-					// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-					defer cancel()
-					// Call StopBatchSubmitting in another goroutine to avoid deadlock.
-					go func() {
-						// Always returns nil. An error is only returned to expose this function as an RPC.
-						_ = l.StopBatchSubmitting(ctx)
-					}()
+				if errors.Is(ctx.Err(), context.Canceled) {
+					// If context is canceled, we're shutting down, so just exit
+					l.Log.Debug("Context canceled while setting max DA size", "endpoint", endpoint)
 					return
 				}
-				l.Log.Error("SetMaxDASize rpc failed, retrying.", "err", err)
-				retryTimer.Reset(retryInterval)
-				return
+				success = false
+				failedEndpoints = append(failedEndpoints, endpoint)
+				l.Log.Error("Failed to set throttling on endpoint", "endpoint", endpoint, "error", err)
 			}
 		}
+
+		// Handle results - any failure means we need to reconnect and retry
+		if !success {
+			l.Log.Error("Failed to set throttling on all endpoints",
+				"failed_endpoints", strings.Join(failedEndpoints, ", "))
+
+			// Clear all connections to ensure consistency on retry
+			for endpoint := range throttlingClients {
+				delete(throttlingClients, endpoint)
+			}
+
+			retryTimer.Reset(retryInterval)
+			return
+		}
+
+		l.Log.Info("Successfully applied throttling configuration to all endpoints",
+			"tx_size", maxTxSize,
+			"block_size", maxBlockSize,
+			"endpoint_count", len(throttlingClients))
 	}
 
+	// Track the last known pending bytes to use when retrying
 	cachedPendingBytes := int64(0)
 
 	for {
@@ -700,13 +728,11 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 		case pendingBytes, ok := <-pendingBytesUpdated:
 			if !ok {
 				// If the channel was closed, this is our signal to exit
-				l.Log.Info("throttlingLoop returning")
+				l.Log.Info("Throttling loop shutting down")
 				return
 			}
 			updateParams(pendingBytes)
 			cachedPendingBytes = pendingBytes
-		case <-l.ActiveSeqChanged:
-			updateParams(cachedPendingBytes)
 		case <-retryTimer.C:
 			updateParams(cachedPendingBytes)
 		}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -547,15 +547,42 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 	retryTimer := time.NewTimer(retryInterval)
 	retryTimer.Stop()
 
+	// Initialize clients for sequencer endpoints and builder
+	// This is used for HA mode with rollup boost enabled, where we have multiple sequencer endpoints and a builder endpoint
+	// In the case of a single sequencer with rollup boost enabled, the sequencerClients will be a map with one entry
+	// In the case of a single sequencer without rollup boost enabled, we will use the old approach of dialing the sequencer endpoint directly
+	sequencerClients := make(map[string]*rpc.Client)
+	var builderClient *rpc.Client
+
+	// Initialize clients if endpoints are configured
+	if len(l.Config.SequencerEndpoints) > 0 {
+		// Initialize sequencer clients
+		for _, endpoint := range l.Config.SequencerEndpoints {
+			client, err := rpc.Dial(endpoint)
+			if err != nil {
+				l.Log.Warn("Failed to connect to sequencer endpoint", "endpoint", endpoint, "err", err)
+				continue
+			}
+			sequencerClients[endpoint] = client
+			l.Log.Info("Connected to sequencer for configuration distribution", "endpoint", endpoint)
+		}
+	}
+
+	// Initialize builder client
+	if l.Config.BuilderEndpoint != "" {
+		var err error
+		builderClient, err = rpc.Dial(l.Config.BuilderEndpoint)
+		if err != nil {
+			l.Log.Warn("Failed to connect to builder endpoint", "endpoint", l.Config.BuilderEndpoint, "err", err)
+		} else {
+			l.Log.Info("Connected to builder for configuration distribution", "endpoint", l.Config.BuilderEndpoint)
+		}
+	}
+
 	updateParams := func(pendingBytes int64) {
 		retryTimer.Stop()
 		ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
 		defer cancel()
-		cl, err := l.EndpointProvider.EthClient(ctx)
-		if err != nil {
-			l.Log.Error("Can't reach sequencer execution RPC", "err", err)
-			return
-		}
 
 		maxTxSize := uint64(0)
 		maxBlockSize := l.Config.ThrottleAlwaysBlockSize
@@ -566,38 +593,134 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 				maxBlockSize = l.Config.ThrottleBlockSize
 			}
 		}
-		var (
-			success bool
-			rpcErr  rpc.Error
-		)
-		err = cl.Client().CallContext(
-			ctx, &success, SetMaxDASizeMethod, hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize),
-		)
-		if errors.Is(ctx.Err(), context.Canceled) {
-			// If the context was cancelled, our work is done and we expect an error here:
-			// So log it quietly and exit.
-			l.Log.Debug("DA throttling context cancelled")
-			return
-		}
-		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()).IsGenericRPCError() {
-			l.Log.Error("SetMaxDASize rpc unavailable or broken, shutting down. Either enable it or disable throttling.", "err", err)
-			// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			// Call StopBatchSubmitting in another goroutine to avoid deadlock.
-			go func() {
-				// Always returns nil. An error is only returned to expose this function as an RPC.
-				_ = l.StopBatchSubmitting(ctx)
-			}()
-			return
-		} else if err != nil {
-			l.Log.Error("SetMaxDASize rpc failed, retrying.", "err", err)
-			retryTimer.Reset(retryInterval)
-			return
-		}
-		if !success {
-			l.Log.Error("Result of SetMaxDASize was false, retrying.")
-			retryTimer.Reset(retryInterval)
+
+		// If we have configured sequencer endpoints, distribute the configuration
+		if len(sequencerClients) > 0 {
+			l.Log.Info("Distributing DA size configuration", "tx_size", maxTxSize, "block_size", maxBlockSize,
+				"sequencer_endpoints", len(sequencerClients), "has_builder", builderClient != nil)
+
+			var wg sync.WaitGroup
+			errors := make(chan error, len(sequencerClients)+1) // +1 for builder
+			success := make(chan bool, len(sequencerClients)+1)
+
+			// Set DA size on all sequencer nodes
+			for endpoint, client := range sequencerClients {
+				wg.Add(1)
+				go func(endpoint string, client *rpc.Client) {
+					defer wg.Done()
+
+					timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
+					defer timeoutCancel()
+
+					var result bool
+					err := client.CallContext(timeoutCtx, &result, SetMaxDASizeMethod,
+						hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
+
+					if err != nil {
+						l.Log.Error("Failed to set max DA size on sequencer",
+							"endpoint", endpoint, "error", err)
+						errors <- err
+					} else if !result {
+						l.Log.Error("Sequencer returned false for SetMaxDASize",
+							"endpoint", endpoint)
+						errors <- fmt.Errorf("sequencer returned false")
+					} else {
+						l.Log.Info("Successfully set max DA size on sequencer",
+							"endpoint", endpoint)
+						success <- true
+					}
+				}(endpoint, client)
+			}
+
+			// Set DA size on builder if configured
+			if builderClient != nil {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
+					defer timeoutCancel()
+
+					var result bool
+					err := builderClient.CallContext(timeoutCtx, &result, SetMaxDASizeMethod,
+						hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
+
+					if err != nil {
+						l.Log.Error("Failed to set max DA size on builder", "error", err)
+						errors <- err
+					} else if !result {
+						l.Log.Error("Builder returned false for SetMaxDASize")
+						errors <- fmt.Errorf("builder returned false")
+					} else {
+						l.Log.Info("Successfully set max DA size on builder")
+						success <- true
+					}
+				}()
+			}
+
+			// Wait for all operations to complete
+			wg.Wait()
+			close(errors)
+			close(success)
+
+			// Count successes vs. required endpoints
+			successCount := len(success)
+			requiredCount := len(sequencerClients)
+			if builderClient != nil {
+				requiredCount++
+			}
+
+			if successCount < requiredCount {
+				l.Log.Error("Failed to distribute DA size configuration to all targets",
+					"success", successCount, "required", requiredCount)
+				retryTimer.Reset(retryInterval)
+				return
+			}
+
+			l.Log.Info("Successfully distributed DA size configuration to all targets",
+				"tx_size", maxTxSize, "block_size", maxBlockSize)
+		} else {
+			// Fall back to the original approach if no sequencer endpoints are configured
+			// meaning in this case we don't have HA mode with rollup boost enabled
+			cl, err := l.EndpointProvider.EthClient(ctx)
+			if err != nil {
+				l.Log.Error("Can't reach sequencer execution RPC", "err", err)
+				return
+			}
+
+			var (
+				success bool
+				rpcErr  rpc.Error
+			)
+			err = cl.Client().CallContext(
+				ctx, &success, SetMaxDASizeMethod, hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize),
+			)
+			if errors.Is(ctx.Err(), context.Canceled) {
+				// If the context was cancelled, our work is done and we expect an error here:
+				// So log it quietly and exit.
+				l.Log.Debug("DA throttling context cancelled")
+				return
+			}
+			if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()).IsGenericRPCError() {
+				l.Log.Error("SetMaxDASize rpc unavailable or broken, shutting down. Either enable it or disable throttling.", "err", err)
+				// We'd probably hit this error right after startup, so a short shutdown duration should suffice.
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				// Call StopBatchSubmitting in another goroutine to avoid deadlock.
+				go func() {
+					// Always returns nil. An error is only returned to expose this function as an RPC.
+					_ = l.StopBatchSubmitting(ctx)
+				}()
+				return
+			} else if err != nil {
+				l.Log.Error("SetMaxDASize rpc failed, retrying.", "err", err)
+				retryTimer.Reset(retryInterval)
+				return
+			}
+			if !success {
+				l.Log.Error("Result of SetMaxDASize was false, retrying.")
+				retryTimer.Reset(retryInterval)
+			}
 		}
 	}
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -535,7 +535,7 @@ func (l *BatchSubmitter) receiptsLoop(wg *sync.WaitGroup, receiptsCh chan txmgr.
 	l.Log.Info("receiptsLoop returning")
 }
 
-func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint string, client *rpc.Client, maxTxSize, maxBlockSize uint64) (bool, error) {
+func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint string, client *rpc.Client, maxTxSize, maxBlockSize uint64) error {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer timeoutCancel()
 
@@ -546,16 +546,58 @@ func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint st
 	if err != nil {
 		l.Log.Error("Failed to set max DA size on endpoint",
 			"endpoint", endpoint, "error", err)
-		return false, err
+		return err
 	} else if !result {
 		l.Log.Error("Endpoint returned false for SetMaxDASize",
 			"endpoint", endpoint)
-		return false, fmt.Errorf("endpoint returned false")
+		return fmt.Errorf("endpoint returned false")
 	}
 
 	l.Log.Info("Successfully set max DA size on endpoint",
 		"endpoint", endpoint)
-	return true, nil
+	return nil
+}
+
+func (l *BatchSubmitter) distributeThrottlingToEndpoints(ctx context.Context, maxTxSize, maxBlockSize uint64, daClients map[string]*rpc.Client, retryTimer *time.Timer, retryInterval time.Duration) bool {
+	l.Log.Info("Distributing throttling configuration",
+		"tx_size", maxTxSize,
+		"block_size", maxBlockSize,
+		"endpoints", len(daClients))
+
+	var wg sync.WaitGroup
+	results := make(chan error, len(daClients))
+
+	// Set throttling on all endpoints
+	for endpoint, client := range daClients {
+		wg.Add(1)
+		go func(endpoint string, client *rpc.Client) {
+			defer wg.Done()
+			results <- l.setMaxDASizeOnEndpoint(ctx, endpoint, client, maxTxSize, maxBlockSize)
+		}(endpoint, client)
+	}
+
+	// Wait for all operations to complete
+	wg.Wait()
+	close(results)
+
+	// Count successes vs. required endpoints
+	successCount := 0
+	for err := range results {
+		if err == nil {
+			successCount++
+		}
+	}
+
+	if successCount < len(daClients) {
+		l.Log.Error("Failed to distribute throttling configuration to all endpoints",
+			"success", successCount, "required", len(daClients))
+		retryTimer.Reset(retryInterval)
+		return false
+	}
+
+	l.Log.Info("Successfully distributed throttling configuration to all endpoints",
+		"tx_size", maxTxSize, "block_size", maxBlockSize)
+	return true
 }
 
 // throttlingLoop monitors the backlog in bytes we need to make available, and appropriately enables or disables
@@ -570,23 +612,23 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 	retryTimer := time.NewTimer(retryInterval)
 	retryTimer.Stop()
 
-	// Initialize clients for DA update endpoints
-	daClients := make(map[string]*rpc.Client)
+	// Initialize clients for throttling endpoints
+	throttlingClients := make(map[string]*rpc.Client)
 
-	// Initialize clients using DAUpdateEndpoints if configured
-	if len(l.Config.DAUpdateEndpoints) > 0 {
-		l.Log.Info("Using DA update endpoints configuration", "count", len(l.Config.DAUpdateEndpoints))
-		for _, endpoint := range l.Config.DAUpdateEndpoints {
+	// Initialize clients using throttling endpoints if configured
+	if len(l.Config.ThrottlingEndpoints) > 0 {
+		l.Log.Info("Using throttling endpoints configuration", "count", len(l.Config.ThrottlingEndpoints))
+		for _, endpoint := range l.Config.ThrottlingEndpoints {
 			client, err := rpc.Dial(endpoint)
 			if err != nil {
-				l.Log.Warn("Failed to connect to DA endpoint", "endpoint", endpoint, "err", err)
+				l.Log.Warn("Failed to connect to throttling endpoint", "endpoint", endpoint, "err", err)
 				continue
 			}
-			daClients[endpoint] = client
-			l.Log.Info("Connected to endpoint for configuration distribution", "endpoint", endpoint)
+			throttlingClients[endpoint] = client
+			l.Log.Info("Connected to endpoint for throttling distribution", "endpoint", endpoint)
 		}
 	} else {
-		l.Log.Info("No DA update endpoints configured, will use default L2 endpoint")
+		l.Log.Info("No throttling endpoints configured, will use default L2 endpoint")
 	}
 
 	updateParams := func(pendingBytes int64) {
@@ -604,48 +646,11 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 			}
 		}
 
-		// If we have configured DA update endpoints, distribute the configuration
-		if len(daClients) > 0 {
-			l.Log.Info("Distributing DA size configuration", "tx_size", maxTxSize, "block_size", maxBlockSize,
-				"endpoints", len(daClients))
-
-			var wg sync.WaitGroup
-			errors := make(chan error, len(daClients))
-			success := make(chan bool, len(daClients))
-
-			// Set DA size on all endpoints
-			for endpoint, client := range daClients {
-				wg.Add(1)
-				go func(endpoint string, client *rpc.Client) {
-					defer wg.Done()
-
-					succeeded, err := l.setMaxDASizeOnEndpoint(ctx, endpoint, client, maxTxSize, maxBlockSize)
-					if err != nil {
-						errors <- err
-					} else if succeeded {
-						success <- true
-					}
-				}(endpoint, client)
+		// If we have configured throttling endpoints, distribute the configuration
+		if len(throttlingClients) > 0 {
+			if !l.distributeThrottlingToEndpoints(ctx, maxTxSize, maxBlockSize, throttlingClients, retryTimer, retryInterval) {
+				return // Return after a failed attempt, as we've scheduled a retry
 			}
-
-			// Wait for all operations to complete
-			wg.Wait()
-			close(errors)
-			close(success)
-
-			// Count successes vs. required endpoints
-			successCount := len(success)
-			requiredCount := len(daClients)
-
-			if successCount < requiredCount {
-				l.Log.Error("Failed to distribute DA size configuration to all endpoints",
-					"success", successCount, "required", requiredCount)
-				retryTimer.Reset(retryInterval)
-				return
-			}
-
-			l.Log.Info("Successfully distributed DA size configuration to all endpoints",
-				"tx_size", maxTxSize, "block_size", maxBlockSize)
 		} else {
 			// Fall back to the original approach if no endpoints are configured
 			cl, err := l.EndpointProvider.EthClient(ctx)
@@ -654,7 +659,7 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 				return
 			}
 
-			succeeded, err := l.setMaxDASizeOnEndpoint(ctx, "default-l2-endpoint", cl.Client(), maxTxSize, maxBlockSize)
+			err = l.setMaxDASizeOnEndpoint(ctx, "default-l2-endpoint", cl.Client(), maxTxSize, maxBlockSize)
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// If the context was cancelled, our work is done and we expect an error here:
 				// So log it quietly and exit.
@@ -679,11 +684,6 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 				l.Log.Error("SetMaxDASize rpc failed, retrying.", "err", err)
 				retryTimer.Reset(retryInterval)
 				return
-			}
-
-			if !succeeded {
-				l.Log.Error("Result of SetMaxDASize was false, retrying.")
-				retryTimer.Reset(retryInterval)
 			}
 		}
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -535,8 +535,6 @@ func (l *BatchSubmitter) receiptsLoop(wg *sync.WaitGroup, receiptsCh chan txmgr.
 	l.Log.Info("receiptsLoop returning")
 }
 
-// setMaxDASizeOnEndpoint attempts to call the SetMaxDASize method on the given RPC endpoint
-// and returns whether it was successful
 func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint string, client *rpc.Client, maxTxSize, maxBlockSize uint64) (bool, error) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer timeoutCancel()
@@ -575,8 +573,9 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 	// Initialize clients for DA update endpoints
 	daClients := make(map[string]*rpc.Client)
 
-	// Initialize clients if endpoints are configured
+	// Initialize clients using DAUpdateEndpoints if configured
 	if len(l.Config.DAUpdateEndpoints) > 0 {
+		l.Log.Info("Using DA update endpoints configuration", "count", len(l.Config.DAUpdateEndpoints))
 		for _, endpoint := range l.Config.DAUpdateEndpoints {
 			client, err := rpc.Dial(endpoint)
 			if err != nil {
@@ -586,6 +585,8 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 			daClients[endpoint] = client
 			l.Log.Info("Connected to endpoint for configuration distribution", "endpoint", endpoint)
 		}
+	} else {
+		l.Log.Info("No DA update endpoints configured, will use default L2 endpoint")
 	}
 
 	updateParams := func(pendingBytes int64) {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/big"
 	_ "net/http/pprof"
-	"strings"
 	"sync"
 	"time"
 
@@ -535,19 +534,41 @@ func (l *BatchSubmitter) receiptsLoop(wg *sync.WaitGroup, receiptsCh chan txmgr.
 	l.Log.Info("receiptsLoop returning")
 }
 
-func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint string, client *rpc.Client, maxTxSize, maxBlockSize uint64) error {
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer timeoutCancel()
+// singleEndpointThrottler handles throttling for a specific endpoint
+// This is almost identical to the original throttlingLoop but operates on a specific endpoint
+func (l *BatchSubmitter) singleEndpointThrottler(wg *sync.WaitGroup, endpointUpdates chan int64, endpoint string, client *rpc.Client) {
+	defer wg.Done()
+	l.Log.Info("Starting endpoint throttling loop", "endpoint", endpoint)
 
-	var result bool
-	err := client.CallContext(timeoutCtx, &result, SetMaxDASizeMethod,
-		hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize))
+	retryInterval := 10 * time.Second
+	retryTimer := time.NewTimer(retryInterval)
+	retryTimer.Stop()
 
-	if err != nil {
+	updateParams := func(pendingBytes int64) {
+		retryTimer.Stop()
+
+		ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
+		defer cancel()
+
+		maxTxSize := uint64(0)
+		maxBlockSize := l.Config.ThrottleAlwaysBlockSize
+		if pendingBytes > int64(l.Config.ThrottleThreshold) {
+			l.Log.Warn("Pending bytes over limit, throttling DA", "endpoint", endpoint, "bytes", pendingBytes, "limit", l.Config.ThrottleThreshold)
+			maxTxSize = l.Config.ThrottleTxSize
+			if maxBlockSize == 0 || (l.Config.ThrottleBlockSize != 0 && l.Config.ThrottleBlockSize < maxBlockSize) {
+				maxBlockSize = l.Config.ThrottleBlockSize
+			}
+		}
+
+		var success bool
+		err := client.CallContext(
+			ctx, &success, SetMaxDASizeMethod, hexutil.Uint64(maxTxSize), hexutil.Uint64(maxBlockSize),
+		)
+
 		if errors.Is(ctx.Err(), context.Canceled) {
 			// If the context was cancelled, our work is done and we expect an error here
 			l.Log.Debug("DA throttling context cancelled for endpoint", "endpoint", endpoint)
-			return ctx.Err()
+			return
 		}
 
 		var rpcErr rpc.Error
@@ -562,179 +583,179 @@ func (l *BatchSubmitter) setMaxDASizeOnEndpoint(ctx context.Context, endpoint st
 			go func() {
 				_ = l.StopBatchSubmitting(ctx)
 			}()
-		} else {
-			l.Log.Error("Failed to set max DA size on endpoint",
-				"endpoint", endpoint, "error", err)
-		}
-		return err
-	} else if !result {
-		l.Log.Error("Endpoint returned false for SetMaxDASize",
-			"endpoint", endpoint)
-		return fmt.Errorf("endpoint returned false")
-	}
-
-	l.Log.Info("Successfully set max DA size on endpoint",
-		"endpoint", endpoint,
-		"max_tx_size", maxTxSize,
-		"max_block_size", maxBlockSize)
-	return nil
-}
-
-// throttlingLoop monitors the backlog in bytes we need to make available, and appropriately enables or disables
-// throttling of incoming data prevent the backlog from growing too large. By looping & calling the miner API setter
-// continuously, we ensure the engine currently in use is always going to be reset to the proper throttling settings
-// even in the event of sequencer failover.
-func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated chan int64) {
-	defer wg.Done()
-	l.Log.Info("Starting DA throttling loop")
-
-	retryInterval := 10 * time.Second
-	retryTimer := time.NewTimer(retryInterval)
-	retryTimer.Stop()
-
-	// Initialize map to store all throttling client connections
-	throttlingClients := make(map[string]*rpc.Client)
-
-	// Function to connect to all configured endpoints or fallback to default
-	connectToEndpoints := func() bool {
-		endpoints := l.Config.ThrottlingEndpoints
-
-		// Clear existing connections to ensure we have a fresh set
-		for endpoint := range throttlingClients {
-			delete(throttlingClients, endpoint)
-		}
-
-		// If no throttling endpoints are configured, use the default L2 endpoint
-		if len(endpoints) == 0 {
-			ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
-			cl, err := l.EndpointProvider.EthClient(ctx)
-			cancel()
-
-			if err != nil {
-				l.Log.Warn("Failed to get default L2 endpoint", "err", err)
-				return false
-			}
-
-			// Add default endpoint to our map
-			defaultEndpoint := "default-l2-endpoint"
-			throttlingClients[defaultEndpoint] = cl.Client()
-			l.Log.Info("Using default L2 endpoint for throttling", "endpoint", defaultEndpoint)
-			return true
-		}
-
-		// Process configured throttling endpoints
-		allConnected := true
-		for _, endpoint := range endpoints {
-			client, err := rpc.Dial(endpoint)
-			if err != nil {
-				l.Log.Warn("Failed to connect to throttling endpoint", "endpoint", endpoint, "err", err)
-				allConnected = false
-				continue
-			}
-			throttlingClients[endpoint] = client
-			l.Log.Info("Connected to endpoint for throttling distribution", "endpoint", endpoint)
-		}
-
-		// Only return true if we connected to all endpoints
-		if !allConnected {
-			// Clean up any connections we did make
-			for endpoint := range throttlingClients {
-				delete(throttlingClients, endpoint)
-			}
-			return false
-		}
-
-		return len(throttlingClients) > 0
-	}
-
-	// Initial connection to endpoints
-	endpointsConnected := connectToEndpoints()
-	if !endpointsConnected {
-		l.Log.Warn("Could not connect to all throttling endpoints, will retry periodically")
-		retryTimer.Reset(retryInterval)
-	}
-
-	updateParams := func(pendingBytes int64) {
-		retryTimer.Stop()
-
-		// If we have no endpoint connections, try to connect again
-		if len(throttlingClients) == 0 {
-			l.Log.Warn("No throttling endpoints available, attempting to reconnect")
-			endpointsConnected = connectToEndpoints()
-			if !endpointsConnected {
-				l.Log.Warn("Still could not connect to all throttling endpoints, will retry")
-				retryTimer.Reset(retryInterval)
-				return
-			}
-		}
-
-		ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
-		defer cancel()
-
-		// Determine throttling parameters based on pending bytes
-		maxTxSize := uint64(0)
-		maxBlockSize := l.Config.ThrottleAlwaysBlockSize
-		if pendingBytes > int64(l.Config.ThrottleThreshold) {
-			l.Log.Warn("Pending bytes over limit, throttling DA", "bytes", pendingBytes, "limit", l.Config.ThrottleThreshold)
-			maxTxSize = l.Config.ThrottleTxSize
-			if maxBlockSize == 0 || (l.Config.ThrottleBlockSize != 0 && l.Config.ThrottleBlockSize < maxBlockSize) {
-				maxBlockSize = l.Config.ThrottleBlockSize
-			}
-		}
-
-		// Apply throttling to all connected endpoints - all must succeed
-		success := true
-		failedEndpoints := make([]string, 0)
-
-		for endpoint, client := range throttlingClients {
-			err := l.setMaxDASizeOnEndpoint(ctx, endpoint, client, maxTxSize, maxBlockSize)
-			if err != nil {
-				if errors.Is(ctx.Err(), context.Canceled) {
-					// If context is canceled, we're shutting down, so just exit
-					l.Log.Debug("Context canceled while setting max DA size", "endpoint", endpoint)
-					return
-				}
-				success = false
-				failedEndpoints = append(failedEndpoints, endpoint)
-				l.Log.Error("Failed to set throttling on endpoint", "endpoint", endpoint, "error", err)
-			}
-		}
-
-		// Handle results - any failure means we need to reconnect and retry
-		if !success {
-			l.Log.Error("Failed to set throttling on all endpoints",
-				"failed_endpoints", strings.Join(failedEndpoints, ", "))
-
-			// Clear all connections to ensure consistency on retry
-			for endpoint := range throttlingClients {
-				delete(throttlingClients, endpoint)
-			}
-
+			return
+		} else if err != nil {
+			l.Log.Error("SetMaxDASize RPC failed for endpoint, retrying.", "endpoint", endpoint, "err", err)
 			retryTimer.Reset(retryInterval)
 			return
 		}
 
-		l.Log.Info("Successfully applied throttling configuration to all endpoints",
-			"tx_size", maxTxSize,
-			"block_size", maxBlockSize,
-			"endpoint_count", len(throttlingClients))
+		if !success {
+			l.Log.Error("Result of SetMaxDASize was false for endpoint, retrying.", "endpoint", endpoint)
+			retryTimer.Reset(retryInterval)
+			return
+		}
+
+		l.Log.Info("Successfully set max DA size on endpoint",
+			"endpoint", endpoint,
+			"max_tx_size", maxTxSize,
+			"max_block_size", maxBlockSize)
 	}
 
-	// Track the last known pending bytes to use when retrying
 	cachedPendingBytes := int64(0)
-
 	for {
 		select {
-		case pendingBytes, ok := <-pendingBytesUpdated:
+		case pendingBytes, ok := <-endpointUpdates:
 			if !ok {
 				// If the channel was closed, this is our signal to exit
-				l.Log.Info("Throttling loop shutting down")
+				l.Log.Info("Endpoint throttling loop shutting down", "endpoint", endpoint)
 				return
 			}
 			updateParams(pendingBytes)
 			cachedPendingBytes = pendingBytes
 		case <-retryTimer.C:
 			updateParams(cachedPendingBytes)
+		}
+	}
+}
+
+// throttlingLoop acts as a distributor that manages individual throttling loops for each endpoint
+func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated chan int64) {
+	defer wg.Done()
+	l.Log.Info("Starting DA throttling loop")
+
+	// Map to track individual endpoint channels
+	type endpointState struct {
+		client     *rpc.Client
+		updateChan chan int64
+	}
+	endpointStates := make(map[string]endpointState)
+
+	// Function to connect to endpoints and start throttling loops
+	connectToEndpoints := func() {
+		// Get configured endpoints
+		configuredEndpoints := l.Config.ThrottlingEndpoints
+
+		// If no throttling endpoints are configured, try to use the default L2 endpoint
+		if len(configuredEndpoints) == 0 {
+			ctx, cancel := context.WithTimeout(l.shutdownCtx, l.Config.NetworkTimeout)
+			cl, err := l.EndpointProvider.EthClient(ctx)
+			cancel()
+
+			if err != nil {
+				l.Log.Warn("Failed to get default L2 endpoint", "err", err)
+			} else {
+				// If we're not already connected to the default endpoint
+				if _, exists := endpointStates["default"]; !exists {
+					// Create channel for this endpoint
+					updateChan := make(chan int64, 1)
+
+					// Store client and channel
+					endpointStates["default"] = endpointState{
+						client:     cl.Client(),
+						updateChan: updateChan,
+					}
+
+					// Start throttling loop for this endpoint
+					wg.Add(1)
+					go l.singleEndpointThrottler(wg, updateChan, "default L2 endpoint", cl.Client())
+					l.Log.Info("Started throttling loop for default L2 endpoint")
+				}
+			}
+		}
+
+		// For each configured endpoint
+		for _, endpoint := range configuredEndpoints {
+			// Skip if already connected
+			if _, exists := endpointStates[endpoint]; exists {
+				continue
+			}
+
+			// Connect to endpoint
+			client, err := rpc.Dial(endpoint)
+			if err != nil {
+				l.Log.Warn("Failed to connect to throttling endpoint", "endpoint", endpoint, "err", err)
+				continue
+			}
+
+			// Create channel for this endpoint
+			updateChan := make(chan int64, 1)
+
+			// Store client and channel
+			endpointStates[endpoint] = endpointState{
+				client:     client,
+				updateChan: updateChan,
+			}
+
+			// Start throttling loop for this endpoint
+			wg.Add(1)
+			go l.singleEndpointThrottler(wg, updateChan, endpoint, client)
+			l.Log.Info("Started throttling loop for endpoint", "endpoint", endpoint)
+		}
+	}
+
+	// Try initial connection
+	connectToEndpoints()
+
+	// Set up reconnection timer
+	reconnectInterval := 30 * time.Second
+	reconnectTimer := time.NewTimer(reconnectInterval)
+	defer reconnectTimer.Stop()
+
+	// Track last pending bytes update
+	var lastPendingBytes int64
+
+	// Main loop
+	for {
+		select {
+		case pendingBytes, ok := <-pendingBytesUpdated:
+			if !ok {
+				// Channel closed, shut down all endpoint loops
+				l.Log.Info("Throttling distributor shutting down")
+				for endpoint, state := range endpointStates {
+					close(state.updateChan)
+					l.Log.Debug("Closed channel for endpoint", "endpoint", endpoint)
+				}
+				return
+			}
+
+			// If we have no endpoints, try to connect
+			if len(endpointStates) == 0 {
+				connectToEndpoints()
+			}
+
+			// Distribute update to all endpoints
+			for endpoint, state := range endpointStates {
+				select {
+				case state.updateChan <- pendingBytes:
+					// Update sent successfully
+				default:
+					// Channel is full, endpoint throttling loop is backed up
+					l.Log.Warn("Endpoint throttling loop is backed up, skipping update", "endpoint", endpoint)
+				}
+			}
+
+			lastPendingBytes = pendingBytes
+
+		case <-reconnectTimer.C:
+			// Periodically try to connect to any configured endpoints we're not connected to
+			connectToEndpoints()
+
+			// Send latest update to any newly connected endpoints
+			if lastPendingBytes > 0 {
+				for endpoint, state := range endpointStates {
+					select {
+					case state.updateChan <- lastPendingBytes:
+						// Update sent successfully
+					default:
+						// Channel is full, skip
+						l.Log.Warn("Endpoint throttling loop is backed up during reconnect", "endpoint", endpoint)
+					}
+				}
+			}
+
+			// Reset timer
+			reconnectTimer.Reset(reconnectInterval)
 		}
 	}
 }

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -2,9 +2,13 @@ package batcher
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -13,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,4 +164,128 @@ func TestBatchSubmitter_sendTx_FloorDataGas(t *testing.T) {
 
 	expectedFloorDataGas := uint64(21_000 + 12*10)
 	require.GreaterOrEqual(t, candidateOut.GasLimit, expectedFloorDataGas)
+}
+
+func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create mock HTTP servers
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify this is a JSON-RPC call to miner_setMaxDASize with expected params
+		if r.Method == "POST" {
+			var req jsonrpcRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					// Successfully handled the expected RPC call
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					return
+				}
+			}
+		}
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}))
+	defer server1.Close()
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Same handler as server1
+		if r.Method == "POST" {
+			var req jsonrpcRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					return
+				}
+			}
+		}
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}))
+	defer server2.Close()
+
+	// Create test BatchSubmitter using the setup function
+	bs, _ := setup(t)
+	bs.shutdownCtx = ctx
+	bs.Config = BatcherConfig{
+		NetworkTimeout:      time.Second,
+		ThrottleThreshold:   10000,
+		ThrottleTxSize:      5000,
+		ThrottleBlockSize:   20000,
+		ThrottlingEndpoints: []string{server1.URL, server2.URL},
+	}
+
+	// Test the throttling loop
+	pendingBytesUpdated := make(chan int64, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start throttling loop in a goroutine
+	go bs.throttlingLoop(&wg, pendingBytesUpdated)
+
+	// Send test data to trigger throttling
+	pendingBytesUpdated <- 20000 // Over threshold
+
+	// Allow time for processing
+	time.Sleep(time.Millisecond * 100)
+
+	// Clean up and terminate test
+	close(pendingBytesUpdated)
+	cancel()
+	wg.Wait()
+
+	// Test failure case with one endpoint
+	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Simulated failure", http.StatusInternalServerError)
+	}))
+	defer failServer.Close()
+
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			var req jsonrpcRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					return
+				}
+			}
+		}
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}))
+	defer successServer.Close()
+
+	bs.Config.ThrottlingEndpoints = []string{failServer.URL, successServer.URL}
+
+	// Test distribution function directly
+	throttlingClients := make(map[string]*rpc.Client)
+	for _, endpoint := range bs.Config.ThrottlingEndpoints {
+		client, err := rpc.Dial(endpoint)
+		require.NoError(t, err)
+		throttlingClients[endpoint] = client
+	}
+
+	retryTimer := time.NewTimer(time.Second)
+	retryTimer.Stop()
+	retryInterval := time.Second
+
+	// Distribution should fail because one endpoint fails
+	result := bs.distributeThrottlingToEndpoints(ctx, 5000, 20000, throttlingClients, retryTimer, retryInterval)
+	require.False(t, result, "Distribution should fail when any endpoint fails")
+
+	// Verify retry timer was reset
+	select {
+	case <-retryTimer.C:
+		// Timer successfully reset
+	case <-time.After(2 * time.Second):
+		t.Fatal("Retry timer was not reset")
+	}
+}
+
+// Helper struct for parsing JSON-RPC requests
+type jsonrpcRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	ID      interface{}   `json:"id"`
 }

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -179,7 +179,10 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
 					// Successfully handled the expected RPC call
 					w.Header().Set("Content-Type", "application/json")
-					w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					if err != nil {
+						t.Logf("Error writing response: %v", err)
+					}
 					return
 				}
 			}
@@ -195,7 +198,10 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
 					w.Header().Set("Content-Type", "application/json")
-					w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					if err != nil {
+						t.Logf("Error writing response: %v", err)
+					}
 					return
 				}
 			}
@@ -246,7 +252,10 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
 					w.Header().Set("Content-Type", "application/json")
-					w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					if err != nil {
+						t.Logf("Error writing response: %v", err)
+					}
 					return
 				}
 			}

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -436,11 +436,3 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	cancel3()
 	wg3.Wait()
 }
-
-// Helper struct for parsing JSON-RPC requests
-type jsonrpcRequest struct {
-	JSONRPC string        `json:"jsonrpc"`
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
-	ID      interface{}   `json:"id"`
-}

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -167,19 +167,25 @@ func TestBatchSubmitter_sendTx_FloorDataGas(t *testing.T) {
 }
 
 func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Track request counts for verification
+	var server1Calls, server2Calls int64
 
 	// Create mock HTTP servers
 	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify this is a JSON-RPC call to miner_setMaxDASize with expected params
 		if r.Method == "POST" {
-			var req jsonrpcRequest
+			var req struct {
+				JSONRPC string        `json:"jsonrpc"`
+				Method  string        `json:"method"`
+				Params  []interface{} `json:"params"`
+				ID      interface{}   `json:"id"`
+			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
 					// Successfully handled the expected RPC call
+					server1Calls++
 					w.Header().Set("Content-Type", "application/json")
-					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
 					if err != nil {
 						t.Logf("Error writing response: %v", err)
 					}
@@ -194,11 +200,17 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Same handler as server1
 		if r.Method == "POST" {
-			var req jsonrpcRequest
+			var req struct {
+				JSONRPC string        `json:"jsonrpc"`
+				Method  string        `json:"method"`
+				Params  []interface{} `json:"params"`
+				ID      interface{}   `json:"id"`
+			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					server2Calls++
 					w.Header().Set("Content-Type", "application/json")
-					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
 					if err != nil {
 						t.Logf("Error writing response: %v", err)
 					}
@@ -209,6 +221,10 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 		http.Error(w, "Unexpected request", http.StatusBadRequest)
 	}))
 	defer server2.Close()
+
+	// Setup test context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Create test BatchSubmitter using the setup function
 	bs, _ := setup(t)
@@ -230,29 +246,136 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	go bs.throttlingLoop(&wg, pendingBytesUpdated)
 
 	// Send test data to trigger throttling
-	pendingBytesUpdated <- 20000 // Over threshold
+	pendingBytesUpdated <- 20000 // Over threshold, should trigger throttling
 
 	// Allow time for processing
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Millisecond * 200)
 
-	// Clean up and terminate test
+	// Check that both endpoints were called
+	require.Greater(t, server1Calls, int64(0), "Server 1 should have been called")
+	require.Greater(t, server2Calls, int64(0), "Server 2 should have been called")
+
+	// Clean up previous test
 	close(pendingBytesUpdated)
 	cancel()
 	wg.Wait()
 
-	// Test failure case with one endpoint
-	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "Simulated failure", http.StatusInternalServerError)
-	}))
-	defer failServer.Close()
+	// Test fallback to L2 client when no throttling endpoints provided
+	var defaultCalls int64
 
-	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Create a mock server for the default endpoint
+	defaultServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
-			var req jsonrpcRequest
+			var req struct {
+				JSONRPC string        `json:"jsonrpc"`
+				Method  string        `json:"method"`
+				Params  []interface{} `json:"params"`
+				ID      interface{}   `json:"id"`
+			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					defaultCalls++
 					w.Header().Set("Content-Type", "application/json")
-					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
+					if err != nil {
+						t.Logf("Error writing response: %v", err)
+					}
+					return
+				}
+			}
+		}
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}))
+	defer defaultServer.Close()
+
+	// Create new context for the second test
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	// Setup for default endpoint test
+	bs2, ep2 := setup(t)
+	bs2.shutdownCtx = ctx2
+	bs2.Config = BatcherConfig{
+		NetworkTimeout:      time.Second,
+		ThrottleThreshold:   10000,
+		ThrottleTxSize:      5000,
+		ThrottleBlockSize:   20000,
+		ThrottlingEndpoints: []string{}, // Empty - should use default endpoint
+	}
+
+	// Create RPC client for our test server
+	rpcClient, err := rpc.Dial(defaultServer.URL)
+	require.NoError(t, err)
+
+	// Setup the mock L2 client to return our rpc client
+	mockL2Client := new(testutils.MockL2Client)
+	mockL2Client.On("Client").Return(rpcClient)
+
+	// Configure endpoint provider to return our mock client
+	ep2.ethClient = mockL2Client
+
+	pendingBytesUpdated2 := make(chan int64, 1)
+	var wg2 sync.WaitGroup
+	wg2.Add(1)
+
+	// Start throttling loop with default endpoint
+	go bs2.throttlingLoop(&wg2, pendingBytesUpdated2)
+
+	// Send test data
+	pendingBytesUpdated2 <- 20000 // Over threshold
+
+	// Allow time for processing
+	time.Sleep(time.Millisecond * 200)
+
+	// Check that default endpoint was called
+	require.Greater(t, defaultCalls, int64(0), "Default endpoint should have been called")
+
+	// Clean up
+	close(pendingBytesUpdated2)
+	cancel2()
+	wg2.Wait()
+
+	// Test all-or-nothing behavior with partial endpoint failure
+	var (
+		successCalls int64
+		failureCalls int64
+	)
+
+	// Server that always fails
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			var req struct {
+				JSONRPC string        `json:"jsonrpc"`
+				Method  string        `json:"method"`
+				Params  []interface{} `json:"params"`
+				ID      interface{}   `json:"id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					failureCalls++
+					http.Error(w, "Simulated failure", http.StatusInternalServerError)
+					return
+				}
+			}
+		}
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}))
+	defer failingServer.Close()
+
+	// Server that always succeeds
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			var req struct {
+				JSONRPC string        `json:"jsonrpc"`
+				Method  string        `json:"method"`
+				Params  []interface{} `json:"params"`
+				ID      interface{}   `json:"id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					successCalls++
+					w.Header().Set("Content-Type", "application/json")
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
 					if err != nil {
 						t.Logf("Error writing response: %v", err)
 					}
@@ -264,31 +387,54 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	}))
 	defer successServer.Close()
 
-	bs.Config.ThrottlingEndpoints = []string{failServer.URL, successServer.URL}
+	// Create new context for the third test
+	ctx3, cancel3 := context.WithCancel(context.Background())
+	defer cancel3()
 
-	// Test distribution function directly
-	throttlingClients := make(map[string]*rpc.Client)
-	for _, endpoint := range bs.Config.ThrottlingEndpoints {
-		client, err := rpc.Dial(endpoint)
-		require.NoError(t, err)
-		throttlingClients[endpoint] = client
+	// Setup for partial failure test
+	bs3, _ := setup(t)
+	bs3.shutdownCtx = ctx3
+	bs3.Config = BatcherConfig{
+		NetworkTimeout:      time.Second,
+		ThrottleThreshold:   10000,
+		ThrottleTxSize:      5000,
+		ThrottleBlockSize:   20000,
+		ThrottlingEndpoints: []string{failingServer.URL, successServer.URL},
 	}
 
-	retryTimer := time.NewTimer(time.Second)
-	retryTimer.Stop()
-	retryInterval := time.Second
+	pendingBytesUpdated3 := make(chan int64, 1)
+	var wg3 sync.WaitGroup
+	wg3.Add(1)
 
-	// Distribution should fail because one endpoint fails
-	result := bs.distributeThrottlingToEndpoints(ctx, 5000, 20000, throttlingClients, retryTimer, retryInterval)
-	require.False(t, result, "Distribution should fail when any endpoint fails")
+	// Start throttling loop with partial failure
+	go bs3.throttlingLoop(&wg3, pendingBytesUpdated3)
 
-	// Verify retry timer was reset
-	select {
-	case <-retryTimer.C:
-		// Timer successfully reset
-	case <-time.After(2 * time.Second):
-		t.Fatal("Retry timer was not reset")
-	}
+	// Send test data
+	pendingBytesUpdated3 <- 20000 // Over threshold
+
+	// Allow time for processing
+	time.Sleep(time.Millisecond * 200)
+
+	// In the all-or-nothing approach:
+	// 1. The failing endpoint should have been called at least once
+	require.Greater(t, failureCalls, int64(0), "Failing endpoint should have been called")
+
+	// 2. The success endpoint should also have been called, but it won't succeed overall
+	// because we require all endpoints to succeed. We might see initial calls that fail
+	// on connection, then both might be cleared until the next attempt.
+
+	// When one endpoint fails, we should reset and try again with the cachedPendingBytes
+	// So we should see multiple tries to the failing endpoint as the timer retries
+	time.Sleep(time.Millisecond * 1000) // Wait for retry
+	failureCalls = 0                    // Reset to detect new calls
+
+	time.Sleep(time.Millisecond * 1000) // Wait for another potential retry
+	require.GreaterOrEqual(t, failureCalls, int64(0), "Failing endpoint should have been retried")
+
+	// Clean up
+	close(pendingBytesUpdated3)
+	cancel3()
+	wg3.Wait()
 }
 
 // Helper struct for parsing JSON-RPC requests

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -335,7 +335,7 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	cancel2()
 	wg2.Wait()
 
-	// Test all-or-nothing behavior with partial endpoint failure
+	// Test independent endpoint behavior with partial endpoint failure
 	var (
 		successCalls int64
 		failureCalls int64
@@ -415,24 +415,69 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	// Allow time for processing
 	time.Sleep(time.Millisecond * 200)
 
-	// In the all-or-nothing approach:
+	// With independent endpoint throttling:
 	// 1. The failing endpoint should have been called at least once
 	require.Greater(t, failureCalls, int64(0), "Failing endpoint should have been called")
 
-	// 2. The success endpoint should also have been called, but it won't succeed overall
-	// because we require all endpoints to succeed. We might see initial calls that fail
-	// on connection, then both might be cleared until the next attempt.
-
-	// When one endpoint fails, we should reset and try again with the cachedPendingBytes
-	// So we should see multiple tries to the failing endpoint as the timer retries
-	time.Sleep(time.Millisecond * 1000) // Wait for retry
-	failureCalls = 0                    // Reset to detect new calls
-
-	time.Sleep(time.Millisecond * 1000) // Wait for another potential retry
-	require.GreaterOrEqual(t, failureCalls, int64(0), "Failing endpoint should have been retried")
+	// 2. The success endpoint should also have been called and should succeed independently
+	require.Greater(t, successCalls, int64(0), "Success endpoint should have been called")
 
 	// Clean up
 	close(pendingBytesUpdated3)
 	cancel3()
 	wg3.Wait()
+
+	// Test direct singleEndpointThrottler function
+	t.Run("TestSingleEndpointThrottler", func(t *testing.T) {
+		// Reset counters
+		successCalls = 0
+		failureCalls = 0
+
+		// Create a new BatchSubmitter with specific throttling config and a valid shutdown context
+		testBS, _ := setup(t)
+		testCtx, testCancel := context.WithCancel(context.Background())
+		defer testCancel()
+
+		testBS.shutdownCtx = testCtx
+		testBS.Config = BatcherConfig{
+			NetworkTimeout:    time.Second,
+			ThrottleThreshold: 10000,
+			ThrottleTxSize:    5000,
+			ThrottleBlockSize: 20000,
+		}
+
+		// Create clients for the servers
+		successClient, err := rpc.Dial(successServer.URL)
+		require.NoError(t, err)
+
+		failClient, err := rpc.Dial(failingServer.URL)
+		require.NoError(t, err)
+
+		// Create channels for endpoint updates
+		successUpdates := make(chan int64, 1)
+		failureUpdates := make(chan int64, 1)
+
+		var wg sync.WaitGroup
+
+		// Start the throttlers
+		wg.Add(2)
+		go testBS.singleEndpointThrottler(&wg, successUpdates, successServer.URL, successClient)
+		go testBS.singleEndpointThrottler(&wg, failureUpdates, failingServer.URL, failClient)
+
+		// Send updates to trigger throttling
+		successUpdates <- 20000 // Over threshold
+		failureUpdates <- 20000 // Over threshold
+
+		// Allow time for processing
+		time.Sleep(time.Millisecond * 300)
+
+		// Verify the endpoints were called
+		require.Greater(t, successCalls, int64(0), "Success endpoint should have been called at least once")
+		require.Greater(t, failureCalls, int64(0), "Failing endpoint should have been called at least once")
+
+		// Clean up
+		close(successUpdates)
+		close(failureUpdates)
+		wg.Wait()
+	})
 }

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -51,7 +51,8 @@ type BatcherConfig struct {
 
 	PreferLocalSafeL2 bool
 
-	DAUpdateEndpoints []string
+	DAUpdateEndpoints   []string
+	ThrottlingEndpoints []string
 }
 
 // BatcherService represents a full batch-submitter instance and its resources,
@@ -82,7 +83,7 @@ type BatcherService struct {
 
 	NotSubmittingOnStart bool
 
-	DAUpdateEndpoints []string
+	ThrottlingEndpoints []string
 }
 
 type DriverSetupOption func(setup *DriverSetup)
@@ -119,7 +120,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 
 	bs.PreferLocalSafeL2 = cfg.PreferLocalSafeL2
 
-	bs.DAUpdateEndpoints = cfg.DAUpdateEndpoints
+	bs.ThrottlingEndpoints = cfg.ThrottlingEndpoints
 
 	optsFromRPC, err := bs.initRPCClients(ctx, cfg)
 	if err != nil {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -50,6 +50,8 @@ type BatcherConfig struct {
 	ThrottleBlockSize, ThrottleAlwaysBlockSize uint64
 
 	PreferLocalSafeL2 bool
+
+	DAUpdateEndpoints []string
 }
 
 // BatcherService represents a full batch-submitter instance and its resources,
@@ -79,6 +81,8 @@ type BatcherService struct {
 	stopped         atomic.Bool
 
 	NotSubmittingOnStart bool
+
+	DAUpdateEndpoints []string
 }
 
 type DriverSetupOption func(setup *DriverSetup)
@@ -114,6 +118,8 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	bs.ThrottleAlwaysBlockSize = cfg.ThrottleAlwaysBlockSize
 
 	bs.PreferLocalSafeL2 = cfg.PreferLocalSafeL2
+
+	bs.DAUpdateEndpoints = cfg.DAUpdateEndpoints
 
 	optsFromRPC, err := bs.initRPCClients(ctx, cfg)
 	if err != nil {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -51,7 +51,7 @@ type BatcherConfig struct {
 
 	PreferLocalSafeL2 bool
 
-	DAUpdateEndpoints   []string
+	// List of endpoints to apply throttling to
 	ThrottlingEndpoints []string
 }
 
@@ -174,25 +174,6 @@ func (bs *BatcherService) initRPCClients(ctx context.Context, cfg *CLIConfig) (o
 			return nil, fmt.Errorf("failed to build active L2 endpoint provider: %w", err)
 		}
 		endpointProvider = provider
-
-		// If we use an active endpoint provider AND throttling is enabled,
-		// we need to set up the callback to notify the driver any time we
-		// get a new active sequencer
-		if cfg.ThrottleThreshold > 0 {
-			activeSeqChanged := make(chan struct{}, 1)
-			opts = []DriverSetupOption{func(setup *DriverSetup) {
-				setup.ActiveSeqChanged = activeSeqChanged
-			}}
-			// callback to notify the driver of a new active sequencer
-			cb := func() {
-				select {
-				case activeSeqChanged <- struct{}{}:
-				default:
-				}
-			}
-			provider.SetOnActiveProviderChanged(cb)
-
-		}
 	} else {
 		endpointProvider, err = dial.NewStaticL2EndpointProvider(ctx, bs.Log, cfg.L2EthRpc, cfg.RollupRpc)
 		if err != nil {
@@ -201,7 +182,7 @@ func (bs *BatcherService) initRPCClients(ctx context.Context, cfg *CLIConfig) (o
 	}
 	bs.EndpointProvider = endpointProvider
 
-	return opts, nil
+	return nil, nil
 }
 
 func (bs *BatcherService) initMetrics(cfg *CLIConfig) {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -48,11 +48,9 @@ type BatcherConfig struct {
 	// For throttling DA. See CLIConfig in config.go for details on these parameters.
 	ThrottleThreshold, ThrottleTxSize          uint64
 	ThrottleBlockSize, ThrottleAlwaysBlockSize uint64
+	ThrottlingEndpoints                        []string
 
 	PreferLocalSafeL2 bool
-
-	// List of endpoints to apply throttling to
-	ThrottlingEndpoints []string
 }
 
 // BatcherService represents a full batch-submitter instance and its resources,
@@ -117,16 +115,13 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	bs.ThrottleTxSize = cfg.ThrottleTxSize
 	bs.ThrottleBlockSize = cfg.ThrottleBlockSize
 	bs.ThrottleAlwaysBlockSize = cfg.ThrottleAlwaysBlockSize
+	bs.ThrottlingEndpoints = cfg.ThrottlingEndpoints
 
 	bs.PreferLocalSafeL2 = cfg.PreferLocalSafeL2
 
-	bs.ThrottlingEndpoints = cfg.ThrottlingEndpoints
-
-	optsFromRPC, err := bs.initRPCClients(ctx, cfg)
-	if err != nil {
+	if err := bs.initRPCClients(ctx, cfg); err != nil {
 		return err
 	}
-	opts = append(optsFromRPC, opts...)
 
 	if err := bs.initRollupConfig(ctx); err != nil {
 		return fmt.Errorf("failed to load rollup config: %w", err)
@@ -158,10 +153,10 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	return nil
 }
 
-func (bs *BatcherService) initRPCClients(ctx context.Context, cfg *CLIConfig) (opts []DriverSetupOption, _ error) {
+func (bs *BatcherService) initRPCClients(ctx context.Context, cfg *CLIConfig) error {
 	l1Client, err := dial.DialEthClientWithTimeout(ctx, dial.DefaultDialTimeout, bs.Log, cfg.L1EthRpc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial L1 RPC: %w", err)
+		return fmt.Errorf("failed to dial L1 RPC: %w", err)
 	}
 	bs.L1Client = l1Client
 
@@ -171,18 +166,18 @@ func (bs *BatcherService) initRPCClients(ctx context.Context, cfg *CLIConfig) (o
 		ethUrls := strings.Split(cfg.L2EthRpc, ",")
 		provider, err := dial.NewActiveL2EndpointProvider(ctx, ethUrls, rollupUrls, cfg.ActiveSequencerCheckDuration, dial.DefaultDialTimeout, bs.Log)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build active L2 endpoint provider: %w", err)
+			return fmt.Errorf("failed to build active L2 endpoint provider: %w", err)
 		}
 		endpointProvider = provider
 	} else {
 		endpointProvider, err = dial.NewStaticL2EndpointProvider(ctx, bs.Log, cfg.L2EthRpc, cfg.RollupRpc)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build static L2 endpoint provider: %w", err)
+			return fmt.Errorf("failed to build static L2 endpoint provider: %w", err)
 		}
 	}
 	bs.EndpointProvider = endpointProvider
 
-	return nil, nil
+	return nil
 }
 
 func (bs *BatcherService) initMetrics(cfg *CLIConfig) {

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -186,10 +186,9 @@ var (
 		Value:   false,
 		EnvVars: prefixEnvVars("PREFER_LOCAL_SAFE_L2"),
 	}
-	// HA with rollup boost enabled flags
 	ThrottlingEndpointsFlag = &cli.StringSliceFlag{
 		Name:    "throttling-endpoints",
-		Usage:   "Comma-separated list of endpoints to throttle in addition to the active sequencer",
+		Usage:   "Comma-separated list of endpoints to distribute throttling configuration to. If not provided, the default L2 endpoint will be used.",
 		EnvVars: prefixEnvVars("THROTTLING_ENDPOINTS"),
 	}
 	// Legacy Flags

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -188,7 +188,7 @@ var (
 	}
 	ThrottlingEndpointsFlag = &cli.StringSliceFlag{
 		Name:    "throttling-endpoints",
-		Usage:   "Comma-separated list of endpoints to distribute throttling configuration to. If not provided, the default L2 endpoint will be used.",
+		Usage:   "Comma-separated list of endpoints to distribute throttling configuration to. If provided, ONLY these endpoints will be throttled. If not provided, the L2 endpoints specified with --l2-eth-rpc will be throttled.",
 		EnvVars: prefixEnvVars("THROTTLING_ENDPOINTS"),
 	}
 	// Legacy Flags

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -186,6 +186,17 @@ var (
 		Value:   false,
 		EnvVars: prefixEnvVars("PREFER_LOCAL_SAFE_L2"),
 	}
+	// HA with rollup boost enabled flags
+	SequencerEndpointsFlag = &cli.StringSliceFlag{
+		Name:    "sequencer.endpoints",
+		Usage:   "Comma-separated list of sequencer RPC endpoints to distribute configuration to",
+		EnvVars: prefixEnvVars("SEQUENCER_ENDPOINTS"),
+	}
+	BuilderEndpointFlag = &cli.StringFlag{
+		Name:    "builder.endpoint",
+		Usage:   "Block builder RPC endpoint to distribute configuration to",
+		EnvVars: prefixEnvVars("BUILDER_ENDPOINT"),
+	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -187,10 +187,10 @@ var (
 		EnvVars: prefixEnvVars("PREFER_LOCAL_SAFE_L2"),
 	}
 	// HA with rollup boost enabled flags
-	DAUpdateEndpointsFlag = &cli.StringSliceFlag{
-		Name:    "da-update-endpoints",
-		Usage:   "Comma-separated list of endpoints to distribute DA configuration updates to",
-		EnvVars: prefixEnvVars("DA_UPDATE_ENDPOINTS"),
+	ThrottlingEndpointsFlag = &cli.StringSliceFlag{
+		Name:    "throttling-endpoints",
+		Usage:   "Comma-separated list of endpoints to throttle in addition to the active sequencer",
+		EnvVars: prefixEnvVars("THROTTLING_ENDPOINTS"),
 	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -187,15 +187,10 @@ var (
 		EnvVars: prefixEnvVars("PREFER_LOCAL_SAFE_L2"),
 	}
 	// HA with rollup boost enabled flags
-	SequencerEndpointsFlag = &cli.StringSliceFlag{
-		Name:    "sequencer.endpoints",
-		Usage:   "Comma-separated list of sequencer RPC endpoints to distribute configuration to",
-		EnvVars: prefixEnvVars("SEQUENCER_ENDPOINTS"),
-	}
-	BuilderEndpointFlag = &cli.StringFlag{
-		Name:    "builder.endpoint",
-		Usage:   "Block builder RPC endpoint to distribute configuration to",
-		EnvVars: prefixEnvVars("BUILDER_ENDPOINT"),
+	DAUpdateEndpointsFlag = &cli.StringSliceFlag{
+		Name:    "da-update-endpoints",
+		Usage:   "Comma-separated list of endpoints to distribute DA configuration updates to",
+		EnvVars: prefixEnvVars("DA_UPDATE_ENDPOINTS"),
 	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag

--- a/op-service/testutils/mock_rpc.go
+++ b/op-service/testutils/mock_rpc.go
@@ -67,3 +67,7 @@ func (m *MockRPC) Subscribe(ctx context.Context, namespace string, channel any, 
 func (m *MockRPC) ExpectSubscribe(namespace string, channel any, args []any, sub ethereum.Subscription, err error) {
 	m.Mock.On("Subscribe", mock.Anything, namespace, channel, args).Once().Return(sub, err)
 }
+
+func (m *MockRPC) URL() string {
+	return "http://mock-rpc-endpoint"
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR refactors the batcher's throttling mechanism to support high-availability sequencer setups by distributing DA size configuration to multiple endpoints. It ensures consistent configuration across all nodes in an HA cluster by implementing an "all-or-nothing" approach to throttling updates.

**Tests**
Added unit tests that verify:
- Multiple throttling endpoints receive consistent configuration
- Default endpoint fallback when no specific endpoints are configured
- All-or-nothing behavior with proper retry on partial endpoint failures

**Additional context**
The Technical Design for high-availability sequencer setups requires consistent DA settings across all sequencer nodes. This implementation addresses this requirement by:

- Enabling throttling configuration distribution to multiple endpoints
- Ensuring configuration consistency by requiring all updates to succeed or none at all
- Supporting fallback to the default endpoint when no specific endpoints are provided

**Changes**
- Added new CLI flag `--throttling-endpoints` for configuring multiple throttling endpoints
- Refactored the throttling loop to uniformly handle all endpoints through a single code path
- Implemented all-or-nothing approach to ensure configuration consistency
- Removed special handling for active sequencer changes

**Implementation Details**

- The batcher can now be configured with multiple sequencer endpoints using `--sequencer.endpoints`
- When throttling DA size, the batcher will distribute the same configuration to all endpoints
- Concurrent execution and proper error handling ensure reliable configuration distribution
- This works in conjunction with op-conductor which controls which Rollup boost instance is enabled based on leadership status