### PR TITLE
feat(op-acceptance-tests): add interop just alias

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -25,4 +25,3 @@ gates:
     description: "Interop network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -8,12 +8,17 @@ ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-ac
 default:
     @just acceptance-test simple holocene
 
-isthmus:
-    @just acceptance-test isthmus isthmus
-
 holocene:
     @just acceptance-test simple holocene
 
+isthmus:
+    @just acceptance-test isthmus isthmus
+
+interop:
+    @just acceptance-test interop interop
+
+
+# DEVNET_ENV_URL
 
 # Run acceptance tests with mise-managed binary
 acceptance-test devnet="simple" gate="holocene":


### PR DESCRIPTION
**Description**

Add an easy just command alias for `interop` testing.
