### PR TITLE
kt-devnet: bump optimism package to f57f766d3902c5044a055d09ac2136da1…

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@0b7814012ba6b0a60ea3cf23f9e54a4cc763aa43
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@f57f766d3902c5044a055d09ac2136da1de38f98
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173


### PR DESCRIPTION
…de38f98

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Bump kt devnet [optimism package](https://github.com/ethpandaops/optimism-package/) to latest(f57f766d3902c5044a055d09ac2136da1de38f98) to pick up multi node support, for different EL implementations(https://github.com/ethpandaops/optimism-package/pull/201).

**Tests**

Checked that all isthmus NAT test pass.

**Additional context**

For unblocking operator fee NAT tests against different EL node implementations.
