### PR TITLE
feat(CrossL2Inbox): make calculateCheckSum public

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
@@ -23,4 +23,6 @@ interface ICrossL2Inbox {
     function version() external view returns (string memory);
 
     function validateMessage(Identifier calldata _id, bytes32 _msgHash) external;
+
+    function calculateChecksum(Identifier memory _id, bytes32 _msgHash) external pure returns (bytes32 checksum_);
 }

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -39,6 +39,57 @@
         "type": "bytes32"
       }
     ],
+    "name": "calculateChecksum",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "checksum_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_msgHash",
+        "type": "bytes32"
+      }
+    ],
     "name": "validateMessage",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0xfa56426153227e798150f6becc30a33fd20a3c6e0d73c797a3922dd631acbb57"
   },
   "src/L2/CrossL2Inbox.sol:CrossL2Inbox": {
-    "initCodeHash": "0xa7d89c648e0dd2f0a95780feb7ce7674dbd35a1c2de354a0222da7cef8b596c6",
-    "sourceCodeHash": "0xe001c9d4cf55e90c227459573b7eaac6015dea6cd9622ebf117e9ecba54cb4cc"
+    "initCodeHash": "0x66c2269abef8605d2ad1a3786fcaa37d5d178085a7d09895e075594ef569c303",
+    "sourceCodeHash": "0x655f706b65ad24661bce70a411d58987422585c16fe8e5831608f8e86e646397"
   },
   "src/L2/ETHLiquidity.sol:ETHLiquidity": {
     "initCodeHash": "0xfcb50f32bbbd7e426f83c5c320ea655b896c026324a5e51983c1b15041ef88ca",

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -50,8 +50,8 @@ contract CrossL2Inbox is ISemver {
     error LogIndexTooHigh();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.14
-    string public constant version = "1.0.0-beta.14";
+    /// @custom:semver 1.0.0-beta.15
+    string public constant version = "1.0.0-beta.15";
 
     /// @notice The mask for the most significant bits of the checksum.
     /// @dev    Used to set the most significant byte to zero.
@@ -77,7 +77,7 @@ contract CrossL2Inbox is ISemver {
     /// @param _id      Identifier of the message.
     /// @param _msgHash Hash of the message payload to call target with.
     function validateMessage(Identifier calldata _id, bytes32 _msgHash) external {
-        bytes32 checksum = _calculateChecksum(_id, _msgHash);
+        bytes32 checksum = calculateChecksum(_id, _msgHash);
         (bool isWarm,) = _isWarm(checksum);
         if (!isWarm) revert NotInAccessList();
 
@@ -88,7 +88,7 @@ contract CrossL2Inbox is ISemver {
     /// @param _id The identifier of the message.
     /// @param _msgHash The hash of the message.
     /// @return checksum_ The checksum of the message.
-    function _calculateChecksum(Identifier memory _id, bytes32 _msgHash) internal pure returns (bytes32 checksum_) {
+    function calculateChecksum(Identifier memory _id, bytes32 _msgHash) public pure returns (bytes32 checksum_) {
         if (_id.blockNumber > type(uint64).max) revert BlockNumberTooHigh();
         if (_id.logIndex > type(uint32).max) revert LogIndexTooHigh();
         if (_id.timestamp > type(uint64).max) revert TimestampTooHigh();

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -8,7 +8,8 @@ import { Test } from "forge-std/Test.sol";
 import { ICrossL2Inbox } from "interfaces/L2/ICrossL2Inbox.sol";
 
 // Target contracts
-import { CrossL2InboxWithSlotWarming, Identifier } from "test/mocks/CrossL2InboxWithSlotWarming.sol";
+import { CrossL2InboxWithSlotWarming } from "test/mocks/CrossL2InboxWithSlotWarming.sol";
+import { Identifier } from "src/L2/CrossL2Inbox.sol";
 
 /// @title CrossL2InboxTest
 /// @dev Contract for testing the CrossL2Inbox contract.

--- a/packages/contracts-bedrock/test/mocks/CrossL2InboxWithSlotWarming.sol
+++ b/packages/contracts-bedrock/test/mocks/CrossL2InboxWithSlotWarming.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 // Target contracts
-import { CrossL2Inbox, Identifier } from "src/L2/CrossL2Inbox.sol";
+import { CrossL2Inbox } from "src/L2/CrossL2Inbox.sol";
 
 /// @title CrossL2InboxWithSlotWarming
 /// @dev CrossL2Inbox contract with a method to warm a slot.
@@ -17,10 +17,5 @@ contract CrossL2InboxWithSlotWarming is CrossL2Inbox {
     // Getter to expose `_isWarm` function for the tests.
     function isWarm(bytes32 _slot) external view returns (bool isWarm_, uint256 value_) {
         (isWarm_, value_) = _isWarm(_slot);
-    }
-
-    // Getter to expose `_calculateChecksum` function for the tests.
-    function calculateChecksum(Identifier memory _id, bytes32 _msgHash) external pure returns (bytes32 checksum_) {
-        checksum_ = _calculateChecksum(_id, _msgHash);
     }
 }


### PR DESCRIPTION
Converts `_calculateCheckSum` to an external function to give the option of using the contract for allowing clients to use the contract for warming the slot during message execution.