### PR TITLE
chore: fixed broken link

### DIFF
--- a/packages/contracts-bedrock/book/src/policies/versioning.md
+++ b/packages/contracts-bedrock/book/src/policies/versioning.md
@@ -77,7 +77,7 @@ Versioning for monorepo releases works as follows:
 
 ## Optimism Contracts Manager (OPCM) Versioning
 
-The [OPCM](https://github.com/ethereum-optimism/optimism/blob/main/packages/contracts-bedrock/src/L1/OPContractsManager.sol) is the contract that manages the deployment of all contracts on L1.
+The [OPCM](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OPContractsManager.sol) is the contract that manages the deployment of all contracts on L1.
 
 The `OPCM` is the source of truth for the contracts that belong in a release, available as on-chain addresses by querying [the `getImplementations` function](https://github.com/ethereum-optimism/optimism/blob/4c8764f0453e141555846d8c9dd2af9edbc1d014/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L1061).
 


### PR DESCRIPTION
**Description**

Hi! I fixed a broken link in the versioning.md documentation. The link to the `OPContractsManager.sol` file was pointing to the wrong branch (`main` instead of `develop`). I updated it to the correct branch to ensure users can access the contract.








































































