### PR TITLE
op-e2e/actions: improve operator fee tests to ensure deposits don't mint ETH

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.7
 
 require (
 	github.com/BurntSushi/toml v1.4.0
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/andybalholm/brotli v1.1.0
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/btcsuite/btcd v0.24.2
@@ -63,7 +64,6 @@ require (
 
 require (
 	github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.2 // indirect
 	github.com/adrg/xdg v0.4.0 // indirect
@@ -274,9 +274,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-//replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.1
-
-replace github.com/ethereum/go-ethereum => github.com/leruaa/op-geth v1.0.0-rc.1
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.2
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,9 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.1
+//replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.1
+
+replace github.com/ethereum/go-ethereum => github.com/leruaa/op-geth v1.0.0-rc.1
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
+github.com/ethereum-optimism/op-geth v1.101503.2-rc.2 h1:SihKdvBN4G0yW6pKb96CzXchq0NiHgetAoPqkZ8tYQA=
+github.com/ethereum-optimism/op-geth v1.101503.2-rc.2/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
@@ -474,8 +476,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kurtosis-tech/kurtosis-portal/api/golang v0.0.0-20230818182330-1a86869414d2 h1:izciXrFyFR+ihJ7nLTOkoIX5GzBPIp8gVKlw94gIc98=
 github.com/kurtosis-tech/kurtosis-portal/api/golang v0.0.0-20230818182330-1a86869414d2/go.mod h1:bWSMQK3WHVTGHX9CjxPAb/LtzcmfOxID2wdzakSWQxo=
-github.com/kurtosis-tech/kurtosis/api/golang v1.4.4 h1:/V6kcQvb91NORCShuvMGz8gGW4NY8yX+ZoNCYsVhfVg=
-github.com/kurtosis-tech/kurtosis/api/golang v1.4.4/go.mod h1:9T22P7Vv3j5g6sbm78DxHQ4s9C4Cj3s9JjFQ7DFyYpM=
 github.com/kurtosis-tech/kurtosis/api/golang v1.5.0 h1:EaHd55F5HYUTu47zjpGXRegc4U5AO4J8JDvn8gP0tM8=
 github.com/kurtosis-tech/kurtosis/api/golang v1.5.0/go.mod h1:9T22P7Vv3j5g6sbm78DxHQ4s9C4Cj3s9JjFQ7DFyYpM=
 github.com/kurtosis-tech/kurtosis/contexts-config-store v0.0.0-20230818184218-f4e3e773463b h1:hMoIM99QKcYQqsnK4AF7Lovi9ZD9ac6lZLZ5D/jx2x8=
@@ -493,8 +493,6 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
-github.com/leruaa/op-geth v1.0.0-rc.1 h1:pOC9bfOcZxcprNoJ0p07HDGNvlaZTTNLEBcBrG7onEc=
-github.com/leruaa/op-geth v1.0.0-rc.1/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101503.2-rc.1 h1:a//Sc0necznugHkwS4gey4uS9qDoSk8g3TazLDVnQ/8=
-github.com/ethereum-optimism/op-geth v1.101503.2-rc.1/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
@@ -495,6 +493,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
+github.com/leruaa/op-geth v1.0.0-rc.1 h1:pOC9bfOcZxcprNoJ0p07HDGNvlaZTTNLEBcBrG7onEc=
+github.com/leruaa/op-geth v1.0.0-rc.1/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -204,7 +204,7 @@ func (s *BasicUser[B]) ActSetTxValue(value *big.Int) Action {
 	}
 }
 
-func (s *BasicUser[B]) ActSetGasLimit(limit uint64) Action {
+func (s *BasicUser[B]) ActSetTxGasLimit(limit uint64) Action {
 	return func(t Testing) {
 		s.txOpts.GasLimit = limit
 	}

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -204,6 +204,12 @@ func (s *BasicUser[B]) ActSetTxValue(value *big.Int) Action {
 	}
 }
 
+func (s *BasicUser[B]) ActSetGasLimit(limit uint64) Action {
+	return func(t Testing) {
+		s.txOpts.GasLimit = limit
+	}
+}
+
 func (s *BasicUser[B]) ActRandomTxData(t Testing) {
 	t.Helper()
 	dataLen := s.rng.Intn(128_000)

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -27,7 +27,7 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 		IsthmusTransitionBlock
 	)
 
-	const testOperatorFeeScalar = uint32(20000)
+	const testOperatorFeeScalar = uint32(100e6)
 	const testOperatorFeeConstant = uint64(500)
 	testStorageUpdateContractAddress := common.HexToAddress("0xffffffff")
 	// contract TestSetter {
@@ -158,7 +158,7 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			// regular Deposit, in new L1 block
 			env.Alice.L1.ActResetTxOpts(t)
 			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
-			env.Alice.L2.ActSetGasLimit(22000)(t)
+			env.Alice.L2.ActSetTxGasLimit(2e6)(t)
 			env.Alice.ActDeposit(t)
 			env.Miner.ActL1StartBlock(12)(t)
 			env.Miner.ActL1IncludeTx(env.Alice.Address())(t)
@@ -208,7 +208,7 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 		}
 
 		if testCfg.Custom == DepositTx {
-			require.True(t, aliceFinalBalance.Cmp(aliceInitialBalance) == 0, "Alice's balance shouldn't have changed")
+			require.Equal(t, aliceInitialBalance, aliceFinalBalance, "Alice's balance shouldn't have changed")
 		} else {
 			require.True(t, aliceFinalBalance.Cmp(aliceInitialBalance) < 0, "Alice's balance should decrease")
 		}

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -162,6 +162,7 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			// regular Deposit, in new L1 block
 			env.Alice.L1.ActResetTxOpts(t)
 			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
+			env.Alice.L2.ActSetGasLimit(22000)(t)
 			env.Alice.ActDeposit(t)
 			env.Miner.ActL1StartBlock(12)(t)
 			env.Miner.ActL1IncludeTx(env.Alice.Address())(t)

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -29,7 +29,6 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 
 	const testOperatorFeeScalar = uint32(20000)
 	const testOperatorFeeConstant = uint64(500)
-	const testDepositValue = uint64(10000)
 	testStorageUpdateContractAddress := common.HexToAddress("0xffffffff")
 	// contract TestSetter {
 	//   uint x;
@@ -37,6 +36,8 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 	// }
 	// The deployed bytecode below is from the contract above
 	testStorageUpdateContractCode := common.FromHex("0x6080604052348015600e575f80fd5b50600436106026575f3560e01c806360fe47b114602a575b5f80fd5b60406004803603810190603c9190607d565b6042565b005b805f8190555050565b5f80fd5b5f819050919050565b605f81604f565b81146068575f80fd5b50565b5f813590506077816058565b92915050565b5f60208284031215608f57608e604b565b5b5f609a84828501606b565b9150509291505056fea26469706673582212201712a1e6e9c5e2ba1f8f7403f5d6e00090c6fa2b70c632beea4be8009331bd2064736f6c63430008190033")
+
+	l1InfoDepositorAddress := common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
 
 	runIsthmusDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
 		t := actionsHelpers.NewDefaultTesting(gt)
@@ -68,14 +69,15 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			return bal
 		}
 
-		getCurrentBalances := func() (alice *big.Int, l1FeeVault *big.Int, baseFeeVault *big.Int, sequencerFeeVault *big.Int, operatorFeeVault *big.Int) {
+		getCurrentBalances := func() (alice *big.Int, l1FeeVault *big.Int, baseFeeVault *big.Int, sequencerFeeVault *big.Int, operatorFeeVault *big.Int, depositor *big.Int) {
 			alice = balanceAt(env.Alice.Address())
 			l1FeeVault = balanceAt(predeploys.L1FeeVaultAddr)
 			baseFeeVault = balanceAt(predeploys.BaseFeeVaultAddr)
 			sequencerFeeVault = balanceAt(predeploys.SequencerFeeVaultAddr)
 			operatorFeeVault = balanceAt(predeploys.OperatorFeeVaultAddr)
+			depositor = balanceAt(l1InfoDepositorAddress)
 
-			return alice, l1FeeVault, baseFeeVault, sequencerFeeVault, operatorFeeVault
+			return alice, l1FeeVault, baseFeeVault, sequencerFeeVault, operatorFeeVault, depositor
 		}
 
 		setStorageInUpdateContractTo := func(value byte) {
@@ -121,12 +123,13 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 		var l1FeeVaultInitialBalance *big.Int
 		var sequencerFeeVaultInitialBalance *big.Int
 		var operatorFeeVaultInitialBalance *big.Int
+		var depositorInitialBalance *big.Int
 
 		var receipt *types.Receipt
 
 		switch testCfg.Custom {
 		case NormalTx, IsthmusTransitionBlock:
-			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance, depositorInitialBalance = getCurrentBalances()
 
 			require.Equal(t, operatorFeeVaultInitialBalance.Sign(), 0)
 
@@ -147,21 +150,18 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			setStorageInUpdateContractTo(1)
 			rSet := env.Alice.L2.LastTxReceipt(t)
 			require.Equal(t, uint64(43696), rSet.GasUsed)
-			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance, depositorInitialBalance = getCurrentBalances()
 			setStorageInUpdateContractTo(0)
 			rUnset := env.Alice.L2.LastTxReceipt(t)
 			// we assert on the exact gas used to show that a refund is happening
 			require.Equal(t, uint64(21784), rUnset.GasUsed)
 
 		case DepositTx:
-			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
-
-			bobInitialBalance := balanceAt(env.Bob.Address())
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance, depositorInitialBalance = getCurrentBalances()
 
 			// regular Deposit, in new L1 block
 			env.Alice.L1.ActResetTxOpts(t)
 			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
-			env.Alice.L2.ActSetTxValue(new(big.Int).SetUint64(testDepositValue))(t)
 			env.Alice.ActDeposit(t)
 			env.Miner.ActL1StartBlock(12)(t)
 			env.Miner.ActL1IncludeTx(env.Alice.Address())(t)
@@ -173,15 +173,11 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 
 			env.Alice.ActCheckDepositStatus(true, true)(t)
 
-			bobFinalBalance := balanceAt(env.Bob.Address())
-
-			require.Equal(t, bobInitialBalance.Uint64()+testDepositValue, bobFinalBalance.Uint64())
-
 			receipt, err = env.Alice.GetLastDepositL2Receipt(t)
 			require.NoError(t, err)
 		}
 
-		aliceFinalBalance, l1FeeVaultFinalBalance, baseFeeVaultFinalBalance, sequencerFeeVaultFinalBalance, operatorFeeVaultFinalBalance := getCurrentBalances()
+		aliceFinalBalance, l1FeeVaultFinalBalance, baseFeeVaultFinalBalance, sequencerFeeVaultFinalBalance, operatorFeeVaultFinalBalance, depositorFinalBalance := getCurrentBalances()
 
 		if receipt == nil {
 			receipt = env.Alice.L2.LastTxReceipt(t)
@@ -213,29 +209,32 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 				new(big.Int).Sub(operatorFeeVaultFinalBalance, operatorFeeVaultInitialBalance),
 			)
 		}
-		require.True(t, aliceFinalBalance.Cmp(aliceInitialBalance) < 0, "Alice's balance should decrease")
+
+		if testCfg.Custom == DepositTx {
+			require.True(t, aliceFinalBalance.Cmp(aliceInitialBalance) == 0, "Alice's balance shouldn't have changed")
+		} else {
+			require.True(t, aliceFinalBalance.Cmp(aliceInitialBalance) < 0, "Alice's balance should decrease")
+		}
 
 		// Check that no Ether has been minted or burned
 		finalTotalBalance := new(big.Int).Add(
 			aliceFinalBalance,
 			new(big.Int).Add(
 				new(big.Int).Add(
-					new(big.Int).Sub(l1FeeVaultFinalBalance, l1FeeVaultInitialBalance),
-					new(big.Int).Sub(sequencerFeeVaultFinalBalance, sequencerFeeVaultInitialBalance),
+					new(big.Int).Add(
+						new(big.Int).Sub(l1FeeVaultFinalBalance, l1FeeVaultInitialBalance),
+						new(big.Int).Sub(sequencerFeeVaultFinalBalance, sequencerFeeVaultInitialBalance),
+					),
+					new(big.Int).Add(
+						new(big.Int).Sub(operatorFeeVaultFinalBalance, operatorFeeVaultInitialBalance),
+						new(big.Int).Sub(baseFeeVaultFinalBalance, baseFeeVaultInitialBalance),
+					),
 				),
-				new(big.Int).Add(
-					new(big.Int).Sub(operatorFeeVaultFinalBalance, operatorFeeVaultInitialBalance),
-					new(big.Int).Sub(baseFeeVaultFinalBalance, baseFeeVaultInitialBalance),
-				),
+				new(big.Int).Sub(depositorFinalBalance, depositorInitialBalance),
 			),
 		)
 
-		if testCfg.Custom == DepositTx {
-			// Minus the deposit value that was sent to Bob
-			require.Equal(t, aliceInitialBalance.Uint64()-testDepositValue, finalTotalBalance.Uint64())
-		} else {
-			require.Equal(t, aliceInitialBalance, finalTotalBalance)
-		}
+		require.Equal(t, aliceInitialBalance, finalTotalBalance)
 
 		l2UnsafeHead := env.Engine.L2Chain().CurrentHeader()
 

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -37,8 +37,6 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 	// The deployed bytecode below is from the contract above
 	testStorageUpdateContractCode := common.FromHex("0x6080604052348015600e575f80fd5b50600436106026575f3560e01c806360fe47b114602a575b5f80fd5b60406004803603810190603c9190607d565b6042565b005b805f8190555050565b5f80fd5b5f819050919050565b605f81604f565b81146068575f80fd5b50565b5f813590506077816058565b92915050565b5f60208284031215608f57608e604b565b5b5f609a84828501606b565b9150509291505056fea26469706673582212201712a1e6e9c5e2ba1f8f7403f5d6e00090c6fa2b70c632beea4be8009331bd2064736f6c63430008190033")
 
-	l1InfoDepositorAddress := common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
-
 	runIsthmusDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
 		t := actionsHelpers.NewDefaultTesting(gt)
 		deployConfigOverrides := func(dp *genesis.DeployConfig) {}
@@ -69,15 +67,14 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			return bal
 		}
 
-		getCurrentBalances := func() (alice *big.Int, l1FeeVault *big.Int, baseFeeVault *big.Int, sequencerFeeVault *big.Int, operatorFeeVault *big.Int, depositor *big.Int) {
+		getCurrentBalances := func() (alice *big.Int, l1FeeVault *big.Int, baseFeeVault *big.Int, sequencerFeeVault *big.Int, operatorFeeVault *big.Int) {
 			alice = balanceAt(env.Alice.Address())
 			l1FeeVault = balanceAt(predeploys.L1FeeVaultAddr)
 			baseFeeVault = balanceAt(predeploys.BaseFeeVaultAddr)
 			sequencerFeeVault = balanceAt(predeploys.SequencerFeeVaultAddr)
 			operatorFeeVault = balanceAt(predeploys.OperatorFeeVaultAddr)
-			depositor = balanceAt(l1InfoDepositorAddress)
 
-			return alice, l1FeeVault, baseFeeVault, sequencerFeeVault, operatorFeeVault, depositor
+			return alice, l1FeeVault, baseFeeVault, sequencerFeeVault, operatorFeeVault
 		}
 
 		setStorageInUpdateContractTo := func(value byte) {
@@ -123,13 +120,12 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 		var l1FeeVaultInitialBalance *big.Int
 		var sequencerFeeVaultInitialBalance *big.Int
 		var operatorFeeVaultInitialBalance *big.Int
-		var depositorInitialBalance *big.Int
 
 		var receipt *types.Receipt
 
 		switch testCfg.Custom {
 		case NormalTx, IsthmusTransitionBlock:
-			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance, depositorInitialBalance = getCurrentBalances()
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
 
 			require.Equal(t, operatorFeeVaultInitialBalance.Sign(), 0)
 
@@ -150,14 +146,14 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			setStorageInUpdateContractTo(1)
 			rSet := env.Alice.L2.LastTxReceipt(t)
 			require.Equal(t, uint64(43696), rSet.GasUsed)
-			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance, depositorInitialBalance = getCurrentBalances()
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
 			setStorageInUpdateContractTo(0)
 			rUnset := env.Alice.L2.LastTxReceipt(t)
 			// we assert on the exact gas used to show that a refund is happening
 			require.Equal(t, uint64(21784), rUnset.GasUsed)
 
 		case DepositTx:
-			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance, depositorInitialBalance = getCurrentBalances()
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
 
 			// regular Deposit, in new L1 block
 			env.Alice.L1.ActResetTxOpts(t)
@@ -178,7 +174,7 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			require.NoError(t, err)
 		}
 
-		aliceFinalBalance, l1FeeVaultFinalBalance, baseFeeVaultFinalBalance, sequencerFeeVaultFinalBalance, operatorFeeVaultFinalBalance, depositorFinalBalance := getCurrentBalances()
+		aliceFinalBalance, l1FeeVaultFinalBalance, baseFeeVaultFinalBalance, sequencerFeeVaultFinalBalance, operatorFeeVaultFinalBalance := getCurrentBalances()
 
 		if receipt == nil {
 			receipt = env.Alice.L2.LastTxReceipt(t)
@@ -222,16 +218,13 @@ func Test_ProgramAction_OperatorFeeConstistency(gt *testing.T) {
 			aliceFinalBalance,
 			new(big.Int).Add(
 				new(big.Int).Add(
-					new(big.Int).Add(
-						new(big.Int).Sub(l1FeeVaultFinalBalance, l1FeeVaultInitialBalance),
-						new(big.Int).Sub(sequencerFeeVaultFinalBalance, sequencerFeeVaultInitialBalance),
-					),
-					new(big.Int).Add(
-						new(big.Int).Sub(operatorFeeVaultFinalBalance, operatorFeeVaultInitialBalance),
-						new(big.Int).Sub(baseFeeVaultFinalBalance, baseFeeVaultInitialBalance),
-					),
+					new(big.Int).Sub(l1FeeVaultFinalBalance, l1FeeVaultInitialBalance),
+					new(big.Int).Sub(sequencerFeeVaultFinalBalance, sequencerFeeVaultInitialBalance),
 				),
-				new(big.Int).Sub(depositorFinalBalance, depositorInitialBalance),
+				new(big.Int).Add(
+					new(big.Int).Sub(operatorFeeVaultFinalBalance, operatorFeeVaultInitialBalance),
+					new(big.Int).Sub(baseFeeVaultFinalBalance, baseFeeVaultInitialBalance),
+				),
 			),
 		)
 


### PR DESCRIPTION

**Description**

Improves operator fee tests to verify that no ETH is minted when operator fees are in use. Deposit transactions currently mint operator fees.

**Metadata**

Fixes https://github.com/ethereum-optimism/pm/issues/42
