### PR TITLE
chore(op-e2e): Prefix proof action tests with `Test_ProgramAction`

### DIFF
--- a/op-e2e/actions/proofs/block_data_hint_test.go
+++ b/op-e2e/actions/proofs/block_data_hint_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_OPProgramAction_BlockDataHint(gt *testing.T) {
+func Test_ProgramAction_BlockDataHint(gt *testing.T) {
 	testCfg := &helpers.TestCfg[any]{
 		Hardfork: helpers.LatestFork,
 	}

--- a/op-e2e/actions/proofs/isthmus_requests_test.go
+++ b/op-e2e/actions/proofs/isthmus_requests_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsthmusExcludedPredeploys(gt *testing.T) {
+func Test_ProgramAction_IsthmusExcludedPredeploys(gt *testing.T) {
 	// Ensures that if EIP-7251, or EIP-7002 predeploys are deployed manually after the fork,
 	// Isthmus block processing still works correctly. Also ensures that if requests are sent to these
 	// contracts, they are not processed and do not show up in the block body or requests hash.

--- a/op-e2e/actions/proofs/l1_prague_fork_test.go
+++ b/op-e2e/actions/proofs/l1_prague_fork_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPragueForkAfterGenesis(gt *testing.T) {
+func Test_ProgramAction_PragueForkAfterGenesis(gt *testing.T) {
 	type testCase struct {
 		name         string
 		useSetCodeTx bool

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Operator_Fee_Constistency(gt *testing.T) {
+func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 
 	const testOperatorFeeScalar = uint32(20000)
 	const testOperatorFeeConstant = uint64(500)

--- a/op-e2e/actions/proofs/pectra_blob_schedule_test.go
+++ b/op-e2e/actions/proofs/pectra_blob_schedule_test.go
@@ -20,7 +20,7 @@ type pectraBlobScheduleTestCfg struct {
 	expectCancunBBF bool
 }
 
-func TestPectraBlobSchedule(gt *testing.T) {
+func Test_ProgramAction_PectraBlobSchedule(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 


### PR DESCRIPTION
## Overview

Prefixes the proof action tests with `Test_ProgramAction`. In kona, we use this test prefix to filter which action tests to run with kona-proof.

Does not touch the set code tx test file, since @sebastianst is working on it and said he'd handle.