### PR TITLE
op-e2e/actions: test batcher should not warn when safe head moves

### DIFF
--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -207,9 +207,8 @@ func (s *L2Batcher) Buffer(t Testing, opts ...BlockModifier) error {
 		s.L2BufferedBlock = syncStatus.SafeL2
 		s.L2ChannelOut = nil
 	}
-	// If it's lagging behind, catch it up.
 	if s.l2SubmittedBlock.Number < syncStatus.SafeL2.Number {
-		s.log.Warn("last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", s.l2SubmittedBlock, "safe", syncStatus.SafeL2)
+		s.log.Info("Safe head progressed, batch submission will continue from the new safe head now", "last", s.l2SubmittedBlock, "safe", syncStatus.SafeL2)
 		s.l2SubmittedBlock = syncStatus.SafeL2
 		s.L2BufferedBlock = syncStatus.SafeL2
 		s.L2ChannelOut = nil


### PR DESCRIPTION
This implementation of a batcher does not have block submission tracking fully implemented. Therefore it is expected that the "last submitted block" won't move before the safe head on the sequencer moves.

This change just marks that as expected behaviour to avoid sending devs on a wild goose chase when debugging.
