### PR TITLE
go-ffi: fix `getMerkleTrieFuzzCase`

### DIFF
--- a/packages/contracts-bedrock/scripts/go-ffi/README.md
+++ b/packages/contracts-bedrock/scripts/go-ffi/README.md
@@ -11,7 +11,7 @@ A lightweight binary for utilities accessed via `forge`'s `ffi` cheatcode in the
 
 ## Usage
 
-To build, run `just build-go-ffi` from this directory or the `contract-bedrock` package.
+To build, run `just build-go-ffi` from the `contract-bedrock` package.
 
 ### In a Forge Test
 
@@ -39,7 +39,7 @@ There are two modes available in `go-ffi`: `diff` and `trie`. Each are present a
 > Variant required for diff mode.
 
 | Variant                               | Description                                                                                                        |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `decodeVersionedNonce`                | Decodes a versioned nonce and prints the decoded arguments                                                         |
 | `encodeCrossDomainMessage`            | Encodes a cross domain message and prints the encoded message                                                      |
 | `hashCrossDomainMessage`              | Encodes and hashes a cross domain message and prints the digest                                                    |

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -225,7 +225,7 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory, bytes memory, bytes[] memory)
     {
-        string[] memory cmds = new string[](6);
+        string[] memory cmds = new string[](3);
         cmds[0] = "./scripts/go-ffi/go-ffi";
         cmds[1] = "trie";
         cmds[2] = variant;


### PR DESCRIPTION
This PR fixes [`getMerkleTrieFuzzCase`](https://github.com/ethereum-optimism/optimism/blob/4941d95852d8001197fc27919f34a126767e54db/packages/contracts-bedrock/test/setup/FFIInterface.sol#L224) to make the size accurate(all others are accurate except this one).

And  fix the mistake in README as `just build-go-ffi` can only be run from the `contract-bedrock` package now.