### PR TITLE
Enable NAT Tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1137,17 +1137,47 @@ jobs:
       - utils/checkout-with-mise
       - attach_workspace:
           at: "."
+      # Restore cached Go modules
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-v1-
+      # Download dependencies first
+      - run:
+          name: Download Go dependencies
+          working_directory: op-acceptance-tests
+          command: go mod download
+      # Prepare the test environment
+      - run:
+          name: Prepare test environment (compile tests and cache results)
+          working_directory: op-acceptance-tests
+          command: go test -v ./... || true # ignore failures; we're just compiling the tests
+      # Run the actual acceptance tests with optimized settings
       - run:
           name: Run acceptance tests
+          working_directory: op-acceptance-tests
           no_output_timeout: <<parameters.no_output_timeout>>
-          command: |
-            cd op-acceptance-tests && just acceptance-test "<<parameters.devnet>>" "<<parameters.gate>>"
-      - store_test_results:
-          path: ./op-acceptance-tests/results
-          when: always
-      - store_artifacts:
-          path: ./op-acceptance-tests/logs
-          when: always
+          environment:
+            GOFLAGS: "-mod=mod"
+            GO111MODULE: "on"
+          command: just acceptance-test "<<parameters.devnet>>" "<<parameters.gate>>"
+      # Save the module cache for future runs
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      # Store test results and artifacts
+      - when:
+          condition: always
+          steps:
+            - store_test_results:
+                path: ./op-acceptance-tests/results
+      - when:
+          condition: always
+          steps:
+            - store_artifacts:
+                path: ./op-acceptance-tests/logs
+      # Notification step
       - when:
           condition: "<<parameters.notify>>"
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1105,6 +1105,55 @@ jobs:
             - notify-failures-on-develop:
                 mentions: "<<parameters.mentions>>"
 
+  op-acceptance-tests:
+    parameters:
+      devnet:
+        description: The name of the devnet to run the acceptance tests against. The devnet must have a recipe defined in kurtosis-devnet/Justfile with the name <devnet>-devnet.
+        type: string
+        default: ""
+      gate:
+        description: The gate to run the acceptance tests against. This gate should be defined in op-acceptance-tests/acceptance-tests.yaml.
+        type: string
+        default: ""
+      notify:
+        description: Whether to notify on failure
+        type: boolean
+        default: false
+      mentions:
+        description: Slack user or group to mention when notifying of failures
+        type: string
+        default: ""
+      resource_class:
+        description: Machine resource class
+        type: string
+        default: xlarge
+      no_output_timeout:
+        description: Timeout for when CircleCI kills the job if there's no output
+        type: string
+        default: 30m
+    machine: true
+    resource_class: <<parameters.resource_class>>
+    steps:
+      - utils/checkout-with-mise
+      - attach_workspace:
+          at: "."
+      - run:
+          name: Run acceptance tests
+          no_output_timeout: <<parameters.no_output_timeout>>
+          command: |
+            cd op-acceptance-tests && just acceptance-test "<<parameters.devnet>>" "<<parameters.gate>>"
+      - store_test_results:
+          path: ./op-acceptance-tests/results
+          when: always
+      - store_artifacts:
+          path: ./op-acceptance-tests/logs
+          when: always
+      - when:
+          condition: "<<parameters.notify>>"
+          steps:
+            - notify-failures-on-develop:
+                mentions: "<<parameters.mentions>>"
+
   sanitize-op-program:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
@@ -1600,13 +1649,17 @@ workflows:
             packages/contracts-bedrock/scripts/verify
             op-dripper
             devnet-sdk
-            kurtosis-devnet
             op-acceptance-tests
+            kurtosis-devnet
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
           context: circleci-repo-readonly-authenticated-github-token
       - analyze-op-program-client:
+          context: circleci-repo-readonly-authenticated-github-token
+      - op-acceptance-tests:
+          devnet: simple
+          gate: localnet
           context: circleci-repo-readonly-authenticated-github-token
       - op-program-compat:
           context: circleci-repo-readonly-authenticated-github-token

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1658,8 +1658,8 @@ workflows:
       - analyze-op-program-client:
           context: circleci-repo-readonly-authenticated-github-token
       - op-acceptance-tests:
-          devnet: simple
-          gate: localnet
+          devnet: isthmus
+          gate: isthmus
           context: circleci-repo-readonly-authenticated-github-token
       - op-program-compat:
           context: circleci-repo-readonly-authenticated-github-token

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -4,7 +4,7 @@ optimism_package:
   chains:
     - participants:
       - el_type: op-geth
-        el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101500.0"
+        el_image: ""
         el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}
@@ -69,18 +69,11 @@ optimism_package:
   global_tolerations: []
   persistent: false
 ethereum_package:
-  participants_matrix:
-    el:
-      - el_type: geth
-        el_image: ethpandaops/geth:prague-devnet-5-f85cde7
-    cl:
-      - cl_type: lighthouse
-        cl_image: ethpandaops/lighthouse:single_attestation-b6d80eb
+  participants:
+    - el_type: geth
+      cl_type: teku
   network_params:
-    electra_fork_epoch: 1
-    min_validator_withdrawability_delay: 1
-    shard_committee_period: 1
-    churn_limit_quotient: 16
+    preset: minimal
     genesis_delay: 5
     additional_preloaded_contracts: |
       {

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -5,23 +5,29 @@
 
 
 gates:
-  - id: holocene
-    description: "Holocene network tests."
+  - id: sanitychecks
+    description: "Sanity checks for the acceptance tests."
     tests:
       - name: TestFindRPCEndpoints
         package: github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis
+
+  - id: holocene
+    inherits:
+      - sanitychecks
+    description: "Holocene network tests."
+    tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord
 
   - id: isthmus
     inherits:
-      - holocene
+      - sanitychecks
     description: "Isthmus network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
 
   - id: interop
     inherits:
-      - isthmus
+      - sanitychecks
     description: "Interop network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -46,7 +46,7 @@ acceptance-test devnet="simple" gate="holocene":
         echo "Using mise-managed binary: $BINARY_PATH"
 
         # Run the op-acceptor binary
-        "$BINARY_PATH" \
+        DEVNET_ENV_URL="kt://{{devnet}}-devnet" "$BINARY_PATH" \
             --testdir "{{REPO_ROOT}}" \
             --gate {{gate}} \
             --validators ./acceptance-tests.yaml \

--- a/op-acceptance-tests/tests/isthmus/erc20_bridge_test.go
+++ b/op-acceptance-tests/tests/isthmus/erc20_bridge_test.go
@@ -139,7 +139,7 @@ func erc20BridgeTestScenario(lowLevelSystemGetter validators.LowLevelSystemGette
 		require.NoError(t, err)
 		require.True(t, big.NewInt(0).Cmp(initialL2Balance) == 0, "Initial L2 token balance should be 0, actual was %s", initialL2Balance.String())
 
-		l1StandardBridgeAddress, ok := l2Chain.Addresses()["l1StandardBridgeProxy"]
+		l1StandardBridgeAddress, ok := l2Chain.L1Addresses()["l1StandardBridgeProxy"]
 		require.True(t, ok, fmt.Errorf("no L1 proxy address configured for this test"))
 
 		l1StandardBridge, err := bindings.NewL1StandardBridge(l1StandardBridgeAddress, l1Client)
@@ -173,7 +173,7 @@ func erc20BridgeTestScenario(lowLevelSystemGetter validators.LowLevelSystemGette
 		logger.Info("Deposit transaction confirmed on L1", "tx", tx.Hash().Hex())
 
 		// Get the OptimismPortal contract to find the deposit event
-		optimismPortal, err := bindings.NewOptimismPortal(l2Chain.Addresses()["optimismPortalProxy"], l1Client)
+		optimismPortal, err := bindings.NewOptimismPortal(l2Chain.L1Addresses()["optimismPortalProxy"], l1Client)
 		require.NoError(t, err)
 
 		// Find the TransactionDeposited event from the logs


### PR DESCRIPTION
Runs as part of the `main` CI workflow. Skips tests that do not pass validators, a later PR will disable this in combination with #14900 which will add more release-level gate configuration.

CI will fail until #14907 is merged.