### PR TITLE
OP-Supervisor: Expand EntryType to include Replacement Type ; Use Replacement Type to trigger Replacements for Syncing Nodes

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -600,8 +600,8 @@ func (su *SupervisorBackend) IsLocalSafe(ctx context.Context, chainID eth.ChainI
 	return su.chainDBs.IsLocalSafe(chainID, block)
 }
 
-func (su *SupervisorBackend) IsReplacement(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error {
-	return su.chainDBs.IsReplacement(chainID, block)
+func (su *SupervisorBackend) IsReplacementAt(ctx context.Context, chainID eth.ChainID, blockNum uint64) error {
+	return su.chainDBs.IsReplacementAt(chainID, blockNum)
 }
 
 func (su *SupervisorBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -600,6 +600,10 @@ func (su *SupervisorBackend) IsLocalSafe(ctx context.Context, chainID eth.ChainI
 	return su.chainDBs.IsLocalSafe(chainID, block)
 }
 
+func (su *SupervisorBackend) IsReplacement(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error {
+	return su.chainDBs.IsReplacement(chainID, block)
+}
+
 func (su *SupervisorBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
 	v, err := su.chainDBs.CrossDerivedToSourceRef(chainID, derived)
 	if err != nil {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -69,7 +69,7 @@ type DerivationStorage interface {
 
 	// type-specific
 	Invalidated() (pair types.DerivedBlockSealPair, err error)
-	Replacement(derived eth.BlockID) error
+	Replacement(blockNum uint64) error
 	ContainsDerived(derived eth.BlockID) error
 
 	// writing

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -69,6 +69,7 @@ type DerivationStorage interface {
 
 	// type-specific
 	Invalidated() (pair types.DerivedBlockSealPair, err error)
+	Replacement(derived eth.BlockID) error
 	ContainsDerived(derived eth.BlockID) error
 
 	// writing

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -128,7 +128,7 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 	if err != nil {
 		return types.DerivedBlockSealPair{}, err
 	}
-	if !link.invalidated {
+	if !link.Invalidated() {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("last entry %s is not invalidated: %w", link, types.ErrConflict)
 	}
 	return types.DerivedBlockSealPair{
@@ -150,7 +150,7 @@ func (db *DB) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, 
 		return types.BlockSeal{}, fmt.Errorf("searched for last derived-from %s but found %s: %w",
 			source, link.source, types.ErrConflict)
 	}
-	if link.invalidated {
+	if link.Invalidated() {
 		return types.BlockSeal{}, types.ErrAwaitReplacementBlock
 	}
 	return link.derived, nil
@@ -193,7 +193,7 @@ func (db *DB) ContainsDerived(derived eth.BlockID) error {
 		return fmt.Errorf("searched if derived %s but found %s: %w",
 			derived, link.derived, types.ErrConflict)
 	}
-	if link.invalidated {
+	if link.Invalidated() {
 		return fmt.Errorf("derived %s, but invalidated it: %w", derived, types.ErrAwaitReplacementBlock)
 	}
 	return nil

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -137,15 +137,17 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 	}, nil
 }
 
-func (db *DB) Replacement(derived eth.BlockID) error {
+// Replacement checks if the block at the given number is a replacement for an invalidated entry.
+// It uses block number because the caller may have only derived the invalid block at this point.
+func (db *DB) Replacement(blockNum uint64) error {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, link, err := db.derivedNumToFirstSource(derived.Number)
+	_, link, err := db.derivedNumToFirstSource(blockNum)
 	if err != nil {
-		return fmt.Errorf("failed to check if block %d is a replacement: %w", derived.Number, err)
+		return fmt.Errorf("failed to check if block %d is a replacement: %w", blockNum, err)
 	}
 	if !link.Replacement() {
-		return fmt.Errorf("last entry %s is not a replacement: %w", link, types.ErrConflict)
+		return fmt.Errorf("entry %s is not a replacement: %w", link, types.ErrConflict)
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -142,14 +142,24 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 func (db *DB) Replacement(blockNum uint64) error {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, link, err := db.derivedNumToFirstSource(blockNum)
+	_, firstLink, err := db.derivedNumToFirstSource(blockNum)
 	if err != nil {
 		return fmt.Errorf("failed to check if block %d is a replacement: %w", blockNum, err)
 	}
-	if !link.Replacement() {
-		return fmt.Errorf("entry %s is not a replacement: %w", link, types.ErrConflict)
+	if firstLink.Replacement() {
+		db.log.Debug("block %d is a replacement", blockNum)
+		return nil
 	}
-	return nil
+	// if the block at the given height changes hash over the course of the database,
+	// we know a replacement occurs at this height
+	_, lastLink, err := db.derivedNumToLastSource(blockNum)
+	if err != nil {
+		return fmt.Errorf("failed to check if block %d is a replacement: %w", blockNum, err)
+	}
+	if firstLink.derived.Hash != lastLink.derived.Hash {
+		return nil
+	}
+	return fmt.Errorf("block %d is not a replacement: %w", blockNum, types.ErrConflict)
 }
 
 // LastDerivedAt returns the last L2 block derived from the given L1 block.

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -137,6 +137,19 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 	}, nil
 }
 
+func (db *DB) Replacement(derived eth.BlockID) error {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	_, link, err := db.derivedNumToFirstSource(derived.Number)
+	if err != nil {
+		return fmt.Errorf("failed to check if block %d is a replacement: %w", derived.Number, err)
+	}
+	if !link.Replacement() {
+		return fmt.Errorf("last entry %s is not a replacement: %w", link, types.ErrConflict)
+	}
+	return nil
+}
+
 // LastDerivedAt returns the last L2 block derived from the given L1 block.
 // This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 func (db *DB) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -1140,9 +1140,9 @@ func TestLookupDetectIfCorruptDB(t *testing.T) {
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// Skip L1 block 1 and L2 block 1, force it into the DB
 			e := LinkEntry{
-				source:      l1Block2,
-				derived:     l2Block2,
-				invalidated: false,
+				source:    l1Block2,
+				derived:   l2Block2,
+				entryType: InvalidatedFromV0,
 			}
 			require.NoError(t, db.store.Append(e.encode()))
 			db.m.RecordDBDerivedEntryCount(db.store.Size())

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -883,6 +883,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block1.ID(), result.Source.ID())
+		require.NoError(t, db.Replacement(replacement.Number), "replacement is marked as a replacement block type")
 
 		pair, err = db.Last()
 		require.NoError(t, err)
@@ -947,6 +948,14 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, invalidated.Source.ID(), pair.Source.ID())
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
+		fmt.Println("--invalid--")
+		srcIndex, srcLink, err := db.sourceNumToFirstDerived(invalidated.Source.Number)
+		derIndex, derLink, err := db.derivedNumToFirstSource(invalidated.Derived.Number)
+		fmt.Println("srcLink", srcLink)
+		fmt.Println("srcIndex", srcIndex)
+		fmt.Println("derLink", derLink)
+		fmt.Println("derIndex", derIndex)
+
 		replacement := l2Ref3
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref3.Hash, replacement.Hash) // different L2 block as replacement
@@ -954,6 +963,15 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block2.ID(), result.Source.ID())
+
+		fmt.Println("--replace--")
+		srcIndex, srcLink, err = db.sourceNumToFirstDerived(result.Source.Number)
+		derIndex, derLink, err = db.derivedNumToFirstSource(result.Derived.Number)
+		fmt.Println("srcLink", srcLink)
+		fmt.Println("srcIndex", srcIndex)
+		fmt.Println("derLink", derLink)
+		fmt.Println("derIndex", derIndex)
+		require.NoError(t, db.Replacement(replacement.Number), "replacement is marked as a replacement block type")
 
 		pair, err = db.Last()
 		require.NoError(t, err)
@@ -1142,7 +1160,7 @@ func TestLookupDetectIfCorruptDB(t *testing.T) {
 			e := LinkEntry{
 				source:    l1Block2,
 				derived:   l2Block2,
-				entryType: InvalidatedFromV0,
+				entryType: SourceV0,
 			}
 			require.NoError(t, db.store.Append(e.encode()))
 			db.m.RecordDBDerivedEntryCount(db.store.Size())

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -948,14 +948,6 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, invalidated.Source.ID(), pair.Source.ID())
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
-		fmt.Println("--invalid--")
-		srcIndex, srcLink, err := db.sourceNumToFirstDerived(invalidated.Source.Number)
-		derIndex, derLink, err := db.derivedNumToFirstSource(invalidated.Derived.Number)
-		fmt.Println("srcLink", srcLink)
-		fmt.Println("srcIndex", srcIndex)
-		fmt.Println("derLink", derLink)
-		fmt.Println("derIndex", derIndex)
-
 		replacement := l2Ref3
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref3.Hash, replacement.Hash) // different L2 block as replacement
@@ -964,14 +956,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block2.ID(), result.Source.ID())
 
-		fmt.Println("--replace--")
-		srcIndex, srcLink, err = db.sourceNumToFirstDerived(result.Source.Number)
-		derIndex, derLink, err = db.derivedNumToFirstSource(result.Derived.Number)
-		fmt.Println("srcLink", srcLink)
-		fmt.Println("srcIndex", srcIndex)
-		fmt.Println("derLink", derLink)
-		fmt.Println("derIndex", derIndex)
-		require.NoError(t, db.Replacement(replacement.Number), "replacement is marked as a replacement block type")
+		require.NoError(t, db.Replacement(replacement.Number), "there is a replacement at this block height")
 
 		pair, err = db.Last()
 		require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -16,11 +16,22 @@ func (e Entry) Type() EntryType {
 	return EntryType(e[0])
 }
 
+func (e Entry) validType() error {
+	et := e.Type()
+	if et != SourceV0 &&
+		et != InvalidatedFromV0 &&
+		et != ReplacementV0 {
+		return fmt.Errorf("%w: unexpected entry type: %s", types.ErrDataCorruption, et)
+	}
+	return nil
+}
+
 type EntryType uint8
 
 const (
 	SourceV0          EntryType = 0
 	InvalidatedFromV0 EntryType = 1
+	ReplacementV0     EntryType = 2
 )
 
 func (s EntryType) String() string {
@@ -29,6 +40,8 @@ func (s EntryType) String() string {
 		return "sourceV0"
 	case InvalidatedFromV0:
 		return "invalidatedFromV0"
+	case ReplacementV0:
+		return "replacementV0"
 	default:
 		return fmt.Sprintf("unknown(%d)", uint8(s))
 	}
@@ -48,28 +61,35 @@ func (EntryBinary) EntrySize() int {
 	return EntrySize
 }
 
-// LinkEntry is a SourceV0 or a InvalidatedFromV0 kind
+// LinkEntry contains a source:derived link, and a type indicating
+// whether the link is a source, an invalidation, or a replacement.
 type LinkEntry struct {
-	source  types.BlockSeal
-	derived types.BlockSeal
-	// when it exists as local-safe, but cannot be cross-safe.
-	// If false: this link is a SourceV0
-	// If true: this link is a InvalidatedFromV0
-	invalidated bool
+	source    types.BlockSeal
+	derived   types.BlockSeal
+	entryType EntryType
 }
 
 func (d LinkEntry) String() string {
-	return fmt.Sprintf("LinkEntry(source: %s, derived: %s, invalidated: %v)", d.source, d.derived, d.invalidated)
+	return fmt.Sprintf("LinkEntry(source: %s, derived: %s, type: %v)", d.source, d.derived, d.entryType)
+}
+
+func (d LinkEntry) Invalidated() bool {
+	return d.entryType == InvalidatedFromV0
+}
+
+func (d LinkEntry) Replacement() bool {
+	return d.entryType == ReplacementV0
 }
 
 func (d *LinkEntry) decode(e Entry) error {
-	if t := e.Type(); t != SourceV0 && t != InvalidatedFromV0 {
-		return fmt.Errorf("%w: unexpected entry type: %s", types.ErrDataCorruption, e.Type())
+	if err := e.validType(); err != nil {
+		return err
 	}
 	if [3]byte(e[1:4]) != ([3]byte{}) {
 		return fmt.Errorf("%w: expected empty data, to pad entry size to round number: %x", types.ErrDataCorruption, e[1:4])
 	}
-	d.invalidated = e.Type() == InvalidatedFromV0
+	d.entryType = e.Type()
+
 	// Format:
 	// l1-number(8) l1-timestamp(8) l2-number(8) l2-timestamp(8) l1-hash(32) l2-hash(32)
 	// Note: attributes are ordered for lexical sorting to nicely match chronological sorting.
@@ -90,8 +110,10 @@ func (d *LinkEntry) decode(e Entry) error {
 
 func (d *LinkEntry) encode() Entry {
 	var out Entry
-	if d.invalidated {
+	if d.Invalidated() {
 		out[0] = uint8(InvalidatedFromV0)
+	} else if d.Replacement() {
+		out[0] = uint8(ReplacementV0)
 	} else {
 		out[0] = uint8(SourceV0)
 	}
@@ -111,7 +133,7 @@ func (d *LinkEntry) encode() Entry {
 }
 
 func (d *LinkEntry) sealOrErr() (types.DerivedBlockSealPair, error) {
-	if d.invalidated {
+	if d.Invalidated() {
 		return types.DerivedBlockSealPair{}, types.ErrAwaitReplacementBlock
 	}
 	return types.DerivedBlockSealPair{

--- a/op-supervisor/supervisor/backend/db/fromda/entry_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry_test.go
@@ -1,6 +1,7 @@
 package fromda
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,5 +40,63 @@ func TestLinkEntry(t *testing.T) {
 		entry[0] = 123
 		var x LinkEntry
 		require.ErrorContains(t, x.decode(entry), "unexpected")
+	})
+	t.Run("test type", func(t *testing.T) {
+		link := LinkEntry{
+			source: types.BlockSeal{
+				Hash:      common.BytesToHash([]byte{1, 2, 3}),
+				Number:    math.MaxUint64,
+				Timestamp: math.MaxUint64,
+			},
+			derived: types.BlockSeal{
+				Hash:      common.BytesToHash([]byte{4, 5, 6}),
+				Number:    math.MaxUint64,
+				Timestamp: math.MaxUint64,
+			},
+			entryType: InvalidatedFromV0,
+		}
+		require.False(t, link.Replacement())
+		require.True(t, link.Invalidated())
+		decoded := LinkEntry{}
+		require.NoError(t, decoded.decode(link.encode()))
+		require.False(t, decoded.Replacement())
+		require.True(t, decoded.Invalidated())
+
+		link.entryType = ReplacementV0
+		require.True(t, link.Replacement())
+		require.False(t, link.Invalidated())
+		decoded = LinkEntry{}
+		require.NoError(t, decoded.decode(link.encode()))
+		require.True(t, decoded.Replacement())
+		require.False(t, decoded.Invalidated())
+
+		link.entryType = SourceV0
+		require.False(t, link.Replacement())
+		require.False(t, link.Invalidated())
+		decoded = LinkEntry{}
+		require.NoError(t, decoded.decode(link.encode()))
+		require.False(t, decoded.Replacement())
+		require.False(t, decoded.Invalidated())
+
+		corrupt := link.encode()
+		corrupt[0] = 17 // invalid type
+		decoded = LinkEntry{}
+		require.ErrorContains(t, decoded.decode(corrupt), "unexpected entry type")
+	})
+	t.Run("test length", func(t *testing.T) {
+		link := LinkEntry{
+			source: types.BlockSeal{
+				Hash:      common.BytesToHash([]byte{1, 2, 3}),
+				Number:    math.MaxUint64,
+				Timestamp: math.MaxUint64,
+			},
+			derived: types.BlockSeal{
+				Hash:      common.BytesToHash([]byte{4, 5, 6}),
+				Number:    math.MaxUint64,
+				Timestamp: math.MaxUint64,
+			},
+			entryType: InvalidatedFromV0,
+		}
+		require.Equal(t, EntrySize, len(link.encode()))
 	})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -33,7 +33,7 @@ func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidat
 	if err != nil {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to read last derivation data: %w", err)
 	}
-	if !last.invalidated {
+	if !last.Invalidated() {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
 	}
 	if last.derived.Hash != invalidated {
@@ -162,8 +162,12 @@ func (db *DB) rewindLocked(t types.DerivedBlockSealPair, including bool) error {
 
 // addLink adds a L1/L2 derivation link, with strong consistency checks.
 // if the link invalidates a prior L2 block, that was valid in a prior L1,
-// the invalidated hash needs to match it, even if a new derived block replaces it.
-func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated common.Hash) error {
+// the invalidRef hash needs to match it, even if a new derived block replaces it.
+func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidRef common.Hash) error {
+	linkType := SourceV0
+	if (invalidRef != common.Hash{}) && derived.Hash == invalidRef {
+		linkType = InvalidatedFromV0
+	}
 	link := LinkEntry{
 		source: types.BlockSeal{
 			Hash:      source.Hash,
@@ -175,11 +179,11 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			Number:    derived.Number,
 			Timestamp: derived.Time,
 		},
-		invalidated: (invalidated != common.Hash{}) && derived.Hash == invalidated,
+		entryType: linkType,
 	}
 	// If we don't have any entries yet, allow any block to start things off
 	if db.store.Size() == 0 {
-		if link.invalidated {
+		if link.Invalidated() {
 			return fmt.Errorf("first DB entry %s cannot be an invalidated entry: %w", link, types.ErrConflict)
 		}
 		e := link.encode()
@@ -195,7 +199,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 	if err != nil {
 		return err
 	}
-	if last.invalidated {
+	if last.Invalidated() {
 		return fmt.Errorf("cannot build %s on top of invalidated entry %s: %w", link, last, types.ErrConflict)
 	}
 	lastSource := last.source
@@ -226,15 +230,17 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 	if lastDerived.Number == derived.Number {
 		// Same block height? Then it must be the same block.
 		// I.e. we encountered an empty L1 block, and the same L2 block continues to be the last block that was derived from it.
-		if invalidated != (common.Hash{}) {
-			if lastDerived.Hash != invalidated {
-				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s: %w", derived.Hash, invalidated, lastDerived.Number, lastDerived.Hash, types.ErrConflict)
+		if invalidRef != (common.Hash{}) {
+			if lastDerived.Hash != invalidRef {
+				return fmt.Errorf("inserting block %s that invalidates %s at height %d, but expected %s: %w", derived.Hash, invalidRef, lastDerived.Number, lastDerived.Hash, types.ErrConflict)
 			}
 		} else {
 			if lastDerived.Hash != derived.Hash {
 				return fmt.Errorf("derived block %s conflicts with known derived block %s at same height: %w",
 					derived, lastDerived, types.ErrConflict)
 			}
+			// invalidRef is used and references pass, so this is actually a replacement block
+			link.entryType = ReplacementV0
 		}
 	} else if lastDerived.Number+1 == derived.Number {
 		if lastDerived.Hash != derived.ParentHash {

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -161,12 +161,21 @@ func (db *DB) rewindLocked(t types.DerivedBlockSealPair, including bool) error {
 }
 
 // addLink adds a L1/L2 derivation link, with strong consistency checks.
-// if the link invalidates a prior L2 block, that was valid in a prior L1,
-// the invalidRef hash needs to match it, even if a new derived block replaces it.
+// - source is the L1 block that the L2 block is derived from
+// - derived is the L2 block that is derived from the source
+// - one of the two must be sequential, but not both
+// - invalidRef is the hash of the L2 block that is being invalidated, if any
+// if invalidRef is provided and matches derived, then the link is marked as invalid
+// if invalidRef is provided but does not match derived, the link is a replacement of the invalidated block
+// if invalidRef is empty, then the link is a normal derivation link
 func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidRef common.Hash) error {
 	linkType := SourceV0
-	if (invalidRef != common.Hash{}) && derived.Hash == invalidRef {
-		linkType = InvalidatedFromV0
+	if (invalidRef != common.Hash{}) {
+		if derived.Hash == invalidRef {
+			linkType = InvalidatedFromV0
+		} else {
+			linkType = ReplacementV0
+		}
 	}
 	link := LinkEntry{
 		source: types.BlockSeal{
@@ -239,8 +248,6 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidRef comm
 				return fmt.Errorf("derived block %s conflicts with known derived block %s at same height: %w",
 					derived, lastDerived, types.ErrConflict)
 			}
-			// invalidRef is used and references pass, so this is actually a replacement block
-			link.entryType = ReplacementV0
 		}
 	} else if lastDerived.Number+1 == derived.Number {
 		if lastDerived.Hash != derived.ParentHash {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -98,12 +98,12 @@ func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
 	return ldb.ContainsDerived(block)
 }
 
-func (db *ChainsDB) IsReplacement(chainID eth.ChainID, block eth.BlockID) error {
+func (db *ChainsDB) IsReplacementAt(chainID eth.ChainID, blockNum uint64) error {
 	ldb, ok := db.localDBs.Get(chainID)
 	if !ok {
 		return types.ErrUnknownChain
 	}
-	return ldb.Replacement(block)
+	return ldb.Replacement(blockNum)
 }
 
 func (db *ChainsDB) IsFinalized(chainID eth.ChainID, block eth.BlockID) error {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -98,6 +98,14 @@ func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
 	return ldb.ContainsDerived(block)
 }
 
+func (db *ChainsDB) IsReplacement(chainID eth.ChainID, block eth.BlockID) error {
+	ldb, ok := db.localDBs.Get(chainID)
+	if !ok {
+		return types.ErrUnknownChain
+	}
+	return ldb.Replacement(block)
+}
+
 func (db *ChainsDB) IsFinalized(chainID eth.ChainID, block eth.BlockID) error {
 	finL1 := db.FinalizedL1()
 	if finL1 == (eth.BlockRef{}) {

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -175,7 +175,7 @@ func (m *mockBackend) CrossUnsafe(ctx context.Context, chainID eth.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
-func (m *mockBackend) IsReplacement(ctx context.Context, chainID eth.ChainID, blockID eth.BlockID) error {
+func (m *mockBackend) IsReplacementAt(ctx context.Context, chainID eth.ChainID, blockNum uint64) error {
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -175,10 +175,6 @@ func (m *mockBackend) CrossUnsafe(ctx context.Context, chainID eth.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
-func (m *mockBackend) IsReplacementAt(ctx context.Context, chainID eth.ChainID, blockNum uint64) error {
-	return nil
-}
-
 var _ backend = (*mockBackend)(nil)
 
 func sampleDepSet(t *testing.T) depset.DependencySet {

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -175,6 +175,10 @@ func (m *mockBackend) CrossUnsafe(ctx context.Context, chainID eth.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
+func (m *mockBackend) IsReplacement(ctx context.Context, chainID eth.ChainID, blockID eth.BlockID) error {
+	return nil
+}
+
 var _ backend = (*mockBackend)(nil)
 
 func sampleDepSet(t *testing.T) depset.DependencySet {

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -31,7 +31,7 @@ type backend interface {
 	FindSealedBlock(ctx context.Context, chainID eth.ChainID, number uint64) (eth.BlockID, error)
 	IsLocalSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	IsCrossSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
-	IsReplacement(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
+	IsReplacementAt(ctx context.Context, chainID eth.ChainID, blockNum uint64) error
 	IsLocalUnsafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (derived eth.BlockID, err error)
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
@@ -282,8 +282,8 @@ func (m *ManagedNode) onUpdateLocalSafeFailed(ev superevents.UpdateLocalSafeFail
 	}
 }
 
-// OnResetReady handles a reset-ready event from the supervisor
-// once the supervisor has determined the reset target by bisecting the search range
+// OnResetReady handles a fully qualified reset command to the node
+// it is called by the resetTracker when the reset is ready to be executed
 func (m *ManagedNode) OnResetReady(lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID) {
 	m.log.Info("Reset ready event received",
 		"localUnsafe", lUnsafe,
@@ -443,8 +443,8 @@ func (m *ManagedNode) Close() error {
 func (m *ManagedNode) replaceIfNeeded() bool {
 	ctx, cancel := context.WithTimeout(m.ctx, internalTimeout)
 	defer cancel()
-	err := m.backend.IsReplacement(ctx, m.chainID, m.lastNodeLocalSafe)
-	if err != nil {
+	err := m.backend.IsReplacementAt(ctx, m.chainID, m.lastNodeLocalSafe.Number)
+	if err == nil {
 		m.log.Info("Replacement block detected, initiating replacement",
 			"lastNodeLocalSafe", m.lastNodeLocalSafe,
 			"err", err)

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -31,7 +31,6 @@ type backend interface {
 	FindSealedBlock(ctx context.Context, chainID eth.ChainID, number uint64) (eth.BlockID, error)
 	IsLocalSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	IsCrossSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
-	IsReplacementAt(ctx context.Context, chainID eth.ChainID, blockNum uint64) error
 	IsLocalUnsafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (derived eth.BlockID, err error)
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
@@ -269,12 +268,7 @@ func (m *ManagedNode) onResetEvent(errStr string) {
 func (m *ManagedNode) onUpdateLocalSafeFailed(ev superevents.UpdateLocalSafeFailedEvent) {
 	switch {
 	case errors.Is(ev.Err, types.ErrConflict):
-		m.log.Warn("DB indicated a conflict with this node")
-		if m.replaceIfNeeded() {
-			m.log.Warn("Node was instructed to replace its local safe block")
-			return
-		}
-		m.log.Warn("Node is inconsistent with the logs db, resetting")
+		m.log.Warn("DB indicated a conflict with this node, checking if node is inconsistent")
 		m.resetIfInconsistent()
 	case errors.Is(ev.Err, types.ErrFuture):
 		m.log.Warn("DB indicated this node provided an update from the future, checking if node is ahead")
@@ -432,34 +426,6 @@ func (m *ManagedNode) Close() error {
 		sub.Unsubscribe()
 	}
 	return nil
-}
-
-// replaceIfNeeded checks the node's last local safe block against the backend
-// to see if it should be replaced. If so, it invalidates the block and returns true.
-// if replacement doesn't happen, it returns false.
-// This codepath is triggered when a node is syncing,
-// and the Supervisor has already dealth with the invalidation and replacement.
-// nodes which are catching up need to know if a replacement is canonical at this point,
-func (m *ManagedNode) replaceIfNeeded() bool {
-	ctx, cancel := context.WithTimeout(m.ctx, internalTimeout)
-	defer cancel()
-	err := m.backend.IsReplacementAt(ctx, m.chainID, m.lastNodeLocalSafe.Number)
-	if err == nil {
-		m.log.Info("Replacement block detected, initiating replacement",
-			"lastNodeLocalSafe", m.lastNodeLocalSafe,
-			"err", err)
-		seal := types.BlockSeal{
-			Hash:      m.lastNodeLocalSafe.Hash,
-			Number:    m.lastNodeLocalSafe.Number,
-			Timestamp: 0, // timestamp is not used when invalidating a block
-		}
-		if err := m.Node.InvalidateBlock(ctx, seal); err != nil {
-			m.log.Warn("Failed to invalidate block", "seal", seal, "err", err)
-			return false
-		}
-		return true
-	}
-	return false
 }
 
 // resetIfInconsistent checks if the node is consistent with the logs db

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -31,6 +31,7 @@ type backend interface {
 	FindSealedBlock(ctx context.Context, chainID eth.ChainID, number uint64) (eth.BlockID, error)
 	IsLocalSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	IsCrossSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
+	IsReplacement(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	IsLocalUnsafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error
 	SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (derived eth.BlockID, err error)
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
@@ -202,7 +203,11 @@ func (m *ManagedNode) Start() {
 			case <-m.ctx.Done():
 				m.log.Info("Exiting node syncing")
 				return
-			case ev := <-m.nodeEvents: // nil, indefinitely blocking, if no node-events subscriber is set up.
+			case ev, ok := <-m.nodeEvents: // nil, indefinitely blocking, if no node-events subscriber is set up.
+				if !ok {
+					m.log.Info("Node events channel closed, stopping")
+					return
+				}
 				m.onNodeEvent(ev)
 			}
 		}
@@ -264,10 +269,15 @@ func (m *ManagedNode) onResetEvent(errStr string) {
 func (m *ManagedNode) onUpdateLocalSafeFailed(ev superevents.UpdateLocalSafeFailedEvent) {
 	switch {
 	case errors.Is(ev.Err, types.ErrConflict):
-		m.log.Warn("DB indicated a conflict, checking consistency")
+		m.log.Warn("DB indicated a conflict with this node")
+		if m.replaceIfNeeded() {
+			m.log.Warn("Node was instructed to replace its local safe block")
+			return
+		}
+		m.log.Warn("Node is inconsistent with the logs db, resetting")
 		m.resetIfInconsistent()
 	case errors.Is(ev.Err, types.ErrFuture):
-		m.log.Warn("DB indicated an update is in the future, checking if node is ahead")
+		m.log.Warn("DB indicated this node provided an update from the future, checking if node is ahead")
 		m.resetIfAhead()
 	}
 }
@@ -407,6 +417,10 @@ func (m *ManagedNode) onReplaceBlock(replacement types.BlockReplacement) {
 		ChainID:     m.chainID,
 		Replacement: replacement,
 	})
+	// if the node replaced a block, both the unsafe and safe are reset to this point
+	m.lastNodeLocalSafe = replacement.Replacement.ID()
+	m.lastNodeLocalUnsafe = replacement.Replacement.ID()
+	m.resetIfInconsistent()
 }
 
 func (m *ManagedNode) Close() error {
@@ -418,6 +432,34 @@ func (m *ManagedNode) Close() error {
 		sub.Unsubscribe()
 	}
 	return nil
+}
+
+// replaceIfNeeded checks the node's last local safe block against the backend
+// to see if it should be replaced. If so, it invalidates the block and returns true.
+// if replacement doesn't happen, it returns false.
+// This codepath is triggered when a node is syncing,
+// and the Supervisor has already dealth with the invalidation and replacement.
+// nodes which are catching up need to know if a replacement is canonical at this point,
+func (m *ManagedNode) replaceIfNeeded() bool {
+	ctx, cancel := context.WithTimeout(m.ctx, internalTimeout)
+	defer cancel()
+	err := m.backend.IsReplacement(ctx, m.chainID, m.lastNodeLocalSafe)
+	if err != nil {
+		m.log.Info("Replacement block detected, initiating replacement",
+			"lastNodeLocalSafe", m.lastNodeLocalSafe,
+			"err", err)
+		seal := types.BlockSeal{
+			Hash:      m.lastNodeLocalSafe.Hash,
+			Number:    m.lastNodeLocalSafe.Number,
+			Timestamp: 0, // timestamp is not used when invalidating a block
+		}
+		if err := m.Node.InvalidateBlock(ctx, seal); err != nil {
+			m.log.Warn("Failed to invalidate block", "seal", seal, "err", err)
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 // resetIfInconsistent checks if the node is consistent with the logs db


### PR DESCRIPTION
- Expands the `invalidated` bool to use the full `EntryType` byte
- Adds `ReplacementV0` as a new Entry Type
- Adds unit testing for all Entry Type parsing, including encode/decode and invalid Types
- Marks the EntryType as a `ReplacementV0` when the `invalidated` block hash is provided to `addLink`
- Wires Replacement checks through the backend
- Adds a new `ReplaceIfNeeded` check for the Managed Node
  - If there is ever an `ErrConflict` when the node reports its new derived block, EITHER:
    - The Node is genuinely out of sync and needs to initate a reset, OR
    - The Node is encountering a natural requirement to invalidate+replace the block they just derived
  - So, we check if a replacement is needed first *before* starting down the reset route
- Updates the `LastSeenSafe` and `LastSeenUnsafe` when a replacement comes in from the Managed Node, and triggers a `ResetIfInconsistent` check. This way if the node is corrupted *after* a replacement, we will still notice. This also makes it so nodes which just did a replacement won't get incorrectly flagged as inconsistent
- Fixes a channel closure bug when Managed Nodes close