### PR TITLE
fix typo in the code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ jobs:
         type: boolean
         default: false
       resource_class:
-        description: Docker resoruce class
+        description: Docker resource class
         type: string
         default: medium
     machine:


### PR DESCRIPTION
In resource class:

resource_class:
        description: Docker resoruce class
        type: string
        default: medium
        
corrected to:

resource_class:
        description: Docker resource class
        type: string
        default: medium