### PR TITLE
feat(op-acceptance-tests): add some starter gates.

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -1,15 +1,28 @@
 # Configuration file for acceptance tests (op-acceptor)
 #
 # All acceptance tests need to be registered here for op-acceptor to run them.
-#
-# Note: The current acceptance tests are placeholders; real ones to come soon.
+
+
 
 gates:
-  - id: localnet
-    description: "Localnet validation gate"
+  - id: holocene
+    description: "Holocene network tests."
     tests:
       - name: TestFindRPCEndpoints
-        package: github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/run
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
+        package: github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord
+
+  - id: isthmus
+    inherits:
+      - holocene
+    description: "Isthmus network tests."
+    tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
+
+  - id: interop
+    inherits:
+      - isthmus
+    description: "Interop network tests."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -6,12 +6,21 @@ ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-ac
 
 # Default recipe - runs acceptance tests
 default:
-    @just acceptance-test
+    @just acceptance-test simple holocene
+
+isthmus:
+    @just acceptance-test isthmus isthmus
+
+holocene:
+    @just acceptance-test simple holocene
+
 
 # Run acceptance tests with mise-managed binary
-acceptance-test devnet="simple" gate="localnet":
+acceptance-test devnet="simple" gate="holocene":
     #!/usr/bin/env bash
     set -euo pipefail
+
+    echo -e "DEVNET: {{devnet}}, GATE: {{gate}}\n"
 
     # Check if mise is installed
     if command -v mise >/dev/null; then
@@ -43,9 +52,11 @@ acceptance-test devnet="simple" gate="localnet":
     fi
 
 # Run acceptance tests against a devnet using Docker (fallback if needed)
-acceptance-test-docker devnet="simple" gate="localnet":
+acceptance-test-docker devnet="simple" gate="holocene":
     #!/usr/bin/env bash
     set -euo pipefail
+
+    echo -e "DEVNET: {{devnet}}, GATE: {{gate}}\n"
 
     # First run the appropriate devnet from the kurtosis-devnet directory if needed.
     # We ignore failures here because if the devnet is already running then this command will fail.
@@ -63,3 +74,7 @@ acceptance-test-docker devnet="simple" gate="localnet":
         --gate {{gate}} \
         --validators /acceptance-tests.yaml \
         --log.level debug
+
+
+clean:
+    kurtosis clean --all


### PR DESCRIPTION
**Description**

Splitting out the gates toward a more realistic end-goal.
This is required as we're about to make the testing more strict (https://github.com/ethereum-optimism/infra/pull/238) by not counting skipped tests as successes. So we need to choose an appropriate pairing of devnet to gate.

**Tests**

Ran it locally.

<img width="1186" alt="Screenshot 2025-03-17 at 18 22 03" src="https://github.com/user-attachments/assets/045be221-9ec6-4cc1-8726-0ce2fe7ad7f1" />

**Metadata**

- Closes https://github.com/ethereum-optimism/infra/issues/176
