### PR TITLE
fix: correct "withdrawl" typos in isthmus_fork_test.go

### DIFF
--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -91,7 +91,7 @@ func TestIsthmusActivationAtGenesis(gt *testing.T) {
 // There are 2 stages pre-Isthmus that we need to test:
 // 1. Pre-Canyon: withdrawals root should be nil
 // 2. Post-Canyon: withdrawals root should be EmptyWithdrawalsHash
-func TestWithdrawlsRootPreCanyonAndIsthmus(gt *testing.T) {
+func TestWithdrawalsRootPreCanyonAndIsthmus(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	canyonOffset := hexutil.Uint64(2)
@@ -157,12 +157,12 @@ func TestWithdrawalsRootBeforeAtAndAfterIsthmus(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testWithdrawlsRootIsthmus(t, test.withdrawalTx, test.withdrawalTxBlock, test.totalBlocks)
+			testWithdrawalsRootIsthmus(t, test.withdrawalTx, test.withdrawalTxBlock, test.totalBlocks)
 		})
 	}
 }
 
-func testWithdrawlsRootIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlock, totalBlocks int) {
+func testWithdrawalsRootIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlock, totalBlocks int) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	const isthmusOffset = 2
@@ -219,7 +219,7 @@ func testWithdrawlsRootIsthmus(gt *testing.T, withdrawalTx bool, withdrawalTxBlo
 	}
 }
 
-func TestWithdrawlsRootPostIsthmus(gt *testing.T) {
+func TestWithdrawalsRootPostIsthmus(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	const isthmusOffset = 2


### PR DESCRIPTION
**Description**

This PR fixes typos in function names in the `op-e2e/actions/upgrades/isthmus_fork_test.go` file, changing "withdrawl" to the correct spelling "withdrawal" in the following functions:

- `TestWithdrawlsRootPreCanyonAndIsthmus` → `TestWithdrawalsRootPreCanyonAndIsthmus`
- `testWithdrawlsRootIsthmus` → `testWithdrawalsRootIsthmus`
- `TestWithdrawlsRootPostIsthmus` → `TestWithdrawalsRootPostIsthmus`

These changes improve code readability and consistency without affecting functionality.

**Tests**

No additional tests were needed as this is a simple typo fix in test function names. The existing tests continue to work as before.

**Additional context**

This is a minor improvement to maintain code quality and readability. The typo correction makes the codebase more consistent and professional.

**Metadata**

- Type: Bug fix (typo correction)
- Impact: Low (test code only, no functional changes)