### PR TITLE
op-e2e: Test that setting op fee pre-Isthmus is ignored

### DIFF
--- a/op-e2e/actions/helpers/l1_replica.go
+++ b/op-e2e/actions/helpers/l1_replica.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
@@ -233,6 +234,30 @@ func (s *L1Replica) FinalizedNum() uint64 {
 		finalizedNum = finalized.Number.Uint64()
 	}
 	return finalizedNum
+}
+
+func (s *L1Replica) UnsafeID() opeth.BlockID {
+	h := s.l1Chain.CurrentBlock()
+	if h == nil {
+		return opeth.BlockID{}
+	}
+	return opeth.HeaderBlockID(h)
+}
+
+func (s *L1Replica) SafeID() opeth.BlockID {
+	h := s.l1Chain.CurrentSafeBlock()
+	if h == nil {
+		return opeth.BlockID{}
+	}
+	return opeth.HeaderBlockID(h)
+}
+
+func (s *L1Replica) FinalizedID() opeth.BlockID {
+	h := s.l1Chain.CurrentFinalBlock()
+	if h == nil {
+		return opeth.BlockID{}
+	}
+	return opeth.HeaderBlockID(h)
 }
 
 // ActL1Finalize finalizes a later block, which must be marked as safe before doing so (see ActL1SafeNext).

--- a/op-e2e/actions/proofs/system_config_test.go
+++ b/op-e2e/actions/proofs/system_config_test.go
@@ -1,0 +1,136 @@
+package proofs_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+// Test_ProgramAction_SystemConfigEarlyUpgrade tests that setting the operator
+// fee parameters pre-Isthmus is ignored and doesn't cause problems during derivation.
+func Test_ProgramAction_SystemConfigEarlyUpgrade(gt *testing.T) {
+	matrix := helpers.NewMatrix[any]()
+	matrix.AddDefaultTestCases(
+		nil,
+		helpers.NewForkMatrix(helpers.Holocene),
+		testSystemConfigEarlyUpgrade,
+	)
+	matrix.Run(gt)
+}
+
+func testSystemConfigEarlyUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	const (
+		testOperatorFeeScalar   = uint32(20000)
+		testOperatorFeeConstant = uint64(500)
+		isthmusOffset           = 24
+	)
+
+	t := actionsHelpers.NewDefaultTesting(gt)
+	testSetup := func(dp *genesis.DeployConfig) {
+		dp.ActivateForkAtOffset(rollup.Isthmus, isthmusOffset)
+	}
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), testSetup)
+	sequencer := env.Sequencer
+	miner := env.Miner
+
+	sysCfg, err := bindings.NewSystemConfig(env.Sd.RollupCfg.L1SystemConfigAddress, env.Miner.EthClient())
+	require.NoError(t, err)
+	opts := &bind.CallOpts{}
+
+	sysCfgVerStr, err := sysCfg.Version(opts)
+	require.NoError(t, err)
+	t.Logf("SystemConfig version: %s", sysCfgVerStr)
+	ver, err := semver.NewVersion(sysCfgVerStr)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, ver.Major(), uint64(3), "expect Isthmus contracts or later")
+
+	opFeeScalarAndConstant := func() (uint32, uint64) {
+		t.Helper()
+		scalar, err := sysCfg.OperatorFeeScalar(opts)
+		require.NoError(t, err)
+		constant, err := sysCfg.OperatorFeeConstant(opts)
+		require.NoError(t, err)
+		return scalar, constant
+	}
+
+	scalar0, constant0 := opFeeScalarAndConstant()
+	require.Zero(t, scalar0)
+	require.Zero(t, constant0)
+
+	owner, err := sysCfg.Owner(opts)
+	require.NoError(t, err)
+	require.Equal(t, env.Dp.Addresses.Deployer, owner)
+	sysCfgOwner, err := bind.NewKeyedTransactorWithChainID(env.Dp.Secrets.Deployer, env.Sd.RollupCfg.L1ChainID)
+	require.NoError(t, err)
+
+	_, err = sysCfg.SetOperatorFeeScalars(sysCfgOwner, testOperatorFeeScalar, testOperatorFeeConstant)
+	require.NoError(t, err)
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(env.Dp.Addresses.Deployer)(t)
+	miner.ActL1EndBlock(t)
+	scalar1, constant1 := opFeeScalarAndConstant()
+	require.Equal(t, testOperatorFeeScalar, scalar1)
+	require.Equal(t, testOperatorFeeConstant, constant1)
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+	u1 := miner.UnsafeID()
+	env.BatchAndMine(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	syncStatus := sequencer.SyncStatus()
+	require.Equal(t, syncStatus.UnsafeL2, syncStatus.SafeL2)
+	require.Equal(t, u1, syncStatus.UnsafeL2.L1Origin)
+	require.False(t, env.Sd.RollupCfg.IsIsthmus(syncStatus.SafeL2.Time))
+
+	sequencer.ActBuildL2ToIsthmus(t)
+	sequencer.ActL2EmptyBlock(t) // one more to have Isthmus L1 info deposit
+	u2 := miner.UnsafeID()
+	env.BatchAndMine(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	syncStatus = sequencer.SyncStatus()
+	require.Equal(t, syncStatus.UnsafeL2, syncStatus.SafeL2)
+	require.Equal(t, syncStatus.UnsafeL2.L1Origin, u2)
+	require.True(t, env.Sd.RollupCfg.IsIsthmus(syncStatus.SafeL2.Time))
+
+	// Assert that operator fee params are zero since they were set before Isthmus activated.
+	l1infoTx := env.Engine.L2Chain().GetBlockByHash(syncStatus.SafeL2.Hash).Transactions()[0]
+	l1info, err := derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, syncStatus.SafeL2.Time, l1infoTx.Data())
+	require.NoError(t, err)
+	require.Zero(t, l1info.OperatorFeeConstant)
+	require.Zero(t, l1info.OperatorFeeScalar)
+
+	// Now set them again with Isthmus active and see that they are set correctly.
+	_, err = sysCfg.SetOperatorFeeScalars(sysCfgOwner, testOperatorFeeScalar, testOperatorFeeConstant)
+	require.NoError(t, err)
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(env.Dp.Addresses.Deployer)(t)
+	miner.ActL1EndBlock(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+	u3 := miner.UnsafeID()
+	env.BatchAndMine(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	syncStatus = sequencer.SyncStatus()
+	require.Equal(t, syncStatus.UnsafeL2, syncStatus.SafeL2)
+	require.Equal(t, u3, syncStatus.UnsafeL2.L1Origin)
+
+	l1infoTx = env.Engine.L2Chain().GetBlockByHash(syncStatus.SafeL2.Hash).Transactions()[0]
+	l1info, err = derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, syncStatus.SafeL2.Time, l1infoTx.Data())
+	require.NoError(t, err)
+	require.Equal(t, testOperatorFeeConstant, l1info.OperatorFeeConstant)
+	require.Equal(t, testOperatorFeeScalar, l1info.OperatorFeeScalar)
+
+	env.RunFaultProofProgram(t, syncStatus.SafeL2.Number, testCfg.CheckResult, testCfg.InputParams...)
+}

--- a/op-e2e/actions/proofs/system_config_test.go
+++ b/op-e2e/actions/proofs/system_config_test.go
@@ -13,26 +13,26 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// Test_ProgramAction_SystemConfigEarlyUpgrade tests that setting the operator
+// Test_ProgramAction_SystemConfigEarlyIsthmusUpgrade tests that setting the operator
 // fee parameters pre-Isthmus is ignored and doesn't cause problems during derivation.
-func Test_ProgramAction_SystemConfigEarlyUpgrade(gt *testing.T) {
+func Test_ProgramAction_SystemConfigEarlyIsthmusUpgrade(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	matrix.AddDefaultTestCases(
 		nil,
 		helpers.NewForkMatrix(helpers.Holocene),
-		testSystemConfigEarlyUpgrade,
+		testSystemConfigEarlyIsthmusUpgrade,
 	)
 	matrix.Run(gt)
 }
 
-func testSystemConfigEarlyUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) {
-	const (
-		testOperatorFeeScalar   = uint32(20000)
-		testOperatorFeeConstant = uint64(500)
-		isthmusOffset           = 24
-	)
+func testSystemConfigEarlyIsthmusUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	const isthmusOffset = 24
+
+	testOperatorFeeScalar := uint32(20000)
+	testOperatorFeeConstant := uint64(500)
 
 	t := actionsHelpers.NewDefaultTesting(gt)
 	testSetup := func(dp *genesis.DeployConfig) {
@@ -60,6 +60,15 @@ func testSystemConfigEarlyUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) 
 		constant, err := sysCfg.OperatorFeeConstant(opts)
 		require.NoError(t, err)
 		return scalar, constant
+	}
+
+	requireL1InfoParams := func(block eth.L2BlockRef, scalar uint32, constant uint64) {
+		t.Helper()
+		l1infoTx := env.Engine.L2Chain().GetBlockByHash(block.Hash).Transactions()[0]
+		l1info, err := derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, block.Time, l1infoTx.Data())
+		require.NoError(t, err)
+		require.Equal(t, scalar, l1info.OperatorFeeScalar)
+		require.Equal(t, constant, l1info.OperatorFeeConstant)
 	}
 
 	scalar0, constant0 := opFeeScalarAndConstant()
@@ -92,6 +101,9 @@ func testSystemConfigEarlyUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) 
 	require.Equal(t, u1, syncStatus.UnsafeL2.L1Origin)
 	require.False(t, env.Sd.RollupCfg.IsIsthmus(syncStatus.SafeL2.Time))
 
+	requireL1InfoParams(syncStatus.SafeL2, 0, 0)
+	env.RunFaultProofProgram(t, syncStatus.SafeL2.Number, testCfg.CheckResult, testCfg.InputParams...)
+
 	sequencer.ActBuildL2ToIsthmus(t)
 	sequencer.ActL2EmptyBlock(t) // one more to have Isthmus L1 info deposit
 	u2 := miner.UnsafeID()
@@ -104,12 +116,12 @@ func testSystemConfigEarlyUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) 
 	require.True(t, env.Sd.RollupCfg.IsIsthmus(syncStatus.SafeL2.Time))
 
 	// Assert that operator fee params are zero since they were set before Isthmus activated.
-	l1infoTx := env.Engine.L2Chain().GetBlockByHash(syncStatus.SafeL2.Hash).Transactions()[0]
-	l1info, err := derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, syncStatus.SafeL2.Time, l1infoTx.Data())
-	require.NoError(t, err)
-	require.Zero(t, l1info.OperatorFeeConstant)
-	require.Zero(t, l1info.OperatorFeeScalar)
+	requireL1InfoParams(syncStatus.SafeL2, 0, 0)
+	env.RunFaultProofProgram(t, syncStatus.SafeL2.Number, testCfg.CheckResult, testCfg.InputParams...)
 
+	// modify both to ensure we test with different parameters
+	testOperatorFeeScalar *= 2
+	testOperatorFeeConstant *= 2
 	// Now set them again with Isthmus active and see that they are set correctly.
 	_, err = sysCfg.SetOperatorFeeScalars(sysCfgOwner, testOperatorFeeScalar, testOperatorFeeConstant)
 	require.NoError(t, err)
@@ -126,11 +138,6 @@ func testSystemConfigEarlyUpgrade(gt *testing.T, testCfg *helpers.TestCfg[any]) 
 	require.Equal(t, syncStatus.UnsafeL2, syncStatus.SafeL2)
 	require.Equal(t, u3, syncStatus.UnsafeL2.L1Origin)
 
-	l1infoTx = env.Engine.L2Chain().GetBlockByHash(syncStatus.SafeL2.Hash).Transactions()[0]
-	l1info, err = derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, syncStatus.SafeL2.Time, l1infoTx.Data())
-	require.NoError(t, err)
-	require.Equal(t, testOperatorFeeConstant, l1info.OperatorFeeConstant)
-	require.Equal(t, testOperatorFeeScalar, l1info.OperatorFeeScalar)
-
+	requireL1InfoParams(syncStatus.SafeL2, testOperatorFeeScalar, testOperatorFeeConstant)
 	env.RunFaultProofProgram(t, syncStatus.SafeL2.Number, testCfg.CheckResult, testCfg.InputParams...)
 }


### PR DESCRIPTION

**Description**

Add a proofs action test that shows that setting the operator fee pre-Isthmus is just ignored and those params don't propagate into Isthmus.

**Additional context**

Shows that the proposed solution in this [P/PS (private)](https://www.notion.so/oplabs/P-PS-Deploy-Isthmus-L1-contracts-in-U14-1b6f153ee16280638e50e9a5ecb7612d#1b6f153ee162809ab5defadde8561cd3) is already implemented. The extra check may still be added in a follow-up to future-proof the code.

**Metadata**

Closes https://github.com/ethereum-optimism/protocol-team/issues/1
