### PR TITLE
op-node: Add pectra blob schedule fix kill-switch

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -419,6 +419,16 @@ var (
 		Destination: new(string),
 		Category:    InteropCategory,
 	}
+
+	IgnoreMissingPectraBlobSchedule = &cli.BoolFlag{
+		Name: "ignore-missing-pectra-blob-schedule",
+		Usage: "Ignore missing pectra blob schedule fix for Sepolia and Holesky chains. Only set if you know what you are doing!" +
+			"Ask your chain's operator for the correct Pectra blob schedule activation time and set it via the rollup.json config" +
+			"or use the --override.pectrablobschedule flag.",
+		EnvVars:  prefixEnvVars("IGNORE_MISSING_PECTRA_BLOB_SCHEDULE"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -471,6 +481,7 @@ var optionalFlags = []cli.Flag{
 	InteropRPCAddr,
 	InteropRPCPort,
 	InteropJWTSecret,
+	IgnoreMissingPectraBlobSchedule,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -76,6 +76,8 @@ type Config struct {
 
 	// AltDA config
 	AltDA altda.CLIConfig
+
+	IgnoreMissingPectraBlobSchedule bool
 }
 
 // ConductorRPCFunc retrieves the endpoint. The RPC may not immediately be available.
@@ -156,7 +158,11 @@ func (cfg *Config) Check() error {
 	if err := cfg.Rollup.Check(); err != nil {
 		return fmt.Errorf("rollup config error: %w", err)
 	}
-	if cfg.Rollup.ProbablyMissingPectraBlobSchedule() {
+	if !cfg.IgnoreMissingPectraBlobSchedule && cfg.Rollup.ProbablyMissingPectraBlobSchedule() {
+		log.Error("Your rollup config seems to be missing the Pectra blob schedule fix. " +
+			"Reach out to your chain operator for the correct Pectra blob schedule configuration. " +
+			"If you know what you are doing, you can disable this error by setting the " +
+			"'--ignore-missing-pectra-blob-schedule' flag or 'IGNORE_MISSING_PECTRA_BLOB_SCHEDULE' env var.")
 		return ErrMissingPectraBlobSchedule
 	}
 	if err := cfg.Metrics.Check(); err != nil {

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -127,6 +127,8 @@ func (cfg *Config) LoadPersisted(log log.Logger) error {
 	return nil
 }
 
+var ErrMissingPectraBlobSchedule = errors.New("probably missing Pectra blob schedule")
+
 // Check verifies that the given configuration makes sense
 func (cfg *Config) Check() error {
 	if err := cfg.L1.Check(); err != nil {
@@ -153,6 +155,9 @@ func (cfg *Config) Check() error {
 	}
 	if err := cfg.Rollup.Check(); err != nil {
 		return fmt.Errorf("rollup config error: %w", err)
+	}
+	if cfg.Rollup.ProbablyMissingPectraBlobSchedule() {
+		return ErrMissingPectraBlobSchedule
 	}
 	if err := cfg.Metrics.Check(); err != nil {
 		return fmt.Errorf("metrics config error: %w", err)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -126,7 +126,14 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		cfg.Driver.SequencerStopped = true
 	}
 
-	if err := cfg.Check(); err != nil {
+	if err := cfg.Check(); errors.Is(err, node.ErrMissingPectraBlobSchedule) &&
+		!ctx.Bool(flags.IgnoreMissingPectraBlobSchedule.Name) {
+		log.Error("Your rollup config seems to be missing the Pectra blob schedule fix. " +
+			"Reach out to your chain operator for the correct Pectra blob schedule configuration. " +
+			"If you know what you are doing, you can disable this error by setting the " +
+			"'--ignore-missing-pectra-blob-schedule' flag or 'IGNORE_MISSING_PECTRA_BLOB_SCHEDULE' env var.")
+		return nil, err
+	} else if err != nil {
 		return nil, err
 	}
 	return cfg, nil

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -115,6 +115,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		ConductorRpcTimeout: ctx.Duration(flags.ConductorRpcTimeoutFlag.Name),
 
 		AltDA: altda.ReadCLIConfig(ctx),
+
+		IgnoreMissingPectraBlobSchedule: ctx.Bool(flags.IgnoreMissingPectraBlobSchedule.Name),
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {
@@ -126,14 +128,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		cfg.Driver.SequencerStopped = true
 	}
 
-	if err := cfg.Check(); errors.Is(err, node.ErrMissingPectraBlobSchedule) &&
-		!ctx.Bool(flags.IgnoreMissingPectraBlobSchedule.Name) {
-		log.Error("Your rollup config seems to be missing the Pectra blob schedule fix. " +
-			"Reach out to your chain operator for the correct Pectra blob schedule configuration. " +
-			"If you know what you are doing, you can disable this error by setting the " +
-			"'--ignore-missing-pectra-blob-schedule' flag or 'IGNORE_MISSING_PECTRA_BLOB_SCHEDULE' env var.")
-		return nil, err
-	} else if err != nil {
+	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
 	return cfg, nil


### PR DESCRIPTION
**Description**

Adds a kill-switch to op-node, where at startup it checks
- if the chain's L1 is Sepolia or Holesky
- if the pectra block schedule fix does not have a timestamp set
- if the L2 genesis timestamp is before the L1's activation of Pectra

and if all of those conditions are true, the node exits with a warning explaining that this chain probably needs to schedule the fix. The warning can be deactivated with a hidden flag to force the node to start without the fix scheduled.

See https://github.com/ethereum-optimism/optimism/issues/14920 for more details.

I've decided to run this check as part of assembling the op-node configurations. While the logic is implemented as a method on the `rollup.Config`, it's not part of `rollup.Config.Check()` to avoid enshrining this check into generic rollup config handling. This can be changed if reviewers prefer to move the check into the rollup config's check.

**Tests**

Added unit test for the check logic on the rollup config.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/14920
