### PR TITLE
doc(kurtosis-devnet): remove kurtosis-specific instructions

### DIFF
--- a/kurtosis-devnet/README.md
+++ b/kurtosis-devnet/README.md
@@ -1,15 +1,8 @@
 # Getting Started
 
 Running a Kurtosis Devnet has the following prerequisites:
-- Kurtosis must be installed
+- Kurtosis must be installed. This is automatically handled by `mise`, same as with other dev tools in this repository
 - Docker Desktop must be installed and running
-
-Platform specific installation instructions for Kurtosis may be found [in Kurtosis documentation](https://docs.kurtosis.com/install/), alternatively Mac, Windows and Linux binaries can be found [here](https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts).
-For Mac users, the following command should suffice:
-```
-brew install kurtosis-tech/tap/kurtosis-cli
-```
-Check your Kurtosis version with `kurtosis version`. The current ideal version for these devnets is `1.5.0`.
 
 Docker Desktop may be substituted by an alternative like Orbstack if you have that installed.
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

kurtosis binary is now handled by mise. We don't need to install it separately.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
