### PR TITLE
op-node/rollup/derive: validate to field non-nil for setcode txs

### DIFF
--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -188,6 +188,10 @@ func (tx *spanBatchTx) convertToFullTx(nonce, gas uint64, to *common.Address, ch
 			S:          S,
 		}
 	case types.SetCodeTxType:
+		if to == nil {
+			return nil, fmt.Errorf("to address is required for SetCodeTx")
+		}
+
 		setCodeTxInner := tx.inner.(*spanBatchSetCodeTxData)
 		inner = &types.SetCodeTx{
 			ChainID:    uint256.MustFromBig(chainID),

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -144,3 +144,11 @@ func TestSpanBatchTxDecodeInvalid(t *testing.T) {
 	err = sbtx.UnmarshalBinary(invalidLegacyTxDecoded)
 	require.ErrorContains(t, err, "failed to decode spanBatchLegacyTxData")
 }
+
+func TestSpanBatchTxSetCodeInvalidTo(t *testing.T) {
+	// invalid to for setcode tx
+	var sbtx spanBatchTx
+	sbtx.inner = &spanBatchSetCodeTxData{}
+	_, err := sbtx.convertToFullTx(0, 0, nil, nil, nil, nil, nil)
+	require.ErrorContains(t, err, "to address is required for SetCodeTx")
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Validates that SetCode transactions decoded from span batches have a non-nil To field.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Added unit tests, but not action tests ensuring span batches with a nil To field are dropped.

Fixes https://github.com/ethereum-optimism/optimism/issues/14880
