### PR TITLE
kt-devnet: fix l2 service representation

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -69,13 +69,6 @@ func (f *ServiceFinder) FindL2Services(network string) ([]descriptors.Node, desc
 			tag, idx := f.serviceTag(strings.TrimPrefix(name, f.l2ServicePrefix))
 			return tag, idx, true
 		}
-
-		// Some services don't have a network suffix, as they span multiple chains
-		// TODO(14849): ideally we'd need to handle *partial* chain coverage.
-		if strings.HasPrefix(serviceName, f.l2ServicePrefix) {
-			tag, idx := f.serviceTag(strings.TrimPrefix(serviceName, f.l2ServicePrefix))
-			return tag, idx, true
-		}
 		return "", 0, false
 	})
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Patch added at https://github.com/ethereum-optimism/optimism/pull/14772 introduced the l2 system representation to be mixed. Revert for a temporary measure cc @sigma 

**Tests**

Confirmed that test included at https://github.com/ethereum-optimism/optimism/pull/14838 which touches both L2 chains passes again.
