### PR TITLE
ci: Remove fpp-verify job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1294,20 +1294,6 @@ jobs:
     steps:
       - run: echo Done
 
-  fpp-verify:
-    circleci_ip_ranges: true
-    docker:
-      - image: cimg/go:1.21
-    steps:
-      - utils/checkout-with-mise
-      - run:
-          name: verify-sepolia
-          command: |
-            make verify-sepolia
-          working_directory: op-program
-      - notify-failures-on-develop:
-          mentions: "@proofs-team"
-
   op-program-compat:
     machine: true
     resource_class: ethereum-optimism/latitude-1
@@ -1796,16 +1782,6 @@ workflows:
             - slack
             - circleci-repo-readonly-authenticated-github-token
 
-  scheduled-fpp:
-    when:
-      equal: [build_hourly, <<pipeline.schedule.name>>]
-    jobs:
-      - fpp-verify:
-          context:
-            - slack
-            - oplabs-fpp-nodes
-            - circleci-repo-readonly-authenticated-github-token
-
   develop-publish-contract-artifacts:
     when:
       or:
@@ -1966,4 +1942,3 @@ workflows:
     jobs:
       - stale-check:
           context: circleci-repo-optimism
-

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -69,12 +69,6 @@ clean:
 test:
 	go test -v ./...
 
-verify-sepolia: op-program-host op-program-client
-	env GO111MODULE=on go run ./verify/sepolia/cmd/sepolia.go --l1 $$SEPOLIA_L1URL --l1.beacon $$SEPOLIA_BEACON_URL --l2 $$SEPOLIA_L2URL --datadir /tmp/test-sepolia
-
-verify-devnet: op-program-host op-program-client
-	env GO111MODULE=on go run ./verify/devnet/cmd/devnet.go --l1 http://localhost:8545 --l1.beacon http://localhost:5052 --l2 http://localhost:9545 --datadir /tmp/test-devnet
-
 capture-mainnet-genesis: op-program-host op-program-client
 	rm -rf "$(COMPAT_DIR)/mainnet-genesis" "$(COMPAT_DIR)/mainnet-genesis.tar.bz"
 	env GO111MODULE=on go run ./verify/mainnet/cmd/mainnet.go --l1 $$MAINNET_L1URL --l1.beacon $$MAINNET_BEACON_URL --l2 $$MAINNET_L2URL --datadir "$(COMPAT_DIR)/mainnet-genesis" --l1.head "0x4903424f6cc2cfba7c2bf8c8f48ca46721c963fa64b411cfee3697b781e3e5f1" --l2.start "105235063" --l2.end "105235064"
@@ -122,8 +116,6 @@ verify-compat: verify-sepolia-delta verify-sepolia-ecotone verify-mainnet-genesi
 	clean \
 	test \
 	capture-goerli-verify \
-	verify-sepolia \
-	verify-devnet \
 	capture-mainnet-genesis \
 	capture-sepolia-delta \
 	capture-sepolia-ecotone \


### PR DESCRIPTION
**Description**

Remove the fpp-verify job. PublicNode is down which is causing it to fail and we now have vm-runner automatically running the latest op-program from develop in cannon which is a much more comprehensive test.