### PR TITLE
Allow go-ffi to be generated dynamically using `make`

### DIFF
--- a/packages/contracts-bedrock/Makefile
+++ b/packages/contracts-bedrock/Makefile
@@ -1,0 +1,22 @@
+# Define the output binaries
+GO_FFI_TARGETS := go-ffi go-ffi-cannon64
+
+# Find all Go source files in the directory
+GO_SOURCES := $(wildcard ./scripts/go-ffi/*.go)
+
+# Default target to build both
+go-ffi: ./scripts/go-ffi/go-ffi ./scripts/go-ffi/go-ffi-cannon64
+
+# Rule for standard build
+./scripts/go-ffi/go-ffi: $(GO_SOURCES)
+	cd ./scripts/go-ffi && go build -o ./go-ffi
+
+# Rule for cannon64 build
+./scripts/go-ffi/go-ffi-cannon64: $(GO_SOURCES)
+	cd ./scripts/go-ffi && go build -tags=cannon64 -o ./go-ffi-cannon64
+
+# Clean target
+clean:
+	rm -f ./scripts/go-ffi/go-ffi ./scripts/go-ffi/go-ffi-cannon64
+
+.PHONY: all clean

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -41,17 +41,19 @@ build-dev *ARGS: lint-fix-no-fail
 
 # Builds the go-ffi tool for contract tests.
 build-go-ffi-default:
-  cd ./scripts/go-ffi && go build
+  make go-ffi-default
 
 # Builds the go-ffi tool for MIPS64 contract tests.
 build-go-ffi-cannon64:
-  cd ./scripts/go-ffi && go build -tags=cannon64 -o ./go-ffi-cannon64
+  make go-ffi-cannon64
 
-build-go-ffi: build-go-ffi-default build-go-ffi-cannon64
+build-go-ffi:
+  make go-ffi
 
 # Cleans build artifacts and deployments.
 clean:
-  rm -rf ./artifacts ./forge-artifacts ./cache ./scripts/go-ffi/go-ffi ./deployments/hardhat/*
+  rm -rf ./artifacts ./forge-artifacts ./cache ./deployments/hardhat/*
+  make clean
 
 
 ########################################################
@@ -59,11 +61,11 @@ clean:
 ########################################################
 
 # Runs standard contract tests.
-test *ARGS: build-go-ffi
+test *ARGS:
   forge test {{ARGS}}
 
 # Runs standard contract tests (developer mode).
-test-dev *ARGS: build-go-ffi
+test-dev *ARGS:
   FOUNDRY_PROFILE=lite forge test {{ARGS}}
 
 # Default block number for the forked upgrade path.
@@ -89,7 +91,7 @@ print-pinned-block-number:
 #   Reusing the default block number greatly speeds up the test execution time by caching the
 #   rpc call responses in ~/.foundry/cache/rpc. The default block will need to be updated
 #   when the L1 chain is upgraded.
-prepare-upgrade-env *ARGS : build-go-ffi
+prepare-upgrade-env *ARGS :
   #!/bin/bash
   export FORK_BLOCK_NUMBER=$pinnedBlockNumber
   echo "Running upgrade tests at block $FORK_BLOCK_NUMBER"
@@ -103,7 +105,7 @@ prepare-upgrade-env *ARGS : build-go-ffi
 test-upgrade *ARGS:
   just prepare-upgrade-env "forge test {{ARGS}}"
 
-test-upgrade-rerun *ARGS: build-go-ffi
+test-upgrade-rerun *ARGS:
   just test-upgrade {{ARGS}} --rerun -vvvv
 
 # Starts a local anvil node with a mainnet fork and sends it to the background
@@ -113,7 +115,7 @@ anvil-fork:
 
 # Use anvil-fork in a separate terminal before running this command.
 # Helpful for debugging.
-test-upgrade-against-anvil *ARGS: build-go-ffi
+test-upgrade-against-anvil *ARGS:
   #!/bin/bash
   echo "Running upgrade tests at block $pinnedBlockNumber"
   export FORK_BLOCK_NUMBER=$pinnedBlockNumber
@@ -123,26 +125,26 @@ test-upgrade-against-anvil *ARGS: build-go-ffi
   --match-path "test/{L1,dispute,cannon}/**"
 
 # Runs standard contract tests with rerun flag.
-test-rerun: build-go-ffi
+test-rerun:
   forge test --rerun -vvv
 
 # Runs standard contract tests with rerun flag (developer mode).
-test-dev-rerun: build-go-ffi
+test-dev-rerun:
   FOUNDRY_PROFILE=lite forge test --rerun -vvv
 
 # Run Kontrol tests and build all dependencies.
-test-kontrol: build-go-ffi build kontrol-summary-full test-kontrol-no-build
+test-kontrol: build kontrol-summary-full test-kontrol-no-build
 
 # Run Kontrol tests without dependencies.
 test-kontrol-no-build:
   ./test/kontrol/scripts/run-kontrol.sh script
 
 # Runs contract coverage.
-coverage: build-go-ffi
+coverage:
   forge coverage
 
 # Runs contract coverage with lcov.
-coverage-lcov *ARGS: build-go-ffi
+coverage-lcov *ARGS:
   forge coverage {{ARGS}} --report lcov --report-file lcov.info
 
 # Runs upgrade path variant of contract coverage tests.
@@ -150,7 +152,7 @@ coverage-upgrade *ARGS:
   just prepare-upgrade-env "forge coverage {{ARGS}}"
 
 # Runs contract coverage with lcov.
-coverage-lcov-upgrade *ARGS: build-go-ffi
+coverage-lcov-upgrade *ARGS:
   just coverage-upgrade {{ARGS}} --report lcov --report-file lcov-upgrade.info
 
 # Runs coverage-lcov and coverage-lcov-upgrade and merges their output files info one file

--- a/packages/contracts-bedrock/scripts/go-ffi/README.md
+++ b/packages/contracts-bedrock/scripts/go-ffi/README.md
@@ -19,10 +19,11 @@ To use `go-ffi` in a forge test, simply invoke the binary using the solidity `Pr
 
 ```solidity
 function myFFITest() public {
-    string[] memory commands = new string[](3);
-    commands[0] = "./scripts/go-ffi/go-ffi";
-    commands[1] = "trie";
-    commands[2] = "valid";
+    string[] memory commands = new string[](4);
+    commands[0] = "./scripts/go-ffi/go-ffi.sh";
+    commands[1] = "go-ffi";
+    commands[2] = "trie";
+    commands[3] = "valid";
     bytes memory result = Process.run(commands);
 
     // Do something with the result of the command

--- a/packages/contracts-bedrock/scripts/go-ffi/go-ffi.sh
+++ b/packages/contracts-bedrock/scripts/go-ffi/go-ffi.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+{
+    # Define a lock file
+    LOCKFILE="/tmp/go-ffi.lock"
+
+    # Function to clean up the lock file on exit
+    cleanup() {
+        rm -rf "$LOCKFILE"
+    }
+
+    # Get the directory of the script
+    dir=$(dirname "$(realpath "$0")")
+    # Check if the target binary exists
+    if [[ ! -f "$dir/$1" ]]; then
+        # Wait for the lock file to be released
+        while ! mkdir "$LOCKFILE" > /dev/null; do
+            sleep 0.3s
+        done
+
+        # Set a trap to call cleanup on exit
+        trap cleanup EXIT
+
+        # Ensure only one process is building the binaries
+        if [[ ! -f "$dir/$1" ]]; then
+            pushd "$dir/../.."
+            just build-go-ffi > /dev/null
+            popd
+        fi
+        cleanup
+        # Remove the trap since it's no longer needed
+        trap - EXIT
+    fi
+} > /dev/null 2>&1 # Ensures nothing is printed to the console during the build process
+
+
+target_binary="$dir/$1"
+shift  # This removes the first argument
+# Call the target binary with remaining arguments
+$target_binary "$@"

--- a/packages/contracts-bedrock/scripts/go-ffi/go-ffi.sh
+++ b/packages/contracts-bedrock/scripts/go-ffi/go-ffi.sh
@@ -1,40 +1,18 @@
 #!/bin/bash
 
-{
-    # Define a lock file
-    LOCKFILE="/tmp/go-ffi.lock"
+set -euo pipefail # Fail on errors, undefined vars, and pipe failures
 
-    # Function to clean up the lock file on exit
-    cleanup() {
-        rm -rf "$LOCKFILE"
-    }
+# Get the directory of the script
+dir=$(dirname "$(realpath "$0")")
 
-    # Get the directory of the script
-    dir=$(dirname "$(realpath "$0")")
-    # Check if the target binary exists
-    if [[ ! -f "$dir/$1" ]]; then
-        # Wait for the lock file to be released
-        while ! mkdir "$LOCKFILE" > /dev/null; do
-            sleep 0.3s
-        done
-
-        # Set a trap to call cleanup on exit
-        trap cleanup EXIT
-
-        # Ensure only one process is building the binaries
-        if [[ ! -f "$dir/$1" ]]; then
-            pushd "$dir/../.."
-            just build-go-ffi > /dev/null
-            popd
-        fi
-        cleanup
-        # Remove the trap since it's no longer needed
-        trap - EXIT
-    fi
-} > /dev/null 2>&1 # Ensures nothing is printed to the console during the build process
-
-
+# Get the target binary name from the first argument
 target_binary="$dir/$1"
-shift  # This removes the first argument
+
+# Build the binaries if needed
+make go-ffi > /dev/null 2>&1
+
+# Remove the first argument
+shift
+
 # Call the target binary with remaining arguments
 $target_binary "$@"

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -1476,12 +1476,13 @@ contract PreimageOracle_LargePreimageProposals_Test is Test {
             leaves[i] = _hashLeaf(_leaves[i]);
         }
 
-        string[] memory commands = new string[](5);
-        commands[0] = "scripts/go-ffi/go-ffi";
-        commands[1] = "merkle";
-        commands[2] = "gen_proof";
-        commands[3] = vm.toString(abi.encodePacked(leaves));
-        commands[4] = vm.toString(_leafIdx);
+        string[] memory commands = new string[](6);
+        commands[0] = "scripts/go-ffi/go-ffi.sh";
+        commands[1] = "go-ffi";
+        commands[2] = "merkle";
+        commands[3] = "gen_proof";
+        commands[4] = vm.toString(abi.encodePacked(leaves));
+        commands[5] = vm.toString(_leafIdx);
         (root_, proof_) = abi.decode(Process.run(commands), (bytes32, bytes32[]));
     }
 

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -17,16 +17,17 @@ contract FFIInterface {
         external
         returns (bytes32, bytes32, bytes32, bytes32, bytes[] memory)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "getProveWithdrawalTransactionInputs";
-        cmds[3] = vm.toString(_tx.nonce);
-        cmds[4] = vm.toString(_tx.sender);
-        cmds[5] = vm.toString(_tx.target);
-        cmds[6] = vm.toString(_tx.value);
-        cmds[7] = vm.toString(_tx.gasLimit);
-        cmds[8] = vm.toString(_tx.data);
+        string[] memory cmds = new string[](10);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "getProveWithdrawalTransactionInputs";
+        cmds[4] = vm.toString(_tx.nonce);
+        cmds[5] = vm.toString(_tx.sender);
+        cmds[6] = vm.toString(_tx.target);
+        cmds[7] = vm.toString(_tx.value);
+        cmds[8] = vm.toString(_tx.gasLimit);
+        cmds[9] = vm.toString(_tx.data);
 
         bytes memory result = Process.run(cmds);
         (
@@ -51,16 +52,17 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashCrossDomainMessage";
-        cmds[3] = vm.toString(_nonce);
-        cmds[4] = vm.toString(_sender);
-        cmds[5] = vm.toString(_target);
-        cmds[6] = vm.toString(_value);
-        cmds[7] = vm.toString(_gasLimit);
-        cmds[8] = vm.toString(_data);
+        string[] memory cmds = new string[](10);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "hashCrossDomainMessage";
+        cmds[4] = vm.toString(_nonce);
+        cmds[5] = vm.toString(_sender);
+        cmds[6] = vm.toString(_target);
+        cmds[7] = vm.toString(_value);
+        cmds[8] = vm.toString(_gasLimit);
+        cmds[9] = vm.toString(_data);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes32));
@@ -77,16 +79,17 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashWithdrawal";
-        cmds[3] = vm.toString(_nonce);
-        cmds[4] = vm.toString(_sender);
-        cmds[5] = vm.toString(_target);
-        cmds[6] = vm.toString(_value);
-        cmds[7] = vm.toString(_gasLimit);
-        cmds[8] = vm.toString(_data);
+        string[] memory cmds = new string[](10);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "hashWithdrawal";
+        cmds[4] = vm.toString(_nonce);
+        cmds[5] = vm.toString(_sender);
+        cmds[6] = vm.toString(_target);
+        cmds[7] = vm.toString(_value);
+        cmds[8] = vm.toString(_gasLimit);
+        cmds[9] = vm.toString(_data);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes32));
@@ -101,14 +104,15 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashOutputRootProof";
-        cmds[3] = Strings.toHexString(uint256(_version));
-        cmds[4] = Strings.toHexString(uint256(_stateRoot));
-        cmds[5] = Strings.toHexString(uint256(_messagePasserStorageRoot));
-        cmds[6] = Strings.toHexString(uint256(_latestBlockhash));
+        string[] memory cmds = new string[](8);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "hashOutputRootProof";
+        cmds[4] = Strings.toHexString(uint256(_version));
+        cmds[5] = Strings.toHexString(uint256(_stateRoot));
+        cmds[6] = Strings.toHexString(uint256(_messagePasserStorageRoot));
+        cmds[7] = Strings.toHexString(uint256(_latestBlockhash));
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes32));
@@ -126,37 +130,39 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](11);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashDepositTransaction";
-        cmds[3] = "0x0000000000000000000000000000000000000000000000000000000000000000";
-        cmds[4] = vm.toString(_logIndex);
-        cmds[5] = vm.toString(_from);
-        cmds[6] = vm.toString(_to);
-        cmds[7] = vm.toString(_mint);
-        cmds[8] = vm.toString(_value);
-        cmds[9] = vm.toString(_gas);
-        cmds[10] = vm.toString(_data);
+        string[] memory cmds = new string[](12);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "hashDepositTransaction";
+        cmds[4] = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        cmds[5] = vm.toString(_logIndex);
+        cmds[6] = vm.toString(_from);
+        cmds[7] = vm.toString(_to);
+        cmds[8] = vm.toString(_mint);
+        cmds[9] = vm.toString(_value);
+        cmds[10] = vm.toString(_gas);
+        cmds[11] = vm.toString(_data);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes32));
     }
 
     function encodeDepositTransaction(Types.UserDepositTransaction calldata txn) external returns (bytes memory) {
-        string[] memory cmds = new string[](12);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeDepositTransaction";
-        cmds[3] = vm.toString(txn.from);
-        cmds[4] = vm.toString(txn.to);
-        cmds[5] = vm.toString(txn.value);
-        cmds[6] = vm.toString(txn.mint);
-        cmds[7] = vm.toString(txn.gasLimit);
+        string[] memory cmds = new string[](13);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "encodeDepositTransaction";
+        cmds[4] = vm.toString(txn.from);
+        cmds[5] = vm.toString(txn.to);
+        cmds[6] = vm.toString(txn.value);
+        cmds[7] = vm.toString(txn.mint);
+        cmds[8] = vm.toString(txn.gasLimit);
         cmds[8] = vm.toString(txn.isCreation);
-        cmds[9] = vm.toString(txn.data);
-        cmds[10] = vm.toString(txn.l1BlockHash);
-        cmds[11] = vm.toString(txn.logIndex);
+        cmds[10] = vm.toString(txn.data);
+        cmds[11] = vm.toString(txn.l1BlockHash);
+        cmds[12] = vm.toString(txn.logIndex);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes));
@@ -173,16 +179,17 @@ contract FFIInterface {
         external
         returns (bytes memory)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeCrossDomainMessage";
-        cmds[3] = vm.toString(_nonce);
-        cmds[4] = vm.toString(_sender);
-        cmds[5] = vm.toString(_target);
-        cmds[6] = vm.toString(_value);
-        cmds[7] = vm.toString(_gasLimit);
-        cmds[8] = vm.toString(_data);
+        string[] memory cmds = new string[](10);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "encodeCrossDomainMessage";
+        cmds[4] = vm.toString(_nonce);
+        cmds[5] = vm.toString(_sender);
+        cmds[6] = vm.toString(_target);
+        cmds[7] = vm.toString(_value);
+        cmds[8] = vm.toString(_gasLimit);
+        cmds[9] = vm.toString(_data);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes));
@@ -211,11 +218,12 @@ contract FFIInterface {
     }
 
     function decodeVersionedNonce(uint256 nonce) external returns (uint256, uint256) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "decodeVersionedNonce";
-        cmds[3] = vm.toString(nonce);
+        string[] memory cmds = new string[](5);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "decodeVersionedNonce";
+        cmds[4] = vm.toString(nonce);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (uint256, uint256));
@@ -225,21 +233,23 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory, bytes memory, bytes[] memory)
     {
-        string[] memory cmds = new string[](3);
-        cmds[0] = "./scripts/go-ffi/go-ffi";
-        cmds[1] = "trie";
-        cmds[2] = variant;
+        string[] memory cmds = new string[](4);
+        cmds[0] = "./scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "trie";
+        cmds[3] = variant;
 
         return abi.decode(Process.run(cmds), (bytes32, bytes, bytes, bytes[]));
     }
 
     function getCannonMemoryProof(uint32 pc, uint32 insn) external returns (bytes32, bytes memory) {
-        string[] memory cmds = new string[](5);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
+        string[] memory cmds = new string[](6);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof";
+        cmds[4] = vm.toString(pc);
+        cmds[5] = vm.toString(insn);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -254,14 +264,15 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
-        cmds[5] = vm.toString(memAddr);
-        cmds[6] = vm.toString(memVal);
+        string[] memory cmds = new string[](8);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof";
+        cmds[4] = vm.toString(pc);
+        cmds[5] = vm.toString(insn);
+        cmds[6] = vm.toString(memAddr);
+        cmds[7] = vm.toString(memVal);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -278,16 +289,17 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
-        cmds[5] = vm.toString(memAddr);
-        cmds[6] = vm.toString(memVal);
-        cmds[7] = vm.toString(memAddr2);
-        cmds[8] = vm.toString(memVal2);
+        string[] memory cmds = new string[](10);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof";
+        cmds[4] = vm.toString(pc);
+        cmds[5] = vm.toString(insn);
+        cmds[6] = vm.toString(memAddr);
+        cmds[7] = vm.toString(memVal);
+        cmds[8] = vm.toString(memAddr2);
+        cmds[9] = vm.toString(memVal2);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -303,15 +315,16 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](8);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof2";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
-        cmds[5] = vm.toString(memAddr);
-        cmds[6] = vm.toString(memVal);
-        cmds[7] = vm.toString(memAddrForProof);
+        string[] memory cmds = new string[](9);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof2";
+        cmds[4] = vm.toString(pc);
+        cmds[5] = vm.toString(insn);
+        cmds[6] = vm.toString(memAddr);
+        cmds[7] = vm.toString(memVal);
+        cmds[8] = vm.toString(memAddrForProof);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -326,26 +339,28 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProofWrongLeaf";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
-        cmds[5] = vm.toString(memAddr);
-        cmds[6] = vm.toString(memVal);
+        string[] memory cmds = new string[](8);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProofWrongLeaf";
+        cmds[4] = vm.toString(pc);
+        cmds[5] = vm.toString(insn);
+        cmds[6] = vm.toString(memAddr);
+        cmds[7] = vm.toString(memVal);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
     }
 
     function getCannonMemory64Proof(uint64 addr, uint64 value) external returns (bytes32, bytes memory) {
-        string[] memory cmds = new string[](5);
-        cmds[0] = "scripts/go-ffi/go-ffi-cannon64";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof";
-        cmds[3] = vm.toString(addr);
-        cmds[4] = vm.toString(value);
+        string[] memory cmds = new string[](6);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi-cannon64";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof";
+        cmds[4] = vm.toString(addr);
+        cmds[5] = vm.toString(value);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -360,14 +375,15 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi-cannon64";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof";
-        cmds[3] = vm.toString(addr0);
-        cmds[4] = vm.toString(value0);
-        cmds[5] = vm.toString(addr1);
-        cmds[6] = vm.toString(value1);
+        string[] memory cmds = new string[](8);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi-cannon64";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof";
+        cmds[4] = vm.toString(addr0);
+        cmds[5] = vm.toString(value0);
+        cmds[6] = vm.toString(addr1);
+        cmds[7] = vm.toString(value1);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -384,16 +400,17 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi-cannon64";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof";
-        cmds[3] = vm.toString(addr0);
-        cmds[4] = vm.toString(value0);
-        cmds[5] = vm.toString(addr1);
-        cmds[6] = vm.toString(value1);
-        cmds[7] = vm.toString(memAddr2);
-        cmds[8] = vm.toString(memVal2);
+        string[] memory cmds = new string[](10);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi-cannon64";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof";
+        cmds[4] = vm.toString(addr0);
+        cmds[5] = vm.toString(value0);
+        cmds[6] = vm.toString(addr1);
+        cmds[7] = vm.toString(value1);
+        cmds[8] = vm.toString(memAddr2);
+        cmds[9] = vm.toString(memVal2);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
@@ -409,37 +426,40 @@ contract FFIInterface {
         external
         returns (bytes32, bytes memory)
     {
-        string[] memory cmds = new string[](8);
-        cmds[0] = "scripts/go-ffi/go-ffi-cannon64";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof2";
-        cmds[3] = vm.toString(addr0);
-        cmds[4] = vm.toString(value0);
-        cmds[5] = vm.toString(addr1);
-        cmds[6] = vm.toString(value1);
-        cmds[7] = vm.toString(memAddrForProof);
+        string[] memory cmds = new string[](9);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi-cannon64";
+        cmds[2] = "diff";
+        cmds[3] = "cannonMemoryProof2";
+        cmds[4] = vm.toString(addr0);
+        cmds[5] = vm.toString(value0);
+        cmds[6] = vm.toString(addr1);
+        cmds[7] = vm.toString(value1);
+        cmds[8] = vm.toString(memAddrForProof);
         bytes memory result = Process.run(cmds);
         (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
         return (memRoot, proof);
     }
 
     function encodeScalarEcotone(uint32 _basefeeScalar, uint32 _blobbasefeeScalar) external returns (bytes32) {
-        string[] memory cmds = new string[](5);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeScalarEcotone";
-        cmds[3] = vm.toString(_basefeeScalar);
-        cmds[4] = vm.toString(_blobbasefeeScalar);
+        string[] memory cmds = new string[](6);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "encodeScalarEcotone";
+        cmds[4] = vm.toString(_basefeeScalar);
+        cmds[5] = vm.toString(_blobbasefeeScalar);
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes32));
     }
 
     function decodeScalarEcotone(bytes32 _scalar) external returns (uint32, uint32) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "decodeScalarEcotone";
-        cmds[3] = vm.toString(_scalar);
+        string[] memory cmds = new string[](5);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "decodeScalarEcotone";
+        cmds[4] = vm.toString(_scalar);
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (uint32, uint32));
     }
@@ -453,25 +473,27 @@ contract FFIInterface {
         external
         returns (bytes memory)
     {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeGasPayingToken";
-        cmds[3] = vm.toString(_token);
-        cmds[4] = vm.toString(_decimals);
-        cmds[5] = vm.toString(_name);
-        cmds[6] = vm.toString(_symbol);
+        string[] memory cmds = new string[](8);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "encodeGasPayingToken";
+        cmds[4] = vm.toString(_token);
+        cmds[5] = vm.toString(_decimals);
+        cmds[6] = vm.toString(_name);
+        cmds[7] = vm.toString(_symbol);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes));
     }
 
     function encodeDependency(uint256 _chainId) external returns (bytes memory) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeDependency";
-        cmds[3] = vm.toString(_chainId);
+        string[] memory cmds = new string[](5);
+        cmds[0] = "scripts/go-ffi/go-ffi.sh";
+        cmds[1] = "go-ffi";
+        cmds[2] = "diff";
+        cmds[3] = "encodeDependency";
+        cmds[4] = vm.toString(_chainId);
 
         bytes memory result = Process.run(cmds);
         return abi.decode(result, (bytes));


### PR DESCRIPTION
Builds on #14978, using `make` to automatically determine when a rebuild is necessary. 
Also removes the `go-build-ffi` calls that occur in `just test` and many other just commands.