### PR TITLE
op-e2e,kurtosis-devnet: enable isthmus in interop tests

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -74,6 +74,7 @@ optimism_package:
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0
+        isthmus_time_offset: 0
         interop_time_offset: 0
         fund_dev_accounts: true
       batcher_params:

--- a/kurtosis-devnet/templates/l2.yaml
+++ b/kurtosis-devnet/templates/l2.yaml
@@ -13,6 +13,7 @@ network_params:
   fjord_time_offset: 0
   granite_time_offset: 0
   holocene_time_offset: 0
+  isthmus_time_offset: 0
   interop_time_offset: 0
   fund_dev_accounts: true
 batcher_params:

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -29,6 +30,9 @@ var (
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
 	upgradeSchedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
 	if intent.UseInterop {
+		if upgradeSchedule.L2GenesisIsthmusTimeOffset == nil {
+			return genesis.DeployConfig{}, errors.New("expecting isthmus fork to be enabled for interop deployments")
+		}
 		upgradeSchedule.UseInterop = true
 	}
 

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -134,6 +134,10 @@ func SetupInterop(t helpers.Testing, opts ...setupOption) *InteropSetup {
 	worldCfg, err := recipe.Build(hdWallet)
 	require.NoError(t, err)
 
+	for _, l2Cfg := range worldCfg.L2s {
+		require.NotNil(t, l2Cfg.L2GenesisIsthmusTimeOffset, "expecting isthmus fork to be enabled for interop deployments")
+	}
+
 	// create the foundry artifacts and source map
 	foundryArtifacts := foundry.OpenArtifactsDir(foundryArtifactsDir)
 	sourceMap := foundry.NewSourceMapFS(os.DirFS(sourceMapDir))

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -174,6 +174,10 @@ func (s *interopE2ESystem) prepareWorld(w WorldResourcePaths) (*interopgen.World
 	worldCfg, err := s.recipe.Build(s.hdWallet)
 	require.NoError(s.t, err)
 
+	for _, l2Cfg := range worldCfg.L2s {
+		require.NotNil(s.t, l2Cfg.L2GenesisIsthmusTimeOffset, "expecting isthmus fork to be enabled for interop deployments")
+	}
+
 	// create a logger for the world configuration
 	logger := s.logger.New("role", "world")
 	require.NoError(s.t, worldCfg.Check(logger))


### PR DESCRIPTION
**Description**

This enables Isthmus to be activated in the Interop tests.

This also includes some sanity-checks, to ensure Isthmus is really activated, when starting an interop net (which uses a boolean config var in some places in addition or instead of the regular fork schedule).

**Tests**

Interop tests now assert that isthmus is activated in the deploy config.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/14905
