### PR TITLE
op-e2e: Unskip FP interop intra-block test cases

### DIFF
--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -233,18 +233,16 @@ func (d *InteropDSL) ProcessCrossSafe(optionalArgs ...func(*ProcessCrossSafeOpts
 	// Process updates on each chain and verify the cross-safe head advanced
 	for _, chain := range opts.Chains {
 		chain.Sequencer.ActL2PipelineFull(d.t)
-		status := chain.Sequencer.SyncStatus()
-		require.Equalf(d.t, status.UnsafeL2, status.SafeL2, "Chain %v did not fully advance safe head", chain.ChainID)
-
 		chain.Sequencer.SyncSupervisor(d.t)
 	}
-
-	// Re-run in case there was an invalid block that was replaced so it can now be considered safe
-	// TODO: Should this just loop until the cross safe heads stop updating or is once enough?
 	d.Actors.Supervisor.ProcessFull(d.t)
-	// Process updates on each chain and verify the cross-safe head advanced
+	// Re-run in case there was an invalid block that was replaced so it can now be considered safe
 	for _, chain := range opts.Chains {
 		chain.Sequencer.ActL2PipelineFull(d.t)
+		chain.Sequencer.SyncSupervisor(d.t)
+	}
+	d.Actors.Supervisor.ProcessFull(d.t)
+	for _, chain := range opts.Chains {
 		status := chain.Sequencer.SyncStatus()
 		require.Equalf(d.t, status.UnsafeL2, status.SafeL2, "Chain %v did not fully advance safe head", chain.ChainID)
 	}

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -379,10 +379,6 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 		c := c
 		name := reflect.TypeOf(c).Elem().Name()
 		gt.Run(name, func(gt *testing.T) {
-			if name == "cascadeInvalidBlockCase" || name == "swapCascadeInvalidBlockCase" || name == "cyclicDependencyInvalidCase" {
-				// TODO(#14307): Support cascading block invalidations in the supervisor
-				gt.Skip("Skipping cascade invalid block case")
-			}
 			t := helpers.NewDefaultTesting(gt)
 			system := dsl.NewInteropDSL(t)
 
@@ -1427,8 +1423,8 @@ func (c *cascadeInvalidBlockCase) Setup(t helpers.StatefulTesting, system *dsl.I
 func (c *cascadeInvalidBlockCase) RunCrossSafeChecks(t helpers.StatefulTesting, system *dsl.InteropDSL, actors *dsl.InteropActors) {
 	c.msgA.CheckNotEmitted()
 	c.msgA.CheckNotExecuted()
-	c.msgB.CheckEmitted()
-	c.msgB.CheckExecuted()
+	c.msgB.CheckNotEmitted()
+	c.msgB.CheckNotExecuted()
 }
 
 type swapCascadeInvalidBlockCase struct {


### PR DESCRIPTION
The cascading block issue is now fully supported by the op-supervisor.
It also turned out that `dsl.ProcessCrossSafe` wasn't handling block replacements correctly. This has been fixed.

ref: #14307