### PR TITLE
feat: add test to ensure invalid setcode tx is dropped

### DIFF
--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -30,7 +30,7 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 	env.Alice.L2.ActCheckReceiptStatusOfLastTx(true)(t)
 
 	// Instruct the batcher to submit a faulty channel, with an invalid tx.
-	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+	env.Batcher.ActL2BatchBuffer(t, actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
 
@@ -53,7 +53,7 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 
 		txs[1] = newTx
 		return block
-	})
+	}))
 	env.Batcher.ActL2ChannelClose(t)
 	env.Batcher.ActL2BatchSubmit(t)
 
@@ -115,7 +115,7 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	// Instruct the batcher to submit a faulty channel, with an invalid tx in the second block
 	// within the span batch.
 	env.Batcher.ActL2BatchBuffer(t)
-	err := env.Batcher.Buffer(t, func(block *types.Block) *types.Block {
+	err := env.Batcher.Buffer(t, actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
 		txs := block.Transactions()
 
 		var newTx *types.Transaction
@@ -137,7 +137,7 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 
 		txs[1] = newTx
 		return block
-	})
+	}))
 	require.NoError(t, err)
 	env.Batcher.ActL2ChannelClose(t)
 	env.Batcher.ActL2BatchSubmit(t)

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -2,17 +2,24 @@ package proofs_test
 
 import (
 	"bytes"
-	"math/rand"
+	"compress/zlib"
+	"encoding/binary"
+	"io"
+	"math/big"
 	"testing"
+
+	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm/program"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
@@ -186,6 +193,227 @@ func testInvalidSetCodeTxBatch(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	recs := env.Logs.FindLogs(testlog.NewMessageFilter("sequencers may not embed any SetCode transactions before Isthmus"))
 	require.Len(t, recs, 1)
+
+	env.RunFaultProofProgram(t, l2safe.Number, testCfg.CheckResult, testCfg.InputParams...)
+}
+
+func Test_ProgramAction_SetCodeTxWithContractCreationBitSet(gt *testing.T) {
+	matrix := helpers.NewMatrix[any]()
+	defer matrix.Run(gt)
+
+	matrix.AddDefaultTestCases(
+		nil,
+		helpers.LatestForkOnly,
+		runSetCodeTxTypeWithContractCreationBitSetTest,
+	)
+}
+
+type readerWithCurrPos struct {
+	io.Reader
+	currPos uint
+}
+
+func (r *readerWithCurrPos) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	r.currPos += uint(n)
+	return n, err
+}
+
+func (r *readerWithCurrPos) CurrPos() uint {
+	return r.currPos
+}
+
+func (r *readerWithCurrPos) ReadByte() (byte, error) {
+	var b [1]byte
+	_, err := r.Read(b[:])
+	return b[0], err
+}
+
+func runSetCodeTxTypeWithContractCreationBitSetTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	var (
+		aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+		bb = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
+	)
+
+	t := actionsHelpers.NewDefaultTesting(gt)
+
+	// hardcoded because it's not available until after we need it
+	bobAddr := common.HexToAddress("0x14dC79964da2C08b23698B3D3cc7Ca32193d9955")
+
+	// Create 2 contracts, (1) writes 42 to slot 42, (2) calls (1)
+	store42Program := program.New().Sstore(0x42, 0x42)
+	callBobProgram := program.New().Call(nil, bobAddr, 1, 0, 0, 0, 0)
+
+	alloc := *actionsHelpers.DefaultAlloc
+	alloc.L2Alloc = make(map[common.Address]types.Account)
+	alloc.L2Alloc[aa] = types.Account{
+		Code: store42Program.Bytes(),
+	}
+	alloc.L2Alloc[bb] = types.Account{
+		Code: callBobProgram.Bytes(),
+	}
+
+	testCfg.Allocs = &alloc
+
+	tp := helpers.NewTestParams()
+	cfg := helpers.NewBatcherCfg()
+	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, cfg)
+	sequencer := env.Sequencer
+	miner := env.Miner
+	batcher := env.Batcher
+
+	require.Equal(gt, env.Bob.Address(), bobAddr)
+	u1 := sequencer.L2Unsafe()
+
+	sequencer.ActL2EmptyBlock(t) // we'll inject the setcode tx in this block's batch
+
+	aliceSecret := env.Alice.L2.Secret()
+
+	chainID := env.Sequencer.RollupCfg.L2ChainID
+
+	// Sign authorization tuples.
+	// The way the auths are combined, it becomes
+	// 1. tx -> addr1 which is delegated to 0xaaaa
+	// 2. addr1:0xaaaa calls into addr2:0xbbbb
+	// 3. addr2:0xbbbb  writes to storage
+	auth1, err := types.SignSetCode(aliceSecret, types.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainID),
+		Address: bb,
+		Nonce:   0,
+	})
+	require.NoError(gt, err, "failed to sign auth1")
+
+	txdata := &types.SetCodeTx{
+		ChainID:   uint256.MustFromBig(chainID),
+		Nonce:     0,
+		To:        env.Alice.Address(),
+		Gas:       500000,
+		GasFeeCap: uint256.NewInt(5000000000),
+		GasTipCap: uint256.NewInt(2),
+		AuthList:  []types.SetCodeAuthorization{auth1},
+	}
+	signer := types.NewIsthmusSigner(chainID)
+	tx := types.MustSignNewTx(aliceSecret, signer, txdata)
+
+	txdata2 := &types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     1,
+		To:        nil,
+		Gas:       500000,
+		GasFeeCap: big.NewInt(5000000000),
+		GasTipCap: big.NewInt(2),
+	}
+	tx2 := types.MustSignNewTx(aliceSecret, signer, txdata2)
+
+	batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+		// inject user tx into upgrade batch
+		return block.WithBody(types.Body{Transactions: append(block.Transactions(), tx, tx2)})
+	})
+	batcher.ActL2ChannelClose(t)
+
+	outputFrame := batcher.ReadNextOutputFrame(t)
+
+	// Zlib decompress
+	require.Equal(t, outputFrame[0], byte(0), "expected zlib compression")
+
+	// extract frame data from frame
+	frameDataLen := binary.BigEndian.Uint32(outputFrame[1+16+2 : 1+16+2+4])
+	frameData := outputFrame[1+16+2+4 : 1+16+2+4+frameDataLen]
+
+	// decompress with zlib
+	bufReader := bytes.NewBuffer(frameData)
+	decompressor, err := zlib.NewReader(bufReader)
+	require.NoError(t, err)
+	decompressedData, err := io.ReadAll(decompressor)
+	require.NoError(t, err)
+
+	// rlp decode
+	var rlpDecoded []byte
+	err = rlp.DecodeBytes(decompressedData, &rlpDecoded)
+	require.NoError(t, err)
+
+	// decode batch data to find contract creation bit offset
+	batchType := rlpDecoded[0]
+	require.Equal(t, batchType, byte(derive.SpanBatchType))
+	batchBuf := &readerWithCurrPos{Reader: bytes.NewReader(rlpDecoded[1:])}
+
+	// read prefix
+	_, err = binary.ReadUvarint(batchBuf)
+	require.NoError(t, err, "failed to read rel timestamp")
+	_, err = binary.ReadUvarint(batchBuf)
+	require.NoError(t, err, "failed to read l1 origin num timestamp")
+	_, err = batchBuf.Read(make([]byte, 40))
+	require.NoError(t, err, "failed to read parent and origin checks")
+
+	// read payload
+	blockCount, err := binary.ReadUvarint(batchBuf)
+	require.NoError(t, err, "failed to read block count")
+
+	originBitfieldSize := (blockCount + 7) / 8
+	originBitfield := make([]byte, originBitfieldSize)
+	_, err = batchBuf.Read(originBitfield)
+	require.NoError(t, err, "failed to read origin bitfield")
+
+	blockTxCounts := make([]uint64, blockCount)
+	totalBlockTxCount := uint64(0)
+
+	for i := uint64(0); i < blockCount; i++ {
+		blockTxCount, err := binary.ReadUvarint(batchBuf)
+		require.NoError(t, err, "failed to read block tx count")
+
+		blockTxCounts[i] = blockTxCount
+		totalBlockTxCount += blockTxCount
+	}
+
+	// read contract creation bits
+	contractCreationBits := make([]byte, (totalBlockTxCount+7)/8)
+	_, err = batchBuf.Read(contractCreationBits)
+	require.NoError(t, err, "failed to read contract creation bits")
+
+	offsetStart := uint64(batchBuf.CurrPos()) - uint64(totalBlockTxCount+7)/8 + 1
+	require.Equal(t, contractCreationBits[0], byte(0b10), "expected contract creation bits to be 0b10")
+
+	// flip the second bit (big endian)
+	rlpDecoded[offsetStart] = 0b01 // unset bit 2 and set bit 1
+
+	// re-encode rlp
+	var buf bytes.Buffer
+	err = rlp.Encode(&buf, rlpDecoded)
+	require.NoError(t, err)
+
+	// re-compress
+	compressedBuf := new(bytes.Buffer)
+	compressor, err := zlib.NewWriterLevel(compressedBuf, zlib.BestCompression)
+	require.NoError(t, err)
+	_, err = compressor.Write(buf.Bytes())
+	require.NoError(t, err)
+	err = compressor.Close()
+	require.NoError(t, err)
+
+	// replace the frame data with the new compressed data
+	newOutputFrame := make([]byte, 1+16+2+4+len(compressedBuf.Bytes())+1)
+	copy(newOutputFrame[:1+16+2], outputFrame[:1+16+2])
+	binary.BigEndian.PutUint32(newOutputFrame[1+16+2:1+16+2+4], uint32(len(compressedBuf.Bytes())))
+	copy(newOutputFrame[1+16+2+4:], compressedBuf.Bytes())
+	newOutputFrame[len(newOutputFrame)-1] = outputFrame[len(outputFrame)-1]
+
+	// submit new batch
+	batcher.ActL2BatchSubmitRaw(t, newOutputFrame)
+
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+	miner.ActL1EndBlock(t)
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+
+	l2safe := sequencer.L2Safe()
+	s2block := env.Engine.L2Chain().GetBlockByHash(l2safe.Hash)
+	require.Len(t, s2block.Transactions(), 0, "safe head should not contain either tx")
+	require.Equal(t, u1, l2safe, "expected last block to be reorgd out due to setcode tx")
+
+	// recs := env.Logs.FindLogs(testlog.NewMessageFilter("to address is required for SetCodeTx"))
+	// require.Len(t, recs, 1)
 
 	env.RunFaultProofProgram(t, l2safe.Number, testCfg.CheckResult, testCfg.InputParams...)
 }

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -414,8 +414,9 @@ func runSetCodeTxTypeWithContractCreationBitSetTest(gt *testing.T, testCfg *help
 	require.Len(t, s2block.Transactions(), 0, "safe head should not contain either tx")
 	require.Equal(t, u1, l2safe, "expected last block to be reorgd out due to setcode tx")
 
-	// recs := env.Logs.FindLogs(testlog.NewMessageFilter("to address is required for SetCodeTx"))
-	// require.Len(t, recs, 1)
+	// find a log with the error message as an attr
+	recs := env.Logs.FindLogs(testlog.NewErrContainsFilter("to address is required for SetCodeTx"))
+	require.GreaterOrEqual(t, len(recs), 1)
 
 	env.RunFaultProofProgram(t, l2safe.Number, testCfg.CheckResult, testCfg.InputParams...)
 }

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -2,8 +2,6 @@ package proofs_test
 
 import (
 	"bytes"
-	"compress/zlib"
-	"encoding/binary"
 	"io"
 	"math/big"
 	"testing"
@@ -13,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm/program"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
@@ -174,10 +171,10 @@ func testInvalidSetCodeTxBatch(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	rng := rand.New(rand.NewSource(0))
 	setcodetx := testutils.RandomSetCodeTx(rng, types.NewPragueSigner(env.Sd.RollupCfg.L2ChainID))
 	batcher.ActL2BatchBuffer(t)
-	batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+	batcher.ActL2BatchBuffer(t, actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
 		// inject user tx into upgrade batch
 		return block.WithBody(types.Body{Transactions: append(block.Transactions(), setcodetx)})
-	})
+	}))
 	batcher.ActL2ChannelClose(t)
 	batcher.ActL2BatchSubmit(t)
 	miner.ActL1StartBlock(12)(t)
@@ -210,25 +207,17 @@ func Test_ProgramAction_SetCodeTxWithContractCreationBitSet(gt *testing.T) {
 	matrix.Run(gt)
 }
 
-type readerWithCurrPos struct {
-	io.Reader
-	currPos uint
+type spanBatchWithContractCreationBits struct {
+	derive.RawSpanBatch
+	overrideContractCreationBits *big.Int
 }
 
-func (r *readerWithCurrPos) Read(p []byte) (n int, err error) {
-	n, err = r.Reader.Read(p)
-	r.currPos += uint(n)
-	return n, err
-}
-
-func (r *readerWithCurrPos) CurrPos() uint {
-	return r.currPos
-}
-
-func (r *readerWithCurrPos) ReadByte() (byte, error) {
-	var b [1]byte
-	_, err := r.Read(b[:])
-	return b[0], err
+func (b *spanBatchWithContractCreationBits) Encode(w io.Writer) error {
+	batchCpy := *b
+	batchTxsCpy := *b.Txs
+	batchCpy.Txs = &batchTxsCpy
+	batchCpy.Txs.ContractCreationBits = b.overrideContractCreationBits
+	return batchCpy.RawSpanBatch.Encode(w)
 }
 
 func runSetCodeTxTypeWithContractCreationBitSetTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
@@ -285,100 +274,27 @@ func runSetCodeTxTypeWithContractCreationBitSetTest(gt *testing.T, testCfg *help
 	}
 	tx2 := types.MustSignNewTx(env.Alice.L2.Secret(), signer, txdata2)
 
-	batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
-		// inject user tx into upgrade batch
-		return block.WithBody(types.Body{Transactions: append(block.Transactions(), tx, tx2)})
-	})
+	batcher.ActL2BatchBuffer(
+		t,
+		actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
+			// inject user tx into upgrade batch
+			return block.WithBody(types.Body{Transactions: append(block.Transactions(), tx, tx2)})
+		}),
+		actionsHelpers.WithChannelModifier(
+			derive.WithBatchDataOptions(
+				derive.WithBatchTypeOverride(func(batchData *derive.RawSpanBatch) derive.InnerBatchData {
+					// ensure contract bits are originally set to 0b10
+					require.Equal(t, big.NewInt(0b10), batchData.SpanBatchPayload.Txs.ContractCreationBits, "expected contract creation bits to be 0b10")
+
+					return &spanBatchWithContractCreationBits{
+						RawSpanBatch:                 *batchData,
+						overrideContractCreationBits: big.NewInt(0b01),
+					}
+				}))),
+	)
 	batcher.ActL2ChannelClose(t)
 
-	outputFrame := batcher.ReadNextOutputFrame(t)
-
-	// Zlib decompress
-	require.Equal(t, outputFrame[0], byte(0), "expected zlib compression")
-
-	// extract frame data from frame
-	frameDataLen := binary.BigEndian.Uint32(outputFrame[1+16+2 : 1+16+2+4])
-	frameData := outputFrame[1+16+2+4 : 1+16+2+4+frameDataLen]
-
-	// decompress with zlib
-	bufReader := bytes.NewBuffer(frameData)
-	decompressor, err := zlib.NewReader(bufReader)
-	require.NoError(t, err)
-	decompressedData, err := io.ReadAll(decompressor)
-	require.NoError(t, err)
-
-	// rlp decode
-	var rlpDecoded []byte
-	err = rlp.DecodeBytes(decompressedData, &rlpDecoded)
-	require.NoError(t, err)
-
-	// decode batch data to find contract creation bit offset
-	batchType := rlpDecoded[0]
-	require.Equal(t, batchType, byte(derive.SpanBatchType))
-	batchBuf := &readerWithCurrPos{Reader: bytes.NewReader(rlpDecoded[1:])}
-
-	// read prefix
-	_, err = binary.ReadUvarint(batchBuf)
-	require.NoError(t, err, "failed to read rel timestamp")
-	_, err = binary.ReadUvarint(batchBuf)
-	require.NoError(t, err, "failed to read l1 origin num timestamp")
-	_, err = batchBuf.Read(make([]byte, 40))
-	require.NoError(t, err, "failed to read parent and origin checks")
-
-	// read payload
-	blockCount, err := binary.ReadUvarint(batchBuf)
-	require.NoError(t, err, "failed to read block count")
-
-	originBitfieldSize := (blockCount + 7) / 8
-	originBitfield := make([]byte, originBitfieldSize)
-	_, err = batchBuf.Read(originBitfield)
-	require.NoError(t, err, "failed to read origin bitfield")
-
-	blockTxCounts := make([]uint64, blockCount)
-	totalBlockTxCount := uint64(0)
-
-	for i := uint64(0); i < blockCount; i++ {
-		blockTxCount, err := binary.ReadUvarint(batchBuf)
-		require.NoError(t, err, "failed to read block tx count")
-
-		blockTxCounts[i] = blockTxCount
-		totalBlockTxCount += blockTxCount
-	}
-
-	// read contract creation bits
-	contractCreationBits := make([]byte, (totalBlockTxCount+7)/8)
-	_, err = batchBuf.Read(contractCreationBits)
-	require.NoError(t, err, "failed to read contract creation bits")
-
-	offsetStart := uint64(batchBuf.CurrPos()) - uint64(totalBlockTxCount+7)/8 + 1
-	require.Equal(t, contractCreationBits[0], byte(0b10), "expected contract creation bits to be 0b10")
-
-	// flip the second bit (big endian)
-	rlpDecoded[offsetStart] = 0b01 // unset bit 2 and set bit 1
-
-	// re-encode rlp
-	var buf bytes.Buffer
-	err = rlp.Encode(&buf, rlpDecoded)
-	require.NoError(t, err)
-
-	// re-compress
-	compressedBuf := new(bytes.Buffer)
-	compressor, err := zlib.NewWriterLevel(compressedBuf, zlib.BestCompression)
-	require.NoError(t, err)
-	_, err = compressor.Write(buf.Bytes())
-	require.NoError(t, err)
-	err = compressor.Close()
-	require.NoError(t, err)
-
-	// replace the frame data with the new compressed data
-	newOutputFrame := make([]byte, 1+16+2+4+len(compressedBuf.Bytes())+1)
-	copy(newOutputFrame[:1+16+2], outputFrame[:1+16+2])
-	binary.BigEndian.PutUint32(newOutputFrame[1+16+2:1+16+2+4], uint32(len(compressedBuf.Bytes())))
-	copy(newOutputFrame[1+16+2+4:], compressedBuf.Bytes())
-	newOutputFrame[len(newOutputFrame)-1] = outputFrame[len(outputFrame)-1]
-
-	// submit new batch
-	batcher.ActL2BatchSubmitRaw(t, newOutputFrame)
+	batcher.ActL2BatchSubmit(t)
 
 	miner.ActL1StartBlock(12)(t)
 	miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -263,39 +263,17 @@ func runSetCodeTxTypeWithContractCreationBitSetTest(gt *testing.T, testCfg *help
 	sequencer := env.Sequencer
 	miner := env.Miner
 	batcher := env.Batcher
+	chainID := env.Sequencer.RollupCfg.L2ChainID
 
 	require.Equal(gt, env.Bob.Address(), bobAddr)
 	u1 := sequencer.L2Unsafe()
 
 	sequencer.ActL2EmptyBlock(t) // we'll inject the setcode tx in this block's batch
 
-	aliceSecret := env.Alice.L2.Secret()
-
-	chainID := env.Sequencer.RollupCfg.L2ChainID
-
-	// Sign authorization tuples.
-	// The way the auths are combined, it becomes
-	// 1. tx -> addr1 which is delegated to 0xaaaa
-	// 2. addr1:0xaaaa calls into addr2:0xbbbb
-	// 3. addr2:0xbbbb  writes to storage
-	auth1, err := types.SignSetCode(aliceSecret, types.SetCodeAuthorization{
-		ChainID: *uint256.MustFromBig(chainID),
-		Address: bb,
-		Nonce:   0,
-	})
-	require.NoError(gt, err, "failed to sign auth1")
-
-	txdata := &types.SetCodeTx{
-		ChainID:   uint256.MustFromBig(chainID),
-		Nonce:     0,
-		To:        env.Alice.Address(),
-		Gas:       500000,
-		GasFeeCap: uint256.NewInt(5000000000),
-		GasTipCap: uint256.NewInt(2),
-		AuthList:  []types.SetCodeAuthorization{auth1},
-	}
 	signer := types.NewIsthmusSigner(chainID)
-	tx := types.MustSignNewTx(aliceSecret, signer, txdata)
+
+	rng := rand.New(rand.NewSource(0))
+	tx := testutils.RandomSetCodeTx(rng, signer)
 
 	txdata2 := &types.DynamicFeeTx{
 		ChainID:   chainID,
@@ -305,7 +283,7 @@ func runSetCodeTxTypeWithContractCreationBitSetTest(gt *testing.T, testCfg *help
 		GasFeeCap: big.NewInt(5000000000),
 		GasTipCap: big.NewInt(2),
 	}
-	tx2 := types.MustSignNewTx(aliceSecret, signer, txdata2)
+	tx2 := types.MustSignNewTx(env.Alice.L2.Secret(), signer, txdata2)
 
 	batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
 		// inject user tx into upgrade batch

--- a/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
+++ b/op-e2e/actions/proofs/isthmus_setcode_tx_test.go
@@ -26,13 +26,14 @@ import (
 
 func Test_ProgramAction_SetCodeTx(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
-	defer matrix.Run(gt)
 
 	matrix.AddDefaultTestCases(
 		nil,
 		helpers.LatestForkOnly,
 		runSetCodeTxTypeTest,
 	)
+
+	matrix.Run(gt)
 }
 
 func runSetCodeTxTypeTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
@@ -199,13 +200,14 @@ func testInvalidSetCodeTxBatch(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 func Test_ProgramAction_SetCodeTxWithContractCreationBitSet(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
-	defer matrix.Run(gt)
 
 	matrix.AddDefaultTestCases(
 		nil,
 		helpers.LatestForkOnly,
 		runSetCodeTxTypeWithContractCreationBitSetTest,
 	)
+
+	matrix.Run(gt)
 }
 
 type readerWithCurrPos struct {

--- a/op-e2e/actions/proofs/l1_lookback_test.go
+++ b/op-e2e/actions/proofs/l1_lookback_test.go
@@ -73,13 +73,13 @@ func runL1LookbackTest_ReopenChannel(gt *testing.T, testCfg *helpers.TestCfg[any
 	env.Miner.ActL1SafeNext(t)
 
 	// Re-submit the first L2 block frame w/ different transaction data.
-	err := env.Batcher.Buffer(t, func(block *types.Block) *types.Block {
+	err := env.Batcher.Buffer(t, actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
 		env.Bob.L2.ActResetTxOpts(t)
 		env.Bob.L2.ActSetTxToAddr(&env.Dp.Addresses.Mallory)
 		tx := env.Bob.L2.MakeTransaction(t)
 		block.Transactions()[1] = tx
 		return block
-	})
+	}))
 	require.NoError(t, err)
 	env.Batcher.ActL2BatchSubmit(t)
 

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -254,7 +254,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 
 			// Instruct the batcher to submit a faulty channel, with Alice's tx re-signed by a new private key.
 			// This key will have 0 balance.
-			env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+			env.Batcher.ActL2BatchBuffer(t, actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
 				txs := block.Transactions()
 
 				// Skip over any L2 blocks that don't contain user-space txs.
@@ -271,7 +271,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 				// Replace Alice's tx with the re-signed one.
 				txs[1] = newSignedTx
 				return block
-			})
+			}))
 			env.Batcher.ActL2ChannelClose(t)
 			env.Batcher.ActL2BatchSubmit(t)
 

--- a/op-e2e/actions/upgrades/holocene_fork_test.go
+++ b/op-e2e/actions/upgrades/holocene_fork_test.go
@@ -170,14 +170,14 @@ func TestHoloceneInvalidPayload(gt *testing.T) {
 	require.Len(t, b.Transactions(), 2)
 
 	// buffer into the batcher, invalidating the tx via signature zeroing
-	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+	env.Batcher.ActL2BatchBuffer(t, helpers.WithBlockModifier(func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
 		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
 		require.NoError(t, err)
 		txs[1] = newTx
 		return block
-	})
+	}))
 
 	// generate two more empty blocks
 	env.Seq.ActL2EmptyBlock(t) // 4

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -54,11 +54,21 @@ func (b batchWithMetadata) LogContext(l log.Logger) log.Logger {
 	return lgr.With("compression_algo", b.comprAlgo)
 }
 
+type BatchDataOption func(*BatchData) *BatchData
+
+func WithBatchTypeOverride(batchTypeOverride func(*RawSpanBatch) InnerBatchData) BatchDataOption {
+	return func(b *BatchData) *BatchData {
+		b.makeBatch = batchTypeOverride
+		return b
+	}
+}
+
 // BatchData is used to represent the typed encoding & decoding.
 // and wraps around a single interface InnerBatchData.
 // Further fields such as cache can be added in the future, without embedding each type of InnerBatchData.
 // Similar design with op-geth's types.Transaction struct.
 type BatchData struct {
+	makeBatch func(*RawSpanBatch) InnerBatchData
 	inner     InnerBatchData
 	ComprAlgo CompressionAlgo
 }
@@ -67,8 +77,8 @@ type BatchData struct {
 // This is implemented by SingularBatch and RawSpanBatch.
 type InnerBatchData interface {
 	GetBatchType() int
-	encode(w io.Writer) error
-	decode(r *bytes.Reader) error
+	Encode(w io.Writer) error
+	Decode(r *bytes.Reader) error
 }
 
 // EncodeRLP implements rlp.Encoder
@@ -98,7 +108,15 @@ func (b *BatchData) encodeTyped(buf *bytes.Buffer) error {
 	if err := buf.WriteByte(b.GetBatchType()); err != nil {
 		return err
 	}
-	return b.inner.encode(buf)
+
+	if b.makeBatch != nil {
+		if sb, ok := b.inner.(*RawSpanBatch); ok {
+			wrappedBatch := b.makeBatch(sb)
+			return wrappedBatch.Encode(buf)
+		}
+	}
+
+	return b.inner.Encode(buf)
 }
 
 // DecodeRLP implements rlp.Decoder
@@ -135,7 +153,7 @@ func (b *BatchData) decodeTyped(data []byte) error {
 	default:
 		return fmt.Errorf("unrecognized batch type: %d", data[0])
 	}
-	if err := inner.decode(bytes.NewReader(data[1:])); err != nil {
+	if err := inner.Decode(bytes.NewReader(data[1:])); err != nil {
 		return err
 	}
 	b.inner = inner
@@ -143,6 +161,12 @@ func (b *BatchData) decodeTyped(data []byte) error {
 }
 
 // NewBatchData creates a new BatchData
-func NewBatchData(inner InnerBatchData) *BatchData {
-	return &BatchData{inner: inner}
+func NewBatchData(inner InnerBatchData, options ...BatchDataOption) *BatchData {
+	d := &BatchData{inner: inner}
+
+	for _, opt := range options {
+		d = opt(d)
+	}
+
+	return d
 }

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -61,17 +61,17 @@ func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 		panic(err.Error())
 	}
 	rawSpanBatch := RawSpanBatch{
-		spanBatchPrefix: spanBatchPrefix{
-			relTimestamp:  uint64(rng.Uint32()),
-			l1OriginNum:   rng.Uint64(),
-			parentCheck:   [20]byte(testutils.RandomData(rng, 20)),
-			l1OriginCheck: [20]byte(testutils.RandomData(rng, 20)),
+		SpanBatchPrefix: SpanBatchPrefix{
+			RelTimestamp:  uint64(rng.Uint32()),
+			L1OriginNum:   rng.Uint64(),
+			ParentCheck:   [20]byte(testutils.RandomData(rng, 20)),
+			L1OriginCheck: [20]byte(testutils.RandomData(rng, 20)),
 		},
-		spanBatchPayload: spanBatchPayload{
-			blockCount:    blockCount,
-			originBits:    originBits,
-			blockTxCounts: blockTxCounts,
-			txs:           spanBatchTxs,
+		SpanBatchPayload: SpanBatchPayload{
+			BlockCount:    blockCount,
+			OriginBits:    originBits,
+			BlockTxCounts: blockTxCounts,
+			Txs:           spanBatchTxs,
 		},
 	}
 	return &rawSpanBatch
@@ -112,8 +112,8 @@ func mockL1Origin(rng *rand.Rand, rawSpanBatch *RawSpanBatch, singularBatches []
 
 	l1Origins := []eth.L1BlockRef{safeHeadOrigin}
 	originBitSum := uint64(0)
-	for i := 0; i < int(rawSpanBatch.blockCount); i++ {
-		if rawSpanBatch.originBits.Bit(i) == 1 {
+	for i := 0; i < int(rawSpanBatch.BlockCount); i++ {
+		if rawSpanBatch.OriginBits.Bit(i) == 1 {
 			l1Origin := testutils.NextRandomRef(rng, l1Origins[originBitSum])
 			originBitSum++
 			l1Origin.Hash = singularBatches[i].EpochHash

--- a/op-node/rollup/derive/singular_batch.go
+++ b/op-node/rollup/derive/singular_batch.go
@@ -61,13 +61,13 @@ func (b *SingularBatch) Epoch() eth.BlockID {
 	return eth.BlockID{Hash: b.EpochHash, Number: uint64(b.EpochNum)}
 }
 
-// encode writes the byte encoding of SingularBatch to Writer stream
-func (b *SingularBatch) encode(w io.Writer) error {
+// Encode writes the byte encoding of SingularBatch to Writer stream
+func (b *SingularBatch) Encode(w io.Writer) error {
 	return rlp.Encode(w, b)
 }
 
-// decode reads the byte encoding of SingularBatch from Reader stream
-func (b *SingularBatch) decode(r *bytes.Reader) error {
+// Decode reads the byte encoding of SingularBatch from Reader stream
+func (b *SingularBatch) Decode(r *bytes.Reader) error {
 	return rlp.Decode(r, b)
 }
 

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -31,24 +31,24 @@ var ErrTooBigSpanBatchSize = errors.New("span batch size limit reached")
 
 var ErrEmptySpanBatch = errors.New("span-batch must not be empty")
 
-type spanBatchPrefix struct {
-	relTimestamp  uint64   // Relative timestamp of the first block
-	l1OriginNum   uint64   // L1 origin number
-	parentCheck   [20]byte // First 20 bytes of the first block's parent hash
-	l1OriginCheck [20]byte // First 20 bytes of the last block's L1 origin hash
+type SpanBatchPrefix struct {
+	RelTimestamp  uint64   // Relative timestamp of the first block
+	L1OriginNum   uint64   // L1 origin number
+	ParentCheck   [20]byte // First 20 bytes of the first block's parent hash
+	L1OriginCheck [20]byte // First 20 bytes of the last block's L1 origin hash
 }
 
-type spanBatchPayload struct {
-	blockCount    uint64        // Number of L2 block in the span
-	originBits    *big.Int      // Standard span-batch bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
-	blockTxCounts []uint64      // List of transaction counts for each L2 block
-	txs           *spanBatchTxs // Transactions encoded in SpanBatch specs
+type SpanBatchPayload struct {
+	BlockCount    uint64        // Number of L2 block in the span
+	OriginBits    *big.Int      // Standard span-batch bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
+	BlockTxCounts []uint64      // List of transaction counts for each L2 block
+	Txs           *SpanBatchTxs // Transactions encoded in SpanBatch specs
 }
 
 // RawSpanBatch is another representation of SpanBatch, that encodes data according to SpanBatch specs.
 type RawSpanBatch struct {
-	spanBatchPrefix
-	spanBatchPayload
+	SpanBatchPrefix
+	SpanBatchPayload
 }
 
 // GetBatchType returns its batch type (batch_version)
@@ -57,41 +57,41 @@ func (b *RawSpanBatch) GetBatchType() int {
 }
 
 // decodeOriginBits parses data into bp.originBits
-func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
-	if bp.blockCount > MaxSpanBatchElementCount {
+func (bp *SpanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
+	if bp.BlockCount > MaxSpanBatchElementCount {
 		return ErrTooBigSpanBatchSize
 	}
-	bits, err := decodeSpanBatchBits(r, bp.blockCount)
+	bits, err := decodeSpanBatchBits(r, bp.BlockCount)
 	if err != nil {
 		return fmt.Errorf("failed to decode origin bits: %w", err)
 	}
-	bp.originBits = bits
+	bp.OriginBits = bits
 	return nil
 }
 
 // decodeRelTimestamp parses data into bp.relTimestamp
-func (bp *spanBatchPrefix) decodeRelTimestamp(r *bytes.Reader) error {
+func (bp *SpanBatchPrefix) decodeRelTimestamp(r *bytes.Reader) error {
 	relTimestamp, err := binary.ReadUvarint(r)
 	if err != nil {
 		return fmt.Errorf("failed to read rel timestamp: %w", err)
 	}
-	bp.relTimestamp = relTimestamp
+	bp.RelTimestamp = relTimestamp
 	return nil
 }
 
 // decodeL1OriginNum parses data into bp.l1OriginNum
-func (bp *spanBatchPrefix) decodeL1OriginNum(r *bytes.Reader) error {
+func (bp *SpanBatchPrefix) decodeL1OriginNum(r *bytes.Reader) error {
 	L1OriginNum, err := binary.ReadUvarint(r)
 	if err != nil {
 		return fmt.Errorf("failed to read l1 origin num: %w", err)
 	}
-	bp.l1OriginNum = L1OriginNum
+	bp.L1OriginNum = L1OriginNum
 	return nil
 }
 
 // decodeParentCheck parses data into bp.parentCheck
-func (bp *spanBatchPrefix) decodeParentCheck(r *bytes.Reader) error {
-	_, err := io.ReadFull(r, bp.parentCheck[:])
+func (bp *SpanBatchPrefix) decodeParentCheck(r *bytes.Reader) error {
+	_, err := io.ReadFull(r, bp.ParentCheck[:])
 	if err != nil {
 		return fmt.Errorf("failed to read parent check: %w", err)
 	}
@@ -99,8 +99,8 @@ func (bp *spanBatchPrefix) decodeParentCheck(r *bytes.Reader) error {
 }
 
 // decodeL1OriginCheck parses data into bp.decodeL1OriginCheck
-func (bp *spanBatchPrefix) decodeL1OriginCheck(r *bytes.Reader) error {
-	_, err := io.ReadFull(r, bp.l1OriginCheck[:])
+func (bp *SpanBatchPrefix) decodeL1OriginCheck(r *bytes.Reader) error {
+	_, err := io.ReadFull(r, bp.L1OriginCheck[:])
 	if err != nil {
 		return fmt.Errorf("failed to read l1 origin check: %w", err)
 	}
@@ -108,7 +108,7 @@ func (bp *spanBatchPrefix) decodeL1OriginCheck(r *bytes.Reader) error {
 }
 
 // decodePrefix parses data into bp.spanBatchPrefix
-func (bp *spanBatchPrefix) decodePrefix(r *bytes.Reader) error {
+func (bp *SpanBatchPrefix) decodePrefix(r *bytes.Reader) error {
 	if err := bp.decodeRelTimestamp(r); err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (bp *spanBatchPrefix) decodePrefix(r *bytes.Reader) error {
 }
 
 // decodeBlockCount parses data into bp.blockCount
-func (bp *spanBatchPayload) decodeBlockCount(r *bytes.Reader) error {
+func (bp *SpanBatchPayload) decodeBlockCount(r *bytes.Reader) error {
 	blockCount, err := binary.ReadUvarint(r)
 	if err != nil {
 		return fmt.Errorf("failed to read block count: %w", err)
@@ -137,15 +137,15 @@ func (bp *spanBatchPayload) decodeBlockCount(r *bytes.Reader) error {
 	if blockCount == 0 {
 		return ErrEmptySpanBatch
 	}
-	bp.blockCount = blockCount
+	bp.BlockCount = blockCount
 	return nil
 }
 
 // decodeBlockTxCounts parses data into bp.blockTxCounts
 // and sets bp.txs.totalBlockTxCount as sum(bp.blockTxCounts)
-func (bp *spanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
+func (bp *SpanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
 	var blockTxCounts []uint64
-	for i := 0; i < int(bp.blockCount); i++ {
+	for i := 0; i < int(bp.BlockCount); i++ {
 		blockTxCount, err := binary.ReadUvarint(r)
 		if err != nil {
 			return fmt.Errorf("failed to read block tx count: %w", err)
@@ -157,21 +157,21 @@ func (bp *spanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
 		}
 		blockTxCounts = append(blockTxCounts, blockTxCount)
 	}
-	bp.blockTxCounts = blockTxCounts
+	bp.BlockTxCounts = blockTxCounts
 	return nil
 }
 
 // decodeTxs parses data into bp.txs
-func (bp *spanBatchPayload) decodeTxs(r *bytes.Reader) error {
-	if bp.txs == nil {
-		bp.txs = &spanBatchTxs{}
+func (bp *SpanBatchPayload) decodeTxs(r *bytes.Reader) error {
+	if bp.Txs == nil {
+		bp.Txs = &SpanBatchTxs{}
 	}
-	if bp.blockTxCounts == nil {
+	if bp.BlockTxCounts == nil {
 		return errors.New("failed to read txs: blockTxCounts not set")
 	}
 	totalBlockTxCount := uint64(0)
-	for i := 0; i < len(bp.blockTxCounts); i++ {
-		total, overflow := math.SafeAdd(totalBlockTxCount, bp.blockTxCounts[i])
+	for i := 0; i < len(bp.BlockTxCounts); i++ {
+		total, overflow := math.SafeAdd(totalBlockTxCount, bp.BlockTxCounts[i])
 		if overflow {
 			return ErrTooBigSpanBatchSize
 		}
@@ -181,15 +181,15 @@ func (bp *spanBatchPayload) decodeTxs(r *bytes.Reader) error {
 	if totalBlockTxCount > MaxSpanBatchElementCount {
 		return ErrTooBigSpanBatchSize
 	}
-	bp.txs.totalBlockTxCount = totalBlockTxCount
-	if err := bp.txs.decode(r); err != nil {
+	bp.Txs.TotalBlockTxCount = totalBlockTxCount
+	if err := bp.Txs.decode(r); err != nil {
 		return err
 	}
 	return nil
 }
 
 // decodePayload parses data into bp.spanBatchPayload
-func (bp *spanBatchPayload) decodePayload(r *bytes.Reader) error {
+func (bp *SpanBatchPayload) decodePayload(r *bytes.Reader) error {
 	if err := bp.decodeBlockCount(r); err != nil {
 		return err
 	}
@@ -205,8 +205,8 @@ func (bp *spanBatchPayload) decodePayload(r *bytes.Reader) error {
 	return nil
 }
 
-// decode reads the byte encoding of SpanBatch from Reader stream
-func (b *RawSpanBatch) decode(r *bytes.Reader) error {
+// Decode reads the byte encoding of SpanBatch from Reader stream
+func (b *RawSpanBatch) Decode(r *bytes.Reader) error {
 	if err := b.decodePrefix(r); err != nil {
 		return fmt.Errorf("failed to decode span batch prefix: %w", err)
 	}
@@ -217,9 +217,9 @@ func (b *RawSpanBatch) decode(r *bytes.Reader) error {
 }
 
 // encodeRelTimestamp encodes bp.relTimestamp
-func (bp *spanBatchPrefix) encodeRelTimestamp(w io.Writer) error {
+func (bp *SpanBatchPrefix) encodeRelTimestamp(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
-	n := binary.PutUvarint(buf[:], bp.relTimestamp)
+	n := binary.PutUvarint(buf[:], bp.RelTimestamp)
 	if _, err := w.Write(buf[:n]); err != nil {
 		return fmt.Errorf("cannot write rel timestamp: %w", err)
 	}
@@ -227,9 +227,9 @@ func (bp *spanBatchPrefix) encodeRelTimestamp(w io.Writer) error {
 }
 
 // encodeL1OriginNum encodes bp.l1OriginNum
-func (bp *spanBatchPrefix) encodeL1OriginNum(w io.Writer) error {
+func (bp *SpanBatchPrefix) encodeL1OriginNum(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
-	n := binary.PutUvarint(buf[:], bp.l1OriginNum)
+	n := binary.PutUvarint(buf[:], bp.L1OriginNum)
 	if _, err := w.Write(buf[:n]); err != nil {
 		return fmt.Errorf("cannot write l1 origin number: %w", err)
 	}
@@ -237,23 +237,23 @@ func (bp *spanBatchPrefix) encodeL1OriginNum(w io.Writer) error {
 }
 
 // encodeParentCheck encodes bp.parentCheck
-func (bp *spanBatchPrefix) encodeParentCheck(w io.Writer) error {
-	if _, err := w.Write(bp.parentCheck[:]); err != nil {
+func (bp *SpanBatchPrefix) encodeParentCheck(w io.Writer) error {
+	if _, err := w.Write(bp.ParentCheck[:]); err != nil {
 		return fmt.Errorf("cannot write parent check: %w", err)
 	}
 	return nil
 }
 
 // encodeL1OriginCheck encodes bp.l1OriginCheck
-func (bp *spanBatchPrefix) encodeL1OriginCheck(w io.Writer) error {
-	if _, err := w.Write(bp.l1OriginCheck[:]); err != nil {
+func (bp *SpanBatchPrefix) encodeL1OriginCheck(w io.Writer) error {
+	if _, err := w.Write(bp.L1OriginCheck[:]); err != nil {
 		return fmt.Errorf("cannot write l1 origin check: %w", err)
 	}
 	return nil
 }
 
 // encodePrefix encodes spanBatchPrefix
-func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
+func (bp *SpanBatchPrefix) encodePrefix(w io.Writer) error {
 	if err := bp.encodeRelTimestamp(w); err != nil {
 		return err
 	}
@@ -270,17 +270,17 @@ func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
 }
 
 // encodeOriginBits encodes bp.originBits
-func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
-	if err := encodeSpanBatchBits(w, bp.blockCount, bp.originBits); err != nil {
+func (bp *SpanBatchPayload) encodeOriginBits(w io.Writer) error {
+	if err := encodeSpanBatchBits(w, bp.BlockCount, bp.OriginBits); err != nil {
 		return fmt.Errorf("failed to encode origin bits: %w", err)
 	}
 	return nil
 }
 
 // encodeBlockCount encodes bp.blockCount
-func (bp *spanBatchPayload) encodeBlockCount(w io.Writer) error {
+func (bp *SpanBatchPayload) encodeBlockCount(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
-	n := binary.PutUvarint(buf[:], bp.blockCount)
+	n := binary.PutUvarint(buf[:], bp.BlockCount)
 	if _, err := w.Write(buf[:n]); err != nil {
 		return fmt.Errorf("cannot write block count: %w", err)
 	}
@@ -288,9 +288,9 @@ func (bp *spanBatchPayload) encodeBlockCount(w io.Writer) error {
 }
 
 // encodeBlockTxCounts encodes bp.blockTxCounts
-func (bp *spanBatchPayload) encodeBlockTxCounts(w io.Writer) error {
+func (bp *SpanBatchPayload) encodeBlockTxCounts(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
-	for _, blockTxCount := range bp.blockTxCounts {
+	for _, blockTxCount := range bp.BlockTxCounts {
 		n := binary.PutUvarint(buf[:], blockTxCount)
 		if _, err := w.Write(buf[:n]); err != nil {
 			return fmt.Errorf("cannot write block tx count: %w", err)
@@ -300,18 +300,18 @@ func (bp *spanBatchPayload) encodeBlockTxCounts(w io.Writer) error {
 }
 
 // encodeTxs encodes bp.txs
-func (bp *spanBatchPayload) encodeTxs(w io.Writer) error {
-	if bp.txs == nil {
+func (bp *SpanBatchPayload) encodeTxs(w io.Writer) error {
+	if bp.Txs == nil {
 		return errors.New("cannot write txs: txs not set")
 	}
-	if err := bp.txs.encode(w); err != nil {
+	if err := bp.Txs.encode(w); err != nil {
 		return err
 	}
 	return nil
 }
 
 // encodePayload encodes spanBatchPayload
-func (bp *spanBatchPayload) encodePayload(w io.Writer) error {
+func (bp *SpanBatchPayload) encodePayload(w io.Writer) error {
 	if err := bp.encodeBlockCount(w); err != nil {
 		return err
 	}
@@ -327,8 +327,8 @@ func (bp *spanBatchPayload) encodePayload(w io.Writer) error {
 	return nil
 }
 
-// encode writes the byte encoding of SpanBatch to Writer stream
-func (b *RawSpanBatch) encode(w io.Writer) error {
+// Encode writes the byte encoding of SpanBatch to Writer stream
+func (b *RawSpanBatch) Encode(w io.Writer) error {
 	if err := b.encodePrefix(w); err != nil {
 		return err
 	}
@@ -341,36 +341,36 @@ func (b *RawSpanBatch) encode(w io.Writer) error {
 // derive converts RawSpanBatch into SpanBatch, which has a list of SpanBatchElement.
 // We need chain config constants to derive values for making payload attributes.
 func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainID *big.Int) (*SpanBatch, error) {
-	if b.blockCount == 0 {
+	if b.BlockCount == 0 {
 		return nil, ErrEmptySpanBatch
 	}
-	blockOriginNums := make([]uint64, b.blockCount)
-	l1OriginBlockNumber := b.l1OriginNum
-	for i := int(b.blockCount) - 1; i >= 0; i-- {
+	blockOriginNums := make([]uint64, b.BlockCount)
+	l1OriginBlockNumber := b.L1OriginNum
+	for i := int(b.BlockCount) - 1; i >= 0; i-- {
 		blockOriginNums[i] = l1OriginBlockNumber
-		if b.originBits.Bit(i) == 1 && i > 0 {
+		if b.OriginBits.Bit(i) == 1 && i > 0 {
 			l1OriginBlockNumber--
 		}
 	}
 
-	if err := b.txs.recoverV(chainID); err != nil {
+	if err := b.Txs.recoverV(chainID); err != nil {
 		return nil, err
 	}
-	fullTxs, err := b.txs.fullTxs(chainID)
+	fullTxs, err := b.Txs.fullTxs(chainID)
 	if err != nil {
 		return nil, err
 	}
 
 	spanBatch := SpanBatch{
-		ParentCheck:   b.parentCheck,
-		L1OriginCheck: b.l1OriginCheck,
+		ParentCheck:   b.ParentCheck,
+		L1OriginCheck: b.L1OriginCheck,
 	}
 	txIdx := 0
-	for i := 0; i < int(b.blockCount); i++ {
+	for i := 0; i < int(b.BlockCount); i++ {
 		batch := SpanBatchElement{}
-		batch.Timestamp = genesisTimestamp + b.relTimestamp + blockTime*uint64(i)
+		batch.Timestamp = genesisTimestamp + b.RelTimestamp + blockTime*uint64(i)
 		batch.EpochNum = rollup.Epoch(blockOriginNums[i])
-		for j := 0; j < int(b.blockTxCounts[i]); j++ {
+		for j := 0; j < int(b.BlockTxCounts[i]); j++ {
 			batch.Transactions = append(batch.Transactions, fullTxs[txIdx])
 			txIdx++
 		}
@@ -419,7 +419,7 @@ type SpanBatch struct {
 	// caching
 	originBits    *big.Int
 	blockTxCounts []uint64
-	sbtxs         *spanBatchTxs
+	sbtxs         *SpanBatchTxs
 }
 
 func (b *SpanBatch) AsSingularBatch() (*SingularBatch, bool) { return nil, false }
@@ -565,17 +565,17 @@ func (b *SpanBatch) ToRawSpanBatch() (*RawSpanBatch, error) {
 	span_end := b.Batches[len(b.Batches)-1]
 
 	return &RawSpanBatch{
-		spanBatchPrefix: spanBatchPrefix{
-			relTimestamp:  span_start.Timestamp - b.GenesisTimestamp,
-			l1OriginNum:   uint64(span_end.EpochNum),
-			parentCheck:   b.ParentCheck,
-			l1OriginCheck: b.L1OriginCheck,
+		SpanBatchPrefix: SpanBatchPrefix{
+			RelTimestamp:  span_start.Timestamp - b.GenesisTimestamp,
+			L1OriginNum:   uint64(span_end.EpochNum),
+			ParentCheck:   b.ParentCheck,
+			L1OriginCheck: b.L1OriginCheck,
 		},
-		spanBatchPayload: spanBatchPayload{
-			blockCount:    uint64(len(b.Batches)),
-			originBits:    b.originBits,
-			blockTxCounts: b.blockTxCounts,
-			txs:           b.sbtxs,
+		SpanBatchPayload: SpanBatchPayload{
+			BlockCount:    uint64(len(b.Batches)),
+			OriginBits:    b.originBits,
+			BlockTxCounts: b.blockTxCounts,
+			Txs:           b.sbtxs,
 		},
 	}, nil
 }

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -67,17 +67,17 @@ func TestEmptySpanBatch(t *testing.T) {
 	require.NoError(t, err)
 
 	rawSpanBatch := RawSpanBatch{
-		spanBatchPrefix: spanBatchPrefix{
-			relTimestamp:  uint64(rng.Uint32()),
-			l1OriginNum:   rng.Uint64(),
-			parentCheck:   *(*[20]byte)(testutils.RandomData(rng, 20)),
-			l1OriginCheck: *(*[20]byte)(testutils.RandomData(rng, 20)),
+		SpanBatchPrefix: SpanBatchPrefix{
+			RelTimestamp:  uint64(rng.Uint32()),
+			L1OriginNum:   rng.Uint64(),
+			ParentCheck:   *(*[20]byte)(testutils.RandomData(rng, 20)),
+			L1OriginCheck: *(*[20]byte)(testutils.RandomData(rng, 20)),
 		},
-		spanBatchPayload: spanBatchPayload{
-			blockCount:    0,
-			originBits:    big.NewInt(0),
-			blockTxCounts: []uint64{},
-			txs:           spanTxs,
+		SpanBatchPayload: SpanBatchPayload{
+			BlockCount:    0,
+			OriginBits:    big.NewInt(0),
+			BlockTxCounts: []uint64{},
+			Txs:           spanTxs,
 		},
 	}
 
@@ -99,7 +99,7 @@ func TestSpanBatchOriginBits(t *testing.T) {
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 
-	blockCount := rawSpanBatch.blockCount
+	blockCount := rawSpanBatch.BlockCount
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeOriginBits(&buf)
@@ -114,12 +114,12 @@ func TestSpanBatchOriginBits(t *testing.T) {
 
 	result := buf.Bytes()
 	var sb RawSpanBatch
-	sb.blockCount = blockCount
+	sb.BlockCount = blockCount
 	r := bytes.NewReader(result)
 	err = sb.decodeOriginBits(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.originBits, sb.originBits)
+	require.Equal(t, rawSpanBatch.OriginBits, sb.OriginBits)
 }
 
 func TestSpanBatchPrefix(t *testing.T) {
@@ -128,7 +128,7 @@ func TestSpanBatchPrefix(t *testing.T) {
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 	// only compare prefix
-	rawSpanBatch.spanBatchPayload = spanBatchPayload{}
+	rawSpanBatch.SpanBatchPayload = SpanBatchPayload{}
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodePrefix(&buf)
@@ -159,7 +159,7 @@ func TestSpanBatchRelTimestamp(t *testing.T) {
 	err = sb.decodeRelTimestamp(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.relTimestamp, sb.relTimestamp)
+	require.Equal(t, rawSpanBatch.RelTimestamp, sb.RelTimestamp)
 }
 
 func TestSpanBatchL1OriginNum(t *testing.T) {
@@ -178,7 +178,7 @@ func TestSpanBatchL1OriginNum(t *testing.T) {
 	err = sb.decodeL1OriginNum(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.l1OriginNum, sb.l1OriginNum)
+	require.Equal(t, rawSpanBatch.L1OriginNum, sb.L1OriginNum)
 }
 
 func TestSpanBatchParentCheck(t *testing.T) {
@@ -200,7 +200,7 @@ func TestSpanBatchParentCheck(t *testing.T) {
 	err = sb.decodeParentCheck(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.parentCheck, sb.parentCheck)
+	require.Equal(t, rawSpanBatch.ParentCheck, sb.ParentCheck)
 }
 
 func TestSpanBatchL1OriginCheck(t *testing.T) {
@@ -222,7 +222,7 @@ func TestSpanBatchL1OriginCheck(t *testing.T) {
 	err = sb.decodeL1OriginCheck(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.l1OriginCheck, sb.l1OriginCheck)
+	require.Equal(t, rawSpanBatch.L1OriginCheck, sb.L1OriginCheck)
 }
 
 func TestSpanBatchPayload(t *testing.T) {
@@ -242,10 +242,10 @@ func TestSpanBatchPayload(t *testing.T) {
 	err = sb.decodePayload(r)
 	require.NoError(t, err)
 
-	err = sb.txs.recoverV(chainID)
+	err = sb.Txs.recoverV(chainID)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
+	require.Equal(t, rawSpanBatch.SpanBatchPayload, sb.SpanBatchPayload)
 }
 
 func TestSpanBatchBlockCount(t *testing.T) {
@@ -265,7 +265,7 @@ func TestSpanBatchBlockCount(t *testing.T) {
 	err = sb.decodeBlockCount(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.blockCount, sb.blockCount)
+	require.Equal(t, rawSpanBatch.BlockCount, sb.BlockCount)
 }
 
 func TestSpanBatchBlockTxCounts(t *testing.T) {
@@ -282,11 +282,11 @@ func TestSpanBatchBlockTxCounts(t *testing.T) {
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 
-	sb.blockCount = rawSpanBatch.blockCount
+	sb.BlockCount = rawSpanBatch.BlockCount
 	err = sb.decodeBlockTxCounts(r)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.blockTxCounts, sb.blockTxCounts)
+	require.Equal(t, rawSpanBatch.BlockTxCounts, sb.BlockTxCounts)
 }
 
 func TestSpanBatchTxs(t *testing.T) {
@@ -303,14 +303,14 @@ func TestSpanBatchTxs(t *testing.T) {
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 
-	sb.blockTxCounts = rawSpanBatch.blockTxCounts
+	sb.BlockTxCounts = rawSpanBatch.BlockTxCounts
 	err = sb.decodeTxs(r)
 	require.NoError(t, err)
 
-	err = sb.txs.recoverV(chainID)
+	err = sb.Txs.recoverV(chainID)
 	require.NoError(t, err)
 
-	require.Equal(t, rawSpanBatch.txs, sb.txs)
+	require.Equal(t, rawSpanBatch.Txs, sb.Txs)
 }
 
 func TestSpanBatchRoundTrip(t *testing.T) {
@@ -320,14 +320,14 @@ func TestSpanBatchRoundTrip(t *testing.T) {
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 
 	var result bytes.Buffer
-	err := rawSpanBatch.encode(&result)
+	err := rawSpanBatch.Encode(&result)
 	require.NoError(t, err)
 
 	var sb RawSpanBatch
-	err = sb.decode(bytes.NewReader(result.Bytes()))
+	err = sb.Decode(bytes.NewReader(result.Bytes()))
 	require.NoError(t, err)
 
-	err = sb.txs.recoverV(chainID)
+	err = sb.Txs.recoverV(chainID)
 	require.NoError(t, err)
 
 	require.Equal(t, rawSpanBatch, &sb)
@@ -357,7 +357,7 @@ func TestSpanBatchDerive(t *testing.T) {
 		blockCount := len(singularBatches)
 		require.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.ParentCheck[:])
 		require.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.L1OriginCheck[:])
-		require.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
+		require.Equal(t, len(singularBatches), int(rawSpanBatch.BlockCount))
 
 		for i := 1; i < len(singularBatches); i++ {
 			require.Equal(t, spanBatchDerived.Batches[i].Timestamp, spanBatchDerived.Batches[i-1].Timestamp+l2BlockTime)
@@ -408,16 +408,16 @@ func TestSpanBatchMerge(t *testing.T) {
 		require.NoError(t, err)
 
 		// check span batch prefix
-		require.Equal(t, rawSpanBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
-		require.Equal(t, rollup.Epoch(rawSpanBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
-		require.Equal(t, rawSpanBatch.parentCheck[:], singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
-		require.Equal(t, rawSpanBatch.l1OriginCheck[:], singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
+		require.Equal(t, rawSpanBatch.RelTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
+		require.Equal(t, rollup.Epoch(rawSpanBatch.L1OriginNum), singularBatches[blockCount-1].EpochNum)
+		require.Equal(t, rawSpanBatch.ParentCheck[:], singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
+		require.Equal(t, rawSpanBatch.L1OriginCheck[:], singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
 
 		// check span batch payload
-		require.Equal(t, int(rawSpanBatch.blockCount), len(singularBatches))
-		require.Equal(t, rawSpanBatch.originBits.Bit(0), uint(originChangedBit))
+		require.Equal(t, int(rawSpanBatch.BlockCount), len(singularBatches))
+		require.Equal(t, rawSpanBatch.OriginBits.Bit(0), uint(originChangedBit))
 		for i := 1; i < blockCount; i++ {
-			if rawSpanBatch.originBits.Bit(i) == 1 {
+			if rawSpanBatch.OriginBits.Bit(i) == 1 {
 				require.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum+1)
 			} else {
 				require.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum)
@@ -425,11 +425,11 @@ func TestSpanBatchMerge(t *testing.T) {
 		}
 		for i := 0; i < len(singularBatches); i++ {
 			txCount := len(singularBatches[i].Transactions)
-			require.Equal(t, txCount, int(rawSpanBatch.blockTxCounts[i]))
+			require.Equal(t, txCount, int(rawSpanBatch.BlockTxCounts[i]))
 		}
 
 		// check invariants
-		endEpochNum := rawSpanBatch.l1OriginNum
+		endEpochNum := rawSpanBatch.L1OriginNum
 		require.Equal(t, endEpochNum, uint64(singularBatches[blockCount-1].EpochNum))
 
 		// we do not check txs field because it has to be derived to be compared
@@ -538,7 +538,7 @@ func TestSpanBatchMaxTxData(t *testing.T) {
 
 func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
 	var sb RawSpanBatch
-	sb.blockCount = math.MaxUint64
+	sb.BlockCount = math.MaxUint64
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
@@ -550,7 +550,7 @@ func TestSpanBatchMaxBlockCount(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	rawSpanBatch.blockCount = math.MaxUint64
+	rawSpanBatch.BlockCount = math.MaxUint64
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeBlockCount(&buf)
@@ -568,7 +568,7 @@ func TestSpanBatchMaxBlockTxCount(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	rawSpanBatch.blockTxCounts[0] = math.MaxUint64
+	rawSpanBatch.BlockTxCounts[0] = math.MaxUint64
 
 	var buf bytes.Buffer
 	err := rawSpanBatch.encodeBlockTxCounts(&buf)
@@ -577,7 +577,7 @@ func TestSpanBatchMaxBlockTxCount(t *testing.T) {
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
-	sb.blockCount = rawSpanBatch.blockCount
+	sb.BlockCount = rawSpanBatch.BlockCount
 	err = sb.decodeBlockTxCounts(r)
 	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }
@@ -587,8 +587,8 @@ func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	rawSpanBatch.blockTxCounts[0] = MaxSpanBatchElementCount - 1
-	rawSpanBatch.blockTxCounts[1] = MaxSpanBatchElementCount - 1
+	rawSpanBatch.BlockTxCounts[0] = MaxSpanBatchElementCount - 1
+	rawSpanBatch.BlockTxCounts[1] = MaxSpanBatchElementCount - 1
 	// we are sure that totalBlockTxCount will overflow on uint64
 
 	var buf bytes.Buffer
@@ -598,7 +598,7 @@ func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
 	result := buf.Bytes()
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
-	sb.blockTxCounts = rawSpanBatch.blockTxCounts
+	sb.BlockTxCounts = rawSpanBatch.BlockTxCounts
 	err = sb.decodeTxs(r)
 
 	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -14,19 +14,21 @@ import (
 	"github.com/holiman/uint256"
 )
 
-type spanBatchTxs struct {
+type spanBatchTxsOption func(*SpanBatchTxs) *SpanBatchTxs
+
+type SpanBatchTxs struct {
 	// this field must be manually set
-	totalBlockTxCount uint64
+	TotalBlockTxCount uint64
 
 	// 8 fields
-	contractCreationBits *big.Int // standard span-batch bitlist
-	yParityBits          *big.Int // standard span-batch bitlist
-	txSigs               []spanBatchSignature
-	txNonces             []uint64
-	txGases              []uint64
-	txTos                []common.Address
-	txDatas              []hexutil.Bytes
-	protectedBits        *big.Int // standard span-batch bitlist
+	ContractCreationBits *big.Int // standard span-batch bitlist
+	YParityBits          *big.Int // standard span-batch bitlist
+	TxSigs               []spanBatchSignature
+	TxNonces             []uint64
+	TxGases              []uint64
+	TxTos                []common.Address
+	TxDatas              []hexutil.Bytes
+	ProtectedBits        *big.Int // standard span-batch bitlist
 
 	// intermediate variables which can be recovered
 	txTypes            []int
@@ -39,33 +41,33 @@ type spanBatchSignature struct {
 	s *uint256.Int
 }
 
-func (btx *spanBatchTxs) encodeContractCreationBits(w io.Writer) error {
-	if err := encodeSpanBatchBits(w, btx.totalBlockTxCount, btx.contractCreationBits); err != nil {
+func (btx *SpanBatchTxs) encodeContractCreationBits(w io.Writer) error {
+	if err := encodeSpanBatchBits(w, btx.TotalBlockTxCount, btx.ContractCreationBits); err != nil {
 		return fmt.Errorf("failed to encode contract creation bits: %w", err)
 	}
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
-	if btx.totalBlockTxCount > MaxSpanBatchElementCount {
+func (btx *SpanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
+	if btx.TotalBlockTxCount > MaxSpanBatchElementCount {
 		return ErrTooBigSpanBatchSize
 	}
-	bits, err := decodeSpanBatchBits(r, btx.totalBlockTxCount)
+	bits, err := decodeSpanBatchBits(r, btx.TotalBlockTxCount)
 	if err != nil {
 		return fmt.Errorf("failed to decode contract creation bits: %w", err)
 	}
-	btx.contractCreationBits = bits
+	btx.ContractCreationBits = bits
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeProtectedBits(w io.Writer) error {
-	if err := encodeSpanBatchBits(w, btx.totalLegacyTxCount, btx.protectedBits); err != nil {
+func (btx *SpanBatchTxs) encodeProtectedBits(w io.Writer) error {
+	if err := encodeSpanBatchBits(w, btx.totalLegacyTxCount, btx.ProtectedBits); err != nil {
 		return fmt.Errorf("failed to encode protected bits: %w", err)
 	}
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeProtectedBits(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decodeProtectedBits(r *bytes.Reader) error {
 	if btx.totalLegacyTxCount > MaxSpanBatchElementCount {
 		return ErrTooBigSpanBatchSize
 	}
@@ -73,17 +75,17 @@ func (btx *spanBatchTxs) decodeProtectedBits(r *bytes.Reader) error {
 	if err != nil {
 		return fmt.Errorf("failed to decode protected bits: %w", err)
 	}
-	btx.protectedBits = bits
+	btx.ProtectedBits = bits
 	return nil
 }
 
-func (btx *spanBatchTxs) contractCreationCount() (uint64, error) {
-	if btx.contractCreationBits == nil {
+func (btx *SpanBatchTxs) contractCreationCount() (uint64, error) {
+	if btx.ContractCreationBits == nil {
 		return 0, errors.New("dev error: contract creation bits not set")
 	}
 	var result uint64 = 0
-	for i := 0; i < int(btx.totalBlockTxCount); i++ {
-		bit := btx.contractCreationBits.Bit(i)
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
+		bit := btx.ContractCreationBits.Bit(i)
 		if bit == 1 {
 			result++
 		}
@@ -91,24 +93,24 @@ func (btx *spanBatchTxs) contractCreationCount() (uint64, error) {
 	return result, nil
 }
 
-func (btx *spanBatchTxs) encodeYParityBits(w io.Writer) error {
-	if err := encodeSpanBatchBits(w, btx.totalBlockTxCount, btx.yParityBits); err != nil {
+func (btx *SpanBatchTxs) encodeYParityBits(w io.Writer) error {
+	if err := encodeSpanBatchBits(w, btx.TotalBlockTxCount, btx.YParityBits); err != nil {
 		return fmt.Errorf("failed to encode y-parity bits: %w", err)
 	}
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
-	bits, err := decodeSpanBatchBits(r, btx.totalBlockTxCount)
+func (btx *SpanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
+	bits, err := decodeSpanBatchBits(r, btx.TotalBlockTxCount)
 	if err != nil {
 		return fmt.Errorf("failed to decode y-parity bits: %w", err)
 	}
-	btx.yParityBits = bits
+	btx.YParityBits = bits
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeTxSigsRS(w io.Writer) error {
-	for _, txSig := range btx.txSigs {
+func (btx *SpanBatchTxs) encodeTxSigsRS(w io.Writer) error {
+	for _, txSig := range btx.TxSigs {
 		rBuf := txSig.r.Bytes32()
 		if _, err := w.Write(rBuf[:]); err != nil {
 			return fmt.Errorf("cannot write tx sig r: %w", err)
@@ -121,9 +123,9 @@ func (btx *spanBatchTxs) encodeTxSigsRS(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeTxNonces(w io.Writer) error {
+func (btx *SpanBatchTxs) encodeTxNonces(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
-	for _, txNonce := range btx.txNonces {
+	for _, txNonce := range btx.TxNonces {
 		n := binary.PutUvarint(buf[:], txNonce)
 		if _, err := w.Write(buf[:n]); err != nil {
 			return fmt.Errorf("cannot write tx nonce: %w", err)
@@ -132,9 +134,9 @@ func (btx *spanBatchTxs) encodeTxNonces(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeTxGases(w io.Writer) error {
+func (btx *SpanBatchTxs) encodeTxGases(w io.Writer) error {
 	var buf [binary.MaxVarintLen64]byte
-	for _, txGas := range btx.txGases {
+	for _, txGas := range btx.TxGases {
 		n := binary.PutUvarint(buf[:], txGas)
 		if _, err := w.Write(buf[:n]); err != nil {
 			return fmt.Errorf("cannot write tx gas: %w", err)
@@ -143,8 +145,8 @@ func (btx *spanBatchTxs) encodeTxGases(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeTxTos(w io.Writer) error {
-	for _, txTo := range btx.txTos {
+func (btx *SpanBatchTxs) encodeTxTos(w io.Writer) error {
+	for _, txTo := range btx.TxTos {
 		if _, err := w.Write(txTo.Bytes()); err != nil {
 			return fmt.Errorf("cannot write tx to address: %w", err)
 		}
@@ -152,8 +154,8 @@ func (btx *spanBatchTxs) encodeTxTos(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) encodeTxDatas(w io.Writer) error {
-	for _, txData := range btx.txDatas {
+func (btx *SpanBatchTxs) encodeTxDatas(w io.Writer) error {
+	for _, txData := range btx.TxDatas {
 		if _, err := w.Write(txData); err != nil {
 			return fmt.Errorf("cannot write tx data: %w", err)
 		}
@@ -161,10 +163,10 @@ func (btx *spanBatchTxs) encodeTxDatas(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
 	var txSigs []spanBatchSignature
 	var sigBuffer [32]byte
-	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		var txSig spanBatchSignature
 		_, err := io.ReadFull(r, sigBuffer[:])
 		if err != nil {
@@ -178,59 +180,59 @@ func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
 		txSig.s, _ = uint256.FromBig(new(big.Int).SetBytes(sigBuffer[:]))
 		txSigs = append(txSigs, txSig)
 	}
-	btx.txSigs = txSigs
+	btx.TxSigs = txSigs
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeTxNonces(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decodeTxNonces(r *bytes.Reader) error {
 	var txNonces []uint64
-	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		txNonce, err := binary.ReadUvarint(r)
 		if err != nil {
 			return fmt.Errorf("failed to read tx nonce: %w", err)
 		}
 		txNonces = append(txNonces, txNonce)
 	}
-	btx.txNonces = txNonces
+	btx.TxNonces = txNonces
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeTxGases(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decodeTxGases(r *bytes.Reader) error {
 	var txGases []uint64
-	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		txGas, err := binary.ReadUvarint(r)
 		if err != nil {
 			return fmt.Errorf("failed to read tx gas: %w", err)
 		}
 		txGases = append(txGases, txGas)
 	}
-	btx.txGases = txGases
+	btx.TxGases = txGases
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeTxTos(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decodeTxTos(r *bytes.Reader) error {
 	var txTos []common.Address
 	txToBuffer := make([]byte, common.AddressLength)
 	contractCreationCount, err := btx.contractCreationCount()
 	if err != nil {
 		return err
 	}
-	for i := 0; i < int(btx.totalBlockTxCount-contractCreationCount); i++ {
+	for i := 0; i < int(btx.TotalBlockTxCount-contractCreationCount); i++ {
 		_, err := io.ReadFull(r, txToBuffer)
 		if err != nil {
 			return fmt.Errorf("failed to read tx to address: %w", err)
 		}
 		txTos = append(txTos, common.BytesToAddress(txToBuffer))
 	}
-	btx.txTos = txTos
+	btx.TxTos = txTos
 	return nil
 }
 
-func (btx *spanBatchTxs) decodeTxDatas(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decodeTxDatas(r *bytes.Reader) error {
 	var txDatas []hexutil.Bytes
 	var txTypes []int
 	// Do not need txDataHeader because RLP byte stream already includes length info
-	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+	for i := 0; i < int(btx.TotalBlockTxCount); i++ {
 		txData, txType, err := ReadTxData(r)
 		if err != nil {
 			return err
@@ -241,25 +243,25 @@ func (btx *spanBatchTxs) decodeTxDatas(r *bytes.Reader) error {
 			btx.totalLegacyTxCount++
 		}
 	}
-	btx.txDatas = txDatas
+	btx.TxDatas = txDatas
 	btx.txTypes = txTypes
 	return nil
 }
 
-func (btx *spanBatchTxs) recoverV(chainID *big.Int) error {
-	if len(btx.txTypes) != len(btx.txSigs) {
+func (btx *SpanBatchTxs) recoverV(chainID *big.Int) error {
+	if len(btx.txTypes) != len(btx.TxSigs) {
 		return errors.New("tx type length and tx sigs length mismatch")
 	}
-	if btx.protectedBits == nil {
+	if btx.ProtectedBits == nil {
 		return errors.New("dev error: protected bits not set")
 	}
 	protectedBitsIdx := 0
 	for idx, txType := range btx.txTypes {
-		bit := uint64(btx.yParityBits.Bit(idx))
+		bit := uint64(btx.YParityBits.Bit(idx))
 		var v uint64
 		switch txType {
 		case types.LegacyTxType:
-			protectedBit := btx.protectedBits.Bit(protectedBitsIdx)
+			protectedBit := btx.ProtectedBits.Bit(protectedBitsIdx)
 			protectedBitsIdx++
 			if protectedBit == 0 {
 				v = 27 + bit
@@ -276,12 +278,12 @@ func (btx *spanBatchTxs) recoverV(chainID *big.Int) error {
 		default:
 			return fmt.Errorf("invalid tx type: %d", txType)
 		}
-		btx.txSigs[idx].v = v
+		btx.TxSigs[idx].v = v
 	}
 	return nil
 }
 
-func (btx *spanBatchTxs) encode(w io.Writer) error {
+func (btx *SpanBatchTxs) encode(w io.Writer) error {
 	if err := btx.encodeContractCreationBits(w); err != nil {
 		return err
 	}
@@ -309,7 +311,7 @@ func (btx *spanBatchTxs) encode(w io.Writer) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) decode(r *bytes.Reader) error {
+func (btx *SpanBatchTxs) decode(r *bytes.Reader) error {
 	if err := btx.decodeContractCreationBits(r); err != nil {
 		return err
 	}
@@ -337,28 +339,28 @@ func (btx *spanBatchTxs) decode(r *bytes.Reader) error {
 	return nil
 }
 
-func (btx *spanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
+func (btx *SpanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
 	var txs [][]byte
 	toIdx := 0
-	for idx := 0; idx < int(btx.totalBlockTxCount); idx++ {
+	for idx := 0; idx < int(btx.TotalBlockTxCount); idx++ {
 		var stx spanBatchTx
-		if err := stx.UnmarshalBinary(btx.txDatas[idx]); err != nil {
+		if err := stx.UnmarshalBinary(btx.TxDatas[idx]); err != nil {
 			return nil, err
 		}
-		nonce := btx.txNonces[idx]
-		gas := btx.txGases[idx]
+		nonce := btx.TxNonces[idx]
+		gas := btx.TxGases[idx]
 		var to *common.Address = nil
-		bit := btx.contractCreationBits.Bit(idx)
+		bit := btx.ContractCreationBits.Bit(idx)
 		if bit == 0 {
-			if len(btx.txTos) <= toIdx {
+			if len(btx.TxTos) <= toIdx {
 				return nil, errors.New("tx to not enough")
 			}
-			to = &btx.txTos[toIdx]
+			to = &btx.TxTos[toIdx]
 			toIdx++
 		}
-		v := new(big.Int).SetUint64(btx.txSigs[idx].v)
-		r := btx.txSigs[idx].r.ToBig()
-		s := btx.txSigs[idx].s.ToBig()
+		v := new(big.Int).SetUint64(btx.TxSigs[idx].v)
+		r := btx.TxSigs[idx].r.ToBig()
+		s := btx.TxSigs[idx].s.ToBig()
 		tx, err := stx.convertToFullTx(nonce, gas, to, chainID, v, r, s)
 		if err != nil {
 			return nil, err
@@ -405,17 +407,17 @@ func isProtectedV(v uint64, txType int) bool {
 	return true
 }
 
-func newSpanBatchTxs(txs [][]byte, chainID *big.Int) (*spanBatchTxs, error) {
-	sbtxs := &spanBatchTxs{
-		contractCreationBits: big.NewInt(0),
-		yParityBits:          big.NewInt(0),
-		txSigs:               []spanBatchSignature{},
-		txNonces:             []uint64{},
-		txGases:              []uint64{},
-		txTos:                []common.Address{},
-		txDatas:              []hexutil.Bytes{},
+func newSpanBatchTxs(txs [][]byte, chainID *big.Int) (*SpanBatchTxs, error) {
+	sbtxs := &SpanBatchTxs{
+		ContractCreationBits: big.NewInt(0),
+		YParityBits:          big.NewInt(0),
+		TxSigs:               []spanBatchSignature{},
+		TxNonces:             []uint64{},
+		TxGases:              []uint64{},
+		TxTos:                []common.Address{},
+		TxDatas:              []hexutil.Bytes{},
 		txTypes:              []int{},
-		protectedBits:        big.NewInt(0),
+		ProtectedBits:        big.NewInt(0),
 	}
 
 	if err := sbtxs.AddTxs(txs, chainID); err != nil {
@@ -424,9 +426,9 @@ func newSpanBatchTxs(txs [][]byte, chainID *big.Int) (*spanBatchTxs, error) {
 	return sbtxs, nil
 }
 
-func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
+func (sbtx *SpanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 	totalBlockTxCount := uint64(len(txs))
-	offset := sbtx.totalBlockTxCount
+	offset := sbtx.TotalBlockTxCount
 	for idx := 0; idx < int(totalBlockTxCount); idx++ {
 		tx := &types.Transaction{}
 		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
@@ -437,7 +439,7 @@ func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 			if tx.Protected() {
 				protectedBit = uint(1)
 			}
-			sbtx.protectedBits.SetBit(sbtx.protectedBits, int(sbtx.totalLegacyTxCount), protectedBit)
+			sbtx.ProtectedBits.SetBit(sbtx.ProtectedBits, int(sbtx.totalLegacyTxCount), protectedBit)
 			sbtx.totalLegacyTxCount++
 		}
 		if tx.Protected() && tx.ChainId().Cmp(chainID) != 0 {
@@ -450,20 +452,20 @@ func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 		txSig.v = v.Uint64()
 		txSig.r = R
 		txSig.s = S
-		sbtx.txSigs = append(sbtx.txSigs, txSig)
+		sbtx.TxSigs = append(sbtx.TxSigs, txSig)
 		contractCreationBit := uint(1)
 		if tx.To() != nil {
-			sbtx.txTos = append(sbtx.txTos, *tx.To())
+			sbtx.TxTos = append(sbtx.TxTos, *tx.To())
 			contractCreationBit = uint(0)
 		}
-		sbtx.contractCreationBits.SetBit(sbtx.contractCreationBits, idx+int(offset), contractCreationBit)
+		sbtx.ContractCreationBits.SetBit(sbtx.ContractCreationBits, idx+int(offset), contractCreationBit)
 		yParityBit, err := convertVToYParity(txSig.v, int(tx.Type()))
 		if err != nil {
 			return err
 		}
-		sbtx.yParityBits.SetBit(sbtx.yParityBits, idx+int(offset), yParityBit)
-		sbtx.txNonces = append(sbtx.txNonces, tx.Nonce())
-		sbtx.txGases = append(sbtx.txGases, tx.Gas())
+		sbtx.YParityBits.SetBit(sbtx.YParityBits, idx+int(offset), yParityBit)
+		sbtx.TxNonces = append(sbtx.TxNonces, tx.Nonce())
+		sbtx.TxGases = append(sbtx.TxGases, tx.Gas())
 		stx, err := newSpanBatchTx(tx)
 		if err != nil {
 			return err
@@ -472,9 +474,9 @@ func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 		if err != nil {
 			return err
 		}
-		sbtx.txDatas = append(sbtx.txDatas, txData)
+		sbtx.TxDatas = append(sbtx.TxDatas, txData)
 		sbtx.txTypes = append(sbtx.txTypes, int(tx.Type()))
 	}
-	sbtx.totalBlockTxCount += totalBlockTxCount
+	sbtx.TotalBlockTxCount += totalBlockTxCount
 	return nil
 }

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -14,8 +14,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-type spanBatchTxsOption func(*SpanBatchTxs) *SpanBatchTxs
-
 type SpanBatchTxs struct {
 	// this field must be manually set
 	TotalBlockTxCount uint64

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -25,12 +25,12 @@ func TestSpanBatchTxsContractCreationBits(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	contractCreationBits := rawSpanBatch.txs.contractCreationBits
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	contractCreationBits := rawSpanBatch.Txs.ContractCreationBits
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.contractCreationBits = contractCreationBits
-	sbt.totalBlockTxCount = totalBlockTxCount
+	var sbt SpanBatchTxs
+	sbt.ContractCreationBits = contractCreationBits
+	sbt.TotalBlockTxCount = totalBlockTxCount
 
 	var buf bytes.Buffer
 	err := sbt.encodeContractCreationBits(&buf)
@@ -44,13 +44,13 @@ func TestSpanBatchTxsContractCreationBits(t *testing.T) {
 	require.Equal(t, buf.Len(), int(contractCreationBitBufferLen))
 
 	result := buf.Bytes()
-	sbt.contractCreationBits = nil
+	sbt.ContractCreationBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeContractCreationBits(r)
 	require.NoError(t, err)
 
-	require.Equal(t, contractCreationBits, sbt.contractCreationBits)
+	require.Equal(t, contractCreationBits, sbt.ContractCreationBits)
 }
 
 func TestSpanBatchTxsContractCreationCount(t *testing.T) {
@@ -59,21 +59,21 @@ func TestSpanBatchTxsContractCreationCount(t *testing.T) {
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
 
-	contractCreationBits := rawSpanBatch.txs.contractCreationBits
-	contractCreationCount, err := rawSpanBatch.txs.contractCreationCount()
+	contractCreationBits := rawSpanBatch.Txs.ContractCreationBits
+	contractCreationCount, err := rawSpanBatch.Txs.contractCreationCount()
 	require.NoError(t, err)
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.contractCreationBits = contractCreationBits
-	sbt.totalBlockTxCount = totalBlockTxCount
+	var sbt SpanBatchTxs
+	sbt.ContractCreationBits = contractCreationBits
+	sbt.TotalBlockTxCount = totalBlockTxCount
 
 	var buf bytes.Buffer
 	err = sbt.encodeContractCreationBits(&buf)
 	require.NoError(t, err)
 
 	result := buf.Bytes()
-	sbt.contractCreationBits = nil
+	sbt.ContractCreationBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeContractCreationBits(r)
@@ -90,12 +90,12 @@ func TestSpanBatchTxsYParityBits(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	yParityBits := rawSpanBatch.txs.yParityBits
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	yParityBits := rawSpanBatch.Txs.YParityBits
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.yParityBits = yParityBits
-	sbt.totalBlockTxCount = totalBlockTxCount
+	var sbt SpanBatchTxs
+	sbt.YParityBits = yParityBits
+	sbt.TotalBlockTxCount = totalBlockTxCount
 
 	var buf bytes.Buffer
 	err := sbt.encodeYParityBits(&buf)
@@ -109,13 +109,13 @@ func TestSpanBatchTxsYParityBits(t *testing.T) {
 	require.Equal(t, buf.Len(), int(yParityBitBufferLen))
 
 	result := buf.Bytes()
-	sbt.yParityBits = nil
+	sbt.YParityBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeYParityBits(r)
 	require.NoError(t, err)
 
-	require.Equal(t, yParityBits, sbt.yParityBits)
+	require.Equal(t, yParityBits, sbt.YParityBits)
 }
 
 func TestSpanBatchTxsProtectedBits(t *testing.T) {
@@ -123,14 +123,14 @@ func TestSpanBatchTxsProtectedBits(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	protectedBits := rawSpanBatch.txs.protectedBits
-	txTypes := rawSpanBatch.txs.txTypes
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
-	totalLegacyTxCount := rawSpanBatch.txs.totalLegacyTxCount
+	protectedBits := rawSpanBatch.Txs.ProtectedBits
+	txTypes := rawSpanBatch.Txs.txTypes
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
+	totalLegacyTxCount := rawSpanBatch.Txs.totalLegacyTxCount
 
-	var sbt spanBatchTxs
-	sbt.protectedBits = protectedBits
-	sbt.totalBlockTxCount = totalBlockTxCount
+	var sbt SpanBatchTxs
+	sbt.ProtectedBits = protectedBits
+	sbt.TotalBlockTxCount = totalBlockTxCount
 	sbt.txTypes = txTypes
 	sbt.totalLegacyTxCount = totalLegacyTxCount
 
@@ -147,13 +147,13 @@ func TestSpanBatchTxsProtectedBits(t *testing.T) {
 	require.Equal(t, buf.Len(), int(protectedBitBufferLen))
 
 	result := buf.Bytes()
-	sbt.protectedBits = nil
+	sbt.ProtectedBits = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeProtectedBits(r)
 	require.NoError(t, err)
 
-	require.Equal(t, protectedBits, sbt.protectedBits)
+	require.Equal(t, protectedBits, sbt.ProtectedBits)
 }
 
 func TestSpanBatchTxsTxSigs(t *testing.T) {
@@ -161,12 +161,12 @@ func TestSpanBatchTxsTxSigs(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	txSigs := rawSpanBatch.txs.txSigs
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	txSigs := rawSpanBatch.Txs.TxSigs
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.totalBlockTxCount = totalBlockTxCount
-	sbt.txSigs = txSigs
+	var sbt SpanBatchTxs
+	sbt.TotalBlockTxCount = totalBlockTxCount
+	sbt.TxSigs = txSigs
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxSigsRS(&buf)
@@ -176,7 +176,7 @@ func TestSpanBatchTxsTxSigs(t *testing.T) {
 	require.Equal(t, buf.Len(), 64*int(totalBlockTxCount))
 
 	result := buf.Bytes()
-	sbt.txSigs = nil
+	sbt.TxSigs = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxSigsRS(r)
@@ -184,8 +184,8 @@ func TestSpanBatchTxsTxSigs(t *testing.T) {
 
 	// v field is not set
 	for i := 0; i < int(totalBlockTxCount); i++ {
-		require.Equal(t, txSigs[i].r, sbt.txSigs[i].r)
-		require.Equal(t, txSigs[i].s, sbt.txSigs[i].s)
+		require.Equal(t, txSigs[i].r, sbt.TxSigs[i].r)
+		require.Equal(t, txSigs[i].s, sbt.TxSigs[i].s)
 	}
 }
 
@@ -194,25 +194,25 @@ func TestSpanBatchTxsTxNonces(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	txNonces := rawSpanBatch.txs.txNonces
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	txNonces := rawSpanBatch.Txs.TxNonces
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.totalBlockTxCount = totalBlockTxCount
-	sbt.txNonces = txNonces
+	var sbt SpanBatchTxs
+	sbt.TotalBlockTxCount = totalBlockTxCount
+	sbt.TxNonces = txNonces
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxNonces(&buf)
 	require.NoError(t, err)
 
 	result := buf.Bytes()
-	sbt.txNonces = nil
+	sbt.TxNonces = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxNonces(r)
 	require.NoError(t, err)
 
-	require.Equal(t, txNonces, sbt.txNonces)
+	require.Equal(t, txNonces, sbt.TxNonces)
 }
 
 func TestSpanBatchTxsTxGases(t *testing.T) {
@@ -220,25 +220,25 @@ func TestSpanBatchTxsTxGases(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	txGases := rawSpanBatch.txs.txGases
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	txGases := rawSpanBatch.Txs.TxGases
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.totalBlockTxCount = totalBlockTxCount
-	sbt.txGases = txGases
+	var sbt SpanBatchTxs
+	sbt.TotalBlockTxCount = totalBlockTxCount
+	sbt.TxGases = txGases
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxGases(&buf)
 	require.NoError(t, err)
 
 	result := buf.Bytes()
-	sbt.txGases = nil
+	sbt.TxGases = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxGases(r)
 	require.NoError(t, err)
 
-	require.Equal(t, txGases, sbt.txGases)
+	require.Equal(t, txGases, sbt.TxGases)
 }
 
 func TestSpanBatchTxsTxTos(t *testing.T) {
@@ -246,15 +246,15 @@ func TestSpanBatchTxsTxTos(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	txTos := rawSpanBatch.txs.txTos
-	contractCreationBits := rawSpanBatch.txs.contractCreationBits
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	txTos := rawSpanBatch.Txs.TxTos
+	contractCreationBits := rawSpanBatch.Txs.ContractCreationBits
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.txTos = txTos
+	var sbt SpanBatchTxs
+	sbt.TxTos = txTos
 	// creation bits and block tx count must be se to decode tos
-	sbt.contractCreationBits = contractCreationBits
-	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.ContractCreationBits = contractCreationBits
+	sbt.TotalBlockTxCount = totalBlockTxCount
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxTos(&buf)
@@ -264,13 +264,13 @@ func TestSpanBatchTxsTxTos(t *testing.T) {
 	require.Equal(t, buf.Len(), 20*len(txTos))
 
 	result := buf.Bytes()
-	sbt.txTos = nil
+	sbt.TxTos = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxTos(r)
 	require.NoError(t, err)
 
-	require.Equal(t, txTos, sbt.txTos)
+	require.Equal(t, txTos, sbt.TxTos)
 }
 
 func TestSpanBatchTxsTxDatas(t *testing.T) {
@@ -278,28 +278,28 @@ func TestSpanBatchTxsTxDatas(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	txDatas := rawSpanBatch.txs.txDatas
-	txTypes := rawSpanBatch.txs.txTypes
-	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+	txDatas := rawSpanBatch.Txs.TxDatas
+	txTypes := rawSpanBatch.Txs.txTypes
+	totalBlockTxCount := rawSpanBatch.Txs.TotalBlockTxCount
 
-	var sbt spanBatchTxs
-	sbt.totalBlockTxCount = totalBlockTxCount
+	var sbt SpanBatchTxs
+	sbt.TotalBlockTxCount = totalBlockTxCount
 
-	sbt.txDatas = txDatas
+	sbt.TxDatas = txDatas
 
 	var buf bytes.Buffer
 	err := sbt.encodeTxDatas(&buf)
 	require.NoError(t, err)
 
 	result := buf.Bytes()
-	sbt.txDatas = nil
+	sbt.TxDatas = nil
 	sbt.txTypes = nil
 
 	r := bytes.NewReader(result)
 	err = sbt.decodeTxDatas(r)
 	require.NoError(t, err)
 
-	require.Equal(t, txDatas, sbt.txDatas)
+	require.Equal(t, txDatas, sbt.TxDatas)
 	require.Equal(t, txTypes, sbt.txTypes)
 }
 func TestSpanBatchTxsAddTxs(t *testing.T) {
@@ -345,7 +345,7 @@ func TestSpanBatchTxsRecoverV(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			var spanBatchTxs spanBatchTxs
+			var spanBatchTxs SpanBatchTxs
 			var txTypes []int
 			var txSigs []spanBatchSignature
 			var originalVs []uint64
@@ -376,16 +376,16 @@ func TestSpanBatchTxsRecoverV(t *testing.T) {
 				yParityBits.SetBit(yParityBits, idx, yParityBit)
 			}
 
-			spanBatchTxs.yParityBits = yParityBits
-			spanBatchTxs.txSigs = txSigs
+			spanBatchTxs.YParityBits = yParityBits
+			spanBatchTxs.TxSigs = txSigs
 			spanBatchTxs.txTypes = txTypes
-			spanBatchTxs.protectedBits = protectedBits
+			spanBatchTxs.ProtectedBits = protectedBits
 			// recover txSig.v
 			err := spanBatchTxs.recoverV(chainID)
 			require.NoError(t, err)
 
 			var recoveredVs []uint64
-			for _, txSig := range spanBatchTxs.txSigs {
+			for _, txSig := range spanBatchTxs.TxSigs {
 				recoveredVs = append(recoveredVs, txSig.v)
 			}
 			require.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
@@ -399,8 +399,8 @@ func TestSpanBatchTxsRoundTrip(t *testing.T) {
 
 	for i := 0; i < 4; i++ {
 		rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-		sbt := rawSpanBatch.txs
-		totalBlockTxCount := sbt.totalBlockTxCount
+		sbt := rawSpanBatch.Txs
+		totalBlockTxCount := sbt.TotalBlockTxCount
 
 		var buf bytes.Buffer
 		err := sbt.encode(&buf)
@@ -409,8 +409,8 @@ func TestSpanBatchTxsRoundTrip(t *testing.T) {
 		result := buf.Bytes()
 		r := bytes.NewReader(result)
 
-		var sbt2 spanBatchTxs
-		sbt2.totalBlockTxCount = totalBlockTxCount
+		var sbt2 SpanBatchTxs
+		sbt2.TotalBlockTxCount = totalBlockTxCount
 		err = sbt2.decode(r)
 		require.NoError(t, err)
 
@@ -461,12 +461,12 @@ func TestSpanBatchTxsRecoverVInvalidTxType(t *testing.T) {
 	rng := rand.New(rand.NewSource(0x321))
 	chainID := big.NewInt(rng.Int63n(1000))
 
-	var sbt spanBatchTxs
+	var sbt SpanBatchTxs
 
 	sbt.txTypes = []int{types.DepositTxType}
-	sbt.txSigs = []spanBatchSignature{{v: 0, r: nil, s: nil}}
-	sbt.yParityBits = new(big.Int)
-	sbt.protectedBits = new(big.Int)
+	sbt.TxSigs = []spanBatchSignature{{v: 0, r: nil, s: nil}}
+	sbt.YParityBits = new(big.Int)
+	sbt.ProtectedBits = new(big.Int)
 
 	err := sbt.recoverV(chainID)
 	require.ErrorContains(t, err, "invalid tx type")
@@ -499,7 +499,7 @@ func TestSpanBatchTxsFullTxNotEnoughTxTos(t *testing.T) {
 			require.NoError(t, err)
 
 			// drop single to field
-			sbt.txTos = sbt.txTos[:len(sbt.txTos)-2]
+			sbt.TxTos = sbt.TxTos[:len(sbt.TxTos)-2]
 
 			_, err = sbt.fullTxs(chainID)
 			require.EqualError(t, err, "tx to not enough")
@@ -508,8 +508,8 @@ func TestSpanBatchTxsFullTxNotEnoughTxTos(t *testing.T) {
 }
 
 func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
-	var sbt spanBatchTxs
-	sbt.totalBlockTxCount = 0xFFFFFFFFFFFFFFFF
+	var sbt SpanBatchTxs
+	sbt.TotalBlockTxCount = 0xFFFFFFFFFFFFFFFF
 
 	r := bytes.NewReader([]byte{})
 	err := sbt.decodeContractCreationBits(r)
@@ -518,7 +518,7 @@ func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
 
 func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
 	var sb RawSpanBatch
-	sb.blockCount = 0xFFFFFFFFFFFFFFFF
+	sb.BlockCount = 0xFFFFFFFFFFFFFFFF
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
@@ -527,10 +527,10 @@ func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
 
 func TestSpanBatchTxsMaxProtectedBitsLength(t *testing.T) {
 	var sb RawSpanBatch
-	sb.txs = &spanBatchTxs{}
-	sb.txs.totalLegacyTxCount = 0xFFFFFFFFFFFFFFFF
+	sb.Txs = &SpanBatchTxs{}
+	sb.Txs.totalLegacyTxCount = 0xFFFFFFFFFFFFFFFF
 
 	r := bytes.NewReader([]byte{})
-	err := sb.txs.decodeProtectedBits(r)
+	err := sb.Txs.decodeProtectedBits(r)
 	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -175,7 +175,6 @@ func (co *SpanChannelOut) addSingularBatch(batch *SingularBatch, seqNum uint64) 
 	co.swapRLP()
 	active := co.activeRLP()
 	active.Truncate(co.sealedRLPBytes)
-	fmt.Println("JULIAN 3", co.batchDataOptions)
 	if err = rlp.Encode(active, NewBatchData(rawSpanBatch, co.batchDataOptions...)); err != nil {
 		return fmt.Errorf("failed to encode RawSpanBatch into bytes: %w", err)
 	}

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -44,7 +44,8 @@ type SpanChannelOut struct {
 	// to seal full span batches (that have reached the max block count) in the rlp slices.
 	sealedRLPBytes int
 
-	chainSpec *rollup.ChainSpec
+	chainSpec        *rollup.ChainSpec
+	batchDataOptions []BatchDataOption
 }
 
 func (co *SpanChannelOut) ID() ChannelID {
@@ -61,6 +62,12 @@ type SpanChannelOutOption func(co *SpanChannelOut)
 func WithMaxBlocksPerSpanBatch(maxBlock int) SpanChannelOutOption {
 	return func(co *SpanChannelOut) {
 		co.maxBlocksPerSpanBatch = maxBlock
+	}
+}
+
+func WithBatchDataOptions(options ...BatchDataOption) SpanChannelOutOption {
+	return func(co *SpanChannelOut) {
+		co.batchDataOptions = options
 	}
 }
 
@@ -168,7 +175,8 @@ func (co *SpanChannelOut) addSingularBatch(batch *SingularBatch, seqNum uint64) 
 	co.swapRLP()
 	active := co.activeRLP()
 	active.Truncate(co.sealedRLPBytes)
-	if err = rlp.Encode(active, NewBatchData(rawSpanBatch)); err != nil {
+	fmt.Println("JULIAN 3", co.batchDataOptions)
+	if err = rlp.Encode(active, NewBatchData(rawSpanBatch, co.batchDataOptions...)); err != nil {
 		return fmt.Errorf("failed to encode RawSpanBatch into bytes: %w", err)
 	}
 

--- a/op-service/testlog/capturing.go
+++ b/op-service/testlog/capturing.go
@@ -151,6 +151,23 @@ func NewMessageContainsFilter(message string) LogFilter {
 	}
 }
 
+func NewErrContainsFilter(errMessage string) LogFilter {
+	return func(r *CapturedRecord) bool {
+		found := false
+		r.Attrs(func(a slog.Attr) bool {
+			if a.Key != "err" {
+				return true
+			}
+			if err, ok := a.Value.Any().(error); ok && strings.Contains(err.Error(), errMessage) {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
+	}
+}
+
 type LogFilter func(record *CapturedRecord) bool
 
 func (c *CapturingHandler) FindLog(filters ...LogFilter) *CapturedRecord {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Tests that a malformed batch with the contract creation bit set for a SetCodeTx is properly dropped.

Fixes #14892
