### PR TITLE
feat(op-acceptor): enable ci go tests for op-acceptor.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1584,6 +1584,7 @@ workflows:
             packages/contracts-bedrock/scripts/verify
             op-dripper
             devnet-sdk
+            op-acceptance-tests
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick


### PR DESCRIPTION
**Description**

This change makes the op-acceptor tests run as part of the CI's main workflow.