### PR TITLE
op-e2e: Interop deposit message action tests

### DIFF
--- a/op-e2e/actions/helpers/l1_miner.go
+++ b/op-e2e/actions/helpers/l1_miner.go
@@ -166,7 +166,7 @@ func (s *L1Miner) ActL1IncludeTxByHash(txHash common.Hash) Action {
 	}
 }
 
-func (s *L1Miner) IncludeTx(t Testing, tx *types.Transaction) {
+func (s *L1Miner) IncludeTx(t Testing, tx *types.Transaction) *types.Receipt {
 	from, err := s.l1Signer.Sender(tx)
 	require.NoError(t, err)
 	s.log.Info("including tx", "nonce", tx.Nonce(), "from", from, "to", tx.To())
@@ -175,7 +175,7 @@ func (s *L1Miner) IncludeTx(t Testing, tx *types.Transaction) {
 	}
 	if tx.Gas() > uint64(*s.L1GasPool) {
 		t.InvalidAction("action takes too much gas: %d, only have %d", tx.Gas(), uint64(*s.L1GasPool))
-		return
+		return nil
 	}
 	s.l1BuildingState.SetTxContext(tx.Hash(), len(s.L1Transactions))
 	blockCtx := core.NewEVMBlockContext(s.l1BuildingHeader, s.l1Chain, nil, s.l1Cfg.Config, s.l1BuildingState)
@@ -196,6 +196,7 @@ func (s *L1Miner) IncludeTx(t Testing, tx *types.Transaction) {
 		}
 		*s.l1BuildingHeader.BlobGasUsed += receipt.BlobGasUsed
 	}
+	return receipt
 }
 
 func (s *L1Miner) ActL1SetFeeRecipient(coinbase common.Address) {

--- a/op-e2e/actions/interop/dsl/dsl_user.go
+++ b/op-e2e/actions/interop/dsl/dsl_user.go
@@ -18,10 +18,10 @@ type DSLUser struct {
 	keys  devkeys.Keys
 }
 
-func (u *DSLUser) TransactOpts(chain *Chain) (*bind.TransactOpts, common.Address) {
-	privKey, err := u.keys.Secret(devkeys.ChainUserKeys(chain.ChainID.ToBig())(u.index))
+func (u *DSLUser) TransactOpts(chainID *big.Int) (*bind.TransactOpts, common.Address) {
+	privKey, err := u.keys.Secret(devkeys.ChainUserKeys(chainID)(u.index))
 	require.NoError(u.t, err)
-	opts, err := bind.NewKeyedTransactorWithChainID(privKey, chain.ChainID.ToBig())
+	opts, err := bind.NewKeyedTransactorWithChainID(privKey, chainID)
 	require.NoError(u.t, err)
 	opts.GasTipCap = big.NewInt(params.GWei)
 

--- a/op-e2e/actions/interop/dsl/emitter.go
+++ b/op-e2e/actions/interop/dsl/emitter.go
@@ -24,7 +24,7 @@ func NewEmitterContract(t helpers.Testing) *EmitterContract {
 
 func (c *EmitterContract) Deploy(user *DSLUser) TransactionCreator {
 	return func(chain *Chain) *GeneratedTransaction {
-		opts, from := user.TransactOpts(chain)
+		opts, from := user.TransactOpts(chain.ChainID.ToBig())
 		emitContract, tx, _, err := emit.DeployEmit(opts, chain.SequencerEngine.EthClient())
 		require.NoError(c.t, err)
 		c.addressByChain[chain.ChainID] = emitContract
@@ -34,7 +34,7 @@ func (c *EmitterContract) Deploy(user *DSLUser) TransactionCreator {
 
 func (c *EmitterContract) EmitMessage(user *DSLUser, message string) TransactionCreator {
 	return func(chain *Chain) *GeneratedTransaction {
-		opts, from := user.TransactOpts(chain)
+		opts, from := user.TransactOpts(chain.ChainID.ToBig())
 		address, ok := c.addressByChain[chain.ChainID]
 		require.Truef(c.t, ok, "not deployed on chain %d", chain.ChainID)
 		bindings, err := emit.NewEmitTransactor(address, chain.SequencerEngine.EthClient())


### PR DESCRIPTION
Introduce FP action tests that cover deposit message execution.

ref https://github.com/ethereum-optimism/optimism/issues/14479