### PR TITLE
kt-devnet: message passing using access list

### DIFF
--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -101,6 +101,7 @@ type TransactionData interface {
 	To() *common.Address
 	Value() *big.Int
 	Data() []byte
+	AccessList() coreTypes.AccessList
 }
 
 // Transaction is the instantiated transaction object.

--- a/devnet-sdk/system/node.go
+++ b/devnet-sdk/system/node.go
@@ -40,10 +40,11 @@ func (n *node) GasLimit(ctx context.Context, tx TransactionData) (uint64, error)
 	}
 
 	msg := ethereum.CallMsg{
-		From:  tx.From(),
-		To:    tx.To(),
-		Value: tx.Value(),
-		Data:  tx.Data(),
+		From:       tx.From(),
+		To:         tx.To(),
+		Value:      tx.Value(),
+		Data:       tx.Data(),
+		AccessList: tx.AccessList(),
 	}
 	estimated, err := client.EstimateGas(ctx, msg)
 	if err != nil {

--- a/devnet-sdk/system/tx.go
+++ b/devnet-sdk/system/tx.go
@@ -41,6 +41,10 @@ func (opts *TxOpts) Data() []byte {
 	return opts.data
 }
 
+func (opts *TxOpts) AccessList() types.AccessList {
+	return opts.accessList
+}
+
 // Validate checks that all required fields are set and consistent
 func (opts *TxOpts) Validate() error {
 	// Check mandatory fields
@@ -189,6 +193,10 @@ func (t *EthTx) Value() *big.Int {
 
 func (t *EthTx) Data() []byte {
 	return t.tx.Data()
+}
+
+func (t *EthTx) AccessList() types.AccessList {
+	return t.tx.AccessList()
 }
 
 func (t *EthTx) Type() uint8 {

--- a/devnet-sdk/system/txprocessor_test.go
+++ b/devnet-sdk/system/txprocessor_test.go
@@ -207,9 +207,10 @@ type mockTransaction struct {
 	from common.Address
 }
 
-func (m *mockTransaction) Hash() common.Hash    { return common.Hash{} }
-func (m *mockTransaction) From() common.Address { return m.from }
-func (m *mockTransaction) To() *common.Address  { return nil }
-func (m *mockTransaction) Value() *big.Int      { return nil }
-func (m *mockTransaction) Data() []byte         { return nil }
-func (m *mockTransaction) Type() uint8          { return 0 }
+func (m *mockTransaction) Hash() common.Hash            { return common.Hash{} }
+func (m *mockTransaction) From() common.Address         { return m.from }
+func (m *mockTransaction) To() *common.Address          { return nil }
+func (m *mockTransaction) Value() *big.Int              { return nil }
+func (m *mockTransaction) Data() []byte                 { return nil }
+func (m *mockTransaction) AccessList() types.AccessList { return nil }
+func (m *mockTransaction) Type() uint8                  { return 0 }

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -489,6 +489,9 @@ func ToCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasPrice != nil {
 		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
 	}
+	if msg.AccessList != nil {
+		arg["accessList"] = msg.AccessList
+	}
 	return arg
 }
 

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -66,15 +66,22 @@ type Message struct {
 	PayloadHash common.Hash `json:"payloadHash"`
 }
 
-func (m *Message) Checksum() MessageChecksum {
-	args := ChecksumArgs{
+func (m *Message) ToCheckSumArgs() ChecksumArgs {
+	return ChecksumArgs{
 		BlockNumber: m.Identifier.BlockNumber,
 		LogIndex:    m.Identifier.LogIndex,
 		Timestamp:   m.Identifier.Timestamp,
 		ChainID:     m.Identifier.ChainID,
 		LogHash:     PayloadHashToLogHash(m.PayloadHash, m.Identifier.Origin),
 	}
-	return args.Checksum()
+}
+
+func (m *Message) Checksum() MessageChecksum {
+	return m.ToCheckSumArgs().Checksum()
+}
+
+func (m *Message) Access() Access {
+	return m.ToCheckSumArgs().Access()
 }
 
 type ChecksumArgs struct {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Access lists are required for executing interop txs after https://github.com/ethereum-optimism/optimism/pull/14831. This caused to break current interop message passing test.

**Tests**

Ensured that all the existing tests are passing, especially `TestMessagePassing`.
