### PR TITLE
fix: improve L1BlockInfoFromBytes to correctly handle upgrade activation blocks

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -393,10 +393,18 @@ func isIsthmusButNotFirstBlock(rollupCfg *rollup.Config, l2Timestamp uint64) boo
 func L1BlockInfoFromBytes(rollupCfg *rollup.Config, l2BlockTime uint64, data []byte) (*L1BlockInfo, error) {
 	var info L1BlockInfo
 	// Important, this should be ordered from most recent to oldest
-	if isIsthmusButNotFirstBlock(rollupCfg, l2BlockTime) {
+	if rollupCfg.IsIsthmus(l2BlockTime) {
+		if rollupCfg.IsIsthmusActivationBlock(l2BlockTime) {
+			// For the activation block, we still use the Ecotone format
+			return &info, info.unmarshalBinaryEcotone(data)
+		}
 		return &info, info.unmarshalBinaryIsthmus(data)
 	}
-	if isEcotoneButNotFirstBlock(rollupCfg, l2BlockTime) {
+	if rollupCfg.IsEcotone(l2BlockTime) {
+		if rollupCfg.IsEcotoneActivationBlock(l2BlockTime) {
+			// For the activation block, we still use the Bedrock format
+			return &info, info.unmarshalBinaryBedrock(data)
+		}
 		return &info, info.unmarshalBinaryEcotone(data)
 	}
 	return &info, info.unmarshalBinaryBedrock(data)

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -232,3 +232,81 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		require.Equal(t, L1InfoIsthmusLen, len(depTx.Data))
 	})
 }
+
+func TestL1BlockInfoFromBytes(t *testing.T) {
+	// Create a rollup config with Ecotone and Isthmus activation times
+	ecotoneTime := uint64(1000)
+	isthmusTime := uint64(2000)
+	cfg := &rollup.Config{
+		EcotoneTime: &ecotoneTime,
+		IsthmusTime: &isthmusTime,
+	}
+
+	// Create a mock L1 block info
+	l1Info := L1BlockInfo{
+		Number:              123,
+		Time:                456,
+		BaseFee:             big.NewInt(789),
+		BlockHash:           common.HexToHash("0x1234"),
+		SequenceNumber:      1,
+		BatcherAddr:         common.HexToAddress("0x5678"),
+		L1FeeOverhead:       eth.Bytes32{},
+		L1FeeScalar:         eth.Bytes32{},
+		BlobBaseFee:         big.NewInt(101112),
+		BaseFeeScalar:       13,
+		BlobBaseFeeScalar:   14,
+		OperatorFeeScalar:   15,
+		OperatorFeeConstant: 16,
+	}
+
+	// Test Bedrock format (before Ecotone)
+	bedrockBytes, err := l1Info.marshalBinaryBedrock()
+	require.NoError(t, err)
+
+	// Before Ecotone
+	beforeEcotone := ecotoneTime - 1
+	parsedBedrockInfo, err := L1BlockInfoFromBytes(cfg, beforeEcotone, bedrockBytes)
+	require.NoError(t, err)
+	assert.Equal(t, l1Info.Number, parsedBedrockInfo.Number)
+	assert.Equal(t, l1Info.Time, parsedBedrockInfo.Time)
+	assert.Equal(t, l1Info.BaseFee.String(), parsedBedrockInfo.BaseFee.String())
+	assert.Equal(t, l1Info.BlockHash, parsedBedrockInfo.BlockHash)
+	assert.Equal(t, l1Info.SequenceNumber, parsedBedrockInfo.SequenceNumber)
+	assert.Equal(t, l1Info.BatcherAddr, parsedBedrockInfo.BatcherAddr)
+
+	// Test Ecotone format
+	ecotoneBytes, err := l1Info.marshalBinaryEcotone()
+	require.NoError(t, err)
+
+	// At Ecotone activation block
+	atEcotone := ecotoneTime
+	parsedEcotoneActivationInfo, err := L1BlockInfoFromBytes(cfg, atEcotone, bedrockBytes)
+	require.NoError(t, err)
+	assert.Equal(t, l1Info.Number, parsedEcotoneActivationInfo.Number)
+
+	// After Ecotone, before Isthmus
+	afterEcotone := ecotoneTime + 1
+	parsedEcotoneInfo, err := L1BlockInfoFromBytes(cfg, afterEcotone, ecotoneBytes)
+	require.NoError(t, err)
+	assert.Equal(t, l1Info.Number, parsedEcotoneInfo.Number)
+	assert.Equal(t, l1Info.BaseFeeScalar, parsedEcotoneInfo.BaseFeeScalar)
+	assert.Equal(t, l1Info.BlobBaseFeeScalar, parsedEcotoneInfo.BlobBaseFeeScalar)
+
+	// Test Isthmus format
+	isthmusBytes, err := l1Info.marshalBinaryIsthmus()
+	require.NoError(t, err)
+
+	// At Isthmus activation block
+	atIsthmus := isthmusTime
+	parsedIsthmusActivationInfo, err := L1BlockInfoFromBytes(cfg, atIsthmus, ecotoneBytes)
+	require.NoError(t, err)
+	assert.Equal(t, l1Info.Number, parsedIsthmusActivationInfo.Number)
+
+	// After Isthmus
+	afterIsthmus := isthmusTime + 1
+	parsedIsthmusInfo, err := L1BlockInfoFromBytes(cfg, afterIsthmus, isthmusBytes)
+	require.NoError(t, err)
+	assert.Equal(t, l1Info.Number, parsedIsthmusInfo.Number)
+	assert.Equal(t, l1Info.OperatorFeeScalar, parsedIsthmusInfo.OperatorFeeScalar)
+	assert.Equal(t, l1Info.OperatorFeeConstant, parsedIsthmusInfo.OperatorFeeConstant)
+}


### PR DESCRIPTION
**Description**

This pull request enhances the L1BlockInfoFromBytes function to properly handle activation blocks for Ecotone and Isthmus network upgrades. Previously, the function was using helper functions that would skip activation blocks, potentially causing incorrect data format handling during network upgrades.

The improved implementation now explicitly checks for activation blocks and applies the appropriate data format for each case, ensuring smooth transitions between different protocol versions.

**Tests**

Added a comprehensive test case TestL1BlockInfoFromBytes that verifies the correct behavior of the function with different block timestamps:

- Before Ecotone upgrade
- At Ecotone activation block
- After Ecotone but before Isthmus
- At Isthmus activation block
- After Isthmus upgrade
- 
The test ensures that each block type is correctly parsed with the appropriate format, and that activation blocks specifically use the previous format as required by the protocol.

**Additional context**

During network upgrades, the activation block itself needs special handling - it should use the previous format rather than the new one. This ensures that the chain can properly transition between different data formats without inconsistencies.
This fix is particularly important for maintaining chain stability during protocol upgrades and prevents potential issues with L1 block information parsing at upgrade boundaries.
