### PR TITLE
fix(kurtosis-devnet): correct fallback for user socket

### DIFF
--- a/kurtosis-devnet/pkg/build/docker.go
+++ b/kurtosis-devnet/pkg/build/docker.go
@@ -56,6 +56,9 @@ func (p *defaultDockerProvider) newClient() (dockerClient, error) {
 	opts := []client.Opt{client.FromEnv}
 
 	// Check if default docker socket exists
+	// See https://github.com/moby/moby/discussions/46015 :
+	// the ParseHostURL function does not technically support `unix`,
+	// and the non-scheme part just ends up in the `.Host` instead of `.Path`
 	hostURL, err := client.ParseHostURL(client.DefaultDockerHost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse default docker host: %w", err)
@@ -65,6 +68,8 @@ func (p *defaultDockerProvider) newClient() (dockerClient, error) {
 	if hostURL.Scheme == "unix" {
 		if _, err := os.Stat(hostURL.Host); os.IsNotExist(err) {
 			// Default socket doesn't exist, try alternate location. Docker Desktop uses ~/.docker/run/docker.sock
+			// Docker Desktop uses ~/.docker/run/docker.sock
+			// or also ~/.docker/desktop/docker.sock
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return nil, fmt.Errorf("failed to get user home directory: %w", err)
@@ -73,6 +78,7 @@ func (p *defaultDockerProvider) newClient() (dockerClient, error) {
 			if _, err := os.Stat(homeSocketHost); os.IsNotExist(err) {
 				return nil, errors.New("failed to find docker socket")
 			}
+			log.Printf("WARNING: using implied user docker socket: %q, make sure Kurtosis is running inside of the same docker context!", homeSocketHost)
 			socketURL := &url.URL{
 				Scheme: "unix",
 				Host:   homeSocketHost,

--- a/kurtosis-devnet/pkg/build/docker.go
+++ b/kurtosis-devnet/pkg/build/docker.go
@@ -63,19 +63,19 @@ func (p *defaultDockerProvider) newClient() (dockerClient, error) {
 
 	// For unix sockets, check if the socket file exists
 	if hostURL.Scheme == "unix" {
-		if _, err := os.Stat(hostURL.Path); os.IsNotExist(err) {
+		if _, err := os.Stat(hostURL.Host); os.IsNotExist(err) {
 			// Default socket doesn't exist, try alternate location. Docker Desktop uses ~/.docker/run/docker.sock
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return nil, fmt.Errorf("failed to get user home directory: %w", err)
 			}
-			homeSocketPath := fmt.Sprintf("%s/.docker/run/docker.sock", homeDir)
-			if _, err := os.Stat(homeSocketPath); os.IsNotExist(err) {
+			homeSocketHost := fmt.Sprintf("%s/.docker/run/docker.sock", homeDir)
+			if _, err := os.Stat(homeSocketHost); os.IsNotExist(err) {
 				return nil, errors.New("failed to find docker socket")
 			}
 			socketURL := &url.URL{
 				Scheme: "unix",
-				Path:   homeSocketPath,
+				Host:   homeSocketHost,
 			}
 			// prepend the host, so that it can still be overridden by the environment.
 			opts = append([]client.Opt{client.WithHost(socketURL.String())}, opts...)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

https://github.com/ethereum-optimism/optimism/pull/14884 handled when default docker socket path is not `/var/run/docker.sock` and uses `client.ParseHostURL(client.DefaultDockerHost)` to check that at this location exists.

From docker/docker package,
```go
func ParseHostURL(host string) (*url.URL, error) {
	proto, addr, ok := strings.Cut(host, "://")
	if !ok || addr == "" {
		return nil, errors.Errorf("unable to parse docker host `%s`", host)
	}

	var basePath string
	if proto == "tcp" {
		parsed, err := url.Parse("tcp://" + addr)
		if err != nil {
			return nil, err
		}
		addr = parsed.Host
		basePath = parsed.Path
	}
	return &url.URL{
		Scheme: proto,
		Host:   addr,
		Path:   basePath,
	}, nil
}
```
Since we are using unix socket, we can see `Path: basePath` is unpopulated but Host is. Fix to make our devnet-sdk code use Host instead of Path.

**Tests**

Checked local devnet sdk spins up normally.

**Additional Context**

Fetching proto's diff from https://github.com/ethereum-optimism/optimism/pull/14908
