### PR TITLE
op-e2e/actions/proofs: run fault proof program from genesis 

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -173,7 +173,7 @@ func WithL1Head(head common.Hash) FixtureInputParam {
 }
 
 func (env *L2FaultProofEnv) RunFaultProofProgram(t helpers.Testing, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
-	fromGenesis := false
+	fromGenesis := true
 	defaultParam := WithPreInteropDefaults(t, l2ClaimBlockNum, env.Sequencer.L2Verifier, env.Engine, fromGenesis)
 	combinedParams := []FixtureInputParam{defaultParam}
 	combinedParams = append(combinedParams, fixtureInputParams...)

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -173,7 +173,8 @@ func WithL1Head(head common.Hash) FixtureInputParam {
 }
 
 func (env *L2FaultProofEnv) RunFaultProofProgram(t helpers.Testing, l2ClaimBlockNum uint64, checkResult CheckResult, fixtureInputParams ...FixtureInputParam) {
-	defaultParam := WithPreInteropDefaults(t, l2ClaimBlockNum, env.Sequencer.L2Verifier, env.Engine)
+	fromGenesis := false
+	defaultParam := WithPreInteropDefaults(t, l2ClaimBlockNum, env.Sequencer.L2Verifier, env.Engine, fromGenesis)
 	combinedParams := []FixtureInputParam{defaultParam}
 	combinedParams = append(combinedParams, fixtureInputParams...)
 	RunFaultProofProgram(t, env.log, env.Miner, checkResult, combinedParams...)

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -27,10 +27,13 @@ type L2 interface {
 	RollupClient() *sources.RollupClient
 }
 
-func WithPreInteropDefaults(t helpers.Testing, l2ClaimBlockNum uint64, l2 *helpers.L2Verifier, l2Eng *helpers.L2Engine) FixtureInputParam {
+func WithPreInteropDefaults(t helpers.Testing, l2ClaimBlockNum uint64, l2 *helpers.L2Verifier, l2Eng *helpers.L2Engine, fromGenesis bool) FixtureInputParam {
 	return func(f *FixtureInputs) {
 		// Fetch the pre and post output roots for the fault proof.
 		l2PreBlockNum := l2ClaimBlockNum - 1
+		if fromGenesis {
+			l2PreBlockNum = uint64(0)
+		}
 		if l2ClaimBlockNum == 0 {
 			// If we are at genesis, we assert that we don't move the chain at all.
 			l2PreBlockNum = 0

--- a/op-e2e/actions/proofs/precompile_test.go
+++ b/op-e2e/actions/proofs/precompile_test.go
@@ -69,7 +69,7 @@ func runPrecompileTest(gt *testing.T, testCase PrecompileTestFixture) {
 	// Ensure the block is marked as safe before we attempt to fault prove it.
 	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
 
-	defaultParam := helpers.WithPreInteropDefaults(t, l2SafeHead.Number.Uint64(), env.Sequencer.L2Verifier, env.Engine)
+	defaultParam := helpers.WithPreInteropDefaults(t, l2SafeHead.Number.Uint64(), env.Sequencer.L2Verifier, env.Engine, false)
 	fixtureInputParams := []helpers.FixtureInputParam{defaultParam, helpers.WithL1Head(l1Head.Hash())}
 	var fixtureInputs helpers.FixtureInputs
 	for _, apply := range fixtureInputParams {


### PR DESCRIPTION
This can be cleaned up somewhat, but I wanted to run a quick experiment to see the impact of running the FPP from genesis for all tests that currently use it (until now, only running the FPP on the final state transition). 

Since most tests don't advance the chain many times, this seems to have a negligible impact on running time. It should give us better coverage for tests which progress through several state transitions of interest. 