### PR TITLE
devnet-sdk: Go in-process backend

### DIFF
--- a/devnet-sdk/system2/l2_network.go
+++ b/devnet-sdk/system2/l2_network.go
@@ -38,6 +38,7 @@ func SortL2NetworkIDs(ids []L2NetworkID) []L2NetworkID {
 
 type L2Deployment interface {
 	SystemConfigProxyAddr() common.Address
+	DisputeGameFactoryProxyAddr() common.Address
 	// Other addresses will be added here later
 }
 

--- a/devnet-sdk/systemext/addrbook.go
+++ b/devnet-sdk/systemext/addrbook.go
@@ -11,6 +11,7 @@ const (
 	SuperchainConfigAddressName = "superchainConfigProxy"
 
 	SystemConfigAddressName = "systemConfigProxy"
+	DisputeGameFactoryName  = "disputeGameFactoryProxy"
 )
 
 type l1AddressBook struct {
@@ -43,20 +44,28 @@ func (a *l1AddressBook) SuperchainConfigAddr() common.Address {
 var _ system2.SuperchainDeployment = (*l1AddressBook)(nil)
 
 type l2AddressBook struct {
-	systemConfig common.Address
+	systemConfig       common.Address
+	disputeGameFactory common.Address
 }
 
 func newL2AddressBook(setup *system2.Setup, l1Addresses descriptors.AddressMap) *l2AddressBook {
 	systemConfig, ok := l1Addresses[SystemConfigAddressName]
 	setup.Require.True(ok)
+	disputeGameFactory, ok := l1Addresses[DisputeGameFactoryName]
+	setup.Require.True(ok)
 
 	return &l2AddressBook{
-		systemConfig: systemConfig,
+		systemConfig:       systemConfig,
+		disputeGameFactory: disputeGameFactory,
 	}
 }
 
 func (a *l2AddressBook) SystemConfigProxyAddr() common.Address {
 	return a.systemConfig
+}
+
+func (a *l2AddressBook) DisputeGameFactoryProxyAddr() common.Address {
+	return a.disputeGameFactory
 }
 
 var _ system2.L2Deployment = (*l2AddressBook)(nil)

--- a/devnet-sdk/systemgo/interopgen.go
+++ b/devnet-sdk/systemgo/interopgen.go
@@ -1,0 +1,171 @@
+package systemgo
+
+import (
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type ContractPaths struct {
+	FoundryArtifacts string
+	SourceMap        string
+}
+
+type L2Deployment struct {
+	systemConfigProxyAddr   common.Address
+	disputeGameFactoryProxy common.Address
+}
+
+var _ system2.L2Deployment = &L2Deployment{}
+
+func (d *L2Deployment) SystemConfigProxyAddr() common.Address {
+	return d.systemConfigProxyAddr
+}
+
+func (d *L2Deployment) DisputeGameFactoryProxyAddr() common.Address {
+	return d.disputeGameFactoryProxy
+}
+
+type SuperchainDeployment struct {
+	protocolVersionsAddr common.Address
+	superchainConfigAddr common.Address
+}
+
+var _ system2.SuperchainDeployment = &SuperchainDeployment{}
+
+func (d *SuperchainDeployment) SuperchainConfigAddr() common.Address {
+	return d.superchainConfigAddr
+}
+
+func (d *SuperchainDeployment) ProtocolVersionsAddr() common.Address {
+	return d.protocolVersionsAddr
+}
+
+// WithInteropGen is a system option that will create a L1 chain, superchain, cluster and L2 chains.
+func WithInteropGen(l1ID system2.L1NetworkID, superchainID system2.SuperchainID,
+	clusterID system2.ClusterID, l2IDs []system2.L2NetworkID, res ContractPaths) system2.Option {
+
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+
+		setup.Require.True(l1ID.ChainID.ToBig().IsInt64(), "interop gen uses small chain IDs")
+		genesisTime := uint64(time.Now().Add(time.Second * 2).Unix())
+		recipe := &interopgen.InteropDevRecipe{
+			L1ChainID:        l1ID.ChainID.ToBig().Uint64(),
+			L2s:              []interopgen.InteropDevL2Recipe{},
+			GenesisTimestamp: genesisTime,
+		}
+		for _, l2 := range l2IDs {
+			setup.Require.True(l2.ChainID.ToBig().IsInt64(), "interop gen uses small chain IDs")
+			recipe.L2s = append(recipe.L2s, interopgen.InteropDevL2Recipe{
+				ChainID:   l2.ChainID.ToBig().Uint64(),
+				BlockTime: 2,
+			})
+		}
+
+		worldCfg, err := recipe.Build(orch.keys)
+		setup.Require.NoError(err)
+
+		// create a logger for the world configuration
+		logger := setup.Log.New("role", "world")
+		setup.Require.NoError(worldCfg.Check(logger))
+
+		// create the foundry artifacts and source map
+		foundryArtifacts := foundry.OpenArtifactsDir(res.FoundryArtifacts)
+		sourceMap := foundry.NewSourceMapFS(os.DirFS(res.SourceMap))
+
+		for addr := range worldCfg.L1.Prefund {
+			logger.Info("Configuring pre-funded L1 account", "addr", addr)
+		}
+
+		// deploy the world, using the logger, foundry artifacts, source map, and world configuration
+		worldDeployment, worldOutput, err := interopgen.Deploy(logger, foundryArtifacts, sourceMap, worldCfg)
+		setup.Require.NoError(err)
+
+		l1Net := &L1Network{
+			genesis:   worldOutput.L1.Genesis,
+			blockTime: 6,
+		}
+		orch.l1Nets.Set(l1ID, l1Net)
+
+		sysL1Net := system2.NewL1Network(system2.L1NetworkConfig{
+			NetworkConfig: system2.NetworkConfig{
+				CommonConfig: setup.CommonConfig(),
+				ChainConfig:  worldOutput.L1.Genesis.Config,
+			},
+			ID: l1ID,
+		})
+		setup.System.AddL1Network(sysL1Net)
+
+		sysSuperchain := system2.NewSuperchain(system2.SuperchainConfig{
+			CommonConfig: setup.CommonConfig(),
+			ID:           superchainID,
+			Deployment: &SuperchainDeployment{
+				protocolVersionsAddr: worldDeployment.Superchain.ProtocolVersions,
+				superchainConfigAddr: worldDeployment.Superchain.SuperchainConfig,
+			},
+		})
+		setup.System.AddSuperchain(sysSuperchain)
+
+		depSetContents := make(map[eth.ChainID]*depset.StaticConfigDependency)
+		for _, l2Out := range worldOutput.L2s {
+			chainID := eth.ChainIDFromBig(l2Out.Genesis.Config.ChainID)
+			index, err := chainID.ToUInt32()
+			setup.Require.NoError(err)
+			depSetContents[chainID] = &depset.StaticConfigDependency{
+				ChainIndex:     supervisortypes.ChainIndex(index),
+				ActivationTime: 0,
+				HistoryMinTime: 0,
+			}
+		}
+		staticDepSet, err := depset.NewStaticConfigDependencySet(depSetContents)
+		setup.Require.NoError(err)
+
+		sysCluster := system2.NewCluster(system2.ClusterConfig{
+			CommonConfig:  setup.CommonConfig(),
+			ID:            clusterID,
+			DependencySet: staticDepSet,
+		})
+		setup.System.AddCluster(sysCluster)
+
+		for _, l2ID := range l2IDs {
+			l2Out, ok := worldOutput.L2s[l2ID.ChainID.String()]
+			setup.Require.True(ok, "L2 output must exist")
+			l2Dep, ok := worldDeployment.L2s[l2ID.ChainID.String()]
+			setup.Require.True(ok, "L2 deployment must exist")
+
+			l2Net := &L2Network{
+				genesis:   l2Out.Genesis,
+				rollupCfg: l2Out.RollupCfg,
+			}
+			orch.l2Nets.Set(l2ID, l2Net)
+
+			dep := &L2Deployment{
+				systemConfigProxyAddr:   l2Dep.SystemConfigProxy,
+				disputeGameFactoryProxy: l2Dep.DisputeGameFactoryProxy,
+			}
+			sysL2Net := system2.NewL2Network(system2.L2NetworkConfig{
+				NetworkConfig: system2.NetworkConfig{
+					CommonConfig: setup.CommonConfig(),
+					ChainConfig:  l2Out.Genesis.Config,
+				},
+				ID:           l2ID,
+				RollupConfig: l2Out.RollupCfg,
+				Deployment:   dep,
+				Keys:         &keyring{keys: orch.keys, require: setup.Require},
+				Superchain:   nil,
+				L1:           sysL1Net,
+				Cluster:      nil,
+			})
+			setup.System.AddL2Network(sysL2Net)
+		}
+	}
+}

--- a/devnet-sdk/systemgo/keyring.go
+++ b/devnet-sdk/systemgo/keyring.go
@@ -1,0 +1,31 @@
+package systemgo
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+)
+
+type keyring struct {
+	keys    devkeys.Keys
+	require *require.Assertions
+}
+
+var _ system2.L2Keys = (*keyring)(nil)
+
+func (k *keyring) Secret(key devkeys.Key) *ecdsa.PrivateKey {
+	pk, err := k.keys.Secret(key)
+	k.require.NoError(err)
+	return pk
+}
+
+func (k *keyring) Address(key devkeys.Key) common.Address {
+	addr, err := k.keys.Address(key)
+	k.require.NoError(err)
+	return addr
+}

--- a/devnet-sdk/systemgo/keys.go
+++ b/devnet-sdk/systemgo/keys.go
@@ -1,0 +1,15 @@
+package systemgo
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+)
+
+func WithMnemonicKeys(mnemonic string) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+		hd, err := devkeys.NewMnemonicDevKeys(mnemonic)
+		setup.Require.NoError(err)
+		orch.keys = hd
+	}
+}

--- a/devnet-sdk/systemgo/l1_network.go
+++ b/devnet-sdk/systemgo/l1_network.go
@@ -1,0 +1,8 @@
+package systemgo
+
+import "github.com/ethereum/go-ethereum/core"
+
+type L1Network struct {
+	genesis   *core.Genesis
+	blockTime uint64
+}

--- a/devnet-sdk/systemgo/l1_nodes.go
+++ b/devnet-sdk/systemgo/l1_nodes.go
@@ -1,0 +1,103 @@
+package systemgo
+
+import (
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+)
+
+type L1ELNode struct {
+	userRPC  string
+	l1Geth   *geth.GethInstance
+	blobPath string
+}
+
+type L1CLNode struct {
+	beaconHTTPAddr string
+	beacon         *fakebeacon.FakeBeacon
+}
+
+func WithL1Nodes(l1ELID system2.L1ELNodeID, l1CLID system2.L1CLNodeID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+
+		l1NetID := setup.System.L1NetworkID(l1ELID.ChainID)
+		l1Net, ok := orch.l1Nets.Get(l1NetID)
+		setup.Require.True(ok, "L1 network must exist")
+
+		sysL1Net := setup.System.L1Network(l1NetID).(system2.ExtensibleL1Network)
+
+		blockTimeL1 := l1Net.blockTime
+		l1FinalizedDistance := uint64(3)
+		l1Clock := clock.SystemClock
+		if orch.timeTravelClock != nil {
+			l1Clock = orch.timeTravelClock
+		}
+
+		blobPath := orch.t.TempDir()
+
+		clLog := setup.Log.New("id", l1CLID)
+		bcn := fakebeacon.NewBeacon(clLog, e2eutils.NewBlobStore(), l1Net.genesis.Timestamp, blockTimeL1)
+		orch.t.Cleanup(func() {
+			_ = bcn.Close()
+		})
+		setup.Require.NoError(bcn.Start("127.0.0.1:0"))
+		beaconApiAddr := bcn.BeaconAddr()
+		setup.Require.NotEmpty(beaconApiAddr, "beacon API listener must be up")
+
+		l1Geth, err := geth.InitL1(
+			blockTimeL1,
+			l1FinalizedDistance,
+			l1Net.genesis,
+			l1Clock,
+			filepath.Join(blobPath, "l1_el"),
+			bcn)
+		setup.Require.NoError(err)
+		setup.Require.NoError(l1Geth.Node.Start())
+		orch.t.Cleanup(func() {
+			clLog.Info("Closing L1 geth")
+			_ = l1Geth.Close()
+		})
+
+		l1ELNode := &L1ELNode{
+			userRPC:  l1Geth.Node.HTTPEndpoint(),
+			l1Geth:   l1Geth,
+			blobPath: blobPath,
+		}
+		setup.Require.True(orch.l1ELs.SetIfMissing(l1ELID, l1ELNode), "must not already exist")
+
+		l1CLNode := &L1CLNode{
+			beaconHTTPAddr: beaconApiAddr,
+			beacon:         bcn,
+		}
+		setup.Require.True(orch.l1CLs.SetIfMissing(l1CLID, l1CLNode), "must not already exist")
+
+		elClient, err := client.NewRPC(setup.Ctx, setup.Log, l1ELNode.userRPC, client.WithLazyDial())
+		setup.Require.NoError(err)
+
+		sysL1Net.AddL1ELNode(
+			system2.NewL1ELNode(system2.L1ELNodeConfig{
+				ID: l1ELID,
+				ELNodeConfig: system2.ELNodeConfig{
+					CommonConfig: setup.CommonConfig(),
+					Client:       elClient,
+					ChainID:      l1ELID.ChainID,
+				},
+			}),
+		)
+
+		beaconCl := client.NewBasicHTTPClient(bcn.BeaconAddr(), clLog)
+		sysL1Net.AddL1CLNode(
+			system2.NewL1CLNode(system2.L1CLNodeConfig{
+				CommonConfig: setup.CommonConfig(),
+				ID:           l1CLID,
+				Client:       beaconCl,
+			}),
+		)
+	}
+}

--- a/devnet-sdk/systemgo/l2_batcher.go
+++ b/devnet-sdk/systemgo/l2_batcher.go
@@ -1,0 +1,113 @@
+package systemgo
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+type L2Batcher struct {
+	service *bss.BatcherService
+	rpc     string
+	l1RPC   string
+	l2CLRPC string
+	l2ELRPC string
+}
+
+func WithBatcher(batcherID system2.L2BatcherID, l1ELID system2.L1ELNodeID, l2CLID system2.L2CLNodeID, l2ELID system2.L2ELNodeID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+		setup.Require.False(orch.batchers.Has(batcherID), "batcher must not already exist")
+
+		l2ID := setup.System.L2NetworkID(l2CLID.ChainID)
+		l2Chain := setup.System.L2Network(l2ID).(system2.ExtensibleL2Network)
+
+		l1ID := setup.System.L1NetworkID(l1ELID.ChainID)
+		setup.Require.Equal(l2Chain.L1().ID(), l1ID, "expecting L1EL on L1 of L2CL")
+
+		setup.Require.Equal(l2CLID.ChainID, l2ELID.ChainID, "L2 CL and EL must be on same L2 chain")
+
+		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		setup.Require.True(ok)
+
+		l2CL, ok := orch.l2CLs.Get(l2CLID)
+		setup.Require.True(ok)
+
+		l2EL, ok := orch.l2ELs.Get(l2ELID)
+		setup.Require.True(ok)
+
+		batcherSecret, err := orch.keys.Secret(devkeys.BatcherRole.Key(l2ELID.ChainID.ToBig()))
+		setup.Require.NoError(err)
+
+		logger := setup.Log.New("id", batcherID)
+		logger.Info("Batcher key acquired", "addr", crypto.PubkeyToAddress(batcherSecret.PublicKey))
+
+		batcherCLIConfig := &bss.CLIConfig{
+			L1EthRpc:                 l1EL.userRPC,
+			L2EthRpc:                 l2EL.userRPC,
+			RollupRpc:                l2CL.rpc,
+			MaxPendingTransactions:   1,
+			MaxChannelDuration:       1,
+			MaxL1TxSize:              120_000,
+			TestUseMaxTxSizeForBlobs: false,
+			TargetNumFrames:          1,
+			ApproxComprRatio:         0.4,
+			SubSafetyMargin:          4,
+			PollInterval:             500 * time.Millisecond,
+			TxMgrConfig:              setuputils.NewTxMgrConfig(endpoint.URL(l1EL.userRPC), batcherSecret),
+			LogConfig: oplog.CLIConfig{
+				Level:  log.LevelInfo,
+				Format: oplog.FormatText,
+			},
+			Stopped:               false,
+			BatchType:             derive.SpanBatchType,
+			MaxBlocksPerSpanBatch: 10,
+			DataAvailabilityType:  batcherFlags.CalldataType,
+			CompressionAlgo:       derive.Brotli,
+		}
+
+		batcher, err := bss.BatcherServiceFromCLIConfig(
+			setup.Ctx, "0.0.1", batcherCLIConfig,
+			logger.New("service", "batcher"))
+		setup.Require.NoError(err)
+		setup.Require.NoError(batcher.Start(setup.Ctx))
+		orch.t.Cleanup(func() {
+			ctx, cancel := context.WithCancel(setup.Ctx)
+			cancel() // force-quit
+			logger.Info("Closing batcher")
+			_ = batcher.Stop(ctx)
+			logger.Info("Closed batcher")
+		})
+
+		b := &L2Batcher{
+			service: batcher,
+			rpc:     batcher.HTTPEndpoint(),
+			l1RPC:   l1EL.userRPC,
+			l2CLRPC: l2CL.rpc,
+			l2ELRPC: l2EL.userRPC,
+		}
+		orch.batchers.Set(batcherID, b)
+
+		rpcCl, err := client.NewRPC(setup.Ctx, setup.Log, b.rpc, client.WithLazyDial())
+		setup.Require.NoError(err)
+
+		bFrontend := system2.NewL2Batcher(system2.L2BatcherConfig{
+			CommonConfig: setup.CommonConfig(),
+			ID:           batcherID,
+			Client:       rpcCl,
+		})
+		l2Chain.AddL2Batcher(bFrontend)
+	}
+}

--- a/devnet-sdk/systemgo/l2_cl.go
+++ b/devnet-sdk/systemgo/l2_cl.go
@@ -1,0 +1,138 @@
+package systemgo
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
+	"github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+type L2CLNode struct {
+	opNode *opnode.Opnode
+	rpc    string
+}
+
+func WithL2CLNode(l2CLID system2.L2CLNodeID, isSequencer bool, l1CLID system2.L1CLNodeID, l1ELID system2.L1ELNodeID, l2ELID system2.L2ELNodeID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+
+		l2ID := setup.System.L2NetworkID(l2CLID.ChainID)
+		sysL2 := setup.System.L2Network(l2ID).(system2.ExtensibleL2Network)
+
+		l2Net, ok := orch.l2Nets.Get(l2ID)
+		setup.Require.True(ok, "l2 network required")
+
+		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		setup.Require.True(ok, "l1 EL node required")
+
+		l1CL, ok := orch.l1CLs.Get(l1CLID)
+		setup.Require.True(ok, "l1 CL node required")
+
+		l2EL, ok := orch.l2ELs.Get(l2ELID)
+		setup.Require.True(ok, "l2 EL node required")
+
+		jwtPath, jwtSecret := orch.writeDefaultJWT()
+
+		var p2pSigner *p2p.PreparedSigner
+		if isSequencer {
+			p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID.ToBig()))
+			setup.Require.NoError(err, "need p2p key for sequencer")
+			p2pSigner = &p2p.PreparedSigner{Signer: opsigner.NewLocalSigner(p2pKey)}
+		}
+
+		nodeCfg := &node.Config{
+			L1: &node.L1EndpointConfig{
+				L1NodeAddr:       l1EL.userRPC,
+				L1TrustRPC:       false,
+				L1RPCKind:        sources.RPCKindDebugGeth,
+				RateLimit:        0,
+				BatchSize:        20,
+				HttpPollInterval: time.Millisecond * 100,
+				MaxConcurrency:   10,
+				CacheSize:        0, // auto-adjust to sequence window
+			},
+			L2: &node.L2EndpointConfig{
+				L2EngineAddr:      l2EL.authRPC,
+				L2EngineJWTSecret: jwtSecret,
+			},
+			Beacon: &node.L1BeaconEndpointConfig{
+				BeaconAddr: l1CL.beacon.BeaconAddr(),
+			},
+			Driver: driver.Config{
+				SequencerEnabled: isSequencer,
+			},
+			Rollup:    *l2Net.rollupCfg,
+			P2PSigner: p2pSigner,
+			RPC: node.RPCConfig{
+				ListenAddr:  "127.0.0.1",
+				ListenPort:  0,
+				EnableAdmin: true,
+			},
+			InteropConfig: &interop.Config{
+				RPCAddr:          "127.0.0.1",
+				RPCPort:          0,
+				RPCJwtSecretPath: jwtPath,
+			},
+			P2P:                         nil, // disabled P2P setup for now
+			L1EpochPollInterval:         time.Second * 2,
+			RuntimeConfigReloadInterval: 0,
+			Tracer:                      nil,
+			Sync: sync.Config{
+				SyncMode:                       sync.CLSync,
+				SkipSyncStartCheck:             false,
+				SupportsPostFinalizationELSync: false,
+			},
+			ConfigPersistence:               node.DisabledConfigPersistence{},
+			Metrics:                         node.MetricsConfig{},
+			Pprof:                           oppprof.CLIConfig{},
+			SafeDBPath:                      "",
+			RollupHalt:                      "",
+			Cancel:                          nil,
+			ConductorEnabled:                false,
+			ConductorRpc:                    nil,
+			ConductorRpcTimeout:             0,
+			AltDA:                           altda.CLIConfig{},
+			IgnoreMissingPectraBlobSchedule: false,
+		}
+		logger := setup.Log.New("service", "op-node", "id", l2CLID)
+		opNode, err := opnode.NewOpnode(logger, nodeCfg, func(err error) {
+			setup.Require.NoError(err, "op-node critical error")
+		})
+		setup.Require.NoError(err, "op-node failed to start")
+		orch.t.Cleanup(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // force-quit
+			logger.Info("Closing op-node")
+			closeErr := opNode.Stop(ctx)
+			logger.Info("Closed op-node", "err", closeErr)
+		})
+
+		l2CLNode := &L2CLNode{
+			opNode: opNode,
+			rpc:    opNode.UserRPC().RPC(),
+		}
+		setup.Require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), "must not already exist")
+
+		rollupClient, err := client.NewRPC(setup.Ctx, logger, l2CLNode.rpc, client.WithLazyDial())
+		setup.Require.NoError(err)
+
+		sysL2CL := system2.NewL2CLNode(system2.L2CLNodeConfig{
+			CommonConfig: setup.CommonConfig(),
+			ID:           l2CLID,
+			Client:       rollupClient,
+		})
+		sysL2.AddL2CLNode(sysL2CL)
+	}
+}

--- a/devnet-sdk/systemgo/l2_el.go
+++ b/devnet-sdk/systemgo/l2_el.go
@@ -1,0 +1,73 @@
+package systemgo
+
+import (
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	gn "github.com/ethereum/go-ethereum/node"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+)
+
+type L2ELNode struct {
+	authRPC string
+	userRPC string
+}
+
+func WithL2ELNode(id system2.L2ELNodeID, supervisorID *system2.SupervisorID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+
+		l2ID := setup.System.L2NetworkID(id.ChainID)
+
+		l2Net, ok := orch.l2Nets.Get(l2ID)
+		setup.Require.True(ok, "L2 network required")
+
+		sysL2Net := setup.System.L2Network(l2ID).(system2.ExtensibleL2Network)
+
+		jwtPath, _ := orch.writeDefaultJWT()
+
+		useInterop := sysL2Net.ChainConfig().InteropTime != nil
+
+		supervisorRPC := ""
+		if useInterop {
+			setup.Require.NotNil(supervisorID, "supervisor is required for interop")
+			sup, ok := orch.supervisors.Get(*supervisorID)
+			setup.Require.True(ok, "supervisor is required for interop")
+			supervisorRPC = sup.userRPC
+		}
+
+		l2Geth, err := geth.InitL2(id.String(), l2Net.genesis, jwtPath,
+			func(ethCfg *ethconfig.Config, nodeCfg *gn.Config) error {
+				ethCfg.InteropMessageRPC = supervisorRPC
+				ethCfg.InteropMempoolFiltering = true // TODO option
+				return nil
+			})
+		setup.Require.NoError(err)
+		setup.Require.NoError(l2Geth.Node.Start())
+		orch.t.Cleanup(func() {
+			setup.Log.Info("Closing op-geth", "id", id)
+			closeErr := l2Geth.Close()
+			setup.Log.Info("Closed op-geth", "id", id, "err", closeErr)
+		})
+
+		rpcCl, err := client.NewRPC(setup.Ctx, setup.Log, l2Geth.UserRPC().RPC(), client.WithLazyDial())
+		setup.Require.NoError(err)
+
+		l2EL := &L2ELNode{
+			authRPC: l2Geth.AuthRPC().RPC(),
+			userRPC: l2Geth.UserRPC().RPC(),
+		}
+		setup.Require.True(orch.l2ELs.SetIfMissing(id, l2EL), "must be unique L2 EL node")
+
+		sysL2EL := system2.NewL2ELNode(system2.L2ELNodeConfig{
+			ELNodeConfig: system2.ELNodeConfig{
+				CommonConfig: setup.CommonConfig(),
+				Client:       rpcCl,
+				ChainID:      id.ChainID,
+			},
+			ID: id,
+		})
+		sysL2Net.AddL2ELNode(sysL2EL)
+	}
+}

--- a/devnet-sdk/systemgo/l2_network.go
+++ b/devnet-sdk/systemgo/l2_network.go
@@ -1,0 +1,11 @@
+package systemgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/core"
+)
+
+type L2Network struct {
+	genesis   *core.Genesis
+	rollupCfg *rollup.Config
+}

--- a/devnet-sdk/systemgo/l2_proposer.go
+++ b/devnet-sdk/systemgo/l2_proposer.go
@@ -1,0 +1,106 @@
+package systemgo
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
+	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+)
+
+type L2Proposer struct {
+	service *ps.ProposerService
+	userRPC string
+}
+
+func WithProposer(proposerID system2.L2ProposerID, l1ELID system2.L1ELNodeID,
+	l2CLID *system2.L2CLNodeID, supervisorID *system2.SupervisorID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+		setup.Require.False(orch.proposers.Has(proposerID), "proposer must not already exist")
+
+		proposerSecret, err := orch.keys.Secret(devkeys.ProposerRole.Key(proposerID.ChainID.ToBig()))
+		setup.Require.NoError(err)
+
+		logger := setup.Log.New("id", proposerID)
+		logger.Info("Proposer key acquired", "addr", crypto.PubkeyToAddress(proposerSecret.PublicKey))
+
+		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		setup.Require.True(ok)
+
+		l2ID := setup.System.L2NetworkID(proposerID.ChainID)
+		l2Net := setup.System.L2Network(l2ID).(system2.ExtensibleL2Network)
+		disputeGameFactoryAddr := l2Net.Deployment().DisputeGameFactoryProxyAddr()
+
+		proposerCLIConfig := &ps.CLIConfig{
+			L1EthRpc:          l1EL.userRPC,
+			L2OOAddress:       "", // legacy, not used, fault-proofs support only for now.
+			PollInterval:      500 * time.Millisecond,
+			AllowNonFinalized: true,
+			TxMgrConfig:       setuputils.NewTxMgrConfig(endpoint.URL(l1EL.userRPC), proposerSecret),
+			RPCConfig:         oprpc.CLIConfig{},
+			LogConfig: oplog.CLIConfig{
+				Level:  log.LvlInfo,
+				Format: oplog.FormatText,
+			},
+			MetricsConfig:                opmetrics.CLIConfig{},
+			PprofConfig:                  oppprof.CLIConfig{},
+			DGFAddress:                   disputeGameFactoryAddr.Hex(),
+			ProposalInterval:             6 * time.Second,
+			DisputeGameType:              1, // Permissioned game type is the only one currently deployed
+			ActiveSequencerCheckDuration: time.Second * 5,
+			WaitNodeSync:                 false,
+		}
+
+		if l2Net.ChainConfig().InteropTime != nil {
+			setup.Require.NotNil(supervisorID, "need supervisor to connect to in interop")
+			supervisorNode, ok := orch.supervisors.Get(*supervisorID)
+			setup.Require.True(ok)
+			proposerCLIConfig.SupervisorRpcs = []string{supervisorNode.userRPC}
+		} else {
+			setup.Require.NotNil(*l2CLID, "need L2 CL to connect to pre-interop")
+			l2CL, ok := orch.l2CLs.Get(*l2CLID)
+			setup.Require.True(ok)
+			proposerCLIConfig.RollupRpc = l2CL.rpc
+		}
+
+		proposer, err := ps.ProposerServiceFromCLIConfig(context.Background(), "0.0.1", proposerCLIConfig, logger)
+		setup.Require.NoError(err)
+
+		setup.Require.NoError(proposer.Start(setup.Ctx))
+		orch.t.Cleanup(func() {
+			ctx, cancel := context.WithCancel(setup.Ctx)
+			cancel() // force-quit
+			logger.Info("Closing proposer")
+			_ = proposer.Stop(ctx)
+			logger.Info("Closed proposer")
+		})
+
+		p := &L2Proposer{
+			service: proposer,
+			userRPC: proposer.HTTPEndpoint(),
+		}
+		orch.proposers.Set(proposerID, p)
+
+		rpcCl, err := client.NewRPC(setup.Ctx, setup.Log, p.userRPC, client.WithLazyDial())
+		setup.Require.NoError(err)
+
+		bFrontend := system2.NewL2Proposer(system2.L2ProposerConfig{
+			CommonConfig: setup.CommonConfig(),
+			ID:           proposerID,
+			Client:       rpcCl,
+		})
+		l2Net.AddL2Proposer(bFrontend)
+	}
+}

--- a/devnet-sdk/systemgo/orchestrator.go
+++ b/devnet-sdk/systemgo/orchestrator.go
@@ -1,0 +1,59 @@
+package systemgo
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+type T interface {
+	system2.T
+	TempDir() string
+	Cleanup(func()) // this orchestrator will shut down its components at the end of the test
+}
+
+type Orchestrator struct {
+	t T
+
+	keys devkeys.Keys
+
+	// nil if no time travel is supported
+	timeTravelClock *clock.AdvancingClock
+
+	l1Nets      locks.RWMap[system2.L1NetworkID, *L1Network]
+	l2Nets      locks.RWMap[system2.L2NetworkID, *L2Network]
+	l1ELs       locks.RWMap[system2.L1ELNodeID, *L1ELNode]
+	l1CLs       locks.RWMap[system2.L1CLNodeID, *L1CLNode]
+	l2ELs       locks.RWMap[system2.L2ELNodeID, *L2ELNode]
+	l2CLs       locks.RWMap[system2.L2CLNodeID, *L2CLNode]
+	supervisors locks.RWMap[system2.SupervisorID, *Supervisor]
+	batchers    locks.RWMap[system2.L2BatcherID, *L2Batcher]
+	//challengers locks.RWMap[system2.L2ChallengerID, *L2Challenger] // TODO(#15057): op-challenger support
+	proposers locks.RWMap[system2.L2ProposerID, *L2Proposer]
+
+	jwtPath     string
+	jwtSecret   [32]byte
+	jwtPathOnce sync.Once
+}
+
+func NewOrchestrator(t T) *Orchestrator {
+	return &Orchestrator{t: t}
+}
+
+func (o *Orchestrator) writeDefaultJWT() (jwtPath string, secret [32]byte) {
+	o.jwtPathOnce.Do(func() {
+		// Sadly the geth node config cannot load JWT secret from memory, it has to be a file
+		o.jwtPath = filepath.Join(o.t.TempDir(), "jwt_secret")
+		o.jwtSecret = [32]byte{123}
+		err := os.WriteFile(o.jwtPath, []byte(hexutil.Encode(o.jwtSecret[:])), 0o600)
+		require.NoError(o.t, err, "failed to prepare jwt file")
+	})
+	return o.jwtPath, o.jwtSecret
+}

--- a/devnet-sdk/systemgo/supervisor.go
+++ b/devnet-sdk/systemgo/supervisor.go
@@ -1,0 +1,106 @@
+package systemgo
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	supervisorConfig "github.com/ethereum-optimism/optimism/op-supervisor/config"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
+)
+
+type Supervisor struct {
+	userRPC string
+}
+
+func WithSupervisor(supervisorID system2.SupervisorID, clusterID system2.ClusterID, l1ELID system2.L1ELNodeID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+
+		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		setup.Require.True(ok, "need L1 EL node to connect supervisor to")
+
+		cluster := setup.System.Cluster(clusterID)
+
+		cfg := &supervisorConfig.Config{
+			MetricsConfig: metrics.CLIConfig{
+				Enabled: false,
+			},
+			PprofConfig: oppprof.CLIConfig{
+				ListenEnabled: false,
+			},
+			LogConfig: oplog.CLIConfig{ // ignored, logger overrides this
+				Level:  log.LevelDebug,
+				Format: oplog.FormatText,
+			},
+			RPC: oprpc.CLIConfig{
+				ListenAddr:  "127.0.0.1",
+				ListenPort:  0,
+				EnableAdmin: true,
+			},
+			SyncSources:           &syncnode.CLISyncNodes{}, // no sync-sources
+			L1RPC:                 l1EL.userRPC,
+			Datadir:               orch.t.TempDir(),
+			Version:               "dev",
+			DependencySetSource:   cluster.DependencySet().(*depset.StaticConfigDependencySet),
+			MockRun:               false,
+			SynchronousProcessors: false,
+			DatadirSyncEndpoint:   "",
+		}
+
+		logger := setup.Log.New("id", supervisorID)
+
+		super, err := supervisor.SupervisorFromConfig(context.Background(), cfg, logger)
+		setup.Require.NoError(err)
+
+		err = super.Start(context.Background())
+		setup.Require.NoError(err)
+
+		orch.t.Cleanup(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // force-quit
+			logger.Info("Closing supervisor")
+			closeErr := super.Stop(ctx)
+			logger.Info("Closed supervisor", "err", closeErr)
+		})
+
+		supervisorNode := &Supervisor{
+			userRPC: super.RPC(),
+		}
+		orch.supervisors.Set(supervisorID, supervisorNode)
+
+		supClient, err := client.NewRPC(setup.Ctx, logger, supervisorNode.userRPC, client.WithLazyDial())
+		setup.Require.NoError(err)
+
+		setup.System.AddSupervisor(system2.NewSupervisor(system2.SupervisorConfig{
+			CommonConfig: setup.CommonConfig(),
+			ID:           supervisorID,
+			Client:       supClient,
+		}))
+	}
+}
+
+func WithManagedBySupervisor(l2CLID system2.L2CLNodeID, supervisorID system2.SupervisorID) system2.Option {
+	return func(setup *system2.Setup) {
+		orch := setup.Orchestrator.(*Orchestrator)
+
+		l2CL, ok := orch.l2CLs.Get(l2CLID)
+		setup.Require.True(ok, "looking for L2 CL node to connect to supervisor")
+		interopEndpoint, secret := l2CL.opNode.InteropRPC()
+
+		super := setup.System.Supervisor(supervisorID)
+		err := retry.Do0(setup.Ctx, 10, retry.Exponential(), func() error {
+			return super.AdminAPI().AddL2RPC(setup.Ctx, interopEndpoint, secret)
+		})
+		setup.Require.NoError(err, "must connect CL node %s to supervisor %s", l2CLID, supervisorID)
+	}
+}

--- a/devnet-sdk/systemgo/system.go
+++ b/devnet-sdk/systemgo/system.go
@@ -1,0 +1,93 @@
+package systemgo
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// struct of the services, so we can access them later and do not have to guess their IDs.
+type DefaultInteropSystemIDs struct {
+	L1   system2.L1NetworkID
+	L1EL system2.L1ELNodeID
+	L1CL system2.L1CLNodeID
+
+	Superchain system2.SuperchainID
+	Cluster    system2.ClusterID
+
+	Supervisor system2.SupervisorID
+
+	L2A   system2.L2NetworkID
+	L2ACL system2.L2CLNodeID
+	L2AEL system2.L2ELNodeID
+
+	L2B   system2.L2NetworkID
+	L2BCL system2.L2CLNodeID
+	L2BEL system2.L2ELNodeID
+
+	L2ABatcher system2.L2BatcherID
+	L2BBatcher system2.L2BatcherID
+
+	L2AProposer system2.L2ProposerID
+	L2BProposer system2.L2ProposerID
+}
+
+func DefaultInteropSystem(contractPaths ContractPaths) (DefaultInteropSystemIDs, system2.Option) {
+	l1ID := eth.ChainIDFromUInt64(900)
+	l2AID := eth.ChainIDFromUInt64(901)
+	l2BID := eth.ChainIDFromUInt64(902)
+	ids := DefaultInteropSystemIDs{
+		L1:          system2.L1NetworkID{Key: "l1", ChainID: l1ID},
+		L1EL:        system2.L1ELNodeID{Key: "l1", ChainID: l1ID},
+		L1CL:        system2.L1CLNodeID{Key: "l1", ChainID: l1ID},
+		Superchain:  "dev",
+		Cluster:     "dev",
+		Supervisor:  "dev",
+		L2A:         system2.L2NetworkID{Key: "l2A", ChainID: l2AID},
+		L2ACL:       system2.L2CLNodeID{Key: "sequencer", ChainID: l2AID},
+		L2AEL:       system2.L2ELNodeID{Key: "sequencer", ChainID: l2AID},
+		L2B:         system2.L2NetworkID{Key: "l2B", ChainID: l2BID},
+		L2BCL:       system2.L2CLNodeID{Key: "sequencer", ChainID: l2BID},
+		L2BEL:       system2.L2ELNodeID{Key: "sequencer", ChainID: l2BID},
+		L2ABatcher:  system2.L2BatcherID{Key: "main", ChainID: l2AID},
+		L2BBatcher:  system2.L2BatcherID{Key: "main", ChainID: l2BID},
+		L2AProposer: system2.L2ProposerID{Key: "main", ChainID: l2AID},
+		L2BProposer: system2.L2ProposerID{Key: "main", ChainID: l2BID},
+	}
+
+	opt := system2.Option(func(setup *system2.Setup) {
+		setup.Log.Info("Setting up")
+	})
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithInteropGen(ids.L1, ids.Superchain, ids.Cluster,
+		[]system2.L2NetworkID{ids.L2A, ids.L2B}, contractPaths))
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
+
+	// TODO(#15027): create L1 Faucet
+
+	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
+	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
+
+	// TODO(#15027): create L2 faucet
+
+	opt.Add(WithL2CLNode(ids.L2ACL, true, ids.L1CL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithL2CLNode(ids.L2BCL, true, ids.L1CL, ids.L1EL, ids.L2BEL))
+
+	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
+	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
+
+	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
+	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
+
+	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, nil, &ids.Supervisor))
+	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, nil, &ids.Supervisor))
+
+	// TODO(#15057): maybe L2 challenger
+
+	return ids, opt
+}

--- a/devnet-sdk/systemgo/system_test.go
+++ b/devnet-sdk/systemgo/system_test.go
@@ -38,7 +38,9 @@ func TestSystem(t *testing.T) {
 
 	seqA := setup.System.L2Network(ids.L2A).L2CLNode(ids.L2ACL)
 	seqB := setup.System.L2Network(ids.L2B).L2CLNode(ids.L2BCL)
-	for i := 0; i < 20*2+10; i++ {
+	blocks := uint64(10)
+	// wait for this many blocks, with some margin for delays
+	for i := uint64(0); i < blocks*2+10; i++ {
 		time.Sleep(time.Second * 2)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -50,9 +52,9 @@ func TestSystem(t *testing.T) {
 		logger.Info("chain A", "tip", statusA.UnsafeL2)
 		logger.Info("chain B", "tip", statusB.UnsafeL2)
 
-		if statusA.UnsafeL2.Number > 20 && statusB.UnsafeL2.Number > 20 {
+		if statusA.UnsafeL2.Number > blocks && statusB.UnsafeL2.Number > blocks {
 			return
 		}
 	}
-	t.Fatal("Expected to reach block 20 on both chains")
+	t.Fatalf("Expected to reach block %d on both chains", blocks)
 }

--- a/devnet-sdk/systemgo/system_test.go
+++ b/devnet-sdk/systemgo/system_test.go
@@ -1,0 +1,58 @@
+package systemgo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestSystem(t *testing.T) {
+	ids, opt := DefaultInteropSystem(ContractPaths{
+		FoundryArtifacts: "../../packages/contracts-bedrock/forge-artifacts",
+		SourceMap:        "../../packages/contracts-bedrock",
+	})
+	logger := testlog.Logger(t, log.LevelInfo)
+	orch := &Orchestrator{
+		t: t,
+	}
+	// TODO(#15026): known issue, setup needs helper functions / polish
+	setup := &system2.Setup{
+		Ctx:          context.Background(),
+		Log:          logger,
+		T:            t,
+		Require:      require.New(t),
+		System:       nil,
+		Orchestrator: orch,
+	}
+	setup.System = system2.NewSystem(system2.SystemConfig{
+		CommonConfig: setup.CommonConfig(),
+	})
+	opt(setup)
+
+	seqA := setup.System.L2Network(ids.L2A).L2CLNode(ids.L2ACL)
+	seqB := setup.System.L2Network(ids.L2B).L2CLNode(ids.L2BCL)
+	for i := 0; i < 20*2+10; i++ {
+		time.Sleep(time.Second * 2)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		statusA, err := seqA.RollupAPI().SyncStatus(ctx)
+		require.NoError(t, err)
+		statusB, err := seqB.RollupAPI().SyncStatus(ctx)
+		require.NoError(t, err)
+		cancel()
+		logger.Info("chain A", "tip", statusA.UnsafeL2)
+		logger.Info("chain B", "tip", statusB.UnsafeL2)
+
+		if statusA.UnsafeL2.Number > 20 && statusB.UnsafeL2.Number > 20 {
+			return
+		}
+	}
+	t.Fatal("Expected to reach block 20 on both chains")
+}

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -507,3 +507,10 @@ func (bs *BatcherService) ThrottlingTestDriver() *TestBatchSubmitter {
 	tbs.BatchSubmitter.channelMgr.metr = new(metrics.ThrottlingMetrics)
 	return tbs
 }
+
+func (bs *BatcherService) HTTPEndpoint() string {
+	if bs.rpcServer == nil {
+		return ""
+	}
+	return "http://" + bs.rpcServer.Endpoint()
+}

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -362,3 +362,10 @@ var _ cliapp.Lifecycle = (*ProposerService)(nil)
 func (ps *ProposerService) Driver() rpc.ProposerDriver {
 	return ps.driver
 }
+
+func (ps *ProposerService) HTTPEndpoint() string {
+	if ps.rpcServer == nil {
+		return ""
+	}
+	return "http://" + ps.rpcServer.Endpoint()
+}


### PR DESCRIPTION
**Description**

Implements an in-process Go based backend of the devnet-sdk, for faster test iteration / development cycles / efficient CI.

Features:
- interop deployment
- L1 fake-beacon CL + geth EL
- L2 op-node CL + op-geth EL, per L2 chain
- L2 op-proposer
- L2 op-batcher
- L2 op-supervisor

And composable, so each type of chain / node can be added as desired.

This also adds getter methods to the batcher and proposer services, to retrieve their RPC endpoints.

In separate PRs we'll swap `interopgen` for op-deployer usage (see #15059), and support the op-challenger (see #15057)

**Tests**

Includes a system test, that runs the system, and sees if both L2s reach block 20, as sanity-check.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/14909
