### PR TITLE
proofs: update execution witness type to match reth

### DIFF
--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -207,13 +207,8 @@ func (p *Prefetcher) bulkPrefetch(ctx context.Context, hint string) error {
 
 		// ignore keys because we want to rehash all of the values for safety
 		values := make([]hexutil.Bytes, 0, len(result.State)+len(result.Codes))
-		for _, value := range result.State {
-			values = append(values, value)
-		}
-
-		for _, value := range result.Codes {
-			values = append(values, value)
-		}
+		values = append(values, result.State...)
+		values = append(values, result.Codes...)
 
 		return p.storeNodes(values)
 	default:

--- a/op-service/eth/execution_witness.go
+++ b/op-service/eth/execution_witness.go
@@ -3,7 +3,7 @@ package eth
 import "github.com/ethereum/go-ethereum/common/hexutil"
 
 type ExecutionWitness struct {
-	Keys  map[string]hexutil.Bytes `json:"keys"`
-	Codes map[string]hexutil.Bytes `json:"codes"`
-	State map[string]hexutil.Bytes `json:"state"`
+	Keys  []hexutil.Bytes `json:"keys"`
+	Codes []hexutil.Bytes `json:"codes"`
+	State []hexutil.Bytes `json:"state"`
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Updates the execution witness type returned by `debug_executePayload` to remove hashes of preimages. Clients should be responsible for hashing the values. 

Included in reth v1.3.0. https://github.com/paradigmxyz/reth/pull/14503

I'm going to work on implementing this method in geth now that the output schema is fixed.
