### PR TITLE
devnet-sdk, op-acceptance-testing: Introduce walletV2 and add few txplan alpha tests

### DIFF
--- a/devnet-sdk/contracts/bindings/eventlogger.go
+++ b/devnet-sdk/contracts/bindings/eventlogger.go
@@ -1,5 +1,11 @@
 package bindings
 
+// This file was generated and edited by below sequences:
+//   cd packages/contracts-bedrock
+//   solc --optimize --bin --abi -o out src/integration/EventLogger.sol
+//   abigen --abi out/EventLogger.abi --bin out/EventLogger.bin --pkg bindings --out eventlogger.go
+// Resulting eventlogger.go was moved to this file, and only the needed implementation was left here.
+
 import (
 	"errors"
 

--- a/devnet-sdk/contracts/bindings/eventlogger.go
+++ b/devnet-sdk/contracts/bindings/eventlogger.go
@@ -1,0 +1,62 @@
+package bindings
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// EventloggerMetaData contains all meta data concerning the Eventlogger contract.
+var EventloggerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"_topics\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"emitLog\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"origin\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"logIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"}],\"internalType\":\"structIdentifier\",\"name\":\"_id\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_msgHash\",\"type\":\"bytes32\"}],\"name\":\"validateMessage\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f80fd5b506102ac8061001c5f395ff3fe608060405234801561000f575f80fd5b5060043610610034575f3560e01c8063ab4d6f7514610038578063edebc13b1461004d575b5f80fd5b61004b61004636600461013e565b610060565b005b61004b61005b36600461016c565b6100bd565b60405163ab4d6f7560e01b81526022602160991b019063ab4d6f759061008c9085908590600401610226565b5f604051808303815f87803b1580156100a3575f80fd5b505af11580156100b5573d5f803e3d5ffd5b505050505050565b80604051818482378486356020880135604089013560608a0135848015610102576001811461010a5760028114610113576003811461011d5760048114610128575f80fd5b8787a0610130565b848888a1610130565b83858989a2610130565b8284868a8aa3610130565b818385878b8ba45b505050505050505050505050565b5f8082840360c0811215610150575f80fd5b60a081121561015d575f80fd5b50919360a08501359350915050565b5f805f806040858703121561017f575f80fd5b843567ffffffffffffffff80821115610196575f80fd5b818701915087601f8301126101a9575f80fd5b8135818111156101b7575f80fd5b8860208260051b85010111156101cb575f80fd5b6020928301965094509086013590808211156101e5575f80fd5b818701915087601f8301126101f8575f80fd5b813581811115610206575f80fd5b886020828501011115610217575f80fd5b95989497505060200194505050565b60c0810183356001600160a01b038116808214610241575f80fd5b8352506020848101359083015260408085013590830152606080850135908301526080938401359382019390935260a001529056fea26469706673582212206da9bc84d514e1a78e2b4160f99f93aa58672040ece82f45ac2a878aeefdfbe164736f6c63430008190033",
+}
+
+// EventloggerABI is the input ABI used to generate the binding from.
+// Deprecated: Use EventloggerMetaData.ABI instead.
+var EventloggerABI = EventloggerMetaData.ABI
+
+// EventloggerBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use EventloggerMetaData.Bin instead.
+var EventloggerBin = EventloggerMetaData.Bin
+
+// DeployEventlogger deploys a new Ethereum contract, binding an instance of Eventlogger to it.
+func DeployEventlogger(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Eventlogger, error) {
+	parsed, err := EventloggerMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(EventloggerBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Eventlogger{EventloggerCaller: EventloggerCaller{contract: contract}, EventloggerTransactor: EventloggerTransactor{contract: contract}, EventloggerFilterer: EventloggerFilterer{contract: contract}}, nil
+}
+
+// Eventlogger is an auto generated Go binding around an Ethereum contract.
+type Eventlogger struct {
+	EventloggerCaller     // Read-only binding to the contract
+	EventloggerTransactor // Write-only binding to the contract
+	EventloggerFilterer   // Log filterer for contract events
+}
+
+// EventloggerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type EventloggerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EventloggerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type EventloggerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EventloggerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type EventloggerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}

--- a/devnet-sdk/system/chain.go
+++ b/devnet-sdk/system/chain.go
@@ -74,6 +74,7 @@ func (m *clientManager) Client(rpcURL string) (*sources.EthClient, error) {
 		TransactionsCacheSize: 10,
 		HeadersCacheSize:      10,
 		PayloadsCacheSize:     10,
+		BlockRefsCacheSize:    10,
 		TrustRPC:              false,
 		MustBePostMerge:       true,
 		RPCProviderKind:       sources.RPCKindStandard,

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
@@ -71,6 +72,13 @@ type Wallet interface {
 	Nonce() uint64
 
 	TransactionProcessor
+}
+
+// WalletV2 is a temporary interface for integrating txplan and txintent
+type WalletV2 interface {
+	PrivateKey() *ecdsa.PrivateKey
+	Client() *sources.EthClient
+	Ctx() context.Context
 }
 
 // TransactionProcessor is a helper interface for signing and sending transactions.

--- a/op-acceptance-tests/tests/interop/interop_test_helpers.go
+++ b/op-acceptance-tests/tests/interop/interop_test_helpers.go
@@ -1,0 +1,128 @@
+package interop
+
+import (
+	"context"
+	"math/big"
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
+	sdktypes "github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/stretchr/testify/require"
+)
+
+func DefaultTxSubmitOptions(w system.WalletV2) txplan.Option {
+	return txplan.Combine(
+		txplan.WithPrivateKey(w.PrivateKey()),
+		txplan.WithChainID(w.Client()),
+		txplan.WithAgainstLatestBlock(w.Client()),
+		txplan.WithPendingNonce(w.Client()),
+		txplan.WithEstimator(w.Client(), false),
+		txplan.WithTransactionSubmitter(w.Client()),
+	)
+}
+
+func DefaultTxInclusionOptions(w system.WalletV2) txplan.Option {
+	return txplan.Combine(
+		txplan.WithRetryInclusion(w.Client(), 10, retry.Exponential()),
+		txplan.WithBlockInclusionInfo(w.Client()),
+	)
+}
+
+func DefaultTxOpts(w system.WalletV2) txplan.Option {
+	return txplan.Combine(
+		DefaultTxSubmitOptions(w),
+		DefaultTxInclusionOptions(w),
+	)
+}
+
+func GetWalletV2AndOpts(ctx context.Context, walletGetter validators.WalletGetter, chain system.Chain) (system.WalletV2, txplan.Option, error) {
+	wallet, err := system.NewWalletV2FromWalletAndChain(ctx, walletGetter(ctx), chain)
+	if err != nil {
+		return nil, nil, err
+	}
+	opts := DefaultTxOpts(wallet)
+	return wallet, opts, nil
+}
+
+func DefaultInteropSetup(t systest.T,
+	sys system.InteropSystem,
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) (context.Context, *rand.Rand, log.Logger, []system.Chain, []system.WalletV2, []txplan.Option) {
+	ctx := t.Context()
+	rng := rand.New(rand.NewSource(1234))
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	chains := make([]system.Chain, l2ChainNums)
+	wallets := make([]system.WalletV2, 0)
+	opts := make([]txplan.Option, 0)
+	for idx := range l2ChainNums {
+		chain := sys.L2s()[idx]
+		chains = append(chains, chain)
+		wallet, opt, err := GetWalletV2AndOpts(ctx, walletGetters[idx], chain)
+		require.NoError(t, err)
+		wallets = append(wallets, wallet)
+		opts = append(opts, opt)
+	}
+	return ctx, rng, logger, chains, wallets, opts
+}
+
+func DeployEventLogger(ctx context.Context, wallet system.WalletV2, logger log.Logger) (common.Address, error) {
+	opts := DefaultTxOpts(wallet)
+	logger.Info("Deploying EventLogger")
+	deployCalldata := common.FromHex(bindings.EventloggerBin)
+	deployTx := txplan.NewPlannedTx(opts, txplan.WithData(deployCalldata))
+
+	res, err := deployTx.Included.Eval(ctx)
+	if err != nil {
+		return common.Address{}, err
+	}
+	eventLoggerAddress := res.ContractAddress
+	logger.Info("Deployed EventLogger", "address", eventLoggerAddress)
+	return eventLoggerAddress, err
+}
+
+func RandomTopicAndData(rng *rand.Rand, cnt, len int) ([][32]byte, []byte) {
+	topics := [][32]byte{}
+	for range cnt {
+		var topic [32]byte
+		copy(topic[:], testutils.RandomData(rng, 32))
+		topics = append(topics, topic)
+	}
+	data := testutils.RandomData(rng, len)
+	return topics, data
+}
+
+func RandomInitTrigger(rng *rand.Rand, eventLoggerAddress common.Address, cnt, len int) *txintent.InitTrigger {
+	topics, data := RandomTopicAndData(rng, cnt, len)
+	return &txintent.InitTrigger{
+		Emitter:    eventLoggerAddress,
+		Topics:     topics,
+		OpaqueData: data,
+	}
+}
+
+func SetupDefaultInteropSystemTest(l2ChainNums int) ([]validators.WalletGetter, []systest.PreconditionValidator) {
+	walletGetters := make([]validators.WalletGetter, l2ChainNums)
+	totalValidators := make([]systest.PreconditionValidator, 0)
+	for i := range l2ChainNums {
+		walletGetter, fundsValidator := validators.AcquireL2WalletWithFunds(
+			uint64(i), sdktypes.NewBalance(big.NewInt(1*constants.ETH)),
+		)
+		walletGetters[i] = walletGetter
+		totalValidators = append(totalValidators, fundsValidator)
+	}
+	return walletGetters, totalValidators
+}

--- a/op-acceptance-tests/tests/interop/interop_txplan_test.go
+++ b/op-acceptance-tests/tests/interop/interop_txplan_test.go
@@ -1,0 +1,302 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/stretchr/testify/require"
+)
+
+// initAndExecMsg tests below scenario:
+// Transaction initiates, and then executes message
+func initAndExecMsg(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate message(or emit event) on chain A
+		txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](opts[0])
+		randomInitTrigger := RandomInitTrigger(rng, eventLoggerAddress, 3, 10)
+		txA.Content.Set(randomInitTrigger)
+
+		// Trigger single event
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate message included", "block", receiptA.BlockHash)
+
+		// Intent to validate message on chain B
+		txB := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](opts[1])
+		txB.Content.DependOn(&txA.Result)
+
+		// Single event in tx so index is 0
+		txB.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &txA.Result, 0))
+
+		receiptB, err := txB.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("validate message included", "block", receiptB.BlockHash)
+
+		// Check single ExecutingMessage triggered
+		require.Equal(t, 1, len(receiptB.Logs))
+	}
+}
+
+// initAndExecMultipleMsg tests below scenario:
+// Transaction initiates and executes multiple messages of self
+func initAndExecMultipleMsg(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate two message(or emit event) on chain A
+		initCalls := []txintent.Call{
+			RandomInitTrigger(rng, eventLoggerAddress, 1, 15),
+			RandomInitTrigger(rng, eventLoggerAddress, 2, 13),
+		}
+		txA := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[0])
+		txA.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: initCalls})
+
+		// Trigger two events
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate messages included", "block", receiptA.BlockHash)
+		require.Equal(t, 2, len(receiptA.Logs))
+
+		// Intent to validate messages on chain B
+		txB := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[1])
+		txB.Content.DependOn(&txA.Result)
+
+		// Two events in tx so use every index
+		indexes := []int{0, 1}
+		txB.Content.Fn(txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txA.Result, indexes))
+
+		receiptB, err := txB.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("validate messages included", "block", receiptB.BlockHash)
+
+		// Check two ExecutingMessage triggered
+		require.Equal(t, 2, len(receiptB.Logs))
+	}
+}
+
+// execSameMsgTwice tests below scenario:
+// Transaction that executes the same message twice.
+func execSameMsgTwice(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate message(or emit event) on chain A
+		txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](opts[0])
+		randomInitTrigger := RandomInitTrigger(rng, eventLoggerAddress, 3, 10)
+		txA.Content.Set(randomInitTrigger)
+
+		// Trigger single event
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate message included", "block", receiptA.BlockHash)
+
+		// Intent to validate same message two times on chain B
+		txB := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[1])
+		txB.Content.DependOn(&txA.Result)
+
+		// Single event in tx so indexes are 0, 0
+		indexes := []int{0, 0}
+		txB.Content.Fn(txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txA.Result, indexes))
+
+		receiptB, err := txB.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("validate messages included", "block", receiptB.BlockHash)
+
+		// Check two ExecutingMessage triggered
+		require.Equal(t, 2, len(receiptB.Logs))
+	}
+}
+
+// execMsgDifferentTopicCount tests below scenario:
+// Execute message that links with initiating message with: 0, 1, 2, 3, or 4 topics in it
+func execMsgDifferentTopicCount(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate message with differet topic counts on chain A
+		initCalls := make([]txintent.Call, 5)
+		for topicCnt := range 5 {
+			index := topicCnt
+			initCalls[index] = RandomInitTrigger(rng, eventLoggerAddress, topicCnt, 10)
+		}
+		txA := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[0])
+		txA.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: initCalls})
+
+		// Trigger five events, each have {0, 1, 2, 3, 4} topics in it
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate messages included", "block", receiptA.BlockHash)
+		require.Equal(t, 5, len(receiptA.Logs))
+
+		for topicCnt := range 5 {
+			index := topicCnt
+			require.Equal(t, topicCnt, len(receiptA.Logs[index].Topics))
+		}
+
+		// Intent to validate message on chain B
+		txB := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[1])
+		txB.Content.DependOn(&txA.Result)
+
+		// Five events in tx so use every index
+		indexes := []int{0, 1, 2, 3, 4}
+		txB.Content.Fn(txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txA.Result, indexes))
+
+		receiptB, err := txB.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("validate message included", "block", receiptB.BlockHash)
+
+		// Check five ExecutingMessage triggered
+		require.Equal(t, 5, len(receiptB.Logs))
+	}
+}
+
+// execMsgOpagueData tests below scenario:
+// Execute message that links with initiating message with: 0, 10KB of opaque event data in it
+func execMsgOpagueData(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate message with two messages: 0, 10KB of opaque event data
+		initCalls := make([]txintent.Call, 2)
+		emptyInitTrigger := RandomInitTrigger(rng, eventLoggerAddress, 2, 0)      // 0B
+		largeInitTrigger := RandomInitTrigger(rng, eventLoggerAddress, 3, 10_000) // 10KB
+		initCalls[0] = emptyInitTrigger
+		initCalls[1] = largeInitTrigger
+
+		txA := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[0])
+		txA.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: initCalls})
+
+		// Trigger two events
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate messages included", "block", receiptA.BlockHash)
+		require.Equal(t, 2, len(receiptA.Logs))
+		require.Equal(t, emptyInitTrigger.OpaqueData, receiptA.Logs[0].Data)
+		require.Equal(t, largeInitTrigger.OpaqueData, receiptA.Logs[1].Data)
+
+		// Intent to validate messages on chain B
+		txB := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[1])
+		txB.Content.DependOn(&txA.Result)
+
+		// Two events in tx so use every index
+		indexes := []int{0, 1}
+		txB.Content.Fn(txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txA.Result, indexes))
+
+		receiptB, err := txB.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("validate messages included", "block", receiptB.BlockHash)
+
+		// Check two ExecutingMessage triggered
+		require.Equal(t, 2, len(receiptB.Logs))
+	}
+}
+
+// execMsgDifferEventIndexInSingleTx tests below scenario:
+// Execute message that links with initiating message with: first, random or last event of a tx.
+func execMsgDifferEventIndexInSingleTx(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate message with multiple messages, all included in single tx
+		eventCnt := 10
+		initCalls := make([]txintent.Call, eventCnt)
+		for index := range eventCnt {
+			initCalls[index] = RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(100))
+		}
+
+		txA := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[0])
+		txA.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: initCalls})
+
+		// Trigger multiple events
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate messages included", "block", receiptA.BlockHash)
+		require.Equal(t, eventCnt, len(receiptA.Logs))
+
+		// Intent to validate messages on chain B
+		txB := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](opts[1])
+		txB.Content.DependOn(&txA.Result)
+
+		// Two events in tx so use every index
+		// first, random or last event of a tx.
+		indexes := []int{0, 1 + rng.Intn(eventCnt-1), eventCnt - 1}
+		txB.Content.Fn(txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txA.Result, indexes))
+
+		receiptB, err := txB.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("validate messages included", "block", receiptB.BlockHash)
+
+		// Check three ExecutingMessage triggered
+		require.Equal(t, len(indexes), len(receiptB.Logs))
+	}
+}
+
+func TestInteropTxTest(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+
+	tests := []struct {
+		name     string
+		testFunc systest.InteropSystemTestFunc
+	}{
+		{"initAndExecMsg", initAndExecMsg(l2ChainNums, walletGetters)},
+		{"initAndExecMultipleMsg", initAndExecMultipleMsg(l2ChainNums, walletGetters)},
+		{"execSameMsgTwice", execSameMsgTwice(l2ChainNums, walletGetters)},
+
+		{"execMsgDifferentTopicCount", execMsgDifferentTopicCount(l2ChainNums, walletGetters)},
+		{"execMsgOpagueData", execMsgOpagueData(l2ChainNums, walletGetters)},
+		{"execMsgDifferEventIndexInSingleTx", execMsgDifferEventIndexInSingleTx(l2ChainNums, walletGetters)},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			systest.InteropSystemTest(t,
+				test.testFunc,
+				totalValidators...,
+			)
+		})
+	}
+}

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -85,6 +85,12 @@ func WithValue(val *big.Int) Option {
 	}
 }
 
+func WithData(data []byte) Option {
+	return func(tx *PlannedTx) {
+		tx.Data.Set(data)
+	}
+}
+
 func WithAccessList(al types.AccessList) Option {
 	return func(tx *PlannedTx) {
 		tx.AccessList.Set(al)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR builds on top of https://github.com/ethereum-optimism/optimism/pull/14948

It introduces `WalletV2` interface, which is a minimal representation for plugging in txplan and txintent. Proto is actively working on the new system2 interface, so this `WalletV2` interface is a temporary addition and eventually be removed. The intent of the addition is to kickstart implementing actual tests based on the txintent abstraction.

Added helpers for removing boilerplates; implemented at `interop_tx_helpers.go` 

Added deployment of `EventLogger` contract, which is to easily emit events. Also the bindings.

**Tests**

New tests are added, picking up the trivial ones from [Interop: tx-plan alpha testing](https://github.com/ethereum-optimism/optimism/issues/14529)

- Transaction initiates, and then executes message
- Transaction initiates and executes multiple messages of self
- Transaction that executes the same message twice
- Execute message that links with initiating message with:
    - 0, 1, 2, 3, or 4 topics in it
    - 0, 10KB of opaque event data in it
    - first, random or last event of a tx.

**Additional context**

For https://github.com/ethereum-optimism/optimism/issues/14529
