### PR TITLE
Update mise.toml to remove kurtosis

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -36,7 +36,6 @@ anvil = "v1.0.0"
 # Other dependencies
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
-kurtosis = "1.5.0"
 op-acceptor = "op-acceptor/v0.1.4"
 
 # Fake dependencies


### PR DESCRIPTION
This causes an error:
```
mise WARN  failed to resolve toolset: [~/code/ethereum-optimism/optimism/mise.toml] kurtosis@1.5.0: kurtosis not found in mise tool registry
```

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
