### PR TITLE
op-program: Add aliases to flags for interop.

### DIFF
--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -82,7 +82,7 @@ func listClaims(ctx context.Context, game contracts.FaultDisputeGameContract, ve
 		return fmt.Errorf("failed to retrieve split depth: %w", err)
 	}
 	status := metadata.Status
-	l2StartBlockNum, l2BlockNum, err := game.GetBlockRange(ctx)
+	l2StartBlockNum, l2BlockNum, err := game.GetGameRange(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve status: %w", err)
 	}

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -116,7 +116,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 				return
 			}
 			infos[currIndex].status = metadata.Status
-			infos[currIndex].l2BlockNum = metadata.L2BlockNum
+			infos[currIndex].l2BlockNum = metadata.L2SequenceNum
 			infos[currIndex].rootClaim = metadata.RootClaim
 			claimCount, err := gameContract.GetClaimCount(ctx)
 			if err != nil {

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -178,10 +178,10 @@ func (f *FaultDisputeGameContractLatest) GetBalanceAndDelay(ctx context.Context,
 	return balance, delay, weth.Addr(), nil
 }
 
-// GetBlockRange returns the block numbers of the absolute pre-state block (typically genesis or the bedrock activation block)
+// GetGameRange returns the block numbers of the absolute pre-state block (typically genesis or the bedrock activation block)
 // and the post-state block (that the proposed output root is for).
-func (f *FaultDisputeGameContractLatest) GetBlockRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error) {
-	defer f.metrics.StartContractRequest("GetBlockRange")()
+func (f *FaultDisputeGameContractLatest) GetGameRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error) {
+	defer f.metrics.StartContractRequest("GetGameRange")()
 	results, err := f.multiCaller.Call(ctx, rpcblock.Latest,
 		f.contract.Call(methodStartingBlockNumber),
 		f.contract.Call(methodL2BlockNumber))
@@ -200,7 +200,7 @@ func (f *FaultDisputeGameContractLatest) GetBlockRange(ctx context.Context) (pre
 
 type GameMetadata struct {
 	L1Head                  common.Hash
-	L2BlockNum              uint64
+	L2SequenceNum           uint64
 	RootClaim               common.Hash
 	Status                  gameTypes.GameStatus
 	MaxClockDuration        uint64
@@ -238,7 +238,7 @@ func (f *FaultDisputeGameContractLatest) GetGameMetadata(ctx context.Context, bl
 	blockChallenger := results[6].GetAddress(0)
 	return GameMetadata{
 		L1Head:                  l1Head,
-		L2BlockNum:              l2BlockNumber,
+		L2SequenceNum:           l2BlockNumber,
 		RootClaim:               rootClaim,
 		Status:                  status,
 		MaxClockDuration:        duration,
@@ -637,7 +637,7 @@ func (f *FaultDisputeGameContractLatest) decodeClaim(result *batching.CallResult
 
 type FaultDisputeGameContract interface {
 	GetBalanceAndDelay(ctx context.Context, block rpcblock.Block) (*big.Int, time.Duration, common.Address, error)
-	GetBlockRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error)
+	GetGameRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error)
 	GetGameMetadata(ctx context.Context, block rpcblock.Block) (GameMetadata, error)
 	GetResolvedAt(ctx context.Context, block rpcblock.Block) (time.Time, error)
 	GetStartingRootHash(ctx context.Context) (common.Hash, error)

--- a/op-challenger/game/fault/contracts/faultdisputegame0180.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame0180.go
@@ -46,7 +46,7 @@ func (f *FaultDisputeGameContract0180) GetGameMetadata(ctx context.Context, bloc
 	duration := results[4].GetUint64(0)
 	return GameMetadata{
 		L1Head:                  l1Head,
-		L2BlockNum:              l2BlockNumber,
+		L2SequenceNum:           l2BlockNumber,
 		RootClaim:               rootClaim,
 		Status:                  status,
 		MaxClockDuration:        duration,

--- a/op-challenger/game/fault/contracts/faultdisputegame080.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame080.go
@@ -53,7 +53,7 @@ func (f *FaultDisputeGameContract080) GetGameMetadata(ctx context.Context, block
 	duration := results[4].GetUint64(0)
 	return GameMetadata{
 		L1Head:                  l1Head,
-		L2BlockNum:              l2BlockNumber,
+		L2SequenceNum:           l2BlockNumber,
 		RootClaim:               rootClaim,
 		Status:                  status,
 		MaxClockDuration:        duration / 2,

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -273,7 +273,7 @@ func (e *RegisterTask) Register(
 			return nil, fmt.Errorf("failed to load oracle for game %v: %w", game.Proxy, err)
 		}
 		oracles.RegisterOracle(oracle)
-		prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
+		prestateBlock, poststateBlock, err := contract.GetGameRange(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/op-challenger/game/fault/trace/super/super_cannon.go
+++ b/op-challenger/game/fault/trace/super/super_cannon.go
@@ -30,23 +30,23 @@ func NewSuperCannonTraceAccessor(
 	dir string,
 	l1Head eth.BlockID,
 	splitDepth types.Depth,
-	prestateBlock uint64,
-	poststateBlock uint64,
+	prestateTimestamp uint64,
+	poststateTimestamp uint64,
 ) (*trace.Accessor, error) {
 	rollupCfgs, err := NewRollupConfigs(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load rollup configs: %w", err)
 	}
-	outputProvider := NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, rootProvider, l1Head, splitDepth, prestateBlock, poststateBlock)
+	outputProvider := NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, rootProvider, l1Head, splitDepth, prestateTimestamp, poststateTimestamp)
 	cannonCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, claimInfo ClaimInfo) (types.TraceProvider, error) {
 		logger := logger.New("agreedPrestate", claimInfo.AgreedPrestate, "claim", claimInfo.Claim, "localContext", localContext)
 		subdir := filepath.Join(dir, localContext.Hex())
 		localInputs := utils.LocalGameInputs{
-			L1Head:         l1Head.Hash,
-			L2OutputRoot:   crypto.Keccak256Hash(claimInfo.AgreedPrestate),
-			AgreedPreState: claimInfo.AgreedPrestate,
-			L2Claim:        claimInfo.Claim,
-			L2BlockNumber:  new(big.Int).SetUint64(poststateBlock),
+			L1Head:           l1Head.Hash,
+			L2OutputRoot:     crypto.Keccak256Hash(claimInfo.AgreedPrestate),
+			AgreedPreState:   claimInfo.AgreedPrestate,
+			L2Claim:          claimInfo.Claim,
+			L2SequenceNumber: new(big.Int).SetUint64(poststateTimestamp),
 		}
 		provider := cannon.NewTraceProvider(logger, m.ToTypedVmMetrics(cfg.VmType.String()), cfg, serverExecutor, prestateProvider, cannonPrestate, localInputs, subdir, depth)
 		return provider, nil

--- a/op-challenger/game/fault/trace/utils/local.go
+++ b/op-challenger/game/fault/trace/utils/local.go
@@ -10,12 +10,12 @@ import (
 )
 
 type LocalGameInputs struct {
-	L1Head         common.Hash
-	L2Head         common.Hash
-	L2OutputRoot   common.Hash
-	AgreedPreState []byte
-	L2Claim        common.Hash
-	L2BlockNumber  *big.Int
+	L1Head           common.Hash
+	L2Head           common.Hash
+	L2OutputRoot     common.Hash
+	AgreedPreState   []byte
+	L2Claim          common.Hash
+	L2SequenceNumber *big.Int
 }
 
 type L2HeaderSource interface {
@@ -57,10 +57,10 @@ func FetchLocalInputsFromProposals(ctx context.Context, l1Head common.Hash, l2Cl
 	l2Head := agreedHeader.Hash()
 
 	return LocalGameInputs{
-		L1Head:        l1Head,
-		L2Head:        l2Head,
-		L2OutputRoot:  agreedOutput.OutputRoot,
-		L2Claim:       claimedOutput.OutputRoot,
-		L2BlockNumber: claimedOutput.L2BlockNumber,
+		L1Head:           l1Head,
+		L2Head:           l2Head,
+		L2OutputRoot:     agreedOutput.OutputRoot,
+		L2Claim:          claimedOutput.OutputRoot,
+		L2SequenceNumber: claimedOutput.L2BlockNumber,
 	}, nil
 }

--- a/op-challenger/game/fault/trace/utils/local_test.go
+++ b/op-challenger/game/fault/trace/utils/local_test.go
@@ -38,7 +38,7 @@ func TestFetchLocalInputs(t *testing.T) {
 	require.Equal(t, l2Client.header.Hash(), inputs.L2Head)
 	require.EqualValues(t, contract.starting.OutputRoot, inputs.L2OutputRoot)
 	require.EqualValues(t, contract.disputed.OutputRoot, inputs.L2Claim)
-	require.Equal(t, contract.disputed.L2BlockNumber, inputs.L2BlockNumber)
+	require.Equal(t, contract.disputed.L2BlockNumber, inputs.L2SequenceNumber)
 }
 
 func TestFetchLocalInputsFromProposals(t *testing.T) {
@@ -66,7 +66,7 @@ func TestFetchLocalInputsFromProposals(t *testing.T) {
 	require.Equal(t, l2Client.header.Hash(), inputs.L2Head)
 	require.EqualValues(t, agreed.OutputRoot, inputs.L2OutputRoot)
 	require.EqualValues(t, claimed.OutputRoot, inputs.L2Claim)
-	require.Equal(t, claimed.L2BlockNumber, inputs.L2BlockNumber)
+	require.Equal(t, claimed.L2BlockNumber, inputs.L2SequenceNumber)
 }
 
 type mockGameInputsSource struct {

--- a/op-challenger/game/fault/trace/vm/executor_test.go
+++ b/op-challenger/game/fault/trace/vm/executor_test.go
@@ -39,11 +39,11 @@ func TestGenerateProof(t *testing.T) {
 	}
 
 	inputs := utils.LocalGameInputs{
-		L1Head:        common.Hash{0x11},
-		L2Head:        common.Hash{0x22},
-		L2OutputRoot:  common.Hash{0x33},
-		L2Claim:       common.Hash{0x44},
-		L2BlockNumber: big.NewInt(3333),
+		L1Head:           common.Hash{0x11},
+		L2Head:           common.Hash{0x22},
+		L2OutputRoot:     common.Hash{0x33},
+		L2Claim:          common.Hash{0x44},
+		L2SequenceNumber: big.NewInt(3333),
 	}
 
 	info := &mipsevm.DebugInfo{

--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -36,7 +36,7 @@ func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.Lo
 		"--l2-head", inputs.L2Head.Hex(),
 		"--l2-output-root", inputs.L2OutputRoot.Hex(),
 		"--l2-claim", inputs.L2Claim.Hex(),
-		"--l2-block-number", inputs.L2BlockNumber.Text(10),
+		"--l2-block-number", inputs.L2SequenceNumber.Text(10),
 	}
 
 	if s.nativeMode {

--- a/op-challenger/game/fault/trace/vm/kona_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor_test.go
@@ -20,11 +20,11 @@ func TestKonaFillHostCommand(t *testing.T) {
 		Networks: []string{"op-mainnet"},
 	}
 	inputs := utils.LocalGameInputs{
-		L1Head:        common.Hash{0x11},
-		L2Head:        common.Hash{0x22},
-		L2OutputRoot:  common.Hash{0x33},
-		L2Claim:       common.Hash{0x44},
-		L2BlockNumber: big.NewInt(3333),
+		L1Head:           common.Hash{0x11},
+		L2Head:           common.Hash{0x22},
+		L2OutputRoot:     common.Hash{0x33},
+		L2Claim:          common.Hash{0x44},
+		L2SequenceNumber: big.NewInt(3333),
 	}
 	vmConfig := NewKonaExecutor()
 

--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
@@ -36,7 +36,7 @@ func (s *KonaSuperExecutor) OracleCommand(cfg Config, dataDir string, inputs uti
 		"--l1-head", inputs.L1Head.Hex(),
 		"--agreed-l2-pre-state", common.Bytes2Hex(inputs.AgreedPreState),
 		"--claimed-l2-post-state", inputs.L2Claim.Hex(),
-		"--claimed-l2-timestamp", inputs.L2BlockNumber.Text(10),
+		"--claimed-l2-timestamp", inputs.L2SequenceNumber.Text(10),
 	}
 
 	if s.nativeMode {

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -28,7 +28,7 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 		"--datadir", dataDir,
 		"--l1.head", inputs.L1Head.Hex(),
 		"--l2.claim", inputs.L2Claim.Hex(),
-		"--l2.blocknumber", inputs.L2BlockNumber.Text(10),
+		"--l2.blocknumber", inputs.L2SequenceNumber.Text(10),
 	}
 	if inputs.L2Head != (common.Hash{}) {
 		args = append(args, "--l2.head", inputs.L2Head.Hex())

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -39,11 +39,11 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 			Server:   "./bin/mockserver",
 		}
 		inputs := utils.LocalGameInputs{
-			L1Head:        common.Hash{0x11},
-			L2Head:        common.Hash{0x22},
-			L2OutputRoot:  common.Hash{0x33},
-			L2Claim:       common.Hash{0x44},
-			L2BlockNumber: big.NewInt(3333),
+			L1Head:           common.Hash{0x11},
+			L2Head:           common.Hash{0x22},
+			L2OutputRoot:     common.Hash{0x33},
+			L2Claim:          common.Hash{0x44},
+			L2SequenceNumber: big.NewInt(3333),
 		}
 		configModifier(&cfg, &inputs)
 		executor := NewOpProgramServerExecutor(testlog.Logger(t, lvl))
@@ -59,7 +59,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		require.Equal(t, dir, pairs["--datadir"])
 		require.Equal(t, inputs.L1Head.Hex(), pairs["--l1.head"])
 		require.Equal(t, inputs.L2Claim.Hex(), pairs["--l2.claim"])
-		require.Equal(t, inputs.L2BlockNumber.String(), pairs["--l2.blocknumber"])
+		require.Equal(t, inputs.L2SequenceNumber.String(), pairs["--l2.blocknumber"])
 		return pairs
 	}
 

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -70,11 +70,11 @@ func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to get claim output: %w", err)
 	}
 	localInputs := utils.LocalGameInputs{
-		L1Head:        l1Head.Hash,
-		L2Head:        parentOutput.BlockRef.Hash,
-		L2OutputRoot:  common.Hash(parentOutput.OutputRoot),
-		L2Claim:       common.Hash(claimOutput.OutputRoot),
-		L2BlockNumber: new(big.Int).SetUint64(blockNumber),
+		L1Head:           l1Head.Hash,
+		L2Head:           parentOutput.BlockRef.Hash,
+		L2OutputRoot:     common.Hash(parentOutput.OutputRoot),
+		L2Claim:          common.Hash(claimOutput.OutputRoot),
+		L2SequenceNumber: new(big.Int).SetUint64(blockNumber),
 	}
 	return localInputs, nil
 }
@@ -137,11 +137,11 @@ func createGameInputsInterop(ctx context.Context, log log.Logger, client *source
 		}
 	}
 	localInputs := utils.LocalGameInputs{
-		L1Head:         l1Head.Hash,
-		AgreedPreState: agreedPrestate,
-		L2OutputRoot:   crypto.Keccak256Hash(agreedPrestate),
-		L2Claim:        claim,
-		L2BlockNumber:  new(big.Int).SetUint64(claimTimestamp + 10), // Anything beyond the claim
+		L1Head:           l1Head.Hash,
+		AgreedPreState:   agreedPrestate,
+		L2OutputRoot:     crypto.Keccak256Hash(agreedPrestate),
+		L2Claim:          claim,
+		L2SequenceNumber: new(big.Int).SetUint64(claimTimestamp + 10), // Anything beyond the claim
 	}
 	return localInputs, nil
 }

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -177,7 +177,7 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, runConfig RunConfig, roll
 		return
 	}
 
-	inputsLogger := r.log.New("l1", localInputs.L1Head, "l2", localInputs.L2Head, "l2Block", localInputs.L2BlockNumber, "claim", localInputs.L2Claim)
+	inputsLogger := r.log.New("l1", localInputs.L1Head, "l2", localInputs.L2Head, "l2Block", localInputs.L2SequenceNumber, "claim", localInputs.L2Claim)
 	// Sanitize the directory name.
 	safeName := regexp.MustCompile("[^a-zA-Z0-9_-]").ReplaceAllString(runConfig.Name, "")
 	dir, err := r.prepDatadir(safeName)

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -152,7 +152,7 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		LastUpdateTime:        e.clock.Now(),
 		GameMetadata:          game,
 		L1Head:                meta.L1Head,
-		L2BlockNumber:         meta.L2BlockNum,
+		L2BlockNumber:         meta.L2SequenceNum,
 		RootClaim:             meta.RootClaim,
 		Status:                meta.Status,
 		MaxClockDuration:      meta.MaxClockDuration,

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -56,11 +56,11 @@ func RunKonaNative(
 		Server:            konaHostPath,
 	}
 	inputs := utils.LocalGameInputs{
-		L1Head:        fixtureInputs.L1Head,
-		L2Head:        fixtureInputs.L2Head,
-		L2OutputRoot:  fixtureInputs.L2OutputRoot,
-		L2Claim:       fixtureInputs.L2Claim,
-		L2BlockNumber: big.NewInt(int64(fixtureInputs.L2BlockNumber)),
+		L1Head:           fixtureInputs.L1Head,
+		L2Head:           fixtureInputs.L2Head,
+		L2OutputRoot:     fixtureInputs.L2OutputRoot,
+		L2Claim:          fixtureInputs.L2Claim,
+		L2SequenceNumber: big.NewInt(int64(fixtureInputs.L2BlockNumber)),
 	}
 
 	var hostCmd []string

--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -337,7 +337,7 @@ func (g *CannonHelper) createCannonTraceProvider(ctx context.Context, l2Node str
 
 	l2Client := g.system.NodeClient(l2Node)
 
-	prestateBlock, poststateBlock, err := g.splitGame.Game.GetBlockRange(ctx)
+	prestateBlock, poststateBlock, err := g.splitGame.Game.GetGameRange(ctx)
 	g.require.NoError(err, "Failed to load block range")
 	rollupClient := g.system.RollupClient(l2Node)
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -202,7 +202,7 @@ func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node 
 	game, err := contracts.NewFaultDisputeGameContract(ctx, metrics.NoopContractMetrics, createdEvent.DisputeProxy, batching.NewMultiCaller(h.Client.Client(), batching.DefaultBatchSize))
 	h.Require.NoError(err)
 
-	prestateBlock, poststateBlock, err := game.GetBlockRange(ctx)
+	prestateBlock, poststateBlock, err := game.GetGameRange(ctx)
 	h.Require.NoError(err, "Failed to load starting block number")
 	splitDepth, err := game.GetSplitDepth(ctx)
 	h.Require.NoError(err, "Failed to load split depth")
@@ -240,7 +240,7 @@ func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestam
 	game, err := contracts.NewFaultDisputeGameContract(ctx, metrics.NoopContractMetrics, createdEvent.DisputeProxy, batching.NewMultiCaller(h.Client.Client(), batching.DefaultBatchSize))
 	h.Require.NoError(err)
 
-	prestateTimestamp, poststateTimestamp, err := game.GetBlockRange(ctx)
+	prestateTimestamp, poststateTimestamp, err := game.GetGameRange(ctx)
 	h.Require.NoError(err, "Failed to load starting block number")
 	splitDepth, err := game.GetSplitDepth(ctx)
 	h.Require.NoError(err, "Failed to load split depth")
@@ -294,7 +294,7 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	game, err := contracts.NewFaultDisputeGameContract(ctx, metrics.NoopContractMetrics, createdEvent.DisputeProxy, batching.NewMultiCaller(h.Client.Client(), batching.DefaultBatchSize))
 	h.Require.NoError(err)
 
-	prestateBlock, poststateBlock, err := game.GetBlockRange(ctx)
+	prestateBlock, poststateBlock, err := game.GetGameRange(ctx)
 	h.Require.NoError(err, "Failed to load starting block number")
 	splitDepth, err := game.GetSplitDepth(ctx)
 	h.Require.NoError(err, "Failed to load split depth")

--- a/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_alphabet_helper.go
@@ -35,7 +35,7 @@ func (g *OutputAlphabetGameHelper) StartChallenger(
 
 func (g *OutputAlphabetGameHelper) CreateHonestActor(ctx context.Context, l2Node string) *OutputHonestHelper {
 	logger := testlog.Logger(g.T, log.LevelInfo).New("role", "HonestHelper", "game", g.Addr)
-	prestateBlock, poststateBlock, err := g.Game.GetBlockRange(ctx)
+	prestateBlock, poststateBlock, err := g.Game.GetGameRange(ctx)
 	g.Require.NoError(err, "Get block range")
 	splitDepth := g.SplitDepth(ctx)
 	l1Head := g.GetL1Head(ctx)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -64,7 +64,7 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 	logger := testlog.Logger(g.T, log.LevelInfo).New("role", "HonestHelper", "game", g.Addr)
 	l2Client := g.System.NodeClient(l2Node)
 
-	realPrestateBlock, realPostStateBlock, err := g.Game.GetBlockRange(ctx)
+	realPrestateBlock, realPostStateBlock, err := g.Game.GetGameRange(ctx)
 	g.Require.NoError(err, "Failed to load block range")
 	splitDepth := g.SplitDepth(ctx)
 	rollupClient := g.System.RollupClient(l2Node)

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -54,7 +54,7 @@ func NewOutputGameHelper(t *testing.T, require *require.Assertions, client *ethc
 }
 
 func (g *OutputGameHelper) StartingBlockNum(ctx context.Context) uint64 {
-	blockNum, _, err := g.Game.GetBlockRange(ctx)
+	blockNum, _, err := g.Game.GetGameRange(ctx)
 	g.Require.NoError(err, "failed to load starting block number")
 	return blockNum
 }

--- a/op-e2e/e2eutils/disputegame/split_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/split_game_helper.go
@@ -68,7 +68,7 @@ func WithIgnoreDuplicates() MoveOpt {
 }
 
 func (g *SplitGameHelper) L2BlockNum(ctx context.Context) uint64 {
-	_, blockNum, err := g.Game.GetBlockRange(ctx)
+	_, blockNum, err := g.Game.GetGameRange(ctx)
 	g.Require.NoError(err, "failed to load l2 block number")
 	return blockNum
 }

--- a/op-e2e/faultproofs/cannon_benchmark_test.go
+++ b/op-e2e/faultproofs/cannon_benchmark_test.go
@@ -94,11 +94,11 @@ func testBenchmarkCannonFPP(t *testing.T, allocType config.AllocType) {
 	l1Head := l1HeadBlock.Hash()
 
 	inputs := utils.LocalGameInputs{
-		L1Head:        l1Head,
-		L2Head:        l2Head,
-		L2Claim:       common.Hash(l2Claim),
-		L2OutputRoot:  common.Hash(l2OutputRoot),
-		L2BlockNumber: l2ClaimBlockNumber,
+		L1Head:           l1Head,
+		L2Head:           l2Head,
+		L2Claim:          common.Hash(l2Claim),
+		L2OutputRoot:     common.Hash(l2OutputRoot),
+		L2SequenceNumber: l2ClaimBlockNumber,
 	}
 	debugfile := path.Join(t.TempDir(), "debug.json")
 	runCannon(t, ctx, sys, inputs, "--debug-info", debugfile)

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -92,11 +92,11 @@ func testPrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 			l1Head := l1HeadBlock.Hash()
 
 			inputs := utils.LocalGameInputs{
-				L1Head:        l1Head,
-				L2Head:        l2Head,
-				L2Claim:       common.Hash(l2Claim),
-				L2OutputRoot:  common.Hash(l2OutputRoot),
-				L2BlockNumber: l2ClaimBlockNumber,
+				L1Head:           l1Head,
+				L2Head:           l2Head,
+				L2Claim:          common.Hash(l2Claim),
+				L2OutputRoot:     common.Hash(l2OutputRoot),
+				L2SequenceNumber: l2ClaimBlockNumber,
 			}
 			runCannon(t, ctx, sys, inputs)
 		})
@@ -209,11 +209,11 @@ func testGranitePrecompiles(t *testing.T, allocType e2e_config.AllocType) {
 	l1Head := l1HeadBlock.Hash()
 
 	inputs := utils.LocalGameInputs{
-		L1Head:        l1Head,
-		L2Head:        l2Head,
-		L2Claim:       common.Hash(l2Claim),
-		L2OutputRoot:  common.Hash(l2OutputRoot),
-		L2BlockNumber: l2ClaimBlockNumber,
+		L1Head:           l1Head,
+		L2Head:           l2Head,
+		L2Claim:          common.Hash(l2Claim),
+		L2OutputRoot:     common.Hash(l2OutputRoot),
+		L2SequenceNumber: l2ClaimBlockNumber,
 	}
 	runCannon(t, ctx, sys, inputs)
 }

--- a/op-e2e/system/proofs/proposer_fp_test.go
+++ b/op-e2e/system/proofs/proposer_fp_test.go
@@ -61,7 +61,7 @@ func TestL2OutputSubmitterFaultProofs(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			_, gameBlockNumber, err := proxy.GetBlockRange(ctx)
+			_, gameBlockNumber, err := proxy.GetGameRange(ctx)
 			require.Nil(t, err)
 			l2Output, err := rollupClient.OutputAtBlock(ctx, gameBlockNumber)
 			require.Nil(t, err)

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -83,7 +83,7 @@ var (
 	}
 	L2Claim = &cli.StringFlag{
 		Name:    "l2.claim",
-		Usage:   "Claimed L2 root to validate",
+		Usage:   "Claimed proposal root to validate",
 		EnvVars: prefixEnvVars("L2_CLAIM"),
 	}
 	L2BlockNumber = &cli.Uint64Flag{

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -67,7 +67,7 @@ var (
 	}
 	L2Head = &cli.StringFlag{
 		Name:    "l2.head",
-		Usage:   "Hash of the L2 block at l2.outputroot",
+		Usage:   "Hash of the L2 block at l2.outputroot. Used for non-interop games.",
 		EnvVars: prefixEnvVars("L2_HEAD"),
 	}
 	L2OutputRoot = &cli.StringFlag{
@@ -83,13 +83,14 @@ var (
 	}
 	L2Claim = &cli.StringFlag{
 		Name:    "l2.claim",
-		Usage:   "Claimed L2 output root to validate",
+		Usage:   "Claimed L2 root to validate",
 		EnvVars: prefixEnvVars("L2_CLAIM"),
 	}
 	L2BlockNumber = &cli.Uint64Flag{
 		Name:    "l2.blocknumber",
-		Usage:   "Number of the L2 block that the claim is from",
-		EnvVars: prefixEnvVars("L2_BLOCK_NUM"),
+		Aliases: []string{"l2.sequencenumber"},
+		Usage:   "Number of the L2 block number or timestamp that the claim is from",
+		EnvVars: append(prefixEnvVars("L2_BLOCK_NUM"), prefixEnvVars("L2_SEQUENCE_NUMBER")...),
 	}
 	L2GenesisPath = &cli.StringSliceFlag{
 		Name:    "l2.genesis",

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -89,7 +89,7 @@ var (
 	L2BlockNumber = &cli.Uint64Flag{
 		Name:    "l2.blocknumber",
 		Aliases: []string{"l2.sequencenumber"},
-		Usage:   "Number of the L2 block number or timestamp that the claim is from",
+		Usage:   "L2 block number or timestamp that the claim is from",
 		EnvVars: append(prefixEnvVars("L2_BLOCK_NUM"), prefixEnvVars("L2_SEQUENCE_NUMBER")...),
 	}
 	L2GenesisPath = &cli.StringSliceFlag{

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -10,6 +10,9 @@ import (
 //go:embed abi/DisputeGameFactory.json
 var disputeGameFactory []byte
 
+//go:embed abi/SuperFaultDisputeGame.json
+var superFaultDisputeGame []byte
+
 //go:embed abi/FaultDisputeGame.json
 var faultDisputeGame []byte
 
@@ -30,6 +33,9 @@ var crossL2Inbox []byte
 
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
+}
+func LoadSuperFaultDisputeGameABI() *abi.ABI {
+	return loadABI(superFaultDisputeGame)
 }
 func LoadFaultDisputeGameABI() *abi.ABI {
 	return loadABI(faultDisputeGame)


### PR DESCRIPTION
**Description**

l2.blocknumber flag now has a l2.sequencenumber alias. Both options work allowing us to eventually migrate to the more generic name without breaking compatibility.

Updated help text for a couple of flags to make them clearer.

Note that challenger still uses the old names to avoid any risk of compatibility issues.  While it typically uses the op-program bundled in its docker image, there's no harm in continuing to use the old names for now and it ensures it doesn't cause issues for anyone using a different version of op-program.

**Additional context**

Buids on https://github.com/ethereum-optimism/optimism/pull/14779

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/13915