### PR TITLE
op-supervisor: fix deep local-safe invalidation case

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -264,13 +264,13 @@ func (su *SupervisorBackend) openChainDBs(chainID eth.ChainID) error {
 	}
 	su.chainDBs.AddLogDB(chainID, logDB)
 
-	localDB, err := db.OpenLocalDerivationDB(su.logger, chainID, su.dataDir, cm)
+	localDB, err := db.OpenLocalDerivationDB(su.logger.New("db-kind", "local-db", "chainID", chainID), chainID, su.dataDir, cm)
 	if err != nil {
 		return fmt.Errorf("failed to open local derived-from DB of chain %s: %w", chainID, err)
 	}
 	su.chainDBs.AddLocalDerivationDB(chainID, localDB)
 
-	crossDB, err := db.OpenCrossDerivationDB(su.logger, chainID, su.dataDir, cm)
+	crossDB, err := db.OpenCrossDerivationDB(su.logger.New("db-kind", "cross-db", "chainID", chainID), chainID, su.dataDir, cm)
 	if err != nil {
 		return fmt.Errorf("failed to open cross derived-from DB of chain %s: %w", chainID, err)
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -20,7 +20,7 @@ type CrossSafeDeps interface {
 
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
 	NextSource(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error)
-	PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+	PreviousCrossDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
 
 	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 
@@ -68,7 +68,7 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) er
 		// TODO: if genesis isn't cross-safe by default, then we can't register something as cross-safe here
 		return fmt.Errorf("failed to identify cross-safe scope to repeat: %w", err)
 	}
-	parent, err := d.PreviousDerived(chainID, currentCrossSafe.Derived.ID())
+	parent, err := d.PreviousCrossDerived(chainID, currentCrossSafe.Derived.ID())
 	if err != nil {
 		return fmt.Errorf("cannot find parent-block of cross-safe: %w", err)
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -558,7 +558,7 @@ func (m *mockCrossSafeDeps) NextSource(chain eth.ChainID, source eth.BlockID) (a
 	return eth.BlockRef{}, nil
 }
 
-func (m *mockCrossSafeDeps) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+func (m *mockCrossSafeDeps) PreviousCrossDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 	if m.previousDerivedFn != nil {
 		return m.previousDerivedFn(chain, derived)
 	}

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -61,24 +61,29 @@ type DerivationStorage interface {
 	SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error)
 
 	// traversal
-	Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error)
 	NextSource(source eth.BlockID) (nextSource types.BlockSeal, err error)
-	NextDerived(derived eth.BlockID, revision types.Revision) (next types.DerivedBlockSealPair, err error)
+
+	Candidate(afterSource eth.BlockID, afterDerived eth.BlockID, revision types.Revision) (pair types.DerivedBlockRefPair, err error)
+
 	PreviousSource(source eth.BlockID) (prevSource types.BlockSeal, err error)
+
+	// Warning: only safe to use on cross-DB
 	PreviousDerived(derived eth.BlockID, revision types.Revision) (prevDerived types.BlockSeal, err error)
 
 	// type-specific
 	Invalidated() (pair types.DerivedBlockSealPair, err error)
 	ContainsDerived(derived eth.BlockID, revision types.Revision) error
 
+	// DerivedToRevision is only safe to use on the cross-safe DB.
 	DerivedToRevision(derived eth.BlockID) (types.Revision, error)
 
-	// writing
-	AddDerived(source eth.BlockRef, derived eth.BlockRef) error
-	AddRevisedDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error
-	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (out types.DerivedBlockRefPair, revision types.Revision, err error)
+	SourceToRevision(source eth.BlockID) (types.Revision, error)
 
-	// rewining
+	// writing
+	AddDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error
+	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (out types.DerivedBlockRefPair, err error)
+
+	// rewinding
 	RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error
 	RewindToScope(scope eth.BlockID) error
 	RewindToFirstDerived(v eth.BlockID, revision types.Revision) error

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -77,6 +77,7 @@ type DerivationStorage interface {
 	// DerivedToRevision is only safe to use on the cross-safe DB.
 	DerivedToRevision(derived eth.BlockID) (types.Revision, error)
 
+	LastRevision() (revision types.Revision, err error)
 	SourceToRevision(source eth.BlockID) (types.Revision, error)
 
 	// writing

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -57,28 +57,31 @@ type DerivationStorage interface {
 	Last() (pair types.DerivedBlockSealPair, err error)
 
 	// mapping from source<>derived
-	DerivedToFirstSource(derived eth.BlockID) (source types.BlockSeal, err error)
+	DerivedToFirstSource(derived eth.BlockID, revision types.Revision) (source types.BlockSeal, err error)
 	SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error)
 
 	// traversal
 	Next(pair types.DerivedIDPair) (next types.DerivedBlockSealPair, err error)
 	NextSource(source eth.BlockID) (nextSource types.BlockSeal, err error)
-	NextDerived(derived eth.BlockID) (next types.DerivedBlockSealPair, err error)
+	NextDerived(derived eth.BlockID, revision types.Revision) (next types.DerivedBlockSealPair, err error)
 	PreviousSource(source eth.BlockID) (prevSource types.BlockSeal, err error)
-	PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+	PreviousDerived(derived eth.BlockID, revision types.Revision) (prevDerived types.BlockSeal, err error)
 
 	// type-specific
 	Invalidated() (pair types.DerivedBlockSealPair, err error)
-	ContainsDerived(derived eth.BlockID) error
+	ContainsDerived(derived eth.BlockID, revision types.Revision) error
+
+	DerivedToRevision(derived eth.BlockID) (types.Revision, error)
 
 	// writing
 	AddDerived(source eth.BlockRef, derived eth.BlockRef) error
-	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error)
+	AddRevisedDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error
+	ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (out types.DerivedBlockRefPair, revision types.Revision, err error)
 
 	// rewining
 	RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error
 	RewindToScope(scope eth.BlockID) error
-	RewindToFirstDerived(v eth.BlockID) error
+	RewindToFirstDerived(v eth.BlockID, revision types.Revision) error
 }
 
 var _ DerivationStorage = (*fromda.DB)(nil)

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -2,6 +2,7 @@ package fromda
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -24,8 +25,22 @@ type EntryStore interface {
 }
 
 // DB implements an append only database for log data and cross-chain dependencies.
-// Each entry is fixed size, and denotes an increment in L1 (derived-from) and/or L2 (derived) block.
+// Each entry is fixed size, and denotes an increment in L1 (source) and/or L2 (derived) block.
+//
 // Data is an append-only log, that can be binary searched for any necessary derivation-link data.
+//
+// The DB only rewinds when the L1 (source) entries are invalidated.
+// If the L2 (derived) entries are no longer valid (due to cross-chain dependency invalidation),
+// then we register the new L2 entries with a higher revision number
+// (matching the block-number of the block where it first invalidated and replaced).
+//
+// The key-space of the DB is thus as following, in order:
+// - source block number -> incremental, there may be adjacent repeat entries (for multiple L2 blocks derived from same L1 block)
+// - revision number -> incremental, repeats until the chain invalidates something
+// - derived block number -> NOT incremental, but incremental within the scope of a single revision.
+//
+// This key-space allows for fast binary-search over the source blocks to find any derived blocks,
+// but also the reverse: if the revision is known, the derived blocks can be searched, to find the relevant source data.
 type DB struct {
 	log    log.Logger
 	m      Metrics
@@ -69,16 +84,16 @@ func (db *DB) First() (pair types.DerivedBlockSealPair, err error) {
 // PreviousDerived returns the previous derived block.
 // This will prioritize the last time the input L2 block number was seen, and consistency-checks it against the hash.
 // Older occurrences of the same number with different hash cannot be iterated from, and are non-canonical.
-func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+func (db *DB) PreviousDerived(derived eth.BlockID, revision types.Revision) (prevDerived types.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// last is always the latest view, and thus canonical.
-	_, lastCanonical, err := db.derivedNumToLastSource(derived.Number)
+	_, lastCanonical, err := db.derivedNumToLastSource(derived.Number, revision)
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("failed to find last derived %d: %w", derived.Number, err)
 	}
 	// get the first time this L2 block was seen.
-	selfIndex, self, err := db.derivedNumToFirstSource(derived.Number)
+	selfIndex, self, err := db.derivedNumToFirstSource(derived.Number, revision)
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("failed to find first derived %d: %w", derived.Number, err)
 	}
@@ -163,11 +178,11 @@ func (db *DB) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, 
 // This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 // This will prioritize the last time the input L2 block number was seen, and consistency-checks it against the hash.
 // Older occurrences of the same number with different hash cannot be iterated from, and are non-canonical.
-func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair, err error) {
+func (db *DB) NextDerived(derived eth.BlockID, revision types.Revision) (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	// Get the last time this L2 block was seen. This is attached to the latest L1 view, and thus canonical.
-	selfIndex, self, err := db.derivedNumToLastSource(derived.Number)
+	selfIndex, self, err := db.derivedNumToLastSource(derived.Number, revision)
 	if err != nil {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to find derived %d: %w", derived.Number, err)
 	}
@@ -181,16 +196,43 @@ func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair,
 	return next.sealOrErr()
 }
 
+// DerivedToRevision retrieves the revision of the latest occurrence of the given block.
+// This may be open-ended (read: match not-yet cross-safe blocks) if the block is not known yet.
+// WARNING: this is only safe to use on the cross-safe DB.
+func (db *DB) DerivedToRevision(derived eth.BlockID) (types.Revision, error) {
+	_, link, err := db.derivedNumToLastSource(derived.Number, types.RevisionAny)
+	if err != nil {
+		if errors.Is(err, types.ErrFuture) {
+			last, err := db.latest()
+			if err != nil {
+				if errors.Is(err, types.ErrFuture) {
+					return FirstRevision, nil // default revision on empty DB
+				}
+				return types.Revision(0), fmt.Errorf("cannot determine revision, failed to get last entry: %w", err)
+			}
+			// The query is in the future, and may be an invalidated block with a later revision.
+			// Use an open-ended revision to match this query.
+			return last.revision.OpenEnded(), nil
+		}
+		return types.Revision(0), fmt.Errorf("cannot determine revision, failed to get link entry: %w", err)
+	}
+	if id := link.derived.ID(); id != derived {
+		return types.Revision(0), fmt.Errorf("cannot determine revision, db entry %s does not match query %s: %w", id, derived, types.ErrConflict)
+	}
+	return link.revision, nil
+}
+
 // ContainsDerived checks if the given block is canonical for the given chain.
 // This returns an ErrFuture if the block is not known yet.
 // An ErrConflict if there is a different block.
 // Or an ErrAwaitReplacementBlock if it was invalidated.
-func (db *DB) ContainsDerived(derived eth.BlockID) error {
+func (db *DB) ContainsDerived(derived eth.BlockID, revision types.Revision) error {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
+
 	// Take the last entry: this will be the latest canonical view,
 	// if the block was previously invalidated.
-	_, link, err := db.derivedNumToLastSource(derived.Number)
+	_, link, err := db.derivedNumToLastSource(derived.Number, revision)
 	if err != nil {
 		return err
 	}
@@ -208,10 +250,10 @@ func (db *DB) ContainsDerived(derived eth.BlockID) error {
 //   - A L2 block may repeat if the following L1 blocks are empty and don't produce additional L2 blocks
 //   - A L2 block may reoccur later (with a gap) attached to a newer L1 block,
 //     if the prior information was invalidated with new L1 information.
-func (db *DB) DerivedToFirstSource(derived eth.BlockID) (types.BlockSeal, error) {
+func (db *DB) DerivedToFirstSource(derived eth.BlockID, revision types.Revision) (types.BlockSeal, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, link, err := db.derivedNumToFirstSource(derived.Number)
+	_, link, err := db.derivedNumToFirstSource(derived.Number, revision)
 	if err != nil {
 		return types.BlockSeal{}, err
 	}
@@ -294,17 +336,40 @@ func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error)
 	return next.sealOrErr()
 }
 
-func (db *DB) derivedNumToFirstSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
+func (db *DB) derivedNumToFirstSource(derivedNum uint64, revision types.Revision) (entrydb.EntryIdx, LinkEntry, error) {
 	// Forward: prioritize the first entry.
 	return db.find(false, false, func(link LinkEntry) int {
-		return cmp.Compare(link.derived.Number, derivedNum)
+		res := -revision.Cmp(link.revision.Number())
+		if res == 0 {
+			return cmp.Compare(link.derived.Number, derivedNum)
+		}
+		return res
 	})
 }
 
-func (db *DB) derivedNumToLastSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
+func (db *DB) derivedNumToLastSource(derivedNum uint64, revision types.Revision) (entrydb.EntryIdx, LinkEntry, error) {
+	// If the revision is open-ended we need to check if we have an invalidated
+	// entry waiting to be matched.
+	if revision.OpenEnd() {
+		lastIndex := db.store.LastEntryIdx()
+		if lastIndex < 0 {
+			return 0, LinkEntry{}, types.ErrFuture
+		}
+		last, err := db.readAt(lastIndex)
+		if err != nil {
+			return 0, LinkEntry{}, err
+		}
+		if last.invalidated && derivedNum == last.derived.Number {
+			return lastIndex, last, nil
+		}
+	}
 	// Reverse: prioritize the last entry.
 	return db.find(true, false, func(link LinkEntry) int {
-		return cmp.Compare(derivedNum, link.derived.Number)
+		res := revision.Cmp(link.revision.Number())
+		if res == 0 {
+			return cmp.Compare(derivedNum, link.derived.Number)
+		}
+		return res
 	})
 }
 
@@ -341,6 +406,11 @@ func (db *DB) lookup(source, derived uint64) (entrydb.EntryIdx, LinkEntry, error
 	})
 }
 
+// lookupOrAfter looks for the (source, derived) pair.
+// However, the pair may not be present, the DB may only have derived later blocks from the given source.
+// If so, return the first derived entry from that source.
+// This is useful when rolling back after invalidating: the local-safe DB may have derived newer data from later sources
+// than what the cross-safe DB is deriving.
 func (db *DB) lookupOrAfter(source, derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	// We search left to right, so that if we miss the `derived` target,
 	// we end up on the first item that is after it.

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -82,8 +82,8 @@ func (db *DB) First() (pair types.DerivedBlockSealPair, err error) {
 }
 
 // PreviousDerived returns the previous derived block.
+// Warning: only safe to use on cross-DB.
 // This will prioritize the last time the input L2 block number was seen, and consistency-checks it against the hash.
-// Older occurrences of the same number with different hash cannot be iterated from, and are non-canonical.
 func (db *DB) PreviousDerived(derived eth.BlockID, revision types.Revision) (prevDerived types.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -124,6 +124,21 @@ func (db *DB) Last() (pair types.DerivedBlockSealPair, err error) {
 		return types.DerivedBlockSealPair{}, err
 	}
 	return link.sealOrErr()
+}
+
+// TODO test SourceToLastRevision
+func (db *DB) SourceToLastRevision(source eth.BlockID) (revision types.Revision, err error) {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	_, link, err := db.sourceNumToLastDerived(source.Number)
+	if err != nil {
+		return types.Revision(0), err
+	}
+	if link.source.ID() != source {
+		return types.Revision(0), fmt.Errorf("expected source %s, got source %s in DB: %w",
+			source, link.source, types.ErrConflict)
+	}
+	return link.revision, nil
 }
 
 // latest is like Latest, but without lock, for internal use.
@@ -196,6 +211,52 @@ func (db *DB) NextDerived(derived eth.BlockID, revision types.Revision) (pair ty
 	return next.sealOrErr()
 }
 
+// TODO Candidate
+func (db *DB) Candidate(maxSource eth.BlockID, afterDerived eth.BlockID, revision types.Revision) (pair types.DerivedBlockRefPair, err error) {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	_, lastOffered, err := db.sourceNumToLastDerived(maxSource.Number)
+	if err != nil {
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to get last derived block from %s: %w", maxSource, err)
+	}
+	if lastOffered.source.ID() != maxSource {
+		return types.DerivedBlockRefPair{}, fmt.Errorf("expected source %s, but got %s: %w", maxSource, afterDerived, types.ErrConflict)
+	}
+	parentSource, err := db.PreviousSource(maxSource)
+	if err != nil {
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to get parent source of %s: %w", maxSource, err)
+	}
+	sourceRef, err := lastOffered.source.WithParent(parentSource.ID())
+	if err != nil {
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to combine %s with parent %s: %w", lastOffered.source, parentSource, err)
+	}
+	if lastOffered.derived.Number > afterDerived.Number {
+		// keep source, just find the next canonical entry.
+		// That entry can be attached to an older source however.
+		_, link, err := db.derivedNumToLastSource(afterDerived.Number+1, revision)
+		if errors.Is(err, types.ErrNotExact) {
+			_, link, err = db.derivedNumToLastSource(afterDerived.Number+1, types.Revision(afterDerived.Number+1))
+			if err != nil {
+				return types.DerivedBlockRefPair{}, fmt.Errorf("cannot find derived block %d: %w", afterDerived.Number+1, types.ErrDataCorruption)
+			}
+		}
+		derivedRef, err := link.derived.WithParent(afterDerived)
+		if err != nil {
+			return types.DerivedBlockRefPair{}, err
+		}
+		return types.DerivedBlockRefPair{
+			Source:  sourceRef,
+			Derived: derivedRef,
+		}, nil
+	} else {
+		// need scope-bump before we can access next derived values
+		return types.DerivedBlockRefPair{
+			Source:  sourceRef,
+			Derived: eth.BlockRef{},
+		}, types.ErrOutOfScope
+	}
+}
+
 // DerivedToRevision retrieves the revision of the latest occurrence of the given block.
 // This may be open-ended (read: match not-yet cross-safe blocks) if the block is not known yet.
 // WARNING: this is only safe to use on the cross-safe DB.
@@ -218,6 +279,27 @@ func (db *DB) DerivedToRevision(derived eth.BlockID) (types.Revision, error) {
 	}
 	if id := link.derived.ID(); id != derived {
 		return types.Revision(0), fmt.Errorf("cannot determine revision, db entry %s does not match query %s: %w", id, derived, types.ErrConflict)
+	}
+	return link.revision, nil
+}
+
+// SourceToRevision lookups a specific source entry, and returns the corresponding revision.
+// This ignores invalidation status of the given pair.
+// It is used in those cases also, to determine the revision to use for a cross-safe DB,
+// based on the invalidated entry in the local-safe DB.
+func (db *DB) SourceToRevision(source eth.BlockID) (types.Revision, error) {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+
+	if db.store.Size() == 0 {
+		return FirstRevision, nil
+	}
+	_, link, err := db.sourceNumToLastDerived(source.Number)
+	if err != nil {
+		return types.Revision(0), err
+	}
+	if link.source.ID() != source {
+		return types.Revision(0), fmt.Errorf("expected %s, got %s: %w", source, link.source, types.ErrConflict)
 	}
 	return link.revision, nil
 }
@@ -486,7 +568,7 @@ func (db *DB) find(reverse bool, acceptClosest bool, cmpFn func(link LinkEntry) 
 				return -1, LinkEntry{}, fmt.Errorf("query is before first entry %s: %w", link, types.ErrSkipped)
 			}
 		} else if !acceptClosest {
-			return -1, LinkEntry{}, fmt.Errorf("traversed data, no exact match found, but hit %s: %w", link, types.ErrDataCorruption)
+			return -1, LinkEntry{}, fmt.Errorf("traversed data, no exact match found, but hit %s: %w", link, types.ErrNotExact)
 		}
 	}
 	return entrydb.EntryIdx(result), link, nil

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -126,17 +126,12 @@ func (db *DB) Last() (pair types.DerivedBlockSealPair, err error) {
 	return link.sealOrErr()
 }
 
-// TODO test SourceToLastRevision
-func (db *DB) SourceToLastRevision(source eth.BlockID) (revision types.Revision, err error) {
+func (db *DB) LastRevision() (revision types.Revision, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	_, link, err := db.sourceNumToLastDerived(source.Number)
+	link, err := db.latest()
 	if err != nil {
 		return types.Revision(0), err
-	}
-	if link.source.ID() != source {
-		return types.Revision(0), fmt.Errorf("expected source %s, got source %s in DB: %w",
-			source, link.source, types.ErrConflict)
 	}
 	return link.revision, nil
 }
@@ -263,19 +258,9 @@ func (db *DB) Candidate(maxSource eth.BlockID, afterDerived eth.BlockID, revisio
 func (db *DB) DerivedToRevision(derived eth.BlockID) (types.Revision, error) {
 	_, link, err := db.derivedNumToLastSource(derived.Number, types.RevisionAny)
 	if err != nil {
-		if errors.Is(err, types.ErrFuture) {
-			last, err := db.latest()
-			if err != nil {
-				if errors.Is(err, types.ErrFuture) {
-					return FirstRevision, nil // default revision on empty DB
-				}
-				return types.Revision(0), fmt.Errorf("cannot determine revision, failed to get last entry: %w", err)
-			}
-			// The query is in the future, and may be an invalidated block with a later revision.
-			// Use an open-ended revision to match this query.
-			return last.revision.OpenEnded(), nil
-		}
-		return types.Revision(0), fmt.Errorf("cannot determine revision, failed to get link entry: %w", err)
+		// This often happens in the cross-safe DB,
+		// when looking for the revision of a local-safe entry that is not yet in the cross-safe DB.
+		return types.Revision(0), fmt.Errorf("failed to get link entry: %w", err)
 	}
 	if id := link.derived.ID(); id != derived {
 		return types.Revision(0), fmt.Errorf("cannot determine revision, db entry %s does not match query %s: %w", id, derived, types.ErrConflict)
@@ -430,21 +415,6 @@ func (db *DB) derivedNumToFirstSource(derivedNum uint64, revision types.Revision
 }
 
 func (db *DB) derivedNumToLastSource(derivedNum uint64, revision types.Revision) (entrydb.EntryIdx, LinkEntry, error) {
-	// If the revision is open-ended we need to check if we have an invalidated
-	// entry waiting to be matched.
-	if revision.OpenEnd() {
-		lastIndex := db.store.LastEntryIdx()
-		if lastIndex < 0 {
-			return 0, LinkEntry{}, types.ErrFuture
-		}
-		last, err := db.readAt(lastIndex)
-		if err != nil {
-			return 0, LinkEntry{}, err
-		}
-		if last.invalidated && derivedNum == last.derived.Number {
-			return lastIndex, last, nil
-		}
-	}
 	// Reverse: prioritize the last entry.
 	return db.find(true, false, func(link LinkEntry) int {
 		res := revision.Cmp(link.revision.Number())

--- a/op-supervisor/supervisor/backend/db/fromda/db.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db.go
@@ -66,6 +66,9 @@ func (db *DB) First() (pair types.DerivedBlockSealPair, err error) {
 	return last.sealOrErr()
 }
 
+// PreviousDerived returns the previous derived block.
+// This will prioritize the last time the input L2 block number was seen, and consistency-checks it against the hash.
+// Older occurrences of the same number with different hash cannot be iterated from, and are non-canonical.
 func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -94,7 +97,7 @@ func (db *DB) PreviousDerived(derived eth.BlockID) (prevDerived types.BlockSeal,
 	return prev.derived, nil
 }
 
-// Latest returns the last known values:
+// Last returns the last known values:
 // source: the L1 block that the L2 block is safe for (not necessarily the first, multiple L2 blocks may be derived from the same L1 block).
 // derived: the L2 block that was derived (not necessarily the first, the L1 block may have been empty and repeated the last safe L2 block).
 // If the last entry is invalidated, this returns a types.ErrAwaitReplacementBlock error.
@@ -137,7 +140,7 @@ func (db *DB) Invalidated() (pair types.DerivedBlockSealPair, err error) {
 	}, nil
 }
 
-// LastDerivedAt returns the last L2 block derived from the given L1 block.
+// SourceToLastDerived returns the last L2 block derived from the given L1 block.
 // This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
 func (db *DB) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, err error) {
 	db.rwLock.RLock()
@@ -158,10 +161,12 @@ func (db *DB) SourceToLastDerived(source eth.BlockID) (derived types.BlockSeal, 
 
 // NextDerived finds the next L2 block after derived, and what it was derived from.
 // This may return types.ErrAwaitReplacementBlock if the entry was invalidated and needs replacement.
+// This will prioritize the last time the input L2 block number was seen, and consistency-checks it against the hash.
+// Older occurrences of the same number with different hash cannot be iterated from, and are non-canonical.
 func (db *DB) NextDerived(derived eth.BlockID) (pair types.DerivedBlockSealPair, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
-	// get the last time this L2 block was seen.
+	// Get the last time this L2 block was seen. This is attached to the latest L1 view, and thus canonical.
 	selfIndex, self, err := db.derivedNumToLastSource(derived.Number)
 	if err != nil {
 		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to find derived %d: %w", derived.Number, err)
@@ -200,7 +205,9 @@ func (db *DB) ContainsDerived(derived eth.BlockID) error {
 }
 
 // DerivedToFirstSource determines where a L2 block was first derived from.
-// (a L2 block may repeat if the following L1 blocks are empty and don't produce additional L2 blocks)
+//   - A L2 block may repeat if the following L1 blocks are empty and don't produce additional L2 blocks
+//   - A L2 block may reoccur later (with a gap) attached to a newer L1 block,
+//     if the prior information was invalidated with new L1 information.
 func (db *DB) DerivedToFirstSource(derived eth.BlockID) (types.BlockSeal, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -250,6 +257,7 @@ func (db *DB) previousSource(source eth.BlockID) (types.BlockSeal, error) {
 func (db *DB) NextSource(source eth.BlockID) (types.BlockSeal, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
+	// Source-entries are unique, doesn't matter if we use the first derived entry or last derived entry.
 	selfIndex, self, err := db.sourceNumToLastDerived(source.Number)
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("failed to find derived-from %d: %w", source.Number, err)
@@ -288,37 +296,63 @@ func (db *DB) Next(pair types.DerivedIDPair) (types.DerivedBlockSealPair, error)
 
 func (db *DB) derivedNumToFirstSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	// Forward: prioritize the first entry.
-	return db.find(false, func(link LinkEntry) int {
+	return db.find(false, false, func(link LinkEntry) int {
 		return cmp.Compare(link.derived.Number, derivedNum)
 	})
 }
 
 func (db *DB) derivedNumToLastSource(derivedNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	// Reverse: prioritize the last entry.
-	return db.find(true, func(link LinkEntry) int {
+	return db.find(true, false, func(link LinkEntry) int {
 		return cmp.Compare(derivedNum, link.derived.Number)
 	})
 }
 
 func (db *DB) sourceNumToFirstDerived(sourceNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	// Forward: prioritize the first entry.
-	return db.find(false, func(link LinkEntry) int {
+	return db.find(false, false, func(link LinkEntry) int {
 		return cmp.Compare(link.source.Number, sourceNum)
 	})
 }
 
 func (db *DB) sourceNumToLastDerived(sourceNum uint64) (entrydb.EntryIdx, LinkEntry, error) {
 	// Reverse: prioritize the last entry.
-	return db.find(true, func(link LinkEntry) int {
+	return db.find(true, false, func(link LinkEntry) int {
 		return cmp.Compare(sourceNum, link.source.Number)
 	})
 }
 
+// lookup returns the *only* entry for which source and derived block numbers match.
+// For any given source block a derived block should only show up once.
+// There may however be other derived blocks.
 func (db *DB) lookup(source, derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
-	return db.find(false, func(link LinkEntry) int {
-		res := cmp.Compare(link.derived.Number, derived)
+	// Lookup direction does not matter, as we do an exact lookup.
+	return db.find(true, false, func(link LinkEntry) int {
+		// Source (L1) is the primary key ("major key"):
+		// the source number is always strictly incremental in the DB,
+		// and can thus safely be used for global search
+		res := cmp.Compare(source, link.source.Number)
 		if res == 0 {
-			return cmp.Compare(link.source.Number, source)
+			// Derived (L2) blocks can re-occur in the DB, after invalidation of local-safe blocks.
+			// Within the same source block it is strictly incremental however.
+			return cmp.Compare(derived, link.derived.Number)
+		}
+		return res
+	})
+}
+
+func (db *DB) lookupOrAfter(source, derived uint64) (entrydb.EntryIdx, LinkEntry, error) {
+	// We search left to right, so that if we miss the `derived` target,
+	// we end up on the first item that is after it.
+	return db.find(false, true, func(link LinkEntry) int {
+		// Source (L1) is the primary key ("major key"):
+		// the source number is always strictly incremental in the DB,
+		// and can thus safely be used for global search
+		res := cmp.Compare(link.source.Number, source)
+		if res == 0 {
+			// Derived (L2) blocks can re-occur in the DB, after invalidation of local-safe blocks.
+			// Within the same source block it is strictly incremental however.
+			return cmp.Compare(link.derived.Number, derived)
 		}
 		return res
 	})
@@ -327,7 +361,7 @@ func (db *DB) lookup(source, derived uint64) (entrydb.EntryIdx, LinkEntry, error
 // find finds the first entry for which cmpFn(link) returns 0.
 // The cmpFn entries to the left should return -1, entries to the right 1.
 // If reverse, the cmpFn should be flipped too, and the last entry for which cmpFn(link) is 0 will be found.
-func (db *DB) find(reverse bool, cmpFn func(link LinkEntry) int) (entrydb.EntryIdx, LinkEntry, error) {
+func (db *DB) find(reverse bool, acceptClosest bool, cmpFn func(link LinkEntry) int) (entrydb.EntryIdx, LinkEntry, error) {
 	n := db.store.Size()
 	if n == 0 {
 		return -1, LinkEntry{}, types.ErrFuture
@@ -381,14 +415,9 @@ func (db *DB) find(reverse bool, cmpFn func(link LinkEntry) int) (entrydb.EntryI
 			} else {
 				return -1, LinkEntry{}, fmt.Errorf("query is before first entry %s: %w", link, types.ErrSkipped)
 			}
-		} else {
+		} else if !acceptClosest {
 			return -1, LinkEntry{}, fmt.Errorf("traversed data, no exact match found, but hit %s: %w", link, types.ErrDataCorruption)
 		}
-	}
-	if cmpFn(link) != 0 {
-		// Search should have returned lowest entry >= the target.
-		// And we already checked it's not > the target
-		panic(fmt.Errorf("invalid search result %s, did not match equality check", link))
 	}
 	return entrydb.EntryIdx(result), link, nil
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
@@ -86,6 +86,9 @@ func invariantFileSizeMatchesEntryCountMetric(stat os.FileInfo, m *stubMetrics) 
 
 func invariantDerivedTimestamp(prev, current LinkEntry) error {
 	if current.derived.Timestamp < prev.derived.Timestamp {
+		if current.source.Number == prev.source.Number+1 {
+			return nil // allowed, if the information is based on a new source block that may have invalidated prior data
+		}
 		return fmt.Errorf("derived timestamp must be >=, current: %s, prev: %s", current.derived, prev.derived)
 	}
 	return nil

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -111,6 +111,14 @@ func mockL1(i uint64) types.BlockSeal {
 	}
 }
 
+func mockL1Ref(i uint64) eth.BlockRef {
+	v := mockL1(i)
+	if i == 0 {
+		v.MustWithParent(eth.BlockID{})
+	}
+	return v.MustWithParent(mockL1(i - 1).ID())
+}
+
 func mockL2(i uint64) types.BlockSeal {
 	var h common.Hash
 	if i != 0 {
@@ -119,8 +127,16 @@ func mockL2(i uint64) types.BlockSeal {
 	return types.BlockSeal{
 		Hash:      h,
 		Number:    i,
-		Timestamp: 1000_000 + i*12,
+		Timestamp: 1000_000 + i*2,
 	}
+}
+
+func mockL2Ref(i uint64) eth.BlockRef {
+	v := mockL2(i)
+	if i == 0 {
+		v.MustWithParent(eth.BlockID{})
+	}
+	return v.MustWithParent(mockL2(i - 1).ID())
 }
 
 func toRef(seal types.BlockSeal, parentHash common.Hash) eth.BlockRef {
@@ -1219,4 +1235,148 @@ func TestRewindToDifferent(t *testing.T) {
 			})
 		},
 	)
+}
+
+func TestDBLookup(t *testing.T) {
+	l1Ref0 := mockL1Ref(0)
+	l1Ref1 := mockL1Ref(1)
+	l1Ref2 := mockL1Ref(2)
+	l1Ref3 := mockL1Ref(3)
+	l1Ref4 := mockL1Ref(4)
+	l1Ref5 := mockL1Ref(5)
+	l1Ref6 := mockL1Ref(6) // candidate cross-safe scope where we learn prior derived blocks need to be invalidated
+	l1Ref7 := mockL1Ref(7)
+
+	l2Ref0 := mockL2Ref(0) // genesis
+	l2Ref1 := mockL2Ref(1) // canonical, from L1 1
+	l2Ref2 := mockL2Ref(2) // canonical, from L1 2
+	l2Ref3 := mockL2Ref(3) // optimistic, from L1 3, to be non-canonical once we reach L1 6
+	l2Ref4 := mockL2Ref(4) // optimistic, from L1 3, to be non-canonical once we reach L1 6
+	l2Ref5 := mockL2Ref(5) // optimistic, from L1 3, to be non-canonical once we reach L1 6
+	l2Ref6 := mockL2Ref(6) // optimistic, from L1 4, to be non-canonical once we reach L1 6
+	l2Ref7 := mockL2Ref(7) // optimistic, from L1 4, to be non-canonical once we reach L1 6
+	l2Ref8 := mockL2Ref(8) // optimistic, from L1 5, to be non-canonical once we reach L1 6
+	l2Ref9 := mockL2Ref(9) // optimistic, from L1 6, to be non-canonical once we reach L1 6 (cross-verification is after local derivation)
+
+	l2Ref3p := l2Ref3 // canonical later, replacement block, from L1 6
+	l2Ref3p.Hash[0] ^= 0xff
+	l2Ref4p := l2Ref4
+
+	l2Ref4p.ParentHash = l2Ref3p.Hash // canonical later, block after replacement block
+	l2Ref4p.Hash[0] ^= 0xff
+
+	runDBTest(t,
+		func(t *testing.T, db *DB, m *stubMetrics) {
+			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
+
+			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
+
+			require.NoError(t, db.AddDerived(l1Ref2, l2Ref1)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2))
+
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref2)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref3))
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref4))
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref5))
+
+			require.NoError(t, db.AddDerived(l1Ref4, l2Ref5)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref4, l2Ref6))
+			require.NoError(t, db.AddDerived(l1Ref4, l2Ref7))
+
+			require.NoError(t, db.AddDerived(l1Ref5, l2Ref7)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref5, l2Ref8))
+
+			require.NoError(t, db.AddDerived(l1Ref6, l2Ref8)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref6, l2Ref9))
+
+			_, _, err := db.lookup(6, 3) // 3 was never derived from 6 at this point, we didn't apply the invalidation yet
+			require.ErrorIs(t, err, types.ErrDataCorruption)
+
+			// If we scan for the first thing at or after (6, 3) we should find (6, 8)
+			_, v, err := db.lookupOrAfter(6, 3)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref6.ID(), v.source.ID())
+			require.Equal(t, l2Ref8.ID(), v.derived.ID())
+
+			invalidated := types.DerivedBlockRefPair{
+				Source:  l1Ref6,
+				Derived: l1Ref3,
+			}
+			require.NoError(t, db.RewindAndInvalidate(invalidated))
+
+			_, v, err = db.lookup(6, 3) // now we have an invalidated place-holder that matches the (6, 3) lookup
+			require.NoError(t, err)
+			require.True(t, v.invalidated)
+			require.Equal(t, l1Ref6.ID(), v.source.ID())
+			require.Equal(t, l2Ref3.ID(), v.derived.ID())
+
+			// we cannot proceed in any way until actually replacing the invalidated placeholder block
+			require.ErrorIs(t, db.AddDerived(l1Ref6, l2Ref4p), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, db.AddDerived(l1Ref7, l2Ref3p), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, db.AddDerived(l1Ref7, l2Ref4p), types.ErrAwaitReplacementBlock)
+
+			replacement, err := db.ReplaceInvalidatedBlock(l2Ref3p, l2Ref3.Hash)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref6.ID(), replacement.Source.ID())
+			require.Equal(t, l2Ref3p.ID(), replacement.Derived.ID())
+
+			_, v, err = db.lookup(6, 3)
+			require.NoError(t, err)
+			require.False(t, v.invalidated) // not invalid, this is canonical now
+			require.Equal(t, l1Ref6.ID(), v.source.ID())
+			require.Equal(t, l2Ref3p.ID(), v.derived.ID())
+
+			require.NoError(t, db.AddDerived(l1Ref7, l2Ref3p)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref7, l2Ref4p))
+		},
+		func(t *testing.T, db *DB, m *stubMetrics) {
+
+			_, link, err := db.lookup(5, 7)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref5.ID(), link.source.ID())
+			require.Equal(t, l2Ref7.ID(), link.derived.ID()) // not canonical in L2, but available, attached to older L1 scope
+
+			_, link, err = db.lookup(5, 3) // block 3 was passed already in scope 5, but returned back to in scope 6, and should thus not be a valid lookup
+			require.ErrorIs(t, err, types.ErrDataCorruption)
+
+			_, link, err = db.lookup(6, 3)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref6.ID(), link.source.ID())
+			require.Equal(t, l2Ref3p.ID(), link.derived.ID())
+
+			_, link, err = db.lookup(7, 3)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref7.ID(), link.source.ID())
+			require.Equal(t, l2Ref3p.ID(), link.derived.ID())
+
+			_, link, err = db.lookup(7, 4)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref7.ID(), link.source.ID())
+			require.Equal(t, l2Ref4p.ID(), link.derived.ID())
+
+			// Now that we have a chain that jumps from (source=5, derived=8) to (source=6, derived=3),
+			// let's do some searches and assert we get the expected results.
+
+			// TODO: these are broken
+			_, v, err := db.derivedNumToLastSource(3)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref6.ID(), v.source.ID())
+			require.Equal(t, l2Ref3p.ID(), v.derived.ID())
+
+			_, v, err = db.derivedNumToFirstSource(3)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref3.ID(), v.source.ID())
+			require.Equal(t, l2Ref3.ID(), v.derived.ID())
+
+			_, v, err = db.derivedNumToLastSource(4)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref7.ID(), v.source.ID())
+			require.Equal(t, l2Ref4p.ID(), v.derived.ID())
+
+			_, v, err = db.derivedNumToFirstSource(4)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref3.ID(), v.source.ID())
+			require.Equal(t, l2Ref4.ID(), v.derived.ID())
+		})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -148,12 +148,16 @@ func toRef(seal types.BlockSeal, parentHash common.Hash) eth.BlockRef {
 	}
 }
 
+func dbAddDerivedAny(db *DB, source eth.BlockRef, derived eth.BlockRef) error {
+	return db.AddDerived(source, derived, types.RevisionAny)
+}
+
 func TestSingleEntryDB(t *testing.T) {
 	expectedSource := mockL1(0)
 	expectedDerived := mockL2(2)
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(toRef(expectedSource, mockL1(0).Hash), toRef(expectedDerived, mockL2(0).Hash)))
+			require.NoError(t, dbAddDerivedAny(db, toRef(expectedSource, mockL1(0).Hash), toRef(expectedDerived, mockL2(0).Hash)))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// First
@@ -235,7 +239,7 @@ func TestGap(t *testing.T) {
 	expectedDerived := mockL2(2)
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(toRef(expectedSource, mockL1(0).Hash), toRef(expectedDerived, mockL2(0).Hash)))
+			require.NoError(t, dbAddDerivedAny(db, toRef(expectedSource, mockL1(0).Hash), toRef(expectedDerived, mockL2(0).Hash)))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			_, err := db.NextDerived(mockL2(0).ID(), types.RevisionAny)
@@ -256,11 +260,11 @@ func TestThreeBlocksDB(t *testing.T) {
 	l2Block2 := mockL2(2)
 
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
-		require.NoError(t, db.AddDerived(toRef(l1Block0, common.Hash{}), toRef(l2Block0, common.Hash{})))
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), toRef(l2Block0, common.Hash{}))) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), toRef(l2Block1, l2Block0.Hash)))
-		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), toRef(l2Block1, l2Block0.Hash))) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), toRef(l2Block2, l2Block1.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block0, common.Hash{}), toRef(l2Block0, common.Hash{})))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), toRef(l2Block0, common.Hash{}))) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), toRef(l2Block1, l2Block0.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block2, l1Block1.Hash), toRef(l2Block1, l2Block0.Hash))) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block2, l1Block1.Hash), toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
 		pair, err := db.Last()
@@ -401,18 +405,18 @@ func TestFastL2Batcher(t *testing.T) {
 
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
 		// L2 genesis derived from L1 genesis
-		require.NoError(t, db.AddDerived(toRef(l1Block0, common.Hash{}), toRef(l2Block0, common.Hash{})))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block0, common.Hash{}), toRef(l2Block0, common.Hash{})))
 		// Many L2 blocks all derived from same L1 block
 		l1Ref1 := toRef(l1Block1, l1Block0.Hash)
-		require.NoError(t, db.AddDerived(l1Ref1, toRef(l2Block0, common.Hash{}))) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref1, toRef(l2Block1, l2Block0.Hash)))
-		require.NoError(t, db.AddDerived(l1Ref1, toRef(l2Block2, l2Block1.Hash)))
-		require.NoError(t, db.AddDerived(l1Ref1, toRef(l2Block3, l2Block2.Hash)))
-		require.NoError(t, db.AddDerived(l1Ref1, toRef(l2Block4, l2Block3.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, toRef(l2Block0, common.Hash{}))) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, toRef(l2Block1, l2Block0.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, toRef(l2Block2, l2Block1.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, toRef(l2Block3, l2Block2.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, toRef(l2Block4, l2Block3.Hash)))
 		// Last L2 block derived from later L1 block
 		l1Ref2 := toRef(l1Block2, l1Block1.Hash)
-		require.NoError(t, db.AddDerived(l1Ref2, toRef(l2Block4, l2Block3.Hash))) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref2, toRef(l2Block5, l2Block4.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref2, toRef(l2Block4, l2Block3.Hash))) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref2, toRef(l2Block5, l2Block4.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
 		pair, err := db.Last()
@@ -521,18 +525,18 @@ func TestSlowL2Batcher(t *testing.T) {
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
 		// L2 genesis derived from L1 genesis
 		l2Ref0 := toRef(l2Block0, common.Hash{})
-		require.NoError(t, db.AddDerived(toRef(l1Block0, common.Hash{}), l2Ref0))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block0, common.Hash{}), l2Ref0))
 		// Many L1 blocks all repeating the same L2 block
 		l2Ref1 := toRef(l2Block1, l2Block0.Hash)
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), l2Ref0)) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block3, l1Block2.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block4, l1Block3.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), l2Ref0)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block2, l1Block1.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block3, l1Block2.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block4, l1Block3.Hash), l2Ref1))
 		// New L1 block that finally produces a new L2 block
 		l1Ref5 := toRef(l1Block5, l1Block4.Hash)
-		require.NoError(t, db.AddDerived(l1Ref5, l2Ref1)) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref5, toRef(l2Block2, l2Block1.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref5, l2Ref1)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref5, toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
 		pair, err := db.Last()
@@ -638,7 +642,7 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
 		// Insert genesis
-		require.NoError(t, db.AddDerived(toRef(mockL1(offsetL1), common.Hash{}), toRef(mockL2(offsetL2), common.Hash{})))
+		require.NoError(t, dbAddDerivedAny(db, toRef(mockL1(offsetL1), common.Hash{}), toRef(mockL2(offsetL2), common.Hash{})))
 		firstSource[mockL2(offsetL2).ID()] = mockL1(offsetL1)
 		lastDerived[mockL1(offsetL1).ID()] = mockL2(offsetL2)
 
@@ -660,7 +664,7 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 			if _, ok := firstSource[derivedRef.ID()]; !ok {
 				firstSource[derivedRef.ID()] = pair.Source
 			}
-			require.NoError(t, db.AddDerived(sourceRef, derivedRef))
+			require.NoError(t, dbAddDerivedAny(db, sourceRef, derivedRef))
 		}
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 		// Now assert we can find what they are all derived from, and match the expectations.
@@ -720,17 +724,17 @@ func TestRewindToScope(t *testing.T) {
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
 		// L2 genesis derived from L1 genesis
 		l2Ref0 := toRef(l2Block0, common.Hash{})
-		require.NoError(t, db.AddDerived(toRef(l1Block0, common.Hash{}), l2Ref0))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block0, common.Hash{}), l2Ref0))
 		// Many L1 blocks all repeating the same L2 block
 		l2Ref1 := toRef(l2Block1, l2Block0.Hash)
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), l2Ref0)) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block3, l1Block2.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block4, l1Block3.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), l2Ref0)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block2, l1Block1.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block3, l1Block2.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block4, l1Block3.Hash), l2Ref1))
 		// New L1 block that finally produces a new L2 block
-		require.NoError(t, db.AddDerived(toRef(l1Block5, l1Block4.Hash), l2Ref1)) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block5, l1Block4.Hash), toRef(l2Block2, l2Block1.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block5, l1Block4.Hash), l2Ref1)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block5, l1Block4.Hash), toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
 		pair, err := db.Last()
@@ -790,17 +794,17 @@ func TestRewindToFirstDerived(t *testing.T) {
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
 		// L2 genesis derived from L1 genesis
 		l2Ref0 := toRef(l2Block0, common.Hash{})
-		require.NoError(t, db.AddDerived(toRef(l1Block0, common.Hash{}), l2Ref0))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block0, common.Hash{}), l2Ref0))
 		// Many L1 blocks all repeating the same L2 block
 		l2Ref1 := toRef(l2Block1, l2Block0.Hash)
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), l2Ref0)) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block1, l1Block0.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block2, l1Block1.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block3, l1Block2.Hash), l2Ref1))
-		require.NoError(t, db.AddDerived(toRef(l1Block4, l1Block3.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), l2Ref0)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block1, l1Block0.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block2, l1Block1.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block3, l1Block2.Hash), l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block4, l1Block3.Hash), l2Ref1))
 		// New L1 block that finally produces a new L2 block
-		require.NoError(t, db.AddDerived(toRef(l1Block5, l1Block4.Hash), l2Ref1)) // bump scope
-		require.NoError(t, db.AddDerived(toRef(l1Block5, l1Block4.Hash), toRef(l2Block2, l2Block1.Hash)))
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block5, l1Block4.Hash), l2Ref1)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, toRef(l1Block5, l1Block4.Hash), toRef(l2Block2, l2Block1.Hash)))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 
 		pair, err := db.Last()
@@ -856,13 +860,13 @@ func TestInvalidateAndReplace(t *testing.T) {
 	l2Ref3 := toRef(l2Block3, l2Block2.Hash)
 
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
-		require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
-		require.NoError(t, db.AddDerived(l1Ref1, l2Ref0)) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
-		require.NoError(t, db.AddDerived(l1Ref2, l2Ref1)) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref2, l2Ref2))
-		require.NoError(t, db.AddDerived(l1Ref3, l2Ref2)) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref3, l2Ref3))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref1)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref2))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref2)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref3))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 		pair, err := db.Last()
 		require.NoError(t, err)
@@ -876,7 +880,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref2.Hash, replacement.Hash) // different L2 block as replacement
 
-		_, _, err = db.ReplaceInvalidatedBlock(replacement, l2Ref2.Hash)
+		_, err = db.ReplaceInvalidatedBlock(replacement, l2Ref2.Hash)
 		require.ErrorIs(t, err, types.ErrConflict, "cannot replace what has not been invalidated")
 
 		invalidated := types.DerivedBlockRefPair{
@@ -892,10 +896,10 @@ func TestInvalidateAndReplace(t *testing.T) {
 		require.Equal(t, invalidated.Source.ID(), pair.Source.ID())
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
-		_, _, err = db.ReplaceInvalidatedBlock(replacement, common.Hash{0xba, 0xd})
+		_, err = db.ReplaceInvalidatedBlock(replacement, common.Hash{0xba, 0xd})
 		require.ErrorIs(t, err, types.ErrConflict, "must point at the right invalidated block")
 
-		result, _, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
+		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block1.ID(), result.Source.ID())
@@ -933,14 +937,14 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 	l2Ref4 := toRef(l2Block4, l2Block3.Hash)
 
 	runDBTest(t, func(t *testing.T, db *DB, m *stubMetrics) {
-		require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
-		require.NoError(t, db.AddDerived(l1Ref1, l2Ref0)) // bump scope
-		require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
-		require.NoError(t, db.AddDerived(l1Ref1, l2Ref2))
-		require.NoError(t, db.AddDerived(l1Ref1, l2Ref3))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0)) // bump scope
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref2))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref3))
 		// note the repeat of the L2 block with the bump in L1 scope
-		require.NoError(t, db.AddDerived(l1Ref2, l2Ref3)) // to be invalidated and replaced
-		require.NoError(t, db.AddDerived(l1Ref2, l2Ref4))
+		require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref3)) // to be invalidated and replaced
+		require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref4))
 	}, func(t *testing.T, db *DB, m *stubMetrics) {
 		pair, err := db.Last()
 		require.NoError(t, err)
@@ -966,7 +970,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		replacement := l2Ref3
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref3.Hash, replacement.Hash) // different L2 block as replacement
-		result, _, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
+		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block2.ID(), result.Source.ID())
@@ -1026,7 +1030,7 @@ func TestNoReplaceFirst(t *testing.T) {
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			l1Block0 := mockL1(0)
 			l1Ref0 := toRef(l1Block0, common.Hash{})
-			_, _, err := db.ReplaceInvalidatedBlock(l1Ref0, common.Hash{0xff})
+			_, err := db.ReplaceInvalidatedBlock(l1Ref0, common.Hash{0xff})
 			require.ErrorIs(t, err, types.ErrFuture)
 		},
 	)
@@ -1054,18 +1058,18 @@ func TestNotOntoInvalidated(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref2))
 			require.NoError(t, db.RewindAndInvalidate(types.DerivedBlockRefPair{
 				Source:  l1Ref2,
 				Derived: l2Ref2,
 			}))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.ErrorIs(t, db.AddDerived(l1Ref2, l2Ref3), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref2, l2Ref3), types.ErrAwaitReplacementBlock)
 		},
 	)
 }
@@ -1094,11 +1098,11 @@ func TestMismatchedInvalidate(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref2))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// This will detect the issue upon rewinding
@@ -1128,10 +1132,10 @@ func TestNoParallelBump(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.ErrorIs(t, db.AddDerived(l1Ref1, l2Ref1), types.ErrOutOfOrder)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref1, l2Ref1), types.ErrOutOfOrder)
 		},
 	)
 }
@@ -1151,7 +1155,7 @@ func TestLookupDetectIfCorruptDB(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			// Skip L1 block 1 and L2 block 1, force it into the DB
@@ -1165,11 +1169,11 @@ func TestLookupDetectIfCorruptDB(t *testing.T) {
 
 			// Look for L1 block 1
 			_, err := db.SourceToLastDerived(l1Block1.ID())
-			require.ErrorIs(t, err, types.ErrDataCorruption)
+			require.ErrorIs(t, err, types.ErrNotExact)
 
 			// Look for L2 block 1
 			_, err = db.DerivedToFirstSource(l2Block1.ID(), types.RevisionAny)
-			require.ErrorIs(t, err, types.ErrDataCorruption)
+			require.ErrorIs(t, err, types.ErrNotExact)
 
 			// Rewind, corrupt data cannot be left at end of test, otherwise invariant checks fail
 			require.NoError(t, db.Rewind(types.DerivedBlockSealPair{
@@ -1206,11 +1210,11 @@ func TestRewindToDifferent(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref2))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 
@@ -1289,31 +1293,31 @@ func TestDeepInvalidate(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
 
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref1)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref1)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref2))
 
-			require.NoError(t, db.AddDerived(l1Ref3, l2Ref2)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref3, l2Ref3))
-			require.NoError(t, db.AddDerived(l1Ref3, l2Ref4))
-			require.NoError(t, db.AddDerived(l1Ref3, l2Ref5))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref2)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref3))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref4))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref5))
 
-			require.NoError(t, db.AddDerived(l1Ref4, l2Ref5)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref4, l2Ref6))
-			require.NoError(t, db.AddDerived(l1Ref4, l2Ref7))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref4, l2Ref5)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref4, l2Ref6))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref4, l2Ref7))
 
-			require.NoError(t, db.AddDerived(l1Ref5, l2Ref7)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref5, l2Ref8))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref5, l2Ref7)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref5, l2Ref8))
 
-			require.NoError(t, db.AddDerived(l1Ref6, l2Ref8)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref6, l2Ref9))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref6, l2Ref8)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref6, l2Ref9))
 
 			_, _, err := db.lookup(6, 3) // 3 was never derived from 6 at this point, we didn't apply the invalidation yet
-			require.ErrorIs(t, err, types.ErrDataCorruption)
+			require.ErrorIs(t, err, types.ErrNotExact)
 
 			// If we scan for the first thing at or after (6, 3) we should find (6, 8)
 			_, v, err := db.lookupOrAfter(6, 3)
@@ -1348,15 +1352,14 @@ func TestDeepInvalidate(t *testing.T) {
 			require.ErrorIs(t, db.RewindAndInvalidate(invalidated), types.ErrAwaitReplacementBlock)
 
 			// we cannot proceed in any way until actually replacing the invalidated placeholder block
-			require.ErrorIs(t, db.AddDerived(l1Ref6, l2Ref4p), types.ErrAwaitReplacementBlock)
-			require.ErrorIs(t, db.AddDerived(l1Ref7, l2Ref3p), types.ErrAwaitReplacementBlock)
-			require.ErrorIs(t, db.AddDerived(l1Ref7, l2Ref4p), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref6, l2Ref4p), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref7, l2Ref3p), types.ErrAwaitReplacementBlock)
+			require.ErrorIs(t, dbAddDerivedAny(db, l1Ref7, l2Ref4p), types.ErrAwaitReplacementBlock)
 
-			replacement, revision, err := db.ReplaceInvalidatedBlock(l2Ref3p, l2Ref3.Hash)
+			replacement, err := db.ReplaceInvalidatedBlock(l2Ref3p, l2Ref3.Hash)
 			require.NoError(t, err)
 			require.Equal(t, l1Ref6.ID(), replacement.Source.ID())
 			require.Equal(t, l2Ref3p.ID(), replacement.Derived.ID())
-			require.Equal(t, secondRevision, revision)
 
 			_, v, err = db.lookup(6, 3)
 			require.NoError(t, err)
@@ -1370,12 +1373,12 @@ func TestDeepInvalidate(t *testing.T) {
 			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision.OpenEnded()), types.ErrConflict)
 			require.NoError(t, db.ContainsDerived(l2Ref3p.ID(), secondRevision))
 
-			require.NoError(t, db.AddDerived(l1Ref7, l2Ref3p)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref7, l2Ref4p))
-			require.NoError(t, db.AddDerived(l1Ref7, l2Ref5p))
-			require.NoError(t, db.AddDerived(l1Ref7, l2Ref6p))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref7, l2Ref3p)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref7, l2Ref4p))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref7, l2Ref5p))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref7, l2Ref6p))
 
-			require.NoError(t, db.AddDerived(l1Ref8, l2Ref6p)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref8, l2Ref6p)) // scope bump
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 
@@ -1385,7 +1388,7 @@ func TestDeepInvalidate(t *testing.T) {
 			require.Equal(t, l2Ref7.ID(), link.derived.ID()) // not canonical in L2, but available, attached to older L1 scope
 
 			_, link, err = db.lookup(5, 3) // block 3 was passed already in scope 5, but returned back to in scope 6, and should thus not be a valid lookup
-			require.ErrorIs(t, err, types.ErrDataCorruption)
+			require.ErrorIs(t, err, types.ErrNotExact)
 
 			_, link, err = db.lookup(6, 3)
 			require.NoError(t, err)
@@ -1460,11 +1463,10 @@ func TestDeepInvalidate(t *testing.T) {
 			require.Equal(t, l2Ref5p.ID(), v.derived.ID())
 			require.Equal(t, thirdRevision, v.revision)
 
-			replacement2, revision2, err := db.ReplaceInvalidatedBlock(l2Ref5pp, l2Ref5p.Hash)
+			replacement2, err := db.ReplaceInvalidatedBlock(l2Ref5pp, l2Ref5p.Hash)
 			require.NoError(t, err)
 			require.Equal(t, l1Ref8.ID(), replacement2.Source.ID())
 			require.Equal(t, l2Ref5pp.ID(), replacement2.Derived.ID())
-			require.Equal(t, thirdRevision, revision2)
 
 			checkRevisionsOf3(t)
 			checkRevisionsOf4(t)
@@ -1533,24 +1535,24 @@ func TestDerivedToRevision(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, FirstRevision, v, "empty DB starts with default revision")
 
-			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
-			require.NoError(t, db.AddDerived(l1Ref1, l2Ref2))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref0)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref1))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref1, l2Ref2))
 
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2)) // scope bump
-			require.NoError(t, db.AddRevisedDerived(l1Ref2, l2Ref3, 3))
-			require.NoError(t, db.AddDerived(l1Ref2, l2Ref4))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref2)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref2, l2Ref3, 3))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref2, l2Ref4))
 
-			require.NoError(t, db.AddDerived(l1Ref3, l2Ref4)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref3, l2Ref4))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref4)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref3, l2Ref4))
 			// when something is revised, the number of the revised data is used as revision number
-			require.ErrorIs(t, db.AddRevisedDerived(l1Ref3, l2Ref5, 6), types.ErrDataCorruption)
-			require.NoError(t, db.AddRevisedDerived(l1Ref3, l2Ref5, 5))
+			require.ErrorIs(t, db.AddDerived(l1Ref3, l2Ref5, 6), types.ErrDataCorruption)
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref5, 5))
 
-			require.NoError(t, db.AddDerived(l1Ref4, l2Ref5)) // scope bump
-			require.NoError(t, db.AddDerived(l1Ref4, l2Ref6))
+			require.NoError(t, dbAddDerivedAny(db, l1Ref4, l2Ref5)) // scope bump
+			require.NoError(t, dbAddDerivedAny(db, l1Ref4, l2Ref6))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			v, err := db.DerivedToRevision(l2Ref0.ID())

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -81,13 +81,13 @@ func TestEmptyDB(t *testing.T) {
 			_, err = db.SourceToLastDerived(eth.BlockID{})
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, err = db.DerivedToFirstSource(eth.BlockID{})
+			_, err = db.DerivedToFirstSource(eth.BlockID{}, types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, err = db.PreviousDerived(eth.BlockID{})
+			_, err = db.PreviousDerived(eth.BlockID{}, types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrFuture)
 
-			_, err = db.NextDerived(eth.BlockID{})
+			_, err = db.NextDerived(eth.BlockID{}, types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			_, err = db.PreviousSource(eth.BlockID{})
@@ -122,7 +122,7 @@ func mockL1Ref(i uint64) eth.BlockRef {
 func mockL2(i uint64) types.BlockSeal {
 	var h common.Hash
 	if i != 0 {
-		h = crypto.Keccak256Hash([]byte(fmt.Sprintf("L1 block %d", i)))
+		h = crypto.Keccak256Hash([]byte(fmt.Sprintf("L2 block %d", i)))
 	}
 	return types.BlockSeal{
 		Hash:      h,
@@ -194,16 +194,16 @@ func TestSingleEntryDB(t *testing.T) {
 			require.ErrorIs(t, err, types.ErrConflict)
 
 			// First Source
-			source, err := db.DerivedToFirstSource(expectedDerived.ID())
+			source, err := db.DerivedToFirstSource(expectedDerived.ID(), types.RevisionAny)
 			require.NoError(t, err)
 			require.Equal(t, expectedSource, source)
 
 			// Source with a non-existent Derived
-			_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: expectedDerived.Number})
+			_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: expectedDerived.Number}, types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrConflict)
 
 			// PreviousDerived
-			prev, err := db.PreviousDerived(expectedDerived.ID())
+			prev, err := db.PreviousDerived(expectedDerived.ID(), types.RevisionAny)
 			require.NoError(t, err)
 			require.Equal(t, types.BlockSeal{}, prev, "zeroed seal before first entry")
 
@@ -213,7 +213,7 @@ func TestSingleEntryDB(t *testing.T) {
 			require.Equal(t, types.BlockSeal{}, prev, "zeroed seal before first entry")
 
 			// NextDerived
-			_, err = db.NextDerived(expectedDerived.ID())
+			_, err = db.NextDerived(expectedDerived.ID(), types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrFuture)
 
 			// NextSource
@@ -238,7 +238,7 @@ func TestGap(t *testing.T) {
 			require.NoError(t, db.AddDerived(toRef(expectedSource, mockL1(0).Hash), toRef(expectedDerived, mockL2(0).Hash)))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			_, err := db.NextDerived(mockL2(0).ID())
+			_, err := db.NextDerived(mockL2(0).ID(), types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrSkipped)
 
 			_, err = db.NextSource(mockL1(0).ID())
@@ -280,18 +280,18 @@ func TestThreeBlocksDB(t *testing.T) {
 		_, err = db.SourceToLastDerived(eth.BlockID{Hash: common.Hash{0xaa}, Number: l1Block2.Number})
 		require.ErrorIs(t, err, types.ErrConflict)
 
-		source, err := db.DerivedToFirstSource(l2Block2.ID())
+		source, err := db.DerivedToFirstSource(l2Block2.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, source)
 
-		_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: l2Block2.Number})
+		_, err = db.DerivedToFirstSource(eth.BlockID{Hash: common.Hash{0xbb}, Number: l2Block2.Number}, types.RevisionAny)
 		require.ErrorIs(t, err, types.ErrConflict)
 
 		derived, err = db.SourceToLastDerived(l1Block1.ID())
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, derived)
 
-		source, err = db.DerivedToFirstSource(l2Block1.ID())
+		source, err = db.DerivedToFirstSource(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, source)
 
@@ -299,33 +299,33 @@ func TestThreeBlocksDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		source, err = db.DerivedToFirstSource(l2Block0.ID())
+		source, err = db.DerivedToFirstSource(l2Block0.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block0, source)
 
-		derived, err = db.PreviousDerived(l2Block0.ID())
+		derived, err = db.PreviousDerived(l2Block0.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, types.BlockSeal{}, derived)
 
-		derived, err = db.PreviousDerived(l2Block1.ID())
+		derived, err = db.PreviousDerived(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		derived, err = db.PreviousDerived(l2Block2.ID())
+		derived, err = db.PreviousDerived(l2Block2.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, derived)
 
-		next, err := db.NextDerived(l2Block0.ID())
+		next, err := db.NextDerived(l2Block0.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, next.Derived)
 		require.Equal(t, l1Block1, next.Source)
 
-		next, err = db.NextDerived(l2Block1.ID())
+		next, err = db.NextDerived(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block2, next.Derived)
 		require.Equal(t, l1Block2, next.Source)
 
-		_, err = db.NextDerived(l2Block2.ID())
+		_, err = db.NextDerived(l2Block2.ID(), types.RevisionAny)
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		source, err = db.PreviousSource(l1Block0.ID())
@@ -425,13 +425,13 @@ func TestFastL2Batcher(t *testing.T) {
 		require.Equal(t, l2Block5, derived)
 
 		// test what tip was derived from
-		source, err := db.DerivedToFirstSource(l2Block5.ID())
+		source, err := db.DerivedToFirstSource(l2Block5.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, source)
 
 		// Multiple L2 blocks all derived from same older L1 block
 		for _, b := range []types.BlockSeal{l2Block1, l2Block2, l2Block3, l2Block4} {
-			source, err = db.DerivedToFirstSource(b.ID())
+			source, err = db.DerivedToFirstSource(b.ID(), types.RevisionAny)
 			require.NoError(t, err)
 			require.Equal(t, l1Block1, source)
 		}
@@ -441,43 +441,43 @@ func TestFastL2Batcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, l2Block4, derived)
 
-		derived, err = db.PreviousDerived(l2Block5.ID())
+		derived, err = db.PreviousDerived(l2Block5.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block4, derived)
-		derived, err = db.PreviousDerived(l2Block4.ID())
+		derived, err = db.PreviousDerived(l2Block4.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block3, derived)
-		derived, err = db.PreviousDerived(l2Block3.ID())
+		derived, err = db.PreviousDerived(l2Block3.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block2, derived)
-		derived, err = db.PreviousDerived(l2Block2.ID())
+		derived, err = db.PreviousDerived(l2Block2.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, derived)
-		derived, err = db.PreviousDerived(l2Block1.ID())
+		derived, err = db.PreviousDerived(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		next, err := db.NextDerived(l2Block0.ID())
+		next, err := db.NextDerived(l2Block0.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block1, next.Derived)
-		next, err = db.NextDerived(l2Block1.ID())
+		next, err = db.NextDerived(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block2, next.Derived)
-		next, err = db.NextDerived(l2Block2.ID())
+		next, err = db.NextDerived(l2Block2.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block3, next.Derived)
-		next, err = db.NextDerived(l2Block3.ID())
+		next, err = db.NextDerived(l2Block3.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block4, next.Derived)
-		next, err = db.NextDerived(l2Block4.ID())
+		next, err = db.NextDerived(l2Block4.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block2, next.Source) // derived from later L1 block
 		require.Equal(t, l2Block5, next.Derived)
-		_, err = db.NextDerived(l2Block5.ID())
+		_, err = db.NextDerived(l2Block5.ID(), types.RevisionAny)
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		source, err = db.PreviousSource(l1Block2.ID())
@@ -553,26 +553,26 @@ func TestSlowL2Batcher(t *testing.T) {
 		}
 
 		// test that the first L1 counts, not the ones that repeat the L2 info
-		source, err := db.DerivedToFirstSource(l2Block1.ID())
+		source, err := db.DerivedToFirstSource(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, source)
 
-		derived, err = db.PreviousDerived(l2Block2.ID())
+		derived, err = db.PreviousDerived(l2Block2.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block1, derived)
-		derived, err = db.PreviousDerived(l2Block1.ID())
+		derived, err = db.PreviousDerived(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Block0, derived)
 
-		next, err := db.NextDerived(l2Block0.ID())
+		next, err := db.NextDerived(l2Block0.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block1, next.Source)
 		require.Equal(t, l2Block1, next.Derived)
-		next, err = db.NextDerived(l2Block1.ID())
+		next, err = db.NextDerived(l2Block1.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l1Block5, next.Source)
 		require.Equal(t, l2Block2, next.Derived)
-		_, err = db.NextDerived(l2Block2.ID())
+		_, err = db.NextDerived(l2Block2.ID(), types.RevisionAny)
 		require.ErrorIs(t, err, types.ErrFuture)
 
 		source, err = db.PreviousSource(l1Block5.ID())
@@ -679,7 +679,7 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 
 		for i := offsetL2; i <= pair.Derived.Number; i++ {
 			l2ID := mockL2(i).ID()
-			source, err := db.DerivedToFirstSource(l2ID)
+			source, err := db.DerivedToFirstSource(l2ID, types.RevisionAny)
 			require.NoError(t, err)
 			require.Contains(t, firstSource, l2ID)
 			require.Equal(t, firstSource[l2ID], source)
@@ -694,10 +694,10 @@ func testManyEntryDB(t *testing.T, offsetL1 uint64, offsetL2 uint64) {
 			require.ErrorIs(t, err, types.ErrSkipped)
 		}
 		if offsetL2 > 0 {
-			_, err := db.DerivedToFirstSource(mockL2(0).ID())
+			_, err := db.DerivedToFirstSource(mockL2(0).ID(), types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrSkipped)
 
-			_, err = db.DerivedToFirstSource(mockL2(offsetL2 - 1).ID())
+			_, err = db.DerivedToFirstSource(mockL2(offsetL2-1).ID(), types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrSkipped)
 		}
 	})
@@ -809,17 +809,17 @@ func TestRewindToFirstDerived(t *testing.T) {
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Rewind to the future
-		require.ErrorIs(t, db.RewindToFirstDerived(l2Block3.ID()), types.ErrFuture)
+		require.ErrorIs(t, db.RewindToFirstDerived(l2Block3.ID(), types.RevisionAny), types.ErrFuture)
 
 		// Rewind to the exact block we're at
-		require.NoError(t, db.RewindToFirstDerived(l2Block2.ID()))
+		require.NoError(t, db.RewindToFirstDerived(l2Block2.ID(), types.RevisionAny))
 		pair, err = db.Last()
 		require.NoError(t, err)
 		require.Equal(t, l1Block5, pair.Source)
 		require.Equal(t, l2Block2, pair.Derived)
 
 		// Now rewind to L2 block 1
-		require.NoError(t, db.RewindToFirstDerived(l2Block1.ID()))
+		require.NoError(t, db.RewindToFirstDerived(l2Block1.ID(), types.RevisionAny))
 
 		// See if we went back to the first occurrence of L2 block 1.
 		pair, err = db.Last()
@@ -828,7 +828,7 @@ func TestRewindToFirstDerived(t *testing.T) {
 		require.Equal(t, l2Block1, pair.Derived)
 
 		// Rewind further to L2 block 0 (inclusive).
-		require.NoError(t, db.RewindToFirstDerived(l2Block0.ID()))
+		require.NoError(t, db.RewindToFirstDerived(l2Block0.ID(), types.RevisionAny))
 		pair, err = db.Last()
 		require.NoError(t, err)
 		require.Equal(t, l1Block0, pair.Source)
@@ -876,7 +876,7 @@ func TestInvalidateAndReplace(t *testing.T) {
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref2.Hash, replacement.Hash) // different L2 block as replacement
 
-		_, err = db.ReplaceInvalidatedBlock(replacement, l2Ref2.Hash)
+		_, _, err = db.ReplaceInvalidatedBlock(replacement, l2Ref2.Hash)
 		require.ErrorIs(t, err, types.ErrConflict, "cannot replace what has not been invalidated")
 
 		invalidated := types.DerivedBlockRefPair{
@@ -892,10 +892,10 @@ func TestInvalidateAndReplace(t *testing.T) {
 		require.Equal(t, invalidated.Source.ID(), pair.Source.ID())
 		require.Equal(t, invalidated.Derived.ID(), pair.Derived.ID())
 
-		_, err = db.ReplaceInvalidatedBlock(replacement, common.Hash{0xba, 0xd})
+		_, _, err = db.ReplaceInvalidatedBlock(replacement, common.Hash{0xba, 0xd})
 		require.ErrorIs(t, err, types.ErrConflict, "must point at the right invalidated block")
 
-		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
+		result, _, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block1.ID(), result.Source.ID())
@@ -966,7 +966,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		replacement := l2Ref3
 		replacement.Hash = common.Hash{0xff, 0xff, 0xff}
 		require.NotEqual(t, l2Ref3.Hash, replacement.Hash) // different L2 block as replacement
-		result, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
+		result, _, err := db.ReplaceInvalidatedBlock(replacement, invalidated.Derived.Hash)
 		require.NoError(t, err)
 		require.Equal(t, replacement.ID(), result.Derived.ID())
 		require.Equal(t, l1Block2.ID(), result.Source.ID())
@@ -977,7 +977,7 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, l1Block2.ID(), pair.Source.ID())
 
 		// The L2 block before the replacement should point to 2
-		prev, err := db.PreviousDerived(replacement.ID())
+		prev, err := db.PreviousDerived(replacement.ID(), types.RevisionAny)
 		require.NoError(t, err)
 		require.Equal(t, l2Ref2.ID(), prev.ID())
 
@@ -1003,9 +1003,9 @@ func TestInvalidateAndReplaceNonFirst(t *testing.T) {
 		require.Equal(t, l1Block2.ID(), entryBlockRepl.Source.ID())
 
 		// Check if canonical chain is represented accurately
-		require.NoError(t, db.ContainsDerived(l2Ref2.ID()), "common block 2 is valid part of canonical chain")
-		require.NoError(t, db.ContainsDerived(replacement.ID()), "replacement is valid part of canonical chain")
-		require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID()), types.ErrConflict, "invalidated block is not valid in canonical chain")
+		require.NoError(t, db.ContainsDerived(l2Ref2.ID(), types.RevisionAny), "common block 2 is valid part of canonical chain")
+		require.NoError(t, db.ContainsDerived(replacement.ID(), types.RevisionAny), "replacement is valid part of canonical chain")
+		require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), types.RevisionAny), types.ErrConflict, "invalidated block is not valid in canonical chain")
 	})
 }
 
@@ -1015,7 +1015,7 @@ func TestNoInvalidatedFirst(t *testing.T) {
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			l1Block20 := toRef(mockL1(20), mockL1(19).Hash)
 			l2Block100 := toRef(mockL1(100), mockL2(99).Hash)
-			require.ErrorIs(t, db.addLink(l1Block20, l2Block100, l2Block100.Hash), types.ErrConflict)
+			require.ErrorIs(t, db.addLink(l1Block20, l2Block100, l2Block100.Hash, FirstRevision), types.ErrConflict)
 		},
 	)
 }
@@ -1026,7 +1026,7 @@ func TestNoReplaceFirst(t *testing.T) {
 		func(t *testing.T, db *DB, m *stubMetrics) {
 			l1Block0 := mockL1(0)
 			l1Ref0 := toRef(l1Block0, common.Hash{})
-			_, err := db.ReplaceInvalidatedBlock(l1Ref0, common.Hash{0xff})
+			_, _, err := db.ReplaceInvalidatedBlock(l1Ref0, common.Hash{0xff})
 			require.ErrorIs(t, err, types.ErrFuture)
 		},
 	)
@@ -1065,7 +1065,7 @@ func TestNotOntoInvalidated(t *testing.T) {
 			}))
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			require.ErrorIs(t, db.AddDerived(l1Ref2, l2Ref3), types.ErrConflict)
+			require.ErrorIs(t, db.AddDerived(l1Ref2, l2Ref3), types.ErrAwaitReplacementBlock)
 		},
 	)
 }
@@ -1107,7 +1107,7 @@ func TestMismatchedInvalidate(t *testing.T) {
 				Derived: l2Ref2Alt,
 			}), types.ErrConflict)
 			// This will detect the issue upon insertion of the new invalidated-entry
-			require.ErrorIs(t, db.addLink(l1Ref3, l2Ref2Alt, l2Ref2Alt.Hash), types.ErrConflict)
+			require.ErrorIs(t, db.addLink(l1Ref3, l2Ref2Alt, l2Ref2Alt.Hash, FirstRevision), types.ErrConflict)
 		},
 	)
 }
@@ -1168,7 +1168,7 @@ func TestLookupDetectIfCorruptDB(t *testing.T) {
 			require.ErrorIs(t, err, types.ErrDataCorruption)
 
 			// Look for L2 block 1
-			_, err = db.DerivedToFirstSource(l2Block1.ID())
+			_, err = db.DerivedToFirstSource(l2Block1.ID(), types.RevisionAny)
 			require.ErrorIs(t, err, types.ErrDataCorruption)
 
 			// Rewind, corrupt data cannot be left at end of test, otherwise invariant checks fail
@@ -1216,7 +1216,7 @@ func TestRewindToDifferent(t *testing.T) {
 
 			t.Run("Bad derived target", func(t *testing.T) {
 				// try to rewind, but towards a mismatching block
-				require.ErrorIs(t, db.RewindToFirstDerived(l2ID1Alt), types.ErrConflict)
+				require.ErrorIs(t, db.RewindToFirstDerived(l2ID1Alt, types.RevisionAny), types.ErrConflict)
 				last, err := db.Last()
 				require.NoError(t, err)
 				// assert we didn't rewind anything
@@ -1237,7 +1237,12 @@ func TestRewindToDifferent(t *testing.T) {
 	)
 }
 
-func TestDBLookup(t *testing.T) {
+// TestDeepInvalidate tests that a local-safe DB can invalidate and rewind entries,
+// even if multiple new local-safe entries with new source blocks or derived blocks have already been added.
+// The blocks stay attached to these sources, but the derived number will fall back and rebuild.
+// This causes different derived blocks with the same block-number to show up multiple times in the DB,
+// and is why we need revisions to distinguish them and search them.
+func TestDeepInvalidate(t *testing.T) {
 	l1Ref0 := mockL1Ref(0)
 	l1Ref1 := mockL1Ref(1)
 	l1Ref2 := mockL1Ref(2)
@@ -1246,6 +1251,7 @@ func TestDBLookup(t *testing.T) {
 	l1Ref5 := mockL1Ref(5)
 	l1Ref6 := mockL1Ref(6) // candidate cross-safe scope where we learn prior derived blocks need to be invalidated
 	l1Ref7 := mockL1Ref(7)
+	l1Ref8 := mockL1Ref(8)
 
 	l2Ref0 := mockL2Ref(0) // genesis
 	l2Ref1 := mockL2Ref(1) // canonical, from L1 1
@@ -1258,12 +1264,28 @@ func TestDBLookup(t *testing.T) {
 	l2Ref8 := mockL2Ref(8) // optimistic, from L1 5, to be non-canonical once we reach L1 6
 	l2Ref9 := mockL2Ref(9) // optimistic, from L1 6, to be non-canonical once we reach L1 6 (cross-verification is after local derivation)
 
+	secondRevision := types.Revision(3)
+	thirdRevision := types.Revision(5)
+
 	l2Ref3p := l2Ref3 // canonical later, replacement block, from L1 6
 	l2Ref3p.Hash[0] ^= 0xff
-	l2Ref4p := l2Ref4
 
-	l2Ref4p.ParentHash = l2Ref3p.Hash // canonical later, block after replacement block
+	l2Ref4p := l2Ref4 // canonical later, block after replacement block, from L1 7
+	l2Ref4p.ParentHash = l2Ref3p.Hash
 	l2Ref4p.Hash[0] ^= 0xff
+
+	l2Ref5p := l2Ref5 // canonical later, block after replacement block, from L1 7, but replaced again!
+	l2Ref5p.ParentHash = l2Ref4p.Hash
+	l2Ref5p.Hash[0] ^= 0xff
+
+	l2Ref6p := l2Ref6 // canonical later, block after replacement block, from L1 7, replaced again
+	l2Ref6p.ParentHash = l2Ref5p.Hash
+	l2Ref6p.Hash[0] ^= 0xff
+
+	l2Ref5pp := l2Ref5 // canonical later, block after replacement block, from L1 8
+	l2Ref5pp.ParentHash = l2Ref4p.Hash
+	l2Ref5pp.Hash[0] ^= 0xff
+	l2Ref5pp.Hash[1] ^= 0xff
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
@@ -1298,10 +1320,11 @@ func TestDBLookup(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, l1Ref6.ID(), v.source.ID())
 			require.Equal(t, l2Ref8.ID(), v.derived.ID())
+			require.Equal(t, FirstRevision, v.revision)
 
 			invalidated := types.DerivedBlockRefPair{
 				Source:  l1Ref6,
-				Derived: l1Ref3,
+				Derived: l2Ref3,
 			}
 			require.NoError(t, db.RewindAndInvalidate(invalidated))
 
@@ -1310,25 +1333,49 @@ func TestDBLookup(t *testing.T) {
 			require.True(t, v.invalidated)
 			require.Equal(t, l1Ref6.ID(), v.source.ID())
 			require.Equal(t, l2Ref3.ID(), v.derived.ID())
+			require.Equal(t, secondRevision, v.revision)
+
+			// Invalidated, but with old revision before invalidation, is considered valid
+			require.NoError(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision))
+			// Invalidated entries are not considered by ContainsDerived as valid
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrAwaitReplacementBlock)
+			// Older non-invalidated entries are considered valid still
+			require.NoError(t, db.ContainsDerived(l2Ref2.ID(), FirstRevision))
+			// If open-ended, we expect to hit the invalidated entry, even though it has a newer revision
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision.OpenEnded()), types.ErrAwaitReplacementBlock)
+
+			// We cannot invalidate what is already invalidated
+			require.ErrorIs(t, db.RewindAndInvalidate(invalidated), types.ErrAwaitReplacementBlock)
 
 			// we cannot proceed in any way until actually replacing the invalidated placeholder block
 			require.ErrorIs(t, db.AddDerived(l1Ref6, l2Ref4p), types.ErrAwaitReplacementBlock)
 			require.ErrorIs(t, db.AddDerived(l1Ref7, l2Ref3p), types.ErrAwaitReplacementBlock)
 			require.ErrorIs(t, db.AddDerived(l1Ref7, l2Ref4p), types.ErrAwaitReplacementBlock)
 
-			replacement, err := db.ReplaceInvalidatedBlock(l2Ref3p, l2Ref3.Hash)
+			replacement, revision, err := db.ReplaceInvalidatedBlock(l2Ref3p, l2Ref3.Hash)
 			require.NoError(t, err)
 			require.Equal(t, l1Ref6.ID(), replacement.Source.ID())
 			require.Equal(t, l2Ref3p.ID(), replacement.Derived.ID())
+			require.Equal(t, secondRevision, revision)
 
 			_, v, err = db.lookup(6, 3)
 			require.NoError(t, err)
 			require.False(t, v.invalidated) // not invalid, this is canonical now
 			require.Equal(t, l1Ref6.ID(), v.source.ID())
 			require.Equal(t, l2Ref3p.ID(), v.derived.ID())
+			require.Equal(t, secondRevision, v.revision) // replacement matches invalidated-placeholder revision
+
+			require.NoError(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision), types.ErrConflict)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrConflict)
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision.OpenEnded()), types.ErrConflict)
+			require.NoError(t, db.ContainsDerived(l2Ref3p.ID(), secondRevision))
 
 			require.NoError(t, db.AddDerived(l1Ref7, l2Ref3p)) // scope bump
 			require.NoError(t, db.AddDerived(l1Ref7, l2Ref4p))
+			require.NoError(t, db.AddDerived(l1Ref7, l2Ref5p))
+			require.NoError(t, db.AddDerived(l1Ref7, l2Ref6p))
+
+			require.NoError(t, db.AddDerived(l1Ref8, l2Ref6p)) // scope bump
 		},
 		func(t *testing.T, db *DB, m *stubMetrics) {
 
@@ -1358,25 +1405,184 @@ func TestDBLookup(t *testing.T) {
 			// Now that we have a chain that jumps from (source=5, derived=8) to (source=6, derived=3),
 			// let's do some searches and assert we get the expected results.
 
-			// TODO: these are broken
-			_, v, err := db.derivedNumToLastSource(3)
-			require.NoError(t, err)
-			require.Equal(t, l1Ref6.ID(), v.source.ID())
-			require.Equal(t, l2Ref3p.ID(), v.derived.ID())
+			checkRevisionsOf3 := func(t *testing.T) {
+				_, v, err := db.derivedNumToLastSource(3, FirstRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref3.ID(), v.source.ID())
+				require.Equal(t, l2Ref3.ID(), v.derived.ID())
+				_, v, err = db.derivedNumToLastSource(3, secondRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref7.ID(), v.source.ID())
+				require.Equal(t, l2Ref3p.ID(), v.derived.ID())
 
-			_, v, err = db.derivedNumToFirstSource(3)
-			require.NoError(t, err)
-			require.Equal(t, l1Ref3.ID(), v.source.ID())
-			require.Equal(t, l2Ref3.ID(), v.derived.ID())
+				_, v, err = db.derivedNumToFirstSource(3, FirstRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref3.ID(), v.source.ID())
+				require.Equal(t, l2Ref3.ID(), v.derived.ID())
+				_, v, err = db.derivedNumToFirstSource(3, secondRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref6.ID(), v.source.ID())
+				require.Equal(t, l2Ref3p.ID(), v.derived.ID())
+			}
+			checkRevisionsOf3(t)
+			checkRevisionsOf4 := func(t *testing.T) {
+				_, v, err := db.derivedNumToLastSource(4, FirstRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref3.ID(), v.source.ID())
+				require.Equal(t, l2Ref4.ID(), v.derived.ID())
 
-			_, v, err = db.derivedNumToLastSource(4)
+				_, v, err = db.derivedNumToLastSource(4, secondRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref7.ID(), v.source.ID())
+				require.Equal(t, l2Ref4p.ID(), v.derived.ID())
+
+				_, v, err = db.derivedNumToFirstSource(4, FirstRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref3.ID(), v.source.ID())
+				require.Equal(t, l2Ref4.ID(), v.derived.ID())
+				_, v, err = db.derivedNumToFirstSource(4, secondRevision)
+				require.NoError(t, err)
+				require.Equal(t, l1Ref7.ID(), v.source.ID())
+				require.Equal(t, l2Ref4p.ID(), v.derived.ID())
+			}
+			checkRevisionsOf4(t)
+
+			// Invalidate again, now replace 5p with 5pp, at L1 8
+			invalidated2 := types.DerivedBlockRefPair{
+				Source:  l1Ref8,
+				Derived: l2Ref5p,
+			}
+			require.NoError(t, db.RewindAndInvalidate(invalidated2))
+			_, v, err := db.lookup(8, 5) // now we have an invalidated place-holder that matches the (8, 5) lookup
+			require.NoError(t, err)
+			require.True(t, v.invalidated)
+			require.Equal(t, l1Ref8.ID(), v.source.ID())
+			require.Equal(t, l2Ref5p.ID(), v.derived.ID())
+			require.Equal(t, thirdRevision, v.revision)
+
+			replacement2, revision2, err := db.ReplaceInvalidatedBlock(l2Ref5pp, l2Ref5p.Hash)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref8.ID(), replacement2.Source.ID())
+			require.Equal(t, l2Ref5pp.ID(), replacement2.Derived.ID())
+			require.Equal(t, thirdRevision, revision2)
+
+			checkRevisionsOf3(t)
+			checkRevisionsOf4(t)
+
+			// We have 3 occurrences of block 5 in the DB now. Let's search for them all.
+			_, v, err = db.derivedNumToLastSource(5, FirstRevision)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref4.ID(), v.source.ID())
+			require.Equal(t, l2Ref5.ID(), v.derived.ID())
+			_, v, err = db.derivedNumToLastSource(5, secondRevision)
 			require.NoError(t, err)
 			require.Equal(t, l1Ref7.ID(), v.source.ID())
-			require.Equal(t, l2Ref4p.ID(), v.derived.ID())
+			require.Equal(t, l2Ref5p.ID(), v.derived.ID())
+			_, v, err = db.derivedNumToLastSource(5, thirdRevision)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref8.ID(), v.source.ID())
+			require.Equal(t, l2Ref5pp.ID(), v.derived.ID())
 
-			_, v, err = db.derivedNumToFirstSource(4)
+			_, v, err = db.derivedNumToFirstSource(5, FirstRevision)
 			require.NoError(t, err)
 			require.Equal(t, l1Ref3.ID(), v.source.ID())
-			require.Equal(t, l2Ref4.ID(), v.derived.ID())
+			require.Equal(t, l2Ref5.ID(), v.derived.ID())
+			_, v, err = db.derivedNumToFirstSource(5, secondRevision)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref7.ID(), v.source.ID())
+			require.Equal(t, l2Ref5p.ID(), v.derived.ID())
+			_, v, err = db.derivedNumToFirstSource(5, thirdRevision)
+			require.NoError(t, err)
+			require.Equal(t, l1Ref8.ID(), v.source.ID())
+			require.Equal(t, l2Ref5pp.ID(), v.derived.ID())
+
+			require.NoError(t, db.ContainsDerived(l2Ref2.ID(), FirstRevision))
+			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrConflict)
+			require.NoError(t, db.ContainsDerived(l2Ref3p.ID(), secondRevision))
+
+			require.NoError(t, db.ContainsDerived(l2Ref5.ID(), FirstRevision))
+			require.ErrorIs(t, db.ContainsDerived(l2Ref5p.ID(), FirstRevision), types.ErrConflict)
+			require.NoError(t, db.ContainsDerived(l2Ref5p.ID(), secondRevision))
+			require.ErrorIs(t, db.ContainsDerived(l2Ref5p.ID(), thirdRevision), types.ErrConflict)
+			require.NoError(t, db.ContainsDerived(l2Ref5pp.ID(), thirdRevision))
+		})
+}
+
+// TestDerivedToRevision matches what we see in the cross-safe DB:
+// some revised data is added, without rewinding and invalidating,
+// and leaving no alternative derived entries with the same number.
+func TestDerivedToRevision(t *testing.T) {
+	l1Ref0 := mockL1Ref(0)
+	l1Ref1 := mockL1Ref(1)
+	l1Ref2 := mockL1Ref(2)
+	l1Ref3 := mockL1Ref(3)
+	l1Ref4 := mockL1Ref(4)
+
+	l2Ref0 := mockL2Ref(0)
+	l2Ref1 := mockL2Ref(1)
+	l2Ref2 := mockL2Ref(2)
+	l2Ref3 := mockL2Ref(3)
+	l2Ref4 := mockL2Ref(4)
+	l2Ref5 := mockL2Ref(5)
+	l2Ref6 := mockL2Ref(6)
+	l2Ref7 := mockL2Ref(7)
+
+	runDBTest(t,
+		func(t *testing.T, db *DB, m *stubMetrics) {
+			v, err := db.DerivedToRevision(l2Ref0.ID())
+			require.NoError(t, err)
+			require.Equal(t, FirstRevision, v, "empty DB starts with default revision")
+
+			require.NoError(t, db.AddDerived(l1Ref0, l2Ref0))
+
+			require.NoError(t, db.AddDerived(l1Ref1, l2Ref0)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref1, l2Ref1))
+			require.NoError(t, db.AddDerived(l1Ref1, l2Ref2))
+
+			require.NoError(t, db.AddDerived(l1Ref2, l2Ref2)) // scope bump
+			require.NoError(t, db.AddRevisedDerived(l1Ref2, l2Ref3, 3))
+			require.NoError(t, db.AddDerived(l1Ref2, l2Ref4))
+
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref4)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref3, l2Ref4))
+			// when something is revised, the number of the revised data is used as revision number
+			require.ErrorIs(t, db.AddRevisedDerived(l1Ref3, l2Ref5, 6), types.ErrDataCorruption)
+			require.NoError(t, db.AddRevisedDerived(l1Ref3, l2Ref5, 5))
+
+			require.NoError(t, db.AddDerived(l1Ref4, l2Ref5)) // scope bump
+			require.NoError(t, db.AddDerived(l1Ref4, l2Ref6))
+		},
+		func(t *testing.T, db *DB, m *stubMetrics) {
+			v, err := db.DerivedToRevision(l2Ref0.ID())
+			require.NoError(t, err)
+			require.Equal(t, FirstRevision, v)
+
+			v, err = db.DerivedToRevision(l2Ref1.ID())
+			require.NoError(t, err)
+			require.Equal(t, FirstRevision, v)
+
+			v, err = db.DerivedToRevision(l2Ref2.ID())
+			require.NoError(t, err)
+			require.Equal(t, FirstRevision, v)
+
+			v, err = db.DerivedToRevision(l2Ref3.ID()) // this was a revised entry
+			require.NoError(t, err)
+			require.Equal(t, types.Revision(3), v)
+
+			v, err = db.DerivedToRevision(l2Ref4.ID())
+			require.NoError(t, err)
+			require.Equal(t, types.Revision(3), v)
+
+			v, err = db.DerivedToRevision(l2Ref5.ID())
+			require.NoError(t, err)
+			require.Equal(t, types.Revision(5), v)
+
+			v, err = db.DerivedToRevision(l2Ref6.ID())
+			require.NoError(t, err)
+			require.Equal(t, types.Revision(5), v)
+
+			v, err = db.DerivedToRevision(l2Ref7.ID())
+			require.NoError(t, err)
+			require.Equal(t, types.Revision(5).OpenEnded(), v)
 		})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/db_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_test.go
@@ -1345,8 +1345,6 @@ func TestDeepInvalidate(t *testing.T) {
 			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrAwaitReplacementBlock)
 			// Older non-invalidated entries are considered valid still
 			require.NoError(t, db.ContainsDerived(l2Ref2.ID(), FirstRevision))
-			// If open-ended, we expect to hit the invalidated entry, even though it has a newer revision
-			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision.OpenEnded()), types.ErrAwaitReplacementBlock)
 
 			// We cannot invalidate what is already invalidated
 			require.ErrorIs(t, db.RewindAndInvalidate(invalidated), types.ErrAwaitReplacementBlock)
@@ -1370,7 +1368,6 @@ func TestDeepInvalidate(t *testing.T) {
 
 			require.NoError(t, db.ContainsDerived(l2Ref3.ID(), FirstRevision), types.ErrConflict)
 			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision), types.ErrConflict)
-			require.ErrorIs(t, db.ContainsDerived(l2Ref3.ID(), secondRevision.OpenEnded()), types.ErrConflict)
 			require.NoError(t, db.ContainsDerived(l2Ref3p.ID(), secondRevision))
 
 			require.NoError(t, dbAddDerivedAny(db, l1Ref7, l2Ref3p)) // scope bump
@@ -1531,9 +1528,8 @@ func TestDerivedToRevision(t *testing.T) {
 
 	runDBTest(t,
 		func(t *testing.T, db *DB, m *stubMetrics) {
-			v, err := db.DerivedToRevision(l2Ref0.ID())
-			require.NoError(t, err)
-			require.Equal(t, FirstRevision, v, "empty DB starts with default revision")
+			_, err := db.DerivedToRevision(l2Ref0.ID())
+			require.ErrorIs(t, err, types.ErrFuture)
 
 			require.NoError(t, dbAddDerivedAny(db, l1Ref0, l2Ref0))
 
@@ -1583,8 +1579,7 @@ func TestDerivedToRevision(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, types.Revision(5), v)
 
-			v, err = db.DerivedToRevision(l2Ref7.ID())
-			require.NoError(t, err)
-			require.Equal(t, types.Revision(5).OpenEnded(), v)
+			_, err = db.DerivedToRevision(l2Ref7.ID())
+			require.ErrorIs(t, err, types.ErrFuture)
 		})
 }

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -8,7 +8,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-const EntrySize = 100
+// FirstRevision is the revision that is used when the first entry is added to the DB.
+const FirstRevision = types.Revision(0)
+
+// EntrySize is the size of the DB entry.
+// 1+3+(8+8)+8+(8+8)+32+32=108
+const EntrySize = 128
 
 type Entry [EntrySize]byte
 
@@ -52,6 +57,9 @@ func (EntryBinary) EntrySize() int {
 type LinkEntry struct {
 	source  types.BlockSeal
 	derived types.BlockSeal
+	// revision: every time we invalidate a block, we increment the revision, to distinguish invalidated data.
+	// The upper bit is reserved.
+	revision types.Revision
 	// when it exists as local-safe, but cannot be cross-safe.
 	// If false: this link is a SourceV0
 	// If true: this link is a InvalidatedFromV0
@@ -71,13 +79,18 @@ func (d *LinkEntry) decode(e Entry) error {
 	}
 	d.invalidated = e.Type() == InvalidatedFromV0
 	// Format:
-	// l1-number(8) l1-timestamp(8) l2-number(8) l2-timestamp(8) l1-hash(32) l2-hash(32)
+	// type(1) padding(3) l1-number(8) l1-timestamp(8) revision(8) l2-number(8) l2-timestamp(8) l1-hash(32) l2-hash(32)
 	// Note: attributes are ordered for lexical sorting to nicely match chronological sorting.
 	offset := 4
 	d.source.Number = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
 	d.source.Timestamp = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
+	d.revision = types.Revision(binary.BigEndian.Uint64(e[offset : offset+8]))
+	offset += 8
+	if d.revision&(1<<63) != 0 {
+		return fmt.Errorf("%w: upper bit of revision may not be set: %b", types.ErrDataCorruption, d.revision)
+	}
 	d.derived.Number = binary.BigEndian.Uint64(e[offset : offset+8])
 	offset += 8
 	d.derived.Timestamp = binary.BigEndian.Uint64(e[offset : offset+8])
@@ -95,10 +108,15 @@ func (d *LinkEntry) encode() Entry {
 	} else {
 		out[0] = uint8(SourceV0)
 	}
+	if d.revision&(1<<63) != 0 {
+		panic(fmt.Errorf("cannot encode invalid revision value: %b", d.revision))
+	}
 	offset := 4
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.source.Number)
 	offset += 8
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.source.Timestamp)
+	offset += 8
+	binary.BigEndian.PutUint64(out[offset:offset+8], uint64(d.revision))
 	offset += 8
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.derived.Number)
 	offset += 8

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -354,7 +354,6 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			// So check if it's canonical, and if it is, we can gracefully accept it, to allow forwards progress.
 			_, got, err := db.lookup(source.Number, derived.Number)
 			if err != nil {
-				// TODO
 				return fmt.Errorf("failed to check if block %s with old source %s was derived from canonical source chain: %w",
 					derived, source, err)
 			}

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -69,13 +69,42 @@ func (db *DB) RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	invalidatedSeals := types.DerivedBlockSealPair{
+	t := types.DerivedBlockSealPair{
 		Source:  types.BlockSealFromRef(invalidated.Source),
 		Derived: types.BlockSealFromRef(invalidated.Derived),
 	}
-	if err := db.rewindLocked(invalidatedSeals, true); err != nil {
+	i, link, err := db.lookupOrAfter(t.Source.Number, t.Derived.Number)
+	if err != nil {
 		return err
 	}
+	if link.invalidated {
+		return fmt.Errorf("cannot invalidate already invalidated block %s with %s: %w", link, invalidated, types.ErrAwaitReplacementBlock)
+	}
+	// We must have an exact match for the source, this is where and when we decide to invalidate
+	if link.source.Hash != t.Source.Hash {
+		return fmt.Errorf("found derived-from %s, but expected %s: %w",
+			link.source, t.Source, types.ErrConflict)
+	}
+	// If we optimistically derived some block already for a previous source,
+	// and only invalidated because of a later view of newer source data,
+	// then we may have derived later blocks and will not exactly match.
+	if link.derived.Hash != t.Derived.Hash {
+		if link.derived.Number <= t.Derived.Number {
+			return fmt.Errorf("found derived %s, but expected %s: %w",
+				link.derived, t.Derived, types.ErrConflict)
+		} else {
+			db.log.Warn("Invalidating block that was previously optimistically assumed as canonical with previous source",
+				"invalidated_source", invalidated.Source, "invalidated_derived", invalidated.Derived,
+				"link_source", link.source, "link_derived", link.derived)
+		}
+	}
+	// we rewind to exclude the entry we found
+	target := i - 1
+	if err := db.store.Truncate(target); err != nil {
+		return fmt.Errorf("failed to rewind upon block invalidation of %s: %w", t, err)
+	}
+	db.m.RecordDBDerivedEntryCount(int64(target) + 1)
+
 	if err := db.addLink(invalidated.Source, invalidated.Derived, invalidated.Derived.Hash); err != nil {
 		return fmt.Errorf("failed to add invalidation entry %s: %w", invalidated, err)
 	}
@@ -132,7 +161,7 @@ func (db *DB) RewindToFirstDerived(v eth.BlockID) error {
 
 // rewindLocked performs the truncate operation to a specified block seal pair.
 // data beyond the specified block seal pair is truncated from the database.
-// if including is true, the block seal pair itself is removed as well.
+// If including is true, the block seal pair itself is removed as well.
 // Note: This function must be called with the rwLock held.
 // Callers are responsible for locking and unlocking the Database.
 func (db *DB) rewindLocked(t types.DerivedBlockSealPair, including bool) error {
@@ -164,6 +193,9 @@ func (db *DB) rewindLocked(t types.DerivedBlockSealPair, including bool) error {
 // if the link invalidates a prior L2 block, that was valid in a prior L1,
 // the invalidated hash needs to match it, even if a new derived block replaces it.
 func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated common.Hash) error {
+	// - we are in regular operation if (invalidated = 0)
+	// - we are invalidating if (invalidated != 0 && derived == invalidated)
+	// - we are replacing an invalidated entry if (invalidated != 0 && derived != invalidated)
 	link := LinkEntry{
 		source: types.BlockSeal{
 			Hash:      source.Hash,
@@ -196,7 +228,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 		return err
 	}
 	if last.invalidated {
-		return fmt.Errorf("cannot build %s on top of invalidated entry %s: %w", link, last, types.ErrConflict)
+		return fmt.Errorf("cannot build %s on top of invalidated entry %s: %w", link, last, types.ErrAwaitReplacementBlock)
 	}
 	lastSource := last.source
 	lastDerived := last.derived
@@ -247,8 +279,15 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			lastDerived, lastSource,
 			types.ErrFuture)
 	} else {
-		return fmt.Errorf("derived block %s is older than current derived block %s: %w",
-			derived, lastDerived, types.ErrOutOfOrder)
+		if invalidated != (common.Hash{}) {
+			// Invalidated blocks may be reverting back to an older derived block.
+			// Let's sanity-check it's a known block that is being invalidated or replaced.
+			if _, v, err := db.derivedNumToLastSource(derived.Number); err != nil {
+				return fmt.Errorf("failed to check if older invalidated derived block was known: %w", err)
+			} else if v.derived.Hash != invalidated {
+				return fmt.Errorf("cannot invalidate mismatching block: expected %s but invalidating %s", link.derived, invalidated)
+			}
+		}
 	}
 
 	// Check derived-from relation: multiple L2 blocks may be derived from the same L1 block. But everything in sequence.

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -10,14 +10,18 @@ import (
 )
 
 func (db *DB) AddDerived(source eth.BlockRef, derived eth.BlockRef) error {
+	return db.AddRevisedDerived(source, derived, types.RevisionAny)
+}
+
+func (db *DB) AddRevisedDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
-	return db.addLink(source, derived, common.Hash{})
+	return db.addLink(source, derived, common.Hash{}, revision)
 }
 
 // ReplaceInvalidatedBlock replaces the current Invalidated block with the given replacement.
 // The to-be invalidated hash must be provided for consistency checks.
-func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (types.DerivedBlockSealPair, error) {
+func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (out types.DerivedBlockRefPair, revision types.Revision, err error) {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
@@ -27,39 +31,39 @@ func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidat
 	// and where we thus stopped building additional entries for it.
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return types.DerivedBlockSealPair{}, types.ErrFuture
+		return types.DerivedBlockRefPair{}, 0, types.ErrFuture
 	}
 	last, err := db.readAt(lastIndex)
 	if err != nil {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to read last derivation data: %w", err)
+		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("failed to read last derivation data: %w", err)
 	}
 	if !last.invalidated {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
 	}
 	if last.derived.Hash != invalidated {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
 	}
 	// Find the parent-block of derived-from.
 	// We need this to build a block-ref, so the DB can be consistency-checked when the next entry is added.
 	// There is always one, since the first entry in the DB should never be an invalidated one.
 	prevSource, err := db.previousSource(last.source.ID())
 	if err != nil {
-		return types.DerivedBlockSealPair{}, err
+		return types.DerivedBlockRefPair{}, 0, err
 	}
 	// Remove the invalidated placeholder and everything after
 	err = db.store.Truncate(lastIndex - 1)
 	if err != nil {
-		return types.DerivedBlockSealPair{}, err
+		return types.DerivedBlockRefPair{}, 0, err
 	}
 	replacement := types.DerivedBlockRefPair{
 		Source:  last.source.ForceWithParent(prevSource.ID()),
 		Derived: replacementDerived,
 	}
 	// Insert the replacement
-	if err := db.addLink(replacement.Source, replacement.Derived, invalidated); err != nil {
-		return types.DerivedBlockSealPair{}, fmt.Errorf("failed to add %s as replacement at %s: %w", replacement.Derived, replacement.Source, err)
+	if err := db.addLink(replacement.Source, replacement.Derived, invalidated, last.revision); err != nil {
+		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("failed to add %s as replacement at %s: %w", replacement.Derived, replacement.Source, err)
 	}
-	return replacement.Seals(), nil
+	return replacement, last.revision, nil
 }
 
 // RewindAndInvalidate rolls back the database to just before the invalidated block,
@@ -105,7 +109,11 @@ func (db *DB) RewindAndInvalidate(invalidated types.DerivedBlockRefPair) error {
 	}
 	db.m.RecordDBDerivedEntryCount(int64(target) + 1)
 
-	if err := db.addLink(invalidated.Source, invalidated.Derived, invalidated.Derived.Hash); err != nil {
+	// Starting with the placeholder invalidated entry, we are building a new canonical chain.
+	// The block-number of the invalidated derived entry is used as revision number,
+	// so that every DB copy that invalidates here uses the same number.
+	revision := types.Revision(invalidated.Derived.Number)
+	if err := db.addLink(invalidated.Source, invalidated.Derived, invalidated.Derived.Hash, revision); err != nil {
 		return fmt.Errorf("failed to add invalidation entry %s: %w", invalidated, err)
 	}
 	return nil
@@ -143,10 +151,10 @@ func (db *DB) RewindToScope(scope eth.BlockID) error {
 
 // RewindToFirstDerived rewinds to the first time
 // when v was derived (inclusive, v is retained in DB).
-func (db *DB) RewindToFirstDerived(v eth.BlockID) error {
+func (db *DB) RewindToFirstDerived(v eth.BlockID, revision types.Revision) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
-	_, link, err := db.derivedNumToFirstSource(v.Number)
+	_, link, err := db.derivedNumToFirstSource(v.Number, revision)
 	if err != nil {
 		return fmt.Errorf("failed to find when %d was first derived: %w", v.Number, err)
 	}
@@ -192,7 +200,8 @@ func (db *DB) rewindLocked(t types.DerivedBlockSealPair, including bool) error {
 // addLink adds a L1/L2 derivation link, with strong consistency checks.
 // if the link invalidates a prior L2 block, that was valid in a prior L1,
 // the invalidated hash needs to match it, even if a new derived block replaces it.
-func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated common.Hash) error {
+// If types.RevisionAny is provided, the last registered revision is repeated.
+func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated common.Hash, revision types.Revision) error {
 	// - we are in regular operation if (invalidated = 0)
 	// - we are invalidating if (invalidated != 0 && derived == invalidated)
 	// - we are replacing an invalidated entry if (invalidated != 0 && derived != invalidated)
@@ -208,11 +217,15 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			Timestamp: derived.Time,
 		},
 		invalidated: (invalidated != common.Hash{}) && derived.Hash == invalidated,
+		revision:    revision,
 	}
 	// If we don't have any entries yet, allow any block to start things off
 	if db.store.Size() == 0 {
 		if link.invalidated {
 			return fmt.Errorf("first DB entry %s cannot be an invalidated entry: %w", link, types.ErrConflict)
+		}
+		if revision.Any() {
+			link.revision = FirstRevision
 		}
 		e := link.encode()
 		if err := db.store.Append(e); err != nil {
@@ -233,6 +246,30 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 	lastSource := last.source
 	lastDerived := last.derived
 
+	if revision.Any() {
+		link.revision = last.revision
+	} else {
+		if invalidated == (common.Hash{}) {
+			// Cross-safe db can bump the revision number without invalidating anything at the same time.
+			// But can only do so when inserting the expected entry
+			if last.revision != revision {
+				if derived.Number != revision.Number() {
+					return fmt.Errorf("cannot insert entry %s with revision %s, after %s with revision %s: %w",
+						derived, revision, last.derived, last.revision, types.ErrDataCorruption)
+				}
+				db.log.Warn("New revision", "revision", revision, "source", source, "derived", derived)
+			}
+		} else if derived.Hash == invalidated {
+			if last.revision == revision {
+				return fmt.Errorf("invalidated link %s should change revision: %w", link, types.ErrConflict)
+			}
+			if derived.Number != revision.Number() {
+				return fmt.Errorf("expecting invalidated/replaced entry %s to match revision %s: %w", derived, revision, types.ErrDataCorruption)
+			}
+			db.log.Debug("Invalidating entry", "revision", revision, "source", source, "derived", derived)
+		}
+	}
+
 	if (lastSource.Number+1 == source.Number) && (lastDerived.Number+1 == derived.Number) {
 		return fmt.Errorf("cannot add source:%s derived:%s on top of last entry source:%s derived:%s, must increment source or derived, not both: %w",
 			source, derived, last.source, last.derived, types.ErrOutOfOrder)
@@ -250,7 +287,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 		// Repeat of same information. No entries to be written.
 		// But we can silently ignore and not return an error, as that brings the caller
 		// in a consistent state, after which it can insert the actual new derived-from information.
-		db.log.Debug("Database link already written", "derived", derived, "lastDerived", lastDerived)
+		db.log.Debug("Database link already written", "derived", derived, "lastDerived", lastDerived, "revision", last.revision)
 		return nil
 	}
 
@@ -280,13 +317,16 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			types.ErrFuture)
 	} else {
 		if invalidated != (common.Hash{}) {
-			// Invalidated blocks may be reverting back to an older derived block.
-			// Let's sanity-check it's a known block that is being invalidated or replaced.
-			if _, v, err := db.derivedNumToLastSource(derived.Number); err != nil {
+			// Invalidated blocks or replacement blocks may be reverting back to an older derived block.
+			// If it is older, let's sanity-check it's a known block that is being invalidated or replaced.
+			if _, v, err := db.derivedNumToLastSource(derived.Number, last.revision); err != nil {
 				return fmt.Errorf("failed to check if older invalidated derived block was known: %w", err)
 			} else if v.derived.Hash != invalidated {
 				return fmt.Errorf("cannot invalidate mismatching block: expected %s but invalidating %s", link.derived, invalidated)
 			}
+		} else {
+			return fmt.Errorf("derived block %s is older than current derived block %s: %w",
+				derived, lastDerived, types.ErrOutOfOrder)
 		}
 	}
 

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -9,11 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-func (db *DB) AddDerived(source eth.BlockRef, derived eth.BlockRef) error {
-	return db.AddRevisedDerived(source, derived, types.RevisionAny)
-}
-
-func (db *DB) AddRevisedDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error {
+func (db *DB) AddDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 	return db.addLink(source, derived, common.Hash{}, revision)
@@ -21,7 +17,8 @@ func (db *DB) AddRevisedDerived(source eth.BlockRef, derived eth.BlockRef, revis
 
 // ReplaceInvalidatedBlock replaces the current Invalidated block with the given replacement.
 // The to-be invalidated hash must be provided for consistency checks.
-func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (out types.DerivedBlockRefPair, revision types.Revision, err error) {
+func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidated common.Hash) (
+	out types.DerivedBlockRefPair, err error) {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
@@ -31,29 +28,29 @@ func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidat
 	// and where we thus stopped building additional entries for it.
 	lastIndex := db.store.LastEntryIdx()
 	if lastIndex < 0 {
-		return types.DerivedBlockRefPair{}, 0, types.ErrFuture
+		return types.DerivedBlockRefPair{}, types.ErrFuture
 	}
 	last, err := db.readAt(lastIndex)
 	if err != nil {
-		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("failed to read last derivation data: %w", err)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to read last derivation data: %w", err)
 	}
 	if !last.invalidated {
-		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("cannot replace block %d, that was not invalidated, with block %s: %w", last.derived, replacementDerived, types.ErrConflict)
 	}
 	if last.derived.Hash != invalidated {
-		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("cannot replace invalidated %s, DB contains %s: %w", invalidated, last.derived, types.ErrConflict)
 	}
 	// Find the parent-block of derived-from.
 	// We need this to build a block-ref, so the DB can be consistency-checked when the next entry is added.
 	// There is always one, since the first entry in the DB should never be an invalidated one.
 	prevSource, err := db.previousSource(last.source.ID())
 	if err != nil {
-		return types.DerivedBlockRefPair{}, 0, err
+		return types.DerivedBlockRefPair{}, err
 	}
 	// Remove the invalidated placeholder and everything after
 	err = db.store.Truncate(lastIndex - 1)
 	if err != nil {
-		return types.DerivedBlockRefPair{}, 0, err
+		return types.DerivedBlockRefPair{}, err
 	}
 	replacement := types.DerivedBlockRefPair{
 		Source:  last.source.ForceWithParent(prevSource.ID()),
@@ -61,9 +58,9 @@ func (db *DB) ReplaceInvalidatedBlock(replacementDerived eth.BlockRef, invalidat
 	}
 	// Insert the replacement
 	if err := db.addLink(replacement.Source, replacement.Derived, invalidated, last.revision); err != nil {
-		return types.DerivedBlockRefPair{}, 0, fmt.Errorf("failed to add %s as replacement at %s: %w", replacement.Derived, replacement.Source, err)
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to add %s as replacement at %s: %w", replacement.Derived, replacement.Source, err)
 	}
-	return replacement, last.revision, nil
+	return replacement, nil
 }
 
 // RewindAndInvalidate rolls back the database to just before the invalidated block,
@@ -357,6 +354,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			// So check if it's canonical, and if it is, we can gracefully accept it, to allow forwards progress.
 			_, got, err := db.lookup(source.Number, derived.Number)
 			if err != nil {
+				// TODO
 				return fmt.Errorf("failed to check if block %s with old source %s was derived from canonical source chain: %w",
 					derived, source, err)
 			}

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -589,9 +589,8 @@ func (db *DB) Rewind(newHead eth.BlockID) error {
 	} else if hash != newHead.Hash {
 		return fmt.Errorf("cannot rewind to %s, have %s: %w", newHead, eth.BlockID{Hash: hash, Number: num}, types.ErrConflict)
 	}
-	// Truncate to contain idx+1 entries, since indices are 0 based,
-	// this deletes everything after idx
-	if err := db.store.Truncate(iter.NextIndex()); err != nil {
+	// Truncate to contain idx entries. The Truncate func keeps the given index as last index.
+	if err := db.store.Truncate(iter.NextIndex() - 1); err != nil {
 		return fmt.Errorf("failed to truncate to block %s: %w", newHead, err)
 	}
 	// Use db.init() to find the log context for the new latest log entry

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -99,7 +99,15 @@ func (db *ChainsDB) findRevision(chainID eth.ChainID, block eth.BlockID) (types.
 	if !ok {
 		return types.Revision(0), types.ErrUnknownChain
 	}
-	return xdb.DerivedToRevision(block)
+	rev, err := xdb.DerivedToRevision(block)
+	if errors.Is(err, types.ErrFuture) {
+		ldb, ok := db.localDBs.Get(chainID)
+		if !ok {
+			return types.Revision(0), types.ErrUnknownChain
+		}
+		return ldb.LastRevision()
+	}
+	return rev, nil
 }
 
 func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
@@ -180,7 +188,9 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 		return fmt.Errorf("failed to get revision: %w", err)
 	}
 	db.logger.Info("Checking if accepted", "chain", chainID, "id", id, "revision", revision)
-	// If the block is not cross-safe, then the revision will be the latest, open-ended.
+	// If the block is not cross-safe, then the revision will be the latest
+	// (assuming the trailing local-safe data only has 1 revision;
+	//  the same or something net-new exactly starting after cross-safe).
 	// If the block was invalidated, then ContainsDerived will error with types.ErrAwaitReplacementBlock.
 	if err := localDB.ContainsDerived(id, revision); err != nil {
 		if errors.Is(err, types.ErrFuture) {
@@ -374,11 +384,11 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 	}
 	db.logger.Debug("Determined cross-safe candidate block revision", "crossSafe", crossSafe)
 
-	if candidate.Source.Number <= crossSafe.Source.Number {
-		db.logger.Debug("Cross-safe source matches or exceeds candidate source", "crossSafe", crossSafe, "candidate", candidate)
-		return candidate, nil
+	if candidate.Source.Number < crossSafe.Source.Number {
+		db.logger.Error("Candidate block has lower source", "crossSafe", crossSafe, "candidate", candidate)
+		return candidate, types.ErrDataCorruption
 	}
-	return candidate, types.ErrOutOfScope
+	return candidate, nil
 }
 
 func (db *ChainsDB) PreviousCrossDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -179,13 +179,14 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 	if err != nil {
 		return fmt.Errorf("failed to get revision: %w", err)
 	}
+	db.logger.Info("Checking if accepted", "chain", chainID, "id", id, "revision", revision)
 	// If the block is not cross-safe, then the revision will be the latest, open-ended.
 	// If the block was invalidated, then ContainsDerived will error with types.ErrAwaitReplacementBlock.
 	if err := localDB.ContainsDerived(id, revision); err != nil {
 		if errors.Is(err, types.ErrFuture) {
 			return nil // Optimistically accept blocks that we haven't seen as local-derived yet.
 		}
-		return fmt.Errorf("failed to check older local-safe db entry: %w", err)
+		return fmt.Errorf("failed to check older local-safe db entry %s: %w", revision, err)
 	}
 	return err
 }
@@ -362,49 +363,26 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 		return types.DerivedBlockRefPair{}, err
 	}
 
-	revision, err := xDB.DerivedToRevision(crossSafe.Derived.ID())
+	revision, err := xDB.SourceToRevision(crossSafe.Source.ID())
 	if err != nil {
-		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to get revision of cross-safe entry: %w", err)
-	}
-	candidate, err := lDB.NextDerived(crossSafe.Derived.ID(), revision)
-	if err != nil {
-		if errors.Is(err, types.ErrAwaitReplacementBlock) {
-			// If we cannot promote due to need for replacement, then abort
-			return types.DerivedBlockRefPair{}, fmt.Errorf("candidate cross-safe block %s is invalidated: %w", crossSafe, err)
-		}
 		return types.DerivedBlockRefPair{}, err
 	}
-	candidateRef := candidate.Derived.MustWithParent(crossSafe.Derived.ID())
-
-	// attach the parent (or zero-block) to the cross-safe source
-	var crossSafeSourceRef eth.BlockRef
-	parentSource, err := lDB.PreviousSource(crossSafe.Source.ID())
-	if errors.Is(err, types.ErrPreviousToFirst) {
-		// if we are working with the first item in the database, PreviousSource will return ErrPreviousToFirst
-		// in which case we can attach a zero parent to the block, as the parent block is unknown
-		// ForceWithParent will not panic if the parent is not as expected (like a zero-block)
-		crossSafeSourceRef = crossSafe.Source.ForceWithParent(eth.BlockID{})
-	} else if err != nil {
-		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to find parent-block of derived-from %s: %w", crossSafe.Source, err)
-	} else {
-		// if we have a parent, we can attach it to the cross-safe source
-		// MustWithParent will panic if the parent is not the previous block
-		crossSafeSourceRef = crossSafe.Source.MustWithParent(parentSource.ID())
+	candidate, err := lDB.Candidate(crossSafe.Source.ID(), crossSafe.Derived.ID(), revision)
+	if err != nil {
+		// forward candidate value, even if error, in case a scope-bump is needed
+		return candidate, err
 	}
+	db.logger.Debug("Determined cross-safe candidate block revision", "crossSafe", crossSafe)
 
-	result = types.DerivedBlockRefPair{
-		Source:  crossSafeSourceRef,
-		Derived: candidateRef,
-	}
 	if candidate.Source.Number <= crossSafe.Source.Number {
 		db.logger.Debug("Cross-safe source matches or exceeds candidate source", "crossSafe", crossSafe, "candidate", candidate)
-		return result, nil
+		return candidate, nil
 	}
-	return result, types.ErrOutOfScope
+	return candidate, types.ErrOutOfScope
 }
 
-func (db *ChainsDB) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
-	lDB, ok := db.localDBs.Get(chain)
+func (db *ChainsDB) PreviousCrossDerived(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error) {
+	xDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
 	}
@@ -412,7 +390,7 @@ func (db *ChainsDB) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (pre
 	if err != nil {
 		return types.BlockSeal{}, err
 	}
-	return lDB.PreviousDerived(derived, revision)
+	return xDB.PreviousDerived(derived, revision)
 }
 
 func (db *ChainsDB) PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -87,7 +87,19 @@ func (db *ChainsDB) IsCrossSafe(chainID eth.ChainID, block eth.BlockID) error {
 	if !ok {
 		return types.ErrUnknownChain
 	}
-	return xdb.ContainsDerived(block)
+	return xdb.ContainsDerived(block, types.RevisionAny)
+}
+
+// findRevision determines what the given block needs as revision for DB lookups.
+// This uses the cross-safe DB as canonical-chain reference.
+// If the block is not in the cross-safe DB (e.g. a newer local-safe block),
+// then the last known revision is used, and kept open-ended, to capture the invalidated-entry block.
+func (db *ChainsDB) findRevision(chainID eth.ChainID, block eth.BlockID) (types.Revision, error) {
+	xdb, ok := db.crossDBs.Get(chainID)
+	if !ok {
+		return types.Revision(0), types.ErrUnknownChain
+	}
+	return xdb.DerivedToRevision(block)
 }
 
 func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
@@ -95,7 +107,11 @@ func (db *ChainsDB) IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error {
 	if !ok {
 		return types.ErrUnknownChain
 	}
-	return ldb.ContainsDerived(block)
+	revision, err := db.findRevision(chainID, block)
+	if err != nil {
+		return err
+	}
+	return ldb.ContainsDerived(block, revision)
 }
 
 func (db *ChainsDB) IsFinalized(chainID eth.ChainID, block eth.BlockID) error {
@@ -159,30 +175,19 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 	if !ok {
 		return types.ErrUnknownChain
 	}
-	latest, err := localDB.Last()
+	revision, err := db.findRevision(chainID, id)
 	if err != nil {
-		// If we have invalidated the latest block, figure out what it is.
-		// Only the tip can be invalidated. So if the block we check is older, it still can be accepted.
-		if errors.Is(err, types.ErrAwaitReplacementBlock) {
-			invalidated, err := localDB.Invalidated()
-			if err != nil {
-				return fmt.Errorf("failed to read invalidated block: %w", err)
-			}
-			if id.Number >= invalidated.Derived.Number {
-				return fmt.Errorf("latest unsafe-block was invalidated, cannot accept blocks at or past it: %w",
-					types.ErrAwaitReplacementBlock)
-			}
-			// If it's older, we should check if the local-safe DB matches.
-			return localDB.ContainsDerived(id)
-		} else {
-			return fmt.Errorf("failed to read latest local-safe block: %w", err)
-		}
-	} else if latest.Derived.Number < id.Number {
-		// Optimistically accept blocks that we haven't seen as local-derived yet.
-		return nil
+		return fmt.Errorf("failed to get revision: %w", err)
 	}
-	// If it's older, we should check if the local-safe DB matches.
-	return localDB.ContainsDerived(id)
+	// If the block is not cross-safe, then the revision will be the latest, open-ended.
+	// If the block was invalidated, then ContainsDerived will error with types.ErrAwaitReplacementBlock.
+	if err := localDB.ContainsDerived(id, revision); err != nil {
+		if errors.Is(err, types.ErrFuture) {
+			return nil // Optimistically accept blocks that we haven't seen as local-derived yet.
+		}
+		return fmt.Errorf("failed to check older local-safe db entry: %w", err)
+	}
+	return err
 }
 
 func (db *ChainsDB) LocalSafe(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
@@ -254,7 +259,7 @@ func (db *ChainsDB) CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.Blo
 	if !ok {
 		return eth.BlockRef{}, types.ErrUnknownChain
 	}
-	res, err := xdb.DerivedToFirstSource(derived)
+	res, err := xdb.DerivedToFirstSource(derived, types.RevisionAny)
 	if err != nil {
 		return eth.BlockRef{}, err
 	}
@@ -296,7 +301,11 @@ func (db *ChainsDB) LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
 	}
-	return lDB.DerivedToFirstSource(derived)
+	revision, err := db.findRevision(chain, derived)
+	if err != nil {
+		return types.BlockSeal{}, err
+	}
+	return lDB.DerivedToFirstSource(derived, revision)
 }
 
 // CrossDerivedToSource returns the block that the given block was derived from, if it exists in the cross derived-from storage.
@@ -306,7 +315,7 @@ func (db *ChainsDB) CrossDerivedToSource(chain eth.ChainID, derived eth.BlockID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
 	}
-	return xDB.DerivedToFirstSource(derived)
+	return xDB.DerivedToFirstSource(derived, types.RevisionAny)
 }
 
 // CandidateCrossSafe returns the candidate local-safe block that may become cross-safe,
@@ -353,7 +362,11 @@ func (db *ChainsDB) CandidateCrossSafe(chain eth.ChainID) (result types.DerivedB
 		return types.DerivedBlockRefPair{}, err
 	}
 
-	candidate, err := lDB.NextDerived(crossSafe.Derived.ID())
+	revision, err := xDB.DerivedToRevision(crossSafe.Derived.ID())
+	if err != nil {
+		return types.DerivedBlockRefPair{}, fmt.Errorf("failed to get revision of cross-safe entry: %w", err)
+	}
+	candidate, err := lDB.NextDerived(crossSafe.Derived.ID(), revision)
 	if err != nil {
 		if errors.Is(err, types.ErrAwaitReplacementBlock) {
 			// If we cannot promote due to need for replacement, then abort
@@ -395,7 +408,11 @@ func (db *ChainsDB) PreviousDerived(chain eth.ChainID, derived eth.BlockID) (pre
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
 	}
-	return lDB.PreviousDerived(derived)
+	revision, err := db.findRevision(chain, derived)
+	if err != nil {
+		return types.BlockSeal{}, err
+	}
+	return lDB.PreviousDerived(derived, revision)
 }
 
 func (db *ChainsDB) PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -95,16 +95,20 @@ func (db *ChainsDB) UpdateLocalSafe(chain eth.ChainID, source eth.BlockRef, last
 }
 
 func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, source eth.BlockRef, lastDerived eth.BlockRef, nodeId string) {
-	logger := db.logger.New("chain", chain, "ource", source, "lastDerived", lastDerived)
+	logger := db.logger.New("chain", chain, "source", source, "lastDerived", lastDerived)
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		logger.Error("Cannot update local-safe DB, unknown chain")
 		return
 	}
 	logger.Debug("Updating local safe DB")
-	if err := localDB.AddDerived(source, lastDerived); err != nil {
+	if err := localDB.AddDerived(source, lastDerived, types.RevisionAny); err != nil {
 		if errors.Is(err, types.ErrIneffective) {
 			logger.Info("Node is syncing known source blocks on known latest local-safe block", "err", err)
+			return
+		}
+		if errors.Is(err, types.ErrDataCorruption) {
+			logger.Warn("TODO", "err", err)
 			return
 		}
 		logger.Warn("Failed to update local safe", "err", err)
@@ -131,7 +135,7 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.Block
 		return fmt.Errorf("cannot UpdateCrossUnsafe: %w: %s", types.ErrUnknownChain, chain)
 	}
 	if !db.isInitialized(chain) {
-		return fmt.Errorf("cannot UpdateCrossSafe on uninitialized database: %w", types.ErrUninitialized)
+		return fmt.Errorf("cannot UpdateCrossUnsafe on uninitialized database: %w", types.ErrUninitialized)
 	}
 	v.Set(crossUnsafe)
 	db.logger.Info("Updated cross-unsafe", "chain", chain, "crossUnsafe", crossUnsafe)
@@ -157,9 +161,18 @@ func (db *ChainsDB) UpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, last
 func (db *ChainsDB) initializedUpdateCrossSafe(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
 	crossDB, ok := db.crossDBs.Get(chain)
 	if !ok {
-		return fmt.Errorf("cannot UpdateCrossSafe: %w: %s", types.ErrUnknownChain, chain)
+		return fmt.Errorf("cannot UpdateCrossSafe, no cross-safe DB: %w: %s", types.ErrUnknownChain, chain)
 	}
-	if err := crossDB.AddDerived(l1View, lastCrossDerived); err != nil {
+	localDB, ok := db.localDBs.Get(chain)
+	if !ok {
+		return fmt.Errorf("cannot UpdateCrossSafe, no local-safe DB: %w: %s", types.ErrUnknownChain, chain)
+	}
+	// local DB here already has the new block, incl. replacement data, to sync with the cross-db
+	revision, err := localDB.SourceToRevision(l1View.ID())
+	if err != nil {
+		return fmt.Errorf("failed to lookup revision: %w", err)
+	}
+	if err := crossDB.AddDerived(l1View, lastCrossDerived, revision); err != nil {
 		return err
 	}
 	db.logger.Info("Updated cross-safe", "chain", chain, "l1View", l1View, "lastCrossDerived", lastCrossDerived)
@@ -321,19 +334,23 @@ func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef
 	}
 
 	db.logger.Warn("Replacing local block", "replacement", replacement)
-	result, revision, err := localSafeDB.ReplaceInvalidatedBlock(replacement, invalidated)
+	result, err := localSafeDB.ReplaceInvalidatedBlock(replacement, invalidated)
 	if err != nil {
 		db.logger.Error("Cannot replace invalidated block in local-safe DB",
 			"invalidated", invalidated, "replacement", replacement, "err", err)
 		return
 	}
 
+	revision := types.Revision(result.Derived.Number)
 	db.logger.Info("Replacing block", "chain", chainID, "replacement", replacement, "revision", revision)
-	if err := crossSafeDB.AddRevisedDerived(result.Source, result.Derived, revision); err != nil {
+
+	// TODO: not strictly necessary, but prevents cross-safe routine from doing it (although a race condition too)
+	if err := crossSafeDB.AddDerived(result.Source, result.Derived, revision); err != nil {
 		db.logger.Error("Cannot register replacement block in cross-safe DB",
 			"invalidated", invalidated, "replacement", replacement, "revision", revision, "err", err)
 		return
 	}
+
 	// Consider the replacement as a new local-unsafe block, so we can try to index the new event-data.
 	db.emitter.Emit(superevents.LocalUnsafeReceivedEvent{
 		ChainID:        chainID,

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -321,12 +321,6 @@ func (db *ChainsDB) ResetCrossUnsafeIfNewerThan(chainID eth.ChainID, number uint
 }
 
 func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef, invalidated common.Hash) {
-	crossSafeDB, ok := db.crossDBs.Get(chainID)
-	if !ok {
-		db.logger.Error("Cannot find DB for replacement block", "chain", chainID)
-		return
-	}
-
 	localSafeDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		db.logger.Error("Cannot find DB for replacement block", "chain", chainID)
@@ -344,13 +338,6 @@ func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef
 	revision := types.Revision(result.Derived.Number)
 	db.logger.Info("Replacing block", "chain", chainID, "replacement", replacement, "revision", revision)
 
-	// TODO: not strictly necessary, but prevents cross-safe routine from doing it (although a race condition too)
-	if err := crossSafeDB.AddDerived(result.Source, result.Derived, revision); err != nil {
-		db.logger.Error("Cannot register replacement block in cross-safe DB",
-			"invalidated", invalidated, "replacement", replacement, "revision", revision, "err", err)
-		return
-	}
-
 	// Consider the replacement as a new local-unsafe block, so we can try to index the new event-data.
 	db.emitter.Emit(superevents.LocalUnsafeReceivedEvent{
 		ChainID:        chainID,
@@ -361,11 +348,6 @@ func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef
 		ChainID:      chainID,
 		NewLocalSafe: result.Seals(),
 	})
-	// The cross-safe DB changed also
-	db.emitter.Emit(superevents.CrossSafeUpdateEvent{
-		ChainID:      chainID,
-		NewCrossSafe: result.Seals(),
-	})
-
-	// TODO Make sure the events-DB has a matching block-hash with the replacement, roll it back otherwise.
+	// The event-DB will start indexing, and then unblock cross-safe update
+	// of the new replaced block, via regular cross-safe update worker routine.
 }

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -60,22 +60,25 @@ func (db *ChainsDB) Rewind(chain eth.ChainID, headBlock eth.BlockID) error {
 		return fmt.Errorf("failed to rewind to block %v: %w", headBlock, err)
 	}
 
-	// Rewind the localDB
 	localDB, ok := db.localDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot Rewind (localDB not found): %w: %s", types.ErrUnknownChain, chain)
 	}
-	if err := localDB.RewindToFirstDerived(headBlock); err != nil {
-		return fmt.Errorf("failed to rewind localDB to block %v: %w", headBlock, err)
-	}
-
-	// Rewind the crossDB
 	crossDB, ok := db.crossDBs.Get(chain)
 	if !ok {
 		return fmt.Errorf("cannot Rewind (crossDB not found): %w: %s", types.ErrUnknownChain, chain)
 	}
-	if err := crossDB.RewindToFirstDerived(headBlock); err != nil {
-		return fmt.Errorf("failed to rewind crossDB to block %v: %w", headBlock, err)
+
+	revision, err := crossDB.DerivedToRevision(headBlock)
+	if err != nil {
+		return fmt.Errorf("cannot determine revision of %s on %s: %w", headBlock, chain, err)
+	}
+
+	if err := localDB.RewindToFirstDerived(headBlock, revision); err != nil {
+		return fmt.Errorf("failed to rewind localDB to block %s on %s: %w", headBlock, chain, err)
+	}
+	if err := crossDB.RewindToFirstDerived(headBlock, revision); err != nil {
+		return fmt.Errorf("failed to rewind crossDB to block %s on %s: %w", headBlock, chain, err)
 	}
 	return nil
 }
@@ -305,16 +308,30 @@ func (db *ChainsDB) ResetCrossUnsafeIfNewerThan(chainID eth.ChainID, number uint
 }
 
 func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef, invalidated common.Hash) {
+	crossSafeDB, ok := db.crossDBs.Get(chainID)
+	if !ok {
+		db.logger.Error("Cannot find DB for replacement block", "chain", chainID)
+		return
+	}
+
 	localSafeDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		db.logger.Error("Cannot find DB for replacement block", "chain", chainID)
 		return
 	}
 
-	result, err := localSafeDB.ReplaceInvalidatedBlock(replacement, invalidated)
+	db.logger.Warn("Replacing local block", "replacement", replacement)
+	result, revision, err := localSafeDB.ReplaceInvalidatedBlock(replacement, invalidated)
 	if err != nil {
 		db.logger.Error("Cannot replace invalidated block in local-safe DB",
 			"invalidated", invalidated, "replacement", replacement, "err", err)
+		return
+	}
+
+	db.logger.Info("Replacing block", "chain", chainID, "replacement", replacement, "revision", revision)
+	if err := crossSafeDB.AddRevisedDerived(result.Source, result.Derived, revision); err != nil {
+		db.logger.Error("Cannot register replacement block in cross-safe DB",
+			"invalidated", invalidated, "replacement", replacement, "revision", revision, "err", err)
 		return
 	}
 	// Consider the replacement as a new local-unsafe block, so we can try to index the new event-data.
@@ -325,7 +342,12 @@ func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef
 	// The local-safe DB changed, so emit an event, so other sub-systems can react to the change.
 	db.emitter.Emit(superevents.LocalSafeUpdateEvent{
 		ChainID:      chainID,
-		NewLocalSafe: result,
+		NewLocalSafe: result.Seals(),
+	})
+	// The cross-safe DB changed also
+	db.emitter.Emit(superevents.CrossSafeUpdateEvent{
+		ChainID:      chainID,
+		NewCrossSafe: result.Seals(),
 	})
 
 	// TODO Make sure the events-DB has a matching block-hash with the replacement, roll it back otherwise.

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -217,7 +217,7 @@ func (s *ChainProcessor) rangeUpdate(target uint64) (int, error) {
 			return
 		}
 		if err := s.rewinder.AcceptedBlock(s.chain, next.ID()); err != nil {
-			s.log.Warn("Cannot accept next block into events DB", "err", err)
+			s.log.Warn("Cannot accept next block into events DB", "next", next.ID(), "err", err)
 			result.err = err
 			return
 		}

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -8,6 +8,8 @@ var (
 	ErrOutOfOrder = errors.New("data out of order")
 	// ErrDataCorruption happens when the underlying DB has some I/O issue
 	ErrDataCorruption = errors.New("data corruption")
+	// ErrNotExact happens when we search the DB, know the data may be there, but is not (e.g. different revision)
+	ErrNotExact = errors.New("missed data")
 	// ErrSkipped happens when we try to retrieve data that is not available (pruned)
 	// It may also happen if we erroneously skip data, that was not considered a conflict, if the DB is corrupted.
 	ErrSkipped = errors.New("skipped data")

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -92,9 +92,6 @@ func (r Revision) Cmp(blockNum uint64) int {
 	if r.Number() == blockNum {
 		return 0
 	}
-	if r.OpenEnd() {
-		return 0
-	}
 	return -1
 }
 

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -39,6 +39,65 @@ func (ci *ChainIndex) UnmarshalText(data []byte) error {
 	return nil
 }
 
+type Revision uint64
+
+// RevisionAny is used as indicator to ignore the revision during lookups.
+// This is used in the cross-safe queries,
+// where there will only ever be a single derived block per derived block number,
+// but where the revision is still tracked to match the local-safe DB block replacements.
+// We use the max-uint64 value, since this is reserved, and will not be allowed to decode/encode.
+const RevisionAny = ^Revision(0)
+
+func (r Revision) Any() bool {
+	return r == RevisionAny
+}
+
+// OpenEnded turns the revision in a new revision with open end (see OpenEnd)
+func (r Revision) OpenEnded() Revision {
+	return r | (1 << 63)
+}
+
+// OpenEnd returns if the revision may additionally match an invalidated entry
+func (r Revision) OpenEnd() bool {
+	return r&(1<<63) != 0
+}
+
+// Number returns the block-number, where the revision started (i.e. the invalidated/replacement block height)
+func (r Revision) Number() uint64 {
+	return uint64(r) &^ uint64(1<<63)
+}
+
+func (r Revision) String() string {
+	if r.Any() {
+		return "Rev(any)"
+	}
+	if r.OpenEnd() {
+		return fmt.Sprintf("Rev(%d open)", r.Number())
+	}
+	return fmt.Sprintf("Rev(%d)", r.Number())
+}
+
+// Cmp returns:
+// 0 if the revision matches any block number
+// 1 if the revision is higher than the given number
+// 0 if the revision is equal than the given number
+// -1 if the revision is lower than the given number
+func (r Revision) Cmp(blockNum uint64) int {
+	if r.Any() {
+		return 0
+	}
+	if r.Number() > blockNum {
+		return 1
+	}
+	if r.Number() == blockNum {
+		return 0
+	}
+	if r.OpenEnd() {
+		return 0
+	}
+	return -1
+}
+
 // ContainsQuery contains all the information needed to check a message
 // against a chain's database, to determine if it is valid (ie all invariants hold).
 type ContainsQuery struct {

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -405,6 +405,10 @@ func (refs *DerivedBlockRefPair) Seals() DerivedBlockSealPair {
 	}
 }
 
+func (refs DerivedBlockRefPair) String() string {
+	return fmt.Sprintf("refPair(source: %s, derived: %s)", refs.Source, refs.Derived)
+}
+
 // DerivedBlockSealPair is a pair of block seals, where Derived (L2) is derived from Source (L1).
 type DerivedBlockSealPair struct {
 	Source  BlockSeal `json:"source"`
@@ -418,10 +422,18 @@ func (seals *DerivedBlockSealPair) IDs() DerivedIDPair {
 	}
 }
 
+func (seals DerivedBlockSealPair) String() string {
+	return fmt.Sprintf("sealPair(source: %s, derived: %s)", seals.Source, seals.Derived)
+}
+
 // DerivedIDPair is a pair of block IDs, where Derived (L2) is derived from Source (L1).
 type DerivedIDPair struct {
 	Source  eth.BlockID `json:"source"`
 	Derived eth.BlockID `json:"derived"`
+}
+
+func (ids DerivedIDPair) String() string {
+	return fmt.Sprintf("idPair(source: %s, derived: %s)", ids.Source, ids.Derived)
 }
 
 type BlockReplacement struct {

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -52,16 +52,6 @@ func (r Revision) Any() bool {
 	return r == RevisionAny
 }
 
-// OpenEnded turns the revision in a new revision with open end (see OpenEnd)
-func (r Revision) OpenEnded() Revision {
-	return r | (1 << 63)
-}
-
-// OpenEnd returns if the revision may additionally match an invalidated entry
-func (r Revision) OpenEnd() bool {
-	return r&(1<<63) != 0
-}
-
 // Number returns the block-number, where the revision started (i.e. the invalidated/replacement block height)
 func (r Revision) Number() uint64 {
 	return uint64(r) &^ uint64(1<<63)
@@ -70,9 +60,6 @@ func (r Revision) Number() uint64 {
 func (r Revision) String() string {
 	if r.Any() {
 		return "Rev(any)"
-	}
-	if r.OpenEnd() {
-		return fmt.Sprintf("Rev(%d open)", r.Number())
 	}
 	return fmt.Sprintf("Rev(%d)", r.Number())
 }

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -549,3 +549,39 @@ func TestEncodeAccessList(t *testing.T) {
 		require.Equal(t, accObjects, result, "roundtrip of random entries should work")
 	})
 }
+
+func TestRevision(t *testing.T) {
+	require.True(t, RevisionAny.Any())
+	// RevisionAny does not have a sort-order
+	require.Equal(t, 0, RevisionAny.Cmp(0))
+	require.Equal(t, 0, RevisionAny.Cmp(1))
+	require.Equal(t, 0, RevisionAny.Cmp(100))
+	require.Equal(t, 0, RevisionAny.Cmp(1000))
+
+	// open-ended leaves the range open for later blocks
+	require.True(t, Revision(123).OpenEnded().OpenEnd())
+	require.False(t, Revision(123).OpenEnd())
+	require.False(t, Revision(0).OpenEnd())
+
+	require.Equal(t, uint64(123), Revision(123).Number())
+	require.Equal(t, uint64(0), Revision(0).Number())
+	require.Equal(t, 0, Revision(0).Cmp(0))
+	require.Equal(t, -1, Revision(0).Cmp(1))
+	require.Equal(t, 0, Revision(0).OpenEnded().Cmp(1))
+
+	require.Equal(t, 1, Revision(123).Cmp(0))
+	require.Equal(t, 1, Revision(123).Cmp(122))
+	require.Equal(t, 0, Revision(123).Cmp(123))
+	require.Equal(t, -1, Revision(123).Cmp(124))
+	require.Equal(t, -1, Revision(123).Cmp(150))
+
+	require.Equal(t, 1, Revision(123).OpenEnded().Cmp(0))
+	require.Equal(t, 1, Revision(123).OpenEnded().Cmp(122))
+	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(123))
+	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(124))
+	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(150))
+
+	require.Equal(t, "Rev(any)", RevisionAny.String())
+	require.Equal(t, "Rev(123 open)", Revision(123).OpenEnded().String())
+	require.Equal(t, "Rev(123)", Revision(123).String())
+}

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -558,16 +558,10 @@ func TestRevision(t *testing.T) {
 	require.Equal(t, 0, RevisionAny.Cmp(100))
 	require.Equal(t, 0, RevisionAny.Cmp(1000))
 
-	// open-ended leaves the range open for later blocks
-	require.True(t, Revision(123).OpenEnded().OpenEnd())
-	require.False(t, Revision(123).OpenEnd())
-	require.False(t, Revision(0).OpenEnd())
-
 	require.Equal(t, uint64(123), Revision(123).Number())
 	require.Equal(t, uint64(0), Revision(0).Number())
 	require.Equal(t, 0, Revision(0).Cmp(0))
 	require.Equal(t, -1, Revision(0).Cmp(1))
-	require.Equal(t, -1, Revision(0).OpenEnded().Cmp(1)) // open-end does not affect comparison
 
 	require.Equal(t, 1, Revision(123).Cmp(0))
 	require.Equal(t, 1, Revision(123).Cmp(122))
@@ -575,13 +569,6 @@ func TestRevision(t *testing.T) {
 	require.Equal(t, -1, Revision(123).Cmp(124))
 	require.Equal(t, -1, Revision(123).Cmp(150))
 
-	require.Equal(t, 1, Revision(123).OpenEnded().Cmp(0))
-	require.Equal(t, 1, Revision(123).OpenEnded().Cmp(122))
-	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(123))
-	require.Equal(t, -1, Revision(123).OpenEnded().Cmp(124))
-	require.Equal(t, -1, Revision(123).OpenEnded().Cmp(150))
-
 	require.Equal(t, "Rev(any)", RevisionAny.String())
-	require.Equal(t, "Rev(123 open)", Revision(123).OpenEnded().String())
 	require.Equal(t, "Rev(123)", Revision(123).String())
 }

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -567,7 +567,7 @@ func TestRevision(t *testing.T) {
 	require.Equal(t, uint64(0), Revision(0).Number())
 	require.Equal(t, 0, Revision(0).Cmp(0))
 	require.Equal(t, -1, Revision(0).Cmp(1))
-	require.Equal(t, 0, Revision(0).OpenEnded().Cmp(1))
+	require.Equal(t, -1, Revision(0).OpenEnded().Cmp(1)) // open-end does not affect comparison
 
 	require.Equal(t, 1, Revision(123).Cmp(0))
 	require.Equal(t, 1, Revision(123).Cmp(122))
@@ -578,8 +578,8 @@ func TestRevision(t *testing.T) {
 	require.Equal(t, 1, Revision(123).OpenEnded().Cmp(0))
 	require.Equal(t, 1, Revision(123).OpenEnded().Cmp(122))
 	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(123))
-	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(124))
-	require.Equal(t, 0, Revision(123).OpenEnded().Cmp(150))
+	require.Equal(t, -1, Revision(123).OpenEnded().Cmp(124))
+	require.Equal(t, -1, Revision(123).OpenEnded().Cmp(150))
 
 	require.Equal(t, "Rev(any)", RevisionAny.String())
 	require.Equal(t, "Rev(123 open)", Revision(123).OpenEnded().String())


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Work in progress.

Fixes:
- `lookup` should use the L1 key as primary key, and L2 as secondary key, not the other way around, to account for local-safe invalidation where a new L1 scope rolls back the L2 chain many blocks
- `lookupOrAfter` should be used by the local-safe invalidation code, to determine what to rewind to
- `addLink` should handle that when invalidating something, that something can be an older block, attached to a new scope
- remove duplicate `if cmpFn(link) != 0` case
- fix logs-DB truncation off-by-one (it was self-recovering, but now it doesn't log anymore about dropping the inconsistent entries after truncation)
- fix `derivedNumToFirstSource`: always use the exact revision number. (any later revision would be from a later source)
- fix `derivedNumToLastSource`: check if the revision query is open-ended, if so, we can accept the trailing invalidated data if it matches. If not, then do an exact search.

### About `revision` in the fromda DB

This is a number that tracks per L1-L2-link when the last block-replacement (local-safe invalidation) happened.

This makes it so that there is a L2-key that is strictly incremental. And for all entries with the same revision, the L2 derived block number is strictly incremental (since there is no block replacement that can set things back within the same revision).

Using the revision number, the local-safe DB can now safely be searched by L2 derived block number again. Previously this was subtly broken, where it would work, unless there was an invalidated local-safe chain that is deeper than a single L1 batch (older tests all did minimal increments, not capturing the deeper invalidation).

The cross-safe DB is still the same canonical chain view, with no conflicting L2 blocks, but now tracks a copy of the revision number with every link. Anyone querying the local-safe DB with an L2 block can first get a revision-number from the cross-safe DB, and then use that for the local-safe lookup. If the cross-safe DB does not include the block yet, then the last known revision is used.
The local-safe DB may be invalidating something (there may be an invalidated placeholder entry, that hasn't been replaced yet), while that new revision isn't yet in the cross-safe DB. This is accepted in the "open ended" case, and checked explicitly, before searching the DB, since it can only affect the last entry in the DB.

![image](https://github.com/user-attachments/assets/a45f6647-b58a-49a6-82f1-5fc41875b7f6)

excalidraw link: https://excalidraw.com/#json=d_hSkpGGBfTlunRlZwMLL,re0b2Ik8PwOpK7JaWReq9A

**Tests**

See new `fromda` unit tests.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/14990