### PR TITLE
op-service: tx plans poc

### DIFF
--- a/op-service/txplan/interop.go
+++ b/op-service/txplan/interop.go
@@ -29,8 +29,8 @@ func (v *InitTrigger) To() (*common.Address, error) {
 
 func (v *InitTrigger) Data() ([]byte, error) {
 	// TODO format call
-	// return nil, nil
-	// temp fix
+	// This OpaqueData was for using the EventLogger contract to test
+	// This is a temp bypass for setting calldata for basic testing
 	return v.OpaqueData, nil
 }
 

--- a/op-service/txplan/interop.go
+++ b/op-service/txplan/interop.go
@@ -48,9 +48,7 @@ func (v *ExecTrigger) To() (*common.Address, error) {
 }
 
 func (v *ExecTrigger) Data() ([]byte, error) {
-	// TODO format call to CrossL2Inbox
-	// Need to do better. very ugly
-	// construct call input, ugly but no bindings...
+	// TODO: Need to do better construct call input than this
 	validateMessage := w3.MustNewFunc("validateMessage((address Origin, uint256 BlockNumber, uint256 LogIndex, uint256 Timestamp, uint256 ChainId), bytes32)", "")
 	type Identifier struct {
 		Origin      common.Address

--- a/op-service/txplan/interop.go
+++ b/op-service/txplan/interop.go
@@ -1,0 +1,178 @@
+package txplan
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/plan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/lmittmann/w3"
+
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type InitTrigger struct {
+	Emitter    common.Address // address of the EventLogger contract
+	Topics     []common.Hash
+	OpaqueData []byte
+}
+
+func (v *InitTrigger) To() (*common.Address, error) {
+	return &v.Emitter, nil
+}
+
+func (v *InitTrigger) Data() ([]byte, error) {
+	// TODO format call
+	// return nil, nil
+	// temp fix
+	return v.OpaqueData, nil
+}
+
+func (v *InitTrigger) AccessList() (types.AccessList, error) {
+	return nil, nil
+}
+
+type ExecTrigger struct {
+	Executor common.Address // address of the EventLogger contract
+	Msg      suptypes.Message
+}
+
+func (v *ExecTrigger) To() (*common.Address, error) {
+	return &v.Executor, nil
+}
+
+func (v *ExecTrigger) Data() ([]byte, error) {
+	// TODO format call to CrossL2Inbox
+	// Need to do better. very ugly
+	// construct call input, ugly but no bindings...
+	validateMessage := w3.MustNewFunc("validateMessage((address Origin, uint256 BlockNumber, uint256 LogIndex, uint256 Timestamp, uint256 ChainId), bytes32)", "")
+	type Identifier struct {
+		Origin      common.Address
+		BlockNumber *big.Int
+		LogIndex    *big.Int
+		Timestamp   *big.Int
+		ChainId     *big.Int
+	}
+	identifier := &Identifier{
+		v.Msg.Identifier.Origin,
+		big.NewInt(int64(v.Msg.Identifier.BlockNumber)),
+		big.NewInt(int64(v.Msg.Identifier.LogIndex)),
+		big.NewInt(int64(v.Msg.Identifier.Timestamp)),
+		v.Msg.Identifier.ChainID.ToBig(),
+	}
+	validateMessageCalldata, err := validateMessage.EncodeArgs(
+		identifier,
+		v.Msg.PayloadHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return validateMessageCalldata, nil
+}
+
+func (v *ExecTrigger) AccessList() (types.AccessList, error) {
+	access := v.Msg.Access()
+	accessList := types.AccessList{{
+		Address:     constants.CrossL2Inbox,
+		StorageKeys: suptypes.EncodeAccessList([]suptypes.Access{access}),
+	}}
+	return accessList, nil
+}
+
+type Call interface {
+	To() (*common.Address, error)
+	Data() ([]byte, error)
+	AccessList() (types.AccessList, error)
+}
+
+type MultiTrigger struct {
+	Calls []Call
+}
+
+func (v *MultiTrigger) Data() ([]byte, error) {
+	// TODO format multi-call
+	return nil, nil
+}
+
+type Result interface {
+	FromReceipt(ctx context.Context, rec *types.Receipt, includedIn eth.BlockRef, chainID eth.ChainID) error
+	Init() Result
+}
+
+type InteropOutput struct {
+	Entries []suptypes.Message
+}
+
+func (i *InteropOutput) Init() Result {
+	return &InteropOutput{}
+}
+
+func (i *InteropOutput) FromReceipt(ctx context.Context, rec *types.Receipt, includedIn eth.BlockRef, chainID eth.ChainID) error {
+	entries := []suptypes.Message{}
+	for _, logEvent := range rec.Logs {
+		payload := suptypes.LogToMessagePayload(logEvent)
+		id := suptypes.Identifier{
+			Origin:      logEvent.Address,
+			BlockNumber: logEvent.BlockNumber,
+			LogIndex:    uint32(logEvent.Index),
+			Timestamp:   includedIn.Time,
+			ChainID:     chainID,
+		}
+		payloadHash := crypto.Keccak256Hash(payload)
+		entries = append(entries, suptypes.Message{
+			Identifier:  id,
+			PayloadHash: payloadHash,
+		})
+	}
+	i.Entries = entries
+	return nil
+}
+
+type IntentTx[V Call, R Result] struct {
+	PlannedTx *PlannedTx
+	Content   plan.Lazy[V]
+	Result    plan.Lazy[R]
+}
+
+func NewIntent[V Call, R Result](opts ...Option) *IntentTx[V, R] {
+	v := &IntentTx[V, R]{
+		PlannedTx: NewPlannedTx(opts...),
+	}
+	v.PlannedTx.To.DependOn(&v.Content)
+	v.PlannedTx.To.Fn(func(ctx context.Context) (*common.Address, error) {
+		return v.Content.Value().To()
+	})
+	v.PlannedTx.Data.DependOn(&v.Content)
+	v.PlannedTx.Data.Fn(func(ctx context.Context) (hexutil.Bytes, error) {
+		return v.Content.Value().Data()
+	})
+	v.PlannedTx.AccessList.DependOn(&v.Content)
+	v.PlannedTx.AccessList.Fn(func(ctx context.Context) (types.AccessList, error) {
+		return v.Content.Value().AccessList()
+	})
+	v.Result.DependOn(&v.PlannedTx.Included, &v.PlannedTx.IncludedBlock, &v.PlannedTx.ChainID)
+	v.Result.Fn(func(ctx context.Context) (R, error) {
+		r := (*new(R)).Init().(R)
+		err := r.FromReceipt(ctx, v.PlannedTx.Included.Value(), v.PlannedTx.IncludedBlock.Value(), v.PlannedTx.ChainID.Value())
+		return r, err
+	})
+	return v
+}
+
+func executeIndexed(executor common.Address, events *plan.Lazy[*InteropOutput], index int) func(ctx context.Context) (*ExecTrigger, error) {
+	return func(ctx context.Context) (*ExecTrigger, error) {
+		if x := len(events.Value().Entries); x <= index {
+			return nil, fmt.Errorf("invalid index: %d, only have %d events", index, x)
+		}
+		return &ExecTrigger{
+			Executor: executor,
+			Msg:      events.Value().Entries[index],
+		}, nil
+	}
+}

--- a/op-service/txplan/interop_test.go
+++ b/op-service/txplan/interop_test.go
@@ -189,6 +189,9 @@ func executeIndexed(executor common.Address, events *plan.Lazy[*InteropOutput], 
 }
 
 func TestSimpleTx(t *testing.T) {
+	t.Skip() // temporal addition for make CI pass.
+	// To run tests, hardcode the endpoint/private key below
+
 	// priv, err := crypto.GenerateKey()
 	// wallets must contain private key and rpc
 	privHex := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
@@ -237,6 +240,9 @@ func TestSimpleTx(t *testing.T) {
 	t.Logf("included simple tx in block %s", res)
 }
 func TestInteropTx(t *testing.T) {
+	t.Skip() // temporal addition for make CI pass.
+	// To run tests, hardcode the endpoint/private key below
+
 	// priv, err := crypto.GenerateKey()
 	privHexRawA := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
 	rpcURLA := "http://127.0.0.1:32948"

--- a/op-service/txplan/interop_test.go
+++ b/op-service/txplan/interop_test.go
@@ -3,11 +3,16 @@ package txplan
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/lmittmann/w3"
 
 	"github.com/stretchr/testify/require"
 
@@ -15,6 +20,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
@@ -33,6 +40,12 @@ func (v *InitTrigger) To() (*common.Address, error) {
 
 func (v *InitTrigger) Data() ([]byte, error) {
 	// TODO format call
+	// return nil, nil
+	// temp fix
+	return v.OpaqueData, nil
+}
+
+func (v *InitTrigger) AccessList() (types.AccessList, error) {
 	return nil, nil
 }
 
@@ -47,13 +60,46 @@ func (v *ExecTrigger) To() (*common.Address, error) {
 
 func (v *ExecTrigger) Data() ([]byte, error) {
 	// TODO format call to CrossL2Inbox
-	return nil, nil
+	// Need to do better. very ugly
+	// construct call input, ugly but no bindings...
+	validateMessage := w3.MustNewFunc("validateMessage((address Origin, uint256 BlockNumber, uint256 LogIndex, uint256 Timestamp, uint256 ChainId), bytes32)", "")
+	type Identifier struct {
+		Origin      common.Address
+		BlockNumber *big.Int
+		LogIndex    *big.Int
+		Timestamp   *big.Int
+		ChainId     *big.Int
+	}
+	identifier := &Identifier{
+		v.Msg.Identifier.Origin,
+		big.NewInt(int64(v.Msg.Identifier.BlockNumber)),
+		big.NewInt(int64(v.Msg.Identifier.LogIndex)),
+		big.NewInt(int64(v.Msg.Identifier.Timestamp)),
+		v.Msg.Identifier.ChainID.ToBig(),
+	}
+	validateMessageCalldata, err := validateMessage.EncodeArgs(
+		identifier,
+		v.Msg.PayloadHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return validateMessageCalldata, nil
+}
+
+func (v *ExecTrigger) AccessList() (types.AccessList, error) {
+	access := v.Msg.Access()
+	accessList := types.AccessList{{
+		Address:     constants.CrossL2Inbox,
+		StorageKeys: suptypes.EncodeAccessList([]suptypes.Access{access}),
+	}}
+	return accessList, nil
 }
 
 type Call interface {
 	To() (*common.Address, error)
 	Data() ([]byte, error)
-	// AccessList
+	AccessList() (types.AccessList, error)
 }
 
 type MultiTrigger struct {
@@ -67,13 +113,19 @@ func (v *MultiTrigger) Data() ([]byte, error) {
 
 type Result interface {
 	FromReceipt(ctx context.Context, rec *types.Receipt, includedIn eth.BlockRef, chainID eth.ChainID) error
+	Init() Result
 }
 
 type InteropOutput struct {
 	Entries []suptypes.Message
 }
 
+func (i *InteropOutput) Init() Result {
+	return &InteropOutput{}
+}
+
 func (i *InteropOutput) FromReceipt(ctx context.Context, rec *types.Receipt, includedIn eth.BlockRef, chainID eth.ChainID) error {
+	entries := []suptypes.Message{}
 	for _, logEvent := range rec.Logs {
 		payload := suptypes.LogToMessagePayload(logEvent)
 		id := suptypes.Identifier{
@@ -84,11 +136,12 @@ func (i *InteropOutput) FromReceipt(ctx context.Context, rec *types.Receipt, inc
 			ChainID:     chainID,
 		}
 		payloadHash := crypto.Keccak256Hash(payload)
-		i.Entries = append(i.Entries, suptypes.Message{
+		entries = append(entries, suptypes.Message{
 			Identifier:  id,
 			PayloadHash: payloadHash,
 		})
 	}
+	i.Entries = entries
 	return nil
 }
 
@@ -110,69 +163,164 @@ func NewIntent[V Call, R Result](opts ...Option) *IntentTx[V, R] {
 	v.PlannedTx.Data.Fn(func(ctx context.Context) (hexutil.Bytes, error) {
 		return v.Content.Value().Data()
 	})
-	// TODO add access-list relation
-
+	v.PlannedTx.AccessList.DependOn(&v.Content)
+	v.PlannedTx.AccessList.Fn(func(ctx context.Context) (types.AccessList, error) {
+		return v.Content.Value().AccessList()
+	})
 	v.Result.DependOn(&v.PlannedTx.Included, &v.PlannedTx.IncludedBlock, &v.PlannedTx.ChainID)
 	v.Result.Fn(func(ctx context.Context) (R, error) {
-		var r R
+		r := (*new(R)).Init().(R)
 		err := r.FromReceipt(ctx, v.PlannedTx.Included.Value(), v.PlannedTx.IncludedBlock.Value(), v.PlannedTx.ChainID.Value())
 		return r, err
 	})
 	return v
 }
 
-func executeIndexed(events *plan.Lazy[*InteropOutput], index int) func(ctx context.Context) (*ExecTrigger, error) {
+func executeIndexed(executor common.Address, events *plan.Lazy[*InteropOutput], index int) func(ctx context.Context) (*ExecTrigger, error) {
 	return func(ctx context.Context) (*ExecTrigger, error) {
 		if x := len(events.Value().Entries); x <= index {
 			return nil, fmt.Errorf("invalid index: %d, only have %d events", index, x)
 		}
 		return &ExecTrigger{
-			Executor: common.Address{},
+			Executor: executor,
 			Msg:      events.Value().Entries[index],
 		}, nil
 	}
 }
 
-func TestInteropTx(t *testing.T) {
-	t.Skip() // TODO
+func TestSimpleTx(t *testing.T) {
+	// priv, err := crypto.GenerateKey()
+	// wallets must contain private key and rpc
+	privHex := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
+	rpcURL := "http://127.0.0.1:32948"
 
-	eventLogger := common.Address{} // TODO deploy tx
-
-	priv, err := crypto.GenerateKey()
+	privRaw, err := hexutil.Decode(privHex)
+	require.NoError(t, err)
+	priv, err := crypto.ToECDSA(privRaw)
 	require.NoError(t, err)
 
-	cl, err := sources.NewEthClient()
+	rpcClient, err := rpc.DialContext(context.Background(), rpcURL)
 	require.NoError(t, err)
 
+	ethClCfg := sources.EthClientConfig{
+		MaxRequestsPerBatch:   10,
+		MaxConcurrentRequests: 10,
+		ReceiptsCacheSize:     10,
+		TransactionsCacheSize: 10,
+		HeadersCacheSize:      10,
+		PayloadsCacheSize:     10,
+		BlockRefsCacheSize:    10,
+		TrustRPC:              false,
+		MustBePostMerge:       true,
+		RPCProviderKind:       sources.RPCKindStandard,
+		MethodResetDuration:   time.Minute,
+	}
+	cl, err := sources.NewEthClient(client.NewBaseRPCClient(rpcClient), log.Root(), nil, &ethClCfg)
+	require.NoError(t, err)
+
+	to := common.HexToAddress("0x0000000000000000000000000000000000001235")
 	opts := Combine(
 		WithPrivateKey(priv),
+		WithChainID(cl),
+		WithAgainstLatestBlock(cl),
+		WithPendingNonce(cl),
+		WithEstimator(cl, false),
+		WithTo(&to),
 		WithTransactionSubmitter(cl),
-		WithAssumedInclusion(cl),
-		WithRetryInclusion(10, retry.Exponential()),
+		WithRetryInclusion(cl, 10, retry.Exponential()),
 		WithBlockInclusionInfo(cl),
 	)
 
-	txSimple := NewPlannedTx(opts, WithEth(big.NewInt(1234)))
-	rec, err := txSimple.Included.Eval(context.Background())
+	txSimple := NewPlannedTx(opts, WithValue(big.NewInt(1000)))
+	res, err := txSimple.IncludedBlock.Eval(context.Background())
+	require.NoError(t, err)
+	t.Logf("included simple tx in block %s", res)
+}
+func TestInteropTx(t *testing.T) {
+	// priv, err := crypto.GenerateKey()
+	privHexRawA := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
+	rpcURLA := "http://127.0.0.1:32948"
+
+	privHexRawB := "0xeaa861a9a01391ed3d587d8a5a84ca56ee277629a8b02c22093a419bf240e65d"
+	rpcURLB := "http://127.0.0.1:32961"
+
+	ethClCfg := sources.EthClientConfig{
+		MaxRequestsPerBatch:   10,
+		MaxConcurrentRequests: 10,
+		ReceiptsCacheSize:     10,
+		TransactionsCacheSize: 10,
+		HeadersCacheSize:      10,
+		PayloadsCacheSize:     10,
+		BlockRefsCacheSize:    10,
+		TrustRPC:              false,
+		MustBePostMerge:       true,
+		RPCProviderKind:       sources.RPCKindStandard,
+		MethodResetDuration:   time.Minute,
+	}
+
+	optsFunc := func(rpcURL string, privHexRaw string) Option {
+		privRaw, err := hexutil.Decode(privHexRaw)
+		require.NoError(t, err)
+		priv, err := crypto.ToECDSA(privRaw)
+		require.NoError(t, err)
+		rpcClient, err := rpc.DialContext(context.Background(), rpcURL)
+		require.NoError(t, err)
+		cl, err := sources.NewEthClient(client.NewBaseRPCClient(rpcClient), log.Root(), nil, &ethClCfg)
+		require.NoError(t, err)
+
+		return Combine(
+			WithPrivateKey(priv),
+			WithChainID(cl),
+			WithAgainstLatestBlock(cl),
+			WithPendingNonce(cl),
+			WithEstimator(cl, false),
+			WithTransactionSubmitter(cl),
+			WithRetryInclusion(cl, 10, retry.Exponential()),
+			WithBlockInclusionInfo(cl),
+		)
+	}
+	optsA := optsFunc(rpcURLA, privHexRawA)
+	optsB := optsFunc(rpcURLB, privHexRawB)
+
+	// eventLogger := common.Address{} // TODO deploy tx
+
+	sha256PrecompileAddr := common.BytesToAddress([]byte{0x2})
+	dummyMessage := []byte("l33t message")
+	destChainID := big.NewInt(2151909) // TODO: remove hardcode
+	// construct call input, ugly but no bindings...
+	sendMessage := w3.MustNewFunc("sendMessage(uint256,address,bytes calldata)", "bytes32")
+	sendMessageCalldata, err := sendMessage.EncodeArgs(
+		destChainID,
+		sha256PrecompileAddr,
+		dummyMessage,
+	)
 	require.NoError(t, err)
 
-	txA := NewIntent[*InitTrigger, *InteropOutput](opts)
+	opagueData := sendMessageCalldata
+	L2toL2CDM := common.HexToAddress(predeploys.L2toL2CrossDomainMessenger)
+	txA := NewIntent[*InitTrigger, *InteropOutput](optsA)
 	txA.Content.Set(&InitTrigger{
-		Emitter:    eventLogger,
+		// Emitter:    eventLogger,
+		Emitter:    L2toL2CDM,
 		Topics:     []common.Hash{},
-		OpaqueData: []byte("hello world!"),
+		OpaqueData: opagueData,
 	})
 
-	txB := NewIntent[*ExecTrigger, *InteropOutput]()
+	txB := NewIntent[*ExecTrigger, *InteropOutput](optsB)
 	txB.Content.DependOn(&txA.Result)
-	txB.Content.Fn(executeIndexed(&txA.Result, 0))
+	CrossL2InboxAddr := common.HexToAddress(predeploys.CrossL2Inbox)
+	txB.Content.Fn(executeIndexed(CrossL2InboxAddr, &txA.Result, 0))
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	recA, err := txA.PlannedTx.Included.Eval(ctx)
+	// recA, err := txA.PlannedTx.Success.Eval(ctx)
+	recA, err := txA.Result.Eval(ctx)
+
 	require.NoError(t, err)
-	t.Logf("included initiating tx in block %s", recA.BlockHash)
+
+	t.Log(recA)
+	t.Log("included initiating tx")
 
 	recB, err := txB.PlannedTx.Included.Eval(ctx)
 	require.NoError(t, err)

--- a/op-service/txplan/interop_test.go
+++ b/op-service/txplan/interop_test.go
@@ -2,331 +2,117 @@ package txplan
 
 import (
 	"context"
-	"fmt"
 	"math/big"
+	"math/rand"
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
-	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/lmittmann/w3"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
-
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/plan"
-	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-type InitTrigger struct {
-	Emitter    common.Address // address of the EventLogger contract
-	Topics     []common.Hash
-	OpaqueData []byte
-}
-
-func (v *InitTrigger) To() (*common.Address, error) {
-	return &v.Emitter, nil
-}
-
-func (v *InitTrigger) Data() ([]byte, error) {
-	// TODO format call
-	// return nil, nil
-	// temp fix
-	return v.OpaqueData, nil
-}
-
-func (v *InitTrigger) AccessList() (types.AccessList, error) {
-	return nil, nil
-}
-
-type ExecTrigger struct {
-	Executor common.Address // address of the EventLogger contract
-	Msg      suptypes.Message
-}
-
-func (v *ExecTrigger) To() (*common.Address, error) {
-	return &v.Executor, nil
-}
-
-func (v *ExecTrigger) Data() ([]byte, error) {
-	// TODO format call to CrossL2Inbox
-	// Need to do better. very ugly
-	// construct call input, ugly but no bindings...
-	validateMessage := w3.MustNewFunc("validateMessage((address Origin, uint256 BlockNumber, uint256 LogIndex, uint256 Timestamp, uint256 ChainId), bytes32)", "")
-	type Identifier struct {
-		Origin      common.Address
-		BlockNumber *big.Int
-		LogIndex    *big.Int
-		Timestamp   *big.Int
-		ChainId     *big.Int
-	}
-	identifier := &Identifier{
-		v.Msg.Identifier.Origin,
-		big.NewInt(int64(v.Msg.Identifier.BlockNumber)),
-		big.NewInt(int64(v.Msg.Identifier.LogIndex)),
-		big.NewInt(int64(v.Msg.Identifier.Timestamp)),
-		v.Msg.Identifier.ChainID.ToBig(),
-	}
-	validateMessageCalldata, err := validateMessage.EncodeArgs(
-		identifier,
-		v.Msg.PayloadHash,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return validateMessageCalldata, nil
-}
-
-func (v *ExecTrigger) AccessList() (types.AccessList, error) {
-	access := v.Msg.Access()
-	accessList := types.AccessList{{
-		Address:     constants.CrossL2Inbox,
-		StorageKeys: suptypes.EncodeAccessList([]suptypes.Access{access}),
-	}}
-	return accessList, nil
-}
-
-type Call interface {
-	To() (*common.Address, error)
-	Data() ([]byte, error)
-	AccessList() (types.AccessList, error)
-}
-
-type MultiTrigger struct {
-	Calls []Call
-}
-
-func (v *MultiTrigger) Data() ([]byte, error) {
-	// TODO format multi-call
-	return nil, nil
-}
-
-type Result interface {
-	FromReceipt(ctx context.Context, rec *types.Receipt, includedIn eth.BlockRef, chainID eth.ChainID) error
-	Init() Result
-}
-
-type InteropOutput struct {
-	Entries []suptypes.Message
-}
-
-func (i *InteropOutput) Init() Result {
-	return &InteropOutput{}
-}
-
-func (i *InteropOutput) FromReceipt(ctx context.Context, rec *types.Receipt, includedIn eth.BlockRef, chainID eth.ChainID) error {
-	entries := []suptypes.Message{}
-	for _, logEvent := range rec.Logs {
-		payload := suptypes.LogToMessagePayload(logEvent)
-		id := suptypes.Identifier{
-			Origin:      logEvent.Address,
-			BlockNumber: logEvent.BlockNumber,
-			LogIndex:    uint32(logEvent.Index),
-			Timestamp:   includedIn.Time,
-			ChainID:     chainID,
-		}
-		payloadHash := crypto.Keccak256Hash(payload)
-		entries = append(entries, suptypes.Message{
-			Identifier:  id,
-			PayloadHash: payloadHash,
-		})
-	}
-	i.Entries = entries
-	return nil
-}
-
-type IntentTx[V Call, R Result] struct {
-	PlannedTx *PlannedTx
-	Content   plan.Lazy[V]
-	Result    plan.Lazy[R]
-}
-
-func NewIntent[V Call, R Result](opts ...Option) *IntentTx[V, R] {
-	v := &IntentTx[V, R]{
-		PlannedTx: NewPlannedTx(opts...),
-	}
-	v.PlannedTx.To.DependOn(&v.Content)
-	v.PlannedTx.To.Fn(func(ctx context.Context) (*common.Address, error) {
-		return v.Content.Value().To()
-	})
-	v.PlannedTx.Data.DependOn(&v.Content)
-	v.PlannedTx.Data.Fn(func(ctx context.Context) (hexutil.Bytes, error) {
-		return v.Content.Value().Data()
-	})
-	v.PlannedTx.AccessList.DependOn(&v.Content)
-	v.PlannedTx.AccessList.Fn(func(ctx context.Context) (types.AccessList, error) {
-		return v.Content.Value().AccessList()
-	})
-	v.Result.DependOn(&v.PlannedTx.Included, &v.PlannedTx.IncludedBlock, &v.PlannedTx.ChainID)
-	v.Result.Fn(func(ctx context.Context) (R, error) {
-		r := (*new(R)).Init().(R)
-		err := r.FromReceipt(ctx, v.PlannedTx.Included.Value(), v.PlannedTx.IncludedBlock.Value(), v.PlannedTx.ChainID.Value())
-		return r, err
-	})
-	return v
-}
-
-func executeIndexed(executor common.Address, events *plan.Lazy[*InteropOutput], index int) func(ctx context.Context) (*ExecTrigger, error) {
-	return func(ctx context.Context) (*ExecTrigger, error) {
-		if x := len(events.Value().Entries); x <= index {
-			return nil, fmt.Errorf("invalid index: %d, only have %d events", index, x)
-		}
-		return &ExecTrigger{
-			Executor: executor,
-			Msg:      events.Value().Entries[index],
-		}, nil
-	}
-}
-
 func TestSimpleTx(t *testing.T) {
-	t.Skip() // temporal addition for make CI pass.
+	// t.Skip() // temporal addition for make CI pass.
 	// To run tests, hardcode the endpoint/private key below
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
-	// priv, err := crypto.GenerateKey()
-	// wallets must contain private key and rpc
+	// To run tests against kt-devnet, hardcode the endpoint/private key below.
+	// Fetch from system descriptor
 	privHex := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
 	rpcURL := "http://127.0.0.1:32948"
 
-	privRaw, err := hexutil.Decode(privHex)
-	require.NoError(t, err)
-	priv, err := crypto.ToECDSA(privRaw)
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	wallet, err := newWallet(rpcURL, privHex, nil, logger)
 	require.NoError(t, err)
 
-	rpcClient, err := rpc.DialContext(context.Background(), rpcURL)
-	require.NoError(t, err)
-
-	ethClCfg := sources.EthClientConfig{
-		MaxRequestsPerBatch:   10,
-		MaxConcurrentRequests: 10,
-		ReceiptsCacheSize:     10,
-		TransactionsCacheSize: 10,
-		HeadersCacheSize:      10,
-		PayloadsCacheSize:     10,
-		BlockRefsCacheSize:    10,
-		TrustRPC:              false,
-		MustBePostMerge:       true,
-		RPCProviderKind:       sources.RPCKindStandard,
-		MethodResetDuration:   time.Minute,
-	}
-	cl, err := sources.NewEthClient(client.NewBaseRPCClient(rpcClient), log.Root(), nil, &ethClCfg)
-	require.NoError(t, err)
-
-	to := common.HexToAddress("0x0000000000000000000000000000000000001235")
-	opts := Combine(
-		WithPrivateKey(priv),
-		WithChainID(cl),
-		WithAgainstLatestBlock(cl),
-		WithPendingNonce(cl),
-		WithEstimator(cl, false),
-		WithTo(&to),
-		WithTransactionSubmitter(cl),
-		WithRetryInclusion(cl, 10, retry.Exponential()),
-		WithBlockInclusionInfo(cl),
+	// send eth to null address
+	opts := CombineOptions(
+		WithTo(&common.Address{}),
+		DefaultTxSubmitOptions(wallet),
+		DefaultTxInclusionOptions(wallet),
 	)
 
 	txSimple := NewPlannedTx(opts, WithValue(big.NewInt(1000)))
-	res, err := txSimple.IncludedBlock.Eval(context.Background())
+	res, err := txSimple.IncludedBlock.Eval(ctx)
 	require.NoError(t, err)
+
 	t.Logf("included simple tx in block %s", res)
 }
-func TestInteropTx(t *testing.T) {
-	t.Skip() // temporal addition for make CI pass.
-	// To run tests, hardcode the endpoint/private key below
 
-	// priv, err := crypto.GenerateKey()
-	privHexRawA := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
-	rpcURLA := "http://127.0.0.1:32948"
-
-	privHexRawB := "0xeaa861a9a01391ed3d587d8a5a84ca56ee277629a8b02c22093a419bf240e65d"
-	rpcURLB := "http://127.0.0.1:32961"
-
-	ethClCfg := sources.EthClientConfig{
-		MaxRequestsPerBatch:   10,
-		MaxConcurrentRequests: 10,
-		ReceiptsCacheSize:     10,
-		TransactionsCacheSize: 10,
-		HeadersCacheSize:      10,
-		PayloadsCacheSize:     10,
-		BlockRefsCacheSize:    10,
-		TrustRPC:              false,
-		MustBePostMerge:       true,
-		RPCProviderKind:       sources.RPCKindStandard,
-		MethodResetDuration:   time.Minute,
-	}
-
-	optsFunc := func(rpcURL string, privHexRaw string) Option {
-		privRaw, err := hexutil.Decode(privHexRaw)
-		require.NoError(t, err)
-		priv, err := crypto.ToECDSA(privRaw)
-		require.NoError(t, err)
-		rpcClient, err := rpc.DialContext(context.Background(), rpcURL)
-		require.NoError(t, err)
-		cl, err := sources.NewEthClient(client.NewBaseRPCClient(rpcClient), log.Root(), nil, &ethClCfg)
-		require.NoError(t, err)
-
-		return Combine(
-			WithPrivateKey(priv),
-			WithChainID(cl),
-			WithAgainstLatestBlock(cl),
-			WithPendingNonce(cl),
-			WithEstimator(cl, false),
-			WithTransactionSubmitter(cl),
-			WithRetryInclusion(cl, 10, retry.Exponential()),
-			WithBlockInclusionInfo(cl),
-		)
-	}
-	optsA := optsFunc(rpcURLA, privHexRawA)
-	optsB := optsFunc(rpcURLB, privHexRawB)
-
-	// eventLogger := common.Address{} // TODO deploy tx
-
-	sha256PrecompileAddr := common.BytesToAddress([]byte{0x2})
-	dummyMessage := []byte("l33t message")
-	destChainID := big.NewInt(2151909) // TODO: remove hardcode
+func buildSendMessageCalldata(chainID eth.ChainID, addr common.Address, msg []byte) ([]byte, error) {
 	// construct call input, ugly but no bindings...
 	sendMessage := w3.MustNewFunc("sendMessage(uint256,address,bytes calldata)", "bytes32")
-	sendMessageCalldata, err := sendMessage.EncodeArgs(
-		destChainID,
-		sha256PrecompileAddr,
-		dummyMessage,
-	)
+	return sendMessage.EncodeArgs(chainID.ToBig(), addr, msg)
+}
+
+func TestInteropTx(t *testing.T) {
+	// t.Skip() // temporal addition for make CI pass.
+
+	rng := rand.New(rand.NewSource(1234))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// To run tests against kt-devnet, hardcode the endpoint/private key below.
+	// Fetch from system descriptor
+	privHexA := "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
+	rpcURLA := "http://127.0.0.1:32948"
+	privHexB := "0xeaa861a9a01391ed3d587d8a5a84ca56ee277629a8b02c22093a419bf240e65d"
+	rpcURLB := "http://127.0.0.1:32961"
+
+	walletA, err := newWallet(rpcURLA, privHexA, nil, logger)
+	require.NoError(t, err)
+	walletB, err := newWallet(rpcURLB, privHexB, nil, logger)
 	require.NoError(t, err)
 
-	opagueData := sendMessageCalldata
-	L2toL2CDM := common.HexToAddress(predeploys.L2toL2CrossDomainMessenger)
-	txA := NewIntent[*InitTrigger, *InteropOutput](optsA)
-	txA.Content.Set(&InitTrigger{
-		// Emitter:    eventLogger,
-		Emitter:    L2toL2CDM,
-		Topics:     []common.Hash{},
-		OpaqueData: opagueData,
-	})
+	optsFunc := func(w Wallet) Option {
+		opts := CombineOptions(
+			DefaultTxSubmitOptions(w),
+			DefaultTxInclusionOptions(w),
+		)
+		return opts
+	}
+
+	optsA := optsFunc(walletA)
+	optsB := optsFunc(walletB)
 
 	txB := NewIntent[*ExecTrigger, *InteropOutput](optsB)
+
+	// eventLogger can be a contract the emits any logs
+	// for easy testing, we use existing L2toL2CDM predeploy
+	eventLogger := common.HexToAddress(predeploys.L2toL2CrossDomainMessenger)
+	randomAddr := testutils.RandomAddress(rng)
+	randomData := testutils.RandomData(rng, 200)
+
+	destChainID, err := txB.PlannedTx.ChainID.Eval(ctx)
+	require.NoError(t, err)
+	opaqueData, err := buildSendMessageCalldata(destChainID, randomAddr, randomData)
+	require.NoError(t, err)
+
+	txA := NewIntent[*InitTrigger, *InteropOutput](optsA)
+	txA.Content.Set(&InitTrigger{
+		Emitter:    eventLogger,
+		Topics:     []common.Hash{},
+		OpaqueData: opaqueData,
+	})
+
 	txB.Content.DependOn(&txA.Result)
 	CrossL2InboxAddr := common.HexToAddress(predeploys.CrossL2Inbox)
 	txB.Content.Fn(executeIndexed(CrossL2InboxAddr, &txA.Result, 0))
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	// recA, err := txA.PlannedTx.Success.Eval(ctx)
-	recA, err := txA.Result.Eval(ctx)
-
+	recA, err := txA.PlannedTx.Included.Eval(ctx)
 	require.NoError(t, err)
-
-	t.Log(recA)
-	t.Log("included initiating tx")
+	t.Logf("included initiating tx in block %s", recA.BlockHash)
 
 	recB, err := txB.PlannedTx.Included.Eval(ctx)
 	require.NoError(t, err)

--- a/op-service/txplan/interop_test.go
+++ b/op-service/txplan/interop_test.go
@@ -32,7 +32,7 @@ func TestSimpleTx(t *testing.T) {
 
 	logger := testlog.Logger(t, log.LevelInfo)
 
-	wallet, err := newWallet(rpcURL, privHex, nil, logger)
+	wallet, err := newWallet(ctx, rpcURL, privHex, nil, logger)
 	require.NoError(t, err)
 
 	// send eth to null address
@@ -55,7 +55,7 @@ func buildSendMessageCalldata(chainID eth.ChainID, addr common.Address, msg []by
 	return sendMessage.EncodeArgs(chainID.ToBig(), addr, msg)
 }
 
-func TestInteropTx(t *testing.T) {
+func TestInteropTxUsingL2toL2CDM(t *testing.T) {
 	// t.Skip() // temporal addition for make CI pass.
 
 	rng := rand.New(rand.NewSource(1234))
@@ -70,9 +70,9 @@ func TestInteropTx(t *testing.T) {
 	privHexB := "0xeaa861a9a01391ed3d587d8a5a84ca56ee277629a8b02c22093a419bf240e65d"
 	rpcURLB := "http://127.0.0.1:32961"
 
-	walletA, err := newWallet(rpcURLA, privHexA, nil, logger)
+	walletA, err := newWallet(ctx, rpcURLA, privHexA, nil, logger)
 	require.NoError(t, err)
-	walletB, err := newWallet(rpcURLB, privHexB, nil, logger)
+	walletB, err := newWallet(ctx, rpcURLB, privHexB, nil, logger)
 	require.NoError(t, err)
 
 	optsFunc := func(w Wallet) Option {

--- a/op-service/txplan/interop_test.go
+++ b/op-service/txplan/interop_test.go
@@ -100,6 +100,8 @@ func TestInteropTxUsingL2toL2CDM(t *testing.T) {
 	require.NoError(t, err)
 
 	txA := NewIntent[*InitTrigger, *InteropOutput](optsA)
+	// Topics field is only needed when we call EventLogger contract
+	// We are using L2toL2CDM so make it empty
 	txA.Content.Set(&InitTrigger{
 		Emitter:    eventLogger,
 		Topics:     []common.Hash{},

--- a/op-service/txplan/interop_test.go
+++ b/op-service/txplan/interop_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 func TestSimpleTx(t *testing.T) {
-	// t.Skip() // temporal addition for make CI pass.
-	// To run tests, hardcode the endpoint/private key below
+	t.Skip() // temporal addition for make CI pass.
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -50,13 +50,13 @@ func TestSimpleTx(t *testing.T) {
 }
 
 func buildSendMessageCalldata(chainID eth.ChainID, addr common.Address, msg []byte) ([]byte, error) {
-	// construct call input, ugly but no bindings...
+	// TODO: Need to do better construct call input than this
 	sendMessage := w3.MustNewFunc("sendMessage(uint256,address,bytes calldata)", "bytes32")
 	return sendMessage.EncodeArgs(chainID.ToBig(), addr, msg)
 }
 
 func TestInteropTxUsingL2toL2CDM(t *testing.T) {
-	// t.Skip() // temporal addition for make CI pass.
+	t.Skip() // temporal addition for make CI pass.
 
 	rng := rand.New(rand.NewSource(1234))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -100,6 +100,7 @@ func TestInteropTxUsingL2toL2CDM(t *testing.T) {
 	require.NoError(t, err)
 
 	txA := NewIntent[*InitTrigger, *InteropOutput](optsA)
+
 	// Topics field is only needed when we call EventLogger contract
 	// We are using L2toL2CDM so make it empty
 	txA.Content.Set(&InitTrigger{

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -169,7 +169,7 @@ func WithAssumedInclusion(cl ReceiptGetter) Option {
 	}
 }
 
-func WithRetryInclusion(cl ReceiptGetter, maxAttempts int, strat retry.Strategy) Option {
+func WithRetryInclusion(cl ReceiptGetter, maxAttempts int, strategy retry.Strategy) Option {
 	return func(tx *PlannedTx) {
 		tx.Included.DependOn(&tx.Signed, &tx.Submitted)
 		tx.Included.Fn(func(ctx context.Context) (*types.Receipt, error) {
@@ -177,7 +177,7 @@ func WithRetryInclusion(cl ReceiptGetter, maxAttempts int, strat retry.Strategy)
 		})
 		tx.Included.Wrap(func(fn plan.Fn[*types.Receipt]) plan.Fn[*types.Receipt] {
 			return func(ctx context.Context) (*types.Receipt, error) {
-				return retry.Do(ctx, maxAttempts, strat, func() (*types.Receipt, error) {
+				return retry.Do(ctx, maxAttempts, strategy, func() (*types.Receipt, error) {
 					return fn(ctx)
 				})
 			}

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -5,8 +5,9 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -21,7 +22,7 @@ import (
 
 type PlannedTx struct {
 	// Block that we schedule against
-	AgainstBlock  plan.Lazy[*types.Header]
+	AgainstBlock  plan.Lazy[eth.BlockInfo]
 	Unsigned      plan.Lazy[types.TxData]
 	Signed        plan.Lazy[*types.Transaction]
 	Submitted     plan.Lazy[struct{}]
@@ -86,15 +87,15 @@ func WithAccessList(al types.AccessList) Option {
 	}
 }
 
-func WithPrivateKey(priv *ecdsa.PrivateKey) Option {
+func WithTo(to *common.Address) Option {
 	return func(tx *PlannedTx) {
-		tx.Priv.Set(priv)
+		tx.To.Set(to)
 	}
 }
 
-func WithEth(value *big.Int) Option {
+func WithPrivateKey(priv *ecdsa.PrivateKey) Option {
 	return func(tx *PlannedTx) {
-		tx.Value.Set(value)
+		tx.Priv.Set(priv)
 	}
 }
 
@@ -168,8 +169,12 @@ func WithAssumedInclusion(cl ReceiptGetter) Option {
 	}
 }
 
-func WithRetryInclusion(maxAttempts int, strat retry.Strategy) Option {
+func WithRetryInclusion(cl ReceiptGetter, maxAttempts int, strat retry.Strategy) Option {
 	return func(tx *PlannedTx) {
+		tx.Included.DependOn(&tx.Signed, &tx.Submitted)
+		tx.Included.Fn(func(ctx context.Context) (*types.Receipt, error) {
+			return cl.TransactionReceipt(ctx, tx.Signed.Value().Hash())
+		})
 		tx.Included.Wrap(func(fn plan.Fn[*types.Receipt]) plan.Fn[*types.Receipt] {
 			return func(ctx context.Context) (*types.Receipt, error) {
 				return retry.Do(ctx, maxAttempts, strat, func() (*types.Receipt, error) {
@@ -207,6 +212,34 @@ func WithPendingNonce(cl PendingNonceAt) Option {
 	}
 }
 
+type AgainstLatestBlock interface {
+	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
+}
+
+func WithAgainstLatestBlock(cl AgainstLatestBlock) Option {
+	return func(tx *PlannedTx) {
+		tx.AgainstBlock.Fn(func(ctx context.Context) (eth.BlockInfo, error) {
+			return cl.InfoByLabel(ctx, eth.Unsafe)
+		})
+	}
+}
+
+type ChainID interface {
+	ChainID(ctx context.Context) (*big.Int, error)
+}
+
+func WithChainID(cl ChainID) Option {
+	return func(tx *PlannedTx) {
+		tx.ChainID.Fn(func(ctx context.Context) (eth.ChainID, error) {
+			chainID, err := cl.ChainID(ctx)
+			if err != nil {
+				return eth.ChainID{}, err
+			}
+			return eth.ChainIDFromBig(chainID), nil
+		})
+	}
+}
+
 func (tx *PlannedTx) Defaults() {
 	tx.Type.Set(types.DynamicFeeTxType)
 	tx.To.Set(nil)
@@ -224,7 +257,7 @@ func (tx *PlannedTx) Defaults() {
 	tx.GasFeeCap.DependOn(&tx.GasTipCap, &tx.AgainstBlock)
 	tx.GasFeeCap.Fn(func(ctx context.Context) (*big.Int, error) {
 		tip := tx.GasTipCap.Value()
-		basefee := tx.AgainstBlock.Value().BaseFee
+		basefee := tx.AgainstBlock.Value().BaseFee()
 		feeCap := big.NewInt(0)
 		feeCap = feeCap.Add(tip, basefee)
 		return feeCap, nil

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -58,7 +58,7 @@ func (ptx *PlannedTx) String() string {
 
 type Option func(tx *PlannedTx)
 
-func Combine(opts ...Option) Option {
+func CombineOptions(opts ...Option) Option {
 	return func(tx *PlannedTx) {
 		for _, opt := range opts {
 			opt(tx)
@@ -66,12 +66,28 @@ func Combine(opts ...Option) Option {
 	}
 }
 
+func DefaultTxSubmitOptions(w Wallet) Option {
+	return CombineOptions(
+		WithPrivateKey(w.PrivateKey()),
+		WithChainID(w.Client()),
+		WithAgainstLatestBlock(w.Client()),
+		WithPendingNonce(w.Client()),
+		WithEstimator(w.Client(), false),
+		WithTransactionSubmitter(w.Client()),
+	)
+}
+
+func DefaultTxInclusionOptions(w Wallet) Option {
+	return CombineOptions(
+		WithRetryInclusion(w.Client(), 10, retry.Exponential()),
+		WithBlockInclusionInfo(w.Client()),
+	)
+}
+
 func NewPlannedTx(opts ...Option) *PlannedTx {
 	tx := &PlannedTx{}
 	tx.Defaults()
-	for _, opt := range opts {
-		opt(tx)
-	}
+	CombineOptions(opts...)(tx)
 	return tx
 }
 

--- a/op-service/txplan/txplan_test.go
+++ b/op-service/txplan/txplan_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,7 +18,10 @@ func TestPlannedTx_Defaults(t *testing.T) {
 
 	ptx := NewPlannedTx(WithPrivateKey(key), WithValue(big.NewInt(123)))
 	t.Log("tx", ptx.Signed.String())
-	ptx.AgainstBlock.Set(&types.Header{BaseFee: big.NewInt(7e9)})
+
+	block := types.NewBlock(&types.Header{BaseFee: big.NewInt(7e9)}, nil, nil, nil, types.DefaultBlockConfig)
+	blockInfo := eth.BlockToInfo(block)
+	ptx.AgainstBlock.Set(blockInfo)
 
 	expectedAddr := crypto.PubkeyToAddress(key.PublicKey)
 	signer := types.LatestSignerForChainID(big.NewInt(1))

--- a/op-service/txplan/wallet.go
+++ b/op-service/txplan/wallet.go
@@ -1,0 +1,73 @@
+package txplan
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type Wallet interface {
+	PrivateKey() *ecdsa.PrivateKey
+	Client() *sources.EthClient
+}
+
+type wallet struct {
+	priv   *ecdsa.PrivateKey
+	client *sources.EthClient
+	ctx    context.Context
+}
+
+func newWallet(rpcURL, privHex string, clCfg *sources.EthClientConfig, log log.Logger) (*wallet, error) {
+	privRaw, err := hexutil.Decode(privHex)
+	if err != nil {
+		return nil, err
+	}
+	priv, err := crypto.ToECDSA(privRaw)
+	if err != nil {
+		return nil, err
+	}
+	if clCfg == nil {
+		clCfg = &sources.EthClientConfig{
+			MaxRequestsPerBatch:   10,
+			MaxConcurrentRequests: 10,
+			ReceiptsCacheSize:     10,
+			TransactionsCacheSize: 10,
+			HeadersCacheSize:      10,
+			PayloadsCacheSize:     10,
+			BlockRefsCacheSize:    10,
+			TrustRPC:              false,
+			MustBePostMerge:       true,
+			RPCProviderKind:       sources.RPCKindStandard,
+			MethodResetDuration:   time.Minute,
+		}
+	}
+	ctx := context.Background()
+	rpcClient, err := rpc.DialContext(ctx, rpcURL)
+	if err != nil {
+		return nil, err
+	}
+	cl, err := sources.NewEthClient(client.NewBaseRPCClient(rpcClient), log, nil, clCfg)
+	if err != nil {
+		return nil, err
+	}
+	return &wallet{
+		client: cl,
+		priv:   priv,
+		ctx:    ctx,
+	}, nil
+}
+
+func (w *wallet) PrivateKey() *ecdsa.PrivateKey {
+	return w.priv
+}
+
+func (w *wallet) Client() *sources.EthClient {
+	return w.client
+}

--- a/op-service/txplan/wallet.go
+++ b/op-service/txplan/wallet.go
@@ -24,7 +24,7 @@ type wallet struct {
 	ctx    context.Context
 }
 
-func newWallet(rpcURL, privHex string, clCfg *sources.EthClientConfig, log log.Logger) (*wallet, error) {
+func newWallet(ctx context.Context, rpcURL, privHex string, clCfg *sources.EthClientConfig, log log.Logger) (*wallet, error) {
 	privRaw, err := hexutil.Decode(privHex)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,6 @@ func newWallet(rpcURL, privHex string, clCfg *sources.EthClientConfig, log log.L
 			MethodResetDuration:   time.Minute,
 		}
 	}
-	ctx := context.Background()
 	rpcClient, err := rpc.DialContext(ctx, rpcURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Based on https://github.com/ethereum-optimism/optimism/pull/14568

Added wallets; which are composed of rpc endpoint and private key.

We have options, which are composable parts that constructs PlannedTx. Options may require wallets to lazy evaluate.

Added `WithAccessList` for making executing message pass for CrossL2Inbox call.

Added `WithAgainstLatestBlock` to make the actual transaction sending work for targeting the local devnet.

**Tests**

All existing tests are passing for targeting the local kt-devnet, including the interop test. Make sure to hardcode the rpc endpoints and private keys for temporary test. This initialization may be eventually handled by the devnet-sdk. Currently the tests are skipped in the CI.

Basic message initialization and execution are tested, using the L2toL2CDM. Ideally we may use the `EventLogger.sol` contract for triggering random events on the source chain, and pick up them on the destination chain. This changes may be followed after this PR.


